### PR TITLE
fix(deps): add Zod v4 override to resolve @jimp/* transitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1760,7 +1760,8 @@
       "tough-cookie": "4.1.3",
       "yauzl": "3.2.1",
       "protobufjs": "7.5.5",
-      "uuid": "14.0.0"
+      "uuid": "14.0.0",
+      "zod": "^4.4.1"
     },
     "onlyBuiltDependencies": [
       "@discordjs/opus",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   yauzl: 3.2.1
   protobufjs: 7.5.5
   uuid: 14.0.0
+  zod: ^4.4.1
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
@@ -1659,12 +1660,12 @@ packages:
   '@agentclientprotocol/sdk@0.20.0':
     resolution: {integrity: sha512-BxEHyE4MvwyOsdyVPub1vEtyrq8E0JSdjC+ckXWimY1VabFCTXdPyXv2y2Omz1j+iod7Z8oBJDXFCJptM0GBqQ==}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: ^4.4.1
 
   '@agentclientprotocol/sdk@0.21.0':
     resolution: {integrity: sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: ^4.4.1
 
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.121':
     resolution: {integrity: sha512-zVHcXvx6Hl/glDcOCH+EyNx4KPE9cMGLk42eEBSZe014tAN5W8bwM/By08iM6dxijnpH0NQRNNEAW+BryWzuDg==}
@@ -1714,13 +1715,13 @@ packages:
     resolution: {integrity: sha512-hwZNYTkGLKVixd/V/OCJwfH/SdfxZXGV0m6wvy5EBq6qfB+lvJTRz/MSOSa7dHqo4/F7zJY68crEEca68Wrxpw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^4.0.0
+      zod: ^4.4.1
 
   '@anthropic-ai/sdk@0.92.0':
     resolution: {integrity: sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==}
     hasBin: true
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: ^4.4.1
     peerDependenciesMeta:
       zod:
         optional: true
@@ -2961,7 +2962,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      zod: ^4.4.1
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -4046,6 +4047,7 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
+    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.25':
     resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
@@ -6491,7 +6493,7 @@ packages:
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.25 || ^4.0
+      zod: ^4.4.1
     peerDependenciesMeta:
       ws:
         optional: true
@@ -6503,7 +6505,7 @@ packages:
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.25 || ^4.0
+      zod: ^4.4.1
     peerDependenciesMeta:
       ws:
         optional: true
@@ -7813,10 +7815,7 @@ packages:
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25.28 || ^4
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+      zod: ^4.4.1
 
   zod@4.4.1:
     resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
@@ -9240,7 +9239,7 @@ snapshots:
     dependencies:
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@jimp/plugin-blur@1.6.1':
     dependencies:
@@ -9252,7 +9251,7 @@ snapshots:
   '@jimp/plugin-circle@1.6.1':
     dependencies:
       '@jimp/types': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@jimp/plugin-color@1.6.1':
     dependencies:
@@ -9260,7 +9259,7 @@ snapshots:
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
       tinycolor2: 1.6.0
-      zod: 3.25.76
+      zod: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9271,7 +9270,7 @@ snapshots:
       '@jimp/plugin-resize': 1.6.1
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9281,7 +9280,7 @@ snapshots:
       '@jimp/plugin-crop': 1.6.1
       '@jimp/plugin-resize': 1.6.1
       '@jimp/types': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9290,7 +9289,7 @@ snapshots:
       '@jimp/core': 1.6.1
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9298,7 +9297,7 @@ snapshots:
     dependencies:
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@jimp/plugin-dither@1.6.1':
     dependencies:
@@ -9308,12 +9307,12 @@ snapshots:
     dependencies:
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@jimp/plugin-flip@1.6.1':
     dependencies:
       '@jimp/types': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@jimp/plugin-hash@1.6.1':
     dependencies:
@@ -9333,7 +9332,7 @@ snapshots:
   '@jimp/plugin-mask@1.6.1':
     dependencies:
       '@jimp/types': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@jimp/plugin-print@1.6.1':
     dependencies:
@@ -9346,20 +9345,20 @@ snapshots:
       parse-bmfont-binary: 1.0.6
       parse-bmfont-xml: 1.1.6
       simple-xml-to-json: 1.2.7
-      zod: 3.25.76
+      zod: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
   '@jimp/plugin-quantize@1.6.1':
     dependencies:
       image-q: 4.0.0
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@jimp/plugin-resize@1.6.1':
     dependencies:
       '@jimp/core': 1.6.1
       '@jimp/types': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9370,7 +9369,7 @@ snapshots:
       '@jimp/plugin-resize': 1.6.1
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9381,13 +9380,13 @@ snapshots:
       '@jimp/plugin-hash': 1.6.1
       '@jimp/types': 1.6.1
       '@jimp/utils': 1.6.1
-      zod: 3.25.76
+      zod: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
   '@jimp/types@1.6.1':
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@jimp/utils@1.6.1':
     dependencies:
@@ -15132,8 +15131,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.1):
     dependencies:
       zod: 4.4.1
-
-  zod@3.25.76: {}
 
   zod@4.4.1: {}
 


### PR DESCRIPTION
@jimp/* packages depend on zod@3.25.76 (transitive), while the project uses zod@^4.4.1. This causes type conflicts and dual version issues.

Add pnpm override to force all zod dependencies to use v4.

**Changes:**
- Add "zod": "^4.4.1" to pnpm.overrides in package.json
- Regenerate pnpm-lock.yaml

**Testing:**
- pnpm install --no-frozen-lockfile --config.minimum-release-age=0 ✓
- pnpm tsgo ✓
- pnpm test (running in CI)