### PR TITLE
fix: add --timeout flag to openclaw message send with SIGTERM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- CLI/message: add `--timeout <ms>` to `openclaw message send` (default 30000) so delivery requests can no longer hang indefinitely. SIGTERM/SIGINT handlers in `executeGatewayRequestWithScopes` properly clean up listeners after request settles, allowing external supervisors like `timeout(1)` to interrupt stuck requests without leaking signal handlers. Fixes #75895. Thanks @EronFan.
+
 ### Changes
 
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -69,7 +69,8 @@ Name lookup:
 - `send`
   - Channels: WhatsApp/Telegram/Discord/Google Chat/Slack/Mattermost (plugin)/Signal/iMessage/Matrix/Microsoft Teams
   - Required: `--target`, plus `--message`, `--media`, or `--presentation`
-  - Optional: `--media`, `--presentation`, `--delivery`, `--pin`, `--reply-to`, `--thread-id`, `--gif-playback`, `--force-document`, `--silent`
+  - Optional: `--media`, `--presentation`, `--delivery`, `--pin`, `--reply-to`, `--thread-id`, `--gif-playback`, `--force-document`, `--silent`, `--timeout`
+  - `--timeout <ms>`: request timeout in milliseconds (default: 30000). When the timeout expires, the gateway request is aborted with a timeout error. Combine with external supervisors like `timeout(1)` — SIGTERM is also handled so they can interrupt cleanly.
   - Shared presentation payloads: `--presentation` sends semantic blocks (`text`, `context`, `divider`, `buttons`, `select`) that core renders through the selected channel's declared capabilities. See [Message Presentation](/plugins/message-presentation).
   - Generic delivery preferences: `--delivery` accepts delivery hints such as `{ "pin": true }`; `--pin` is shorthand for pinned delivery when the channel supports it.
   - Telegram only: `--force-document` (send images and GIFs as documents to avoid Telegram compression)

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -33,10 +33,17 @@ type MessagePluginPreloadPlan =
 
 function normalizeMessageOptions(opts: Record<string, unknown>): Record<string, unknown> {
   const { account, timeout, ...rest } = opts;
+  let timeoutMs: number | undefined;
+  if (typeof timeout === "string") {
+    const parsed = parseInt(timeout, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      timeoutMs = parsed;
+    }
+  }
   return {
     ...rest,
     accountId: typeof account === "string" ? account : undefined,
-    timeoutMs: typeof timeout === "string" ? parseInt(timeout, 10) : undefined,
+    timeoutMs,
   };
 }
 

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -32,10 +32,11 @@ type MessagePluginPreloadPlan =
   | { preload: false };
 
 function normalizeMessageOptions(opts: Record<string, unknown>): Record<string, unknown> {
-  const { account, ...rest } = opts;
+  const { account, timeout, ...rest } = opts;
   return {
     ...rest,
     accountId: typeof account === "string" ? account : undefined,
+    timeoutMs: typeof timeout === "string" ? parseInt(timeout, 10) : undefined,
   };
 }
 

