### PR TITLE
fix(cron): prevent deleteAfterRun from deleting non-cron sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Cron/delivery: guard deleteAfterRun cleanup to only delete cron-created sessions, preventing accidental deletion of user-owned or integration sessions when a cron job targets a custom session key. Thanks @wAngByg.
 - Gateway/startup: skip plugin-backed auth-profile overlays during startup secrets preflight, reducing gateway readiness latency while keeping reload and OAuth recovery paths overlay-capable. (#68327) Thanks @JIRBOY.
 - Plugins/ClawHub: make diagnostics, onboarding, doctor repair, and channel setup carry ClawPack metadata through install records while keeping explicit `clawhub:` installs on ClawHub and bare package installs on npm for the launch cutover. Thanks @vincentkoc.
 - Plugins/runtime: scope broad runtime preloads to the effective plugin ids derived from config, startup planning, configured channels, slots, and auto-enable rules instead of importing every discoverable plugin.

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -619,6 +619,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     const params = makeBaseParams({ synthesizedText: SILENT_REPLY_TOKEN });
     (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    params.agentSessionKey = "agent:main:cron:test-job";
 
     const state = await dispatchCronDelivery(params);
 
@@ -632,7 +633,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(callGateway).toHaveBeenCalledWith({
       method: "sessions.delete",
       params: {
-        key: "agent:main",
+        key: "agent:main:cron:test-job",
         deleteTranscript: true,
         emitLifecycleHooks: false,
       },
@@ -646,6 +647,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     const params = makeBaseParams({ synthesizedText: "HEARTBEAT_OK 🦞" });
     (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    params.agentSessionKey = "agent:main:cron:test-job";
 
     const state = await dispatchCronDelivery(params);
 
@@ -655,7 +657,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(callGateway).toHaveBeenCalledWith({
       method: "sessions.delete",
       params: {
-        key: "agent:main",
+        key: "agent:main:cron:test-job",
         deleteTranscript: true,
         emitLifecycleHooks: false,
       },
@@ -670,6 +672,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     const params = makeBaseParams({ synthesizedText: SILENT_REPLY_TOKEN });
     (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    params.agentSessionKey = "agent:main:cron:test-job";
 
     const state = await dispatchCronDelivery(params);
 
@@ -1090,6 +1093,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       threadId: 42,
     };
     (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    params.agentSessionKey = "agent:main:cron:test-job";
 
     const state = await dispatchCronDelivery(params);
 
@@ -1099,7 +1103,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(callGateway).toHaveBeenCalledWith({
       method: "sessions.delete",
       params: {
-        key: "agent:main",
+        key: "agent:main:cron:test-job",
         deleteTranscript: true,
         emitLifecycleHooks: false,
       },
@@ -1148,6 +1152,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       { text: "HEARTBEAT_OK", mediaUrl: "https://example.com/img.png" },
     ] as never;
     (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    params.agentSessionKey = "agent:main:cron:test-job";
 
     const state = await dispatchCronDelivery(params);
 
@@ -1157,7 +1162,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(callGateway).toHaveBeenCalledWith({
       method: "sessions.delete",
       params: {
-        key: "agent:main",
+        key: "agent:main:cron:test-job",
         deleteTranscript: true,
         emitLifecycleHooks: false,
       },
@@ -1228,6 +1233,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     const params = makeBaseParams({ synthesizedText: SILENT_REPLY_TOKEN });
     (params as Record<string, unknown>).deliveryPayloadHasStructuredContent = true;
     (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    params.agentSessionKey = "agent:main:cron:test-job";
 
     const state = await dispatchCronDelivery(params);
 
@@ -1241,7 +1247,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(callGateway).toHaveBeenCalledWith({
       method: "sessions.delete",
       params: {
-        key: "agent:main",
+        key: "agent:main:cron:test-job",
         deleteTranscript: true,
         emitLifecycleHooks: false,
       },
@@ -1249,6 +1255,31 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
     expect(callGateway).toHaveBeenCalledTimes(1);
   });
+
+  it("skips deleteAfterRun cleanup for non-cron sessions", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: SILENT_REPLY_TOKEN });
+    params.agentSessionKey = "agent:main:meeting";
+    (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toEqual(
+      expect.objectContaining({
+        status: "ok",
+        delivered: false,
+      }),
+    );
+    expect(callGateway).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.delete",
+      }),
+    );
+    expect(retireSessionMcpRuntime).not.toHaveBeenCalled();
+  });
+
 
   it("suppresses trailing NO_REPLY after summary text in direct delivery (#64976)", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1280,7 +1280,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(retireSessionMcpRuntime).not.toHaveBeenCalled();
   });
 
-
   it("suppresses trailing NO_REPLY after summary text in direct delivery (#64976)", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,3 +1,4 @@
+import { isCronSessionKey } from "../../sessions/session-key-utils.js";
 import { retireSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
@@ -514,6 +515,14 @@ export async function dispatchCronDelivery(
     });
   const cleanupDirectCronSessionIfNeeded = async (): Promise<void> => {
     if (!params.job.deleteAfterRun || directCronSessionDeleted) {
+      return;
+    }
+
+    // deleteAfterRun only applies to sessions created for cron runs.
+    // Non-cron sessions (user-owned, meeting, feishu, etc.) must not be deleted.
+    // Mark as handled so repeated finalizers do not retry.
+    if (!isCronSessionKey(params.agentSessionKey)) {
+      directCronSessionDeleted = true;
       return;
     }
     try {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,4 +1,3 @@
-import { isCronSessionKey } from "../../sessions/session-key-utils.js";
 import { retireSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
@@ -27,6 +26,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { isCronSessionKey } from "../../sessions/session-key-utils.js";
 import { shouldAttemptTtsPayload } from "../../tts/tts-config.js";
 import { createCronExecutionId } from "../run-id.js";
 import { hasScheduledNextRunAtMs } from "../service/jobs.js";


### PR DESCRIPTION
## Summary

- Problem: `deleteAfterRun` cleanup for isolated cron dispatch can delete a user-owned session when a cron job targets a custom non-cron `sessionKey`.
- Why it matters: `schedule.kind: "at"` defaults `deleteAfterRun` to `true`, so a one-shot cron job can delete a persistent user session and transcript without an explicit deletion opt-in.
- What changed: `cleanupDirectCronSessionIfNeeded` now uses the existing canonical `isCronSessionKey()` guard before calling `sessions.delete`.
- What did NOT change (scope boundary): cron-owned sessions are still cleaned up when `deleteAfterRun` is enabled; this PR does not change scheduling, delivery routing, session creation, auth, config, or storage formats.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #69467
- [x] This PR fixes a bug or regression

## Problem

`cleanupDirectCronSessionIfNeeded` calls `sessions.delete` with:

```ts
{
  key: params.agentSessionKey,
  deleteTranscript: true,
  emitLifecycleHooks: false,
}
```

Before this PR, that destructive cleanup did not verify that `params.agentSessionKey` belonged to a cron-created session.

Combined with the one-shot `schedule.kind: "at"` default of `deleteAfterRun: true`, a cron job targeting a non-cron persistent session key could delete the user-owned session and its transcript.

| `sessionKey` | `deleteAfterRun` | Before this PR | After this PR |
|---|---:|---|---|
| `"agent:main:cron:test-job"` | `true` | Deletes cron session | Still deletes cron session |
| `"agent:main:meeting"` | `true` | BUG: deletes user session | Preserves user session |
| `"agent:main:meeting"` | `at` default `true` | BUG: deletes user session | Preserves user session |
| unset / cron-created key | `true` | Deletes cron session | Still deletes cron session |

## Why `isCronSessionKey`

`isCronSessionKey()` already exists in `src/sessions/session-key-utils.ts` and is the canonical cron-ownership boundary for session keys. It returns `true` only when the normalized session-key rest begins with `cron:`.

Using the existing helper keeps the fix minimal and avoids introducing a parallel ownership rule.

## Changes

- `src/cron/isolated-agent/delivery-dispatch.ts`
  - Import `isCronSessionKey`.
  - In `cleanupDirectCronSessionIfNeeded`, return before `sessions.delete` when `params.agentSessionKey` is not cron-owned.
  - Set `directCronSessionDeleted = true` in the non-cron branch to mark the cleanup phase as handled, so repeated finalizers in the same dispatch do not re-enter this branch.
  - The flag means "cleanup phase complete", not "session was actually deleted".

```ts
if (!isCronSessionKey(params.agentSessionKey)) {
  directCronSessionDeleted = true;
  return;
}
```

- `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`
  - Updated existing `deleteAfterRun` cleanup fixtures to use a cron-owned key: `"agent:main:cron:test-job"`.
  - Updated `sessions.delete` assertions to expect the cron-owned key.
  - Added regression coverage for the bug:
    - `deleteAfterRun=true`
    - `agentSessionKey="agent:main:meeting"`
    - `sessions.delete` must not be called.
    - `retireSessionMcpRuntime` must not be called.

- `CHANGELOG.md`
  - Added an Unreleased entry for the cron/delivery cleanup guard.

## Real behavior proof

- Behavior or issue addressed: A one-shot cron job can default `deleteAfterRun` to `true` and then delete a non-cron, user-owned session through the direct cron cleanup path. The changed behavior is that `cleanupDirectCronSessionIfNeeded` must reach the cleanup finalizer with `deleteAfterRun=true`, preserve non-cron session keys such as `agent:main:meeting`, and still delete cron-owned session keys such as `agent:main:cron:test-job`.

- Real environment tested: Focused cleanup-path proof was run on 2026-05-14 09:06 CST in a real PR checkout at `/root/.openclaw/workspace/pr/openclaw-repo/202605140900-pr76177-proof-e7f8a9b0/openclaw`, commit `7c16ce3007295b8b46c140f86ac9329c3c919841`, branch `fix/cron-deleteAfterRun-non-cron-guard`, OpenClaw version `2026.5.3`, Node `v24.14.1`, pnpm `10.33.2`. The proof imports the real `dispatchCronDelivery` implementation from this PR and uses mocked external adapters only to avoid sending messages or deleting real sessions during verification. An earlier live cron-run attempt was also performed on OpenClaw `v2026.5.10-beta.5` at PR head `7c16ce300729`, but that run failed delivery-target resolution because no chat channel was configured, so it is included only as supporting evidence.

- Exact steps or command run after this patch:

  ```bash
  grep -n "isCronSessionKey" src/cron/isolated-agent/delivery-dispatch.ts

  pnpm test src/cron/isolated-agent/delivery-dispatch.pr76177-proof.test.ts

  pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
  ```

  The focused proof uses `SILENT_REPLY_TOKEN` as the delivery payload. In `dispatchCronDelivery`, `normalizeSilentReplyText()` strips the silent token and produces empty normalized payloads. Empty normalized payloads enter `finishSilentReplyDelivery()`, which calls `cleanupDirectCronSessionIfNeeded()` directly. The proof sets `resolvedDelivery.ok = true`, so it does not return early from delivery-target resolution. The proof checks both sides of the guard: non-cron key `agent:main:meeting` and cron-owned control key `agent:main:cron:test-job`.

- Evidence after fix: Terminal capture, console output, copied live output, and log excerpt are included below.

  Patch verification:

  ```text
  $ grep -n "isCronSessionKey" src/cron/isolated-agent/delivery-dispatch.ts
  29:import { isCronSessionKey } from "../../sessions/session-key-utils.js";
  524:    if (!isCronSessionKey(params.agentSessionKey)) {
  ```

  Focused cleanup-path proof console output for the non-cron session:

  ```json
  {
    "case": "non-cron",
    "agentSessionKey": "agent:main:meeting",
    "deleteAfterRun": true,
    "isCronSessionKey": false,
    "cleanupFinalizerReached": true,
    "resultStatus": "ok",
    "deliveryAttempted": true,
    "sessionsDeleteCallCount": 0,
    "retireSessionMcpRuntimeCallCount": 0
  }
  ```

  Focused cleanup-path proof console output for the cron-owned control case:

  ```json
  {
    "case": "cron",
    "agentSessionKey": "agent:main:cron:test-job",
    "deleteAfterRun": true,
    "isCronSessionKey": true,
    "cleanupFinalizerReached": true,
    "resultStatus": "ok",
    "deliveryAttempted": true,
    "sessionsDeleteCallCount": 1,
    "retireSessionMcpRuntimeCallCount": 0
  }
  ```

  Full focused proof terminal capture:

  ```text
  > openclaw@2026.5.3 test /root/.openclaw/workspace/pr/openclaw-repo/202605140900-pr76177-proof-e7f8a9b0/openclaw
  > node scripts/test-projects.mjs src/cron/isolated-agent/delivery-dispatch.pr76177-proof.test.ts

  [test] starting test/vitest/vitest.cron.config.ts

   RUN  v4.1.5 /root/.openclaw/workspace/pr/openclaw-repo/202605140900-pr76177-proof-e7f8a9b0/openclaw

  stdout | src/cron/isolated-agent/delivery-dispatch.pr76177-proof.test.ts > PR #76177 real-behavior proof for deleteAfterRun cleanup guard > executes cleanup finalizer but skips sessions.delete for non-cron session key
  {
    "case": "non-cron",
    "agentSessionKey": "agent:main:meeting",
    "deleteAfterRun": true,
    "isCronSessionKey": false,
    "cleanupFinalizerReached": true,
    "resultStatus": "ok",
    "deliveryAttempted": true,
    "sessionsDeleteCallCount": 0,
    "retireSessionMcpRuntimeCallCount": 0
  }

  stdout | src/cron/isolated-agent/delivery-dispatch.pr76177-proof.test.ts > PR #76177 real-behavior proof for deleteAfterRun cleanup guard > executes cleanup finalizer and calls sessions.delete for cron session key
  {
    "case": "cron",
    "agentSessionKey": "agent:main:cron:test-job",
    "deleteAfterRun": true,
    "isCronSessionKey": true,
    "cleanupFinalizerReached": true,
    "resultStatus": "ok",
    "deliveryAttempted": true,
    "sessionsDeleteCallCount": 1,
    "retireSessionMcpRuntimeCallCount": 0
  }

   ✓  cron  src/cron/isolated-agent/delivery-dispatch.pr76177-proof.test.ts (2 tests) 74ms

   Test Files  1 passed (1)
        Tests  2 passed (2)
     Start at  09:06:20
     Duration  1.80s (transform 1.36s, setup 1.09s, import 361ms, tests 74ms, environment 0ms)

  [test] passed 1 Vitest shard in 8.19s
  ```

  Earlier live cron-run log excerpt from a real OpenClaw setup, included as supporting evidence only:

  ```bash
  $ grep -c "sessions.delete" /tmp/openclaw/openclaw-2026-05-12.log
  0
  ```

  ```log
  [2026-05-12T10:10:09.021Z] INFO  [cron] job added
    jobId: 1c63032b-0786-4f38-86f0-59e85fe4b8db
    jobName: test-deleteAfterRun-non-cron-guard
    sessionKey: agent:main:meeting
    deleteAfterRun: true

  [2026-05-12T10:10:09.025Z] INFO  [gateway] cron: job created
    jobId: 1c63032b-0786-4f38-86f0-59e85fe4b8db
    schedule: { kind: "at", at: "2026-05-12T02:12:04.000Z" }

  [2026-05-12T10:12:04.126Z] INFO  [cron] job triggered (model: qwen/glm-5)

  [2026-05-12T10:12:15.232Z] WARN  [cron] job run returned error status
    jobId: 1c63032b-0786-4f38-86f0-59e85fe4b8db
    error: "Channel is required (no configured channels detected)..."

  [2026-05-12T10:12:15.237Z] WARN  [cron] disabling one-shot job after error
    jobId: 1c63032b-0786-4f38-86f0-59e85fe4b8db
    reason: "permanent error"
  ```

  Targeted regression suite terminal capture:

  ```text
  > openclaw@2026.5.3 test /root/.openclaw/workspace/pr/openclaw-repo/202605140900-pr76177-proof-e7f8a9b0/openclaw
  > node scripts/test-projects.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts

  [test] starting test/vitest/vitest.cron.config.ts

   RUN  v4.1.5 /root/.openclaw/workspace/pr/openclaw-repo/202605140900-pr76177-proof-e7f8a9b0/openclaw

   ✓  cron  src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts (51 tests) 590ms
       ✓ prunes the completed-delivery cache back to the entry cap  492ms

   Test Files  1 passed (1)
        Tests  51 passed (51)
     Start at  09:56:51
     Duration  1.42s (transform 340ms, setup 452ms, import 133ms, tests 590ms, environment 0ms)

  [test] passed 1 Vitest shard in 7.77s
  ```

  Before-fix local bug-tracker entry captured when the bug was found:

  ```text
  [2026-04-29] deleteAfterRun deletes sessions that do not start with cron:
  Source location: isolated-agent-CcTl_LjD.js:425-450
  Symptom: cron job with sessionKey "agent:main:meeting" + deleteAfterRun: true deleted the target session after the isolated run completed.
  Evidence: baseSessionKey = input.sessionKey?.trim() || "cron:${job.id}".
  When the sessionKey does not start with cron:, runSessionKey becomes agentSessionKey.
  deleteAfterRun then deletes the agent session.
  Impact: agent:main:meeting session, about 1.5 MB of data, was permanently deleted.
  ```

- Observed result after fix: For non-cron key `agent:main:meeting`, `isCronSessionKey` is `false`, the cleanup finalizer path is reached, `sessions.delete` call count is `0`, `retireSessionMcpRuntime` call count is `0`, result status is `ok`, and `deliveryAttempted` is `true`. For cron-owned key `agent:main:cron:test-job`, `isCronSessionKey` is `true`, the cleanup finalizer path is reached, `sessions.delete` call count is `1`, `retireSessionMcpRuntime` call count is `0`, result status is `ok`, and `deliveryAttempted` is `true`. The targeted regression suite also passed with 51 tests, 0 failed.

- What was not tested: A destructive live run against a real persistent session containing private conversation data was not performed, to avoid irreversible transcript loss. The earlier live cron attempt did not reach the cleanup branch because no chat channel was configured. The focused cleanup-path proof mocks external adapters only; the real implementation under test is `dispatchCronDelivery` and the changed `cleanupDirectCronSessionIfNeeded` path.

- Before evidence: Two production incidents were observed before the fix. First, a one-shot cron job with `sessionKey` set to a user-owned non-cron session and `deleteAfterRun: true` permanently deleted the conversation history using `deleteTranscript: true`; the affected session contained roughly 1.5 MB of data over 10+ days. Second, a cron job configured with `sessionTarget: "session:<user-owned-key>"` replaced the sessionId binding in `sessions.json`, orphaning about 10 days of conversation metadata. Both cases involved one-shot `at` jobs where `deleteAfterRun` defaults to `true`.

  **Live `journalctl` timeline of the 04-29 incident on a real host (hostname redacted to `<host>`)**:

  ```text
  2026-04-29T16:45:50 [diagnostic] stuck session: sessionId=main sessionKey=agent:main:meeting state=processing age=148s queueDepth=1
  2026-04-29T16:45:50 [diagnostic] stuck session: sessionId=main sessionKey=agent:main:pending3 state=processing age=125s queueDepth=1
  2026-04-29T16:47:35 [diagnostic] stuck session: sessionId=main sessionKey=agent:main:pending5 state=processing age=132s queueDepth=1
  2026-04-29T16:49:36 [diagnostic] stuck session: sessionId=main sessionKey=agent:main:feishu:direct:<redacted> state=processing age=120s queueDepth=1
  2026-04-29T16:51:18 [operator-memory] edit: "04-29 lesson: 7 cron jobs deleted the meeting session. deleteAfterRun must not target a persistent sessionKey..."
  ```

  Metadata of the deleted `agent:main:meeting` session, recovered from a stale `sessions.json.<uuid>.tmp` artifact on the same host:

  | Field | Value |
  |---|---|
  | key | `agent:main:meeting` |
  | sessionId | `251e6831-f7d8-4287-a584-649d68d80534` |
  | sessionStartedAt | 2025-04-17 (≈ 12 days alive at time of delete) |
  | lastInteractionAt | 2026-04-29T16:42:27 |
  | compactionCount | 1 |
  | transcript file size | 7,299,981 bytes / 179 lines / 51 truncation events |

  The same host has the patched `isCronSessionKey` guard active since 2026-05-03; no further `agent:main:meeting`-style deletion has occurred.


## Root Cause (if applicable)

- Root cause: The direct cron cleanup path treated `params.agentSessionKey` as cron-owned solely because `deleteAfterRun` was enabled. It did not check whether the key actually belonged to a cron-created session.
- Missing detection / guardrail: No cron-ownership guard existed before the destructive `sessions.delete` call.
- Contributing context (if known): One-shot `schedule.kind: "at"` jobs default `deleteAfterRun` to `true`, so the destructive cleanup path could run without an explicit user deletion opt-in.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient

- Target test or file:
  - `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`

- Scenario the test should lock in:
  - `deleteAfterRun=true` with `agentSessionKey="agent:main:meeting"` must not call `sessions.delete`.
  - `deleteAfterRun=true` with `agentSessionKey="agent:main:cron:test-job"` must still call `sessions.delete`.

- Why this is the smallest reliable guardrail:
  - The bug is in `dispatchCronDelivery` cleanup finalization. The smallest reliable guard is a dispatch-level test that directly observes whether `sessions.delete` and `retireSessionMcpRuntime` are called.

- Existing test that already covers this (if any):
  - Existing `deleteAfterRun` tests covered cleanup but used the default non-cron-ish `agent:main` key. This PR updates those fixtures to use a cron-owned key and adds the missing non-cron preservation test.

- If no new test is added, why not:
  - N/A. A new regression test is added.

## User-visible / Behavior Changes

Users no longer lose persistent, non-cron sessions when a one-shot cron job with `deleteAfterRun=true` targets a custom non-cron `sessionKey`.

No config migration or CLI behavior change is required.

## Diagram (if applicable)

```text
Before:
[one-shot cron job]
  -> deleteAfterRun=true
  -> agentSessionKey="agent:main:meeting"
  -> sessions.delete(key="agent:main:meeting", deleteTranscript=true)
  -> user-owned session deleted

After:
[one-shot cron job]
  -> deleteAfterRun=true
  -> agentSessionKey="agent:main:meeting"
  -> isCronSessionKey(...) === false
  -> cleanup marked handled
  -> sessions.delete is skipped
  -> user-owned session preserved

Control:
[cron-owned session]
  -> deleteAfterRun=true
  -> agentSessionKey="agent:main:cron:test-job"
  -> isCronSessionKey(...) === true
  -> sessions.delete still runs
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes`
- If any `Yes`, explain risk + mitigation:
  - The data access scope is narrowed. The code no longer deletes sessions unless the key is cron-owned according to the existing `isCronSessionKey()` helper. This reduces destructive access and does not add new access.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js v24.14.1, pnpm 10.33.2
- Model/provider: N/A for focused cleanup-path proof
- Integration/channel (if any): External delivery adapters mocked for the focused proof
- Relevant config (redacted): N/A

### Steps

1. Check out PR head `7c16ce3007295b8b46c140f86ac9329c3c919841`.
2. Verify the `isCronSessionKey()` guard is present in `delivery-dispatch.ts`.
3. Run focused cleanup-path proof:

   ```bash
   pnpm test src/cron/isolated-agent/delivery-dispatch.pr76177-proof.test.ts
   ```

4. Run targeted regression suite:

   ```bash
   pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
   ```

### Expected

- Non-cron key:
  - `isCronSessionKey("agent:main:meeting") === false`
  - cleanup finalizer path completes
  - `sessions.delete` is not called
  - `retireSessionMcpRuntime` is not called

- Cron-owned key:
  - `isCronSessionKey("agent:main:cron:test-job") === true`
  - cleanup finalizer path completes
  - `sessions.delete` is called exactly once
  - `retireSessionMcpRuntime` is not called

### Actual

- Non-cron key:
  - `sessionsDeleteCallCount: 0`
  - `retireSessionMcpRuntimeCallCount: 0`
  - `resultStatus: "ok"`
  - `deliveryAttempted: true`

- Cron-owned key:
  - `sessionsDeleteCallCount: 1`
  - `retireSessionMcpRuntimeCallCount: 0`
  - `resultStatus: "ok"`
  - `deliveryAttempted: true`

- Targeted regression suite:
  - 51 passed, 0 failed

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence included above:

- Before-fix production incidents.
- Local `bugs.md` entry captured when the bug was found.
- Focused cleanup-path proof output.
- Earlier live cron-run log showing no `sessions.delete`, included as supporting evidence only.
- Targeted regression test output.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Non-cron session key `agent:main:meeting` with `deleteAfterRun=true` reaches the cleanup finalizer and does not call `sessions.delete`.
  - Cron-owned session key `agent:main:cron:test-job` with `deleteAfterRun=true` still calls `sessions.delete`.
  - `retireSessionMcpRuntime` fallback is not invoked for non-cron skip.
  - Existing direct cleanup tests still pass with cron-owned keys.
  - Targeted suite passes: 51 tests, 0 failed.

- Edge cases checked:
  - Silent-reply cleanup path.
  - Cron-owned cleanup control case.
  - Non-cron skip does not trigger fallback cleanup.
  - Gateway-failure fallback fixture uses a cron-owned key.

- What you did **not** verify:
  - A destructive live run against a real persistent session containing private conversation data.
  - A full live end-to-end run with an actual configured chat channel after this patch. The earlier live run lacked a configured channel and is therefore supporting evidence only.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Addresses ClawSweeper finding `[P2] Update the fallback cleanup fixture to a cron key` by correcting the fallback cleanup fixture and related `deleteAfterRun` fixtures.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A future cron-owned session using a non-cron-shaped key would no longer be deleted by `deleteAfterRun`.
  - Mitigation: `isCronSessionKey()` is the existing canonical ownership check. Cron-created sessions should use cron-shaped keys by construction. If a future caller needs cron cleanup, it must use the cron-owned key contract.

- Risk: Future contributors may misread `directCronSessionDeleted = true` in the non-cron branch as meaning the session was actually deleted.
  - Mitigation: Inline comment explains that the flag marks cleanup as handled so repeated finalizers do not retry; it does not mean an actual delete occurred.

- Risk: Test fixtures could drift back to non-cron keys and accidentally stop exercising the delete path.
  - Mitigation: Existing `deleteAfterRun` cleanup fixtures now share the explicit cron-owned key `"agent:main:cron:test-job"`, and the non-cron preservation test separately locks the skip path.

