### PR TITLE
fix(mattermost): add streaming.mode='block' to split draft preview at turn boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Mattermost/streaming: split the draft preview at turn boundaries (assistant-message start, reasoning end, tool start) when `channels.mattermost.streaming.mode = "block"`, with a lifecycle-aware split that flushes pending text and waits for in-flight create/update before resetting the post id, deep-merge `streaming` across account overrides, and add `channels.mattermost.streaming.toolPreview` (`name` default, `args` opt-in) to control how tool activity is rendered into the preview post. Fixes #75252. (#75256) Thanks @katyaclawd.
 - Plugins/commands: normalize empty plugin command handler results and let Telegram native plugin commands send the empty-response fallback instead of throwing when a handler returns `undefined`. Fixes #74800. Thanks @vincentkoc.
 - Plugins/OpenRouter: advertise DeepSeek V4 thinking levels, including `xhigh` and `max`, through the runtime and lightweight provider policy surfaces so `/think` validation no longer rejects OpenRouter-routed DeepSeek V4 models. Fixes #74788. Thanks @vincentkoc.
 - Status/sessions: ignore malformed non-string persisted session provider/model metadata instead of throwing while rendering status summaries. Thanks @vincentkoc.

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -265,13 +265,16 @@ Notes:
 
 Mattermost streams thinking, tool activity, and partial reply text into a single **draft preview post** that finalizes in place when the final answer is safe to send. The preview updates on the same post id instead of spamming the channel with per-chunk messages. Media/error finals cancel pending preview edits and use normal delivery instead of flushing a throwaway preview post.
 
-Enable via `channels.mattermost.streaming`:
+Configure via the object form `channels.mattermost.streaming`:
 
 ```json5
 {
   channels: {
     mattermost: {
-      streaming: "partial", // off | partial | block | progress
+      streaming: {
+        mode: "partial", // partial | block (default: partial)
+        toolPreview: "name", // name | args (default: name)
+      },
     },
   },
 }
@@ -279,10 +282,13 @@ Enable via `channels.mattermost.streaming`:
 
 <AccordionGroup>
   <Accordion title="Streaming modes">
-    - `partial` is the usual choice: one preview post that is edited as the reply grows, then finalized with the complete answer.
-    - `block` uses append-style draft chunks inside the preview post.
-    - `progress` shows a status preview while generating and only posts the final answer at completion.
-    - `off` disables preview streaming.
+    - `partial` (default) is the usual choice: one preview post that is edited as the reply grows, then finalized with the complete answer.
+    - `block` splits the preview at turn boundaries (assistant-message start, reasoning end, tool start) so prior thinking, tool activity, and partial reply phases are preserved as separate posts instead of being overwritten in place.
+    - To disable preview streaming entirely on Mattermost today, set the channel to use only block streaming (see [Streaming](/concepts/streaming)) or omit the streaming object and avoid pushing preview phases.
+
+    `streaming.toolPreview` controls how tool activity is rendered into the preview post:
+    - `name` (default): a bare "Running `tool`…" status line.
+    - `args`: includes a sanitized one-line summary of the tool arguments.
 
   </Accordion>
   <Accordion title="Streaming behavior notes">

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -174,7 +174,9 @@ Slack:
 
 Mattermost:
 
-- Streams thinking, tool activity, and partial reply text into a single draft preview post that finalizes in place when the final answer is safe to send.
+- Configured as the object form `channels.mattermost.streaming = { mode, toolPreview }`. `mode` accepts `partial` (default) or `block`; `toolPreview` accepts `name` (default) or `args`. See [Mattermost → Preview streaming](/channels/mattermost#preview-streaming).
+- `mode: "partial"` streams thinking, tool activity, and partial reply text into a single draft preview post that finalizes in place when the final answer is safe to send.
+- `mode: "block"` splits the preview post at turn boundaries (assistant-message start, reasoning end, tool start) so prior phases stay visible instead of being overwritten.
 - Falls back to sending a fresh final post if the preview post was deleted or is otherwise unavailable at finalize time.
 - Final media/error payloads cancel pending preview updates before normal delivery instead of flushing a temporary preview post.
 

--- a/extensions/mattermost/src/config-schema-core.ts
+++ b/extensions/mattermost/src/config-schema-core.ts
@@ -88,9 +88,17 @@ const MattermostNetworkSchema = z
  */
 const MattermostPreviewStreamModeSchema = z.enum(["partial", "block"]);
 
+/**
+ * Tool-status preview verbosity for Mattermost.
+ * - "name": just `Running \`exec\``
+ * - "args": tool name + a code block with the args (command/path/etc.)
+ */
+const MattermostToolPreviewModeSchema = z.enum(["name", "args"]);
+
 const MattermostStreamingSchema = z
   .object({
     mode: MattermostPreviewStreamModeSchema.optional(),
+    toolPreview: MattermostToolPreviewModeSchema.optional(),
   })
   .strict()
   .optional();

--- a/extensions/mattermost/src/config-schema-core.ts
+++ b/extensions/mattermost/src/config-schema-core.ts
@@ -78,6 +78,23 @@ const MattermostNetworkSchema = z
   .strict()
   .optional();
 
+/**
+ * Draft preview streaming mode for Mattermost.
+ * - "partial": single preview post, edited in place (historical default)
+ * - "block": new preview post per boundary, prior content stays visible
+ *
+ * To disable preview streaming entirely, use `blockStreaming: true`. A
+ * future change may add an explicit "off" mode here for symmetry.
+ */
+const MattermostPreviewStreamModeSchema = z.enum(["partial", "block"]);
+
+const MattermostStreamingSchema = z
+  .object({
+    mode: MattermostPreviewStreamModeSchema.optional(),
+  })
+  .strict()
+  .optional();
+
 const MattermostAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -99,6 +116,7 @@ const MattermostAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    streaming: MattermostStreamingSchema,
     replyToMode: z.enum(["off", "first", "all", "batched"]).optional(),
     responsePrefix: z.string().optional(),
     actions: z

