### PR TITLE
fix(telegram): trigger synthetic session after enqueuing reaction events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/reactions: fire an immediate synthetic heartbeat session after enqueueing reaction system events, so approval reactions (e.g. ✅ on a confirmation card) are processed right away instead of waiting for the next scheduled heartbeat or incoming message. Fixes a dedupe edge case where multiple reactions on the same message shared the same synthetic session id by including the Telegram update_id as a discriminator. Fixes #75899.
+
 - WhatsApp/security: keep contact/vCard/location structured-object free text out of the inline message body and render it through fenced untrusted metadata JSON, limiting hidden prompt-injection payloads in names, phone fields, and location labels/comments.
 - Plugins/startup: restore bundled plugin `openclaw/plugin-sdk/*` resolution from packaged installs and external runtime-deps stage roots, so Telegram/Discord no longer crash-loop with `Cannot find package 'openclaw'` after missing dependency repair.
 - CLI/Claude: run the same prompt-build hooks and trigger/channel context on `claude-cli` turns as on direct embedded runs, keeping Claude Code sessions aligned with OpenClaw workspace identity, routing, and hook-driven prompt mutations. (#70625) Thanks @mbelinky.

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1014,7 +1014,7 @@ export const registerTelegramHandlers = ({
           storeAllowFrom,
           {
             forceWasMentioned: true,
-            messageIdOverride: `reaction:${chatId}:${messageId}`,
+            messageIdOverride: `reaction:${chatId}:${messageId}:${ctx.update.update_id}`,
           },
         );
         logVerbose(`telegram: reaction session triggered for sessionKey=${sessionKey}`);

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -27,6 +27,7 @@ import {
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/infra-runtime";
 import { formatModelsAvailableHeader } from "openclaw/plugin-sdk/models-provider-runtime";
+import { HEARTBEAT_PROMPT } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
@@ -984,6 +985,41 @@ export const registerTelegramHandlers = ({
           contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
         });
         logVerbose(`telegram: reaction event enqueued: ${text}`);
+      }
+
+      // Trigger a synthetic heartbeat session so the queued reaction
+      // system events are drained and processed immediately, rather than
+      // waiting for the next scheduled heartbeat or an incoming message.
+      // Without this, approval reactions (e.g. ✅ on a confirmation card)
+      // are silently delayed until the next session start.
+      try {
+        const storeAllowFrom = await loadStoreAllowFrom();
+        const syntheticBase: Message = {
+          message_id: messageId,
+          from: user ?? { id: 0, is_bot: false, first_name: "unknown" },
+          chat: reaction.chat,
+          date: Math.floor(Date.now() / 1000),
+          text: "",
+        };
+        await processMessage(
+          buildSyntheticContext(
+            ctx,
+            buildSyntheticTextMessage({
+              base: syntheticBase,
+              from: user,
+              text: HEARTBEAT_PROMPT,
+            }),
+          ),
+          [],
+          storeAllowFrom,
+          {
+            forceWasMentioned: true,
+            messageIdOverride: `reaction:${chatId}:${messageId}`,
+          },
+        );
+        logVerbose(`telegram: reaction session triggered for sessionKey=${sessionKey}`);
+      } catch (reactionTriggerErr) {
+        logVerbose(`telegram: reaction session trigger failed: ${String(reactionTriggerErr)}`);
       }
     } catch (err) {
       runtime.error?.(danger(`telegram reaction handler failed: ${String(err)}`));

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2887,4 +2887,43 @@ describe("createTelegramBot", () => {
 
     expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
   });
+
+  it("triggers a synthetic session after enqueuing reaction system events", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    replySpy.mockClear();
+    wasSentByBot.mockReturnValue(true);
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "own" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 700 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada", username: "ada_bot" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+      },
+      me: { id: 1, is_bot: true, first_name: "Bot" },
+    });
+
+    // Reaction system event must be enqueued.
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+
+    // A synthetic heartbeat session must have been triggered so the queued
+    // reaction event is drained immediately, without waiting for the next
+    // scheduled heartbeat or an incoming message.
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Telegram `message_reaction` updates arrive fire-and-forget with no retry. The handler correctly enqueues a system event via `enqueueSystemEvent`, but previously never triggered a new session run — leaving the queued event dormant until the next scheduled heartbeat or an incoming message.

For user-approval flows that rely on reactions (e.g. ✅ on a confirmation card), this meant the approved action could be silently delayed for minutes (or indefinitely if no heartbeat is configured).

Fix: after enqueueing all reaction system events, call `processMessage` with a synthetic heartbeat context so the events are drained and processed immediately. All the necessary helpers (`processMessage`, `buildSyntheticContext`, `buildSyntheticTextMessage`, `loadStoreAllowFrom`) are already in the `registerTelegramHandlers` closure — the same pattern is used by the callback_query handler.

The `HEARTBEAT_PROMPT` text makes the synthetic session self-contained: the agent reads `HEARTBEAT.md`, processes system events (including the newly queued reaction), and exits quietly with `HEARTBEAT_OK` if there is nothing else to do. Errors from the synthetic session are caught and logged at verbose level so they never surface as reaction handler failures.

This only fires when `reactionMode !== "off"` and `addedReactions.length > 0`. For `reactionMode === "own"`, reactions on non-bot messages are already filtered out before this point, so the extra session cost is limited to reactions on bot-sent messages only.

Adds a test that verifies `replySpy` (proxy for `processMessage`) is called after a valid reaction is received.

Note: pre-existing typecheck failure in `extensions/amazon-bedrock-mantle` (#private mismatch from nested @anthropic-ai/sdk versions) is unrelated to this change and exists on the base branch.

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
