### PR TITLE
fix(auth): harden codex auth probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/Codex: run OpenAI Codex auth probes through raw PI model runs with the resolved profile credential and native-compatible instructions, so valid OAuth profiles no longer report false `models status --probe` failures. Thanks @ecochran76.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1138,6 +1138,36 @@ describe("openai transport stream", () => {
     expect(sanitized).toEqual(payload);
   });
 
+  it("adds required fallback instructions for raw Codex responses probes", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: "",
+        messages: [{ role: "user", content: "Reply OK", timestamp: 1 }],
+        tools: [],
+      } as never,
+      {
+        maxTokens: 16,
+        sessionId: "session-123",
+      },
+    ) as Record<string, unknown>;
+
+    expect(params.instructions).toBe("Follow the user request.");
+    expect(params.max_output_tokens).toBeUndefined();
+    expect(params.prompt_cache_retention).toBeUndefined();
+  });
+
   it("adds minimal user input for Codex responses when only the system prompt is present", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -54,6 +54,7 @@ import { mergeTransportMetadata, sanitizeTransportPayloadText } from "./transpor
 
 const DEFAULT_AZURE_OPENAI_API_VERSION = "2024-12-01-preview";
 const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
+const OPENAI_CODEX_RESPONSES_DEFAULT_INSTRUCTIONS = "Follow the user request.";
 const log = createSubsystemLogger("openai-transport");
 
 type BaseStreamOptions = {
@@ -933,6 +934,12 @@ function buildOpenAICodexResponsesInstructions(context: Context): string | undef
   return sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt));
 }
 
+function resolveOpenAICodexResponsesInstructions(context: Context): string {
+  return (
+    buildOpenAICodexResponsesInstructions(context) ?? OPENAI_CODEX_RESPONSES_DEFAULT_INSTRUCTIONS
+  );
+}
+
 function ensureOpenAICodexResponsesInput(messages: ResponseInput, context: Context): void {
   if (messages.length > 0 || !context.systemPrompt) {
     return;
@@ -978,7 +985,7 @@ export function buildOpenAIResponsesParams(
     stream: true,
     prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
-    ...(isCodexResponses ? { instructions: buildOpenAICodexResponsesInstructions(context) } : {}),
+    ...(isCodexResponses ? { instructions: resolveOpenAICodexResponsesInstructions(context) } : {}),
     ...(metadata ? { metadata } : {}),
   };
   if (options?.maxTokens) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1801,6 +1801,13 @@ export async function runEmbeddedAttempt(
             `(${params.provider}/${params.modelId})`,
         );
       }
+      if (params.resolvedApiKey?.trim()) {
+        const previousGetApiKey = activeSession.agent.getApiKey;
+        const runProvider = params.provider;
+        const runApiKey = params.resolvedApiKey;
+        activeSession.agent.getApiKey = async (provider) =>
+          provider === runProvider ? runApiKey : await previousGetApiKey?.(provider);
+      }
       prepStages.mark("stream-setup");
       emitPrepStageSummary("stream-ready");
 

--- a/src/agents/pi-embedded-runner/stream-resolution.test.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.test.ts
@@ -84,6 +84,20 @@ describe("describeEmbeddedAgentStreamStrategy", () => {
       }),
     ).toBe("session-custom");
   });