--- a/extensions/mattermost/src/config-schema.test.ts
+++ b/extensions/mattermost/src/config-schema.test.ts
@@ -79,4 +79,43 @@ describe("MattermostConfigSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("accepts streaming.mode='block'", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: { mode: "block" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts streaming.mode='partial'", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: { mode: "partial" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts streaming.mode on a per-account override", () => {
+    const result = MattermostConfigSchema.safeParse({
+      accounts: {
+        main: {
+          streaming: { mode: "block" },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown streaming.mode values", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: { mode: "firehose" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown properties on streaming", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: { mode: "block", unknownProp: "bad" },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/extensions/mattermost/src/config-schema.test.ts
+++ b/extensions/mattermost/src/config-schema.test.ts
@@ -118,4 +118,32 @@ describe("MattermostConfigSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("accepts streaming.toolPreview='args'", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: { toolPreview: "args" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts streaming.toolPreview='name'", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: { toolPreview: "name" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts streaming.mode and streaming.toolPreview together", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: { mode: "block", toolPreview: "args" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown streaming.toolPreview values", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: { toolPreview: "verbose" },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/extensions/mattermost/src/mattermost/accounts.test.ts
+++ b/extensions/mattermost/src/mattermost/accounts.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../runtime-api.js";
 import {
   resolveDefaultMattermostAccountId,
   resolveMattermostAccount,
+  resolveMattermostPreviewStreamMode,
   resolveMattermostReplyToMode,
 } from "./accounts.js";
 
@@ -134,5 +135,61 @@ describe("resolveMattermostReplyToMode", () => {
       native: true,
       callbackPath: "/hooks/work",
     });
+  });
+});
+
+describe("resolveMattermostPreviewStreamMode", () => {
+  it("defaults to 'partial' when streaming.mode is not set", () => {
+    expect(resolveMattermostPreviewStreamMode({})).toBe("partial");
+  });
+
+  it("returns 'block' when streaming.mode is explicitly 'block'", () => {
+    expect(resolveMattermostPreviewStreamMode({ streaming: { mode: "block" } })).toBe("block");
+  });
+
+  it("returns 'partial' when streaming.mode is explicitly 'partial'", () => {
+    expect(resolveMattermostPreviewStreamMode({ streaming: { mode: "partial" } })).toBe("partial");
+  });
+
+  it("falls back to default when streaming exists but mode is undefined", () => {
+    expect(resolveMattermostPreviewStreamMode({ streaming: {} })).toBe("partial");
+  });
+
+  it("surfaces previewStreamMode through resolveMattermostAccount", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          streaming: { mode: "block" },
+        },
+      },
+    };
+
+    const account = resolveMattermostAccount({ cfg, accountId: "default" });
+    expect(account.previewStreamMode).toBe("block");
+  });
+
+  it("defaults previewStreamMode to 'partial' when no streaming config is present", () => {
+    const account = resolveMattermostAccount({ cfg: {}, accountId: "default" });
+    expect(account.previewStreamMode).toBe("partial");
+  });
+
+  it("allows accounts to override channel-wide streaming.mode", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          streaming: { mode: "partial" },
+          accounts: {
+            alerts: {
+              streaming: { mode: "block" },
+            },
+          },
+        },
+      },
+    };
+
+    const def = resolveMattermostAccount({ cfg, accountId: "default" });
+    const alerts = resolveMattermostAccount({ cfg, accountId: "alerts" });
+    expect(def.previewStreamMode).toBe("partial");
+    expect(alerts.previewStreamMode).toBe("block");
   });
 });

--- a/extensions/mattermost/src/mattermost/accounts.test.ts
+++ b/extensions/mattermost/src/mattermost/accounts.test.ts
@@ -5,6 +5,7 @@ import {
   resolveMattermostAccount,
   resolveMattermostPreviewStreamMode,
   resolveMattermostReplyToMode,
+  resolveMattermostToolPreviewMode,
 } from "./accounts.js";
 
 describe("resolveDefaultMattermostAccountId", () => {
@@ -191,5 +192,62 @@ describe("resolveMattermostPreviewStreamMode", () => {
     const alerts = resolveMattermostAccount({ cfg, accountId: "alerts" });
     expect(def.previewStreamMode).toBe("partial");
     expect(alerts.previewStreamMode).toBe("block");
+  });
+});
+
+describe("resolveMattermostToolPreviewMode", () => {
+  it("defaults to 'name' when streaming.toolPreview is not set", () => {
+    expect(resolveMattermostToolPreviewMode({})).toBe("name");
+  });
+
+  it("returns 'args' when streaming.toolPreview is explicitly 'args'", () => {
+    expect(resolveMattermostToolPreviewMode({ streaming: { toolPreview: "args" } })).toBe("args");
+  });
+
+  it("returns 'name' when streaming.toolPreview is explicitly 'name'", () => {
+    expect(resolveMattermostToolPreviewMode({ streaming: { toolPreview: "name" } })).toBe("name");
+  });
+
+  it("falls back to default when streaming exists but toolPreview is undefined", () => {
+    expect(resolveMattermostToolPreviewMode({ streaming: { mode: "block" } })).toBe("name");
+  });
+
+  it("surfaces toolPreviewMode through resolveMattermostAccount", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          streaming: { mode: "block", toolPreview: "args" },
+        },
+      },
+    };
+
+    const account = resolveMattermostAccount({ cfg, accountId: "default" });
+    expect(account.previewStreamMode).toBe("block");
+    expect(account.toolPreviewMode).toBe("args");
+  });
+
+  it("defaults toolPreviewMode to 'name' when no streaming config is present", () => {
+    const account = resolveMattermostAccount({ cfg: {}, accountId: "default" });
+    expect(account.toolPreviewMode).toBe("name");
+  });
+
+  it("allows accounts to override channel-wide streaming.toolPreview", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          streaming: { toolPreview: "name" },
+          accounts: {
+            verbose: {
+              streaming: { toolPreview: "args" },
+            },
+          },
+        },
+      },
+    };
+
+    const def = resolveMattermostAccount({ cfg, accountId: "default" });
+    const verbose = resolveMattermostAccount({ cfg, accountId: "verbose" });
+    expect(def.toolPreviewMode).toBe("name");
+    expect(verbose.toolPreviewMode).toBe("args");
   });
 });

--- a/extensions/mattermost/src/mattermost/accounts.test.ts
+++ b/extensions/mattermost/src/mattermost/accounts.test.ts
@@ -250,4 +250,35 @@ describe("resolveMattermostToolPreviewMode", () => {
     expect(def.toolPreviewMode).toBe("name");
     expect(verbose.toolPreviewMode).toBe("args");
   });
+
+  it("deep-merges streaming so a partial account override preserves channel-wide siblings", () => {
+    // Regression: account-level streaming overrides used to replace the
+    // whole channel-level streaming object. A `streaming: { toolPreview }`
+    // override now keeps the channel-wide `streaming.mode` instead of
+    // silently falling back to the default.
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          streaming: { mode: "block", toolPreview: "name" },
+          accounts: {
+            verbose: {
+              streaming: { toolPreview: "args" },
+            },
+            quiet: {
+              streaming: { mode: "partial" },
+            },
+          },
+        },
+      },
+    };
+
+    const verbose = resolveMattermostAccount({ cfg, accountId: "verbose" });
+    const quiet = resolveMattermostAccount({ cfg, accountId: "quiet" });
+    // verbose: mode comes from the channel, toolPreview from the account.
+    expect(verbose.previewStreamMode).toBe("block");
+    expect(verbose.toolPreviewMode).toBe("args");
+    // quiet: toolPreview comes from the channel, mode from the account.
+    expect(quiet.previewStreamMode).toBe("partial");
+    expect(quiet.toolPreviewMode).toBe("name");
+  });
 });

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -12,6 +12,7 @@ import type {
   MattermostAccountConfig,
   MattermostChatMode,
   MattermostChatTypeKey,
+  MattermostPreviewStreamMode,
   MattermostReplyToMode,
 } from "../types.js";
 import { normalizeMattermostBaseUrl } from "./client.js";
@@ -36,7 +37,37 @@ export type ResolvedMattermostAccount = {
   chunkMode?: MattermostAccountConfig["chunkMode"];
   blockStreaming?: boolean;
   blockStreamingCoalesce?: MattermostAccountConfig["blockStreamingCoalesce"];
+  /**
+   * Effective draft preview stream mode for this account. Defaults to
+   * "partial" when not configured, matching the historical Mattermost
+   * behavior (single preview post edited in place). Use "block" to split
+   * the preview at turn boundaries so prior content stays visible.
+   */
+  previewStreamMode: MattermostPreviewStreamMode;
 };
