### PR TITLE
feat(feishu): add topicRequireMention for topic thread mention control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Feishu: add `topicRequireMention` config option for groups so operators can require @mention in the main chat but allow free replies inside topic threads, with per-group and top-level overrides. Fixes #76010. Thanks @seaurching.
 - Tools: add a platform-level tool descriptor planner for descriptor-first visibility, generic availability checks, and executor references. Thanks @shakkernerd.
 - Docs/Codex: clarify that ChatGPT/Codex subscription setups should use `openai/gpt-*` with `agentRuntime.id: "codex"` for native Codex runtime, while `openai-codex/*` remains the PI OAuth route. Thanks @pashpashpash.
 - Plugins/source checkout: load bundled plugins from the `extensions/*` pnpm workspace tree in source checkouts, so plugin-local dependencies and edits are used directly while packaged installs keep using the built runtime tree. Thanks @vincentkoc.

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -74,6 +74,13 @@ Default: `allowlist`
 - Per-group override: `channels.feishu.groups.<chat_id>.requireMention`
 - Broadcast-only `@all` and `@_all` are not treated as bot mentions. A message that mentions both `@all` and the bot directly still counts as a bot mention.
 
+**Topic thread mention override** (`channels.feishu.topicRequireMention`):
+
+When a message is part of a Feishu topic thread (`thread_id` is set), `topicRequireMention` takes precedence over `requireMention` if configured. This lets you require @mention for new conversations in the main chat while allowing free replies inside a started thread.
+
+- Per-group override: `channels.feishu.groups.<chat_id>.topicRequireMention`
+- When unset, `requireMention` applies to topic thread messages as well (backwards-compatible default).
+
 ---
 
 ## Group configuration examples
