### PR TITLE
fix: log and recover from swallowed subagent completion errors

### DIFF
--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -239,8 +239,14 @@ export function createSubagentRunManager(params: {
         accountId: entry.requesterOrigin?.accountId,
         triggerCleanup: true,
       });
-    } catch {
-      // ignore
+    } catch (error) {
+      const entry = params.runs.get(runId);
+      log.warn("subagent completion failed; scheduling orphan recovery", {
+        runId,
+        childSessionKey: entry?.childSessionKey,
+        error,
+      });
+      params.scheduleOrphanRecovery({ delayMs: 1_000 });
     }
   };
 


### PR DESCRIPTION
## Summary

The `waitForSubagentCompletion` catch block in `src/agents/subagent-registry-run-manager.ts` silently swallowed all errors — including failures from `completeSubagentRun`. This caused subagent runs to appear permanently stuck with no diagnostic trace when completion failed.

## Problem

The entire `waitForSubagentCompletion` function was wrapped in a `try/catch` with an empty catch body (`// ignore`). If `completeSubagentRun` or any preceding step threw an error, the subagent run would never be properly completed, cleaned up, or announced to the parent session — creating ghost runs that consume resources indefinitely.

## Fix

Replace the silent `catch {}` with:
1. **Logging** — `log.warn` with `runId`, `childSessionKey`, and the error, giving operators visibility into what failed and why.
2. **Orphan recovery** — `scheduleOrphanRecovery({ delayMs: 1_000 })` to trigger the existing recovery mechanism, which will attempt to reconcile the stuck run. This follows the same pattern already used for recoverable wait errors at line 183.

## Related issues

- #62968 — subagent announce direct-send error silently swallowed when queue fallback recovers
- #67777 — subagent completion delivery can be lost on direct-announce timeout, drain, or orphan prune
- #44925 — subagent completion silently lost — no retry, no notification, no auto-restart on timeout
- #75196 — subagent completion event sometimes drops result payload and/or token stats
- #72293 — aborted subagent with empty content silently marked done, never auto-announces
- #74448 — subagent task completion event fires on session-compaction, not on actual task end
- #68668 — subagent-registry: cleanupBrowserSessionsForLifecycleEnd wrapper invoked twice for same runId
- #74363 — subagent runs can be falsely marked failed/lost after clean gateway close
- #69767 — async/subagent completion can be announced before the result payload exists

## Testing

All 74 subagent-registry test shards pass (`pnpm test src/agents/subagent-registry`).

Closes #82306