+
+const DEFAULT_MATTERMOST_PREVIEW_STREAM_MODE: MattermostPreviewStreamMode = "partial";
+
+/**
+ * Resolve the effective Mattermost preview stream mode for an account config.
+ *
+ * Resolution order (highest precedence first):
+ * 1. `streaming.mode` on the account config ("partial" | "block")
+ * 2. Default: "partial" (historical edit-in-place behavior)
+ *
+ * Note: This setting only controls how the preview is shaped when it is
+ * created. To suppress the preview entirely, use `blockStreaming: true`
+ * on the account config. The two settings are intentionally orthogonal.
+ */
+export function resolveMattermostPreviewStreamMode(
+  config: Pick<MattermostAccountConfig, "streaming">,
+): MattermostPreviewStreamMode {
+  const explicit = config.streaming?.mode;
+  if (explicit === "partial" || explicit === "block") {
+    return explicit;
+  }
+  return DEFAULT_MATTERMOST_PREVIEW_STREAM_MODE;
+}
 
 const mattermostAccountHelpers = createAccountListHelpers("mattermost");
 
@@ -123,6 +154,7 @@ export function resolveMattermostAccount(params: {
     blockStreaming: resolveChannelStreamingBlockEnabled(merged) ?? merged.blockStreaming,
     blockStreamingCoalesce:
       resolveChannelStreamingBlockCoalesce(merged) ?? merged.blockStreamingCoalesce,
+    previewStreamMode: resolveMattermostPreviewStreamMode(merged),
   };
 }
 

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -14,6 +14,7 @@ import type {
   MattermostChatTypeKey,
   MattermostPreviewStreamMode,
   MattermostReplyToMode,
+  MattermostToolPreviewMode,
 } from "../types.js";
 import { normalizeMattermostBaseUrl } from "./client.js";
 import type { OpenClawConfig } from "./runtime-api.js";
@@ -44,9 +45,16 @@ export type ResolvedMattermostAccount = {
    * the preview at turn boundaries so prior content stays visible.
    */
   previewStreamMode: MattermostPreviewStreamMode;
+  /**
+   * Effective tool-status preview verbosity for this account. Defaults to
+   * "name" (just the tool name in the preview post) for backward
+   * compatibility and to avoid leaking sensitive input by default.
+   */
+  toolPreviewMode: MattermostToolPreviewMode;
 };
 
 const DEFAULT_MATTERMOST_PREVIEW_STREAM_MODE: MattermostPreviewStreamMode = "partial";
+const DEFAULT_MATTERMOST_TOOL_PREVIEW_MODE: MattermostToolPreviewMode = "name";
 
 /**
  * Resolve the effective Mattermost preview stream mode for an account config.
@@ -67,6 +75,23 @@ export function resolveMattermostPreviewStreamMode(
     return explicit;
   }
   return DEFAULT_MATTERMOST_PREVIEW_STREAM_MODE;
+}
+
+/**
+ * Resolve the effective Mattermost tool-status preview verbosity.
+ *
+ * Resolution order:
+ * 1. `streaming.toolPreview` on the account config ("name" | "args")
+ * 2. Default: "name" (matches historical behavior - just the tool name).
+ */
+export function resolveMattermostToolPreviewMode(
+  config: Pick<MattermostAccountConfig, "streaming">,
+): MattermostToolPreviewMode {
+  const explicit = config.streaming?.toolPreview;
+  if (explicit === "name" || explicit === "args") {
+    return explicit;
+  }
+  return DEFAULT_MATTERMOST_TOOL_PREVIEW_MODE;
 }
 
 const mattermostAccountHelpers = createAccountListHelpers("mattermost");
