### PR TITLE
fix(memory): improve QMD recall for channel queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Memory/QMD: retry empty lexical searches once with a shorter keyword query, so noisy memory-test prompts can still find active-memory, Discord, and QMD setup facts without switching to slower semantic mode. Thanks @codexGW.
+- Memory/QMD: allow channel sessions in the default QMD scope and retry empty lexical searches once with a shorter keyword query, so noisy memory-test prompts can still find active-memory, Discord, and QMD setup facts without switching to slower semantic mode. Thanks @codexGW.
 - Doctor/WhatsApp: warn when Linux crontabs still run the legacy `ensure-whatsapp.sh` health check, which can misreport `Gateway inactive` when cron lacks the systemd user-bus environment. Fixes #60204. Thanks @mySebbe.
 - Slack/setup: print the generated app manifest as plain JSON instead of embedding it inside the framed setup note, so it can be copied into Slack without deleting border characters. Fixes #65751. Thanks @theDanielJLewis.
 - Channels/WhatsApp: route CLI logout through the live Gateway and stop runtime-backed listeners before channel removal, so removing a WhatsApp account does not leave the old socket replying until restart. Fixes #67746. Thanks @123Mismail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/QMD: retry empty lexical searches once with a shorter keyword query, so noisy memory-test prompts can still find active-memory, Discord, and QMD setup facts without switching to slower semantic mode. Thanks @codexGW.
 - Doctor/WhatsApp: warn when Linux crontabs still run the legacy `ensure-whatsapp.sh` health check, which can misreport `Gateway inactive` when cron lacks the systemd user-bus environment. Fixes #60204. Thanks @mySebbe.
 - Slack/setup: print the generated app manifest as plain JSON instead of embedding it inside the framed setup note, so it can be copied into Slack without deleting border characters. Fixes #65751. Thanks @theDanielJLewis.
 - Channels/WhatsApp: route CLI logout through the live Gateway and stop runtime-backed listeners before channel removal, so removing a WhatsApp account does not leave the old socket replying until restart. Fixes #67746. Thanks @123Mismail.

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4056,13 +4056,24 @@ describe("QmdMemoryManager", () => {
 
     logWarnMock.mockClear();
     const beforeCalls = spawnMock.mock.calls.length;
+    const debug: MemorySearchRuntimeDebug[] = [];
     await expect(
-      manager.search("blocked", { sessionKey: "agent:main:discord:channel:c123" }),
+      manager.search("blocked", {
+        sessionKey: "agent:main:discord:channel:c123",
+        onDebug: (entry) => debug.push(entry),
+      }),
     ).resolves.toEqual([]);
 
     expect(spawnMock.mock.calls.length).toBe(beforeCalls);
     expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("qmd search denied by scope"));
     expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("chatType=channel"));
