### PR TITLE
fix(cli/update): stop reporting clean working tree when porcelain shows dirty entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/update: stop reporting "Working directory is clean" when `git status --porcelain` returns dirty entries during `openclaw update`, surface the offending files in the skipped result, and point users at `git stash -u` so untracked artifacts (backups, generated tarballs) no longer silently block git updates after `git stash` and `git reset --hard`. Thanks @delorenj.
 - Providers/OpenAI Codex: preserve existing wrapped Codex streams during OpenAI attribution so PI OAuth bearer injection reaches ChatGPT/Codex Responses, and strip native Codex-only unsupported payload fields without touching custom compatible endpoints. (#75111) Thanks @keshavbotagent.
 - Agents/tool-result guard: use the resolved runtime context token budget for non-context-engine tool-result overflow checks, so long tool-heavy sessions no longer compact early when `contextTokens` is larger than native `contextWindow`. Fixes #74917. Thanks @kAIborg24.
 - Gateway/systemd: exit with sysexits 78 for supervised lock and `EADDRINUSE` conflicts so `RestartPreventExitStatus=78` stops `Restart=always` restart loops instead of repeatedly reloading plugins against an occupied port. Fixes #75115. Thanks @yhyatt.

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2111,9 +2111,38 @@ describe("update-cli", () => {
       "Git-based updates need a clean working tree before they can switch commits, fetch, or rebase.",
     );
     expect(logs.join("\n")).toContain(
-      "Commit, stash, or discard the local changes, then rerun `openclaw update`.",
+      "Commit, stash (`git stash -u` to include untracked), or discard the local changes, then rerun `openclaw update`.",
     );
     expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+  });
