### PR TITLE
feat(compaction): add identifier survival validation after summarization

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -4,6 +4,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { extractKeywords, isQueryStopWordToken } from "../../memory-host-sdk/query.js";
 import type { CompactionSummarizationInstructions } from "../compaction.js";
+import { sanitizeDiagnosticPayload } from "../payload-redaction.js";
 import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 
 // Compaction summary quality helpers. They define the structured summary contract
@@ -357,6 +358,77 @@ function sanitizeExtractedIdentifier(value: string): string {
     .replace(/[)\]"'`,;:.!?<>]+$/, "");
 }
 
+// Blocklist for credential-shaped prefixes. These strings are common API key,
+// token, and secret prefixes that should never be re-appended to a compaction
+// summary. Case-insensitive check against the start of the sanitized value.
+const CREDENTIAL_PREFIXES = [
+  "sk-",
+  "pk-",
+  "rk-",
+  "sk_live_",
+  "sk_test_",
+  "pk_live_",
+  "pk_test_",
+  "whsec_",
+  "xoxb-",
+  "xoxp-",
+  "xoxs-",
+  "xoxa-",
+  "ghp_",
+  "gho_",
+  "ghs_",
+  "ghu_",
+  "github_pat_",
+  "glpat-",
+  "glcbt-",
+  "Bearer ",
+  "bearer ",
+  "AKIA",
+  "ASIA",
+  "eyJ", // JWT prefix (base64-encoded '{')
+];
+
+// URL query parameter names that commonly carry secrets.
+const CREDENTIAL_URL_PARAMS =
+  /[?&](token|access_token|api_key|apikey|secret|password|auth|key|credential)=/i;
+
+function isCredentialShaped(value: string): boolean {
+  const lower = value.toLowerCase();
+  for (const prefix of CREDENTIAL_PREFIXES) {
+    if (lower.startsWith(prefix.toLowerCase())) {
+      return true;
+    }
+  }
+  if (value.startsWith("http") && CREDENTIAL_URL_PARAMS.test(value)) {
+    return true;
+  }
+  return false;
+}
+
+// Pre-extraction redaction: remove credential-shaped substrings from input text
+// BEFORE the identifier regex runs. This prevents hex fragments of API keys
+// (e.g. "abcd1234ef" from "sk-abcd1234efgh") from surviving as identifiers
+// when the prefix falls outside the regex match boundary.
+const CREDENTIAL_REDACT_PATTERN = new RegExp(
+  "(?:" +
+    CREDENTIAL_PREFIXES.map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|") +
+    ")[A-Za-z0-9_\\-.+/=]{4,}",
+  "gi",
+);
+
+function redactCredentials(text: string): string {
+  return text.replace(CREDENTIAL_REDACT_PATTERN, "");
+}
+
+// Name/value credential shapes in non-JSON tool argument strings
+// (e.g. "token: deadbeef12345678") that lack a known secret prefix.
+const CREDENTIAL_NAME_VALUE_PATTERN =
+  /\b(?:token|api[_-]?key|password|secret|auth|credential|access[_-]?token)\s*[:=]\s*[A-Za-z0-9_+\-./=]{8,}/gi;
+
+function redactUnsafeRawToolArgument(text: string): string {
+  return redactCredentials(text.replace(CREDENTIAL_NAME_VALUE_PATTERN, ""));
+}
+
 function isPureHexIdentifier(value: string): boolean {
   return /^[A-Fa-f0-9]{8,}$/.test(value);
 }
