### PR TITLE
[codex] Fallback when Windows gateway task exits early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - **Plugin module identity:** keep OpenClaw package chunks on Node's native module graph when jiti transforms plugin entries, preventing duplicate evaluation and class identity drift. (#88384) Thanks @vincentkoc.
 - **Shell completion repair:** generate core-only caches during doctor and update repair while preserving full plugin command completion for onboarding and explicit user rebuilds. (#76235)
 - **MCP schema diagnostics:** attribute draft-2020-12 compiler failures to the external MCP schema so malformed patterns produce actionable setup errors. Thanks @vincentkoc.
+- **Windows Scheduled Task recovery:** keep clean early exits inside the existing bounded launch poll, falling back only when neither the task process nor Gateway listener becomes observable. (#76245)
 - **iMessage group warnings:** suppress the false drop-all startup warning when an effective group sender allowlist can admit groups, and point true empty-allowlist configurations at the correct remedy. (#100046)
 - **Control UI mobile login:** keep Gateway recovery guidance visible after connection failures, make the disconnected gate scroll safely on constrained screens, and improve mobile keyboard and tap-target behavior. (#100208)
 

--- a/package.json
+++ b/package.json
@@ -1936,7 +1936,7 @@
     "test:unit:fast:audit": "node scripts/test-unit-fast-audit.mjs",
     "test:voicecall:closedloop": "node scripts/test-voicecall-closedloop.mjs",
     "test:watch": "node scripts/test-projects.mjs --watch",
-    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
+    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts src/daemon/schtasks.startup-fallback.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
     "tool-display:check": "node --import tsx scripts/tool-display.ts --check",
     "tool-display:write": "node --import tsx scripts/tool-display.ts --write",
     "ts-topology": "node --import tsx scripts/ts-topology.ts",

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -165,6 +165,12 @@ function notYetRunTaskQueryOutput() {
   ].join("\r\n");
 }
 
+function cleanExitTaskQueryOutput() {
+  return ["Status: Ready", "Last Run Time: 5/2/2026 2:41:39 PM", "Last Run Result: 0", ""].join(
+    "\r\n",
+  );
+}
+
 beforeEach(() => {
   resetSchtasksBaseMocks();
   findVerifiedGatewayListenerPidsOnPortSync.mockReset();
@@ -248,6 +254,22 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       fastForwardTaskStartWait();
       addAcceptedRunNeverStartsResponses();
+
+      await installGatewayScheduledTask(env);
+
+      expectStartupFallbackSpawn();
+    });
+  });
+
+  it("launches through the Startup-style launcher when schtasks /Run exits cleanly without a listener", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      fastForwardTaskStartWait();
+      addStartupFallbackMissingResponses([
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: cleanExitTaskQueryOutput(), stderr: "" },
+      ]);
 
       await installGatewayScheduledTask(env);
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -257,6 +257,21 @@ function notYetRunTaskQueryOutput() {
   ].join("\r\n");
 }
 
+function cleanExitTaskQueryOutput(lastRunTime = "5/2/2026 2:41:39 PM") {
+  return ["Status: Ready", `Last Run Time: ${lastRunTime}`, "Last Run Result: 0", ""].join("\r\n");
+}
+
+function addAcceptedRunCleanExitResponses(initialOutput = cleanExitTaskQueryOutput()): void {
+  addStartupFallbackMissingResponses([
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: initialOutput, stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: cleanExitTaskQueryOutput(), stderr: "" },
+  ]);
+}
+
 beforeEach(() => {
   resetSchtasksBaseMocks();
   findVerifiedGatewayListenerPidsOnPortSync.mockReset();
@@ -389,6 +404,51 @@ describe("Windows startup fallback", () => {
       await installGatewayScheduledTask(env);
 
       expectStartupFallbackSpawn();
+    });
+  });
+
+  it("falls back after an accepted task exits cleanly without launch evidence", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      fastForwardTaskStartWait();
+      addAcceptedRunCleanExitResponses();
+
+      await installGatewayScheduledTask(env);
+
+      expectStartupFallbackSpawn();
+    });
+  });
+
+  it("falls back when Task Scheduler records a fresh clean exit without launch evidence", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      fastForwardTaskStartWait();
+      addAcceptedRunCleanExitResponses(cleanExitTaskQueryOutput("5/2/2026 2:40:00 PM"));
+
+      await installGatewayScheduledTask(env);
+
+      expectStartupFallbackSpawn();
+    });
+  });
+
+  it("keeps polling when an accepted task transitions from not-yet-run to clean exit", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      fastForwardTaskStartWait();
+      addAcceptedRunCleanExitResponses(notYetRunTaskQueryOutput());
+
+      await installGatewayScheduledTask(env);
+
+      expectStartupFallbackSpawn();
+    });
+  });
+
+  it("does not fall back when a listener appears after the clean task exit", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      fastForwardTaskStartWait();
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValueOnce([]).mockReturnValue([4242]);
+      addAcceptedRunCleanExitResponses();
+
+      await installGatewayScheduledTask(env);
+
+      expect(spawn).not.toHaveBeenCalled();
     });
   });
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -782,7 +782,7 @@ describe("Windows startup fallback", () => {
       });
 
       const runtime = await readScheduledTaskRuntime(nodeEnv);
-      expect(runtime.status).toBe("unknown");
+      expect(runtime.status).not.toBe("running");
       expect(runtime.pid).toBeUndefined();
       expect(inspectPortUsage).not.toHaveBeenCalled();
     });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -225,6 +225,7 @@ const UNKNOWN_STATUS_DETAIL =
   "Task status is locale-dependent and no numeric Last Run Result was available.";
 const SCHEDULED_TASK_FALLBACK_POLL_MS = 250;
 const SCHEDULED_TASK_FALLBACK_TIMEOUT_MS = 15_000;
