### PR TITLE
fix: preserve provider default model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/auth: preserve existing default model primary and fallbacks when provider presets or auth patches register new models, so auto-onboarded plugins cannot silently replace user-selected custom models unless `--set-default` is used. Fixes #75720. Thanks @shandutta.
 - Agents/tools: skip unavailable media generation and PDF tool factories from the live reply path when Gateway metadata and the active auth store prove no configured provider can back them, while keeping explicit config and auth-backed providers on the normal factory path. Thanks @shakkernerd.
 - Agents/runtime: reuse the Gateway metadata startup plan when ensuring reply runtime plugins are loaded, so live agent turns do not broad-load plugin runtimes after the Gateway already scoped startup activation. Thanks @shakkernerd.
 - Agents/runtime: delegate scoped reply runtime registry reuse to the plugin loader cache-key compatibility checks, so config changes with the same startup plugin ids cannot keep stale runtime hooks or tools active. Thanks @shakkernerd.
@@ -196,6 +197,7 @@ Docs: https://docs.openclaw.ai
 - Agents/tools: let plugins declare media generation auth aliases and base-url guards in manifests, preserving OpenAI Codex OAuth image generation availability without core-owned provider special cases. Thanks @shakkernerd.
 - Agents/tools: reuse the auth profile store already loaded for the active run when deciding media and generation tool availability, avoiding repeated provider-auth runtime discovery during reply startup. Thanks @shakkernerd.
 - Agents/tools: keep image, video, and music generation tool registration on manifest/auth control-plane checks instead of loading runtime provider registries during reply startup, reducing live-path tool-prep blocking while leaving provider runtime resolution for execution and list actions. Thanks @shakkernerd.
+- Providers/auth: preserve existing default model primary and fallbacks when provider presets or auth patches register new models, so auto-onboarded plugins cannot silently replace user-selected custom models unless `--set-default` is used. Fixes #75720. Thanks @shandutta.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -185,6 +185,9 @@ openclaw models auth login --provider openai-codex --set-default
 
 Notes:
 
+- `models auth login` can make a provider's models available without replacing
+  an existing default model. Pass `--set-default` when you intentionally want the
+  provider's default model to replace `agents.defaults.model.primary`.
 - `setup-token` and `paste-token` remain generic token commands for providers
   that expose token auth methods.
 - `setup-token` requires an interactive TTY and runs the provider's token-auth

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -244,6 +244,12 @@ API key auth, and dynamic model resolution.
     only for bundled provider plugins, with an empty config, empty env, and no
     agent/workspace paths.
 
+    Provider auth defaults are additive. A provider can register models, aliases,
+    and provider config from auth setup, but existing `agents.defaults.model`
+    primary/fallback selection is kept unless the user runs an explicit default
+    model command such as `openclaw models auth login --set-default` or
+    `openclaw models set`.
+
     If your auth flow also needs to patch `models.providers.*`, aliases, and
     the agent default model during onboarding, use the preset helpers from
     `openclaw/plugin-sdk/provider-onboard`. The narrowest helpers are

--- a/extensions/moonshot/index.test.ts
+++ b/extensions/moonshot/index.test.ts
@@ -4,6 +4,7 @@ import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-ru
 import { createCapturedThinkingConfigStream } from "openclaw/plugin-sdk/provider-test-contracts";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
