### PR TITLE
fix(signal): support Note-to-Self in linked-device mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Signal: support Note-to-Self chat in linked-device mode — when the operator's E.164 number appears in `channels.signal.allowFrom`, self-addressed `syncMessage.sentMessage` envelopes (`destination === source`) are promoted to inbound `dataMessage` so personal-account users can chat with their agent via Note-to-Self. Mirrors WhatsApp's `selfChatMode` opt-in pattern. Other syncMessages (sentTranscripts to third parties, read receipts, etc.) and direct own-account messages remain dropped, preserving loop protection for outbound replies. Fixes #75870, #5722. Thanks @jeffhu1.
 - Heartbeat: strip legacy `[TOOL_CALL]...[/TOOL_CALL]` and `[TOOL_RESULT]...[/TOOL_RESULT]` pseudo-call blocks from heartbeat replies before channel delivery. Fixes #54138. Thanks @Deniable9570.
 - macOS/Voice Wake: send wake-word and Push-to-Talk transcripts through the selected macOS session target instead of always falling back to main WebChat. Fixes #51040. Thanks @carl-jeffrolc.
 - Providers/xAI: give Grok `web_search` a 60s default timeout, harden malformed xAI Responses parsing, and return structured timeout errors instead of aborting the tool call. Fixes #58063 and #58733. Thanks @dnishimura, @marvcasasola-svg, and @Nanako0129.

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -71,8 +71,12 @@ Disable with:
 ## The number model (important)
 
 - The gateway connects to a **Signal device** (the `signal-cli` account).
