### PR TITLE
feat(browser): add --headed flag to browser start for runtime headed handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Doctor/plugins: run a one-time 2026.5.2 configured-plugin install repair based on `meta.lastTouchedVersion`, installing actively used downloadable OpenClaw plugins from ClawHub with npm fallback before marking the config touched for the release.
+- Browser: add `--headed` flag to `openclaw browser start` and `headed: true` to the browser tool start action, so agents and operators can request a visible (non-headless) browser launch at runtime without changing config. `--headed` and `--headless` are mutually exclusive; both remain no-ops for already-running browsers. Fixes #75879. Thanks @hclsys.
 - Sessions/transcripts: use one `session.writeLock.acquireTimeoutMs` policy for session transcript lock acquisitions and raise the default wait to 60 seconds, avoiding user-visible lock timeouts during legitimate slow prep, cleanup, compaction, and mirror work. Fixes #75894. Thanks @shandutta.
 - Control UI: contain the standalone iOS PWA viewport with safe-area-aware document locking, so Add-to-Home-Screen launches cannot scroll past the device bounds. Refs #76072. Thanks @kvncrw.
 - Agents/restart recovery: match cleaned transcript locks by exact transcript lock paths plus the canonical session fallback, so interrupted main sessions using topic-suffixed transcripts resume after gateway restart. Refs #76052. Thanks @anyech.
@@ -387,7 +388,6 @@ Docs: https://docs.openclaw.ai
 - MCP/stdio: settle MCP stdio transport send() from the write callback instead of resolving immediately on buffer acceptance, so async write errors reject the promise instead of being lost. Refs #75438.
 - Process/exec: add stdin error listener in runCommandWithTimeout so EPIPE from a prematurely-exited child is swallowed instead of escaping to uncaughtException. Refs #75438.
 - Voice Call/realtime: add default-off fast memory/session context for `openclaw_agent_consult`, giving live calls a bounded answer-or-miss path before the full agent consult. Fixes #71849. Thanks @amzzzzzzz.
-
 - Google Meet: interrupt Realtime provider output when local barge-in clears playback, so command-pair audio stops model speech instead of only restarting Chrome playback. Fixes #73850. (#73834) Thanks @shhtheonlyperson.
 - Gateway/config: cap oversized plugin-owned schemas in the full `config.schema` response so large installed plugin sets cannot balloon Gateway RSS or crash schema clients. Thanks @vincentkoc.
 - Plugins/update: skip ClawHub and marketplace plugin updates when the bundled version is newer than the recorded installed version, so `openclaw update` no longer overwrites working bundled plugins with older external packages. Fixes #75447. Thanks @amknight.
