### PR TITLE
feat(channels): add explicit lifecycle CLI controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/runtime: memoize transcript replay-policy resolution for stable config and process-env runs while preserving custom-env provider hook behavior. Thanks @DmitryPogodaev.
+- CLI/channels: add explicit channel lifecycle commands so operators can start, stop, or restart an existing linked channel account without re-running login or QR pairing. Closes #75153. Thanks @Jason-Vaughan and @vyctorbrzezowski.
 - Infra/path-guards: add a fast path for canonical absolute POSIX containment checks, avoiding repeated `path.resolve` and `path.relative` work in hot filesystem walkers. Refs #75895, #75575, and #68782. Thanks @Enderfga.
 - Tools: add a platform-level tool descriptor planner for descriptor-first visibility, generic availability checks, and executor references. Thanks @shakkernerd.
 - Docs/Codex: clarify that ChatGPT/Codex subscription setups should use `openai/gpt-*` with `agentRuntime.id: "codex"` for native Codex runtime, while `openai-codex/*` remains the PI OAuth route. Thanks @pashpashpash.

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2824,6 +2824,24 @@ public struct ChannelsStopParams: Codable, Sendable {
     }
 }
 
+public struct ChannelsRestartParams: Codable, Sendable {
+    public let channel: String
+    public let accountid: String?
+
+    public init(
+        channel: String,
+        accountid: String?)
+    {
+        self.channel = channel
+        self.accountid = accountid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case channel
+        case accountid = "accountId"
+    }
+}
+
 public struct ChannelsLogoutParams: Codable, Sendable {
     public let channel: String
     public let accountid: String?

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2824,6 +2824,24 @@ public struct ChannelsStopParams: Codable, Sendable {
     }
 }
 
