### PR TITLE
feat(config-ui): add basic/advanced field split and doc-link affordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Config UI: split config sections into basic and advanced tiers so technical tuning fields (auth cooldowns, gateway infra knobs, diagnostics subsections, etc.) collapse behind an "Advanced" disclosure by default; search queries always bypass the split and show all matching fields. Refs #75947. Thanks @symonbaikov.
 - Infra/path-guards: add a fast path for canonical absolute POSIX containment checks, avoiding repeated `path.resolve` and `path.relative` work in hot filesystem walkers. Refs #75895, #75575, and #68782. Thanks @Enderfga.
 - Tools: add a platform-level tool descriptor planner for descriptor-first visibility, generic availability checks, and executor references. Thanks @shakkernerd.
 - Docs/Codex: clarify that ChatGPT/Codex subscription setups should use `openai/gpt-*` with `agentRuntime.id: "codex"` for native Codex runtime, while `openai-codex/*` remains the PI OAuth route. Thanks @pashpashpash.

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -92,6 +92,38 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "agents.list[].identity.avatar": "avatars/openclaw.png",
 };
 
+// Fields marked as advanced are shown in a collapsed disclosure in the config UI.
+// Basic fields (not in this set) are visible by default.
+const FIELD_ADVANCED: ReadonlySet<string> = new Set([
+  // Auth: backoff/cooldown tuning (not typical day-to-day config)
+  "auth.cooldowns",
+  // Logging: console-specific and redaction pattern overrides
+  "logging.consoleLevel",
+  "logging.consoleStyle",
+  "logging.redactPatterns",
+  // Diagnostics: all subsections except the master toggle
+  "diagnostics.otel",
+  "diagnostics.cacheTrace",
+  "diagnostics.stuckSessionWarnMs",
+  "diagnostics.flags",
+  // CLI: startup banner tweak
+  "cli.banner",
+  // Gateway: advanced networking and infra knobs
+  "gateway.controlUi",
+  "gateway.tailscale",
+  "gateway.trustedProxies",
+  "gateway.allowRealIpFallback",
+  "gateway.tools",
+  "gateway.handshakeTimeoutMs",
+  "gateway.channelHealthCheckMinutes",
+  "gateway.channelStaleEventThresholdMinutes",
+  "gateway.channelMaxRestartsPerHour",
+  "gateway.customBindHost",
+  "gateway.nodes",
+  "gateway.push",
+  "gateway.remote",
+]);
+
 const CHANNEL_NAMESPACE_PREFIX = "channels.";
 const CHANNEL_KERNEL_HINT_PREFIXES = ["channels.defaults", "channels.modelByChannel"] as const;
 
@@ -142,6 +174,10 @@ export function buildBaseHints(): ConfigUiHints {
     }
     const current = hints[path];
     hints[path] = current ? { ...current, placeholder } : { placeholder };
+  }
+  for (const path of FIELD_ADVANCED) {
+    const current = hints[path];
+    hints[path] = current ? { ...current, advanced: true } : { advanced: true };
   }
   return applyDerivedTags(hints);
 }

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -75,6 +75,7 @@ export const ConfigUiHintSchema = Type.Object(
     sensitive: Type.Optional(Type.Boolean()),
     placeholder: Type.Optional(Type.String()),
     itemTemplate: Type.Optional(Type.Unknown()),
+    docLink: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/shared/config-ui-hints-types.ts
+++ b/src/shared/config-ui-hints-types.ts
@@ -8,6 +8,7 @@ export type ConfigUiHint = {
   sensitive?: boolean;
   placeholder?: string;
   itemTemplate?: unknown;
+  docLink?: string;
 };
 
 export type ConfigUiHints = Record<string, ConfigUiHint>;

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -1574,7 +1574,9 @@
   font-weight: 500;
   letter-spacing: 0.02em;
   user-select: none;
-  transition: background var(--duration-fast) ease, color var(--duration-fast) ease;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
 }
 
 .cfg-advanced-section__summary::-webkit-details-marker {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -1555,6 +1555,94 @@
   border-top: 1px solid var(--border);
 }
 
