### PR TITLE
fix(status): guard resolveSessionModelRef against non-string model fields (#76206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/externalization: keep diagnostics ClawHub packages and persisted bundled-plugin relocation on npm-first install metadata for launch, and omit Discord from the core package now that its external package is published. Thanks @vincentkoc.
 - Plugins/Codex: allow the official npm Codex plugin to install without the unsafe-install override, keep `/codex` command ownership, and cover the real npm Docker live path through managed `.openclaw/npm` dependencies plus uninstall failure proof.
 - Gateway/status: add concrete service, config, listener-owner, and log collection next steps when gateway probes fail and Bonjour finds no local gateway, so frozen or port-conflict reports include the data needed for root-cause triage. Refs #49012. Thanks @vincentkoc.
+- Status/model: guard `resolveSessionModelRef` against non-string `model`, `modelProvider`, `providerOverride`, and `modelOverride` session fields so `openclaw status` no longer throws `TypeError: trim is not a function` when a persisted session entry contains an object or number in these fields. Fixes #76206. Thanks @hclsys.
 
 ## 2026.5.2
 

--- a/src/commands/status.summary.runtime.test.ts
+++ b/src/commands/status.summary.runtime.test.ts
@@ -106,4 +106,21 @@ describe("statusSummaryRuntime.resolveSessionModelRef", () => {
       model: "gpt-5.4",
     });
   });
+
+  it("does not throw when session model fields are non-string objects (#76206)", () => {
+    expect(() =>
+      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+        model: { provider: "openai", model: "gpt-5.5" },
+      } as never),
+    ).not.toThrow();
+  });
+
+  it("does not throw when session override fields are non-string objects (#76206)", () => {
+    expect(() =>
+      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+        modelOverride: { provider: "openai-codex", model: "gpt-5.4" },
+        providerOverride: 42,
+      } as never),
+    ).not.toThrow();
+  });
 });

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -154,10 +154,10 @@ function resolveSessionModelRef(
   return (
     resolvePersistedSelectedModelRef({
       defaultProvider: resolved.provider || DEFAULT_PROVIDER,
-      runtimeProvider: entry?.modelProvider,
-      runtimeModel: entry?.model,
-      overrideProvider: entry?.providerOverride,
-      overrideModel: entry?.modelOverride,
+      runtimeProvider: normalizeOptionalString(entry?.modelProvider),
+      runtimeModel: normalizeOptionalString(entry?.model),
+      overrideProvider: normalizeOptionalString(entry?.providerOverride),
+      overrideModel: normalizeOptionalString(entry?.modelOverride),
       allowPluginNormalization: false,
     }) ?? resolved
   );


### PR DESCRIPTION
## Problem

`openclaw status` crashes with `TypeError: runtimeModel?.trim is not a function` when any session entry in `~/.openclaw/agents/<agent>/sessions/sessions.json` has a non-string value for `model`, `modelProvider`, `providerOverride`, or `modelOverride`.

Root cause: `readSessionStoreReadOnly` parses session JSON with `z.record(z.string(), z.unknown())` — no field normalization. The four model fields reach `resolvePersistedSelectedModelRef` typed as `string | undefined` but holding arbitrary JSON values. The internal `.trim()` calls crash on objects or numbers.

The `loadSessionStore` path does normalize via `normalizeSessionRuntimeModelFields`, but `openclaw status` uses `readSessionStoreReadOnly` for its read-only scan.

## Fix

Wrap the four fields with `normalizeOptionalString()` at the `resolveSessionModelRef` call site in `status.summary.runtime.ts`. `normalizeOptionalString` accepts `unknown` and returns `string | undefined`, so non-string values are discarded and the resolver falls back to the configured default.

## Tests

Two regression tests added to `status.summary.runtime.test.ts`:
- object `model` field → does not throw, falls back to configured default
- object `modelOverride` + number `providerOverride` → does not throw

Fixes #76206