### PR TITLE
fix(subagents): reconcile timed-out waits against child session state

### DIFF
--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -344,9 +344,10 @@ export async function readLatestSubagentOutputWithRetry(params: {
 export async function waitForSubagentRunOutcome(
   runId: string,
   timeoutMs: number,
+  sessionKey?: string,
 ): Promise<AgentWaitResult> {
   const waitMs = Math.max(0, Math.floor(timeoutMs));
-  return await subagentAnnounceOutputDeps.callGateway({
+  const wait = await subagentAnnounceOutputDeps.callGateway({
     method: "agent.wait",
     params: {
       runId,
@@ -354,6 +355,96 @@ export async function waitForSubagentRunOutcome(
     },
     timeoutMs: waitMs + 2000,
   });
+  if (wait?.status !== "timeout" || !sessionKey?.trim()) {
+    return wait;
+  }
+  return await reconcileTimedOutSubagentWaitUsingSessionEntry({ wait, sessionKey });
+}
+
+function findSessionEntryByKey(
+  store: Record<string, Record<string, unknown>>,
+  sessionKey: string,
+): Record<string, unknown> | undefined {
+  const direct = store[sessionKey];
+  if (direct) {
+    return direct;
+  }
+  const normalized = sessionKey.trim().toLowerCase();
+  for (const [key, entry] of Object.entries(store)) {
+    if (key.trim().toLowerCase() === normalized) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function loadSubagentSessionEntry(sessionKey: string): Record<string, unknown> | undefined {
+  const cfg = subagentAnnounceOutputDeps.getRuntimeConfig();
+  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  const store = loadSessionStore(storePath) as Record<string, Record<string, unknown>>;
+  return findSessionEntryByKey(store, sessionKey);
+}
+
+function resolveCompletionFromSessionEntry(
+  sessionEntry: Record<string, unknown> | undefined,
+  fallbackEndedAt?: number,
+): AgentWaitResult | undefined {
+  const status = typeof sessionEntry?.status === "string" ? sessionEntry.status : undefined;
+  const endedAt =
+    typeof sessionEntry?.endedAt === "number" && Number.isFinite(sessionEntry.endedAt)
+      ? sessionEntry.endedAt
+      : fallbackEndedAt;
+  if (status === "done") {
+    return { status: "ok", endedAt };
+  }
+  if (status === "timeout") {
+    return { status: "timeout", endedAt };
+  }
+  if (status === "failed") {
+    return {
+      status: "error",
+      endedAt,
+      error: "session completed before registry settled",
+    };
+  }
+  if (status === "killed") {
+    return {
+      status: "error",
+      endedAt,
+      error: "subagent run terminated",
+    };
+  }
+  if (status !== "running" && typeof sessionEntry?.endedAt === "number") {
+    return { status: "ok", endedAt };
+  }
+  return undefined;
+}
+
+async function reconcileTimedOutSubagentWaitUsingSessionEntry(params: {
+  wait: AgentWaitResult;
+  sessionKey: string;
+}): Promise<AgentWaitResult> {
+  const attempts = isFastTestMode() ? 1 : 4;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const sessionEntry = loadSubagentSessionEntry(params.sessionKey);
+    const resolved = resolveCompletionFromSessionEntry(
+      sessionEntry,
+      typeof params.wait.endedAt === "number" ? params.wait.endedAt : undefined,
+    );
+    if (resolved) {
+      return {
+        ...params.wait,
+        ...resolved,
+      };
+    }
+    if (attempt + 1 < attempts) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, isFastTestMode() ? FAST_TEST_RETRY_INTERVAL_MS : 100),
+      );
+    }
+  }
+  return params.wait;
 }
 
 export function applySubagentWaitOutcome(params: {

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -453,6 +453,48 @@ describe("subagent announce timeout config", () => {
     expect(internalEvents[0]?.result).not.toContain("data");
   });
 
+  it("reconciles a timed-out wait against persisted child success before announcing", async () => {
+    chatHistoryMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Inspection finished with the full result." }],
+      },
+    ];
+    sessionStore = {
+      "agent:main:subagent:worker": {
+        status: "done",
+        endedAt: 222,
+      },
+    };
+    callGatewayImpl = async (request) => {
+      if (request.method === "agent.wait") {
+        return { status: "timeout", startedAt: 111, endedAt: 200 };
+      }
+      if (request.method === "chat.history") {
+        return { messages: chatHistoryMessages };
+      }
+      return {};
+    };
+
+    await runAnnounceFlowForTest("run-timeout-reconciled-success", {
+      roundOneReply: undefined,
+      waitForCompletion: true,
+      outcome: undefined,
+    });
+
+    const directAgentCall = findFinalDirectAgentCall();
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{
+        status?: string;
+        statusLabel?: string;
+        result?: string;
+      }>) ?? [];
+    expect(internalEvents[0]?.status).toBe("ok");
+    expect(internalEvents[0]?.statusLabel).toBe("completed successfully");
+    expect(internalEvents[0]?.result).toContain("Inspection finished with the full result.");
+    expect(internalEvents[0]?.result).not.toContain("tool call(s) executed before timeout");
+  });
+
   it("does not announce cached reply text when the child run terminally failed", async () => {
     chatHistoryMessages = [
       { role: "assistant", content: [{ type: "text", text: "stale history output" }] },

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -272,7 +272,11 @@ export async function runSubagentAnnounceFlow(params: {
     }
 
     if (!reply && params.waitForCompletion !== false) {
-      const wait = await waitForSubagentRunOutcome(params.childRunId, settleTimeoutMs);
+      const wait = await waitForSubagentRunOutcome(
+        params.childRunId,
+        settleTimeoutMs,
+        params.childSessionKey,
+      );
       const applied = applySubagentWaitOutcome({
         wait,
         outcome,
@@ -404,7 +408,11 @@ export async function runSubagentAnnounceFlow(params: {
       // outcome instead of dropping the announcement entirely.
       if (outcome?.status === "timeout" && reply?.trim() && params.waitForCompletion !== false) {
         try {
-          const rechecked = await waitForSubagentRunOutcome(params.childRunId, 0);
+          const rechecked = await waitForSubagentRunOutcome(
+            params.childRunId,
+            0,
+            params.childSessionKey,
+          );
           const applied = applySubagentWaitOutcome({
             wait: rechecked,
             outcome,


### PR DESCRIPTION
Fixes #75785.

## Summary

Reconcile timed-out `agent.wait` results against the persisted child session state before announcing subagent completion.

This fixes a false-timeout path where the child run can finish successfully, but the parent-side completion handoff still reports `timed out` and falls back to a partial-progress stub.

## Problem / Motivation

The announce flow currently trusts the immediate `agent.wait` timeout result. In the observed failure mode, that timeout can be stale relative to the child session store state. When that happens, the parent announces a timeout even though the child session has already completed successfully.

## What Changed

- `src/agents/subagent-announce-output.ts`
  - `waitForSubagentRunOutcome(runId, timeoutMs, sessionKey?)` now optionally re-checks session-store state after a timeout
  - added helpers to load and interpret the child session entry
- `src/agents/subagent-announce.ts`
  - pass `childSessionKey` into `waitForSubagentRunOutcome(...)`
  - do the same for the immediate recheck path
- `src/agents/subagent-announce.timeout.test.ts`
  - adds a regression test covering a timed-out wait that should reconcile to persisted child success before announcing

## Why this is the smallest reliable guardrail

The reconciliation only runs:
- when `agent.wait` returns `timeout`
- when the child session key is available
- for a short bounded retry loop

Normal successful and failed paths are unchanged.

## User-visible / Behavior Changes

Parent sessions stop receiving false `timed out` completion events for already-finished child runs in this path.

## Diagram

```text
Before:
child finishes successfully -> agent.wait returns timeout -> parent announces timeout -> actual child result is replaced by partial progress

After:
child finishes successfully -> agent.wait returns timeout -> announce flow rechecks child session state -> parent announces success -> child result is delivered
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux 6.8
- Runtime/container: npm global install
- Model/provider: openai-codex/gpt-5.4
- Integration/channel: subagent completion announce path
- Relevant config: default subagent announce flow with completion handoff enabled

### Steps

1. Spawn a subagent that performs many tool calls and completes successfully.
2. Let the child session reach a terminal successful state.
3. Have the parent-side announce flow observe `agent.wait` return `timeout`.
4. Compare the child session state with the parent completion event.

### Expected

- Parent completion announce resolves to child success and includes the child result.

### Actual

- Parent completion announce can resolve to timeout and replace the child result with a partial-progress stub.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- Verified scenarios:
  - observed a child run with successful terminal state while the parent announce path still emitted a timeout result
  - applied equivalent reconciliation logic locally in the installed build and confirmed it corrected the announce outcome for that bug path
- Edge cases checked:
  - no reconciliation path is used unless `agent.wait` returns `timeout`
  - still falls back to original timeout result if the child session store is not terminal
- What I did not verify:
  - full upstream CI suite
  - multi-provider or multi-channel coverage beyond the local reproduction path

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: session-store terminal state could be briefly stale in the opposite direction
  - Mitigation: reconciliation runs only after a timeout and only upgrades the announce outcome when the child session entry is already terminal
- Risk: additional small read on timeout path
  - Mitigation: only occurs on timeout, with a short bounded retry loop
