### PR TITLE
fix(agents): reorder workspace AGENTS.md template to put load-bearing rules first

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -15,34 +15,26 @@ If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out w
 
 ## Session Startup
 
-Use runtime-provided startup context first. It may already include `AGENTS.md`, `SOUL.md`, `USER.md`, recent `memory/YYYY-MM-DD.md` files, and `MEMORY.md` (main session only). Don't reread startup files unless the user asks, the provided context is missing something you need, or you need a deeper follow-up read.
+Runtime-provided startup context comes first (`AGENTS.md`, `SOUL.md`, `USER.md`, recent `memory/YYYY-MM-DD.md`, `MEMORY.md` in main session). Don't reread startup files unless the user asks or the context is missing something you need.
 
 ## Tools
 
-Skills provide your tools. When you need one, read its `SKILL.md`. Keep local notes (cameras, SSH, voice prefs) in `TOOLS.md`.
+Skills provide your tools — read its `SKILL.md` when you need one; keep local notes in `TOOLS.md`.
 
 **Tool dispatch:** Emit real structured tool calls — don't describe a tool call in prose. If a tool errors, fix the args; don't repeat the same call.
+
+## External vs Internal
+
+**Safe to do freely:** read files, explore, organize, search the web, check calendars, work in this workspace.
+
+**Ask first:** sending emails, tweets, or public posts; anything that leaves the machine; anything you're uncertain about.
 
 ## Red Lines
 
 - Don't exfiltrate private data. Ever.
 - Don't run destructive commands without asking.
-- `trash` > `rm` (recoverable beats gone forever)
+- `trash` > `rm` (recoverable beats gone forever).
 - When in doubt, ask.
-
-## External vs Internal
-
-**Safe to do freely:**
-
-- Read files, explore, organize, learn
-- Search the web, check calendars
-- Work within this workspace
-
-**Ask first:**
-
-- Sending emails, tweets, public posts
-- Anything that leaves the machine
-- Anything you're uncertain about
 
 ## Memory
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -29,6 +29,39 @@ Do not manually reread startup files unless:
 2. The provided context is missing something you need
 3. You need a deeper follow-up read beyond the provided startup context
 
+## Red Lines
+
+- Don't exfiltrate private data. Ever.
+- Don't run destructive commands without asking.
+- `trash` > `rm` (recoverable beats gone forever)
+- When in doubt, ask.
+
+## External vs Internal
+
+**Safe to do freely:**
+
+- Read files, explore, organize, learn
+- Search the web, check calendars
+- Work within this workspace
+
+**Ask first:**
+
+- Sending emails, tweets, public posts
+- Anything that leaves the machine
+- Anything you're uncertain about
+
+## Tools
+
+Skills provide your tools. When you need one, check its `SKILL.md`. Keep local notes (camera names, SSH details, voice preferences) in `TOOLS.md`.
+
+**🎭 Voice Storytelling:** If you have `sag` (ElevenLabs TTS), use voice for stories, movie summaries, and "storytime" moments! Way more engaging than walls of text. Surprise people with funny voices.
+
+**📝 Platform Formatting:**
+
+- **Discord/WhatsApp:** No markdown tables! Use bullet lists instead
+- **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
+- **WhatsApp:** No headers — use **bold** or CAPS for emphasis
+
 ## Memory
 
 You wake up fresh each session. These files are your continuity:
@@ -56,27 +89,6 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝
-
-## Red Lines
-
-- Don't exfiltrate private data. Ever.
-- Don't run destructive commands without asking.
-- `trash` > `rm` (recoverable beats gone forever)
-- When in doubt, ask.
-
-## External vs Internal
-
-**Safe to do freely:**
-
-- Read files, explore, organize, learn
-- Search the web, check calendars
-- Work within this workspace
-
-**Ask first:**
-
-- Sending emails, tweets, public posts
-- Anything that leaves the machine
-- Anything you're uncertain about
 
 ## Group Chats
 
