### PR TITLE
Include MEDIA hint in browser screenshot results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser: include a `MEDIA:<path>` hint in screenshot tool results, matching the CLI output so chat channels can attach captured browser screenshots more reliably. Thanks @sumurtk2.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -644,6 +644,33 @@ describe("browser tool snapshot maxChars", () => {
     );
   });
 
+  it("includes a MEDIA path hint in browser screenshot tool results", async () => {
+    const imageResult = {
+      content: [
+        { type: "text" as const, text: "MEDIA:/tmp/test.png" },
+        { type: "image" as const, data: "base64", mimeType: "image/png" },
+      ],
+      details: { path: "/tmp/test.png" },
+    };
+    toolCommonMocks.imageResultFromFile.mockResolvedValueOnce(imageResult);
+
+    const tool = createBrowserTool();
+    const result = await tool.execute?.("call-1", {
+      action: "screenshot",
+      target: "host",
+      targetId: "tab-1",
+    });
+
+    expect(toolCommonMocks.imageResultFromFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "browser:screenshot",
+        path: "/tmp/test.png",
+        extraText: "MEDIA:/tmp/test.png",
+      }),
+    );
+    expect(result).toEqual(imageResult);
+  });
+
   it("passes screenshot timeoutMs through the node browser proxy", async () => {
     mockSingleBrowserProxyNode();
     gatewayMocks.callGatewayTool.mockResolvedValueOnce({

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -759,6 +759,7 @@ export function createBrowserTool(opts?: {
           return await browserToolDeps.imageResultFromFile({
             label: "browser:screenshot",
             path: result.path,
+            extraText: `MEDIA:${result.path}`,
             details: result,
           });
         }


### PR DESCRIPTION
## Summary

This PR makes the agent-facing browser screenshot tool include a `MEDIA:<path>` text hint alongside the existing image result.

The browser screenshot route already saves screenshots to managed media, and the CLI already prints a `MEDIA:<path>` line for `openclaw browser screenshot`. This change aligns the tool result with that CLI behavior so chat/channel delivery layers can reliably discover the saved screenshot path.

## Motivation

In a Telegram flow, `browser.screenshot` successfully captured the screenshot and returned image data internally, but the assistant response did not attach the screenshot to the user. Sending the same browser tab screenshot worked when captured through CDP, saved to a file, and sent explicitly via the channel `media` parameter.

That suggests capture and channel upload were working; the missing piece was an explicit media path hint in the browser screenshot tool result.

## Changes

- Pass `extraText: MEDIA:<result.path>` when returning browser screenshot results via `imageResultFromFile`.
- Add a regression test to verify screenshot tool results include the media path hint.

## Testing

```bash
pnpm exec vitest run --config test/vitest/vitest.extension-browser.config.ts extensions/browser/src/browser-tool.test.ts
```

Result:

```text
✓ extension-browser extensions/browser/src/browser-tool.test.ts (49 tests)

Test Files  1 passed (1)
Tests       49 passed (49)
```
