### PR TITLE
fix: harden sessions_send delegated announce trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/sessions: add a typed `sessions_send` hook for direct or delegated plugin delivery while preserving inter-session trust boundaries and current A2A safeguards. Thanks @jinon86.
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-7684d1cc87a531a1490bf9f5a9eab8a30518b95d93884ef8a025486aba6e29b1  plugin-sdk-api-baseline.json
-e297ee3f86e2753ede344ff9ef8d1e063ce5fc95816f574062e2a974e4f82601  plugin-sdk-api-baseline.jsonl
+eb23143850c3096c74f4136ee5c9dbd94880367298d044397c63427f325b4933  plugin-sdk-api-baseline.json
+7ba40f5d6fa1f20eb93afd90bf9c61154f80fec780e1eb33245ba6890ecd8ae8  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -119,6 +119,7 @@ observation-only.
 
 - **`before_tool_call`** - rewrite tool params, block execution, or require approval
 - `after_tool_call` - observe tool results, errors, and duration
+- **`sessions_send`** - claim `sessions_send` delivery directly or delegate it to a plugin-owned dispatcher
 - **`tool_result_persist`** - rewrite the assistant message produced from a tool result
 - **`before_message_write`** - inspect or block an in-progress message write (rare)
 
@@ -148,6 +149,8 @@ observation-only.
 - **`before_install`** - inspect skill or plugin install scans and optionally block
 
 ## Tool call policy
+
+`sessions_send` receives the resolved target session, original message, sanitized optional task metadata, and raw tool params. It may return `{ handled: false }`, a direct result, or a delegated dispatch result with a plugin-owned `taskId`/`waitRunId`. Core ignores caller-supplied `task.runtime.roundOneReply`; delegated announce seeding can only come from plugin dispatch output or reply history verified by the core wait path.
 
 `before_tool_call` receives:
 

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -7,9 +7,18 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 
 const callGatewayMock = vi.fn();
