### PR TITLE
fix(docker): raise HEALTHCHECK start-period to 600s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker/healthcheck: extend Dockerfile `HEALTHCHECK --start-period` from 15s to 600s so orchestrators (Compose `depends_on: service_healthy`, Swarm, podman, k8s probes derived from the OCI healthcheck) do not flip containers to `(unhealthy)` during a legitimate cold start while bundled runtime deps stage and the gateway binds. (#75701) Thanks @inxaos.
 - Gateway/config: report failed backup restores as failed in logs and config observe audit records instead of marking them valid. (#70515) Thanks @davidangularme.
 
 ## 2026.4.30

--- a/Dockerfile
+++ b/Dockerfile
@@ -294,6 +294,6 @@ USER node
 #   - GET /healthz (liveness) and GET /readyz (readiness)
 #   - aliases: /health and /ready
 # For external access from host/ingress, override bind to "lan" and set auth.
-HEALTHCHECK --interval=3m --timeout=10s --start-period=15s --retries=3 \
+HEALTHCHECK --interval=3m --timeout=10s --start-period=600s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]


### PR DESCRIPTION
## Summary

- Problem: `Dockerfile` `HEALTHCHECK --start-period=15s` flips containers to `(unhealthy)` ~15s after `docker run` while bundled runtime deps stage and the Gateway is still progressing through `[plugins] staging bundled runtime deps before gateway startup` → `[plugins] installed bundled runtime deps` → `[gateway] starting HTTP server` → `http server listening`.
- Why it matters: Anyone consuming the OCI healthcheck (Compose `depends_on: service_healthy`, Swarm, podman, k8s probes that mirror the OCI healthcheck via the CRI, systemd units gating on `docker inspect` health) sees false-positive unhealthy on every legitimate cold start.
- What changed: `--start-period=15s` → `--start-period=600s`. Other healthcheck knobs (`--interval=3m --timeout=10s --retries=3`) are unchanged.
- What did NOT change: the probe command, the bind defaults, and any non-Docker health check paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #75701
- Related #73339, #75069, #73055, #74948 (cold-start envelope context)
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `--start-period` was set to a value (15s) shorter than even a hot-restart, much shorter than the documented cold-start envelope dominated by bundled runtime mirror work, and shorter than the additional ~30s a fresh-host first-ever bundled-runtime-deps install adds on top.
- Missing detection / guardrail: no test pins the start-period to the documented envelope; the value drifted without anyone catching that orchestrators consuming OCI health flip on every cold start.
- Contributing context: same directive value carried forward across releases; downstream operators worked around it with bespoke healthcheck overrides per #62850.

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Why this is the smallest reliable guardrail: this is a single Dockerfile literal whose appropriate value is determined by documented cold-start envelope (#73339 / #75069 / #73055). A unit/seam/E2E test would either tautologically read back the literal or run a real Docker cold start, neither of which adds durable signal beyond the linked observability issues.
- If no new test is added, why not: see above.

## User-visible / Behavior Changes

- During the first 600s after `docker run`, the OCI health state stays `starting` instead of flipping to `(unhealthy)`. After the start-period, behavior is unchanged (`--interval=3m --timeout=10s --retries=3` continue to apply).

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 / macOS / Windows Docker Desktop (any host running the openclaw image)
- Runtime/container: `ghcr.io/openclaw/openclaw:2026.4.29` (and earlier; same value still on `main` before this PR)

### Steps

1. `docker run --rm --name oc-test -p 18789:18789 -v /tmp/oc-test-state:/home/node/.openclaw ghcr.io/openclaw/openclaw:2026.4.29 node openclaw.mjs gateway --bind lan`
2. After ~15s, run `docker ps --format '{{.Status}}' | grep oc-test`.

### Expected

- Container reports `Up <n> seconds (health: starting)` until the gateway has actually bound.

### Actual (before)

- Container reports `Up 16 seconds (unhealthy)` while the gateway is still legitimately staging runtime deps.

## Evidence

- [x] Trace/log snippets — see issue #75701 for the staging → bind log sequence and the `(unhealthy)` flip timestamp.

## Human Verification

- Verified scenarios: Dockerfile literal change matches the suggested fix in #75701; no other Dockerfile or CI scripts depend on the previous 15s value (`grep -rn 'start-period' --include='*.ts' --include='*.mjs' --include='Dockerfile*'` returns only this directive).
- Edge cases checked: existing reasoning around `--interval=3m --timeout=10s --retries=3` is preserved; the change is limited to `--start-period`.
- What I did not verify: I did not run a fresh-host cold start end-to-end; the appropriate envelope is documented in #73339 / #75069 / #73055.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: a genuinely broken container that never becomes healthy now stays in `health: starting` for 10 minutes instead of `unhealthy` after 15s.
  - Mitigation: `--interval=3m --timeout=10s --retries=3` is unchanged, so once the start period elapses the container still flips to unhealthy on the same schedule as before; orchestrators that need a tighter probe can override the image-level healthcheck with their own.
