### PR TITLE
Sanitize modern runtime context wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: strip echoed modern runtime-context wrappers without deleting JSON or fenced user-visible replies. Fixes #75726. Thanks @pfrederiksen.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2007,6 +2007,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: strip echoed modern runtime-context wrappers without deleting JSON or fenced user-visible replies. Fixes #75726. Thanks @pfrederiksen.
 - Agents/tools: skip unavailable media generation and PDF tool factories from the live reply path when Gateway metadata and the active auth store prove no configured provider can back them, while keeping explicit config and auth-backed providers on the normal factory path. Thanks @shakkernerd.
 - Agents/runtime: reuse the Gateway metadata startup plan when ensuring reply runtime plugins are loaded, so live agent turns do not broad-load plugin runtimes after the Gateway already scoped startup activation. Thanks @shakkernerd.
 - Agents/runtime: delegate scoped reply runtime registry reuse to the plugin loader cache-key compatibility checks, so config changes with the same startup plugin ids cannot keep stale runtime hooks or tools active. Thanks @shakkernerd.

--- a/src/agents/internal-runtime-context.test.ts
+++ b/src/agents/internal-runtime-context.test.ts
@@ -132,6 +132,30 @@ describe("internal runtime context codec", () => {
     expect(stripInternalRuntimeContext(input)).toBe('{"answer":"visible"}');
   });
 
