### PR TITLE
fix(copilot): remove stale claude-opus-4.6 from default model IDs

### DIFF
--- a/extensions/github-copilot/models-defaults.ts
+++ b/extensions/github-copilot/models-defaults.ts
@@ -10,7 +10,6 @@ const DEFAULT_MAX_TOKENS = 8192;
 const DEFAULT_MODEL_IDS = [
   "claude-haiku-4.5",
   "claude-opus-4.5",
-  "claude-opus-4.6",
   "claude-opus-4.7",
   "claude-sonnet-4",
   "claude-sonnet-4.6",


### PR DESCRIPTION
## Summary

Removes the stale `claude-opus-4.6` model ID from the `DEFAULT_MODEL_IDS` array in the `github-copilot` extension.

## Problem

GitHub Copilot no longer supports `claude-opus-4.6`. Having an unsupported model in the hardcoded defaults triggers a provider-wide cooldown when Copilot rejects the model, blocking the entire provider from working.

## Fix

Remove `"claude-opus-4.6"` from the `DEFAULT_MODEL_IDS` array in `extensions/github-copilot/models-defaults.ts`.

## Testing

- Verified the change compiles cleanly against the extension's `tsconfig.json`
- No other files reference `claude-opus-4.6` in the github-copilot extension

Closes #75349
