### PR TITLE
fix(gateway): reject malformed canvas request urls

### DIFF
--- a/src/gateway/canvas-capability.test.ts
+++ b/src/gateway/canvas-capability.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { normalizeCanvasScopedUrl } from "./canvas-capability.js";
+
+describe("normalizeCanvasScopedUrl", () => {
+  test("marks malformed request targets without throwing", () => {
+    for (const rawUrl of ["//", "///", "//${jndi:ldap://example}.action"]) {
+      expect(() => normalizeCanvasScopedUrl(rawUrl)).not.toThrow();
+      expect(normalizeCanvasScopedUrl(rawUrl)).toMatchObject({
+        malformedScopedPath: true,
+        scopedPath: false,
+      });
+    }
+  });
+});

--- a/src/gateway/canvas-capability.ts
+++ b/src/gateway/canvas-capability.ts
@@ -40,7 +40,16 @@ export function buildCanvasScopedHostUrl(baseUrl: string, capability: string): s
 }
 
 export function normalizeCanvasScopedUrl(rawUrl: string): NormalizedCanvasScopedUrl {
-  const url = new URL(rawUrl, "http://localhost");
+  let url: URL;
+  try {
+    url = new URL(rawUrl, "http://localhost");
+  } catch {
+    return {
+      pathname: "/",
+      scopedPath: false,
+      malformedScopedPath: true,
+    };
+  }
   const prefix = `${CANVAS_CAPABILITY_PATH_PREFIX}/`;
   let scopedPath = false;
   let malformedScopedPath = false;

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -535,7 +535,13 @@ export function createGatewayHttpServer(opts: {
     }
 
     try {
-      const requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
+      let requestPath: string;
+      try {
+        requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
+      } catch {
+        sendGatewayAuthFailure(res, { ok: false, reason: "unauthorized" });
+        return;
+      }
       if (GATEWAY_PROBE_STATUS_BY_PATH.get(requestPath) === "live") {
         await handleGatewayProbeRequest(
           req,

--- a/src/gateway/server.canvas-auth.test.ts
+++ b/src/gateway/server.canvas-auth.test.ts
@@ -1,4 +1,4 @@
-import type { Socket } from "node:net";
+import { connect, type Socket } from "node:net";
 import { describe, expect, test } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "../canvas-host/a2ui.js";
@@ -157,6 +157,32 @@ async function expectWsConnected(url: string, headers?: Record<string, string>):
     ws.once("error", (err) => {
       finish(() => reject(err));
     });
+  });
+}
+
+async function sendRawHttpRequest(params: {
+  host: string;
+  port: number;
+  requestTarget: string;
+}): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const socket = connect({ host: params.host, port: params.port }, () => {
+      socket.write(
+        `GET ${params.requestTarget} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`,
+      );
+    });
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.setTimeout(WS_REJECT_TIMEOUT_MS, () => {
+      socket.destroy(new Error("timeout"));
+    });
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    socket.once("end", () => {
+      resolve(response);
+    });
+    socket.once("error", reject);
   });
 }
 
