### PR TITLE
fix(docker): bump HEALTHCHECK start-period from 15s to 120s (AI-assisted)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -294,6 +294,6 @@ USER node
 #   - GET /healthz (liveness) and GET /readyz (readiness)
 #   - aliases: /health and /ready
 # For external access from host/ingress, override bind to "lan" and set auth.
-HEALTHCHECK --interval=3m --timeout=10s --start-period=15s --retries=3 \
+HEALTHCHECK --interval=3m --timeout=10s --start-period=120s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]


### PR DESCRIPTION
## Summary

- **Problem:** Docker HEALTHCHECK `--start-period=15s` is too aggressive — cold starts (npm install, model downloads, bootstrapping) can take 30-60 seconds on resource-constrained/ARM machines, causing premature unhealthy status and unnecessary restarts.
- **Why it matters:** Containers get killed/restarted before they finish booting, causing flaky deployments.
- **What changed:** Bumped `--start-period` from `15s` to `120s` in the root `Dockerfile`.
- **What did NOT change:** Interval (3m), timeout (10s), retries (3), and the health check command itself are untouched. Only the start grace period.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #75701

## Root Cause

- **Root cause:** `--start-period=15s` was chosen for fast CI/cloud environments but does not account for cold starts on resource-constrained hardware (Raspberry Pi, ARM Mac, low-RAM VPS).
- **Missing detection:** No CI coverage for container health check timing on ARM/slow hardware.
- **Contributing context:** OpenClaw's startup involves pnpm dependencies, plugin loading, and model resolution — all of which compound on first runs.

## Regression Test Plan

N/A — this is a one-line config value change. The existing Docker health check logic remains unchanged; only the grace period is widened. No new test needed.

## User-visible / Behavior Changes

None. Users only see the difference if they were previously hitting unhealthy state during cold starts — now they won't.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## AI-Assisted

- [x] AI-assisted PR (Claude via OpenClaw)
- [x] Testing: light — verified Dockerfile syntax, confirmed only one HEALTHCHECK line exists
- [x] I understand what the code does
- [x] One-line change with clear rationale

## Human Verification

- **Verified:** Single HEALTHCHECK line in root Dockerfile; no other Dockerfiles have HEALTHCHECK; grep confirmed only one instance.
- **Edge cases:** Considered 60s, 90s, 120s — went with 120s to be generous without being wasteful.
- **Not verified:** Did not build the Docker image end-to-end (requires full container build).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`