### PR TITLE
fix(tasks): mark exec-approval-followup cli tasks lost when run ends (#76162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,7 @@ Docs: https://docs.openclaw.ai
 - Cron: retry recurring wake-now main-session jobs through temporary heartbeat busy skips before recording success, so queued cron events no longer appear as ok ghost runs while the main lane is still busy. Fixes #75964. (#76083) Thanks @kshetrajna12 and @xuruiray.
 - Providers/Google: keep Gemini thinking-signature-only stream chunks active during reasoning, so Gemini 3.1 Pro Preview replies no longer hit idle timeouts before visible text. Fixes #76071. (#76080) Thanks @marcoschierhorn and @zhangguiping-xydt.
 - CLI/skills: show per-agent model and command visibility in `openclaw skills check --agent`, and let doctor report or disable unavailable skills allowed for the default agent. (#75983) Thanks @mbelinky.
+- Tasks/maintenance: mark `exec-approval-followup` and other cli tasks lost as soon as their embedded agent run ends, instead of keeping them stuck in `running` forever because the persistent `agent:main:main` session always exists. (#76199) Thanks @hclsys.
 
 ## 2026.4.30
 

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -151,11 +151,10 @@ Agent run completion is authoritative for active task records. A successful deta
 - Cron tasks: the cron runtime no longer tracks the job as active and durable
   cron run history does not show a terminal result for that run. Offline CLI
   audit does not treat its own empty in-process cron runtime state as authority.
-- CLI tasks: isolated child-session tasks use the child session; chat-backed
-  CLI tasks use the live run context instead, so lingering
-  channel/group/direct session rows do not keep them alive. Gateway-backed
-  `openclaw agent` runs also finalize from their run result, so completed runs
-  do not sit active until the sweeper marks them `lost`.
+- CLI tasks: all CLI tasks (including `exec-approval-followup` and gateway-backed
+  `openclaw agent` runs) use the owning live run context as their backing signal.
+  Once the embedded agent run ends, the task is eligible to be marked `lost` — a
+  persistent session row such as `agent:main:main` does not keep it alive.
 
 ## Delivery and notifications
 
@@ -316,7 +315,7 @@ A sweeper runs every **60 seconds** and handles four things:
 
 <Steps>
   <Step title="Reconciliation">
-    Checks whether active tasks still have authoritative runtime backing. ACP/subagent tasks use child-session state, cron tasks use active-job ownership, and chat-backed CLI tasks use the owning run context. If that backing state is gone for more than 5 minutes, the task is marked `lost`.
+    Checks whether active tasks still have authoritative runtime backing. ACP/subagent tasks use child-session state, cron tasks use active-job ownership, and CLI tasks use the owning live run context (not the persistent session row). If that backing state is gone for more than 5 minutes, the task is marked `lost`.
   </Step>
   <Step title="ACP session repair">
     Closes terminal or orphaned parent-owned one-shot ACP sessions, and closes stale terminal or orphaned persistent ACP sessions only when no active conversation binding remains.

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -87,7 +87,7 @@ describe("tasks commands", () => {
         };
       };
 
-      expect(payload.summary.byCode.stale_running).toBe(1);
+      expect(payload.summary.byCode.lost).toBe(1);
       expect(payload.summary.taskFlows.byCode.stale_waiting).toBe(1);
       expect(payload.summary.taskFlows.byCode.missing_linked_tasks).toBe(1);
       expect(payload.summary.combined.total).toBe(3);

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -197,7 +197,7 @@ describe("task-registry maintenance issue #60299", () => {
     expect(loadSessionStoreMock).toHaveBeenCalledTimes(1);
   });
 
-  it("reuses CLI channel session type derivation across duplicate stale task checks", async () => {
+  it("marks stale CLI tasks lost when the owning run context is gone, regardless of session key", async () => {
     const childSessionKey = "agent:main:discord:direct:user-1";
     const tasks = Array.from({ length: 10 }, (_, index) =>
       makeStaleTask({
@@ -206,15 +206,12 @@ describe("task-registry maintenance issue #60299", () => {
         childSessionKey,
       }),
     );
-    const deriveSessionChatTypeMock = vi.fn(() => "direct" as const);
 
     createTaskRegistryMaintenanceHarness({
       tasks,
-      deriveSessionChatTypeFromKey: deriveSessionChatTypeMock,
     });
 
     expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: tasks.length });
-    expect(deriveSessionChatTypeMock).toHaveBeenCalledTimes(1);
   });
 
   it("marks stale cron tasks lost once the runtime no longer tracks the job as active", async () => {
@@ -476,6 +473,30 @@ describe("task-registry maintenance issue #60299", () => {
 
     expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 0 });
     expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
+  });
+
+  it("marks exec-approval-followup cli tasks lost when run ends even if persistent session exists (#76162)", async () => {
+    const persistentSessionKey = "agent:main:main";
+    const task = makeStaleTask({
+      runtime: "cli",
+      sourceId: "exec-approval-followup:abc123",
+      runId: "exec-approval-followup:abc123",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: persistentSessionKey,
+      childSessionKey: persistentSessionKey,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      // Persistent session always exists in the store — the bug was that this
+      // caused hasBackingSession to return true even when the run had ended.
+      sessionStore: {
+        [persistentSessionKey]: { sessionId: persistentSessionKey, updatedAt: Date.now() },
+      },
+    });
+
+    expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
   });
 
   it("skips markTaskLost and counts recovered when recovery hook recovers a stale task", async () => {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -24,10 +24,7 @@ import {
   sweepExpiredPluginStateEntries,
 } from "../plugin-state/plugin-state-store.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
-import {
-  deriveSessionChatTypeFromKey,
-  type SessionKeyChatType,
-} from "../sessions/session-chat-type-shared.js";
+import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -183,7 +180,6 @@ type SessionStoreLookup = {
 
 type BackingSessionLookupContext = {
   sessionStoresByPath: Map<string, SessionStoreLookup>;
-  sessionChatTypesByKey: Map<string, SessionKeyChatType>;
 };
 
 function createCronRecoveryContext(): CronRecoveryContext {
@@ -196,7 +192,6 @@ function createCronRecoveryContext(): CronRecoveryContext {
 function createBackingSessionLookupContext(): BackingSessionLookupContext {
   return {
     sessionStoresByPath: new Map<string, SessionStoreLookup>(),
-    sessionChatTypesByKey: new Map<string, SessionKeyChatType>(),
   };
 }
 
@@ -247,24 +242,6 @@ function findSessionEntryByKey(
     return undefined;
   }
   return getNormalizedSessionEntries(lookup).get(normalized);
-}
-
-function resolveSessionChatType(
-  sessionKey: string,
-  context?: BackingSessionLookupContext,
-): SessionKeyChatType {
-  const derive =
-    taskRegistryMaintenanceRuntime.deriveSessionChatTypeFromKey ?? deriveSessionChatTypeFromKey;
-  if (!context) {
-    return derive(sessionKey);
-  }
-  const cached = context.sessionChatTypesByKey.get(sessionKey);
-  if (cached) {
-    return cached;
-  }
-  const chatType = derive(sessionKey);
-  context.sessionChatTypesByKey.set(sessionKey, chatType);
-  return chatType;
 }
 
 function findTaskSessionEntry(
@@ -449,8 +426,13 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
     return jobId ? taskRegistryMaintenanceRuntime.isCronJobActive(jobId) : false;
   }
 
-  if (task.runtime === "cli" && hasActiveCliRun(task)) {
-    return true;
+  if (task.runtime === "cli") {
+    // CLI task liveness is determined solely by whether the embedded agent run
+    // is still active. Falling through to session-existence checks is wrong:
+    // exec-approval-followup tasks use childSessionKey="agent:main:main" which
+    // is a persistent session — it always exists, so the session-existence path
+    // would never mark the task lost (#76162). Same pattern as cron above.
+    return hasActiveCliRun(task);
   }
 
   const childSessionKey = task.childSessionKey?.trim();
@@ -466,15 +448,9 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
     }
     return Boolean(acpEntry.entry);
   }
-  if (task.runtime === "subagent" || task.runtime === "cli") {
-    if (task.runtime === "cli") {
-      const chatType = resolveSessionChatType(childSessionKey, context);
-      if (chatType === "channel" || chatType === "group" || chatType === "direct") {
-        return false;
-      }
-    }
+  if (task.runtime === "subagent") {
     const entry = findTaskSessionEntry(task, context);
-    if (task.runtime === "subagent" && isSubagentRecoveryWedgedEntry(entry)) {
+    if (isSubagentRecoveryWedgedEntry(entry)) {
       return false;
     }
     return Boolean(entry);


### PR DESCRIPTION
## Problem

`exec-approval-followup` tasks (and any cli task that uses `childSessionKey="agent:main:main"`) get stuck in `running` forever after the embedded agent run ends.

Root cause: `hasBackingSession()` in `task-registry.maintenance.ts` had:

```ts
if (task.runtime === "cli" && hasActiveCliRun(task)) {
  return true;
}
// falls through to session-existence check when hasActiveCliRun is false
```

When the run ends, `hasActiveCliRun` returns false, so it falls through to the session-existence check. `exec-approval-followup` tasks use `childSessionKey="agent:main:main"` — the persistent main session, which always exists. So `hasBackingSession` returns `true` indefinitely and the task is never marked lost.

## Fix

Return `hasActiveCliRun(task)` immediately for all cli tasks — same pattern already used for cron tasks:

```ts
if (task.runtime === "cli") {
  // CLI task liveness is determined solely by whether the embedded agent run
  // is still active. Falling through to session-existence checks is wrong:
  // exec-approval-followup tasks use childSessionKey="agent:main:main" which
  // is a persistent session — it always exists, so the session-existence path
  // would never mark the task lost (#76162). Same pattern as cron above.
  return hasActiveCliRun(task);
}
```

Also removes the now-dead `resolveSessionChatType()` helper and `sessionChatTypesByKey` from the lookup context.

## Tests

- Updated existing test to remove dead caching assertion (the removed `resolveSessionChatType` was the only caller)
- Added regression test: `exec-approval-followup` cli task with `childSessionKey="agent:main:main"` and a live session store entry gets marked lost when run ends
- 302/302 tests pass in `src/tasks/`

Fixes #76162