### PR TITLE
docs: clarify Codex coding executor patterns

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -36,6 +36,35 @@ changing config.
 | Image generation or editing                          | `openai/gpt-image-2`                             | Works with either `OPENAI_API_KEY` or OpenAI Codex OAuth.                 |
 | Transparent-background images                        | `openai/gpt-image-1.5`                           | Use `outputFormat=png` or `webp` and `openai.background=transparent`.     |
 
+## Coding executor patterns
+
+When you want OpenAI to handle coding or tool-heavy execution, say **Codex**,
+not generic **OpenAI**. Generic `openai/*` usually means direct OpenAI Platform
+API-key traffic unless you also select the native Codex runtime.
+
+A common split is to keep a strong planner/personality model in front and route
+mechanical coding work to a subscription-backed coding executor:
+
+| Pattern | Planner / reviewer | Coding executor | Billing/auth path |
+| ------- | ------------------ | --------------- | ----------------- |
+| Claude plans, Codex codes | `anthropic/claude-*` using API key or `agentRuntime.id: "claude-cli"` | `openai/gpt-5.5` with `agentRuntime.id: "codex"` | Claude API/CLI for planning; ChatGPT/Codex sign-in for execution |
+| Codex-only coding agent | `openai/gpt-5.5` | `agentRuntime.id: "codex"` | ChatGPT/Codex sign-in |
+| PI runner with Codex OAuth | Any planner | `openai-codex/gpt-5.5` | ChatGPT/Codex OAuth through PI |
+
+Use the native Codex runtime for repo edits, shell work, debugging, and agentic
+coding sessions when you want subscription-backed Codex behavior. Use
+`openai-codex/*` only when you intentionally want Codex OAuth through the normal
+OpenClaw PI runner. Use direct `openai/*` without the Codex runtime only when
+you want OpenAI Platform API-key billing.
+
+<Note>
+Claude CLI and Codex OAuth are both subscription-style routes, but they are not
+the same product or runtime. Claude CLI is a Claude execution backend;
+OpenAI Codex OAuth/native Codex runtime is the OpenAI coding executor path.
+Pick either for coding if it matches your subscription and reliability needs,
+but keep the model prefix, auth route, and runtime label explicit in config.
+</Note>
+
 ## Naming map
 
 The names are similar but not interchangeable:

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -42,14 +42,16 @@ When you want OpenAI to handle coding or tool-heavy execution, say **Codex**,
 not generic **OpenAI**. Generic `openai/*` usually means direct OpenAI Platform
 API-key traffic unless you also select the native Codex runtime.
 
-A common split is to keep a strong planner/personality model in front and route
-mechanical coding work to a subscription-backed coding executor:
+A common split is to keep orchestration on your preferred default model and
+route mechanical coding work to a subscription-backed coding executor. Use
+Claude CLI as an explicit writing or second-review lane when you want that
+model's taste or critique, not as an implied orchestration default:
 
-| Pattern                    | Planner / reviewer                                                    | Coding executor                                  | Billing/auth path                                                |
-| -------------------------- | --------------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------- |
-| Claude plans, Codex codes  | `anthropic/claude-*` using API key or `agentRuntime.id: "claude-cli"` | `openai/gpt-5.5` with `agentRuntime.id: "codex"` | Claude API/CLI for planning; ChatGPT/Codex sign-in for execution |
-| Codex-only coding agent    | `openai/gpt-5.5`                                                      | `agentRuntime.id: "codex"`                       | ChatGPT/Codex sign-in                                            |
-| PI runner with Codex OAuth | Any planner                                                           | `openai-codex/gpt-5.5`                           | ChatGPT/Codex OAuth through PI                                   |
+| Pattern                    | Orchestrator / reviewer                                               | Coding executor                                  | Billing/auth path                                      |
+| -------------------------- | --------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| Codex-default agent        | `openai/gpt-5.5` with `agentRuntime.id: "codex"`                      | `agentRuntime.id: "codex"`                       | ChatGPT/Codex sign-in                                  |
+| Claude review, Codex codes | `anthropic/claude-*` using API key or `agentRuntime.id: "claude-cli"` | `openai/gpt-5.5` with `agentRuntime.id: "codex"` | Claude for review; ChatGPT/Codex sign-in for execution |
+| PI runner with Codex OAuth | Any orchestrator                                                      | `openai-codex/gpt-5.5`                           | ChatGPT/Codex OAuth through PI                         |
 
 Use the native Codex runtime for repo edits, shell work, debugging, and agentic
 coding sessions when you want subscription-backed Codex behavior. Use

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -45,11 +45,11 @@ API-key traffic unless you also select the native Codex runtime.
 A common split is to keep a strong planner/personality model in front and route
 mechanical coding work to a subscription-backed coding executor:
 