--- a/src/cli/program/message/register.send.ts
+++ b/src/cli/program/message/register.send.ts
@@ -33,6 +33,11 @@ export function registerMessageSendCommand(message: Command, helpers: MessageCli
           "--silent",
           "Send message silently without notification (Telegram + Discord)",
           false,
+        )
+        .option(
+          "--timeout <ms>",
+          "Request timeout in milliseconds (default: 30000)",
+          "30000",
         ),
     )
     .action(async (opts) => {

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -76,6 +76,7 @@ export async function messageCommand(
       gateway: {
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
+        timeoutMs: typeof opts.timeoutMs === "number" ? opts.timeoutMs : 30_000,
       },
     });
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1178,6 +1178,18 @@ describe("callGateway error details", () => {
     await expect(promise).resolves.toEqual({ ok: true });
   });
 
+  it("disposes SIGTERM/SIGINT listeners after gateway request settles", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    const initialSigtermCount = process.listenerCount("SIGTERM");
+    const initialSigintCount = process.listenerCount("SIGINT");
+
+    await callGateway({ method: "health" });
+
+    expect(process.listenerCount("SIGTERM")).toBe(initialSigtermCount);
+    expect(process.listenerCount("SIGINT")).toBe(initialSigintCount);
+  });
+
   it("fails fast when remote mode is missing remote url", async () => {
     getRuntimeConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -625,6 +625,8 @@ async function executeGatewayRequestWithScopes<T>(params: {
         return;
       }
       settled = true;
+      process.off("SIGTERM", abortHandler);
+      process.off("SIGINT", abortHandler);
       startAbort.abort();
       clearTimeout(timer);
       void stopGatewayClient(client).finally(() => {
@@ -698,6 +700,14 @@ async function executeGatewayRequestWithScopes<T>(params: {
         }),
       );
     }, safeTimerTimeoutMs);
+
+    // Honor SIGTERM so external supervisors (e.g. GNU timeout(1)) can interrupt cleanly.
+    const abortHandler = () => {
+      ignoreClose = true;
+      stop(new Error("SIGTERM received, gateway request aborted"));
+    };
+    process.on("SIGTERM", abortHandler);
+    process.on("SIGINT", abortHandler);
 
     void startGatewayClientWhenEventLoopReady(client, {
       timeoutMs: safeTimerTimeoutMs,


### PR DESCRIPTION
## Summary

Add a `--timeout <ms>` flag to `openclaw message send` (default: 30000ms) so that delivery requests can no longer hang indefinitely. Also adds SIGTERM/SIGINT handling in `executeGatewayRequestWithScopes` with proper listener cleanup so external supervisors like `GNU timeout(1)` can cleanly interrupt stuck requests.

## Problem

When `openclaw message send` calls the gateway and the channel delivery hangs (e.g. Telegram rate limit, network issue), the CLI process:
- Has no internal timeout — waits forever
- Ignores SIGTERM from external `timeout` command
- Consumes 60-70% CPU indefinitely

**Impact:** Cron jobs calling `openclaw message send` become unsafe; one stuck delivery can cascade into gateway/agent pileups.

## Fix

1. **register.send.ts** — Add `--timeout <ms>` option (default: 30000)
2. **helpers.ts** — Parse timeout, validate (reject NaN/negative/zero), pass as `timeoutMs`
3. **message.ts** — Inject `timeoutMs` into the gateway params passed to `runMessageAction`
4. **call.ts** — Add SIGTERM/SIGINT handler in `executeGatewayRequestWithScopes` using `process.on` (not `process.once`) with proper `process.off` cleanup in the `stop` function so listeners don't leak after each gateway call
5. **call.test.ts** — Add test verifying signal listeners are disposed after gateway request settles
6. **CHANGELOG.md**, **docs/cli/message.md** — Document the new flag

## Testing

### Unit tests

```
pnpm test src/gateway/call.test.ts src/cli/program/message/helpers.test.ts src/commands/message.test.ts

✓ gateway (79 tests) — includes "disposes SIGTERM/SIGINT listeners after gateway request settles"
✓ cli (23 tests)
✓ commands (5 tests)
```

### Signal listener cleanup (standalone proof)

Without cleanup, listeners persist after normal path:
```
onHelloOk -> stop() -> resolve() -> SIGTERM/SIGINT remain registered = leak
```

Proof that cleanup works:
```
$ node -e "
const h = () => {};
const bS = process.listenerCount('SIGTERM');  // 0
const bI = process.listenerCount('SIGINT');   // 0
process.on('SIGTERM', h); process.on('SIGINT', h);
process.off('SIGTERM', h); process.off('SIGINT', h);
console.log('SIGTERM:', process.listenerCount('SIGTERM')); // 0
console.log('SIGINT:', process.listenerCount('SIGINT'));   // 0
"
SIGTERM: 0
SIGINT: 0
```

### Timeout input validation

| Input | Result |
|-------|--------|
| `--timeout 5000` | timeoutMs: 5000 |
| `--timeout -100` | timeoutMs: undefined (falls to default 30000) |
| `--timeout 0` | timeoutMs: undefined (falls to default 30000) |
| `--timeout abc` | timeoutMs: undefined (falls to default 30000) |

Fixes #75895