### PR TITLE
[codex] feat(webchat): add gateway read aloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Dependencies: refresh workspace dependency pins, including TypeBox 1.1.37, AWS SDK 3.1041.0, Microsoft Teams 2.0.9, and Marked 18.0.3. Thanks @mariozechner, @aws, and @microsoft.
 - Discord/channels: add reusable message-channel access groups plus Discord channel-audience DM authorization, so allowlists can reference `accessGroup:<name>` across channel auth paths. (#75813)
 - Crabbox/scripts: print the selected Crabbox binary, version, and supported providers before `pnpm crabbox:*` commands, and reject stale binaries that lack `blacksmith-testbox` provider support.
+- Control UI/WebChat: add gateway-backed assistant Read aloud playback through configured `messages.tts` providers, without falling back to browser speech synthesis. Refs #45508.
 
 ### Fixes
 

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -37,6 +37,7 @@ Status: the macOS/iOS SwiftUI chat UI talks directly to the Gateway WebSocket.
   and assistant entries whose whole visible text is only the exact silent
   token `NO_REPLY` / `no_reply` are omitted.
 - Reasoning-flagged reply payloads (`isReasoning: true`) are excluded from WebChat assistant content, transcript replay text, and audio content blocks, so thinking-only payloads do not surface as visible assistant messages or playable audio.
+- Assistant messages can be read aloud from the Control UI through the Gateway `tts.convert` RPC, so playback uses `messages.tts` providers instead of browser speech synthesis.
 - `chat.inject` appends an assistant note directly to the transcript and broadcasts it to the UI (no agent run).
 - Aborted runs can keep partial assistant output visible in the UI.
 - Gateway persists aborted partial assistant text into transcript history when buffered output exists, and marks those entries with abort metadata.

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -241,11 +241,13 @@ img.chat-avatar {
 }
 
 .chat-copy-btn,
-.chat-expand-btn {
+.chat-expand-btn,
+.chat-read-aloud-btn {
   background: var(--bg);
   color: var(--muted);
 }
 
+.chat-read-aloud-btn__icon,
 .chat-copy-btn__icon {
   display: inline-flex;
   width: 14px;
@@ -254,7 +256,8 @@ img.chat-avatar {
 }
 
 .chat-copy-btn__icon svg,
-.chat-expand-btn__icon svg {
+.chat-expand-btn__icon svg,
+.chat-read-aloud-btn__icon svg {
   width: 14px;
   height: 14px;
 }
@@ -297,7 +300,8 @@ img.chat-avatar {
 }
 
 .chat-copy-btn:focus-visible,
-.chat-expand-btn:focus-visible {
+.chat-expand-btn:focus-visible,
+.chat-read-aloud-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -31,7 +31,7 @@ import {
 } from "./controllers/agents.ts";
 import { setAssistantAvatarOverride } from "./controllers/assistant-identity.ts";
 import { loadChannels } from "./controllers/channels.ts";
-import { loadChatHistory } from "./controllers/chat.ts";
+import { loadChatHistory, readAloudAssistantMessage } from "./controllers/chat.ts";
 import {
   applyConfig,
   ensureAgentConfigEntry,
@@ -2411,6 +2411,16 @@ export function renderApp(state: AppViewState) {
               splitRatio: state.splitRatio,
               canvasHostUrl: state.hello?.canvasHostUrl ?? null,
               onOpenSidebar: (content) => state.handleOpenSidebar(content),
+              onReadAloud:
+                state.connected &&
+                state.client &&
+                (state.hello?.features?.methods ?? []).includes("tts.convert")
+                  ? (text) =>
+                      readAloudAssistantMessage(state, text, {
+                        basePath: state.basePath ?? "",
+                        authToken: resolveAssistantAttachmentAuthToken(state),
+                      })
+                  : undefined,
               onCloseSidebar: () => state.handleCloseSidebar(),
               onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
               assistantName: state.assistantName,

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -255,7 +255,7 @@ afterEach(() => {
 });
 
 describe("grouped chat rendering", () => {
-  it("does not render the stale assistant read-aloud footer action", () => {
+  it("does not render read-aloud without a gateway handler", () => {
     const container = document.createElement("div");
     renderAssistantMessage(container, {
       role: "assistant",
@@ -265,6 +265,29 @@ describe("grouped chat rendering", () => {
 
     expect(container.querySelector(".chat-tts-btn")).toBeNull();
     expect(container.querySelector('[aria-label="Read aloud"]')).toBeNull();
+  });
+
+  it("renders gateway-backed read-aloud when a handler is supplied", async () => {
+    const onReadAloud = vi.fn();
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: "hello from assistant",
+        timestamp: 1000,
+      },
+      { onReadAloud },
+    );
+
+    const button = container.querySelector<HTMLButtonElement>('[aria-label="Read aloud"]');
+    expect(button).not.toBeNull();
+    expect(button?.classList.contains("chat-read-aloud-btn")).toBe(true);
+    button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+
+    expect(onReadAloud).toHaveBeenCalledWith("hello from assistant");
+    expect(container.querySelector(".chat-tts-btn")).toBeNull();
   });
 
   it("positions delete confirm by message side", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -369,6 +369,7 @@ export function renderMessageGroup(
   group: MessageGroup,
   opts: {
     onOpenSidebar?: (content: SidebarContent) => void;
+    onReadAloud?: (text: string) => void | Promise<void>;
     showReasoning: boolean;
     showToolCalls?: boolean;
     autoExpandToolCalls?: boolean;
@@ -453,6 +454,7 @@ export function renderMessageGroup(
               localMediaPreviewRoots: opts.localMediaPreviewRoots,
               assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
               embedSandboxMode: opts.embedSandboxMode,
+              onReadAloud: opts.onReadAloud,
             },
             opts.onOpenSidebar,
           ),
@@ -1250,6 +1252,40 @@ function renderExpandButton(markdown: string, onOpenSidebar: (content: SidebarCo
   `;
 }
 
+function renderReadAloudButton(
+  markdown: string,
+  onReadAloud: (text: string) => void | Promise<void>,
+) {
+  return html`
+    <button
+      class="btn btn--xs chat-read-aloud-btn"
+      type="button"
+      title="Read aloud"
+      aria-label="Read aloud"
+      @click=${async (e: Event) => {
+        const btn = e.currentTarget as HTMLButtonElement | null;
+        if (!btn || btn.dataset.reading === "1") {
+          return;
+        }
+        btn.dataset.reading = "1";
+        btn.setAttribute("aria-busy", "true");
+        btn.disabled = true;
+        try {
+          await onReadAloud(markdown);
+        } finally {
+          if (btn.isConnected) {
+            delete btn.dataset.reading;
+            btn.removeAttribute("aria-busy");
+            btn.disabled = false;
+          }
+        }
+      }}
+    >
+      <span class="chat-read-aloud-btn__icon" aria-hidden="true">${icons.volume2}</span>
+    </button>
+  `;
+}
+
 function renderGroupedMessage(
   message: unknown,
   messageKey: string,
@@ -1269,6 +1305,7 @@ function renderGroupedMessage(
     assistantAttachmentAuthToken?: string | null;
     embedSandboxMode?: EmbedSandboxMode;
     allowExternalEmbedUrls?: boolean;
+    onReadAloud?: (text: string) => void | Promise<void>;
   },
   onOpenSidebar?: (content: SidebarContent) => void,
 ) {
@@ -1316,6 +1353,8 @@ function renderGroupedMessage(
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
+  const canReadAloud =
+    role === "assistant" && !opts.isStreaming && Boolean(opts.onReadAloud && markdown?.trim());
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
@@ -1360,13 +1399,14 @@ function renderGroupedMessage(
         : "Tool call"
       : "Tool output";
 
-  const hasActions = canCopyMarkdown || canExpand;
+  const hasActions = canReadAloud || canCopyMarkdown || canExpand;
 
   return html`
     <div class="${bubbleClasses}">
       ${renderReplyPill(normalizedMessage.replyTarget)}
       ${hasActions
         ? html`<div class="chat-bubble-actions">
+            ${canReadAloud ? renderReadAloudButton(markdown!, opts.onReadAloud!) : nothing}
             ${canExpand ? renderExpandButton(markdown!, onOpenSidebar!) : nothing}
             ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
           </div>`

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -8,6 +8,7 @@ import {
   abortChatRun,
   handleChatEvent,
   loadChatHistory,
+  readAloudAssistantMessage,
   sendChatMessage,
   type ChatEventPayload,
   type ChatState,
@@ -794,6 +795,50 @@ describe("loadChatHistory", () => {
     await loadChatHistory(state);
 
     expect(state.chatMessages).toEqual(messages);
+  });
+});
+
+describe("readAloudAssistantMessage", () => {
+  it("converts assistant text through gateway TTS and plays assistant media", async () => {
+    const request = vi.fn().mockResolvedValue({ audioPath: "/tmp/openclaw/tts/voice.mp3" });
+    const play = vi.fn();
+    const createAudio = vi.fn(() => ({ play }));
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    await readAloudAssistantMessage(state, "  hello from assistant  ", {
+      basePath: "/openclaw",
+      authToken: "session-token",
+      createAudio,
+    });
+
+    expect(request).toHaveBeenCalledWith("tts.convert", {
+      text: "hello from assistant",
+      channel: "webchat",
+    });
+    expect(createAudio).toHaveBeenCalledWith(
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftts%2Fvoice.mp3&token=session-token",
+    );
+    expect(play).toHaveBeenCalledOnce();
+    expect(state.lastError).toBeNull();
+  });
+
+  it("stores a readable error when TTS conversion fails", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValue(
+        new GatewayRequestError({ code: "UNAVAILABLE", message: "provider unavailable" }),
+      );
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    await readAloudAssistantMessage(state, "hello");
+
+    expect(state.lastError).toContain("provider unavailable");
   });
 });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -23,6 +23,7 @@ const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
 const chatHistoryRequestVersions = new WeakMap<object, number>();
+const WEBCHAT_TTS_CHANNEL = "webchat";
 
 function beginChatHistoryRequest(state: ChatState): number {
   const key = state as object;
@@ -510,6 +511,61 @@ type AssistantMessageNormalizationOptions = {
   requireContentArray?: boolean;
   allowTextField?: boolean;
 };
+
+type AssistantReadAloudOptions = {
+  basePath?: string;
+  authToken?: string | null;
+  createAudio?: (url: string) => { play: () => Promise<void> | void };
+};
+
+function buildAssistantMediaPlaybackUrl(
+  source: string,
+  basePath?: string,
+  authToken?: string | null,
+): string {
+  const normalizedBasePath =
+    basePath && basePath !== "/" ? (basePath.endsWith("/") ? basePath.slice(0, -1) : basePath) : "";
+  const params = new URLSearchParams({ source });
+  const normalizedToken = authToken?.trim();
+  if (normalizedToken) {
+    params.set("token", normalizedToken);
+  }
+  return `${normalizedBasePath}/__openclaw__/assistant-media?${params.toString()}`;
+}
+
+export async function readAloudAssistantMessage(
+  state: ChatState,
+  text: string,
+  options: AssistantReadAloudOptions = {},
+) {
+  const trimmed = text.trim();
+  if (!trimmed || !state.client || !state.connected) {
+    return;
+  }
+
+  try {
+    const result = await state.client.request<{
+      audioPath?: unknown;
+      provider?: unknown;
+      outputFormat?: unknown;
+      voiceCompatible?: unknown;
+    }>("tts.convert", { text: trimmed, channel: WEBCHAT_TTS_CHANNEL });
+    const audioPath = typeof result.audioPath === "string" ? result.audioPath.trim() : "";
+    if (!audioPath) {
+      throw new Error("TTS conversion returned no audio path");
+    }
+    const url = buildAssistantMediaPlaybackUrl(audioPath, options.basePath, options.authToken);
+    const audio =
+      options.createAudio?.(url) ?? (typeof Audio === "function" ? new Audio(url) : undefined);
+    if (!audio) {
+      throw new Error("Audio playback is not available in this browser");
+    }
+    await audio.play();
+    state.lastError = null;
+  } catch (err) {
+    state.lastError = err instanceof GatewayRequestError ? err.message : String(err);
+  }
+}
 
 function normalizeAssistantMessage(
   message: unknown,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -125,6 +125,7 @@ export type ChatProps = {
   onNavigateToAgent?: () => void;
   onSessionSelect?: (sessionKey: string) => void;
   onOpenSidebar?: (content: SidebarContent) => void;
+  onReadAloud?: (text: string) => void | Promise<void>;
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
@@ -936,6 +937,7 @@ export function renderChat(props: ChatProps) {
               }
               return renderMessageGroup(item, {
                 onOpenSidebar: props.onOpenSidebar,
+                onReadAloud: props.onReadAloud,
                 showReasoning,
                 showToolCalls: props.showToolCalls,
                 autoExpandToolCalls: Boolean(props.autoExpandToolCalls),


### PR DESCRIPTION
## Summary

- add a Control UI/WebChat assistant Read aloud action backed by the existing `tts.convert` Gateway RPC
- play returned audio through the authenticated assistant-media route, so configured `messages.tts` providers are used instead of browser speech synthesis
- document the WebChat behavior and add a changelog entry for #45508

## Validation

- `pnpm --dir ui test src/ui/chat/grouped-render.test.ts src/ui/controllers/chat.test.ts`
- `pnpm --dir ui test src/ui/views/chat.test.ts src/ui/app-render.assistant-avatar.test.ts`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/chat/grouped-render.ts ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/app-render.ts ui/src/ui/views/chat.ts docs/web/webchat.md CHANGELOG.md`
- `git diff --check`

## Notes

- `pnpm tsgo:test:ui` currently fails on current main at `src/plugins/loader.ts:1381` with `Type 'string[] | undefined' is not assignable to type 'string[]'`, unrelated to this diff.

Refs #45508.
