### PR TITLE
fix(sessions): sweep orphaned session artifacts during cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Status: show the `openai-codex` OAuth profile for `openai/gpt-*` sessions running through the native Codex runtime instead of reporting auth as unknown. (#76197) Thanks @mbelinky.
+- Sessions/cleanup: garbage-collect orphaned session transcript, trajectory, and compaction-checkpoint files whose index entries have been pruned (by age or count cap) but whose on-disk artifacts were left behind; `sessions cleanup` now sweeps the sessions directory and removes unreferenced artifacts, preventing unbounded directory growth that can wedge the gateway on filesystems sensitive to large directory sizes. Fixes #76220.
 
 ## 2026.5.2
 

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -141,6 +141,12 @@ function renderAppliedSummaries(params: {
     }
     params.runtime.log(`Session store: ${summary.storePath}`);
     params.runtime.log(`Applied maintenance. Current entries: ${summary.appliedCount ?? 0}`);
+    const orphaned = summary.orphanedArtifacts;
+    if (orphaned && orphaned.removedFiles > 0) {
+      params.runtime.log(
+        `Removed ${orphaned.removedFiles} orphaned session artifact file(s) (${orphaned.freedBytes} bytes).`,
+      );
+    }
   }
 }
 

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -4,7 +4,7 @@ import { resolveStoredSessionOwnerAgentId } from "../../gateway/session-store-ke
 import { getLogger } from "../../logging/logger.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { enforceSessionDiskBudget } from "./disk-budget.js";
+import { enforceSessionDiskBudget, sweepOrphanedSessionArtifacts } from "./disk-budget.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -55,6 +55,7 @@ export type SessionCleanupSummary = {
   pruned: number;
   capped: number;
   diskBudget: Awaited<ReturnType<typeof enforceSessionDiskBudget>>;
+  orphanedArtifacts: Awaited<ReturnType<typeof sweepOrphanedSessionArtifacts>> | null;
   wouldMutate: boolean;
   applied?: true;
   appliedCount?: number;
