### PR TITLE
fix: allow disabling heartbeats with false

### DIFF
--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -196,7 +196,7 @@ export function applyAnthropicConfigDefaults(params: {
   let mutated = false;
   const nextDefaults = { ...defaults };
   const contextPruning = defaults.contextPruning ?? {};
-  const heartbeat = defaults.heartbeat ?? {};
+  const heartbeat = defaults.heartbeat === false ? {} : (defaults.heartbeat ?? {});
 
   if (defaults.contextPruning?.mode === undefined) {
     nextDefaults.contextPruning = {
@@ -207,7 +207,7 @@ export function applyAnthropicConfigDefaults(params: {
     mutated = true;
   }
 
-  if (defaults.heartbeat?.every === undefined) {
+  if (defaults.heartbeat !== false && defaults.heartbeat?.every === undefined) {
     nextDefaults.heartbeat = {
       ...heartbeat,
       every: authMode === "oauth" ? "1h" : "30m",

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -371,7 +371,9 @@ export function resolveDreamingBlockedReason(cfg: OpenClawConfig): string | null
   // resolveHeartbeatSummaryForAgent since it would apply the per-agent override
   // and diverge from actual runtime behavior.
   const enabledForDefault = isHeartbeatEnabledForAgent(cfg, defaultAgentId);
-  const intervalMs = resolveHeartbeatIntervalMs(cfg, undefined, cfg.agents?.defaults?.heartbeat);
+  const defaultsHeartbeat =
+    cfg.agents?.defaults?.heartbeat === false ? undefined : cfg.agents?.defaults?.heartbeat;
+  const intervalMs = resolveHeartbeatIntervalMs(cfg, undefined, defaultsHeartbeat);
   if (enabledForDefault && intervalMs != null) {
     return null;
   }

--- a/extensions/whatsapp/src/auto-reply/heartbeat-runner.ts
+++ b/extensions/whatsapp/src/auto-reply/heartbeat-runner.ts
@@ -177,10 +177,12 @@ export async function runWebHeartbeatOnce(opts: {
       return;
     }
 
+    const defaultsHeartbeat =
+      cfg.agents?.defaults?.heartbeat === false ? undefined : cfg.agents?.defaults?.heartbeat;
     const replyResult = await replyResolver(
       {
         Body: appendCronStyleCurrentTimeLine(
-          resolveHeartbeatPrompt(cfg.agents?.defaults?.heartbeat?.prompt),
+          resolveHeartbeatPrompt(defaultsHeartbeat?.prompt),
           cfg,
           Date.now(),
         ),
@@ -217,7 +219,7 @@ export async function runWebHeartbeatOnce(opts: {
     const hasMedia = reply.hasMedia;
     const ackMaxChars = Math.max(
       0,
-      cfg.agents?.defaults?.heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+      defaultsHeartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
     );
     const stripped = stripHeartbeatToken(replyPayload.text, {
       mode: "heartbeat",

--- a/gates/openclaw-heartbeat-false-disable.sh
+++ b/gates/openclaw-heartbeat-false-disable.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# GATE_LEVEL: P1
+# GATE_VERIFY: heartbeat false disables heartbeat config parsing and runtime helpers
+cd /Users/karlkarl/Documents/vibe_coding/openclaw-upstream
+node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/zod-schema.agent-defaults.test.ts src/config/config.pruning-defaults.test.ts
+node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/heartbeat-runner.returns-default-unset.test.ts

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -322,10 +322,11 @@ function isHeartbeatEnabledForSessionAgent(params: {
     return false;
   }
 
-  const heartbeatEvery =
-    resolveAgentConfig(params.cfg, requesterAgentId)?.heartbeat?.every ??
-    params.cfg.agents?.defaults?.heartbeat?.every ??
-    DEFAULT_HEARTBEAT_EVERY;
+  const heartbeat = resolveHeartbeatConfigForAgent({
+    cfg: params.cfg,
+    agentId: requesterAgentId,
+  });
+  const heartbeatEvery = heartbeat?.every ?? DEFAULT_HEARTBEAT_EVERY;
   const trimmedEvery = normalizeOptionalString(heartbeatEvery) ?? "";
   if (!trimmedEvery) {
     return false;
@@ -340,14 +341,23 @@ function isHeartbeatEnabledForSessionAgent(params: {
 function resolveHeartbeatConfigForAgent(params: {
   cfg: OpenClawConfig;
   agentId: string;
-}): NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["heartbeat"] {
+}):
+  | Exclude<
+      NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["heartbeat"],
+      false | undefined
+    >
+  | undefined {
   const defaults = params.cfg.agents?.defaults?.heartbeat;
+  const resolvedDefaults = defaults === false ? undefined : defaults;
   const overrides = resolveAgentConfig(params.cfg, params.agentId)?.heartbeat;
-  if (!defaults && !overrides) {
+  if (overrides === false) {
+    return undefined;
+  }
+  if (!resolvedDefaults && !overrides) {
     return undefined;
   }
   return {
-    ...defaults,
+    ...resolvedDefaults,
     ...overrides,
   };
 }

--- a/src/agents/heartbeat-system-prompt.ts
+++ b/src/agents/heartbeat-system-prompt.ts
@@ -3,23 +3,27 @@ import {
   resolveHeartbeatPrompt as resolveHeartbeatPromptText,
 } from "../auto-reply/heartbeat.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
+import type { HeartbeatConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { listAgentEntries, resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
-
-type HeartbeatConfig = AgentDefaultsConfig["heartbeat"];
 
 function resolveHeartbeatConfigForSystemPrompt(
   config?: OpenClawConfig,
   agentId?: string,
 ): HeartbeatConfig | undefined {
   const defaults = config?.agents?.defaults?.heartbeat;
+  if (defaults === false) {
+    return undefined;
+  }
   if (!config || !agentId) {
     return defaults;
   }
   const overrides = resolveAgentConfig(config, agentId)?.heartbeat;
+  if (overrides === false) {
+    return undefined;
+  }
   if (!defaults && !overrides) {
     return overrides;
   }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -200,9 +200,10 @@ export async function getReplyFromConfig(
   if (opts?.isHeartbeat) {
     // Prefer the resolved per-agent heartbeat model passed from the heartbeat runner,
     // fall back to the global defaults heartbeat model for backward compatibility.
+    const defaultHeartbeat = agentCfg?.heartbeat === false ? undefined : agentCfg?.heartbeat;
     const heartbeatRaw =
       normalizeOptionalString(opts.heartbeatModelOverride) ??
-      normalizeOptionalString(agentCfg?.heartbeat?.model) ??
+      normalizeOptionalString(defaultHeartbeat?.model) ??
       "";
     const heartbeatRef = heartbeatRaw
       ? resolveModelRefFromString({

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -604,9 +604,7 @@ describe("config plugin validation", () => {
     });
     expect(res.ok).toBe(false);
     if (!res.ok) {
-      expect(
-        res.issues.some((issue) => issue.path === "agents.defaults.heartbeat.directPolicy"),
-      ).toBe(true);
+      expect(res.issues.some((issue) => issue.path === "agents.defaults.heartbeat")).toBe(true);
     }
   });
 });

--- a/src/config/config.pruning-defaults.test.ts
+++ b/src/config/config.pruning-defaults.test.ts
@@ -5,7 +5,9 @@ import { applyProviderConfigDefaultsForConfig } from "./provider-policy.js";
 function expectAnthropicPruningDefaults(cfg: OpenClawConfig, heartbeatEvery = "30m") {
   expect(cfg.agents?.defaults?.contextPruning?.mode).toBe("cache-ttl");
   expect(cfg.agents?.defaults?.contextPruning?.ttl).toBe("1h");
-  expect(cfg.agents?.defaults?.heartbeat?.every).toBe(heartbeatEvery);
+  const heartbeat =
+    cfg.agents?.defaults?.heartbeat === false ? undefined : cfg.agents?.defaults?.heartbeat;
+  expect(heartbeat?.every).toBe(heartbeatEvery);
 }
 
 function applyAnthropicDefaultsForTest(config: OpenClawConfig) {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5024,94 +5024,102 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 ],
               },
               heartbeat: {
-                type: "object",
-                properties: {
-                  every: {
-                    type: "string",
+                anyOf: [
+                  {
+                    type: "boolean",
+                    const: false,
                   },
-                  activeHours: {
+                  {
                     type: "object",
                     properties: {
-                      start: {
+                      every: {
                         type: "string",
                       },
-                      end: {
+                      activeHours: {
+                        type: "object",
+                        properties: {
+                          start: {
+                            type: "string",
+                          },
+                          end: {
+                            type: "string",
+                          },
+                          timezone: {
+                            type: "string",
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                      model: {
                         type: "string",
                       },
-                      timezone: {
+                      session: {
                         type: "string",
+                      },
+                      includeReasoning: {
+                        type: "boolean",
+                      },
+                      target: {
+                        type: "string",
+                      },
+                      directPolicy: {
+                        anyOf: [
+                          {
+                            type: "string",
+                            const: "allow",
+                          },
+                          {
+                            type: "string",
+                            const: "block",
+                          },
+                        ],
+                        title: "Heartbeat Direct Policy",
+                        description:
+                          'Controls whether heartbeat delivery may target direct/DM chats: "allow" (default) permits DM delivery and "block" suppresses direct-target sends.',
+                      },
+                      to: {
+                        type: "string",
+                      },
+                      accountId: {
+                        type: "string",
+                      },
+                      prompt: {
+                        type: "string",
+                      },
+                      includeSystemPromptSection: {
+                        type: "boolean",
+                        title: "Heartbeat Include System Prompt Section",
+                        description:
+                          "Includes the default agent's ## Heartbeats system prompt section when true. Turn this off to keep heartbeat runtime behavior while omitting the heartbeat prompt instructions from the agent system prompt.",
+                      },
+                      ackMaxChars: {
+                        type: "integer",
+                        minimum: 0,
+                        maximum: 9007199254740991,
+                      },
+                      suppressToolErrorWarnings: {
+                        type: "boolean",
+                        title: "Heartbeat Suppress Tool Error Warnings",
+                        description: "Suppress tool error warning payloads during heartbeat runs.",
+                      },
+                      timeoutSeconds: {
+                        type: "integer",
+                        exclusiveMinimum: 0,
+                        maximum: 9007199254740991,
+                        title: "Heartbeat Timeout (Seconds)",
+                        description:
+                          "Maximum time in seconds allowed for a heartbeat agent turn before it is aborted. Leave unset to use agents.defaults.timeoutSeconds.",
+                      },
+                      lightContext: {
+                        type: "boolean",
+                      },
+                      isolatedSession: {
+                        type: "boolean",
                       },
                     },
                     additionalProperties: false,
                   },
-                  model: {
-                    type: "string",
-                  },
-                  session: {
-                    type: "string",
-                  },
-                  includeReasoning: {
-                    type: "boolean",
-                  },
-                  target: {
-                    type: "string",
-                  },
-                  directPolicy: {
-                    anyOf: [
-                      {
-                        type: "string",
-                        const: "allow",
-                      },
-                      {
-                        type: "string",
-                        const: "block",
-                      },
-                    ],
-                    title: "Heartbeat Direct Policy",
-                    description:
-                      'Controls whether heartbeat delivery may target direct/DM chats: "allow" (default) permits DM delivery and "block" suppresses direct-target sends.',
-                  },
-                  to: {
-                    type: "string",
-                  },
-                  accountId: {
-                    type: "string",
-                  },
-                  prompt: {
-                    type: "string",
-                  },
-                  includeSystemPromptSection: {
-                    type: "boolean",
-                    title: "Heartbeat Include System Prompt Section",
-                    description:
-                      "Includes the default agent's ## Heartbeats system prompt section when true. Turn this off to keep heartbeat runtime behavior while omitting the heartbeat prompt instructions from the agent system prompt.",
-                  },
-                  ackMaxChars: {
-                    type: "integer",
-                    minimum: 0,
-                    maximum: 9007199254740991,
-                  },
-                  suppressToolErrorWarnings: {
-                    type: "boolean",
-                    title: "Heartbeat Suppress Tool Error Warnings",
-                    description: "Suppress tool error warning payloads during heartbeat runs.",
-                  },
-                  timeoutSeconds: {
-                    type: "integer",
-                    exclusiveMinimum: 0,
-                    maximum: 9007199254740991,
-                    title: "Heartbeat Timeout (Seconds)",
-                    description:
-                      "Maximum time in seconds allowed for a heartbeat agent turn before it is aborted. Leave unset to use agents.defaults.timeoutSeconds.",
-                  },
-                  lightContext: {
-                    type: "boolean",
-                  },
-                  isolatedSession: {
-                    type: "boolean",
-                  },
-                },
-                additionalProperties: false,
+                ],
               },
               maxConcurrent: {
                 type: "integer",
@@ -6335,94 +6343,103 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     "Optional per-agent overrides for the focused context budget knobs. Omitted fields inherit agents.defaults.contextLimits.",
                 },
                 heartbeat: {
-                  type: "object",
-                  properties: {
-                    every: {
-                      type: "string",
+                  anyOf: [
+                    {
+                      type: "boolean",
+                      const: false,
                     },
-                    activeHours: {
+                    {
                       type: "object",
                       properties: {
-                        start: {
+                        every: {
                           type: "string",
                         },
-                        end: {
+                        activeHours: {
+                          type: "object",
+                          properties: {
+                            start: {
+                              type: "string",
+                            },
+                            end: {
+                              type: "string",
+                            },
+                            timezone: {
+                              type: "string",
+                            },
+                          },
+                          additionalProperties: false,
+                        },
+                        model: {
                           type: "string",
                         },
-                        timezone: {
+                        session: {
                           type: "string",
+                        },
+                        includeReasoning: {
+                          type: "boolean",
+                        },
+                        target: {
+                          type: "string",
+                        },
+                        directPolicy: {
+                          anyOf: [
+                            {
+                              type: "string",
+                              const: "allow",
+                            },
+                            {
+                              type: "string",
+                              const: "block",
+                            },
+                          ],
+                          title: "Heartbeat Direct Policy",
+                          description:
+                            'Per-agent override for heartbeat direct/DM delivery policy; use "block" for agents that should only send heartbeat alerts to non-DM destinations.',
+                        },
+                        to: {
+                          type: "string",
+                        },
+                        accountId: {
+                          type: "string",
+                        },
+                        prompt: {
+                          type: "string",
+                        },
+                        includeSystemPromptSection: {
+                          type: "boolean",
+                          title: "Heartbeat Include System Prompt Section",
+                          description:
+                            "Per-agent override for whether the default agent's ## Heartbeats system prompt section is injected. Use false to keep heartbeat runtime behavior but omit the heartbeat prompt instructions from that agent's system prompt.",
+                        },
+                        ackMaxChars: {
+                          type: "integer",
+                          minimum: 0,
+                          maximum: 9007199254740991,
+                        },
+                        suppressToolErrorWarnings: {
+                          type: "boolean",
+                          title: "Heartbeat Suppress Tool Error Warnings",
+                          description:
+                            "Suppress tool error warning payloads during heartbeat runs.",
+                        },
+                        timeoutSeconds: {
+                          type: "integer",
+                          exclusiveMinimum: 0,
+                          maximum: 9007199254740991,
+                          title: "Heartbeat Timeout (Seconds)",
+                          description:
+                            "Per-agent maximum time in seconds allowed for a heartbeat agent turn before it is aborted. Leave unset to inherit the merged heartbeat/default agent timeout.",
+                        },
+                        lightContext: {
+                          type: "boolean",
+                        },
+                        isolatedSession: {
+                          type: "boolean",
                         },
                       },
                       additionalProperties: false,
                     },
-                    model: {
-                      type: "string",
-                    },
-                    session: {
-                      type: "string",
-                    },
-                    includeReasoning: {
-                      type: "boolean",
-                    },
-                    target: {
-                      type: "string",
-                    },
-                    directPolicy: {
-                      anyOf: [
-                        {
-                          type: "string",
-                          const: "allow",
-                        },
-                        {
-                          type: "string",
-                          const: "block",
-                        },
-                      ],
-                      title: "Heartbeat Direct Policy",
-                      description:
-                        'Per-agent override for heartbeat direct/DM delivery policy; use "block" for agents that should only send heartbeat alerts to non-DM destinations.',
-                    },
-                    to: {
-                      type: "string",
-                    },
-                    accountId: {
-                      type: "string",
-                    },
-                    prompt: {
-                      type: "string",
-                    },
-                    includeSystemPromptSection: {
-                      type: "boolean",
-                      title: "Heartbeat Include System Prompt Section",
-                      description:
-                        "Per-agent override for whether the default agent's ## Heartbeats system prompt section is injected. Use false to keep heartbeat runtime behavior but omit the heartbeat prompt instructions from that agent's system prompt.",
-                    },
-                    ackMaxChars: {
-                      type: "integer",
-                      minimum: 0,
-                      maximum: 9007199254740991,
-                    },
-                    suppressToolErrorWarnings: {
-                      type: "boolean",
-                      title: "Heartbeat Suppress Tool Error Warnings",
-                      description: "Suppress tool error warning payloads during heartbeat runs.",
-                    },
-                    timeoutSeconds: {
-                      type: "integer",
-                      exclusiveMinimum: 0,
-                      maximum: 9007199254740991,
-                      title: "Heartbeat Timeout (Seconds)",
-                      description:
-                        "Per-agent maximum time in seconds allowed for a heartbeat agent turn before it is aborted. Leave unset to inherit the merged heartbeat/default agent timeout.",
-                    },
-                    lightContext: {
-                      type: "boolean",
-                    },
-                    isolatedSession: {
-                      type: "boolean",
-                    },
-                  },
-                  additionalProperties: false,
+                  ],
                 },
                 identity: {
                   type: "object",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -173,6 +173,61 @@ export type CliBackendConfig = {
   };
 };
 
+export type HeartbeatConfig = {
+  /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */
+  every?: string;
+  /** Optional active-hours window (local time); heartbeats run only inside this window. */
+  activeHours?: {
+    /** Start time (24h, HH:MM). Inclusive. */
+    start?: string;
+    /** End time (24h, HH:MM). Exclusive. Use "24:00" for end-of-day. */
+    end?: string;
+    /** Timezone for the window ("user", "local", or IANA TZ id). Default: "user". */
+    timezone?: string;
+  };
+  /** Heartbeat model override (provider/model). */
+  model?: string;
+  /** Session key for heartbeat runs ("main" or explicit session key). */
+  session?: string;
+  /** Delivery target ("last", "none", or a channel id). */
+  target?: string;
+  /** Direct/DM delivery policy. Default: "allow". */
+  directPolicy?: "allow" | "block";
+  /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). Supports :topic:NNN suffix for Telegram topics. */
+  to?: string;
+  /** Optional account id for multi-account channels. */
+  accountId?: string;
+  /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."). */
+  prompt?: string;
+  /** Include the ## Heartbeats system prompt section for the default agent (default: true). */
+  includeSystemPromptSection?: boolean;
+  /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */
+  ackMaxChars?: number;
+  /** Suppress tool error warning payloads during heartbeat runs. */
+  suppressToolErrorWarnings?: boolean;
+  /** Run timeout in seconds for heartbeat agent turns. */
+  timeoutSeconds?: number;
+  /**
+   * If true, run heartbeat turns with lightweight bootstrap context.
+   * Lightweight mode keeps only HEARTBEAT.md from workspace bootstrap files.
+   */
+  lightContext?: boolean;
+  /**
+   * If true, run heartbeat turns in an isolated session with no prior
+   * conversation history. The heartbeat only sees its bootstrap context
+   * (HEARTBEAT.md when lightContext is also enabled). Dramatically reduces
+   * per-heartbeat token cost by avoiding the full session transcript.
+   */
+  isolatedSession?: boolean;
+  /**
+   * When enabled, deliver the model's reasoning payload for heartbeat runs (when available)
+   * as a separate message prefixed with `Reasoning:` (same as `/reasoning on`).
+   *
+   * Default: false (only the final heartbeat payload is delivered).
+   */
+  includeReasoning?: boolean;
+};
+
 export type AgentDefaultsConfig = {
   /** Global default provider params applied to all models before per-model and per-agent overrides. */
   params?: Record<string, unknown>;
@@ -328,61 +383,8 @@ export type AgentDefaultsConfig = {
   typingIntervalSeconds?: number;
   /** Typing indicator start mode (never|instant|thinking|message). */
   typingMode?: TypingMode;
-  /** Periodic background heartbeat runs. */
-  heartbeat?: {
-    /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */
-    every?: string;
-    /** Optional active-hours window (local time); heartbeats run only inside this window. */
-    activeHours?: {
-      /** Start time (24h, HH:MM). Inclusive. */
-      start?: string;
-      /** End time (24h, HH:MM). Exclusive. Use "24:00" for end-of-day. */
-      end?: string;
-      /** Timezone for the window ("user", "local", or IANA TZ id). Default: "user". */
-      timezone?: string;
-    };
-    /** Heartbeat model override (provider/model). */
-    model?: string;
-    /** Session key for heartbeat runs ("main" or explicit session key). */
-    session?: string;
-    /** Delivery target ("last", "none", or a channel id). */
-    target?: string;
-    /** Direct/DM delivery policy. Default: "allow". */
-    directPolicy?: "allow" | "block";
-    /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). Supports :topic:NNN suffix for Telegram topics. */
-    to?: string;
-    /** Optional account id for multi-account channels. */
-    accountId?: string;
-    /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."). */
-    prompt?: string;
-    /** Include the ## Heartbeats system prompt section for the default agent (default: true). */
-    includeSystemPromptSection?: boolean;
-    /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */
-    ackMaxChars?: number;
-    /** Suppress tool error warning payloads during heartbeat runs. */
-    suppressToolErrorWarnings?: boolean;
-    /** Run timeout in seconds for heartbeat agent turns. */
-    timeoutSeconds?: number;
-    /**
-     * If true, run heartbeat turns with lightweight bootstrap context.
-     * Lightweight mode keeps only HEARTBEAT.md from workspace bootstrap files.
-     */
-    lightContext?: boolean;
-    /**
-     * If true, run heartbeat turns in an isolated session with no prior
-     * conversation history. The heartbeat only sees its bootstrap context
-     * (HEARTBEAT.md when lightContext is also enabled). Dramatically reduces
-     * per-heartbeat token cost by avoiding the full session transcript.
-     */
-    isolatedSession?: boolean;
-    /**
-     * When enabled, deliver the model's reasoning payload for heartbeat runs (when available)
-     * as a separate message prefixed with `Reasoning:` (same as `/reasoning on`).
-     *
-     * Default: false (only the final heartbeat payload is delivered).
-     */
-    includeReasoning?: boolean;
-  };
+  /** Periodic background heartbeat runs. Use false to disable explicitly. */
+  heartbeat?: false | HeartbeatConfig;
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -990,13 +990,13 @@ function validateConfigObjectWithPluginsBase(
     issues.push({ path, message: `unknown heartbeat target: ${target}` });
   };
 
-  validateHeartbeatTarget(
-    config.agents?.defaults?.heartbeat?.target,
-    "agents.defaults.heartbeat.target",
-  );
+  const defaultHeartbeat =
+    config.agents?.defaults?.heartbeat === false ? undefined : config.agents?.defaults?.heartbeat;
+  validateHeartbeatTarget(defaultHeartbeat?.target, "agents.defaults.heartbeat.target");
   if (Array.isArray(config.agents?.list)) {
     for (const [index, entry] of config.agents.list.entries()) {
-      validateHeartbeatTarget(entry?.heartbeat?.target, `agents.list.${index}.heartbeat.target`);
+      const entryHeartbeat = entry?.heartbeat === false ? undefined : entry?.heartbeat;
+      validateHeartbeatTarget(entryHeartbeat?.target, `agents.list.${index}.heartbeat.target`);
     }
   }
 

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -99,6 +99,19 @@ describe("agent defaults schema", () => {
     expect(agent.contextLimits?.memoryGetMaxChars).toBe(18_000);
   });
 
+  it("accepts heartbeat: false on defaults and agent entries", () => {
+    const defaults = AgentDefaultsSchema.parse({
+      heartbeat: false,
+    })!;
+    const agent = AgentEntrySchema.parse({
+      id: "ops",
+      heartbeat: false,
+    });
+
+    expect(defaults.heartbeat).toBe(false);
+    expect(agent.heartbeat).toBe(false);
+  });
+
   it("accepts positive heartbeat timeoutSeconds on defaults and agent entries", () => {
     const defaults = AgentDefaultsSchema.parse({
       heartbeat: { timeoutSeconds: 45 },
@@ -108,8 +121,11 @@ describe("agent defaults schema", () => {
       heartbeat: { timeoutSeconds: 45 },
     });
 
-    expect(defaults.heartbeat?.timeoutSeconds).toBe(45);
-    expect(agent.heartbeat?.timeoutSeconds).toBe(45);
+    const defaultHeartbeat = defaults.heartbeat === false ? undefined : defaults.heartbeat;
+    const agentHeartbeat = agent.heartbeat === false ? undefined : agent.heartbeat;
+
+    expect(defaultHeartbeat?.timeoutSeconds).toBe(45);
+    expect(agentHeartbeat?.timeoutSeconds).toBe(45);
   });
 
   it("rejects zero heartbeat timeoutSeconds", () => {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -17,86 +17,94 @@ import {
 import { sensitive } from "./zod-schema.sensitive.js";
 
 export const HeartbeatSchema = z
-  .object({
-    every: z.string().optional(),
-    activeHours: z
+  .union([
+    z.literal(false),
+    z
       .object({
-        start: z.string().optional(),
-        end: z.string().optional(),
-        timezone: z.string().optional(),
+        every: z.string().optional(),
+        activeHours: z
+          .object({
+            start: z.string().optional(),
+            end: z.string().optional(),
+            timezone: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        model: z.string().optional(),
+        session: z.string().optional(),
+        includeReasoning: z.boolean().optional(),
+        target: z.string().optional(),
+        directPolicy: z.union([z.literal("allow"), z.literal("block")]).optional(),
+        to: z.string().optional(),
+        accountId: z.string().optional(),
+        prompt: z.string().optional(),
+        includeSystemPromptSection: z.boolean().optional(),
+        ackMaxChars: z.number().int().nonnegative().optional(),
+        suppressToolErrorWarnings: z.boolean().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+        lightContext: z.boolean().optional(),
+        isolatedSession: z.boolean().optional(),
       })
       .strict()
-      .optional(),
-    model: z.string().optional(),
-    session: z.string().optional(),
-    includeReasoning: z.boolean().optional(),
-    target: z.string().optional(),
-    directPolicy: z.union([z.literal("allow"), z.literal("block")]).optional(),
-    to: z.string().optional(),
-    accountId: z.string().optional(),
-    prompt: z.string().optional(),
-    includeSystemPromptSection: z.boolean().optional(),
-    ackMaxChars: z.number().int().nonnegative().optional(),
-    suppressToolErrorWarnings: z.boolean().optional(),
-    timeoutSeconds: z.number().int().positive().optional(),
-    lightContext: z.boolean().optional(),
-    isolatedSession: z.boolean().optional(),
-  })
-  .strict()
-  .superRefine((val, ctx) => {
-    if (!val.every) {
-      return;
-    }
-    try {
-      parseDurationMs(val.every, { defaultUnit: "m" });
-    } catch {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["every"],
-        message: "invalid duration (use ms, s, m, h)",
-      });
-    }
+      .superRefine((val, ctx) => {
+        if (!val.every) {
+          return;
+        }
+        try {
+          parseDurationMs(val.every, { defaultUnit: "m" });
+        } catch {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["every"],
+            message: "invalid duration (use ms, s, m, h)",
+          });
+        }
 
-    const active = val.activeHours;
-    if (!active) {
-      return;
-    }
-    const timePattern = /^([01]\d|2[0-3]|24):([0-5]\d)$/;
-    const validateTime = (raw: string | undefined, opts: { allow24: boolean }, path: string) => {
-      if (!raw) {
-        return;
-      }
-      if (!timePattern.test(raw)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["activeHours", path],
-          message: 'invalid time (use "HH:MM" 24h format)',
-        });
-        return;
-      }
-      const [hourStr, minuteStr] = raw.split(":");
-      const hour = Number(hourStr);
-      const minute = Number(minuteStr);
-      if (hour === 24 && minute !== 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["activeHours", path],
-          message: "invalid time (24:00 is the only allowed 24:xx value)",
-        });
-        return;
-      }
-      if (hour === 24 && !opts.allow24) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["activeHours", path],
-          message: "invalid time (start cannot be 24:00)",
-        });
-      }
-    };
+        const active = val.activeHours;
+        if (!active) {
+          return;
+        }
+        const timePattern = /^([01]\d|2[0-3]|24):([0-5]\d)$/;
+        const validateTime = (
+          raw: string | undefined,
+          opts: { allow24: boolean },
+          path: string,
+        ) => {
+          if (!raw) {
+            return;
+          }
+          if (!timePattern.test(raw)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["activeHours", path],
+              message: 'invalid time (use "HH:MM" 24h format)',
+            });
+            return;
+          }
+          const [hourStr, minuteStr] = raw.split(":");
+          const hour = Number(hourStr);
+          const minute = Number(minuteStr);
+          if (hour === 24 && minute !== 0) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["activeHours", path],
+              message: "invalid time (24:00 is the only allowed 24:xx value)",
+            });
+            return;
+          }
+          if (hour === 24 && !opts.allow24) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["activeHours", path],
+              message: "invalid time (start cannot be 24:00)",
+            });
+          }
+        };
 
-    validateTime(active.start, { allow24: false }, "start");
-    validateTime(active.end, { allow24: true }, "end");
-  })
+        validateTime(active.start, { allow24: false }, "start");
+        validateTime(active.end, { allow24: true }, "end");
+      }),
+  ])
   .optional();
 
 export const SandboxDockerSchema = z

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -129,8 +129,11 @@ export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars
   return shouldSkipHeartbeatOnlyDelivery(payloads, ackMaxChars);
 }
 
-export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxChars?: number } }) {
-  const raw = agentCfg?.heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
+export function resolveHeartbeatAckMaxChars(agentCfg?: {
+  heartbeat?: false | { ackMaxChars?: number };
+}) {
+  const heartbeat = agentCfg?.heartbeat === false ? undefined : agentCfg?.heartbeat;
+  const raw = heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
   return Math.max(0, raw);
 }
 

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -433,7 +433,13 @@ export function collectConfiguredModelPricingRefs(config: OpenClawConfig): Model
   addModelListLike({ value: config.agents?.defaults?.imageModel, aliasIndex, refs });
   addModelListLike({ value: config.agents?.defaults?.pdfModel, aliasIndex, refs });
   addResolvedModelRef({ raw: config.agents?.defaults?.compaction?.model, aliasIndex, refs });
-  addResolvedModelRef({ raw: config.agents?.defaults?.heartbeat?.model, aliasIndex, refs });
+  const defaultHeartbeat =
+    config.agents?.defaults?.heartbeat === false ? undefined : config.agents?.defaults?.heartbeat;
+  addResolvedModelRef({
+    raw: defaultHeartbeat?.model,
+    aliasIndex,
+    refs,
+  });
   addModelListLike({ value: config.tools?.subagents?.model, aliasIndex, refs });
   addResolvedModelRef({ raw: config.messages?.tts?.summaryModel, aliasIndex, refs });
   addResolvedModelRef({ raw: config.hooks?.gmail?.model, aliasIndex, refs });
@@ -441,7 +447,8 @@ export function collectConfiguredModelPricingRefs(config: OpenClawConfig): Model
   for (const agent of config.agents?.list ?? []) {
     addModelListLike({ value: agent.model, aliasIndex, refs });
     addModelListLike({ value: agent.subagents?.model, aliasIndex, refs });
-    addResolvedModelRef({ raw: agent.heartbeat?.model, aliasIndex, refs });
+    const agentHeartbeat = agent.heartbeat === false ? undefined : agent.heartbeat;
+    addResolvedModelRef({ raw: agentHeartbeat?.model, aliasIndex, refs });
   }
 
   for (const mapping of config.hooks?.mappings ?? []) {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -23,10 +23,9 @@ import { formatForLog } from "./ws-log.js";
 function resolveHeartbeatAckMaxChars(): number {
   try {
     const cfg = loadConfig();
-    return Math.max(
-      0,
-      cfg.agents?.defaults?.heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-    );
+    const heartbeat =
+      cfg.agents?.defaults?.heartbeat === false ? undefined : cfg.agents?.defaults?.heartbeat;
+    return Math.max(0, heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS);
   } catch {
     return DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
   }

--- a/src/infra/heartbeat-active-hours.ts
+++ b/src/infra/heartbeat-active-hours.ts
@@ -1,8 +1,6 @@
 import { resolveUserTimezone } from "../agents/date-time.js";
-import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
+import type { HeartbeatConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-
-type HeartbeatConfig = AgentDefaultsConfig["heartbeat"];
 
 const ACTIVE_HOURS_TIME_PATTERN = /^(?:([01]\d|2[0-3]):([0-5]\d)|24:00)$/;
 

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -285,6 +285,14 @@ describe("resolveHeartbeatIntervalMs", () => {
       ),
     ).toBe(5 * 60_000);
   });
+
+  it("returns null when heartbeat is explicitly disabled with false", () => {
+    expect(
+      resolveHeartbeatIntervalMs({
+        agents: { defaults: { heartbeat: false } },
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("resolveHeartbeatPrompt", () => {
@@ -322,6 +330,17 @@ describe("isHeartbeatEnabledForAgent", () => {
       },
     };
     expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+  });
+
+  it("disables default-agent heartbeat when config is false", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { heartbeat: false },
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -44,7 +44,7 @@ import {
   saveSessionStore,
   updateSessionStore,
 } from "../config/sessions/store.js";
-import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
+import type { HeartbeatConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -142,7 +142,6 @@ export {
   type HeartbeatSummary,
 } from "./heartbeat-summary.js";
 
-type HeartbeatConfig = AgentDefaultsConfig["heartbeat"];
 type HeartbeatAgent = {
   agentId: string;
   heartbeat?: HeartbeatConfig;
@@ -189,14 +188,18 @@ function resolveHeartbeatConfig(
   agentId?: string,
 ): HeartbeatConfig | undefined {
   const defaults = cfg.agents?.defaults?.heartbeat;
+  const resolvedDefaults = defaults === false ? undefined : defaults;
   if (!agentId) {
-    return defaults;
+    return resolvedDefaults;
   }
   const overrides = resolveAgentConfig(cfg, agentId)?.heartbeat;
-  if (!defaults && !overrides) {
+  if (overrides === false) {
+    return undefined;
+  }
+  if (!resolvedDefaults && !overrides) {
     return overrides;
   }
-  return { ...defaults, ...overrides };
+  return { ...resolvedDefaults, ...overrides };
 }
 
 function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
@@ -215,15 +218,17 @@ function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
 }
 
 export function resolveHeartbeatPrompt(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
-  return resolveHeartbeatPromptText(heartbeat?.prompt ?? cfg.agents?.defaults?.heartbeat?.prompt);
+  const defaultHeartbeat =
+    cfg.agents?.defaults?.heartbeat === false ? undefined : cfg.agents?.defaults?.heartbeat;
+  return resolveHeartbeatPromptText(heartbeat?.prompt ?? defaultHeartbeat?.prompt);
 }
 
 function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
+  const defaultHeartbeat =
+    cfg.agents?.defaults?.heartbeat === false ? undefined : cfg.agents?.defaults?.heartbeat;
   return Math.max(
     0,
-    heartbeat?.ackMaxChars ??
-      cfg.agents?.defaults?.heartbeat?.ackMaxChars ??
-      DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+    heartbeat?.ackMaxChars ?? defaultHeartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   );
 }
 

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -5,12 +5,10 @@ import {
   resolveHeartbeatPrompt as resolveHeartbeatPromptText,
 } from "../auto-reply/heartbeat.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
+import type { AgentDefaultsConfig, HeartbeatConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
-
-type HeartbeatConfig = AgentDefaultsConfig["heartbeat"];
 
 export type HeartbeatSummary = {
   enabled: boolean;
@@ -24,9 +22,15 @@ export type HeartbeatSummary = {
 
 const DEFAULT_HEARTBEAT_TARGET = "none";
 
+function isHeartbeatConfigEnabled(
+  heartbeat: AgentDefaultsConfig["heartbeat"],
+): heartbeat is HeartbeatConfig {
+  return Boolean(heartbeat) && heartbeat !== false;
+}
+
 function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   const list = cfg.agents?.list ?? [];
-  return list.some((entry) => Boolean(entry?.heartbeat));
+  return list.some((entry) => isHeartbeatConfigEnabled(entry?.heartbeat));
 }
 
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
@@ -35,8 +39,14 @@ export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string
   const hasExplicit = hasExplicitHeartbeatAgents(cfg);
   if (hasExplicit) {
     return list.some(
-      (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
+      (entry) =>
+        isHeartbeatConfigEnabled(entry?.heartbeat) &&
+        normalizeAgentId(entry?.id) === resolvedAgentId,
     );
+  }
+  const defaultsHeartbeat = cfg.agents?.defaults?.heartbeat;
+  if (defaultsHeartbeat === false) {
+    return false;
   }
   return resolvedAgentId === resolveDefaultAgentId(cfg);
 }
@@ -46,11 +56,13 @@ export function resolveHeartbeatIntervalMs(
   overrideEvery?: string,
   heartbeat?: HeartbeatConfig,
 ) {
+  const defaultsHeartbeat = cfg.agents?.defaults?.heartbeat;
   const raw =
     overrideEvery ??
     heartbeat?.every ??
-    cfg.agents?.defaults?.heartbeat?.every ??
-    DEFAULT_HEARTBEAT_EVERY;
+    (defaultsHeartbeat === false
+      ? undefined
+      : (defaultsHeartbeat?.every ?? DEFAULT_HEARTBEAT_EVERY));
   if (!raw) {
     return null;
   }
@@ -74,8 +86,11 @@ export function resolveHeartbeatSummaryForAgent(
   cfg: OpenClawConfig,
   agentId?: string,
 ): HeartbeatSummary {
-  const defaults = cfg.agents?.defaults?.heartbeat;
-  const overrides = agentId ? resolveAgentConfig(cfg, agentId)?.heartbeat : undefined;
+  const defaults = isHeartbeatConfigEnabled(cfg.agents?.defaults?.heartbeat)
+    ? cfg.agents?.defaults?.heartbeat
+    : undefined;
+  const agentHeartbeat = agentId ? resolveAgentConfig(cfg, agentId)?.heartbeat : undefined;
+  const overrides = isHeartbeatConfigEnabled(agentHeartbeat) ? agentHeartbeat : undefined;
   const enabled = isHeartbeatEnabledForAgent(cfg, agentId);
 
   if (!enabled) {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -2,7 +2,7 @@ import { mapAllowFromEntries } from "openclaw/plugin-sdk/channel-config-helpers"
 import { normalizeChatType, type ChatType } from "../../channels/chat-type.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.core.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
+import type { AgentDefaultsConfig, HeartbeatConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import {
@@ -88,7 +88,11 @@ export function resolveHeartbeatDeliveryTarget(params: {
   turnSource?: DeliveryContext;
 }): OutboundTarget {
   const { cfg, entry } = params;
-  const heartbeat = params.heartbeat ?? cfg.agents?.defaults?.heartbeat;
+  const defaultHeartbeat = cfg.agents?.defaults?.heartbeat;
+  const heartbeat: HeartbeatConfig | undefined =
+    params.heartbeat === false
+      ? undefined
+      : (params.heartbeat ?? (defaultHeartbeat === false ? undefined : defaultHeartbeat));
   const rawTarget = heartbeat?.target;
   let target: HeartbeatTarget = "none";
   if (rawTarget === "none" || rawTarget === "last") {
@@ -301,7 +305,7 @@ function resolveHeartbeatDeliveryChatType(params: {
 function shouldReuseHeartbeatRouteThreadId(params: {
   cfg: OpenClawConfig;
   target: HeartbeatTarget;
-  heartbeat?: AgentDefaultsConfig["heartbeat"];
+  heartbeat?: HeartbeatConfig;
   turnSource?: DeliveryContext;
   entry?: SessionEntry;
   resolvedTarget: SessionDeliveryTarget;


### PR DESCRIPTION
## Summary
- allow `agents.defaults.heartbeat` and per-agent `heartbeat` to be set to `false` in config schemas
- thread the disabled heartbeat state through runtime helpers, prompt resolution, summary/target resolution, and WhatsApp heartbeat runner
- add regression tests for config parsing/runtime behavior and refresh the generated base config schema

## Testing
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/zod-schema.agent-defaults.test.ts src/config/config.pruning-defaults.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
- `bash ~/.openclaw/workspace/scripts/coding_harness.sh /Users/karlkarl/Documents/vibe_coding/openclaw-upstream/gates/openclaw-heartbeat-false-disable.sh 3`

## Notes
- local `pnpm check:changed` is still blocked by an existing `extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts` duplicate Anthropic SDK type error unrelated to this branch.