### PR TITLE
fix(cli): resolve SecretRefs in capability web search CLI path

### DIFF
--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -84,6 +84,8 @@ import {
   runWebSearch,
 } from "../web-search/runtime.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
+import { resolveCommandConfigWithSecrets } from "./command-config-resolution.js";
+import { getWebSearchCommandSecretTargetIds } from "./command-secret-targets.js";
 import { removeCommandByName } from "./program/command-tree.js";
 import { collectOption } from "./program/helpers.js";
 
@@ -1454,9 +1456,17 @@ async function runTtsStateMutation(params: {
 }
 
 async function runWebSearchCommand(params: { query: string; provider?: string; limit?: number }) {
-  const cfg = getRuntimeConfig();
+  const rawConfig = getRuntimeConfig();
+  const { effectiveConfig: cfg } = await resolveCommandConfigWithSecrets({
+    config: rawConfig,
+    commandName: "capability web search",
+    targetIds: getWebSearchCommandSecretTargetIds(),
+    mode: "read_only_operational",
+  });
+  const { setRuntimeConfigSnapshot } = await import("../config/config.js");
+  setRuntimeConfigSnapshot(cfg, rawConfig);
   const result = await runWebSearch({
-    config: cfg,
+    config: undefined,
     providerId: params.provider,
     args: {
       query: params.query,

--- a/src/cli/command-secret-resolution.coverage.test.ts
+++ b/src/cli/command-secret-resolution.coverage.test.ts
@@ -4,6 +4,7 @@ import { readCommandSource } from "./command-source.test-helpers.js";
 
 const SECRET_TARGET_CALLSITES = [
   bundledPluginFile("memory-core", "src/cli.runtime.ts"),
+  "src/cli/capability-cli.ts",
   "src/cli/qr-cli.ts",
   "src/agents/agent-runtime-config.ts",
   "src/commands/agent.ts",

--- a/src/cli/command-secret-targets.import.test.ts
+++ b/src/cli/command-secret-targets.import.test.ts
@@ -25,6 +25,29 @@ describe("command secret targets module import", () => {
     expect(listSecretTargetRegistryEntries).toHaveBeenCalledTimes(1);
   });
 
+  it("loads registry lazily for web search plugin credential targets", async () => {
+    const listSecretTargetRegistryEntries = vi.fn(() => [
+      { id: "plugins.entries.example.config.webSearch.apiKey" },
+      { id: "plugins.entries.example.config.webFetch.apiKey" },
+      { id: "plugins.entries.example.config.other.apiKey" },
+    ]);
+
+    vi.doMock("../secrets/target-registry.js", () => ({
+      discoverConfigSecretTargetsByIds: vi.fn(() => []),
+      listSecretTargetRegistryEntries,
+    }));
+
+    const mod = await import("./command-secret-targets.js");
+
+    expect(listSecretTargetRegistryEntries).not.toHaveBeenCalled();
+    const ids = mod.getWebSearchCommandSecretTargetIds();
+    expect(ids.has("tools.web.search.apiKey")).toBe(true);
+    expect(ids.has("plugins.entries.example.config.webSearch.apiKey")).toBe(true);
+    expect(ids.has("plugins.entries.example.config.webFetch.apiKey")).toBe(false);
+    expect(ids.has("plugins.entries.example.config.other.apiKey")).toBe(false);
+    expect(listSecretTargetRegistryEntries).toHaveBeenCalledTimes(1);
+  });
+
   it("loads registry lazily for agent runtime plugin credential targets", async () => {
     const listSecretTargetRegistryEntries = vi.fn(() => [
       { id: "plugins.entries.example.config.webSearch.apiKey" },

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -32,6 +32,8 @@ const STATIC_AGENT_RUNTIME_BASE_TARGET_IDS = [
   "skills.entries.*.apiKey",
   "tools.web.search.apiKey",
 ] as const;
+const STATIC_WEB_SEARCH_COMMAND_TARGET_IDS = ["tools.web.search.apiKey"] as const;
+
 const STATIC_STATUS_TARGET_IDS = [
   "agents.defaults.memorySearch.remote.apiKey",
   "agents.list[].memorySearch.remote.apiKey",
@@ -73,6 +75,15 @@ function isPluginWebCredentialTargetId(id: string): boolean {
   }
   const configPath = segments.slice(4).join(".");
   return configPath === "webSearch.apiKey" || configPath === "webFetch.apiKey";
+}
+
+function isPluginWebSearchCredentialTargetId(id: string): boolean {
+  const segments = id.split(".");
+  if (segments[0] !== "plugins" || segments[1] !== "entries" || segments[3] !== "config") {
+    return false;
+  }
+  const configPath = segments.slice(4).join(".");
+  return configPath === "webSearch.apiKey";
 }
 
 function getAgentRuntimeBaseTargetIds(): string[] {
@@ -238,6 +249,16 @@ export function getStatusCommandSecretTargetIds(
     ? getConfiguredChannelSecretTargetIds(config, env)
     : getChannelSecretTargetIds();
   return toTargetIdSet([...STATIC_STATUS_TARGET_IDS, ...channelTargetIds]);
+}
+
+export function getWebSearchCommandSecretTargetIds(): Set<string> {
+  return toTargetIdSet([
+    ...STATIC_WEB_SEARCH_COMMAND_TARGET_IDS,
+    ...listSecretTargetRegistryEntries()
+      .map((entry) => entry.id)
+      .filter(isPluginWebSearchCredentialTargetId)
+      .toSorted(),
+  ]);
 }
 
 export function getSecurityAuditCommandSecretTargetIds(): Set<string> {


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw capability web search --query "hello"` crashes with "unresolved SecretRef" when the API key is a file SecretRef
- **Why it matters:** CLI capability commands are unusable for any user storing secrets via SecretRef — the gateway resolves SecretRefs at startup, but the CLI path never does
- **What changed:** `runWebSearchCommand` now calls `resolveCommandConfigWithSecrets` + `setRuntimeConfigSnapshot` before invoking the runtime, matching the pattern used by `resolveAgentRuntimeConfig` and `loadModelsConfigWithSource`
- **What did NOT change:** Gateway path, other CLI capability commands, `isPluginWebCredentialTargetId` (used by agent runtime), or any runtime resolution logic

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `runWebSearchCommand` passed raw `getRuntimeConfig()` to `runWebSearch()`. `selectApplicableRuntimeConfig` (runtime-snapshot.ts:219) returns stale unresolved `runtimeConfig` when `runtimeSourceConfig` is null (CLI scenario), ignoring `inputConfig` entirely.
- **Missing detection / guardrail:** CLI capability commands had no SecretRef resolution step; only `resolveAgentRuntimeConfig` and `loadModelsConfigWithSource` did.
- **Contributing context:** `selectApplicableRuntimeConfig` was designed for gateway-served runtime configs; CLI never registered a snapshot source, so the "prefer runtime over input" heuristic broke the CLI scenario.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file:** `src/cli/command-secret-targets.import.test.ts`
- **Scenario the test should lock in:** `getWebSearchCommandSecretTargetIds()` returns `tools.web.search.apiKey` + plugin `webSearch.apiKey` entries but not `webFetch.apiKey`
- **Why this is the smallest reliable guardrail:** Full CLI integration with real SecretRefs requires filesystem secrets; the unit test verifies the target-ID plumbing `resolveCommandConfigWithSecrets` uses
- **If no new test is added, why not:** N/A — new test added

## User-visible / Behavior Changes

- `openclaw capability web search --query "..."` now works when API key is a file SecretRef (previously crashed)
- No config/env changes; no default behavior changes for plaintext keys

## Diagram (if applicable)

```text
Before:
[CLI] -> getRuntimeConfig() -> runWebSearch(config: rawCfg)
  -> selectApplicableRuntimeConfig() -> runtimeSourceConfig=null
  -> returns stale runtimeConfig -> CRASH: "unresolved SecretRef"

After:
[CLI] -> getRuntimeConfig() -> resolveCommandConfigWithSecrets(targetIds)
  -> effectiveConfig (SecretRefs resolved)
  -> setRuntimeConfigSnapshot(cfg, rawConfig)
  -> runWebSearch(config: undefined) -> reads resolved snapshot -> SUCCESS
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **Yes** — CLI now resolves existing SecretRefs via the same infrastructure the gateway uses; no new secret paths accessed
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux (Node 22+)
- Runtime/container: `pnpm openclaw capability web search` (CLI-only, no gateway)
- Model/provider: Brave web search
- Relevant config (redacted): `tools.web.search.apiKey: "file:~/.openclaw/secrets/brave-api-key"`

### Steps

1. Configure `tools.web.search.apiKey` as a file SecretRef
2. Run `pnpm openclaw capability web search --query "hello"`

### Expected

Search results from the configured provider

### Actual (before fix)

`Error: tools.web.search.apiKey: unresolved SecretRef "file:.../brave-api-key"`

## Evidence

- [x] Trace/log snippets — before: "unresolved SecretRef" error; after: Brave search results returned
- [x] Unit tests pass: `command-secret-targets.import.test.ts`, `command-secret-resolution.coverage.test.ts`

## Human Verification (required)

- **Verified scenarios:** `pnpm openclaw capability web search --query "hello"` with file SecretRef Brave API key returns search results; build passes
- **Edge cases checked:** `webFetch.apiKey` plugin entries excluded from web-search targetIds (test asserts `false`)
- **What did NOT verify:** env-style SecretRef (`env:VAR_NAME`), Gemini fallback via `models.providers.google.apiKey`, other capability commands

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** `setRuntimeConfigSnapshot` swaps the global snapshot without restore
  - **Mitigation:** CLI process exits after the command; no subsequent commands affected. Same pattern as `resolveAgentRuntimeConfig` and `loadModelsConfigWithSource`