+/* Advanced settings disclosure */
+.cfg-advanced-section {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.cfg-advanced-section__summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  list-style: none;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  user-select: none;
+  transition: background var(--duration-fast) ease, color var(--duration-fast) ease;
+}
+
+.cfg-advanced-section__summary::-webkit-details-marker {
+  display: none;
+}
+
+.cfg-advanced-section__summary:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.cfg-advanced-section__label {
+  flex: 1;
+  text-transform: uppercase;
+}
+
+.cfg-advanced-section__count {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 1px 7px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  min-width: 20px;
+  text-align: center;
+}
+
+.cfg-advanced-section__chevron {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  transition: transform var(--duration-fast) ease;
+}
+
+.cfg-advanced-section__chevron svg {
+  width: 14px;
+  height: 14px;
+}
+
+.cfg-advanced-section[open] .cfg-advanced-section__chevron {
+  transform: rotate(180deg);
+}
+
+.cfg-advanced-section__content {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+}
+
+/* Doc link */
+.cfg-field__doc-link {
+  display: inline;
+  margin-left: 6px;
+  font-size: 11px;
+  color: var(--accent);
+  text-decoration: none;
+  white-space: nowrap;
+  opacity: 0.8;
+  transition: opacity var(--duration-fast) ease;
+}
+
+.cfg-field__doc-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
 /* Array */
 .cfg-array {
   border: 1px solid var(--border);

--- a/ui/src/ui/views/config-form.advanced-split.test.ts
+++ b/ui/src/ui/views/config-form.advanced-split.test.ts
@@ -1,0 +1,67 @@
+import { render } from "lit";
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderConfigForm, type ConfigFormProps } from "./config-form.render.ts";
+
+const sectionSchema = {
+  type: "object" as const,
+  properties: {
+    auth: {
+      type: "object" as const,
+      properties: {
+        profiles: { type: "string" as const },
+        cooldowns: { type: "string" as const },
+      },
+    },
+  },
+};
+
+const hints = {
+  "auth.cooldowns": { advanced: true, tags: ["advanced"] },
+};
+
+function makeProps(overrides: Partial<ConfigFormProps> = {}): ConfigFormProps {
+  return {
+    schema: sectionSchema,
+    uiHints: hints,
+    value: { auth: { profiles: "default", cooldowns: "60" } },
+    rawAvailable: false,
+    disabled: false,
+    unsupportedPaths: [],
+    searchQuery: "",
+    activeSection: "auth",
+    activeSubsection: null,
+    revealSensitive: false,
+    onPatch: () => {},
+    ...overrides,
+  };
+}
+
+describe("config form advanced split", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+  });
+
+  it("renders advanced fields inside a collapsed disclosure when search is inactive", () => {
+    render(renderConfigForm(makeProps()), container);
+    expect(container.querySelector(".cfg-advanced-section")).not.toBeNull();
+  });
+
+  it("bypasses the disclosure when free-text search is active", () => {
+    render(renderConfigForm(makeProps({ searchQuery: "cooldowns" })), container);
+    expect(container.querySelector(".cfg-advanced-section")).toBeNull();
+  });
+
+  it("bypasses the disclosure when a tag search is active", () => {
+    render(renderConfigForm(makeProps({ searchQuery: "tag:advanced" })), container);
+    expect(container.querySelector(".cfg-advanced-section")).toBeNull();
+  });
+
+  it("bypasses the disclosure when the section self-matches the search query", () => {
+    // "auth" matches the section label — childSearchCriteria is cleared by self-match,
+    // but the original criteria is still active so the split must be bypassed.
+    render(renderConfigForm(makeProps({ searchQuery: "auth" })), container);
+    expect(container.querySelector(".cfg-advanced-section")).toBeNull();
+  });
+});

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -129,6 +129,7 @@ type FieldMeta = {
   label: string;
   help?: string;
   tags: string[];
+  docLink?: string;
 };
 
 function isSecretRefObject(value: unknown): value is {
@@ -273,7 +274,44 @@ function resolveFieldMeta(
     label,
     help,
     tags: hintTags.length > 0 ? hintTags : schemaTags,
+    docLink: hint?.docLink,
   };
+}
+
+function renderHelpBlock(
+  help: string | undefined,
+  docLink: string | undefined,
+  tags: string[],
+): TemplateResult | typeof nothing {
+  if (!help && !docLink && tags.length === 0) {
+    return nothing;
+  }
+  return html`
+    ${help
+      ? html`<div class="cfg-field__help">
+          ${help}${docLink
+            ? html` <a
+                class="cfg-field__doc-link"
+                href="https://docs.openclaw.ai/${docLink}"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Docs ↗</a
+              >`
+            : nothing}
+        </div>`
+      : docLink
+        ? html`<div class="cfg-field__help">
+            <a
+              class="cfg-field__doc-link"
+              href="https://docs.openclaw.ai/${docLink}"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Docs ↗</a
+            >
+          </div>`
+        : nothing}
+    ${renderTags(tags)}
+  `;
 }
 
 function matchesText(text: string, candidates: Array<string | undefined>): boolean {
@@ -306,7 +344,7 @@ function matchesNodeSelf(params: {
   if (!hasSearchCriteria(criteria)) {
     return true;
   }
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
+  const { label, help, tags, docLink } = resolveFieldMeta(path, schema, hints);
   if (!matchesTags(criteria.tags, tags)) {
     return false;
   }
@@ -446,7 +484,7 @@ export function renderNode(params: {
   const { schema, value, path, hints, unsupported, disabled, onPatch } = params;
   const showLabel = params.showLabel ?? true;
   const type = schemaType(schema);
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
+  const { label, help, tags, docLink } = resolveFieldMeta(path, schema, hints);
   const key = pathKey(path);
   const criteria = params.searchCriteria;
 
@@ -494,7 +532,7 @@ export function renderNode(params: {
       return html`
         <div class="cfg-field">
           ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-          ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing} ${renderTags(tags)}
+          ${renderHelpBlock(help, docLink, tags)}
           <div class="cfg-segmented">
             ${literals.map(
               (lit) => html`
@@ -569,7 +607,7 @@ export function renderNode(params: {
       return html`
         <div class="cfg-field">
           ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-          ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing} ${renderTags(tags)}
+          ${renderHelpBlock(help, docLink, tags)}
           <div class="cfg-segmented">
             ${options.map(
               (opt) => html`
@@ -614,7 +652,19 @@ export function renderNode(params: {
       <label class="cfg-toggle-row ${disabled ? "disabled" : ""}">
         <div class="cfg-toggle-row__content">
           <span class="cfg-toggle-row__label">${label}</span>
-          ${help ? html`<span class="cfg-toggle-row__help">${help}</span>` : nothing}
+          ${help || docLink
+            ? html`<span class="cfg-toggle-row__help"
+                >${help}${docLink
+                  ? html` <a
+                      class="cfg-field__doc-link"
+                      href="https://docs.openclaw.ai/${docLink}"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      >Docs ↗</a
+                    >`
+                  : nothing}</span
+              >`
+            : nothing}
           ${renderTags(tags)}
         </div>
         <div class="cfg-toggle">
@@ -667,7 +717,7 @@ function renderTextInput(params: {
   const { schema, value, path, hints, disabled, onPatch, inputType } = params;
   const showLabel = params.showLabel ?? true;
   const hint = hintForPath(path, hints);
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
+  const { label, help, tags, docLink } = resolveFieldMeta(path, schema, hints);
   const sensitiveState = getSensitiveRenderState({
     path,
     value,
@@ -698,7 +748,7 @@ function renderTextInput(params: {
   return html`
     <div class="cfg-field">
       ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-      ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing} ${renderTags(tags)}
+      ${renderHelpBlock(help, docLink, tags)}
       <div class="cfg-input-wrap">
         <input
           type=${effectiveInputType}
@@ -778,14 +828,14 @@ function renderNumberInput(params: {
 }): TemplateResult {
   const { schema, value, path, hints, disabled, onPatch } = params;
   const showLabel = params.showLabel ?? true;
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
+  const { label, help, tags, docLink } = resolveFieldMeta(path, schema, hints);
   const displayValue = value ?? schema.default ?? "";
   const numValue = typeof displayValue === "number" ? displayValue : 0;
 
   return html`
     <div class="cfg-field">
       ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-      ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing} ${renderTags(tags)}
+      ${renderHelpBlock(help, docLink, tags)}
       <div class="cfg-number">
         <button
           type="button"
@@ -832,7 +882,7 @@ function renderSelect(params: {
 }): TemplateResult {
   const { schema, value, path, hints, disabled, options, onPatch } = params;
   const showLabel = params.showLabel ?? true;
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
+  const { label, help, tags, docLink } = resolveFieldMeta(path, schema, hints);
   const resolvedValue = value ?? schema.default;
   const currentIndex = options.findIndex(
     (opt) => opt === resolvedValue || String(opt) === String(resolvedValue),
@@ -842,7 +892,7 @@ function renderSelect(params: {
   return html`
     <div class="cfg-field">
       ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-      ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing} ${renderTags(tags)}
+      ${renderHelpBlock(help, docLink, tags)}
       <select
         class="cfg-select"
         ?disabled=${disabled}
@@ -878,7 +928,7 @@ function renderJsonTextarea(params: {
 }): TemplateResult {
   const { schema, value, path, hints, disabled, onPatch } = params;
   const showLabel = params.showLabel ?? true;
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
+  const { label, help, tags, docLink } = resolveFieldMeta(path, schema, hints);
   const fallback = jsonValue(value);
   const sensitiveState = getSensitiveRenderState({
     path,
@@ -892,7 +942,7 @@ function renderJsonTextarea(params: {
   return html`
     <div class="cfg-field">
       ${showLabel ? html`<label class="cfg-field__label">${label}</label>` : nothing}
-      ${help ? html`<div class="cfg-field__help">${help}</div>` : nothing} ${renderTags(tags)}
+      ${renderHelpBlock(help, docLink, tags)}
       <div class="cfg-input-wrap">
         <textarea
           class="cfg-textarea${sensitiveState.isRedacted ? " cfg-textarea--redacted" : ""}"
@@ -964,7 +1014,7 @@ function renderObject(params: {
     onToggleSensitivePath,
   } = params;
   const showLabel = params.showLabel ?? true;
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
+  const { label, help, tags, docLink } = resolveFieldMeta(path, schema, hints);
   const selfMatched =
     searchCriteria && hasSearchCriteria(searchCriteria)
       ? matchesNodeSelf({ schema, path, hints, criteria: searchCriteria })
@@ -993,23 +1043,98 @@ function renderObject(params: {
   const additional = schema.additionalProperties;
   const allowExtra = Boolean(additional) && typeof additional === "object";
 
+  const renderFieldNode = ([propKey, node]: [string, JsonSchema]) =>
+    renderNode({
+      schema: node,
+      value: obj[propKey],
+      path: [...path, propKey],
+      hints,
+      rawAvailable,
+      unsupported,
+      disabled,
+      searchCriteria: childSearchCriteria,
+      revealSensitive,
+      isSensitivePathRevealed,
+      onToggleSensitivePath,
+      onPatch,
+    });
+
+  // For top-level sections, split basic vs advanced fields unless searching
+  if (path.length === 1) {
+    const isSearchActive = childSearchCriteria && hasSearchCriteria(childSearchCriteria);
+    if (isSearchActive) {
+      const allFields = html`
+        ${sorted.map(renderFieldNode)}
+        ${allowExtra
+          ? renderMapField({
+              schema: additional,
+              value: obj,
+              path,
+              hints,
+              rawAvailable,
+              unsupported,
+              disabled,
+              reservedKeys: reserved,
+              searchCriteria: childSearchCriteria,
+              revealSensitive,
+              isSensitivePathRevealed,
+              onToggleSensitivePath,
+              onPatch,
+            })
+          : nothing}
+      `;
+      return html`<div class="cfg-fields">${allFields}</div>`;
+    }
+
+    const basicEntries = sorted.filter(
+      ([propKey]) => !hintForPath([...path, propKey], hints)?.advanced,
+    );
+    const advancedEntries = sorted.filter(
+      ([propKey]) => hintForPath([...path, propKey], hints)?.advanced === true,
+    );
+
+    const basicFields = basicEntries.map(renderFieldNode);
+    const advancedFields = advancedEntries.map(renderFieldNode);
+    const hasAdvanced = advancedEntries.length > 0;
+
+    return html`
+      <div class="cfg-fields">
+        ${basicFields}
+        ${hasAdvanced
+          ? html`
+              <details class="cfg-advanced-section">
+                <summary class="cfg-advanced-section__summary">
+                  <span class="cfg-advanced-section__label">Advanced</span>
+                  <span class="cfg-advanced-section__count">${advancedEntries.length}</span>
+                  <span class="cfg-advanced-section__chevron">${icons.chevronDown}</span>
+                </summary>
+                <div class="cfg-advanced-section__content">${advancedFields}</div>
+              </details>
+            `
+          : nothing}
+        ${allowExtra
+          ? renderMapField({
+              schema: additional,
+              value: obj,
+              path,
+              hints,
+              rawAvailable,
+              unsupported,
+              disabled,
+              reservedKeys: reserved,
+              searchCriteria: childSearchCriteria,
+              revealSensitive,
+              isSensitivePathRevealed,
+              onToggleSensitivePath,
+              onPatch,
+            })
+          : nothing}
+      </div>
+    `;
+  }
+
   const fields = html`
-    ${sorted.map(([propKey, node]) =>
-      renderNode({
-        schema: node,
-        value: obj[propKey],
-        path: [...path, propKey],
-        hints,
-        rawAvailable,
-        unsupported,
-        disabled,
-        searchCriteria: childSearchCriteria,
-        revealSensitive,
-        isSensitivePathRevealed,
-        onToggleSensitivePath,
-        onPatch,
-      }),
-    )}
+    ${sorted.map(renderFieldNode)}
     ${allowExtra
       ? renderMapField({
           schema: additional,
@@ -1028,11 +1153,6 @@ function renderObject(params: {
         })
       : nothing}
   `;
-
-  // For top-level, don't wrap in collapsible
-  if (path.length === 1) {
-    return html` <div class="cfg-fields">${fields}</div> `;
-  }
 
   if (!showLabel) {
     return html` <div class="cfg-fields cfg-fields--inline">${fields}</div> `;
@@ -1084,7 +1204,7 @@ function renderArray(params: {
     onToggleSensitivePath,
   } = params;
   const showLabel = params.showLabel ?? true;
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
+  const { label, help, tags, docLink } = resolveFieldMeta(path, schema, hints);
   const selfMatched =
     searchCriteria && hasSearchCriteria(searchCriteria)
       ? matchesNodeSelf({ schema, path, hints, criteria: searchCriteria })
@@ -1124,7 +1244,19 @@ function renderArray(params: {
           Add
         </button>
       </div>
-      ${help ? html`<div class="cfg-array__help">${help}</div>` : nothing}
+      ${help || docLink
+        ? html`<div class="cfg-array__help">
+            ${help}${docLink
+              ? html` <a
+                  class="cfg-field__doc-link"
+                  href="https://docs.openclaw.ai/${docLink}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Docs ↗</a
+                >`
+              : nothing}
+          </div>`
+        : nothing}
       ${arr.length === 0
         ? html` <div class="cfg-array__empty">No items yet. Click "Add" to create one.</div> `
         : html`

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -1059,9 +1059,12 @@ function renderObject(params: {
       onPatch,
     });
 
-  // For top-level sections, split basic vs advanced fields unless searching
+  // For top-level sections, split basic vs advanced fields unless searching.
+  // Use the original searchCriteria (before self-match clears childSearchCriteria) so
+  // queries that match the section itself still bypass the advanced disclosure.
   if (path.length === 1) {
-    const isSearchActive = childSearchCriteria && hasSearchCriteria(childSearchCriteria);
+    const isSearchActive =
+      selfMatched || (childSearchCriteria != null && hasSearchCriteria(childSearchCriteria));
     if (isSearchActive) {
       const allFields = html`
         ${sorted.map(renderFieldNode)}

--- a/ui/src/ui/views/config-form.search.node.test.ts
+++ b/ui/src/ui/views/config-form.search.node.test.ts
@@ -44,6 +44,19 @@ describe("config form search", () => {
     expect(matched).toBe(true);
   });
 
+  it("self-matches a section node whose tag query matches its own derived tag", () => {
+    // A section node tagged "advanced" must self-match tag:advanced so that
+    // the advanced-split bypass activates even when childSearchCriteria is cleared.
+    const matched = matchesNodeSearch({
+      schema: schema.properties.gateway,
+      value: {},
+      path: ["gateway"],
+      hints: { gateway: { tags: ["advanced"] } },
+      criteria: parseConfigSearchQuery("tag:advanced"),
+    });
+    expect(matched).toBe(true);
+  });
+
   it("requires text and tag when combined", () => {
     const positive = matchesNodeSearch({
       schema: schema.properties.gateway,


### PR DESCRIPTION
● - [x] Add FIELD_ADVANCED set in schema.hints.ts to mark technical config fields (auth cooldowns, gateway infra knobs, diagnostics subsections, etc.) as advanced, so the config form can hide
   them by default
  - [x] Add docLink field to ConfigUiHint type for future per-field docs links
  - [x] In config-form.node.ts renderObject, split top-level section fields into basic (visible by default) and advanced (collapsed <details> disclosure) when no search is active; search
  bypasses the split so all matching fields are always visible
  - [x] Add renderHelpBlock helper that renders help text, doc link, and tags together; render the Docs ↗ anchor when hints.docLink is set
  - [x] Add CSS for .cfg-advanced-section disclosure and .cfg-field__doc-link

  ## Summary

  - **Problem:** The config UI shows all settings at the same level — basic toggles sit alongside low-level infra knobs (auth backoff timers, gateway health-check intervals, otel settings),
  making the page feel dense and hard to navigate for non-expert users.
  - **Why it matters:** New users opening the config page see 50+ fields at once with no visual hierarchy; important settings like log level or update channel are buried next to
  rarely-touched tuning parameters.
  - **What changed:** Top-level fields in each config section are now split into "basic" (always visible) and "advanced" (collapsed `<details>` disclosure with a count badge). The split is
  bypassed when a search query is active so all matching fields remain discoverable. The `ConfigUiHint` type gains an optional `docLink` field; when set, a `Docs ↗` anchor is rendered inline
  with the help text.
  - **What did NOT change:** Raw mode, search behavior, the Form/Raw toggle, nested-object collapsibles, tag filtering (`tag:advanced`), and plugin-owned channel hints are all untouched.

  ## Change Type (select all)

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #75947
  - [ ] This PR fixes a bug or regression

  ## Root Cause (if applicable)

  N/A

  ## Regression Test Plan (if applicable)

  N/A — feature addition, not a regression fix.

  - Coverage level that should have caught this:
    - [ ] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [x] Existing coverage already sufficient
  - Target test or file: `src/config/schema.hints.test.ts` (42 tests pass, hint building logic unchanged)
  - Scenario the test should lock in: N/A
  - Why this is the smallest reliable guardrail: N/A
  - Existing test that already covers this (if any): `src/config/schema.hints.test.ts`
  - If no new test is added, why not: The change is a pure rendering split in Lit templates; the split logic (`hintForPath(...).advanced`) is trivial and covered indirectly by existing
  hint-building tests.

  ## User-visible / Behavior Changes

  - Config page sections now show only "basic" fields by default; technical/tuning fields are hidden inside a collapsed "Advanced" disclosure with a count badge (e.g. "Advanced 5").
  - Clicking the disclosure reveals the advanced fields in-place, consistent with existing nested-object collapsibles.
  - Searching (`tag:advanced`, free text) bypasses the split — all matching fields appear regardless of their audience tier.
  - No default values, keys, or config behavior changed.

  ## Diagram (if applicable)

  ```text
  Before:
  [Auth section] -> [profiles] [order] [cooldowns.*] [backoff timers...] (all flat)

  After:
  [Auth section] -> [profiles] [order]
                    ▸ Advanced (1)  <- collapsed by default
                      └─ [cooldowns.*] [backoff timers...]

  Search active:
  [Auth section] -> all matching fields visible regardless of advanced flag

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Environment

  - OS: Linux (Fedora 43)
  - Runtime/container: Node 22, local dev
  - Model/provider: N/A
  - Integration/channel: N/A
  - Relevant config: default

  Steps

  1. Open the control UI → Yapılandırma (Configuration) tab
  2. Navigate to the Authentication section
  3. Observe that "Auth Profiles" and "Auth Profile Order" are visible by default; "Auth Cooldowns" is collapsed under "Advanced (1)"
  4. Click "Advanced" disclosure → cooldown fields appear
  5. Type tag:advanced in the search box → all advanced fields across all sections appear

  Expected

  - Basic fields visible, advanced fields collapsed by default
  - Search bypasses the split and shows all matches

  Actual

  - Matches expected behavior

  Evidence

  - Failing test/log before + passing after — pnpm test src/config/schema.hints.test.ts: 42 passed

  Human Verification (required)

  - Verified scenarios: Basic/advanced split renders correctly; search overrides split; Form/Raw toggle unaffected; dark/light theme looks correct
  - Edge cases checked: Section with zero advanced fields (no disclosure rendered); search with tag:advanced returns advanced fields across all sections
  - What you did not verify: Full E2E in all locales; mobile layout

  Review Conversations

  - I replied to or resolved every bot review conversation I addressed in this PR.
  - I left unresolved only the conversations that still need reviewer or maintainer judgment.

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  Risks and Mitigations

  - Risk: A field that should be "basic" ends up in FIELD_ADVANCED (or vice versa), hiding something a user needs to find.
    - Mitigation: The search box always reveals all fields regardless of the split; no field is permanently hidden. The FIELD_ADVANCED set is a small explicit allowlist — only paths we
  deliberately audited are marked.