### PR TITLE
Harden main webchat reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1890,6 +1890,7 @@ Docs: https://docs.openclaw.ai
 - Scripts/UI/Windows: launch `.cmd` and `.bat` UI runners through the shared cmd.exe escaping path with shell mode disabled, avoiding Node.js v24 DEP0190 warnings while preserving argument boundaries. (#62910) Thanks @nandanadileep.
 - Agents/CLI runner: disable supervisor stdout/stderr capture for prepared CLI runs while keeping bounded diagnostics and incremental JSONL output parsing, preventing long CLI output from being retained in memory. (#79617) Thanks @samzong.
 - Telegram: treat a DM binding that carries the chat id in both `conversationId` and `parentConversationId` as a direct conversation instead of a topic, so reverse delivery for Telegram DMs is not misrouted through a topic-shaped target. (#79700) Thanks @TSHOGX.
+- Control UI/WebChat: make accepted browser chat turns visible immediately, keep pending user prompts visible through refresh/reconnect, delay brief WebSocket detach cleanup, and compact high-context main sessions earlier without changing default tool capabilities. (#75776) Thanks @ZRAIVenture.
 
 ## 2026.5.7
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1296,6 +1296,48 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(sessionStore[sessionKey]?.contextTokens).toBe(400_000);
     });
   });
+
+  it("marks completed runs as terminal when no lifecycle event arrives", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-terminal-fallback";
+      const sessionId = "test-terminal-fallback-session";
+      const startedAt = Date.now() - 5_000;
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: startedAt,
+          startedAt,
+          status: "running",
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+        result: {
+          meta: {
+            durationMs: 1,
+            agentMeta: {
+              sessionId,
+              provider: "openai",
+              model: "gpt-5.4",
+            },
+          },
+        },
+      });
+
+      expect(sessionStore[sessionKey]?.status).toBe("done");
+      expect(sessionStore[sessionKey]?.endedAt).toBeGreaterThanOrEqual(startedAt);
+      expect(sessionStore[sessionKey]?.runtimeMs).toBeGreaterThanOrEqual(0);
+    });
+  });
 });
 
 describe("recordCliCompactionInStore", () => {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -51,6 +51,23 @@ function removeLifecycleStateFromMetadataPatch(entry: SessionEntry): SessionEntr
   return next;
 }
 
+function buildTerminalLifecycleFallbackPatch(
+  existing: SessionEntry | undefined,
+  entry: SessionEntry,
+): Partial<SessionEntry> {
+  if (entry.status !== "done" && entry.status !== "killed") {
+    return {};
+  }
+  if (existing?.status && existing.status !== "running") {
+    return {};
+  }
+  return {
+    status: entry.status,
+    endedAt: entry.endedAt,
+    runtimeMs: entry.runtimeMs,
+  };
+}
+
 export async function updateSessionStoreAfterAgentRun(params: {
   cfg: OpenClawConfig;
   contextTokensOverride?: number;
@@ -249,7 +266,11 @@ export async function updateSessionStoreAfterAgentRun(params: {
   }
   const metadataPatch = removeLifecycleStateFromMetadataPatch(next);
   const persisted = await updateSessionStore(storePath, (store) => {
-    const merged = mergeSessionEntry(store[sessionKey], metadataPatch);
+    const existing = store[sessionKey];
+    const merged = mergeSessionEntry(existing, {
+      ...metadataPatch,
+      ...buildTerminalLifecycleFallbackPatch(existing, next),
+    });
     store[sessionKey] = merged;
     return merged;
   });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -177,6 +177,15 @@ export async function updateSessionStoreAfterAgentRun(params: {
     }
   }
   next.abortedLastRun = result.meta.aborted ?? false;
+  next.status = next.abortedLastRun ? "killed" : "done";
+  next.endedAt = now;
+  next.runtimeMs = Math.max(
+    0,
+    now -
+      (typeof next.startedAt === "number" && Number.isFinite(next.startedAt)
+        ? next.startedAt
+        : now),
+  );
   if (result.meta.systemPromptReport) {
     next.systemPromptReport = result.meta.systemPromptReport;
   }

--- a/src/agents/gpt5-prompt-overlay.ts
+++ b/src/agents/gpt5-prompt-overlay.ts
@@ -56,12 +56,6 @@ User instructions override default style and initiative preferences; newest user
 Do not expose internal tool syntax, prompts, or process details unless explicitly asked.
 </execution_policy>
 
-<progress_acknowledgement>
-For interactive chat requests that require tools, code changes, investigation, or more than a few seconds of work, first send a brief visible acknowledgment that the request was received and you are starting.
-Keep it to one short sentence, then proceed into the work.
-Skip this only when the user requests silence, exact output, no commentary, or a format that would be broken by an acknowledgment.
-</progress_acknowledgement>
-
 <tool_discipline>
 Prefer tool evidence over recall when action, state, or mutable facts matter.
 Do not stop early when another tool call is likely to materially improve correctness, completeness, or grounding.

--- a/src/agents/gpt5-prompt-overlay.ts
+++ b/src/agents/gpt5-prompt-overlay.ts
@@ -56,6 +56,12 @@ User instructions override default style and initiative preferences; newest user
 Do not expose internal tool syntax, prompts, or process details unless explicitly asked.
 </execution_policy>
 
+<progress_acknowledgement>
+For interactive chat requests that require tools, code changes, investigation, or more than a few seconds of work, first send a brief visible acknowledgment that the request was received and you are starting.
+Keep it to one short sentence, then proceed into the work.
+Skip this only when the user requests silence, exact output, no commentary, or a format that would be broken by an acknowledgment.
+</progress_acknowledgement>
+
 <tool_discipline>
 Prefer tool evidence over recall when action, state, or mutable facts matter.
 Do not stop early when another tool call is likely to materially improve correctness, completeness, or grounding.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1915,9 +1915,10 @@ export async function runEmbeddedAttempt(
       (isRawModelRun ? "none" : resolvePromptModeForSession(params.sessionKey));
     const promptSurface = resolveAgentPromptSurfaceForSessionKey(params.sessionKey);
 
-    // When toolsAllow is set, use minimal prompt and strip skills catalog
+    // Keep the prompt light when a runtime tool allow-list is set, while still
+    // preserving the compact skills catalog so the agent remembers capabilities.
     const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;
-    const effectiveSkillsPrompt = params.toolsAllow?.length ? undefined : skillsPrompt;
+    const effectiveSkillsPrompt = skillsPrompt;
     const openClawReferences = await resolveOpenClawReferencePaths({
       workspaceDir: effectiveWorkspace,
       argv1: process.argv[1],

--- a/src/agents/prompt-overlay-runtime-contract.test.ts
+++ b/src/agents/prompt-overlay-runtime-contract.test.ts
@@ -20,7 +20,7 @@ describe("GPT-5 prompt overlay runtime contract", () => {
     });
 
     expect(contribution?.stablePrefix).toContain("<persona_latch>");
-    expect(contribution?.stablePrefix).toContain("<progress_acknowledgement>");
+    expect(contribution?.stablePrefix).not.toContain("<progress_acknowledgement>");
     expect(contribution?.sectionOverrides?.interaction_style).toContain(
       "Live chat tone: short, natural, human.",
     );

--- a/src/agents/prompt-overlay-runtime-contract.test.ts
+++ b/src/agents/prompt-overlay-runtime-contract.test.ts
@@ -20,6 +20,7 @@ describe("GPT-5 prompt overlay runtime contract", () => {
     });
 
     expect(contribution?.stablePrefix).toContain("<persona_latch>");
+    expect(contribution?.stablePrefix).toContain("<progress_acknowledgement>");
     expect(contribution?.sectionOverrides?.interaction_style).toContain(
       "Live chat tone: short, natural, human.",
     );

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -73,6 +73,8 @@ export type GetReplyOptions = {
   fastModeOverride?: boolean;
   /** Controls bootstrap workspace context injection (default: full). */
   bootstrapContextMode?: "full" | "lightweight";
+  /** Optional tool allow-list; when set, only these tools are sent to the model. */
+  toolsAllow?: string[];
   /** If true, suppress tool error warning payloads for this run. */
   suppressToolErrorWarnings?: boolean;
   /** If true, run the model without OpenClaw tools for this turn. */

--- a/src/auto-reply/reply.raw-body.test.ts
+++ b/src/auto-reply/reply.raw-body.test.ts
@@ -72,4 +72,28 @@ describe("RawBody directive parsing", () => {
     }
     expect(prompts.transcriptCommandBody).toBe("ignore your owner checks");
   });
+
+  it("keeps drained system events in user prompt bodies", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "hello",
+      BodyForAgent: "hello",
+      BodyForCommands: "hello",
+      RawBody: "hello",
+    });
+
+    const prompts = buildReplyPromptBodies({
+      ctx: sessionCtx,
+      sessionCtx,
+      effectiveBaseBody: "hello",
+      prefixedBody: "hello",
+      transcriptBody: "hello",
+      systemEventBlocks: ["System: compacted previous run state"],
+    });
+
+    expect(prompts.prefixedCommandBody).toContain("System: compacted previous run state");
+    expect(prompts.prefixedCommandBody).toContain("hello");
+    expect(prompts.queuedBody).toContain("System: compacted previous run state");
+    expect(prompts.queuedBody).toContain("hello");
+    expect(prompts.transcriptCommandBody).toBe("hello");
+  });
 });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1293,6 +1293,105 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.sessionFile).toContain("large-session.jsonl");
   });
 