@@ -1403,7 +1403,6 @@ Docs: https://docs.openclaw.ai
 - Docker/update smoke: keep the package-derived update-channel fixture on package-shipped files and make its UI build stub create the asset the updater verifies. Thanks @vincentkoc.
 - Gateway/models: repair legacy `models.providers.*.api = "openai"` config values to `openai-completions`, and skip providers with future stale API enum values during startup instead of bricking the gateway. Fixes #72477. (#72542) Thanks @JooyoungChoi14 and @obviyus.
 - Gateway/skills: redact `apiKey` and secret-named `env` values from the `skills.update` RPC response to prevent leaking credentials into WebSocket traffic, client logs, or session transcripts. Config is still written to disk in full; only the response payload is redacted. (#69998) Thanks @Ziy1-Tan.
-
 - Plugins/CLI: let flag-driven `openclaw channels add` install the selected channel plugin from its default source without opening an interactive prompt, fixing published npm Telegram setup in stdin-closed automation.
 - Onboarding/setup: keep first-run config reads, plugin compatibility notices, and post-model sanity checks on cold metadata paths unless the user chooses to browse all models, avoiding full plugin/runtime catalog work between prompts. Thanks @shakkernerd.
 - Onboarding/auth: run manifest-owned provider auth choices through scoped setup providers so selecting OpenAI Codex browser/device auth no longer loads every provider runtime before OAuth starts. Thanks @shakkernerd.
@@ -2830,7 +2829,6 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/outbound: fall back to the first `mediaUrls` entry when `mediaUrl` is empty so gateway media sends stop silently dropping attachments that already have a resolved media list. (#64394) Thanks @eric-fr4 and @vincentkoc.
 - Doctor/Discord: stop `openclaw doctor --fix` from rewriting legacy Discord preview-streaming config into the nested modern shape, so downgrades can still recover without hand-editing `channels.discord.streaming`. (#65035) Thanks @vincentkoc.
 - Gateway/auth: blank the shipped example gateway credential in `.env.example` and fail startup when a copied placeholder token or password is still configured, so operators cannot accidentally launch with a publicly known secret. (#64586) Thanks @navarrotech and @vincentkoc.
-
 - Memory/active-memory+dreaming: keep active-memory recall runs on the strongest resolved channel, consume managed dreaming heartbeat events exactly once, stop dreaming from re-ingesting its own narrative transcripts, and add explicit repair/dedupe recovery flows in CLI, doctor, and the Dreams UI.
 - Agents/queueing: carry orphaned active-turn user text into the next prompt before repairing transcript ordering, so follow-up messages that arrive mid-run are no longer silently dropped. (#65388) Thanks @adminfedres and @vincentkoc.
 - Gateway/keepalive: stop marking WebSocket tick broadcasts as droppable so slow or backpressured clients do not self-disconnect with `tick timeout` while long-running work is still alive. (#65256) Thanks @100yenadmin and @vincentkoc.
@@ -3030,7 +3028,6 @@ Docs: https://docs.openclaw.ai
 - Agents/exec: extend exec completion detection to cover local background exec formats so the owner-downgrade fires correctly for all exec paths. (#64376) Thanks @mmaps.
 - Security/dependencies: pin axios to 1.15.0 and add a plugin install dependency denylist that blocks known malicious packages before install. (#63891) Thanks @mmaps.
 - Browser/security: apply three-phase interaction navigation guard to pressKey and type(submit) so delayed JS redirects from keypress cannot bypass SSRF policy. (#63889) Thanks @mmaps.
-
 - Browser/security: guard existing-session Chrome MCP interaction routes with SSRF post-checks so delayed navigation from click, type, press, and evaluate cannot bypass the configured policy. (#64370) Thanks @eleqtrizit.
 - Browser/security: default browser SSRF policy to strict mode so unconfigured installs block private-network navigation, and align external-content marker span mapping so ZWS-injected boundary spoofs are fully sanitized. (#63885) Thanks @eleqtrizit.
 - Browser/security: apply SSRF navigation policy to subframe document navigations so iframe-targeted private-network hops are blocked without quarantining the parent page. (#64371) Thanks @eleqtrizit.

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -58,6 +58,7 @@ openclaw browser doctor
 openclaw browser doctor --deep
 openclaw browser start
 openclaw browser start --headless
+openclaw browser start --headed
 openclaw browser stop
 openclaw browser --browser-profile openclaw reset-profile
 ```
@@ -75,6 +76,11 @@ Notes:
   only when OpenClaw launches a local managed browser. It does not rewrite
   `browser.headless` or profile config, and it is a no-op for an already-running
   browser.
+- `openclaw browser start --headed` is the symmetric counterpart: it requests a
+  visible (non-headless) start for this request only, overriding config-level
+  `browser.headless=true` for the duration of the launch. Use it for human-handoff
+  workflows — stop the headless browser, then `openclaw browser start --headed` to
+  reopen it in a visible window. `--headed` and `--headless` are mutually exclusive.
 - On Linux hosts without `DISPLAY` or `WAYLAND_DISPLAY`, local managed profiles
   run headless automatically unless `OPENCLAW_BROWSER_HEADLESS=0`,
   `browser.headless=false`, or `browser.profiles.<name>.headless=false`

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -31,8 +31,14 @@ For local integrations only, the Gateway exposes a small loopback HTTP API:
 
 All endpoints accept `?profile=<name>`. `POST /start?headless=true` requests a
 one-shot headless launch for local managed profiles without changing persisted
-browser config; attach-only, remote CDP, and existing-session profiles reject
-that override because OpenClaw does not launch those browser processes.
+browser config. `POST /start?headless=false` requests a one-shot headed
+(visible) launch — useful for human-handoff workflows where the operator needs
+to observe or interact with the browser. Attach-only, remote CDP, and
+existing-session profiles reject these overrides because OpenClaw does not
+launch those browser processes.
+
+The same override is available via the CLI (`openclaw browser start --headed` /
+`--headless`) and the browser tool (`{ "action": "start", "headed": true }`).
 
 If shared-secret gateway auth is configured, browser HTTP routes require auth too:
 
@@ -131,6 +137,7 @@ All commands accept `--browser-profile <name>` to target a specific profile, and
 openclaw browser status
 openclaw browser start
 openclaw browser start --headless # one-shot local managed headless launch
+openclaw browser start --headed   # one-shot headed (visible) launch for human handoff
 openclaw browser stop            # also clears emulation on attach-only/remote CDP
 openclaw browser tabs
 openclaw browser tab             # shortcut for current tab

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -38,6 +38,8 @@ openclaw browser --browser-profile openclaw doctor
 openclaw browser --browser-profile openclaw doctor --deep
 openclaw browser --browser-profile openclaw status
 openclaw browser --browser-profile openclaw start
+openclaw browser --browser-profile openclaw start --headed   # one-shot visible launch for human handoff
+openclaw browser --browser-profile openclaw start --headless # one-shot headless launch override
 openclaw browser --browser-profile openclaw open https://example.com
 openclaw browser --browser-profile openclaw snapshot
 ```

--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -103,6 +103,8 @@ export const BrowserToolSchema = Type.Object({
   mode: optionalStringEnum(BROWSER_SNAPSHOT_MODES),
   snapshotFormat: optionalStringEnum(BROWSER_SNAPSHOT_FORMATS),
   refs: optionalStringEnum(BROWSER_SNAPSHOT_REFS),
+  headed: Type.Optional(Type.Boolean()),
+  headless: Type.Optional(Type.Boolean()),
   interactive: Type.Optional(Type.Boolean()),
   compact: Type.Optional(Type.Boolean()),
   depth: Type.Optional(Type.Number()),

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1378,3 +1378,63 @@ describe("browser tool act stale target recovery", () => {
     expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("browser tool start headless param", () => {
+  beforeEach(() => {
+    resetBrowserToolMocks();
+  });
+
+  it("passes headless=false when headless: false is given", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "start", headless: false });
+
+    expect(browserClientMocks.browserStart).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ headless: false }),
+    );
+  });
+
+  it("passes headless=true when headless: true is given", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "start", headless: true });
+
+    expect(browserClientMocks.browserStart).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ headless: true }),
+    );
+  });
+
+  it("passes no headless override when neither headed nor headless is given", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "start" });
+
+    expect(browserClientMocks.browserStart).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ headless: undefined }),
+    );
+  });
+
+  it("returns conflict error when headed and headless disagree", async () => {
+    const tool = createBrowserTool();
+    const result = await tool.execute?.("call-1", {
+      action: "start",
+      headed: true,
+      headless: true,
+    });
+
+    expect(result).toMatchObject({
+      content: [expect.objectContaining({ text: expect.stringContaining("conflict") })],
+    });
+    expect(browserClientMocks.browserStart).not.toHaveBeenCalled();
+  });
+
+  it("accepts consistent headed=true headless=false combination", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "start", headed: true, headless: false });
+
+    expect(browserClientMocks.browserStart).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ headless: false }),
+    );
+  });
+});

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -559,11 +559,25 @@ export function createBrowserTool(opts?: {
           return jsonResult(
             await browserToolDeps.browserStatus(baseUrl, { profile, timeoutMs: toolTimeoutMs }),
           );
-        case "start":
+        case "start": {
+          const headedParam = params.headed;
+          const headlessParam = params.headless;
+          const fromHeaded = typeof headedParam === "boolean" ? !headedParam : undefined;
+          const fromHeadless = typeof headlessParam === "boolean" ? headlessParam : undefined;
+          if (
+            fromHeaded !== undefined &&
+            fromHeadless !== undefined &&
+            fromHeaded !== fromHeadless
+          ) {
+            return jsonResult({ error: "`headed` and `headless` conflict — use one or the other" });
+          }
+          const headlessOverride = fromHeaded ?? fromHeadless;
           if (proxyRequest) {
             await proxyRequest({
               method: "POST",
               path: "/start",
+              query:
+                typeof headlessOverride === "boolean" ? { headless: headlessOverride } : undefined,
               profile,
               timeoutMs: toolTimeoutMs,
             });
@@ -576,10 +590,15 @@ export function createBrowserTool(opts?: {
               }),
             );
           }
-          await browserToolDeps.browserStart(baseUrl, { profile, timeoutMs: toolTimeoutMs });
+          await browserToolDeps.browserStart(baseUrl, {
+            profile,
+            timeoutMs: toolTimeoutMs,
+            headless: headlessOverride,
+          });
           return jsonResult(
             await browserToolDeps.browserStatus(baseUrl, { profile, timeoutMs: toolTimeoutMs }),
           );
+        }
         case "stop":
           if (proxyRequest) {
             await proxyRequest({

--- a/extensions/browser/src/browser/client.ts
+++ b/extensions/browser/src/browser/client.ts
@@ -110,10 +110,12 @@ export async function browserProfiles(
 
 export async function browserStart(
   baseUrl?: string,
-  opts?: { profile?: string; timeoutMs?: number },
+  opts?: { profile?: string; timeoutMs?: number; headless?: boolean },
 ): Promise<void> {
   const q = buildProfileQuery(opts?.profile);
-  await fetchBrowserJson(withBaseUrl(baseUrl, `/start${q}`), {
+  const headlessParam =
+    typeof opts?.headless === "boolean" ? `${q ? "&" : "?"}headless=${opts.headless}` : "";
+  await fetchBrowserJson(withBaseUrl(baseUrl, `/start${q}${headlessParam}`), {
     method: "POST",
     timeoutMs:
       typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)

--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   createBrowserManageProgram,
+  findBrowserManageCall,
   getBrowserManageCallBrowserRequestMock,
 } from "./browser-cli-manage.test-helpers.js";
 import { getBrowserCliRuntime, getBrowserCliRuntimeCapture } from "./browser-cli.test-support.js";
@@ -231,5 +232,45 @@ describe("browser manage output", () => {
     const output = getBrowserCliRuntime().log.mock.calls.at(-1)?.[0] as string;
     expect(output).toContain("OK gateway: browser control endpoint reachable");
     expect(output).toContain("OK tabs: 1 visible, use target t1");
+  });
+
+  it("passes headless=false query param when --headed flag is used", async () => {
+    const program = createBrowserManageProgram();
+    await program.parseAsync(["browser", "start", "--headed"], { from: "user" });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall).toBeDefined();
+    expect(startCall?.[1].query).toEqual({ headless: false });
+  });
+
+  it("passes headless=true query param when --headless flag is used", async () => {
+    const program = createBrowserManageProgram();
+    await program.parseAsync(["browser", "start", "--headless"], { from: "user" });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall).toBeDefined();
+    expect(startCall?.[1].query).toEqual({ headless: true });
+  });
+
+  it("passes no headless query param when neither --headed nor --headless is used", async () => {
+    const program = createBrowserManageProgram();
+    await program.parseAsync(["browser", "start"], { from: "user" });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall).toBeDefined();
+    expect(startCall?.[1].query).toBeUndefined();
+  });
+
+  it("logs error and exits when --headless and --headed are both used", async () => {
+    const program = createBrowserManageProgram();
+    await program
+      .parseAsync(["browser", "start", "--headless", "--headed"], { from: "user" })
+      .catch(() => undefined);
+
+    const logOutput = getBrowserCliRuntime().log.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("mutually exclusive"),
+    );
+    expect(logOutput).toBeDefined();
+    expect(getBrowserCliRuntime().exit).toHaveBeenCalledWith(1);
   });
 });

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -352,14 +352,21 @@ export function registerBrowserManageCommands(
     .command("start")
     .description("Start the browser (no-op if already running)")
     .option("--headless", "Launch a local managed browser headless for this start")
-    .action(async (opts: { headless?: boolean }, cmd) => {
+    .option("--headed", "Launch a local managed browser in headed (visible) mode for this start")
+    .action(async (opts: { headless?: boolean; headed?: boolean }, cmd) => {
+      if (opts.headless && opts.headed) {
+        defaultRuntime.log("error: --headless and --headed are mutually exclusive");
+        defaultRuntime.exit(1);
+        return;
+      }
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
+      const headlessOverride = opts.headless ? true : opts.headed ? false : undefined;
       await runBrowserCommand(async () => {
         await runBrowserToggle(parent, {
           profile,
           path: "/start",
-          query: opts.headless ? { headless: true } : undefined,
+          query: typeof headlessOverride === "boolean" ? { headless: headlessOverride } : undefined,
         });
       });
     });


### PR DESCRIPTION
Fixes #75879.

## What changes

Exposes the existing `POST /start?headless=false` route via three public surfaces that previously only offered the headless direction:

**1. CLI (`--headed` flag)**
```bash
openclaw browser start --headed
```
Symmetric counterpart to `--headless`. Sends `headless=false` to the route for this start only, without touching config. `--headed` and `--headless` are mutually exclusive (error if both passed).

**2. Browser tool (`headed: true` param)**
```json
{ "action": "start", "headed": true }
```
Added `headed?: boolean` to `BrowserToolSchema`. The tool derives `headless = !headed` and forwards it via query param on both the proxy-request path and the direct `browserStart` path.

**3. `browserStart` client helper (`headless` opt)**
Added `headless?: boolean` to the `browserStart` opts so library callers can request the override without URL construction.

## What does NOT change

- Route `parseHeadlessStartOverride` — untouched; already handles `?headless=false` correctly
- Config-level `browser.headless` — not written; override applies to this start request only
- Already-running browser — no-op (route behavior unchanged)
- Attach-only / remote CDP / existing-session profiles — still reject the override (route rejects them)

## Commit shape

3 commits, each independently testable:
1. `client.ts` — headless opt on `browserStart`
2. CLI + schema + browser-tool — end-to-end wiring
3. Docs + CHANGELOG

## Tests

```
pnpm test extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts \
          extensions/browser/src/browser/routes/basic.existing-session.test.ts \
          extensions/browser/src/browser/client.test.ts \
          extensions/browser/src/browser-tool.test.ts
# 72/72 passed
```

```
pnpm exec oxfmt --check --threads=1 <changed files>
# All matched files use the correct format.
```