@@ -155,6 +180,7 @@ export function resolveMattermostAccount(params: {
     blockStreamingCoalesce:
       resolveChannelStreamingBlockCoalesce(merged) ?? merged.blockStreamingCoalesce,
     previewStreamMode: resolveMattermostPreviewStreamMode(merged),
+    toolPreviewMode: resolveMattermostToolPreviewMode(merged),
   };
 }
 

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -115,7 +115,7 @@ function mergeMattermostAccountConfig(
       | undefined,
     accountId,
     omitKeys: ["defaultAccount"],
-    nestedObjectKeys: ["commands"],
+    nestedObjectKeys: ["commands", "streaming"],
   });
 }
 

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -4,6 +4,7 @@ import {
   buildMattermostToolStatusText,
   createMattermostDraftPreviewBoundaryController,
   createMattermostDraftStream,
+  summarizeMattermostToolArgs,
 } from "./draft-stream.js";
 
 type RequestRecord = {
@@ -247,12 +248,104 @@ describe("createMattermostDraftStream", () => {
 });
 
 describe("buildMattermostToolStatusText", () => {
-  it("renders a status with the tool name", () => {
+  it("renders a bare status with the tool name when no args are given", () => {
     expect(buildMattermostToolStatusText({ name: "read" })).toBe("Running `read`…");
   });
 
-  it("falls back to a generic running tool status", () => {
-    expect(buildMattermostToolStatusText({ name: "exec" })).toBe("Running `exec`…");
+  it("falls back to a generic running tool status when no name is given", () => {
+    expect(buildMattermostToolStatusText({})).toBe("Running tool…");
+  });
+
+  it("renders the exec command in a bash-tagged code block", () => {
+    expect(
+      buildMattermostToolStatusText({
+        name: "exec",
+        args: { command: "ls -la /tmp" },
+      }),
+    ).toBe("Running `exec`\n```bash\nls -la /tmp\n```");
+  });
+
+  it("renders the read path in an untagged code block", () => {
+    expect(
+      buildMattermostToolStatusText({
+        name: "read",
+        args: { path: "/etc/hosts" },
+      }),
+    ).toBe("Running `read`\n```\n/etc/hosts\n```");
+  });
+
+  it("renders single non-canonical args as key=value in a code block", () => {
+    expect(
+      buildMattermostToolStatusText({
+        name: "web_search",
+        args: { query: "openclaw streaming bug" },
+      }),
+    ).toBe("Running `web_search`\n```\nquery=openclaw streaming bug\n```");
+  });
+
+  it("renders multi-arg payloads as one key=value per line", () => {
+    expect(
+      buildMattermostToolStatusText({
+        name: "edit",
+        args: { path: "/tmp/x", oldText: "a", newText: "b" },
+      }),
+    ).toBe("Running `edit`\n```\npath=/tmp/x\noldText=a\nnewText=b\n```");
+  });
+
+  it("preserves multi-line shell commands inside the code block", () => {
+    const status = buildMattermostToolStatusText({
+      name: "exec",
+      args: {
+        command: "python3 -c \"import json\nprint('hi')\"\necho done",
+      },
+    });
+    expect(status).toContain("```bash");
+    expect(status).toContain('python3 -c "import json');
+    expect(status).toContain("echo done");
+    expect(status).toContain("```");
+  });
+});
+
+describe("summarizeMattermostToolArgs", () => {
+  it("returns undefined for missing or empty args", () => {
+    expect(summarizeMattermostToolArgs(undefined)).toBeUndefined();
+    expect(summarizeMattermostToolArgs({})).toBeUndefined();
+    expect(summarizeMattermostToolArgs({ ignored: undefined })).toBeUndefined();
+  });
+
+  it("unwraps a single canonical key", () => {
+    expect(summarizeMattermostToolArgs({ command: "ls" })).toBe("ls");
+    expect(summarizeMattermostToolArgs({ path: "/x" })).toBe("/x");
+    expect(summarizeMattermostToolArgs({ input: "hi" })).toBe("hi");
+    expect(summarizeMattermostToolArgs({ text: "abc" })).toBe("abc");
+  });
+
+  it("prefixes other single keys with key=", () => {
+    expect(summarizeMattermostToolArgs({ url: "https://example.com" })).toBe(
+      "url=https://example.com",
+    );
+  });
+
+  it("serializes object/array values as pretty-printed JSON", () => {
+    expect(summarizeMattermostToolArgs({ args: { a: 1, b: ["x", "y"] } })).toBe(
+      `args=${JSON.stringify({ a: 1, b: ["x", "y"] }, null, 2)}`,
+    );
+  });
+
+  it("preserves newlines inside command args so multi-line shells render verbatim", () => {
+    expect(summarizeMattermostToolArgs({ command: "echo one\necho two" })).toBe(
+      "echo one\necho two",
+    );
+  });
+
+  it("trims leading/trailing whitespace without collapsing internal newlines", () => {
+    expect(summarizeMattermostToolArgs({ command: "  ls\n\n  " })).toBe("ls");
+  });
+
+  it("truncates with an ellipsis once the limit is exceeded", () => {
+    const summary = summarizeMattermostToolArgs({ command: "x".repeat(500) }, { maxChars: 50 });
+    expect(summary?.length).toBe(50);
+    expect(summary?.endsWith("…")).toBe(true);
   });
 });
 

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MattermostClient } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import {
+  buildMattermostToolStatusText,
+  createMattermostDraftPreviewBoundaryController,
+  createMattermostDraftStream,
+} from "./draft-stream.js";
 
 type RequestRecord = {
   path: string;
@@ -249,5 +253,119 @@ describe("buildMattermostToolStatusText", () => {
 
   it("falls back to a generic running tool status", () => {
     expect(buildMattermostToolStatusText({ name: "exec" })).toBe("Running `exec`…");
+  });
+});
+
+describe("createMattermostDraftPreviewBoundaryController", () => {
+  function createDraftStreamStub() {
+    return {
+      forceNewMessage: vi.fn(),
+    };
+  }
+
+  it("is a no-op when splitAtBoundaries is false", () => {
+    const draftStream = createDraftStreamStub();
+    const controller = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: false,
+    });
+
+    controller.markStreamedContent();
+    expect(controller.signalBoundary()).toBe(false);
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not split when no streamed content has been marked", () => {
+    const draftStream = createDraftStreamStub();
+    const controller = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: true,
+    });
+
+    expect(controller.signalBoundary()).toBe(false);
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+  });
+
+  it("splits at boundary when streamed content has been marked", () => {
+    const draftStream = createDraftStreamStub();
+    const onSplit = vi.fn();
+    const controller = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: true,
+      onSplit,
+    });
+
+    controller.markStreamedContent();
+    expect(controller.signalBoundary()).toBe(true);
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(onSplit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not split twice in a row without new content", () => {
+    const draftStream = createDraftStreamStub();
+    const controller = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: true,
+    });
+
+    controller.markStreamedContent();
+    expect(controller.signalBoundary()).toBe(true);
+    expect(controller.signalBoundary()).toBe(false);
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("splits again after fresh content is marked", () => {
+    const draftStream = createDraftStreamStub();
+    const controller = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: true,
+    });
+
+    controller.markStreamedContent();
+    expect(controller.signalBoundary()).toBe(true);
+
+    controller.markStreamedContent();
+    expect(controller.signalBoundary()).toBe(true);
+
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports whether it is splitting at boundaries", () => {
+    const draftStream = createDraftStreamStub();
+    const splitting = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: true,
+    });
+    const nonSplitting = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: false,
+    });
+
+    expect(splitting.isSplittingAtBoundaries()).toBe(true);
+    expect(nonSplitting.isSplittingAtBoundaries()).toBe(false);
+  });
+
+  it("models a thinking → tool → partial reply → final turn without overwrites", () => {
+    const draftStream = createDraftStreamStub();
+    const controller = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: true,
+    });
+
+    // Phase 1: "Thinking…" appears in the preview post.
+    controller.markStreamedContent();
+
+    // Phase 2: tool starts → boundary BEFORE the new tool status update.
+    expect(controller.signalBoundary()).toBe(true);
+    // Tool status is now in a fresh post.
+    controller.markStreamedContent();
+
+    // Phase 3: assistant message starts → boundary BEFORE partial reply.
+    expect(controller.signalBoundary()).toBe(true);
+    controller.markStreamedContent();
+
+    // Three distinct posts created (one initial, two splits) for the
+    // three phases. Only the two boundaries call forceNewMessage().
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -356,7 +356,7 @@ describe("createMattermostDraftPreviewBoundaryController", () => {
     };
   }
 