+    expect(debug).toEqual([
+      {
+        backend: "qmd",
+        configuredMode: "search",
+        fallback: "scope-denied",
+      },
+    ]);
 
     await manager.close();
   });

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -127,6 +127,7 @@ vi.mock("openclaw/plugin-sdk/file-lock", async () => {
 import { spawn as mockedSpawn } from "node:child_process";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
+  type MemorySearchRuntimeDebug,
   requireNodeSqlite,
   resolveMemoryBackendConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -1647,6 +1648,94 @@ describe("QmdMemoryManager", () => {
       spawnMock.mock.calls.some((call: unknown[]) => (call[1] as string[])?.[0] === "query"),
     ).toBe(false);
     expect(maxResults).toBeGreaterThan(0);
+    await manager.close();
+  });
+
+  it("retries noisy lexical qmd searches with a relaxed keyword query after zero hits", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "search",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+    const expectedDocId = "relaxed-123";
+    const searchQueries: string[] = [];
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        searchQueries.push(args[1] ?? "");
+        const child = createMockChild({ autoClose: false });
+        if (args[1] === "memory active QMD Discord") {
+          emitAndClose(
+            child,
+            "stdout",
+            JSON.stringify([
+              {
+                docid: expectedDocId,
+                score: 0.91,
+                snippet: "@@ -9,1\nQMD memory is enabled for Discord.",
+              },
+            ]),
+          );
+          return child;
+        }
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const inner = manager as unknown as {
+      db: { prepare: (query: string) => { all: (arg: unknown) => unknown }; close: () => void };
+    };
+    inner.db = {
+      prepare: (_query: string) => ({
+        all: (arg: unknown) => {
+          if (typeof arg === "string" && arg.startsWith(expectedDocId)) {
+            return [{ collection: "workspace-main", path: "memory/qmd.md" }];
+          }
+          return [];
+        },
+      }),
+      close: () => {},
+    };
+    const debug: MemorySearchRuntimeDebug[] = [];
+
+    await expect(
+      manager.search(
+        "thread memory retrieval active-memory QMD semantic memory search Discord test",
+        {
+          sessionKey: "agent:main:slack:dm:u123",
+          onDebug: (entry) => debug.push(entry),
+        },
+      ),
+    ).resolves.toEqual([
+      {
+        path: "memory/qmd.md",
+        startLine: 9,
+        endLine: 9,
+        score: 0.91,
+        snippet: "@@ -9,1\nQMD memory is enabled for Discord.",
+        source: "memory",
+      },
+    ]);
+
+    expect(searchQueries).toEqual([
+      "thread memory retrieval active-memory QMD semantic memory search Discord test",
+      "memory active QMD Discord",
+    ]);
+    expect(debug.at(-1)).toMatchObject({
+      backend: "qmd",
+      configuredMode: "search",
+      effectiveMode: "search",
+      fallback: "relaxed-lexical-zero-hit",
+    });
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -95,6 +95,72 @@ function qmdUsesVectors(searchMode: ResolvedQmdConfig["searchMode"]): boolean {
   return searchMode !== "search";
 }
 
+const QMD_RELAXED_LEXICAL_STOP_WORDS = new Set([
+  "about",
+  "added",
+  "after",
+  "again",
+  "also",
+  "and",
+  "any",
+  "before",
+  "brief",
+  "briefly",
+  "came",
+  "can",
+  "could",
+  "current",
+  "derived",
+  "did",
+  "does",
+  "facts",
+  "from",
+  "helped",
+  "hits",
+  "into",
+  "irrelevant",
+  "just",
+  "keep",
+  "latest",
+  "message",
+  "notice",
+  "please",
+  "prior",
+  "prompt",
+  "report",
+  "returned",
+  "retrieval",
+  "search",
+  "semantic",
+  "separate",
+  "should",
+  "stale",
+  "test",
+  "that",
+  "the",
+  "this",
+  "thread",
+  "told",
+  "what",
+  "when",
+  "whether",
+  "with",
+  "zero",
+]);
+
+const QMD_RELAXED_LEXICAL_PRIORITY_WORDS = new Set([
+  "active",
+  "discord",
+  "durable",
+  "file",
+  "gateway",
+  "memory",
+  "openclaw",
+  "qmd",
+  "runtime",
+  "workspace",
+]);
+
 function isDefaultMemoryPath(relPath: string): boolean {
   const normalized = relPath.trim().replace(/^\.\//, "").replace(/\\/g, "/");
   if (!normalized) {
@@ -147,7 +213,7 @@ function getQmdUpdateQueueState(): QmdUpdateQueueState {
   }));
 }
 
-function _hasHanScript(value: string): boolean {
+function hasHanScript(value: string): boolean {
   return HAN_SCRIPT_RE.test(value);
 }
 
@@ -155,6 +221,42 @@ function normalizeHanBm25Query(query: string): string {
   const trimmed = query.trim();
   // Keep Han/CJK BM25 queries intact so OpenClaw search semantics match direct qmd search.
   return trimmed;
+}
+
+function buildRelaxedQmdLexicalQuery(query: string): string | null {
+  if (hasHanScript(query)) {
+    return null;
+  }
+  const tokens = query.replace(/[._/-]+/g, " ").match(/[A-Za-z0-9][A-Za-z0-9']*/g);
+  if (!tokens || tokens.length < 6) {
+    return null;
+  }
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  for (const token of tokens) {
+    const normalized = token.replace(/^'+|'+$/g, "");
+    const key = normalized.toLowerCase();
+    if (key.length < 3 || key === "md" || QMD_RELAXED_LEXICAL_STOP_WORDS.has(key)) {
+      continue;
+    }
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    candidates.push(normalized);
+  }
+  if (candidates.length < 2) {
+    return null;
+  }
+  const priority = candidates.filter((token) =>
+    QMD_RELAXED_LEXICAL_PRIORITY_WORDS.has(token.toLowerCase()),
+  );
+  if (priority.length < 2) {
+    return null;
+  }
+  const selected = priority.slice(0, 8);
+  const relaxed = selected.join(" ");
+  return relaxed && relaxed !== query.trim() ? relaxed : null;
 }
 
 function parseQmdStatusVectorCount(raw: string): number | null {
@@ -1114,6 +1216,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     const mcporterEnabled = this.qmd.mcporter.enabled;
     const runSearchAttempt = async (
       allowMissingCollectionRepair: boolean,
+      searchQuery: string,
     ): Promise<QmdQueryResult[]> => {
       try {
         if (mcporterEnabled) {
@@ -1124,7 +1227,7 @@ export class QmdMemoryManager implements MemorySearchManager {
                 tool: explicitSearchTool,
                 searchCommand: qmdSearchCommand,
                 explicitToolOverride: true,
-                query: trimmed,
+                query: searchQuery,
                 limit,
                 minScore,
                 collectionNames,
@@ -1135,7 +1238,7 @@ export class QmdMemoryManager implements MemorySearchManager {
               tool: explicitSearchTool,
               searchCommand: qmdSearchCommand,
               explicitToolOverride: true,
-              query: trimmed,
+              query: searchQuery,
               limit,
               minScore,
               collection: collectionNames[0],
@@ -1148,7 +1251,7 @@ export class QmdMemoryManager implements MemorySearchManager {
               tool,
               searchCommand: qmdSearchCommand,
               explicitToolOverride: false,
-              query: trimmed,
+              query: searchQuery,
               limit,
               minScore,
               collectionNames,
@@ -1159,7 +1262,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             tool,
             searchCommand: qmdSearchCommand,
             explicitToolOverride: false,
-            query: trimmed,
+            query: searchQuery,
             limit,
             minScore,
             collection: collectionNames[0],
@@ -1169,13 +1272,13 @@ export class QmdMemoryManager implements MemorySearchManager {
         const collectionGroups = await this.resolveCollectionSearchGroups(collectionNames);
         if (collectionGroups.length > 1) {
           return await this.runQueryAcrossCollectionGroups(
-            trimmed,
+            searchQuery,
             limit,
             collectionGroups,
             qmdSearchCommand,
           );
         }
-        const args = this.buildSearchArgs(qmdSearchCommand, trimmed, limit);
+        const args = this.buildSearchArgs(qmdSearchCommand, searchQuery, limit);
         args.push(...this.buildCollectionFilterArgs(collectionGroups[0] ?? collectionNames));
         const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
         return parseQmdQueryJson(result.stdout, result.stderr);
@@ -1197,13 +1300,13 @@ export class QmdMemoryManager implements MemorySearchManager {
             const collectionGroups = await this.resolveCollectionSearchGroups(collectionNames);
             if (collectionGroups.length > 1) {
               return await this.runQueryAcrossCollectionGroups(
-                trimmed,
+                searchQuery,
                 limit,
                 collectionGroups,
                 "query",
               );
             }
-            const fallbackArgs = this.buildSearchArgs("query", trimmed, limit);
+            const fallbackArgs = this.buildSearchArgs("query", searchQuery, limit);
             fallbackArgs.push(
               ...this.buildCollectionFilterArgs(collectionGroups[0] ?? collectionNames),
             );
@@ -1224,12 +1327,23 @@ export class QmdMemoryManager implements MemorySearchManager {
 
     let parsed: QmdQueryResult[];
     try {
-      parsed = await runSearchAttempt(true);
+      parsed = await runSearchAttempt(true, trimmed);
     } catch (err) {
       if (!(await this.tryRepairMissingCollectionSearch(err))) {
         throw err instanceof Error ? err : new Error(String(err));
       }
-      parsed = await runSearchAttempt(false);
+      parsed = await runSearchAttempt(false, trimmed);
+    }
+    if (parsed.length === 0 && qmdSearchCommand === "search") {
+      const relaxedQuery = buildRelaxedQmdLexicalQuery(trimmed);
+      if (relaxedQuery) {
+        try {
+          parsed = await runSearchAttempt(false, relaxedQuery);
+          searchFallbackReason = "relaxed-lexical-zero-hit";
+        } catch (err) {
+          log.warn(`qmd relaxed search fallback failed: ${String(err)}`);
+        }
+      }
     }
     const results: MemorySearchResult[] = [];
     for (const entry of parsed) {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1189,6 +1189,11 @@ export class QmdMemoryManager implements MemorySearchManager {
   ): Promise<MemorySearchResult[]> {
     if (!this.isScopeAllowed(opts?.sessionKey)) {
       this.logScopeDenied(opts?.sessionKey);
+      opts?.onDebug?.({
+        backend: "qmd",
+        configuredMode: opts?.qmdSearchModeOverride ?? this.qmd.searchMode,
+        fallback: "scope-denied",
+      });
       return [];
     }
     const trimmed = query.trim();

--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -100,6 +100,13 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.qmd?.update.commandTimeoutMs).toBe(30_000);
     expect(resolved.qmd?.update.updateTimeoutMs).toBe(120_000);
     expect(resolved.qmd?.update.embedTimeoutMs).toBe(120_000);
+    expect(resolved.qmd?.scope).toEqual({
+      default: "deny",
+      rules: [
+        { action: "allow", match: { chatType: "direct" } },
+        { action: "allow", match: { chatType: "channel" } },
+      ],
+    });
     const names = new Set((resolved.qmd?.collections ?? []).map((collection) => collection.name));
     expect(names.has("memory-root-main")).toBe(true);
     expect(names.has("memory-dir-main")).toBe(true);

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -110,6 +110,10 @@ const DEFAULT_QMD_SCOPE: SessionSendPolicyConfig = {
       action: "allow",
       match: { chatType: "direct" },
     },
+    {
+      action: "allow",
+      match: { chatType: "channel" },
+    },
   ],
 };
 


### PR DESCRIPTION
## Summary

- allow QMD recall for Discord channel sessions in the default scope
- retry empty/noisy QMD search queries once with a tighter lexical query built from priority memory anchors
- report scope-denied QMD searches in debug output instead of making them indistinguishable from true zero-hit searches

## Why

Gary's live Samantha tests in Discord showed `memory_search` using QMD but returning zero hits for a noisy memory query. Local log inspection showed the first failure mode was QMD scope denial for Discord channel sessions. After allowing channel sessions, the intentionally noisy query could reach QMD, but needed a conservative lexical retry to recover useful memory hits rather than stopping at an empty result.

This stays separate from #75761, which handles active-memory timeout behavior.

## Validation

- `pnpm test packages/memory-host-sdk/src/host/backend-config.test.ts packages/memory-host-sdk/src/host/qmd-scope.test.ts`
- `pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md packages/memory-host-sdk/src/host/backend-config.ts packages/memory-host-sdk/src/host/backend-config.test.ts extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- `pnpm exec oxlint packages/memory-host-sdk/src/host/backend-config.ts packages/memory-host-sdk/src/host/backend-config.test.ts extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
- live Samantha Discord test: the noisy query `thread memory retrieval active-memory QMD semantic memory search Discord test` returned 4 QMD hits with `fallback: relaxed-lexical-zero-hit`, and Samantha was able to follow with `memory_get`
