### PR TITLE
fix(signal): keep quiet SSE receive streams open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Signal: keep the inbound SSE receive stream open by default while the account is quiet instead of aborting before response headers after 10s, preventing reconnect/backoff gaps that can make inbound DMs unreliable even when outbound sends and daemon probes work. Fixes #75426.
 - Agents/pi-embedded-runner: extract the `abortable` provider-call wrapper from `runEmbeddedAttempt` to module scope so its promise handlers no longer close over the run lexical context, releasing transcripts, tool buffers, and subscription callbacks when a provider call hangs past abort. (#74182) Thanks @cjboy007.
 - Docker: restore `python3` in the gateway runtime image after the slim-runtime switch. Fixes #75041.
 - CLI/Voice Call: scope `voicecall` command activation to the Voice Call plugin so setup and smoke checks no longer broad-load unrelated plugin runtimes or hang after printing JSON. Thanks @vincentkoc.

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -308,6 +308,30 @@ describe("streamSignalEvents", () => {
     ).rejects.toMatchObject({ name: "AbortError", message: "Signal SSE aborted" });
   });
 
+  it("keeps quiet event streams open by default until aborted", async () => {
+    const baseUrl = await withSignalServer(() => {
+      // Leave the request open without response headers.
+    });
+    const abortController = new AbortController();
+    let settled = false;
+    const stream = streamSignalEvents({
+      baseUrl,
+      abortSignal: abortController.signal,
+      onEvent: () => {},
+    }).finally(() => {
+      settled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    expect(settled).toBe(false);
+
+    abortController.abort();
+    await expect(stream).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Signal SSE aborted",
+    });
+  });
+
   it("rejects oversized SSE line buffers by byte size", async () => {
     const baseUrl = await withSignalServer((_req, res) => {
       res.writeHead(200, { "Content-Type": "text/event-stream" });

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -102,8 +102,8 @@ function normalizeSignalHttpResponseMaxBytes(value: number | undefined): number 
   return Math.floor(value);
 }
 
-function normalizeSignalSseTimeoutMs(timeoutMs: number): number | null {
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+function normalizeSignalSseTimeoutMs(timeoutMs: number | undefined): number | null {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return null;
   }
   return timeoutMs;
@@ -253,7 +253,7 @@ export async function signalCheck(
 function openSignalEventStream(
   url: URL,
   abortSignal?: AbortSignal,
-  timeoutMs = DEFAULT_TIMEOUT_MS,
+  timeoutMs?: number,
 ): Promise<{ response: IncomingMessage; cleanup: () => void }> {
   assertSignalHttpProtocol(url, "SSE");
   if (abortSignal?.aborted) {
@@ -346,7 +346,7 @@ export async function streamSignalEvents(params: {
   const { response, cleanup } = await openSignalEventStream(
     url,
     params.abortSignal,
-    params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    params.timeoutMs,
   );
   const decoder = new TextDecoder();
   let buffer = "";


### PR DESCRIPTION
Fixes #75426.

## Summary
- stop applying the default 10s header deadline to long-lived Signal SSE receive streams
- keep explicit SSE deadlines available for tests/callers that request them
- add regression coverage for quiet streams that do not send response headers until aborted
- add a changelog entry

## Verification
- pnpm test extensions/signal/src/client.test.ts
- pnpm test extensions/signal/src/monitor.tool-result.autostart.test.ts extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
- pnpm exec oxfmt --check --threads=1 extensions/signal/src/client.ts extensions/signal/src/client.test.ts CHANGELOG.md
- pnpm check:changelog-attributions
- git diff --check