### PR TITLE
fix(slack): preserve media roots for custom invokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Docs: https://docs.openclaw.ai
 - Pairing: surface unexpected allowlist filesystem stat errors instead of treating the allowlist as missing, so permission and I/O failures are visible during pairing authorization checks. (#63324) Thanks @franciscomaestre.
 - macOS app: reserve layout space for exec approval command details so the allow dialog no longer overlaps the command, context, and action buttons. (#75470) Thanks @ngutman.
 - Agents/failover: carry `sessionId`, `lane`, `provider`, `model`, and `profileId` attribution through `FailoverError` and `describeFailoverError`/`coerceToFailoverError` so structured error logs (e.g. `gateway.err.log` ingestion) can attribute exhausted-fallback wrapper errors to the originating session and last-attempted provider instead of dropping the metadata after the per-profile errors. Fixes #42713. (#73506) Thanks @wenxu007.
+- Slack/tools: preserve agent-scoped `mediaLocalRoots` and `mediaReadFile` when `upload-file` actions use Slack's custom invoke path, so trusted workspace files can be uploaded without relaxing local-media guards. Fixes #64625. Thanks @vyctorbrzezowski and @benpchandler.
 
 ## 2026.4.29
 

--- a/extensions/slack/src/channel-actions.ts
+++ b/extensions/slack/src/channel-actions.ts
@@ -32,14 +32,19 @@ export function createSlackActions(
         ctx,
         normalizeChannelId: resolveSlackChannelId,
         includeReadThreadId: true,
-        invoke: async (action, cfg, toolContext) =>
-          await (options?.invoke
-            ? options.invoke(action, cfg, toolContext)
-            : (await loadSlackActionRuntime()).handleSlackAction(action, cfg, {
-                ...(toolContext as SlackActionContext | undefined),
-                mediaLocalRoots: ctx.mediaLocalRoots,
-                mediaReadFile: ctx.mediaReadFile,
-              })),
+        invoke: async (action, cfg, toolContext) => {
+          const actionContext =
+            toolContext || ctx.mediaLocalRoots || ctx.mediaReadFile
+              ? {
+                  ...(toolContext as SlackActionContext | undefined),
+                  mediaLocalRoots: ctx.mediaLocalRoots,
+                  mediaReadFile: ctx.mediaReadFile,
+                }
+              : undefined;
+          return await (options?.invoke
+            ? options.invoke(action, cfg, actionContext)
+            : (await loadSlackActionRuntime()).handleSlackAction(action, cfg, actionContext));
+        },
       });
     },
   };

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1,5 +1,7 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackActions } from "./channel-actions.js";
 import { slackPlugin } from "./channel.js";
 import { slackOutbound } from "./outbound-adapter.js";
 import * as probeModule from "./probe.js";
@@ -182,6 +184,60 @@ describe("slackPlugin actions", () => {
       ],
       capabilities: expect.arrayContaining(["presentation"]),
     });
+  });
+
+  it("forwards media access to custom action invokes for upload-file", async () => {
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          appToken: "xapp-test",
+        },
+      },
+    } as OpenClawConfig;
+    const mediaReadFile = vi.fn(async () => Buffer.from("media"));
+    const invoke = vi.fn(
+      async (): Promise<AgentToolResult<unknown>> => ({
+        content: [{ type: "text", text: "uploaded" }],
+        details: { ok: true },
+      }),
+    );
+    const actions = createSlackActions("slack", { invoke });
+    if (!actions.handleAction) {
+      throw new Error("slack actions.handleAction unavailable");
+    }
+
+    await actions.handleAction({
+      channel: "slack",
+      action: "upload-file",
+      cfg,
+      params: {
+        channelId: "channel:C123",
+        filePath: "/tmp/workspace/render.wav",
+      },
+      mediaLocalRoots: ["/tmp/workspace"],
+      mediaReadFile,
+      toolContext: {
+        currentChannelId: "C123",
+        currentThreadTs: "111.222",
+        replyToMode: "all",
+      },
+    } as never);
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "uploadFile",
+        to: "C123",
+        filePath: "/tmp/workspace/render.wav",
+      }),
+      cfg,
+      expect.objectContaining({
+        currentChannelId: "C123",
+        currentThreadTs: "111.222",
+        mediaLocalRoots: ["/tmp/workspace"],
+        mediaReadFile,
+      }),
+    );
   });
 
   it("uses configured defaultAccount for pairing approval notifications", async () => {


### PR DESCRIPTION
## Summary

- Problem: Slack `upload-file` actions could lose agent-scoped media access when routed through Slack's custom invoke callback.
- Why it matters: trusted files inside the agent workspace could be rejected by the local-media guard even though core had already resolved the allowed roots.
- What changed: build one augmented Slack action context with `mediaLocalRoots` and `mediaReadFile`, then pass it to both the custom invoke and fallback runtime paths.
- What did NOT change (scope boundary): this does not relax local-media path validation or change Slack upload authorization.

AI-assisted: yes. I understand the code change and verified it locally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64625
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `createSlackActions` injected `mediaLocalRoots` and `mediaReadFile` only on the fallback `handleSlackAction` path, while the primary Slack plugin uses a custom `options.invoke` callback.
- Missing detection / guardrail: no regression test covered media access propagation through the custom Slack invoke path.
- Contributing context (if known): Slack upload-file eventually relies on the same local-media guard as other outbound media sends.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/channel.test.ts`
- Scenario the test should lock in: `upload-file` through `createSlackActions(..., { invoke })` forwards `mediaLocalRoots` and `mediaReadFile`.
- Why this is the smallest reliable guardrail: it exercises the Slack wrapper boundary where the context was dropped.
- Existing test that already covers this (if any): existing Slack action tests covered fallback/runtime behavior, not the custom invoke path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Slack `upload-file` actions can upload trusted agent-workspace files when core has already supplied the allowed media roots.

## Diagram (if applicable)

```text
Before:
message upload-file -> Slack custom invoke -> raw toolContext -> local-media guard rejects workspace file

After:
message upload-file -> augmented Slack action context -> custom invoke/runtime -> local-media guard receives trusted roots
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node/pnpm local checkout
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): N/A

### Steps

1. Trigger Slack `message` tool `upload-file` through the Slack plugin's custom action invoke path.
2. Use a file path under an agent workspace root that core already resolved into `mediaLocalRoots`.
3. Observe whether Slack upload receives `mediaLocalRoots`/`mediaReadFile`.

### Expected

- The custom invoke path receives the same trusted media access context as the fallback runtime path.

### Actual

- Before this change, the custom invoke path received only the raw `toolContext`, so the local-media guard could reject the trusted workspace path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- `pnpm test extensions/slack/src/channel.test.ts extensions/slack/src/message-action-dispatch.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/slack/src/channel-actions.ts extensions/slack/src/channel.test.ts CHANGELOG.md`
- `node scripts/run-oxlint.mjs extensions/slack/src/channel-actions.ts extensions/slack/src/channel.test.ts CHANGELOG.md`
- `git diff --check`
- `pnpm check:changed`
- `codex review --base origin/main`

Edge cases checked:

- Existing Slack action test expecting no third context argument still passes when no tool context or media access exists.
- The fallback runtime path still receives the same augmented context.

What I did not verify:

- Live Slack upload against a real workspace.
- Blacksmith/Testbox; `blacksmith` was unavailable locally, so `pnpm check:changed` was run locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: context augmentation could change calls that previously had no context.
  - Mitigation: preserve `undefined` when there is no existing `toolContext`, `mediaLocalRoots`, or `mediaReadFile`, and keep existing regression coverage passing.
