### PR TITLE
fix(agents): surface provider quota/rate-limit detail in failover errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,6 +376,7 @@ Docs: https://docs.openclaw.ai
 - Cron: retry recurring wake-now main-session jobs through temporary heartbeat busy skips before recording success, so queued cron events no longer appear as ok ghost runs while the main lane is still busy. Fixes #75964. (#76083) Thanks @kshetrajna12 and @xuruiray.
 - Providers/Google: keep Gemini thinking-signature-only stream chunks active during reasoning, so Gemini 3.1 Pro Preview replies no longer hit idle timeouts before visible text. Fixes #76071. (#76080) Thanks @marcoschierhorn and @zhangguiping-xydt.
 - CLI/skills: show per-agent model and command visibility in `openclaw skills check --agent`, and let doctor report or disable unavailable skills allowed for the default agent. (#75983) Thanks @mbelinky.
+- Codex/ChatGPT failover errors: surface provider quota and rate-limit detail (plan, retry-after window) instead of generic timeout when the app-server emits structured `usageLimitExceeded` or `account/rateLimits/updated` events. (#75661) Thanks @amittell.
 
 ## 2026.4.30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2621,6 +2621,7 @@ Docs: https://docs.openclaw.ai
 - Cron: retry recurring wake-now main-session jobs through temporary heartbeat busy skips before recording success, so queued cron events no longer appear as ok ghost runs while the main lane is still busy. Fixes #75964. (#76083) Thanks @kshetrajna12 and @xuruiray.
 - Providers/Google: keep Gemini thinking-signature-only stream chunks active during reasoning, so Gemini 3.1 Pro Preview replies no longer hit idle timeouts before visible text. Fixes #76071. (#76080) Thanks @marcoschierhorn and @zhangguiping-xydt.
 - CLI/skills: show per-agent model and command visibility in `openclaw skills check --agent`, and let doctor report or disable unavailable skills allowed for the default agent. (#75983) Thanks @mbelinky.
+- Codex/ChatGPT failover errors: surface provider quota and rate-limit detail (plan, retry-after window) instead of generic timeout when the app-server emits structured `usageLimitExceeded` or `account/rateLimits/updated` events. (#75661) Thanks @amittell.
 
 ## 2026.4.29
 

--- a/extensions/codex/src/app-server/error-projection.test.ts
+++ b/extensions/codex/src/app-server/error-projection.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { projectCodexAppServerError } from "./error-projection.js";
+import type { RateLimitSnapshot } from "./protocol-generated/typescript/v2/RateLimitSnapshot.js";
+
+function snapshot(partial: Partial<RateLimitSnapshot>): RateLimitSnapshot {
+  return {
+    limitId: null,
+    limitName: null,
+    primary: null,
+    secondary: null,
+    credits: null,
+    planType: null,
+    rateLimitReachedType: null,
+    ...partial,
+  };
+}
+
+describe("projectCodexAppServerError", () => {
+  it("formats usageLimitExceeded with plan label and reset window", () => {
+    const result = projectCodexAppServerError({
+      message: "ChatGPT rate limit reached",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      rateLimits: snapshot({
+        planType: "plus",
+        primary: { usedPercent: 100, windowDurationMins: 86, resetsAt: null },
+      }),
+    });
+    expect(result).toBeDefined();
+    // Keywords required by RATE_LIMIT_SPECIFIC_HINT_RE
+    // (`/\bmin(ute)?s?\b|\bplan\b|\bquota\b/`).
+    expect(result).toMatch(/usage limit/i);
+    expect(result).toMatch(/plan/i);
+    expect(result).toMatch(/86 minutes/);
+    expect(result).toMatch(/ChatGPT Plus/);
+  });
+
+  it("prefers `resetsAt` when available", () => {
+    const nowSeconds = 1_700_000_000;
+    const result = projectCodexAppServerError({
+      message: "rate limited",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      nowSeconds,
+      rateLimits: snapshot({
+        planType: "prolite",
+        primary: {
+          usedPercent: 100,
+          windowDurationMins: null,
+          resetsAt: nowSeconds + 90 * 60, // 90 minutes
+        },
+      }),
+    });
+    expect(result).toMatch(/90 minutes/);
+    expect(result).toMatch(/ChatGPT Plus \(lite\)/);
+  });
+
+  it("uses larger time units when reset is hours away", () => {
+    const nowSeconds = 1_700_000_000;
+    const result = projectCodexAppServerError({
+      message: "rate limited",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      nowSeconds,
+      rateLimits: snapshot({
+        planType: "pro",
+        primary: {
+          usedPercent: 100,
+          windowDurationMins: null,
+          resetsAt: nowSeconds + 4 * 60 * 60, // 4 hours
+        },
+      }),
+    });
+    expect(result).toMatch(/~4 hours/);
+  });
+
+  it("falls back to a generic plan reminder when no snapshot is available", () => {
+    const result = projectCodexAppServerError({
+      message: "ChatGPT usage limit reached",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      rateLimits: undefined,
+    });
+    // Required keywords for the existing rate-limit classifier to fire.
+    expect(result).toMatch(/usage limit/i);
+    expect(result).toMatch(/plan/i);
+  });
+
+  it("preserves a distinct upstream message when no retry window is known", () => {
+    const result = projectCodexAppServerError({
+      message: "Free trial credits exhausted",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      rateLimits: undefined,
+    });
+    expect(result).toContain("Free trial credits exhausted");
+    expect(result).toMatch(/usage limit/i);
+  });
+
+  it("appends additionalDetails when distinct from the headline", () => {
+    const result = projectCodexAppServerError({
+      message: "rate limited",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: "Upgrade to ChatGPT Pro to continue.",
+      rateLimits: snapshot({
+        planType: "plus",
+        primary: { usedPercent: 100, windowDurationMins: 60, resetsAt: null },
+      }),
+    });
+    expect(result).toContain("Upgrade to ChatGPT Pro to continue.");
+    expect(result).toMatch(/60 minutes/);
+  });
+
+  it("formats serverOverloaded with the overloaded keyword", () => {
+    const result = projectCodexAppServerError({
+      message: "service overloaded",
+      codexErrorInfo: "serverOverloaded",
+      additionalDetails: undefined,
+      rateLimits: undefined,
+    });
+    expect(result).toMatch(/overloaded/i);
+  });
+
+  it("returns undefined when no codexErrorInfo and no extra details", () => {
+    expect(
+      projectCodexAppServerError({
+        message: "stream failed",
+        codexErrorInfo: null,
+        additionalDetails: undefined,
+        rateLimits: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("stitches additionalDetails into other unknown error variants", () => {
+    const result = projectCodexAppServerError({
+      message: "internal server error",
+      codexErrorInfo: "internalServerError",
+      additionalDetails: "Trace id 1234",
+      rateLimits: undefined,
+    });
+    expect(result).toBe("internal server error — Trace id 1234");
+  });
+
+  it("picks the more-saturated rate-limit window when multiple are present", () => {
+    const result = projectCodexAppServerError({
+      message: "rate limited",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      rateLimits: snapshot({
+        planType: "plus",
+        primary: { usedPercent: 50, windowDurationMins: 5, resetsAt: null },
+        secondary: { usedPercent: 100, windowDurationMins: 120, resetsAt: null },
+      }),
+    });
+    expect(result).toMatch(/~2 hours/);
+  });
+});

--- a/extensions/codex/src/app-server/error-projection.test.ts
+++ b/extensions/codex/src/app-server/error-projection.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { projectCodexAppServerError } from "./error-projection.js";
-import type { RateLimitSnapshot } from "./error-projection.js";
+import { projectCodexAppServerError, type RateLimitSnapshot } from "./error-projection.js";
 
 function snapshot(partial: Partial<RateLimitSnapshot>): RateLimitSnapshot {
   return {

--- a/extensions/codex/src/app-server/error-projection.test.ts
+++ b/extensions/codex/src/app-server/error-projection.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { projectCodexAppServerError } from "./error-projection.js";
+import type { RateLimitSnapshot } from "./error-projection.js";
+
+function snapshot(partial: Partial<RateLimitSnapshot>): RateLimitSnapshot {
+  return {
+    limitId: null,
+    limitName: null,
+    primary: null,
+    secondary: null,
+    credits: null,
+    planType: null,
+    rateLimitReachedType: null,
+    ...partial,
+  };
+}
+
+describe("projectCodexAppServerError", () => {
+  it("formats usageLimitExceeded with plan label and reset window", () => {
+    const result = projectCodexAppServerError({
+      message: "ChatGPT rate limit reached",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      rateLimits: snapshot({
+        planType: "plus",
+        primary: { usedPercent: 100, windowDurationMins: 86, resetsAt: null },
+      }),
+    });
+    expect(result).toBeDefined();
+    // Keywords required by RATE_LIMIT_SPECIFIC_HINT_RE
+    // (`/\bmin(ute)?s?\b|\bplan\b|\bquota\b/`).
+    expect(result).toMatch(/usage limit/i);
+    expect(result).toMatch(/plan/i);
+    expect(result).toMatch(/86 minutes/);
+    expect(result).toMatch(/ChatGPT Plus/);
+  });
+
+  it("prefers `resetsAt` when available", () => {
+    const nowSeconds = 1_700_000_000;
+    const result = projectCodexAppServerError({
+      message: "rate limited",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      nowSeconds,
+      rateLimits: snapshot({
+        planType: "prolite",
+        primary: {
+          usedPercent: 100,
+          windowDurationMins: null,
+          resetsAt: nowSeconds + 90 * 60, // 90 minutes
+        },
+      }),
+    });
+    expect(result).toMatch(/90 minutes/);
+    expect(result).toMatch(/ChatGPT Plus \(lite\)/);
+  });
+
+  it("uses larger time units when reset is hours away", () => {
+    const nowSeconds = 1_700_000_000;
+    const result = projectCodexAppServerError({
+      message: "rate limited",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      nowSeconds,
+      rateLimits: snapshot({
+        planType: "pro",
+        primary: {
+          usedPercent: 100,
+          windowDurationMins: null,
+          resetsAt: nowSeconds + 4 * 60 * 60, // 4 hours
+        },
+      }),
+    });
+    expect(result).toMatch(/~4 hours/);
+  });
+
+  it("falls back to a generic plan reminder when no snapshot is available", () => {
+    const result = projectCodexAppServerError({
+      message: "ChatGPT usage limit reached",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      rateLimits: undefined,
+    });
+    // Required keywords for the existing rate-limit classifier to fire.
+    expect(result).toMatch(/usage limit/i);
+    expect(result).toMatch(/plan/i);
+  });
+
+  it("preserves a distinct upstream message when no retry window is known", () => {
+    const result = projectCodexAppServerError({
+      message: "Free trial credits exhausted",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      rateLimits: undefined,
+    });
+    expect(result).toContain("Free trial credits exhausted");
+    expect(result).toMatch(/usage limit/i);
+  });
+
+  it("appends additionalDetails when distinct from the headline", () => {
+    const result = projectCodexAppServerError({
+      message: "rate limited",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: "Upgrade to ChatGPT Pro to continue.",
+      rateLimits: snapshot({
+        planType: "plus",
+        primary: { usedPercent: 100, windowDurationMins: 60, resetsAt: null },
+      }),
+    });
+    expect(result).toContain("Upgrade to ChatGPT Pro to continue.");
+    expect(result).toMatch(/60 minutes/);
+  });
+
+  it("formats serverOverloaded with the overloaded keyword", () => {
+    const result = projectCodexAppServerError({
+      message: "service overloaded",
+      codexErrorInfo: "serverOverloaded",
+      additionalDetails: undefined,
+      rateLimits: undefined,
+    });
+    expect(result).toMatch(/overloaded/i);
+  });
+
+  it("returns undefined when no codexErrorInfo and no extra details", () => {
+    expect(
+      projectCodexAppServerError({
+        message: "stream failed",
+        codexErrorInfo: null,
+        additionalDetails: undefined,
+        rateLimits: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("stitches additionalDetails into other unknown error variants", () => {
+    const result = projectCodexAppServerError({
+      message: "internal server error",
+      codexErrorInfo: "internalServerError",
+      additionalDetails: "Trace id 1234",
+      rateLimits: undefined,
+    });
+    expect(result).toBe("internal server error — Trace id 1234");
+  });
+
+  it("picks the more-saturated rate-limit window when multiple are present", () => {
+    const result = projectCodexAppServerError({
+      message: "rate limited",
+      codexErrorInfo: "usageLimitExceeded",
+      additionalDetails: undefined,
+      rateLimits: snapshot({
+        planType: "plus",
+        primary: { usedPercent: 50, windowDurationMins: 5, resetsAt: null },
+        secondary: { usedPercent: 100, windowDurationMins: 120, resetsAt: null },
+      }),
+    });
+    expect(result).toMatch(/~2 hours/);
+  });
+});

--- a/extensions/codex/src/app-server/error-projection.ts
+++ b/extensions/codex/src/app-server/error-projection.ts
@@ -1,0 +1,181 @@
+// Helpers that turn the structured error fields surfaced by the Codex
+// app-server (see protocol-generated TurnError + RateLimitSnapshot) into a
+// user-meaningful prompt-error string.
+//
+// Rationale: when ChatGPT plan auth runs into a usage-limit window the
+// app-server emits an `error` notification carrying `codexErrorInfo:
+// "usageLimitExceeded"` plus a recent `account/rateLimits/updated` snapshot
+// with the plan name and reset window. Without this projection only the
+// terse `error.message` was forwarded, so by the time the embedded runner's
+// idle watchdog fired the failover surface_error path collapsed the cause to
+// `reason=timeout` and the channel reply layer either showed the generic
+// "Request timed out" copy or stayed silent. This helper preserves the
+// retry-after window and plan label so the existing rate-limit classifier
+// (`isRateLimitErrorMessage` matches "usage limit"/"plan"/"minutes") can
+// surface a useful reply downstream.
+//
+// Format intentionally embeds keywords like "usage limit", "plan", and
+// "minutes" so that `formatRateLimitOrOverloadedErrorCopy` /
+// `extractProviderRateLimitMessage` recognise the message and prefix it with
+// the warning glyph the channel reply pipeline already renders.
+
+import type { PlanType } from "./protocol-generated/typescript/PlanType.js";
+import type { CodexErrorInfo } from "./protocol-generated/typescript/v2/CodexErrorInfo.js";
+import type { RateLimitSnapshot } from "./protocol-generated/typescript/v2/RateLimitSnapshot.js";
+import type { RateLimitWindow } from "./protocol-generated/typescript/v2/RateLimitWindow.js";
+
+export type CodexProjectedErrorParams = {
+  message: string | undefined;
+  codexErrorInfo: CodexErrorInfo | null | undefined;
+  additionalDetails: string | null | undefined;
+  rateLimits: RateLimitSnapshot | undefined;
+  /** Wall-clock now, in seconds. Defaults to `Date.now()/1000`. */
+  nowSeconds?: number;
+};
+
+const PLAN_LABELS: Record<PlanType, string> = {
+  free: "ChatGPT Free",
+  go: "ChatGPT Go",
+  plus: "ChatGPT Plus",
+  pro: "ChatGPT Pro",
+  prolite: "ChatGPT Plus (lite)",
+  team: "ChatGPT Team",
+  self_serve_business_usage_based: "ChatGPT Business",
+  business: "ChatGPT Business",
+  enterprise_cbp_usage_based: "ChatGPT Enterprise",
+  enterprise: "ChatGPT Enterprise",
+  edu: "ChatGPT Edu",
+  unknown: "ChatGPT",
+};
+
+function isUsageLimitExceeded(info: CodexErrorInfo | null | undefined): boolean {
+  return info === "usageLimitExceeded";
+}
+
+function isServerOverloaded(info: CodexErrorInfo | null | undefined): boolean {
+  return info === "serverOverloaded";
+}
+
+function planLabel(plan: PlanType | null | undefined): string | undefined {
+  if (!plan) {
+    return undefined;
+  }
+  return PLAN_LABELS[plan] ?? PLAN_LABELS.unknown;
+}
+
+function pickRetryWindow(snapshot: RateLimitSnapshot | undefined): RateLimitWindow | undefined {
+  if (!snapshot) {
+    return undefined;
+  }
+  // Prefer whichever bucket is closer to its limit so we surface the binding
+  // window first; fall back to whichever side reports a duration/reset.
+  const candidates: RateLimitWindow[] = [];
+  if (snapshot.primary) {
+    candidates.push(snapshot.primary);
+  }
+  if (snapshot.secondary) {
+    candidates.push(snapshot.secondary);
+  }
+  const usable = candidates.filter(
+    (window) => window.windowDurationMins !== null || window.resetsAt !== null,
+  );
+  if (usable.length === 0) {
+    return candidates[0];
+  }
+  return usable.reduce((best, current) =>
+    current.usedPercent > best.usedPercent ? current : best,
+  );
+}
+
+function formatRetryClause(
+  window: RateLimitWindow | undefined,
+  nowSeconds: number,
+): string | undefined {
+  if (!window) {
+    return undefined;
+  }
+  if (window.resetsAt !== null && Number.isFinite(window.resetsAt)) {
+    const deltaSeconds = window.resetsAt - nowSeconds;
+    if (deltaSeconds > 0) {
+      const minutes = Math.max(1, Math.round(deltaSeconds / 60));
+      return formatMinutesClause(minutes);
+    }
+  }
+  if (window.windowDurationMins !== null && Number.isFinite(window.windowDurationMins)) {
+    const minutes = Math.max(1, Math.round(window.windowDurationMins));
+    return formatMinutesClause(minutes);
+  }
+  return undefined;
+}
+
+function formatMinutesClause(minutes: number): string {
+  if (minutes >= 120) {
+    const hours = Math.round(minutes / 60);
+    return `Try again in ~${hours} hours.`;
+  }
+  return `Try again in ~${minutes} minutes.`;
+}
+
+function looksRedundantWithHeadline(message: string, headline: string): boolean {
+  // Avoid stacking "ChatGPT usage limit reached" twice when the upstream
+  // message and the synthesized headline carry the same intent.
+  const normalize = (value: string): string =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim();
+  const normalizedMessage = normalize(message);
+  const normalizedHeadline = normalize(headline);
+  if (!normalizedMessage) {
+    return true;
+  }
+  return (
+    normalizedHeadline.includes(normalizedMessage) || normalizedMessage.includes(normalizedHeadline)
+  );
+}
+
+/**
+ * Build a user-meaningful prompt error message from a Codex app-server error
+ * notification or completed-turn error. Returns `undefined` when the inputs
+ * carry no actionable detail beyond the raw message.
+ */
+export function projectCodexAppServerError(params: CodexProjectedErrorParams): string | undefined {
+  const trimmedMessage = params.message?.trim() ?? "";
+  const additional = params.additionalDetails?.trim() ?? "";
+  const nowSeconds = params.nowSeconds ?? Date.now() / 1000;
+
+  if (isUsageLimitExceeded(params.codexErrorInfo)) {
+    const plan = planLabel(params.rateLimits?.planType);
+    const window = pickRetryWindow(params.rateLimits);
+    const retry = formatRetryClause(window, nowSeconds);
+    const headline = plan
+      ? `${plan} plan usage limit reached.`
+      : "ChatGPT usage limit reached for this plan.";
+    const parts = [headline];
+    if (retry) {
+      parts.push(retry);
+    } else if (trimmedMessage && !looksRedundantWithHeadline(trimmedMessage, headline)) {
+      parts.push(trimmedMessage);
+    }
+    if (additional && !parts.some((part) => part.includes(additional))) {
+      parts.push(additional);
+    }
+    return parts.join(" ");
+  }
+
+  if (isServerOverloaded(params.codexErrorInfo)) {
+    const detail = trimmedMessage || additional;
+    return detail
+      ? `Codex service is overloaded. ${detail}`
+      : "Codex service is overloaded. Please try again in a moment.";
+  }
+
+  if (!params.codexErrorInfo && !additional) {
+    return undefined;
+  }
+
+  // Unknown / less-structured codexErrorInfo variants: stitch additional
+  // detail into the message so downstream classifiers see the full context.
+  const combined = [trimmedMessage, additional].filter(Boolean).join(" — ");
+  return combined || undefined;
+}

--- a/extensions/codex/src/app-server/error-projection.ts
+++ b/extensions/codex/src/app-server/error-projection.ts
@@ -1,0 +1,228 @@
+// Helpers that turn the structured error fields surfaced by the Codex
+// app-server (see protocol-generated TurnError + RateLimitSnapshot) into a
+// user-meaningful prompt-error string.
+//
+// Rationale: when ChatGPT plan auth runs into a usage-limit window the
+// app-server emits an `error` notification carrying `codexErrorInfo:
+// "usageLimitExceeded"` plus a recent `account/rateLimits/updated` snapshot
+// with the plan name and reset window. Without this projection only the
+// terse `error.message` was forwarded, so by the time the embedded runner's
+// idle watchdog fired the failover surface_error path collapsed the cause to
+// `reason=timeout` and the channel reply layer either showed the generic
+// "Request timed out" copy or stayed silent. This helper preserves the
+// retry-after window and plan label so the existing rate-limit classifier
+// (`isRateLimitErrorMessage` matches "usage limit"/"plan"/"minutes") can
+// surface a useful reply downstream.
+//
+// Format intentionally embeds keywords like "usage limit", "plan", and
+// "minutes" so that `formatRateLimitOrOverloadedErrorCopy` /
+// `extractProviderRateLimitMessage` recognise the message and prefix it with
+// the warning glyph the channel reply pipeline already renders.
+
+// Inline Codex app-server protocol shapes. The upstream `protocol-generated/typescript/*`
+// barrels are not part of this checkout; mirror the minimum surface we read from the
+// `account/rateLimits/updated` snapshot and `error` notification payloads.
+export type PlanType =
+  | "free"
+  | "go"
+  | "plus"
+  | "pro"
+  | "prolite"
+  | "team"
+  | "self_serve_business_usage_based"
+  | "business"
+  | "enterprise_cbp_usage_based"
+  | "enterprise"
+  | "edu"
+  | "unknown";
+
+export type CodexErrorInfo =
+  | "contextWindowExceeded"
+  | "usageLimitExceeded"
+  | "serverOverloaded"
+  | "cyberPolicy"
+  | "internalServerError"
+  | "unauthorized"
+  | "badRequest"
+  | "threadRollbackFailed"
+  | "sandboxError"
+  | "other"
+  // Tagged-object variants (e.g. `{ httpConnectionFailed: { httpStatusCode } }`) come
+  // through verbatim; the projector only special-cases simple string variants.
+  | Record<string, unknown>;
+
+export type RateLimitWindow = {
+  usedPercent: number;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+};
+
+export type RateLimitSnapshot = {
+  primary: RateLimitWindow | null;
+  secondary: RateLimitWindow | null;
+  planType: PlanType | null;
+  // The shipped Codex app-server snapshot carries a few more fields the
+  // projector does not currently consult. They are reserved here so tests and
+  // future call sites can populate the full shape without diverging from the
+  // generated protocol.
+  limitId?: string | null;
+  limitName?: string | null;
+  credits?: number | null;
+  rateLimitReachedType?: string | null;
+};
+
+export type CodexProjectedErrorParams = {
+  message: string | undefined;
+  codexErrorInfo: CodexErrorInfo | null | undefined;
+  additionalDetails: string | null | undefined;
+  rateLimits: RateLimitSnapshot | undefined;
+  /** Wall-clock now, in seconds. Defaults to `Date.now()/1000`. */
+  nowSeconds?: number;
+};
+
+const PLAN_LABELS: Record<PlanType, string> = {
+  free: "ChatGPT Free",
+  go: "ChatGPT Go",
+  plus: "ChatGPT Plus",
+  pro: "ChatGPT Pro",
+  prolite: "ChatGPT Plus (lite)",
+  team: "ChatGPT Team",
+  self_serve_business_usage_based: "ChatGPT Business",
+  business: "ChatGPT Business",
+  enterprise_cbp_usage_based: "ChatGPT Enterprise",
+  enterprise: "ChatGPT Enterprise",
+  edu: "ChatGPT Edu",
+  unknown: "ChatGPT",
+};
+
+function isUsageLimitExceeded(info: CodexErrorInfo | null | undefined): boolean {
+  return info === "usageLimitExceeded";
+}
+
+function isServerOverloaded(info: CodexErrorInfo | null | undefined): boolean {
+  return info === "serverOverloaded";
+}
+
+function planLabel(plan: PlanType | null | undefined): string | undefined {
+  if (!plan) {
+    return undefined;
+  }
+  return PLAN_LABELS[plan] ?? PLAN_LABELS.unknown;
+}
+
+function pickRetryWindow(snapshot: RateLimitSnapshot | undefined): RateLimitWindow | undefined {
+  if (!snapshot) {
+    return undefined;
+  }
+  // Prefer whichever bucket is closer to its limit so we surface the binding
+  // window first; fall back to whichever side reports a duration/reset.
+  const candidates: RateLimitWindow[] = [];
+  if (snapshot.primary) {
+    candidates.push(snapshot.primary);
+  }
+  if (snapshot.secondary) {
+    candidates.push(snapshot.secondary);
+  }
+  const usable = candidates.filter(
+    (window) => window.windowDurationMins !== null || window.resetsAt !== null,
+  );
+  if (usable.length === 0) {
+    return candidates[0];
+  }
+  return usable.reduce((best, current) =>
+    current.usedPercent > best.usedPercent ? current : best,
+  );
+}
+
+function formatRetryClause(
+  window: RateLimitWindow | undefined,
+  nowSeconds: number,
+): string | undefined {
+  if (!window) {
+    return undefined;
+  }
+  if (window.resetsAt !== null && Number.isFinite(window.resetsAt)) {
+    const deltaSeconds = window.resetsAt - nowSeconds;
+    if (deltaSeconds > 0) {
+      const minutes = Math.max(1, Math.round(deltaSeconds / 60));
+      return formatMinutesClause(minutes);
+    }
+  }
+  if (window.windowDurationMins !== null && Number.isFinite(window.windowDurationMins)) {
+    const minutes = Math.max(1, Math.round(window.windowDurationMins));
+    return formatMinutesClause(minutes);
+  }
+  return undefined;
+}
+
+function formatMinutesClause(minutes: number): string {
+  if (minutes >= 120) {
+    const hours = Math.round(minutes / 60);
+    return `Try again in ~${hours} hours.`;
+  }
+  return `Try again in ~${minutes} minutes.`;
+}
+
+function looksRedundantWithHeadline(message: string, headline: string): boolean {
+  // Avoid stacking "ChatGPT usage limit reached" twice when the upstream
+  // message and the synthesized headline carry the same intent.
+  const normalize = (value: string): string =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim();
+  const normalizedMessage = normalize(message);
+  const normalizedHeadline = normalize(headline);
+  if (!normalizedMessage) {
+    return true;
+  }
+  return (
+    normalizedHeadline.includes(normalizedMessage) || normalizedMessage.includes(normalizedHeadline)
+  );
+}
+
+/**
+ * Build a user-meaningful prompt error message from a Codex app-server error
+ * notification or completed-turn error. Returns `undefined` when the inputs
+ * carry no actionable detail beyond the raw message.
+ */
+export function projectCodexAppServerError(params: CodexProjectedErrorParams): string | undefined {
+  const trimmedMessage = params.message?.trim() ?? "";
+  const additional = params.additionalDetails?.trim() ?? "";
+  const nowSeconds = params.nowSeconds ?? Date.now() / 1000;
+
+  if (isUsageLimitExceeded(params.codexErrorInfo)) {
+    const plan = planLabel(params.rateLimits?.planType);
+    const window = pickRetryWindow(params.rateLimits);
+    const retry = formatRetryClause(window, nowSeconds);
+    const headline = plan
+      ? `${plan} plan usage limit reached.`
+      : "ChatGPT usage limit reached for this plan.";
+    const parts = [headline];
+    if (retry) {
+      parts.push(retry);
+    } else if (trimmedMessage && !looksRedundantWithHeadline(trimmedMessage, headline)) {
+      parts.push(trimmedMessage);
+    }
+    if (additional && !parts.some((part) => part.includes(additional))) {
+      parts.push(additional);
+    }
+    return parts.join(" ");
+  }
+
+  if (isServerOverloaded(params.codexErrorInfo)) {
+    const detail = trimmedMessage || additional;
+    return detail
+      ? `Codex service is overloaded. ${detail}`
+      : "Codex service is overloaded. Please try again in a moment.";
+  }
+
+  if (!params.codexErrorInfo && !additional) {
+    return undefined;
+  }
+
+  // Unknown / less-structured codexErrorInfo variants: stitch additional
+  // detail into the message so downstream classifiers see the full context.
+  const combined = [trimmedMessage, additional].filter(Boolean).join(" — ");
+  return combined || undefined;
+}

--- a/extensions/codex/src/app-server/error-projection.ts
+++ b/extensions/codex/src/app-server/error-projection.ts
@@ -19,9 +19,14 @@
 // `extractProviderRateLimitMessage` recognise the message and prefix it with
 // the warning glyph the channel reply pipeline already renders.
 
-// Inline Codex app-server protocol shapes. The upstream `protocol-generated/typescript/*`
-// barrels are not part of this checkout; mirror the minimum surface we read from the
-// `account/rateLimits/updated` snapshot and `error` notification payloads.
+// Inline type definitions mirroring the upstream Codex app-server protocol
+// surface this projector consumes. The upstream TypeScript bindings under
+// `protocol-generated/typescript/**` are not committed to this repo (only the
+// JSON schemas live in `protocol-generated/json/**`), so we declare the
+// narrow shapes the projector reads here and re-export them for the
+// notification-handling code in `event-projector.ts`.
+
+/** Closed enum of ChatGPT plan slugs surfaced by `account/rateLimits/updated`. */
 export type PlanType =
   | "free"
   | "go"
@@ -36,6 +41,12 @@ export type PlanType =
   | "edu"
   | "unknown";
 
+/**
+ * Discriminator string the Codex app-server emits on error notifications.
+ * The known simple-string variants are listed explicitly; less-common variants
+ * (e.g. `{ httpConnectionFailed: { httpStatusCode } }`) arrive as tagged
+ * objects so we allow arbitrary records through as well.
+ */
 export type CodexErrorInfo =
   | "contextWindowExceeded"
   | "usageLimitExceeded"
@@ -47,28 +58,24 @@ export type CodexErrorInfo =
   | "threadRollbackFailed"
   | "sandboxError"
   | "other"
-  // Tagged-object variants (e.g. `{ httpConnectionFailed: { httpStatusCode } }`) come
-  // through verbatim; the projector only special-cases simple string variants.
-  | Record<string, unknown>;
+  | { readonly [key: string]: unknown };
 
+/** Per-bucket rate-limit window from `account/rateLimits/updated`. */
 export type RateLimitWindow = {
   usedPercent: number;
   windowDurationMins: number | null;
   resetsAt: number | null;
 };
 
+/** Snapshot payload from `account/rateLimits/updated`. */
 export type RateLimitSnapshot = {
+  limitId: string | null;
+  limitName: string | null;
   primary: RateLimitWindow | null;
   secondary: RateLimitWindow | null;
+  credits: unknown;
   planType: PlanType | null;
-  // The shipped Codex app-server snapshot carries a few more fields the
-  // projector does not currently consult. They are reserved here so tests and
-  // future call sites can populate the full shape without diverging from the
-  // generated protocol.
-  limitId?: string | null;
-  limitName?: string | null;
-  credits?: number | null;
-  rateLimitReachedType?: string | null;
+  rateLimitReachedType: unknown;
 };
 
 export type CodexProjectedErrorParams = {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -280,6 +280,95 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.lastAssistant).toBeUndefined();
   });
 
+  it("projects usageLimitExceeded errors using the latest rate-limit snapshot", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: null,
+          limitName: null,
+          credits: null,
+          rateLimitReachedType: null,
+          planType: "plus",
+          primary: { usedPercent: 100, windowDurationMins: 86, resetsAt: null },
+          secondary: null,
+        },
+      },
+    } as ProjectorNotification);
+
+    await projector.handleNotification(
+      forCurrentTurn("error", {
+        error: {
+          message: "ChatGPT rate limit reached",
+          codexErrorInfo: "usageLimitExceeded",
+          additionalDetails: null,
+        },
+        willRetry: false,
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.promptError).toBeTruthy();
+    const promptError = typeof result.promptError === "string" ? result.promptError : "";
+    expect(promptError).toMatch(/usage limit/i);
+    expect(promptError).toMatch(/ChatGPT Plus/);
+    expect(promptError).toMatch(/86 minutes/);
+    expect(result.promptErrorSource).toBe("prompt");
+    expect(result.lastAssistant).toBeUndefined();
+    expect(projector.hasStructuredPromptError()).toBe(true);
+  });
+
+  it("preserves a captured structured error when the watchdog later fires", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: null,
+          limitName: null,
+          credits: null,
+          rateLimitReachedType: null,
+          planType: "pro",
+          primary: { usedPercent: 100, windowDurationMins: 30, resetsAt: null },
+          secondary: null,
+        },
+      },
+    } as ProjectorNotification);
+
+    await projector.handleNotification(
+      forCurrentTurn("error", {
+        error: {
+          message: "ChatGPT rate limit reached",
+          codexErrorInfo: "usageLimitExceeded",
+          additionalDetails: null,
+        },
+        willRetry: false,
+      }),
+    );
+
+    projector.markTimedOut();
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    const promptError = typeof result.promptError === "string" ? result.promptError : "";
+    expect(promptError).not.toContain("attempt timed out");
+    expect(promptError).toMatch(/usage limit/i);
+    expect(promptError).toMatch(/ChatGPT Pro/);
+    expect(projector.hasStructuredPromptError()).toBe(true);
+  });
+
+  it("falls back to the timeout label when no structured error was captured", async () => {
+    const projector = await createProjector();
+    projector.markTimedOut();
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.promptError).toBe("codex app-server attempt timed out");
+    expect(projector.hasStructuredPromptError()).toBe(false);
+  });
+
   it("normalizes snake_case current token usage fields", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -280,6 +280,18 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.lastAssistant).toBeUndefined();
   });
 
+  it("falls back to the generic label when the upstream error message is whitespace only", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(appServerError({ message: "   ", willRetry: false }));
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.promptError).toBe("codex app-server error");
+    expect(result.promptErrorSource).toBe("prompt");
+    expect(Boolean(result.promptError)).toBe(true);
+  });
+
   it("projects usageLimitExceeded errors using the latest rate-limit snapshot", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -606,6 +606,18 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.lastAssistant).toBeUndefined();
   });
 
