### PR TITLE
fix(cli-runner): classify session_expired when CLI returns errors[] without result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/cli-runner: read `parsed.errors[]` strings into the `createResultError` message fallback chain in the Claude live-session runner, so `classifyFailoverReason` sees the original CLI text (e.g. "No conversation found with session ID: …") and returns `session_expired` instead of `unknown`. Without this, the existing `clearCliSessionInStore` + retry-without-`--resume` recovery branch in `attempt-execution.ts` was silently skipped and the session loop wedged on stale `claudeCliSessionId` entries.
 - Google Meet/Voice Call: play Twilio Meet DTMF before opening the realtime media stream and carry the intro as the initial Voice Call message, so the greeting is generated after Meet admits the phone participant instead of racing a live-call TwiML update. Thanks @donkeykong91 and @PfanP.
 - Google Meet/Voice Call: make Twilio setup preflight honor explicit `--transport twilio` and fail local/private Voice Call webhook URLs before joins. Thanks @donkeykong91 and @PfanP.
 - Voice Call/Twilio: retry transient 21220 live-call TwiML updates and catch answered-path initial-greeting failures, so a fast answered callback no longer crashes the Gateway or drops the Twilio greeting/listen transition. (#74606) Thanks @Sivan22.

--- a/src/agents/cli-runner/claude-live-session.test.ts
+++ b/src/agents/cli-runner/claude-live-session.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { createResultError } from "./claude-live-session.js";
+
+const fakeSession = {
+  providerId: "claude-cli",
+  modelId: "claude-opus-4-7",
+} as Parameters<typeof createResultError>[0];
+
+describe("createResultError", () => {
+  test("classifies session_expired when CLI returns errors[] (no result string)", () => {
+    const parsed = {
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      errors: ["No conversation found with session ID: bcef6ad0-1f50-4a30-b7b9-9a2c0e1ca625"],
+      result: null,
+    };
+    const raw = JSON.stringify(parsed);
+    const err = createResultError(fakeSession, parsed, raw);
+    expect(err.reason).toBe("session_expired");
+    expect(err.message).toContain("No conversation found");
+  });
+
+  test("falls back to result string when no errors[] (existing behavior)", () => {
+    const parsed = {
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      result: "API Error: 500 Internal",
+    };
+    const err = createResultError(fakeSession, parsed, JSON.stringify(parsed));
+    expect(err.message).toContain("API Error");
+  });
+
+  test("uses generic fallback when no errors[] and no result string", () => {
+    const parsed = { type: "result", is_error: true };
+    const err = createResultError(fakeSession, parsed, JSON.stringify(parsed));
+    expect(err.message).toBe("Claude CLI failed.");
+    expect(err.reason).toBe("unknown");
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -460,13 +460,20 @@ function parseClaudeLiveJsonLine(
   return isRecord(parsed) ? parsed : null;
 }
 
-function createResultError(
+export function createResultError(
   session: ClaudeLiveSession,
   parsed: Record<string, unknown>,
   raw: string,
 ): FailoverError {
   const result = typeof parsed.result === "string" ? parsed.result.trim() : "";
-  const message = extractCliErrorMessage(raw) ?? (result || "Claude CLI failed.");
+  const errorsArray = Array.isArray(parsed.errors)
+    ? parsed.errors
+        .filter((x): x is string => typeof x === "string")
+        .map((x) => x.trim())
+        .filter((x) => x.length > 0)
+        .join("\n")
+    : "";
+  const message = extractCliErrorMessage(raw) ?? (errorsArray || result || "Claude CLI failed.");
   const reason = classifyFailoverReason(message, { provider: session.providerId }) ?? "unknown";
   return new FailoverError(message, {
     reason,


### PR DESCRIPTION
## Summary

When the Claude CLI emits an `error_during_execution` result event with an `errors:[...]` array but `result:null` (the actual format for "No conversation found with session ID" failures), `createResultError` falls back to `"Claude CLI failed."` and `classifyFailoverReason` cannot match the registered `isCliSessionExpiredErrorMessage` patterns. This makes `attempt-execution.ts` skip its `clearCliSessionInStore` + retry-without-session recovery path, so the bot is permanently wedged on a stale `claudeCliSessionId` until the entry is cleared by hand or the pod restarts.

## Repro

\`\`\`bash
claude --print --verbose --model claude-opus-4-7 \
  --resume bcef6ad0-1f50-4a30-b7b9-9a2c0e1ca625 \
  --input-format stream-json --output-format stream-json \
  <<<'{"type":"user","message":{"role":"user","content":[{"type":"text","text":"x"}]}}'
\`\`\`

Output (any UUID with no backing JSONL produces this shape):

\`\`\`json
{"type":"result","subtype":"error_during_execution","is_error":true,
 "errors":["No conversation found with session ID: bcef6ad0-..."],"result":null,...}
\`\`\`

## Production logs (before fix)

\`\`\`
[agent/cli-backend] claude live session turn failed: ... error=FailoverError
[model-fallback/decision] decision=candidate_failed ... reason=unknown ... detail=Claude CLI failed.
Embedded agent failed before reply: Claude CLI failed.
\`\`\`

`reason=unknown` here should have been `reason=session_expired`. Walking the call chain:

1. `claude-live-session.ts createResultError` reads `parsed.result` — null in this payload — and falls back to the literal `"Claude CLI failed."`.
2. `pi-embedded-helpers/errors.ts:1280 isCliSessionExpiredErrorMessage` already includes `"no conversation found"` (and several siblings) in its match list, but never gets a chance to see the original CLI text because step 1 dropped it.
3. `attempt-execution.ts:482` only enters its `clearCliSessionInStore` + retry-without-session branch when `err.reason === "session_expired"`, so the bot loops forever on a stale `claudeCliSessionId`.

## Fix

Read `parsed.errors[]` (filter to strings, trim, drop empties, join with `\n`) into the message-fallback chain in `createResultError` before the `result` string and the generic literal. Now the message text passed to `classifyFailoverReason` contains the original "No conversation found ..." string and `isCliSessionExpiredErrorMessage` matches it. The existing recovery path in `attempt-execution.ts` then fires automatically.

## Test plan

- [x] Unit test added: `claude-live-session.test.ts` — `createResultError` returns `reason="session_expired"` when only `errors[]` is populated, preserves existing behavior when `result` string is present, preserves "Claude CLI failed." fallback when neither is set.
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/cli-runner/claude-live-session.test.ts` → 3/3 pass.
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/cli-runner/` → 35/35 pass (no regression).
- [x] Typecheck via `node scripts/run-tsgo.mjs -p tsconfig.core.test.agents.json` clean.