### PR TITLE
fix(plugins): replace misleading stale-config warnings for ownership-blocked plugins and deduplicate suspicious-ownership diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,7 @@ Docs: https://docs.openclaw.ai
 - Cron: retry recurring wake-now main-session jobs through temporary heartbeat busy skips before recording success, so queued cron events no longer appear as ok ghost runs while the main lane is still busy. Fixes #75964. (#76083) Thanks @kshetrajna12 and @xuruiray.
 - Providers/Google: keep Gemini thinking-signature-only stream chunks active during reasoning, so Gemini 3.1 Pro Preview replies no longer hit idle timeouts before visible text. Fixes #76071. (#76080) Thanks @marcoschierhorn and @zhangguiping-xydt.
 - CLI/skills: show per-agent model and command visibility in `openclaw skills check --agent`, and let doctor report or disable unavailable skills allowed for the default agent. (#75983) Thanks @mbelinky.
+- Plugins/discovery: replace misleading "stale config entry — remove it from plugins config" warnings with an actionable "plugin present but blocked by file ownership; run `chown root:root <plugin-path>` to allow load" message when an ownership-blocked plugin is referenced in config; deduplicate the `blocked plugin candidate: suspicious ownership` diagnostic so it fires once per blocked path per boot rather than 2–3 times. (#76151) Thanks @hclsys.
 
 ## 2026.4.30
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1230,10 +1230,12 @@ function validateConfigObjectWithPluginsBase(
       return;
     }
     if (blockedOwnershipPluginIds.has(pluginId)) {
-      warnings.push({
-        path,
-        message: `plugin ${pluginId} present but blocked by file ownership; run \`chown root:root <plugin-path>\` to allow load`,
-      });
+      const ownershipMessage = `plugin ${pluginId} present but blocked by file ownership; run \`chown root:root <plugin-path>\` to allow load`;
+      if (opts?.warnOnly) {
+        warnings.push({ path, message: ownershipMessage });
+      } else {
+        issues.push({ path, message: ownershipMessage });
+      }
       return;
     }
     if (opts?.warnOnly) {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1210,6 +1210,13 @@ function validateConfigObjectWithPluginsBase(
   const knownIds = ensureKnownIds();
   const normalizedPlugins = ensureNormalizedPlugins();
   const effectiveConfig = ensureCompatConfig();
+  const blockedOwnershipPluginIds = new Set(
+    registry.diagnostics
+      .filter(
+        (diag) => diag.pluginId !== undefined && diag.message.includes("suspicious ownership"),
+      )
+      .map((diag) => diag.pluginId as string),
+  );
   const pushMissingPluginIssue = (
     path: string,
     pluginId: string,
@@ -1219,6 +1226,13 @@ function validateConfigObjectWithPluginsBase(
       warnings.push({
         path,
         message: `plugin removed: ${pluginId} (stale config entry ignored; remove it from plugins config)`,
+      });
+      return;
+    }
+    if (blockedOwnershipPluginIds.has(pluginId)) {
+      warnings.push({
+        path,
+        message: `plugin ${pluginId} present but blocked by file ownership; run \`chown root:root <plugin-path>\` to allow load`,
       });
       return;
     }

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -1553,6 +1553,61 @@ describe("discoverOpenClawPlugins", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32" && typeof process.getuid === "function")(
+    "attaches idHint as pluginId on blocked-ownership diagnostics",
+    async () => {
+      const stateDir = makeTempDir();
+      const globalExt = path.join(stateDir, "extensions");
+      mkdirSafe(globalExt);
+      fs.writeFileSync(
+        path.join(globalExt, "my-plugin.ts"),
+        "export default function () {}",
+        "utf-8",
+      );
+
+      const actualUid = (process as NodeJS.Process & { getuid: () => number }).getuid();
+      if (actualUid === 0) {
+        return; // root bypasses ownership check
+      }
+      const result = await discoverWithStateDir(stateDir, { ownershipUid: actualUid + 1 });
+      const blockedDiag = result.diagnostics.find((d) =>
+        d.message.includes("suspicious ownership"),
+      );
+      expect(blockedDiag).toBeDefined();
+      expect(blockedDiag?.pluginId).toBe("my-plugin");
+    },
+  );
+
+  it.runIf(process.platform !== "win32" && typeof process.getuid === "function")(
+    "emits blocked-ownership diagnostic only once per path even when seen via multiple discovery paths",
+    async () => {
+      const stateDir = makeTempDir();
+      const globalExt = path.join(stateDir, "extensions");
+      mkdirSafe(globalExt);
+      fs.writeFileSync(
+        path.join(globalExt, "dup-plugin.ts"),
+        "export default function () {}",
+        "utf-8",
+      );
+
+      const actualUid = (process as NodeJS.Process & { getuid: () => number }).getuid();
+      if (actualUid === 0) {
+        return;
+      }
+      // Pass the same extension path twice via extraPaths to force two addCandidate calls.
+      const env = buildDiscoveryEnv(stateDir);
+      const result = await discoverOpenClawPlugins({
+        env,
+        ownershipUid: actualUid + 1,
+        extraPaths: [globalExt, globalExt],
+      });
+      const ownershipDiags = result.diagnostics.filter((d) =>
+        d.message.includes("suspicious ownership"),
+      );
+      expect(ownershipDiags.length).toBe(1);
+    },
+  );
+
   it("reflects plugin root changes on the next discovery call", async () => {
     const stateDir = makeTempDir();
     const globalExt = path.join(stateDir, "extensions");

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -1580,7 +1580,7 @@ describe("discoverOpenClawPlugins", () => {
 
   it.runIf(process.platform !== "win32" && typeof process.getuid === "function")(
     "emits blocked-ownership diagnostic only once per path even when seen via multiple discovery paths",
-    async () => {
+    () => {
       const stateDir = makeTempDir();
       const globalExt = path.join(stateDir, "extensions");
       mkdirSafe(globalExt);
@@ -1596,7 +1596,7 @@ describe("discoverOpenClawPlugins", () => {
       }
       // Pass the same extension path twice via extraPaths to force two addCandidate calls.
       const env = buildDiscoveryEnv(stateDir);
-      const result = await discoverOpenClawPlugins({
+      const result = discoverOpenClawPlugins({
         env,
         ownershipUid: actualUid + 1,
         extraPaths: [globalExt, globalExt],

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -372,8 +372,12 @@ function mergeDiscoveryResult(
     target.candidates.push(candidate);
   }
   for (const diag of source.diagnostics) {
-    const key = `${diag.pluginId ?? ""}::${diag.message}`;
-    if (!target.diagnostics.some((d) => `${d.pluginId ?? ""}::${d.message}` === key)) {
+    const key = `${diag.pluginId ?? ""}::${diag.source ?? ""}::${diag.message}`;
+    if (
+      !target.diagnostics.some(
+        (d) => `${d.pluginId ?? ""}::${d.source ?? ""}::${d.message}` === key,
+      )
+    ) {
       target.diagnostics.push(diag);
     }
   }

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -250,6 +250,7 @@ function isUnsafePluginCandidate(params: {
   diagnostics: PluginDiagnostic[];
   ownershipUid?: number | null;
   realpathCache: Map<string, string>;
+  idHint?: string;
 }): boolean {
   const issue = findCandidateBlockIssue({
     source: params.source,
@@ -261,11 +262,16 @@ function isUnsafePluginCandidate(params: {
   if (!issue) {
     return false;
   }
-  params.diagnostics.push({
-    level: "warn",
-    source: issue.targetPath,
-    message: formatCandidateBlockMessage(issue),
-  });
+  const message = formatCandidateBlockMessage(issue);
+  const key = `${params.idHint ?? ""}::${message}`;
+  if (!params.diagnostics.some((d) => `${d.pluginId ?? ""}::${d.message}` === key)) {
+    params.diagnostics.push({
+      level: "warn",
+      pluginId: params.idHint,
+      source: issue.targetPath,
+      message,
+    });
+  }
   return true;
 }
 
@@ -365,7 +371,12 @@ function mergeDiscoveryResult(
     seenSources.add(key);
     target.candidates.push(candidate);
   }
-  target.diagnostics.push(...source.diagnostics);
+  for (const diag of source.diagnostics) {
+    const key = `${diag.pluginId ?? ""}::${diag.message}`;
+    if (!target.diagnostics.some((d) => `${d.pluginId ?? ""}::${d.message}` === key)) {
+      target.diagnostics.push(diag);
+    }
+  }
 }
 
 function collectInstalledPluginRecordPaths(
@@ -494,8 +505,10 @@ function addCandidate(params: {
       diagnostics: params.diagnostics,
       ownershipUid: params.ownershipUid,
       realpathCache: params.realpathCache,
+      idHint: params.idHint,
     })
   ) {
+    params.seen.add(resolved);
     return;
   }
   params.seen.add(resolved);


### PR DESCRIPTION
## Problem

When a plugin directory is blocked by file ownership (uid mismatch), the gateway emits two categories of compounding bad UX:

**Defect A** — misleading "stale config entry" warnings: for every reference to the blocked plugin in config (entries, allow, deny, slots), the gateway emits `plugin not found: <id> (stale config entry ignored; remove it from plugins config)`. This actively misdirects operators into deleting valid config blocks.

**Defect B** — duplicate "suspicious ownership" warnings: the same diagnostic fires once per discovery scope (scoped result + shared result) rather than once per blocked path per boot, producing 2–3 identical lines.

Addresses #76144.

## Root cause

`isUnsafePluginCandidate` (discovery.ts) pushed a `PluginDiagnostic` without a `pluginId` field. Without a `pluginId`, `pushRegistryDiagnostics` (validation.ts) could not tell that "plugin not found for id X" corresponded to a blocked-ownership candidate — so `pushMissingPluginIssue` emitted the stale-config message without checking for block signals.

For Defect B: `discoverOpenClawPlugins` runs two separate discovery passes (`scopedResult`, `sharedResult`) each with their own `seen` set. The global extensions dir (`roots.global`) is scanned in `sharedResult`; if the same path also appears in `extraPaths` (in `scopedResult`), the cross-scope merge in `mergeDiscoveryResult` appended diagnostics unconditionally.

## Changes

**`src/plugins/discovery.ts`**
- `isUnsafePluginCandidate`: add `idHint?: string` param; set `pluginId: params.idHint` on the pushed diagnostic; inline-dedup prevents same-array duplicates via `pluginId+message` key
- `addCandidate`: pass `idHint` through to `isUnsafePluginCandidate`; add the resolved path to `seen` even when blocked, so a second `addCandidate` call for the same path returns immediately without re-evaluating
- `mergeDiscoveryResult`: dedup diagnostics by `pluginId+message` key when merging `scopedResult` and `sharedResult` into the final result

**`src/config/validation.ts`**
- Before `pushMissingPluginIssue`: build `blockedOwnershipPluginIds` from registry diagnostics that have `pluginId` and contain "suspicious ownership"
- Inside `pushMissingPluginIssue`: if `pluginId` is in `blockedOwnershipPluginIds`, emit `"plugin <id> present but blocked by file ownership; run \`chown root:root <plugin-path>\` to allow load"` instead of the stale-config message

**`src/plugins/discovery.test.ts`**
- New test: `attaches idHint as pluginId on blocked-ownership diagnostics` — asserts `diagnostic.pluginId === "my-plugin"` when `ownershipUid` mismatches
- New test: `emits blocked-ownership diagnostic only once per path even when seen via multiple discovery paths` — passes the same path twice via `extraPaths` (triggering both the scoped and shared discovery of the same dir), asserts `ownershipDiags.length === 1`

## Test result

`53 passed (53)` in `src/plugins/discovery.test.ts`. `oxlint`: 0 warnings, 0 errors on all changed files.