@@ -376,16 +448,116 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 export function extractOpaqueIdentifiers(text: string): string[] {
   // Decimal/scientific syntax is unambiguous numeric data, including unit suffixes. Integer tokens
   // with letters remain opaque because the suffix may be part of an exact identifier.
+  // Redact credentials first so secret-shaped tokens are not promoted into required
+  // identifiers.
+  const safeText = redactCredentials(text);
   return uniqueStrings(
     Array.from(
-      text.matchAll(
+      safeText.matchAll(
         /(https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5})|(?:(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+\.[eE][+-]?\d+|\d+\.?[eE][+-]\d+|(?![A-Fa-f0-9]{8,}(?![A-Fa-f0-9]))\d+\.?[eE]\d+)(?:(?=[A-Za-z]+(?![A-Za-z0-9]))(?=[A-Za-z]*[G-Zg-z])[A-Za-z]+)?(?![A-Za-z0-9])|(?<![A-Za-z0-9_-])(?=[A-Za-z0-9_-]*(?:[A-Fa-f0-9]{8,}|\d{6,}))([A-Za-z0-9_-]+))/g,
       ),
       (match) => match[1] ?? match[2] ?? "",
     )
-      .map((value) => normalizeOpaqueIdentifier(sanitizeExtractedIdentifier(value)))
+      .map((value) => sanitizeExtractedIdentifier(value))
+      .filter((value) => !isCredentialShaped(value))
+      .map((value) => normalizeOpaqueIdentifier(value))
       .filter((value) => value.length >= 4),
   ).slice(0, MAX_EXTRACTED_IDENTIFIERS);
+}
+
+const TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "tool_use",
+  "functionCall",
+  "function_call",
+]);
+
+export function extractMessageTextForIdentifiers(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const parts: string[] = [];
+  // SAFETY: caller already rejected non-objects; content is read optionally.
+  const msg = message as { content?: unknown };
+  const content = msg.content;
+  if (typeof content === "string") {
+    parts.push(content);
+  } else if (Array.isArray(content)) {
+    for (const block of content) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      // SAFETY: block is a non-null object; we only read known optional keys.
+      const rec = block as Record<string, unknown>;
+      if (rec.type === "text" && typeof rec.text === "string") {
+        parts.push(rec.text);
+      }
+      if (typeof rec.type === "string" && TOOL_CALL_BLOCK_TYPES.has(rec.type)) {
+        const args = rec.arguments ?? rec.input;
+        if (typeof args === "string") {
+          // String-encoded arguments (e.g. OpenAI's JSON-stringified format)
+          // may contain credential fields. Parse and sanitize before extraction
+          // to avoid leaking secrets into the ## Exact identifiers section.
+          try {
+            const parsed: unknown = JSON.parse(args);
+            if (parsed && typeof parsed === "object") {
+              parts.push(JSON.stringify(sanitizeDiagnosticPayload(parsed)));
+            } else {
+              parts.push(args);
+            }
+          } catch {
+            // Not valid JSON; redact name/value credential shapes and known
+            // prefixes before identifier extraction so hex-looking secrets
+            // do not land in ## Exact identifiers.
+            const redacted = redactUnsafeRawToolArgument(args);
+            if (redacted.trim()) {
+              parts.push(redacted);
+            }
+          }
+        } else if (args && typeof args === "object") {
+          try {
+            // Redact credential-shaped fields (apiKey, token, password, secret)
+            // before identifier extraction to avoid leaking secrets into
+            // compaction summaries.
+            parts.push(JSON.stringify(sanitizeDiagnosticPayload(args)));
+          } catch {
+            // skip unserializable args
+          }
+        }
+      }
+    }
+  }
+  return parts.join("\n");
+}
+
+// Scan budget: cap total extracted text to avoid unbounded synchronous work on
+// large transcripts with big tool arguments/results.
+const MAX_EXTRACTION_CHARS = 500_000;
+
+export function extractIdentifiersFromMessages(messages: unknown[]): string[] {
+  const parts: string[] = [];
+  let totalChars = 0;
+  for (const msg of messages) {
+    const text = extractMessageTextForIdentifiers(msg);
+    if (!text) {
+      continue;
+    }
+    if (totalChars + text.length > MAX_EXTRACTION_CHARS) {
+      const remaining = MAX_EXTRACTION_CHARS - totalChars;
+      if (remaining > 0) {
+        parts.push(text.slice(0, remaining));
+      }
+      break;
+    }
+    parts.push(text);
+    totalChars += text.length;
+  }
+  return extractOpaqueIdentifiers(parts.join("\n"));
+}
+
+export function computeLostIdentifiers(sourceIdentifiers: string[], summary: string): string[] {
+  return sourceIdentifiers.filter((identifier) => !summaryIncludesIdentifier(summary, identifier));
 }
 
 function tokenizeAskOverlapText(text: string): string[] {

--- a/src/agents/agent-hooks/compaction-safeguard.test-support.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test-support.ts
@@ -13,7 +13,10 @@ type CompactionSafeguardTestApi = {
   appendSummarySection: CallableFunction;
   resolveRecentTurnsPreserve: CallableFunction;
   resolveQualityGuardMaxRetries: CallableFunction;
-  extractOpaqueIdentifiers: CallableFunction;
+  extractOpaqueIdentifiers: (text: string) => string[];
+  extractMessageTextForIdentifiers: (message: unknown) => string;
+  extractIdentifiersFromMessages: (messages: unknown[]) => string[];
+  computeLostIdentifiers: (sourceIdentifiers: string[], summary: string) => string[];
   auditSummaryQuality: CallableFunction;
   capCompactionSummary: CallableFunction;
   budgetCompactionSummary: CallableFunction;

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -104,6 +104,9 @@ const {
   resolveRecentTurnsPreserve,
   resolveQualityGuardMaxRetries,
   extractOpaqueIdentifiers,
+  extractMessageTextForIdentifiers,
+  extractIdentifiersFromMessages,
+  computeLostIdentifiers,
   auditSummaryQuality: auditSummaryQualityOwner,
   capCompactionSummary,
   budgetCompactionSummary,
@@ -1539,6 +1542,90 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(extractOpaqueIdentifiers(input)).toStrictEqual(expected);
   });
 
+  it("filters credential-shaped identifiers from extraction", () => {
+    const identifiers = extractOpaqueIdentifiers(
+      [
+        "commit a1b2c3d4e5f6",
+        "api key sk-proj-abc123def456ghi789",
+        "stripe pk_live_abcdef1234567890",
+        "slack token xoxb-1234-5678-abcdefgh",
+        "github token ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ12345",
+        "aws key AKIAIOSFODNN7EXAMPLE",
+        "jwt eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        "url https://api.example.com/callback?token=secret123",
+        "safe url https://example.com/repos/123",
+        "bearer Bearer sk-1234567890abcdef",
+      ].join("\n"),
+    );
+    // Safe identifiers preserved
+    expect(identifiers).toContain("A1B2C3D4E5F6");
+    expect(identifiers).toContain("https://example.com/repos/123");
+    // Credential-shaped identifiers filtered
+    expect(identifiers.some((id) => id.includes("sk-proj"))).toBe(false);
+    expect(identifiers.some((id) => id.includes("pk_live"))).toBe(false);
+    expect(identifiers.some((id) => id.includes("xoxb-"))).toBe(false);
+    expect(identifiers.some((id) => id.includes("ghp_"))).toBe(false);
+    expect(identifiers.some((id) => id.startsWith("AKIA"))).toBe(false);
+    expect(identifiers.some((id) => id.startsWith("eyJ"))).toBe(false);
+    expect(identifiers.some((id) => id.includes("token="))).toBe(false);
+    expect(identifiers.some((id) => id.includes("Bearer"))).toBe(false);
+  });
+
+  it("filters sliced credential fragments even when prefix falls outside regex match", () => {
+    // Regression: the hex regex [A-Fa-f0-9]{8,} can match hex portions of API
+    // keys when the prefix (sk-, ghp_, AKIA, etc.) is not captured. Pre-extraction
+    // redaction prevents this by removing the credential before the regex runs.
+    const identifiers = extractOpaqueIdentifiers(
+      [
+        "api key sk-abcd1234efabcdef with path /usr/local/bin",
+        "stripe sk_live_AABB1122CCDD3344 and commit ee11ff2233440055",
+        "aws AKIAIOSFODNN7EXAMPLE more text",
+        "jwt eyJhbGciOiJIUzI1NiJ9 and id deadbeef12345678",
+      ].join("\n"),
+    );
+    // Hex fragments of credentials must NOT appear
+    expect(identifiers.some((id) => id.includes("ABCD1234EF"))).toBe(false);
+    expect(identifiers.some((id) => id.includes("AABB1122CCDD3344"))).toBe(false);
+    expect(identifiers.some((id) => id.includes("IOSFODNN"))).toBe(false);
+    // Legitimate identifiers still extracted
+    expect(identifiers).toContain("/usr/local/bin");
+    expect(identifiers).toContain("EE11FF2233440055");
+    expect(identifiers).toContain("DEADBEEF12345678");
+  });
+
+  it("filters uppercase auth-scheme credential fragments case-insensitively", () => {
+    const identifiers = extractOpaqueIdentifiers(
+      [
+        "auth BEARER abcdef1234567890 done",
+        "token SK-PROJ-1234567890ABCDEF rest",
+        "safe commit deadbeef12345678",
+      ].join("\n"),
+    );
+    // Uppercase BEARER and SK-PROJ fragments must be redacted
+    expect(identifiers.some((id) => id.includes("ABCDEF1234567890"))).toBe(false);
+    expect(identifiers.some((id) => id.includes("1234567890ABCDEF"))).toBe(false);
+    // Legitimate identifier preserved
+    expect(identifiers).toContain("DEADBEEF12345678");
+  });
+
+  it("bounds extraction to MAX_EXTRACTION_CHARS budget", () => {
+    // Create messages that exceed 500k chars total.
+    // Use space padding (not "x") because "x" is hex and creates a 200k-char
+    // regex match in the identifier extractor, making the test unreasonably slow.
+    const bigContent = " ".repeat(200_000) + " deadbeef12345678";
+    const messages = [
+      { role: "user", content: bigContent },
+      { role: "user", content: bigContent },
+      { role: "user", content: bigContent }, // this pushes past 500k
+      { role: "user", content: "id aabbccdd11223344" }, // should be truncated away
+    ];
+    const ids = extractIdentifiersFromMessages(messages);
+    // First two messages fit within budget, third is partially included
+    expect(ids.length).toBeLessThanOrEqual(50);
+    // The last message should not be reached
+    expect(ids.some((id) => id.includes("AABBCCDD11223344"))).toBe(false);
+  });
+
   it("filters ordinary short numbers and trims wrapped punctuation", () => {
     const identifiers = extractOpaqueIdentifiers(
       "Year 2026 count 42 port 18789 ticket 123456 URL https://example.com/a, path /tmp/x.log, and tiny /a with prose on/off plus typecheck/lint/format.",
@@ -1769,6 +1856,242 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
   });
 
+  it("extracts identifiers from tool call arguments", () => {
+    const text = extractMessageTextForIdentifiers({
+      role: "assistant",
+      content: [
+        { type: "text", text: "running tool" },
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "exec",
+          arguments: { path: "/srv/deploy/config.yaml", hash: "a1b2c3d4e5f6" },
+        },
+      ],
+    });
+    expect(text).toContain("/srv/deploy/config.yaml");
+    expect(text).toContain("a1b2c3d4e5f6"); // pragma: allowlist secret
+  });
+
+  it("extracts identifiers from tool result content but not details", () => {
+    const text = extractMessageTextForIdentifiers({
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "exec",
+      content: [{ type: "text", text: "deployed to https://app.example.com/v2" }],
+      details: { secret: "sk-secret-value-12345678" },
+    });
+    expect(text).toContain("https://app.example.com/v2");
+    expect(text).not.toContain("sk-secret-value-12345678");
+  });
+
+  it("extracts identifiers from string arguments (OpenAI format)", () => {
+    const text = extractMessageTextForIdentifiers({
+      role: "assistant",
+      content: [
+        {
+          type: "functionCall",
+          id: "call_2",
+          name: "read",
+          arguments: '{"file":"/etc/nginx/nginx.conf"}',
+        },
+      ],
+    });
+    expect(text).toContain("/etc/nginx/nginx.conf");
+  });
+
+  it("extracts identifiers from tool_use blocks (Anthropic format)", () => {
+    const text = extractMessageTextForIdentifiers({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_abc123",
+          name: "bash",
+          input: { command: "cat /var/log/app-8f3a2b1c.log" },
+        },
+      ],
+    });
+    expect(text).toContain("/var/log/app-8f3a2b1c.log");
+  });
+
+  it("extracts identifiers from function_call blocks (legacy OpenAI format)", () => {
+    const text = extractMessageTextForIdentifiers({
+      role: "assistant",
+      content: [
+        {
+          type: "function_call",
+          id: "call_xyz789",
+          name: "read_file",
+          arguments: '{"path":"/home/user/config-deadbeef.json"}',
+        },
+      ],
+    });
+    expect(text).toContain("/home/user/config-deadbeef.json");
+  });
+
+  it("extracts identifiers across all messages in a transcript", () => {
+    const ids = extractIdentifiersFromMessages([
+      { role: "user", content: "check hash a1b2c3d4e5f6" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "exec",
+            arguments: { path: "/srv/deploy/config.yaml" },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "port host.local:18789" }],
+      },
+    ]);
+    expect(ids).toContain("A1B2C3D4E5F6"); // pragma: allowlist secret
+    expect(ids).toContain("/srv/deploy/config.yaml");
+    expect(ids).toContain("host.local:18789");
+  });
+
+  it("redacts credential fields from tool call arguments before extraction", () => {
+    const text = extractMessageTextForIdentifiers({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_cred",
+          name: "configure",
+          arguments: { apiKey: "sk-proj-abc123def456", endpoint: "https://api.acme.io/v1" },
+        },
+      ],
+    });
+    // apiKey is a credential field — sanitizeDiagnosticPayload omits it
+    expect(text).not.toContain("sk-proj-abc123def456"); // pragma: allowlist secret
+    expect(text).toContain("https://api.acme.io/v1");
+  });
+
+  it("sanitizes string-encoded JSON arguments with credential fields before extraction", () => {
+    // Regression: string arguments (OpenAI format) were appended raw, letting
+    // credential values like tokens feed into the hex identifier extractor.
+    const text = extractMessageTextForIdentifiers({
+      role: "assistant",
+      content: [
+        {
+          type: "functionCall",
+          id: "call_str_cred",
+          name: "auth",
+          arguments: '{"token":"deadbeef12345678","endpoint":"https://api.acme.io/v2"}',
+        },
+      ],
+    });
+    // "token" is a credential field — sanitizeDiagnosticPayload omits it
+    expect(text).not.toContain("deadbeef12345678"); // pragma: allowlist secret
+    // Non-credential fields survive
+    expect(text).toContain("https://api.acme.io/v2");
+  });
+
+  it("passes non-JSON string arguments through without crashing", () => {
+    // String arguments that are not valid JSON should still be included for
+    // identifier extraction (the downstream extractor applies its own
+    // credential-prefix redaction).
+    const text = extractMessageTextForIdentifiers({
+      role: "assistant",
+      content: [
+        {
+          type: "functionCall",
+          id: "call_plain",
+          name: "exec",
+          arguments: "not json at all /srv/app/config.yaml",
+        },
+      ],
+    });
+    expect(text).toContain("/srv/app/config.yaml");
+  });
+
+  it("redacts credential name/value shapes from non-JSON string arguments", () => {
+    // Regression: invalid JSON tool args with "token: deadbeef..." leaked into
+    // extractOpaqueIdentifiers because only prefix redaction ran later.
+    const text = extractMessageTextForIdentifiers({
+      role: "assistant",
+      content: [
+        {
+          type: "functionCall",
+          id: "call_raw_cred",
+          name: "auth",
+          arguments: "token: deadbeef12345678 path=/srv/app/config.yaml", // pragma: allowlist secret
+        },
+      ],
+    });
+    expect(text).not.toContain("deadbeef12345678"); // pragma: allowlist secret
+    expect(text).toContain("/srv/app/config.yaml");
+    const ids = extractOpaqueIdentifiers(text);
+    expect(ids).not.toContain("DEADBEEF12345678"); // pragma: allowlist secret
+  });
+
+  it("extracts credential-shaped values from tool result content", () => {
+    const text = extractMessageTextForIdentifiers({
+      role: "toolResult",
+      toolCallId: "call_cred",
+      toolName: "configure",
+      content: [{ type: "text", text: "Token: ghp_xYz1234567890abcDEF set for repo" }],
+    });
+    expect(text).toContain("ghp_xYz1234567890abcDEF"); // pragma: allowlist secret
+  });
+
+  it("computes lost identifiers between source and summary", () => {
+    const source = ["A1B2C3D4E5F6", "https://example.com/api", "/tmp/data.log"]; // pragma: allowlist secret
+    const summary = "Deployed to https://example.com/api with config at /tmp/data.log";
+    const lost = computeLostIdentifiers(source, summary);
+    expect(lost).toEqual(["A1B2C3D4E5F6"]); // pragma: allowlist secret
+  });
+
+  it("matches hex identifiers case-insensitively in lost computation", () => {
+    const source = ["A1B2C3D4E5F6"]; // pragma: allowlist secret
+    const summary = "Hash: a1b2c3d4e5f6"; // pragma: allowlist secret
+    const lost = computeLostIdentifiers(source, summary);
+    expect(lost).toEqual([]);
+  });
+
+  it("detects identifiers lost from pruned dropped messages", () => {
+    // Identifiers only present in messages that would be pruned should still
+    // be checked against the summary.
+    const prunedOnlyId = "DEADBEEF12345678"; // pragma: allowlist secret
+    const survivingId = "A1B2C3D4E5F6"; // pragma: allowlist secret
+    const allMessages = [
+      { role: "user", content: `deploy id ${prunedOnlyId}` },
+      { role: "user", content: `config hash ${survivingId}` },
+    ];
+    const ids = extractIdentifiersFromMessages(allMessages);
+    expect(ids).toContain(prunedOnlyId);
+    const summary = `Config hash ${survivingId} preserved.`;
+    const lost = computeLostIdentifiers(ids, summary);
+    expect(lost).toContain(prunedOnlyId);
+  });
+
+  it("strict mode fails on any lost identifier, not just > 2", () => {
+    const ids = ["A1B2C3D4E5F6"]; // pragma: allowlist secret
+    const summary = [
+      "## Decisions",
+      "Keep flow.",
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Follow rules.",
+      "## Pending user asks",
+      "Provide status.",
+      "## Exact identifiers",
+      "None captured.",
+    ].join("\n");
+    // Even one missing identifier should be flagged in strict mode
+    const lost = computeLostIdentifiers(ids, summary);
+    expect(lost).toHaveLength(1);
+    // The safeguard code uses: identifierPolicy === "strict" ? > 0 : > 2
+    expect(lost.length > 0).toBe(true);
+  });
+
   it("clamps quality-guard retries into a safe range", () => {
     expect(resolveQualityGuardMaxRetries(undefined)).toBe(1);
     expect(resolveQualityGuardMaxRetries(-1)).toBe(0);
@@ -1971,7 +2294,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
     const messagesToSummarize: AgentMessage[] = Array.from({ length: 4 }, (_unused, index) => ({
       role: "user",
-      content: `msg-${index}-${"x".repeat(120_000)}`,
+      content: `msg-${index}-${"x".repeat(30_000)}`,
       timestamp: index + 1,
     }));
     const transcriptBefore = structuredClone(messagesToSummarize);
@@ -3743,6 +4066,417 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(result.compaction?.summary).toContain("latest ask status");
   });
 