+import { applyMoonshotConfig, MOONSHOT_DEFAULT_MODEL_REF } from "./onboard.js";
 import { createKimiWebSearchProvider } from "./src/kimi-web-search-provider.js";
 
 type MoonshotManifest = {
@@ -17,6 +18,31 @@ function readManifest(): MoonshotManifest {
 }
 
 describe("moonshot provider plugin", () => {
+  it("adds Moonshot defaults without replacing an existing primary model", () => {
+    const next = applyMoonshotConfig({
+      agents: {
+        defaults: {
+          model: {
+            primary: "claude-max-proxy/claude-opus-4-7",
+            fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+          },
+          models: {
+            "claude-max-proxy/claude-opus-4-7": {},
+            "claude-max-proxy/claude-sonnet-4-6": {},
+          },
+        },
+      },
+    });
+
+    expect(next.agents?.defaults?.models?.[MOONSHOT_DEFAULT_MODEL_REF]).toEqual({
+      alias: "Kimi",
+    });
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "claude-max-proxy/claude-opus-4-7",
+      fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+    });
+  });
+
   it("mirrors Kimi web-search env credentials in manifest metadata", () => {
     const manifestEnvVars = readManifest().providerAuthEnvVars?.moonshot ?? [];
 

--- a/extensions/openai/default-models.test.ts
+++ b/extensions/openai/default-models.test.ts
@@ -26,10 +26,14 @@ describe("openai default models", () => {
     expect(next.agents?.defaults?.model).toEqual({ primary: OPENAI_DEFAULT_MODEL });
   });
 
-  it("overrides model.primary while preserving fallbacks", () => {
+  it("preserves existing model.primary and fallbacks", () => {
     const next = applyOpenAIConfig({
       agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] } } },
     } as OpenClawConfig);
-    expect(next.agents?.defaults?.model).toEqual({ primary: OPENAI_DEFAULT_MODEL, fallbacks: [] });
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "anthropic/claude-opus-4-6",
+      fallbacks: [],
+    });
+    expect(next.agents?.defaults?.models?.[OPENAI_DEFAULT_MODEL]).toEqual({ alias: "GPT" });
   });
 });

--- a/extensions/openai/default-models.ts
+++ b/extensions/openai/default-models.ts
@@ -36,5 +36,7 @@ export function applyOpenAIProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
 }
 
 export function applyOpenAIConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return applyAgentDefaultModelPrimary(applyOpenAIProviderConfig(cfg), OPENAI_DEFAULT_MODEL);
+  return applyAgentDefaultModelPrimary(applyOpenAIProviderConfig(cfg), OPENAI_DEFAULT_MODEL, {
+    preserveExistingPrimary: true,
+  });
 }

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -653,6 +653,66 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     });
   });
 