+public struct ChannelsRestartParams: Codable, Sendable {
+    public let channel: String
+    public let accountid: String?
+
+    public init(
+        channel: String,
+        accountid: String?)
+    {
+        self.channel = channel
+        self.accountid = accountid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case channel
+        case accountid = "accountId"
+    }
+}
+
 public struct ChannelsLogoutParams: Codable, Sendable {
     public let channel: String
     public let accountid: String?

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -24,6 +24,7 @@ openclaw channels capabilities
 openclaw channels capabilities --channel discord --target channel:123
 openclaw channels resolve --channel slack "#general" "@jane"
 openclaw channels logs --channel all
+openclaw channels restart --channel whatsapp --account default
 ```
 
 ## Status / capabilities / resolve / logs
@@ -44,6 +45,22 @@ Do not use `openclaw sessions`, Gateway `sessions.list`, or the agent
 stored conversation rows, not provider runtime state. After a Discord provider
 restart, a connected but quiet account may be healthy while no Discord session
 row appears until the next inbound or outbound conversation event.
+
+## Runtime lifecycle
+
+```bash
+openclaw channels start --channel whatsapp --account default
+openclaw channels stop --channel whatsapp --account default
+openclaw channels restart --channel whatsapp --account default
+```
+
+These commands start, stop, or restart an existing linked channel account through the Gateway runtime. They do not log out, remove config, clear credentials, unlink accounts, or start QR pairing. Use them when `channels status` shows a linked account as stopped after a transient failure and you want an explicit operator recovery path.
+
+- `--channel <name>` is required.
+- `--account <id>` defaults to the channel's default account.
+- `--json` prints the Gateway result for scripts.
+
+`restart` is an explicit stop followed by start. It does not change health-monitor retry/backoff policy or add automatic recovery.
 
 ## Add / remove accounts
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -342,6 +342,9 @@ enumeration of `src/gateway/server-methods/*.ts`.
 
   <Accordion title="Channels and login helpers">
     - `channels.status` returns built-in + bundled channel/plugin status summaries.
+    - `channels.start` starts an existing linked channel account without running login or QR pairing.
+    - `channels.stop` stops an existing linked channel account without logging it out, unlinking it, or clearing credentials.
+    - `channels.restart` stops then starts an existing linked channel account as an explicit operator action; it does not change health-monitor retry/backoff policy or add automatic recovery.
     - `channels.logout` logs out a specific channel/account where the channel supports logout.
     - `web.login.start` starts a QR/web login flow for the current QR-capable web channel provider.
     - `web.login.wait` waits for that QR/web login flow to complete and starts the channel on success.

--- a/src/cli/channels-cli.lifecycle.test.ts
+++ b/src/cli/channels-cli.lifecycle.test.ts
@@ -1,0 +1,78 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerChannelsCli } from "./channels-cli.js";
+
+const mocks = vi.hoisted(() => ({
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+  channelsLifecycleCommand: vi.fn(async () => {}),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+vi.mock("../plugins/bundled-package-channel-metadata.js", () => ({
+  listBundledPackageChannelMetadata: () => [],
+}));
+
+vi.mock("./channel-options.js", () => ({
+  formatCliChannelOptions: () => "whatsapp|telegram",
+}));
+
+vi.mock("../commands/channels.js", () => ({
+  channelsLifecycleCommand: mocks.channelsLifecycleCommand,
+}));
+
+describe("channels CLI lifecycle commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createProgram() {
+    const program = new Command();
+    program.exitOverride();
+    registerChannelsCli(program);
+    return program;
+  }
+
+  it("registers start, stop, and restart commands", () => {
+    const channels = createProgram().commands.find((command) => command.name() === "channels");
+
+    expect(channels?.commands.map((command) => command.name())).toEqual(
+      expect.arrayContaining(["start", "stop", "restart"]),
+    );
+  });
+
+  it.each(["start", "stop", "restart"] as const)(
+    "routes channels %s to the lifecycle command",
+    async (action) => {
+      const program = createProgram();
+
+      await program.parseAsync([
+        "node",
+        "openclaw",
+        "channels",
+        action,
+        "--channel",
+        "whatsapp",
+        "--account",
+        "acct-1",
+        "--json",
+      ]);
+
+      expect(mocks.channelsLifecycleCommand).toHaveBeenCalledWith(
+        action,
+        {
+          channel: "whatsapp",
+          account: "acct-1",
+          json: true,
+        },
+        mocks.runtime,
+      );
+    },
+  );
+});

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -15,6 +15,7 @@ import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 type ChannelsCommandsModule = typeof import("../commands/channels.js");
 
 const optionNamesRemove = ["channel", "account", "delete"] as const;
+const lifecycleActions = ["start", "stop", "restart"] as const;
 
 const channelsCommandsLoader = createLazyImportLoader<ChannelsCommandsModule>(
   () => import("../commands/channels.js"),
@@ -162,6 +163,27 @@ export function registerChannelsCli(program: Command) {
         await channelsLogsCommand(opts, defaultRuntime);
       });
     });
+
+  for (const action of lifecycleActions) {
+    const description =
+      action === "start"
+        ? "Start an existing linked channel account"
+        : action === "stop"
+          ? "Stop a channel account without logging it out"
+          : "Stop then start an existing linked channel account";
+    channels
+      .command(action)
+      .description(description)
+      .option("--channel <name>", `Channel (${channelNames})`)
+      .option("--account <id>", "Account id (default when omitted)")
+      .option("--json", "Output JSON", false)
+      .action(async (opts) => {
+        await runChannelsCommand(async () => {
+          const { channelsLifecycleCommand } = await loadChannelsCommands();
+          await channelsLifecycleCommand(action, opts, defaultRuntime);
+        });
+      });
+  }
 
   addChannelSetupOptions(
     channels

--- a/src/commands/channels.ts
+++ b/src/commands/channels.ts
@@ -4,6 +4,8 @@ export type { ChannelsCapabilitiesOptions } from "./channels/capabilities.js";
 export { channelsCapabilitiesCommand } from "./channels/capabilities.js";
 export type { ChannelsListOptions } from "./channels/list.js";
 export { channelsListCommand } from "./channels/list.js";
+export type { ChannelLifecycleAction, ChannelsLifecycleOptions } from "./channels/lifecycle.js";
+export { channelsLifecycleCommand } from "./channels/lifecycle.js";
 export type { ChannelsLogsOptions } from "./channels/logs.js";
 export { channelsLogsCommand } from "./channels/logs.js";
 export type { ChannelsRemoveOptions } from "./channels/remove.js";

--- a/src/commands/channels/lifecycle.test.ts
+++ b/src/commands/channels/lifecycle.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelsLifecycleCommand } from "./lifecycle.js";
+
+const mocks = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+}));
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
+}));
+
+describe("channelsLifecycleCommand", () => {
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.callGateway.mockResolvedValue({
+      channel: "whatsapp",
+      accountId: "acct-1",
+      started: true,
+    });
+  });
+
+  it("calls channels.start with channel and account id", async () => {
+    await channelsLifecycleCommand(
+      "start",
+      { channel: " whatsapp ", account: " acct-1 " },
+      runtime as never,
+    );
+
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "channels.start",
+      params: {
+        channel: "whatsapp",
+        accountId: "acct-1",
+      },
+    });
+    expect(runtime.log).toHaveBeenCalledWith("Started whatsapp/acct-1.");
+  });
+
+  it("calls channels.stop without account id when omitted", async () => {
+    mocks.callGateway.mockResolvedValueOnce({
+      channel: "whatsapp",
+      accountId: "default",
+      stopped: true,
+    });
+
+    await channelsLifecycleCommand("stop", { channel: "whatsapp" }, runtime as never);
+
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "channels.stop",
+      params: {
+        channel: "whatsapp",
+      },
+    });
+    expect(runtime.log).toHaveBeenCalledWith("Stopped whatsapp/default.");
+  });
+
+  it("calls channels.restart and supports JSON output", async () => {
+    const payload = {
+      channel: "whatsapp",
+      accountId: "acct-1",
+      stopped: true,
+      started: true,
+    };
+    mocks.callGateway.mockResolvedValueOnce(payload);
+
+    await channelsLifecycleCommand(
+      "restart",
+      { channel: "whatsapp", account: "acct-1", json: true },
+      runtime as never,
+    );
+
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "channels.restart",
+      params: {
+        channel: "whatsapp",
+        accountId: "acct-1",
+      },
+    });
+    expect(runtime.writeJson).toHaveBeenCalledWith(payload, 2);
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("Restarted"));
+  });
+
+  it("does not report restart success when the stop phase failed", async () => {
+    mocks.callGateway.mockResolvedValueOnce({
+      channel: "whatsapp",
+      accountId: "acct-1",
+      stopped: false,
+      started: true,
+    });
+
+    await channelsLifecycleCommand(
+      "restart",
+      { channel: "whatsapp", account: "acct-1" },
+      runtime as never,
+    );
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Restart requested for whatsapp/acct-1, but the stop phase did not complete.",
+    );
+  });
+
+  it("rejects missing channel before calling the Gateway", async () => {
+    await expect(channelsLifecycleCommand("start", {}, runtime as never)).rejects.toThrow(
+      "Channel is required (--channel <name>).",
+    );
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/channels/lifecycle.ts
+++ b/src/commands/channels/lifecycle.ts
@@ -1,0 +1,79 @@
+import { callGateway } from "../../gateway/call.js";
+import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+
+export type ChannelLifecycleAction = "start" | "stop" | "restart";
+
+export type ChannelsLifecycleOptions = {
+  channel?: string;
+  account?: string;
+  json?: boolean;
+};
+
+type ChannelLifecyclePayload = {
+  channel?: string;
+  accountId?: string;
+  started?: boolean;
+  stopped?: boolean;
+};
+
+function resolveRequiredChannel(raw: string | undefined): string {
+  const channel = raw?.trim();
+  if (!channel) {
+    throw new Error("Channel is required (--channel <name>).");
+  }
+  return channel;
+}
+
+function resolveOptionalAccount(raw: string | undefined): string | undefined {
+  const account = raw?.trim();
+  return account || undefined;
+}
+
+function formatChannelAccount(payload: ChannelLifecyclePayload, fallbackChannel: string) {
+  const channel = payload.channel || fallbackChannel;
+  const accountId = payload.accountId || "default";
+  return `${channel}/${accountId}`;
+}
+
+function formatLifecycleResult(action: ChannelLifecycleAction, payload: ChannelLifecyclePayload) {
+  const target = formatChannelAccount(payload, payload.channel || "channel");
+  if (action === "start") {
+    return payload.started === false
+      ? `Start requested for ${target}, but the runtime still reports stopped.`
+      : `Started ${target}.`;
+  }
+  if (action === "stop") {
+    return payload.stopped === false
+      ? `Stop requested for ${target}, but the runtime still reports running.`
+      : `Stopped ${target}.`;
+  }
+  if (payload.stopped === false) {
+    return `Restart requested for ${target}, but the stop phase did not complete.`;
+  }
+  return payload.started === false
+    ? `Restart requested for ${target}, but the runtime still reports stopped.`
+    : `Restarted ${target}.`;
+}
+
+export async function channelsLifecycleCommand(
+  action: ChannelLifecycleAction,
+  opts: ChannelsLifecycleOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+) {
+  const channel = resolveRequiredChannel(opts.channel);
+  const accountId = resolveOptionalAccount(opts.account);
+  const payload = (await callGateway({
+    method: `channels.${action}`,
+    params: {
+      channel,
+      ...(accountId ? { accountId } : {}),
+    },
+  })) as ChannelLifecyclePayload;
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, payload);
+    return;
+  }
+
+  runtime.log(formatLifecycleResult(action, payload));
+}

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -170,6 +170,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
   [ADMIN_SCOPE]: [
     "channels.start",
     "channels.stop",
+    "channels.restart",
     "channels.logout",
     "agents.create",
     "agents.update",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -59,6 +59,8 @@ import {
   ChannelsStartParamsSchema,
   type ChannelsStopParams,
   ChannelsStopParamsSchema,
+  type ChannelsRestartParams,
+  ChannelsRestartParamsSchema,
   type ChannelsLogoutParams,
   ChannelsLogoutParamsSchema,
   type TalkConfigParams,
@@ -531,6 +533,9 @@ export const validateChannelsStatusParams = ajv.compile<ChannelsStatusParams>(
 export const validateChannelsStartParams =
   ajv.compile<ChannelsStartParams>(ChannelsStartParamsSchema);
 export const validateChannelsStopParams = ajv.compile<ChannelsStopParams>(ChannelsStopParamsSchema);
+export const validateChannelsRestartParams = ajv.compile<ChannelsRestartParams>(
+  ChannelsRestartParamsSchema,
+);
 export const validateChannelsLogoutParams = ajv.compile<ChannelsLogoutParams>(
   ChannelsLogoutParamsSchema,
 );
@@ -744,6 +749,7 @@ export {
   ChannelsStatusResultSchema,
   ChannelsStartParamsSchema,
   ChannelsStopParamsSchema,
+  ChannelsRestartParamsSchema,
   ChannelsLogoutParamsSchema,
   WebLoginStartParamsSchema,
   WebLoginWaitParamsSchema,
@@ -859,6 +865,7 @@ export type {
   ChannelsStatusResult,
   ChannelsStartParams,
   ChannelsStopParams,
+  ChannelsRestartParams,
   ChannelsLogoutParams,
   WebLoginStartParams,
   WebLoginWaitParams,

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -310,6 +310,14 @@ export const ChannelsLogoutParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const ChannelsStartParamsSchema = Type.Object(
+  {
+    channel: NonEmptyString,
+    accountId: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
 export const ChannelsStopParamsSchema = Type.Object(
   {
     channel: NonEmptyString,
@@ -318,7 +326,7 @@ export const ChannelsStopParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export const ChannelsStartParamsSchema = Type.Object(
+export const ChannelsRestartParamsSchema = Type.Object(
   {
     channel: NonEmptyString,
     accountId: Type.Optional(Type.String()),

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -62,6 +62,7 @@ import {
   ArtifactsListResultSchema,
 } from "./artifacts.js";
 import {
+  ChannelsRestartParamsSchema,
   ChannelsStartParamsSchema,
   ChannelsStopParamsSchema,
   ChannelsLogoutParamsSchema,
@@ -330,6 +331,7 @@ export const ProtocolSchemas = {
   ChannelsStatusResult: ChannelsStatusResultSchema,
   ChannelsStartParams: ChannelsStartParamsSchema,
   ChannelsStopParams: ChannelsStopParamsSchema,
+  ChannelsRestartParams: ChannelsRestartParamsSchema,
   ChannelsLogoutParams: ChannelsLogoutParamsSchema,
   WebLoginStartParams: WebLoginStartParamsSchema,
   WebLoginWaitParams: WebLoginWaitParamsSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -100,6 +100,7 @@ export type ChannelsStatusParams = SchemaType<"ChannelsStatusParams">;
 export type ChannelsStatusResult = SchemaType<"ChannelsStatusResult">;
 export type ChannelsStartParams = SchemaType<"ChannelsStartParams">;
 export type ChannelsStopParams = SchemaType<"ChannelsStopParams">;
+export type ChannelsRestartParams = SchemaType<"ChannelsRestartParams">;
 export type ChannelsLogoutParams = SchemaType<"ChannelsLogoutParams">;
 export type WebLoginStartParams = SchemaType<"WebLoginStartParams">;
 export type WebLoginWaitParams = SchemaType<"WebLoginWaitParams">;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -16,6 +16,7 @@ const BASE_METHODS = [
   "channels.status",
   "channels.start",
   "channels.stop",
+  "channels.restart",
   "channels.logout",
   "status",
   "usage.status",

--- a/src/gateway/server-methods/channels.start.test.ts
+++ b/src/gateway/server-methods/channels.start.test.ts
@@ -183,8 +183,10 @@ describe("channelsHandlers channels.stop", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
     mocks.getChannelPlugin.mockReturnValue({
       id: "whatsapp",
+      gateway: { startAccount: vi.fn(), logoutAccount: vi.fn() },
       config: {
         defaultAccountId: () => "default-account",
         listAccountIds: () => ["default-account"],
@@ -193,13 +195,23 @@ describe("channelsHandlers channels.stop", () => {
     });
   });
 
-  it("stops a channel account without clearing auth state", async () => {
-    const stopChannel = vi.fn(async () => undefined);
+  it("stops the channel runtime without logging out or clearing credentials", async () => {
+    const stopChannel = vi.fn();
+    const logoutAccount = vi.fn();
     const respond = vi.fn();
+    mocks.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      gateway: { startAccount: vi.fn(), logoutAccount },
+      config: {
+        defaultAccountId: () => "default-account",
+        listAccountIds: () => ["default-account"],
+        resolveAccount: () => ({}),
+      },
+    });
 
     await channelsHandlers["channels.stop"](
       createOptions(
-        { channel: "whatsapp" },
+        { channel: "whatsapp", accountId: "acct-1" },
         {
           respond,
           context: {
@@ -210,8 +222,8 @@ describe("channelsHandlers channels.stop", () => {
                 channels: {},
                 channelAccounts: {
                   whatsapp: {
-                    "default-account": {
-                      accountId: "default-account",
+                    "acct-1": {
+                      accountId: "acct-1",
                       running: false,
                     },
                   },
@@ -223,13 +235,167 @@ describe("channelsHandlers channels.stop", () => {
       ),
     );
 
-    expect(stopChannel).toHaveBeenCalledWith("whatsapp", "default-account");
+    expect(stopChannel).toHaveBeenCalledWith("whatsapp", "acct-1");
+    expect(logoutAccount).not.toHaveBeenCalled();
     expect(respond).toHaveBeenCalledWith(
       true,
       {
         channel: "whatsapp",
-        accountId: "default-account",
+        accountId: "acct-1",
         stopped: true,
+      },
+      undefined,
+    );
+  });
+
+  it("reports an actionable error when the plugin has no lifecycle stop support", async () => {
+    const respond = vi.fn();
+    mocks.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      gateway: {},
+      config: {
+        defaultAccountId: () => "default-account",
+        listAccountIds: () => ["default-account"],
+        resolveAccount: () => ({}),
+      },
+    });
+
+    await channelsHandlers["channels.stop"](createOptions({ channel: "whatsapp" }, { respond }));
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "channel whatsapp does not support runtime stop",
+      }),
+    );
+  });
+
+  it("uses the existing validation error style for invalid params", async () => {
+    const respond = vi.fn();
+
+    await channelsHandlers["channels.stop"](createOptions({ channel: "" }, { respond }));
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("invalid channels.stop params"),
+      }),
+    );
+  });
+
+  it("does not stop when the requested account cannot be resolved", async () => {
+    const stopChannel = vi.fn();
+    const respond = vi.fn();
+    mocks.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      gateway: { startAccount: vi.fn() },
+      config: {
+        defaultAccountId: () => "default-account",
+        listAccountIds: () => ["default-account"],
+        resolveAccount: vi.fn(() => {
+          throw new Error("unknown account");
+        }),
+      },
+    });
+
+    await channelsHandlers["channels.stop"](
+      createOptions(
+        { channel: "whatsapp", accountId: "missing" },
+        {
+          respond,
+          context: {
+            getRuntimeConfig: mocks.getRuntimeConfig,
+            stopChannel,
+            getRuntimeSnapshot: vi.fn(
+              (): ChannelRuntimeSnapshot => ({
+                channels: {},
+                channelAccounts: {},
+              }),
+            ),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(stopChannel).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("unknown account"),
+      }),
+    );
+  });
+});
+
+describe("channelsHandlers channels.restart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
+    mocks.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      gateway: { startAccount: vi.fn() },
+      config: {
+        defaultAccountId: () => "default-account",
+        listAccountIds: () => ["default-account"],
+        resolveAccount: () => ({}),
+      },
+    });
+  });
+
+  it("stops then starts the channel account in order", async () => {
+    const calls: string[] = [];
+    const stopChannel = vi.fn(async () => {
+      calls.push("stop");
+    });
+    const startChannel = vi.fn(async () => {
+      calls.push("start");
+    });
+    const respond = vi.fn();
+    let running = false;
+
+    await channelsHandlers["channels.restart"](
+      createOptions(
+        { channel: "whatsapp", accountId: "acct-1" },
+        {
+          respond,
+          context: {
+            getRuntimeConfig: mocks.getRuntimeConfig,
+            stopChannel,
+            startChannel,
+            getRuntimeSnapshot: vi.fn((): ChannelRuntimeSnapshot => {
+              const snapshot = {
+                channels: {},
+                channelAccounts: {
+                  whatsapp: {
+                    "acct-1": {
+                      accountId: "acct-1",
+                      running,
+                    },
+                  },
+                },
+              };
+              running = true;
+              return snapshot;
+            }),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(calls).toEqual(["stop", "start"]);
+    expect(stopChannel).toHaveBeenCalledWith("whatsapp", "acct-1");
+    expect(startChannel).toHaveBeenCalledWith("whatsapp", "acct-1");
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        channel: "whatsapp",
+        accountId: "acct-1",
+        stopped: true,
+        started: true,
       },
       undefined,
     );

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -21,14 +21,19 @@ import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
+  validateChannelsLogoutParams,
+  validateChannelsRestartParams,
   validateChannelsStartParams,
   validateChannelsStopParams,
-  validateChannelsLogoutParams,
   validateChannelsStatusParams,
 } from "../protocol/index.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestHandlerOptions,
+  GatewayRequestHandlers,
+} from "./types.js";
 
 type ChannelLogoutPayload = {
   channel: ChannelId;
@@ -47,6 +52,10 @@ type ChannelStopPayload = {
   channel: ChannelId;
   accountId: string;
   stopped: boolean;
+};
+
+type ChannelRestartPayload = ChannelStopPayload & {
+  started: boolean;
 };
 
 const CHANNEL_STATUS_MAX_TIMEOUT_MS = 30_000;
@@ -152,7 +161,11 @@ export async function stopChannelAccount(params: {
   context: GatewayRequestContext;
   plugin: ChannelPlugin;
 }): Promise<ChannelStopPayload> {
+  if (!params.plugin.gateway?.startAccount && !params.plugin.gateway?.stopAccount) {
+    throw new Error(`Channel ${params.channelId} does not support runtime stop`);
+  }
   const resolvedAccountId = resolveChannelGatewayAccountId(params);
+  params.plugin.config.resolveAccount(params.cfg, resolvedAccountId);
   await params.context.stopChannel(params.channelId, resolvedAccountId);
   const runtime = params.context.getRuntimeSnapshot();
   const stopped =
@@ -165,6 +178,63 @@ export async function stopChannelAccount(params: {
     channel: params.channelId,
     accountId: resolvedAccountId,
     stopped,
+  };
+}
+
+export async function restartChannelAccount(params: {
+  channelId: ChannelId;
+  accountId?: string | null;
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  plugin: ChannelPlugin;
+}): Promise<ChannelRestartPayload> {
+  const stopped = await stopChannelAccount(params);
+  const started = await startChannelAccount(params);
+  return {
+    channel: params.channelId,
+    accountId: stopped.accountId,
+    stopped: stopped.stopped,
+    started: started.started,
+  };
+}
+
+type ChannelLifecycleMethod = "channels.start" | "channels.stop" | "channels.restart";
+type ChannelLifecycleValidator =
+  | typeof validateChannelsStartParams
+  | typeof validateChannelsStopParams
+  | typeof validateChannelsRestartParams;
+
+async function resolveLifecycleRequest(params: {
+  method: ChannelLifecycleMethod;
+  validator: ChannelLifecycleValidator;
+  rawParams: unknown;
+  respond: GatewayRequestHandlerOptions["respond"];
+}): Promise<{ channelId: ChannelId; rawChannel: unknown; accountId?: string | null } | undefined> {
+  if (!params.validator(params.rawParams)) {
+    params.respond(
+      false,
+      undefined,
+      errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        `invalid ${params.method} params: ${formatValidationErrors(params.validator.errors)}`,
+      ),
+    );
+    return undefined;
+  }
+  const rawChannel = (params.rawParams as { channel?: unknown }).channel;
+  const channelId = typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : null;
+  if (!channelId) {
+    params.respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, `invalid ${params.method} channel`),
+    );
+    return undefined;
+  }
+  return {
+    channelId,
+    rawChannel,
+    accountId: (params.rawParams as { accountId?: string | null }).accountId,
   };
 }
 
@@ -366,33 +436,24 @@ export const channelsHandlers: GatewayRequestHandlers = {
     respond(true, payload, undefined);
   },
   "channels.start": async ({ params, respond, context }) => {
-    if (!validateChannelsStartParams(params)) {
+    const resolved = await resolveLifecycleRequest({
+      method: "channels.start",
+      validator: validateChannelsStartParams,
+      rawParams: params,
+      respond,
+    });
+    if (!resolved) {
+      return;
+    }
+    const plugin = getChannelPlugin(resolved.channelId);
+    if (!plugin) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          `invalid channels.start params: ${formatValidationErrors(validateChannelsStartParams.errors)}`,
+          `unknown channel: ${formatForLog(resolved.rawChannel)}`,
         ),
-      );
-      return;
-    }
-    const rawChannel = (params as { channel?: unknown }).channel;
-    const channelId = typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : null;
-    if (!channelId) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid channels.start channel"),
-      );
-      return;
-    }
-    const plugin = getChannelPlugin(channelId);
-    if (!plugin) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `unknown channel: ${formatForLog(rawChannel)}`),
       );
       return;
     }
@@ -400,7 +461,10 @@ export const channelsHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `channel ${channelId} does not support start`),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `channel ${resolved.channelId} does not support start`,
+        ),
       );
       return;
     }
@@ -410,8 +474,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
         env: process.env,
       }).config;
       const payload = await startChannelAccount({
-        channelId,
-        accountId: (params as { accountId?: string | null }).accountId,
+        channelId: resolved.channelId,
+        accountId: resolved.accountId,
         cfg,
         context,
         plugin,
@@ -422,43 +486,97 @@ export const channelsHandlers: GatewayRequestHandlers = {
     }
   },
   "channels.stop": async ({ params, respond, context }) => {
-    if (!validateChannelsStopParams(params)) {
+    const resolved = await resolveLifecycleRequest({
+      method: "channels.stop",
+      validator: validateChannelsStopParams,
+      rawParams: params,
+      respond,
+    });
+    if (!resolved) {
+      return;
+    }
+    const plugin = getChannelPlugin(resolved.channelId);
+    if (!plugin) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          `invalid channels.stop params: ${formatValidationErrors(validateChannelsStopParams.errors)}`,
+          `unknown channel: ${formatForLog(resolved.rawChannel)}`,
         ),
       );
       return;
     }
-    const rawChannel = (params as { channel?: unknown }).channel;
-    const channelId = typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : null;
-    if (!channelId) {
+    if (!plugin.gateway?.startAccount && !plugin.gateway?.stopAccount) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid channels.stop channel"),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `channel ${resolved.channelId} does not support runtime stop`,
+        ),
       );
       return;
     }
-    const plugin = getChannelPlugin(channelId);
+    try {
+      const cfg = applyPluginAutoEnable({
+        config: context.getRuntimeConfig(),
+        env: process.env,
+      }).config;
+      const payload = await stopChannelAccount({
+        channelId: resolved.channelId,
+        accountId: resolved.accountId,
+        cfg,
+        context,
+        plugin,
+      });
+      respond(true, payload, undefined);
+    } catch (error) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(error)));
+    }
+  },
+  "channels.restart": async ({ params, respond, context }) => {
+    const resolved = await resolveLifecycleRequest({
+      method: "channels.restart",
+      validator: validateChannelsRestartParams,
+      rawParams: params,
+      respond,
+    });
+    if (!resolved) {
+      return;
+    }
+    const plugin = getChannelPlugin(resolved.channelId);
     if (!plugin) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `unknown channel ${channelId}`),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `unknown channel: ${formatForLog(resolved.rawChannel)}`,
+        ),
       );
       return;
     }
-    const accountIdRaw = (params as { accountId?: unknown }).accountId;
-    const accountId = normalizeOptionalString(accountIdRaw);
+    if (!plugin.gateway?.startAccount) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `channel ${resolved.channelId} does not support start`,
+        ),
+      );
+      return;
+    }
     try {
-      const payload = await stopChannelAccount({
-        channelId,
-        accountId,
-        cfg: context.getRuntimeConfig(),
+      const cfg = applyPluginAutoEnable({
+        config: context.getRuntimeConfig(),
+        env: process.env,
+      }).config;
+      const payload = await restartChannelAccount({
+        channelId: resolved.channelId,
+        accountId: resolved.accountId,
+        cfg,
         context,
         plugin,
       });


### PR DESCRIPTION
## Summary

- Operator gap: linked channel accounts can remain stopped/disconnected after a transient failure while auth is still valid, leaving operators without an explicit CLI recovery path.
- Why it matters: the current workaround is to re-run login/QR pairing or restart the container even though the account is still linked.
- What changed: adds `openclaw channels start|stop|restart --channel <name> [--account <id>]`, Gateway RPCs for `channels.stop` and `channels.restart`, protocol schemas/scopes/generated Swift models, focused tests, and concise CLI/protocol docs.
- What did NOT change (scope boundary): This intentionally does not change health-monitor retry/backoff policy or add automatic recovery; it only exposes an explicit operator recovery path.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75153
- Related: N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A. This is a feature PR for an explicit operator lifecycle control path, not a bug fix.

## Feature Test Plan

- Coverage added:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
- Target test or file: `src/cli/channels-cli.lifecycle.test.ts`, `src/commands/channels/lifecycle.test.ts`, `src/gateway/server-methods/channels.start.test.ts`
- Scenario the tests lock in: CLI registration and Gateway method calls for start/stop/restart, stop without logout, restart stop-then-start ordering, validation errors, missing lifecycle support, JSON output, and restart output when the stop phase does not complete.
- Why this is the smallest reliable coverage: the regression is in CLI/Gateway lifecycle wiring, not channel-specific provider behavior.
- Existing nearby coverage retained: `src/cli/channel-auth.test.ts` covers login reconciliation still using `channels.start`.

## User-visible / Behavior Changes

Operators can now run:

```bash
openclaw channels start --channel whatsapp --account default
openclaw channels stop --channel whatsapp --account default
openclaw channels restart --channel whatsapp --account default
```

These commands operate on existing linked accounts and do not log out, unlink accounts, clear auth state, delete credentials, or start QR pairing.

## Diagram (if applicable)

```text
Before:
[linked account stopped] -> [operator] -> [login/QR pairing or container restart]

After:
[linked account stopped] -> [openclaw channels restart] -> [Gateway stop then start existing account]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: exposes explicit lifecycle operations through existing CLI/Gateway auth and classifies the new methods as `operator.admin`, matching `channels.start`/`channels.logout`; stop/restart do not clear credentials or broaden data access.

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node/pnpm repo scripts
- Model/provider: N/A
- Integration/channel (if any): Gateway channel lifecycle, provider-agnostic tests
- Relevant config (redacted): test fixtures only

### Steps

1. Link/configure a channel account.
2. Let the runtime account become stopped while auth remains linked.
3. Run `openclaw channels restart --channel <name> [--account <id>]`.

### Expected

- Gateway stops then starts the existing linked account without logout, unlink, QR pairing, or credential deletion.

### Actual

- The new Gateway path resolves the existing account, calls runtime stop/start primitives, and keeps auth/logout/credential-clearing paths out of start/stop/restart.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New feature coverage was added for the CLI/Gateway lifecycle path and would fail on the pre-change code because `channels stop`/`channels restart` were not registered/exposed.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: CLI command registration/call routing, Gateway start/stop/restart behavior, restart ordering, stop not calling logout, invalid params, missing lifecycle support, protocol generated artifacts, docs/changelog.
- Edge cases checked: missing `--channel`, omitted `--account`, JSON output, restart with incomplete stop phase.
- What you did **not** verify: live WhatsApp/browser channel behavior against a real account.

Commands run:

```bash
pnpm test src/gateway/server-methods/channels.start.test.ts src/commands/channels/lifecycle.test.ts src/cli/channels-cli.lifecycle.test.ts src/cli/channel-auth.test.ts src/gateway/method-scopes.test.ts
pnpm protocol:check
pnpm exec oxfmt --check --threads=1 $(git diff --name-only origin/main...HEAD)
PATH=/tmp/openclaw-swiftlint:$PATH SWIFTLINT_DISABLE_SOURCEKIT=1 pnpm check:changed
git diff --check && git diff --cached --check
```

Also ran `codex review --base origin/main`; addressed its lifecycle module/protocol artifact findings and the restart-output P2.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: an explicit stop/restart can interrupt an active channel runtime.
  - Mitigation: methods require `operator.admin`, are operator-initiated, and preserve auth/credentials so recovery remains non-destructive.

## AI Assistance

This PR was prepared with AI assistance and reviewed with local tests plus `codex review --base origin/main`.