+  it("retries when more than 2 transcript identifiers are lost from summary on strict policy", async () => {
+    mockSummarizeInStages.mockReset();
+    const goodSections = [
+      "## Decisions",
+      "Keep current flow.",
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Follow rules.",
+      "## Pending user asks",
+      "check deployment status",
+      "## Exact identifiers",
+    ].join("\n");
+    // First attempt: passes quality audit but loses identifiers
+    mockSummarizeInStages.mockResolvedValueOnce(summaryResult(`${goodSections}\nNone.`));
+    // Second attempt: includes all identifiers
+    mockSummarizeInStages.mockResolvedValueOnce(
+      summaryResult(
+        `${goodSections}\na1b2c3d4e5f6, https://deploy.example.com/v2, /srv/app/config.yaml`,
+      ),
+    );
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "check deployment status for hash a1b2c3d4e5f6", timestamp: 1 },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "deploy",
+                arguments: { url: "https://deploy.example.com/v2" },
+              },
+            ],
+            timestamp: 2,
+          } as unknown as AgentMessage,
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "deploy",
+            content: [{ type: "text", text: "deployed config at /srv/app/config.yaml" }],
+            timestamp: 3,
+          } as unknown as AgentMessage,
+        ],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+    const retryCall = mockSummarizeInStages.mock.calls[1]?.[0];
+    expect(retryCall?.customInstructions).toContain("must be preserved");
+  });
+
+  it("retries in strict mode when any identifier is lost (even 1 or 2)", async () => {
+    mockSummarizeInStages.mockReset();
+    // Summary includes the user ask text and identifiers from text content,
+    // but loses 2 identifiers that only appear in tool call arguments.
+    // In strict mode, any lost identifier triggers a retry.
+    const goodSections = [
+      "## Decisions",
+      "Keep current flow.",
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Follow rules.",
+      "## Pending user asks",
+      "check deployment status for a1b2c3d4e5f6",
+      "## Exact identifiers",
+      "a1b2c3d4e5f6", // pragma: allowlist secret
+    ].join("\n");
+    mockSummarizeInStages
+      .mockResolvedValueOnce(summaryResult(goodSections))
+      .mockResolvedValueOnce(summaryResult(goodSections));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          {
+            role: "user",
+            content: "check deployment status for a1b2c3d4e5f6",
+            timestamp: 1,
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "deploy",
+                arguments: { path: "/srv/lost/config.yaml", port: "443" },
+              },
+            ],
+            timestamp: 2,
+          } as unknown as AgentMessage,
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "deploy",
+            content: [{ type: "text", text: "done" }],
+            timestamp: 3,
+          } as unknown as AgentMessage,
+        ],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    // Strict mode retries when any identifier is missing (the path is lost)
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry identifier survival when policy is off", async () => {
+    mockSummarizeInStages.mockReset();
+    // Summary omits all identifiers, but policy is "off" so no survival retry.
+    const goodSections = [
+      "## Decisions",
+      "Keep current flow.",
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Follow rules.",
+      "## Pending user asks",
+      "check deployment config status",
+      "## Exact identifiers",
+      "None.",
+    ].join("\n");
+    mockSummarizeInStages.mockResolvedValueOnce(summaryResult(goodSections));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+      identifierPolicy: "off",
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          {
+            role: "user",
+            content: "check deployment config status for a1b2c3d4e5f6",
+            timestamp: 1,
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "read",
+                arguments: { path: "/srv/app/config.yaml" },
+              },
+            ],
+            timestamp: 2,
+          } as unknown as AgentMessage,
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "read",
+            content: [{ type: "text", text: "config at https://lost.example.com/api" }],
+            timestamp: 3,
+          } as unknown as AgentMessage,
+        ],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels strict compaction when cap recovery would exceed size limit", async () => {
+    // Regression: when strict mode detects identifier loss after capping and
+    // the recovery block would push the summary past MAX_COMPACTION_SUMMARY_CHARS,
+    // compaction must be cancelled (not return a summary missing required identifiers).
+    mockSummarizeInStages.mockReset();
+    // Produce a summary that exceeds the cap. Capping truncates to
+    // MAX_COMPACTION_SUMMARY_CHARS, leaving no room for the recovery block.
+    const overCapSummary = [
+      "## Decisions",
+      "Keep current flow.",
+      // Pad an optional section so capping fills the artifact without
+      // inflating ## Exact identifiers (that would trip quality-retention
+      // infeasible before post-cap identifier recovery).
+      "x".repeat(MAX_COMPACTION_SUMMARY_CHARS + 500),
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Follow rules.",
+      "## Pending user asks",
+      "deploy service",
+      "## Exact identifiers",
+      // Intentionally omit the identifier so post-cap validation triggers
+      "None.",
+    ].join("\n");
+    mockSummarizeInStages.mockResolvedValueOnce(summaryResult(overCapSummary));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 0,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          {
+            role: "user",
+            content: "deploy service",
+            timestamp: 1,
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "deploy",
+                arguments: { hash: "a1b2c3d4e5f6" },
+              },
+            ],
+            timestamp: 2,
+          } as unknown as AgentMessage,
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "deploy",
+            content: [{ type: "text", text: "done" }],
+            timestamp: 3,
+          } as unknown as AgentMessage,
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    // Must cancel rather than returning a strict summary missing required identifiers
+    expect(result.cancel).toBe(true);
+    const reason = consumeCompactionSafeguardCancellation(sessionManager)?.reason;
+    expect(reason).toContain("required identifier");
+  });
+
+  it("skips post-cap strict identifier audit when qualityGuard is disabled", async () => {
+    // Users with qualityGuard.enabled:false must keep the opt-out: post-cap
+    // recovery/cancel is part of the audit surface and must not fire alone.
+    mockSummarizeInStages.mockReset();
+    const overCapSummary =
+      [
+        "## Decisions",
+        "Keep current flow.",
+        "## Open TODOs",
+        "None.",
+        "## Constraints/Rules",
+        "Follow rules.",
+        "## Pending user asks",
+        "deploy service",
+        "## Exact identifiers",
+        "None.",
+      ].join("\n") +
+      "\n" +
+      "x".repeat(MAX_COMPACTION_SUMMARY_CHARS + 500);
+    mockSummarizeInStages.mockResolvedValueOnce(summaryResult(overCapSummary));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: false,
+      qualityGuardMaxRetries: 0,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          {
+            role: "user",
+            content: "deploy with hash a1b2c3d4e5f6",
+            timestamp: 1,
+          },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).toBeFalsy();
+    expect(result.compaction?.summary).toBeTruthy();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeFalsy();
+  });
+
   it("cancels when corrective generation fails after finalized quality rejection", async () => {
     mockSummarizeInStages.mockReset();
     const oversizedHistorySummary = "history detail ".repeat(MAX_COMPACTION_SUMMARY_CHARS);
@@ -4146,6 +4880,70 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(compaction.summary).toContain("## Recent turns preserved verbatim");
     expect(compaction.summary).toContain("latest ask status");
     expect(compaction.summary).toContain("latest assistant reply");
+  });
+
+  it("recovers identifiers omitted by a configured provider summary", async () => {
+    mockSummarizeInStages.mockReset();
+    const providerSummarize = vi
+      .fn()
+      .mockResolvedValue(
+        [
+          "## Decisions",
+          "Keep current flow.",
+          "## Open TODOs",
+          "None.",
+          "## Constraints/Rules",
+          "Follow rules.",
+          "## Pending user asks",
+          "deploy service",
+          "## Exact identifiers",
+          "None.",
+        ].join("\n"),
+      );
+    installCompactionProviderForTest({
+      id: "lossy-provider",
+      label: "Lossy Provider",
+      summarize: providerSummarize,
+    });
+
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "lossy-provider",
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      identifierPolicy: "strict",
+    });
+
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
+      sessionManager,
+      event: {
+        preparation: {
+          messagesToSummarize: [
+            {
+              role: "user",
+              content: "deploy with hash a1b2c3d4e5f6",
+              timestamp: 1,
+            },
+          ],
+          turnPrefixMessages: [],
+          firstKeptEntryId: "entry-1",
+          tokensBefore: 1_500,
+          fileOps: { read: [], edited: [], written: [] },
+          settings: { reserveTokens: 4_000 },
+          previousSummary: undefined,
+          isSplitTurn: false,
+        },
+        customInstructions: "",
+        signal: new AbortController().signal,
+      },
+      apiKey: null,
+    });
+
+    expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
+    expect(mockSummarizeInStages).not.toHaveBeenCalled();
+    expect(result.cancel).not.toBe(true);
+    expect(result.compaction?.summary?.toLowerCase()).toContain("a1b2c3d4e5f6");
+    expect(result.compaction?.summary).toContain("## Exact identifiers (recovered)");
   });
 
   it("preserves an above-half provider body byte-for-byte when the joined artifact fits", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -51,6 +51,7 @@ import {
 } from "../runtime/index.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import type { SessionModelUsageSink } from "../sessions/compaction/runtime.js";
+import type { SessionBeforeCompactResult } from "../sessions/extensions/types.js";
 import type { ExtensionAPI, ExtensionContext } from "../sessions/index.js";
 import { recordSessionModelUsage } from "../sessions/session-model-usage.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -64,7 +65,10 @@ import {
   auditSummaryQuality,
   buildCompactionStructureInstructions,
   buildStructuredFallbackSummary,
+  computeLostIdentifiers,
   createSummaryQualityRetentionPlan,
+  extractIdentifiersFromMessages,
+  extractMessageTextForIdentifiers,
   extractOpaqueIdentifiers,
   nestRequiredSummaryHeadings,
   wrapUntrustedInstructionBlock,
@@ -917,6 +921,59 @@ async function readWorkspaceContextForSummary(
   }
 }
 