+  it("preserves existing default model selection when provider auth patches are deferred", async () => {
+    const method: ProviderAuthMethod = {
+      id: "local",
+      label: "Local",
+      kind: "custom",
+      run: async () => ({
+        profiles: [],
+        configPatch: {
+          agents: {
+            defaults: {
+              model: {
+                primary: LOCAL_DEFAULT_MODEL,
+                fallbacks: ["moonshot/kimi-k2.6"],
+              },
+              models: {
+                [LOCAL_DEFAULT_MODEL]: {},
+                "moonshot/kimi-k2.6": {},
+              },
+            },
+          },
+        },
+        defaultModel: LOCAL_DEFAULT_MODEL,
+      }),
+    };
+
+    const result = await runProviderPluginAuthMethod({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "claude-max-proxy/claude-opus-4-7",
+              fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+            },
+            models: {
+              "claude-max-proxy/claude-opus-4-7": {},
+              "claude-max-proxy/claude-sonnet-4-6": {},
+            },
+          },
+        },
+      },
+      runtime: {} as ApplyAuthChoiceParams["runtime"],
+      prompter: {
+        note: vi.fn(async () => {}),
+      } as unknown as ApplyAuthChoiceParams["prompter"],
+      method,
+      preserveExistingDefaultModel: true,
+    });
+
+    expect(result.config.agents?.defaults?.model).toEqual({
+      primary: "claude-max-proxy/claude-opus-4-7",
+      fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+    });
+    expect(result.config.agents?.defaults?.models).toEqual({
+      "claude-max-proxy/claude-opus-4-7": {},
+      "claude-max-proxy/claude-sonnet-4-6": {},
+      [LOCAL_DEFAULT_MODEL]: {},
+      "moonshot/kimi-k2.6": {},
+    });
+  });
+
   it("returns an agent-scoped override for plugin auth choices when default model application is deferred", async () => {
     const provider = buildProvider();
     resolvePluginProviders.mockReturnValue([provider]);

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -163,25 +163,48 @@ vi.mock("../../plugins/provider-auth-choice-helpers.js", () => {
       );
     }),
     applyProviderAuthConfigPatch: vi.fn(
-      (cfg: OpenClawConfig, patch: unknown, options?: { replaceDefaultModels?: boolean }) => {
+      (
+        cfg: OpenClawConfig,
+        patch: unknown,
+        options?: { replaceDefaultModels?: boolean; preserveExistingDefaultModel?: boolean },
+      ) => {
         const merged = mergePatch(cfg, patch);
+        const patchModel = isRecord(patch)
+          ? (patch.agents as { defaults?: { model?: unknown } } | undefined)?.defaults?.model
+          : undefined;
+        const existingModel = cfg.agents?.defaults?.model;
+        const preserved =
+          options?.preserveExistingDefaultModel &&
+          patchModel !== undefined &&
+          existingModel !== undefined
+            ? {
+                ...merged,
+                agents: {
+                  ...merged.agents,
+                  defaults: {
+                    ...merged.agents?.defaults,
+                    model: existingModel,
+                  },
+                },
+              }
+            : merged;
         if (!options?.replaceDefaultModels) {
-          return merged;
+          return preserved;
         }
         const patchModels = (patch as { agents?: { defaults?: { models?: unknown } } })?.agents
           ?.defaults?.models;
         return isRecord(patchModels)
           ? {
-              ...merged,
+              ...preserved,
               agents: {
-                ...merged.agents,
+                ...preserved.agents,
                 defaults: {
-                  ...merged.agents?.defaults,
+                  ...preserved.agents?.defaults,
                   models: patchModels,
                 },
               },
             }
-          : merged;
+          : preserved;
       },
     ),
     applyDefaultModel: vi.fn((cfg: OpenClawConfig, model: string) => ({
@@ -686,6 +709,70 @@ describe("modelsAuthLoginCommand", () => {
       ...existingModels,
       "openai-codex/gpt-5.5": {},
     });
+  });
+
+  it("keeps existing default model when login config patch suggests one without --set-default", async () => {
+    const runtime = createRuntime();
+    currentConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "claude-max-proxy/claude-opus-4-7",
+            fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+          },
+          models: {
+            "claude-max-proxy/claude-opus-4-7": {},
+            "claude-max-proxy/claude-sonnet-4-6": {},
+          },
+        },
+      },
+    };
+    runProviderAuth.mockResolvedValue({
+      profiles: [
+        {
+          profileId: "openai-codex:user@example.com",
+          credential: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "a",
+            refresh: "r",
+            expires: Date.now() + 60_000,
+            email: "user@example.com",
+          },
+        },
+      ],
+      configPatch: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.5",
+              fallbacks: ["moonshot/kimi-k2.6"],
+            },
+            models: {
+              "openai-codex/gpt-5.5": {},
+              "moonshot/kimi-k2.6": {},
+            },
+          },
+        },
+      },
+      defaultModel: "openai-codex/gpt-5.5",
+    });
+
+    await modelsAuthLoginCommand({ provider: "openai-codex" }, runtime);
+
+    expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
+      primary: "claude-max-proxy/claude-opus-4-7",
+      fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+    });
+    expect(lastUpdatedConfig?.agents?.defaults?.models).toEqual({
+      "claude-max-proxy/claude-opus-4-7": {},
+      "claude-max-proxy/claude-sonnet-4-6": {},
+      "openai-codex/gpt-5.5": {},
+      "moonshot/kimi-k2.6": {},
+    });
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Default model available: openai-codex/gpt-5.5 (use --set-default to apply)",
+    );
   });
 
   it("overwrites an existing primary when login uses --set-default", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -254,6 +254,7 @@ async function persistProviderAuthResult(params: {
     if (params.result.configPatch) {
       next = applyProviderAuthConfigPatch(next, params.result.configPatch, {
         replaceDefaultModels: params.result.replaceDefaultModels,
+        preserveExistingDefaultModel: params.setDefault !== true,
       });
     }
     for (const profile of params.result.profiles) {

--- a/src/commands/onboard-auth.config-shared.test.ts
+++ b/src/commands/onboard-auth.config-shared.test.ts
@@ -175,6 +175,39 @@ describe("onboard auth provider config merges", () => {
     expect(next.agents?.defaults?.model).toEqual({ primary: "custom/model-z" });
   });
 
+  it("keeps existing primary and fallbacks when applying default-model presets", () => {
+    const next = applyProviderConfigWithDefaultModelPreset(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "user-provider/custom-primary",
+              fallbacks: ["user-provider/custom-fallback"],
+            },
+            models: {
+              "user-provider/custom-primary": {},
+              "user-provider/custom-fallback": {},
+            },
+          },
+        },
+      },
+      {
+        providerId: "custom",
+        api: "openai-completions",
+        baseUrl: "https://example.com/v1",
+        defaultModel: makeModel("model-z"),
+        aliases: [{ modelRef: "custom/model-z", alias: "Preset" }],
+        primaryModelRef: "custom/model-z",
+      },
+    );
+
+    expect(next.agents?.defaults?.models?.["custom/model-z"]).toEqual({ alias: "Preset" });
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "user-provider/custom-primary",
+      fallbacks: ["user-provider/custom-fallback"],
+    });
+  });
+
   it("applies catalog presets with alias and merged catalog models", () => {
     const next = applyProviderConfigWithModelCatalogPreset(
       {

--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -37,6 +37,10 @@ export type ProviderOnboardPresetAppliers<TArgs extends unknown[]> = {
   applyConfig: (cfg: OpenClawConfig, ...args: TArgs) => OpenClawConfig;
 };
 
+export type ApplyAgentDefaultModelPrimaryOptions = {
+  preserveExistingPrimary?: boolean;
+};
+
 function extractAgentDefaultModelFallbacks(model: unknown): string[] | undefined {
   if (!model || typeof model !== "object") {
     return undefined;
@@ -205,7 +209,9 @@ export function applyOnboardAuthAgentModelsAndProviders(
 export function applyAgentDefaultModelPrimary(
   cfg: OpenClawConfig,
   primary: string,
+  options?: ApplyAgentDefaultModelPrimaryOptions,
 ): OpenClawConfig {
+  const existingPrimary = resolvePrimaryStringValue(cfg.agents?.defaults?.model);
   const existingFallbacks = extractAgentDefaultModelFallbacks(cfg.agents?.defaults?.model);
   return {
     ...cfg,
@@ -215,7 +221,8 @@ export function applyAgentDefaultModelPrimary(
         ...cfg.agents?.defaults,
         model: {
           ...(existingFallbacks ? { fallbacks: existingFallbacks } : undefined),
-          primary,
+          primary:
+            options?.preserveExistingPrimary === true ? (existingPrimary ?? primary) : primary,
         },
       },
     },
@@ -316,7 +323,9 @@ export function applyProviderConfigWithDefaultModelPreset(
     defaultModelId: params.defaultModelId,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef, {
+        preserveExistingPrimary: true,
+      })
     : next;
 }
 
@@ -358,7 +367,9 @@ export function applyProviderConfigWithDefaultModelsPreset(
     defaultModelId: params.defaultModelId,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef, {
+        preserveExistingPrimary: true,
+      })
     : next;
 }
 
@@ -430,7 +441,9 @@ export function applyProviderConfigWithModelCatalogPreset(
     catalogModels: params.catalogModels,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef, {
+        preserveExistingPrimary: true,
+      })
     : next;
 }
 

--- a/src/plugins/provider-api-key-auth.ts
+++ b/src/plugins/provider-api-key-auth.ts
@@ -66,6 +66,7 @@ async function applyApiKeyConfig(params: {
 }) {
   const { applyAuthProfileConfig, applyPrimaryModel } = await loadProviderApiKeyAuthRuntime();
   let next = params.ctx.config;
+  const originalDefaultModel = params.ctx.config.agents?.defaults?.model;
   for (const profileId of params.profileIds) {
     next = applyAuthProfileConfig(next, {
       profileId,
@@ -76,7 +77,21 @@ async function applyApiKeyConfig(params: {
   if (params.applyConfig) {
     next = params.applyConfig(next);
   }
-  return params.defaultModel ? applyPrimaryModel(next, params.defaultModel) : next;
+  if (originalDefaultModel !== undefined) {
+    next = {
+      ...next,
+      agents: {
+        ...next.agents,
+        defaults: {
+          ...next.agents?.defaults,
+          model: originalDefaultModel,
+        },
+      },
+    };
+  }
+  return params.defaultModel
+    ? applyPrimaryModel(next, params.defaultModel, { preserveExistingPrimary: true })
+    : next;
 }
 
 export function createProviderApiKeyAuthMethod(

--- a/src/plugins/provider-auth-choice-helpers.test.ts
+++ b/src/plugins/provider-auth-choice-helpers.test.ts
@@ -101,6 +101,114 @@ describe("applyProviderAuthConfigPatch", () => {
       },
     });
   });
+
+  it("preserves existing default model selection when provider patches register defaults", () => {
+    const patch = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.5",
+            fallbacks: ["moonshot/kimi-k2.6"],
+          },
+          models: {
+            "openai-codex/gpt-5.5": {},
+            "moonshot/kimi-k2.6": {},
+          },
+        },
+      },
+    };
+
+    const next = applyProviderAuthConfigPatch(base, patch, {
+      preserveExistingDefaultModel: true,
+    });
+
+    expect(next.agents?.defaults?.model).toEqual(base.agents.defaults.model);
+    expect(next.agents?.defaults?.models).toEqual({
+      ...base.agents.defaults.models,
+      "openai-codex/gpt-5.5": {},
+      "moonshot/kimi-k2.6": {},
+    });
+  });
+
+  it("preserves an explicit empty fallback selection when provider patches suggest fallbacks", () => {
+    const cfg = {
+      ...base,
+      agents: {
+        defaults: {
+          ...base.agents.defaults,
+          model: { primary: "anthropic/claude-sonnet-4-6", fallbacks: [] },
+        },
+      },
+    };
+    const patch = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.5",
+            fallbacks: ["moonshot/kimi-k2.6"],
+          },
+        },
+      },
+    };
+
+    const next = applyProviderAuthConfigPatch(cfg, patch, {
+      preserveExistingDefaultModel: true,
+    });
+
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+      fallbacks: [],
+    });
+  });
+
+  it("preserves fallback absence for an existing primary-only default model", () => {
+    const cfg = {
+      ...base,
+      agents: {
+        defaults: {
+          ...base.agents.defaults,
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+        },
+      },
+    };
+    const patch = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.5",
+            fallbacks: ["moonshot/kimi-k2.6"],
+          },
+        },
+      },
+    };
+
+    const next = applyProviderAuthConfigPatch(cfg, patch, {
+      preserveExistingDefaultModel: true,
+    });
+
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+    });
+  });
+
+  it("fills default model selection when none exists", () => {
+    const patch = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.5",
+            fallbacks: ["moonshot/kimi-k2.6"],
+          },
+        },
+      },
+    };
+
+    const next = applyProviderAuthConfigPatch({}, patch, {
+      preserveExistingDefaultModel: true,
+    });
+
+    expect(next.agents?.defaults?.model).toEqual(patch.agents.defaults.model);
+  });
 });
 
 describe("applyDefaultModel", () => {

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -68,7 +68,85 @@ function sanitizeConfigPatchValue(value: unknown): unknown {
   return next;
 }
 
-function mergeConfigPatch<T>(base: T, patch: unknown): T {
+function resolveDefaultModelPrimary(model: unknown): string | undefined {
+  if (typeof model === "string") {
+    return normalizeOptionalString(model);
+  }
+  if (!isPlainRecord(model)) {
+    return undefined;
+  }
+  return normalizeOptionalString(model.primary);
+}
+
+function resolveDefaultModelFallbacks(model: unknown): string[] | undefined {
+  if (!isPlainRecord(model) || !Array.isArray(model.fallbacks)) {
+    return undefined;
+  }
+  return model.fallbacks.map((fallback) => String(fallback));
+}
+
+function extractPatchedDefaultModel(patch: unknown): unknown {
+  if (!isPlainRecord(patch)) {
+    return undefined;
+  }
+  const agents = patch.agents;
+  if (!isPlainRecord(agents)) {
+    return undefined;
+  }
+  const defaults = agents.defaults;
+  if (!isPlainRecord(defaults) || !Object.prototype.hasOwnProperty.call(defaults, "model")) {
+    return undefined;
+  }
+  return defaults.model;
+}
+
+function preserveExistingDefaultModelSelection(
+  base: OpenClawConfig,
+  merged: OpenClawConfig,
+  patch: unknown,
+): OpenClawConfig {
+  if (extractPatchedDefaultModel(patch) === undefined) {
+    return merged;
+  }
+
+  const existingModel = base.agents?.defaults?.model;
+  const existingPrimary = resolveDefaultModelPrimary(existingModel);
+  const existingFallbacks = resolveDefaultModelFallbacks(existingModel);
+  if (!existingPrimary && existingFallbacks === undefined) {
+    return merged;
+  }
+
+  const mergedModel = merged.agents?.defaults?.model;
+  const mergedPrimary = resolveDefaultModelPrimary(mergedModel);
+  const nextModel = {
+    ...(mergedPrimary ? { primary: mergedPrimary } : undefined),
+    ...(existingFallbacks !== undefined ? { fallbacks: existingFallbacks } : undefined),
+    ...(existingPrimary ? { primary: existingPrimary } : undefined),
+  };
+
+  return {
+    ...merged,
+    agents: {
+      ...merged.agents,
+      defaults: {
+        ...merged.agents?.defaults,
+        model: nextModel,
+      },
+    },
+  };
+}
+
+export function mergeConfigPatch<T>(base: T, patch: unknown): T {
+  const merged = originalMergeConfigPatch(base, patch);
+  return preserveExistingDefaultModelSelection(
+    base as OpenClawConfig,
+    merged as OpenClawConfig,
+    patch,
+  ) as T;
+}
+
+// Placeholder so TypeScript doesn't complain - actual implementation below
+function originalMergeConfigPatch<T>(base: T, patch: unknown): T {
   if (!isPlainRecord(base) || !isPlainRecord(patch)) {
     return sanitizeConfigPatchValue(patch) as T;
   }
@@ -91,25 +169,29 @@ function mergeConfigPatch<T>(base: T, patch: unknown): T {
 export function applyProviderAuthConfigPatch(
   cfg: OpenClawConfig,
   patch: unknown,
-  options?: { replaceDefaultModels?: boolean },
+  options?: { replaceDefaultModels?: boolean; preserveExistingDefaultModel?: boolean },
 ): OpenClawConfig {
   const merged = mergeConfigPatch(cfg, patch);
+  const next =
+    options?.preserveExistingDefaultModel === true
+      ? preserveExistingDefaultModelSelection(cfg, merged, patch)
+      : merged;
   if (!options?.replaceDefaultModels || !isPlainRecord(patch)) {
-    return merged;
+    return next;
   }
 
   const patchModels = (patch.agents as { defaults?: { models?: unknown } } | undefined)?.defaults
     ?.models;
   if (!isPlainRecord(patchModels)) {
-    return merged;
+    return next;
   }
 
   return {
-    ...merged,
+    ...next,
     agents: {
-      ...merged.agents,
+      ...next.agents,
       defaults: {
-        ...merged.agents?.defaults,
+        ...next.agents?.defaults,
         // Opt-in replacement for migrations that rename/remove model keys.
         models: sanitizeConfigPatchValue(patchModels) as NonNullable<
           NonNullable<OpenClawConfig["agents"]>["defaults"]

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -219,6 +219,7 @@ export async function runProviderPluginAuthMethod(params: {
   secretInputMode?: ProviderAuthOptionBag["secretInputMode"];
   allowSecretRefPrompt?: boolean;
   opts?: Partial<ProviderAuthOptionBag>;
+  preserveExistingDefaultModel?: boolean;
 }): Promise<{ config: OpenClawConfig; defaultModel?: string }> {
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
   const defaultAgentId = resolveDefaultAgentId(params.config);
@@ -255,6 +256,7 @@ export async function runProviderPluginAuthMethod(params: {
   if (result.configPatch) {
     nextConfig = applyProviderAuthConfigPatch(nextConfig, result.configPatch, {
       replaceDefaultModels: result.replaceDefaultModels,
+      preserveExistingDefaultModel: params.preserveExistingDefaultModel,
     });
   }
 
@@ -413,6 +415,8 @@ export async function applyAuthChoiceLoadedPluginProvider(
     secretInputMode: params.opts?.secretInputMode,
     allowSecretRefPrompt: false,
     opts: params.opts,
+    preserveExistingDefaultModel:
+      params.preserveExistingDefaultModel === true || !params.setDefaultModel,
   });
 
   nextConfig = applied.config;
@@ -509,6 +513,8 @@ export async function applyAuthChoicePluginProvider(
     secretInputMode: params.opts?.secretInputMode,
     allowSecretRefPrompt: false,
     opts: params.opts,
+    preserveExistingDefaultModel:
+      params.preserveExistingDefaultModel === true || !params.setDefaultModel,
   });
 
   nextConfig = applied.config;

--- a/src/plugins/provider-model-primary.ts
+++ b/src/plugins/provider-model-primary.ts
@@ -44,10 +44,15 @@ export function applyAgentDefaultPrimaryModel(params: {
   };
 }
 
-export function applyPrimaryModel(cfg: OpenClawConfig, model: string): OpenClawConfig {
+export function applyPrimaryModel(
+  cfg: OpenClawConfig,
+  model: string,
+  options?: { preserveExistingPrimary?: boolean },
+): OpenClawConfig {
   const defaults = cfg.agents?.defaults;
   const existingModel = defaults?.model;
   const existingModels = defaults?.models;
+  const existingPrimary = resolvePrimaryModel(existingModel);
   const fallbacks =
     typeof existingModel === "object" && existingModel !== null && "fallbacks" in existingModel
       ? (existingModel as { fallbacks?: string[] }).fallbacks
@@ -60,7 +65,7 @@ export function applyPrimaryModel(cfg: OpenClawConfig, model: string): OpenClawC
         ...defaults,
         model: {
           ...(fallbacks ? { fallbacks } : undefined),
-          primary: model,
+          primary: options?.preserveExistingPrimary === true ? (existingPrimary ?? model) : model,
         },
         models: {
           ...existingModels,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -301,7 +301,8 @@ export type ProviderAuthResult = {
    *
    * Use this for provider-owned onboarding defaults such as
    * `models.providers.<id>` entries, default aliases, or agent model helpers.
-   * The caller still persists auth-profile bindings separately.
+   * Callers preserve existing default model selection unless the user requested
+   * an explicit default-model replacement.
    */
   configPatch?: Partial<OpenClawConfig>;
   defaultModel?: string;


### PR DESCRIPTION
## Summary

- Problem: provider presets/auth config patches could overwrite an existing `agents.defaults.model.primary` and fallbacks while registering new provider defaults.
- Why it matters: auto-onboarded or newly available provider plugins could silently move users off custom model selections, surfacing later as quota/auth failures.
- What changed: provider preset helpers and auth patch application now preserve existing default model selection unless an explicit default replacement path is used.
- What did NOT change (scope boundary): explicit `openclaw models set` and `openclaw models auth login --set-default` still replace the default model.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75720
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: provider-owned preset helpers and auth config patch merging treated provider default model choices as authoritative writes, so `agents.defaults.model.primary` could be replaced during setup/onboarding even when the user already had an explicit default.
- Missing detection / guardrail: helper-level tests covered allowlist merging and explicit default setting, but not provider preset/auth patches against an existing custom primary/fallback pair.
- Contributing context (if known): OpenAI and Moonshot setup paths could register new defaults while a custom provider-backed primary was already configured.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/onboard-auth.config-shared.test.ts`, `src/plugins/provider-auth-choice-helpers.test.ts`, `src/commands/models/auth.test.ts`, `src/commands/auth-choice.apply.plugin-provider.test.ts`, `extensions/moonshot/index.test.ts`, `extensions/openai/default-models.test.ts`
- Scenario the test should lock in: provider setup may add model allowlist/provider entries but must keep existing default primary/fallbacks unless `--set-default` is used.
- Why this is the smallest reliable guardrail: the bug is in shared config helper seams, so helper and command-path tests catch the regression without needing live provider credentials.
- Existing test that already covers this (if any): existing `--set-default` tests continue to cover intentional replacement.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Provider auth/setup can make newly installed provider models available without replacing a user's existing default model. Users can still opt into replacement with `openclaw models auth login --set-default` or `openclaw models set`.

## Diagram (if applicable)

```text
Before:
[provider setup] -> [register model defaults] -> [replace user primary]

After:
[provider setup] -> [register model defaults] -> [keep user primary/fallbacks]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node/pnpm repo scripts
- Model/provider: OpenAI/Moonshot/provider-auth helper paths
- Integration/channel (if any): N/A
- Relevant config (redacted): existing `agents.defaults.model.primary` plus provider setup patch adding OpenAI/Moonshot defaults

### Steps

1. Start with `agents.defaults.model.primary` set to a custom provider model and fallbacks set to a custom fallback.
2. Apply provider preset/auth config that registers OpenAI/Moonshot defaults.
3. Verify provider model entries are added while default primary/fallbacks remain unchanged.

### Expected

- Provider models are available additively.
- Existing `agents.defaults.model.primary` and non-empty fallbacks are preserved.
- `--set-default` still replaces the default model intentionally.

### Actual

- Fixed in this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted helper/command/provider tests listed below passed locally.
- Edge cases checked: existing custom primary/fallbacks preserved; empty config still receives provider default; `models auth login --set-default` remains replacement path.
- What you did **not** verify: full `pnpm check:changed` was not run because the requester asked to skip Testbox and proceed directly to PR.

Validation run locally:

```text
pnpm test src/commands/onboard-auth.config-shared.test.ts src/plugins/provider-auth-choice-helpers.test.ts src/commands/models/auth.test.ts src/commands/auth-choice.apply.plugin-provider.test.ts extensions/moonshot/index.test.ts extensions/openai/default-models.test.ts
pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/cli/models.md docs/plugins/sdk-provider-plugins.md extensions/moonshot/index.test.ts extensions/openai/default-models.test.ts extensions/openai/default-models.ts src/commands/auth-choice.apply.plugin-provider.test.ts src/commands/models/auth.test.ts src/commands/models/auth.ts src/commands/onboard-auth.config-shared.test.ts src/plugin-sdk/provider-onboard.ts src/plugins/provider-api-key-auth.ts src/plugins/provider-auth-choice-helpers.test.ts src/plugins/provider-auth-choice-helpers.ts src/plugins/provider-auth-choice.ts src/plugins/provider-model-primary.ts src/plugins/types.ts
git diff --check
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: provider migrations that intentionally replace defaults could accidentally be preserved.
  - Mitigation: direct migration helper behavior remains opt-in; command paths still allow explicit replacement through `--set-default`, and existing migration replacement tests remain covered.
