### PR TITLE
feat(voice-call): add realtime caller context

### DIFF
--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -240,6 +240,67 @@ export type VoiceCallRealtimeFastContextConfig = z.infer<
   typeof VoiceCallRealtimeFastContextConfigSchema
 >;
 
+export const VoiceCallRealtimeCallerConfigSchema = z
+  .object({
+    /** Display/first name resolved from caller ID. */
+    name: z.string().min(1).optional(),
+    /** Optional exact first greeting phrase, e.g. "Hi Yme". Defaults to "Hi {name}". */
+    greeting: z.string().min(1).optional(),
+    /** Extra bounded instructions for this caller. Keep short; not a transcript store. */
+    instructions: z.string().min(1).optional(),
+    /** Optional local file with durable caller profile context. */
+    profilePath: z.string().min(1).optional(),
+    /** Optional local file with compact daily/current voice context. */
+    voiceCardPath: z.string().min(1).optional(),
+  })
+  .strict();
+export type VoiceCallRealtimeCallerConfig = z.infer<typeof VoiceCallRealtimeCallerConfigSchema>;
+
+export const VoiceCallRealtimeCallerContextConfigSchema = z
+  .object({
+    /** Enable caller-ID-specific greetings and bounded context injection. */
+    enabled: z.boolean().default(false),
+    /** Caller configs keyed by E.164 number or digit-only normalized phone number. */
+    callers: z.record(z.string(), VoiceCallRealtimeCallerConfigSchema).default({}),
+    /** Maximum characters read from profilePath per call. */
+    maxProfileChars: z.number().int().positive().default(1200),
+    /** Maximum characters read from voiceCardPath per call. */
+    maxVoiceCardChars: z.number().int().positive().default(1800),
+    /** Instructions used when caller ID is not configured. */
+    unknownCallerInstructions: z
+      .string()
+      .default(
+        "Caller identity: unknown. Ask briefly who is calling before using personal context.",
+      ),
+  })
+  .strict()
+  .default({
+    enabled: false,
+    callers: {},
+    maxProfileChars: 1200,
+    maxVoiceCardChars: 1800,
+    unknownCallerInstructions:
+      "Caller identity: unknown. Ask briefly who is calling before using personal context.",
+  });
+export type VoiceCallRealtimeCallerContextConfig = z.infer<
+  typeof VoiceCallRealtimeCallerContextConfigSchema
+>;
+
+export const VoiceCallRealtimeTranscriptLogConfigSchema = z
+  .object({
+    /** Append realtime transcript fragments to JSONL for aftercare/recovery. */
+    enabled: z.boolean().default(false),
+    /** Optional JSONL path. Defaults to the voice-call store directory. */
+    path: z.string().min(1).optional(),
+    /** Include interim/non-final transcript fragments as a best-effort recovery trail. */
+    includeInterim: z.boolean().default(true),
+  })
+  .strict()
+  .default({ enabled: false, includeInterim: true });
+export type VoiceCallRealtimeTranscriptLogConfig = z.infer<
+  typeof VoiceCallRealtimeTranscriptLogConfigSchema
+>;
+
 export const VoiceCallStreamingProvidersConfigSchema = z
   .record(z.string(), z.record(z.string(), z.unknown()))
   .default({});
@@ -260,6 +321,10 @@ export const VoiceCallRealtimeConfigSchema = z
     tools: z.array(RealtimeToolSchema).default([]),
     /** Low-latency memory/session context for the consult tool. */
     fastContext: VoiceCallRealtimeFastContextConfigSchema,
+    /** Caller-ID specific greetings and compact context. */
+    callerContext: VoiceCallRealtimeCallerContextConfigSchema,
+    /** Best-effort realtime transcript fragment logging for aftercare/recovery. */
+    transcriptLog: VoiceCallRealtimeTranscriptLogConfigSchema,
     /** Provider-owned raw config blobs keyed by provider id. */
     providers: VoiceCallRealtimeProvidersConfigSchema,
   })
@@ -276,6 +341,15 @@ export const VoiceCallRealtimeConfigSchema = z
       sources: ["memory", "sessions"],
       fallbackToConsult: false,
     },