-| Pattern | Planner / reviewer | Coding executor | Billing/auth path |
-| ------- | ------------------ | --------------- | ----------------- |
-| Claude plans, Codex codes | `anthropic/claude-*` using API key or `agentRuntime.id: "claude-cli"` | `openai/gpt-5.5` with `agentRuntime.id: "codex"` | Claude API/CLI for planning; ChatGPT/Codex sign-in for execution |
-| Codex-only coding agent | `openai/gpt-5.5` | `agentRuntime.id: "codex"` | ChatGPT/Codex sign-in |
-| PI runner with Codex OAuth | Any planner | `openai-codex/gpt-5.5` | ChatGPT/Codex OAuth through PI |
+| Pattern                    | Planner / reviewer                                                    | Coding executor                                  | Billing/auth path                                                |
+| -------------------------- | --------------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------- |
+| Claude plans, Codex codes  | `anthropic/claude-*` using API key or `agentRuntime.id: "claude-cli"` | `openai/gpt-5.5` with `agentRuntime.id: "codex"` | Claude API/CLI for planning; ChatGPT/Codex sign-in for execution |
+| Codex-only coding agent    | `openai/gpt-5.5`                                                      | `agentRuntime.id: "codex"`                       | ChatGPT/Codex sign-in                                            |
+| PI runner with Codex OAuth | Any planner                                                           | `openai-codex/gpt-5.5`                           | ChatGPT/Codex OAuth through PI                                   |
 
 Use the native Codex runtime for repo edits, shell work, debugging, and agentic
 coding sessions when you want subscription-backed Codex behavior. Use

--- a/extensions/duckduckgo/src/ddg-search-provider.shared.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.shared.ts
@@ -1,11 +1,16 @@
-import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-contract";
+import {
+  createWebSearchProviderContractFields,
+  type WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search-contract";
 
-export function createDuckDuckGoWebSearchProviderBase() {
+type DuckDuckGoWebSearchProviderBase = Omit<WebSearchProviderPlugin, "createTool">;
+
+export function createDuckDuckGoWebSearchProviderBase(): DuckDuckGoWebSearchProviderBase {
   return {
     id: "duckduckgo",
     label: "DuckDuckGo Search (experimental)",
     hint: "Free web search fallback with no API key required",
-    onboardingScopes: ["text-inference"] as const,
+    onboardingScopes: ["text-inference"],
     requiresCredential: false,
     envVars: [],
     placeholder: "(no key needed)",

--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -77,7 +77,7 @@ function isoDateExclusiveEnd(value: string): string {
 }
 
 function freshnessStartTime(freshness: GeminiFreshness, now: Date): string {
-  const start = new Date(now.getTime());
+  const start = new Date(now);
   start.setUTCDate(start.getUTCDate() - GEMINI_FRESHNESS_DAYS[freshness]);
   return start.toISOString();
 }

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -126,7 +126,8 @@ describe("google web search provider", () => {
 
     await tool?.execute({ query: "latest ai news", freshness: "week" });
 
-    const body = JSON.parse(String(mockFetch.mock.calls[0]?.[1]?.body)) as {
+    const requestInit = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    const body = JSON.parse(requestInit?.body as string) as {
       tools?: Array<{ google_search?: { timeRangeFilter?: unknown } }>;
     };
     expect(body.tools?.[0]?.google_search?.timeRangeFilter).toEqual({
@@ -161,7 +162,8 @@ describe("google web search provider", () => {
       date_before: "2026-04-30",
     });
 
-    const body = JSON.parse(String(mockFetch.mock.calls[0]?.[1]?.body)) as {
+    const requestInit = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    const body = JSON.parse(requestInit?.body as string) as {
       tools?: Array<{ google_search?: { timeRangeFilter?: unknown } }>;
     };
     expect(body.tools?.[0]?.google_search?.timeRangeFilter).toEqual({

--- a/extensions/voice-call/src/manager.restore.test.ts
+++ b/extensions/voice-call/src/manager.restore.test.ts
@@ -127,8 +127,8 @@ describe("CallManager verification on restore", () => {
     vi.setSystemTime(now);
     const { manager, provider } = await initializeManager({
       callOverrides: {
-        startedAt: now.getTime() - 290_000,
-        answeredAt: now.getTime() - 290_000,
+        startedAt: Date.now() - 290_000,
+        answeredAt: Date.now() - 290_000,
         state: "answered",
       },
       configOverrides: { maxDurationSeconds: 300 },


### PR DESCRIPTION
## Summary
- clarify that generic OpenAI and Codex are different routes for coding execution
- document planner/reviewer plus subscription-backed coding executor patterns
- call out Claude CLI vs OpenAI Codex OAuth/native Codex runtime as distinct subscription-style paths

## Validation
- Attempted `pnpm format:docs:check`; blocked because the fresh clone has no `node_modules/oxfmt` installed.
- Inspected the generated docs diff manually.