### PR TITLE
OP-014: progressive skill disclosure (default-legacy, opt-in via skills.promptMode)

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SkillsPromptDisclosureMode } from "../config/types.skills.js";
 import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime.js";
@@ -12,6 +13,7 @@ import {
   isUpdatePlanToolEnabledForOpenClawTools,
 } from "./openclaw-tools.registration.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import type { SkillSnapshot } from "./skills/types.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
@@ -33,6 +35,8 @@ import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
+import { createSkillSearchTool } from "./tools/skill-search-tool.js";
+import { createSkillViewTool } from "./tools/skill-view-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
 import { createUpdatePlanTool } from "./tools/update-plan-tool.js";
@@ -50,6 +54,11 @@ const defaultOpenClawToolsDeps: OpenClawToolsDeps = {
 };
 
 let openClawToolsDeps: OpenClawToolsDeps = defaultOpenClawToolsDeps;
+
+function resolveSkillsPromptMode(config?: OpenClawConfig): SkillsPromptDisclosureMode {
+  const mode = config?.skills?.promptMode;
+  return mode === "compact" || mode === "view" || mode === "search" ? mode : "legacy";
+}
 
 export function createOpenClawTools(
   options?: {
@@ -117,6 +126,8 @@ export function createOpenClawTools(
     onYield?: (message: string) => Promise<void> | void;
     /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
     allowGatewaySubagentBinding?: boolean;
+    /** Already-resolved prompt-visible skill snapshot for progressive disclosure tools. */
+    skillsSnapshot?: SkillSnapshot;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const resolvedConfig = options?.config ?? openClawToolsDeps.config;
@@ -239,6 +250,18 @@ export function createOpenClawTools(
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;
+  const skillsPromptMode = resolveSkillsPromptMode(resolvedConfig);
+  const promptVisibleResolvedSkills = Array.isArray(options?.skillsSnapshot?.resolvedSkills)
+    ? options.skillsSnapshot.resolvedSkills
+    : undefined;
+  const skillViewTool =
+    promptVisibleResolvedSkills && (skillsPromptMode === "view" || skillsPromptMode === "search")
+      ? createSkillViewTool({ resolvedSkills: promptVisibleResolvedSkills })
+      : null;
+  const skillSearchTool =
+    promptVisibleResolvedSkills && skillsPromptMode === "search"
+      ? createSkillSearchTool({ resolvedSkills: promptVisibleResolvedSkills })
+      : null;
   const tools: AnyAgentTool[] = [
     ...(embedded
       ? []
@@ -338,6 +361,7 @@ export function createOpenClawTools(
       config: resolvedConfig,
       sandboxed: options?.sandboxed,
     }),
+    ...collectPresentOpenClawTools([skillViewTool, skillSearchTool]),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),
   ];
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -677,6 +677,7 @@ async function compactEmbeddedPiSessionDirectOnce(
       modelProvider: model.provider,
       modelId,
       modelCompat: extractModelCompat(effectiveModel),
+      skillsSnapshot: params.skillsSnapshot,
       modelApi: model.api,
       modelContextWindowTokens: ctxInfo.tokens,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config, undefined, {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -846,6 +846,7 @@ export async function runEmbeddedAttempt(
                 runAbortController.abort("sessions_yield");
                 abortSessionForYield?.();
               },
+              skillsSnapshot: params.skillsSnapshot,
             });
             return applyEmbeddedAttemptToolsAllow(allTools, params.toolsAllow);
           })();

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -50,6 +50,7 @@ import {
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
+import type { SkillSnapshot } from "./skills/types.js";
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
@@ -361,6 +362,8 @@ export function createOpenClawCodingTools(options?: {
   ownerOnlyToolAllowlist?: string[];
   /** Callback invoked when sessions_yield tool is called. */
   onYield?: (message: string) => Promise<void> | void;
+  /** Already-resolved prompt-visible skill snapshot for progressive disclosure tools. */
+  skillsSnapshot?: SkillSnapshot;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -668,6 +671,7 @@ export function createOpenClawCodingTools(options?: {
       sessionId: options?.sessionId,
       onYield: options?.onYield,
       allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
+      skillsSnapshot: options?.skillsSnapshot,
     }),
   ];
   const toolsForMemoryFlush =

--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -40,12 +40,17 @@ function makeEntry(skill: Skill): SkillEntry {
 
 function buildPrompt(
   skills: Skill[],
-  limits: { maxChars?: number; maxCount?: number } = {},
+  limits: {
+    maxChars?: number;
+    maxCount?: number;
+    promptMode?: "legacy" | "compact" | "view" | "search";
+  } = {},
 ): string {
   return buildWorkspaceSkillsPrompt("/fake", {
     entries: skills.map(makeEntry),
     config: {
       skills: {
+        ...(limits.promptMode !== undefined && { promptMode: limits.promptMode }),
         limits: {
           ...(limits.maxChars !== undefined && { maxSkillsPromptChars: limits.maxChars }),
           ...(limits.maxCount !== undefined && { maxSkillsInPrompt: limits.maxCount }),
@@ -283,6 +288,58 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     });
     const nameMatches = [...prompt.matchAll(/<name>(\w+)<\/name>/g)].map((m) => m[1]);
     expect(nameMatches).toEqual(["apple", "banana", "mango", "zoo"]);
+  });
+
+  it("defaults to legacy prompt behavior when no progressive mode is configured", () => {
+    const prompt = buildPrompt([makeSkill("weather", "Get weather data")], { maxChars: 50_000 });
+    expect(prompt).toContain(
+      "Use the read tool to load a skill's file when the task matches its description.",
+    );
+    expect(prompt).not.toContain("prefer skill_view");
+  });
+
+  it("progressive compact mode renders a name and description index with read-only guidance", () => {
+    const prompt = buildPrompt([makeSkill("weather", "Get weather data")], {
+      maxChars: 50_000,
+      promptMode: "compact",
+    });
+    expect(prompt).toContain("<name>weather</name>");
+    expect(prompt).toContain("<description>Get weather data</description>");
+    expect(prompt).toContain(
+      "Use the read tool to load a listed skill's file from its location when the skill clearly applies.",
+    );
+    expect(prompt).not.toContain("skill_view");
+    expect(prompt).not.toContain("skill_search");
+  });
+
+  it("progressive view mode mentions skill_view but not skill_search", () => {
+    const prompt = buildPrompt([makeSkill("weather", "Get weather data")], {
+      maxChars: 50_000,
+      promptMode: "view",
+    });
+    expect(prompt).toContain("prefer skill_view when available; fall back to read");
+    expect(prompt).not.toContain("skill_search");
+  });
+
+  it("progressive search mode emphasizes skill_search for missing or uncertain matches", () => {
+    const prompt = buildPrompt([makeSkill("weather", "Get weather data")], {
+      maxChars: 50_000,
+      promptMode: "search",
+    });
+    expect(prompt).toContain("prefer skill_view when available; fall back to read");
+    expect(prompt).toContain(
+      "Use skill_search when you need a relevant skill that is not listed or you are unsure which skill matches.",
+    );
+  });
+
+  it("progressive modes preserve count and char truncation limits", () => {
+    const skills = Array.from({ length: 30 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
+    const prompt = buildPrompt(skills, { maxChars: 2_000, maxCount: 20, promptMode: "view" });
+    const match = prompt.match(/included (\d+) of (\d+)/);
+    expect(match).toBeTruthy();
+    expect(Number(match![1])).toBeLessThanOrEqual(20);
+    expect(Number(match![2])).toBe(30);
+    expect(prompt).toContain("progressive view mode");
   });
 
   it("resolvedSkills in snapshot keeps canonical paths, not compacted", () => {

--- a/src/agents/skills/skill-contract.ts
+++ b/src/agents/skills/skill-contract.ts
@@ -62,3 +62,38 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
   lines.push("</available_skills>");
   return lines.join("\n");
 }
+
+export function formatSkillsProgressiveIndex(
+  skills: Skill[],
+  mode: "compact" | "view" | "search",
+): string {
+  if (skills.length === 0) {
+    return "";
+  }
+  const accessGuidance =
+    mode === "compact"
+      ? "Use the read tool to load a listed skill's file from its location when the skill clearly applies."
+      : "Before using a listed skill, prefer skill_view when available; fall back to read on the skill location.";
+  const lines = [
+    "\n\nThe following skills provide specialized instructions for specific tasks.",
+    "This is a compact skill index; do not load a skill unless it clearly applies.",
+    accessGuidance,
+    ...(mode === "search"
+      ? [
+          "Use skill_search when you need a relevant skill that is not listed or you are unsure which skill matches.",
+        ]
+      : []),
+    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+    "",
+    "<available_skills>",
+  ];
+  for (const skill of skills) {
+    lines.push("  <skill>");
+    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    lines.push(`    <description>${escapeXml(skill.description)}</description>`);
+    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -975,6 +975,15 @@ function resolveWorkspaceSkillPromptState(
     promptBlock = formatSkillsProgressiveIndex(skillsForPrompt, promptMode);
   }
   const prompt = [remoteNote, promptModeNote, promptBlock].filter(Boolean).join("\n");
+  skillsLogger.info("skills_prompt", {
+    mode: promptMode,
+    agentId: opts?.agentId,
+    eligibleCount: eligible.length,
+    resolvedSkillCount: resolvedSkills.length,
+    promptSkillCount: skillsForPrompt.length,
+    truncated,
+    promptChars: prompt.length,
+  });
   return { eligible, prompt, resolvedSkills };
 }
 

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -2,6 +2,7 @@ import fs, { type Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { SkillsPromptDisclosureMode } from "../../config/types.skills.js";
 import { resolveOsHomeDir } from "../../infra/home-dir.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -19,7 +20,11 @@ import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "./frontma
 import { loadSkillsFromDirSafe, readSkillFrontmatterSafe } from "./local-loader.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
-import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
+import {
+  formatSkillsForPrompt,
+  formatSkillsProgressiveIndex,
+  type Skill,
+} from "./skill-contract.js";
 import type {
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
@@ -762,6 +767,11 @@ export function formatSkillsCompact(skills: Skill[]): string {
 // Budget reserved for the compact-mode warning line prepended by the caller.
 const COMPACT_WARNING_OVERHEAD = 150;
 
+function resolveSkillsPromptMode(config?: OpenClawConfig): SkillsPromptDisclosureMode {
+  const mode = config?.skills?.promptMode;
+  return mode === "compact" || mode === "view" || mode === "search" ? mode : "legacy";
+}
+
 function applySkillsPromptLimits(params: {
   skills: Skill[];
   config?: OpenClawConfig;
@@ -812,6 +822,45 @@ function applySkillsPromptLimits(params: {
   }
 
   return { skillsForPrompt, truncated, compact };
+}
+
+function applyProgressiveSkillsPromptLimits(params: {
+  skills: Skill[];
+  config?: OpenClawConfig;
+  agentId?: string;
+  mode: Exclude<SkillsPromptDisclosureMode, "legacy">;
+}): {
+  skillsForPrompt: Skill[];
+  truncated: boolean;
+} {
+  const limits = resolveSkillsLimits(params.config, params.agentId);
+  const total = params.skills.length;
+  let skillsForPrompt = params.skills.slice(0, Math.max(0, limits.maxSkillsInPrompt));
+  let truncated = total > skillsForPrompt.length;
+  const initialBudget = truncated
+    ? limits.maxSkillsPromptChars - COMPACT_WARNING_OVERHEAD
+    : limits.maxSkillsPromptChars;
+
+  const fitsProgressive = (skills: Skill[], budget = initialBudget): boolean =>
+    formatSkillsProgressiveIndex(skills, params.mode).length <= budget;
+
+  if (!fitsProgressive(skillsForPrompt)) {
+    const truncatedBudget = limits.maxSkillsPromptChars - COMPACT_WARNING_OVERHEAD;
+    let lo = 0;
+    let hi = skillsForPrompt.length;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (fitsProgressive(skillsForPrompt.slice(0, mid), truncatedBudget)) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    skillsForPrompt = skillsForPrompt.slice(0, lo);
+    truncated = true;
+  }
+
+  return { skillsForPrompt, truncated };
 }
 
 export function buildWorkspaceSkillSnapshot(
@@ -889,23 +938,43 @@ function resolveWorkspaceSkillPromptState(
   const promptSkills = compactSkillPaths(resolvedSkills)
     .slice()
     .sort((a, b) => a.name.localeCompare(b.name, "en"));
-  const { skillsForPrompt, truncated, compact } = applySkillsPromptLimits({
-    skills: promptSkills,
-    config: opts?.config,
-    agentId: opts?.agentId,
-  });
-  const truncationNote = truncated
-    ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}${compact ? " (compact format, descriptions omitted)" : ""}. Run \`openclaw skills check\` to audit.`
-    : compact
-      ? `⚠️ Skills catalog using compact format (descriptions omitted). Run \`openclaw skills check\` to audit.`
+  const promptMode = resolveSkillsPromptMode(opts?.config);
+  let skillsForPrompt: Skill[];
+  let truncated: boolean;
+  let promptBlock: string;
+  let promptModeNote = "";
+
+  if (promptMode === "legacy") {
+    const limited = applySkillsPromptLimits({
+      skills: promptSkills,
+      config: opts?.config,
+      agentId: opts?.agentId,
+    });
+    skillsForPrompt = limited.skillsForPrompt;
+    truncated = limited.truncated;
+    promptModeNote = truncated
+      ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}${limited.compact ? " (compact format, descriptions omitted)" : ""}. Run \`openclaw skills check\` to audit.`
+      : limited.compact
+        ? `⚠️ Skills catalog using compact format (descriptions omitted). Run \`openclaw skills check\` to audit.`
+        : "";
+    promptBlock = limited.compact
+      ? formatSkillsCompact(skillsForPrompt)
+      : formatSkillsForPrompt(skillsForPrompt);
+  } else {
+    const limited = applyProgressiveSkillsPromptLimits({
+      skills: promptSkills,
+      config: opts?.config,
+      agentId: opts?.agentId,
+      mode: promptMode,
+    });
+    skillsForPrompt = limited.skillsForPrompt;
+    truncated = limited.truncated;
+    promptModeNote = truncated
+      ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length} (progressive ${promptMode} mode). Run \`openclaw skills check\` to audit.`
       : "";
-  const prompt = [
-    remoteNote,
-    truncationNote,
-    compact ? formatSkillsCompact(skillsForPrompt) : formatSkillsForPrompt(skillsForPrompt),
-  ]
-    .filter(Boolean)
-    .join("\n");
+    promptBlock = formatSkillsProgressiveIndex(skillsForPrompt, promptMode);
+  }
+  const prompt = [remoteNote, promptModeNote, promptBlock].filter(Boolean).join("\n");
   return { eligible, prompt, resolvedSkills };
 }
 

--- a/src/agents/tools/skill-search-tool.test.ts
+++ b/src/agents/tools/skill-search-tool.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../skills/skill-contract.js";
+import { createSkillSearchTool } from "./skill-search-tool.js";
+
+function skill(name: string, description: string, filePath = `/skills/${name}/SKILL.md`): Skill {
+  return { name, description, filePath } as Skill;
+}
+
+describe("skill_search tool", () => {
+  it("searches resolved skill names and descriptions only", async () => {
+    const tool = createSkillSearchTool({
+      resolvedSkills: [
+        skill("memory-access", "Search and read persistent memory."),
+        skill("web-markdown-navigator", "Navigate fetched markdown pages."),
+        skill("dispatch-send", "Send a dispatch message."),
+      ],
+    });
+
+    const result = await tool.execute("call", { query: "memory" });
+
+    expect(result.details).toMatchObject({
+      ok: true,
+      query: "memory",
+      count: 1,
+      results: [
+        {
+          name: "memory-access",
+          description: "Search and read persistent memory.",
+          filePath: "/skills/memory-access/SKILL.md",
+        },
+      ],
+    });
+  });
+
+  it("clamps limit to 1-20 and returns metadata without content", async () => {
+    const resolvedSkills = Array.from({ length: 25 }, (_, index) =>
+      skill(`skill-${index.toString().padStart(2, "0")}`, "common term"),
+    );
+    const tool = createSkillSearchTool({ resolvedSkills });
+
+    const result = await tool.execute("call", { query: "common", limit: 50 });
+    const details = result.details as { results: Array<Record<string, unknown>> };
+
+    expect(details.results).toHaveLength(20);
+    expect(details.results[0]).not.toHaveProperty("content");
+  });
+});

--- a/src/agents/tools/skill-search-tool.ts
+++ b/src/agents/tools/skill-search-tool.ts
@@ -1,7 +1,10 @@
 import { Type } from "typebox";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { Skill } from "../skills/skill-contract.js";
 import type { AnyAgentTool } from "./common.js";
 import { asToolParamsRecord, jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const log = createSubsystemLogger("agents/tools/skill-search");
 
 const SkillSearchToolSchema = Type.Object({
   query: Type.String({ minLength: 1 }),
@@ -98,6 +101,14 @@ export function createSkillSearchTool(opts: { resolvedSkills: readonly Skill[] }
         .toSorted((a, b) => b.score - a.score || a.skill.name.localeCompare(b.skill.name))
         .slice(0, limit)
         .map((entry) => toSearchResult(entry.skill));
+
+      log.info("skill_search", {
+        queryLength: query.length,
+        termCount: terms.length,
+        limit,
+        resultCount: results.length,
+        resolvedSkillCount: opts.resolvedSkills.length,
+      });
 
       return jsonResult({
         ok: true,

--- a/src/agents/tools/skill-search-tool.ts
+++ b/src/agents/tools/skill-search-tool.ts
@@ -1,0 +1,110 @@
+import { Type } from "typebox";
+import type { Skill } from "../skills/skill-contract.js";
+import type { AnyAgentTool } from "./common.js";
+import { asToolParamsRecord, jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const SkillSearchToolSchema = Type.Object({
+  query: Type.String({ minLength: 1 }),
+  limit: Type.Optional(Type.Number({ minimum: 1, maximum: 20 })),
+});
+
+type SkillSearchResult = {
+  name: string;
+  description: string;
+  filePath: string;
+  sourceInfo?: Skill["sourceInfo"];
+};
+
+type ScoredSkill = {
+  skill: Skill;
+  score: number;
+};
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 20;
+
+function clampLimit(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(MAX_LIMIT, Math.max(1, Math.trunc(value)));
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9_-]+/u)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function scoreSkill(skill: Skill, query: string, queryTerms: readonly string[]): number {
+  const name = skill.name.toLowerCase();
+  const description = skill.description.toLowerCase();
+  const haystack = `${name}\n${description}`;
+  let score = 0;
+
+  if (name === query) {
+    score += 100;
+  } else if (name.includes(query)) {
+    score += 50;
+  }
+  if (description.includes(query)) {
+    score += 20;
+  }
+
+  for (const term of queryTerms) {
+    if (name === term) {
+      score += 30;
+    } else if (name.includes(term)) {
+      score += 12;
+    }
+    if (description.includes(term)) {
+      score += 6;
+    }
+    if (haystack.includes(term)) {
+      score += 1;
+    }
+  }
+
+  return score;
+}
+
+function toSearchResult(skill: Skill): SkillSearchResult {
+  return {
+    name: skill.name,
+    description: skill.description,
+    filePath: skill.filePath,
+    sourceInfo: skill.sourceInfo,
+  };
+}
+
+export function createSkillSearchTool(opts: { resolvedSkills: readonly Skill[] }): AnyAgentTool {
+  return {
+    label: "Skill Search",
+    name: "skill_search",
+    description:
+      "Search the skills already resolved for this run by name and description. Returns metadata only; use skill_view to read a selected skill file.",
+    parameters: SkillSearchToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = asToolParamsRecord(args);
+      const query = readStringParam(params, "query", { required: true }).toLowerCase();
+      const limit = clampLimit(readNumberParam(params, "limit", { integer: true }));
+      const terms = tokenize(query);
+
+      const results = opts.resolvedSkills
+        .map((skill): ScoredSkill => ({ skill, score: scoreSkill(skill, query, terms) }))
+        .filter((entry) => entry.score > 0)
+        .toSorted((a, b) => b.score - a.score || a.skill.name.localeCompare(b.skill.name))
+        .slice(0, limit)
+        .map((entry) => toSearchResult(entry.skill));
+
+      return jsonResult({
+        ok: true,
+        query,
+        count: results.length,
+        results,
+      });
+    },
+  };
+}

--- a/src/agents/tools/skill-view-tool.test.ts
+++ b/src/agents/tools/skill-view-tool.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Skill } from "../skills/skill-contract.js";
+import { createSkillViewTool } from "./skill-view-tool.js";
+
+let tmpDir: string;
+
+function makeSkill(name: string, description: string, filePath: string): Skill {
+  return { name, description, filePath } as Skill;
+}
+
+async function writeSkill(name: string, content = `# ${name}\n`): Promise<Skill> {
+  const dir = path.join(tmpDir, name);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, "SKILL.md");
+  await fs.writeFile(filePath, content, "utf8");
+  return makeSkill(name, `${name} description`, filePath);
+}
+
+describe("skill_view tool", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-view-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads the matched skill file and prefers exact match over case-insensitive match", async () => {
+    const exact = await writeSkill("Demo", "# exact\n");
+    const ci = await writeSkill("demo", "# lower\n");
+    const tool = createSkillViewTool({ resolvedSkills: [ci, exact] });
+
+    const result = await tool.execute("call", { name: "Demo" });
+
+    expect(result.details).toMatchObject({
+      ok: true,
+      skill: { name: "Demo" },
+      content: "# exact\n",
+    });
+  });
+
+  it("falls back to a case-insensitive name match", async () => {
+    const resolved = await writeSkill("Memory-Access", "# Memory\n");
+    const tool = createSkillViewTool({ resolvedSkills: [resolved] });
+
+    const result = await tool.execute("call", { name: "memory-access" });
+
+    expect(result.details).toMatchObject({ ok: true, skill: { name: "Memory-Access" } });
+  });
+
+  it("reads an optional relative file contained in the skill directory", async () => {
+    const resolved = await writeSkill("demo");
+    await fs.mkdir(path.join(tmpDir, "demo", "docs"));
+    await fs.writeFile(path.join(tmpDir, "demo", "docs", "extra.md"), "extra", "utf8");
+    const tool = createSkillViewTool({ resolvedSkills: [resolved] });
+
+    const result = await tool.execute("call", { name: "demo", file: "docs/extra.md" });
+
+    expect(result.details).toMatchObject({ ok: true, content: "extra" });
+  });
+
+  it("rejects absolute, url-like, and parent-relative file paths", async () => {
+    const resolved = await writeSkill("demo");
+    const tool = createSkillViewTool({ resolvedSkills: [resolved] });
+
+    await expect(
+      tool.execute("call", { name: "demo", file: "/etc/passwd" }),
+    ).resolves.toHaveProperty("details.ok", false);
+    await expect(
+      tool.execute("call", { name: "demo", file: "https://example.com/SKILL.md" }),
+    ).resolves.toHaveProperty("details.ok", false);
+    await expect(
+      tool.execute("call", { name: "demo", file: "../outside.md" }),
+    ).resolves.toHaveProperty("details.ok", false);
+  });
+
+  it("rejects symlink escapes after realpath containment", async () => {
+    const resolved = await writeSkill("demo");
+    const outside = path.join(tmpDir, "outside.txt");
+    await fs.writeFile(outside, "secret", "utf8");
+    await fs.symlink(outside, path.join(tmpDir, "demo", "link.txt"));
+    const tool = createSkillViewTool({ resolvedSkills: [resolved] });
+
+    const result = await tool.execute("call", { name: "demo", file: "link.txt" });
+
+    expect(result.details).toMatchObject({ ok: false, error: "file escapes skill directory" });
+  });
+
+  it("rejects directories, oversized files, and reports close matches", async () => {
+    const resolved = await writeSkill("memory-access", "123456");
+    const tool = createSkillViewTool({ resolvedSkills: [resolved], maxBytes: 3 });
+
+    await expect(
+      tool.execute("call", { name: "memory-access", file: "." }),
+    ).resolves.toHaveProperty("details.ok", false);
+    await expect(tool.execute("call", { name: "memory-access" })).resolves.toMatchObject({
+      details: { ok: false, error: "file too large", bytes: 6, maxBytes: 3 },
+    });
+
+    const missing = await tool.execute("call", { name: "memory" });
+    expect(missing.details).toMatchObject({
+      ok: false,
+      error: "skill not found",
+      closeMatches: [{ name: "memory-access" }],
+    });
+  });
+});

--- a/src/agents/tools/skill-view-tool.ts
+++ b/src/agents/tools/skill-view-tool.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Type } from "typebox";
+import type { Skill } from "../skills/skill-contract.js";
+import type { AnyAgentTool } from "./common.js";
+import { asToolParamsRecord, jsonResult, readStringParam } from "./common.js";
+
+const SkillViewToolSchema = Type.Object({
+  name: Type.String({ minLength: 1 }),
+  file: Type.Optional(Type.String({ minLength: 1 })),
+});
+
+type SkillMetadata = {
+  name: string;
+  description: string;
+  filePath: string;
+  sourceInfo?: Skill["sourceInfo"];
+};
+
+type SkillViewOptions = {
+  resolvedSkills: readonly Skill[];
+  maxBytes?: number;
+};
+
+const DEFAULT_MAX_BYTES = 256 * 1024;
+const MAX_CLOSE_MATCHES = 5;
+
+function toMetadata(skill: Skill): SkillMetadata {
+  return {
+    name: skill.name,
+    description: skill.description,
+    filePath: skill.filePath,
+    sourceInfo: skill.sourceInfo,
+  };
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  const previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  const current = Array<number>(b.length + 1).fill(0);
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitution = previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, substitution);
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+  return previous[b.length] ?? 0;
+}
+
+function closeMatches(skills: readonly Skill[], requestedName: string): SkillMetadata[] {
+  const query = requestedName.toLowerCase();
+  return skills
+    .map((skill) => {
+      const name = skill.name.toLowerCase();
+      const score =
+        name.includes(query) || query.includes(name) ? 0 : levenshteinDistance(query, name);
+      return { skill, score };
+    })
+    .toSorted((a, b) => a.score - b.score || a.skill.name.localeCompare(b.skill.name))
+    .slice(0, MAX_CLOSE_MATCHES)
+    .map((entry) => toMetadata(entry.skill));
+}
+
+function findSkill(skills: readonly Skill[], name: string): Skill | undefined {
+  return (
+    skills.find((skill) => skill.name === name) ??
+    skills.find((skill) => skill.name.toLowerCase() === name.toLowerCase())
+  );
+}
+
+function isUrlLike(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//iu.test(value) || /^file:/iu.test(value);
+}
+
+function isUnsafeRelativeFile(value: string): boolean {
+  if (value.includes("\0") || isUrlLike(value)) {
+    return true;
+  }
+  if (path.isAbsolute(value) || path.win32.isAbsolute(value)) {
+    return true;
+  }
+  const normalized = value.replace(/\\/gu, "/");
+  return normalized
+    .split("/")
+    .filter(Boolean)
+    .some((part) => part === "..");
+}
+
+function isWithinDirectory(candidate: string, directory: string): boolean {
+  const relative = path.relative(directory, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function resolveReadableFile(skill: Skill, requestedFile: string | undefined) {
+  const skillFileRealPath = await fs.realpath(skill.filePath);
+  const skillDirRealPath = await fs.realpath(path.dirname(skillFileRealPath));
+  const targetPath = requestedFile
+    ? path.resolve(skillDirRealPath, requestedFile)
+    : skillFileRealPath;
+  const targetRealPath = await fs.realpath(targetPath);
+
+  if (!isWithinDirectory(targetRealPath, skillDirRealPath)) {
+    return { ok: false as const, error: "file escapes skill directory" };
+  }
+
+  const stat = await fs.stat(targetRealPath);
+  if (!stat.isFile()) {
+    return { ok: false as const, error: "not a regular file" };
+  }
+
+  return { ok: true as const, path: targetRealPath, stat };
+}
+
+export function createSkillViewTool(opts: SkillViewOptions): AnyAgentTool {
+  const maxBytes = Math.max(1, Math.trunc(opts.maxBytes ?? DEFAULT_MAX_BYTES));
+  return {
+    label: "Skill View",
+    name: "skill_view",
+    description:
+      "Read a skill file up to 256KB from the skills already resolved for this run. Selects skills by exact name first, then case-insensitive name; optional file must stay within that skill directory.",
+    parameters: SkillViewToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = asToolParamsRecord(args);
+      const name = readStringParam(params, "name", { required: true });
+      const file = readStringParam(params, "file");
+      const skill = findSkill(opts.resolvedSkills, name);
+
+      if (!skill) {
+        return jsonResult({
+          ok: false,
+          error: "skill not found",
+          requestedName: name,
+          closeMatches: closeMatches(opts.resolvedSkills, name),
+        });
+      }
+
+      if (file && isUnsafeRelativeFile(file)) {
+        return jsonResult({
+          ok: false,
+          error: "invalid relative file path",
+          skill: toMetadata(skill),
+          requestedFile: file,
+        });
+      }
+
+      let resolved: Awaited<ReturnType<typeof resolveReadableFile>>;
+      try {
+        resolved = await resolveReadableFile(skill, file);
+      } catch (error) {
+        return jsonResult({
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+          skill: toMetadata(skill),
+          requestedFile: file,
+        });
+      }
+
+      if (!resolved.ok) {
+        return jsonResult({
+          ok: false,
+          error: resolved.error,
+          skill: toMetadata(skill),
+          requestedFile: file,
+        });
+      }
+
+      if (resolved.stat.size > maxBytes) {
+        return jsonResult({
+          ok: false,
+          error: "file too large",
+          skill: toMetadata(skill),
+          path: resolved.path,
+          bytes: resolved.stat.size,
+          maxBytes,
+        });
+      }
+
+      const content = await fs.readFile(resolved.path, "utf8");
+      return jsonResult({
+        ok: true,
+        skill: toMetadata(skill),
+        path: resolved.path,
+        bytes: Buffer.byteLength(content, "utf8"),
+        content,
+      });
+    },
+  };
+}

--- a/src/agents/tools/skill-view-tool.ts
+++ b/src/agents/tools/skill-view-tool.ts
@@ -1,9 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Type } from "typebox";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { Skill } from "../skills/skill-contract.js";
 import type { AnyAgentTool } from "./common.js";
 import { asToolParamsRecord, jsonResult, readStringParam } from "./common.js";
+
+const log = createSubsystemLogger("agents/tools/skill-view");
 
 const SkillViewToolSchema = Type.Object({
   name: Type.String({ minLength: 1 }),
@@ -127,6 +130,12 @@ export function createSkillViewTool(opts: SkillViewOptions): AnyAgentTool {
       const skill = findSkill(opts.resolvedSkills, name);
 
       if (!skill) {
+        log.info("skill_view", {
+          ok: false,
+          reason: "skill_not_found",
+          requestedName: name,
+          resolvedSkillCount: opts.resolvedSkills.length,
+        });
         return jsonResult({
           ok: false,
           error: "skill not found",
@@ -136,6 +145,12 @@ export function createSkillViewTool(opts: SkillViewOptions): AnyAgentTool {
       }
 
       if (file && isUnsafeRelativeFile(file)) {
+        log.info("skill_view", {
+          ok: false,
+          reason: "invalid_relative_file_path",
+          skill: skill.name,
+          requestedFile: file,
+        });
         return jsonResult({
           ok: false,
           error: "invalid relative file path",
@@ -148,15 +163,29 @@ export function createSkillViewTool(opts: SkillViewOptions): AnyAgentTool {
       try {
         resolved = await resolveReadableFile(skill, file);
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log.info("skill_view", {
+          ok: false,
+          reason: "resolve_failed",
+          skill: skill.name,
+          requestedFile: file,
+          error: message,
+        });
         return jsonResult({
           ok: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: message,
           skill: toMetadata(skill),
           requestedFile: file,
         });
       }
 
       if (!resolved.ok) {
+        log.info("skill_view", {
+          ok: false,
+          reason: resolved.error,
+          skill: skill.name,
+          requestedFile: file,
+        });
         return jsonResult({
           ok: false,
           error: resolved.error,
@@ -166,6 +195,14 @@ export function createSkillViewTool(opts: SkillViewOptions): AnyAgentTool {
       }
 
       if (resolved.stat.size > maxBytes) {
+        log.info("skill_view", {
+          ok: false,
+          reason: "file_too_large",
+          skill: skill.name,
+          requestedFile: file,
+          bytes: resolved.stat.size,
+          maxBytes,
+        });
         return jsonResult({
           ok: false,
           error: "file too large",
@@ -177,6 +214,12 @@ export function createSkillViewTool(opts: SkillViewOptions): AnyAgentTool {
       }
 
       const content = await fs.readFile(resolved.path, "utf8");
+      log.info("skill_view", {
+        ok: true,
+        skill: skill.name,
+        requestedFile: file,
+        bytes: Buffer.byteLength(content, "utf8"),
+      });
       return jsonResult({
         ok: true,
         skill: toMetadata(skill),

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -23653,6 +23653,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
               type: "string",
             },
           },
+          promptMode: {
+            type: "string",
+            enum: ["legacy", "compact", "view", "search"],
+          },
           load: {
             type: "object",
             properties: {

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -1,5 +1,7 @@
 import type { SecretInput } from "./types.secrets.js";
 
+export type SkillsPromptDisclosureMode = "legacy" | "compact" | "view" | "search";
+
 export type SkillConfig = {
   enabled?: boolean;
   apiKey?: SecretInput;
@@ -40,6 +42,8 @@ export type SkillsLimitsConfig = {
 export type SkillsConfig = {
   /** Optional bundled-skill allowlist (only affects bundled skills). */
   allowBundled?: string[];
+  /** Model-facing skills prompt disclosure mode. Defaults to legacy existing behavior. */
+  promptMode?: SkillsPromptDisclosureMode;
   load?: SkillsLoadConfig;
   install?: SkillsInstallConfig;
   limits?: SkillsLimitsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -986,6 +986,7 @@ export const OpenClawSchema = z
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
+        promptMode: z.enum(["legacy", "compact", "view", "search"]).optional(),
         load: z
           .object({
             extraDirs: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Adds **progressive skill disclosure** as an opt-in overlay on the existing skill loading path, plus prompt-assembly and tool-call telemetry to support safer pilot evaluation.

Two commits:

- `f643ff03` — `feat: add progressive skill disclosure`
- `07f4a6bd` — `chore: add progressive skill telemetry`

## Behavior

A new global config key `skills.promptMode` selects the skill-prompt shape and which optional tools are registered. Modes:

| Mode | Prompt | Tools registered |
|------|--------|------------------|
| `legacy` (default) | Existing full skill prompt | None added |
| `compact` | Compact name+description index, `read`-only fallback | None added |
| `view` | Compact index | `skill_view` |
| `search` | Compact index | `skill_view`, `skill_search` |

Skill eligibility is unchanged: the same prompt-visible `resolvedSkills` registry is used; only the *shape* of the prompt and the *optional* tool surface change.

## Important framing

- **Default behavior remains `legacy`.** Merging this PR does not change runtime behavior for any existing config.
- **No live enablement is implied.** Pilot/live deployment is a separate decision and remains gated.
- **`skills.promptMode` is global-only in this phase.** Per-agent override is intentionally out of scope for phase 1; pilot governance is operational unless/until a per-agent override is implemented.
- **HTTP / MCP / direct paths are intentionally deferred** because those construction paths do not currently carry `skillsSnapshot` into tool creation. This PR threads `skillsSnapshot` through OpenClaw tool construction only on the paths that already produce it (attempt path, embedded compact runner). Other paths fall back to legacy mode.
- **Telemetry is included** (`skills_prompt`, `skill_view`, `skill_search`) to make pilot evaluation safer. Telemetry does not log raw query text — `skill_search` records only query length and term count.

## What changed

- New tool implementations: `src/agents/tools/skill-view-tool.ts`, `src/agents/tools/skill-search-tool.ts` and tests.
- New compact index formatter and tests under `src/agents/skills/`.
- `skills.promptMode` added to TS config types **and** strict zod schema (`src/config/zod-schema.ts`); `config:schema:gen` regenerated `src/config/schema.base.generated.ts`.
- `skillsSnapshot` threaded through `createOpenClawCodingTools` -> `createOpenClawTools` (`src/agents/openclaw-tools.ts`, `src/agents/pi-tools.ts`) and through the embedded compact runner (`src/agents/pi-embedded-runner/compact.ts`) so progressive prompts only advertise tools the same path actually registers.
- Telemetry events emitted at prompt assembly and at `skill_view` / `skill_search` invocation.

## Verification

Run from the source checkout used to produce this branch:

- `pnpm install --frozen-lockfile`
- focused vitest: `skill-search-tool.test.ts`, `skill-view-tool.test.ts`, `compact-format.test.ts` — 5 files / 62 tests passed
- `pnpm tsgo:core` ✓
- `pnpm tsgo:core:test` ✓
- `pnpm config:schema:check` ✓ (after regenerate)
- `pnpm build` ✓
- `git diff --check` ✓

No live install. No gateway restart. PR/push only.

## Operation

OP-014 — Skills Progressive Disclosure. Originated by Sergent-Skills with implementation lanes coordinated by that role; source-maintainer review and PR submission performed by Sapeur per Corps officer boundary.