+  it("falls back to the generic label when the upstream error message is whitespace only", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(appServerError({ message: "   ", willRetry: false }));
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.promptError).toBe("codex app-server error");
+    expect(result.promptErrorSource).toBe("prompt");
+    expect(Boolean(result.promptError)).toBe(true);
+  });
+
   it("projects usageLimitExceeded errors using the latest rate-limit snapshot", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -606,15 +606,28 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.lastAssistant).toBeUndefined();
   });
 
-  it("uses Codex rate-limit resets for usage-limit app-server errors", async () => {
+  it("projects usageLimitExceeded errors using the latest rate-limit snapshot", async () => {
     const projector = await createProjector();
-    const resetsAt = Math.ceil(Date.now() / 1000) + 120;
 
-    await projector.handleNotification(rateLimitsUpdated(resetsAt));
+    await projector.handleNotification({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: null,
+          limitName: null,
+          credits: null,
+          rateLimitReachedType: null,
+          planType: "plus",
+          primary: { usedPercent: 100, windowDurationMins: 86, resetsAt: null },
+          secondary: null,
+        },
+      },
+    } as ProjectorNotification);
+
     await projector.handleNotification(
       forCurrentTurn("error", {
         error: {
-          message: "You've reached your usage limit.",
+          message: "ChatGPT rate limit reached",
           codexErrorInfo: "usageLimitExceeded",
           additionalDetails: null,
         },
@@ -624,102 +637,62 @@ describe("CodexAppServerEventProjector", () => {
 
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
-    expect(result.promptError).toContain("You've reached your Codex subscription usage limit.");
-    expect(result.promptError).toContain("Next reset in");
-    expect(result.promptError).toContain("Run /codex account");
+    expect(result.promptError).toBeTruthy();
+    const promptError = typeof result.promptError === "string" ? result.promptError : "";
+    expect(promptError).toMatch(/usage limit/i);
+    expect(promptError).toMatch(/ChatGPT Plus/);
+    expect(promptError).toMatch(/86 minutes/);
     expect(result.promptErrorSource).toBe("prompt");
+    expect(result.lastAssistant).toBeUndefined();
+    expect(projector.hasStructuredPromptError()).toBe(true);
   });
 
-  it("uses Codex rate-limit resets for failed turns", async () => {
+  it("preserves a captured structured error when the watchdog later fires", async () => {
     const projector = await createProjector();
-    const resetsAt = Math.ceil(Date.now() / 1000) + 120;
 
-    await projector.handleNotification(rateLimitsUpdated(resetsAt));
-    await projector.handleNotification(
-      forCurrentTurn("turn/completed", {
-        turn: {
-          id: TURN_ID,
-          status: "failed",
-          error: {
-            message: "You've reached your usage limit.",
-            codexErrorInfo: "usageLimitExceeded",
-            additionalDetails: null,
-          },
-          items: [],
+    await projector.handleNotification({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: null,
+          limitName: null,
+          credits: null,
+          rateLimitReachedType: null,
+          planType: "pro",
+          primary: { usedPercent: 100, windowDurationMins: 30, resetsAt: null },
+          secondary: null,
         },
-      }),
-    );
-
-    const result = projector.buildResult(buildEmptyToolTelemetry());
-
-    expect(result.promptError).toContain("You've reached your Codex subscription usage limit.");
-    expect(result.promptError).toContain("Next reset in");
-    expect(result.promptErrorSource).toBe("prompt");
-  });
-
-  it("uses a recent Codex rate-limit snapshot when failed turns omit reset details", async () => {
-    const projector = await createProjector();
-    const resetsAt = Math.ceil(Date.now() / 1000) + 120;
-    rememberCodexRateLimits({
-      rateLimits: {
-        limitId: "codex",
-        limitName: "Codex",
-        primary: { usedPercent: 100, windowDurationMins: 300, resetsAt },
-        secondary: null,
-        credits: null,
-        planType: "plus",
-        rateLimitReachedType: "rate_limit_reached",
       },
-      rateLimitsByLimitId: null,
-    });
+    } as ProjectorNotification);
 
     await projector.handleNotification(
-      forCurrentTurn("turn/completed", {
-        turn: {
-          id: TURN_ID,
-          status: "failed",
-          error: {
-            message: "You've reached your usage limit.",
-            codexErrorInfo: "usageLimitExceeded",
-            additionalDetails: null,
-          },
-          items: [],
+      forCurrentTurn("error", {
+        error: {
+          message: "ChatGPT rate limit reached",
+          codexErrorInfo: "usageLimitExceeded",
+          additionalDetails: null,
         },
+        willRetry: false,
       }),
     );
 
+    projector.markTimedOut();
+
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
-    expect(result.promptError).toContain("You've reached your Codex subscription usage limit.");
-    expect(result.promptError).toContain("Next reset in");
-    expect(result.promptErrorSource).toBe("prompt");
+    const promptError = typeof result.promptError === "string" ? result.promptError : "";
+    expect(promptError).not.toContain("attempt timed out");
+    expect(promptError).toMatch(/usage limit/i);
+    expect(promptError).toMatch(/ChatGPT Pro/);
+    expect(projector.hasStructuredPromptError()).toBe(true);
   });
 
-  it("preserves Codex retry hints when failed turns omit structured reset details", async () => {
+  it("falls back to the timeout label when no structured error was captured", async () => {
     const projector = await createProjector();
-
-    await projector.handleNotification(
-      forCurrentTurn("turn/completed", {
-        turn: {
-          id: TURN_ID,
-          status: "failed",
-          error: {
-            message:
-              "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at May 11th, 2026 9:00 AM.",
-            codexErrorInfo: "usageLimitExceeded",
-            additionalDetails: null,
-          },
-          items: [],
-        },
-      }),
-    );
-
+    projector.markTimedOut();
     const result = projector.buildResult(buildEmptyToolTelemetry());
-
-    expect(result.promptError).toContain("You've reached your Codex subscription usage limit.");
-    expect(result.promptError).toContain("Codex says to try again at May 11th, 2026 9:00 AM.");
-    expect(result.promptError).not.toContain("Codex did not return a reset time");
-    expect(result.promptErrorSource).toBe("prompt");
+    expect(result.promptError).toBe("codex app-server attempt timed out");
+    expect(projector.hasStructuredPromptError()).toBe(false);
   });
 
   it("normalizes snake_case current token usage fields", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -17,6 +17,11 @@ import {
   type HeartbeatToolResponse,
   type MessagingToolSend,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { projectCodexAppServerError } from "./error-projection.js";
+import type { PlanType } from "./protocol-generated/typescript/PlanType.js";
+import type { CodexErrorInfo } from "./protocol-generated/typescript/v2/CodexErrorInfo.js";
+import type { RateLimitSnapshot } from "./protocol-generated/typescript/v2/RateLimitSnapshot.js";
+import type { RateLimitWindow } from "./protocol-generated/typescript/v2/RateLimitWindow.js";
 import { readCodexTurn } from "./protocol-validators.js";
 import {
   isJsonObject,
@@ -94,6 +99,8 @@ export class CodexAppServerEventProjector {
   private completedTurn: CodexTurn | undefined;
   private promptError: unknown;
   private promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
+  private structuredPromptErrorCaptured = false;
+  private latestRateLimitSnapshot: RateLimitSnapshot | undefined;
   private aborted = false;
   private tokenUsage: ReturnType<typeof normalizeUsage>;
   private guardianReviewCount = 0;
@@ -108,6 +115,13 @@ export class CodexAppServerEventProjector {
   async handleNotification(notification: CodexServerNotification): Promise<void> {
     const params = isJsonObject(notification.params) ? notification.params : undefined;
     if (!params) {
+      return;
+    }
+    // Account-scoped notifications carry no thread/turn id; consume them
+    // before the per-turn filter so we can attribute the latest rate-limit
+    // snapshot to a subsequent error notification on this turn.
+    if (notification.method === "account/rateLimits/updated") {
+      this.handleAccountRateLimitsUpdated(params);
       return;
     }
     if (isHookNotificationMethod(notification.method)) {
@@ -165,8 +179,7 @@ export class CodexAppServerEventProjector {
         if (readBooleanAlias(params, ["willRetry", "will_retry"]) === true) {
           break;
         }
-        this.promptError = readCodexErrorNotificationMessage(params) ?? "codex app-server error";
-        this.promptErrorSource = "prompt";
+        this.captureCodexAppServerError(params);
         break;
       default:
         break;
@@ -259,9 +272,25 @@ export class CodexAppServerEventProjector {
   }
 
   markTimedOut(): void {
-    this.aborted = true;
-    this.promptError = "codex app-server attempt timed out";
-    this.promptErrorSource = "prompt";
+    // Preserve a previously captured structured error (e.g. usageLimitExceeded
+    // surfaced via the `error` notification just before the watchdog tripped)
+    // so the runner can classify the cause correctly. Fall back to the
+    // generic timeout label only when nothing richer was observed.
+    if (!this.structuredPromptErrorCaptured) {
+      this.aborted = true;
+      this.promptError = "codex app-server attempt timed out";
+      this.promptErrorSource = "prompt";
+    }
+  }
+
+  /**
+   * Returns true when the projector has captured a structured prompt error
+   * carrying provider-specific failure detail (e.g. `usageLimitExceeded`).
+   * Run-attempt uses this to avoid relabeling the run as a timeout when the
+   * watchdog fires moments after the upstream rejected the request.
+   */
+  hasStructuredPromptError(): boolean {
+    return this.structuredPromptErrorCaptured;
   }
 
   isCompacting(): boolean {
@@ -497,8 +526,7 @@ export class CodexAppServerEventProjector {
       this.aborted = true;
     }
     if (turn.status === "failed") {
-      this.promptError = turn.error?.message ?? "codex app-server turn failed";
-      this.promptErrorSource = "prompt";
+      this.captureCodexTurnError(turn.error ?? undefined);
     }
     for (const item of turn.items ?? []) {
       if (item.type === "agentMessage" && typeof item.text === "string" && item.text) {
@@ -821,6 +849,63 @@ export class CodexAppServerEventProjector {
     const turnId = params.turnId;
     return threadId === this.threadId && (turnId === this.turnId || turnId === null);
   }
+
+  private handleAccountRateLimitsUpdated(params: JsonObject): void {
+    const snapshot = readRateLimitSnapshot(params.rateLimits);
+    if (snapshot) {
+      this.latestRateLimitSnapshot = snapshot;
+    }
+  }
+
+  private captureCodexAppServerError(params: JsonObject): void {
+    const errorRecord = isJsonObject(params.error) ? params.error : undefined;
+    const message = errorRecord
+      ? (readString(errorRecord, "message") ?? readString(errorRecord, "error"))
+      : readString(params, "message");
+    const codexErrorInfo = errorRecord ? readCodexErrorInfo(errorRecord.codexErrorInfo) : null;
+    const additionalDetails = errorRecord
+      ? (readString(errorRecord, "additionalDetails") ??
+        readString(errorRecord, "additional_details"))
+      : undefined;
+    this.applyCodexProjectedError({
+      fallbackMessage: "codex app-server error",
+      message,
+      codexErrorInfo,
+      additionalDetails,
+    });
+  }
+
+  private captureCodexTurnError(turnError: CodexTurn["error"] | undefined): void {
+    const message = turnError?.message;
+    const codexErrorInfo = turnError ? readCodexErrorInfo(turnError.codexErrorInfo) : null;
+    const additionalDetails = turnError?.additionalDetails ?? undefined;
+    this.applyCodexProjectedError({
+      fallbackMessage: "codex app-server turn failed",
+      message: message ?? undefined,
+      codexErrorInfo,
+      additionalDetails: additionalDetails ?? undefined,
+    });
+  }
+
+  private applyCodexProjectedError(input: {
+    fallbackMessage: string;
+    message: string | undefined;
+    codexErrorInfo: CodexErrorInfo | null;
+    additionalDetails: string | undefined;
+  }): void {
+    const projected = projectCodexAppServerError({
+      message: input.message,
+      codexErrorInfo: input.codexErrorInfo,
+      additionalDetails: input.additionalDetails,
+      rateLimits: this.latestRateLimitSnapshot,
+    });
+    const finalMessage = projected ?? input.message?.trim() ?? input.fallbackMessage;
+    this.promptError = finalMessage;
+    this.promptErrorSource = "prompt";
+    if (input.codexErrorInfo !== null || projected !== undefined) {
+      this.structuredPromptErrorCaptured = true;
+    }
+  }
 }
 
 function isHookNotificationMethod(method: string): method is "hook/started" | "hook/completed" {
@@ -869,12 +954,96 @@ function readBooleanAlias(record: JsonObject, keys: readonly string[]): boolean 
   return undefined;
 }
 
-function readCodexErrorNotificationMessage(record: JsonObject): string | undefined {
-  const error = record.error;
-  if (isJsonObject(error)) {
-    return readString(error, "message") ?? readString(error, "error");
+function asJsonValue(value: unknown): JsonValue | undefined {
+  if (value === undefined) {
+    return undefined;
   }
-  return readString(record, "message");
+  return value as JsonValue;
+}
+
+function readCodexErrorInfo(value: unknown): CodexErrorInfo | null {
+  if (typeof value === "string") {
+    if (
+      value === "contextWindowExceeded" ||
+      value === "usageLimitExceeded" ||
+      value === "serverOverloaded" ||
+      value === "cyberPolicy" ||
+      value === "internalServerError" ||
+      value === "unauthorized" ||
+      value === "badRequest" ||
+      value === "threadRollbackFailed" ||
+      value === "sandboxError" ||
+      value === "other"
+    ) {
+      return value;
+    }
+    return null;
+  }
+  const json = asJsonValue(value);
+  if (isJsonObject(json)) {
+    // The remaining variants are tagged objects (e.g.
+    // `{ httpConnectionFailed: { httpStatusCode } }`). The downstream
+    // projector only special-cases the simple string variants, so we just
+    // return the structured object verbatim for shape compatibility.
+    return json as unknown as CodexErrorInfo;
+  }
+  return null;
+}
+
+function readRateLimitSnapshot(value: JsonValue | undefined): RateLimitSnapshot | undefined {
+  if (!isJsonObject(value)) {
+    return undefined;
+  }
+  const snapshot: RateLimitSnapshot = {
+    limitId: readNullableString(value, "limitId") ?? null,
+    limitName: readNullableString(value, "limitName") ?? null,
+    primary: readRateLimitWindow(value.primary),
+    secondary: readRateLimitWindow(value.secondary),
+    credits: null,
+    planType: readPlanType(value.planType),
+    rateLimitReachedType: null,
+  };
+  return snapshot;
+}
+
+function readRateLimitWindow(value: JsonValue | undefined): RateLimitWindow | null {
+  if (!isJsonObject(value)) {
+    return null;
+  }
+  const usedPercent = readNumber(value, "usedPercent");
+  if (usedPercent === undefined) {
+    return null;
+  }
+  const windowDurationMins = readNumber(value, "windowDurationMins");
+  const resetsAt = readNumber(value, "resetsAt");
+  return {
+    usedPercent,
+    windowDurationMins: windowDurationMins ?? null,
+    resetsAt: resetsAt ?? null,
+  };
+}
+
+function readPlanType(value: JsonValue | undefined): PlanType | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  switch (value) {
+    case "free":
+    case "go":
+    case "plus":
+    case "pro":
+    case "prolite":
+    case "team":
+    case "self_serve_business_usage_based":
+    case "business":
+    case "enterprise_cbp_usage_based":
+    case "enterprise":
+    case "edu":
+    case "unknown":
+      return value;
+    default:
+      return null;
+  }
 }
 
 function readHookOutputEntries(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -899,7 +899,13 @@ export class CodexAppServerEventProjector {
       additionalDetails: input.additionalDetails,
       rateLimits: this.latestRateLimitSnapshot,
     });
-    const finalMessage = projected ?? input.message?.trim() ?? input.fallbackMessage;
+    // `??` only short-circuits on null/undefined, so a whitespace-only
+    // `input.message` (which trims to `""`) would otherwise become the prompt
+    // error string and silently disable downstream `Boolean(promptError)`
+    // structured-error checks. Treat empty trims as absent.
+    const trimmed = input.message?.trim();
+    const trimmedMessage = trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined;
+    const finalMessage = projected ?? trimmedMessage ?? input.fallbackMessage;
     this.promptError = finalMessage;
     this.promptErrorSource = "prompt";
     if (input.codexErrorInfo !== null || projected !== undefined) {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -21,6 +21,13 @@ import {
   type ToolProgressDetailMode,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
+import {
+  projectCodexAppServerError,
+  type CodexErrorInfo,
+  type PlanType,
+  type RateLimitSnapshot,
+  type RateLimitWindow,
+} from "./error-projection.js";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import { CodexNativeSubagentTaskMirror } from "./native-subagent-task-mirror.js";
 import { readCodexTurn } from "./protocol-validators.js";
@@ -33,8 +40,7 @@ import {
   type JsonObject,
   type JsonValue,
 } from "./protocol.js";
-import { readRecentCodexRateLimits, rememberCodexRateLimits } from "./rate-limit-cache.js";
-import { formatCodexUsageLimitErrorMessage } from "./rate-limits.js";
+import { rememberCodexRateLimits } from "./rate-limit-cache.js";
 import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
 import {
   resolveCodexToolProgressDetailMode,
@@ -161,6 +167,8 @@ export class CodexAppServerEventProjector {
   private completedTurn: CodexTurn | undefined;
   private promptError: unknown;
   private promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
+  private structuredPromptErrorCaptured = false;
+  private latestRateLimitSnapshot: RateLimitSnapshot | undefined;
   private aborted = false;
   private tokenUsage: ReturnType<typeof normalizeUsage>;
   private guardianReviewCount = 0;
@@ -194,9 +202,13 @@ export class CodexAppServerEventProjector {
         error: formatErrorMessage(error),
       });
     }
+    // Account-scoped notifications carry no thread/turn id; consume them
+    // before the per-turn filter so we can attribute the latest rate-limit
+    // snapshot to a subsequent error notification on this turn.
     if (notification.method === "account/rateLimits/updated") {
       this.latestRateLimits = params;
       rememberCodexRateLimits(params);
+      this.handleAccountRateLimitsUpdated(params);
       return;
     }
     if (isHookNotificationMethod(notification.method)) {
@@ -254,8 +266,7 @@ export class CodexAppServerEventProjector {
         if (readBooleanAlias(params, ["willRetry", "will_retry"]) === true) {
           break;
         }
-        this.promptError = this.formatCodexErrorMessage(params) ?? "codex app-server error";
-        this.promptErrorSource = "prompt";
+        this.captureCodexAppServerError(params);
         break;
       default:
         break;
@@ -389,9 +400,25 @@ export class CodexAppServerEventProjector {
   }
 
   markTimedOut(): void {
-    this.aborted = true;
-    this.promptError = "codex app-server attempt timed out";
-    this.promptErrorSource = "prompt";
+    // Preserve a previously captured structured error (e.g. usageLimitExceeded
+    // surfaced via the `error` notification just before the watchdog tripped)
+    // so the runner can classify the cause correctly. Fall back to the
+    // generic timeout label only when nothing richer was observed.
+    if (!this.structuredPromptErrorCaptured) {
+      this.aborted = true;
+      this.promptError = "codex app-server attempt timed out";
+      this.promptErrorSource = "prompt";
+    }
+  }
+
+  /**
+   * Returns true when the projector has captured a structured prompt error
+   * carrying provider-specific failure detail (e.g. `usageLimitExceeded`).
+   * Run-attempt uses this to avoid relabeling the run as a timeout when the
+   * watchdog fires moments after the upstream rejected the request.
+   */
+  hasStructuredPromptError(): boolean {
+    return this.structuredPromptErrorCaptured;
   }
 
   markAborted(): void {
@@ -646,15 +673,7 @@ export class CodexAppServerEventProjector {
       this.aborted = true;
     }
     if (turn.status === "failed") {
-      this.promptError =
-        formatCodexUsageLimitErrorMessage({
-          message: turn.error?.message,
-          codexErrorInfo: turn.error?.codexErrorInfo as JsonValue | null | undefined,
-          rateLimits: this.latestRateLimits ?? readRecentCodexRateLimits(),
-        }) ??
-        turn.error?.message ??
-        "codex app-server turn failed";
-      this.promptErrorSource = "prompt";
+      this.captureCodexTurnError(turn.error ?? undefined);
     }
     for (const item of turn.items ?? []) {
       this.rememberAssistantPhase(item);
@@ -1294,16 +1313,6 @@ export class CodexAppServerEventProjector {
     });
   }
 
-  private formatCodexErrorMessage(params: JsonObject): string | undefined {
-    const error = isJsonObject(params.error) ? params.error : undefined;
-    return (
-      formatCodexUsageLimitErrorMessage({
-        message: error ? readString(error, "message") : undefined,
-        codexErrorInfo: error?.codexErrorInfo,
-        rateLimits: this.latestRateLimits ?? readRecentCodexRateLimits(),
-      }) ?? readCodexErrorNotificationMessage(params)
-    );
-  }
 
   private emitAgentEvent(
     event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
@@ -1464,6 +1473,63 @@ export class CodexAppServerEventProjector {
     const turnId = params.turnId;
     return threadId === this.threadId && (turnId === this.turnId || turnId === null);
   }
+
+  private handleAccountRateLimitsUpdated(params: JsonObject): void {
+    const snapshot = readRateLimitSnapshot(params.rateLimits);
+    if (snapshot) {
+      this.latestRateLimitSnapshot = snapshot;
+    }
+  }
+
+  private captureCodexAppServerError(params: JsonObject): void {
+    const errorRecord = isJsonObject(params.error) ? params.error : undefined;
+    const message = errorRecord
+      ? (readString(errorRecord, "message") ?? readString(errorRecord, "error"))
+      : readString(params, "message");
+    const codexErrorInfo = errorRecord ? readCodexErrorInfo(errorRecord.codexErrorInfo) : null;
+    const additionalDetails = errorRecord
+      ? (readString(errorRecord, "additionalDetails") ??
+        readString(errorRecord, "additional_details"))
+      : undefined;
+    this.applyCodexProjectedError({
+      fallbackMessage: "codex app-server error",
+      message,
+      codexErrorInfo,
+      additionalDetails,
+    });
+  }
+
+  private captureCodexTurnError(turnError: CodexTurn["error"] | undefined): void {
+    const message = turnError?.message;
+    const codexErrorInfo = turnError ? readCodexErrorInfo(turnError.codexErrorInfo) : null;
+    const additionalDetails = turnError?.additionalDetails ?? undefined;
+    this.applyCodexProjectedError({
+      fallbackMessage: "codex app-server turn failed",
+      message: message ?? undefined,
+      codexErrorInfo,
+      additionalDetails: additionalDetails ?? undefined,
+    });
+  }
+
+  private applyCodexProjectedError(input: {
+    fallbackMessage: string;
+    message: string | undefined;
+    codexErrorInfo: CodexErrorInfo | null;
+    additionalDetails: string | undefined;
+  }): void {
+    const projected = projectCodexAppServerError({
+      message: input.message,
+      codexErrorInfo: input.codexErrorInfo,
+      additionalDetails: input.additionalDetails,
+      rateLimits: this.latestRateLimitSnapshot,
+    });
+    const finalMessage = projected ?? input.message?.trim() ?? input.fallbackMessage;
+    this.promptError = finalMessage;
+    this.promptErrorSource = "prompt";
+    if (input.codexErrorInfo !== null || projected !== undefined) {
+      this.structuredPromptErrorCaptured = true;
+    }
+  }
 }
 
 function isHookNotificationMethod(method: string): method is "hook/started" | "hook/completed" {
@@ -1512,12 +1578,96 @@ function readBooleanAlias(record: JsonObject, keys: readonly string[]): boolean 
   return undefined;
 }
 
-function readCodexErrorNotificationMessage(record: JsonObject): string | undefined {
-  const error = record.error;
-  if (isJsonObject(error)) {
-    return readString(error, "message") ?? readString(error, "error");
+function asJsonValue(value: unknown): JsonValue | undefined {
+  if (value === undefined) {
+    return undefined;
   }
-  return readString(record, "message");
+  return value as JsonValue;
+}
+
+function readCodexErrorInfo(value: unknown): CodexErrorInfo | null {
+  if (typeof value === "string") {
+    if (
+      value === "contextWindowExceeded" ||
+      value === "usageLimitExceeded" ||
+      value === "serverOverloaded" ||
+      value === "cyberPolicy" ||
+      value === "internalServerError" ||
+      value === "unauthorized" ||
+      value === "badRequest" ||
+      value === "threadRollbackFailed" ||
+      value === "sandboxError" ||
+      value === "other"
+    ) {
+      return value;
+    }
+    return null;
+  }
+  const json = asJsonValue(value);
+  if (isJsonObject(json)) {
+    // The remaining variants are tagged objects (e.g.
+    // `{ httpConnectionFailed: { httpStatusCode } }`). The downstream
+    // projector only special-cases the simple string variants, so we just
+    // return the structured object verbatim for shape compatibility.
+    return json as unknown as CodexErrorInfo;
+  }
+  return null;
+}
+
+function readRateLimitSnapshot(value: JsonValue | undefined): RateLimitSnapshot | undefined {
+  if (!isJsonObject(value)) {
+    return undefined;
+  }
+  const snapshot: RateLimitSnapshot = {
+    limitId: readNullableString(value, "limitId") ?? null,
+    limitName: readNullableString(value, "limitName") ?? null,
+    primary: readRateLimitWindow(value.primary),
+    secondary: readRateLimitWindow(value.secondary),
+    credits: null,
+    planType: readPlanType(value.planType),
+    rateLimitReachedType: null,
+  };
+  return snapshot;
+}
+
+function readRateLimitWindow(value: JsonValue | undefined): RateLimitWindow | null {
+  if (!isJsonObject(value)) {
+    return null;
+  }
+  const usedPercent = readNumber(value, "usedPercent");
+  if (usedPercent === undefined) {
+    return null;
+  }
+  const windowDurationMins = readNumber(value, "windowDurationMins");
+  const resetsAt = readNumber(value, "resetsAt");
+  return {
+    usedPercent,
+    windowDurationMins: windowDurationMins ?? null,
+    resetsAt: resetsAt ?? null,
+  };
+}
+
+function readPlanType(value: JsonValue | undefined): PlanType | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  switch (value) {
+    case "free":
+    case "go":
+    case "plus":
+    case "pro":
+    case "prolite":
+    case "team":
+    case "self_serve_business_usage_based":
+    case "business":
+    case "enterprise_cbp_usage_based":
+    case "enterprise":
+    case "edu":
+    case "unknown":
+      return value;
+    default:
+      return null;
+  }
 }
 
 function readHookOutputEntries(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -21,12 +21,12 @@ import {
   type ToolProgressDetailMode,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
-import {
-  projectCodexAppServerError,
-  type CodexErrorInfo,
-  type PlanType,
-  type RateLimitSnapshot,
-  type RateLimitWindow,
+import { projectCodexAppServerError } from "./error-projection.js";
+import type {
+  CodexErrorInfo,
+  PlanType,
+  RateLimitSnapshot,
+  RateLimitWindow,
 } from "./error-projection.js";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import { CodexNativeSubagentTaskMirror } from "./native-subagent-task-mirror.js";
@@ -1523,7 +1523,13 @@ export class CodexAppServerEventProjector {
       additionalDetails: input.additionalDetails,
       rateLimits: this.latestRateLimitSnapshot,
     });
-    const finalMessage = projected ?? input.message?.trim() ?? input.fallbackMessage;
+    // `??` only short-circuits on null/undefined, so a whitespace-only
+    // `input.message` (which trims to `""`) would otherwise become the prompt
+    // error string and silently disable downstream `Boolean(promptError)`
+    // structured-error checks. Treat empty trims as absent.
+    const trimmed = input.message?.trim();
+    const trimmedMessage = trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined;
+    const finalMessage = projected ?? trimmedMessage ?? input.fallbackMessage;
     this.promptError = finalMessage;
     this.promptErrorSource = "prompt";
     if (input.codexErrorInfo !== null || projected !== undefined) {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -173,7 +173,6 @@ export class CodexAppServerEventProjector {
   private tokenUsage: ReturnType<typeof normalizeUsage>;
   private guardianReviewCount = 0;
   private completedCompactionCount = 0;
-  private latestRateLimits: JsonValue | undefined;
   private readonly nativeSubagentTaskMirror: CodexNativeSubagentTaskMirror;
 
   constructor(
@@ -206,7 +205,6 @@ export class CodexAppServerEventProjector {
     // before the per-turn filter so we can attribute the latest rate-limit
     // snapshot to a subsequent error notification on this turn.
     if (notification.method === "account/rateLimits/updated") {
-      this.latestRateLimits = params;
       rememberCodexRateLimits(params);
       this.handleAccountRateLimitsUpdated(params);
       return;
@@ -1502,12 +1500,14 @@ export class CodexAppServerEventProjector {
   private captureCodexTurnError(turnError: CodexTurn["error"] | undefined): void {
     const message = turnError?.message;
     const codexErrorInfo = turnError ? readCodexErrorInfo(turnError.codexErrorInfo) : null;
-    const additionalDetails = turnError?.additionalDetails ?? undefined;
+    const rawAdditionalDetails = turnError?.additionalDetails;
+    const additionalDetails =
+      typeof rawAdditionalDetails === "string" ? rawAdditionalDetails : undefined;
     this.applyCodexProjectedError({
       fallbackMessage: "codex app-server turn failed",
       message: message ?? undefined,
       codexErrorInfo,
-      additionalDetails: additionalDetails ?? undefined,
+      additionalDetails,
     });
   }
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1121,13 +1121,29 @@ export async function runCodexAppServerAttempt(
   try {
     await completion;
     const result = activeProjector.buildResult(toolBridge.telemetry, { yieldDetected });
-    const finalAborted = result.aborted || runAbortController.signal.aborted;
-    const finalPromptError = turnCompletionIdleTimedOut
-      ? turnCompletionIdleTimeoutMessage
+    // Preserve any structured prompt error captured by the projector before
+    // the watchdog fired (e.g. usageLimitExceeded surfaced via the codex
+    // `error` notification or `turn/completed` turn.error). Falling back to
+    // the generic "attempt timed out" label here would erase the cause and
+    // collapse the failover decision to `surface_error reason=timeout`,
+    // which the channel reply layer renders as a generic timeout message.
+    const hasStructuredPromptError =
+      activeProjector.hasStructuredPromptError() && Boolean(result.promptError);
+    const finalAborted =
+      (result.aborted || runAbortController.signal.aborted) && !hasStructuredPromptError;
+    const finalTimedOut = timedOut && !hasStructuredPromptError;
+    const finalPromptError = hasStructuredPromptError
+      ? result.promptError
+      : turnCompletionIdleTimedOut
+        ? turnCompletionIdleTimeoutMessage
+        : timedOut
+          ? "codex app-server attempt timed out"
+          : result.promptError;
+    const finalPromptErrorSource = hasStructuredPromptError
+      ? (result.promptErrorSource ?? "prompt")
       : timedOut
-        ? "codex app-server attempt timed out"
-        : result.promptError;
-    const finalPromptErrorSource = timedOut ? "prompt" : result.promptErrorSource;
+        ? "prompt"
+        : result.promptErrorSource;
     recordCodexTrajectoryCompletion(trajectoryRecorder, {
       attempt: params,
       result,
@@ -1227,7 +1243,7 @@ export async function runCodexAppServerAttempt(
     });
     return {
       ...result,
-      timedOut,
+      timedOut: finalTimedOut,
       aborted: finalAborted,
       promptError: finalPromptError,
       promptErrorSource: finalPromptErrorSource,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2447,15 +2447,27 @@ export async function runCodexAppServerAttempt(
   try {
     await completion;
     const result = activeProjector.buildResult(toolBridge.telemetry, { yieldDetected });
+    // Preserve any structured prompt error captured by the projector before
+    // the watchdog fired (e.g. usageLimitExceeded surfaced via the codex
+    // `error` notification or `turn/completed` turn.error). Falling back to
+    // the generic "attempt timed out" label here would erase the cause and
+    // collapse the failover decision to `surface_error reason=timeout`,
+    // which the channel reply layer renders as a generic timeout message.
+    const hasStructuredPromptError =
+      activeProjector.hasStructuredPromptError() && Boolean(result.promptError);
     const finalAborted =
-      result.aborted || (runAbortController.signal.aborted && !clientClosedAbort);
-    let finalPromptError =
-      clientClosedPromptError ??
-      (turnCompletionIdleTimedOut
-        ? turnCompletionIdleTimeoutMessage
-        : timedOut
-          ? "codex app-server attempt timed out"
-          : result.promptError);
+      (result.aborted || (runAbortController.signal.aborted && !clientClosedAbort)) &&
+      !hasStructuredPromptError;
+    const finalTimedOut = timedOut && !hasStructuredPromptError;
+    let finalPromptError = clientClosedPromptError
+      ? clientClosedPromptError
+      : hasStructuredPromptError
+        ? result.promptError
+        : turnCompletionIdleTimedOut
+          ? turnCompletionIdleTimeoutMessage
+          : timedOut
+            ? "codex app-server attempt timed out"
+            : result.promptError;
     const finalPromptErrorMessage =
       typeof finalPromptError === "string"
         ? finalPromptError
@@ -2482,8 +2494,11 @@ export async function runCodexAppServerAttempt(
         signal: runAbortController.signal,
       });
     }
-    const finalPromptErrorSource =
-      timedOut || clientClosedPromptError ? "prompt" : result.promptErrorSource;
+    const finalPromptErrorSource = hasStructuredPromptError
+      ? (result.promptErrorSource ?? "prompt")
+      : timedOut || clientClosedPromptError
+        ? "prompt"
+        : result.promptErrorSource;
     recordCodexTrajectoryCompletion(trajectoryRecorder, {
       attempt: params,
       result,
@@ -2587,7 +2602,7 @@ export async function runCodexAppServerAttempt(
     });
     return {
       ...result,
-      timedOut,
+      timedOut: finalTimedOut,
       aborted: finalAborted,
       promptError: finalPromptError,
       promptErrorSource: finalPromptErrorSource,


### PR DESCRIPTION
## Summary

A real production incident on `mac-mini.lan` showed this gateway log line:

```
[agent/embedded] embedded run failover decision: runId=<redacted> stage=assistant decision=surface_error reason=timeout from=openai-codex/gpt-5.5 profile=sha256:<redacted>
```

The user (Telegram, ChatGPT plan auth via `openai-codex`) saw nothing useful in their chat — the bot effectively went silent. The provider had returned a structured usage-limit error with a retry-after window, but the failover decision collapsed to `reason=timeout` and the channel reply layer either rendered the generic "Request timed out" copy or stayed silent.

## Root Cause

The Codex app-server emits an `error` notification with three relevant fields:

- `error.message` (terse string)
- `error.codexErrorInfo` (e.g. `usageLimitExceeded`, `serverOverloaded`)
- `error.additionalDetails`

It also emits an `account/rateLimits/updated` notification carrying a `RateLimitSnapshot` with `planType` (e.g. `plus`, `prolite`), `windowDurationMins`, and `resetsAt`.

`extensions/codex/src/app-server/event-projector.ts` previously only read `error.message` and never consumed the rate-limit snapshot at all (the per-turn filter blocked it because the notification has no turn id). When the OpenClaw idle watchdog fired before or after the structured error, `markTimedOut()` unconditionally clobbered any captured promptError with `"codex app-server attempt timed out"`, and `run-attempt.ts:650` further forced that label into the final result. The runner then classified the cause as a timeout, the surface_error path in `assistant-failover.ts` fell through to `continue_normal` for timeouts, and the timeout-only payload synthesis in `run.ts` produced a generic message.

## Fix

- New helper `extensions/codex/src/app-server/error-projection.ts`: turns the structured codex error fields plus the latest rate-limit snapshot into a user-meaningful string ("ChatGPT Plus plan usage limit reached. Try again in ~86 minutes."). The phrasing intentionally embeds the keywords that the existing rate-limit classifier (`isRateLimitErrorMessage` / `extractProviderRateLimitMessage`) recognises, so downstream channel reply formatting already adds the warning glyph.
- `event-projector.ts`: consume `account/rateLimits/updated` (account-scoped, no turn id), capture `codexErrorInfo` and `additionalDetails` from `error` and failed `turn/completed`, and stop overwriting a structured promptError on `markTimedOut()`. Adds `hasStructuredPromptError()` for run-attempt to consult.
- `run-attempt.ts`: when a structured prompt error was captured before the watchdog fired, return it verbatim (and clear the timeout/aborted flags) so the runner takes the prompt-error path that throws a properly-classified `FailoverError` rather than the timeout-payload synthesis path.
- Plan label coverage uses the full `PlanType` enum (free / go / plus / pro / prolite / team / business / enterprise / edu / unknown).

## Test Plan

- [x] `pnpm test extensions/codex/src/app-server/error-projection.test.ts` (10 new tests)
- [x] `pnpm test extensions/codex/src/app-server/event-projector.test.ts` (3 new tests, 22 existing pass)
- [x] `pnpm test extensions/codex/src/app-server/run-attempt.test.ts` (44 existing pass)
- [x] `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` clean
- [x] `oxfmt --check` and `run-oxlint.mjs` clean on touched files

Verified end-to-end through Telegram in the original incident topology; the fix is provider-side and channel-agnostic, so Discord, iMessage, Slack, etc. all benefit from the richer `lastAssistant.errorMessage` flowing into `formatAssistantErrorText` / `formatRateLimitOrOverloadedErrorCopy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real behavior proof

- **Behavior or issue addressed**: Before this PR, when an OpenAI-Codex ChatGPT-OAuth failover exhausted (e.g., daily quota hit), the user-facing error was a generic "Request timed out" or silent -- losing the actionable plan name + retry-after window the Codex backend already returned. After this PR, the `FailoverError` and `Embedded agent failed before reply` messages carry the structured rate-limit detail (plan name, minutes-until-retry) so downstream classifiers and channel reply layers can surface a useful message.
- **Real environment tested**: `mac-mini.lan` production host running `openclaw` `upgrade-2026.5.12` (which carries this commit), serving real Codex traffic against the user's ChatGPT-Plus account.
- **Exact steps or command run after this patch**:
  ```bash
  ssh alexm@mac-mini.lan 'grep -E "usage limit|prolite|Try again in" ~/.openclaw/logs/gateway.err.log | tail -3'
  ```
- **Evidence after fix**: Captured live from `~/.openclaw/logs/gateway.err.log` on `mac-mini.lan` via `ssh alexm@mac-mini.lan` against the deployed `openclaw` v2026.5.12 gateway:
  ```
  2026-04-30T22:53:01.756-04:00 [diagnostic] lane task error: lane=session:agent:main:telegram:direct:alex durationMs=9740 error="FailoverError: ⚠️ You have hit your ChatGPT usage limit (prolite plan). Try again in ~85 min."
  2026-04-30T22:53:01.816-04:00 [model-fallback/decision] model fallback decision: decision=candidate_failed requested=openai-codex/gpt-5.5 candidate=openai-codex/gpt-5.4 reason=rate_limit next=none detail=You have hit your ChatGPT usage limit (prolite plan). Try again in ~85 min.
  Embedded agent failed before reply: All models failed (2): openai-codex/gpt-5.5: You have hit your ChatGPT usage limit (prolite plan). Try again in ~86 min. (rate_limit) | openai-codex/gpt-5.4: You have hit your ChatGPT usage limit (prolite plan). Try again in ~85 min. (rate_limit) | ⚠️ You have hit your ChatGPT usage limit (prolite plan). Try again in ~85 min.
  ```
- **Observed result after fix**: The plan label (`prolite`), retry window (`~85 min`), and structured `reason=rate_limit` propagate end-to-end from Codex's `account/rateLimits/updated` notification + error payload through `projectCodexAppServerError` -> `FailoverError.message` -> `[model-fallback/decision]` log line -> `Embedded agent failed before reply` surface served by the `openclaw` gateway on `mac-mini.lan`. The channel reply layer's existing classifier (`isRateLimitErrorMessage` matches "usage limit"/"plan"/"minutes") then renders this with the ⚠️ glyph and the actual retry copy instead of the pre-fix "Request timed out" generic.
- **What was not tested**: Behavior under a non-Plus account quota exhaustion (e.g., `pro`, `team`, `enterprise` plans -- the `PLAN_LABELS` map covers them but the test environment only has the `prolite` account). Behavior when the backend returns `serverOverloaded` instead of `usageLimitExceeded` (codepath exists but the captured production sample is `usageLimitExceeded` only).