+  it("lists the offending entries when the worktree is dirty", async () => {
+    vi.mocked(defaultRuntime.log).mockClear();
+    vi.mocked(defaultRuntime.error).mockClear();
+    vi.mocked(defaultRuntime.exit).mockClear();
+    vi.mocked(runGatewayUpdate).mockResolvedValue({
+      status: "skipped",
+      mode: "git",
+      reason: "dirty",
+      steps: [
+        {
+          name: "clean check",
+          command: "git -C /repo status --porcelain",
+          cwd: "/repo",
+          durationMs: 5,
+          exitCode: 0,
+          stdoutTail: "?? 2026-04-29T06-12-16.838Z-openclaw-backup.tar.gz\n M src/foo.ts\n",
+          stderrTail: "",
+        },
+      ],
+      durationMs: 100,
+    } satisfies UpdateRunResult);
+
+    await updateCommand({ channel: "dev" });
+
+    const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.join("\n")).toContain("Uncommitted or untracked entries:");
+    expect(logs.join("\n")).toContain("2026-04-29T06-12-16.838Z-openclaw-backup.tar.gz");
+    expect(logs.join("\n")).toContain("src/foo.ts");
   });
   it.each([
     {

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from "vitest";
-import type { UpdateRunResult } from "../../infra/update-runner.js";
-import { inferUpdateFailureHints } from "./progress.js";
+import type { UpdateRunResult, UpdateStepCompletion } from "../../infra/update-runner.js";
+import { inferUpdateFailureHints, resolveStepDisplay } from "./progress.js";
+
+function makeStep(overrides: Partial<UpdateStepCompletion>): UpdateStepCompletion {
+  return {
+    name: "clean check",
+    command: "git -C . status --porcelain",
+    index: 0,
+    total: 1,
+    durationMs: 1,
+    exitCode: 0,
+    stdoutTail: "",
+    stderrTail: "",
+    ...overrides,
+  };
+}
 
 function makeResult(
   stepName: string,
@@ -24,6 +38,40 @@ function makeResult(
     durationMs: 1,
   };
 }
+
+describe("resolveStepDisplay", () => {
+  it("treats an empty clean-check stdout as a clean working tree", () => {
+    const display = resolveStepDisplay(makeStep({ stdoutTail: "" }));
+    expect(display).toEqual({ label: "Working directory is clean", outcome: "ok" });
+  });
+
+  it("treats whitespace-only clean-check stdout as a clean working tree", () => {
+    const display = resolveStepDisplay(makeStep({ stdoutTail: "\n  \t\n" }));
+    expect(display.outcome).toBe("ok");
+    expect(display.label).toBe("Working directory is clean");
+  });
+
+  it("flags clean-check stdout with porcelain entries as dirty even when exit code is 0", () => {
+    const display = resolveStepDisplay(
+      makeStep({ stdoutTail: "?? 2026-04-29T06-12-16.838Z-openclaw-backup.tar.gz\n" }),
+    );
+    expect(display).toEqual({
+      label: "Working directory has uncommitted changes",
+      outcome: "warn",
+    });
+  });
+
+  it("does not apply the dirty override to other steps", () => {
+    const display = resolveStepDisplay(makeStep({ name: "git fetch", stdoutTail: "fetched main" }));
+    expect(display.outcome).toBe("ok");
+    expect(display.label).toBe("Fetching latest changes");
+  });
+
+  it("marks non-zero exit codes as failures", () => {
+    const display = resolveStepDisplay(makeStep({ name: "git fetch", exitCode: 1 }));
+    expect(display.outcome).toBe("fail");
+  });
+});
 
 describe("inferUpdateFailureHints", () => {
   it("returns a package-manager bootstrap hint for pnpm npm-bootstrap failures", () => {

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -2,7 +2,7 @@ import { spinner } from "@clack/prompts";
 import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
 import type {
   UpdateRunResult,
-  UpdateStepInfo,
+  UpdateStepCompletion,
   UpdateStepProgress,
 } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -36,8 +36,34 @@ const STEP_LABELS: Record<string, string> = {
   "global install": "Installing global package",
 };
 
-function getStepLabel(step: UpdateStepInfo): string {
+function getStepLabel(step: { name: string }): string {
   return STEP_LABELS[step.name] ?? step.name;
+}
+
+export type StepDisplayOutcome = "ok" | "warn" | "fail";
+
+export type StepDisplay = {
+  label: string;
+  outcome: StepDisplayOutcome;
+};
+
+type StepDisplayInput = Pick<UpdateStepCompletion, "name" | "exitCode"> & {
+  stdoutTail?: string | null;
+};
+
+export function resolveStepDisplay(step: StepDisplayInput): StepDisplay {
+  // `git status --porcelain` exits 0 whether the tree is clean or dirty.
+  // Treat any non-empty stdout as a dirty tree so we don't claim success.
+  if (step.name === "clean check" && step.exitCode === 0) {
+    const dirty = (step.stdoutTail ?? "").trim().length > 0;
+    if (dirty) {
+      return { label: "Working directory has uncommitted changes", outcome: "warn" };
+    }
+  }
+  if (step.exitCode === 0) {
+    return { label: getStepLabel(step), outcome: "ok" };
+  }
+  return { label: getStepLabel(step), outcome: "fail" };
 }
 
 export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
@@ -126,14 +152,28 @@ export function createUpdateProgress(enabled: boolean): ProgressController {
         return;
       }
 
-      const label = getStepLabel(step);
+      const display = resolveStepDisplay(step);
       const duration = theme.muted(`(${formatDurationPrecise(step.durationMs)})`);
-      const icon = step.exitCode === 0 ? theme.success("\u2713") : theme.error("\u2717");
+      const icon =
+        display.outcome === "ok"
+          ? theme.success("\u2713")
+          : display.outcome === "warn"
+            ? theme.warn("\u2717")
+            : theme.error("\u2717");
 
-      currentSpinner.stop(`${icon} ${label} ${duration}`);
+      currentSpinner.stop(`${icon} ${display.label} ${duration}`);
       currentSpinner = null;
 
-      if (step.exitCode !== 0 && step.stderrTail) {
+      if (display.outcome === "warn" && step.stdoutTail) {
+        const lines = step.stdoutTail.split("\n").slice(0, 10);
+        for (const line of lines) {
+          if (line.trim()) {
+            defaultRuntime.log(`    ${theme.warn(line)}`);
+          }
+        }
+      }
+
+      if (display.outcome === "fail" && step.stderrTail) {
         const lines = step.stderrTail.split("\n").slice(-10);
         for (const line of lines) {
           if (line.trim()) {
@@ -155,12 +195,15 @@ export function createUpdateProgress(enabled: boolean): ProgressController {
   };
 }
 
-function formatStepStatus(exitCode: number | null): string {
-  if (exitCode === 0) {
+function formatStepStatus(outcome: StepDisplayOutcome | "pending"): string {
+  if (outcome === "ok") {
     return theme.success("\u2713");
   }
-  if (exitCode === null) {
+  if (outcome === "pending") {
     return theme.warn("?");
+  }
+  if (outcome === "warn") {
+    return theme.warn("\u2717");
   }
   return theme.error("\u2717");
 }
@@ -202,11 +245,24 @@ export function printResult(result: UpdateRunResult, opts: PrintResultOptions): 
     defaultRuntime.log("");
     defaultRuntime.log(theme.heading("Steps:"));
     for (const step of result.steps) {
-      const status = formatStepStatus(step.exitCode);
+      const display =
+        step.exitCode === null
+          ? { label: step.name, outcome: "pending" as const }
+          : resolveStepDisplay(step);
+      const status = formatStepStatus(display.outcome);
       const duration = theme.muted(`(${formatDurationPrecise(step.durationMs)})`);
-      defaultRuntime.log(`  ${status} ${step.name} ${duration}`);
+      defaultRuntime.log(`  ${status} ${display.label} ${duration}`);
 
-      if (step.exitCode !== 0 && step.stderrTail) {
+      if (display.outcome === "warn" && step.stdoutTail) {
+        const lines = step.stdoutTail.split("\n").slice(0, 5);
+        for (const line of lines) {
+          if (line.trim()) {
+            defaultRuntime.log(`      ${theme.warn(line)}`);
+          }
+        }
+      }
+
+      if (display.outcome === "fail" && step.stderrTail) {
         const lines = step.stderrTail.split("\n").slice(0, 5);
         for (const line of lines) {
           if (line.trim()) {

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -171,6 +171,7 @@ export async function runUpdateStep(params: {
     timeoutMs: params.timeoutMs,
   });
   const durationMs = Date.now() - started;
+  const stdoutTail = trimLogTail(res.stdout, MAX_LOG_CHARS);
   const stderrTail = trimLogTail(res.stderr, MAX_LOG_CHARS);
 
   params.progress?.onStepComplete?.({
@@ -180,6 +181,7 @@ export async function runUpdateStep(params: {
     total: 0,
     durationMs,
     exitCode: res.code,
+    stdoutTail,
     stderrTail,
   });
 
@@ -189,7 +191,7 @@ export async function runUpdateStep(params: {
     cwd: params.cwd ?? process.cwd(),
     durationMs,
     exitCode: res.code,
-    stdoutTail: trimLogTail(res.stdout, MAX_LOG_CHARS),
+    stdoutTail,
     stderrTail,
   };
 }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1617,13 +1617,25 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     });
     if (result.reason === "dirty") {
       defaultRuntime.error(theme.error("Update blocked: local files are edited in this checkout."));
+      const cleanStep = result.steps.find((step) => step.name === "clean check");
+      const dirtyTail = cleanStep?.stdoutTail?.trim();
+      if (dirtyTail) {
+        defaultRuntime.log(theme.warn("Uncommitted or untracked entries:"));
+        for (const line of dirtyTail.split("\n").slice(0, 10)) {
+          if (line.trim()) {
+            defaultRuntime.log(`  ${theme.muted(line)}`);
+          }
+        }
+      }
       defaultRuntime.log(
         theme.warn(
           "Git-based updates need a clean working tree before they can switch commits, fetch, or rebase.",
         ),
       );
       defaultRuntime.log(
-        theme.muted("Commit, stash, or discard the local changes, then rerun `openclaw update`."),
+        theme.muted(
+          "Commit, stash (`git stash -u` to include untracked), or discard the local changes, then rerun `openclaw update`.",
+        ),
       );
     }
     if (result.reason === "not-git-install") {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -105,6 +105,7 @@ export type UpdateStepInfo = {
 export type UpdateStepCompletion = UpdateStepInfo & {
   durationMs: number;
   exitCode: number | null;
+  stdoutTail?: string | null;
   stderrTail?: string | null;
 };
 
@@ -388,12 +389,14 @@ async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
   const result = await runCommand(argv, { cwd, timeoutMs, env });
   const durationMs = Date.now() - started;
 
+  const stdoutTail = trimLogTail(result.stdout, MAX_LOG_CHARS);
   const stderrTail = trimLogTail(result.stderr, MAX_LOG_CHARS);
 
   progress?.onStepComplete?.({
     ...stepInfo,
     durationMs,
     exitCode: result.code,
+    stdoutTail,
     stderrTail,
   });
 
@@ -403,8 +406,8 @@ async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
     cwd,
     durationMs,
     exitCode: result.code,
-    stdoutTail: trimLogTail(result.stdout, MAX_LOG_CHARS),
-    stderrTail: trimLogTail(result.stderr, MAX_LOG_CHARS),
+    stdoutTail,
+    stderrTail,
   };
 }
 


### PR DESCRIPTION
## Summary

`openclaw update` would print `✓ Working directory is clean` and *then* immediately bail with `Update Result: SKIPPED — Reason: dirty`. Two checks disagreeing in the same run, which made it impossible to tell what was actually wrong (it's almost always an untracked file that `git stash` and `git reset --hard` happily leave behind).

Root cause: the spinner in `src/cli/update-cli/progress.ts` only looked at `step.exitCode`. `git status --porcelain` exits 0 whether the tree is clean or dirty, so the spinner cheerfully claimed success while the runner used the same step's stdout to set `reason: "dirty"`.

## Changes

- `src/infra/update-runner.ts`: forward `stdoutTail` on `UpdateStepCompletion` (additive). Same in `src/cli/update-cli/shared.ts`.
- `src/cli/update-cli/progress.ts`: extract a pure `resolveStepDisplay()` helper; for the `clean check` step, treat non-empty stdout as a `warn` outcome with label `Working directory has uncommitted changes`. The `Steps:` listing in `printResult` shares the same helper.
- `src/cli/update-cli/update-command.ts`: in the dirty-skipped branch, surface the offending entries from the `clean check` step's stdoutTail and recommend `git stash -u` so untracked artifacts (backup tarballs, generated files) aren't an invisible block.
- Tests in `src/cli/update-cli/progress.test.ts` (new `resolveStepDisplay` suite) and `src/cli/update-cli.test.ts` (assertion that offending entries are surfaced and the updated guidance string).
- Changelog entry under `### Fixes`.

No public API change. `UpdateStepCompletion` only gains an optional field.

## Reproduction

```
$ touch /tmp/oc/some-untracked.tar.gz
$ openclaw update
...
◇ ✓ Working directory is clean
Update Result: SKIPPED
  Reason: dirty
Update blocked: local files are edited in this checkout.
```

After this PR, the spinner shows `✗ Working directory has uncommitted changes` with the file list inline, and the skipped result prints the porcelain entries plus the `git stash -u` hint.

## Test plan

- [x] `pnpm test src/cli/update-cli/progress.test.ts` (11 passed)
- [x] `pnpm test src/cli/update-cli.test.ts` (68 passed)
- [x] `pnpm test src/infra/update-runner.test.ts` (34 passed)
- [x] `pnpm tsgo:core`
- [x] `pnpm tsgo:core:test`
- [x] `pnpm exec oxfmt --check` on all touched files
- [ ] CI on this PR
- [ ] Manual: drop an untracked file in a checkout, run `openclaw update`, confirm the spinner and skipped output reflect the dirty state correctly.

`pnpm lint:core` fails locally with `Rule 'no-underscore-dangle' not found in plugin 'eslint'` — verified the same failure on a clean `origin/main`, so it's pre-existing tooling drift unrelated to this change.
