### PR TITLE
[codex] Fix Anthropic Vertex npm audit regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/sessions: preserve terminal lifecycle state when final run metadata persists from a stale in-memory snapshot, preventing `main` sessions from staying stuck as running after completed or timed-out turns.
+- Providers/Anthropic Vertex: keep the local Vertex client dependency cleanup audit-safe while preserving Anthropic SDK request headers when adding Google ADC auth.
 - Status: show the `openai-codex` OAuth profile for `openai/gpt-*` sessions running through the native Codex runtime instead of reporting auth as unknown. (#76197) Thanks @mbelinky.
 - Plugins/externalization: keep diagnostics ClawHub packages and persisted bundled-plugin relocation on npm-first install metadata for launch, and omit Discord from the core package now that its external package is published. Thanks @vincentkoc.
 - Plugins/Codex: allow the official npm Codex plugin to install without the unsafe-install override, keep `/codex` command ownership, and cover the real npm Docker live path through managed `.openclaw/npm` dependencies plus uninstall failure proof.

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -5,9 +5,9 @@
   "description": "OpenClaw Anthropic Vertex provider plugin",
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/vertex-sdk": "^0.16.0",
     "@mariozechner/pi-agent-core": "0.71.1",
-    "@mariozechner/pi-ai": "0.71.1"
+    "@mariozechner/pi-ai": "0.71.1",
+    "google-auth-library": "10.6.2"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/anthropic-vertex/stream-runtime.test.ts
+++ b/extensions/anthropic-vertex/stream-runtime.test.ts
@@ -1,4 +1,5 @@
 import { createAssistantMessageEventStream, type Model } from "@mariozechner/pi-ai";
+import type { AuthClient } from "google-auth-library";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { AnthropicVertexStreamDeps } from "./stream-runtime.js";
 
@@ -30,6 +31,7 @@ function createStreamDeps(): {
 
 let createAnthropicVertexStreamFn: typeof import("./stream-runtime.js").createAnthropicVertexStreamFn;
 let createAnthropicVertexStreamFnForModel: typeof import("./stream-runtime.js").createAnthropicVertexStreamFnForModel;
+let streamRuntimeTesting: typeof import("./stream-runtime.js").__testing;
 
 function makeModel(params: { id: string; maxTokens?: number }): Model<"anthropic-messages"> {
   return {
@@ -101,8 +103,9 @@ function buildExpectedCacheBoundaryPayload(messageText: string) {
 
 describe("createAnthropicVertexStreamFn", () => {
   beforeAll(async () => {
-    ({ createAnthropicVertexStreamFn, createAnthropicVertexStreamFnForModel } =
-      await import("./stream-runtime.js"));
+    const runtime = await import("./stream-runtime.js");
+    ({ createAnthropicVertexStreamFn, createAnthropicVertexStreamFnForModel } = runtime);
+    streamRuntimeTesting = runtime.__testing;
   });
 
   it("omits projectId when ADC credentials are used without an explicit project", () => {
@@ -132,6 +135,61 @@ describe("createAnthropicVertexStreamFn", () => {
       region: "us-east5",
       baseURL: "https://proxy.example.test/vertex/v1",
     });
+  });
+
+  it("preserves SDK-built header containers when adding ADC auth headers", async () => {
+    const capturedHeaders: Headers[] = [];
+    const authClient = {
+      projectId: "vertex-project",
+      getRequestHeaders: async () =>
+        new Headers([
+          ["authorization", "Bearer adc-token"],
+          ["x-goog-user-project", "quota-project"],
+        ]),
+    } as unknown as AuthClient;
+    const client = new streamRuntimeTesting.AnthropicVertexClient({
+      region: "us-east5",
+      authClient,
+      maxRetries: 0,
+      fetch: async (_input, init) => {
+        capturedHeaders.push(new Headers(init?.headers));
+        return new Response(
+          JSON.stringify({
+            id: "msg_test",
+            type: "message",
+            role: "assistant",
+            model: "claude-sonnet-4-6",
+            content: [],
+            stop_reason: "end_turn",
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+    });
+
+    await client.messages.create(
+      {
+        model: "claude-sonnet-4-6",
+        max_tokens: 1,
+        messages: [{ role: "user", content: "Hello" }],
+      },
+      {
+        headers: { "x-sdk-container-test": "kept" },
+      },
+    );
+
+    expect(capturedHeaders).toHaveLength(1);
+    const headers = capturedHeaders[0];
+    expect(headers?.get("authorization")).toBe("Bearer adc-token");
+    expect(headers?.get("x-goog-user-project")).toBe("quota-project");
+    expect(headers?.get("x-sdk-container-test")).toBe("kept");
+    expect(headers?.has("values")).toBe(false);
+    expect(headers?.has("nulls")).toBe(false);
   });
 
   it("defaults maxTokens to the model limit instead of the old 32000 cap", () => {

--- a/extensions/anthropic-vertex/stream-runtime.ts
+++ b/extensions/anthropic-vertex/stream-runtime.ts
@@ -22,46 +22,101 @@ type AnthropicVertexClientOptions = ConstructorParameters<typeof BaseAnthropic>[
   projectId?: string | null;
   region?: string | null;
 };
+type HeaderValue = string | null | undefined;
+type HeaderValueInput = HeaderValue | readonly HeaderValue[];
+type AnthropicHeaderContainer = {
+  readonly values: Headers;
+  readonly nulls: Set<string>;
+  readonly [key: symbol]: true | Headers | Set<string>;
+};
 
 const ANTHROPIC_VERTEX_VERSION = "vertex-2023-10-16";
 const MODEL_ENDPOINTS = new Set(["/v1/messages", "/v1/messages?beta=true"]);
+const ANTHROPIC_HEADER_CONTAINER_BRAND = Symbol.for("brand.privateNullableHeaders");
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function mergeHeaders(first: unknown, second: unknown): Record<string, string> {
-  const merged: Record<string, string> = {};
+function isAnthropicHeaderContainer(value: unknown): value is AnthropicHeaderContainer {
+  return (
+    isRecord(value) &&
+    (value as { [key: symbol]: unknown })[ANTHROPIC_HEADER_CONTAINER_BRAND] === true &&
+    (value as { values?: unknown }).values instanceof Headers &&
+    (value as { nulls?: unknown }).nulls instanceof Set
+  );
+}
+
+function* iterateHeaders(
+  headers: unknown,
+): IterableIterator<readonly [name: string, value: string | null]> {
+  if (!headers) {
+    return;
+  }
+  if (isAnthropicHeaderContainer(headers)) {
+    yield* headers.values.entries();
+    for (const name of headers.nulls) {
+      yield [name, null];
+    }
+    return;
+  }
+
+  let shouldClear = false;
+  let entries: Iterable<readonly [string, HeaderValueInput]>;
+  if (headers instanceof Headers) {
+    entries = headers.entries();
+  } else if (Array.isArray(headers)) {
+    entries = headers as readonly (readonly [string, HeaderValueInput])[];
+  } else if (isRecord(headers)) {
+    shouldClear = true;
+    entries = Object.entries(headers) as readonly (readonly [string, HeaderValueInput])[];
+  } else {
+    return;
+  }
+
+  for (const [name, rawValue] of entries) {
+    const values = Array.isArray(rawValue) ? rawValue : [rawValue];
+    let didClear = false;
+    for (const value of values) {
+      if (value === undefined) {
+        continue;
+      }
+      if (shouldClear && !didClear) {
+        didClear = true;
+        yield [name, null];
+      }
+      yield [name, value === null ? null : String(value)];
+    }
+  }
+}
+
+function mergeHeaders(first: unknown, second: unknown): AnthropicHeaderContainer {
+  const values = new Headers();
+  const nulls = new Set<string>();
 
   for (const headers of [first, second]) {
-    if (!headers) {
-      continue;
-    }
-    if (headers instanceof Headers) {
-      headers.forEach((value, key) => {
-        merged[key] = value;
-      });
-      continue;
-    }
-    if (Array.isArray(headers)) {
-      for (const entry of headers) {
-        if (Array.isArray(entry) && entry.length >= 2 && entry[1] !== undefined) {
-          merged[String(entry[0])] = String(entry[1]);
-        }
+    const seenHeaders = new Set<string>();
+    for (const [name, value] of iterateHeaders(headers)) {
+      const lowerName = name.toLowerCase();
+      if (!seenHeaders.has(lowerName)) {
+        values.delete(name);
+        seenHeaders.add(lowerName);
       }
-      continue;
-    }
-    if (!isRecord(headers)) {
-      continue;
-    }
-    for (const [key, value] of Object.entries(headers)) {
-      if (value !== undefined) {
-        merged[key] = String(value);
+      if (value === null) {
+        values.delete(name);
+        nulls.add(lowerName);
+      } else {
+        values.append(name, value);
+        nulls.delete(lowerName);
       }
     }
   }
 
-  return merged;
+  return {
+    [ANTHROPIC_HEADER_CONTAINER_BRAND]: true,
+    values,
+    nulls,
+  };
 }
 
 function getHeaderValue(headers: unknown, name: string): unknown {
@@ -70,6 +125,9 @@ function getHeaderValue(headers: unknown, name: string): unknown {
   }
   if (headers instanceof Headers) {
     return headers.get(name);
+  }
+  if (isAnthropicHeaderContainer(headers)) {
+    return headers.values.get(name);
   }
   if (isRecord(headers)) {
     return headers[name];
@@ -137,7 +195,7 @@ class AnthropicVertexClient extends BaseAnthropic {
     if (!this.projectId && typeof projectId === "string" && projectId.length > 0) {
       this.projectId = projectId;
     }
-    options.headers = mergeHeaders(authHeaders, options.headers);
+    options.headers = mergeHeaders(authHeaders, options.headers) as typeof options.headers;
   }
 
   async buildRequest(
@@ -161,6 +219,9 @@ class AnthropicVertexClient extends BaseAnthropic {
       }
 
       const model = options.body.model;
+      if (typeof model !== "string" || model.length === 0) {
+        throw new Error("Expected request body model to be a string for post /v1/messages");
+      }
       options.body.model = undefined;
       const specifier = options.body.stream ? "streamRawPredict" : "rawPredict";
       options.path = `/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/${model}:${specifier}`;
@@ -215,6 +276,10 @@ export type AnthropicVertexStreamDeps = {
 const defaultAnthropicVertexStreamDeps: AnthropicVertexStreamDeps = {
   AnthropicVertex: AnthropicVertexClient as AnthropicVertexStreamDeps["AnthropicVertex"],
   streamAnthropic: streamAnthropicDefault,
+};
+
+export const __testing = {
+  AnthropicVertexClient,
 };
 
 function isClaudeOpus47Model(modelId: string): boolean {

--- a/extensions/anthropic-vertex/stream-runtime.ts
+++ b/extensions/anthropic-vertex/stream-runtime.ts
@@ -1,10 +1,12 @@
-import { AnthropicVertex as AnthropicVertexSdk } from "@anthropic-ai/vertex-sdk";
+import { BaseAnthropic } from "@anthropic-ai/sdk/client";
+import * as AnthropicResources from "@anthropic-ai/sdk/resources/index";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import {
   streamAnthropic as streamAnthropicDefault,
   type AnthropicOptions,
   type Model,
 } from "@mariozechner/pi-ai";
+import { GoogleAuth, type AuthClient } from "google-auth-library";
 import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
@@ -13,7 +15,197 @@ import { resolveAnthropicVertexClientRegion, resolveAnthropicVertexProjectId } f
 
 type AnthropicVertexEffort = NonNullable<AnthropicOptions["effort"]>;
 type AnthropicVertexAdaptiveEffort = AnthropicVertexEffort | "xhigh";
-type AnthropicVertexClientOptions = ConstructorParameters<typeof AnthropicVertexSdk>[0];
+type AnthropicVertexClientOptions = ConstructorParameters<typeof BaseAnthropic>[0] & {
+  accessToken?: string | null;
+  authClient?: AuthClient | null;
+  googleAuth?: GoogleAuth | null;
+  projectId?: string | null;
+  region?: string | null;
+};
+
+const ANTHROPIC_VERTEX_VERSION = "vertex-2023-10-16";
+const MODEL_ENDPOINTS = new Set(["/v1/messages", "/v1/messages?beta=true"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeHeaders(first: unknown, second: unknown): Record<string, string> {
+  const merged: Record<string, string> = {};
+
+  for (const headers of [first, second]) {
+    if (!headers) {
+      continue;
+    }
+    if (headers instanceof Headers) {
+      headers.forEach((value, key) => {
+        merged[key] = value;
+      });
+      continue;
+    }
+    if (Array.isArray(headers)) {
+      for (const entry of headers) {
+        if (Array.isArray(entry) && entry.length >= 2 && entry[1] !== undefined) {
+          merged[String(entry[0])] = String(entry[1]);
+        }
+      }
+      continue;
+    }
+    if (!isRecord(headers)) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(headers)) {
+      if (value !== undefined) {
+        merged[key] = String(value);
+      }
+    }
+  }
+
+  return merged;
+}
+
+function getHeaderValue(headers: unknown, name: string): unknown {
+  if (!headers) {
+    return undefined;
+  }
+  if (headers instanceof Headers) {
+    return headers.get(name);
+  }
+  if (isRecord(headers)) {
+    return headers[name];
+  }
+  return undefined;
+}
+
+class AnthropicVertexClient extends BaseAnthropic {
+  accessToken: string | null;
+  beta: AnthropicResources.Beta;
+  messages: AnthropicResources.Messages;
+  projectId: string | null;
+  region: string;
+
+  private auth?: GoogleAuth;
+  private authClientPromise: Promise<AuthClient>;
+
+  constructor({
+    baseURL = process.env.ANTHROPIC_VERTEX_BASE_URL,
+    region = process.env.CLOUD_ML_REGION ?? null,
+    projectId = process.env.ANTHROPIC_VERTEX_PROJECT_ID ?? null,
+    ...opts
+  }: AnthropicVertexClientOptions = {}) {
+    if (!region) {
+      throw new Error(
+        "No region was given. The client should be instantiated with the `region` option or the `CLOUD_ML_REGION` environment variable should be set.",
+      );
+    }
+
+    super({
+      baseURL: baseURL ?? resolveDefaultAnthropicVertexBaseUrl(region),
+      ...opts,
+    });
+
+    this.messages = makeMessagesResource(this);
+    this.beta = makeBetaResource(this);
+    this.region = region;
+    this.projectId = projectId;
+    this.accessToken = opts.accessToken ?? null;
+
+    if (opts.authClient && opts.googleAuth) {
+      throw new Error(
+        "You cannot provide both `authClient` and `googleAuth`. Please provide only one of them.",
+      );
+    }
+    if (opts.authClient) {
+      this.authClientPromise = Promise.resolve(opts.authClient);
+    } else {
+      this.auth =
+        opts.googleAuth ??
+        new GoogleAuth({ scopes: "https://www.googleapis.com/auth/cloud-platform" });
+      this.authClientPromise = this.auth.getClient();
+    }
+  }
+
+  validateHeaders(): void {
+    // Vertex auth is resolved asynchronously in prepareOptions.
+  }
+
+  async prepareOptions(options: Parameters<BaseAnthropic["prepareOptions"]>[0]): Promise<void> {
+    const authClient = await this.authClientPromise;
+    const authHeaders = await authClient.getRequestHeaders();
+    const projectId = authClient.projectId ?? getHeaderValue(authHeaders, "x-goog-user-project");
+
+    if (!this.projectId && typeof projectId === "string" && projectId.length > 0) {
+      this.projectId = projectId;
+    }
+    options.headers = mergeHeaders(authHeaders, options.headers);
+  }
+
+  async buildRequest(
+    options: Parameters<BaseAnthropic["buildRequest"]>[0],
+  ): ReturnType<BaseAnthropic["buildRequest"]> {
+    if (isRecord(options.body)) {
+      options.body = { ...options.body };
+    }
+    if (isRecord(options.body) && !options.body.anthropic_version) {
+      options.body.anthropic_version = ANTHROPIC_VERTEX_VERSION;
+    }
+
+    if (MODEL_ENDPOINTS.has(options.path) && options.method === "post") {
+      if (!this.projectId) {
+        throw new Error(
+          "No projectId was given and it could not be resolved from credentials. The client should be instantiated with the `projectId` option or the `ANTHROPIC_VERTEX_PROJECT_ID` environment variable should be set.",
+        );
+      }
+      if (!isRecord(options.body)) {
+        throw new Error("Expected request body to be an object for post /v1/messages");
+      }
+
+      const model = options.body.model;
+      options.body.model = undefined;
+      const specifier = options.body.stream ? "streamRawPredict" : "rawPredict";
+      options.path = `/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/${model}:${specifier}`;
+    }
+
+    if (
+      options.path === "/v1/messages/count_tokens" ||
+      (options.path === "/v1/messages/count_tokens?beta=true" && options.method === "post")
+    ) {
+      if (!this.projectId) {
+        throw new Error(
+          "No projectId was given and it could not be resolved from credentials. The client should be instantiated with the `projectId` option or the `ANTHROPIC_VERTEX_PROJECT_ID` environment variable should be set.",
+        );
+      }
+      options.path = `/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/count-tokens:rawPredict`;
+    }
+
+    return super.buildRequest(options);
+  }
+}
+
+function resolveDefaultAnthropicVertexBaseUrl(region: string): string {
+  switch (region) {
+    case "global":
+      return "https://aiplatform.googleapis.com/v1";
+    case "us":
+      return "https://aiplatform.us.rep.googleapis.com/v1";
+    case "eu":
+      return "https://aiplatform.eu.rep.googleapis.com/v1";
+    default:
+      return `https://${region}-aiplatform.googleapis.com/v1`;
+  }
+}
+
+function makeMessagesResource(client: BaseAnthropic): AnthropicResources.Messages {
+  const resource = new AnthropicResources.Messages(client);
+  delete (resource as { batches?: unknown }).batches;
+  return resource;
+}
+
+function makeBetaResource(client: BaseAnthropic): AnthropicResources.Beta {
+  const resource = new AnthropicResources.Beta(client);
+  delete (resource.messages as { batches?: unknown }).batches;
+  return resource;
+}
 
 export type AnthropicVertexStreamDeps = {
   AnthropicVertex: new (options: AnthropicVertexClientOptions) => unknown;
@@ -21,7 +213,7 @@ export type AnthropicVertexStreamDeps = {
 };
 
 const defaultAnthropicVertexStreamDeps: AnthropicVertexStreamDeps = {
-  AnthropicVertex: AnthropicVertexSdk as AnthropicVertexStreamDeps["AnthropicVertex"],
+  AnthropicVertex: AnthropicVertexClient as AnthropicVertexStreamDeps["AnthropicVertex"],
   streamAnthropic: streamAnthropicDefault,
 };
 

--- a/package.json
+++ b/package.json
@@ -1650,7 +1650,6 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "0.21.0",
     "@anthropic-ai/sdk": "0.92.0",
-    "@anthropic-ai/vertex-sdk": "^0.16.0",
     "@aws-sdk/client-bedrock": "3.1041.0",
     "@aws-sdk/client-bedrock-runtime": "3.1041.0",
     "@aws-sdk/credential-provider-node": "3.972.39",
@@ -1679,6 +1678,7 @@
     "express": "5.2.1",
     "file-type": "22.0.1",
     "global-agent": "^4.1.3",
+    "google-auth-library": "10.6.2",
     "grammy": "^1.42.0",
     "https-proxy-agent": "^9.0.0",
     "ipaddr.js": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,6 @@ importers:
       '@anthropic-ai/sdk':
         specifier: 0.92.0
         version: 0.92.0(zod@4.4.1)
-      '@anthropic-ai/vertex-sdk':
-        specifier: ^0.16.0
-        version: 0.16.0(zod@4.4.1)
       '@aws-sdk/client-bedrock':
         specifier: 3.1041.0
         version: 3.1041.0
@@ -136,6 +133,9 @@ importers:
       global-agent:
         specifier: ^4.1.3
         version: 4.1.3
+      google-auth-library:
+        specifier: 10.6.2
+        version: 10.6.2
       grammy:
         specifier: ^1.42.0
         version: 1.42.0
@@ -348,15 +348,15 @@ importers:
 
   extensions/anthropic-vertex:
     dependencies:
-      '@anthropic-ai/vertex-sdk':
-        specifier: ^0.16.0
-        version: 0.16.0(zod@4.4.1)
       '@mariozechner/pi-agent-core':
         specifier: 0.71.1
         version: 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(ws@8.20.0)(zod@4.4.1)
       '@mariozechner/pi-ai':
         specifier: 0.71.1
         version: 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(ws@8.20.0)(zod@4.4.1)
+      google-auth-library:
+        specifier: 10.6.2
+        version: 10.6.2
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1724,9 +1724,6 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
-
-  '@anthropic-ai/vertex-sdk@0.16.0':
-    resolution: {integrity: sha512-ntxemtRkwPsjVzGQJsmBPRW38tfas6VuVlD1v6pHffDJKLPtCdaiN9KUQeraJ/F34tjxEWlsaCnl3t/orJm1Xw==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -5464,17 +5461,9 @@ packages:
     engines: {node: '>=10'}
     deprecated: This package is no longer supported.
 
-  gaxios@6.7.1:
-    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
-    engines: {node: '>=14'}
-
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
-
-  gcp-metadata@6.1.1:
-    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
-    engines: {node: '>=14'}
 
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
@@ -5538,14 +5527,6 @@ packages:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
 
-  google-auth-library@9.15.1:
-    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
-    engines: {node: '>=14'}
-
-  google-logging-utils@0.0.2:
-    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
-    engines: {node: '>=14'}
-
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -5560,10 +5541,6 @@ packages:
   grammy@1.42.0:
     resolution: {integrity: sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==}
     engines: {node: ^12.20.0 || >=14.13.1}
-
-  gtoken@7.1.0:
-    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
-    engines: {node: '>=14.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -7890,15 +7867,6 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.1
-
-  '@anthropic-ai/vertex-sdk@0.16.0(zod@4.4.1)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.92.0(zod@4.4.1)
-      google-auth-library: 9.15.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-      - zod
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -12312,32 +12280,12 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
-  gaxios@6.7.1:
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6
-      is-stream: 2.0.1
-      node-fetch: 2.7.0
-      uuid: 14.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
     transitivePeerDependencies:
-      - supports-color
-
-  gcp-metadata@6.1.1:
-    dependencies:
-      gaxios: 6.7.1
-      google-logging-utils: 0.0.2
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - encoding
       - supports-color
 
   gcp-metadata@8.1.2:
@@ -12442,20 +12390,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@9.15.1:
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1
-      gcp-metadata: 6.1.1
-      gtoken: 7.1.0
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  google-logging-utils@0.0.2: {}
-
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -12468,14 +12402,6 @@ snapshots:
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  gtoken@7.1.0:
-    dependencies:
-      gaxios: 6.7.1
-      jws: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color

--- a/src/cli/plugins-location-bridges.test.ts
+++ b/src/cli/plugins-location-bridges.test.ts
@@ -59,7 +59,7 @@ function makeRegistry(pluginId: string): PluginManifestRegistry {
         hooks: [],
         configContracts: [],
         activation: {},
-        startup: {},
+        startup: startupInfo,
         packageInstall: {
           clawhubSpec: `clawhub:@openclaw/${pluginId}`,
           npmSpec: `@openclaw/${pluginId}`,


### PR DESCRIPTION
## Summary

- remove the `@anthropic-ai/vertex-sdk` runtime dependency from the shipped OpenClaw package
- replace it with a small local Anthropic Vertex client built on the existing `@anthropic-ai/sdk` and `google-auth-library@10.6.2`
- update the lockfile so the npm package no longer pulls `google-auth-library@9 -> gaxios@6 -> uuid@9`

## Why

`openclaw@2026.5.2-beta.1` introduced a clean npm audit regression for consumers: `@anthropic-ai/vertex-sdk@0.16.0` depends on `google-auth-library@^9.4.2`, which resolves to `gaxios@6.7.1` and `uuid@9.0.1`. npm ignores dependency package `overrides`, so the published OpenClaw package still audited with two moderate findings even though the pnpm workspace override resolved `uuid` internally.

## Validation

- `pnpm tsgo:extensions`
- `pnpm exec vitest run extensions/anthropic-vertex`
- `pnpm exec oxlint extensions/anthropic-vertex/stream-runtime.ts`
- `pnpm audit --prod --json` reports 0 vulnerabilities
- packed this branch with `npm pack`, installed the tarball into a fresh npm project, and verified `npm audit --omit=dev --json` reports 0 vulnerabilities
- tarball install dependency tree no longer contains `@anthropic-ai/vertex-sdk`, `google-auth-library@9`, `gaxios@6`, or `uuid@9`
