### PR TITLE
fix(telegram): suppress silent callback fallback

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1772,6 +1772,7 @@ export const registerTelegramHandlers = ({
         ...(nativeCallbackCommand ? { commandSource: "native" as const } : {}),
         forceWasMentioned: true,
         messageIdOverride: callback.id,
+        suppressSilentReplyFallback: true,
       });
     } catch (err) {
       if (err instanceof TelegramRetryableCallbackError) {

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2761,6 +2761,7 @@ export const registerTelegramHandlers = ({
           ...(nativeCallbackCommand ? { commandSource: "native" as const } : {}),
           forceWasMentioned: true,
           messageIdOverride: callback.id,
+          suppressSilentReplyFallback: true,
         },
       });
     } catch (err) {

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2359,6 +2359,7 @@ export const registerTelegramHandlers = ({
             options: {
               forceWasMentioned: true,
               messageIdOverride: callback.id,
+              suppressSilentReplyFallback: true,
             },
           });
           return;
@@ -2390,6 +2391,7 @@ export const registerTelegramHandlers = ({
           options: {
             forceWasMentioned: true,
             messageIdOverride: callback.id,
+            suppressSilentReplyFallback: true,
           },
         });
         return;

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -100,6 +100,7 @@ export type TelegramMessageContext = {
   removeAckAfterReply: boolean;
   statusReactionController: TelegramStatusReactionController | null;
   accountId: string;
+  suppressSilentReplyFallback: boolean;
 };
 
 export const buildTelegramMessageContext = async ({
@@ -617,5 +618,6 @@ export const buildTelegramMessageContext = async ({
     removeAckAfterReply,
     statusReactionController,
     accountId: account.accountId,
+    suppressSilentReplyFallback: options?.suppressSilentReplyFallback === true,
   };
 };

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -117,6 +117,7 @@ export type TelegramMessageContext = {
   removeAckAfterReply: boolean;
   statusReactionController: TelegramStatusReactionController | null;
   accountId: string;
+  suppressSilentReplyFallback: boolean;
 };
 
 export const buildTelegramMessageContext = async ({
@@ -664,5 +665,6 @@ export const buildTelegramMessageContext = async ({
     removeAckAfterReply,
     statusReactionController,
     accountId: account.accountId,
+    suppressSilentReplyFallback: options?.suppressSilentReplyFallback === true,
   };
 };

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -19,6 +19,12 @@ export type TelegramMessageContextOptions = {
   commandSource?: "text" | "native";
   forceWasMentioned?: boolean;
   messageIdOverride?: string;
+  /**
+   * Callback-query button taps can be legitimate control actions whose handler
+   * has nothing visible to add.  Suppress the direct-chat silent-reply rewrite
+   * and the Telegram empty-turn fallback for those synthetic turns only.
+   */
+  suppressSilentReplyFallback?: boolean;
   receivedAtMs?: number;
   ingressBuffer?: "inbound-debounce" | "text-fragment";
 };

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -22,6 +22,12 @@ export type TelegramMessageContextOptions = {
   commandSource?: "text" | "native";
   forceWasMentioned?: boolean;
   messageIdOverride?: string;
+  /**
+   * Callback-query button taps can be legitimate control actions whose handler
+   * has nothing visible to add.  Suppress the direct-chat silent-reply rewrite
+   * and the Telegram empty-turn fallback for those synthetic turns only.
+   */
+  suppressSilentReplyFallback?: boolean;
   receivedAtMs?: number;
   ingressBuffer?: "inbound-debounce" | "text-fragment";
   promptContextMinTimestampMs?: number;

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2424,7 +2424,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   it("returns retryable when callback silence suppresses fallback after non-silent delivery failure", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      dispatcherOptions.onError?.(new Error("send failed"), { kind: "final" });
+      await dispatcherOptions.onError?.(new Error("send failed"), { kind: "final" });
       return { queuedFinal: false };
     });
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2422,6 +2422,25 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("returns retryable when callback silence suppresses fallback after non-silent delivery failure", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      dispatcherOptions.onError?.(new Error("send failed"), { kind: "final" });
+      return { queuedFinal: false };
+    });
+
+    const result = await dispatchWithContext({
+      context: createContext({
+        suppressSilentReplyFallback: true,
+      }),
+      retryDispatchErrors: true,
+      suppressFailureFallback: true,
+    });
+
+    expect(result).toMatchObject({ kind: "failed-retryable" });
+    expect((result as { error?: unknown }).error).toBeInstanceOf(Error);
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("does not return retryable after spooled replay already showed visible output", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -265,6 +265,7 @@ export const dispatchTelegramMessage = async ({
     reactionApi,
     removeAckAfterReply,
     statusReactionController,
+    suppressSilentReplyFallback,
   } = context;
   const statusReactionTiming = {
     ...DEFAULT_TIMING,
@@ -868,6 +869,20 @@ export const dispatchTelegramMessage = async ({
                 cfg,
                 dispatcherOptions: {
                   ...replyPipeline,
+                  // Telegram callback_query button taps can be valid no-op control
+                  // turns.  Treat exact NO_REPLY as group-like silence for those
+                  // synthetic turns so the direct-chat rewrite does not create a
+                  // visible fallback after a button tap.
+                  ...(suppressSilentReplyFallback
+                    ? {
+                        silentReplyContext: {
+                          cfg,
+                          sessionKey: ctxPayload.SessionKey,
+                          surface: "telegram",
+                          conversationType: "group" as const,
+                        },
+                      }
+                    : {}),
                   beforeDeliver: async (payload) => payload,
                   deliver: async (payload, info) => {
                     if (isDispatchSuperseded()) {
@@ -1301,7 +1316,13 @@ export const dispatchTelegramMessage = async ({
     sentFallback = result.delivered;
   }
 
-  if (!queuedFinal && !sentFallback && !dispatchError && !deliverySummary.delivered) {
+  if (
+    !suppressSilentReplyFallback &&
+    !queuedFinal &&
+    !sentFallback &&
+    !dispatchError &&
+    !deliverySummary.delivered
+  ) {
     const policySessionKey =
       ctxPayload.CommandSource === "native"
         ? (ctxPayload.CommandTargetSessionKey ?? ctxPayload.SessionKey)
@@ -1330,13 +1351,18 @@ export const dispatchTelegramMessage = async ({
     });
   }
 
-  const hasFinalResponse = hasFinalInboundReplyDispatch(
-    { queuedFinal },
-    {
-      fallbackDelivered: sentFallback,
-      deliverySummaryDelivered: deliverySummary.delivered,
-    },
-  );
+  const silentCallbackSuppressed =
+    suppressSilentReplyFallback && !dispatchError && !deliverySummary.delivered && !sentFallback;
+
+  const hasFinalResponse =
+    silentCallbackSuppressed ||
+    hasFinalInboundReplyDispatch(
+      { queuedFinal },
+      {
+        fallbackDelivered: sentFallback,
+        deliverySummaryDelivered: deliverySummary.delivered,
+      },
+    );
 
   if (statusReactionController && !hasFinalResponse) {
     void finalizeTelegramStatusReaction({ outcome: "error", hasFinalResponse: false }).catch(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -754,6 +754,7 @@ export const dispatchTelegramMessage = async ({
     reactionApi,
     removeAckAfterReply,
     statusReactionController: rawStatusReactionController,
+    suppressSilentReplyFallback: callbackSuppressSilentFallback,
   } = dispatchContext;
   const isRoomEvent = ctxPayload.InboundEventKind === "room_event";
   const statusReactionController = isRoomEvent ? null : rawStatusReactionController;
@@ -1907,6 +1908,20 @@ export const dispatchTelegramMessage = async ({
                 cfg,
                 dispatcherOptions: {
                   ...replyPipeline,
+                  // Telegram callback_query button taps can be valid no-op control
+                  // turns.  Treat exact NO_REPLY as group-like silence for those
+                  // synthetic turns so the direct-chat rewrite does not create a
+                  // visible fallback after a button tap.
+                  ...(callbackSuppressSilentFallback
+                    ? {
+                        silentReplyContext: {
+                          cfg,
+                          sessionKey: ctxPayload.SessionKey,
+                          surface: "telegram",
+                          conversationType: "group" as const,
+                        },
+                      }
+                    : {}),
                   beforeDeliver: async (payload) => payload,
                   onBeforeDeliverCancelled: (payload, info) => {
                     if (info.kind === "block") {
@@ -2606,8 +2621,15 @@ export const dispatchTelegramMessage = async ({
     });
   }
 
+  const silentCallbackSuppressed =
+    callbackSuppressSilentFallback && !dispatchError && !deliverySummary.delivered && !sentFallback;
+
   const hasFinalResponse =
-    deliverySummary.delivered || sentFallback || suppressSilentReplyFallback || queuedFinal;
+    silentCallbackSuppressed ||
+    deliverySummary.delivered ||
+    sentFallback ||
+    suppressSilentReplyFallback ||
+    queuedFinal;
   const deliveryFailureWithoutFinalResponse =
     !deliverySummary.delivered &&
     (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2622,7 +2622,12 @@ export const dispatchTelegramMessage = async ({
   }
 
   const silentCallbackSuppressed =
-    callbackSuppressSilentFallback && !dispatchError && !deliverySummary.delivered && !sentFallback;
+    callbackSuppressSilentFallback &&
+    !dispatchError &&
+    !deliverySummary.delivered &&
+    !sentFallback &&
+    deliverySummary.skippedNonSilent === 0 &&
+    deliverySummary.failedNonSilent === 0;
 
   const hasFinalResponse =
     silentCallbackSuppressed ||

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -165,6 +165,12 @@ async function dispatchHarnessReplies(
       !payload.text.startsWith(params.dispatcherOptions.responsePrefix)
         ? `${params.dispatcherOptions.responsePrefix} ${payload.text}`
         : payload.text;
+    if (
+      text === "NO_REPLY" &&
+      params.dispatcherOptions.silentReplyContext?.conversationType === "group"
+    ) {
+      continue;
+    }
     const finalPayload = text === payload.text ? payload : { ...payload, text };
     try {
       await params.dispatcherOptions.deliver?.(finalPayload, { kind: "final" });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -629,6 +629,66 @@ describe("createTelegramBot", () => {
     expect(payload.Body).toContain("cmd:option_a");
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-1");
   });
+
+  it("suppresses direct-chat silent fallback for silent callback_query replies", async () => {
+    replySpy.mockResolvedValueOnce({ text: "NO_REPLY" });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-silent-1",
+        data: "cmd:quiet",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-silent-1");
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("still sends real callback_query replies", async () => {
+    replySpy.mockResolvedValueOnce({ text: "Handled option A" });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-visible-1",
+        data: "cmd:option_a",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-visible-1");
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      "1234",
+      "Handled option A",
+      expect.objectContaining({ parse_mode: "HTML" }),
+    );
+  });
+
   it("preserves native command source for prefixed callback_query payloads", async () => {
     loadConfig.mockReturnValue({
       commands: { text: false, native: true },

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1232,6 +1232,64 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-opaque-1");
   });
 
+  it("suppresses direct-chat silent fallback for silent callback_query replies", async () => {
+    replySpy.mockResolvedValueOnce({ text: "NO_REPLY" });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-silent-1",
+        data: "cmd:quiet",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-silent-1");
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("still sends real callback_query replies", async () => {
+    replySpy.mockResolvedValueOnce({ text: "Handled option A" });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-visible-1",
+        data: "cmd:option_a",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-visible-1");
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      1234,
+      "Handled option A",
+      expect.objectContaining({ parse_mode: "HTML" }),
+    );
+  });
+
   it("toggles OC_MULTI buttons without routing through the generic callback message path", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = requireValue(

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1364,6 +1364,43 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it("suppresses direct-chat silent fallback for silent OC_MULTI submits", async () => {
+    replySpy.mockResolvedValueOnce({ text: "NO_REPLY" });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = requireValue(
+      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
+        | ((ctx: Record<string, unknown>) => Promise<void>)
+        | undefined,
+      "callback_query handler",
+    );
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-multi-submit-silent-1",
+        data: "OC_MULTI|submit",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+          reply_markup: {
+            inline_keyboard: [
+              [{ text: "✅ Prod", callback_data: "OC_MULTI|toggle|env|prod" }],
+              [{ text: "Blue", callback_data: "OC_MULTI|toggle|blue" }],
+            ],
+          },
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-multi-submit-silent-1");
+  });
+
   it("submits OC_SELECT values as a synthetic inbound message and clears buttons", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = requireValue(
@@ -1398,6 +1435,43 @@ describe("createTelegramBot", () => {
     expect(requireValue(replySpy.mock.calls.at(0), "replySpy call")[0].Body).toContain(
       "Single-select submitted: env|canary",
     );
+  });
+
+  it("suppresses direct-chat silent fallback for silent OC_SELECT submits", async () => {
+    replySpy.mockResolvedValueOnce({ text: "NO_REPLY" });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = requireValue(
+      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
+        | ((ctx: Record<string, unknown>) => Promise<void>)
+        | undefined,
+      "callback_query handler",
+    );
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-select-silent-1",
+        data: "OC_SELECT|env|canary",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+          reply_markup: {
+            inline_keyboard: [[{ text: "Canary", callback_data: "OC_SELECT|env|canary" }]],
+          },
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
+      reply_markup: { inline_keyboard: [] },
+    });
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-select-silent-1");
   });
 
   it("preserves native command source for prefixed callback_query payloads", async () => {


### PR DESCRIPTION
## Summary
- suppress Telegram direct-chat silent reply fallback for synthetic `callback_query` button turns
- keep answering callback queries so Telegram clears the button spinner
- preserve normal visible callback replies and non-callback silent reply behavior

## Real behavior proof
- **Behavior or issue addressed:** Telegram private-chat callback button taps that intentionally return `NO_REPLY` no longer emit a visible fallback message, while non-empty callback replies still send normally and callback queries are still answered.
- **Real environment tested:** Real Telegram Bot API with throwaway bot `@O_Demo_Bot`, private Telegram chat, PR head commit `ebe2c6a3783b0aa432a5f377fe549e91850f97b4`.
- **Exact steps or command run after this patch:** Ran a Node proof harness from the PR worktree that sent an inline-keyboard message to Telegram, then tapped `Silent NO_REPLY` and `Visible reply` in the actual Telegram client.
- **Evidence after fix:** Redacted terminal capture / live output from the real Telegram run:

```text
sendMessage chat=6566057320 text="PR #75857 live proof v2. Tap Silent, then Visible."
proofMessage chat=6566057320 message_id=4
callback data=proof2:silent from=6566057320 chat=6566057320 message_id=4
answerCallbackQuery id=53088534…
agentReply text="NO_REPLY"
delivery sendMessage count=0 reason=silentReplyContext group-like callback suppression
callback data=proof2:visible from=6566057320 chat=6566057320 message_id=4
answerCallbackQuery id=53088534…
agentReply text="Handled option A"
sendMessage chat=6566057320 text="Handled option A"
delivery sendMessage count=1
result silent=true visible=true
```

- **Observed result after fix:** Silent callback answered the callback query and produced `sendMessage count=0`; visible callback answered the callback query and sent exactly one `Handled option A` message.
- **What was not tested:** Full long-running OpenClaw gateway deployment was not restarted for this proof; validation used the PR branch behavior path plus real Telegram callback/query delivery.

## Tests
- `pnpm test extensions/telegram/src/bot.create-telegram-bot.test.ts -- -t callback_query`
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts`
- `pnpm check:changed`