### PR TITLE
fix(kimi): include reasoning_content on thinking tool replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2329,6 +2329,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Kimi: add blank `reasoning_content` to replayed assistant tool-call messages when thinking is enabled, preventing Kimi API 400 errors on conversation replay. (#76073)
 - Packaged installs: preserve package-root runtime dependencies and their exported subpaths when bundled plugin runtime mirrors fall back to copying shared chunks, fixing Windows npm updates that could fail to load copied `dist` modules.
 - Heartbeat: clamp oversized scheduler delays through the shared safe timer helper, preventing `every` values over Node's timeout cap from becoming a 1 ms crash loop. Fixes #71414. (#71478) Thanks @hclsys.
 - Agents/heartbeat: stop injecting the heartbeat system prompt into non-heartbeat runs, preventing ordinary user replies from being suppressed as `HEARTBEAT_OK` acknowledgments. Fixes #69079. (#69278) Thanks @stainlu.

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -331,4 +331,125 @@ describe("kimi tool-call markup wrapper", () => {
       thinking: { type: "enabled" },
     });
   });
+
+  it("adds blank reasoning_content to replayed assistant tool calls when thinking is enabled", () => {
+    const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream({
+      messages: [
+        { role: "user", content: "Use the tool." },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Checking." },
+            {
+              type: "toolCall",
+              id: "tool_1",
+              name: "read",
+              arguments: { path: "/tmp/file.txt" },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Already reasoned." }],
+          reasoning_content: "kept",
+          tool_calls: [
+            {
+              id: "tool_2",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const wrapped = createKimiThinkingWrapper(baseStreamFn, "enabled");
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "kimi",
+        id: "kimi-code",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(getCapturedPayload()).toEqual({
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "user", content: "Use the tool." },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Checking." },
+            {
+              type: "toolCall",
+              id: "tool_1",
+              name: "read",
+              arguments: { path: "/tmp/file.txt" },
+            },
+          ],
+          reasoning_content: "",
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Already reasoned." }],
+          reasoning_content: "kept",
+          tool_calls: [
+            {
+              id: "tool_2",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("does not add reasoning_content to replayed assistant tool calls when thinking is disabled", () => {
+    const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "tool_1",
+              name: "read",
+              arguments: { path: "/tmp/file.txt" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const wrapped = createKimiThinkingWrapper(baseStreamFn, "disabled");
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "kimi",
+        id: "kimi-code",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(getCapturedPayload()).toEqual({
+      thinking: { type: "disabled" },
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "tool_1",
+              name: "read",
+              arguments: { path: "/tmp/file.txt" },
+            },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -197,6 +197,38 @@ export function createKimiToolCallMarkupWrapper(baseStreamFn: StreamFn | undefin
   };
 }
 
+function messageHasKimiToolCall(message: Record<string, unknown>): boolean {
+  if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+    return true;
+  }
+  if (!Array.isArray(message.content)) {
+    return false;
+  }
+  return message.content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type === "toolCall" || type === "tool_use";
+  });
+}
+
+function ensureKimiToolCallReasoningContent(payload: Record<string, unknown>): void {
+  if (!Array.isArray(payload.messages)) {
+    return;
+  }
+  for (const message of payload.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role !== "assistant" || !messageHasKimiToolCall(record)) {
+      continue;
+    }
+    record.reasoning_content ??= "";
+  }
+}
+
 export function createKimiThinkingWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingType: KimiThinkingType,
@@ -208,6 +240,9 @@ export function createKimiThinkingWrapper(
       delete payloadObj.reasoning;
       delete payloadObj.reasoning_effort;
       delete payloadObj.reasoningEffort;
+      if (thinkingType === "enabled") {
+        ensureKimiToolCallReasoningContent(payloadObj);
+      }
     });
 }
 


### PR DESCRIPTION
## Summary
- Add `reasoning_content: ""` to replayed Kimi assistant tool-call messages when Kimi thinking is enabled.
- Preserve existing `reasoning_content` values and leave disabled-thinking payloads unchanged.
- Add Kimi stream wrapper regression coverage for enabled and disabled thinking replay payloads.

## Problem
Kimi rejects replayed conversations that include assistant tool-call turns when thinking is enabled unless those assistant tool-call messages include `reasoning_content`. OpenClaw currently enables Kimi thinking with `thinking: { type: "enabled" }`, but the Kimi stream wrapper does not normalize replayed assistant tool-call messages before dispatch.

Observed runtime failure from `~/.openclaw/logs/gateway.err.log`:

```text
LLM request rejected: thinking is enabled but reasoning_content is missing in assistant tool call message at index 29
rawError=400 {"error":{"type":"invalid_request_error","message":"thinking is enabled but reasoning_content is missing in assistant tool call message at index 29"},"type":"error"}
```

The same error reproduced across different conversation lengths/indexes, including `2`, `7`, `8`, `29`, `36`, and `45`, which points to replay serialization rather than a single malformed tool result.

## Reproduction
1. Configure the bundled Kimi provider, for example `kimi/kimi-code` against the Kimi coding endpoint.
2. Enable thinking for the session, for example `/think low` or any non-`off` Kimi thinking level.
3. Ask a prompt that causes an assistant tool call, such as reading a file or tracker.
4. Send a follow-up message so OpenClaw replays the prior assistant tool-call turn.
5. Kimi returns HTTP 400 with `thinking is enabled but reasoning_content is missing in assistant tool call message at index ...`; OpenClaw surfaces the generic processing error to the channel.

## Fix
When the Kimi thinking wrapper sets `thinking: { type: "enabled" }`, it now scans replayed `payload.messages` and adds a blank `reasoning_content` only to assistant messages that contain structured tool calls (`tool_calls`, `toolCall`, or `tool_use`) and do not already have the field.

This mirrors the existing OpenAI-compatible thinking-provider pattern used elsewhere in OpenClaw for strict replay validation while keeping the change scoped to the bundled Kimi provider.

## Validation
- `npm exec --yes pnpm@10.33.0 -- exec vitest run extensions/kimi-coding/stream.test.ts`
- `npm exec --yes pnpm@10.33.0 -- exec oxlint extensions/kimi-coding/stream.ts extensions/kimi-coding/stream.test.ts`
- `npm exec --yes pnpm@10.33.0 -- exec oxfmt --check extensions/kimi-coding/stream.ts extensions/kimi-coding/stream.test.ts`
- `npm exec --yes pnpm@10.33.0 -- tsgo:extensions:test`