+
+  it("prefers boundary-aware Codex responses over custom session streams", () => {
+    expect(
+      describeEmbeddedAgentStreamStrategy({
+        currentStreamFn: vi.fn() as never,
+        shouldUseWebSocketTransport: false,
+        model: {
+          api: "openai-codex-responses",
+          provider: "openai-codex",
+          id: "gpt-5.5",
+        } as never,
+      }),
+    ).toBe("boundary-aware:openai-codex-responses");
+  });
 });
 
 describe("resolveEmbeddedAgentStreamFn", () => {
@@ -244,6 +258,29 @@ describe("resolveEmbeddedAgentStreamFn", () => {
       streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, {} as never, {}),
     ).resolves.toMatchObject({ apiKey: "oauth-bearer-token" });
     expect(innerStreamFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes custom Codex responses streams through boundary-aware transports", async () => {
+    const sessionStreamFn = vi.fn(async (_model, _context, options) => options);
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: sessionStreamFn as never,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.5",
+      } as never,
+      resolvedApiKey: "oauth-bearer-token",
+    });
+
+    await expect(
+      streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ apiKey: "oauth-bearer-token" });
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
+    expect(sessionStreamFn).not.toHaveBeenCalled();
   });
 
   it("falls back to authStorage when no resolved api key is available for boundary-aware fallback", async () => {

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -41,12 +41,23 @@ export function describeEmbeddedAgentStreamStrategy(params: {
   if (params.model.provider === "anthropic-vertex") {
     return "anthropic-vertex";
   }
+  if (shouldPreferBoundaryAwareStreamOverSessionCustom(params.model)) {
+    return createBoundaryAwareStreamFnForModel(params.model)
+      ? `boundary-aware:${params.model.api}`
+      : "session-custom";
+  }
   if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
     return createBoundaryAwareStreamFnForModel(params.model)
       ? `boundary-aware:${params.model.api}`
       : "stream-simple";
   }
   return "session-custom";
+}
+
+function shouldPreferBoundaryAwareStreamOverSessionCustom(
+  model: EmbeddedRunAttemptParams["model"],
+): boolean {
+  return model.api === "openai-codex-responses";
 }
 
 export async function resolveEmbeddedAgentApiKey(params: {
@@ -102,6 +113,18 @@ export function resolveEmbeddedAgentStreamFn(params: {
 
   if (params.model.provider === "anthropic-vertex") {
     return createAnthropicVertexStreamFnForModel(params.model);
+  }
+
+  if (shouldPreferBoundaryAwareStreamOverSessionCustom(params.model)) {
+    const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
+    if (boundaryAwareStreamFn) {
+      return wrapEmbeddedAgentStreamFn(boundaryAwareStreamFn, {
+        runSignal: params.signal,
+        resolvedApiKey: params.resolvedApiKey,
+        authStorage: params.authStorage,
+        providerId: params.model.provider,
+      });
+    }
   }
 
   if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -566,7 +566,7 @@ describe("channelsAddCommand", () => {
           plugin: {
             ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
             setup: {
-              applyAccountConfig: ({ cfg, input }) => ({
+              applyAccountConfig: ({ cfg, input }: ApplyAccountConfigParams) => ({
                 ...cfg,
                 channels: {
                   ...cfg.channels,

--- a/src/commands/models/list.probe.test.ts
+++ b/src/commands/models/list.probe.test.ts
@@ -38,3 +38,75 @@ describe("mapFailoverReasonToProbeStatus", () => {
     expect(mapFailoverReasonToProbeStatus("something_else")).toBe("unknown");
   });
 });
+
+describe("runAuthProbes", () => {
+  it("forces the PI harness so provider auth probes forward resolved credentials", async () => {
+    const runEmbeddedPiAgent = vi.fn(async () => ({ text: "OK" }));
+    vi.doMock("../../agents/auth-profiles.js", () => ({
+      externalCliDiscoveryScoped: () => undefined,
+      ensureAuthProfileStore: () => ({
+        version: 1,
+        profiles: {
+          "openai-codex:soylei": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+      }),
+      listProfilesForProvider: () => ["openai-codex:soylei"],
+      resolveAuthProfileDisplayLabel: ({ profileId }: { profileId: string }) => profileId,
+      resolveAuthProfileEligibility: () => ({ eligible: true }),
+      resolveAuthProfileOrder: () => ["openai-codex:soylei"],
+    }));
+    vi.doMock("../../agents/model-auth.js", () => ({
+      hasUsableCustomProviderApiKey: () => false,
+      resolveEnvApiKey: () => null,
+    }));
+    vi.doMock("../../agents/model-catalog.js", () => ({
+      loadModelCatalog: async () => [{ provider: "openai-codex", id: "gpt-5.5" }],
+    }));
+    vi.doMock("../../agents/pi-embedded.js", () => ({
+      runEmbeddedPiAgent,
+    }));
+    try {
+      const module = await importFreshModule<typeof import("./list.probe.js")>(
+        import.meta.url,
+        `./list.probe.js?scope=${Math.random().toString(36).slice(2)}`,
+      );
+      const result = await module.runAuthProbes({
+        cfg: {} as never,
+        agentId: "probe-agent",
+        agentDir: "/tmp/probe-agent",
+        workspaceDir: "/tmp/probe-workspace",
+        providers: ["openai-codex"],
+        modelCandidates: ["openai-codex/gpt-5.5"],
+        options: {
+          provider: "openai-codex",
+          profileIds: ["openai-codex:soylei"],
+          timeoutMs: 5_000,
+          concurrency: 1,
+          maxTokens: 8,
+        },
+      });
+
+      expect(result.results[0]?.status).toBe("ok");
+      expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentHarnessId: "pi",
+          authProfileId: "openai-codex:soylei",
+          authProfileIdSource: "user",
+          disableTools: true,
+          modelRun: true,
+        }),
+      );
+    } finally {
+      vi.doUnmock("../../agents/auth-profiles.js");
+      vi.doUnmock("../../agents/model-auth.js");
+      vi.doUnmock("../../agents/model-catalog.js");
+      vi.doUnmock("../../agents/pi-embedded.js");
+    }
+  });
+});

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -485,6 +485,7 @@ async function probeTarget(params: {
       model: target.model.model,
       authProfileId: target.profileId,
       authProfileIdSource: target.profileId ? "user" : undefined,
+      agentHarnessId: "pi",
       timeoutMs,
       runId: `probe-${crypto.randomUUID()}`,
       lane: `auth-probe:${target.provider}:${target.profileId ?? target.source}`,
@@ -493,6 +494,7 @@ async function probeTarget(params: {
       verboseLevel: "off",
       streamParams: { maxTokens },
       disableTools: true,
+      modelRun: true,
       cleanupBundleMcpOnRunEnd: true,
     });
     return buildResult("ok");


### PR DESCRIPTION
## Summary

- Problem: `models status --probe` can report false auth/format failures for OpenAI Codex OAuth profiles even when the selected profile is valid.
- Why it matters: the probe path is the operator-facing way to confirm whether a profile needs re-auth; false failures can send users into unnecessary login loops.
- What changed: run auth probes through the PI harness in raw model-run mode, forward resolved profile credentials through the embedded agent API-key seam, keep Codex Responses on the boundary-aware transport even when a session custom stream exists, and provide required fallback instructions for native Codex Responses requests.
- What did NOT change (scope boundary): no auth storage format changes, no profile-order changes, no external CLI credential discovery changes, and no new provider/network surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #75223
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the auth probe path used a non-raw embedded run shape that could retain session/custom transport behavior and did not reliably expose the resolved auth profile credential through the PI agent API-key seam.
- Missing detection / guardrail: existing tests covered status/probe mapping and default boundary-aware fallbacks, but not the selected-profile probe call shape or Codex Responses with custom session streams.
- Contributing context (if known): native ChatGPT Codex Responses requests require a non-empty instructions field, and probes can have an intentionally empty system prompt.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/models/list.probe.test.ts`, `src/agents/pi-embedded-runner/stream-resolution.test.ts`, `src/agents/openai-transport-stream.test.ts`
- Scenario the test should lock in: selected-profile OpenAI Codex probes use the PI harness and raw model-run mode, Codex Responses keeps the boundary-aware stream over custom session streams, and native Codex Responses probes always send required instructions.
- Why this is the smallest reliable guardrail: it exercises the call-shape and transport seams without a live provider dependency.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw models status --probe --probe-provider openai-codex --probe-profile <profile>` should be less likely to return false auth/format failures for valid OpenAI Codex OAuth profiles.

## Diagram (if applicable)

```text
Before:
models status --probe -> embedded run with session/custom transport -> missing or malformed Codex request -> false probe failure

After:
models status --probe -> PI raw model run -> resolved profile credential + boundary-aware Codex transport -> accurate probe result
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: resolved credentials are forwarded only to the matching run provider via the existing API-key seam; no credential material is logged or exposed in tests.

## Repro + Verification

### Environment

- OS: Linux / WSL2
- Runtime/container: Node 24, pnpm workspace
- Model/provider: `openai-codex/gpt-5.5`
- Integration/channel (if any): CLI auth probe
- Relevant config (redacted): user-scoped auth profile store with an OpenAI Codex OAuth profile

### Steps

1. Configure an OpenAI Codex OAuth profile.
2. Run `openclaw models status --agent graphiti-agent --probe --probe-provider openai-codex --probe-profile openai-codex:soylei --probe-timeout 90000 --probe-max-tokens 16 --json`.
3. Inspect the probe result.

### Expected

- A valid profile reports `status: ok`.

### Actual

- Before this fix, the same valid profile could report auth/format failure because the probe run did not consistently reach the Codex Responses transport with the resolved profile credential and native-compatible payload shape.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted unit/seam tests for Codex transport params, stream-resolution routing, and probe run call shape.
- Edge cases checked: native ChatGPT Codex backend vs custom Codex-compatible proxy behavior; custom session stream preservation for non-Codex providers.
- What you did **not** verify: live provider probe on this exact upstream-main worktree, because local user config contains downstream-only keys rejected by upstream `main`; the same fix was live-verified on the downstream runtime before extracting this minimal upstream patch.

Commands run:

- `pnpm docs:list`
- `pnpm install`
- `pnpm exec oxfmt --check --threads=1 src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/stream-resolution.ts src/agents/pi-embedded-runner/stream-resolution.test.ts src/commands/models/list.probe.ts src/commands/models/list.probe.test.ts`
- `pnpm test src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner/stream-resolution.test.ts src/commands/models/list.probe.test.ts`
- `pnpm check:changed --staged`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: forcing Codex Responses over a custom session stream could surprise a caller that expected a generic custom stream for Codex.
  - Mitigation: the override is limited to `openai-codex-responses`, which needs provider-specific credential/payload handling; non-Codex custom session streams keep existing behavior.
