### PR TITLE
feat: add configurable promptMode to agents.defaults

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -203,11 +203,17 @@ export async function resolvePromptBuildHookResult(params: {
   };
 }
 
-export function resolvePromptModeForSession(sessionKey?: string): "minimal" | "full" {
+export function resolvePromptModeForSession(
+  sessionKey?: string,
+  configPromptMode?: "full" | "minimal",
+): "minimal" | "full" {
   if (!sessionKey) {
-    return "full";
+    return configPromptMode ?? "full";
   }
-  return isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey) ? "minimal" : "full";
+  if (isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey)) {
+    return "minimal";
+  }
+  return configPromptMode ?? "full";
 }
 
 export function shouldInjectHeartbeatPrompt(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -404,6 +404,21 @@ describe("resolvePromptModeForSession", () => {
     expect(resolvePromptModeForSession("agent:main")).toBe("full");
     expect(resolvePromptModeForSession("agent:main:thread:abc")).toBe("full");
   });
+
+  it("respects configPromptMode for primary sessions", () => {
+    expect(resolvePromptModeForSession("agent:main", "minimal")).toBe("minimal");
+    expect(resolvePromptModeForSession("agent:main:thread:abc", "minimal")).toBe("minimal");
+    expect(resolvePromptModeForSession(undefined, "minimal")).toBe("minimal");
+  });
+
+  it("subagent and cron sessions stay minimal regardless of config", () => {
+    expect(resolvePromptModeForSession("agent:main:subagent:child", "full")).toBe("minimal");
+    expect(resolvePromptModeForSession("agent:main:cron:job-1", "full")).toBe("minimal");
+  });
+
+  it("defaults to full when configPromptMode is undefined", () => {
+    expect(resolvePromptModeForSession("agent:main", undefined)).toBe("full");
+  });
 });
 
 describe("shouldStripBootstrapFromEmbeddedContext", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1135,9 +1135,10 @@ export async function runEmbeddedAttempt(
       },
     });
     const isDefaultAgent = sessionAgentId === defaultAgentId;
+    const configPromptMode = params.config?.agents?.defaults?.promptMode;
     const promptMode =
       params.promptMode ??
-      (isRawModelRun ? "none" : resolvePromptModeForSession(params.sessionKey));
+      (isRawModelRun ? "none" : resolvePromptModeForSession(params.sessionKey, configPromptMode));
 
     // When toolsAllow is set, use minimal prompt and strip skills catalog
     const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -204,6 +204,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Agent runtime configuration root covering defaults and explicit agent entries used for routing and execution context. Keep this section explicit so model/tool behavior stays predictable across multi-agent workflows.",
   "agents.defaults":
     "Shared default settings inherited by agents unless overridden per entry in agents.list. Use defaults to enforce consistent baseline behavior and reduce duplicated per-agent configuration.",
+  "agents.defaults.promptMode":
+    "System prompt verbosity for primary sessions. 'minimal' strips Documentation, Self-Update, Model Aliases, and other non-essential sections to reduce token overhead — especially useful for local models (Ollama) where every system prompt token is re-sent on every turn. Subagent and cron sessions always use 'minimal' regardless of this setting. Default: 'full'.",
   "agents.defaults.skills":
     "Optional default skill allowlist inherited by agents that omit agents.list[].skills. Omit for unrestricted skills, set [] to give inheriting agents no skills, and remember explicit agents.list[].skills replaces this default instead of merging with it.",
   "agents.defaults.contextLimits":

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -88,6 +88,12 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    promptMode: z
+      .union([z.literal("full"), z.literal("minimal")])
+      .optional()
+      .describe(
+        "System prompt verbosity for primary sessions. 'minimal' strips Documentation, Self-Update, Model Aliases, and other non-essential sections to reduce token overhead on local models. Subagent and cron sessions always use 'minimal' regardless of this setting. Default: 'full'.",
+      ),
     skipBootstrap: z.boolean().optional(),
     contextInjection: z
       .union([z.literal("always"), z.literal("continuation-skip"), z.literal("never")])


