### PR TITLE
fix(reply): steer active embedded Pi runs between streams

### DIFF
--- a/src/agents/pi-embedded-runner/run-state.ts
+++ b/src/agents/pi-embedded-runner/run-state.ts
@@ -15,6 +15,7 @@ export type EmbeddedPiQueueHandle = {
 
 export type EmbeddedPiQueueMessageOptions = {
   steeringMode?: "all" | "one-at-a-time";
+  toolCallSteeringBehavior?: "inject" | "interrupt";
   debounceMs?: number;
 };
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -191,6 +191,7 @@ import { observeReplayMetadata, replayMetadataFromState } from "../replay-state.
 import {
   clearActiveEmbeddedRun,
   type EmbeddedPiQueueHandle,
+  type EmbeddedPiQueueMessageOptions,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
 } from "../runs.js";
@@ -1503,6 +1504,13 @@ export async function runEmbeddedAttempt(
       }
       session.setActiveToolsByName(sessionToolAllowlist);
       const activeSession = session;
+      // OpenClaw wants active-run steering to classify normal corrections as
+      // inject and stop-like messages as interrupt. Enable Pi's tool-boundary
+      // checkpoints up front; queueMessage below snapshots the per-message
+      // inject/interrupt behavior before each steer() call.
+      (activeSession.agent as typeof activeSession.agent & {
+        toolCallSteeringBehavior: NonNullable<EmbeddedPiQueueMessageOptions["toolCallSteeringBehavior"]>;
+      }).toolCallSteeringBehavior = "interrupt";
       prepStages.mark("agent-session");
       if (isRawModelRun) {
         // Raw model probes should measure exactly the requested prompt against
@@ -2243,6 +2251,13 @@ export async function runEmbeddedAttempt(
         queueMessage: async (text: string, options) => {
           if (options?.steeringMode) {
             activeSession.agent.steeringMode = options.steeringMode;
+          }
+          if (options?.toolCallSteeringBehavior) {
+            // Paired pi-agent-core steering support adds this setter; keep the
+            // local shape explicit until OpenClaw can bump to that published SDK.
+            (activeSession.agent as typeof activeSession.agent & {
+              toolCallSteeringBehavior: NonNullable<EmbeddedPiQueueMessageOptions["toolCallSteeringBehavior"]>;
+            }).toolCallSteeringBehavior = options.toolCallSteeringBehavior;
           }
           await activeSession.steer(text);
         },

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -19,12 +19,12 @@ import {
 type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
 
 function createRunHandle(
-  overrides: { isCompacting?: boolean; abort?: () => void } = {},
+  overrides: { isCompacting?: boolean; isStreaming?: boolean; abort?: () => void } = {},
 ): RunHandle {
   const abort = overrides.abort ?? (() => {});
   return {
     queueMessage: async () => {},
-    isStreaming: () => true,
+    isStreaming: () => overrides.isStreaming ?? true,
     isCompacting: () => overrides.isCompacting ?? false,
     abort,
   };
@@ -75,10 +75,16 @@ describe("pi-embedded runner run registry", () => {
     });
 
     expect(
-      queueEmbeddedPiMessage("session-steer", "continue", { steeringMode: "one-at-a-time" }),
+      queueEmbeddedPiMessage("session-steer", "continue", {
+        steeringMode: "one-at-a-time",
+        toolCallSteeringBehavior: "interrupt",
+      }),
     ).toBe(true);
 
-    expect(queueMessage).toHaveBeenCalledWith("continue", { steeringMode: "one-at-a-time" });
+    expect(queueMessage).toHaveBeenCalledWith("continue", {
+      steeringMode: "one-at-a-time",
+      toolCallSteeringBehavior: "interrupt",
+    });
   });
 
   it("defaults active embedded steering to all pending messages", () => {
@@ -91,6 +97,18 @@ describe("pi-embedded runner run registry", () => {
     expect(queueEmbeddedPiMessage("session-default-steer", "continue")).toBe(true);
 
     expect(queueMessage).toHaveBeenCalledWith("continue", { steeringMode: "all" });
+  });
+
+  it("queues steering to active embedded runs even while they are between stream chunks", () => {
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun("session-tooling", {
+      ...createRunHandle({ isStreaming: false }),
+      queueMessage,
+    });
+
+    expect(queueEmbeddedPiMessage("session-tooling", "stop after current tool")).toBe(true);
+
+    expect(queueMessage).toHaveBeenCalledWith("stop after current tool", { steeringMode: "all" });
   });
 
   it("force-clears an aborted run that does not drain", async () => {

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -74,10 +74,6 @@ export function queueEmbeddedPiMessage(
     diag.debug(`queue message failed: sessionId=${sessionId} reason=no_active_run`);
     return false;
   }
-  if (!handle.isStreaming()) {
-    diag.debug(`queue message failed: sessionId=${sessionId} reason=not_streaming`);
-    return false;
-  }
   if (handle.isCompacting()) {
     diag.debug(`queue message failed: sessionId=${sessionId} reason=compacting`);
     return false;

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -88,6 +88,7 @@ function makeRunReplyAgentParams(
     commandBody: prompt,
     followupRun: createMockFollowupRun({
       prompt,
+      summaryLine: prompt,
       run: {
         agentId: "main",
         agentDir: "/tmp/agent",
@@ -216,6 +217,7 @@ describe("runReplyAgent media path normalization", () => {
 
     expect(queueEmbeddedPiMessageMock).toHaveBeenLastCalledWith("session", "generate chart", {
       steeringMode: "all",
+      toolCallSteeringBehavior: "inject",
     });
 
     await runReplyAgent(
@@ -228,7 +230,70 @@ describe("runReplyAgent media path normalization", () => {
 
     expect(queueEmbeddedPiMessageMock).toHaveBeenLastCalledWith("session", "generate chart", {
       steeringMode: "one-at-a-time",
+      toolCallSteeringBehavior: "inject",
     });
+  });
+
+  it("steers active embedded runs even when the busy snapshot is not streaming", async () => {
+    queueEmbeddedPiMessageMock.mockReturnValue(true);
+
+    await runReplyAgent(
+      makeRunReplyAgentParams({
+        resolvedQueue: { mode: "steer" } as QueueSettings,
+        shouldSteer: true,
+        isActive: true,
+        isStreaming: false,
+      }),
+    );
+
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith("session", "generate chart", {
+      steeringMode: "all",
+      toolCallSteeringBehavior: "inject",
+    });
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to follow-up queue when active-run steering cannot be delivered", async () => {
+    queueEmbeddedPiMessageMock.mockReturnValue(false);
+
+    await runReplyAgent(
+      makeRunReplyAgentParams({
+        resolvedQueue: { mode: "steer" } as QueueSettings,
+        shouldSteer: true,
+        isActive: true,
+        isStreaming: false,
+        isRunActive: () => true,
+      }),
+    );
+
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith("session", "generate chart", {
+      steeringMode: "all",
+      toolCallSteeringBehavior: "inject",
+    });
+    expect(enqueueFollowupRunMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("interrupts remaining tool calls for stop-like active-run steering", async () => {
+    queueEmbeddedPiMessageMock.mockReturnValue(true);
+
+    await runReplyAgent(
+      makeRunReplyAgentParams({
+        prompt: "stop",
+        resolvedQueue: { mode: "steer" } as QueueSettings,
+        shouldSteer: true,
+        isActive: true,
+        isStreaming: false,
+      }),
+    );
+
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith("session", "stop", {
+      steeringMode: "all",
+      toolCallSteeringBehavior: "interrupt",
+    });
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
   });
 
   it("shares one media cache between block accumulation and final payload delivery", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -61,6 +61,7 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-l
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
+import { isAbortRequestText } from "./abort-primitives.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
@@ -995,12 +996,15 @@ export async function runReplyAgent(params: {
     }
   };
 
-  if (shouldSteer && isStreaming) {
+  if (shouldSteer && (isStreaming || isActive)) {
     const steerSessionId =
       (sessionKey ? replyRunRegistry.resolveSessionId(sessionKey) : undefined) ??
       followupRun.run.sessionId;
     const steered = queueEmbeddedPiMessage(steerSessionId, followupRun.prompt, {
       steeringMode: resolvePiSteeringModeForQueueMode(resolvedQueue.mode),
+      toolCallSteeringBehavior: isAbortRequestText(followupRun.summaryLine ?? followupRun.prompt)
+        ? "interrupt"
+        : "inject",
       ...(resolvedQueue.debounceMs !== undefined ? { debounceMs: resolvedQueue.debounceMs } : {}),
     });
     if (steered && !shouldFollowup) {


### PR DESCRIPTION
## Summary

- steer active embedded Pi runs while the run is active even when it is between stream chunks
- classify normal active-run steering as `toolCallSteeringBehavior: "inject"`
- classify stop-like/abort steering through `isAbortRequestText(...)` as `"interrupt"`
- enable Pi tool-boundary interrupt checkpoints up front, with a typed forward-compat seam until the paired `@mariozechner/pi-agent-core` API is published
- fall back to follow-up queue if active-run steering cannot be delivered

## Related issues

- Addresses part of #50880 (steer mode silently degrading instead of injecting mid-turn)
- Addresses part of #70319 (stronger stop/correction control during active work)
- Avoids the stale transcript shape behind #50145 by using provider-valid skipped tool results in the paired Pi change instead of replaying stale assistant output

## Verification

- `node scripts/run-vitest.mjs run src/agents/pi-embedded-runner/runs.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts` — 33 tests passed
- `PATH=/tmp/openclaw-realbin:/etc/profiles/per-user/openclaw/bin:/run/current-system/sw/bin:/usr/bin:/bin /etc/profiles/per-user/openclaw/bin/corepack pnpm check:changed` — passed
- `clawctl verify raw` via OpenCode — PASS: `/home/openclaw/.openclaw/workspace/tmp/steering-verifiers-20260430/current/openclaw.opencode.final.md`
- `clawctl verify raw` via Cursor — PASS: `/home/openclaw/.openclaw/workspace/tmp/steering-verifiers-20260430/current/openclaw.cursor.final.md`

## Dependency note

This is paired with a local `badlogic/pi-mono` branch `openclaw-steering-tool-boundary` that adds `toolCallSteeringBehavior` support to `@mariozechner/pi-agent-core`. The current published SDK is `0.70.6`, so this PR keeps the OpenClaw side as an explicit typed forward-compat seam until the Pi change is available.