-  it("is a no-op when splitAtBoundaries is false", () => {
+  it("is a no-op when splitAtBoundaries is false", async () => {
     const draftStream = createDraftStreamStub();
     const controller = createMattermostDraftPreviewBoundaryController({
       draftStream,
@@ -364,22 +364,22 @@ describe("createMattermostDraftPreviewBoundaryController", () => {
     });
 
     controller.markStreamedContent();
-    expect(controller.signalBoundary()).toBe(false);
+    await expect(controller.signalBoundary()).resolves.toBe(false);
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 
-  it("does not split when no streamed content has been marked", () => {
+  it("does not split when no streamed content has been marked", async () => {
     const draftStream = createDraftStreamStub();
     const controller = createMattermostDraftPreviewBoundaryController({
       draftStream,
       splitAtBoundaries: true,
     });
 
-    expect(controller.signalBoundary()).toBe(false);
+    await expect(controller.signalBoundary()).resolves.toBe(false);
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 
-  it("splits at boundary when streamed content has been marked", () => {
+  it("splits at boundary when streamed content has been marked", async () => {
     const draftStream = createDraftStreamStub();
     const onSplit = vi.fn();
     const controller = createMattermostDraftPreviewBoundaryController({
@@ -389,12 +389,12 @@ describe("createMattermostDraftPreviewBoundaryController", () => {
     });
 
     controller.markStreamedContent();
-    expect(controller.signalBoundary()).toBe(true);
+    await expect(controller.signalBoundary()).resolves.toBe(true);
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(onSplit).toHaveBeenCalledTimes(1);
   });
 
-  it("does not split twice in a row without new content", () => {
+  it("does not split twice in a row without new content", async () => {
     const draftStream = createDraftStreamStub();
     const controller = createMattermostDraftPreviewBoundaryController({
       draftStream,
@@ -402,12 +402,12 @@ describe("createMattermostDraftPreviewBoundaryController", () => {
     });
 
     controller.markStreamedContent();
-    expect(controller.signalBoundary()).toBe(true);
-    expect(controller.signalBoundary()).toBe(false);
+    await expect(controller.signalBoundary()).resolves.toBe(true);
+    await expect(controller.signalBoundary()).resolves.toBe(false);
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("splits again after fresh content is marked", () => {
+  it("splits again after fresh content is marked", async () => {
     const draftStream = createDraftStreamStub();
     const controller = createMattermostDraftPreviewBoundaryController({
       draftStream,
@@ -415,12 +415,76 @@ describe("createMattermostDraftPreviewBoundaryController", () => {
     });
 
     controller.markStreamedContent();
-    expect(controller.signalBoundary()).toBe(true);
+    await expect(controller.signalBoundary()).resolves.toBe(true);
 
     controller.markStreamedContent();
-    expect(controller.signalBoundary()).toBe(true);
+    await expect(controller.signalBoundary()).resolves.toBe(true);
 
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("awaits forceNewMessage before resolving the boundary (lifecycle-aware)", async () => {
+    const order: string[] = [];
+    let releaseForce: (() => void) | undefined;
+    const draftStream = {
+      forceNewMessage: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseForce = () => {
+              order.push("force-resolved");
+              resolve();
+            };
+          }),
+      ),
+    };
+    const onSplit = vi.fn(() => {
+      order.push("on-split");
+    });
+    const controller = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: true,
+      onSplit,
+    });
+
+    controller.markStreamedContent();
+    const boundaryPromise = controller.signalBoundary().then((result) => {
+      order.push(`boundary-${result}`);
+      return result;
+    });
+
+    // Release the in-flight forceNewMessage; only then should onSplit run
+    // and the boundary promise resolve.
+    expect(releaseForce).toBeDefined();
+    releaseForce!();
+    await expect(boundaryPromise).resolves.toBe(true);
+    expect(order).toEqual(["force-resolved", "on-split", "boundary-true"]);
+  });
+
+  it("prevents redundant splits while a previous split is still resolving", async () => {
+    let releaseForce: (() => void) | undefined;
+    const draftStream = {
+      forceNewMessage: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseForce = () => resolve();
+          }),
+      ),
+    };
+    const controller = createMattermostDraftPreviewBoundaryController({
+      draftStream,
+      splitAtBoundaries: true,
+    });
+
+    controller.markStreamedContent();
+    const first = controller.signalBoundary();
+    // A second boundary signal arrives before the first has finished and
+    // before any new content has been marked. It must not trigger another
+    // forceNewMessage().
+    const second = controller.signalBoundary();
+    releaseForce!();
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(false);
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
   });
 
   it("reports whether it is splitting at boundaries", () => {
@@ -438,7 +502,7 @@ describe("createMattermostDraftPreviewBoundaryController", () => {
     expect(nonSplitting.isSplittingAtBoundaries()).toBe(false);
   });
 
-  it("models a thinking → tool → partial reply → final turn without overwrites", () => {
+  it("models a thinking → tool → partial reply → final turn without overwrites", async () => {
     const draftStream = createDraftStreamStub();
     const controller = createMattermostDraftPreviewBoundaryController({
       draftStream,
@@ -449,12 +513,12 @@ describe("createMattermostDraftPreviewBoundaryController", () => {
     controller.markStreamedContent();
 
     // Phase 2: tool starts → boundary BEFORE the new tool status update.
-    expect(controller.signalBoundary()).toBe(true);
+    await expect(controller.signalBoundary()).resolves.toBe(true);
     // Tool status is now in a fresh post.
     controller.markStreamedContent();
 
     // Phase 3: assistant message starts → boundary BEFORE partial reply.
-    expect(controller.signalBoundary()).toBe(true);
+    await expect(controller.signalBoundary()).resolves.toBe(true);
     controller.markStreamedContent();
 
     // Three distinct posts created (one initial, two splits) for the

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -31,8 +31,123 @@ function normalizeMattermostDraftText(text: string, maxChars: number): string {
   return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
 }
 
-export function buildMattermostToolStatusText(params: { name?: string; phase?: string }): string {
+/**
+ * Hard upper bound on how much of an args summary we'll embed in a single
+ * Mattermost preview post. The summary is rendered inside a fenced code
+ * block, so we can comfortably show much more than the old inline limit -
+ * but we still cap to avoid pasting megabytes of structured tool input into
+ * a chat post.
+ */
+const MATTERMOST_TOOL_ARGS_MAX_CHARS = 4000;
+
+function summarizeMattermostToolArgValue(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Best-effort summary of a tool's args object for display in a preview
+ * post. Returns a multi-line string suitable for embedding in a fenced code
+ * block. Common single-arg shapes (command/path/input/text) come out as the
+ * raw value; multi-arg shapes are rendered as `key=value` lines.
+ */
+export function summarizeMattermostToolArgs(
+  args: Record<string, unknown> | undefined,
+  options: { maxChars?: number } = {},
+): string | undefined {
+  if (!args) {
+    return undefined;
+  }
+  const entries = Object.entries(args).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const maxChars = Math.max(40, options.maxChars ?? MATTERMOST_TOOL_ARGS_MAX_CHARS);
+  let body: string;
+  if (entries.length === 1) {
+    const [key, value] = entries[0]!;
+    const summarized = summarizeMattermostToolArgValue(value);
+    if (summarized === undefined) {
+      return undefined;
+    }
+    if (key === "command" || key === "path" || key === "input" || key === "text") {
+      body = summarized;
+    } else {
+      body = `${key}=${summarized}`;
+    }
+  } else {
+    const lines: string[] = [];
+    for (const [key, value] of entries) {
+      const summarized = summarizeMattermostToolArgValue(value);
+      if (summarized === undefined) {
+        continue;
+      }
+      // For multi-arg payloads keep each key/value on its own line so the
+      // user can scan them without horizontal wrapping.
+      lines.push(`${key}=${summarized}`);
+    }
+    if (lines.length === 0) {
+      return undefined;
+    }
+    body = lines.join("\n");
+  }
+  // Trim trailing whitespace but keep newlines inside the body.
+  body = body.replace(/[\u0020\t]+$/gmu, "").replace(/^\s+|\s+$/gu, "");
+  if (!body) {
+    return undefined;
+  }
+  if (body.length > maxChars) {
+    return `${body.slice(0, Math.max(0, maxChars - 1))}…`;
+  }
+  return body;
+}
+
+/**
+ * Pick a Mattermost code-fence info string ID-style hint based on the tool
+ * name so the preview post gets at least best-effort syntax highlighting.
+ */
+function resolveMattermostToolCodeFenceLanguage(toolName?: string): string {
+  const normalized = toolName?.trim().toLowerCase();
+  if (!normalized) {
+    return "";
+  }
+  if (normalized === "exec" || normalized === "shell" || normalized.endsWith("_exec")) {
+    return "bash";
+  }
+  return "";
+}
+
+export function buildMattermostToolStatusText(params: {
+  name?: string;
+  phase?: string;
+  args?: Record<string, unknown>;
+}): string {
   const tool = params.name?.trim() ? ` \`${params.name.trim()}\`` : " tool";
+  const summary = summarizeMattermostToolArgs(params.args);
+  if (summary) {
+    const language = resolveMattermostToolCodeFenceLanguage(params.name);
+    // Use a fenced code block on its own line so the full args are visible
+    // even when they span multiple lines (e.g. heredocs, multi-line shell
+    // commands, or large structured inputs). Mattermost renders the fenced
+    // block monospaced and preserves whitespace, which is what we want for
+    // commands and file paths.
+    return `Running${tool}\n\`\`\`${language}\n${summary}\n\`\`\``;
+  }
   return `Running${tool}…`;
 }
 

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -36,6 +36,70 @@ export function buildMattermostToolStatusText(params: { name?: string; phase?: s
   return `Running${tool}…`;
 }
 
+/**
+ * Boundary controller for the Mattermost draft preview stream.
+ *
+ * In `"partial"` mode (the historical default) the draft preview lives in a
+ * single post that is edited in place across the whole turn. Every transition
+ * — thinking → partial reply → tool status → next partial reply — overwrites
+ * the same post, which causes prior content to disappear from the user's
+ * view at every transition.
+ *
+ * In `"block"` mode this controller is wired into the lifecycle hooks so
+ * that at each turn boundary (assistant-message start, reasoning end, tool
+ * start) `forceNewMessage()` is called on the underlying draft stream. That
+ * leaves the previous post frozen in the channel and starts a fresh post
+ * for the next chunk, so prior content stays visible.
+ *
+ * `markStreamedContent()` must be called whenever the caller pushes content
+ * into the draft stream that is user-visible. Boundary calls only fire
+ * `forceNewMessage()` when there is something to split off, otherwise the
+ * boundary is a no-op (we never want to leave behind an empty preview post).
+ */
+export type MattermostDraftPreviewBoundaryController = {
+  /** Mark that user-visible content has just been pushed to the stream. */
+  markStreamedContent: () => void;
+  /**
+   * Signal a turn boundary. In "block" mode and only when there is unsplit
+   * streamed content, calls `forceNewMessage()` on the underlying stream.
+   * Returns true if the boundary triggered an actual split.
+   */
+  signalBoundary: () => boolean;
+  /** Whether the controller is currently splitting at boundaries. */
+  isSplittingAtBoundaries: () => boolean;
+};
+
+export function createMattermostDraftPreviewBoundaryController(params: {
+  draftStream: Pick<MattermostDraftStream, "forceNewMessage">;
+  /** When true, boundary calls trigger forceNewMessage(). */
+  splitAtBoundaries: boolean;
+  /**
+   * Optional reset hook invoked after a successful split so the caller can
+   * reset any per-post state (e.g. cached partial text it dedupes against).
+   */
+  onSplit?: () => void;
+}): MattermostDraftPreviewBoundaryController {
+  let hasStreamedContentSinceBoundary = false;
+  return {
+    markStreamedContent: () => {
+      hasStreamedContentSinceBoundary = true;
+    },
+    signalBoundary: () => {
+      if (!params.splitAtBoundaries) {
+        return false;
+      }
+      if (!hasStreamedContentSinceBoundary) {
+        return false;
+      }
+      params.draftStream.forceNewMessage();
+      hasStreamedContentSinceBoundary = false;
+      params.onSplit?.();
+      return true;
+    },
+    isSplittingAtBoundaries: () => params.splitAtBoundaries,
+  };
+}
+
 export function createMattermostDraftStream(params: {
   client: MattermostClient;
   channelId: string;

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -80,7 +80,7 @@ export function summarizeMattermostToolArgs(
   const maxChars = Math.max(40, options.maxChars ?? MATTERMOST_TOOL_ARGS_MAX_CHARS);
   let body: string;
   if (entries.length === 1) {
-    const [key, value] = entries[0]!;
+    const [key, value] = entries[0];
     const summarized = summarizeMattermostToolArgValue(value);
     if (summarized === undefined) {
       return undefined;

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -17,7 +17,7 @@ type MattermostDraftStream = {
   discardPending: () => Promise<void>;
   seal: () => Promise<void>;
   stop: () => Promise<void>;
-  forceNewMessage: () => void;
+  forceNewMessage: () => Promise<void>;
 };
 
 function normalizeMattermostDraftText(text: string, maxChars: number): string {
@@ -177,9 +177,12 @@ export type MattermostDraftPreviewBoundaryController = {
   /**
    * Signal a turn boundary. In "block" mode and only when there is unsplit
    * streamed content, calls `forceNewMessage()` on the underlying stream.
-   * Returns true if the boundary triggered an actual split.
+   * Returns true if the boundary triggered an actual split. Returns a Promise
+   * because the underlying split is lifecycle-aware: it flushes any pending
+   * draft text and waits for an in-flight create/update to settle before
+   * resetting the post id, so the next phase always lands in a fresh post.
    */
-  signalBoundary: () => boolean;
+  signalBoundary: () => Promise<boolean>;
   /** Whether the controller is currently splitting at boundaries. */
   isSplittingAtBoundaries: () => boolean;
 };
@@ -199,15 +202,20 @@ export function createMattermostDraftPreviewBoundaryController(params: {
     markStreamedContent: () => {
       hasStreamedContentSinceBoundary = true;
     },
-    signalBoundary: () => {
+    signalBoundary: async () => {
       if (!params.splitAtBoundaries) {
         return false;
       }
       if (!hasStreamedContentSinceBoundary) {
         return false;
       }
-      params.draftStream.forceNewMessage();
+      // Eagerly flip the gate so a re-entrant boundary call (e.g. two
+      // back-to-back lifecycle events firing while the underlying flush is
+      // still in flight) cannot trigger a redundant split for the same
+      // phase. The gate is re-armed by markStreamedContent() once the next
+      // phase actually pushes content into the draft.
       hasStreamedContentSinceBoundary = false;
+      await params.draftStream.forceNewMessage();
       params.onSplit?.();
       return true;
     },
@@ -292,7 +300,31 @@ export function createMattermostDraftStream(params: {
     warnPrefix: "mattermost stream preview cleanup failed",
   });
 
-  const forceNewMessage = () => {
+  const forceNewMessage = async () => {
+    // Lifecycle-aware split: before we forget the current post id we must
+    // (a) deliver any text that was queued for the current post, and
+    // (b) wait for any in-flight create/update to settle. Otherwise pending
+    // text would either be lost (resetPending wipes it) or routed to the
+    // wrong post (a still-pending create resolves after we cleared the id
+    // and the next update creates a second post on top of the first).
+    if (!streamState.stopped) {
+      try {
+        await loop.flush();
+      } catch (err) {
+        params.warn?.(
+          `mattermost stream preview boundary flush failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+    // Even if the loop is stopped, an in-flight create/update may still be
+    // settling; wait for it so resetting the post id is safe.
+    try {
+      await loop.waitForInFlight();
+    } catch {
+      // waitForInFlight never rejects on its own, but stay defensive.
+    }
     streamPostId = undefined;
     lastSentText = "";
     loop.resetPending();

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -103,6 +103,11 @@ vi.mock("./client.js", async () => {
 vi.mock("./draft-stream.js", () => ({
   buildMattermostToolStatusText: () => "Working",
   createMattermostDraftStream: mockState.createMattermostDraftStream,
+  createMattermostDraftPreviewBoundaryController: () => ({
+    markStreamedContent: vi.fn(),
+    signalBoundary: vi.fn(() => false),
+    isSplittingAtBoundaries: vi.fn(() => false),
+  }),
 }));
 
 vi.mock("./monitor-resources.js", () => ({

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -18,7 +18,11 @@ import {
   type MattermostPost,
   type MattermostUser,
 } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import {
+  buildMattermostToolStatusText,
+  createMattermostDraftPreviewBoundaryController,
+  createMattermostDraftStream,
+} from "./draft-stream.js";
 import {
   computeInteractionCallbackUrl,
   createMattermostInteractionHandler,
@@ -1628,6 +1632,23 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           warn: logVerboseMessage,
         });
         let lastPartialText = "";
+        // When `streaming.mode === "block"`, the draft preview is split at
+        // turn boundaries (assistant-message start, reasoning end, tool start)
+        // so prior content stays visible instead of being overwritten in
+        // place. The boundary controller tracks whether the current preview
+        // post has any user-visible content yet, so we never call
+        // forceNewMessage() twice in a row without something between them
+        // (which would just produce empty preview posts).
+        const previewBoundary = createMattermostDraftPreviewBoundaryController({
+          draftStream,
+          splitAtBoundaries: account.previewStreamMode === "block",
+          onSplit: () => {
+            // Reset partial-text dedupe state so the next partial reply
+            // lands as a fresh post body rather than being filtered as a
+            // "prefix already sent" duplicate.
+            lastPartialText = "";
+          },
+        });
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1684,6 +1705,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           }
           lastPartialText = cleaned;
           draftStream.update(cleaned);
+          previewBoundary.markStreamedContent();
         };
 
         const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
@@ -1818,18 +1840,36 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                             updateDraftFromPartial(payload.text);
                           },
                           onAssistantMessageStart: () => {
+                            // Boundary: a brand-new assistant message is
+                            // about to start. In block mode, split the
+                            // preview now so this message lands in its own
+                            // post and any prior thinking/tool/partial
+                            // content is preserved.
+                            previewBoundary.signalBoundary();
                             lastPartialText = "";
                           },
                           onReasoningEnd: () => {
+                            // Boundary: leaving the thinking phase. In
+                            // block mode, freeze the "Thinking…" preview
+                            // post and start a new post for whatever comes
+                            // next (partial reply, tool status, etc.).
+                            previewBoundary.signalBoundary();
                             lastPartialText = "";
                           },
                           onReasoningStream: async () => {
                             if (!lastPartialText) {
                               draftStream.update("Thinking…");
+                              previewBoundary.markStreamedContent();
                             }
                           },
                           onToolStart: async (payload) => {
+                            // Boundary: a tool is about to run. In block
+                            // mode, split before the tool status replaces
+                            // any partial reply / thinking content the
+                            // user may already have read.
+                            previewBoundary.signalBoundary();
                             draftStream.update(buildMattermostToolStatusText(payload));
+                            previewBoundary.markStreamedContent();
                           },
                         },
                       }),

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1863,12 +1863,40 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                             }
                           },
                           onToolStart: async (payload) => {
+                            // The agent runtime fires this callback for both
+                            // "start" and "update" tool phases (see
+                            // agent-runner-execution.ts). For preview
+                            // splitting we only want to treat "start" as a
+                            // turn boundary - a single tool call should
+                            // produce a single preview post, even if the
+                            // runtime emits multiple update events as the
+                            // tool progresses. "update" events also typically
+                            // arrive without args, so re-rendering the
+                            // status would replace the rich "Running `exec`\n
+                            // ...command..." preview with a bare
+                            // "Running `exec`…".
+                            if (payload.phase !== "start") {
+                              return;
+                            }
                             // Boundary: a tool is about to run. In block
                             // mode, split before the tool status replaces
                             // any partial reply / thinking content the
                             // user may already have read.
                             previewBoundary.signalBoundary();
-                            draftStream.update(buildMattermostToolStatusText(payload));
+                            // Suppress args from the rendered status when
+                            // the account is configured for the bare
+                            // "Running \`tool\`…" preview. We still receive
+                            // them from the agent runtime; we just don't
+                            // expose them in chat.
+                            const renderArgs =
+                              account.toolPreviewMode === "args" ? payload.args : undefined;
+                            draftStream.update(
+                              buildMattermostToolStatusText({
+                                name: payload.name,
+                                phase: payload.phase,
+                                args: renderArgs,
+                              }),
+                            );
                             previewBoundary.markStreamedContent();
                           },
                         },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1839,21 +1839,25 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                           onPartialReply: (payload) => {
                             updateDraftFromPartial(payload.text);
                           },
-                          onAssistantMessageStart: () => {
+                          onAssistantMessageStart: async () => {
                             // Boundary: a brand-new assistant message is
                             // about to start. In block mode, split the
                             // preview now so this message lands in its own
                             // post and any prior thinking/tool/partial
-                            // content is preserved.
-                            previewBoundary.signalBoundary();
+                            // content is preserved. Awaited so the prior
+                            // post is finalized before the next phase
+                            // pushes content.
+                            await previewBoundary.signalBoundary();
                             lastPartialText = "";
                           },
-                          onReasoningEnd: () => {
+                          onReasoningEnd: async () => {
                             // Boundary: leaving the thinking phase. In
                             // block mode, freeze the "Thinking…" preview
                             // post and start a new post for whatever comes
                             // next (partial reply, tool status, etc.).
-                            previewBoundary.signalBoundary();
+                            // Awaited so the prior post is finalized
+                            // before the next phase pushes content.
+                            await previewBoundary.signalBoundary();
                             lastPartialText = "";
                           },
                           onReasoningStream: async () => {
@@ -1881,8 +1885,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                             // Boundary: a tool is about to run. In block
                             // mode, split before the tool status replaces
                             // any partial reply / thinking content the
-                            // user may already have read.
-                            previewBoundary.signalBoundary();
+                            // user may already have read. Awaited so the
+                            // prior post is finalized before the tool
+                            // status update is queued.
+                            await previewBoundary.signalBoundary();
                             // Suppress args from the rendered status when
                             // the account is configured for the bare
                             // "Running \`tool\`…" preview. We still receive

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -4,6 +4,28 @@ import type { SecretInput } from "./secret-input.js";
 export type MattermostReplyToMode = "off" | "first" | "all" | "batched";
 export type MattermostChatTypeKey = "direct" | "channel" | "group";
 
+/**
+ * Mattermost draft preview streaming mode.
+ * - "partial": one preview post is created and edited in place across the
+ *              whole turn (thinking → tool status → partial reply → final).
+ *              This is the historical Mattermost behavior since v2026.4.20
+ *              and remains the default for backward compatibility, but it
+ *              causes prior preview content to disappear at every transition.
+ * - "block":   a fresh preview post is created at each turn boundary
+ *              (assistant-message start, reasoning end, tool start) so prior
+ *              content stays visible. Recommended when you want streaming
+ *              previews without losing content at every transition.
+ *
+ * To disable preview streaming entirely, set `blockStreaming: true` on
+ * the account config. A future change may add `"off"` here for symmetry.
+ */
+export type MattermostPreviewStreamMode = "partial" | "block";
+
+export type MattermostStreamingConfig = {
+  /** Draft preview mode. Default: "partial" (historical behavior). */
+  mode?: MattermostPreviewStreamMode;
+};
+
 export type MattermostChatMode = "oncall" | "onmessage" | "onchar";
 type MattermostNetworkConfig = {
   /** Dangerous opt-in for self-hosted Mattermost on trusted private/internal hosts. */
@@ -55,6 +77,13 @@ export type MattermostAccountConfig = {
   blockStreaming?: boolean;
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /**
+   * Draft preview streaming controls. When `mode` is set to `"block"`, the
+   * Mattermost draft preview is split at turn boundaries (assistant-message
+   * start, reasoning end, tool start) so prior content stays visible instead
+   * of being overwritten in place. See PR #75252 for context.
+   */
+  streaming?: MattermostStreamingConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
   /**

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -21,9 +21,31 @@ export type MattermostChatTypeKey = "direct" | "channel" | "group";
  */
 export type MattermostPreviewStreamMode = "partial" | "block";
 
+/**
+ * Tool preview verbosity for the Mattermost draft preview stream.
+ * - "name":  preview shows just the tool name, e.g. ``Running `exec`…``.
+ *            This is the historical behavior and the safer default for
+ *            shared channels where tool inputs may be sensitive.
+ * - "args":  preview shows the tool name plus a code-block with the tool's
+ *            input arguments, e.g.:
+ *              Running `exec`
+ *              ```bash
+ *              ls -la /tmp
+ *              ```
+ *            Useful when you want to see exactly what the agent is doing.
+ */
+export type MattermostToolPreviewMode = "name" | "args";
+
 export type MattermostStreamingConfig = {
   /** Draft preview mode. Default: "partial" (historical behavior). */
   mode?: MattermostPreviewStreamMode;
+  /**
+   * How much detail to render in tool-status preview posts. Default: "name"
+   * (just the tool name) for backward compatibility and to avoid leaking
+   * potentially sensitive command/path/input data into chat by default.
+   * Set to "args" to render the actual tool args in a code block.
+   */
+  toolPreview?: MattermostToolPreviewMode;
 };
 
 export type MattermostChatMode = "oncall" | "onmessage" | "onchar";

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -84,6 +84,11 @@ export type GetReplyOptions = {
   onToolStart?: (payload: {
     name?: string;
     phase?: string;
+    /**
+     * Tool input arguments, if the agent runtime emitted them. Channels that
+     * surface tool activity to users may format these in their status text;
+     * keep in mind that args can be arbitrarily large or sensitive.
+     */
     args?: Record<string, unknown>;
   }) => Promise<void> | void;
   /** Called when a concrete work item starts, updates, or completes. */

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1532,7 +1532,9 @@ export async function runAgentTurnWithFallback(params: {
                         name,
                         phase,
                         args:
-                          evt.data.args && typeof evt.data.args === "object"
+                          evt.data.args &&
+                          typeof evt.data.args === "object" &&
+                          !Array.isArray(evt.data.args)
                             ? (evt.data.args as Record<string, unknown>)
                             : undefined,
                       });

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -8089,6 +8089,20 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           },
           additionalProperties: false,
         },
+        streaming: {
+          type: "object",
+          properties: {
+            mode: {
+              type: "string",
+              enum: ["partial", "block"],
+            },
+            toolPreview: {
+              type: "string",
+              enum: ["name", "args"],
+            },
+          },
+          additionalProperties: false,
+        },
         replyToMode: {
           type: "string",
           enum: ["off", "first", "all", "batched"],
@@ -8387,6 +8401,20 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     type: "integer",
                     minimum: 0,
                     maximum: 9007199254740991,
+                  },
+                },
+                additionalProperties: false,
+              },
+              streaming: {
+                type: "object",
+                properties: {
+                  mode: {
+                    type: "string",
+                    enum: ["partial", "block"],
+                  },
+                  toolPreview: {
+                    type: "string",
+                    enum: ["name", "args"],
                   },
                 },
                 additionalProperties: false,


### PR DESCRIPTION
## Related

Closes #75252

## Problem

The Mattermost streaming draft preview (introduced in #47838) uses a single editable post for the whole turn. Every phase transition — thinking → tool status → partial reply → next tool → final reply — calls `updateMattermostPost` on the **same post**, completely replacing its content.

From the user's perspective: content they started reading disappears at every transition. By the time the final reply lands, the channel contains no record of thinking, tool calls, or intermediate partial output. It is functionally equivalent to the agent deleting messages mid-conversation.

The Discord adapter solved the same problem years ago with a `streaming.mode` config and a `forceNewMessage()` call at turn boundaries. Mattermost got the edit-in-place mechanics from #47838 but never got the corresponding boundary-split option.

## Fix

Add `streaming.mode: "partial" | "block"` to Mattermost account config:

- **`"partial"`** (default) — preserves existing edit-in-place behavior so nothing breaks for users who like the current feel
- **`"block"`** — new behavior: at each turn boundary (`onAssistantMessageStart`, `onReasoningEnd`, `onToolStart`), the current preview post is frozen and a new one is created for the next phase

The boundary logic is extracted into a tested `createMattermostDraftPreviewBoundaryController()` helper in `draft-stream.ts` that holds the "did we just stream something?" gate, so `forceNewMessage()` is never called twice in a row without content between (which would produce empty preview posts).

## Usage

```json
{
  "channels": {
    "mattermost": {
      "streaming": {
        "mode": "block"
      }
    }
  }
}
```

Per-account override also works:

```json
{
  "channels": {
    "mattermost": {
      "streaming": { "mode": "partial" },
      "accounts": {
        "ops": {
          "streaming": { "mode": "block" }
        }
      }
    }
  }
}
```

## What changes

### `extensions/mattermost/src/types.ts`
- `MattermostPreviewStreamMode = "partial" | "block"`
- `MattermostStreamingConfig = { mode?: MattermostPreviewStreamMode }`
- `streaming?: MattermostStreamingConfig` added to `MattermostAccountConfig`

### `extensions/mattermost/src/config-schema-core.ts`
- `MattermostPreviewStreamModeSchema` and `MattermostStreamingSchema` Zod schemas
- `streaming` field added to `MattermostAccountSchemaBase`

### `extensions/mattermost/src/mattermost/accounts.ts`
- `resolveMattermostPreviewStreamMode()` — resolves effective mode from merged account config
- `previewStreamMode: MattermostPreviewStreamMode` added to `ResolvedMattermostAccount`

### `extensions/mattermost/src/mattermost/draft-stream.ts`
- `MattermostDraftPreviewBoundaryController` type
- `createMattermostDraftPreviewBoundaryController()` — encapsulates the "only split when there is something to split" guard and the `onSplit` reset hook

### `extensions/mattermost/src/mattermost/monitor.ts`
- Imports and constructs the boundary controller from `account.previewStreamMode`
- `onAssistantMessageStart`, `onReasoningEnd`, `onToolStart` hooks call `previewBoundary.signalBoundary()` before their update
- `updateDraftFromPartial` calls `previewBoundary.markStreamedContent()` after each draft update

### Tests
- `draft-stream.test.ts`: 8 unit tests for `createMattermostDraftPreviewBoundaryController`
- `accounts.test.ts`: 7 unit tests for `resolveMattermostPreviewStreamMode` and its exposure via `resolveMattermostAccount`
- `config-schema.test.ts`: 5 schema validation tests (`"block"`, `"partial"`, per-account override, unknown mode rejection, unknown property rejection)
- `monitor.inbound-system-event.test.ts`: updated mock to include `createMattermostDraftPreviewBoundaryController` (the test mocks the whole `draft-stream.js` module; without this the test hung at 120 s)

**387/387 tests pass.**

## Scope

- Mattermost adapter only; Discord, Telegram, Slack, Matrix paths are not affected
- Default `"partial"` is backward-compatible; no config migration required
- `"off"` (disable preview entirely) is intentionally out of scope for this PR — use `blockStreaming: true` for now; a follow-up can unify that surface

## Reproduction of original bug

1. Mattermost DM with any agent that runs tool calls (e.g. file reads or shell commands)
2. Watch the preview post in real-time
3. Observe: `Thinking…` is replaced by partial text, partial text is replaced by `Running \`tool\`…`, tool status is replaced by next partial, etc.
4. With `streaming.mode: "block"`: each phase creates a new post; prior content stays in the channel
