### PR TITLE
fix(feishu): render buttons/selects in buildFeishuPresentationCard

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -22,7 +22,13 @@ import {
 import {
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
+  type MessagePresentationBlock,
+  type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import {
+  buildFeishuCardElementForBlock,
+  buildFeishuPayloadButton,
+} from "./outbound.js";
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import { createRuntimeOutboundDelegates } from "openclaw/plugin-sdk/outbound-runtime";
 import { createComputedAccountStatusAdapter } from "openclaw/plugin-sdk/status-helpers";
@@ -135,10 +141,27 @@ function buildFeishuPresentationCard(params: {
   presentation: NonNullable<ReturnType<typeof normalizeMessagePresentation>>;
   fallbackText?: string;
 }): Record<string, unknown> {
-  const fallbackPresentation: NonNullable<ReturnType<typeof normalizeMessagePresentation>> = {
-    ...(params.presentation.tone ? { tone: params.presentation.tone } : {}),
-    blocks: params.presentation.blocks,
-  };
+  const elements: Record<string, unknown>[] = [];
+
+  // Render blocks (text, context, divider, buttons, selects) using the same logic as buildFeishuPayloadCard
+  for (const block of params.presentation.blocks) {
+    const element = buildFeishuCardElementForBlock(block);
+    if (element) {
+      elements.push(element);
+    }
+  }
+
+  // If no elements were generated (e.g., empty blocks array), fall back to the markdown fallback
+  if (elements.length === 0 && params.fallbackText) {
+    elements.push({
+      tag: "markdown",
+      content: renderMessagePresentationFallbackText({
+        text: params.fallbackText,
+        presentation: params.presentation,
+      }),
+    });
+  }
+
   return {
     schema: "2.0",
     config: {
@@ -153,15 +176,7 @@ function buildFeishuPresentationCard(params: {
         }
       : {}),
     body: {
-      elements: [
-        {
-          tag: "markdown",
-          content: renderMessagePresentationFallbackText({
-            text: params.fallbackText,
-            presentation: fallbackPresentation,
-          }),
-        },
-      ],
+      elements,
     },
   };
 }

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -233,7 +233,7 @@ function mapFeishuButtonType(style: MessagePresentationButton["style"]) {
   return "default";
 }
 
-function buildFeishuPayloadButton(
+export function buildFeishuPayloadButton(
   button: MessagePresentationButton,
 ): Record<string, unknown> | undefined {
   const rendered: Record<string, unknown> = {
@@ -260,7 +260,7 @@ function buildFeishuPayloadButton(
   return rendered.url || rendered.value ? rendered : undefined;
 }
 
-function buildFeishuCardElementForBlock(
+export function buildFeishuCardElementForBlock(
   block: MessagePresentationBlock,
 ): Record<string, unknown> | undefined {
   if (block.type === "text") {


### PR DESCRIPTION
## Problem

`buildFeishuPresentationCard` (used by the `message` tool) only rendered `text`/`context`/`divider` blocks as markdown, silently ignoring `buttons` and `selects` blocks.

`buildFeishuPayloadCard` (used by the deliver pipeline's `sendPayload`) correctly handles all block types including buttons via `buildFeishuCardElementForBlock`.

## Fix

Import `buildFeishuCardElementForBlock` from `outbound.ts` and use it in `buildFeishuPresentationCard` so the `message` tool also renders buttons and selects correctly.

## Changes

- `channel.ts` (`buildFeishuPresentationCard`): Replaced single markdown fallback element with a loop that calls `buildFeishuCardElementForBlock` for each block (matching `buildFeishuPayloadCard` logic)
- `outbound.ts`: Exported `buildFeishuPayloadButton` and `buildFeishuCardElementForBlock` so they can be reused in `channel.ts`

## Testing

Manual test: send a Feishu card with buttons via the `message` tool and verify buttons are rendered as interactive Feishu buttons instead of plain text fallback.

Fixes: buttons/selects in message tool presentation not rendered for Feishu