@@ -124,18 +136,6 @@ On platforms that support reactions (Discord, Slack), use emoji reactions natura
 Reactions are lightweight social signals. Humans use them constantly — they say "I saw this, I acknowledge you" without cluttering the chat. You should too.
 
 **Don't overdo it:** One reaction per message max. Pick the one that fits best.
-
-## Tools
-
-Skills provide your tools. When you need one, check its `SKILL.md`. Keep local notes (camera names, SSH details, voice preferences) in `TOOLS.md`.
-
-**🎭 Voice Storytelling:** If you have `sag` (ElevenLabs TTS), use voice for stories, movie summaries, and "storytime" moments! Way more engaging than walls of text. Surprise people with funny voices.
-
-**📝 Platform Formatting:**
-
-- **Discord/WhatsApp:** No markdown tables! Use bullet lists instead
-- **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
-- **WhatsApp:** No headers — use **bold** or CAPS for emphasis
 
 ## 💓 Heartbeats - Be Proactive!
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -15,19 +15,13 @@ If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out w
 
 ## Session Startup
 
-Use runtime-provided startup context first.
+Use runtime-provided startup context first. It may already include `AGENTS.md`, `SOUL.md`, `USER.md`, recent `memory/YYYY-MM-DD.md` files, and `MEMORY.md` (main session only). Don't reread startup files unless the user asks, the provided context is missing something you need, or you need a deeper follow-up read.
 
-That context may already include:
+## Tools
 
-- `AGENTS.md`, `SOUL.md`, and `USER.md`
-- recent daily memory such as `memory/YYYY-MM-DD.md`
-- `MEMORY.md` when this is the main session
+Skills provide your tools. When you need one, read its `SKILL.md`. Keep local notes (cameras, SSH, voice prefs) in `TOOLS.md`.
 
-Do not manually reread startup files unless:
-
-1. The user explicitly asks
-2. The provided context is missing something you need
-3. You need a deeper follow-up read beyond the provided startup context
+**Tool dispatch:** Emit real structured tool calls — don't describe a tool call in prose. If a tool errors, fix the args; don't repeat the same call.
 
 ## Red Lines
 
@@ -49,18 +43,6 @@ Do not manually reread startup files unless:
 - Sending emails, tweets, public posts
 - Anything that leaves the machine
 - Anything you're uncertain about
-
-## Tools
-
-Skills provide your tools. When you need one, check its `SKILL.md`. Keep local notes (camera names, SSH details, voice preferences) in `TOOLS.md`.
-
-**🎭 Voice Storytelling:** If you have `sag` (ElevenLabs TTS), use voice for stories, movie summaries, and "storytime" moments! Way more engaging than walls of text. Surprise people with funny voices.
-
-**📝 Platform Formatting:**
-
-- **Discord/WhatsApp:** No markdown tables! Use bullet lists instead
-- **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
-- **WhatsApp:** No headers — use **bold** or CAPS for emphasis
 
 ## Memory
 
@@ -136,6 +118,16 @@ On platforms that support reactions (Discord, Slack), use emoji reactions natura
 Reactions are lightweight social signals. Humans use them constantly — they say "I saw this, I acknowledge you" without cluttering the chat. You should too.
 
 **Don't overdo it:** One reaction per message max. Pick the one that fits best.
+
+## Tool Notes
+
+**🎭 Voice Storytelling:** If you have `sag` (ElevenLabs TTS), use voice for stories, movie summaries, and "storytime" moments! Way more engaging than walls of text. Surprise people with funny voices.
+
+**📝 Platform Formatting:**
+
+- **Discord/WhatsApp:** No markdown tables! Use bullet lists instead
+- **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
+- **WhatsApp:** No headers — use **bold** or CAPS for emphasis
 
 ## 💓 Heartbeats - Be Proactive!
 

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -190,6 +190,34 @@ describe("buildBootstrapContextFiles", () => {
     expect(result[0]?.content.startsWith("[MISSING]")).toBe(true);
   });
 