@@ -195,12 +196,18 @@ async function previewStoreCleanup(params: {
   }
   const beforeCount = Object.keys(beforeStore).length;
   const afterPreviewCount = Object.keys(previewStore).length;
+  const orphanedArtifacts = await sweepOrphanedSessionArtifacts({
+    store: beforeStore,
+    storePath: params.target.storePath,
+    dryRun: true,
+  });
   const wouldMutate =
     missing > 0 ||
     pruned > 0 ||
     capped > 0 ||
     (diskBudget?.removedEntries ?? 0) > 0 ||
-    (diskBudget?.removedFiles ?? 0) > 0;
+    (diskBudget?.removedFiles ?? 0) > 0 ||
+    orphanedArtifacts.removedFiles > 0;
 
   const summary: SessionCleanupSummary = {
     agentId: params.target.agentId,
@@ -213,6 +220,7 @@ async function previewStoreCleanup(params: {
     pruned,
     capped,
     diskBudget,
+    orphanedArtifacts,
     wouldMutate,
   };
 
@@ -281,6 +289,13 @@ export async function runSessionsCleanup(params: {
         },
       );
       const afterStore = loadSessionStore(target.storePath, { skipCache: true });
+      // Sweep orphaned artifacts against the post-maintenance store so entries pruned
+      // during this run are already excluded from the "referenced" set.
+      const appliedOrphanedArtifacts = await sweepOrphanedSessionArtifacts({
+        store: afterStore,
+        storePath: target.storePath,
+        dryRun: false,
+      });
       const preview = previewResults.find(
         (result) => result.summary.storePath === target.storePath,
       );
@@ -299,8 +314,10 @@ export async function runSessionsCleanup(params: {
                 pruned: 0,
                 capped: 0,
                 diskBudget: null,
+                orphanedArtifacts: null,
                 wouldMutate: false,
               }),
+              orphanedArtifacts: appliedOrphanedArtifacts,
               dryRun: false,
               applied: true,
               appliedCount: Object.keys(afterStore).length,
@@ -316,12 +333,14 @@ export async function runSessionsCleanup(params: {
               pruned: appliedReport.pruned,
               capped: appliedReport.capped,
               diskBudget: appliedReport.diskBudget,
+              orphanedArtifacts: appliedOrphanedArtifacts,
               wouldMutate:
                 missingApplied > 0 ||
                 appliedReport.pruned > 0 ||
                 appliedReport.capped > 0 ||
                 (appliedReport.diskBudget?.removedEntries ?? 0) > 0 ||
-                (appliedReport.diskBudget?.removedFiles ?? 0) > 0,
+                (appliedReport.diskBudget?.removedFiles ?? 0) > 0 ||
+                appliedOrphanedArtifacts.removedFiles > 0,
               applied: true,
               appliedCount: Object.keys(afterStore).length,
             };

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -7,7 +7,7 @@ import {
   resolveTrajectoryPointerFilePath,
 } from "../../trajectory/paths.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
-import { enforceSessionDiskBudget } from "./disk-budget.js";
+import { enforceSessionDiskBudget, sweepOrphanedSessionArtifacts } from "./disk-budget.js";
 import type { SessionEntry } from "./types.js";
 
 describe("enforceSessionDiskBudget", () => {
@@ -240,6 +240,67 @@ describe("enforceSessionDiskBudget", () => {
           removedEntries: 1,
         }),
       );
+    });
+  });
+});
+
+describe("sweepOrphanedSessionArtifacts", () => {
+  it("removes unreferenced primary transcript files and preserves referenced ones (#76220)", async () => {
+    await withTempDir({ prefix: "openclaw-orphan-sweep-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const referencedId = "session-active";
+      const orphanedId = "session-orphaned";
+      const referencedTranscript = path.join(dir, `${referencedId}.jsonl`);
+      const orphanedTranscript = path.join(dir, `${orphanedId}.jsonl`);
+      const store: Record<string, SessionEntry> = {
+        "agent:main:main": {
+          sessionId: referencedId,
+          updatedAt: Date.now(),
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(referencedTranscript, "active transcript data", "utf-8");
+      await fs.writeFile(orphanedTranscript, "orphaned transcript data", "utf-8");
+
+      const result = await sweepOrphanedSessionArtifacts({ store, storePath });
+
+      await expect(fs.stat(referencedTranscript)).resolves.toBeDefined();
+      await expect(fs.stat(orphanedTranscript)).rejects.toThrow();
+      expect(result.removedFiles).toBe(1);
+      expect(result.freedBytes).toBeGreaterThan(0);
+    });
+  });
+
+  it("does not remove files in dry-run mode (#76220)", async () => {
+    await withTempDir({ prefix: "openclaw-orphan-sweep-dry-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const orphanedTranscript = path.join(dir, "orphan.jsonl");
+      const store: Record<string, SessionEntry> = {};
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(orphanedTranscript, "orphaned", "utf-8");
+
+      const result = await sweepOrphanedSessionArtifacts({ store, storePath, dryRun: true });
+
+      await expect(fs.stat(orphanedTranscript)).resolves.toBeDefined();
+      expect(result.removedFiles).toBe(1);
+    });
+  });
+
+  it("preserves archive backup files even when not referenced by index (#76220)", async () => {
+    await withTempDir({ prefix: "openclaw-orphan-sweep-arch-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const archiveBackup = path.join(
+        dir,
+        `orphan.jsonl.deleted.${formatSessionArchiveTimestamp(Date.now() - 1000)}`,
+      );
+      const store: Record<string, SessionEntry> = {};
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(archiveBackup, "archive data", "utf-8");
+
+      const result = await sweepOrphanedSessionArtifacts({ store, storePath });
+
+      await expect(fs.stat(archiveBackup)).resolves.toBeDefined();
+      expect(result.removedFiles).toBe(0);
     });
   });
 });

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -424,3 +424,63 @@ export async function enforceSessionDiskBudget(params: {
     overBudget: true,
   };
 }
+
+export type OrphanSweepResult = {
+  removedFiles: number;
+  freedBytes: number;
+};
+
+/**
+ * Remove session artifact files in `sessionsDir` that are not referenced by any entry in `store`.
+ * Covers primary transcripts (`.jsonl`), trajectory pointers (`.trajectory-path.json`),
+ * trajectory files, and compaction checkpoint transcripts.  Archive backups (`.jsonl.deleted.*`,
+ * `.jsonl.bak-*`) are intentionally left alone — they are managed by the archive retention path.
+ *
+ * This is the companion to index-entry pruning: when entries are removed (by age or count caps),
+ * normal gateway writes archive the linked transcripts, but files orphaned before that write
+ * (e.g. by a crash or a prior bug) accumulate indefinitely.  This sweep catches them.
+ */
+export async function sweepOrphanedSessionArtifacts(params: {
+  store: Record<string, SessionEntry>;
+  storePath: string;
+  dryRun?: boolean;
+  log?: SessionDiskBudgetLogger;
+}): Promise<OrphanSweepResult> {
+  const sessionsDir = path.dirname(params.storePath);
+  const log = params.log ?? NOOP_LOGGER;
+  const dryRun = params.dryRun === true;
+
+  const files = await readSessionsDirFiles(sessionsDir);
+  const referencedPaths = resolveReferencedSessionArtifactPaths({
+    sessionsDir,
+    store: params.store,
+  });
+
+  let removedFiles = 0;
+  let freedBytes = 0;
+  for (const file of files) {
+    const isSessionArtifact =
+      isPrimarySessionTranscriptFileName(file.name) ||
+      isTrajectorySessionArtifactName(file.name) ||
+      isCompactionCheckpointTranscriptFileName(file.name);
+    if (!isSessionArtifact || referencedPaths.has(file.canonicalPath)) {
+      continue;
+    }
+    if (!dryRun) {
+      await fs.promises.rm(file.path, { force: true }).catch(() => undefined);
+    }
+    removedFiles += 1;
+    freedBytes += file.size;
+  }
+
+  if (removedFiles > 0) {
+    log.info("swept orphaned session artifact files", {
+      sessionsDir,
+      removedFiles,
+      freedBytes,
+      dryRun,
+    });
+  }
+
+  return { removedFiles, freedBytes };
+}


### PR DESCRIPTION
Fixes #76220.

## What

`sessions cleanup` walks the index and removes entries, but never removed the
corresponding on-disk artifact files when entries were pruned by age
(`pruneAfter`) or count (`maxEntries`).  Files orphaned by earlier runs, crashes,
or prior bugs accumulated indefinitely, causing large sessions directories that
wedge the gateway on APFS and other filesystems sensitive to directory size.

## How

**`src/config/sessions/disk-budget.ts`**
- Add `sweepOrphanedSessionArtifacts(params)`:
  - Read all files in the sessions directory via the existing
    `readSessionsDirFiles` helper.
  - Compute the referenced path set via the existing
    `resolveReferencedSessionArtifactPaths` helper (covers primary `.jsonl`,
    trajectory sidecars, and compaction checkpoints).
  - Delete files whose names match `isPrimarySessionTranscriptFileName`,
    `isTrajectorySessionArtifactName`, or
    `isCompactionCheckpointTranscriptFileName` but are not in the referenced
    set.  Archive backups (`.jsonl.deleted.*`, `.jsonl.bak-*`) are intentionally
    skipped — they are managed by the archive retention path.
  - Supports `dryRun: true` for preview without deleting.
- Export `OrphanSweepResult { removedFiles, freedBytes }`.

**`src/config/sessions/cleanup-service.ts`**
- Import `sweepOrphanedSessionArtifacts`.
- Add `orphanedArtifacts` field to `SessionCleanupSummary`.
- `previewStoreCleanup`: run sweep in dry-run mode and fold its count into
  `wouldMutate`.
- `runSessionsCleanup` (apply path): run sweep against the post-maintenance
  store (so entries pruned in this same run are already excluded from the
  referenced set).

**`src/commands/sessions-cleanup.ts`**
- Text output: print removed file count when non-zero.
- JSON output: `orphanedArtifacts` appears automatically in the summary.

## Tests

Three new tests in `src/config/sessions/disk-budget.test.ts`:
1. Deletes unreferenced primary transcript; preserves referenced one.
2. Dry-run: reports count without deleting.
3. Archive backups untouched even when not in index.

All 8 tests pass (5 original + 3 new).  `oxlint` clean.