### PR TITLE
fix(deepseek): strip reasoning_content from input messages when thinking is enabled

### DIFF
--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -259,7 +259,19 @@ function stripDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void
   }
 }
 
-function ensureDeepSeekV4AssistantReasoningContent(payload: Record<string, unknown>): void {
+/**
+ * Strip reasoning_content from assistant messages that did NOT perform a tool
+ * call while preserving it for tool-call turns.
+ *
+ * DeepSeek V4 thinking-mode contract:
+ *   • No-tool-call turns: reasoning_content should NOT be passed back; the
+ *     API silently ignores it, but older endpoints return 400.
+ *   • Tool-call turns: reasoning_content MUST be present in every subsequent
+ *     request or the API returns 400.
+ */
+function stripDeepSeekV4ReasoningContentForNonToolCallTurns(
+  payload: Record<string, unknown>,
+): void {
   if (!Array.isArray(payload.messages)) {
     return;
   }
@@ -271,9 +283,15 @@ function ensureDeepSeekV4AssistantReasoningContent(payload: Record<string, unkno
     if (record.role !== "assistant") {
       continue;
     }
-    if (!("reasoning_content" in record)) {
-      record.reasoning_content = "";
+    // Tool-call turns: preserve reasoning_content, backfill if missing
+    if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) {
+      if (!("reasoning_content" in record)) {
+        record.reasoning_content = "";
+      }
+      continue;
     }
+    // Non-tool-call turns: strip reasoning_content
+    delete record.reasoning_content;
   }
 }
 
@@ -302,7 +320,7 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
 
       payload.thinking = { type: "enabled" };
       payload.reasoning_effort = resolveDeepSeekV4ReasoningEffort(params.thinkingLevel);
-      stripDeepSeekV4ReasoningContent(payload);
+      stripDeepSeekV4ReasoningContentForNonToolCallTurns(payload);
     });
   };
 }

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -302,7 +302,7 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
 
       payload.thinking = { type: "enabled" };
       payload.reasoning_effort = resolveDeepSeekV4ReasoningEffort(params.thinkingLevel);
-      ensureDeepSeekV4AssistantReasoningContent(payload);
+      stripDeepSeekV4ReasoningContent(payload);
     });
   };
 }


### PR DESCRIPTION
## Problem

When using DeepSeek V4 reasoning models with thinking enabled, OpenClaw returns a **400 error** on multi-turn conversations:

> 400 The reasoning_content in the thinking mode must be passed back to the API.

## Root Cause

In `createDeepSeekV4OpenAICompatibleThinkingWrapper()`, when thinking is **enabled**, the code calls `ensureDeepSeekV4AssistantReasoningContent()` which **adds** an empty `reasoning_content` field to assistant messages that lack it.

However, DeepSeek's V4 thinking-mode contract is nuanced:

| Scenario | `reasoning_content` in input? |
|---|---|
| Non-tool-call follow-up turns | Should NOT be passed back (API ignores it; older endpoints return 400) |
| Tool-call continuation turns | MUST be passed back (API returns 400 if missing) |

The blanket `ensureDeepSeekV4AssistantReasoningContent()` was wrong because it backfills `reasoning_content` on ALL assistant messages, including non-tool-call turns where the field should be stripped.

## Fix

Introduce a new function `stripDeepSeekV4ReasoningContentForNonToolCallTurns()` that:

- **Preserves** `reasoning_content` for assistant messages with `tool_calls` (backfills with `""` if missing)
- **Strips** `reasoning_content` from all other assistant messages (non-tool-call turns)

The existing `stripDeepSeekV4ReasoningContent()` (strips ALL) is still used in the **thinking-disabled** branch where `reasoning_content` is unconditionally removed.

## Verification

This aligns with:
- DeepSeek's Thinking Mode documentation: *"if the model did not perform a tool call, the intermediate assistant's reasoning_content does not need to participate in the context concatenation"*
- DeepSeek's Thinking Mode documentation: *"if the model performed a tool call, the intermediate assistant's reasoning_content must participate in the context concatenation and must be passed back to the API in all subsequent user interaction turns"*
- The existing enabled-path behavior for tool-call replay (fixes for #71372, #73417)

## Related

- DeepSeek Thinking Mode docs: https://api-docs.deepseek.com/guides/thinking_mode
- Previous DeepSeek V4 fixes: #70931, #71372, #73417