+const SCHEDULED_TASK_EARLY_EXIT_FALLBACK_TIMEOUT_MS = 2_000;
 
 export function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
   status: GatewayServiceRuntime["status"];
@@ -673,7 +674,7 @@ async function shouldFallbackScheduledTaskLaunch(params: {
   scriptPath: string;
 }): Promise<boolean> {
   const readLaunchObservation = async (): Promise<{
-    state: "running" | "not-yet-run" | "other";
+    state: "running" | "not-yet-run" | "stopped-success" | "other";
     signature: string;
   }> => {
     const runtime = await readScheduledTaskRuntime(params.env).catch(() => null);
@@ -689,6 +690,14 @@ async function shouldFallbackScheduledTaskLaunch(params: {
     if (normalizedResult && NOT_YET_RUN_RESULT_CODES.has(normalizedResult)) {
       return {
         state: "not-yet-run",
+        signature: [runtime?.state, runtime?.lastRunTime, runtime?.lastRunResult, runtime?.detail]
+          .filter(Boolean)
+          .join("|"),
+      };
+    }
+    if (normalizedResult === "0x0") {
+      return {
+        state: "stopped-success",
         signature: [runtime?.state, runtime?.lastRunTime, runtime?.lastRunResult, runtime?.detail]
           .filter(Boolean)
           .join("|"),
@@ -781,6 +790,27 @@ async function shouldFallbackScheduledTaskLaunch(params: {
   };
 
   const initial = await readLaunchObservation();
+  if (initial.state === "stopped-success") {
+    const deadline = Date.now() + SCHEDULED_TASK_EARLY_EXIT_FALLBACK_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (await hasLaunchEvidence()) {
+        return false;
+      }
+      await sleep(SCHEDULED_TASK_FALLBACK_POLL_MS);
+      if (Date.now() >= deadline) {
+        break;
+      }
+      const current = await readLaunchObservation();
+      if (current.state === "running" || current.state === "not-yet-run") {
+        return false;
+      }
+      if (current.state !== "stopped-success") {
+        return false;
+      }
+    }
+    return !(await hasLaunchEvidence());
+  }
+
   if (initial.state !== "not-yet-run") {
     return false;
   }

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1099,7 +1099,7 @@ async function shouldFallbackScheduledTaskLaunch(params: {
   scriptPath: string;
 }): Promise<boolean> {
   const readLaunchObservation = async (): Promise<{
-    state: "running" | "not-yet-run" | "other";
+    state: "running" | "not-yet-run" | "stopped-success" | "other";
     signature: string;
   }> => {
     const runtime = await readScheduledTaskRuntime(params.env).catch(() => null);
@@ -1115,6 +1115,14 @@ async function shouldFallbackScheduledTaskLaunch(params: {
     if (normalizedResult && NOT_YET_RUN_RESULT_CODES.has(normalizedResult)) {
       return {
         state: "not-yet-run",
+        signature: [runtime?.state, runtime?.lastRunTime, runtime?.lastRunResult, runtime?.detail]
+          .filter(Boolean)
+          .join("|"),
+      };
+    }
+    if (normalizedResult === "0x0") {
+      return {
+        state: "stopped-success",
         signature: [runtime?.state, runtime?.lastRunTime, runtime?.lastRunResult, runtime?.detail]
           .filter(Boolean)
           .join("|"),
@@ -1186,8 +1194,8 @@ async function shouldFallbackScheduledTaskLaunch(params: {
     });
   };
 
-  const initial = await readLaunchObservation();
-  if (initial.state !== "not-yet-run") {
+  let previous = await readLaunchObservation();
+  if (previous.state !== "not-yet-run" && previous.state !== "stopped-success") {
     return false;
   }
 
@@ -1195,14 +1203,27 @@ async function shouldFallbackScheduledTaskLaunch(params: {
   while (Date.now() < deadline) {
     await sleep(SCHEDULED_TASK_FALLBACK_POLL_MS);
     const current = await readLaunchObservation();
-    if (current.state !== "not-yet-run") {
+    if (current.state !== "not-yet-run" && current.state !== "stopped-success") {
       return false;
     }
-    if (current.signature !== initial.signature) {
+    if (
+      current.state === "not-yet-run" &&
+      previous.state === "not-yet-run" &&
+      current.signature !== previous.signature
+    ) {
+      return false;
+    }
+    // A queued task may finish cleanly before its process/listener becomes observable.
+    // Keep that transition inside this bounded poll; the reverse means a new run is starting.
+    if (previous.state === "stopped-success" && current.state === "not-yet-run") {
+      return false;
+    }
+    previous = current;
+    if (await hasLaunchEvidence()) {
       return false;
     }
   }
-  return !(await hasLaunchEvidence());
+  return true;
 }
 
 async function runScheduledTaskOrThrow(params: {


### PR DESCRIPTION
## Summary

Adds a Windows scheduled-task fallback for the failure shape from Brad's workshop log: `schtasks /Run` is accepted, but the task quickly reports `Last Run Result=0` / stopped and no gateway listener appears.

Previously the fallback only handled the "accepted but never starts" state (`0x41303`). This extends it to the early clean-exit/no-listener case by briefly polling for launch evidence, then launching the gateway script directly via the existing Startup-style detached fallback.

## Validation

- `pnpm exec vitest run src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.test.ts`
- `pnpm exec oxlint src/daemon/schtasks.ts src/daemon/schtasks.startup-fallback.test.ts`
