### PR TITLE
fix(config): skip writeConfigFile disk I/O when config is semantically unchanged

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1573,6 +1573,39 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
     const nextHash = hashConfigRaw(json);
     const previousHash = resolveConfigSnapshotHash(snapshot);
+
+    // No-op short-circuit: if the only difference between the next config and
+    // the on-disk config is the volatile `meta.lastTouchedAt` / `lastTouchedVersion`
+    // fields, skip the disk write entirely.  This avoids the file-watcher →
+    // SIGUSR1 gateway-restart cascade on semantically-equal config patches
+    // (see #75534).
+    if (snapshot.exists && previousHash !== null && nextHash !== previousHash) {
+      // Hashes differ — check if it's only the meta timestamp that changed.
+      const stripVolatileMeta = (raw: string): string => {
+        try {
+          const obj = JSON.parse(raw);
+          if (obj && typeof obj === "object" && obj.meta) {
+            const { lastTouchedAt: _lta, lastTouchedVersion: _ltv, ...rest } = obj.meta;
+            obj.meta = Object.keys(rest).length > 0 ? rest : undefined;
+            if (obj.meta === undefined) {
+              delete obj.meta;
+            }
+          }
+          return JSON.stringify(obj, null, 2).trimEnd().concat("\n");
+        } catch {
+          return raw;
+        }
+      };
+      const nextStable = hashConfigRaw(stripVolatileMeta(json));
+      const prevStable = hashConfigRaw(stripVolatileMeta(snapshot.raw ?? ""));
+      if (nextStable === prevStable) {
+        return { persistedHash: previousHash };
+      }
+    } else if (snapshot.exists && previousHash !== null && nextHash === previousHash) {
+      // Byte-identical — trivial no-op.
+      return { persistedHash: nextHash };
+    }
+
     const changedPathCount = changedPaths?.size;
     const previousBytes =
       typeof snapshot.raw === "string" ? Buffer.byteLength(snapshot.raw, "utf-8") : null;

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -2152,6 +2152,39 @@ export function createConfigIO(
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
     const nextHash = hashConfigRaw(json);
     const previousHash = resolveConfigSnapshotHash(snapshot);
+
+    // No-op short-circuit: if the only difference between the next config and
+    // the on-disk config is the volatile `meta.lastTouchedAt` / `lastTouchedVersion`
+    // fields, skip the disk write entirely.  This avoids the file-watcher →
+    // SIGUSR1 gateway-restart cascade on semantically-equal config patches
+    // (see #75534).
+    if (snapshot.exists && previousHash !== null && nextHash !== previousHash) {
+      // Hashes differ — check if it's only the meta timestamp that changed.
+      const stripVolatileMeta = (raw: string): string => {
+        try {
+          const obj = JSON.parse(raw);
+          if (obj && typeof obj === "object" && obj.meta) {
+            const { lastTouchedAt: _lta, lastTouchedVersion: _ltv, ...rest } = obj.meta;
+            obj.meta = Object.keys(rest).length > 0 ? rest : undefined;
+            if (obj.meta === undefined) {
+              delete obj.meta;
+            }
+          }
+          return JSON.stringify(obj, null, 2).trimEnd().concat("\n");
+        } catch {
+          return raw;
+        }
+      };
+      const nextStable = hashConfigRaw(stripVolatileMeta(json));
+      const prevStable = hashConfigRaw(stripVolatileMeta(snapshot.raw ?? ""));
+      if (nextStable === prevStable) {
+        return { persistedHash: previousHash };
+      }
+    } else if (snapshot.exists && previousHash !== null && nextHash === previousHash) {
+      // Byte-identical — trivial no-op.
+      return { persistedHash: nextHash };
+    }
+
     const changedPathCount = changedPaths?.size;
     const previousBytes =
       typeof snapshot.raw === "string" ? Buffer.byteLength(snapshot.raw, "utf-8") : null;

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -2178,11 +2178,12 @@ export function createConfigIO(
       const nextStable = hashConfigRaw(stripVolatileMeta(json));
       const prevStable = hashConfigRaw(stripVolatileMeta(snapshot.raw ?? ""));
       if (nextStable === prevStable) {
-        return { persistedHash: previousHash };
+        // Skip the write: the on-disk config is the canonical persisted value.
+        return { persistedHash: previousHash, persistedConfig: snapshot.sourceConfig };
       }
     } else if (snapshot.exists && previousHash !== null && nextHash === previousHash) {
-      // Byte-identical — trivial no-op.
-      return { persistedHash: nextHash };
+      // Byte-identical — trivial no-op.  On-disk content is canonical.
+      return { persistedHash: nextHash, persistedConfig: snapshot.sourceConfig };
     }
 
     const changedPathCount = changedPaths?.size;

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -308,4 +308,52 @@ describe("config io write", () => {
       plugins: [],
     } satisfies PluginManifestRegistry);
   });
