### PR TITLE
Gateway: guard session-run cancel requester in minimal tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugin SDK/Gateway: add the `openclaw/plugin-sdk/session-run-cancel-runtime` import path so plugin-owned delegated tasks can observe core session-run aborts and request Gateway cancellation through a bounded, core-owned cancel replay seam.
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-7684d1cc87a531a1490bf9f5a9eab8a30518b95d93884ef8a025486aba6e29b1  plugin-sdk-api-baseline.json
-e297ee3f86e2753ede344ff9ef8d1e063ce5fc95816f574062e2a974e4f82601  plugin-sdk-api-baseline.jsonl
+bcea508261ccbb7152cb6dbecea4a03e3bd9bee69244cf2f1183a1fbbe4462de  plugin-sdk-api-baseline.json
+9ec3ff871d982aba56acb045d27d919afe9050dfbf7538bc7c93e17171a1f109  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -199,6 +199,7 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
     | `plugin-sdk/reply-reference` | `createReplyReferencePlanner` |
     | `plugin-sdk/reply-chunking` | Narrow text/markdown chunking helpers |
     | `plugin-sdk/session-store-runtime` | Session store path, session-key, updated-at, and store mutation helpers |
+    | `plugin-sdk/session-run-cancel-runtime` | Delegated task/run cancellation seam for plugins: `onSessionRunCancel`, `requestSessionRunCancel`, and types `RequestSessionRunCancelResult`, `SessionRunCancelHandler`, `SessionRunCancelReason`, `SessionRunCancelTarget`. The core-owned `emitSessionRunCancel` emitter is intentionally not public. |
     | `plugin-sdk/cron-store-runtime` | Cron store path/load/save helpers |
     | `plugin-sdk/state-paths` | State/OAuth dir path helpers |
     | `plugin-sdk/routing` | Route/session-key/account binding helpers such as `resolveAgentRoute`, `buildAgentSessionKey`, and `resolveDefaultAgentBoundAccountId` |

--- a/package.json
+++ b/package.json
@@ -858,6 +858,10 @@
       "types": "./dist/plugin-sdk/session-key-runtime.d.ts",
       "default": "./dist/plugin-sdk/session-key-runtime.js"
     },
+    "./plugin-sdk/session-run-cancel-runtime": {
+      "types": "./dist/plugin-sdk/session-run-cancel-runtime.d.ts",
+      "default": "./dist/plugin-sdk/session-run-cancel-runtime.js"
+    },
     "./plugin-sdk/session-store-runtime": {
       "types": "./dist/plugin-sdk/session-store-runtime.d.ts",
       "default": "./dist/plugin-sdk/session-store-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -191,6 +191,7 @@
   "response-limit-runtime",
   "session-binding-runtime",
   "session-key-runtime",
+  "session-run-cancel-runtime",
   "session-store-runtime",
   "session-transcript-hit",
   "session-visibility",

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as sessionRunCancelTesting,
+  onSessionRunCancel,
+  requestSessionRunCancel,
+} from "../sessions/session-run-cancel.js";
 import {
   abortChatRunById,
   isChatStopCommandText,
+  wireSessionRunCancelRequester,
   type ChatAbortOps,
   type ChatAbortControllerEntry,
 } from "./chat-abort.js";
