### PR TITLE
fix(bluebubbles): dedupe updated-message follow-ups by base guid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ Docs: https://docs.openclaw.ai
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.
 - Config/BlueBubbles: remove the duplicate core-owned BlueBubbles config schema while preserving plugin-owned `dmPolicy` allowFrom validation for channel and account configs. Fixes #69238. Thanks @omarshahine.
+- BlueBubbles: dedupe no-attachment `updated-message` replay noise without dropping late attachment-bearing updates for the same message. (#75526) Thanks @zqchris.
 - Tavily: resolve dedicated `tavily_search` and `tavily_extract` tool credentials from the active runtime config snapshot, so `exec` SecretRef-backed API keys do not reach the tools unresolved. (#78610) Thanks @VACInc.
 - Gateway/sessions: clear cached skills snapshots during `/new` and `sessions.reset` so long-lived channel sessions rebuild the visible skill list after skills change. (#78873) Thanks @Evizero.
 - fix(auto-reply): gate inline skill tool dispatch [AI]. (#78517) Thanks @pgondhi987.

--- a/extensions/bluebubbles/src/inbound-dedupe.test.ts
+++ b/extensions/bluebubbles/src/inbound-dedupe.test.ts
@@ -6,8 +6,21 @@ import {
   resolveBlueBubblesInboundDedupeKey,
 } from "./inbound-dedupe.js";
 
-async function claimAndFinalize(guid: string | undefined, accountId: string): Promise<string> {
-  const claim = await claimBlueBubblesInboundMessage({ guid, accountId });
+type TestMessage = Parameters<typeof claimBlueBubblesInboundMessage>[0]["message"];
+
+function newMessage(messageId: string | undefined): TestMessage {
+  return { messageId, eventType: "new-message" };
+}
+
+function updatedMessage(
+  messageId: string | undefined,
+  attachments: TestMessage["attachments"] = [],
+): TestMessage {
+  return { messageId, eventType: "updated-message", attachments };
+}
+
+async function claimAndFinalize(message: TestMessage, accountId: string): Promise<string> {
+  const claim = await claimBlueBubblesInboundMessage({ message, accountId });
   if (claim.kind === "claimed") {
     await claim.finalize();
   }
@@ -20,42 +33,85 @@ describe("claimBlueBubblesInboundMessage", () => {
   });
 
   it("claims a new guid and rejects committed duplicates", async () => {
-    expect(await claimAndFinalize("g1", "acc")).toBe("claimed");
-    expect(await claimAndFinalize("g1", "acc")).toBe("duplicate");
+    expect(await claimAndFinalize(newMessage("g1"), "acc")).toBe("claimed");
+    expect(await claimAndFinalize(newMessage("g1"), "acc")).toBe("duplicate");
   });
 
   it("scopes dedupe per account", async () => {
-    expect(await claimAndFinalize("g1", "a")).toBe("claimed");
-    expect(await claimAndFinalize("g1", "b")).toBe("claimed");
+    expect(await claimAndFinalize(newMessage("g1"), "a")).toBe("claimed");
+    expect(await claimAndFinalize(newMessage("g1"), "b")).toBe("claimed");
   });
 
   it("reports skip when guid is missing or blank", async () => {
-    expect((await claimBlueBubblesInboundMessage({ guid: undefined, accountId: "acc" })).kind).toBe(
-      "skip",
-    );
-    expect((await claimBlueBubblesInboundMessage({ guid: "", accountId: "acc" })).kind).toBe(
-      "skip",
-    );
-    expect((await claimBlueBubblesInboundMessage({ guid: "   ", accountId: "acc" })).kind).toBe(
-      "skip",
-    );
+    expect(
+      (await claimBlueBubblesInboundMessage({ message: newMessage(undefined), accountId: "acc" }))
+        .kind,
+    ).toBe("skip");
+    expect(
+      (await claimBlueBubblesInboundMessage({ message: newMessage(""), accountId: "acc" })).kind,
+    ).toBe("skip");
+    expect(
+      (await claimBlueBubblesInboundMessage({ message: newMessage("   "), accountId: "acc" })).kind,
+    ).toBe("skip");
   });
 
   it("rejects overlong guids to cap on-disk size", async () => {
     const huge = "x".repeat(10_000);
-    expect((await claimBlueBubblesInboundMessage({ guid: huge, accountId: "acc" })).kind).toBe(
-      "skip",
-    );
+    expect(
+      (await claimBlueBubblesInboundMessage({ message: newMessage(huge), accountId: "acc" })).kind,
+    ).toBe("skip");
   });
 
   it("releases the claim so a later replay can retry after a transient failure", async () => {
-    const first = await claimBlueBubblesInboundMessage({ guid: "g1", accountId: "acc" });
+    const first = await claimBlueBubblesInboundMessage({
+      message: newMessage("g1"),
+      accountId: "acc",
+    });
     expect(first.kind).toBe("claimed");
     if (first.kind === "claimed") {
       first.release();
     }
     // Released claims should be re-claimable on the next delivery.
-    expect(await claimAndFinalize("g1", "acc")).toBe("claimed");
+    expect(await claimAndFinalize(newMessage("g1"), "acc")).toBe("claimed");
+  });
+
+  it("treats no-attachment updated-message follow-ups as duplicates once the base GUID committed", async () => {
+    // Original new-message: agent processes and replies, base GUID gets committed.
+    expect(await claimAndFinalize(newMessage("g1"), "acc")).toBe("claimed");
+    // Follow-up updated-message with no attachments for the same GUID: even
+    // though `g1:updated` has never been claimed, the base commit is enough to
+    // recognize replay noise so it cannot re-trigger a reply (especially after
+    // losing group chat context).
+    expect(await claimAndFinalize(updatedMessage("g1"), "acc")).toBe("duplicate");
+  });
+
+  it("preserves late attachment-bearing updated-message processing after the base committed", async () => {
+    // Attachment indexing can arrive after the initial text-only event; this
+    // path must stay claimable even when the new-message base GUID committed.
+    expect(await claimAndFinalize(newMessage("g1"), "acc")).toBe("claimed");
+    expect(
+      await claimAndFinalize(
+        updatedMessage("g1", [{ guid: "att-1", mimeType: "image/png" }]),
+        "acc",
+      ),
+    ).toBe("claimed");
+    expect(
+      await claimAndFinalize(
+        updatedMessage("g1", [{ guid: "att-1", mimeType: "image/png" }]),
+        "acc",
+      ),
+    ).toBe("duplicate");
+  });
+
+  it("lets an updated-message-first webhook through when the base GUID was never committed", async () => {
+    // Rare case: BlueBubbles delivers only the updated-message webhook (e.g.
+    // attachment-only path with no preceding new-message). Without a prior
+    // base commit, the suffixed key proceeds normally so the agent still sees
+    // the message.
+    expect(await claimAndFinalize(updatedMessage("g1"), "acc")).toBe("claimed");
+    // A subsequent updated-message with the same GUID is a duplicate via the
+    // standard `:updated` key dedupe.
+    expect(await claimAndFinalize(updatedMessage("g1"), "acc")).toBe("duplicate");
   });
 });
 
@@ -66,7 +122,7 @@ describe("commitBlueBubblesCoalescedMessageIds", () => {
 
   it("marks every coalesced source messageId as seen so a later replay dedupes", async () => {
     // Primary was processed via claim+finalize by the debouncer flush.
-    expect(await claimAndFinalize("primary", "acc")).toBe("claimed");
+    expect(await claimAndFinalize(newMessage("primary"), "acc")).toBe("claimed");
     // Secondaries reach dedupe through the bulk-commit path.
     await commitBlueBubblesCoalescedMessageIds({
       messageIds: ["secondary-1", "secondary-2"],
@@ -74,9 +130,9 @@ describe("commitBlueBubblesCoalescedMessageIds", () => {
     });
     // A MessagePoller replay of any individual source event is now a duplicate
     // rather than a fresh agent turn — the core bug this helper exists to fix.
-    expect(await claimAndFinalize("primary", "acc")).toBe("duplicate");
-    expect(await claimAndFinalize("secondary-1", "acc")).toBe("duplicate");
-    expect(await claimAndFinalize("secondary-2", "acc")).toBe("duplicate");
+    expect(await claimAndFinalize(newMessage("primary"), "acc")).toBe("duplicate");
+    expect(await claimAndFinalize(newMessage("secondary-1"), "acc")).toBe("duplicate");
+    expect(await claimAndFinalize(newMessage("secondary-2"), "acc")).toBe("duplicate");
   });
 
   it("scopes coalesced commits per account", async () => {
@@ -85,8 +141,8 @@ describe("commitBlueBubblesCoalescedMessageIds", () => {
       accountId: "a",
     });
     // Same messageId under a different account is still claimable.
-    expect(await claimAndFinalize("g1", "a")).toBe("duplicate");
-    expect(await claimAndFinalize("g1", "b")).toBe("claimed");
+    expect(await claimAndFinalize(newMessage("g1"), "a")).toBe("duplicate");
+    expect(await claimAndFinalize(newMessage("g1"), "b")).toBe("claimed");
   });
 
   it("skips empty or overlong guids without throwing", async () => {
@@ -94,9 +150,9 @@ describe("commitBlueBubblesCoalescedMessageIds", () => {
       messageIds: ["", "   ", "x".repeat(10_000), "valid"],
       accountId: "acc",
     });
-    expect(await claimAndFinalize("valid", "acc")).toBe("duplicate");
+    expect(await claimAndFinalize(newMessage("valid"), "acc")).toBe("duplicate");
     // Overlong guid was skipped by sanitization, not committed.
-    expect(await claimAndFinalize("x".repeat(10_000), "acc")).toBe("skip");
+    expect(await claimAndFinalize(newMessage("x".repeat(10_000)), "acc")).toBe("skip");
   });
 });
 

--- a/extensions/bluebubbles/src/inbound-dedupe.ts
+++ b/extensions/bluebubbles/src/inbound-dedupe.ts
@@ -113,6 +113,27 @@ function sanitizeGuid(guid: string | undefined | null): string | null {
   return trimmed;
 }
 
+type DedupeMessageInput = Pick<
+  NormalizedWebhookMessage,
+  "messageId" | "balloonBundleId" | "associatedMessageGuid" | "eventType" | "attachments"
+>;
+
+/**
+ * Resolve the underlying "base" dedupe key for a BlueBubbles inbound message,
+ * without the `:updated` suffix that distinguishes follow-up webhooks. Used
+ * both by `resolveBlueBubblesInboundDedupeKey` (which appends the suffix when
+ * appropriate) and the `updated-message` short-circuit inside
+ * `claimBlueBubblesInboundMessage`.
+ */
+function resolveBaseDedupeKey(message: DedupeMessageInput): string | undefined {
+  const balloonBundleId = message.balloonBundleId?.trim();
+  const associatedMessageGuid = message.associatedMessageGuid?.trim();
+  if (balloonBundleId && associatedMessageGuid) {
+    return associatedMessageGuid;
+  }
+  return message.messageId?.trim() || undefined;
+}
+
 /**
  * Resolve the canonical dedupe key for a BlueBubbles inbound message.
  *
@@ -134,25 +155,19 @@ function sanitizeGuid(guid: string | undefined | null): string | null {
  * reply against the same parent GUID and silently drop real messages.
  */
 export function resolveBlueBubblesInboundDedupeKey(
-  message: Pick<
-    NormalizedWebhookMessage,
-    "messageId" | "balloonBundleId" | "associatedMessageGuid" | "eventType"
-  >,
+  message: DedupeMessageInput,
 ): string | undefined {
-  const balloonBundleId = message.balloonBundleId?.trim();
-  const associatedMessageGuid = message.associatedMessageGuid?.trim();
-  let base: string | undefined;
-  if (balloonBundleId && associatedMessageGuid) {
-    base = associatedMessageGuid;
-  } else {
-    base = message.messageId?.trim() || undefined;
-  }
+  const base = resolveBaseDedupeKey(message);
   if (!base) {
     return undefined;
   }
   // `updated-message` events get a distinct key so they are not rejected as
   // duplicates of the already-committed `new-message` for the same GUID.
-  // This lets attachment-carrying follow-up webhooks through. (#65430, #52277)
+  // This lets attachment-carrying follow-up webhooks through when the original
+  // text-only event was processed without media (#65430, #52277). The
+  // no-attachment `updated-message` short-circuit inside
+  // `claimBlueBubblesInboundMessage` re-collapses the suffixed key onto the
+  // base only for replay noise — see that helper for the reasoning.
   if (message.eventType === "updated-message") {
     return `${base}:updated`;
   }
@@ -166,7 +181,7 @@ type InboundDedupeClaim =
   | { kind: "skip" };
 
 /**
- * Attempt to claim an inbound BlueBubbles message GUID.
+ * Attempt to claim an inbound BlueBubbles message for processing.
  *
  * - `claimed`: caller should process the message, then call `finalize()` on
  *   success (persists the GUID) or `release()` on failure (lets a later
@@ -176,15 +191,39 @@ type InboundDedupeClaim =
  *   rather than race.
  * - `skip`: GUID was missing or invalid — caller should continue processing
  *   without dedup (no finalize/release needed).
+ *
+ * For no-attachment `updated-message` events specifically: when the
+ * underlying base GUID has already been committed (the `new-message` was
+ * processed and the agent replied), the follow-up is recognized as a duplicate
+ * even though the `:updated`-suffixed dedupe key has never been seen. This
+ * stops replay-only follow-ups from re-triggering a reply, especially when the
+ * follow-up payload arrives stripped of group chat context and would otherwise
+ * route into the sender's DM session. Attachment-bearing updates still keep the
+ * suffixed key so late media indexing remains processable.
  */
 export async function claimBlueBubblesInboundMessage(params: {
-  guid: string | undefined | null;
+  message: DedupeMessageInput;
   accountId: string;
   onDiskError?: (error: unknown) => void;
 }): Promise<InboundDedupeClaim> {
-  const normalized = sanitizeGuid(params.guid);
+  const dedupeKey = resolveBlueBubblesInboundDedupeKey(params.message);
+  const normalized = sanitizeGuid(dedupeKey);
   if (!normalized) {
     return { kind: "skip" };
+  }
+  const hasAttachments = (params.message.attachments?.length ?? 0) > 0;
+  if (params.message.eventType === "updated-message" && !hasAttachments) {
+    const baseKey = resolveBaseDedupeKey(params.message);
+    const baseSanitized = baseKey ? sanitizeGuid(baseKey) : null;
+    if (baseSanitized && baseSanitized !== normalized) {
+      const baseAlreadyCommitted = await impl.hasRecent(baseSanitized, {
+        namespace: params.accountId,
+        onDiskError: params.onDiskError,
+      });
+      if (baseAlreadyCommitted) {
+        return { kind: "duplicate" };
+      }
+    }
   }
   const claim = await impl.claim(normalized, {
     namespace: params.accountId,

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -685,7 +685,7 @@ export async function processMessage(
 
   // Drop BlueBubbles MessagePoller replays after server restart (#19176, #12053).
   const claim = await claimBlueBubblesInboundMessage({
-    guid: dedupeKey,
+    message,
     accountId: account.accountId,
     onDiskError: (error) =>
       logVerbose(core, runtime, `inbound-dedupe disk error: ${sanitizeForLog(error)}`),


### PR DESCRIPTION
## Summary

- Problem: BlueBubbles delivers a `new-message` plus a follow-up `updated-message` for the same GUID. The current dedupe key suffixes `:updated`, so once the agent has already replied to the base GUID, the no-attachment follow-up still passes the dedupe check and re-triggers a reply (especially after losing group chat context).
- Why it matters: Duplicate replies on real BlueBubbles traffic — same message, same GUID, two agent turns.
- What changed: For `updated-message` events without attachments, after explicit-claim resolution check whether the base GUID is already committed (`hasRecent` on the base namespace). If so, return `duplicate` before claiming the suffixed key. Late attachment-bearing updates for the same GUID stay claimable so attachment indexing still goes through.
- What did NOT change: Reaction handling, transport, credentials, monitor.ts webhook filter, and CI behavior are unchanged.

## Real behavior proof

- Behavior or issue addressed: BlueBubbles `new-message` + no-attachment `updated-message` follow-up for the same GUID re-enters `claimBlueBubblesInboundMessage` and gets re-claimed, causing the agent to reply twice. Late attachment-bearing updates for the same GUID must still claim through (so attachment indexing is preserved).
- Real environment tested: Local OpenClaw checkout on macOS Darwin 25.4.0, Node 22, pnpm 10.33.2 against the rebased PR head `9264fd0206` on top of upstream/main `95a1c91531`. The actual production `claimBlueBubblesInboundMessage` exported from `extensions/bluebubbles/src/inbound-dedupe.ts` is invoked directly from a `node` runner (`pnpm exec tsx proof.ts`) with redacted message GUIDs to walk the new-message → updated-message → updated-message-with-attachment sequence.
- Exact steps or command run after this patch:
  1. Rebase the branch onto upstream/main and `pnpm install`.
  2. Author `proof.ts` that imports the production `claimBlueBubblesInboundMessage` and `_resetBlueBubblesInboundDedupForTest`, then walks the production code path: claim a `new-message` GUID, claim a no-attachment `updated-message` follow-up for the same GUID, and finally claim an attachment-bearing `updated-message` follow-up for the same GUID.
  3. Run `pnpm exec tsx proof.ts` and capture stdout.
- Evidence after fix (redacted runtime log excerpt + copied live `node` console output):

  ```text
  2026-05-07T16:52:19+00 bluebubbles dedupe repro start: {"case":"new-message then no-attachment updated-message replay"}
  2026-05-07T16:52:19+00 inbound claim outcome: {"event":"new-message","guid":"g1<redacted>","outcome":"claimed"}
  2026-05-07T16:52:19+00 inbound claim outcome: {"event":"updated-message (no attachments)","guid":"g1<redacted>","outcome":"duplicate"}
  2026-05-07T16:52:19+00 inbound claim outcome: {"event":"updated-message with attachment","guid":"g1<redacted>","outcome":"claimed"}
  2026-05-07T16:52:19+00 bluebubbles dedupe repro end: {"ok":true}
  ```

  On plain upstream/main (`git checkout upstream/main -- extensions/bluebubbles/src/inbound-dedupe.ts extensions/bluebubbles/src/monitor-processing.ts && pnpm exec tsx proof.ts`), the no-attachment updated-message GUID is NOT recognized as a duplicate — it claims through as a fresh inbound, which is exactly what re-triggers a reply in production traffic. After the patch, the same path returns `"outcome":"duplicate"` for the no-attachment follow-up, while the late attachment-bearing update still claims through.

- Observed result after fix: The `node` repro shows the production dedupe path now returns `duplicate` for the no-attachment `updated-message` follow-up of an already-committed base GUID, while attachment-bearing updates of the same GUID still claim through. This matches the `claimBlueBubblesInboundMessage` semantics that `monitor-processing.ts` calls for every inbound BlueBubbles webhook event.
- What was not tested: A paired live BlueBubbles → iMessage server roundtrip (would require a paired BlueBubbles deployment); the `node` repro above exercises the exact dedupe path the monitor invokes for every webhook event.

## Note on the prior review's "test typo" finding

ClawSweeper's previous review claimed that `extensions/bluebubbles/src/inbound-dedupe.test.ts:155` calls `claimAndFinalize(newMessage(...))` without `accountId`. Re-reading the file at the same SHA the review cited (`5227bbef217a`) shows both calls in the overlong-guid test pass `accountId` correctly:

```ts
expect(await claimAndFinalize(newMessage("valid"), "acc")).toBe("duplicate");
expect(await claimAndFinalize(newMessage("x".repeat(10_000)), "acc")).toBe("skip");
```

Both targeted tests pass under `pnpm test`. The finding appears to be a parse-level mismatch by the reviewer; the helper-call shape is intact.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations
- [x] API / contracts

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause

`extensions/bluebubbles/src/inbound-dedupe.ts` always suffixes `:updated` for `updated-message` events; the suffixed key has never been claimed even when the base `new-message` was already processed, so the follow-up re-enters the agent.

## Regression Test Plan

- Coverage level: unit test in `extensions/bluebubbles/src/inbound-dedupe.test.ts`.
  - `treats no-attachment updated-message follow-ups as duplicates once the base GUID committed`
  - `preserves late attachment-bearing updated-message processing after the base committed`
  - `lets an updated-message-first webhook through when the base GUID was never committed`

## User-visible / Behavior Changes

Same-GUID `new-message` + no-attachment `updated-message` no longer produces a duplicate reply. Late attachment-bearing updates for the same GUID still process normally.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Verification

- Targeted: `pnpm test extensions/bluebubbles/src/inbound-dedupe.test.ts` — 16 tests passing on PR head; the new regressions fail on plain upstream/main when only `inbound-dedupe.ts` + `monitor-processing.ts` are reverted.
- Changed gate: `pnpm check:changed --base upstream/main` exit 0.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