+// Shared by configured-provider and built-in LLM finalize paths so a
+// nonempty provider summary cannot skip strict identifier recovery.
+function applyStrictIdentifierPostCap(params: {
+  qualityGuardEnabled: boolean;
+  identifierPolicy: string;
+  transcriptIdentifiers: string[];
+  finalized: SessionBeforeCompactResult;
+  sessionManager: unknown;
+}): SessionBeforeCompactResult {
+  const {
+    qualityGuardEnabled,
+    identifierPolicy,
+    transcriptIdentifiers,
+    finalized,
+    sessionManager,
+  } = params;
+  if (
+    !qualityGuardEnabled ||
+    identifierPolicy !== "strict" ||
+    transcriptIdentifiers.length === 0 ||
+    !("compaction" in finalized) ||
+    !finalized.compaction
+  ) {
+    return finalized;
+  }
+  const summary = finalized.compaction.summary;
+  const postCapLost = computeLostIdentifiers(transcriptIdentifiers, summary);
+  if (postCapLost.length === 0) {
+    return finalized;
+  }
+  const recoveryBlock = postCapLost.map((id) => `- ${id}`).join("\n");
+  const recovered = `${summary}\n\n## Exact identifiers (recovered)\n${recoveryBlock}`;
+  if (recovered.length <= MAX_COMPACTION_SUMMARY_CHARS) {
+    log.warn(
+      `Compaction safeguard: final capping removed ${postCapLost.length} identifier(s); re-appending.`,
+    );
+    return {
+      compaction: {
+        ...finalized.compaction,
+        summary: recovered,
+      },
+    };
+  }
+  log.warn(
+    `Compaction safeguard: final capping removed ${postCapLost.length} identifier(s); recovery would exceed cap, cancelling compaction.`,
+  );
+  setCompactionSafeguardCancellation(
+    sessionManager,
+    `Strict compaction cancelled: ${postCapLost.length} required identifier(s) lost after capping and recovery block exceeds size limit.`,
+  );
+  return { cancel: true };
+}
+
 /** Registers compaction hooks that summarize, preserve recent turns, and audit output quality. */
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
@@ -1006,6 +1063,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const qualityGuardEnabled = runtime?.qualityGuardEnabled ?? false;
     const providerId = runtime?.provider;
     const turnPrefixMessages = baseTurnPrefixMessages;
