### PR TITLE
docs: link Copilot model availability

### DIFF
--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -99,7 +99,9 @@ back to `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, then `GITHUB_TOKEN`. Use
 
   <Accordion title="Model availability depends on your plan">
     Copilot model availability depends on your GitHub plan. If a model is
-    rejected, try another ID (for example `github-copilot/gpt-4.1`).
+    rejected, try another ID (for example `github-copilot/gpt-4.1`). See
+    GitHub's [supported models per Copilot plan](https://docs.github.com/en/copilot/reference/ai-models/supported-models#supported-ai-models-per-copilot-plan)
+    for the current model list.
   </Accordion>
 
   <Accordion title="Transport selection">


### PR DESCRIPTION
## Summary

- Problem: The GitHub Copilot provider docs mentioned that model availability depends on the user's GitHub plan, but did not link to the official model availability table.
- Why it matters: Users need a reliable source to check which Copilot models are available for their plan.
- What changed: Added a link to GitHub's official supported models per Copilot plan documentation.
- What did NOT change (scope boundary): No runtime behavior, configuration, authentication, token handling, or model selection logic was changed.

AI-assisted: yes. I used ChatGPT to help with wording and reviewed the final change myself.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: Documentation-only change.

## User-visible / Behavior Changes

Users reading the GitHub Copilot provider docs now have a direct link to GitHub's official supported models per Copilot plan documentation.

## Diagram (if applicable)

N/A

```text
Before:
[user reads Copilot model availability note] -> [no official model list link]

After:
[user reads Copilot model availability note] -> [opens official GitHub model availability table]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Pop!_OS / Linux
- Runtime/container: N/A
- Model/provider: GitHub Copilot
- Integration/channel (if any): GitHub Copilot provider docs
- Relevant config (redacted): N/A

### Steps

1. Open `docs/providers/github-copilot.md`.
2. Review the "Model availability depends on your plan" accordion.
3. Confirm the note links to GitHub's supported models per Copilot plan documentation.

### Expected

- The Copilot model availability note links to GitHub's official supported model list.

### Actual

- The Copilot model availability note links to GitHub's official supported model list.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Documentation-only change; verified via local `git diff`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed the Markdown diff locally and confirmed the Copilot model availability note includes the official GitHub documentation link.
- Edge cases checked: Confirmed no runtime code, configuration, authentication, token handling, or model selection logic changed.
- What you did **not** verify: I did not run the full test suite because this is a documentation-only change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.