-- If you run the bot on **your personal Signal account**, it will ignore your own messages (loop protection).
-- For "I text the bot and it replies," use a **separate bot number**.
+- For "I text the bot and it replies," the cleanest option is still a **separate bot number** — fully isolates bot identity from your personal traffic.
+- If you run the bot as a **linked device on your personal Signal account**, by default it ignores your own messages and all sync messages (loop protection — prevents the bot from replying to its own outbound).
+- You can **opt in to Note-to-Self chat** by adding your own number to `channels.signal.allowFrom`. When the operator's E.164 number appears in `allowFrom`, Note-to-Self syncMessages (`destination === source`) are promoted to inbound and processed by the agent. This is the same implicit-opt-in pattern WhatsApp uses (`channels.whatsapp.selfChatMode`).
+- Other syncMessages (sentTranscripts to third parties, read receipts, etc.) and direct own-account messages are still dropped — loop protection for outbound replies is preserved.
+
+> **Privacy note:** when self-chat is on, your Note-to-Self thread becomes a real channel into the agent. Tune `dmPolicy` and per-agent permissions accordingly. To opt out at any time, remove your own number from `allowFrom`.
 
 ## Setup path A: link existing Signal account (QR)
 

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -59,6 +59,7 @@ import { normalizeSignalMessagingTarget } from "../normalize.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
 import type {
+  SignalDataMessage,
   SignalEnvelope,
   SignalEventHandlerDeps,
   SignalReactionMessage,
@@ -543,10 +544,23 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     // truthiness — required to avoid replaying the bot's own sent messages on
     // daemon restart (see related work in the loop-protection / sentTranscript
     // bug fixes).
-    const sentSyncMessage = envelope.syncMessage?.sentMessage;
+    // signal-cli's `syncMessage` envelope is typed as `unknown` since its shape
+    // varies across versions; cast through a narrow shape we care about. The
+    // `sentMessage` shape is the same as a regular dataMessage plus the
+    // destination* fields that identify the recipient of the sent message.
+    type SyncSentMessage = SignalDataMessage & {
+      destinationNumber?: string | null;
+      destination?: string | null;
+      destinationUuid?: string | null;
+    };
+    const syncMessage = envelope.syncMessage as
+      | { sentMessage?: SyncSentMessage | null }
+      | null
+      | undefined;
+    const sentSyncMessage = syncMessage?.sentMessage;
     if (sentSyncMessage) {
       const destNum = sentSyncMessage.destinationNumber ?? sentSyncMessage.destination;
-      const srcNum = envelope.sourceNumber ?? envelope.source;
+      const srcNum = envelope.sourceNumber;
       const destUuid = sentSyncMessage.destinationUuid;
       const srcUuid = envelope.sourceUuid;
       const isNoteToSelf =

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -541,7 +541,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const isSelfChatMode =
       normalizedAccount != null &&
       deps.allowFrom.some((entry) => {
-        if (entry === "*") return false;
+        if (entry === "*") {
+          return false;
+        }
         try {
           return normalizeE164(entry) === normalizedAccount;
         } catch {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -522,21 +522,45 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
-    // Check if the message is from our own account to prevent loop/self-reply
-    // This handles both phone number and UUID based identification
+    // Check if the message is from our own account.
+    // We treat Note-to-Self syncMessages as regular inbound (since the bot's user
+    // wants to chat via Note-to-Self when running as a linked device on their personal
+    // account), and drop all other own-account messages to prevent reply loops.
+    // This handles both phone number and UUID based identification.
     const normalizedAccount = deps.account ? normalizeE164(deps.account) : undefined;
-    const isOwnMessage =
+    const isOwnAccount =
       (sender.kind === "phone" && normalizedAccount != null && sender.e164 === normalizedAccount) ||
       (sender.kind === "uuid" && deps.accountUuid != null && sender.raw === deps.accountUuid);
-    if (isOwnMessage) {
-      return;
-    }
 
-    // Filter all sync messages (sentTranscript, readReceipts, etc.).
-    // signal-cli may set syncMessage to null instead of omitting it, so
-    // check property existence rather than truthiness to avoid replaying
-    // the bot's own sent messages on daemon restart.
-    if ("syncMessage" in envelope) {
+    // sentTranscript syncMessages where destination === source are Note-to-Self.
+    // Promote them to dataMessage so downstream allowFrom/dmPolicy/agent processing
+    // treats them as a normal inbound message. Other syncMessages (sentTranscripts
+    // to third parties, read receipts, etc.) are still dropped, as are direct
+    // own-account messages (loop protection for our own outbound replies).
+    //
+    // signal-cli may set syncMessage to null instead of omitting it, so the
+    // `"syncMessage" in envelope` check uses property existence rather than
+    // truthiness — required to avoid replaying the bot's own sent messages on
+    // daemon restart (see related work in the loop-protection / sentTranscript
+    // bug fixes).
+    const sentSyncMessage = envelope.syncMessage?.sentMessage;
+    if (sentSyncMessage) {
+      const destNum = sentSyncMessage.destinationNumber ?? sentSyncMessage.destination;
+      const srcNum = envelope.sourceNumber ?? envelope.source;
+      const destUuid = sentSyncMessage.destinationUuid;
+      const srcUuid = envelope.sourceUuid;
+      const isNoteToSelf =
+        (!!destNum && !!srcNum && destNum === srcNum) ||
+        (!!destUuid && !!srcUuid && destUuid === srcUuid);
+      if (isNoteToSelf) {
+        envelope.dataMessage = sentSyncMessage;
+        // fall through to normal inbound processing
+      } else {
+        return;
+      }
+    } else if ("syncMessage" in envelope) {
+      return;
+    } else if (isOwnAccount) {
       return;
     }
 

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -523,31 +523,41 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
-    // Check if the message is from our own account.
-    // We treat Note-to-Self syncMessages as regular inbound (since the bot's user
-    // wants to chat via Note-to-Self when running as a linked device on their personal
-    // account), and drop all other own-account messages to prevent reply loops.
-    // This handles both phone number and UUID based identification.
+    // Identify the operator's own account (used for both loop protection and
+    // self-chat detection below). Handles phone number and UUID identification.
     const normalizedAccount = deps.account ? normalizeE164(deps.account) : undefined;
     const isOwnAccount =
       (sender.kind === "phone" && normalizedAccount != null && sender.e164 === normalizedAccount) ||
       (sender.kind === "uuid" && deps.accountUuid != null && sender.raw === deps.accountUuid);
 
-    // sentTranscript syncMessages where destination === source are Note-to-Self.
-    // Promote them to dataMessage so downstream allowFrom/dmPolicy/agent processing
-    // treats them as a normal inbound message. Other syncMessages (sentTranscripts
-    // to third parties, read receipts, etc.) are still dropped, as are direct
-    // own-account messages (loop protection for our own outbound replies).
-    //
-    // signal-cli may set syncMessage to null instead of omitting it, so the
-    // `"syncMessage" in envelope` check uses property existence rather than
-    // truthiness — required to avoid replaying the bot's own sent messages on
-    // daemon restart (see related work in the loop-protection / sentTranscript
-    // bug fixes).
+    // Self-chat mode: implicitly opt-in via allowFrom containing the operator's
+    // own number. Same pattern as WhatsApp's selfChatMode — see
+    // extensions/whatsapp/src/targets-runtime.ts `isSelfChatMode`. When this is
+    // on, Note-to-Self syncMessages are promoted to dataMessage so the user can
+    // chat with their agent via Note-to-Self while signal-cli runs as a linked
+    // device on their personal Signal account. When off, all syncMessages are
+    // dropped (existing behavior — preserves loop protection for dedicated-bot
+    // deployments where allowFrom contains other people's numbers).
+    const isSelfChatMode =
+      normalizedAccount != null &&
+      deps.allowFrom.some((entry) => {
+        if (entry === "*") return false;
+        try {
+          return normalizeE164(entry) === normalizedAccount;
+        } catch {
+          return false;
+        }
+      });
+
     // signal-cli's `syncMessage` envelope is typed as `unknown` since its shape
     // varies across versions; cast through a narrow shape we care about. The
     // `sentMessage` shape is the same as a regular dataMessage plus the
     // destination* fields that identify the recipient of the sent message.
+    //
+    // signal-cli may set syncMessage to null instead of omitting it, so the
+    // `"syncMessage" in envelope` check uses property existence rather than
+    // truthiness — required to avoid replaying the bot's own sent messages on
+    // daemon restart (loop-protection for sentTranscripts).
     type SyncSentMessage = SignalDataMessage & {
       destinationNumber?: string | null;
       destination?: string | null;
@@ -558,7 +568,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       | null
       | undefined;
     const sentSyncMessage = syncMessage?.sentMessage;
-    if (sentSyncMessage) {
+    if (sentSyncMessage && isSelfChatMode) {
+      // Promote sentTranscript syncMessages where destination === source
+      // (Note-to-Self) to dataMessage. Other sentTranscripts (to third
+      // parties) are still dropped via the syncMessage branch below.
       const destNum = sentSyncMessage.destinationNumber ?? sentSyncMessage.destination;
       const srcNum = envelope.sourceNumber;
       const destUuid = sentSyncMessage.destinationUuid;


### PR DESCRIPTION
## Summary

- **Problem:** When `signal-cli` runs as a linked device on the operator's personal Signal account, the existing loop-protection in `event-handler.ts` blanket-drops all messages from the bot's own account AND all syncMessages. Note-to-Self chat is therefore impossible.
- **Why it matters:** Note-to-Self is the natural chat surface for users running OpenClaw as a personal agent on their existing Signal account. Without this, users must acquire a dedicated bot number to chat with their own agent — significant friction for personal-use deployments.
- **What changed:** Added a Note-to-Self carve-out: syncMessages where `destination === source` are promoted to `dataMessage` so downstream `allowFrom`/`dmPolicy`/agent processing treats them as normal inbound. Both phone-number and UUID identification paths are handled.
- **What did NOT change (scope boundary):** Loop protection is preserved. Other syncMessages (sentTranscripts to third parties, read receipts, etc.) and direct own-account messages are still dropped.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #75870
- Related: #5722 (original feature request with equivalent patch, closed via maintainer triage without review)
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** Loop-protection was implemented as "drop anything from own account; drop anything that's a syncMessage" — correct for preventing outbound replies from re-triggering the agent, but blanket-blocks legitimate Note-to-Self conversations on a linked-device personal-account setup.
- **Missing detection / guardrail:** Implementation didn't distinguish syncMessages-to-self (legitimate inbound) from syncMessages-to-others (true outbound replays). Treating them the same is the bug.
- **Contributing context:** This carve-out is the canonical pattern other Signal-cli bots use (`signal-ai-chat-bot`, `signalbot`, Hermes Agent). Requested by multiple users since Feb 2026.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/signal/src/monitor/event-handler.test.ts` (or equivalent)
- Scenario the test should lock in: `syncMessage` with `destination === source` (Note-to-Self) is promoted to `dataMessage`; `destination !== source` (third-party transcript) is still dropped; direct own-account non-sync messages still dropped.
- If no new test is added, why not: Author doesn't have local pnpm/CI set up for this repo. Happy to add a unit test in a follow-up or per maintainer guidance.

## User-visible / Behavior Changes

- Linked-device deployments where `signal-cli` is paired to the operator's personal Signal account can now chat with the agent via Note-to-Self.
- No new config flag; behavior is automatic when `destination === source`.
- No change for dedicated-bot-number deployments (the typical pattern).

## Diagram

```text
Before:
phone -> Note-to-Self -> Signal server -> linked signal-cli -> envelope
   -> "syncMessage" in envelope -> RETURN (dropped)
   -> agent never sees it

After:
phone -> Note-to-Self -> Signal server -> linked signal-cli -> envelope
   -> envelope.syncMessage.sentMessage exists
   -> destination === source ? YES
   -> envelope.dataMessage = sentMessage; fall through
   -> agent processes as normal inbound (subject to allowFrom/dmPolicy)
```

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** (existing `dmPolicy`/`allowFrom` gates still apply)
- Data access scope changed? **No** — only routing decision changes.

The patch only changes which messages get routed inbound. Existing access-control machinery still gates whether the agent processes them.

## Repro + Verification

### Environment

- OS: macOS 15 (Apple Silicon M2 Max)
- Runtime: openclaw@2026.4.29 globally installed; daemon as launchd LaunchAgent
- Model/provider: anthropic/claude-opus-4-7 (direct API)
- Channel: Signal (`signal-cli 0.14.3` linked as device)
- Config: `channels.signal.dmPolicy=allowlist`, `allowFrom=["+1xxxxx"]` (operator's own number), `groupPolicy=disabled`

### Steps

1. Pair `signal-cli` as a linked device of operator's personal Signal account (`signal-cli link -n "OpenClaw"` + scan QR)
2. Configure OpenClaw signal channel for the linked account
3. From operator's phone, send a message to the "Note to Self" thread

### Expected

- Agent receives the message and responds in the same thread.

### Actual (before patch)

- Message silently dropped; no agent response in Note-to-Self.

### Actual (after patch)

- Agent processes Note-to-Self message and replies in the same thread.

## Evidence

- [x] Trace/log snippets

Manually verified end-to-end against a working OpenClaw 2026.4.29 install with the equivalent patch applied to the bundled `dist/monitor-D141zc1R.js` (same logic). Note-to-Self bidirectional chat works; non-Note-to-Self syncMessages and direct own-account outbound are still correctly dropped (no spurious replies, no infinite loops over a multi-hour test session).

## Human Verification

- Verified scenarios:
  - Note-to-Self message from primary device (phone) → agent responds correctly ✅
  - Outbound message from agent to Note-to-Self → not re-processed (no loop) ✅
  - sentTranscript syncMessages to third parties → dropped (`destination !== source`) ✅
  - Other inbound (third-party DMs to operator) → unaffected by this change ✅
- Edge cases checked:
  - UUID identification path (`destinationUuid === sourceUuid`)
  - Phone-number identification path (`destinationNumber === sourceNumber`)
  - Envelope with only one of phone/UUID populated — falsy guards handle gracefully
- What I did **not** verify:
  - Did NOT run `pnpm build && pnpm check && pnpm test` locally (no local pnpm setup for this monorepo)
  - Did NOT add a new unit test
  - Did NOT run `codex review --base origin/main` locally

## Compatibility / Migration

- Backward compatible? **Yes** — behavior only changes for syncMessages with `destination === source`, which were previously dropped. No config or migration required.
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Future Signal/signal-cli protocol changes could rename `destinationNumber`/`destinationUuid` fields.
  - **Mitigation:** Falsy-guarded checks (`!!destNum && !!srcNum`); missing fields cause the syncMessage to fall through to the existing `"syncMessage" in envelope → return` branch (preserves loop protection).

---

## AI-assisted PR

- [x] Marked as AI-assisted (this section)
- **Degree of testing:** lightly tested — manual end-to-end against a running daemon; no pnpm test suite run.
- **Confirm I understand what the code does:** Yes. The patch promotes self-addressed `syncMessage.sentMessage` envelopes to `dataMessage` to allow Note-to-Self routing through the existing inbound pipeline.
- **Codex review:** Did NOT run `codex review --base origin/main` locally (no local codex CLI setup); flagging for first-push CI review.
- **Bot review conversations:** Will resolve any addressed bot conversations after first push.