### PR TITLE
fix(agents): exclude tool result details from guard budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1414,6 +1414,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: cap summarization output reserve tokens to the selected model's `maxTokens` so 1M-context Anthropic compactions do not request more output than the API permits. Fixes #54383.
 - Control UI/login: replace raw connection failures with structured, actionable login guidance for auth, pairing, insecure HTTP, origin, protocol, and transport failures. Thanks @BunsDev.
 - Agents/tools: fail `exec host=node` before `system.run` when the selected node is known to be disconnected, with an actionable reconnect message instead of a raw node invoke failure. Thanks @BunsDev.
+- Agents/tool-result guard: ignore internal tool-result `details` when estimating model-visible context, so large diagnostic metadata no longer triggers unnecessary truncation or compaction even though the provider boundary already strips `details` before model conversion. (#75525) Thanks @zqchris.
 - Agents/models: accept legacy `anthropic-cli/*` model refs as Claude CLI runtime refs instead of failing model resolution with `Unknown model`. Thanks @BunsDev.
 - Agents/tools: keep restrictive-profile tool-section warnings scoped to the configured sections whose tools are still missing from `alsoAllow`, so already re-allowed filesystem tools do not make exec-only fixes look broader than they are. Thanks @BunsDev.
 - Agents/tools: avoid warning messaging-only agents about inherited global `tools.exec` or `tools.fs` sections when the agent profile did not configure those tool sections itself. Thanks @BunsDev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ Docs: https://docs.openclaw.ai
 - Native chat: decode gateway-provided thinking metadata for the iOS/macOS picker so provider-specific levels such as `adaptive`, `xhigh`, and `max` appear without leaking unsupported default-model options. Thanks @BunsDev.
 - Agents/compaction: cap summarization output reserve tokens to the selected model's `maxTokens` so 1M-context Anthropic compactions do not request more output than the API permits. Fixes #54383.
 - Agents/tools: fail `exec host=node` before `system.run` when the selected node is known to be disconnected, with an actionable reconnect message instead of a raw node invoke failure. Thanks @BunsDev.
+- Agents/tool-result guard: ignore internal tool-result `details` when estimating model-visible context, so large diagnostic metadata no longer triggers unnecessary truncation or compaction even though the provider boundary already strips `details` before model conversion. (#75525) Thanks @zqchris.
 - Agents/models: accept legacy `anthropic-cli/*` model refs as Claude CLI runtime refs instead of failing model resolution with `Unknown model`. Thanks @BunsDev.
 - Agents/tools: keep restrictive-profile tool-section warnings scoped to the configured sections whose tools are still missing from `alsoAllow`, so already re-allowed filesystem tools do not make exec-only fixes look broader than they are. Thanks @BunsDev.
 - Agents/tools: avoid warning messaging-only agents about inherited global `tools.exec` or `tools.fs` sections when the agent profile did not configure those tool sections itself. Thanks @BunsDev.

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -125,10 +125,9 @@ function estimateMessageChars(msg: AgentMessage): number {
   }
 
   if (isToolResultMessage(msg)) {
+    // `details` is stripped before provider conversion; estimate only visible content.
     const content = getToolResultContent(msg);
-    let chars = estimateContentBlockChars(content);
-    const details = (msg as { details?: unknown }).details;
-    chars += estimateUnknownChars(details);
+    const chars = estimateContentBlockChars(content);
     const weightedChars = Math.ceil(
       chars * (CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE),
     );

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -125,10 +125,15 @@ function estimateMessageChars(msg: AgentMessage): number {
   }
 
   if (isToolResultMessage(msg)) {
+    // NOTE: toolResult.details is stripped before messages are sent to the
+    // model (see stripToolResultDetails in src/agents/compaction.ts), so it
+    // must not count toward the guard's context budget. Counting it here
+    // caused the preemptive overflow guard to fire on long tool loops even
+    // when the real prompt was nowhere near the context window, because verbose
+    // process/exec/gateway `details` payloads are often several times larger
+    // than the `content` text that actually reaches the LLM.
     const content = getToolResultContent(msg);
-    let chars = estimateContentBlockChars(content);
-    const details = (msg as { details?: unknown }).details;
-    chars += estimateUnknownChars(details);
+    const chars = estimateContentBlockChars(content);
     const weightedChars = Math.ceil(
       chars * (CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE),
     );

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -371,6 +371,36 @@ describe("installToolResultContextGuard", () => {
       expect((err as MidTurnPrecheckSignal).request.route).toBe("compact_only");
     }
   });
+  it("does not count tool-result details toward the context budget", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [
+      makeToolResultWithDetails("call_small_text", "x".repeat(100), "d".repeat(50_000)),
+      makeToolResultWithDetails("call_another", "y".repeat(120), "e".repeat(80_000)),
+    ];
+
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
+
+    expect(transformed).toBe(contextForNextCall);
+    expect(getToolResultText(transformed[0])).toBe("x".repeat(100));
+    expect(getToolResultText(transformed[1])).toBe("y".repeat(120));
+    expect((contextForNextCall[0] as { details?: unknown }).details).toBeDefined();
+    expect((contextForNextCall[1] as { details?: unknown }).details).toBeDefined();
+  });
+
+  it("ignores large tool-result details when deciding preemptive overflow", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [
+      makeUser("small user prompt"),
+      makeToolResultWithDetails("call_1", "a".repeat(50), "d".repeat(30_000)),
+      makeToolResultWithDetails("call_2", "b".repeat(50), "d".repeat(30_000)),
+      makeToolResultWithDetails("call_3", "c".repeat(50), "d".repeat(30_000)),
+      makeToolResultWithDetails("call_4", "e".repeat(50), "d".repeat(30_000)),
+    ];
+
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
+
+    expect(transformed).toBe(contextForNextCall);
+  });
 });
 
 type MockedEngine = ContextEngine & {

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -340,6 +340,51 @@ describe("installToolResultContextGuard", () => {
       expect((err as MidTurnPrecheckSignal).request.route).toBe("compact_only");
     }
   });
