### PR TITLE
Protect macOS config fallback from redacted secret clobbering

### DIFF
--- a/apps/macos/Sources/OpenClaw/ChannelConfigForm.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelConfigForm.swift
@@ -265,8 +265,10 @@ struct ConfigSchemaForm: View {
     private func stringBinding(_ path: ConfigPath, defaultValue: String?) -> Binding<String> {
         Binding(
             get: {
-                if let value = store.configValue(at: path) as? String { return value }
-                return defaultValue ?? ""
+                if let value = store.configValue(at: path) as? String {
+                    return value == "__OPENCLAW_REDACTED__" ? "" : value
+                }
+                return defaultValue == "__OPENCLAW_REDACTED__" ? "" : (defaultValue ?? "")
             },
             set: { newValue in
                 let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
@@ -6,7 +6,16 @@ enum OpenClawConfigFile {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "config")
     private static let configAuditFileName = "config-audit.jsonl"
     private static let configHealthFileName = "config-health.json"
+    private static let redactedSentinel = "__OPENCLAW_REDACTED__"
     private static let fileLock = NSRecursiveLock()
+
+    private struct RedactedSentinelRestoreError: LocalizedError {
+        let path: String
+
+        var errorDescription: String? {
+            "Refusing to save reserved redaction sentinel at \(self.path)."
+        }
+    }
 
     private static func withFileLock<T>(_ body: () throws -> T) rethrows -> T {
         self.fileLock.lock()
@@ -64,10 +73,10 @@ enum OpenClawConfigFile {
             let hadMetaBefore = self.hasMeta(previousRoot)
             let gatewayModeBefore = self.gatewayMode(previousRoot)
 
-            var output = dict
-            self.stampMeta(&output)
-
             do {
+                var output = try self.restoreRedactedSentinels(in: dict, original: previousRoot, path: [])
+                self.stampMeta(&output)
+
                 let data = try JSONSerialization.data(withJSONObject: output, options: [.prettyPrinted, .sortedKeys])
                 try FileManager().createDirectory(
                     at: url.deletingLastPathComponent(),
@@ -120,9 +129,9 @@ enum OpenClawConfigFile {
                     "previousBytes": previousBytes ?? NSNull(),
                     "nextBytes": NSNull(),
                     "hasMetaBefore": hadMetaBefore,
-                    "hasMetaAfter": self.hasMeta(output),
+                    "hasMetaAfter": self.hasMeta(dict),
                     "gatewayModeBefore": gatewayModeBefore ?? NSNull(),
-                    "gatewayModeAfter": self.gatewayMode(output) ?? NSNull(),
+                    "gatewayModeAfter": self.gatewayMode(dict) ?? NSNull(),
                     "suspicious": [],
                     "error": error.localizedDescription,
                 ])
@@ -615,6 +624,57 @@ enum OpenClawConfigFile {
         nextEntry["lastObservedSuspiciousSignature"] = signature
         state = self.setConfigHealthEntry(state: state, configPath: configURL.path, entry: nextEntry)
         self.writeConfigHealthState(state)
+    }
+
+    private static func restoreRedactedSentinels(
+        in incoming: [String: Any],
+        original: [String: Any]?,
+        path: ConfigPath) throws -> [String: Any]
+    {
+        var result: [String: Any] = [:]
+        for (key, value) in incoming {
+            let nextPath = path + [.key(key)]
+            let originalValue = original?[key]
+            result[key] = try self.restoreRedactedSentinels(
+                value,
+                original: originalValue,
+                path: nextPath)
+        }
+        return result
+    }
+
+    private static func restoreRedactedSentinels(
+        _ incoming: Any,
+        original: Any?,
+        path: ConfigPath) throws -> Any
+    {
+        if let string = incoming as? String, string == self.redactedSentinel {
+            if let original {
+                return original
+            }
+            throw RedactedSentinelRestoreError(path: pathKey(path).isEmpty ? "<root>" : pathKey(path))
+        }
+
+        if let array = incoming as? [Any] {
+            let originalArray = original as? [Any] ?? []
+            return try array.enumerated().map { index, item in
+                let originalItem = originalArray.indices.contains(index) ? originalArray[index] : nil
+                return try self.restoreRedactedSentinels(
+                    item,
+                    original: originalItem,
+                    path: path + [.index(index)])
+            }
+        }
+
+        if let dictionary = incoming as? [String: Any] {
+            let originalDictionary = original as? [String: Any]
+            return try self.restoreRedactedSentinels(
+                in: dictionary,
+                original: originalDictionary,
+                path: path)
+        }
+
+        return incoming
     }
 
     private static func appendConfigWriteAudit(_ fields: [String: Any]) {

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import OpenClaw
 
@@ -64,5 +65,60 @@ struct ConfigStoreTests {
         await ConfigStore._testClearOverrides()
         #expect(localHit)
         #expect(!remoteHit)
+    }
+
+    @Test func `local save fallback preserves gateway redacted secrets`() async throws {
+        let stateDir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-config-store-\(UUID().uuidString)", isDirectory: true)
+        let configPath = stateDir.appendingPathComponent("openclaw.json")
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_STATE_DIR": stateDir.path,
+            "OPENCLAW_CONFIG_PATH": configPath.path,
+            "OPENCLAW_GATEWAY_PORT": "1",
+        ]) {
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "local",
+                    "auth": [
+                        "mode": "token",
+                        "token": "real-secret-token",
+                    ],
+                ],
+                "channels": [
+                    "discord": [
+                        "enabled": true,
+                        "dmPolicy": "pairing",
+                    ],
+                ],
+            ])
+
+            await ConfigStore._testSetOverrides(.init(isRemoteMode: { false }))
+
+            try await ConfigStore.save([
+                "gateway": [
+                    "mode": "local",
+                    "auth": [
+                        "mode": "token",
+                        "token": "__OPENCLAW_REDACTED__",
+                    ],
+                ],
+                "channels": [
+                    "discord": [
+                        "enabled": true,
+                        "dmPolicy": "open",
+                    ],
+                ],
+            ])
+
+            let root = OpenClawConfigFile.loadDict()
+            let auth = ((root["gateway"] as? [String: Any])?["auth"] as? [String: Any]) ?? [:]
+            let discord = ((root["channels"] as? [String: Any])?["discord"] as? [String: Any]) ?? [:]
+            #expect(auth["token"] as? String == "real-secret-token")
+            #expect(discord["dmPolicy"] as? String == "open")
+
+            await ConfigStore._testClearOverrides()
+        }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
@@ -232,4 +232,128 @@ struct OpenClawConfigFileTests {
             }
         }
     }
+
+    @MainActor
+    @Test
+    func `save dict restores redacted sentinel from previous config`() async {
+        let override = self.makeConfigOverridePath()
+
+        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "local",
+                    "auth": [
+                        "mode": "token",
+                        "token": "real-token",
+                    ],
+                ],
+            ])
+
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "local",
+                    "auth": [
+                        "mode": "token",
+                        "token": "__OPENCLAW_REDACTED__",
+                    ],
+                ],
+            ])
+
+            let root = OpenClawConfigFile.loadDict()
+            let auth = ((root["gateway"] as? [String: Any])?["auth"] as? [String: Any]) ?? [:]
+            #expect(auth["token"] as? String == "real-token")
+        }
+    }
+
+    @MainActor
+    @Test
+    func `save dict restores redacted sentinel inside arrays from previous config`() async {
+        let override = self.makeConfigOverridePath()
+
+        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
+            OpenClawConfigFile.saveDict([
+                "channels": [
+                    "slack": [
+                        "accounts": [
+                            [
+                                "botToken": "first-token",
+                                "name": "first",
+                            ],
+                            [
+                                "botToken": "second-token",
+                                "name": "second",
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+
+            OpenClawConfigFile.saveDict([
+                "channels": [
+                    "slack": [
+                        "accounts": [
+                            [
+                                "botToken": "__OPENCLAW_REDACTED__",
+                                "name": "first-updated",
+                            ],
+                            [
+                                "botToken": "replacement-token",
+                                "name": "second-updated",
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+
+            let root = OpenClawConfigFile.loadDict()
+            let channels = root["channels"] as? [String: Any]
+            let slack = channels?["slack"] as? [String: Any]
+            let accounts = slack?["accounts"] as? [[String: Any]] ?? []
+            #expect(accounts.count == 2)
+            #expect(accounts[0]["botToken"] as? String == "first-token")
+            #expect(accounts[0]["name"] as? String == "first-updated")
+            #expect(accounts[1]["botToken"] as? String == "replacement-token")
+            #expect(accounts[1]["name"] as? String == "second-updated")
+        }
+    }
+
+    @MainActor
+    @Test
+    func `save dict rejects orphan redacted sentinel`() async throws {
+        let stateDir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
+        let configPath = stateDir.appendingPathComponent("openclaw.json")
+        let auditPath = stateDir.appendingPathComponent("logs/config-audit.jsonl")
+
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_STATE_DIR": stateDir.path,
+            "OPENCLAW_CONFIG_PATH": configPath.path,
+        ]) {
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "local",
+                    "auth": [
+                        "mode": "token",
+                        "token": "__OPENCLAW_REDACTED__",
+                    ],
+                ],
+            ])
+
+            #expect(!FileManager().fileExists(atPath: configPath.path))
+
+            let rawAudit = try String(contentsOf: auditPath, encoding: .utf8)
+            let lines = rawAudit
+                .split(whereSeparator: \.isNewline)
+                .map(String.init)
+            guard let last = lines.last else {
+                Issue.record("Missing failed config.write audit line")
+                return
+            }
+            let auditRoot = try JSONSerialization.jsonObject(with: Data(last.utf8)) as? [String: Any]
+            #expect(auditRoot?["result"] as? String == "failed")
+            #expect((auditRoot?["error"] as? String)?.contains("reserved redaction sentinel") == true)
+        }
+    }
 }

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -633,6 +633,13 @@ Both `config.apply` and `config.patch` accept `raw`, `baseHash`, `sessionKey`,
 `note`, and `restartDelayMs`. `baseHash` is required for both methods when a
 config already exists.
 
+Write-side secret safety:
+
+- `config.get` redacts sensitive values with the reserved sentinel `__OPENCLAW_REDACTED__`.
+- `config.set`, `config.apply`, and `config.patch` restore those redacted placeholders from the current on-disk config before validation/write.
+- Literal submissions of `__OPENCLAW_REDACTED__` are rejected when there is no original value to restore.
+- The macOS app's local-file fallback follows the same rule so an offline or degraded gateway save cannot clobber secrets in `openclaw.json`.
+
 ## Environment variables
 
 OpenClaw reads env vars from the parent process plus:

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -370,6 +370,7 @@ Runtime-minted or rotating credentials and OAuth refresh material are intentiona
 - Field with a ref: required on active surfaces during activation.
 - If both plaintext and ref are present, ref takes precedence on supported precedence paths.
 - The redaction sentinel `__OPENCLAW_REDACTED__` is reserved for internal config redaction/restore and is rejected as literal submitted config data.
+- Write paths that round-trip redacted config (`config.set` / `config.apply` / `config.patch`, plus the macOS app's local config-file fallback) restore the original secret when that sentinel appears on an existing field instead of persisting the placeholder.
 
 Warning and audit signals:
 


### PR DESCRIPTION
## Summary
- protect the macOS local config-file fallback from persisting `__OPENCLAW_REDACTED__`
- render redacted sentinels as blank in the macOS config UI binding
- add regression coverage for direct save, array recursion, orphan sentinel rejection, and local fallback after gateway save failure
- document the write-side redaction restore contract in gateway docs

## Problem
`config.get` intentionally redacts secrets with the reserved sentinel `__OPENCLAW_REDACTED__`.
Gateway write paths already restore those placeholders before persisting config, but the macOS app's local-file fallback path could still round-trip the sentinel back into `openclaw.json` if a gateway save failed.

That created a nasty failure mode: a degraded/offline gateway save could clobber a real secret on disk with the redacted placeholder.

## Fix
- restore redacted sentinels from the previous on-disk config in `OpenClawConfigFile.saveDict`
- reject orphan sentinel writes when no original value exists
- recurse through nested objects and arrays
- hide the sentinel from editable UI state in `ChannelConfigForm`
- cover the exact fallback path in `ConfigStoreTests`

## Verification
- `swift test --package-path apps/macos --filter 'ConfigStoreTests|OpenClawConfigFileTests'`
- `pnpm vitest run src/config/redact-snapshot.restore.test.ts src/gateway/server-methods/skills.update.normalizes-api-key.test.ts`
