### PR TITLE
feat(gateway): add gateway.reload.recovery option to disable config auto-revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/config: add `gateway.reload.recovery` option (`"on"` | `"off"`) to disable automatic last-known-good config revert on invalid startup or hot-reload, so mid-edit or externally-written config files are not silently overwritten; logs all validation issues instead.
 - Agents/runtime: memoize transcript replay-policy resolution for stable config and process-env runs while preserving custom-env provider hook behavior. Thanks @DmitryPogodaev.
 - Infra/path-guards: add a fast path for canonical absolute POSIX containment checks, avoiding repeated `path.resolve` and `path.relative` work in hot filesystem walkers. Refs #75895, #75575, and #68782. Thanks @Enderfga.
 - Tools: add a platform-level tool descriptor planner for descriptor-first visibility, generic availability checks, and executor references. Thanks @shakkernerd.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -554,6 +554,20 @@ If you see `Config auto-restored from last-known-good` or
 `openclaw config validate`. See [Gateway troubleshooting](/gateway/troubleshooting#gateway-restored-last-known-good-config)
 for the recovery checklist.
 
+To disable automatic revert entirely — for example, when using an external config
+management tool that writes the file atomically — set `gateway.reload.recovery: "off"`.
+The Gateway will log the full validation issues and block the reload or startup
+rather than overwriting the file from the last-known-good backup. When `reload.mode`
+is `"off"`, recovery is disabled automatically.
+
+```json5
+{
+  gateway: {
+    reload: { recovery: "off" },
+  },
+}
+```
+
 ### Reload modes
 
 | Mode                   | Behavior                                                                                |

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -61,7 +61,9 @@ import {
   maybeRecoverSuspiciousConfigReadSync,
   promoteConfigSnapshotToLastKnownGood as promoteConfigSnapshotToLastKnownGoodWithDeps,
   recoverConfigFromLastKnownGood as recoverConfigFromLastKnownGoodWithDeps,
+  resolveLastKnownGoodConfigPath,
 } from "./io.observe-recovery.js";
+export { resolveLastKnownGoodConfigPath } from "./io.observe-recovery.js";
 import { persistGeneratedOwnerDisplaySecret } from "./io.owner-display-secret.js";
 import {
   collectChangedPaths,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -22866,6 +22866,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 description:
                   'Controls how config edits are applied: "off" ignores live edits, "restart" always restarts, "hot" applies in-process, and "hybrid" tries hot then restarts if required. Keep "hybrid" for safest routine updates.',
               },
+              recovery: {
+                type: "string",
+                enum: ["on", "off"],
+                title: "Config Reload Recovery",
+                description:
+                  'Whether to restore the last-known-good config when an invalid config is written to disk: "on" (default) restores automatically; "off" logs validation errors and leaves the file untouched. Automatically "off" when mode is "off".',
+              },
               debounceMs: {
                 type: "integer",
                 minimum: 0,
@@ -26076,6 +26083,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "gateway.reload.mode": {
       label: "Config Reload Mode",
       help: 'Controls how config edits are applied: "off" ignores live edits, "restart" always restarts, "hot" applies in-process, and "hybrid" tries hot then restarts if required. Keep "hybrid" for safest routine updates.',
+      tags: ["network", "reliability"],
+    },
+    "gateway.reload.recovery": {
+      label: "Config Reload Recovery",
+      help: 'Whether to restore the last-known-good config when an invalid config is written to disk: "on" (default) restores automatically; "off" logs validation errors and leaves the file untouched. Automatically "off" when mode is "off".',
       tags: ["network", "reliability"],
     },
     "gateway.reload.debounceMs": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -500,6 +500,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Timeout in milliseconds for `image_url` URL fetches (default: 10000).",
   "gateway.reload.mode":
     'Controls how config edits are applied: "off" ignores live edits, "restart" always restarts, "hot" applies in-process, and "hybrid" tries hot then restarts if required. Keep "hybrid" for safest routine updates.',
+  "gateway.reload.recovery":
+    'Whether to restore the last-known-good config when an invalid config is written to disk: "on" (default) restores automatically; "off" logs validation errors and leaves the file untouched. Automatically "off" when mode is "off".',
   "gateway.reload.debounceMs": "Debounce window (ms) before applying config changes.",
   "gateway.reload.deferralTimeoutMs":
     "Optional maximum time (ms) to wait for in-flight operations before forcing a restart. Omit to use the default bounded wait; set 0 to wait indefinitely with periodic still-pending warnings. Lower positive values risk aborting active subagent LLM calls.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -337,6 +337,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.http.endpoints.chatCompletions.images.timeoutMs":
     "OpenAI Chat Completions Image Timeout (ms)",
   "gateway.reload.mode": "Config Reload Mode",
+  "gateway.reload.recovery": "Config Reload Recovery",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",
   "gateway.reload.deferralTimeoutMs": "Restart Deferral Timeout (ms)",
   "gateway.nodes.browser.mode": "Gateway Node Browser Mode",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -211,6 +211,17 @@ export type GatewayReloadMode = "off" | "restart" | "hot" | "hybrid";
 export type GatewayReloadConfig = {
   /** Reload strategy for config changes (default: hybrid). */
   mode?: GatewayReloadMode;
+  /**
+   * Whether to restore the last-known-good config when an invalid config is
+   * detected on disk (default: "on"). Set to "off" to log the validation errors
+   * and leave the file untouched — the running config is unaffected either way.
+   * Automatically defaults to "off" when mode is "off".
+   *
+   * Applies to both the live file-watcher reload path and gateway startup.
+   * When "off" and the config is invalid at startup, the gateway will fail to
+   * start rather than silently restoring a backup.
+   */
+  recovery?: "on" | "off";
   /** Debounce window for config reloads (ms). Default: 300. */
   debounceMs?: number;
   /**

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -873,6 +873,7 @@ export const OpenClawSchema = z
                 z.literal("hybrid"),
               ])
               .optional(),
+            recovery: z.enum(["on", "off"]).optional(),
             debounceMs: z.number().int().min(0).optional(),
             deferralTimeoutMs: z.number().int().min(0).optional(),
           })

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -30,11 +30,13 @@ export type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
 type GatewayReloadSettings = {
   mode: GatewayReloadMode;
   debounceMs: number;
+  recovery: "on" | "off";
 };
 
 const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
   mode: "hybrid",
   debounceMs: 300,
+  recovery: "on",
 };
 const MISSING_CONFIG_RETRY_DELAY_MS = 150;
 const MISSING_CONFIG_MAX_RETRIES = 2;
@@ -151,7 +153,14 @@ export function resolveGatewayReloadSettings(cfg: OpenClawConfig): GatewayReload
     typeof debounceRaw === "number" && Number.isFinite(debounceRaw)
       ? Math.max(0, Math.floor(debounceRaw))
       : DEFAULT_RELOAD_SETTINGS.debounceMs;
-  return { mode, debounceMs };
+  const rawRecovery = cfg.gateway?.reload?.recovery;
+  const recovery: "on" | "off" =
+    rawRecovery === "on" || rawRecovery === "off"
+      ? rawRecovery
+      : mode === "off"
+        ? "off"
+        : DEFAULT_RELOAD_SETTINGS.recovery;
+  return { mode, debounceMs, recovery };
 }
 
 type GatewayConfigReloader = {
@@ -245,20 +254,32 @@ export function startGatewayConfigReloader(opts: {
     return true;
   };
 
+  const formatSnapshotIssueLines = (snapshot: ConfigFileSnapshot): string[] =>
+    formatConfigIssueLines([...snapshot.issues, ...snapshot.legacyIssues], "-");
+
   const handleInvalidSnapshot = (snapshot: ConfigFileSnapshot): boolean => {
     if (snapshot.valid) {
       return false;
     }
-    const issues = formatConfigIssueLines(snapshot.issues, "").join(", ");
-    opts.log.warn(`config reload skipped (invalid config): ${issues}`);
+    const issueLines = formatSnapshotIssueLines(snapshot);
+    opts.log.warn(
+      `config reload skipped, invalid config (${issueLines.length} issue${issueLines.length === 1 ? "" : "s"}): ${issueLines.join("; ")}`,
+    );
     return true;
   };
 
   const recoverAndReadSnapshot = async (
     snapshot: ConfigFileSnapshot,
     reason: string,
-  ): Promise<ConfigFileSnapshot | null> => {
-    if (!opts.recoverSnapshot) {
+  ): Promise<ConfigFileSnapshot | "logged-and-skipped" | null> => {
+    if (!opts.recoverSnapshot || settings.recovery === "off") {
+      if (settings.recovery === "off") {
+        const issueLines = formatSnapshotIssueLines(snapshot);
+        opts.log.warn(
+          `config reload skipped, invalid config, recovery disabled (${issueLines.length} issue${issueLines.length === 1 ? "" : "s"}): ${issueLines.join("; ")}`,
+        );
+        return "logged-and-skipped";
+      }
       return null;
     }
     if (!shouldAttemptLastKnownGoodRecovery(snapshot)) {
@@ -433,6 +454,9 @@ export function startGatewayConfigReloader(opts: {
       let degradedPluginSnapshot = false;
       if (!snapshot.valid) {
         const recoveredSnapshot = await recoverAndReadSnapshot(snapshot, "invalid-config");
+        if (recoveredSnapshot === "logged-and-skipped") {
+          return;
+        }
         if (!recoveredSnapshot) {
           const pluginLocalSnapshot = resolvePluginLocalInvalidReloadSnapshot({
             snapshot,

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -240,14 +240,21 @@ export async function loadGatewayStartupConfigSnapshot(params: {
     if (!configSnapshot.valid) {
       const rejectedSnapshot = configSnapshot;
       const rejectedConfigIssues = collectConfigSnapshotIssueDetails(rejectedSnapshot);
-      const canRecoverFromLastKnownGood = shouldAttemptLastKnownGoodRecovery(configSnapshot);
+      const startupRecoveryEnabled =
+        rejectedSnapshot.sourceConfig?.gateway?.reload?.recovery !== "off";
+      const canRecoverFromLastKnownGood =
+        startupRecoveryEnabled && shouldAttemptLastKnownGoodRecovery(configSnapshot);
       const recovered = canRecoverFromLastKnownGood
         ? await recoverConfigFromLastKnownGood({
             snapshot: configSnapshot,
             reason: "startup-invalid-config",
           })
         : false;
-      if (!canRecoverFromLastKnownGood) {
+      if (!startupRecoveryEnabled) {
+        params.log.warn(
+          `gateway: last-known-good recovery skipped at startup (gateway.reload.recovery=off): ${configSnapshot.path}`,
+        );
+      } else if (!canRecoverFromLastKnownGood) {
         params.log.warn(
           `gateway: last-known-good recovery skipped for plugin-local config invalidity: ${configSnapshot.path}`,
         );

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -1,8 +1,11 @@
+import { promises as fsPromises } from "node:fs";
+import JSON5 from "json5";
 import { formatCliCommand } from "../cli/command-format.js";
 import {
   readConfigFileSnapshotWithPluginMetadata,
   recoverConfigFromLastKnownGood,
   recoverConfigFromJsonRootSuffix,
+  resolveLastKnownGoodConfigPath,
 } from "../config/io.js";
 import { formatConfigIssueLines, formatConfigIssueSummary } from "../config/issue-format.js";
 import { asResolvedSourceConfig, materializeRuntimeConfig } from "../config/materialize.js";
@@ -41,6 +44,19 @@ type GatewayStartupLog = {
   warn: (message: string) => void;
   error?: (message: string) => void;
 };
+
+async function readLKGRecoverySetting(configPath: string): Promise<"on" | "off" | undefined> {
+  try {
+    const lkgPath = resolveLastKnownGoodConfigPath(configPath);
+    const raw = await fsPromises.readFile(lkgPath, "utf-8");
+    const parsed = JSON5.parse(raw) as { gateway?: { reload?: { recovery?: string } } };
+    const v = parsed?.gateway?.reload?.recovery;
+    if (v === "on" || v === "off") return v;
+  } catch {
+    // LKG file missing or unreadable — no setting available
+  }
+  return undefined;
+}
 
 type GatewaySecretsStateEventCode = "SECRETS_RELOADER_DEGRADED" | "SECRETS_RELOADER_RECOVERED";
 
@@ -240,8 +256,10 @@ export async function loadGatewayStartupConfigSnapshot(params: {
     if (!configSnapshot.valid) {
       const rejectedSnapshot = configSnapshot;
       const rejectedConfigIssues = collectConfigSnapshotIssueDetails(rejectedSnapshot);
-      const startupRecoveryEnabled =
-        rejectedSnapshot.sourceConfig?.gateway?.reload?.recovery !== "off";
+      const recoveryFromSource = rejectedSnapshot.sourceConfig?.gateway?.reload?.recovery;
+      const effectiveRecovery =
+        recoveryFromSource ?? (await readLKGRecoverySetting(rejectedSnapshot.path));
+      const startupRecoveryEnabled = effectiveRecovery !== "off";
       const canRecoverFromLastKnownGood =
         startupRecoveryEnabled && shouldAttemptLastKnownGoodRecovery(configSnapshot);
       const recovered = canRecoverFromLastKnownGood


### PR DESCRIPTION
## Summary

- Adds `gateway.reload.recovery` config option (`"on"` | `"off"`) to control whether the gateway auto-reverts to last-known-good config when an invalid config is detected
- Applies to both the hot-reload watcher path and the startup recovery path
- When `mode: "off"`, recovery defaults to `"off"` automatically (no breaking change to existing `mode: "off"` users)
- When recovery is disabled, the gateway logs the exact validation issues (including legacy issues) and blocks the reload/startup rather than silently reverting

## Motivation

The auto-revert behaviour introduced in `ffb1628727` (2026-04-20) is destructive: a hot-reload watchdog detecting a temporarily-invalid config file (e.g. mid-edit, or written by an external tool) will silently overwrite it with a stale snapshot. Users who intentionally write an invalid config to inspect error messages lose their edits without warning.

With `gateway.reload.recovery: "off"`, the gateway instead logs all validation issues with precise error detail and blocks the reload — matching the pre-`ffb1628727` behaviour.

## Config usage

```yaml
gateway:
  reload:
    recovery: "off"   # disable auto-revert; log issues and block reload instead
```

## Changes

- `src/config/types.gateway.ts` — `recovery?: "on" | "off"` on `GatewayReloadConfig`
- `src/config/zod-schema.ts` — zod schema entry
- `src/config/schema.labels.ts` — display label
- `src/config/schema.help.ts` — help text
- `src/config/schema.base.generated.ts` — regenerated via `pnpm config:schema:gen`
- `src/gateway/config-reload.ts` — `recovery` field in `GatewayReloadSettings`; `resolveGatewayReloadSettings`; `formatSnapshotIssueLines` helper (includes `legacyIssues`); `recoverAndReadSnapshot` returns `"logged-and-skipped"` sentinel when recovery disabled; `runReload` early-returns on sentinel to prevent double-logging
- `src/gateway/server-startup-config.ts` — startup recovery path gated by `startupRecoveryEnabled` (reads `rejectedSnapshot.sourceConfig?.gateway?.reload?.recovery`)

## Test plan

- [ ] `pnpm test src/gateway/config-reload.test.ts src/gateway/server-startup-config.test.ts` passes
- [ ] `pnpm config:schema:gen` produces no drift
- [ ] With `recovery: "off"`: writing an invalid config logs issues and does not revert
- [ ] With `recovery: "on"` (default): existing auto-revert behaviour unchanged
- [ ] `mode: "off"` still implies `recovery: "off"` (no regression for users with reload disabled)