+  it("strips markdown-style inbound context and exec state blocks", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "## Inbound Context (trusted metadata)",
+      "```json",
+      '{"channel":"webchat","messageId":"m_123"}',
+      "```",
+      "",
+      "## Current Exec Session State",
+      "",
+      "Current session exec defaults: workdir=/repo, shell=bash",
+      "",
+      "Current elevated level: none",
+      "",
+      "If the user asks to run a command, use the exec tool.",
+      "",
+      "Visible reply.",
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe("Visible reply.");
+  });
+
   it("fuzzes delimiter injection and nested marker handling deterministically", () => {
     const rng = createDeterministicRng(0xc0ff_ee42);
     const tokenPool = [

--- a/src/agents/internal-runtime-context.test.ts
+++ b/src/agents/internal-runtime-context.test.ts
@@ -47,6 +47,91 @@ describe("internal runtime context codec", () => {
     ).toBe(false);
   });
 
+  it("strips a modern runtime context wrapper and preserves the visible reply", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "An async command you ran earlier has completed. The command completion details are:",
+      'Exec completed (wild-moo, code 0) :: {"status":"healthy"}',
+      "",
+      "Please relay the command output to the user in a helpful way.",
+      "",
+      "Three async commands completed:",
+      "1. wild-moo — OpenClaw healthy.",
+    ].join("\n");
+
+    expect(hasInternalRuntimeContext(input)).toBe(true);
+    expect(stripInternalRuntimeContext(input)).toBe(
+      ["Three async commands completed:", "1. wild-moo — OpenClaw healthy."].join("\n"),
+    );
+  });
+
+  it("strips modern conversation metadata blocks and preserves surrounding text", () => {
+    const input = [
+      "Visible intro.",
+      "",
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"chat_id":"telegram:-1003710118964","message_id":"14398"}',
+      "```",
+      "",
+      "Sender (untrusted metadata):",
+      "```json",
+      '{"name":"Paul Frederiksen"}',
+      "```",
+      "",
+      "Visible reply.",
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe("Visible intro.\n\nVisible reply.");
+  });
+
+  it("preserves a visible JSON reply after an echoed modern preface", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      '{"status":"ok","message":"done"}',
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe('{"status":"ok","message":"done"}');
+  });
+
+  it("preserves a visible fenced reply after an echoed modern preface", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "```json",
+      '{"status":"ok"}',
+      "```",
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe(
+      ["```json", '{"status":"ok"}', "```"].join("\n"),
+    );
+  });
+
+  it("strips structured metadata before preserving a visible JSON reply", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"chat_id":"telegram:-1003710118964"}',
+      "```",
+      "",
+      '{"answer":"visible"}',
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe('{"answer":"visible"}');
+  });
+
   it("fuzzes delimiter injection and nested marker handling deterministically", () => {
     const rng = createDeterministicRng(0xc0ff_ee42);
     const tokenPool = [

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -204,7 +204,7 @@ function readParagraph(text: string, from: number): { end: number; text: string 
 }
 
 function isMetadataHeading(paragraph: string): boolean {
-  return /^(?:Conversation info \(untrusted metadata\):|Sender \(untrusted metadata\):|Replied message \(untrusted, for context\):|Inbound Context \(trusted metadata\):)$/u.test(
+  return /^(?:Conversation info \(untrusted metadata\):|Sender \(untrusted metadata\):|Replied message \(untrusted, for context\):|(?:##\s+)?Inbound Context \(trusted metadata\):?)$/u.test(
     paragraph,
   );
 }
@@ -258,7 +258,10 @@ function isAsyncCompletionScaffold(paragraph: string): boolean {
 
 function consumeExecStateSection(text: string, cursor: number): number | null {
   const heading = readParagraph(text, cursor);
-  if (heading.text !== "Current Exec Session State") {
+  if (
+    heading.text !== "Current Exec Session State" &&
+    heading.text !== "## Current Exec Session State"
+  ) {
     return null;
   }
 

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -157,40 +157,194 @@ function stripLegacyInternalRuntimeContext(text: string): string {
   }
 }
 
-function isRuntimeContextPromptHeader(line: string): boolean {
-  return (
-    line === OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER || line === OPENCLAW_RUNTIME_EVENT_HEADER
+function findRuntimeContextPromptHeader(text: string, from: number): RegExpExecArray | null {
+  const headerRe = new RegExp(
+    `${escapeRegExp(OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER)}|${escapeRegExp(OPENCLAW_RUNTIME_EVENT_HEADER)}`,
+    "g",
+  );
+  headerRe.lastIndex = from;
+  for (;;) {
+    const match = headerRe.exec(text);
+    if (!match) {
+      return null;
+    }
+    const lineStart = match.index === 0 || /\r?\n$/.test(text.slice(0, match.index));
+    const afterHeader = match.index + match[0].length;
+    const lineEnd = afterHeader >= text.length || /^\r?\n/.test(text.slice(afterHeader));
+    if (lineStart && lineEnd) {
+      return match;
+    }
+  }
+}
+
+function findLineEnd(text: string, from: number): number {
+  const newline = text.indexOf("\n", from);
+  return newline === -1 ? text.length : newline;
+}
+
+function skipBlankLines(text: string, from: number): number {
+  let cursor = from;
+  for (;;) {
+    const lineEnd = findLineEnd(text, cursor);
+    const line = text.slice(cursor, lineEnd).replace(/\r$/, "");
+    if (line.trim() !== "") {
+      return cursor;
+    }
+    if (lineEnd >= text.length) {
+      return text.length;
+    }
+    cursor = lineEnd + 1;
+  }
+}
+
+function readParagraph(text: string, from: number): { end: number; text: string } {
+  const nextBreak = text.indexOf("\n\n", from);
+  const end = nextBreak === -1 ? text.length : nextBreak;
+  return { end, text: text.slice(from, end).trim() };
+}
+
+function isMetadataHeading(paragraph: string): boolean {
+  return /^(?:Conversation info \(untrusted metadata\):|Sender \(untrusted metadata\):|Replied message \(untrusted, for context\):|Inbound Context \(trusted metadata\):)$/u.test(
+    paragraph,
   );
 }
 
-function stripRuntimeContextPromptPreface(text: string): string {
-  const lines = text.split(/\r?\n/);
-  let changed = false;
-  const output: string[] = [];
+function isStructuredMetadataPayload(paragraph: string): boolean {
+  return /^(?:```(?:json)?\s*[\s\S]*```\s*|\{[\s\S]*\}\s*)$/u.test(paragraph);
+}
 
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
-    const nextLine = lines[index + 1] ?? "";
-    if (
-      isRuntimeContextPromptHeader(line.trim()) &&
-      nextLine.trim() === OPENCLAW_RUNTIME_CONTEXT_NOTICE
-    ) {
-      changed = true;
-      index += 1;
-      while (index + 1 < lines.length && (lines[index + 1] ?? "").trim() === "") {
-        index += 1;
-      }
-      continue;
-    }
-    output.push(line);
+function consumeMetadataSection(text: string, cursor: number): number | null {
+  const heading = readParagraph(text, cursor);
+  const firstLineEnd = heading.text.indexOf("\n");
+  const firstLine = firstLineEnd === -1 ? heading.text : heading.text.slice(0, firstLineEnd);
+  if (!isMetadataHeading(firstLine)) {
+    return null;
   }
 
-  return changed
-    ? output
-        .join("\n")
-        .replace(/\n{3,}/g, "\n\n")
-        .trim()
-    : text;
+  if (firstLineEnd !== -1) {
+    const inlinePayload = heading.text.slice(firstLineEnd + 1).trim();
+    if (isStructuredMetadataPayload(inlinePayload)) {
+      return heading.end;
+    }
+  }
+
+  let nextCursor = skipBlankLines(text, heading.end);
+  if (nextCursor >= text.length) {
+    return heading.end;
+  }
+
+  const payload = readParagraph(text, nextCursor);
+  if (!isStructuredMetadataPayload(payload.text)) {
+    return heading.end;
+  }
+  nextCursor = payload.end;
+
+  return nextCursor;
+}
+
+function isAsyncCompletionIntro(paragraph: string): boolean {
+  return paragraph.startsWith(
+    "An async command you ran earlier has completed. The command completion details are:",
+  );
+}
+
+function isAsyncCompletionScaffold(paragraph: string): boolean {
+  return (
+    paragraph.startsWith("The command completion details are:") ||
+    paragraph.startsWith("Exec completed (") ||
+    paragraph.startsWith("Please relay the command output to the user")
+  );
+}
+
+function consumeExecStateSection(text: string, cursor: number): number | null {
+  const heading = readParagraph(text, cursor);
+  if (heading.text !== "Current Exec Session State") {
+    return null;
+  }
+
+  let nextCursor = skipBlankLines(text, heading.end);
+  while (nextCursor < text.length) {
+    const paragraph = readParagraph(text, nextCursor);
+    if (
+      !paragraph.text.startsWith("Current session exec defaults:") &&
+      !paragraph.text.startsWith("Current elevated level:") &&
+      !paragraph.text.startsWith("If the user asks to run a command,")
+    ) {
+      break;
+    }
+    nextCursor = skipBlankLines(text, paragraph.end);
+  }
+
+  return nextCursor;
+}
+
+function consumeModernRuntimeContextWrapperSection(
+  text: string,
+  cursor: number,
+  state: { sawAsyncCompletionIntro: boolean },
+): number | null {
+  const metadataEnd = consumeMetadataSection(text, cursor);
+  if (metadataEnd !== null) {
+    return metadataEnd;
+  }
+
+  const execStateEnd = consumeExecStateSection(text, cursor);
+  if (execStateEnd !== null) {
+    return execStateEnd;
+  }
+
+  const paragraph = readParagraph(text, cursor);
+  if (!paragraph.text) {
+    return null;
+  }
+
+  if (isAsyncCompletionIntro(paragraph.text)) {
+    state.sawAsyncCompletionIntro = true;
+    return paragraph.end;
+  }
+
+  if (state.sawAsyncCompletionIntro && isAsyncCompletionScaffold(paragraph.text)) {
+    return paragraph.end;
+  }
+
+  return null;
+}
+
+function stripRuntimeContextPromptBlocks(text: string): string {
+  let next = text;
+  let searchFrom = 0;
+  for (;;) {
+    const match = findRuntimeContextPromptHeader(next, searchFrom);
+    if (!match) {
+      return next;
+    }
+
+    const headerStart = match.index;
+    let cursor = findLineEnd(next, headerStart) + 1;
+    const noticeLineEnd = findLineEnd(next, cursor);
+    const noticeLine = next.slice(cursor, noticeLineEnd).replace(/\r$/, "").trim();
+    if (noticeLine !== OPENCLAW_RUNTIME_CONTEXT_NOTICE) {
+      searchFrom = cursor;
+      continue;
+    }
+
+    cursor = noticeLineEnd >= next.length ? next.length : noticeLineEnd + 1;
+    cursor = skipBlankLines(next, cursor);
+
+    const state = { sawAsyncCompletionIntro: false };
+    for (let consumed = 0; consumed < 50 && cursor < next.length; consumed += 1) {
+      const nextCursor = consumeModernRuntimeContextWrapperSection(next, cursor, state);
+      if (nextCursor === null) {
+        break;
+      }
+      cursor = skipBlankLines(next, nextCursor);
+    }
+
+    const before = next.slice(0, headerStart).trimEnd();
+    const after = next.slice(cursor).trimStart();
+    next = before && after ? `${before}\n\n${after}` : `${before}${after}`;
+    searchFrom = Math.max(0, before.length - 1);
+  }
 }
 
 export function stripInternalRuntimeContext(text: string): string {
@@ -202,9 +356,7 @@ export function stripInternalRuntimeContext(text: string): string {
     INTERNAL_RUNTIME_CONTEXT_BEGIN,
     INTERNAL_RUNTIME_CONTEXT_END,
   );
-  return stripRuntimeContextPromptPreface(
-    stripLegacyInternalRuntimeContext(withoutDelimitedBlocks),
-  );
+  return stripRuntimeContextPromptBlocks(stripLegacyInternalRuntimeContext(withoutDelimitedBlocks));
 }
 
 export function hasInternalRuntimeContext(text: string): boolean {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -373,6 +373,30 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Visible reply.");
   });
 
+  it("strips copied markdown-style inbound context and exec state sections", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "## Inbound Context (trusted metadata)",
+      "```json",
+      '{"messageId":"m_123","route":"webchat"}',
+      "```",
+      "",
+      "## Current Exec Session State",
+      "",
+      "Current session exec defaults: workdir=/repo, shell=bash",
+      "",
+      "Current elevated level: none",
+      "",
+      "If the user asks to run a command, use the exec tool.",
+      "",
+      "Visible reply.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Visible reply.");
+  });
+
   it("strips copied runtime event prefaces when no visible text remains", () => {
     const input = [
       "OpenClaw runtime event.",

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -423,6 +423,30 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Visible reply.");
   });
 
+  it("strips copied markdown-style inbound context and exec state sections", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "## Inbound Context (trusted metadata)",
+      "```json",
+      '{"messageId":"m_123","route":"webchat"}',
+      "```",
+      "",
+      "## Current Exec Session State",
+      "",
+      "Current session exec defaults: workdir=/repo, shell=bash",
+      "",
+      "Current elevated level: none",
+      "",
+      "If the user asks to run a command, use the exec tool.",
+      "",
+      "Visible reply.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Visible reply.");
+  });
+
   it("strips copied runtime event prefaces when no visible text remains", () => {
     const input = [
       "OpenClaw runtime event.",


### PR DESCRIPTION
Fixes #75726.

## Summary
- strip the modern runtime-context wrapper that starts with the generated OpenClaw runtime-context notice
- consume known metadata/async-completion paragraphs after that notice while preserving the actual user-facing reply
- add regression coverage for conversation metadata and async command completion wrappers

## Real behavior proof
- **Behavior or issue addressed:** The sanitizer removes OpenClaw-generated runtime context/metadata wrappers from user-facing assistant text, including Telegram-style conversation/sender metadata, while preserving the actual visible reply.
- **Real environment tested:** Local OpenClaw checkout for PR #75755 on Linux/Node 22, using the real sanitizer implementation from `src/agents/internal-runtime-context.ts` against a Telegram group-chat shaped runtime wrapper from this OpenClaw setup.
- **Exact steps or command run after this patch:** Ran `node --import tsx tmp/runtime-proof.mjs` from the patched checkout. The script imported `stripInternalRuntimeContext` and `hasInternalRuntimeContext`, fed a sample containing the generated runtime-context notice plus `Conversation info (untrusted metadata)` and `Sender (untrusted metadata)` JSON blocks, then printed whether metadata leaked after stripping.
- **Evidence after fix:** Copied terminal output from the after-fix command:

  ```text
  $ node --import tsx tmp/runtime-proof.mjs
  hasInternalRuntimeContext: true
  stripped output:
  Still on it — the visible reply survives, metadata is gone.
  leaked metadata: false
  ```

- **Observed result after fix:** The runtime wrapper was detected (`hasInternalRuntimeContext: true`), the user-facing reply text remained intact, and the Telegram metadata/runtime-generated fields were absent from the stripped output (`leaked metadata: false`).
- **What was not tested:** Full end-to-end Telegram delivery was not rerun for this PR proof; this proof directly exercises the production sanitizer with copied live-output style terminal evidence, and CI/unit coverage remains supplemental.

## Validation
- `node --import tsx tmp/runtime-proof.mjs`
- `pnpm exec oxfmt --check src/agents/internal-runtime-context.ts src/agents/internal-runtime-context.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.agents.json --noEmit`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/internal-runtime-context.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts` — exits 0, but this scoped config narrows to no matching files in this checkout; the direct smoke assertion above covers the sanitizer behavior.
