### PR TITLE
[codex] browser: expose headed start override

### DIFF
--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -94,6 +94,8 @@ export const BrowserToolSchema = Type.Object({
   target: optionalStringEnum(BROWSER_TARGETS),
   node: Type.Optional(Type.String()),
   profile: Type.Optional(Type.String()),
+  headless: Type.Optional(Type.Boolean()),
+  headed: Type.Optional(Type.Boolean()),
   targetUrl: Type.Optional(Type.String()),
   url: Type.Optional(Type.String()),
   targetId: Type.Optional(Type.String()),

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -381,6 +381,46 @@ describe("browser tool snapshot maxChars", () => {
     );
   });
 
+  it("passes headless=false through local browser start", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "start", profile: "openclaw", headless: false });
+
+    expect(browserClientMocks.browserStart).toHaveBeenCalledWith(undefined, {
+      profile: "openclaw",
+      timeoutMs: undefined,
+      headless: false,
+    });
+  });
+
+  it("maps headed=true to headless=false for browser start through node proxy", async () => {
+    mockSingleBrowserProxyNode();
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "start", target: "node", headed: true });
+
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 25000 },
+      expect.objectContaining({
+        nodeId: "node-1",
+        command: "browser.proxy",
+        params: expect.objectContaining({
+          method: "POST",
+          path: "/start",
+          query: { headless: false },
+          timeoutMs: 20000,
+        }),
+      }),
+    );
+  });
+
+  it("rejects conflicting browser start headless/headed params", async () => {
+    const tool = createBrowserTool();
+
+    await expect(
+      tool.execute?.("call-1", { action: "start", headless: true, headed: true }),
+    ).rejects.toThrow(/Use either headless or headed/);
+  });
+
   it("uses a longer default timeout for existing-session profile status through node proxy", async () => {
     mockSingleBrowserProxyNode();
     setResolvedBrowserProfiles({

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -70,6 +70,24 @@ const browserToolDeps = {
   untrackSessionBrowserTab,
 };
 
+function resolveStartHeadlessOverride(params: Record<string, unknown>): boolean | undefined {
+  const headless = params.headless;
+  const headed = params.headed;
+  if (typeof headless === "boolean" && typeof headed === "boolean") {
+    if (headless === headed) {
+      throw new Error("Use either headless or headed for browser start, not both.");
+    }
+    return headless;
+  }
+  if (typeof headless === "boolean") {
+    return headless;
+  }
+  if (typeof headed === "boolean") {
+    return !headed;
+  }
+  return undefined;
+}
+
 export const __testing = {
   setDepsForTest(
     overrides: Partial<{
@@ -559,12 +577,14 @@ export function createBrowserTool(opts?: {
           return jsonResult(
             await browserToolDeps.browserStatus(baseUrl, { profile, timeoutMs: toolTimeoutMs }),
           );
-        case "start":
+        case "start": {
+          const startHeadless = resolveStartHeadlessOverride(params);
           if (proxyRequest) {
             await proxyRequest({
               method: "POST",
               path: "/start",
               profile,
+              query: typeof startHeadless === "boolean" ? { headless: startHeadless } : undefined,
               timeoutMs: toolTimeoutMs,
             });
             return jsonResult(
@@ -576,10 +596,15 @@ export function createBrowserTool(opts?: {
               }),
             );
           }
-          await browserToolDeps.browserStart(baseUrl, { profile, timeoutMs: toolTimeoutMs });
+          await browserToolDeps.browserStart(baseUrl, {
+            profile,
+            timeoutMs: toolTimeoutMs,
+            headless: startHeadless,
+          });
           return jsonResult(
             await browserToolDeps.browserStatus(baseUrl, { profile, timeoutMs: toolTimeoutMs }),
           );
+        }
         case "stop":
           if (proxyRequest) {
             await proxyRequest({

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -12,6 +12,7 @@ import {
   browserDoctor,
   browserOpenTab,
   browserSnapshot,
+  browserStart,
   browserStatus,
   browserTabs,
 } from "./client.js";
@@ -277,6 +278,9 @@ describe("browser client", () => {
       profile: "openclaw",
     });
 
+    await expect(
+      browserStart("http://127.0.0.1:18791", { profile: "work", headless: false }),
+    ).resolves.toBeUndefined();
     await expect(browserTabs("http://127.0.0.1:18791")).resolves.toHaveLength(1);
     await expect(
       browserOpenTab("http://127.0.0.1:18791", "https://example.com"),
@@ -314,6 +318,7 @@ describe("browser client", () => {
       browserScreenshotAction("http://127.0.0.1:18791", { targetId: "t-default" }),
     ).resolves.toMatchObject({ ok: true, path: "/tmp/a.png" });
 
+    expect(calls.some((c) => c.url.endsWith("/start?profile=work&headless=false"))).toBe(true);
     expect(calls.some((c) => c.url.endsWith("/tabs"))).toBe(true);
     expect(calls.some((c) => c.url.endsWith("/doctor"))).toBe(true);
     expect(calls.some((c) => c.url.endsWith("/doctor?profile=openclaw&deep=true"))).toBe(true);

--- a/extensions/browser/src/browser/client.ts
+++ b/extensions/browser/src/browser/client.ts
@@ -110,9 +110,16 @@ export async function browserProfiles(
 
 export async function browserStart(
   baseUrl?: string,
-  opts?: { profile?: string; timeoutMs?: number },
+  opts?: { profile?: string; timeoutMs?: number; headless?: boolean },
 ): Promise<void> {
-  const q = buildProfileQuery(opts?.profile);
+  const params = new URLSearchParams();
+  if (opts?.profile) {
+    params.set("profile", opts.profile);
+  }
+  if (typeof opts?.headless === "boolean") {
+    params.set("headless", String(opts.headless));
+  }
+  const q = params.size ? `?${params.toString()}` : "";
   await fetchBrowserJson(withBaseUrl(baseUrl, `/start${q}`), {
     method: "POST",
     timeoutMs:

--- a/extensions/browser/src/cli/browser-cli-examples.ts
+++ b/extensions/browser/src/cli/browser-cli-examples.ts
@@ -2,6 +2,7 @@ export const browserCoreExamples = [
   "openclaw browser status",
   "openclaw browser start",
   "openclaw browser start --headless",
+  "openclaw browser start --headed",
   "openclaw browser stop",
   "openclaw browser tabs",
   "openclaw browser open https://example.com",

--- a/extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts
@@ -30,6 +30,22 @@ describe("browser manage start timeout option", () => {
     expect(startCall?.[1]?.query).toEqual({ headless: true });
   });
 
+  it("passes headless=false for browser start --headed", async () => {
+    const program = createBrowserManageProgram({ withParentTimeout: true });
+    await program.parseAsync(["browser", "start", "--headed"], { from: "user" });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall?.[1]?.query).toEqual({ headless: false });
+  });
+
+  it("rejects browser start with both --headless and --headed", async () => {
+    const program = createBrowserManageProgram({ withParentTimeout: true });
+
+    await expect(
+      program.parseAsync(["browser", "start", "--headless", "--headed"], { from: "user" }),
+    ).rejects.toThrow(/Use either --headless or --headed/);
+  });
+
   it("combines browser profile with browser start --headless", async () => {
     const program = createBrowserManageProgram({ withParentTimeout: true });
     await program.parseAsync(["browser", "--browser-profile", "work", "start", "--headless"], {
@@ -38,6 +54,16 @@ describe("browser manage start timeout option", () => {
 
     const startCall = findBrowserManageCall("/start");
     expect(startCall?.[1]?.query).toEqual({ profile: "work", headless: true });
+  });
+
+  it("combines browser profile with browser start --headed", async () => {
+    const program = createBrowserManageProgram({ withParentTimeout: true });
+    await program.parseAsync(["browser", "--browser-profile", "work", "start", "--headed"], {
+      from: "user",
+    });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall?.[1]?.query).toEqual({ profile: "work", headless: false });
   });
 
   it("uses a longer built-in timeout for browser status", async () => {

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -112,6 +112,19 @@ function runBrowserCommand(action: () => Promise<void>) {
   });
 }
 
+function resolveStartHeadlessQuery(opts: { headless?: boolean; headed?: boolean }) {
+  if (opts.headless && opts.headed) {
+    throw new Error("Use either --headless or --headed, not both.");
+  }
+  if (opts.headless) {
+    return { headless: true };
+  }
+  if (opts.headed) {
+    return { headless: false };
+  }
+  return undefined;
+}
+
 function logBrowserTabs(tabs: BrowserTab[], json?: boolean) {
   if (json) {
     defaultRuntime.writeJson({ tabs });
@@ -352,14 +365,15 @@ export function registerBrowserManageCommands(
     .command("start")
     .description("Start the browser (no-op if already running)")
     .option("--headless", "Launch a local managed browser headless for this start")
-    .action(async (opts: { headless?: boolean }, cmd) => {
+    .option("--headed", "Launch a local managed browser headed for this start")
+    .action(async (opts: { headless?: boolean; headed?: boolean }, cmd) => {
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
       await runBrowserCommand(async () => {
         await runBrowserToggle(parent, {
           profile,
           path: "/start",
-          query: opts.headless ? { headless: true } : undefined,
+          query: resolveStartHeadlessQuery(opts),
         });
       });
     });


### PR DESCRIPTION
## Summary

- Add `openclaw browser start --headed` as the runtime counterpart to existing `--headless`.
- Forward `headless=false` through the browser client and browser tool start action, including node proxy requests.
- Add schema/tests for `headless: false` and `headed: true` start overrides, plus conflict handling.

## Why

OpenClaw already supports request-local `headless=false` internally on `/start`, but the public CLI/tool surface could only force headless. Human handoff workflows need to stop the managed browser and restart the same profile headed without editing `openclaw.json` or restarting the Gateway.

Fixes #75879.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts extensions/browser/src/browser/client.test.ts extensions/browser/src/browser-tool.test.ts`
- `pnpm tsgo:extensions:test`
- `pnpm exec oxfmt --check extensions/browser/src/cli/browser-cli-examples.ts extensions/browser/src/cli/browser-cli-manage.ts extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts extensions/browser/src/browser/client.ts extensions/browser/src/browser/client.test.ts extensions/browser/src/browser-tool.schema.ts extensions/browser/src/browser-tool.ts extensions/browser/src/browser-tool.test.ts`
- `git diff --check`
