### PR TITLE
fix(tui): expose verbose full mode [AI-assisted]

### DIFF
--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -24,6 +24,7 @@ describe("getSlashCommands", () => {
       { value: "on", label: "on" },
       { value: "off", label: "off" },
     ]);
+    expect(verbose?.getArgumentCompletions?.("f")).toEqual([{ value: "full", label: "full" }]);
     expect(activation?.getArgumentCompletions?.("a")).toEqual([
       { value: "always", label: "always" },
     ]);
@@ -60,6 +61,7 @@ describe("getSlashCommands", () => {
 describe("helpText", () => {
   it("includes slash command help for aliases", () => {
     const output = helpText();
+    expect(output).toContain("/verbose <on|full|off>");
     expect(output).toContain("/elevated <on|off|ask|full>");
     expect(output).toContain("/elev <on|off|ask|full>");
     expect(output).toContain("/gateway-status");

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -4,7 +4,7 @@ import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thi
 import type { OpenClawConfig } from "../config/types.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
-const VERBOSE_LEVELS = ["on", "off"];
+const VERBOSE_LEVELS = ["on", "full", "off"];
 const TRACE_LEVELS = ["on", "off"];
 const FAST_LEVELS = ["status", "on", "off"];
 const REASONING_LEVELS = ["on", "off"];
@@ -96,7 +96,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     },
     {
       name: "verbose",
-      description: "Set verbose on/off",
+      description: "Set verbose on/full/off",
       getArgumentCompletions: verboseCompletions,
     },
     {
@@ -170,7 +170,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/model <provider/model> (or /models)",
     `/think <${thinkLevels}>`,
     "/fast <status|on|off>",
-    "/verbose <on|off>",
+    "/verbose <on|full|off>",
     "/trace <on|off>",
     "/reasoning <on|off>",
     "/usage <off|tokens|full>",

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -450,4 +450,34 @@ describe("tui command handlers", () => {
     expect(applySessionInfoFromPatch).toHaveBeenCalledWith({ groupActivation: "always" });
     expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
   });
+
+  it("shows all verbose levels in /verbose usage", async () => {
+    const { handleCommand, patchSession, addSystem } = createHarness();
+
+    await handleCommand("/verbose");
+
+    expect(patchSession).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("usage: /verbose <on|full|off>");
+  });
+
+  it("patches the session for /verbose full", async () => {
+    const patchSession = vi.fn().mockResolvedValue({ verboseLevel: "full" });
+    const applySessionInfoFromPatch = vi.fn();
+    const loadHistory = vi.fn().mockResolvedValue(undefined) as LoadHistoryMock;
+    const { handleCommand, addSystem } = createHarness({
+      patchSession,
+      applySessionInfoFromPatch,
+      loadHistory,
+    });
+
+    await handleCommand("/verbose full");
+
+    expect(patchSession).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      verboseLevel: "full",
+    });
+    expect(addSystem).toHaveBeenCalledWith("verbose set to full");
+    expect(applySessionInfoFromPatch).toHaveBeenCalledWith({ verboseLevel: "full" });
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -423,7 +423,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "verbose":
         if (!args) {
-          chatLog.addSystem("usage: /verbose <on|off>");
+          chatLog.addSystem("usage: /verbose <on|full|off>");
           break;
         }
         try {


### PR DESCRIPTION
## Summary
- add `full` to TUI `/verbose` completions and command description
- update `/verbose` usage/help text to show `on|full|off`
- cover `/verbose full` in command handler tests

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/commands.test.ts src/tui/tui-command-handlers.test.ts`