+
+  it("short-circuits without disk write when only meta timestamp changes (#75534)", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const warn = vi.fn();
+      const io = createConfigIO({
+        env: { OPENCLAW_TEST_CONFIG_OVERWRITE_LOG: "1" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: { warn, error: vi.fn() },
+      });
+
+      // First write: creates the file.
+      await io.writeConfigFile({
+        gateway: { mode: "local", port: 18789 },
+      });
+
+      // Record modification time after first write.
+      const statAfterFirst = await fs.stat(configPath);
+
+      // Reset mocks and call counts.
+      warn.mockClear();
+      mockMaintainConfigBackups.mockClear();
+
+      // Small delay to ensure lastTouchedAt timestamp differs.
+      await new Promise((r) => setTimeout(r, 5));
+
+      // Second write: same logical content — should short-circuit.
+      const secondResult = await io.writeConfigFile({
+        gateway: { mode: "local", port: 18789 },
+      });
+
+      // Should return a hash (the on-disk one, since nothing was written).
+      expect(secondResult.persistedHash).toEqual(expect.any(String));
+
+      // No "Config overwrite" log should fire on a no-op write.
+      const overwriteLogs = warn.mock.calls.filter(
+        (call) => typeof call[0] === "string" && call[0].startsWith("Config overwrite:"),
+      );
+      expect(overwriteLogs).toHaveLength(0);
+
+      // Backup rotation should NOT be called on a no-op write.
+      expect(mockMaintainConfigBackups).not.toHaveBeenCalled();
+
+      // File mtime should be unchanged (no disk write occurred).
+      const statAfterSecond = await fs.stat(configPath);
+      expect(statAfterSecond.mtimeMs).toBe(statAfterFirst.mtimeMs);
+    });
+  });
 });

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1586,4 +1586,52 @@ describe("config io write", () => {
       expect(persisted.logging?.level).toBe("debug");
     });
   });
+
+  it("short-circuits without disk write when only meta timestamp changes (#75534)", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const warn = vi.fn();
+      const io = createConfigIO({
+        env: { OPENCLAW_TEST_CONFIG_OVERWRITE_LOG: "1" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: { warn, error: vi.fn() },
+      });
+
+      // First write: creates the file.
+      await io.writeConfigFile({
+        gateway: { mode: "local", port: 18789 },
+      });
+
+      // Record modification time after first write.
+      const statAfterFirst = await fs.stat(configPath);
+
+      // Reset mocks and call counts.
+      warn.mockClear();
+      mockMaintainConfigBackups.mockClear();
+
+      // Small delay to ensure lastTouchedAt timestamp differs.
+      await new Promise((r) => setTimeout(r, 5));
+
+      // Second write: same logical content — should short-circuit.
+      const secondResult = await io.writeConfigFile({
+        gateway: { mode: "local", port: 18789 },
+      });
+
+      // Should return a hash (the on-disk one, since nothing was written).
+      expect(secondResult.persistedHash).toEqual(expect.any(String));
+
+      // No "Config overwrite" log should fire on a no-op write.
+      const overwriteLogs = warn.mock.calls.filter(
+        (call) => typeof call[0] === "string" && call[0].startsWith("Config overwrite:"),
+      );
+      expect(overwriteLogs).toHaveLength(0);
+
+      // Backup rotation should NOT be called on a no-op write.
+      expect(mockMaintainConfigBackups).not.toHaveBeenCalled();
+
+      // File mtime should be unchanged (no disk write occurred).
+      const statAfterSecond = await fs.stat(configPath);
+      expect(statAfterSecond.mtimeMs).toBe(statAfterFirst.mtimeMs);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When `config.patch` is called with a payload that results in no substantive change (only `meta.lastTouchedAt` / `meta.lastTouchedVersion` differ), the `writeConfigFile` function now returns early without touching disk.

## Problem

On deployments where an admin layer calls `config.patch` on every inbound message (e.g., to register a per-message agent in `allowAgents`), a thrash loop occurs:

1. `config.patch` writes byte-different but semantically-identical JSON (only `meta.lastTouchedAt` changes)
2. File-watcher fires
3. `[reload] config change detected` lists 25+ false-positive "changed" plugin paths
4. SIGUSR1 → full gateway restart
5. In-flight Service Bus / WebSocket messages dropped
6. Repeat on next inbound message

## Fix

After computing `nextHash` and `previousHash`, the function now:

1. **Fast path:** If byte-identical (`nextHash === previousHash`), return immediately
2. **Semantic path:** If hashes differ, strip volatile meta fields (`lastTouchedAt`, `lastTouchedVersion`) from both sides and re-compare. If the stable content is identical, short-circuit without disk I/O

When the short-circuit fires, no atomic rename, backup rotation, audit log, or suspicious-reason check is performed — there is nothing to record.

## Test

Added regression test in `io.write-config.test.ts` that verifies:
- Second write of identical config does not touch disk (mtime unchanged)
- No "Config overwrite" log is emitted
- Backup rotation is not triggered

Fixes #75534