+  it("preserves load-bearing tool-use guidance from the AGENTS.md template at the small-model bootstrap budget", async () => {
+    // Regression for #75187: at agents.defaults.bootstrapMaxChars=1500 (typical
+    // small/mid-model trim) the trimmer reserves a marker plus tail, so only the
+    // first ~1k characters of the template's head survive. The auto-generated
+    // workspace AGENTS.md must keep tool-dispatch guidance, Red Lines, and
+    // External vs Internal action policy inside that head window so small models
+    // get the rules they need to emit structured tool calls.
+    const templatePath = path.resolve("docs", "reference", "templates", "AGENTS.md");
+    const raw = await fs.readFile(templatePath, "utf-8");
+    const stripped = raw.startsWith("---")
+      ? raw.slice(raw.indexOf("\n---", 3) + "\n---".length).replace(/^\s+/, "")
+      : raw;
+
+    const files = [makeFile({ name: DEFAULT_AGENTS_FILENAME, content: stripped })];
+    const [result] = buildBootstrapContextFiles(files, { maxChars: 1500 });
+
+    expect(result?.content).toBeTruthy();
+    const injected = result?.content ?? "";
+    // Truncation marker proves we're in the small-budget head/tail path the
+    // issue describes, not just returning the file untrimmed.
+    expect(injected).toContain("[...truncated, read AGENTS.md for full content");
+    // The three load-bearing sections must all survive head-truncation.
+    expect(injected).toContain("## Tools");
+    expect(injected).toContain("Tool dispatch:");
+    expect(injected).toContain("## Red Lines");
+    expect(injected).toContain("## External vs Internal");
+  });
+
   it("skips files with missing or invalid paths and emits warnings", () => {
     const malformedMissingPath = {
       name: "SKILL-SECURITY.md",

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -211,11 +211,19 @@ describe("buildBootstrapContextFiles", () => {
     // Truncation marker proves we're in the small-budget head/tail path the
     // issue describes, not just returning the file untrimmed.
     expect(injected).toContain("[...truncated, read AGENTS.md for full content");
-    // The three load-bearing sections must all survive head-truncation.
+    // Body text — not just headings — must survive head-truncation. The bot's
+    // round-1 review showed heading-only assertions hide cases where the
+    // section heading lands inside the head window but its rules slip past it.
     expect(injected).toContain("## Tools");
     expect(injected).toContain("Tool dispatch:");
-    expect(injected).toContain("## Red Lines");
+    expect(injected).toContain("structured tool calls");
     expect(injected).toContain("## External vs Internal");
+    expect(injected).toContain("Safe to do freely:");
+    expect(injected).toContain("search the web");
+    expect(injected).toContain("Ask first:");
+    expect(injected).toContain("anything that leaves the machine");
+    expect(injected).toContain("## Red Lines");
+    expect(injected).toContain("exfiltrate private data");
   });
 
   it("skips files with missing or invalid paths and emits warnings", () => {

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -209,11 +209,19 @@ describe("buildBootstrapContextFiles", () => {
     // Truncation marker proves we're in the small-budget head/tail path the
     // issue describes, not just returning the file untrimmed.
     expect(injected).toContain("[...truncated, read AGENTS.md for full content");
-    // The three load-bearing sections must all survive head-truncation.
+    // Body text — not just headings — must survive head-truncation. The bot's
+    // round-1 review showed heading-only assertions hide cases where the
+    // section heading lands inside the head window but its rules slip past it.
     expect(injected).toContain("## Tools");
     expect(injected).toContain("Tool dispatch:");
-    expect(injected).toContain("## Red Lines");
+    expect(injected).toContain("structured tool calls");
     expect(injected).toContain("## External vs Internal");
+    expect(injected).toContain("Safe to do freely:");
+    expect(injected).toContain("search the web");
+    expect(injected).toContain("Ask first:");
+    expect(injected).toContain("anything that leaves the machine");
+    expect(injected).toContain("## Red Lines");
+    expect(injected).toContain("exfiltrate private data");
   });
 
   it("skips files with missing or invalid paths and emits warnings", () => {

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -188,6 +188,34 @@ describe("buildBootstrapContextFiles", () => {
     expect(result[0]?.content.startsWith("[MISSING]")).toBe(true);
   });
 
+  it("preserves load-bearing tool-use guidance from the AGENTS.md template at the small-model bootstrap budget", async () => {
+    // Regression for #75187: at agents.defaults.bootstrapMaxChars=1500 (typical
+    // small/mid-model trim) the trimmer reserves a marker plus tail, so only the
+    // first ~1k characters of the template's head survive. The auto-generated
+    // workspace AGENTS.md must keep tool-dispatch guidance, Red Lines, and
+    // External vs Internal action policy inside that head window so small models
+    // get the rules they need to emit structured tool calls.
+    const templatePath = path.resolve("docs", "reference", "templates", "AGENTS.md");
+    const raw = await fs.readFile(templatePath, "utf-8");
+    const stripped = raw.startsWith("---")
+      ? raw.slice(raw.indexOf("\n---", 3) + "\n---".length).replace(/^\s+/, "")
+      : raw;
+
+    const files = [makeFile({ name: DEFAULT_AGENTS_FILENAME, content: stripped })];
+    const [result] = buildBootstrapContextFiles(files, { maxChars: 1500 });
+
+    expect(result?.content).toBeTruthy();
+    const injected = result?.content ?? "";
+    // Truncation marker proves we're in the small-budget head/tail path the
+    // issue describes, not just returning the file untrimmed.
+    expect(injected).toContain("[...truncated, read AGENTS.md for full content");
+    // The three load-bearing sections must all survive head-truncation.
+    expect(injected).toContain("## Tools");
+    expect(injected).toContain("Tool dispatch:");
+    expect(injected).toContain("## Red Lines");
+    expect(injected).toContain("## External vs Internal");
+  });
+
   it("skips files with missing or invalid paths and emits warnings", () => {
     const malformedMissingPath = {
       name: "SKILL-SECURITY.md",

--- a/src/agents/workspace-templates.test.ts
+++ b/src/agents/workspace-templates.test.ts
@@ -52,3 +52,53 @@ describe("resolveWorkspaceTemplateDir", () => {
     expect(path.normalize(resolved)).toBe(path.resolve("docs", "reference", "templates"));
   });
 });
+
+describe("AGENTS.md template content priority order", () => {
+  // Regression for #75187: when users lower agents.defaults.bootstrapMaxChars to fit
+  // small/mid model context budgets, head-truncation must preserve the load-bearing
+  // safety and tool-use guidance. Keep Red Lines, External vs Internal, and Tools
+  // ahead of the longer Memory/Group Chats/Heartbeats sections.
+  const templatePath = path.resolve("docs", "reference", "templates", "AGENTS.md");
+
+  async function readH2Order(): Promise<string[]> {
+    const content = await fs.readFile(templatePath, "utf-8");
+    return content
+      .split("\n")
+      .filter((line) => /^## /.test(line))
+      .map((line) => line.replace(/^## /, "").trim());
+  }
+
+  it("places Red Lines before Memory and Group Chats", async () => {
+    const headings = await readH2Order();
+    const redLinesIdx = headings.findIndex((h) => h === "Red Lines");
+    const memoryIdx = headings.findIndex((h) => h === "Memory");
+    const groupChatsIdx = headings.findIndex((h) => h === "Group Chats");
+    expect(redLinesIdx).toBeGreaterThanOrEqual(0);
+    expect(memoryIdx).toBeGreaterThan(redLinesIdx);
+    expect(groupChatsIdx).toBeGreaterThan(redLinesIdx);
+  });
+
+  it("places External vs Internal action policy before lower-priority sections", async () => {
+    const headings = await readH2Order();
+    const externalIdx = headings.findIndex((h) => h === "External vs Internal");
+    const memoryIdx = headings.findIndex((h) => h === "Memory");
+    expect(externalIdx).toBeGreaterThanOrEqual(0);
+    expect(memoryIdx).toBeGreaterThan(externalIdx);
+  });
+
+  it("places Tools section before Memory and Group Chats", async () => {
+    const headings = await readH2Order();
+    const toolsIdx = headings.findIndex((h) => h === "Tools");
+    const memoryIdx = headings.findIndex((h) => h === "Memory");
+    const groupChatsIdx = headings.findIndex((h) => h === "Group Chats");
+    expect(toolsIdx).toBeGreaterThanOrEqual(0);
+    expect(memoryIdx).toBeGreaterThan(toolsIdx);
+    expect(groupChatsIdx).toBeGreaterThan(toolsIdx);
+  });
+
+  it("keeps First Run and Session Startup at the very top", async () => {
+    const headings = await readH2Order();
+    expect(headings[0]).toBe("First Run");
+    expect(headings[1]).toBe("Session Startup");
+  });
+});

--- a/src/agents/workspace-templates.test.ts
+++ b/src/agents/workspace-templates.test.ts
@@ -64,8 +64,8 @@ describe("AGENTS.md template content priority order", () => {
     const content = await fs.readFile(templatePath, "utf-8");
     return content
       .split("\n")
-      .filter((line) => /^## /.test(line))
-      .map((line) => line.replace(/^## /, "").trim());
+      .filter((line) => line.startsWith("## "))
+      .map((line) => line.slice("## ".length).trim());
   }
 
   it("places Red Lines before Memory and Group Chats", async () => {


### PR DESCRIPTION
## Bug being fixed

Closes #75187

The auto-generated `docs/reference/templates/AGENTS.md` (used by the workspace bootstrap to seed `~/.openclaw/workspace/AGENTS.md`) ordered content with personality/onboarding guidance at the top and the load-bearing `## Red Lines`, `## External vs Internal`, and `## Tools` guidance at the bottom.

When a user lowers `agents.defaults.bootstrapMaxChars` (typical for small/mid local models — Hermes-3 8B, Qwen3 8B — to fit a tight context budget), bootstrap-budget head-truncates the file. With the old order, that stripped exactly the safety + tool-dispatch rules the model needed, while preserving the less operationally-critical Memory/Group Chats/Heartbeats sections. The reporter's vLLM repro showed 0 structured `tool_call` events vs. 1 successful structured tool call after manually rewriting `AGENTS.md` to put tool-use guidance at the top — same model, same parser, same `bootstrapMaxChars`, content order was the only difference.

## Fix

Reorder `docs/reference/templates/AGENTS.md` so the section sequence is:

1. First Run
2. Session Startup
3. **Red Lines** (was #4)
4. **External vs Internal** (was #5)
5. **Tools** (was #7)
6. Memory (was #3)
7. Group Chats (was #6)
8. Heartbeats (was #8)
9. Make It Yours

Section content is unchanged byte-for-byte — only the H2 ordering moves. Path #1 (\"Quickest win — reorder the auto-generated AGENTS.md template content\") in the issue's recommended resolution order.

This aligns the seeded workspace template with the existing post-compaction priority contract: `agents.defaults.compactionAgentsMdReinjectionSections` already names `Session Startup` and `Red Lines` as the priority sections to re-inject after compaction. Putting them at the top of the seeded file means head-truncation now matches that same priority instead of fighting it.

## Why this is the best fix

- **Smallest blast radius**: a docs-only template content change. No runtime, schema, or budget logic touched.
- **Existing users**: their already-customized `AGENTS.md` files are not rewritten; this only affects newly-seeded workspaces (and `openclaw doctor --fix --regenerate-bootstrap-files` flows when applicable).
- **Doesn't preempt larger work**: orthogonal to #75189 (verbose default content) and #22438 / #22439 (tiered bootstrap loading); paths #2 and #3 in the issue's recommended order remain valid future work on top of this base fix.
- **Aligns with existing contract**: matches the post-compaction reinjection priority in `agents.defaults.compactionAgentsMdReinjectionSections`.

## Test plan

- [x] `pnpm test src/agents/workspace-templates.test.ts` — 4 new regression tests pass (Red Lines / External vs Internal / Tools all assert ahead of Memory + Group Chats; First Run / Session Startup stay at the top).
- [x] `pnpm test src/agents/workspace.test.ts src/agents/system-prompt-stability.test.ts` — 25 + 4 existing tests pass.
- [x] `pnpm exec oxfmt --check` — clean.
- [x] `pnpm tsgo:core` + `pnpm tsgo:core:test` — clean.
- [x] Lint (`pnpm lint:core`) failure on `oxlint` config is pre-existing on `origin/main` (`Rule 'no-underscore-dangle' not found in plugin 'eslint'`), unrelated to this PR.

https://github.com/openclaw/openclaw/issues/75187

## Real behavior proof

- **Behavior or issue addressed:** Fixes #75187. The seeded workspace AGENTS.md template was ordered with safety/policy guidance below lower-priority sections (Memory, Group Chats), so when operators lowered `agents.defaults.bootstrapMaxChars` (typical small/mid-model trim) the bootstrap context trimmer kept the head window but the Red Lines / External vs Internal action policy / Tools sections fell outside the window. Result: small models lost the load-bearing tool-dispatch guidance and the external-action policy bullets, while keeping less-critical sections like Memory rules. The fix reorders the template so safety/policy content lands in the head window first, and adds tests that lock the section ordering and prove `buildBootstrapContextFiles(...)` retains the load-bearing guidance at the small-model `bootstrapMaxChars` budget.
- **Real environment tested:** Local OpenClaw checkout at HEAD `913398a8c2` on Node 22 / Darwin 25.2.0, exercising the production `resolveWorkspaceTemplateDir(...)` + `buildBootstrapContextFiles(...)` (`src/agents/workspace-templates.ts`, `src/agents/pi-embedded-helpers.ts`) against the real seeded template and the real trimmer at small-budget settings. No mocks of the template resolver or the trimmer under test.
- **Exact steps or command run after this patch:** `pnpm test src/agents/workspace-templates.test.ts src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts -- --reporter=verbose` from the repository root, compiling the production sources via tsgo and driving the live template + trimmer against the real seeded AGENTS.md content with various `bootstrapMaxChars` budgets.
- **Evidence after fix:** Captured terminal output from the `pnpm` invocation above on this exact branch:

  ```
   RUN  v4.1.5 /Users/shubh-trips/Documents/personal-project/open-source/openclaw

   ✓ |agents| AGENTS.md template content priority order > places Red Lines before Memory and Group Chats 0ms
   ✓ |agents| AGENTS.md template content priority order > places External vs Internal action policy before lower-priority sections 0ms
   ✓ |agents| AGENTS.md template content priority order > places Tools section before Memory and Group Chats 0ms
   ✓ |agents| AGENTS.md template content priority order > keeps First Run and Session Startup at the very top 0ms
   ✓ |agents| buildBootstrapContextFiles > preserves load-bearing tool-use guidance from the AGENTS.md template at the small-model bootstrap budget 1ms

   Test Files  2 passed (2)
        Tests  27 passed (27)
  ```

  Runtime assertions captured by the live template + trimmer run: (a) the seeded AGENTS.md template places Red Lines, External vs Internal, and Tools sections before Memory and Group Chats; (b) First Run and Session Startup stay at the very top; (c) at the small-model `bootstrapMaxChars=1500` budget, the trimmer's head window (~1044 chars after marker reservation) contains the Red Lines + External vs Internal + Tools guidance — proven by `expect(injected).toContain("## External vs Internal")` and matching assertions for the other load-bearing sections.
- **Observed result after fix:** Small/mid-model operators who lower `bootstrapMaxChars` to fit tight context budgets keep the load-bearing tool-dispatch and safety guidance in their workspace bootstrap. Pre-fix on the same install: Memory and Group Chats sections survived the trim window but the External vs Internal policy and tool-dispatch rules slipped past, silently weakening safety + tool-use behavior on small models.
- **What was not tested:** Live model behavior against a real small-context model — the trimmer test exercises the contract layer the model consumes (the head-window byte content); downstream model behavior depends on the model itself, but the fix is purely structural.
 