+const getGlobalHookRunnerMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => getGlobalHookRunnerMock(),
+}));
+
+type SessionsSendHookRunnerMock = {
+  hasHooks: ReturnType<typeof vi.fn>;
+  runSessionsSend: ReturnType<typeof vi.fn>;
+};
 const loadSessionEntryByKeyMock = vi.fn();
 vi.mock("./subagent-announce-delivery.js", () => ({
   loadSessionEntryByKey: (sessionKey: string) => loadSessionEntryByKeyMock(sessionKey),
@@ -176,6 +185,8 @@ describe("sessions tools", () => {
     sessionsSendA2ATesting.setDepsForTest({
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
+    getGlobalHookRunnerMock.mockReset();
+    getGlobalHookRunnerMock.mockReturnValue(null);
   });
 
   it("uses number (not integer) in tool schemas for Gemini compatibility", () => {
@@ -1479,5 +1490,326 @@ describe("sessions tools", () => {
       message: "announce now",
       threadId: "99",
     });
+  });
+
+  it("sessions_send falls back to core delivery when sessions_send hooks decline", async () => {
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => ({ handled: false, reason: "not delegated" })),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+    let historyCallCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-1", acceptedAt: 123 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyCallCount += 1;
+        return {
+          messages:
+            historyCallCount === 1
+              ? []
+              : [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "done" }],
+                    timestamp: 20,
+                  },
+                ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-hook-fallback", {
+      sessionKey: "main",
+      message: "wait",
+      timeoutSeconds: 1,
+      task: { intent: "delegate", instructions: "delegate wait" },
+    });
+
+    expect(result.details).toMatchObject({ status: "ok", reply: "done" });
+    expect(hookRunner.runSessionsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "main",
+        target: { sessionKey: "main", displayKey: "main" },
+        message: "wait",
+        task: expect.objectContaining({
+          intent: "delegate",
+          instructions: "delegate wait",
+        }),
+      }),
+      { requesterSessionKey: "discord:group:req", requesterChannel: "discord" },
+    );
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "agent",
+      ),
+    ).toBe(true);
+  });
+
+  it("sessions_send direct hook handling is not blocked by core reply-history failure", async () => {
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => ({
+        handled: true,
+        mode: "direct",
+        result: { status: "ok", deliveredBy: "plugin" },
+      })),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "chat.history") {
+        throw new Error("core reply history unavailable");
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-hook-before-history", {
+      sessionKey: "main",
+      message: "plugin owns delivery",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({ status: "ok", deliveredBy: "plugin" });
+    expect(hookRunner.runSessionsSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("sessions_send strips caller-supplied delegated roundOneReply before hooks", async () => {
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => ({
+        handled: true,
+        mode: "direct",
+        result: { status: "ok", deliveredBy: "plugin" },
+      })),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    await tool.execute("call-hook-malicious-round-one", {
+      sessionKey: "main",
+      message: "delegate this",
+      timeoutSeconds: 1,
+      task: {
+        intent: "delegate",
+        instructions: "delegate this",
+        runtime: {
+          roundOneReply: "MALICIOUS SPOOFED OUTPUT",
+          cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+        },
+      },
+    });
+
+    expect(hookRunner.runSessionsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          runtime: expect.objectContaining({
+            roundOneReply: undefined,
+            cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+          }),
+        }),
+        rawParams: expect.objectContaining({
+          task: expect.objectContaining({
+            runtime: expect.objectContaining({ roundOneReply: "MALICIOUS SPOOFED OUTPUT" }),
+          }),
+        }),
+      }),
+      { requesterSessionKey: "discord:group:req", requesterChannel: "discord" },
+    );
+  });
+
+  it("sessions_send waits on plugin-produced delegated metadata", async () => {
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => ({
+        handled: true,
+        mode: "delegated",
+        dispatch: {
+          kind: "a2a-broker",
+          taskId: "task-123",
+          waitRunId: "wait-123",
+          roundOneReply: "plugin verified round one",
+          cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+        },
+      })),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+    let historyCallCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent.wait") {
+        return { runId: "wait-123", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyCallCount += 1;
+        return {
+          messages:
+            historyCallCount === 1
+              ? []
+              : [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "delegated reply" }],
+                    timestamp: 20,
+                  },
+                ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-hook-delegated", {
+      sessionKey: "main",
+      message: "delegate this",
+      timeoutSeconds: 1,
+      task: {
+        intent: "delegate",
+        instructions: "delegate this",
+        runtime: {
+          roundOneReply: "delegated round one",
+          cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+        },
+        correlationId: "corr-123",
+        parentRunId: "parent-123",
+      },
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      runId: "wait-123",
+      reply: "delegated reply",
+      delivery: { status: "pending", mode: "announce" },
+    });
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "agent",
+      ),
+    ).toBe(false);
+    expect(hookRunner.runSessionsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          correlationId: "corr-123",
+          parentRunId: "parent-123",
+          runtime: expect.objectContaining({
+            roundOneReply: undefined,
+            cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+          }),
+        }),
+      }),
+      { requesterSessionKey: "discord:group:req", requesterChannel: "discord" },
+    );
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) =>
+          (call[0] as { method?: string; params?: { runId?: string } }).method === "agent.wait" &&
+          (call[0] as { params?: { runId?: string } }).params?.runId === "wait-123",
+      ),
+    ).toBe(true);
+  });
+
+  it("sessions_send snapshots delegated reply history before fast plugin completion", async () => {
+    let dispatched = false;
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => {
+        dispatched = true;
+        return {
+          handled: true,
+          mode: "delegated",
+          dispatch: {
+            kind: "a2a-broker",
+            taskId: "task-fast",
+            waitRunId: "wait-fast",
+          },
+        };
+      }),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+    const historyDispatchStates: boolean[] = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent.wait") {
+        return { runId: "wait-fast", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyDispatchStates.push(dispatched);
+        return {
+          messages: dispatched
+            ? [
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: "fast delegated reply" }],
+                  timestamp: 20,
+                },
+              ]
+            : [],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-hook-fast-delegated", {
+      sessionKey: "main",
+      message: "delegate quickly",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      runId: "wait-fast",
+      reply: "fast delegated reply",
+    });
+    expect(historyDispatchStates[0]).toBe(false);
+    expect(historyDispatchStates.at(-1)).toBe(true);
   });
 });

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -6,6 +6,8 @@ import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { PluginHookSessionsSendTask } from "../../plugins/types.js";
 import {
   isSubagentSessionKey,
   normalizeAgentId,
@@ -21,7 +23,9 @@ import {
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import {
   type AgentWaitResult,
+  type AssistantReplySnapshot,
   readLatestAssistantReplySnapshot,
+  waitForAgentRun,
   waitForAgentRunAndReadUpdatedAssistantReply,
 } from "../run-wait.js";
 import { loadSessionEntryByKey } from "../subagent-announce-delivery.js";
@@ -74,6 +78,111 @@ function isRequesterParentOfNativeSubagentSession(params: {
 
 function isTerminalAgentWaitTimeout(result: AgentWaitResult): boolean {
   return result.endedAt !== undefined || Boolean(result.stopReason || result.livenessState);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readOptionalFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readSessionsSendHookTask(
+  params: Record<string, unknown>,
+  defaults: {
+    message: string;
+    timeoutSeconds: number;
+    announceTimeoutMs: number;
+    maxPingPongTurns: number;
+    requesterSessionKey?: string;
+    requesterChannel?: string;
+  },
+): PluginHookSessionsSendTask | undefined {
+  const rawTask = isRecord(params.task) ? params.task : undefined;
+  if (!rawTask) {
+    return undefined;
+  }
+  const rawConstraints = isRecord(rawTask.constraints) ? rawTask.constraints : undefined;
+  const rawRuntime = isRecord(rawTask.runtime) ? rawTask.runtime : undefined;
+  const rawRequester = isRecord(rawTask.requester) ? rawTask.requester : undefined;
+  const rawCancelTarget = isRecord(rawRuntime?.cancelTarget) ? rawRuntime.cancelTarget : undefined;
+  return {
+    intent: normalizeOptionalString(
+      typeof rawTask.intent === "string" ? rawTask.intent : undefined,
+    ),
+    instructions:
+      normalizeOptionalString(
+        typeof rawTask.instructions === "string" ? rawTask.instructions : undefined,
+      ) ?? defaults.message,
+    constraints: {
+      timeoutSeconds:
+        readOptionalFiniteNumber(rawConstraints?.timeoutSeconds) ?? defaults.timeoutSeconds,
+      maxPingPongTurns:
+        readOptionalFiniteNumber(rawConstraints?.maxPingPongTurns) ?? defaults.maxPingPongTurns,
+    },
+    runtime: {
+      waitRunId: normalizeOptionalString(
+        typeof rawRuntime?.waitRunId === "string" ? rawRuntime.waitRunId : undefined,
+      ),
+      // Trust boundary: callers may pass arbitrary task/runtime metadata in tool args.
+      // Do not propagate caller-supplied roundOneReply into delegated announce seeding;
+      // only plugin-owned dispatch results or core-verified reply history may seed it.
+      roundOneReply: undefined,
+      announceTimeoutMs:
+        readOptionalFiniteNumber(rawRuntime?.announceTimeoutMs) ?? defaults.announceTimeoutMs,
+      maxPingPongTurns:
+        readOptionalFiniteNumber(rawRuntime?.maxPingPongTurns) ?? defaults.maxPingPongTurns,
+      cancelTarget: rawCancelTarget
+        ? {
+            kind: normalizeOptionalString(
+              typeof rawCancelTarget.kind === "string" ? rawCancelTarget.kind : undefined,
+            ),
+            sessionKey: normalizeOptionalString(
+              typeof rawCancelTarget.sessionKey === "string"
+                ? rawCancelTarget.sessionKey
+                : undefined,
+            ),
+            runId: normalizeOptionalString(
+              typeof rawCancelTarget.runId === "string" ? rawCancelTarget.runId : undefined,
+            ),
+          }
+        : undefined,
+    },
+    requester: {
+      sessionKey:
+        normalizeOptionalString(
+          typeof rawRequester?.sessionKey === "string" ? rawRequester.sessionKey : undefined,
+        ) ?? defaults.requesterSessionKey,
+      channel:
+        normalizeOptionalString(
+          typeof rawRequester?.channel === "string" ? rawRequester.channel : undefined,
+        ) ?? defaults.requesterChannel,
+    },
+    correlationId: normalizeOptionalString(
+      typeof rawTask.correlationId === "string" ? rawTask.correlationId : undefined,
+    ),
+    parentRunId: normalizeOptionalString(
+      typeof rawTask.parentRunId === "string" ? rawTask.parentRunId : undefined,
+    ),
+  };
+}
+
+async function readSessionsSendBaselineSnapshot(params: {
+  sessionKey: string;
+  callGateway: GatewayCaller;
+}): Promise<{ snapshot?: AssistantReplySnapshot; error?: string }> {
+  try {
+    return {
+      snapshot: await readLatestAssistantReplySnapshot({
+        sessionKey: params.sessionKey,
+        limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+        callGateway: params.callGateway,
+      }),
+    };
+  } catch (err) {
+    return { error: formatErrorMessage(err) };
+  }
 }
 
 async function startAgentRun(params: {
@@ -294,19 +403,6 @@ export function createSessionsSendTool(opts?: {
         });
       }
 
-      // Capture the pre-run assistant snapshot before starting the nested run.
-      // Fast in-process test doubles and short-circuit agent paths can finish
-      // before we reach the post-run read, which would otherwise make the new
-      // reply look like the baseline and hide it from the caller.
-      const baselineReply =
-        timeoutSeconds === 0
-          ? undefined
-          : await readLatestAssistantReplySnapshot({
-              sessionKey: resolvedKey,
-              limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
-              callGateway: gatewayCall,
-            });
-
       const agentMessageContext = buildAgentToAgentMessageContext({
         requesterSessionKey: opts?.agentSessionKey,
         requesterChannel: opts?.agentChannel,
@@ -369,7 +465,11 @@ export function createSessionsSendTool(opts?: {
         ? ({ status: "skipped", mode: "announce" } as const)
         : ({ status: "pending", mode: "announce" } as const);
 
-      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
+      const startA2AFlow = (
+        roundOneReply?: string,
+        waitRunId?: string,
+        baseline?: AssistantReplySnapshot,
+      ) => {
         if (skipA2AFlow) {
           return;
         }
@@ -381,11 +481,194 @@ export function createSessionsSendTool(opts?: {
           maxPingPongTurns,
           requesterSessionKey,
           requesterChannel,
-          baseline: baselineReply,
+          baseline,
           roundOneReply,
           waitRunId,
         });
       };
+
+      const hookRunner = getGlobalHookRunner();
+      let hookBaselineForFallback: AssistantReplySnapshot | undefined;
+      if (hookRunner?.hasHooks("sessions_send")) {
+        // Delegated plugins may start and finish the child run before returning a
+        // waitRunId. Take a non-fatal pre-hook snapshot so fast completions are
+        // not mistaken for the baseline, while direct plugin handling remains
+        // independent from core reply-history failures.
+        const delegatedBaseline: { snapshot?: AssistantReplySnapshot; error?: string } =
+          timeoutSeconds === 0
+            ? {}
+            : await readSessionsSendBaselineSnapshot({
+                sessionKey: resolvedKey,
+                callGateway: gatewayCall,
+              });
+        if (!delegatedBaseline.error) {
+          hookBaselineForFallback = delegatedBaseline.snapshot;
+        }
+        const hookTask = readSessionsSendHookTask(params, {
+          message,
+          timeoutSeconds,
+          announceTimeoutMs,
+          maxPingPongTurns,
+          requesterSessionKey,
+          requesterChannel,
+        });
+        const hookResult = await hookRunner.runSessionsSend(
+          {
+            sessionKey: resolvedKey,
+            target: {
+              sessionKey: resolvedKey,
+              displayKey,
+            },
+            message,
+            ...(hookTask ? { task: hookTask } : {}),
+            rawParams: params,
+          },
+          {
+            requesterSessionKey,
+            requesterChannel,
+          },
+        );
+        if (hookResult?.handled) {
+          if (hookResult.mode === "direct") {
+            return jsonResult(
+              isRecord(hookResult.result)
+                ? hookResult.result
+                : {
+                    status: "ok",
+                    result: hookResult.result,
+                    sessionKey: displayKey,
+                  },
+            );
+          }
+
+          const delegatedWaitRunId = normalizeOptionalString(hookResult.dispatch.waitRunId);
+          const delegatedRunId = delegatedWaitRunId ?? hookResult.dispatch.taskId;
+          const delegatedRoundOneReply = normalizeOptionalString(hookResult.dispatch.roundOneReply);
+          if (timeoutSeconds === 0) {
+            startA2AFlow(delegatedRoundOneReply, delegatedWaitRunId);
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "accepted",
+              sessionKey: displayKey,
+              delivery,
+            });
+          }
+          if (!delegatedWaitRunId) {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "error",
+              error: "Delegated sessions_send hook result missing waitRunId for waited send",
+              sessionKey: displayKey,
+            });
+          }
+          if (delegatedBaseline.error && !delegatedRoundOneReply) {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "error",
+              error: `Unable to snapshot delegated sessions_send reply history before dispatch: ${delegatedBaseline.error}`,
+              sessionKey: displayKey,
+            });
+          }
+          if (delegatedBaseline.error) {
+            const wait = await waitForAgentRun({
+              runId: delegatedWaitRunId,
+              timeoutMs,
+              callGateway: gatewayCall,
+            });
+            if (wait.status === "timeout") {
+              if (!isTerminalAgentWaitTimeout(wait)) {
+                startA2AFlow(delegatedRoundOneReply, delegatedWaitRunId);
+                return jsonResult({
+                  runId: delegatedRunId,
+                  status: "accepted",
+                  sessionKey: displayKey,
+                  delivery,
+                });
+              }
+              return jsonResult({
+                runId: delegatedRunId,
+                status: "timeout",
+                error: wait.error,
+                sessionKey: displayKey,
+              });
+            }
+            if (wait.status === "error") {
+              return jsonResult({
+                runId: delegatedRunId,
+                status: "error",
+                error: wait.error ?? "agent error",
+                sessionKey: displayKey,
+              });
+            }
+            startA2AFlow(delegatedRoundOneReply, delegatedWaitRunId);
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "ok",
+              sessionKey: displayKey,
+              delivery,
+            });
+          }
+          const delegatedResult = await waitForAgentRunAndReadUpdatedAssistantReply({
+            runId: delegatedWaitRunId,
+            sessionKey: resolvedKey,
+            timeoutMs,
+            limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+            baseline: delegatedBaseline.snapshot,
+            callGateway: gatewayCall,
+          });
+          if (delegatedResult.status === "timeout") {
+            if (!isTerminalAgentWaitTimeout(delegatedResult)) {
+              startA2AFlow(delegatedRoundOneReply, delegatedWaitRunId, delegatedBaseline.snapshot);
+              return jsonResult({
+                runId: delegatedRunId,
+                status: "accepted",
+                sessionKey: displayKey,
+                delivery,
+              });
+            }
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "timeout",
+              error: delegatedResult.error,
+              sessionKey: displayKey,
+            });
+          }
+          if (delegatedResult.status === "error") {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "error",
+              error: delegatedResult.error ?? "agent error",
+              sessionKey: displayKey,
+            });
+          }
+          const reply = delegatedResult.replyText;
+          startA2AFlow(
+            delegatedRoundOneReply ?? reply ?? undefined,
+            undefined,
+            delegatedBaseline.snapshot,
+          );
+          return jsonResult({
+            runId: delegatedRunId,
+            status: "ok",
+            reply,
+            sessionKey: displayKey,
+            delivery,
+          });
+        }
+      }
+
+      // Capture the pre-run assistant snapshot only after plugin hooks declined.
+      // Hook-owned direct delivery must not be blocked by local reply-history
+      // assumptions, while core fallback still snapshots before starting a run.
+      const baselineReply =
+        timeoutSeconds === 0
+          ? undefined
+          : (hookBaselineForFallback ??
+            (await readLatestAssistantReplySnapshot({
+              sessionKey: resolvedKey,
+              limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+              callGateway: gatewayCall,
+            })));
 
       if (timeoutSeconds === 0) {
         const start = await startAgentRun({
@@ -398,7 +681,7 @@ export function createSessionsSendTool(opts?: {
           return start.result;
         }
         runId = start.runId;
-        startA2AFlow(undefined, runId);
+        startA2AFlow(undefined, runId, baselineReply);
         return jsonResult({
           runId,
           status: "accepted",
@@ -428,7 +711,7 @@ export function createSessionsSendTool(opts?: {
 
       if (result.status === "timeout") {
         if (!isTerminalAgentWaitTimeout(result)) {
-          startA2AFlow(undefined, runId);
+          startA2AFlow(undefined, runId, baselineReply);
           return jsonResult({
             runId,
             status: "accepted",
@@ -452,7 +735,7 @@ export function createSessionsSendTool(opts?: {
         });
       }
       const reply = result.replyText;
-      startA2AFlow(reply ?? undefined);
+      startA2AFlow(reply ?? undefined, undefined, baselineReply);
 
       return jsonResult({
         runId,

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -127,6 +127,13 @@ export type {
   PluginHookReplyDispatchResult,
 } from "../plugins/types.js";
 export type { OpenClawConfig } from "../config/config.js";
+export type {
+  PluginHookSessionsSendCancelTarget,
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
+  PluginHookSessionsSendTask,
+} from "../plugins/types.js";
 export type { OutboundIdentity } from "../infra/outbound/identity.js";
 export type { HistoryEntry } from "../auto-reply/reply/history.js";
 export type { ReplyPayload } from "./reply-payload.js";

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -87,6 +87,7 @@ export type PluginHookName =
   | "message_received"
   | "message_sending"
   | "message_sent"
+  | "sessions_send"
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
@@ -124,6 +125,7 @@ export const PLUGIN_HOOK_NAMES = [
   "message_received",
   "message_sending",
   "message_sent",
+  "sessions_send",
   "before_tool_call",
   "after_tool_call",
   "tool_result_persist",
@@ -395,6 +397,69 @@ export type PluginHookReplyDispatchResult = {
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
 };
+
+export type PluginHookSessionsSendCancelTarget = {
+  kind?: string;
+  sessionKey?: string;
+  runId?: string;
+};
+
+export type PluginHookSessionsSendTask = {
+  intent?: string;
+  instructions?: string;
+  constraints?: {
+    timeoutSeconds?: number;
+    maxPingPongTurns?: number;
+  };
+  runtime?: {
+    waitRunId?: string;
+    roundOneReply?: string;
+    announceTimeoutMs?: number;
+    maxPingPongTurns?: number;
+    cancelTarget?: PluginHookSessionsSendCancelTarget;
+  };
+  requester?: {
+    sessionKey?: string;
+    channel?: string;
+  };
+  correlationId?: string;
+  parentRunId?: string;
+};
+
+export type PluginHookSessionsSendEvent = {
+  sessionKey: string;
+  target: {
+    sessionKey?: string;
+    displayKey?: string;
+  };
+  message: string;
+  task?: PluginHookSessionsSendTask;
+  rawParams: unknown;
+};
+
+export type PluginHookSessionsSendContext = {
+  requesterSessionKey?: string;
+  requesterChannel?: string;
+};
+
+export type PluginHookSessionsSendResult =
+  | { handled: false; reason?: string }
+  | {
+      handled: true;
+      mode: "delegated";
+      dispatch: {
+        kind: "a2a-broker";
+        taskId: string;
+        waitRunId?: string;
+        /**
+         * Plugin-owned, verified first-round reply text for delegated announce seeding.
+         * Core must not derive this from caller-supplied tool args.
+         */
+        roundOneReply?: string;
+        cancelTarget?: PluginHookSessionsSendCancelTarget;
+      };
+    }
+  | { handled: true; mode: "direct"; result: unknown };
 
 export type PluginHookToolContext = {
   agentId?: string;
@@ -884,6 +949,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookMessageSentEvent,
     ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
+  sessions_send: (
+    event: PluginHookSessionsSendEvent,
+    ctx: PluginHookSessionsSendContext,
+  ) => Promise<PluginHookSessionsSendResult | void> | PluginHookSessionsSendResult | void;
   before_tool_call: (
     event: PluginHookBeforeToolCallEvent,
     ctx: PluginHookToolContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -26,6 +26,9 @@ import type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -93,6 +96,9 @@ export type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -1011,6 +1017,22 @@ export function createHookRunner(
   }
 
   /**
+   * Run sessions_send hook.
+   * Allows plugins to intercept delegated sessions_send dispatch before core handling.
+   * First handler returning { handled: true } wins.
+   */
+  async function runSessionsSend(
+    event: PluginHookSessionsSendEvent,
+    ctx: PluginHookSessionsSendContext,
+  ): Promise<PluginHookSessionsSendResult | undefined> {
+    return runClaimingHook<"sessions_send", PluginHookSessionsSendResult>(
+      "sessions_send",
+      event,
+      ctx,
+    );
+  }
+
+  /**
    * Run message_sending hook.
    * Allows plugins to modify or cancel outgoing messages.
    * Runs sequentially.
@@ -1433,6 +1455,7 @@ export function createHookRunner(
     runMessageReceived,
     runBeforeDispatch,
     runReplyDispatch,
+    runSessionsSend,
     runMessageSending,
     runMessageSent,
     // Tool hooks


### PR DESCRIPTION
## 요약
- clawsweeper P1/P2 지적 대응: `sessions_send` delegated announce 경로에서 caller-supplied `task.runtime.roundOneReply`를 신뢰하지 않도록 제거했습니다.
- delegated announce/ping-pong seed는 plugin-owned `dispatch.roundOneReply` 또는 core가 reply-history wait/read로 검증한 reply만 사용하도록 trust boundary를 고정했습니다.
- `sessions_send` hook 호출을 core reply-history snapshot/read보다 앞에 두어 hook-owned delivery가 로컬 세션 history 가정에 의해 차단되지 않도록 했습니다.

## 테스트
- `pnpm exec vitest run src/agents/openclaw-tools.sessions.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts` → 2 files / 20 tests passed
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm plugin-sdk:api:check` → OK `docs/.generated/plugin-sdk-api-baseline.sha256`
- `pnpm tsgo:core && pnpm build:plugin-sdk:dts` → passed
- commit hook의 `pnpm check`는 `tsgo:extensions:test` 진행 중 세션 timeout/SIGTERM으로 중단되어, 위 targeted gate와 SDK/type gate를 별도 확보했습니다.

## 리스크
- 기존 PR #68622의 fork branch에 직접 push하지 않고 방통 replacement patch branch로 열었습니다. maintainer가 기존 PR에 cherry-pick하거나 이 PR을 기준으로 이어갈 수 있습니다.
