### PR TITLE
fix(tui): bound shutdown after terminal hangup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI: handle terminal hangups as shutdown signals and bound exit cleanup so orphaned `openclaw-tui` processes do not keep spinning after terminal close or failed terminal drain. Fixes #75289. Thanks @hclsys.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -4,7 +4,9 @@ import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-
 import { getSlashCommands, parseCommand } from "./commands.js";
 import {
   createBackspaceDeduper,
+  drainAndStopTuiForExitSafely,
   drainAndStopTuiSafely,
+  getTuiShutdownSignals,
   isIgnorableTuiStopError,
   resolveCodexCliBin,
   resolveCtrlCAction,
@@ -260,6 +262,12 @@ describe("resolveCtrlCAction", () => {
 });
 
 describe("TUI shutdown safety", () => {
+  it("registers SIGHUP shutdown on POSIX but not Windows", () => {
+    expect(getTuiShutdownSignals("linux")).toEqual(["SIGINT", "SIGTERM", "SIGHUP"]);
+    expect(getTuiShutdownSignals("darwin")).toEqual(["SIGINT", "SIGTERM", "SIGHUP"]);
+    expect(getTuiShutdownSignals("win32")).toEqual(["SIGINT", "SIGTERM"]);
+  });
+
   it("drains terminal input before stopping the TUI", async () => {
     const calls: string[] = [];
     const drainInput = vi.fn(async () => {
@@ -336,6 +344,40 @@ describe("TUI shutdown safety", () => {
         throw new Error("boom");
       });
     }).toThrow("boom");
+  });
+
+  it("bounds signal-exit cleanup when terminal drain hangs", async () => {
+    const stop = vi.fn();
+    const drainInput = vi.fn(() => new Promise<void>(() => {}));
+
+    await drainAndStopTuiForExitSafely(
+      {
+        stop,
+        terminal: { drainInput },
+      },
+      1,
+    );
+
+    expect(drainInput).toHaveBeenCalledOnce();
+    expect(drainInput).toHaveBeenCalledWith(1, 50);
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("swallows terminal stop errors during signal-exit cleanup", async () => {
+    const stop = vi.fn(() => {
+      throw new Error("dead terminal");
+    });
+
+    await expect(
+      drainAndStopTuiForExitSafely(
+        {
+          stop,
+        },
+        1,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(stop).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -363,6 +363,25 @@ describe("TUI shutdown safety", () => {
     expect(stop).toHaveBeenCalledOnce();
   });
 
+  it("still calls tui.stop() when terminal drain rejects (#75289)", async () => {
+    // Regression: if drainInput rejects (e.g. dead terminal after SIGHUP), the old
+    // implementation jumped into the catch block and skipped stopTuiSafely. Terminal
+    // listeners were left alive and the orphaned TUI process could not be killed cleanly.
+    const stop = vi.fn();
+    const drainInput = vi.fn(() => Promise.reject(new Error("terminal closed")));
+
+    await drainAndStopTuiForExitSafely(
+      {
+        stop,
+        terminal: { drainInput },
+      },
+      10,
+    );
+
+    expect(drainInput).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("swallows terminal stop errors during signal-exit cleanup", async () => {
     const stop = vi.fn(() => {
       throw new Error("dead terminal");

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -280,13 +280,18 @@ export async function drainAndStopTuiForExitSafely(
         }),
       ]);
     }
-    stopTuiSafely(() => tui.stop());
   } catch {
-    // Signal shutdown is best-effort. Do not keep an orphaned TUI alive because
-    // terminal cleanup threw after the controlling terminal disappeared.
+    // Drain is best-effort. A dead terminal can reject or timeout; stop runs regardless.
   } finally {
     if (timeout) {
       clearTimeout(timeout);
+    }
+    // Always stop the TUI — drain failure must not leave terminal listeners alive.
+    // Signal-exit cleanup: swallow all stop errors (terminal may already be dead).
+    try {
+      stopTuiSafely(() => tui.stop());
+    } catch {
+      // Ignore — we're in signal-exit cleanup, best-effort only.
     }
   }
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -252,6 +252,8 @@ type DrainableTui = {
   };
 };
 
+const TUI_EXIT_CLEANUP_TIMEOUT_MS = 1000;
+
 export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
   if (typeof tui.terminal?.drainInput === "function") {
     try {
@@ -261,6 +263,38 @@ export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
     }
   }
   stopTuiSafely(() => tui.stop());
+}
+
+export async function drainAndStopTuiForExitSafely(
+  tui: DrainableTui,
+  timeoutMs = TUI_EXIT_CLEANUP_TIMEOUT_MS,
+): Promise<void> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    if (typeof tui.terminal?.drainInput === "function") {
+      await Promise.race([
+        tui.terminal.drainInput(Math.max(1, timeoutMs), 50),
+        new Promise<void>((resolve) => {
+          timeout = setTimeout(resolve, Math.max(1, timeoutMs));
+          timeout.unref?.();
+        }),
+      ]);
+    }
+    stopTuiSafely(() => tui.stop());
+  } catch {
+    // Signal shutdown is best-effort. Do not keep an orphaned TUI alive because
+    // terminal cleanup threw after the controlling terminal disappeared.
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function getTuiShutdownSignals(
+  platform: NodeJS.Platform = process.platform,
+): NodeJS.Signals[] {
+  return platform === "win32" ? ["SIGINT", "SIGTERM"] : ["SIGINT", "SIGTERM", "SIGHUP"];
 }
 
 type CtrlCAction = "clear" | "warn" | "exit";
@@ -925,6 +959,16 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   });
 
   let finishTui: (() => void) | null = null;
+  const stopStatusUi = () => {
+    stopStatusTimer();
+    stopWaitingTimer();
+    try {
+      statusLoader?.stop();
+    } catch {
+      // Exit path only: a dead terminal should not keep the process alive.
+    }
+    statusLoader = null;
+  };
   const requestExit = (result?: Partial<TuiResult>) => {
     if (exitRequested) {
       return;
@@ -934,8 +978,9 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       exitReason: result?.exitReason ?? "exit",
       ...(result?.crestodianMessage ? { crestodianMessage: result.crestodianMessage } : {}),
     };
+    stopStatusUi();
     client.stop();
-    void drainAndStopTuiSafely(tui).then(() => {
+    void drainAndStopTuiForExitSafely(tui).finally(() => {
       finishTui?.();
     });
   };
@@ -1130,11 +1175,15 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const sigintHandler = () => {
     handleCtrlC();
   };
-  const sigtermHandler = () => {
+  const shutdownHandler = () => {
     requestExit();
   };
-  process.on("SIGINT", sigintHandler);
-  process.on("SIGTERM", sigtermHandler);
+  const signalHandlers = new Map<NodeJS.Signals, () => void>();
+  for (const signal of getTuiShutdownSignals()) {
+    const handler = signal === "SIGINT" ? sigintHandler : shutdownHandler;
+    process.on(signal, handler);
+    signalHandlers.set(signal, handler);
+  }
   tui.start();
   client.start();
   await new Promise<void>((resolve) => {
@@ -1142,8 +1191,10 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       if (isLocalMode) {
         setConsoleSubsystemFilter(previousConsoleSubsystemFilter);
       }
-      process.removeListener("SIGINT", sigintHandler);
-      process.removeListener("SIGTERM", sigtermHandler);
+      for (const [signal, handler] of signalHandlers) {
+        process.removeListener(signal, handler);
+      }
+      signalHandlers.clear();
       process.removeListener("exit", finish);
       finishTui = null;
       resolve();


### PR DESCRIPTION
## Summary

- handle POSIX `SIGHUP` as a TUI shutdown signal so terminal-tab close follows the same exit path as SIGTERM
- stop status loader/timers before exit cleanup and bound terminal drain to avoid orphaned spinner/render loops
- keep normal Ctrl+C behavior unchanged while making signal shutdown best-effort and idempotent

Fixes #75289.

## Pre-implement audit

- Existing helper: reused `drainAndStopTuiSafely` / `stopTuiSafely` shape and added a bounded exit-only wrapper instead of changing normal suspend behavior.
- Shared callers: `drainAndStopTuiSafely` remains unchanged for existing callers; `runTui` uses the new exit-only helper only on shutdown.
- Broader rival: no open PR references #75289; existing TUI PRs target different surfaces.

## Tests

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/tui/tui.ts src/tui/tui.test.ts`
- `pnpm test src/tui/tui.test.ts -- --run`
- `pnpm check:changed` *(passes conflict/changelog/extension guards, duplicate coverage, core typecheck, core test typecheck; fails at existing oxlint config parse: `Rule 'no-underscore-dangle' not found in plugin 'eslint'`)*