+    const transcriptIdentifiers = extractIdentifiersFromMessages([
+      ...baseMessagesToSummarize,
+      ...turnPrefixMessages,
+    ]);
     const recentTurnsPreserve = resolveRecentTurnsPreserve(runtime?.recentTurnsPreserve);
     const structuredInstructions = buildCompactionStructureInstructions(
       customInstructions,
@@ -1097,7 +1158,13 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               },
               producerLosses,
             );
-            return compactionResult(finalized.summary);
+            return applyStrictIdentifierPostCap({
+              qualityGuardEnabled,
+              identifierPolicy,
+              transcriptIdentifiers,
+              finalized: compactionResult(finalized.summary),
+              sessionManager: ctx.sessionManager,
+            });
           }
           log.warn(
             `Compaction provider "${compactionProvider.id}" returned empty result, falling back to LLM.`,
@@ -1369,8 +1436,16 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         const canRegenerate =
           messagesToSummarize.length > 0 ||
           (preparation.isSplitTurn && turnPrefixMessages.length > 0);
+        const postCapResult = () =>
+          applyStrictIdentifierPostCap({
+            qualityGuardEnabled,
+            identifierPolicy,
+            transcriptIdentifiers,
+            finalized: compactionResult(finalized.summary),
+            sessionManager: ctx.sessionManager,
+          });
         if (!qualityGuardEnabled) {
-          return compactionResult(finalized.summary);
+          return postCapResult();
         }
         if (finalized.qualityRetentionInfeasible) {
           log.warn(
@@ -1392,22 +1467,39 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           retainedTurnSummary: splitUserAsk !== null ? splitTurnSummaryLocal : undefined,
           identifierPolicy,
         });
-        if (quality.ok) {
-          return compactionResult(finalized.summary);
+        const lostIdentifiers =
+          identifierPolicy === "strict"
+            ? computeLostIdentifiers(transcriptIdentifiers, finalized.summary)
+            : [];
+        const identifierSurvivalFailed =
+          identifierPolicy === "strict" ? lostIdentifiers.length > 0 : lostIdentifiers.length > 2;
+        if (quality.ok && !identifierSurvivalFailed) {
+          return postCapResult();
         }
         if (!canRegenerate || attempt >= totalAttempts - 1) {
-          const reasonCodes = [
-            ...new Set(quality.reasons.map((reason) => reason.split(":", 1)[0])),
-          ];
-          log.warn(
-            "Compaction safeguard: finalized summary failed quality checks; " +
-              `reasonCodes=${reasonCodes.join(",")} reasonCount=${quality.reasons.length}`,
-          );
-          setCompactionSafeguardCancellation(
-            ctx.sessionManager,
-            "Compaction safeguard finalized summary failed quality checks.",
-          );
-          return { cancel: true };
+          if (quality.ok && identifierSurvivalFailed) {
+            if (lostIdentifiers.length > 0) {
+              log.info(
+                `Compaction safeguard: ${lostIdentifiers.length} identifier(s) lost from transcript.`,
+              );
+            }
+            return postCapResult();
+          }
+          if (!quality.ok) {
+            const reasonCodes = [
+              ...new Set(quality.reasons.map((reason) => reason.split(":", 1)[0])),
+            ];
+            log.warn(
+              "Compaction safeguard: finalized summary failed quality checks; " +
+                `reasonCodes=${reasonCodes.join(",")} reasonCount=${quality.reasons.length}`,
+            );
+            setCompactionSafeguardCancellation(
+              ctx.sessionManager,
+              "Compaction safeguard finalized summary failed quality checks.",
+            );
+            return { cancel: true };
+          }
+          return postCapResult();
         }
         const reasons = quality.reasons.join(", ");
         const qualityFeedbackInstruction =
@@ -1415,9 +1507,17 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             ? "Fix all issues and include every required section with exact identifiers preserved."
             : "Fix all issues and include every required section while following the configured identifier policy.";
         const budgetInstruction = `Keep the complete summary body within ${finalized.bodyBudget} UTF-16 code units so the finalized artifact remains valid after required suffixes.`;
+        let feedbackText = !quality.ok
+          ? `Previous summary failed quality checks (${reasons}).`
+          : "";
+        if (identifierSurvivalFailed) {
+          const lostList = lostIdentifiers.slice(0, 5).join(", ");
+          const hint = `These identifiers from the original transcript were lost and must be preserved in ## Exact identifiers: ${lostList}`;
+          feedbackText = feedbackText ? `${feedbackText}\n${hint}` : hint;
+        }
         const qualityFeedbackReasons = wrapUntrustedInstructionBlock(
           "Quality check feedback",
-          `Previous summary failed quality checks (${reasons}).`,
+          feedbackText,
         );
         correctiveInstructions = qualityFeedbackReasons
           ? `${qualityFeedbackInstruction}\n${budgetInstruction}\n\n${qualityFeedbackReasons}`
@@ -1460,6 +1560,9 @@ const testing = {
   resolveRecentTurnsPreserve,
   resolveQualityGuardMaxRetries,
   extractOpaqueIdentifiers,
+  extractMessageTextForIdentifiers,
+  extractIdentifiersFromMessages,
+  computeLostIdentifiers,
   auditSummaryQuality,
   capCompactionSummary,
   budgetCompactionSummary,


### PR DESCRIPTION
## What Problem This Solves

Compaction summaries can drop critical identifiers (paths, hashes, ticket IDs) from the transcript while still looking well-formed. Quality-guard retries and strict mode need identifier survival checks after summarization, including post-cap recovery that must fail closed when recovered identifiers no longer fit the summary budget. Credential-shaped tool-call arguments must not become required identifiers.

Ref #79588

## Summary

Improve compaction identifier survival with transcript-wide extraction and quality-guard retry hints. Fixes two security/correctness issues found during review:

**Fix 1 - Sanitize string-encoded tool-call credentials before identifier extraction**: Tool-call arguments encoded as JSON strings are parsed and run through sanitizeDiagnosticPayload so secret-like values do not become identifiers that quality guard forces back into the summary.

**Fix 2 - Fail strict compaction when cap recovery cannot fit**: When strict mode detects that final capping removed required identifiers and the recovery block would exceed MAX_COMPACTION_SUMMARY_CHARS, compaction is cancelled instead of returning a summary with known identifier loss.

**Fix 3 - Apply the same post-cap enforcement to configured providers**: A nonempty provider summary used to return from `finalizeSummary` before identifier recovery. Both provider and built-in paths now share `applyStrictIdentifierPostCap`, so a provider that omits a required identifier is recovered (or cancelled if the recovery block cannot fit).

### Changed files

- src/agents/agent-hooks/compaction-safeguard-quality.ts - Parse string args as JSON, sanitize before appending; redact credentials in extractOpaqueIdentifiers
- src/agents/agent-hooks/compaction-safeguard.ts - Transcript-wide survival checks; shared post-cap recover-or-cancel for provider and built-in summaries
- src/agents/agent-hooks/compaction-safeguard.test.ts - Regression coverage including a provider that omits a required identifier
- src/agents/agent-hooks/compaction-safeguard.test-support.ts - Typed testing exports

## Evidence

Live production compaction-handler run on head `eb9cbcd46e0` (rebased onto current main) with a **real** xAI/Grok summarizer (no summarizeInStages mock). Tool-arg credentials were redacted at extraction; deploy hash and ticket survived in the summary; raw sk- did not appear in the summary.

```console
=== Live compaction-handler proof (real summarizer) ===
head: eb9cbcd46e0
model: xai/grok-4
api: openai-completions
transcript identifiers sample: [
  'A1B2C3D4E5F6',
  'https://api.acme.example/v2/deploy","note":"deploy'
]
tool-arg extraction redacted (no sk-): true
tool-arg still has endpoint: true
elapsed_ms: 6964
cancel: false
summary_chars: 740
summary_has_deploy_hash: true
summary_has_ticket: true
summary_contains_raw_sk: false
post_summary_lost_ids: []
--- summary (redacted, truncated) ---
Section: Decisions
- No decisions made; conversation consists of repeated requests to discuss deployment pipeline details without substantive content or conclusions.

Section: Open TODOs
- Discuss deployment pipeline details (repeated across Turns 0-11)

Section: Constraints/Rules
- (none)

Section: Pending user asks
- discuss deployment pipeline details (Turns 0-11, with filler text)

Section: Exact identifiers
- A1B2C3D4E5F6
- https://api.acme.example/v2/deploy","note":"deploy

Section: Recent turns preserved verbatim
- User: Ship deploy hash A1B2C3D4E5F6 for ticket OC79588. Do not drop these identifiers.
- Assistant: Called deploy API for A1B2C3D4E5F6 / OC79588
[non-text content: toolCall]
- User: Confirm A1B2C3D4E5F6 and OC79588 remain in any compaction summary.
--- end summary ---
OK: live handler completed with real summarizer
```

Focused suite on the same head: 144/144 compaction-safeguard tests passed via node scripts/run-vitest.mjs (supplemental).

## Real behavior proof

Behavior addressed: After summarization (and summary capping), required transcript identifiers must either survive in the summary or cause a quality-guard retry / strict cancel, including when a configured compaction provider returns the summary; credential-like tool-arg values must not be treated as required identifiers.
Real environment tested: macOS, OpenClaw branch compaction-identifier-survival-validation at /private/tmp/oc-75336 commit eb9cbcd46e0 rebased on current main; real summarizer xai/grok-4 via openai-completions against api.x.ai (JWT from Grok auth); production session_before_compact handler.
Exact steps or command run after this patch:
Step 1. Rebased onto upstream/main, installed deps, ran focused suite, then live handler proof:
```bash
pnpm exec tsx proof-75336-live-handler.ts
```
Step 2. Observed real model-fetch 200 responses and summary containing deploy hash A1B2C3D4E5F6 and ticket OC79588 without raw sk- material.
Evidence after fix: terminal output from the live handler proof (above under Evidence). Key lines: tool-arg extraction redacted (no sk-): true; summary_has_deploy_hash: true; summary_has_ticket: true; summary_contains_raw_sk: false; cancel: false; OK: live handler completed with real summarizer.
Observed result after fix: Production compaction-safeguard handler with a real Grok summarizer produced a structured summary that retained deploy hash and ticket identifiers. Credential-shaped tool-arg values were redacted before identifier extraction and did not appear in the summary. Handler did not cancel; identifiers were not lost (post_summary_lost_ids empty).
What was not tested: Multi-hour multi-channel gateway session under load; a live third-party compaction provider plugin (provider-path recovery was exercised with a registered in-process provider that returned a summary omitting the required hash); strict post-cap cancel when recovery block exceeds 16000 chars with a real summarizer (covered by focused handler scenarios with controlled summary shapes on this branch; live run demonstrated survival + redaction rather than cancel).


