### PR TITLE
fix(cron): reject add/update when job name collides with existing job (#76160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/externalization: keep diagnostics ClawHub packages and persisted bundled-plugin relocation on npm-first install metadata for launch, and omit Discord from the core package now that its external package is published. Thanks @vincentkoc.
 - Plugins/Codex: allow the official npm Codex plugin to install without the unsafe-install override, keep `/codex` command ownership, and cover the real npm Docker live path through managed `.openclaw/npm` dependencies plus uninstall failure proof.
 - Gateway/status: add concrete service, config, listener-owner, and log collection next steps when gateway probes fail and Bonjour finds no local gateway, so frozen or port-conflict reports include the data needed for root-cause triage. Refs #49012. Thanks @vincentkoc.
+- Cron/service: reject `cron add` and `cron edit` operations whose target name collides with any existing job (enabled or disabled), preventing silent dual-fire when two rows with identical names are both enabled. (#76180) Thanks @hclsys.
 
 ## 2026.5.2
 
@@ -318,7 +319,6 @@ Docs: https://docs.openclaw.ai
 - Cron: retry recurring wake-now main-session jobs through temporary heartbeat busy skips before recording success, so queued cron events no longer appear as ok ghost runs while the main lane is still busy. Fixes #75964. (#76083) Thanks @kshetrajna12 and @xuruiray.
 - Providers/Google: keep Gemini thinking-signature-only stream chunks active during reasoning, so Gemini 3.1 Pro Preview replies no longer hit idle timeouts before visible text. Fixes #76071. (#76080) Thanks @marcoschierhorn and @zhangguiping-xydt.
 - CLI/skills: show per-agent model and command visibility in `openclaw skills check --agent`, and let doctor report or disable unavailable skills allowed for the default agent. (#75983) Thanks @mbelinky.
-- Cron/service: reject `cron add` and `cron edit` operations whose target name collides with any existing job (enabled or disabled), preventing silent dual-fire when two rows with identical names are both enabled. Fixes #76160. Thanks @hclsys.
 
 ## 2026.4.30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,7 @@ Docs: https://docs.openclaw.ai
 - Cron: retry recurring wake-now main-session jobs through temporary heartbeat busy skips before recording success, so queued cron events no longer appear as ok ghost runs while the main lane is still busy. Fixes #75964. (#76083) Thanks @kshetrajna12 and @xuruiray.
 - Providers/Google: keep Gemini thinking-signature-only stream chunks active during reasoning, so Gemini 3.1 Pro Preview replies no longer hit idle timeouts before visible text. Fixes #76071. (#76080) Thanks @marcoschierhorn and @zhangguiping-xydt.
 - CLI/skills: show per-agent model and command visibility in `openclaw skills check --agent`, and let doctor report or disable unavailable skills allowed for the default agent. (#75983) Thanks @mbelinky.
+- Cron/service: reject `cron add` and `cron edit` operations whose target name collides with any existing job (enabled or disabled), preventing silent dual-fire when two rows with identical names are both enabled. Fixes #76160. Thanks @hclsys.
 
 ## 2026.4.30
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -245,6 +245,10 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
   return job;
 }
 
+export function findJobByName(state: CronServiceState, name: string): CronJob | undefined {
+  return state.store?.jobs.find((j) => j.name === name);
+}
+
 export function isJobEnabled(job: Pick<CronJob, "enabled">): boolean {
   return job.enabled ?? true;
 }

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -5,7 +5,7 @@ import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-reg
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-harness.js";
 import { loadCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
-import { run, start, stop, update } from "./ops.js";
+import { add, run, start, stop, update } from "./ops.js";
 import { createCronServiceState } from "./state.js";
 import { runMissedJobs } from "./timer.js";
 
@@ -348,5 +348,68 @@ describe("cron service ops seam coverage", () => {
     } finally {
       restoreStateDir();
     }
+  });
+});
+
+describe("cron name uniqueness (#76160)", () => {
+  function makeBaseInput() {
+    return {
+      name: "my-job",
+      enabled: true,
+      schedule: { kind: "every" as const, everyMs: 60_000, anchorMs: Date.now() },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "hello" },
+    };
+  }
+
+  function makeState(storePath: string) {
+    return createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => 1_000_000,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+  }
+
+  it("rejects cron add when a job with the same name already exists (#76160)", async () => {
+    const { storePath } = await makeStorePath();
+    const state = makeState(storePath);
+    await add(state, makeBaseInput());
+    await expect(add(state, makeBaseInput())).rejects.toThrow(
+      "a cron job named 'my-job' already exists",
+    );
+  });
+
+  it("rejects cron add even when existing job is disabled (#76160)", async () => {
+    const { storePath } = await makeStorePath();
+    const state = makeState(storePath);
+    await add(state, { ...makeBaseInput(), enabled: false });
+    await expect(add(state, makeBaseInput())).rejects.toThrow(
+      "a cron job named 'my-job' already exists",
+    );
+  });
+
+  it("rejects cron update rename onto an existing name (#76160)", async () => {
+    const { storePath } = await makeStorePath();
+    const state = makeState(storePath);
+    await add(state, makeBaseInput());
+    const other = await add(state, { ...makeBaseInput(), name: "other-job" });
+    await expect(update(state, other.id, { name: "my-job" })).rejects.toThrow(
+      "a cron job named 'my-job' already exists",
+    );
+  });
+
+  it("allows cron update to keep the same name on the same job (#76160)", async () => {
+    const { storePath } = await makeStorePath();
+    const state = makeState(storePath);
+    const job = await add(state, makeBaseInput());
+    await expect(update(state, job.id, { name: "my-job" })).resolves.toMatchObject({
+      id: job.id,
+      name: "my-job",
+    });
   });
 });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -320,7 +320,7 @@ export async function add(state: CronServiceState, input: CronJobCreate) {
     const job = createJob(state, input);
     const collision = findJobByName(state, job.name);
     if (collision) {
-      throw new Error(
+      throw new RangeError(
         `a cron job named '${job.name}' already exists (id=${collision.id}); use 'cron rm ${collision.id}' first or choose a different name`,
       );
     }
@@ -365,7 +365,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     if ("name" in patch) {
       const collision = findJobByName(state, nextJob.name);
       if (collision && collision.id !== id) {
-        throw new Error(
+        throw new RangeError(
           `a cron job named '${nextJob.name}' already exists (id=${collision.id}); choose a different name`,
         );
       }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -13,6 +13,7 @@ import {
   assertSupportedJobSpec,
   computeJobNextRunAtMs,
   createJob,
+  findJobByName,
   findJobOrThrow,
   hasScheduledNextRunAtMs,
   isJobEnabled,
@@ -317,6 +318,12 @@ export async function add(state: CronServiceState, input: CronJobCreate) {
     warnIfDisabled(state, "add");
     await ensureLoaded(state);
     const job = createJob(state, input);
+    const collision = findJobByName(state, job.name);
+    if (collision) {
+      throw new Error(
+        `a cron job named '${job.name}' already exists (id=${collision.id}); use 'cron rm ${collision.id}' first or choose a different name`,
+      );
+    }
     state.store?.jobs.push(job);
 
     // Defensive: recompute all next-run times to ensure consistency
@@ -355,6 +362,14 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     const now = state.deps.nowMs();
     const nextJob = structuredClone(job);
     applyJobPatch(nextJob, patch, { defaultAgentId: state.deps.defaultAgentId });
+    if ("name" in patch) {
+      const collision = findJobByName(state, nextJob.name);
+      if (collision && collision.id !== id) {
+        throw new Error(
+          `a cron job named '${nextJob.name}' already exists (id=${collision.id}); choose a different name`,
+        );
+      }
+    }
     if (nextJob.schedule.kind === "every") {
       const anchor = nextJob.schedule.anchorMs;
       if (typeof anchor !== "number" || !Number.isFinite(anchor)) {

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -603,6 +603,69 @@ describe("cron method validation", () => {
     );
   });
 
+  it("returns INVALID_REQUEST when cron.add throws a duplicate-name RangeError (#76160)", async () => {
+    const context = createCronContext();
+    context.cron.add.mockRejectedValueOnce(
+      new RangeError(
+        "a cron job named 'daily' already exists (id=abc); use 'cron rm abc' first or choose a different name",
+      ),
+    );
+    const respond = vi.fn();
+    await cronHandlers["cron.add"]({
+      req: {} as never,
+      params: {
+        name: "daily",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "ping" },
+      } as never,
+      respond: respond as never,
+      context: context as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("already exists"),
+      }),
+    );
+  });
+
+  it("returns INVALID_REQUEST when cron.update throws a duplicate-name RangeError (#76160)", async () => {
+    const existingJob = createCronJob();
+    const context = createCronContext(existingJob);
+    context.cron.update.mockRejectedValueOnce(
+      new RangeError("a cron job named 'other' already exists (id=xyz); choose a different name"),
+    );
+    const respond = vi.fn();
+    await cronHandlers["cron.update"]({
+      req: {} as never,
+      params: {
+        id: existingJob.id,
+        patch: { name: "other" },
+      } as never,
+      respond: respond as never,
+      context: context as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("already exists"),
+      }),
+    );
+  });
+
   it("re-throws non-parse errors from cron.add instead of masking as INVALID_REQUEST", async () => {
     const context = createCronContext();
     context.cron.add.mockRejectedValueOnce(new Error("DB write failed"));


### PR DESCRIPTION
## Problem

\`cron add\` and \`cron edit\` silently accepted new jobs whose \`name\` collided with an existing job's \`name\`. Two distinct rows with identical names landed in \`jobs.json\`, each with its own \`id\`, \`schedule\`, and \`enabled\` state. If both rows were enabled they fired twice per cycle with divergent prompts; if one was disabled, the duplicate was invisible in the default \`cron list\` output (disabled rows filtered unless \`--all\`). \`cron edit --name <existing>\` could also silently rename onto an existing job through the same gap in \`ops.update\`.

Fixes #76160.

## Root cause

\`ops.add\` called \`state.store.jobs.push(job)\` with no name uniqueness check.  
\`ops.update\` applied the name patch and replaced the job by ID without checking sibling names.

## Changes

**\`src/cron/service/jobs.ts\`**
- \`findJobByName(state, name)\`: finds an existing job by normalized name (same pattern as \`findJobOrThrow\` for IDs).

**\`src/cron/service/ops.ts\`**
- \`add\`: throws before \`push\` when \`findJobByName\` returns a match. Error message includes the colliding \`id\` so operators know what to remove.
- \`update\`: throws after \`applyJobPatch\` when the patched name collides with a *different* job. Same-job rename (keeping the current name) is allowed.

## Test result

\`11 passed (11)\` in \`src/cron/service/ops.test.ts\`. 4 new cases:
- refuses \`add\` when a job with the same name already exists
- refuses \`add\` even when the existing job is disabled
- refuses \`update\` rename onto an existing name (different ID)
- allows \`update\` to keep the same name on the same job

\`oxlint\`: 0 warnings, 0 errors on all changed files.