@@ -63,6 +69,10 @@ describe("isChatStopCommandText", () => {
 });
 
 describe("abortChatRunById", () => {
+  afterEach(() => {
+    sessionRunCancelTesting.reset();
+  });
+
   it("broadcasts aborted payload with partial message when buffered text exists", () => {
     const runId = "run-1";
     const sessionKey = "main";
@@ -116,6 +126,94 @@ describe("abortChatRunById", () => {
     expect(result).toEqual({ aborted: true });
     const payload = ops.broadcast.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(payload.message).toBeUndefined();
+  });
+
+  it("fans out cancel to delegated-task handlers registered for the session_run target", () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    const handler = vi.fn();
+    onSessionRunCancel({ kind: "session_run", sessionKey, runId }, handler);
+
+    abortChatRunById(ops, { runId, sessionKey, stopReason: "user" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      { kind: "session_run", sessionKey, runId },
+      { source: "chat-abort", message: "user" },
+    );
+  });
+
+  it("does not fan out when the abort no-ops because no controller is tracked", () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    ops.chatAbortControllers.clear();
+    const handler = vi.fn();
+    onSessionRunCancel({ kind: "session_run", sessionKey, runId }, handler);
+
+    const result = abortChatRunById(ops, { runId, sessionKey });
+
+    expect(result).toEqual({ aborted: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("wires requestSessionRunCancel to abortChatRunById for matching runs", async () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    const dispose = wireSessionRunCancelRequester(ops);
+
+    const result = await requestSessionRunCancel(
+      { kind: "session_run", sessionKey, runId },
+      { source: "plugin:test", message: "cancelled" },
+    );
+
+    expect(result).toEqual({ requested: true, aborted: true });
+    expect(entry.controller.signal.aborted).toBe(true);
+    const payload = ops.broadcast.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload.stopReason).toBe("cancelled");
+
+    dispose();
+  });
+
+  it("reports aborted=false when no active run matches the requester", async () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    ops.chatAbortControllers.clear();
+    const dispose = wireSessionRunCancelRequester(ops);
+
+    const result = await requestSessionRunCancel({
+      kind: "session_run",
+      sessionKey,
+      runId,
+    });
+
+    expect(result).toEqual({ requested: true, aborted: false });
+    dispose();
+  });
+
+  it("unwires the requester on disposer so later requests report requested=false", async () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    const dispose = wireSessionRunCancelRequester(ops);
+    dispose();
+
+    const result = await requestSessionRunCancel({
+      kind: "session_run",
+      sessionKey,
+      runId,
+    });
+
+    expect(result).toEqual({ requested: false, aborted: false });
+    expect(entry.controller.signal.aborted).toBe(false);
   });
 
   it("preserves partial message even when abort listeners clear buffers synchronously", () => {

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   abortChatRunById,
   isChatStopCommandText,
+  registerChatAbortController,
   wireSessionRunCancelRequester,
   type ChatAbortOps,
   type ChatAbortControllerEntry,
@@ -143,6 +144,35 @@ describe("abortChatRunById", () => {
       { kind: "session_run", sessionKey, runId },
       { source: "chat-abort", message: "user" },
     );
+  });
+
+  it("clears sticky delegated-task cancel replay when the registered run is cleaned up", () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const activeRunAbort = registerChatAbortController({
+      chatAbortControllers,
+      runId,
+      sessionId: "sess-1",
+      sessionKey,
+      timeoutMs: 30_000,
+    });
+    expect(activeRunAbort.entry).toBeDefined();
+    const ops = createOps({ runId, entry: activeRunAbort.entry! });
+    ops.chatAbortControllers = chatAbortControllers;
+
+    abortChatRunById(ops, { runId, sessionKey, stopReason: "user" });
+    const lateBeforeCleanup = vi.fn();
+    onSessionRunCancel({ kind: "session_run", sessionKey, runId }, lateBeforeCleanup);
+    activeRunAbort.cleanup();
+    const lateAfterCleanup = vi.fn();
+    onSessionRunCancel({ kind: "session_run", sessionKey, runId }, lateAfterCleanup);
+
+    expect(lateBeforeCleanup).toHaveBeenCalledTimes(1);
+    expect(lateAfterCleanup).not.toHaveBeenCalled();
+    expect(
+      sessionRunCancelTesting.hasTerminalCancel({ kind: "session_run", sessionKey, runId }),
+    ).toBe(false);
   });
 
   it("does not fan out when the abort no-ops because no controller is tracked", () => {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -1,6 +1,7 @@
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import {
+  clearSessionRunCancelTarget,
   emitSessionRunCancel,
   setSessionRunAbortRequester,
 } from "../sessions/session-run-cancel.js";
@@ -84,10 +85,14 @@ export function registerChatAbortController(params: {
   expiresAtMs?: number;
 }): RegisteredChatAbortController {
   const controller = new AbortController();
+  let cleanupTarget: { kind: "session_run"; sessionKey: string; runId: string } | undefined;
   const cleanup = () => {
     const entry = params.chatAbortControllers.get(params.runId);
     if (entry?.controller === controller) {
       params.chatAbortControllers.delete(params.runId);
+    }
+    if (cleanupTarget) {
+      clearSessionRunCancelTarget(cleanupTarget);
     }
   };
 
@@ -107,6 +112,7 @@ export function registerChatAbortController(params: {
     ownerDeviceId: params.ownerDeviceId,
     kind: params.kind,
   };
+  cleanupTarget = { kind: "session_run", sessionKey: params.sessionKey, runId: params.runId };
   params.chatAbortControllers.set(params.runId, entry);
   return { controller, registered: true, entry, cleanup };
 }

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -1,5 +1,9 @@
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  emitSessionRunCancel,
+  setSessionRunAbortRequester,
+} from "../sessions/session-run-cancel.js";
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
 
@@ -177,6 +181,12 @@ export function abortChatRunById(
   ops.chatDeltaSentAt.delete(runId);
   ops.chatDeltaLastBroadcastLen.delete(runId);
   const removed = ops.removeChatRun(runId, runId, sessionKey);
+  // Fan out cancel to delegated-task handlers before broadcasting the UI event
+  // so plugin-owned tasks tied to this run observe the stop deterministically.
+  emitSessionRunCancel(
+    { kind: "session_run", sessionKey, runId },
+    stopReason ? { source: "chat-abort", message: stopReason } : { source: "chat-abort" },
+  );
   broadcastChatAborted(ops, { runId, sessionKey, stopReason, partialText });
   emitAgentEvent({
     runId,
@@ -196,4 +206,19 @@ export function abortChatRunById(
     ops.agentRunSeq.delete(removed.clientRunId);
   }
   return { aborted: true };
+}
+
+// Wires the `requestSessionRunCancel` seam so plugin-owned delegated tasks
+// can trigger a real core abort for the owning OpenClaw run without any
+// plugin-specific branching in core. Returns a disposer that removes the
+// requester (idempotent, safe to call during shutdown).
+export function wireSessionRunCancelRequester(ops: ChatAbortOps): () => void {
+  return setSessionRunAbortRequester((target, reason) => {
+    const { aborted } = abortChatRunById(ops, {
+      runId: target.runId,
+      sessionKey: target.sessionKey,
+      ...(reason?.message ? { stopReason: reason.message } : {}),
+    });
+    return aborted;
+  });
 }

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -140,6 +140,7 @@ export async function runGatewayClosePrelude(params: {
   stopDiagnostics?: () => void;
   clearSkillsRefreshTimer?: () => void;
   skillsChangeUnsub?: () => void;
+  sessionRunCancelRequesterUnsub?: () => void;
   disposeAuthRateLimiter?: () => void;
   disposeBrowserAuthRateLimiter: () => void;
   stopModelPricingRefresh?: () => void;
@@ -151,6 +152,7 @@ export async function runGatewayClosePrelude(params: {
   params.stopDiagnostics?.();
   params.clearSkillsRefreshTimer?.();
   params.skillsChangeUnsub?.();
+  params.sessionRunCancelRequesterUnsub?.();
   params.disposeAuthRateLimiter?.();
   params.disposeBrowserAuthRateLimiter();
   params.stopModelPricingRefresh?.();

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -18,6 +18,7 @@ export type GatewayServerMutableState = {
   skillsRefreshTimer: ReturnType<typeof setTimeout> | null;
   skillsRefreshDelayMs: number;
   skillsChangeUnsub: () => void;
+  sessionRunCancelRequesterUnsub: () => void;
   channelHealthMonitor: ChannelHealthMonitor | null;
   stopModelPricingRefresh: () => void;
   mcpServer: { port: number; close: () => Promise<void> } | undefined;
@@ -49,6 +50,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     skillsRefreshTimer: null as ReturnType<typeof setTimeout> | null,
     skillsRefreshDelayMs: 30_000,
     skillsChangeUnsub: () => {},
+    sessionRunCancelRequesterUnsub: () => {},
     channelHealthMonitor: null as ChannelHealthMonitor | null,
     stopModelPricingRefresh: () => {},
     mcpServer: undefined as { port: number; close: () => Promise<void> } | undefined,

--- a/src/gateway/server-startup-early.test.ts
+++ b/src/gateway/server-startup-early.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getMachineDisplayName: vi.fn(async () => "Test Machine"),
@@ -13,6 +13,10 @@ vi.mock("./server-discovery-runtime.js", () => ({
   startGatewayDiscovery: mocks.startGatewayDiscovery,
 }));
 
+import {
+  __testing as sessionRunCancelTesting,
+  requestSessionRunCancel,
+} from "../sessions/session-run-cancel.js";
 import { startGatewayEarlyRuntime, startGatewayPluginDiscovery } from "./server-startup-early.js";
 
 describe("startGatewayEarlyRuntime", () => {
@@ -20,6 +24,11 @@ describe("startGatewayEarlyRuntime", () => {
     mocks.getMachineDisplayName.mockClear();
     mocks.startGatewayDiscovery.mockClear();
     mocks.startGatewayDiscovery.mockResolvedValue({ bonjourStop: null });
+    sessionRunCancelTesting.reset();
+  });
+
+  afterEach(() => {
+    sessionRunCancelTesting.reset();
   });
 
   it("does not eagerly start the MCP loopback server", async () => {
@@ -60,6 +69,53 @@ describe("startGatewayEarlyRuntime", () => {
     });
 
     expect(earlyRuntime).not.toHaveProperty("mcpServer");
+  });
+
+  it("does not wire the session-run cancel requester for minimal gateways", async () => {
+    const earlyRuntime = await startGatewayEarlyRuntime({
+      minimalTestGateway: true,
+      cfgAtStart: {} as never,
+      port: 18_789,
+      gatewayTls: { enabled: false },
+      tailscaleMode: "off" as never,
+      log: {
+        info: () => {},
+        warn: () => {},
+      },
+      logDiscovery: {
+        info: () => {},
+        warn: () => {},
+      },
+      nodeRegistry: {} as never,
+      broadcast: () => {},
+      nodeSendToAllSubscribed: () => {},
+      getPresenceVersion: () => 0,
+      getHealthVersion: () => 0,
+      refreshGatewayHealthSnapshot: async () => ({}) as never,
+      logHealth: { error: () => {} },
+      dedupe: new Map(),
+      chatAbortControllers: new Map(),
+      chatRunState: { abortedRuns: new Map() },
+      chatRunBuffers: new Map(),
+      chatDeltaSentAt: new Map(),
+      chatDeltaLastBroadcastLen: new Map(),
+      removeChatRun: () => {},
+      agentRunSeq: new Map(),
+      nodeSendToSession: () => {},
+      skillsRefreshDelayMs: 30_000,
+      getSkillsRefreshTimer: () => null,
+      setSkillsRefreshTimer: () => {},
+      getRuntimeConfig: () => ({}) as never,
+    });
+
+    const result = await requestSessionRunCancel({
+      kind: "session_run",
+      sessionKey: "agent:test:main",
+      runId: "run-minimal",
+    });
+
+    expect(result).toEqual({ requested: false, aborted: false });
+    earlyRuntime.sessionRunCancelRequesterUnsub();
   });
 
   it("starts discovery with the current plugin registry services", async () => {

--- a/src/gateway/server-startup-early.ts
+++ b/src/gateway/server-startup-early.ts
@@ -176,10 +176,33 @@ export async function startGatewayEarlyRuntime(params: {
     });
   };
 
+  // Wire the plugin -> core cancel seam against the live chat-abort state so
+  // delegated-task code (including plugins) can abort the owning run through
+  // `requestSessionRunCancel({ kind: "session_run", sessionKey, runId })`.
+  // Minimal test gateways intentionally skip module-level requester wiring so
+  // tests that import the SDK seam do not inherit live gateway abort state.
+  const sessionRunCancelRequesterUnsub = params.minimalTestGateway
+    ? () => {}
+    : await measureStartup(params.startupTrace, "runtime.early.session-run-cancel", async () => {
+        const { wireSessionRunCancelRequester } = await import("./chat-abort.js");
+        return wireSessionRunCancelRequester({
+          chatAbortControllers: params.chatAbortControllers,
+          chatRunBuffers: params.chatRunBuffers,
+          chatDeltaSentAt: params.chatDeltaSentAt,
+          chatDeltaLastBroadcastLen: params.chatDeltaLastBroadcastLen,
+          chatAbortedRuns: params.chatRunState.abortedRuns,
+          removeChatRun: params.removeChatRun,
+          agentRunSeq: params.agentRunSeq,
+          broadcast: params.broadcast,
+          nodeSendToSession: params.nodeSendToSession,
+        });
+      });
+
   return {
     bonjourStop,
     getActiveTaskCount,
     skillsChangeUnsub,
+    sessionRunCancelRequesterUnsub,
     startMaintenance,
   };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -927,6 +927,7 @@ export async function startGatewayServer(
         runtimeState.skillsRefreshTimer = null;
       },
       skillsChangeUnsub: runtimeState.skillsChangeUnsub,
+      sessionRunCancelRequesterUnsub: runtimeState.sessionRunCancelRequesterUnsub,
       ...(authRateLimiter ? { disposeAuthRateLimiter: () => authRateLimiter.dispose() } : {}),
       disposeBrowserAuthRateLimiter: () => browserAuthRateLimiter.dispose(),
       stopModelPricingRefresh: runtimeState.stopModelPricingRefresh,
@@ -1036,6 +1037,7 @@ export async function startGatewayServer(
     runtimeState.bonjourStop = earlyRuntime.bonjourStop;
     getActiveTaskCount = earlyRuntime.getActiveTaskCount;
     runtimeState.skillsChangeUnsub = earlyRuntime.skillsChangeUnsub;
+    runtimeState.sessionRunCancelRequesterUnsub = earlyRuntime.sessionRunCancelRequesterUnsub;
 
     const [{ startGatewayEventSubscriptions }, gatewayRuntimeServices] = await Promise.all([
       import("./server-runtime-subscriptions.js"),

--- a/src/plugin-sdk/session-run-cancel-runtime.test.ts
+++ b/src/plugin-sdk/session-run-cancel-runtime.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __testing } from "../sessions/session-run-cancel.js";
+import * as runtime from "./session-run-cancel-runtime.js";
+import {
+  onSessionRunCancel,
+  requestSessionRunCancel,
+  type SessionRunCancelTarget,
+} from "./session-run-cancel-runtime.js";
+
+const target: SessionRunCancelTarget = {
+  kind: "session_run",
+  sessionKey: "agent:main:main",
+  runId: "run-1",
+};
+
+describe("plugin-sdk/session-run-cancel-runtime", () => {
+  afterEach(() => {
+    __testing.reset();
+  });
+
+  it("re-exports onSessionRunCancel registered against the same core store", () => {
+    const handler = vi.fn();
+    onSessionRunCancel(target, handler);
+    expect(__testing.handlerCount(target)).toBe(1);
+  });
+
+  it("re-exports requestSessionRunCancel wired to the same core requester", async () => {
+    const requester = vi.fn(async () => true);
+    const { setSessionRunAbortRequester } = await import("../sessions/session-run-cancel.js");
+    setSessionRunAbortRequester(requester);
+
+    const result = await requestSessionRunCancel(target, { source: "plugin:test" });
+
+    expect(requester).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ requested: true, aborted: true });
+  });
+
+  it("does not expose the core-owned cancel emitter to plugin runtime consumers", () => {
+    expect("emitSessionRunCancel" in runtime).toBe(false);
+  });
+});

--- a/src/plugin-sdk/session-run-cancel-runtime.ts
+++ b/src/plugin-sdk/session-run-cancel-runtime.ts
@@ -1,0 +1,22 @@
+// Narrow public seam for the cancel fan-out between delegated tasks (often
+// plugin-owned) and the OpenClaw run that owns them. Plugins import this
+// subpath to:
+//   - register an `onSessionRunCancel` handler tied to a specific session_run
+//     target, so core-side aborts notify the delegated task deterministically.
+//   - call `requestSessionRunCancel` to ask core to abort the owning run,
+//     without importing core internals or branching on specific channels.
+//
+// The seam is intentionally plugin-neutral: `{ kind: "session_run",
+// sessionKey, runId }` is the only target shape.
+//
+// `emitSessionRunCancel` is deliberately NOT exported here. It is core-owned
+// because it clears/replays terminal cancel state; plugins observe cancels with
+// `onSessionRunCancel` or request them with `requestSessionRunCancel`.
+export {
+  onSessionRunCancel,
+  requestSessionRunCancel,
+  type RequestSessionRunCancelResult,
+  type SessionRunCancelHandler,
+  type SessionRunCancelReason,
+  type SessionRunCancelTarget,
+} from "../sessions/session-run-cancel.js";

--- a/src/sessions/session-run-cancel.test.ts
+++ b/src/sessions/session-run-cancel.test.ts
@@ -16,6 +16,7 @@ function target(sessionKey: string, runId: string): SessionRunCancelTarget {
 
 describe("session-run cancel fan-out seam", () => {
   afterEach(() => {
+    vi.useRealTimers();
     __testing.reset();
   });
 
@@ -87,6 +88,36 @@ describe("session-run cancel fan-out seam", () => {
 
       expect(handler).not.toHaveBeenCalled();
       expect(__testing.handlerCount(cancelTarget)).toBe(1);
+    });
+
+    it("prunes sticky terminal state after the replay TTL", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      const cancelTarget = target("agent:main:main", "run-ttl");
+      emitSessionRunCancel(cancelTarget, { source: "chat-abort" });
+      vi.setSystemTime(Date.now() + __testing.terminalCancelTtlMs() + 1);
+      const handler = vi.fn();
+
+      onSessionRunCancel(cancelTarget, handler);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(__testing.handlerCount(cancelTarget)).toBe(1);
+      expect(__testing.hasTerminalCancel(cancelTarget)).toBe(false);
+    });
+
+    it("bounds sticky terminal state to the newest max entries", () => {
+      const maxEntries = __testing.terminalCancelMaxEntries();
+      for (let i = 0; i < maxEntries + 3; i += 1) {
+        emitSessionRunCancel(target("agent:main:main", `run-${i}`), { source: "chat-abort" });
+      }
+
+      expect(__testing.terminalCancelCount()).toBe(maxEntries);
+      expect(__testing.hasTerminalCancel(target("agent:main:main", "run-0"))).toBe(false);
+      expect(__testing.hasTerminalCancel(target("agent:main:main", "run-1"))).toBe(false);
+      expect(__testing.hasTerminalCancel(target("agent:main:main", "run-2"))).toBe(false);
+      expect(__testing.hasTerminalCancel(target("agent:main:main", `run-${maxEntries + 2}`))).toBe(
+        true,
+      );
     });
 
     it("reports no live handlers when nothing is registered", () => {

--- a/src/sessions/session-run-cancel.test.ts
+++ b/src/sessions/session-run-cancel.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  clearSessionRunCancelTarget,
+  emitSessionRunCancel,
+  onSessionRunCancel,
+  requestSessionRunCancel,
+  setSessionRunAbortRequester,
+  type SessionRunAbortRequester,
+  type SessionRunCancelTarget,
+} from "./session-run-cancel.js";
+
+function target(sessionKey: string, runId: string): SessionRunCancelTarget {
+  return { kind: "session_run", sessionKey, runId };
+}
+
+describe("session-run cancel fan-out seam", () => {
+  afterEach(() => {
+    __testing.reset();
+  });
+
+  describe("core -> plugin (emitSessionRunCancel)", () => {
+    it("notifies handlers registered for the matching session_run target", () => {
+      const matched = vi.fn();
+      const other = vi.fn();
+      onSessionRunCancel(target("agent:main:main", "run-1"), matched);
+      onSessionRunCancel(target("agent:main:main", "run-2"), other);
+
+      const result = emitSessionRunCancel(target("agent:main:main", "run-1"), {
+        source: "test",
+        message: "stopped",
+      });
+
+      expect(result.handlerCount).toBe(1);
+      expect(matched).toHaveBeenCalledTimes(1);
+      expect(matched).toHaveBeenCalledWith(
+        { kind: "session_run", sessionKey: "agent:main:main", runId: "run-1" },
+        { source: "test", message: "stopped" },
+      );
+      expect(other).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent when the same target is cancelled twice (already-terminal)", () => {
+      const handler = vi.fn();
+      onSessionRunCancel(target("agent:main:main", "run-1"), handler);
+
+      expect(emitSessionRunCancel(target("agent:main:main", "run-1")).handlerCount).toBe(1);
+      expect(emitSessionRunCancel(target("agent:main:main", "run-1")).handlerCount).toBe(0);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("records terminal cancel for late handler registration and replays it", () => {
+      const cancelTarget = target("agent:main:main", "run-late");
+      const first = emitSessionRunCancel(cancelTarget, {
+        source: "chat-abort",
+        message: "user",
+      });
+      const late = vi.fn();
+
+      const dispose = onSessionRunCancel(cancelTarget, late);
+
+      expect(first.handlerCount).toBe(0);
+      expect(late).toHaveBeenCalledTimes(1);
+      expect(late).toHaveBeenCalledWith(cancelTarget, { source: "chat-abort", message: "user" });
+      expect(__testing.hasTerminalCancel(cancelTarget)).toBe(true);
+      dispose();
+    });
+
+    it("keeps the first terminal reason for deterministic late replay", () => {
+      const cancelTarget = target("agent:main:main", "run-terminal");
+      emitSessionRunCancel(cancelTarget, { source: "first", message: "one" });
+      emitSessionRunCancel(cancelTarget, { source: "second", message: "two" });
+      const late = vi.fn();
+
+      onSessionRunCancel(cancelTarget, late);
+
+      expect(late).toHaveBeenCalledWith(cancelTarget, { source: "first", message: "one" });
+    });
+
+    it("clears sticky terminal state for explicit run teardown", () => {
+      const cancelTarget = target("agent:main:main", "run-clear");
+      emitSessionRunCancel(cancelTarget, { source: "chat-abort" });
+      clearSessionRunCancelTarget(cancelTarget);
+      const handler = vi.fn();
+
+      onSessionRunCancel(cancelTarget, handler);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(__testing.handlerCount(cancelTarget)).toBe(1);
+    });
+
+    it("reports no live handlers when nothing is registered", () => {
+      const result = emitSessionRunCancel(target("agent:main:main", "run-1"));
+      expect(result.handlerCount).toBe(0);
+    });
+
+    it("removes handlers via the returned disposer without affecting others", () => {
+      const stays = vi.fn();
+      const leaves = vi.fn();
+      onSessionRunCancel(target("agent:main:main", "run-1"), stays);
+      const dispose = onSessionRunCancel(target("agent:main:main", "run-1"), leaves);
+
+      dispose();
+      emitSessionRunCancel(target("agent:main:main", "run-1"));
+
+      expect(stays).toHaveBeenCalledTimes(1);
+      expect(leaves).not.toHaveBeenCalled();
+    });
+
+    it("continues fan-out when a handler throws", () => {
+      const noisy = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const healthy = vi.fn();
+      onSessionRunCancel(target("agent:main:main", "run-1"), noisy);
+      onSessionRunCancel(target("agent:main:main", "run-1"), healthy);
+
+      expect(() => emitSessionRunCancel(target("agent:main:main", "run-1"))).not.toThrow();
+      expect(noisy).toHaveBeenCalledTimes(1);
+      expect(healthy).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows async handler rejections", async () => {
+      const rejecting = vi.fn(async () => {
+        throw new Error("async boom");
+      });
+      onSessionRunCancel(target("agent:main:main", "run-1"), rejecting);
+
+      emitSessionRunCancel(target("agent:main:main", "run-1"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(rejecting).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("plugin -> core (requestSessionRunCancel)", () => {
+    it("routes the cancel request through the registered abort requester", async () => {
+      const requester: SessionRunAbortRequester = vi.fn(async () => true);
+      setSessionRunAbortRequester(requester);
+
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"), {
+        source: "plugin:test",
+      });
+
+      expect(result).toEqual({ requested: true, aborted: true });
+      expect(requester).toHaveBeenCalledWith(
+        { kind: "session_run", sessionKey: "agent:main:main", runId: "run-1" },
+        { source: "plugin:test" },
+      );
+    });
+
+    it("reports aborted=false when the requester finds no active run", async () => {
+      setSessionRunAbortRequester(() => false);
+
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"));
+
+      expect(result).toEqual({ requested: true, aborted: false });
+    });
+
+    it("reports requested=false when no requester is registered", async () => {
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"));
+      expect(result).toEqual({ requested: false, aborted: false });
+    });
+
+    it("reports aborted=false when the requester throws", async () => {
+      setSessionRunAbortRequester(() => {
+        throw new Error("abort boom");
+      });
+
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"));
+      expect(result).toEqual({ requested: true, aborted: false });
+    });
+
+    it("clears the requester when the setter disposer runs", async () => {
+      const requester = vi.fn(async () => true);
+      const dispose = setSessionRunAbortRequester(requester);
+
+      dispose();
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"));
+
+      expect(requester).not.toHaveBeenCalled();
+      expect(result).toEqual({ requested: false, aborted: false });
+    });
+  });
+});

--- a/src/sessions/session-run-cancel.ts
+++ b/src/sessions/session-run-cancel.ts
@@ -1,0 +1,184 @@
+// Supported cancel fan-out seam between delegated tasks (often plugin-owned)
+// and the OpenClaw run that owns them.
+//
+// Two directions converge on the same shape:
+//   { kind: "session_run", sessionKey, runId }
+//
+//   1. Plugin -> core: delegated-task code calls `requestSessionRunCancel` to
+//      ask core to abort the owning OpenClaw run. Core registers the concrete
+//      abort behavior through `setSessionRunAbortRequester`.
+//   2. Core -> plugin: core calls `emitSessionRunCancel` (core-internal) when it
+//      aborts a run, which notifies any delegated-task cancel handlers registered
+//      via `onSessionRunCancel`.
+//
+// The seam is intentionally plugin-neutral: core call sites must not branch on
+// specific plugins or transports (for example A2A). Plugins opt in via the
+// public plugin-sdk/session-run-cancel-runtime subpath, which deliberately does
+// not export the core emitter.
+//
+// Sticky cancellation: if core aborts before a handler registers,
+// `onSessionRunCancel` replays the terminal cancel to the late subscriber.
+// The terminal state lives until explicit cleanup (`clearSessionRunCancelTarget`)
+// or the test reset hook.
+
+export type SessionRunCancelTarget = {
+  kind: "session_run";
+  sessionKey: string;
+  runId: string;
+};
+
+export type SessionRunCancelReason = {
+  source: string;
+  message?: string;
+};
+
+export type SessionRunCancelHandler = (
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+) => void | Promise<void>;
+
+export type SessionRunAbortRequester = (
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+) => boolean | Promise<boolean>;
+
+export type RequestSessionRunCancelResult = {
+  requested: boolean;
+  aborted: boolean;
+};
+
+type HandlerKey = `${string}\u0000${string}`;
+
+const HANDLERS = new Map<HandlerKey, Set<SessionRunCancelHandler>>();
+const TERMINAL_CANCELS = new Map<HandlerKey, SessionRunCancelReason | undefined>();
+
+let abortRequester: SessionRunAbortRequester | undefined;
+
+function keyFor(target: SessionRunCancelTarget): HandlerKey {
+  return `${target.sessionKey}\u0000${target.runId}`;
+}
+
+function invokeBestEffort(
+  handler: SessionRunCancelHandler,
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+): void {
+  try {
+    const result = handler(target, reason);
+    if (result && typeof (result as Promise<unknown>).then === "function") {
+      (result as Promise<unknown>).catch(() => {
+        // Best-effort fan-out/replay; swallow async handler errors.
+      });
+    }
+  } catch {
+    // Best-effort fan-out/replay; swallow sync handler errors.
+  }
+}
+
+export function onSessionRunCancel(
+  target: SessionRunCancelTarget,
+  handler: SessionRunCancelHandler,
+): () => void {
+  const key = keyFor(target);
+
+  if (TERMINAL_CANCELS.has(key)) {
+    invokeBestEffort(handler, target, TERMINAL_CANCELS.get(key));
+    return () => {};
+  }
+
+  let bucket = HANDLERS.get(key);
+  if (!bucket) {
+    bucket = new Set();
+    HANDLERS.set(key, bucket);
+  }
+  bucket.add(handler);
+  let disposed = false;
+  return () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    const current = HANDLERS.get(key);
+    if (!current) {
+      return;
+    }
+    current.delete(handler);
+    if (current.size === 0) {
+      HANDLERS.delete(key);
+    }
+  };
+}
+
+// Core-internal emitter. Do not expose this from plugin SDK runtime subpaths;
+// plugins observe via `onSessionRunCancel` or request via
+// `requestSessionRunCancel` instead.
+export function emitSessionRunCancel(
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+): { handlerCount: number } {
+  const key = keyFor(target);
+  if (!TERMINAL_CANCELS.has(key)) {
+    TERMINAL_CANCELS.set(key, reason);
+  }
+
+  const bucket = HANDLERS.get(key);
+  if (!bucket || bucket.size === 0) {
+    return { handlerCount: 0 };
+  }
+  // Snapshot so handlers can unregister during dispatch without affecting the
+  // remaining fan-out, and clear eagerly so duplicate emits are idempotent.
+  const snapshot = Array.from(bucket);
+  HANDLERS.delete(key);
+  for (const handler of snapshot) {
+    invokeBestEffort(handler, target, reason);
+  }
+  return { handlerCount: snapshot.length };
+}
+
+export function clearSessionRunCancelTarget(target: SessionRunCancelTarget): void {
+  TERMINAL_CANCELS.delete(keyFor(target));
+}
+
+export function setSessionRunAbortRequester(
+  requester: SessionRunAbortRequester | undefined,
+): () => void {
+  abortRequester = requester;
+  return () => {
+    if (abortRequester === requester) {
+      abortRequester = undefined;
+    }
+  };
+}
+
+export async function requestSessionRunCancel(
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+): Promise<RequestSessionRunCancelResult> {
+  const requester = abortRequester;
+  if (!requester) {
+    return { requested: false, aborted: false };
+  }
+  try {
+    const aborted = await requester(target, reason);
+    return { requested: true, aborted };
+  } catch {
+    return { requested: true, aborted: false };
+  }
+}
+
+export const __testing = {
+  reset(): void {
+    HANDLERS.clear();
+    TERMINAL_CANCELS.clear();
+    abortRequester = undefined;
+  },
+  handlerCount(target: SessionRunCancelTarget): number {
+    return HANDLERS.get(keyFor(target))?.size ?? 0;
+  },
+  terminalCancelCount(): number {
+    return TERMINAL_CANCELS.size;
+  },
+  hasTerminalCancel(target: SessionRunCancelTarget): boolean {
+    return TERMINAL_CANCELS.has(keyFor(target));
+  },
+};

--- a/src/sessions/session-run-cancel.ts
+++ b/src/sessions/session-run-cancel.ts
@@ -18,8 +18,9 @@
 //
 // Sticky cancellation: if core aborts before a handler registers,
 // `onSessionRunCancel` replays the terminal cancel to the late subscriber.
-// The terminal state lives until explicit cleanup (`clearSessionRunCancelTarget`)
-// or the test reset hook.
+// The terminal state is intentionally bounded: production run teardown should
+// clear it with `clearSessionRunCancelTarget`, and the module also prunes old
+// entries by TTL/max-size as a safety net for missed cleanup paths.
 
 export type SessionRunCancelTarget = {
   kind: "session_run";
@@ -50,12 +51,38 @@ export type RequestSessionRunCancelResult = {
 type HandlerKey = `${string}\u0000${string}`;
 
 const HANDLERS = new Map<HandlerKey, Set<SessionRunCancelHandler>>();
-const TERMINAL_CANCELS = new Map<HandlerKey, SessionRunCancelReason | undefined>();
+const TERMINAL_CANCEL_TTL_MS = 10 * 60_000;
+const TERMINAL_CANCEL_MAX_ENTRIES = 1_000;
+const TERMINAL_CANCELS = new Map<
+  HandlerKey,
+  { reason: SessionRunCancelReason | undefined; recordedAtMs: number }
+>();
 
 let abortRequester: SessionRunAbortRequester | undefined;
 
 function keyFor(target: SessionRunCancelTarget): HandlerKey {
   return `${target.sessionKey}\u0000${target.runId}`;
+}
+
+function pruneTerminalCancels(now = Date.now()): void {
+  for (const [key, entry] of TERMINAL_CANCELS) {
+    if (now - entry.recordedAtMs > TERMINAL_CANCEL_TTL_MS) {
+      TERMINAL_CANCELS.delete(key);
+    }
+  }
+
+  const excess = TERMINAL_CANCELS.size - TERMINAL_CANCEL_MAX_ENTRIES;
+  if (excess <= 0) {
+    return;
+  }
+  let removed = 0;
+  for (const key of TERMINAL_CANCELS.keys()) {
+    TERMINAL_CANCELS.delete(key);
+    removed += 1;
+    if (removed >= excess) {
+      break;
+    }
+  }
 }
 
 function invokeBestEffort(
@@ -80,9 +107,11 @@ export function onSessionRunCancel(
   handler: SessionRunCancelHandler,
 ): () => void {
   const key = keyFor(target);
+  pruneTerminalCancels();
 
-  if (TERMINAL_CANCELS.has(key)) {
-    invokeBestEffort(handler, target, TERMINAL_CANCELS.get(key));
+  const terminalCancel = TERMINAL_CANCELS.get(key);
+  if (terminalCancel) {
+    invokeBestEffort(handler, target, terminalCancel.reason);
     return () => {};
   }
 
@@ -117,8 +146,10 @@ export function emitSessionRunCancel(
   reason?: SessionRunCancelReason,
 ): { handlerCount: number } {
   const key = keyFor(target);
+  pruneTerminalCancels();
   if (!TERMINAL_CANCELS.has(key)) {
-    TERMINAL_CANCELS.set(key, reason);
+    TERMINAL_CANCELS.set(key, { reason, recordedAtMs: Date.now() });
+    pruneTerminalCancels();
   }
 
   const bucket = HANDLERS.get(key);
@@ -176,9 +207,17 @@ export const __testing = {
     return HANDLERS.get(keyFor(target))?.size ?? 0;
   },
   terminalCancelCount(): number {
+    pruneTerminalCancels();
     return TERMINAL_CANCELS.size;
   },
   hasTerminalCancel(target: SessionRunCancelTarget): boolean {
+    pruneTerminalCancels();
     return TERMINAL_CANCELS.has(keyFor(target));
+  },
+  terminalCancelMaxEntries(): number {
+    return TERMINAL_CANCEL_MAX_ENTRIES;
+  },
+  terminalCancelTtlMs(): number {
+    return TERMINAL_CANCEL_TTL_MS;
   },
 };


### PR DESCRIPTION
## Summary
- Rebased this replacement lane onto latest `origin/main` and kept the minimal-test-gateway requester guard from the prior patch.
- Bounded sticky session-run cancel replay state with a 10 minute TTL plus a 1,000-entry cap, while preserving late-handler replay semantics.
- Added a production cleanup path: registered chat/agent run teardown now clears the matching sticky cancel target after the owning run finishes/aborts.
- Documented `openclaw/plugin-sdk/session-run-cancel-runtime` in `docs/plugins/sdk-subpaths.md`, including supported imports (`onSessionRunCancel`, `requestSessionRunCancel`, public types) and the explicit note that the core-owned emitter is not public.
- Added the required `CHANGELOG.md` Unreleased entry for the Plugin SDK import path and Gateway cancel behavior.

## Integration note
- #75371 remains the clean replacement lane for #68624. It no longer carries the earlier stacked `sessions_send` scope from #68622.

## Real behavior proof

Behavior or issue addressed: Plugin-owned delegated tasks can use `openclaw/plugin-sdk/session-run-cancel-runtime` to request cancellation of the owning Gateway session run; Gateway aborts the run, emits the core-owned cancel to plugin observers, preserves sticky replay briefly for late registration, and clears sticky replay during run cleanup. The core-owned emitter remains unavailable through the public plugin SDK subpath.

Real environment tested: Local OpenClaw checkout at PR head `f9343ffcda` on Node `v22.22.2` in the repository worktree, using the real in-process Gateway chat-abort runtime (`registerChatAbortController` + `wireSessionRunCancelRequester`) and the plugin-facing session-run-cancel runtime import path. No external network sends or secrets were used.

Exact steps or command run after this patch: Ran a one-off local runtime proof script with `node --import tsx <proof-script>.mts`. The script registered a real Gateway chat abort controller, wired `wireSessionRunCancelRequester(...)`, imported `onSessionRunCancel` and `requestSessionRunCancel` through the plugin SDK runtime source path, requested cancel for `{ kind:"session_run", sessionKey:"agent:proof:main", runId:"proof-run-1" }`, then checked the Gateway abort signal, plugin observer callback, sticky replay before cleanup, and cleanup state after `active.cleanup()`.

Evidence after fix: Copied terminal output from the local proof command:

```json
{
  "proof": "local gateway chat-abort runtime + public plugin SDK session-run-cancel-runtime",
  "publicPluginImport": "openclaw/plugin-sdk/session-run-cancel-runtime",
  "coreEmitterPublic": false,
  "requestResult": { "requested": true, "aborted": true },
  "abortSignalAborted": true,
  "pluginObservedCancel": {
    "target": { "kind": "session_run", "sessionKey": "agent:proof:main", "runId": "proof-run-1" },
    "reason": { "source": "chat-abort", "message": "real runtime proof" }
  },
  "stickyReplayBeforeRunCleanup": { "source": "chat-abort", "message": "real runtime proof" },
  "stickyReplayAfterRunCleanupCount": 0,
  "terminalStateAfterRunCleanup": false,
  "abortedBroadcast": { "runId": "proof-run-1", "sessionKey": "agent:proof:main", "seq": 5, "state": "aborted", "stopReason": "real runtime proof" },
  "nodeSessionEventCount": 1,
  "boundedTerminalMaxEntries": 1000,
  "boundedTerminalTtlMs": 600000
}
```

Observed result after fix: The plugin-side cancel request returned `{ requested:true, aborted:true }`; the Gateway AbortController signal was aborted; the plugin observer saw exactly one `{ source:"chat-abort" }` cancellation; late registration replayed the sticky cancel before run cleanup; run cleanup removed sticky replay (`stickyReplayAfterRunCleanupCount:0`, `terminalStateAfterRunCleanup:false`); and the Gateway emitted an aborted chat payload with the requested stop reason.

What was not tested: External channel delivery, remote production Gateway deployment, and third-party plugin package publishing were not exercised in this local proof.

## Verification
- `pnpm exec vitest run src/sessions/session-run-cancel.test.ts src/gateway/chat-abort.test.ts src/plugin-sdk/session-run-cancel-runtime.test.ts src/gateway/server-startup-early.test.ts` → pass (6 files, 52 tests across configured projects)
- `pnpm exec vitest run src/gateway/server.chat.gateway-server-chat-b.test.ts --testNamePattern "smoke: supports abort and idempotent completion"` → pass
- `pnpm run plugin-sdk:api:gen && pnpm run plugin-sdk:api:check` → pass (`OK docs/.generated/plugin-sdk-api-baseline.sha256`)
- `pnpm run lint:plugins:plugin-sdk-subpaths-exported` → pass
- `pnpm run format:docs:check` → pass
- `node scripts/check-docs-mdx.mjs docs/plugins/sdk-subpaths.md` → pass
- `pnpm run lint:core` → pass
- `pnpm run build` → pass