+    callerContext: {
+      enabled: false,
+      callers: {},
+      maxProfileChars: 1200,
+      maxVoiceCardChars: 1800,
+      unknownCallerInstructions:
+        "Caller identity: unknown. Ask briefly who is calling before using personal context.",
+    },
+    transcriptLog: { enabled: false, includeInterim: true },
     providers: {},
   });
 export type VoiceCallRealtimeConfig = z.infer<typeof VoiceCallRealtimeConfigSchema>;
@@ -515,6 +589,20 @@ export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCal
     ...config.realtime?.fastContext,
     sources: config.realtime?.fastContext?.sources ?? defaults.realtime.fastContext.sources,
   };
+  const realtimeCallerContextCallers = Object.fromEntries(
+    Object.entries(
+      config.realtime?.callerContext?.callers ?? defaults.realtime.callerContext.callers,
+    ).filter((entry): entry is [string, VoiceCallRealtimeCallerConfig] => Boolean(entry[1])),
+  );
+  const realtimeCallerContext = {
+    ...defaults.realtime.callerContext,
+    ...config.realtime?.callerContext,
+    callers: realtimeCallerContextCallers,
+  };
+  const realtimeTranscriptLog = {
+    ...defaults.realtime.transcriptLog,
+    ...config.realtime?.transcriptLog,
+  };
   return {
     ...defaults,
     ...config,
@@ -546,6 +634,8 @@ export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCal
       tools:
         (config.realtime?.tools as RealtimeToolConfig[] | undefined) ?? defaults.realtime.tools,
       fastContext: realtimeFastContext,
+      callerContext: realtimeCallerContext,
+      transcriptLog: realtimeTranscriptLog,
       providers: realtimeProviders,
     },
     tts: normalizeVoiceCallTtsConfig(defaults.tts, config.tts),

--- a/extensions/voice-call/src/test-fixtures.ts
+++ b/extensions/voice-call/src/test-fixtures.ts
@@ -57,6 +57,15 @@ export function createVoiceCallBaseConfig(params?: {
         sources: ["memory", "sessions"],
         fallbackToConsult: false,
       },
+      callerContext: {
+        enabled: false,
+        callers: {},
+        maxProfileChars: 1200,
+        maxVoiceCardChars: 1800,
+        unknownCallerInstructions:
+          "Caller identity: unknown. Ask briefly who is calling before using personal context.",
+      },
+      transcriptLog: { enabled: false, includeInterim: true },
       providers: {},
     },
     skipSignatureVerification: false,

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -83,6 +83,15 @@ const createConfig = (overrides: VoiceCallConfigInput = {}): VoiceCallConfig => 
         ...overrides.realtime?.fastContext,
         sources: overrides.realtime?.fastContext?.sources ?? base.realtime.fastContext.sources,
       },
+      callerContext: {
+        ...base.realtime.callerContext,
+        ...overrides.realtime?.callerContext,
+        callers: overrides.realtime?.callerContext?.callers ?? base.realtime.callerContext.callers,
+      },
+      transcriptLog: {
+        ...base.realtime.transcriptLog,
+        ...overrides.realtime?.transcriptLog,
+      },
       providers: overrides.realtime?.providers ?? base.realtime.providers,
     },
   };

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1,4 +1,7 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import http from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type {
   RealtimeVoiceBridge,
   RealtimeVoiceProviderPlugin,
@@ -67,6 +70,15 @@ function makeHandler(
       sources: ["memory", "sessions"],
       fallbackToConsult: false,
     },
+    callerContext: overrides?.callerContext ?? {
+      enabled: false,
+      callers: {},
+      maxProfileChars: 1200,
+      maxVoiceCardChars: 1800,
+      unknownCallerInstructions:
+        "Caller identity: unknown. Ask briefly who is calling before using personal context.",
+    },
+    transcriptLog: overrides?.transcriptLog ?? { enabled: false, includeInterim: true },
     providers: overrides?.providers ?? {},
     ...(overrides?.provider ? { provider: overrides.provider } : {}),
   };
