### PR TITLE
fix(gateway): include auth mode "none" in backend self-pairing skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@ Docs: https://docs.openclaw.ai
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.
+- Gateway/auth: allow `gateway.auth.mode: "none"` loopback backend RPC clients to skip device identity only for local non-browser backend connections, restoring subagent spawns and gateway tools without opening remote or browser-origin bypasses. Fixes #75780. Thanks @yozakura-ava.
 - Tavily: resolve dedicated `tavily_search` and `tavily_extract` tool credentials from the active runtime config snapshot, so `exec` SecretRef-backed API keys do not reach the tools unresolved. (#78610) Thanks @VACInc.
 - Gateway/sessions: clear cached skills snapshots during `/new` and `sessions.reset` so long-lived channel sessions rebuild the visible skill list after skills change. (#78873) Thanks @Evizero.
 - fix(auto-reply): gate inline skill tool dispatch [AI]. (#78517) Thanks @pgondhi987.
@@ -1199,7 +1200,6 @@ Docs: https://docs.openclaw.ai
 - Agents/replies: defer implicit image model discovery and keep OAuth auth-store adoption on persisted profiles during reply startup, cutting OCM MarCodex warm prep to sub-second in live checks. Thanks @shakkernerd.
 - Plugins/tools: enforce `contracts.tools` as the manifest ownership contract for plugin tool registration, rejecting undeclared runtime tool names and adding bundled plugin drift coverage. Thanks @shakkernerd.
 - Agents/Codex: stop prompting message-tool-only source turns to finish with `NO_REPLY`, so quiet turns are represented by not calling the visible message tool instead of conflicting final-text instructions. Thanks @pashpashpash.
-
 - Gateway/config: report failed backup restores as failed in logs and config observe audit records instead of marking them valid. (#70515) Thanks @davidangularme.
 - Compaction: use the active session model fallback chain for implicit summarization failures without persisting fallback model selection, so Azure content-filter 400s can recover. Fixes #64960. (#74470) Thanks @jalehman and @OpenCodeEngineer.
 - Gateway/config: allow `gateway config.patch` to update documented subagent thinking defaults. Fixes #75764. (#75802) Thanks @kAIborg24.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1199,6 +1199,7 @@ Docs: https://docs.openclaw.ai
 - Agents/replies: defer implicit image model discovery and keep OAuth auth-store adoption on persisted profiles during reply startup, cutting OCM MarCodex warm prep to sub-second in live checks. Thanks @shakkernerd.
 - Plugins/tools: enforce `contracts.tools` as the manifest ownership contract for plugin tool registration, rejecting undeclared runtime tool names and adding bundled plugin drift coverage. Thanks @shakkernerd.
 - Agents/Codex: stop prompting message-tool-only source turns to finish with `NO_REPLY`, so quiet turns are represented by not calling the visible message tool instead of conflicting final-text instructions. Thanks @pashpashpash.
+
 - Gateway/config: report failed backup restores as failed in logs and config observe audit records instead of marking them valid. (#70515) Thanks @davidangularme.
 - Compaction: use the active session model fallback chain for implicit summarization failures without persisting fallback model selection, so Azure content-filter 400s can recover. Fixes #64960. (#74470) Thanks @jalehman and @OpenCodeEngineer.
 - Gateway/config: allow `gateway config.patch` to update documented subagent thinking defaults. Fixes #75764. (#75802) Thanks @kAIborg24.

--- a/src/gateway/server.auth.compat-baseline.test.ts
+++ b/src/gateway/server.auth.compat-baseline.test.ts
@@ -333,6 +333,52 @@ describe("gateway auth compatibility baseline", () => {
       }
     });
 
+    test("allows auth-none local backend connects without device identity", async () => {
+      const ws = await openWs(port);
+      try {
+        const res = await connectReq(ws, {
+          skipDefaultAuth: true,
+          client: { ...BACKEND_GATEWAY_CLIENT },
+          scopes: ["operator.admin"],
+          device: null,
+        });
+        expect(res.ok, JSON.stringify(res)).toBe(true);
+
+        const helloOk = res.payload as
+          | {
+              auth?: {
+                scopes?: unknown;
+              };
+            }
+          | undefined;
+        expect(helloOk?.auth?.scopes).toEqual(["operator.admin"]);
+
+        const adminRes = await rpcReq(ws, "set-heartbeats", { enabled: false });
+        expect(adminRes.ok).toBe(true);
+      } finally {
+        ws.close();
+      }
+    });
+
+    test("rejects auth-none browser-origin backend connects without device identity", async () => {
+      const ws = await openWs(port, { origin: originForPort(port) });
+      try {
+        const res = await connectReq(ws, {
+          skipDefaultAuth: true,
+          client: { ...BACKEND_GATEWAY_CLIENT },
+          scopes: ["operator.admin"],
+          device: null,
+        });
+        expect(res.ok).toBe(false);
+        expect(res.error?.message ?? "").toContain("device identity required");
+        expect((res.error?.details as { code?: string } | undefined)?.code).toBe(
+          ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED,
+        );
+      } finally {
+        ws.close();
+      }
+    });
+
     test("keeps auth-none control ui first-connect token absence unchanged", async () => {
       const ws = await openWs(port, { origin: originForPort(port) });
       try {

--- a/src/gateway/server/ws-connection/auth-context.state.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.state.test.ts
@@ -82,6 +82,7 @@ describe("resolveConnectAuthDecision", () => {
     const state = await resolveConnectAuthState({
       resolvedAuth: {
         mode: "none",
+        allowTailscale: false,
       } satisfies ResolvedGatewayAuth,
       connectAuth: {},
       hasDeviceIdentity: false,

--- a/src/gateway/server/ws-connection/auth-context.state.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.state.test.ts
@@ -78,6 +78,31 @@ describe("resolveConnectAuthState", () => {
 });
 
 describe("resolveConnectAuthDecision", () => {
+  it("sets sharedAuthOk false when auth mode is none (no shared secret provided)", async () => {
+    const state = await resolveConnectAuthState({
+      resolvedAuth: {
+        mode: "none",
+      } satisfies ResolvedGatewayAuth,
+      connectAuth: {},
+      hasDeviceIdentity: false,
+      req: {
+        headers: {},
+        socket: { remoteAddress: "127.0.0.1" },
+      } as never,
+      trustedProxies: [],
+      allowRealIpFallback: false,
+      rateLimiter: createLimiter(),
+      clientIp: "127.0.0.1",
+    });
+
+    expect(state.authOk).toBe(true);
+    expect(state.authMethod).toBe("none");
+    // auth:none does NOT set sharedAuthOk globally — it's not a shared secret.
+    // Only shouldSkipLocalBackendSelfPairing treats auth:none as shared-auth-scoped
+    // for local backend connections specifically.
+    expect(state.sharedAuthOk).toBe(false);
+  });
+
   it("resets the shared-secret limiter after device-token auth succeeds", async () => {
     const rateLimiter = createLimiter();
     await resolveConnectAuthDecision({

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -135,6 +135,36 @@ describe("ws connect policy", () => {
         isControlUi: false,
         controlUiAuthPolicy: policy,
         trustedProxyAuthOk: false,
+        localBackendSelfPairingOk: true,
+        sharedAuthOk: false,
+        authOk: true,
+        hasSharedAuth: false,
+        isLocalClient: true,
+      }).kind,
+    ).toBe("allow");
+
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "node",
+        isControlUi: false,
+        controlUiAuthPolicy: policy,
+        trustedProxyAuthOk: false,
+        localBackendSelfPairingOk: true,
+        sharedAuthOk: false,
+        authOk: true,
+        hasSharedAuth: false,
+        isLocalClient: true,
+      }).kind,
+    ).toBe("reject-device-required");
+
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "operator",
+        isControlUi: false,
+        controlUiAuthPolicy: policy,
+        trustedProxyAuthOk: false,
         sharedAuthOk: false,
         authOk: false,
         hasSharedAuth: true,

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -111,6 +111,7 @@ export function evaluateMissingDeviceIdentity(params: {
   isControlUi: boolean;
   controlUiAuthPolicy: ControlUiAuthPolicy;
   trustedProxyAuthOk?: boolean;
+  localBackendSelfPairingOk?: boolean;
   sharedAuthOk: boolean;
   authOk: boolean;
   hasSharedAuth: boolean;
@@ -128,6 +129,9 @@ export function evaluateMissingDeviceIdentity(params: {
     // sessions only; node-role sessions must still satisfy device identity so
     // that the break-glass flag cannot be abused to admit device-less node
     // registrations (see #45405 review).
+    return { kind: "allow" };
+  }
+  if (params.localBackendSelfPairingOk && params.role === "operator") {
     return { kind: "allow" };
   }
   if (params.isControlUi && !params.controlUiAuthPolicy.allowBypass) {

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -451,6 +451,64 @@ describe("handshake auth helpers", () => {
     ).toBe(false);
   });
 
+  it("skips backend self-pairing when auth mode is none (scoped, sharedAuthOk-independent)", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      },
+    } as ConnectParams;
+    // auth:none on local backend skips regardless of sharedAuthOk
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "none",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "shared_secret_loopback_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "none",
+      }),
+    ).toBe(true);
+    // sharedAuthOk=false is fine for auth:none on local backend
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "none",
+      }),
+    ).toBe(true);
+    // Remote connections with auth:none should NOT skip
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "remote",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "none",
+      }),
+    ).toBe(false);
+    // Browser origin with auth:none should NOT skip
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authMethod: "none",
+      }),
+    ).toBe(false);
+  });
+
   it("classifies non-CLI loopback + shared-secret clients as shared_secret_loopback_local", () => {
     const connectParams = {
       client: {

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -262,13 +262,19 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   if (!isBackendClient) {
     return false;
   }
+  const isLocal =
+    params.locality === "direct_local" || params.locality === "shared_secret_loopback_local";
+  if (!isLocal || params.hasBrowserOriginHeader) {
+    return false;
+  }
+  // No-auth local backend: scoped bypass — not shared secret, but local-only
+  // device-less operation is safe when auth.mode is explicitly "none".
+  if (params.authMethod === "none") {
+    return true;
+  }
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   const usesDeviceTokenAuth = params.authMethod === "device-token";
-  return (
-    (params.locality === "direct_local" || params.locality === "shared_secret_loopback_local") &&
-    !params.hasBrowserOriginHeader &&
-    ((params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth)
-  );
+  return (params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth;
 }
 
 function resolveSignatureToken(connectParams: ConnectParams): string | null {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -673,6 +673,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             isControlUi,
             controlUiAuthPolicy,
             trustedProxyAuthOk,
+            localBackendSelfPairingOk: skipLocalBackendSelfPairing,
             sharedAuthOk,
             authOk,
             hasSharedAuth,


### PR DESCRIPTION
## Summary

Fixes #75780

When `gateway.auth.mode` is `"none"`, local non-browser backend RPC clients (`gateway-client` in `backend` mode) still hit `device identity required` because the backend self-pairing skip was not wired into the missing-device decision path.

## Changes

- Thread the existing scoped local backend self-pairing decision into `evaluateMissingDeviceIdentity`.
- Keep the bypass limited to operator-role, local, non-browser backend connections.
- Add full Gateway auth compatibility coverage for auth-none backend success and browser-origin rejection.
- Add a changelog fix entry.

## Testing

- `pnpm test src/gateway/server/ws-connection/handshake-auth-helpers.test.ts src/gateway/server/ws-connection/auth-context.state.test.ts src/gateway/server/ws-connection/connect-policy.test.ts`
- `pnpm test src/gateway/server.auth.compat-baseline.test.ts`
- `pnpm test src/gateway/server.auth.modes.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server/ws-connection/connect-policy.ts src/gateway/server/ws-connection/message-handler.ts src/gateway/server/ws-connection/connect-policy.test.ts src/gateway/server.auth.compat-baseline.test.ts CHANGELOG.md`
- `git diff --check`
- `pnpm build`

## Real Behavior Proof

Behavior or issue addressed: `gateway.auth.mode: "none"` local backend RPC clients should connect without a device identity when they are local, non-browser backend connections, while browser-origin backend claims still fail with `device identity required`.

Real environment tested: macOS, local source checkout at PR 75781 maintainer fix, Node 24.1.0, isolated temp OpenClaw config/state. Gateway started on loopback with `gateway.auth.mode: "none"` and port 28781.

Exact steps or command run after this patch: Built the PR, started `pnpm openclaw gateway run --port 28781 --auth none --bind loopback --allow-unconfigured --verbose --compact` with temp `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`, then ran configured CLI probes and a raw `ws` backend client probe against the live loopback Gateway.

Evidence after fix: Terminal output from the real Gateway process and live CLI/backend WebSocket probes is copied below.

Gateway startup proof:

```text
auth mode=none explicitly configured; all gateway connections are unauthenticated.
http server listening ...
gateway ready
```

Configured CLI probes:

```text
$ node dist/entry.js gateway health
Gateway Health
OK (56ms)

$ node dist/entry.js health
Agents: dev (default)
Heartbeat interval: 30m (dev)
Session store (dev): <temp-state>/agents/dev/sessions/sessions.json (1 entries)
- agent:dev:main (1m ago)

$ node dist/entry.js gateway status --deep --require-rpc
Read probe: ok
Capability: read-only
Listening: 127.0.0.1:28781
```

Backend RPC proof for the fixed path:

```text
backend_no_origin_connect_ok=true
backend_no_origin_scopes=["operator.admin"]
backend_admin_rpc_ok=true
backend_browser_origin_connect_ok=false
backend_browser_origin_error=device identity required
```

Observed result after fix: The local no-origin backend connection succeeded with `["operator.admin"]` scope and completed an admin RPC; the browser-origin backend connection was rejected with `device identity required`.

What was not tested: No additional gaps.

## Security Impact

The new allow path uses the existing `shouldSkipLocalBackendSelfPairing` locality/browser/client checks and only lets operator local backend self-pairing skip device identity. Browser-origin backend claims and remote/non-local paths still fail.
