### PR TITLE
fix(qqbot): surface C2C msg element attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- QQ Bot: normalize C2C and group media from `msg_elements` into inbound attachments when top-level attachments are absent, so private-chat images reach agent media handling. Fixes #76062. Thanks @xuruiray.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Discord/gateway: measure heartbeat ACK timeouts from the actual heartbeat send, preventing late initial heartbeats from triggering false reconnect loops while the channel is still awaiting readiness. Fixes #77668. (#78087) Thanks @bryce-d-greybeard and @NikolaFC.

--- a/extensions/qqbot/src/engine/gateway/event-dispatcher.test.ts
+++ b/extensions/qqbot/src/engine/gateway/event-dispatcher.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { MSG_TYPE_QUOTE } from "../utils/text-parsing.js";
+import { GatewayEvent } from "./constants.js";
+import { dispatchEvent } from "./event-dispatcher.js";
+
+vi.mock("../session/known-users.js", () => ({
+  recordKnownUser: vi.fn(),
+}));
+
+function expectMessageResult(result: ReturnType<typeof dispatchEvent>) {
+  expect(result.action).toBe("message");
+  if (result.action !== "message") {
+    throw new Error(`expected message dispatch, got ${result.action}`);
+  }
+  return result.msg;
+}
+
+describe("engine/gateway/event-dispatcher", () => {
+  it("uses C2C msg_elements attachments when the top-level attachments field is absent", () => {
+    const msg = expectMessageResult(
+      dispatchEvent(
+        GatewayEvent.C2C_MESSAGE_CREATE,
+        {
+          id: "msg-1",
+          content: "look",
+          timestamp: "2026-05-02T00:00:00.000Z",
+          author: { user_openid: "user-1" },
+          message_type: 7,
+          msg_elements: [
+            {
+              attachments: [
+                {
+                  content_type: "image/jpeg",
+                  url: "//cdn.example.test/rainbow.jpg",
+                  filename: "rainbow.jpg",
+                  width: 1024,
+                  height: 768,
+                },
+              ],
+            },
+          ],
+        },
+        "qq-main",
+      ),
+    );
+
+    expect(msg.type).toBe("c2c");
+    expect(msg.attachments).toEqual([
+      expect.objectContaining({
+        content_type: "image/jpeg",
+        url: "//cdn.example.test/rainbow.jpg",
+        filename: "rainbow.jpg",
+      }),
+    ]);
+  });
+
+  it("does not treat quoted C2C msg_elements attachments as current-message attachments", () => {
+    const msg = expectMessageResult(
+      dispatchEvent(
+        GatewayEvent.C2C_MESSAGE_CREATE,
+        {
+          id: "msg-2",
+          content: "replying",
+          timestamp: "2026-05-02T00:00:00.000Z",
+          author: { user_openid: "user-1" },
+          message_type: MSG_TYPE_QUOTE,
+          msg_elements: [
+            {
+              msg_idx: "quoted-msg",
+              attachments: [
+                {
+                  content_type: "image/png",
+                  url: "https://cdn.example.test/quoted.png",
+                  filename: "quoted.png",
+                },
+              ],
+            },
+          ],
+        },
+        "qq-main",
+      ),
+    );
+
+    expect(msg.refMsgIdx).toBe("quoted-msg");
+    expect(msg.attachments).toBeUndefined();
+    expect(msg.msgElements?.[0]?.attachments).toHaveLength(1);
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/event-dispatcher.ts
+++ b/extensions/qqbot/src/engine/gateway/event-dispatcher.ts
@@ -7,7 +7,7 @@
 
 import { recordKnownUser } from "../session/known-users.js";
 import type { InteractionEvent } from "../types.js";
-import { parseRefIndices } from "../utils/text-parsing.js";
+import { MSG_TYPE_QUOTE, parseRefIndices } from "../utils/text-parsing.js";
 import { readOptionalMessageSceneExt } from "./codec.js";
 import { GatewayEvent } from "./constants.js";
 import type { QueuedMessage } from "./message-queue.js";
@@ -66,7 +66,7 @@ export function dispatchEvent(
         content: ev.content,
         messageId: ev.id,
         timestamp: ev.timestamp,
-        attachments: ev.attachments,
+        attachments: resolveCurrentMessageAttachments(ev),
         refMsgIdx: refs.refMsgIdx,
         msgIdx: refs.msgIdx,
         msgType: ev.message_type,
@@ -165,7 +165,7 @@ function buildGroupQueuedMessage(
     messageId: ev.id,
     timestamp: ev.timestamp,
     groupOpenid: ev.group_openid,
-    attachments: ev.attachments,
+    attachments: resolveCurrentMessageAttachments(ev),
     refMsgIdx: refs.refMsgIdx,
     msgIdx: refs.msgIdx,
     msgType: ev.message_type,
@@ -174,4 +174,21 @@ function buildGroupQueuedMessage(
     mentions: ev.mentions,
     messageScene: ev.message_scene,
   };
+}
+
+function resolveCurrentMessageAttachments(event: {
+  attachments?: QueuedMessage["attachments"];
+  message_type?: number;
+  msg_elements?: Array<{ attachments?: QueuedMessage["attachments"] }>;
+}): QueuedMessage["attachments"] | undefined {
+  if (event.attachments?.length) {
+    return event.attachments;
+  }
+  if (event.message_type === MSG_TYPE_QUOTE) {
+    return undefined;
+  }
+
+  const elementAttachments =
+    event.msg_elements?.flatMap((element) => element.attachments ?? []) ?? [];
+  return elementAttachments.length > 0 ? elementAttachments : undefined;
 }


### PR DESCRIPTION
## Summary
- normalize QQ Bot C2C and group media from msg_elements into inbound attachments when top-level attachments are absent
- preserve quoted msg_elements as quote metadata instead of treating quoted media as current-message attachments
- add dispatcher regression coverage and changelog for #76062

Fixes #76062

## Test plan
- pnpm test extensions/qqbot/src/engine/gateway/event-dispatcher.test.ts extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
- pnpm test src/auto-reply/reply.media-note.test.ts src/agents/pi-embedded-runner/run/images.test.ts
- pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/qqbot/src/engine/gateway/event-dispatcher.ts extensions/qqbot/src/engine/gateway/event-dispatcher.test.ts
- pnpm check:changed

## Real behavior proof
- **Behavior or issue addressed**: QQ Bot C2C `msg_elements` media is normalized into inbound message attachments when the top-level `attachments` field is absent.
- **Real environment tested**: Local OpenClaw QQ Bot gateway dispatcher from this PR branch (`OpenClaw 2026.5.4`, commit `aca3669`) using the actual dispatcher module with a provider-shaped C2C payload.
- **Exact steps or command run after this patch**:
  ```sh
  node --import tsx --input-type=module
  # Imported dispatchEvent/GatewayEvent, dispatched a C2C_MESSAGE_CREATE payload containing msg_elements[0].attachments,
  # and printed the normalized dispatch result.
  ```
- **Evidence after fix**: Console output from the node command:
  ```json
  {
    "action": "message",
    "type": "c2c",
    "attachments": [
      {
        "content_type": "image/jpeg",
        "url": "//cdn.example.test/rainbow.jpg",
        "filename": "rainbow.jpg",
        "width": 1024,
        "height": 768
      }
    ]
  }
  ```
- **Observed result after fix**: The dispatcher emitted a queued C2C message with the image attachment preserved in `attachments`, so downstream inbound media handling receives the media metadata.
- **What was not tested**: A live Tencent QQ Bot account was not exercised; the proof uses the actual OpenClaw QQ Bot gateway dispatcher with a provider-shaped payload because credentials are not available locally.

