### PR TITLE
[codex] Suppress empty native reasoning placeholders

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -312,4 +312,25 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
 
     expectSinglePayloadText(payloads, "THINKING-OFF-OK");
   });
+
+  it("does not emit a reasoning payload for empty native reasoning summaries", () => {
+    const payloads = buildPayloads({
+      reasoningLevel: "on",
+      thinkingLevel: "high",
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "thinking",
+            thinking: "",
+            thinkingSignature: JSON.stringify({ type: "reasoning", id: "rs_live", summary: [] }),
+          },
+          { type: "text", text: "EMPTY-REASONING-SUMMARY-OK" },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "EMPTY-REASONING-SUMMARY-OK");
+  });
 });

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -643,7 +643,7 @@ describe("formatReasoningMessage", () => {
 });
 
 describe("extractAssistantThinking", () => {
-  it("surfaces signed native reasoning even when the provider returns an empty summary", () => {
+  it("does not fabricate reasoning text when native reasoning has no summary", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
       content: [
@@ -657,9 +657,24 @@ describe("extractAssistantThinking", () => {
       timestamp: Date.now(),
     });
 
-    expect(extractAssistantThinking(msg)).toBe(
-      "Native reasoning was produced; no summary text was returned.",
-    );
+    expect(extractAssistantThinking(msg)).toBe("");
+  });
+
+  it("surfaces native reasoning when the provider returns summary text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "Reasoning summary",
+          thinkingSignature: JSON.stringify({ type: "reasoning", id: "rs_live" }),
+        },
+        { type: "text", text: "Done." },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantThinking(msg)).toBe("Reasoning summary");
   });
 });
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -151,9 +151,6 @@ export function extractAssistantThinking(msg: AssistantMessage): string {
         if (thinking) {
           return thinking;
         }
-        if (typeof record.thinkingSignature === "string" && record.thinkingSignature.trim()) {
-          return "Native reasoning was produced; no summary text was returned.";
-        }
       }
       return "";
     })


### PR DESCRIPTION
## Summary

- Stop fabricating a visible reasoning placeholder when a native reasoning block has only a signature and no summary text.
- Preserve normal reasoning display when the provider returns actual thinking/summary text.
- Add regression coverage for payload construction so empty native reasoning summaries do not create user-visible reasoning messages.

## Why

Some providers can return signed native reasoning metadata without any summary text. Turning that metadata into a placeholder sentence creates noisy user-facing `Reasoning:` messages even though there is no useful reasoning content to show.

## Validation

- `git diff --check`
- `node scripts/test-projects.mjs src/agents/pi-embedded-utils.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts`