### PR TITLE
Expose session context to exec commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Exec: expose the current agent session context to spawned commands through `OPENCLAW_SESSION_KEY`, plus `OPENCLAW_SESSION_ID` when an ephemeral run session id is available.
 - Agents/runtime: memoize transcript replay-policy resolution for stable config and process-env runs while preserving custom-env provider hook behavior. Thanks @DmitryPogodaev.
 - Infra/path-guards: add a fast path for canonical absolute POSIX containment checks, avoiding repeated `path.resolve` and `path.relative` work in hot filesystem walkers. Refs #75895, #75575, and #68782. Thanks @Enderfga.
 - Tools: add a platform-level tool descriptor planner for descriptor-first visibility, generic availability checks, and executor references. Thanks @shakkernerd.

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -61,6 +61,8 @@ Env var equivalents:
 OpenClaw also injects context markers into spawned child processes:
 
 - `OPENCLAW_SHELL=exec`: set for commands run through the `exec` tool.
+- `OPENCLAW_SESSION_KEY`: set for `exec` tool commands when they run from an agent session.
+- `OPENCLAW_SESSION_ID`: set for `exec` tool commands when an ephemeral run session id is available.
 - `OPENCLAW_SHELL=acp`: set for ACP runtime backend process spawns (for example `acpx`).
 - `OPENCLAW_SHELL=acp-client`: set for `openclaw acp client` when it spawns the ACP bridge process.
 - `OPENCLAW_SHELL=tui-local`: set for local TUI `!` shell commands.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -78,7 +78,7 @@ Notes:
   then falls back to Windows PowerShell 5.1.
 - Host execution (`gateway`/`node`) rejects `env.PATH` and loader overrides (`LD_*`/`DYLD_*`) to
   prevent binary hijacking or injected code.
-- OpenClaw sets `OPENCLAW_SHELL=exec` in the spawned command environment (including PTY and sandbox execution) so shell/profile rules can detect exec-tool context.
+- OpenClaw sets `OPENCLAW_SHELL=exec` in the spawned command environment (including PTY and sandbox execution) so shell/profile rules can detect exec-tool context. Agent-session exec commands also receive `OPENCLAW_SESSION_KEY`, and `OPENCLAW_SESSION_ID` when an ephemeral run session id is available.
 - `openclaw channels login` is blocked from `exec` because it is an interactive channel-auth flow; run it in a terminal on the gateway host, or use the channel-native login tool from chat when one exists.
 - Important: sandboxing is **off by default**. If sandboxing is off, implicit `host=auto`
   resolves to `gateway`. Explicit `host=sandbox` still fails closed instead of silently

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -557,6 +557,7 @@ export async function runExecProcess(opts: {
   notifyOnExitEmptySuccess?: boolean;
   scopeKey?: string;
   sessionKey?: string;
+  sessionId?: string;
   notifyDeliveryContext?: DeliveryContext;
   timeoutSec: number | null;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
@@ -568,6 +569,8 @@ export async function runExecProcess(opts: {
   const supervisor = getProcessSupervisor();
   const shellRuntimeEnv: Record<string, string> = {
     ...opts.env,
+    ...(opts.sessionKey?.trim() ? { OPENCLAW_SESSION_KEY: opts.sessionKey.trim() } : {}),
+    ...(opts.sessionId?.trim() ? { OPENCLAW_SESSION_ID: opts.sessionId.trim() } : {}),
     OPENCLAW_SHELL: "exec",
   };
 

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -29,6 +29,7 @@ export type ExecToolDefaults = {
   allowBackground?: boolean;
   scopeKey?: string;
   sessionKey?: string;
+  sessionId?: string;
   messageProvider?: string;
   currentChannelId?: string;
   currentThreadTs?: string;

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -40,7 +40,9 @@ vi.mock("../process/supervisor/index.js", () => ({
     }) => {
       const command = input.argv?.at(-1) ?? "";
       const env = input.env ?? {};
-      if (command.includes("OPENCLAW_SHELL")) {
+      if (command.includes("OPENCLAW_SESSION_KEY") && command.includes("OPENCLAW_SESSION_ID")) {
+        input.onStdout?.(`${env.OPENCLAW_SESSION_KEY ?? ""}:${env.OPENCLAW_SESSION_ID ?? ""}`);
+      } else if (command.includes("OPENCLAW_SHELL")) {
         input.onStdout?.(env.OPENCLAW_SHELL ?? "");
       } else if (command.includes("SSLKEYLOGFILE")) {
         input.onStdout?.(env.SSLKEYLOGFILE ?? "");
@@ -177,6 +179,29 @@ describe("exec PATH login shell merge", () => {
     const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
 
     expect(value).toBe("exec");
+  });
+
+  it("sets OpenClaw session env for host=gateway commands", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:discord:channel:1500088601525096659",
+      sessionId: "123e4567-e89b-12d3-a456-426614174000",
+    });
+    const result = await tool.execute("call-openclaw-session-env", {
+      command: 'printf "%s:%s" "${OPENCLAW_SESSION_KEY:-}" "${OPENCLAW_SESSION_ID:-}"',
+      yieldMs: FOREGROUND_TEST_YIELD_MS,
+    });
+    const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(value).toBe(
+      "agent:main:discord:channel:1500088601525096659:123e4567-e89b-12d3-a456-426614174000",
+    );
   });
 
   it("throws security violation when env.PATH is provided", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1422,6 +1422,7 @@ export function createExecTool(
   const notifyOnExit = defaults?.notifyOnExit !== false;
   const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
   const notifySessionKey = normalizeOptionalString(defaults?.sessionKey);
+  const execSessionId = normalizeOptionalString(defaults?.sessionId);
   const notifyDeliveryContext = normalizeDeliveryContext({
     channel: defaults?.messageProvider,
     to: defaults?.currentChannelId,
@@ -1781,6 +1782,7 @@ export function createExecTool(
         notifyOnExitEmptySuccess,
         scopeKey: defaults?.scopeKey,
         sessionKey: notifySessionKey,
+        sessionId: execSessionId,
         notifyDeliveryContext,
         timeoutSec: effectiveTimeout,
         onUpdate,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -564,6 +564,7 @@ export function createOpenClawCodingTools(options?: {
         allowBackground,
         scopeKey,
         sessionKey: options?.sessionKey,
+        sessionId: options?.sessionId,
         messageProvider: options?.messageProvider,
         currentChannelId: options?.currentChannelId,
         currentThreadTs: options?.currentThreadTs,


### PR DESCRIPTION
## Summary
- expose the current agent session key to `exec` commands as `OPENCLAW_SESSION_KEY`
- pass through the ephemeral run session id as `OPENCLAW_SESSION_ID` when available
- document the runtime-injected env vars and cover gateway exec env propagation with a focused test

## Validation
- `corepack pnpm docs:list`
- `corepack pnpm exec oxfmt --check --threads=1 src/agents/bash-tools.exec-types.ts src/agents/pi-tools.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec.path.test.ts`
- `corepack pnpm exec vitest run src/agents/bash-tools.exec.path.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/format-docs.mjs --check docs/tools/exec.md docs/help/environment.md`
- `corepack pnpm check:changelog-attributions`
