### PR TITLE
Bound webchat chat.send terminal timeouts

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -64,6 +64,7 @@ const mockState = vi.hoisted(() => ({
   saveMediaError: null as Error | null,
   savedMediaCalls: [] as Array<{ contentType?: string; subdir?: string; size: number }>,
   saveMediaWait: null as Promise<void> | null,
+  dispatchWaitsForAbort: false,
   activeSaveMediaCalls: 0,
   maxActiveSaveMediaCalls: 0,
   sandboxWorkspace: null as { workspaceDir: string; containerWorkdir?: string } | null,
@@ -164,6 +165,7 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       };
       replyOptions?: {
         onAgentRunStart?: (runId: string) => void;
+        abortSignal?: AbortSignal;
         images?: Array<{ mimeType: string; data: string }>;
         imageOrder?: string[];
       };
@@ -176,6 +178,17 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       }
       if (mockState.triggerAgentRunStart) {
         params.replyOptions?.onAgentRunStart?.(mockState.agentRunId);
+      }
+      if (mockState.dispatchWaitsForAbort) {
+        await new Promise<never>((_resolve, reject) => {
+          const signal = params.replyOptions?.abortSignal;
+          const rejectAbort = () => reject(new Error("test dispatch aborted"));
+          if (signal?.aborted) {
+            rejectAbort();
+            return;
+          }
+          signal?.addEventListener("abort", rejectAbort, { once: true });
+        });
       }
       if (mockState.dispatchedReplies.length > 0) {
         for (const reply of mockState.dispatchedReplies) {
@@ -323,6 +336,12 @@ function createTranscriptFixture(prefix: string) {
     "utf-8",
   );
   mockState.transcriptPath = transcriptPath;
+  return dir;
+}
+
+function createMissingTranscriptFixture(prefix: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  mockState.transcriptPath = path.join(dir, "sess.jsonl");
   return dir;
 }
 
@@ -513,6 +532,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.saveMediaError = null;
     mockState.savedMediaCalls = [];
     mockState.saveMediaWait = null;
+    mockState.dispatchWaitsForAbort = false;
     mockState.activeSaveMediaCalls = 0;
     mockState.maxActiveSaveMediaCalls = 0;
     bindingMocks.resolveByConversation.mockReset();
@@ -1927,6 +1947,93 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       context.broadcast as unknown as ReturnType<typeof vi.fn>
     ).mock.calls.find((call) => call[0] === "chat" && call[1]?.state === "final")?.[1];
     expect(finalBroadcast).toBeUndefined();
+  });
+
+  it("broadcasts a terminal error and creates the transcript when a webchat agent run times out", async () => {
+    createMissingTranscriptFixture("openclaw-chat-send-webchat-terminal-timeout-");
+    mockState.triggerAgentRunStart = true;
+    mockState.agentRunId = "run-webchat-timeout";
+    mockState.dispatchWaitsForAbort = true;
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-webchat-timeout",
+      message: "hello from webchat timeout",
+      requestParams: { timeoutMs: 5 },
+      client: {
+        connect: {
+          caps: [],
+          client: {
+            id: GATEWAY_CLIENT_NAMES.WEBCHAT,
+            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            displayName: "Webchat",
+            version: "1.0.0",
+          },
+        },
+      },
+      waitFor: "none",
+    });
+
+    await waitForAssertion(() => {
+      expect(context.broadcast).toHaveBeenCalledWith(
+        "chat",
+        expect.objectContaining({
+          runId: "idem-webchat-timeout",
+          sessionKey: "main",
+          state: "error",
+          errorMessage: expect.stringContaining("timed out after 5ms"),
+        }),
+      );
+    });
+    expect(context.chatAbortControllers.has("idem-webchat-timeout")).toBe(false);
+    expect(context.removeChatRun).toHaveBeenCalledWith(
+      "idem-webchat-timeout",
+      "idem-webchat-timeout",
+      "main",
+    );
+    expect(context.dedupe.get("chat:idem-webchat-timeout")).toMatchObject({
+      ok: false,
+      payload: {
+        runId: "idem-webchat-timeout",
+        status: "error",
+        summary: expect.stringContaining("timed out after 5ms"),
+      },
+    });
+    let userUpdate:
+      | {
+          sessionFile: string;
+          sessionKey?: string;
+          message?: unknown;
+          messageId?: string;
+        }
+      | undefined;
+    await waitForAssertion(() => {
+      userUpdate = mockState.emittedTranscriptUpdates.find(
+        (update) =>
+          typeof update.message === "object" &&
+          update.message !== null &&
+          (update.message as { role?: unknown }).role === "user",
+      );
+      expect(userUpdate).toBeTruthy();
+      expect(fs.existsSync(userUpdate?.sessionFile ?? "")).toBe(true);
+    });
+    const header = JSON.parse(fs.readFileSync(userUpdate!.sessionFile, "utf-8").split("\n")[0]);
+    expect(header).toMatchObject({
+      type: "session",
+      id: mockState.sessionId,
+    });
+    expect(userUpdate).toMatchObject({
+      sessionFile: expect.any(String),
+      sessionKey: "main",
+      message: {
+        role: "user",
+        content: "hello from webchat timeout",
+        timestamp: expect.any(Number),
+      },
+    });
   });
 
   it("adds persisted media paths to the user transcript update", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -47,6 +47,7 @@ import {
   isWebchatClient,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { setSafeTimeout } from "../../utils/timer-delay.js";
 import {
   abortChatRunById,
   type ChatAbortControllerEntry,
@@ -190,6 +191,7 @@ export {
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 const MANAGED_OUTGOING_IMAGE_PATH_PREFIX = "/api/chat/media/outgoing/";
+const DEFAULT_WEBCHAT_CHAT_SEND_TERMINAL_TIMEOUT_MS = 30_000;
 let chatHistoryPlaceholderEmitCount = 0;
 const chatHistoryManagedImageCleanupState = new Map<string, Promise<void>>();
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
@@ -1640,6 +1642,31 @@ function broadcastChatError(params: {
   params.context.agentRunSeq.delete(params.runId);
 }
 
+function resolveWebchatChatSendTerminalTimeoutMs(params: {
+  client?: { mode?: string | null; id?: string | null } | null;
+  requestedTimeoutMs?: number;
+  resolvedAgentTimeoutMs: number;
+}): number | null {
+  if (!isWebchatClient(params.client)) {
+    return null;
+  }
+  if (
+    typeof params.requestedTimeoutMs === "number" &&
+    Number.isFinite(params.requestedTimeoutMs) &&
+    params.requestedTimeoutMs > 0
+  ) {
+    return Math.max(1, Math.floor(params.requestedTimeoutMs));
+  }
+  return Math.min(
+    Math.max(1, Math.floor(params.resolvedAgentTimeoutMs)),
+    DEFAULT_WEBCHAT_CHAT_SEND_TERMINAL_TIMEOUT_MS,
+  );
+}
+
+function formatWebchatChatSendTerminalTimeout(timeoutMs: number): string {
+  return `chat.send timed out after ${timeoutMs}ms without an assistant final event`;
+}
+
 export const chatHandlers: GatewayRequestHandlers = {
   "chat.history": async ({ params, respond, context }) => {
     if (!validateChatHistoryParams(params)) {
@@ -2097,6 +2124,63 @@ export const chatHandlers: GatewayRequestHandlers = {
         mainKey: cfg.session?.mainKey,
         sessionKey,
       });
+      const terminalTimeoutMs = resolveWebchatChatSendTerminalTimeoutMs({
+        client: clientInfo,
+        requestedTimeoutMs: p.timeoutMs,
+        resolvedAgentTimeoutMs: timeoutMs,
+      });
+      let chatSendTerminalClosed = false;
+      let chatSendTerminalTimedOut = false;
+      let chatSendTerminalTimer: NodeJS.Timeout | null = null;
+      const clearChatSendTerminalTimer = () => {
+        if (!chatSendTerminalTimer) {
+          return;
+        }
+        clearTimeout(chatSendTerminalTimer);
+        chatSendTerminalTimer = null;
+      };
+      const closeChatSendTerminal = () => {
+        if (chatSendTerminalClosed) {
+          return false;
+        }
+        chatSendTerminalClosed = true;
+        clearChatSendTerminalTimer();
+        return true;
+      };
+      const broadcastChatSendTerminalTimeout = (summary: string) => {
+        chatSendTerminalTimedOut = true;
+        if (!closeChatSendTerminal()) {
+          return;
+        }
+        activeRunAbort.controller.abort(new Error(summary));
+        context.chatAbortedRuns.set(clientRunId, Date.now());
+        context.chatRunBuffers.delete(clientRunId);
+        context.chatDeltaSentAt.delete(clientRunId);
+        context.chatDeltaLastBroadcastLen.delete(clientRunId);
+        activeRunAbort.cleanup();
+        context.removeChatRun(clientRunId, clientRunId, sessionKey);
+        const error = errorShape(ErrorCodes.UNAVAILABLE, summary);
+        setGatewayDedupeEntry({
+          dedupe: context.dedupe,
+          key: `chat:${clientRunId}`,
+          entry: {
+            ts: Date.now(),
+            ok: false,
+            payload: {
+              runId: clientRunId,
+              status: "error" as const,
+              summary,
+            },
+            error,
+          },
+        });
+        broadcastChatError({
+          context,
+          runId: clientRunId,
+          sessionKey,
+          errorMessage: summary,
+        });
+      };
       // Inject timestamp so agents know the current date/time.
       // Only BodyForAgent gets the timestamp — Body stays raw for UI display.
       // See: https://github.com/moltbot/moltbot/issues/3658
@@ -2168,6 +2252,17 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (!transcriptPath) {
             return;
           }
+          if (!fs.existsSync(transcriptPath)) {
+            const ensured = ensureTranscriptFile({
+              transcriptPath,
+              sessionId: resolvedSessionId,
+            });
+            if (!ensured.ok) {
+              context.logGateway.warn(
+                `webchat user transcript file create failed: ${ensured.error ?? "unknown error"}`,
+              );
+            }
+          }
           const persistedImages = await persistedImagesPromise;
           emitSessionTranscriptUpdate({
             sessionFile: transcriptPath,
@@ -2181,6 +2276,23 @@ export const chatHandlers: GatewayRequestHandlers = {
         })();
         await userTranscriptUpdatePromise;
       };
+      if (terminalTimeoutMs !== null) {
+        chatSendTerminalTimer = setSafeTimeout(() => {
+          void (async () => {
+            await emitUserTranscriptUpdate().catch((transcriptErr) => {
+              context.logGateway.warn(
+                `webchat user transcript update failed before terminal timeout: ${formatForLog(
+                  transcriptErr,
+                )}`,
+              );
+            });
+            broadcastChatSendTerminalTimeout(
+              formatWebchatChatSendTerminalTimeout(terminalTimeoutMs),
+            );
+          })();
+        }, terminalTimeoutMs);
+        chatSendTerminalTimer.unref?.();
+      }
       let transcriptMediaRewriteDone = false;
       const rewriteUserTranscriptMedia = async () => {
         if (transcriptMediaRewriteDone) {
@@ -2352,6 +2464,9 @@ export const chatHandlers: GatewayRequestHandlers = {
       })
         .then(async () => {
           await rewriteUserTranscriptMedia();
+          if (chatSendTerminalTimedOut) {
+            return;
+          }
           if (!agentRunStarted) {
             await emitUserTranscriptUpdate();
             const btwReplies = deliveredReplies
@@ -2363,6 +2478,9 @@ export const chatHandlers: GatewayRequestHandlers = {
               .join("\n\n")
               .trim();
             if (btwReplies.length > 0 && btwText) {
+              if (!closeChatSendTerminal()) {
+                return;
+              }
               broadcastSideResult({
                 context,
                 payload: {
@@ -2509,6 +2627,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                   };
                 }
               }
+              if (!closeChatSendTerminal()) {
+                return;
+              }
               broadcastChatFinal({
                 context,
                 runId: clientRunId,
@@ -2518,6 +2639,9 @@ export const chatHandlers: GatewayRequestHandlers = {
             }
           } else {
             void emitUserTranscriptUpdate();
+            if (!closeChatSendTerminal()) {
+              return;
+            }
           }
           if (!context.chatAbortedRuns.has(clientRunId)) {
             setGatewayDedupeEntry({
@@ -2542,6 +2666,9 @@ export const chatHandlers: GatewayRequestHandlers = {
               `webchat user transcript update failed after error: ${formatForLog(transcriptErr)}`,
             );
           });
+          if (!closeChatSendTerminal()) {
+            return;
+          }
           const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
           setGatewayDedupeEntry({
             dedupe: context.dedupe,
@@ -2565,6 +2692,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           });
         })
         .finally(() => {
+          clearChatSendTerminalTimer();
           activeRunAbort.cleanup();
           context.removeChatRun(clientRunId, clientRunId, sessionKey);
         });


### PR DESCRIPTION
## Summary
- add a webchat chat.send terminal backstop that emits a chat error when an embedded run does not produce a terminal event before the requested/default gateway timeout
- initialize missing transcript files before emitting eager user transcript updates
- cover the timeout path with a focused gateway chat regression test

## Validation
- npx --yes pnpm@10.33.2 exec vitest run src/gateway/server-methods/chat.directive-tags.test.ts --testNamePattern "webchat agent run times out"
- npx --yes pnpm@10.33.2 exec vitest run src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server.chat.gateway-server-chat.test.ts
- npx --yes pnpm@10.33.2 run tsgo:core
- git diff --check origin/main...HEAD