### PR TITLE
fix(telegram): await stale transport close before dirty rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: preserve scoped background exec/process session references across embedded compaction and after-turn runtime contexts without exposing sessions from unrelated scopes. Fixes #79284. (#79307) Thanks @TurboTheTurtle.
 - CLI/onboarding: improve setup, onboarding, configure, and channel command wayfinding so terminal flows explain the next useful command instead of relying on terse setup labels.
 - Agents/Codex: remove the configurable Codex dynamic-tools profile so Codex app-server always owns workspace, edit, patch, exec, process, and plan tools while OpenClaw integration tools remain available.
-
 ### Fixes
 
+- Telegram/polling: await stale transport close before returning the replacement transport on dirty rebuild, preventing 409 Conflict loops when the old keep-alive socket races with a fresh getUpdates request. Fixes #75852.
+HEAD
 - OpenAI/realtime voice: accept Codex-compatible legacy audio and transcript event aliases so provider protocol drift does not drop assistant audio or captions.
 - Discord/voice: keep default agent-proxy realtime sessions from auto-speaking filler before the forced OpenClaw consult answer, finish Discord playback on realtime response completion, and queue later exact-speech answers until playback idles to avoid mid-sentence replacement.
 - Gateway: return deterministic `400 invalid_request_error` responses for malformed encoded session-kill HTTP paths instead of letting route-shaped requests fall through to later Gateway handlers. (#72439) Thanks @rubencu.
@@ -60,6 +61,7 @@ Docs: https://docs.openclaw.ai
 - ACP/gateway: preserve `AcpRuntimeError` cause chain (code/method/JSON-RPC detail) through the lifecycle boundary so gateway logs, telegram replies, and tool-result text show the actual upstream failure instead of opaque `Internal error`/`[object Object]`, with redaction applied before the chain reaches log or reply surfaces.
 - Channels/iMessage: wire `action: "reply"` attachments through `imsg send-rich --file` when the installed imsg build advertises that capability (probed once via `imsg send-rich --help` and cached on the private-API status). Reply now hydrates `media`/`mediaUrl`/`fileUrl`/`mediaUrls[0]`/`filePath`/`path`/base64 `buffer`+`filename` through the shared outbound resolver, stages buffers via the existing `withTempFile` helper, rejects `http(s)://` URL attachments with a targeted error pointing callers at `send`'s full attachment-resolver pipeline, and falls back to the explicit `imsg#114 not landed yet` error on older imsg builds. Depends on the upstream `openclaw/imsg#114` capability landing in an installable release; until then the new path stays gated and users see the same explicit fallback `#79822` introduced. (#79864) Thanks @omarshahine.
 - Telegram: preserve the first-preview debounce while appending true partial-stream deltas, so edited draft previews no longer duplicate earlier text when providers emit incremental output. (#80045) Thanks @TurboTheTurtle.
+ transport close before dirty rebuild)
 
 ## 2026.5.9
 

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1093,7 +1093,7 @@ describe("TelegramPollingSession", () => {
 
     await session.runUntilAbort();
 
-    // Dirty-rebuild closes transport1 (fire-and-forget via #closeTransportAsync).
+    // Dirty-rebuild closes transport1 before the next polling cycle continues.
     // dispose() closes transport2 since it becomes the held transport after the rebuild.
     expect(transport1.close).toHaveBeenCalled();
     expect(transport2.close).toHaveBeenCalled();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -180,7 +180,7 @@ export class TelegramPollingSession {
   async #createPollingBot(): Promise<TelegramBot | undefined> {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
-    const telegramTransport = this.#transportState.acquireForNextCycle();
+    const telegramTransport = await this.#transportState.acquireForNextCycle();
     try {
       return createTelegramBot({
         token: this.opts.token,

--- a/extensions/telegram/src/polling-transport-state.test.ts
+++ b/extensions/telegram/src/polling-transport-state.test.ts
@@ -22,27 +22,20 @@ function anyLogMatches(log: LogSpy, fragment: string): boolean {
   });
 }
 
-async function flushMicrotasks() {
-  // The dirty-rebuild path fires close() without awaiting it so the polling
-  // cycle is not blocked; tests must flush microtasks before asserting on it.
-  await Promise.resolve();
-  await Promise.resolve();
-}
-
 describe("TelegramPollingTransportState", () => {
   let log: LogSpy;
   beforeEach(() => {
     log = vi.fn<LogFn>();
   });
 
-  it("returns the initial transport when not dirty", () => {
+  it("returns the initial transport when not dirty", async () => {
     const initial = makeMockTransport("initial");
     const state = new TelegramPollingTransportState({
       log,
       initialTransport: initial,
     });
 
-    const acquired = state.acquireForNextCycle();
+    const acquired = await state.acquireForNextCycle();
 
     expect(acquired).toBe(initial);
     expect(initial.close).not.toHaveBeenCalled();
@@ -59,10 +52,9 @@ describe("TelegramPollingTransportState", () => {
     });
 
     state.markDirty();
-    const acquired = state.acquireForNextCycle();
+    const acquired = await state.acquireForNextCycle();
 
     expect(acquired).toBe(rebuilt);
-    await flushMicrotasks();
     expect(initial.close).toHaveBeenCalledTimes(1);
     expect(rebuilt.close).not.toHaveBeenCalled();
     expect(anyLogMatches(log, "closing stale transport")).toBe(true);
@@ -79,9 +71,8 @@ describe("TelegramPollingTransportState", () => {
     });
 
     state.markDirty();
-    state.acquireForNextCycle();
+    await state.acquireForNextCycle();
 
-    await flushMicrotasks();
     expect(initial.close).not.toHaveBeenCalled();
   });
 
@@ -92,7 +83,7 @@ describe("TelegramPollingTransportState", () => {
       initialTransport: initial,
     });
     // Force the state to promote the initial transport into the held slot.
-    state.acquireForNextCycle();
+    await state.acquireForNextCycle();
 
     let closeResolved = false;
     initial.close.mockImplementationOnce(async () => {
@@ -119,7 +110,7 @@ describe("TelegramPollingTransportState", () => {
       log,
       initialTransport: initial,
     });
-    state.acquireForNextCycle();
+    await state.acquireForNextCycle();
 
     await expect(state.dispose()).resolves.toBeUndefined();
     expect(anyLogMatches(log, "failed to close transport during dispose")).toBe(true);
@@ -136,12 +127,12 @@ describe("TelegramPollingTransportState", () => {
 
     await state.dispose();
 
-    const acquired = state.acquireForNextCycle();
+    const acquired = await state.acquireForNextCycle();
     expect(acquired).toBeUndefined();
     expect(createTelegramTransport).not.toHaveBeenCalled();
   });
 
-  it("clears the dirty flag even when no factory is configured", () => {
+  it("clears the dirty flag even when no factory is configured", async () => {
     const initial = makeMockTransport("initial");
     const state = new TelegramPollingTransportState({
       log,
@@ -149,11 +140,11 @@ describe("TelegramPollingTransportState", () => {
     });
     state.markDirty();
 
-    const acquired = state.acquireForNextCycle();
+    const acquired = await state.acquireForNextCycle();
 
     expect(acquired).toBe(initial);
     // Next cycle without markDirty should not trigger another rebuild log.
-    state.acquireForNextCycle();
+    await state.acquireForNextCycle();
     const rebuildLogs = log.mock.calls.filter((call) => {
       const line = call[0];
       return typeof line === "string" && line.includes("rebuilding transport");

--- a/extensions/telegram/src/polling-transport-state.ts
+++ b/extensions/telegram/src/polling-transport-state.ts
@@ -19,7 +19,7 @@ export class TelegramPollingTransportState {
     this.#transportDirty = true;
   }
 
-  acquireForNextCycle(): TelegramTransport | undefined {
+  async acquireForNextCycle(): Promise<TelegramTransport | undefined> {
     if (this.#disposed) {
       return undefined;
     }
@@ -29,13 +29,18 @@ export class TelegramPollingTransportState {
       ? (this.opts.createTelegramTransport?.() ?? previous)
       : previous;
     // When the dirty flag triggered a rebuild, release the old transport's
-    // dispatchers. Without this, each network stall / recoverable error
-    // leaves a full pool of keep-alive sockets to api.telegram.org dangling
-    // forever — which over long-running sessions accumulates into the
-    // hundreds of ESTABLISHED connections that choke per-IP upstream quotas.
+    // dispatchers before using the replacement transport. Without this, the
+    // stale keep-alive socket may still be considered the active poll session
+    // by Telegram while a new getUpdates request races in on a fresh socket.
     if (this.#transportDirty && previous && nextTransport !== previous) {
       this.opts.log("[telegram][diag] closing stale transport before rebuild");
-      this.#closeTransportAsync(previous, "stale-transport rebuild");
+      try {
+        await previous.close();
+      } catch (err) {
+        this.opts.log(
+          `[telegram][diag] failed to close stale transport before rebuild: ${formatCloseError(err)}`,
+        );
+      }
     }
     if (this.#transportDirty && nextTransport) {
       this.opts.log("[telegram][diag] rebuilding transport for next polling cycle");
@@ -62,16 +67,6 @@ export class TelegramPollingTransportState {
         `[telegram][diag] failed to close transport during dispose: ${formatCloseError(err)}`,
       );
     }
-  }
-
-  // Fire-and-forget close used on the rebuild path so the polling cycle is not
-  // blocked by a slow destroy. The error path is logged but never rethrown.
-  #closeTransportAsync(transport: TelegramTransport, context: string) {
-    void transport.close().catch((err) => {
-      this.opts.log(
-        `[telegram][diag] failed to close transport (${context}): ${formatCloseError(err)}`,
-      );
-    });
   }
 }
 


### PR DESCRIPTION
## Summary

When a Telegram polling transport is marked dirty (due to 409 conflict, network error, or stall), the old transport's `close()` was previously called via fire-and-forget. This allowed the next `getUpdates` request to start before Telegram saw the old session as terminated, causing repeated 409 Conflict loops.

This fix serializes the stale transport close by making `acquireForNextCycle()` async and awaiting `previous.close()` before returning the replacement transport. This ensures the keep-alive socket to `api.telegram.org` is fully terminated before the new polling cycle starts.

## Changes

- `polling-transport-state.ts`: `acquireForNextCycle()` now async and awaits stale transport close
- `polling-session.ts`: Added `await` when calling `acquireForNextCycle()`
- Updated tests to use `await` for the now-async method

## Test plan

- [x] `pnpm test extensions/telegram/src/polling-session.test.ts extensions/telegram/src/polling-transport-state.test.ts` passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #75852