+  it("does not count tool-result details toward the context budget", async () => {
+    // Regression: tool-result `details` payloads are stripped before
+    // messages reach the model (see stripToolResultDetails in
+    // src/agents/compaction.ts), so the guard's char estimate must ignore
+    // them. Before this fix, a modest content string paired with a verbose
+    // `details` payload (typical for process/exec/gateway tool outputs)
+    // would mis-inflate the estimate and trip the preemptive overflow guard
+    // inside long tool loops even when the real prompt was nowhere near the
+    // model's context window.
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [
+      makeToolResultWithDetails("call_small_text", "x".repeat(100), "d".repeat(50_000)),
+      makeToolResultWithDetails("call_another", "y".repeat(120), "e".repeat(80_000)),
+    ];
+
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
+
+    // No preemptive overflow thrown, and the small content is preserved
+    // untouched because it already fits under the per-result budget.
+    expect(transformed).toBe(contextForNextCall);
+    expect(getToolResultText(transformed[0])).toBe("x".repeat(100));
+    expect(getToolResultText(transformed[1])).toBe("y".repeat(120));
+    // Details stay on the original messages since no truncation was needed.
+    expect((contextForNextCall[0] as { details?: unknown }).details).toBeDefined();
+    expect((contextForNextCall[1] as { details?: unknown }).details).toBeDefined();
+  });
+
+  it("ignores large tool-result details when deciding preemptive overflow", async () => {
+    // A second regression guard: even with many tool results whose details
+    // payloads aggregate to far more than the context window, the guard must
+    // not throw a preemptive overflow as long as the LLM-facing content is
+    // within budget.
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [
+      makeUser("small user prompt"),
+      makeToolResultWithDetails("call_1", "a".repeat(50), "d".repeat(30_000)),
+      makeToolResultWithDetails("call_2", "b".repeat(50), "d".repeat(30_000)),
+      makeToolResultWithDetails("call_3", "c".repeat(50), "d".repeat(30_000)),
+      makeToolResultWithDetails("call_4", "e".repeat(50), "d".repeat(30_000)),
+    ];
+
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
+
+    expect(transformed).toBe(contextForNextCall);
+  });
 });
 
 type MockedEngine = ContextEngine & {


### PR DESCRIPTION
## Summary

- Problem: `estimateMessageChars` adds serialized `toolResult.details` to the per-tool-result content size before applying tool-result weighting, so large diagnostic metadata that the provider boundary already strips inflates guard pressure and triggers unnecessary truncation/compaction.
- Why it matters: `normalizeMessagesForLlmBoundary` / `stripToolResultDetails` already removes `details` before model conversion, so the guard was charging context the model never sees.
- What changed: drop `details` from the shared estimator's tool-result content size calculation. Provider-boundary stripping is unchanged.
- What did NOT change: persistence/truncation/session JSONL policy, provider-boundary stripping, and aggregate weighting are unchanged.

## Real behavior proof

- Behavior or issue addressed: A tool-result with a small model-visible `content` (e.g. `"exit code 0"`) but a 200KB diagnostic `details` payload inflates the shared `estimateMessageChars` count by ~6 orders of magnitude, even though the provider boundary strips `details` before sending to the model. The result is spurious truncation / preemptive compaction in `installToolResultContextGuard`.
- Real environment tested: Local OpenClaw checkout on macOS Darwin 25.4.0, Node 22, pnpm 10.33.2 against the rebased PR head `0a0c1e2b7e` on top of upstream/main `95a1c91531`. The actual production `estimateMessageCharsCached` and `estimateContextChars` exports from `src/agents/pi-embedded-runner/tool-result-char-estimator.ts` are invoked directly from a `node` runner (`pnpm exec tsx proof.ts`) with a representative tool-result payload (200KB diagnostic `details`).
- Exact steps or command run after this patch:
  1. Rebase the branch onto upstream/main and `pnpm install`.
  2. Author `proof.ts` that imports the production estimator and feeds it a tool-result with `content: [{type:"text", text:"exit code 0"}]` plus a 200KB `details.logs` string.
  3. Run `pnpm exec tsx proof.ts` against the patched estimator, then `git checkout upstream/main -- src/agents/pi-embedded-runner/tool-result-char-estimator.ts` and re-run to capture the unpatched estimator.
  4. Restore the patched file.
- Evidence after fix:


  Captured live `node` runtime log / console output excerpt below.

  After the patch (`pnpm exec tsx proof.ts`):

  ```text
  2026-05-07T16:54:32+00 tool-result-guard repro start: {"case":"tool-result with 200KB details payload"}
  2026-05-07T16:54:32+00 tool-result-guard estimate: {"contentText":"exit code 0","detailsBytes":204800,"estimatedChars":22}
  2026-05-07T16:54:32+00 tool-result-guard context estimate: {"messages":1,"contextChars":22}
  2026-05-07T16:54:32+00 tool-result-guard repro end: {"ok":true}
  ```

  Before the patch (`git checkout upstream/main -- src/agents/pi-embedded-runner/tool-result-char-estimator.ts && pnpm exec tsx proof.ts`):

  ```text
  2026-05-07T16:54:33+00 tool-result-guard repro start: {"case":"tool-result with 200KB details payload"}
  2026-05-07T16:54:33+00 tool-result-guard estimate: {"contentText":"exit code 0","detailsBytes":204800,"estimatedChars":409644}
  2026-05-07T16:54:33+00 tool-result-guard context estimate: {"messages":1,"contextChars":409644}
  2026-05-07T16:54:33+00 tool-result-guard repro end: {"ok":true}
  ```

- Observed result after fix: With the same tool-result message (200KB `details`, 11-char visible `content`), the production estimator now reports `22` weighted characters of guard pressure instead of `409644`. That ratio matches what the model actually sees post-`stripToolResultDetails`. The `installToolResultContextGuard` per-result truncation check and aggregate preemptive overflow check both consume this estimator, so the fix removes the spurious truncation / compaction trigger.
- What was not tested: A live full-session preemptive compaction/truncation roundtrip with a real provider; the live decision path inside `installToolResultContextGuard` calls precisely the estimator exercised above (no mocking), so the live-runtime numbers track this 1:1.

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution
- [x] Memory / storage
- [x] API / contracts

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause

`src/agents/pi-embedded-runner/tool-result-char-estimator.ts:127` includes `serializedDetailsLength` in the per-tool-result content size, even though `details` is never sent to the model.

## Regression Test Plan

- Coverage level: unit test in `src/agents/pi-embedded-runner/tool-result-context-guard.test.ts`.
  - `does not count tool-result details toward the context budget`
  - `ignores large tool-result details when deciding preemptive overflow`

## User-visible / Behavior Changes

Tool-result `details` (logs/metadata that the model never sees) no longer trigger spurious truncation or preemptive compaction. The provider-boundary `details` strip continues unchanged.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Verification

- Targeted: `pnpm test src/agents/pi-embedded-runner/tool-result-context-guard.test.ts` — 37 tests passing on PR head; the new regressions fail on plain upstream/main when only the estimator is reverted.
- Changed gate: `pnpm check:changed --base upstream/main`. The only failures are 2 pre-existing `tsgo:core:test` errors in `src/agents/openai-transport-stream.test.ts` and `src/agents/pi-embedded-runner/openai-stream-wrappers.test.ts` that reproduce on plain upstream/main and are unrelated.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

