### PR TITLE
fix(telegram): honor bound top-level group native commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: honor runtime conversation bindings for native slash commands in bound top-level groups, so commands like `/status@bot` route to the active non-`main` session instead of falling back to the default route. Fixes #75405. Thanks @yfge.
 - Plugins/runtime-deps: prune legacy version-scoped plugin runtime-deps roots during bundled dependency repair and cover the path in Package Acceptance's upgrade-survivor matrix, so upgrades from 2026.4.x no longer leave stale per-plugin runtime trees after doctor runs. Thanks @vincentkoc.
 - Plugins/runtime-deps: keep Gateway startup plugin imports and runtime plugin fallback loads verify-only after startup/config repair planning, so packaged installs no longer spawn package-manager repair from hot paths after readiness. Refs #75283 and #75069. Thanks @brokemac79 and @xiaohuaxi.
 - Voice Call/realtime: add default-off fast memory/session context for `openclaw_agent_consult`, giving live calls a bounded answer-or-miss path before the full agent consult. Fixes #71849. Thanks @amzzzzzzz.

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -837,6 +837,52 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(dispatchCall?.ctx).not.toHaveProperty("OwnerAllowFrom");
   });
 
+  it("routes Telegram native commands through bound top-level group sessions", async () => {
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "default:-1001234567890",
+      targetSessionKey: "agent:codex-acp:session-group",
+    });
+
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {},
+      allowFrom: ["200"],
+      groupAllowFrom: ["200"],
+    });
+    await handler({
+      match: "",
+      message: {
+        message_id: 2,
+        date: Math.floor(Date.now() / 1000),
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "OpenClaw",
+        },
+        from: { id: 200, username: "bob" },
+      },
+    });
+
+    expect(sessionBindingMocks.resolveByConversation).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "-1001234567890",
+    });
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [{ ctx?: { CommandTargetSessionKey?: string; OriginatingTo?: string } }]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe("agent:codex-acp:session-group");
+    expect(dispatchCall?.ctx?.OriginatingTo).toBe("telegram:-1001234567890");
+    const sessionMetaCall = (
+      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
+        [{ sessionKey?: string }]
+      >
+    )[0]?.[0];
+    expect(sessionMetaCall?.sessionKey).toBe("agent:codex-acp:session-group");
+    expect(sessionBindingMocks.touch).toHaveBeenCalledWith("default:-1001234567890", undefined);
+  });
+
   it("routes Telegram native commands through bound topic sessions", async () => {
     sessionBindingMocks.resolveByConversation.mockReturnValue({
       bindingId: "default:-1001234567890:topic:42",

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -105,19 +105,17 @@ export function resolveTelegramConversationRoute(params: {
   let configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
   route = configuredRoute.route;
 
-  const threadBindingConversationId =
+  const runtimeBindingConversationId =
     params.replyThreadId != null
       ? `${params.chatId}:topic:${params.replyThreadId}`
-      : !params.isGroup
-        ? String(params.chatId)
-        : undefined;
-  if (threadBindingConversationId) {
+      : String(params.chatId);
+  if (runtimeBindingConversationId) {
     const runtimeRoute = resolveRuntimeConversationBindingRoute({
       route,
       conversation: {
         channel: "telegram",
         accountId: params.accountId,
-        conversationId: threadBindingConversationId,
+        conversationId: runtimeBindingConversationId,
       },
     });
     route = runtimeRoute.route;
@@ -126,8 +124,8 @@ export function resolveTelegramConversationRoute(params: {
       configuredBindingSessionKey = "";
       logVerbose(
         runtimeRoute.boundSessionKey
-          ? `telegram: routed via bound conversation ${threadBindingConversationId} -> ${runtimeRoute.boundSessionKey}`
-          : `telegram: plugin-bound conversation ${threadBindingConversationId}`,
+          ? `telegram: routed via bound conversation ${runtimeBindingConversationId} -> ${runtimeRoute.boundSessionKey}`
+          : `telegram: plugin-bound conversation ${runtimeBindingConversationId}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- fix Telegram native slash commands so top-level groups honor active conversation bindings, not just DMs and forum topics
- add a regression test covering `/status` in a bound non-topic supergroup and asserting routing + session metadata land on the bound target session

## Background
`#75405` reports a regression after `2026.4.27`: Telegram native slash commands like `/status@bot` were silently dropped in groups bound to non-`main` agents.

The root cause was in `resolveTelegramConversationRoute()`: runtime conversation bindings were only consulted for DMs and forum topics. Top-level groups fell through to the default route, so native commands never targeted the bound session.

## Verification
- `pnpm test extensions/telegram/src/bot-native-commands.session-meta.test.ts extensions/telegram/src/conversation-route.base-session-key.test.ts`
- `pnpm check:changed`

## Impact
- restores native Telegram slash commands in bound top-level groups
- keeps existing DM and forum-topic binding behavior unchanged

Fixes #75405.