@@ -448,6 +474,26 @@ describe("gateway canvas host auth", () => {
         await expectWsConnected(url, {
           authorization: "Bearer rotated-token",
         });
+      },
+    });
+  }, 60_000);
+
+  test("rejects malformed raw HTTP request targets without disrupting gateway", async () => {
+    await withCanvasGatewayHarness({
+      resolvedAuth: tokenResolvedAuth,
+      handleHttpRequest: allowCanvasHostHttp,
+      run: async ({ listener }) => {
+        for (const requestTarget of ["//", "///", "//${jndi:ldap://example}.action"]) {
+          const response = await sendRawHttpRequest({
+            host: "127.0.0.1",
+            port: listener.port,
+            requestTarget,
+          });
+          expect(response).toMatch(/^HTTP\/1\.1 401 /);
+        }
+
+        const res = await fetchCanvas(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`);
+        expect(res.status).toBe(401);
       },
     });
   }, 60_000);

--- a/src/gateway/server.canvas-auth.test.ts
+++ b/src/gateway/server.canvas-auth.test.ts
@@ -164,25 +164,43 @@ async function sendRawHttpRequest(params: {
   host: string;
   port: number;
   requestTarget: string;
+  headers?: readonly string[];
 }): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const socket = connect({ host: params.host, port: params.port }, () => {
-      socket.write(
-        `GET ${params.requestTarget} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`,
-      );
+      const headers = params.headers ?? ["Host: localhost", "Connection: close"];
+      socket.write([`GET ${params.requestTarget} HTTP/1.1`, ...headers, "", ""].join("\r\n"));
     });
     let response = "";
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.setTimeout(0);
+      fn();
+    };
     socket.setEncoding("utf8");
     socket.setTimeout(WS_REJECT_TIMEOUT_MS, () => {
-      socket.destroy(new Error("timeout"));
+      const error = new Error("timeout");
+      finish(() => {
+        socket.destroy(error);
+        reject(error);
+      });
     });
     socket.on("data", (chunk) => {
       response += chunk;
     });
     socket.once("end", () => {
-      resolve(response);
+      finish(() => resolve(response));
     });
-    socket.once("error", reject);
+    socket.once("close", () => {
+      finish(() => resolve(response));
+    });
+    socket.once("error", (err) => {
+      finish(() => reject(err));
+    });
   });
 }
 
@@ -488,6 +506,33 @@ describe("gateway canvas host auth", () => {
             host: "127.0.0.1",
             port: listener.port,
             requestTarget,
+          });
+          expect(response).toMatch(/^HTTP\/1\.1 401 /);
+        }
+
+        const res = await fetchCanvas(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`);
+        expect(res.status).toBe(401);
+      },
+    });
+  }, 60_000);
+
+  test("rejects malformed raw WebSocket upgrade targets without disrupting gateway", async () => {
+    await withCanvasGatewayHarness({
+      resolvedAuth: tokenResolvedAuth,
+      handleHttpRequest: allowCanvasHostHttp,
+      run: async ({ listener }) => {
+        for (const requestTarget of ["//", "///", "//${jndi:ldap://example}.action"]) {
+          const response = await sendRawHttpRequest({
+            host: "127.0.0.1",
+            port: listener.port,
+            requestTarget,
+            headers: [
+              "Host: localhost",
+              "Upgrade: websocket",
+              "Connection: Upgrade",
+              "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+              "Sec-WebSocket-Version: 13",
+            ],
           });
           expect(response).toMatch(/^HTTP\/1\.1 401 /);
         }


### PR DESCRIPTION
## Summary
- Reject malformed gateway request targets through existing auth failure paths instead of the generic error handler.
- Add regression coverage for parser failures and raw gateway requests.

## Changes
- Wrapped canvas scoped URL normalization in a URL parser guard that returns the existing malformed-path signal.
- Added a fail-closed guard around the gateway HTTP request-path parse.
- Added parser coverage for malformed request targets.
- Added a raw HTTP gateway regression that verifies malformed targets return 401 and the gateway remains responsive.
- Added the active-version changelog entry.

## Validation
- `corepack pnpm test -- src/gateway/canvas-capability.test.ts src/gateway/server.canvas-auth.test.ts`
- `corepack pnpm check`
- `corepack pnpm exec oxfmt --check src/gateway/canvas-capability.ts src/gateway/canvas-capability.test.ts src/gateway/server.canvas-auth.test.ts src/gateway/server-http.ts CHANGELOG.md`
- Ran local review command; no actionable pre-PR findings were produced.

## Notes
- Valid canvas-scoped URLs continue through the existing normalization and rewrite path.
- Full repo `corepack pnpm format:check` currently reports unrelated latest-main files outside this PR; touched files pass oxfmt.