### PR TITLE
fix(agents): canonicalize subagent list requester keys

### DIFF
--- a/src/agents/openclaw-tools.subagents.scope.test.ts
+++ b/src/agents/openclaw-tools.subagents.scope.test.ts
@@ -91,6 +91,37 @@ describe("openclaw-tools: subagents scope isolation", () => {
     writeStore(storePath, {});
   });
 
+  it("lets the logical main alias list runs registered under the canonical main session", async () => {
+    const childKey = "agent:main:subagent:main-alias-child";
+
+    addSubagentRunForTests({
+      runId: "run-main-alias-child",
+      childSessionKey: childKey,
+      controllerSessionKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "main alias child",
+      cleanup: "keep",
+      createdAt: Date.now() - 30_000,
+      startedAt: Date.now() - 30_000,
+    });
+
+    const tool = createSubagentsTool({ agentSessionKey: "main" });
+    const result = await tool.execute("call-main-alias-list", { action: "list" });
+    const details = result.details as {
+      total?: number;
+      active?: Array<{ sessionKey?: string }>;
+    };
+
+    expect(details.total).toBe(1);
+    expect(details.active).toEqual([
+      expect.objectContaining({
+        sessionKey: childKey,
+      }),
+    ]);
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("leaf subagents do not inherit parent sibling control scope", async () => {
     const leafKey = "agent:main:subagent:leaf";
     const siblingKey = "agent:main:subagent:unsandboxed";

--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -6,6 +6,10 @@ import {
   sortSubagentRuns,
   type SubagentTargetResolution,
 } from "../auto-reply/reply/subagents-utils.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveMainSessionKey,
+} from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore, updateSessionStore } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -118,10 +122,18 @@ export function resolveSubagentController(params: {
 }): ResolvedSubagentController {
   const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
   const callerRaw = params.agentSessionKey?.trim() || alias;
-  const callerSessionKey = resolveInternalSessionKey({
+  const resolvedCallerSessionKey = resolveInternalSessionKey({
     key: callerRaw,
     alias,
     mainKey,
+  });
+  const callerSessionKey = canonicalizeMainSessionAlias({
+    cfg: params.cfg,
+    agentId:
+      parseAgentSessionKey(resolvedCallerSessionKey)?.agentId ??
+      parseAgentSessionKey(resolveMainSessionKey(params.cfg))?.agentId ??
+      "main",
+    sessionKey: resolvedCallerSessionKey,
   });
   if (!isSubagentSessionKey(callerSessionKey)) {
     return {

--- a/src/auto-reply/reply/commands-subagents-routing.test.ts
+++ b/src/auto-reply/reply/commands-subagents-routing.test.ts
@@ -13,6 +13,7 @@ import type { HandleCommandsParams } from "./commands-types.js";
 function buildParams(
   commandBody: string,
   ctxOverrides?: Record<string, unknown>,
+  cfg: HandleCommandsParams["cfg"] = {},
 ): HandleCommandsParams {
   const normalized = commandBody.trim();
   const ctx = {
@@ -27,7 +28,7 @@ function buildParams(
   const provider = ctx.Provider ?? "whatsapp";
 
   return {
-    cfg: {},
+    cfg,
     ctx,
     command: {
       commandBodyNormalized: normalized,
@@ -64,6 +65,32 @@ describe("subagents command dispatch", () => {
       CommandTargetSessionKey: "agent:main:main",
       SessionKey: "agent:main:slack:slash:u1",
     });
+    expect(resolveRequesterSessionKey(params)).toBe("agent:main:main");
+  });
+
+  it("canonicalizes native command target main aliases", () => {
+    const params = buildParams(
+      "/subagents list",
+      {
+        CommandSource: "native",
+        CommandTargetSessionKey: "main",
+        SessionKey: "agent:main:telegram:slash:u1",
+      },
+      { session: { mainKey: "main", scope: "per-sender" } },
+    );
+    expect(resolveRequesterSessionKey(params)).toBe("agent:main:main");
+  });
+
+  it("canonicalizes text command main session aliases", () => {
+    const params = buildParams(
+      "/subagents list",
+      {
+        CommandSource: "text",
+        SessionKey: "main",
+        CommandTargetSessionKey: "agent:main:main",
+      },
+      { session: { mainKey: "main", scope: "per-sender" } },
+    );
     expect(resolveRequesterSessionKey(params)).toBe("agent:main:main");
   });
 

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -10,6 +10,10 @@ import {
   resolveMainSessionAlias,
   stripToolMessages,
 } from "../../../agents/tools/sessions-helpers.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveMainSessionKey,
+} from "../../../config/sessions/main-session.js";
 import { callGateway } from "../../../gateway/call.js";
 import { parseAgentSessionKey } from "../../../routing/session-key.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
@@ -141,7 +145,15 @@ export function resolveRequesterSessionKey(
     return undefined;
   }
   const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
-  return resolveInternalSessionKey({ key: raw, alias, mainKey });
+  const resolved = resolveInternalSessionKey({ key: raw, alias, mainKey });
+  return canonicalizeMainSessionAlias({
+    cfg: params.cfg,
+    agentId:
+      parseAgentSessionKey(resolved)?.agentId ??
+      parseAgentSessionKey(resolveMainSessionKey(params.cfg))?.agentId ??
+      "main",
+    sessionKey: resolved,
+  });
 }
 
 export function resolveCommandSubagentController(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

  - Problem: `/subagents list` and related subagent control paths could miss runs when the requester was represented by a main-session alias such as `main` versus `agent:<agentId>:main`.
  - Why it matters: Users could spawn subagents successfully but fail to list or control them from the main session, making background work appear lost.
  - What changed: Canonicalized main-session requester/controller keys at the subagent list/ control boundaries and added regression coverage for both tool and slash-command paths.
  - What did NOT change (scope boundary): No changes to spawn semantics, permissions, session storage schema, thread binding, delivery behavior, or plugin APIs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75593
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

  - Root cause: Main-session aliases were not canonicalized consistently before subagent requester/controller lookup, so equivalent requester keys could diverge.
  - Missing detection / guardrail: Existing tests did not cover listing or routing subagents across equivalent main-session aliases.
  - Contributing context (if known): Subagent runs are tracked by requester/controller keys, and the main session can be addressed through more than one valid key shape.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
  - Target test or file:
    - `src/agents/openclaw-tools.subagents.scope.test.ts`
    - `src/auto-reply/reply/commands-subagents-routing.test.ts`
  - Scenario the test should lock in: A subagent spawned under a canonical main-session key remains visible/control-addressable when listed from an equivalent main-session alias.
  - Why this is the smallest reliable guardrail: The bug was in requester/controller key normalization, so focused tool and command tests cover the affected lookup boundaries without broad E2E setup.
  - Existing test that already covers this (if any): None for the alias mismatch case.
  - If no new test is added, why not: N/A

## User-visible / Behavior Changes

  `/subagents list` and related subagent control/list behavior now correctly find subagent runs from equivalent main-session aliases.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
  Before:
  [main session alias] -> [raw requester key lookup] -> [no matching subagent runs]

  After:
  [main session alias] -> [canonical requester key] -> [matching subagent runs listed]
```

## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

  - OS: macOS local workstation
  - Runtime/container: Local Node/pnpm workspace
  - Model/provider: N/A
  - Integration/channel (if any): Subagents tool and slash-command routing
  - Relevant config (redacted): N/A

### Steps

  1. Spawn or register a subagent run associated with a canonical main-session requester key.
  2. Attempt to list/control subagents from an equivalent main-session alias.
  3. Compare behavior before and after canonicalizing requester/controller keys.

### Expected

  - Equivalent main-session aliases resolve to the same requester/controller scope, and the subagent run is listed.

### Actual

  - Before this fix, alias mismatch could return no runs.
  - After this fix, the run is found consistently.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)
  Targeted verification passed:

  - pnpm test src/agents/openclaw-tools.subagents.scope.test.ts src/auto-reply/reply/commands- subagents-routing.test.ts src/agents/subagent-control.test.ts src/agents/subagent-list.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/auto-reply/reply/commands-subagents-spawn- action.test.ts
  - pnpm build
  - pnpm check:changed
  - codex review --base origin/main

## Human Verification (required)

What you personally verified (not just CI), and how:

  - Verified scenarios:
      - Main-session alias lookup fails before the fix and succeeds after the fix.
      - Tool-path subagent listing resolves equivalent main-session aliases.
      - Slash-command subagent routing resolves equivalent main-session aliases.
  - Edge cases checked:
      - Existing subagent control/list tests still pass.
      - Existing spawn-action tests still pass.
  - What you did not verify:
      - Live channel delivery in an external messaging integration.
      - Remote CI/Testbox execution.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: Canonicalizing aliases could unintentionally affect subagent lookup scope.
      - Mitigation: The change is limited to main-session alias normalization at requester/ controller resolution boundaries and is covered by focused regression tests for both tool and command paths.

### Built with Codex