### PR DESCRIPTION
## Summary

- **Problem:** The system prompt for primary sessions is always `"full"` (~35K chars), with ~18-26K chars of framework overhead (Documentation links, Self-Update instructions, Model Aliases, etc.) that cannot be reduced via config. For local model deployments using Ollama (no prompt caching), this overhead is re-sent on every turn, consuming ~60% of the context window on small models (e.g. `num_ctx=16384`).
- **Why it matters:** Operators running local models on consumer GPUs (8-12GB VRAM) have tight context budgets. Every token saved in the system prompt is available for conversation history and tool results, improving response quality.
- **What changed:** Added `agents.defaults.promptMode` config field accepting `"full"` (default) or `"minimal"`. When set to `"minimal"`, primary sessions use the same lean prompt that subagent/cron sessions already use — stripping Documentation, Self-Update, Model Aliases, User Identity, Reply Tags, and Voice sections.
- **What did NOT change:** Subagent and cron sessions always use `"minimal"` regardless of this setting. The `"full"` default preserves existing behavior. No prompt content was modified — only which sections are included.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Token overhead discussion for local model deployments
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — this is a new feature, not a bug fix.

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
- Target test: `src/agents/pi-embedded-runner/run/attempt.test.ts`
- Scenarios locked in:
  - `configPromptMode: "minimal"` is respected for primary sessions
  - Subagent/cron sessions stay `"minimal"` even when config says `"full"`
  - `undefined` configPromptMode defaults to `"full"`
- Why this is the smallest reliable guardrail: The function is pure (no side effects), so unit tests fully cover the logic.

## User-visible / Behavior Changes

- New config field: `agents.defaults.promptMode` (`"full"` | `"minimal"`)
- When set to `"minimal"`, primary session system prompts are shorter (strips ~6K chars of Documentation, Self-Update, Model Aliases, etc.)
- Default behavior unchanged (`"full"`)

## Diagram (if applicable)

```text
Before:
resolvePromptModeForSession(sessionKey)
  subagent/cron → "minimal"
  everything else → "full" (hardcoded)

After:
resolvePromptModeForSession(sessionKey, configPromptMode?)
  subagent/cron → "minimal" (always, ignores config)
  everything else → configPromptMode ?? "full"
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (Linux 6.8.0)
- Runtime: OpenClaw 2026.4.2 (Docker)
- Model: Ollama gemma4-oc (8B, num_ctx=16384)

### Steps

1. Set `agents.defaults.promptMode: "minimal"` in `openclaw.json`
2. Start a new primary session
3. Check `context-diag` log for `systemPromptChars`

### Expected

- `systemPromptChars` reduced by ~6K compared to `"full"` mode

### Actual

- (Verified via source reading that `isMinimal` gates apply to Documentation, Self-Update, Model Aliases, User Identity, Reply Tags, and Voice sections)

## Evidence

- [x] Unit tests added covering all branches
- [x] Source analysis confirming `isMinimal` gates in `buildAgentSystemPrompt`

## Human Verification (required)

- Verified: Source code analysis of `buildAgentSystemPrompt` confirms `isMinimal` guards on Documentation, Self-Update, Model Aliases, User Identity, Reply Tags, Voice sections
- Verified: Existing `promptMode: "minimal"` path is well-tested (used by all subagent/cron sessions)
- Edge cases: `undefined` config defaults to `"full"`, subagent/cron override is preserved
- Not verified: Full integration test with running OpenClaw instance (unit tests only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional field `agents.defaults.promptMode`
- Migration needed? No — default is `"full"` (existing behavior)

## Risks and Mitigations

- Risk: Operators set `"minimal"` and lose access to Self-Update guidance or Documentation links.
  - Mitigation: These are convenience sections, not functional requirements. Operators choosing `"minimal"` are explicitly opting for lean prompts. The config help text explains what is stripped.