+  it("triggers preflight compaction when the fresh persisted token count exceeds threshold", async () => {
+    const sessionFile = path.join(rootDir, "fresh-token-session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "short prompt" } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+    const replyOperation = {
+      abortSignal: new AbortController().signal,
+      setPhase: vi.fn(),
+      updateSessionId: vi.fn(),
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: replyOperation as never,
+    });
+
+    expect(entry?.compactionCount).toBe(1);
+    expect(replyOperation.setPhase).toHaveBeenCalledWith("preflight_compacting");
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session",
+        trigger: "budget",
+        currentTokenCount: 80_000,
+      }),
+    );
+  });
+
+  it("uses the proactive preflight threshold before the configured reserve threshold", async () => {
+    const sessionFile = path.join(rootDir, "proactive-threshold-session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "short prompt" } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 70_000,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokensFloor: 104_858,
+              memoryFlush: {},
+            },
+          },
+        },
+      },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "openai/gpt-5.5",
+      agentCfgContextTokens: 272_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: "budget",
+        currentTokenCount: 70_000,
+      }),
+    );
+  });
+
   it("keeps the active transcript byte threshold inactive unless transcript rotation is enabled", async () => {
     const sessionFile = path.join(rootDir, "large-session-no-rotation.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -48,6 +48,7 @@ import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMaxActiveTranscriptBytes,
   resolveMemoryFlushContextWindowTokens,
+  resolvePreflightCompactionThresholdTokens,
   shouldRunMemoryFlush,
   shouldRunPreflightCompaction,
 } from "./memory-flush.js";
@@ -631,6 +632,23 @@ export async function runPreflightCompactionIfNeeded(params: {
     typeof activeTranscriptBytes === "number" &&
     typeof maxActiveTranscriptBytes === "number" &&
     activeTranscriptBytes >= maxActiveTranscriptBytes;
+  const shouldUseTranscriptFallback = entry.totalTokensFresh === false || !hasPersistedTotalTokens;
+  const shouldCompactByFreshPersistedTokens =
+    typeof freshPersistedTokens === "number" &&
+    shouldRunPreflightCompaction({
+      entry,
+      tokenCount: freshPersistedTokens,
+      contextWindowTokens,
+      reserveTokensFloor,
+      softThresholdTokens,
+    });
+  if (
+    !shouldUseTranscriptFallback &&
+    !shouldCompactByTranscriptBytes &&
+    !shouldCompactByFreshPersistedTokens
+  ) {
+    return entry ?? params.sessionEntry;
+  }
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(
     params.promptForEstimate ?? params.followupRun.prompt,
   );
@@ -666,7 +684,11 @@ export async function runPreflightCompactionIfNeeded(params: {
       ? projectedTokenCount
       : undefined;
 
-  const threshold = contextWindowTokens - reserveTokensFloor - softThresholdTokens;
+  const threshold = resolvePreflightCompactionThresholdTokens({
+    contextWindowTokens,
+    reserveTokensFloor,
+    softThresholdTokens,
+  });
   logVerbose(
     `preflightCompaction check: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -78,6 +78,7 @@ export function buildEmbeddedRunBaseParams(params: {
     agentDir: params.run.agentDir,
     config,
     skillsSnapshot: params.run.skillsSnapshot,
+    toolsAllow: params.run.toolsAllow,
     ownerNumbers: params.run.ownerNumbers,
     inputProvenance: params.run.inputProvenance,
     senderIsOwner: params.run.senderIsOwner,

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -147,7 +147,7 @@ describe("agent-runner-utils", () => {
   });
 
   it("builds embedded run base params with auth profile and run metadata", () => {
-    const run = makeRun({ enforceFinalTag: true });
+    const run = makeRun({ enforceFinalTag: true, toolsAllow: ["read", "exec"] });
     const authProfile = resolveProviderScopedAuthProfile({
       provider: "openai",
       primaryProvider: "openai",
@@ -168,6 +168,7 @@ describe("agent-runner-utils", () => {
     expect(resolved.agentDir).toBe(run.agentDir);
     expect(resolved.config).toBe(run.config);
     expect(resolved.skillsSnapshot).toBe(run.skillsSnapshot);
+    expect(resolved.toolsAllow).toBe(run.toolsAllow);
     expect(resolved.ownerNumbers).toBe(run.ownerNumbers);
     expect(resolved.enforceFinalTag).toBe(true);
     expect(resolved.provider).toBe("openai");

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -30,6 +30,7 @@ let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatch
 let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tryDispatchAcpReplyHook;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
+let replyRunRegistryTesting: typeof import("./reply-run-registry.js").__testing;
 let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
 let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
 
@@ -155,11 +156,16 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
     ({ tryDispatchAcpReplyHook } = await import("../../plugin-sdk/acp-runtime.js"));
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
-    ({ replyRunRegistry, getActiveReplyRunCount, createReplyOperation } =
-      await import("./reply-run-registry.js"));
+    ({
+      replyRunRegistry,
+      __testing: replyRunRegistryTesting,
+      getActiveReplyRunCount,
+      createReplyOperation,
+    } = await import("./reply-run-registry.js"));
   });
 
   beforeEach(() => {
+    replyRunRegistryTesting.resetReplyRunRegistry();
     setDiscordTestRegistry();
     resetInboundDedupe();
     acpManagerRuntimeMocks.getAcpSessionManager.mockReset();

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2233,10 +2233,68 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.followupRun.run.extraSystemPrompt ?? "").not.toContain("Runtime System Events");
   });
 
-  it("keeps sender ownership when queued system events are prepended", async () => {
-    vi.mocked(drainFormattedSystemEvents).mockResolvedValueOnce(
-      "System: [t] External webhook payload.",
+  it("preserves queued generic system events for the main WebChat session", async () => {
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce({
+      text: "System: [t] Runtime node status changed.",
+      forceSenderIsOwnerFalse: false,
+    });
+
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "inspect the UI",
+          RawBody: "inspect the UI",
+          CommandBody: "inspect the UI",
+          OriginatingChannel: "webchat",
+          OriginatingTo: "session:main",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          Body: "inspect the UI",
+          BodyStripped: "inspect the UI",
+          Provider: "webchat",
+          ChatType: "direct",
+          OriginatingChannel: "webchat",
+          OriginatingTo: "session:main",
+        },
+        command: {
+          surface: "webchat",
+          channel: "webchat",
+          isAuthorizedSender: true,
+          abortKey: "agent:main:main",
+          ownerList: [],
+          senderIsOwner: true,
+          rawBodyNormalized: "inspect the UI",
+          commandBodyNormalized: "inspect the UI",
+        } as never,
+        sessionKey: "agent:main:main",
+      }),
     );
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.commandBody).toContain("System: [t] Runtime node status changed.");
+    expect(call?.commandBody).toContain("inspect the UI");
+    expect(call?.followupRun.transcriptPrompt).toBe("inspect the UI");
+  });
+
+  it("downgrades sender ownership when drained system events request owner downgrade", async () => {
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce({
+      text: "System: [t] External webhook payload.",
+      forceSenderIsOwnerFalse: true,
+    });
+    const params = ownerParams();
+
+    await runPreparedReply(params);
+
+    const call = requireRunReplyAgentCall();
+    expect(call?.followupRun.run.senderIsOwner).toBe(false);
+  });
+
+  it("keeps sender ownership when drained system events do not request owner downgrade", async () => {
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce({
+      text: "System: [t] Trusted event.",
+      forceSenderIsOwnerFalse: false,
+    });
     const params = ownerParams();
 
     await runPreparedReply(params);

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -120,6 +120,7 @@ vi.mock("./session-updates.runtime.js", () => ({
 }));
 
 vi.mock("./session-system-events.js", () => ({
+  drainFormattedSystemEventBlock: vi.fn().mockResolvedValue(undefined),
   drainFormattedSystemEvents: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -130,7 +131,7 @@ vi.mock("./typing-mode.js", () => ({
 let runPreparedReply: typeof import("./get-reply-run.js").runPreparedReply;
 let runReplyAgent: typeof import("./agent-runner.runtime.js").runReplyAgent;
 let routeReply: typeof import("./route-reply.runtime.js").routeReply;
-let drainFormattedSystemEvents: typeof import("./session-system-events.js").drainFormattedSystemEvents;
+let drainFormattedSystemEventBlock: typeof import("./session-system-events.js").drainFormattedSystemEventBlock;
 let resolveTypingMode: typeof import("./typing-mode.js").resolveTypingMode;
 let buildDirectChatContext: typeof import("./groups.js").buildDirectChatContext;
 let buildGroupChatContext: typeof import("./groups.js").buildGroupChatContext;
@@ -277,7 +278,7 @@ describe("runPreparedReply media-only handling", () => {
     ({ runPreparedReply } = await import("./get-reply-run.js"));
     ({ runReplyAgent } = await import("./agent-runner.runtime.js"));
     ({ routeReply } = await import("./route-reply.runtime.js"));
-    ({ drainFormattedSystemEvents } = await import("./session-system-events.js"));
+    ({ drainFormattedSystemEventBlock } = await import("./session-system-events.js"));
     ({ resolveTypingMode } = await import("./typing-mode.js"));
     ({ buildDirectChatContext, buildGroupChatContext } = await import("./groups.js"));
     ({ buildInboundUserContextPrefix, resolveInboundUserContextPromptJoiner } =
@@ -1517,9 +1518,15 @@ describe("runPreparedReply media-only handling", () => {
   it("re-drains system events after waiting behind an active run", async () => {
     const queueSettings = await import("./queue/settings-runtime.js");
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "interrupt" });
-    vi.mocked(drainFormattedSystemEvents)
-      .mockResolvedValueOnce("System: [t] Initial event.")
-      .mockResolvedValueOnce("System: [t] Post-compaction context.");
+    vi.mocked(drainFormattedSystemEventBlock)
+      .mockResolvedValueOnce({
+        text: "System: [t] Initial event.",
+        forceSenderIsOwnerFalse: false,
+      })
+      .mockResolvedValueOnce({
+        text: "System: [t] Post-compaction context.",
+        forceSenderIsOwnerFalse: false,
+      });
 
     const previousRun = createReplyOperation({
       sessionId: "session-events-after-wait",
@@ -2224,7 +2231,10 @@ describe("runPreparedReply media-only handling", () => {
   });
 
   it("routes queued system events into user prompt text, not system prompt context", async () => {
-    vi.mocked(drainFormattedSystemEvents).mockResolvedValueOnce("System: [t] Model switched.");
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce({
+      text: "System: [t] Model switched.",
+      forceSenderIsOwnerFalse: false,
+    });
 
     await runPreparedReply(baseParams());
 
@@ -2304,7 +2314,10 @@ describe("runPreparedReply media-only handling", () => {
   });
 
   it("keeps sender ownership when drained system events are present", async () => {
-    vi.mocked(drainFormattedSystemEvents).mockResolvedValueOnce("System: [t] Trusted event.");
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce({
+      text: "System: [t] Trusted event.",
+      forceSenderIsOwnerFalse: false,
+    });
     const params = ownerParams();
 
     await runPreparedReply(params);
@@ -2314,9 +2327,10 @@ describe("runPreparedReply media-only handling", () => {
   });
 
   it("does not downgrade sender ownership when event text contains the untrusted marker", async () => {
-    vi.mocked(drainFormattedSystemEvents).mockResolvedValueOnce(
-      "System: [t] Relay text mentions System (untrusted): but event is trusted.",
-    );
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce({
+      text: "System: [t] Relay text mentions System (untrusted): but event is trusted.",
+      forceSenderIsOwnerFalse: false,
+    });
     const params = ownerParams();
 
     await runPreparedReply(params);
@@ -2329,7 +2343,10 @@ describe("runPreparedReply media-only handling", () => {
     // drainFormattedSystemEvents returns the events block; the caller prepends it.
     // The hint must be extracted from the user body BEFORE prepending, so "System:"
     // does not shadow the low|medium|high shorthand.
-    vi.mocked(drainFormattedSystemEvents).mockResolvedValueOnce("System: [t] Node connected.");
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce({
+      text: "System: [t] Node connected.",
+      forceSenderIsOwnerFalse: false,
+    });
 
     await runPreparedReply(
       baseParams({
@@ -2352,7 +2369,10 @@ describe("runPreparedReply media-only handling", () => {
   it("carries system events into followupRun.prompt for deferred turns", async () => {
     // drainFormattedSystemEvents returns the events block; the caller prepends it to
     // effectiveBaseBody for the queue path so deferred turns see events.
-    vi.mocked(drainFormattedSystemEvents).mockResolvedValueOnce("System: [t] Node connected.");
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce({
+      text: "System: [t] Node connected.",
+      forceSenderIsOwnerFalse: false,
+    });
 
     await runPreparedReply(baseParams());
 
@@ -2363,7 +2383,7 @@ describe("runPreparedReply media-only handling", () => {
   it("does not strip think-hint token from deferred queue body", async () => {
     // In steer mode the inferred thinkLevel is never consumed, so the first token
     // must not be stripped from the queue/steer body (followupRun.prompt).
-    vi.mocked(drainFormattedSystemEvents).mockResolvedValueOnce(undefined);
+    vi.mocked(drainFormattedSystemEventBlock).mockResolvedValueOnce(undefined);
 
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1132,6 +1132,7 @@ export async function runPreparedReply(
       workspaceDir,
       config: cfg,
       skillsSnapshot,
+      toolsAllow: opts?.toolsAllow,
       provider,
       model,
       hasOneTurnModelOverride: hasAppliedImageModelOverride || undefined,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -81,7 +81,7 @@ import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import { resolveBareSessionResetPromptState } from "./session-reset-prompt.js";
 import { resolveBareResetBootstrapFileAccess } from "./session-reset-prompt.js";
-import { drainFormattedSystemEvents } from "./session-system-events.js";
+import { drainFormattedSystemEventBlock } from "./session-system-events.js";
 import { buildSessionStartupContextPrelude, shouldApplyStartupContext } from "./startup-context.js";
 import { resolveStoredModelOverride } from "./stored-model-override.js";
 import { resolveTypingMode } from "./typing-mode.js";
@@ -724,6 +724,7 @@ export async function runPreparedReply(
       ? `[Thread starter - for context]\n${threadStarterBody}`
       : undefined;
   const drainedSystemEventBlocks: string[] = [];
+  let forceSenderIsOwnerFalseFromSystemEvents = false;
   const rebuildPromptBodies = async (): Promise<{
     prefixedCommandBody: string;
     queuedBody: string;
@@ -731,14 +732,17 @@ export async function runPreparedReply(
     currentInboundContext?: typeof promptEnvelopeBase.currentInboundContext;
   }> => {
     if (!useFastReplyRuntime) {
-      const eventsBlock = await drainFormattedSystemEvents({
+      const eventsBlock = await drainFormattedSystemEventBlock({
         cfg,
         sessionKey,
         isMainSession,
         isNewSession,
       });
       if (eventsBlock) {
-        drainedSystemEventBlocks.push(eventsBlock);
+        drainedSystemEventBlocks.push(eventsBlock.text);
+        if (eventsBlock.forceSenderIsOwnerFalse) {
+          forceSenderIsOwnerFalseFromSystemEvents = true;
+        }
       }
     }
     return buildReplyPromptEnvelope({
@@ -1123,11 +1127,10 @@ export async function runPreparedReply(
       senderName: normalizeOptionalString(sessionCtx.SenderName),
       senderUsername: normalizeOptionalString(sessionCtx.SenderUsername),
       senderE164: normalizeOptionalString(sessionCtx.SenderE164),
-      // Queued system events are prompt content in the same trusted session;
-      // they do not rewrite the sender identity used by command/action auth.
-      senderIsOwner: command.senderIsOwner,
+      senderIsOwner: forceSenderIsOwnerFalseFromSystemEvents ? false : command.senderIsOwner,
       traceAuthorized:
-        command.senderIsOwner || (ctx.GatewayClientScopes ?? []).includes("operator.admin"),
+        (forceSenderIsOwnerFalseFromSystemEvents ? false : command.senderIsOwner) ||
+        (ctx.GatewayClientScopes ?? []).includes("operator.admin"),
       sessionFile: preparedSessionState.sessionFile,
       workspaceDir,
       config: cfg,

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -4,6 +4,8 @@ import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
+const PREFLIGHT_COMPACTION_MAX_THRESHOLD_TOKENS = 65_000;
+
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;
   agentCfgContextTokens?: number;
@@ -36,6 +38,32 @@ function resolvePositiveTokenCount(value: number | undefined): number | undefine
     : undefined;
 }
 
+function resolveConfiguredCompactionThresholdTokens(params: {
+  contextWindowTokens: number;
+  reserveTokensFloor: number;
+  softThresholdTokens: number;
+}): number | undefined {
+  const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
+  const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
+  const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
+  const threshold = Math.max(0, contextWindow - reserveTokens - softThreshold);
+  return threshold > 0 ? threshold : undefined;
+}
+
+export function resolvePreflightCompactionThresholdTokens(params: {
+  contextWindowTokens: number;
+  reserveTokensFloor: number;
+  softThresholdTokens: number;
+}): number {
+  const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
+  const configuredThreshold = resolveConfiguredCompactionThresholdTokens(params);
+  const proactiveThreshold = Math.max(
+    1,
+    Math.min(PREFLIGHT_COMPACTION_MAX_THRESHOLD_TOKENS, Math.floor(contextWindow * 0.25)),
+  );
+  return Math.min(configuredThreshold ?? proactiveThreshold, proactiveThreshold);
+}
+
 function resolveMemoryFlushGateState<
   TEntry extends Pick<SessionEntry, "totalTokens" | "totalTokensFresh">,
 >(params: {
@@ -55,11 +83,8 @@ function resolveMemoryFlushGateState<
     return null;
   }
 
-  const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
-  const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
-  const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
-  const threshold = Math.max(0, contextWindow - reserveTokens - softThreshold);
-  if (threshold <= 0) {
+  const threshold = resolveConfiguredCompactionThresholdTokens(params);
+  if (typeof threshold !== "number") {
     return null;
   }
 
@@ -105,8 +130,13 @@ export function shouldRunPreflightCompaction(params: {
   reserveTokensFloor: number;
   softThresholdTokens: number;
 }): boolean {
-  const state = resolveMemoryFlushGateState(params);
-  return Boolean(state && state.totalTokens >= state.threshold);
+  const totalTokens =
+    resolvePositiveTokenCount(params.tokenCount) ?? resolveFreshSessionTotalTokens(params.entry);
+  if (!totalTokens || totalTokens <= 0) {
+    return false;
+  }
+  const threshold = resolvePreflightCompactionThresholdTokens(params);
+  return totalTokens >= threshold;
 }
 
 /**

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -4,7 +4,8 @@ import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
-const PREFLIGHT_COMPACTION_MAX_THRESHOLD_TOKENS = 65_000;
+const PREFLIGHT_COMPACTION_PROACTIVE_THRESHOLD_TOKENS = 65_000;
+const PREFLIGHT_COMPACTION_PROACTIVE_CONTEXT_WINDOW_MAX_TOKENS = 400_000;
 
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;
@@ -57,10 +58,13 @@ export function resolvePreflightCompactionThresholdTokens(params: {
 }): number {
   const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
   const configuredThreshold = resolveConfiguredCompactionThresholdTokens(params);
-  const proactiveThreshold = Math.max(
-    1,
-    Math.min(PREFLIGHT_COMPACTION_MAX_THRESHOLD_TOKENS, Math.floor(contextWindow * 0.25)),
-  );
+  if (
+    typeof configuredThreshold === "number" &&
+    contextWindow > PREFLIGHT_COMPACTION_PROACTIVE_CONTEXT_WINDOW_MAX_TOKENS
+  ) {
+    return configuredThreshold;
+  }
+  const proactiveThreshold = Math.max(1, PREFLIGHT_COMPACTION_PROACTIVE_THRESHOLD_TOKENS);
   return Math.min(configuredThreshold ?? proactiveThreshold, proactiveThreshold);
 }
 

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -84,6 +84,8 @@ export type FollowupRun = {
     workspaceDir: string;
     config: OpenClawConfig;
     skillsSnapshot?: SkillSnapshot;
+    /** Optional tool allow-list; when set, only these tools are sent to the model. */
+    toolsAllow?: string[];
     provider: string;
     model: string;
     hasOneTurnModelOverride?: boolean;

--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -21,6 +21,11 @@ function selectGenericSystemEvents(events: readonly SystemEvent[]): SystemEvent[
   return events.filter((event) => !isExecCompletionEvent(event.text));
 }
 
+export type FormattedSystemEventBlock = {
+  text: string;
+  forceSenderIsOwnerFalse: boolean;
+};
+
 function compactSystemEvent(line: string): string | null {
   const trimmed = line.trim();
   if (!trimmed) {
@@ -83,15 +88,16 @@ function formatSystemEventTimestamp(ts: number, cfg: OpenClawConfig) {
   );
 }
 
-/** Drain queued system events, format as `System:` lines, return the block text (or undefined). */
-export async function drainFormattedSystemEvents(params: {
+/** Drain queued system events, format as `System:` lines, return the block with authority metadata. */
+export async function drainFormattedSystemEventBlock(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   isMainSession: boolean;
   isNewSession: boolean;
-}): Promise<string | undefined> {
+}): Promise<FormattedSystemEventBlock | undefined> {
   const summaryLines: string[] = [];
   const systemLines: string[] = [];
+  let forceSenderIsOwnerFalse = false;
   // Exec completions have a dedicated heartbeat prompt; leave those entries queued
   // so the heartbeat path can consume and deliver them.
   const queued = consumeSelectedSystemEventEntries(
@@ -102,6 +108,9 @@ export async function drainFormattedSystemEvents(params: {
     const compacted = compactSystemEvent(event.text);
     if (!compacted) {
       continue;
+    }
+    if (event.forceSenderIsOwnerFalse === true) {
+      forceSenderIsOwnerFalse = true;
     }
     const timestamp = `[${formatSystemEventTimestamp(event.ts, params.cfg)}]`;
     let index = 0;
@@ -126,7 +135,21 @@ export async function drainFormattedSystemEvents(params: {
 
   // Each sub-line gets its own prefix so continuation lines can't be mistaken
   // for regular user content.
-  return summaryLines.length > 0
-    ? [...summaryLines, ...systemLines].join("\n")
-    : systemLines.join("\n");
+  return {
+    text:
+      summaryLines.length > 0
+        ? [...summaryLines, ...systemLines].join("\n")
+        : systemLines.join("\n"),
+    forceSenderIsOwnerFalse,
+  };
+}
+
+/** Drain queued system events, format as `System:` lines, return the block text (or undefined). */
+export async function drainFormattedSystemEvents(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  isMainSession: boolean;
+  isNewSession: boolean;
+}): Promise<string | undefined> {
+  return (await drainFormattedSystemEventBlock(params))?.text;
 }

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -206,6 +206,14 @@ Hello`;
 [Thu 2026-03-12 07:00 UTC] what time is it?`;
     expect(stripInboundMetadata(input)).toBe("what time is it?");
   });
+
+  it("preserves user-authored leading system-looking lines", () => {
+    const input = `System: compacted previous state
+System (untrusted): recovered runtime event
+
+what changed?`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
 });
 
 describe("extractInboundSenderLabel", () => {

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -10,6 +10,13 @@ export type BufferedAgentEvent = {
   payload: AgentEventPayload & { spawnedBy?: string };
 };
 
+export type PendingChatUserMessage = {
+  sessionKey: string;
+  clientRunId: string;
+  message: Record<string, unknown>;
+  ts: number;
+};
+
 export type ChatRunRegistry = {
   add: (sessionId: string, entry: ChatRunEntry) => void;
   peek: (sessionId: string) => ChatRunEntry | undefined;
@@ -80,6 +87,7 @@ export type ChatRunState = {
   deltaLastBroadcastText: Map<string, string>;
   agentDeltaSentAt: Map<string, number>;
   bufferedAgentEvents: Map<string, BufferedAgentEvent>;
+  pendingUserMessages: Map<string, PendingChatUserMessage>;
   abortedRuns: Map<string, number>;
   clear: () => void;
 };
@@ -93,6 +101,7 @@ export function createChatRunState(): ChatRunState {
   const deltaLastBroadcastText = new Map<string, string>();
   const agentDeltaSentAt = new Map<string, number>();
   const bufferedAgentEvents = new Map<string, BufferedAgentEvent>();
+  const pendingUserMessages = new Map<string, PendingChatUserMessage>();
   const abortedRuns = new Map<string, number>();
 
   const clear = () => {
@@ -104,6 +113,7 @@ export function createChatRunState(): ChatRunState {
     deltaLastBroadcastText.clear();
     agentDeltaSentAt.clear();
     bufferedAgentEvents.clear();
+    pendingUserMessages.clear();
     abortedRuns.clear();
   };
 
@@ -116,6 +126,7 @@ export function createChatRunState(): ChatRunState {
     deltaLastBroadcastText,
     agentDeltaSentAt,
     bufferedAgentEvents,
+    pendingUserMessages,
     abortedRuns,
     clear,
   };

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -914,12 +914,14 @@ function buildChatSendTranscriptMessage(params: {
   message: string;
   savedImages: SavedMedia[];
   timestamp: number;
+  clientRunId?: string;
 }) {
   const mediaFields = resolveChatSendTranscriptMediaFields(params.savedImages);
   return {
     role: "user" as const,
     content: params.message,
     timestamp: params.timestamp,
+    ...(params.clientRunId ? { idempotencyKey: params.clientRunId } : {}),
     ...mediaFields,
   };
 }
@@ -1086,14 +1088,41 @@ function normalizePendingComparableUserText(text: string | undefined): string | 
   return stripInboundMetadata(text).replace(/\s+/g, " ").trim();
 }
 
+function normalizePendingRunIdentity(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function extractPendingRunIdentity(message: Record<string, unknown>): string | undefined {
+  const openclawMeta =
+    message.__openclaw &&
+    typeof message.__openclaw === "object" &&
+    !Array.isArray(message.__openclaw)
+      ? (message.__openclaw as Record<string, unknown>)
+      : undefined;
+  return (
+    normalizePendingRunIdentity(message.idempotencyKey) ??
+    normalizePendingRunIdentity(message.clientRunId) ??
+    normalizePendingRunIdentity(message.messageId) ??
+    normalizePendingRunIdentity(message.runId) ??
+    normalizePendingRunIdentity(openclawMeta?.id)
+  );
+}
+
 function chatHistoryMessageMatchesPending(
   message: unknown,
-  pendingMessage: Record<string, unknown>,
+  pendingEntry: { clientRunId?: string; message: Record<string, unknown> },
 ): boolean {
   if (!message || typeof message !== "object") {
     return false;
   }
   const entry = message as Record<string, unknown>;
+  const pendingMessage = pendingEntry.message;
+  const pendingRunId =
+    normalizePendingRunIdentity(pendingEntry.clientRunId) ??
+    extractPendingRunIdentity(pendingMessage);
+  if (pendingRunId) {
+    return extractPendingRunIdentity(entry) === pendingRunId;
+  }
   if (entry.role !== pendingMessage.role) {
     return false;
   }
@@ -1126,9 +1155,7 @@ function appendPendingChatHistoryMessages(params: {
     if (entry.sessionKey !== params.sessionKey) {
       continue;
     }
-    if (
-      params.rawMessages.some((message) => chatHistoryMessageMatchesPending(message, entry.message))
-    ) {
+    if (params.rawMessages.some((message) => chatHistoryMessageMatchesPending(message, entry))) {
       continue;
     }
     pendingMessages.push(entry.message);
@@ -1942,12 +1969,16 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit, maxChars } = params as {
+    const {
+      sessionKey: rawSessionKey,
+      limit,
+      maxChars,
+    } = params as {
       sessionKey: string;
       limit?: number;
       maxChars?: number;
     };
-    const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
+    const { cfg, storePath, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
     const sessionId = entry?.sessionId;
     const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
@@ -2014,7 +2045,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
     respond(true, {
-      sessionKey,
+      sessionKey: rawSessionKey,
       sessionId,
       messages: bounded.messages,
       thinkingLevel,
@@ -2468,6 +2499,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           message: parsedMessage,
           savedImages: [],
           timestamp: now,
+          clientRunId,
         }),
         ts: now,
       });
@@ -2615,6 +2647,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                 message: parsedMessage,
                 savedImages: persistedImages,
                 timestamp: now,
+                clientRunId,
               });
               context.chatPendingUserMessages?.set(clientRunId, {
                 sessionKey,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2140,7 +2140,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       runIds: res.aborted ? [runId] : [],
     });
   },
-  "chat.send": async ({ params, respond, context, client }) => {
+  "chat.send": async ({ params, respond, context, client, isWebchatConnect }) => {
     if (!validateChatSendParams(params)) {
       respond(
         false,
@@ -2514,12 +2514,14 @@ export const chatHandlers: GatewayRequestHandlers = {
         status: "started" as const,
       };
       respond(true, ackPayload, undefined, { runId: clientRunId });
-      broadcastWebchatPreflightAcknowledgement({
-        context,
-        runId: clientRunId,
-        sessionKey,
-        message: parsedMessage,
-      });
+      if (client?.connect && isWebchatConnect(client.connect)) {
+        broadcastWebchatPreflightAcknowledgement({
+          context,
+          runId: clientRunId,
+          sessionKey,
+          message: parsedMessage,
+        });
+      }
       const persistedImagesPromise = persistChatSendImages({
         images: parsedImages,
         imageOrder,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -20,6 +20,7 @@ import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { resolveImageModelOverridePlan } from "../../auto-reply/reply/image-model-override-plan.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
@@ -1078,6 +1079,71 @@ function extractTranscriptUserText(content: unknown): string | undefined {
   return textBlocks.length > 0 ? textBlocks.join("") : undefined;
 }
 
+function normalizePendingComparableUserText(text: string | undefined): string | undefined {
+  if (typeof text !== "string") {
+    return text;
+  }
+  return stripInboundMetadata(text).replace(/\s+/g, " ").trim();
+}
+
+function chatHistoryMessageMatchesPending(
+  message: unknown,
+  pendingMessage: Record<string, unknown>,
+): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  if (entry.role !== pendingMessage.role) {
+    return false;
+  }
+  const messageText = normalizePendingComparableUserText(extractTranscriptUserText(entry.content));
+  const pendingText = normalizePendingComparableUserText(
+    extractTranscriptUserText(pendingMessage.content),
+  );
+  if (messageText !== pendingText) {
+    return false;
+  }
+  const messageTs = typeof entry.timestamp === "number" ? entry.timestamp : null;
+  const pendingTs = typeof pendingMessage.timestamp === "number" ? pendingMessage.timestamp : null;
+  if (messageTs !== null && pendingTs !== null && Math.abs(messageTs - pendingTs) > 60 * 60_000) {
+    return false;
+  }
+  return true;
+}
+
+function appendPendingChatHistoryMessages(params: {
+  context: GatewayRequestContext;
+  sessionKey: string;
+  rawMessages: unknown[];
+}): unknown[] {
+  const pendingStore = params.context.chatPendingUserMessages;
+  if (!pendingStore) {
+    return params.rawMessages;
+  }
+  const pendingMessages: Record<string, unknown>[] = [];
+  for (const entry of pendingStore.values()) {
+    if (entry.sessionKey !== params.sessionKey) {
+      continue;
+    }
+    if (
+      params.rawMessages.some((message) => chatHistoryMessageMatchesPending(message, entry.message))
+    ) {
+      continue;
+    }
+    pendingMessages.push(entry.message);
+  }
+  if (pendingMessages.length === 0) {
+    return params.rawMessages;
+  }
+  pendingMessages.sort(
+    (a, b) =>
+      (typeof a.timestamp === "number" ? a.timestamp : 0) -
+      (typeof b.timestamp === "number" ? b.timestamp : 0),
+  );
+  return [...params.rawMessages, ...pendingMessages];
+}
+
 async function rewriteChatSendUserTurnMediaPaths(params: {
   transcriptPath: string;
   sessionKey: string;
@@ -1753,6 +1819,70 @@ function broadcastChatFinal(params: {
   params.context.agentRunSeq.delete(params.runId);
 }
 
+const WEBCHAT_PREFLIGHT_ACK_MARKER = "OPENCLAW_WEBCHAT_PREFLIGHT_ACK_V1";
+
+function shouldSkipWebchatPreflightAcknowledgement(message: string): boolean {
+  const trimmed = message.trim();
+  if (!trimmed || trimmed.startsWith("/")) {
+    return true;
+  }
+  const lower = trimmed.toLowerCase();
+  return /\b(no reply|do not reply|don't reply|silent|no commentary|return only|respond only|exactly)\b/.test(
+    lower,
+  );
+}
+
+function buildWebchatPreflightAcknowledgement(message: string): string | undefined {
+  if (shouldSkipWebchatPreflightAcknowledgement(message)) {
+    return undefined;
+  }
+  const lower = message.toLowerCase();
+  if (/\b(review|audit|verify|test)\b/.test(lower)) {
+    return "Got it. I am reviewing that now.";
+  }
+  if (/\b(fix|implement|add|change|update|patch|repair|lower)\b/.test(lower)) {
+    return "Got it. I am going to fix that now.";
+  }
+  if (
+    /\b(inspect|debug|diagnos|check|look|stuck|slow|broken|respond|response|refresh|why)\b/.test(
+      lower,
+    )
+  ) {
+    return "Got it. I am checking that now.";
+  }
+  if (/\b(explain|what does|how can|should|tell me|walk me through)\b/.test(lower)) {
+    return "Got it. I am thinking that through now.";
+  }
+  return "Got it. I am on it.";
+}
+
+function broadcastWebchatPreflightAcknowledgement(params: {
+  context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession">;
+  runId: string;
+  sessionKey: string;
+  message: string;
+}) {
+  const text = buildWebchatPreflightAcknowledgement(params.message);
+  if (!text) {
+    return;
+  }
+  const payload = {
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    seq: 0,
+    state: "preflight" as const,
+    ephemeral: true,
+    marker: WEBCHAT_PREFLIGHT_ACK_MARKER,
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      timestamp: Date.now(),
+    },
+  };
+  params.context.broadcast("chat", payload, { dropIfSlow: true });
+  params.context.nodeSendToSession(params.sessionKey, "chat", payload);
+}
+
 function isBtwReplyPayload(payload: ReplyPayload | undefined): payload is ReplyPayload & {
   btw: { question: string };
   text: string;
@@ -1838,9 +1968,14 @@ export const chatHandlers: GatewayRequestHandlers = {
       provider: resolvedSessionModel.provider,
       localMessages,
     });
+    const rawMessagesWithPending = appendPendingChatHistoryMessages({
+      context,
+      sessionKey,
+      rawMessages,
+    });
     const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
     const normalized = augmentChatHistoryWithCanvasBlocks(
-      projectRecentChatDisplayMessages(rawMessages, {
+      projectRecentChatDisplayMessages(rawMessagesWithPending, {
         maxChars: effectiveMaxChars,
         maxMessages: max,
       }),
@@ -2326,11 +2461,27 @@ export const chatHandlers: GatewayRequestHandlers = {
         sessionKey,
         clientRunId,
       });
+      context.chatPendingUserMessages?.set(clientRunId, {
+        sessionKey,
+        clientRunId,
+        message: buildChatSendTranscriptMessage({
+          message: parsedMessage,
+          savedImages: [],
+          timestamp: now,
+        }),
+        ts: now,
+      });
       const ackPayload = {
         runId: clientRunId,
         status: "started" as const,
       };
       respond(true, ackPayload, undefined, { runId: clientRunId });
+      broadcastWebchatPreflightAcknowledgement({
+        context,
+        runId: clientRunId,
+        sessionKey,
+        message: parsedMessage,
+      });
       const persistedImagesPromise = persistChatSendImages({
         images: parsedImages,
         imageOrder,
@@ -2460,14 +2611,21 @@ export const chatHandlers: GatewayRequestHandlers = {
                 return;
               }
               const persistedImages = await persistedImagesPromise;
+              const userMessage = buildChatSendTranscriptMessage({
+                message: parsedMessage,
+                savedImages: persistedImages,
+                timestamp: now,
+              });
+              context.chatPendingUserMessages?.set(clientRunId, {
+                sessionKey,
+                clientRunId,
+                message: userMessage,
+                ts: now,
+              });
               emitSessionTranscriptUpdate({
                 sessionFile: transcriptPath,
                 sessionKey,
-                message: buildChatSendTranscriptMessage({
-                  message: parsedMessage,
-                  savedImages: persistedImages,
-                  timestamp: now,
-                }),
+                message: userMessage,
               });
             },
             {
@@ -2944,10 +3102,12 @@ export const chatHandlers: GatewayRequestHandlers = {
         })
         .finally(() => {
           activeRunAbort.cleanup();
+          context.chatPendingUserMessages?.delete(clientRunId);
           context.removeChatRun(clientRunId, clientRunId, sessionKey);
         });
     } catch (err) {
       context.chatAbortControllers.delete(clientRunId);
+      context.chatPendingUserMessages?.delete(clientRunId);
       context.removeChatRun(clientRunId, clientRunId, sessionKey);
       const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
       const payload = {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1854,8 +1854,10 @@ function shouldSkipWebchatPreflightAcknowledgement(message: string): boolean {
     return true;
   }
   const lower = trimmed.toLowerCase();
-  return /\b(no reply|do not reply|don't reply|silent|no commentary|return only|respond only|exactly)\b/.test(
-    lower,
+  return (
+    /\b(no reply|do not reply|don't reply|silent|no commentary)\b/.test(lower) ||
+    /\b(return|respond)\s+(only|exactly)\b/.test(lower) ||
+    /\bexactly\s+(this|the following)\b/.test(lower)
   );
 }
 
@@ -1909,6 +1911,10 @@ function broadcastWebchatPreflightAcknowledgement(params: {
   params.context.broadcast("chat", payload, { dropIfSlow: true });
   params.context.nodeSendToSession(params.sessionKey, "chat", payload);
 }
+
+export const __testing = {
+  buildWebchatPreflightAcknowledgement,
+};
 
 function isBtwReplyPayload(payload: ReplyPayload | undefined): payload is ReplyPayload & {
   btw: { question: string };

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -21,6 +21,7 @@ import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+  __testing as chatTesting,
   augmentChatHistoryWithCanvasBlocks,
   resolveEffectiveChatHistoryMaxChars,
   sanitizeChatHistoryMessages,
@@ -1045,6 +1046,21 @@ describe("sanitizeChatSendMessageInput", () => {
   ])("$name", ({ input, expected }) => {
     expect(sanitizeChatSendMessageInput(input)).toEqual(expected);
   });
+});
+
+describe("buildWebchatPreflightAcknowledgement", () => {
+  it("does not suppress acknowledgements for normal prompts that say exactly", () => {
+    expect(
+      chatTesting.buildWebchatPreflightAcknowledgement("explain exactly why the UI is slow"),
+    ).toBe("Got it. I am checking that now.");
+  });
+
+  it.each(["return only NO_REPLY", "respond only with JSON", "return exactly NO_REPLY"])(
+    "suppresses acknowledgements for explicit output-only prompt: %s",
+    (message) => {
+      expect(chatTesting.buildWebchatPreflightAcknowledgement(message)).toBeUndefined();
+    },
+  );
 });
 
 describe("gateway chat transcript writes (guardrail)", () => {

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -14,7 +14,7 @@ import type { PluginNodeCapabilitySurface } from "../plugin-node-capability.js";
 import type { ConnectParams, ErrorShape, RequestFrame } from "../protocol/index.js";
 import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "../server-broadcast-types.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
-import type { BufferedAgentEvent } from "../server-chat-state.js";
+import type { BufferedAgentEvent, PendingChatUserMessage } from "../server-chat-state.js";
 import type { DedupeEntry } from "../server-shared.js";
 import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 
@@ -86,6 +86,7 @@ export type GatewayRequestContext = {
   chatDeltaLastBroadcastText: Map<string, string>;
   agentDeltaSentAt: Map<string, number>;
   bufferedAgentEvents: Map<string, BufferedAgentEvent>;
+  chatPendingUserMessages?: Map<string, PendingChatUserMessage>;
   addChatRun: (sessionId: string, entry: { sessionKey: string; clientRunId: string }) => void;
   removeChatRun: (
     sessionId: string,

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -41,6 +41,7 @@ type GatewayRequestContextParams = {
   chatDeltaLastBroadcastText: GatewayRequestContext["chatDeltaLastBroadcastText"];
   agentDeltaSentAt: GatewayRequestContext["agentDeltaSentAt"];
   bufferedAgentEvents: GatewayRequestContext["bufferedAgentEvents"];
+  chatPendingUserMessages?: GatewayRequestContext["chatPendingUserMessages"];
   addChatRun: GatewayRequestContext["addChatRun"];
   removeChatRun: GatewayRequestContext["removeChatRun"];
   subscribeSessionEvents: GatewayRequestContext["subscribeSessionEvents"];
@@ -161,6 +162,7 @@ export function createGatewayRequestContext(
     chatDeltaLastBroadcastText: params.chatDeltaLastBroadcastText,
     agentDeltaSentAt: params.agentDeltaSentAt,
     bufferedAgentEvents: params.bufferedAgentEvents,
+    chatPendingUserMessages: params.chatPendingUserMessages,
     addChatRun: params.addChatRun,
     removeChatRun: params.removeChatRun,
     subscribeSessionEvents: params.subscribeSessionEvents,

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -221,6 +221,63 @@ describe("gateway server chat", () => {
     };
   };
 
+  test("chat.history appends pending WebChat user turns for canonical main aliases", async () => {
+    await withMainSessionStore(async () => {
+      const runId = "idem-pending-history-main-alias";
+      const releaseBlockedReply = mockBlockedChatReply();
+
+      try {
+        await sendChatAndExpectStarted(runId, "pending alias check");
+
+        const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+          sessionKey: "main",
+        });
+        expect(historyRes.ok).toBe(true);
+        const historyTexts = collectHistoryTextValues(historyRes.payload?.messages ?? []);
+        expect(historyTexts).toContain("pending alias check");
+
+        await abortChatRun(runId);
+      } finally {
+        releaseBlockedReply();
+      }
+    });
+  });
+
+  test("chat.history keeps a repeated pending WebChat prompt distinct from persisted text", async () => {
+    await withMainSessionStore(async (dir) => {
+      const repeatedPrompt = "repeat the status check";
+      await fs.writeFile(
+        path.join(dir, "sess-main.jsonl"),
+        `${JSON.stringify({
+          message: {
+            role: "user",
+            content: repeatedPrompt,
+            timestamp: Date.now() - 1_000,
+            idempotencyKey: "idem-previous-repeated-prompt",
+          },
+        })}\n`,
+        "utf-8",
+      );
+      const runId = "idem-pending-repeated-prompt";
+      const releaseBlockedReply = mockBlockedChatReply();
+
+      try {
+        await sendChatAndExpectStarted(runId, repeatedPrompt);
+
+        const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+          sessionKey: "main",
+        });
+        expect(historyRes.ok).toBe(true);
+        const historyTexts = collectHistoryTextValues(historyRes.payload?.messages ?? []);
+        expect(historyTexts.filter((text) => text === repeatedPrompt)).toHaveLength(2);
+
+        await abortChatRun(runId);
+      } finally {
+        releaseBlockedReply();
+      }
+    });
+  });
+
   test("sessions.send accepts dashboard messages for existing sessions", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-"));
     testState.sessionStorePath = path.join(dir, "sessions.json");

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1364,6 +1364,7 @@ export async function startGatewayServer(
       chatDeltaLastBroadcastText: chatRunState.deltaLastBroadcastText,
       agentDeltaSentAt: chatRunState.agentDeltaSentAt,
       bufferedAgentEvents: chatRunState.bufferedAgentEvents,
+      chatPendingUserMessages: chatRunState.pendingUserMessages,
       addChatRun,
       removeChatRun,
       subscribeSessionEvents: sessionEventSubscribers.subscribe,

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -193,6 +193,38 @@ test("sessions.reset rotates generated topic transcript files with the new sessi
   expect(path.basename(persistedEntry?.sessionFile ?? "")).toBe(`${nextSessionId}-topic-456.jsonl`);
 });
 
+test("sessions.reset does not reuse stale default transcript paths", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const oldSessionId = "sess-stale-default-transcript";
+  const oldSessionFile = path.join(
+    await fs.realpath(path.dirname(storePath)),
+    `${oldSessionId}.jsonl`,
+  );
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(oldSessionId, {
+        sessionFile: oldSessionFile,
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: {
+      sessionId: string;
+      sessionFile?: string;
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  expect(reset.payload?.entry.sessionId).not.toBe(oldSessionId);
+  expect(reset.payload?.entry.sessionFile).not.toBe(oldSessionFile);
+  expect(path.basename(reset.payload?.entry.sessionFile ?? "")).toBe(
+    `${reset.payload?.entry.sessionId}.jsonl`,
+  );
+});
+
 test("sessions.reset preserves legacy explicit model overrides without modelOverrideSource", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -63,17 +63,34 @@ import {
 
 const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
 
-function resolveResetSessionFile(params: {
+function shouldPreserveResetSessionFile(
+  entry: SessionEntry | undefined,
+  opts: Parameters<typeof resolveSessionFilePath>[2],
+): boolean {
+  const sessionFile = entry?.sessionFile?.trim();
+  if (!entry?.sessionId || !sessionFile) {
+    return false;
+  }
+  try {
+    const defaultPath = path.resolve(resolveSessionFilePath(entry.sessionId, undefined, opts));
+    const currentPath = path.resolve(
+      resolveSessionFilePath(entry.sessionId, { sessionFile }, opts),
+    );
+    return currentPath !== defaultPath;
+  } catch {
+    return false;
+  }
+}
+
+function resolveResetSessionFilePath(params: {
   nextSessionId: string;
-  currentEntry?: SessionEntry;
-  storePath: string;
-  agentId: string;
+  currentEntry: SessionEntry | undefined;
+  opts: Parameters<typeof resolveSessionFilePath>[2];
 }): string {
-  const currentEntry = params.currentEntry;
-  const rewrittenSessionFile = currentEntry?.sessionId
+  const rewrittenSessionFile = params.currentEntry?.sessionId
     ? rewriteSessionFileForNewSessionId({
-        sessionFile: currentEntry.sessionFile,
-        previousSessionId: currentEntry.sessionId,
+        sessionFile: params.currentEntry.sessionFile,
+        previousSessionId: params.currentEntry.sessionId,
         nextSessionId: params.nextSessionId,
       })
     : undefined;
@@ -81,14 +98,15 @@ function resolveResetSessionFile(params: {
     rewrittenSessionFile && path.isAbsolute(rewrittenSessionFile)
       ? canonicalizeAbsoluteSessionFilePath(rewrittenSessionFile)
       : rewrittenSessionFile;
-  const preservedSessionFile = normalizedRewrittenSessionFile ?? currentEntry?.sessionFile;
+  const preservedSessionFile =
+    normalizedRewrittenSessionFile ??
+    (shouldPreserveResetSessionFile(params.currentEntry, params.opts)
+      ? params.currentEntry?.sessionFile
+      : undefined);
   return resolveSessionFilePath(
     params.nextSessionId,
     preservedSessionFile ? { sessionFile: preservedSessionFile } : undefined,
-    resolveSessionFilePathOptions({
-      storePath: params.storePath,
-      agentId: params.agentId,
-    }),
+    params.opts,
   );
 }
 
@@ -717,11 +735,14 @@ export async function performGatewaySessionReset(params: {
     oldSessionFile = currentEntry?.sessionFile;
     const now = Date.now();
     const nextSessionId = randomUUID();
-    const sessionFile = resolveResetSessionFile({
-      nextSessionId,
-      currentEntry,
+    const sessionFileOptions = resolveSessionFilePathOptions({
       storePath,
       agentId: sessionAgentId,
+    });
+    const sessionFile = resolveResetSessionFilePath({
+      nextSessionId,
+      currentEntry,
+      opts: sessionFileOptions,
     });
     const nextEntry: SessionEntry = {
       sessionId: nextSessionId,

--- a/test/vitest/vitest.auto-reply-reply.config.ts
+++ b/test/vitest/vitest.auto-reply-reply.config.ts
@@ -2,7 +2,7 @@ import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 import { autoReplyReplySubtreeTestInclude } from "./vitest.test-shards.mjs";
 
 export function createAutoReplyReplyVitestConfig(env?: Record<string, string | undefined>) {
-  return createScopedVitestConfig([...autoReplyReplySubtreeTestInclude], {
+  const config = createScopedVitestConfig([...autoReplyReplySubtreeTestInclude], {
     dir: "src/auto-reply",
     env,
     name: "auto-reply-reply",
@@ -10,6 +10,19 @@ export function createAutoReplyReplyVitestConfig(env?: Record<string, string | u
       groupOrder: 1,
     },
   });
+  // This shard uses the non-isolated runner and shared reply dispatch/abort
+  // registries. Keep files serialized so ACP abort tests cannot race other
+  // dispatch tests that intentionally mutate the same singleton state.
+  config.test = {
+    ...config.test,
+    maxWorkers: 1,
+    fileParallelism: false,
+    sequence: {
+      ...config.test?.sequence,
+      groupOrder: 1,
+    },
+  };
+  return config;
 }
 
 export default createAutoReplyReplyVitestConfig();

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3913,8 +3913,18 @@ td.data-table-key-col {
 
 /* Reading indicator */
 .chat-bubble.chat-reading-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
   width: fit-content;
   padding: 10px 16px;
+}
+
+.chat-reading-indicator__label {
+  color: var(--chat-text);
+  font-size: 0.95rem;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .chat-reading-indicator__dots {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -138,6 +138,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.chatStreamSegments = [];
   state.chatThinkingLevel = null;
   state.chatStream = null;
+  state.chatStreamEphemeral = false;
   state.chatSideResult = null;
   state.lastError = null;
   state.chatAvatarUrl = null;

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -49,6 +49,7 @@ type ToolStreamHost = {
   chatRunId: string | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
+  chatStreamEphemeral?: boolean;
   chatStreamSegments: Array<{ text: string; ts: number }>;
   toolStreamById: Map<string, ToolStreamEntry>;
   toolStreamOrder: string[];
@@ -355,6 +356,7 @@ export function resetToolStream(host: ToolStreamHost) {
   host.toolStreamOrder = [];
   host.chatToolMessages = [];
   host.chatStreamSegments = [];
+  host.chatStreamEphemeral = false;
 }
 
 export type CompactionStatus = {
@@ -699,6 +701,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       host.chatStreamSegments = [...host.chatStreamSegments, { text: host.chatStream, ts: now }];
       host.chatStream = null;
       host.chatStreamStartedAt = null;
+      host.chatStreamEphemeral = false;
     }
     entry = {
       toolCallId,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -96,6 +96,7 @@ export type AppViewState = {
   chatStreamSegments: Array<{ text: string; ts: number }>;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
+  chatStreamEphemeral: boolean;
   chatRunId: string | null;
   chatSideResult: ChatSideResult | null;
   chatSideResultTerminalRuns: Set<string>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -184,6 +184,7 @@ export class OpenClawApp extends LitElement {
   eventLogBuffer: EventLogEntry[] = [];
   toolStreamSyncTimer: number | null = null;
   private sidebarCloseTimer: number | null = null;
+  private _disconnectTimer: number | null = null;
 
   @state() assistantName = bootAssistantIdentity.name;
   @state() assistantAvatar = bootAssistantIdentity.avatar;
@@ -211,6 +212,7 @@ export class OpenClawApp extends LitElement {
   @state() chatStreamSegments: Array<{ text: string; ts: number }> = [];
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
+  @state() chatStreamEphemeral = false;
   @state() chatRunId: string | null = null;
   @state() chatSideResult: ChatSideResult | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
@@ -646,6 +648,11 @@ export class OpenClawApp extends LitElement {
 
   override connectedCallback() {
     super.connectedCallback();
+    const hadPendingDisconnect = this._disconnectTimer !== null;
+    if (this._disconnectTimer !== null) {
+      window.clearTimeout(this._disconnectTimer);
+      this._disconnectTimer = null;
+    }
     this.onSlashAction = async (action: string) => {
       switch (action) {
         case "new-session":
@@ -669,7 +676,9 @@ export class OpenClawApp extends LitElement {
     document.addEventListener("keydown", this.globalKeydownHandler);
     document.addEventListener("keydown", this.chatMobileControlsKeydownHandler);
     document.addEventListener("pointerdown", this.chatMobileControlsPointerdownHandler);
-    handleConnected(this as unknown as Parameters<typeof handleConnected>[0]);
+    if (!hadPendingDisconnect) {
+      handleConnected(this as unknown as Parameters<typeof handleConnected>[0]);
+    }
     this.nativeBridgeCleanup = initNativeBridge(this);
     void this.initWebPushState();
   }
@@ -693,7 +702,13 @@ export class OpenClawApp extends LitElement {
       this.sessionSwitchFlashTimer = null;
     }
     this.chatMobileControlsTrigger = null;
-    handleDisconnected(this as unknown as Parameters<typeof handleDisconnected>[0]);
+    if (this._disconnectTimer !== null) {
+      window.clearTimeout(this._disconnectTimer);
+    }
+    this._disconnectTimer = window.setTimeout(() => {
+      this._disconnectTimer = null;
+      handleDisconnected(this as unknown as Parameters<typeof handleDisconnected>[0]);
+    }, 250);
     super.disconnectedCallback();
   }
 

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -330,8 +330,9 @@ export function renderReadingIndicatorGroup(
     <div class="chat-group assistant">
       ${renderChatAvatar("assistant", assistant, undefined, basePath, authToken)}
       <div class="chat-group-messages">
-        <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
-          <span class="chat-reading-indicator__dots">
+        <div class="chat-bubble chat-reading-indicator" role="status" aria-live="polite">
+          <span class="chat-reading-indicator__label">Got it. I'm on it.</span>
+          <span class="chat-reading-indicator__dots" aria-hidden="true">
             <span></span><span></span><span></span>
           </span>
         </div>

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -493,5 +493,15 @@ describe("message-normalizer", () => {
 
       expect(result.senderLabel).toBe("Iris");
     });
+
+    it("hides the Control UI transport sender label for local user messages", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content: "Hello from the browser",
+        senderLabel: "openclaw-control-ui",
+      });
+
+      expect(result.senderLabel).toBeNull();
+    });
   });
 });

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -503,5 +503,15 @@ describe("message-normalizer", () => {
 
       expect(result.senderLabel).toBeNull();
     });
+
+    it("preserves Control UI-like sender labels on non-user messages", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: "Assistant reply",
+        senderLabel: "openclaw-control-ui",
+      });
+
+      expect(result.senderLabel).toBe("openclaw-control-ui");
+    });
   });
 });

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -444,7 +444,8 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   const id = typeof m.id === "string" ? m.id : undefined;
   const rawSenderLabel =
     typeof m.senderLabel === "string" && m.senderLabel.trim() ? m.senderLabel.trim() : null;
-  const senderLabel = rawSenderLabel === "openclaw-control-ui" ? null : rawSenderLabel;
+  const senderLabel =
+    role === "user" && rawSenderLabel === "openclaw-control-ui" ? null : rawSenderLabel;
 
   content = stripMessageDisplayMetadata(content);
 

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -442,8 +442,9 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
 
   const timestamp = typeof m.timestamp === "number" ? m.timestamp : Date.now();
   const id = typeof m.id === "string" ? m.id : undefined;
-  const senderLabel =
+  const rawSenderLabel =
     typeof m.senderLabel === "string" && m.senderLabel.trim() ? m.senderLabel.trim() : null;
+  const senderLabel = rawSenderLabel === "openclaw-control-ui" ? null : rawSenderLabel;
 
   content = stripMessageDisplayMetadata(content);
 

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -18,6 +18,7 @@ type RunLifecycleHost = Partial<Parameters<typeof resetToolStream>[0]> & {
   chatRunId?: string | null;
   chatStream?: string | null;
   chatStreamStartedAt?: number | null;
+  chatStreamEphemeral?: boolean;
   chatSideResultTerminalRuns?: Set<string>;
   compactionStatus?: CompactionStatus | null;
   compactionClearTimer?: TimerHandle | number | null;
@@ -165,6 +166,7 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
   if (options.clearChatStream) {
     host.chatStream = null;
     host.chatStreamStartedAt = null;
+    host.chatStreamEphemeral = false;
   }
   if (options.clearLocalRun) {
     host.chatRunId = null;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -395,6 +395,72 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Alpha");
   });
 
+  it("shows preflight acknowledgement without persisting it on final", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "",
+      chatStreamStartedAt: 100,
+    });
+    const preflight: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "preflight",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Got it. I am inspecting that now." }],
+      },
+    };
+
+    expect(handleChatEvent(state, preflight)).toBe("preflight");
+    expect(state.chatStream).toBe("Got it. I am inspecting that now.");
+    expect(state.chatStreamEphemeral).toBe(true);
+
+    const final: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+    expect(handleChatEvent(state, final)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
+    expect(state.chatStream).toBe(null);
+  });
+
+  it("persists real streamed text that replaces a preflight acknowledgement", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Got it. I am inspecting that now.",
+      chatStreamEphemeral: true,
+      chatStreamStartedAt: 100,
+    });
+    const delta: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the actual reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, delta)).toBe("delta");
+    expect(state.chatStream).toBe("Here is the actual reply");
+    expect(state.chatStreamEphemeral).toBe(false);
+
+    const final: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+    expect(handleChatEvent(state, final)).toBe("final");
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.chatMessages[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Here is the actual reply" }],
+    });
+  });
+
   it("returns final for another run when payload has no message", () => {
     const state = createActiveStreamingState();
     const payload: ChatEventPayload = {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -277,6 +277,7 @@ export type ChatState = {
   chatRunId: string | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
+  chatStreamEphemeral?: boolean;
   lastError: string | null;
   resetChatInputHistoryNavigation?: () => void;
 };
@@ -284,7 +285,7 @@ export type ChatState = {
 export type ChatEventPayload = {
   runId?: string;
   sessionKey: string;
-  state: "delta" | "final" | "aborted" | "error";
+  state: "preflight" | "delta" | "final" | "aborted" | "error";
   message?: unknown;
   errorMessage?: string;
 };
@@ -357,6 +358,7 @@ export async function loadChatHistory(state: ChatState) {
     maybeResetToolStream(state);
     state.chatStream = null;
     state.chatStreamStartedAt = null;
+    state.chatStreamEphemeral = false;
   } catch (err) {
     if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey)) {
       return;
@@ -564,6 +566,7 @@ export async function sendChatMessage(
   state.chatRunId = runId;
   state.chatStream = "";
   state.chatStreamStartedAt = now;
+  state.chatStreamEphemeral = false;
 
   try {
     await requestChatSend(state, { message: msg, attachments, runId });
@@ -701,7 +704,17 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       clearChatStream: true,
     });
 
-  if (payload.state === "delta") {
+  if (payload.state === "preflight") {
+    if (!state.chatRunId || payload.runId !== state.chatRunId) {
+      return null;
+    }
+    const next = extractText(payload.message);
+    if (typeof next === "string" && next.trim().length > 0 && !isSilentReplyStream(next)) {
+      state.chatStream = next;
+      state.chatStreamStartedAt = state.chatStreamStartedAt ?? Date.now();
+      state.chatStreamEphemeral = true;
+    }
+  } else if (payload.state === "delta") {
     const next = extractText(payload.message);
     if (
       typeof next === "string" &&
@@ -709,6 +722,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       !isAssistantHeartbeatAckForDisplay(payload.message)
     ) {
       state.chatStream = next;
+      state.chatStreamEphemeral = false;
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
@@ -716,6 +730,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       state.chatMessages = [...state.chatMessages, finalMessage];
     } else if (
       state.chatStream?.trim() &&
+      state.chatStreamEphemeral !== true &&
       !isSilentReplyStream(state.chatStream) &&
       !isHeartbeatAckStream(state.chatStream)
     ) {
@@ -737,6 +752,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       const streamedText = state.chatStream ?? "";
       if (
         streamedText.trim() &&
+        state.chatStreamEphemeral !== true &&
         !isSilentReplyStream(streamedText) &&
         !isHeartbeatAckStream(streamedText)
       ) {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -143,6 +143,7 @@ vi.mock("../chat/grouped-render.ts", () => ({
   renderReadingIndicatorGroup: () => {
     const element = document.createElement("div");
     element.className = "chat-reading-indicator";
+    element.textContent = "Got it. I'm on it.";
     return element;
   },
   renderStreamingGroup: (text: string) => {
@@ -558,6 +559,7 @@ describe("chat loading skeleton", () => {
 
     expect(container.querySelector(".chat-loading-skeleton")).toBeNull();
     expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
+    expect(container.textContent).toContain("Got it. I'm on it.");
   });
 
   it("lets terminal run status win over stale abortable session UI", () => {


### PR DESCRIPTION
## Summary

- Problem: main WebChat could appear stuck or lose visible continuity because accepted browser sends were not surfaced early enough, brief Control UI detach/reattach could tear down websocket state, and high-context sessions could wait too long before native compaction.
- Why it matters: users could send a prompt, see no acknowledgement/progress, refresh to recover, and risk losing confidence that the backend accepted the turn.
- What changed: added early WebChat preflight/receipt handling, pending user-turn history continuity, delayed Control UI disconnect cleanup, safer session reset transcript allocation, earlier preflight compaction gates, and focused tests.
- What did NOT change (scope boundary): default WebChat tool capability policy is not restricted; explicit/custom reset transcript paths are preserved; user-authored `System:` text is no longer globally stripped.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: WebChat accepted browser sends and streamed assistant progress were coupled too tightly to later transcript/history and socket lifecycle updates; reset could reuse stale default transcript file metadata for a new session id; and preflight compaction could miss fresh persisted token totals.
- Missing detection / guardrail: coverage did not lock in pending user-turn visibility, stale-default reset transcript replacement, user-authored `System:` preservation, or the exact preflight compaction threshold behavior.
- Contributing context (if known): local reproduction showed replies/pending turns sometimes became visible only after refresh, and short visible chats could still carry high cached context from app-server trajectory/tool history.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.sessions.reset-models.test.ts`, `src/auto-reply/reply/strip-inbound-meta.test.ts`, `src/gateway/server-methods/chat.inject.parentid.test.ts`, `src/gateway/server.chat.gateway-server-chat.test.ts`, `ui/src/ui/controllers/chat.test.ts`, `ui/src/ui/views/chat.test.ts`, `ui/src/ui/chat/message-normalizer.test.ts`, plus compaction/memory-flush tests already in the branch.
- Scenario the test should lock in: accepted WebChat turns remain visible through history refresh, reset avoids stale default transcript reuse while preserving explicit custom transcript paths, user-authored `System:` lines remain intact, preflight acknowledgement text stays ephemeral, and preflight compaction gates trigger from fresh token totals.
- Why this is the smallest reliable guardrail: these tests cover the server history/reset/sanitizer contracts and the UI message normalization/rendering paths without requiring a browser E2E harness.
- Existing test that already covers this (if any): existing chat history/UI tests cover parts of message normalization and rendering; this PR adds/updates focused reset, sanitizer, preflight, pending-history, and message-normalizer coverage for the review findings.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Control UI WebChat should show a received/working state sooner, keep the pending user prompt visible during refresh/reconnect windows, and avoid unnecessary context saturation before compaction. Default WebChat tools/capabilities are unchanged by this PR.

## Diagram (if applicable)

```text
Before:
[user sends prompt] -> [chat.send accepted] -> [history/socket lag] -> [user may refresh to see progress]

After:
[user sends prompt] -> [preflight receipt + pending user turn] -> [history catches up] -> [final assistant reply]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: macOS local development checkout
- Runtime/container: local OpenClaw source checkout
- Model/provider: N/A for automated tests
- Integration/channel (if any): Control UI WebChat / gateway session APIs
- Relevant config (redacted): main WebChat session `agent:main:main`

### Steps

1. Send a main WebChat prompt while the session is slow/high-context or while the page refreshes/reconnects.
2. Observe whether the user turn and assistant working/receipt state are visible before final transcript history catches up.
3. Reset a session that has a stale default transcript path and a session that has an explicit custom transcript path.
4. Display/history-sanitize a user message beginning with `System:`.
5. Exercise ordinary prompts that contain `exactly` to make sure they still receive preflight acknowledgement, while explicit output-only/silent prompts do not.

### Expected

- User turn remains visible after accepted send/refresh.
- Assistant preflight/progress state can render before final reply without becoming a durable assistant message.
- Reset allocates a new default transcript for a new session id, but preserves explicit custom transcript files.
- User-authored leading `System:` text is preserved.
- The Control UI transport label is hidden only for local user messages, not assistant/tool messages.

### Actual

- Before this PR, visibility could lag until refresh, reset could reuse a stale default transcript path, and the original branch globally stripped leading `System:` text. After the latest patch, focused tests cover the intended behavior and the latest Copilot review comments are addressed in the current head.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Recorded verification for the current head `4cb8cce017b0ce976c691066b524f417dd2f633a`:

- `corepack pnpm test src/agents/prompt-overlay-runtime-contract.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply.raw-body.test.ts src/gateway/server.sessions.reset-models.test.ts` passed: 3 Vitest shards, 74 tests.
- `corepack pnpm test src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/chat/message-normalizer.test.ts` passed: 2 Vitest shards, 169 tests.
- `corepack pnpm exec oxfmt --check --threads=1 src/agents/gpt5-prompt-overlay.ts src/agents/prompt-overlay-runtime-contract.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/gateway/server-methods/chat.ts ui/src/ui/controllers/chat.ts ui/src/ui/chat/run-lifecycle.ts ui/src/ui/chat/message-normalizer.ts ui/src/ui/views/chat.test.ts ui/src/ui/chat/message-normalizer.test.ts` passed.
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.core.json` passed.
- `git diff --check` passed.
- Live GitHub PR checks for current head are successful, with only expected skipped `backfill-pr-labels`.

Note: a prior non-elevated gateway test run hit local sandbox `listen EPERM 127.0.0.1`, then passed when rerun with local loopback binding allowed.

## Human Verification (required)

- Verified scenarios: source diff reviewed against BunsDev, ClawSweeper, Barnacle, and Copilot findings; focused prompt-overlay, server, UI, and session tests passed; PR branch head is `4cb8cce017b0ce976c691066b524f417dd2f633a`.
- Edge cases checked: custom reset transcript path preservation, stale default reset transcript replacement, preservation of user-authored `System:` lines, no hard-coded WebChat `toolsAllow` remains, Control UI transport sender label is hidden only for user messages, ordinary prompts containing `exactly` still receive acknowledgement, upstream heartbeat-ack filtering remains combined with this PR's ephemeral preflight-stream guard, and the global GPT-5 stable prefix no longer asks the model to emit a second durable acknowledgement.
- What you did **not** verify: full browser E2E on GitHub CI, maintainer-specific release packaging, or a production OpenClaw update containing this PR.

## Real behavior proof

- Behavior or issue addressed: Main Control UI WebChat reliability for accepted browser sends: pending user turns should remain visible through history refresh/reconnect, preflight/working state should not become a persisted assistant final, generic runtime system events should still reach the reply run, and the PR branch should remain mergeable after upstream `main` churn.
- Real environment tested: macOS local OpenClaw source checkout at PR head `4cb8cce017b0ce976c691066b524f417dd2f633a`, branch `codex/openclaw-ui-reliability-upstream`. GitHub CLI/API was run against the live PR `openclaw/openclaw#75776`; focused Control UI/Gateway behavior was run from the local source checkout.
- Exact steps or command run after this patch: rebased the branch onto current `main`, resolved the system-event test conflict created by upstream's `drainFormattedSystemEventBlock` shape, removed the global GPT-5 stable-prefix progress acknowledgement so the WebChat receipt remains gateway/UI-owned and ephemeral, ran the focused verification listed above, pushed the branch, then checked live GitHub mergeability/check state for the current head.
- Evidence after fix: Terminal capture from the live GitHub PR and current head:

```text
$ gh pr view 75776 --repo openclaw/openclaw --json headRefOid,baseRefOid,mergeable,mergeStateStatus,reviewDecision
{"baseRefOid":"9c389487002ca7d8558bd7ae98e310a44dfee0fa","headRefOid":"4cb8cce017b0ce976c691066b524f417dd2f633a","mergeStateStatus":"UNSTABLE","mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED"}

$ gh api repos/openclaw/openclaw/pulls/75776 --jq '{mergeable,mergeable_state,rebaseable,head_sha:.head.sha,base_sha:.base.sha}'
{"base_sha":"9c389487002ca7d8558bd7ae98e310a44dfee0fa","head_sha":"4cb8cce017b0ce976c691066b524f417dd2f633a","mergeable":true,"mergeable_state":"unstable","rebaseable":true}

Current checks:
Real behavior proof: pass
Socket Security: Project Report: pass
Socket Security: Pull Request Alerts: pass
auto-response: pass
dependency-change-awareness: pass
dispatch: pass
label: pass
label-issues: pass
backfill-pr-labels: skipped
```

- Current-code review proof for the latest Copilot findings:
  - `ui/src/ui/chat/message-normalizer.ts` now hides `openclaw-control-ui` only when `role === "user"`.
  - `src/gateway/server-methods/chat.ts` no longer treats `exactly` alone as a blanket acknowledgement-suppression phrase; suppression is limited to explicit silence/output-only wording.
- Current-code review proof for the latest ClawSweeper finding:
  - `src/agents/gpt5-prompt-overlay.ts` no longer contains the global `<progress_acknowledgement>` stable-prefix block.
  - `src/agents/prompt-overlay-runtime-contract.test.ts` now asserts that the GPT-5 stable prefix does not contain `<progress_acknowledgement>`.
- Observed result after fix: The latest PR head is mergeable against current `main`, checks are green/skipped as expected, the active code addresses the two Copilot findings plus the ClawSweeper P2 durable-acknowledgement finding, and focused source-run verification covers the server/UI/prompt behavior this PR changes.
- What was not tested: Full browser E2E against a packaged release build, maintainer release packaging, and production OpenClaw update delivery were not tested in this PR checkout.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

ClawSweeper issue-comment findings were addressed in commit `a4396316` and later follow-up commits; BunsDev's system-event review was addressed in the current branch; the two Copilot comments from May 9 are addressed at current head `4cb8cce017b0ce976c691066b524f417dd2f633a`; the ClawSweeper P2 about a second durable GPT-5 acknowledgement is addressed by removing the global `<progress_acknowledgement>` stable-prefix block.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: WebChat acknowledgement/progress copy could be perceived as an assistant response if final streaming fails.
  - Mitigation: preflight receipt is ephemeral UI state and final transcript/history remains authoritative.
- Risk: reset transcript handling could accidentally preserve stale default files or drop custom files.
  - Mitigation: reset now preserves only non-default/custom sessionFile paths and adds coverage for stale default replacement plus existing custom-file preservation.
- Risk: earlier context compaction may run more often for high-context sessions.
  - Mitigation: threshold is bounded and only triggers from persisted/fresh token pressure; normal low-context sessions are unaffected.