@@ -127,6 +134,24 @@ In `allowlist` mode, you can also admit a group by adding an explicit `groups.<c
       groups: {
         oc_xxx: {
           requireMention: false,
+        },
+      },
+    },
+  },
+}
+```
+
+### Require @mention in the main chat, but allow free replies inside topic threads
+
+```json5
+{
+  channels: {
+    feishu: {
+      groupPolicy: "allowlist",
+      groups: {
+        oc_xxx: {
+          requireMention: true, // @mention required for new messages
+          topicRequireMention: false, // no @mention needed inside a topic thread
         },
       },
     },
@@ -403,34 +428,36 @@ See [Get group/user IDs](#get-groupuser-ids) for lookup tips.
 
 Full configuration: [Gateway configuration](/gateway/configuration)
 
-| Setting                                           | Description                                                                      | Default          |
-| ------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------- |
-| `channels.feishu.enabled`                         | Enable/disable the channel                                                       | `true`           |
-| `channels.feishu.domain`                          | API domain (`feishu` or `lark`)                                                  | `feishu`         |
-| `channels.feishu.connectionMode`                  | Event transport (`websocket` or `webhook`)                                       | `websocket`      |
-| `channels.feishu.defaultAccount`                  | Default account for outbound routing                                             | `default`        |
-| `channels.feishu.verificationToken`               | Required for webhook mode                                                        | —                |
-| `channels.feishu.encryptKey`                      | Required for webhook mode                                                        | —                |
-| `channels.feishu.webhookPath`                     | Webhook route path                                                               | `/feishu/events` |
-| `channels.feishu.webhookHost`                     | Webhook bind host                                                                | `127.0.0.1`      |
-| `channels.feishu.webhookPort`                     | Webhook bind port                                                                | `3000`           |
-| `channels.feishu.accounts.<id>.appId`             | App ID                                                                           | —                |
-| `channels.feishu.accounts.<id>.appSecret`         | App Secret                                                                       | —                |
-| `channels.feishu.accounts.<id>.domain`            | Per-account domain override                                                      | `feishu`         |
-| `channels.feishu.accounts.<id>.tts`               | Per-account TTS override                                                         | `messages.tts`   |
-| `channels.feishu.dmPolicy`                        | DM policy                                                                        | `allowlist`      |
-| `channels.feishu.allowFrom`                       | DM allowlist (open_id list)                                                      | [BotOwnerId]     |
-| `channels.feishu.groupPolicy`                     | Group policy                                                                     | `allowlist`      |
-| `channels.feishu.groupAllowFrom`                  | Group allowlist                                                                  | —                |
-| `channels.feishu.requireMention`                  | Require @mention in groups                                                       | `true`           |
-| `channels.feishu.groups.<chat_id>.requireMention` | Per-group @mention override; explicit IDs also admit the group in allowlist mode | inherited        |
-| `channels.feishu.groups.<chat_id>.enabled`        | Enable/disable a specific group                                                  | `true`           |
-| `channels.feishu.textChunkLimit`                  | Message chunk size                                                               | `2000`           |
-| `channels.feishu.mediaMaxMb`                      | Media size limit                                                                 | `30`             |
-| `channels.feishu.streaming`                       | Streaming card output                                                            | `true`           |
-| `channels.feishu.blockStreaming`                  | Block-level streaming                                                            | `true`           |
-| `channels.feishu.typingIndicator`                 | Send typing reactions                                                            | `true`           |
-| `channels.feishu.resolveSenderNames`              | Resolve sender display names                                                     | `true`           |
+| Setting                                                | Description                                                                                        | Default          |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ---------------- |
+| `channels.feishu.enabled`                              | Enable/disable the channel                                                                         | `true`           |
+| `channels.feishu.domain`                               | API domain (`feishu` or `lark`)                                                                    | `feishu`         |
+| `channels.feishu.connectionMode`                       | Event transport (`websocket` or `webhook`)                                                         | `websocket`      |
+| `channels.feishu.defaultAccount`                       | Default account for outbound routing                                                               | `default`        |
+| `channels.feishu.verificationToken`                    | Required for webhook mode                                                                          | —                |
+| `channels.feishu.encryptKey`                           | Required for webhook mode                                                                          | —                |
+| `channels.feishu.webhookPath`                          | Webhook route path                                                                                 | `/feishu/events` |
+| `channels.feishu.webhookHost`                          | Webhook bind host                                                                                  | `127.0.0.1`      |
+| `channels.feishu.webhookPort`                          | Webhook bind port                                                                                  | `3000`           |
+| `channels.feishu.accounts.<id>.appId`                  | App ID                                                                                             | —                |
+| `channels.feishu.accounts.<id>.appSecret`              | App Secret                                                                                         | —                |
+| `channels.feishu.accounts.<id>.domain`                 | Per-account domain override                                                                        | `feishu`         |
+| `channels.feishu.accounts.<id>.tts`                    | Per-account TTS override                                                                           | `messages.tts`   |
+| `channels.feishu.dmPolicy`                             | DM policy                                                                                          | `allowlist`      |
+| `channels.feishu.allowFrom`                            | DM allowlist (open_id list)                                                                        | [BotOwnerId]     |
+| `channels.feishu.groupPolicy`                          | Group policy                                                                                       | `allowlist`      |
+| `channels.feishu.groupAllowFrom`                       | Group allowlist                                                                                    | —                |
+| `channels.feishu.requireMention`                       | Require @mention in groups                                                                         | `true`           |
+| `channels.feishu.topicRequireMention`                  | @mention requirement override for topic thread messages; falls back to `requireMention` when unset | unset            |
+| `channels.feishu.groups.<chat_id>.requireMention`      | Per-group @mention override; explicit IDs also admit the group in allowlist mode                   | inherited        |
+| `channels.feishu.groups.<chat_id>.topicRequireMention` | Per-group @mention override for topic thread messages                                              | inherited        |
+| `channels.feishu.groups.<chat_id>.enabled`             | Enable/disable a specific group                                                                    | `true`           |
+| `channels.feishu.textChunkLimit`                       | Message chunk size                                                                                 | `2000`           |
+| `channels.feishu.mediaMaxMb`                           | Media size limit                                                                                   | `30`             |
+| `channels.feishu.streaming`                            | Streaming card output                                                                              | `true`           |
+| `channels.feishu.blockStreaming`                       | Block-level streaming                                                                              | `true`           |
+| `channels.feishu.typingIndicator`                      | Send typing reactions                                                                              | `true`           |
+| `channels.feishu.resolveSenderNames`                   | Resolve sender display names                                                                       | `true`           |
 
 ---
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1542,6 +1542,79 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 
+  it("dispatches topic thread message without mention when topicRequireMention=false (requireMention=true)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "allowlist",
+          groups: {
+            "oc-topic-group": {
+              requireMention: true,
+              topicRequireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: { open_id: "ou-sender" },
+      },
+      message: {
+        message_id: "msg-topic-no-mention",
+        chat_id: "oc-topic-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "continuing the thread" }),
+        thread_id: "omt_thread_abc123",
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalled();
+  });
+
+  it("drops non-topic message without mention when requireMention=true and topicRequireMention=false", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "allowlist",
+          groups: {
+            "oc-topic-group-2": {
+              requireMention: true,
+              topicRequireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: { open_id: "ou-sender" },
+      },
+      message: {
+        message_id: "msg-normal-no-mention",
+        chat_id: "oc-topic-group-2",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello without mention" }),
+        // no thread_id — normal group message
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
   it("drops message when groupConfig.enabled is false", async () => {
     const cfg: ClawdbotConfig = {
       channels: {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -604,6 +604,7 @@ export async function handleFeishuMessage(params: {
       accountId: account.accountId,
       groupId: ctx.chatId,
       groupPolicy,
+      isTopic: Boolean(ctx.threadId),
     }));
 
     if (requireMention && !ctx.mentionedBot) {

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -307,3 +307,46 @@ describe("FeishuConfigSchema defaultAccount", () => {
     }
   });
 });
+
+describe("FeishuConfigSchema topicRequireMention", () => {
+  it("accepts topicRequireMention at top level", () => {
+    const result = FeishuConfigSchema.safeParse({ topicRequireMention: false });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.topicRequireMention).toBe(false);
+    }
+  });
+
+  it("accepts topicRequireMention inside a group entry", () => {
+    const result = FeishuGroupSchema.safeParse({
+      requireMention: true,
+      topicRequireMention: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.topicRequireMention).toBe(false);
+    }
+  });
+
+  it("accepts topicRequireMention inside an account config", () => {
+    const result = FeishuConfigSchema.safeParse({
+      accounts: {
+        main: { topicRequireMention: true },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accounts?.main?.topicRequireMention).toBe(true);
+    }
+  });
+
+  it("rejects non-boolean topicRequireMention at top level", () => {
+    const result = FeishuConfigSchema.safeParse({ topicRequireMention: "yes" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-boolean topicRequireMention in group entry", () => {
+    const result = FeishuGroupSchema.safeParse({ topicRequireMention: 1 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -159,6 +159,7 @@ const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    topicRequireMention: z.boolean().optional(),
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -182,6 +183,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  topicRequireMention: z.boolean().optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),
@@ -241,6 +243,7 @@ export const FeishuConfigSchema = z
     reactionNotifications: ReactionNotificationModeSchema.optional().default("own"),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     requireMention: z.boolean().optional(),
+    topicRequireMention: z.boolean().optional(),
     groupSessionScope: GroupSessionScopeSchema,
     topicSessionMode: TopicSessionModeSchema,
     // Dynamic agent creation for DM users

--- a/extensions/feishu/src/policy.test.ts
+++ b/extensions/feishu/src/policy.test.ts
@@ -332,3 +332,102 @@ describe("isFeishuGroupAllowed", () => {
     ).toBe(false);
   });
 });
+
+describe("resolveFeishuReplyPolicy — topicRequireMention", () => {
+  it("overrides requireMention with topicRequireMention=false for topic messages", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        cfg: createCfg({
+          groupPolicy: "allowlist",
+          groups: {
+            oc_xxx: { requireMention: true, topicRequireMention: false },
+          },
+        }),
+        groupPolicy: "allowlist",
+        groupId: "oc_xxx",
+        isTopic: true,
+      }),
+    ).toEqual({ requireMention: false });
+  });
+
+  it("falls back to requireMention in topic thread when topicRequireMention is absent", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        cfg: createCfg({
+          groupPolicy: "allowlist",
+          groups: { oc_xxx: { requireMention: true } },
+        }),
+        groupPolicy: "allowlist",
+        groupId: "oc_xxx",
+        isTopic: true,
+      }),
+    ).toEqual({ requireMention: true });
+  });
+
+  it("ignores topicRequireMention for non-topic messages", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        cfg: createCfg({
+          groupPolicy: "allowlist",
+          groups: {
+            oc_xxx: { requireMention: true, topicRequireMention: false },
+          },
+        }),
+        groupPolicy: "allowlist",
+        groupId: "oc_xxx",
+        isTopic: false,
+      }),
+    ).toEqual({ requireMention: true });
+  });
+
+  it("DM short-circuits to false regardless of topicRequireMention", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: true,
+        cfg: createCfg({
+          requireMention: true,
+          topicRequireMention: true,
+          groups: { oc_xxx: { requireMention: true, topicRequireMention: true } },
+        }),
+        groupPolicy: "allowlist",
+        groupId: "oc_xxx",
+        isTopic: true,
+      }),
+    ).toEqual({ requireMention: false });
+  });
+
+  it("resolves top-level topicRequireMention when no per-group entry exists", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        cfg: createCfg({
+          groupPolicy: "allowlist",
+          requireMention: true,
+          topicRequireMention: false,
+        }),
+        groupPolicy: "allowlist",
+        groupId: "oc_xxx",
+        isTopic: true,
+      }),
+    ).toEqual({ requireMention: false });
+  });
+
+  it("per-group topicRequireMention beats top-level topicRequireMention", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        cfg: createCfg({
+          groupPolicy: "allowlist",
+          topicRequireMention: true,
+          groups: { oc_xxx: { topicRequireMention: false } },
+        }),
+        groupPolicy: "allowlist",
+        groupId: "oc_xxx",
+        isTopic: true,
+      }),
+    ).toEqual({ requireMention: false });
+  });
+});

--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -207,6 +207,12 @@ export function resolveFeishuReplyPolicy(params: {
    * @-mentions are still delivered to the agent.
    */
   groupPolicy?: "open" | "allowlist" | "disabled" | "allowall";
+  /**
+   * Whether the incoming message is inside a Feishu topic thread
+   * (event.message.thread_id is set). When true, topicRequireMention
+   * takes precedence over requireMention if configured.
+   */
+  isTopic?: boolean;
 }): { requireMention: boolean } {
   if (params.isDirectMessage) {
     return { requireMention: false };
@@ -220,11 +226,23 @@ export function resolveFeishuReplyPolicy(params: {
     normalizeAccountId,
     omitKeys: ["defaultAccount"],
   });
-  const groupRequireMention = resolveFeishuGroupConfig({
+  const groupCfg = resolveFeishuGroupConfig({
     cfg: resolvedCfg,
     groupId: params.groupId,
-  })?.requireMention;
+  });
 
+  if (params.isTopic) {
+    const groupTopicRequireMention = groupCfg?.topicRequireMention;
+    const topLevelTopicRequireMention = resolvedCfg.topicRequireMention;
+    if (typeof groupTopicRequireMention === "boolean") {
+      return { requireMention: groupTopicRequireMention };
+    }
+    if (typeof topLevelTopicRequireMention === "boolean") {
+      return { requireMention: topLevelTopicRequireMention };
+    }
+  }
+
+  const groupRequireMention = groupCfg?.requireMention;
   return {
     requireMention:
       typeof groupRequireMention === "boolean"


### PR DESCRIPTION
  Summary

  - Problem: requireMention in Feishu groups applies equally to normal group messages and topic thread replies, with no way to separate the two. Users who want to require @mention for new
  conversations but allow free replies inside started threads cannot do so.
  - Why it matters: In busy group chats, requiring @mention on every topic reply is noisy and breaks the natural conversation flow inside a thread.
  - What changed: Added optional topicRequireMention boolean at top-level, per-account, and per-group config levels. When a message has thread_id set (Feishu topic thread),
  topicRequireMention takes precedence over requireMention. Falls back to existing requireMention cascade when unset.
  - What did NOT change: DM behavior, topic session routing (groupSessionScope, topicSessionMode), replyInThread, broadcast dispatch, and all other group access-control logic are unchanged.

  Change Type (select all)

  - Bug fix
  - Feature
  - Refactor required for the fix
  - Docs
  - Security hardening
  - Chore/infra

  Scope (select all touched areas)

  - Gateway / orchestration
  - Skills / tool execution
  - Auth / tokens
  - Memory / storage
  - Integrations
  - API / contracts
  - UI / DX
  - CI/CD / infra

  Linked Issue/PR

  - Closes #76010
  - This PR fixes a bug or regression

  Root Cause (if applicable)

  N/A — this is a new feature, not a bug fix.

  Regression Test Plan (if applicable)

  N/A — new feature, no regression to guard against. New test coverage added instead:

  - Coverage level:
    - Unit test ✓
    - Seam / integration test
    - End-to-end test
    - Existing coverage already sufficient
  - Target test or file: extensions/feishu/src/policy.test.ts, extensions/feishu/src/bot.test.ts, extensions/feishu/src/config-schema.test.ts
  - Scenario the test should lock in: topic thread messages bypass mention gate when topicRequireMention=false; non-topic messages are unaffected by topicRequireMention
  - Why this is the smallest reliable guardrail: policy resolution is pure and fully unit-testable; bot-level integration test covers the full dispatch path
  - Existing test that already covers this (if any): N/A
  - If no new test is added, why not: Tests were added (6 unit + 2 integration + 5 schema)

  User-visible / Behavior Changes

  New optional config keys:

  - channels.feishu.topicRequireMention — top-level override for topic thread messages
  - channels.feishu.groups.<chat_id>.topicRequireMention — per-group override

  When unset, behavior is identical to today. No defaults changed.

  Diagram (if applicable)

  Before:
  [group message] -> requireMention check -> respond / drop

  After:
  [group message, thread_id set] -> topicRequireMention (if set) -> respond / drop
                                                 ↓ (fallback)
  [group message, no thread_id]  -> requireMention check          -> respond / drop

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Environment

  - OS: Linux
  - Runtime/container: Node 22
  - Model/provider: any
  - Integration/channel: Feishu (websocket mode)
  - Relevant config (redacted):

  {
    channels: {
      feishu: {
        groupPolicy: "allowlist",
        groups: {
          "oc_xxx": {
            requireMention: true,
            topicRequireMention: false,
          },
        },
      },
    },
  }

  Steps

  1. Configure group with requireMention: true, topicRequireMention: false
  2. Send a normal group message without @mention → bot should not respond
  3. Send a message inside a topic thread without @mention → bot should respond

  Expected

  - Step 2: no response
  - Step 3: bot responds

  Actual

  - Verified via unit and integration tests (712 passed)

  Evidence

  - Failing test/log before + passing after — 6 new unit tests in policy.test.ts, 2 integration tests in bot.test.ts, 5 schema tests in config-schema.test.ts, all passing (712 total)

  Human Verification (required)

  - Verified scenarios: policy resolution cascade (per-group beats top-level, topic beats non-topic, DM short-circuit), schema acceptance/rejection at all three levels, bot dispatch gate with
   and without thread_id
  - Edge cases checked: topicRequireMention absent → full backwards compat; DM with both knobs set → still false; wildcard group entry with topicRequireMention
  - What you did not verify: live Feishu WebSocket delivery (no test credentials available)

  Review Conversations

  - I replied to or resolved every bot review conversation I addressed in this PR.
  - I left unresolved only the conversations that still need reviewer or maintainer judgment.

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? Yes — two new optional config keys (topicRequireMention at top-level and per-group); no breaking changes, no migration needed
  - Migration needed? No

  Risks and Mitigations

  - Risk: operator sets topicRequireMention: false globally and accidentally opens the bot to all topic thread messages without realizing requireMention only guards the main chat now
    - Mitigation: documented clearly in docs/channels/feishu.md with an explicit example showing the combined use of both flags