@@ -97,11 +109,12 @@ function makeHandler(
 
 const startRealtimeServer = async (
   handler: RealtimeCallHandler,
+  form = new URLSearchParams(),
 ): Promise<{
   url: string;
   close: () => Promise<void>;
 }> => {
-  const payload = handler.buildTwiMLPayload(makeRequest("/voice/webhook"));
+  const payload = handler.buildTwiMLPayload(makeRequest("/voice/webhook"), form);
   const match = payload.body.match(/wss:\/\/[^/]+(\/[^"]+)/);
   if (!match) {
     throw new Error("Failed to extract realtime stream path");
@@ -256,7 +269,14 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(
+      handler,
+      new URLSearchParams({
+        Direction: "inbound",
+        From: "+15550001234",
+        To: "+15550009999",
+      }),
+    );
 
     try {
       const ws = await connectWs(server.url);
@@ -327,6 +347,197 @@ describe("RealtimeCallHandler path routing", () => {
           success: true,
         });
         expect(triggerGreeting).toHaveBeenCalledWith("Say exactly: hello from Meet.");
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("injects bounded caller context and opens known callers with their configured greeting", async () => {
+    let callbacks:
+      | {
+          onReady?: () => void;
+        }
+      | undefined;
+    let providerRequest: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const triggerGreeting = vi.fn();
+    const profilePath = join(mkdtempSync(join(tmpdir(), "voice-profile-")), "profile.md");
+    const voiceCardPath = join(mkdtempSync(join(tmpdir(), "voice-card-")), "voice-card.md");
+    writeFileSync(profilePath, "Stable profile: direct Dutch-speaking user.", "utf8");
+    writeFileSync(voiceCardPath, "Current voice context: testing caller greetings.", "utf8");
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks = request;
+        providerRequest = request;
+        return makeBridge({ triggerGreeting });
+      },
+    );
+    const getCallByProviderCallId = vi.fn(
+      (): CallRecord => ({
+        callId: "call-1",
+        providerCallId: "CA-caller",
+        provider: "twilio",
+        direction: "inbound",
+        state: "ringing",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: {},
+      }),
+    );
+    const handler = makeHandler(
+      {
+        callerContext: {
+          enabled: true,
+          callers: {
+            "+15550001234": {
+              name: "Yme",
+              greeting: "Hi Yme",
+              profilePath,
+              voiceCardPath,
+            },
+          },
+          maxProfileChars: 1200,
+          maxVoiceCardChars: 1800,
+          unknownCallerInstructions: "Ask who is calling.",
+        },
+      },
+      {
+        manager: {
+          getCallByProviderCallId,
+        },
+        realtimeProvider: makeRealtimeProvider(createBridge),
+      },
+    );
+    const server = await startRealtimeServer(
+      handler,
+      new URLSearchParams({
+        Direction: "inbound",
+        From: "+15550001234",
+        To: "+15550009999",
+      }),
+    );
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-caller", callSid: "CA-caller" },
+          }),
+        );
+        await vi.waitFor(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+
+        expect(providerRequest?.instructions).toContain(
+          "Caller identity from verified caller ID: Yme.",
+        );
+        expect(providerRequest?.instructions).toContain(
+          "Stable profile: direct Dutch-speaking user.",
+        );
+        expect(providerRequest?.instructions).toContain(
+          "Current voice context: testing caller greetings.",
+        );
+
+        callbacks?.onReady?.();
+
+        expect(triggerGreeting).toHaveBeenCalledWith(expect.stringContaining("Hi Yme"));
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("writes realtime transcript fragments to the configured aftercare log", async () => {
+    let callbacks:
+      | {
+          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+        }
+      | undefined;
+    const logPath = join(mkdtempSync(join(tmpdir(), "voice-transcripts-")), "fragments.jsonl");
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks = request;
+        return makeBridge();
+      },
+    );
+    const getCallByProviderCallId = vi.fn(
+      (): CallRecord => ({
+        callId: "call-1",
+        providerCallId: "CA-log",
+        provider: "twilio",
+        direction: "inbound",
+        state: "ringing",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: {},
+      }),
+    );
+    const handler = makeHandler(
+      {
+        transcriptLog: { enabled: true, path: logPath, includeInterim: true },
+      },
+      {
+        manager: {
+          getCallByProviderCallId,
+        },
+        realtimeProvider: makeRealtimeProvider(createBridge),
+      },
+    );
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-log", callSid: "CA-log" },
+          }),
+        );
+        await vi.waitFor(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+
+        callbacks?.onTranscript?.("user", "partial question", false);
+        callbacks?.onTranscript?.("assistant", "final answer", true);
+
+        const entries = readFileSync(logPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(entries).toEqual([
+          expect.objectContaining({
+            callId: "call-1",
+            providerCallId: "CA-log",
+            streamSid: "MZ-log",
+            role: "user",
+            text: "partial question",
+            isFinal: false,
+          }),
+          expect.objectContaining({
+            callId: "call-1",
+            providerCallId: "CA-log",
+            role: "assistant",
+            text: "final answer",
+            isFinal: true,
+          }),
+        ]);
       } finally {
         if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
           ws.close();

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "node:crypto";
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import http from "node:http";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import type { Duplex } from "node:stream";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -11,7 +14,11 @@ import {
   type RealtimeVoiceProviderPlugin,
 } from "openclaw/plugin-sdk/realtime-voice";
 import WebSocket, { WebSocketServer } from "ws";
-import type { VoiceCallRealtimeConfig } from "../config.js";
+import type {
+  VoiceCallRealtimeCallerContextConfig,
+  VoiceCallRealtimeConfig,
+  VoiceCallRealtimeTranscriptLogConfig,
+} from "../config.js";
 import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
@@ -51,10 +58,120 @@ function buildGreetingInstructions(
     return undefined;
   }
   const intro =
-    "Start the call by greeting the caller naturally. Include this greeting in your first spoken reply:";
+    "Start the call now. Begin the first spoken reply with this exact greeting phrase, then continue naturally and briefly:";
   return baseInstructions
     ? `${baseInstructions}\n\n${intro} "${trimmedGreeting}"`
     : `${intro} "${trimmedGreeting}"`;
+}
+
+function normalizePhone(value: string | undefined): string {
+  return value?.replace(/\D/g, "") ?? "";
+}
+
+function resolveCallerContext(
+  config: VoiceCallRealtimeCallerContextConfig,
+  phone: string | undefined,
+) {
+  if (!config.enabled) {
+    return undefined;
+  }
+  const normalized = normalizePhone(phone);
+  if (!normalized) {
+    return undefined;
+  }
+  return (
+    config.callers[phone ?? ""] ?? config.callers[normalized] ?? config.callers[`+${normalized}`]
+  );
+}
+
+function readBoundedFile(path: string | undefined, maxChars: number): string | null {
+  if (!path) {
+    return null;
+  }
+  try {
+    const text = readFileSync(path, "utf8").trim();
+    if (!text) {
+      return null;
+    }
+    return text.length > maxChars ? `${text.slice(0, maxChars).trim()}\n…[trimmed]` : text;
+  } catch {
+    return null;
+  }
+}
+
+function buildCallerContextInstructions(
+  config: VoiceCallRealtimeCallerContextConfig,
+  phone: string | undefined,
+): string | undefined {
+  if (!config.enabled) {
+    return undefined;
+  }
+  const caller = resolveCallerContext(config, phone);
+  if (!caller) {
+    return config.unknownCallerInstructions;
+  }
+  const profile = readBoundedFile(caller.profilePath, config.maxProfileChars);
+  const voiceCard = readBoundedFile(caller.voiceCardPath, config.maxVoiceCardChars);
+  return [
+    caller.name ? `Caller identity from verified caller ID: ${caller.name}.` : undefined,
+    caller.name
+      ? `Required opening: begin the first spoken reply with exactly “${
+          caller.greeting?.trim() || `Hi ${caller.name}`
+        }”.`
+      : undefined,
+    caller.instructions,
+    profile || voiceCard
+      ? "Compact caller memory for this live call. Use only when relevant; do not recite it. Keep privacy boundaries strict."
+      : undefined,
+    profile,
+    voiceCard,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function buildRuntimeInstructions(
+  baseInstructions: string,
+  callerContext: VoiceCallRealtimeCallerContextConfig,
+  phone: string | undefined,
+): string {
+  const callerInstructions = buildCallerContextInstructions(callerContext, phone);
+  return callerInstructions ? `${baseInstructions}\n\n${callerInstructions}` : baseInstructions;
+}
+
+function resolveCallerGreeting(
+  config: VoiceCallRealtimeCallerContextConfig,
+  phone: string | undefined,
+  fallbackGreeting: string | undefined,
+): string | undefined {
+  const caller = resolveCallerContext(config, phone);
+  if (!caller?.name) {
+    return fallbackGreeting;
+  }
+  return caller.greeting?.trim() || `Hi ${caller.name}`;
+}
+
+function resolveTranscriptLogPath(config: VoiceCallRealtimeTranscriptLogConfig): string {
+  return config.path ?? join(homedir(), ".openclaw", "voice-calls", "realtime-transcripts.jsonl");
+}
+
+function appendTranscriptFragment(
+  config: VoiceCallRealtimeTranscriptLogConfig,
+  entry: Record<string, unknown>,
+): void {
+  if (!config.enabled) {
+    return;
+  }
+  if (!config.includeInterim && entry.isFinal !== true) {
+    return;
+  }
+  try {
+    const path = resolveTranscriptLogPath(config);
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, `${JSON.stringify(entry)}\n`, "utf8");
+  } catch {
+    // Best-effort aftercare logging only; never break the live call path.
+  }
 }
 
 type PendingStreamToken = {
@@ -266,6 +383,11 @@ export class RealtimeCallHandler {
     }
 
     const { callId, initialGreetingInstructions } = registration;
+    const runtimeInstructions = buildRuntimeInstructions(
+      this.config.instructions,
+      this.config.callerContext,
+      callerMeta.from,
+    );
     console.log(
       `[voice-call] Realtime bridge starting for call ${callId} (providerCallId=${callSid}, initialGreeting=${initialGreetingInstructions ? "queued" : "absent"})`,
     );
@@ -281,7 +403,7 @@ export class RealtimeCallHandler {
     const bridge = createRealtimeVoiceBridgeSession({
       provider: this.realtimeProvider,
       providerConfig: this.providerConfig,
-      instructions: this.config.instructions,
+      instructions: runtimeInstructions,
       tools: this.config.tools,
       initialGreetingInstructions,
       triggerGreetingOnReady: Boolean(initialGreetingInstructions),
@@ -304,6 +426,20 @@ export class RealtimeCallHandler {
         },
       },
       onTranscript: (role, text, isFinal) => {
+        const trimmedTranscript = text.trim();
+        if (trimmedTranscript) {
+          appendTranscriptFragment(this.config.transcriptLog, {
+            timestamp: Date.now(),
+            callId,
+            providerCallId: callSid,
+            streamSid,
+            from: callerMeta.from,
+            to: callerMeta.to,
+            role,
+            text: trimmedTranscript,
+            isFinal,
+          });
+        }
         if (!isFinal) {
           if (role === "user" && text.trim()) {
             this.partialUserTranscriptsByCallId.set(callId, text);
@@ -412,7 +548,11 @@ export class RealtimeCallHandler {
       return null;
     }
 
-    const initialGreeting = this.extractInitialGreeting(callRecord);
+    const initialGreeting = resolveCallerGreeting(
+      this.config.callerContext,
+      callerMeta.from,
+      this.extractInitialGreeting(callRecord),
+    );
     console.log(
       `[voice-call] Realtime call ${callRecord.callId} initial greeting ${initialGreeting ? "queued" : "absent"}`,
     );
@@ -429,10 +569,7 @@ export class RealtimeCallHandler {
 
     return {
       callId: callRecord.callId,
-      initialGreetingInstructions: buildGreetingInstructions(
-        this.config.instructions,
-        initialGreeting,
-      ),
+      initialGreetingInstructions: buildGreetingInstructions(undefined, initialGreeting),
     };
   }
 


### PR DESCRIPTION
## Summary
- add realtime voice caller context config keyed by caller ID
- support exact known-caller opening greetings plus bounded profile/voice-card context injection
- add best-effort realtime transcript JSONL logging for aftercare/recovery

## Tests
- npm exec --yes --package=pnpm@10.33.2 -- pnpm --dir projects/openclaw-pr exec vitest run --config test/vitest/vitest.extension-voice-call.config.ts extensions/voice-call/src/webhook/realtime-handler.test.ts extensions/voice-call/src/webhook.test.ts extensions/voice-call/src/config.test.ts
- npm exec --yes --package=pnpm@10.33.2 -- pnpm --dir projects/openclaw-pr tsgo:extensions:test