### PR TITLE
fix(agents): ingest CLI turns into the context engine

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -14,8 +14,10 @@ import {
 
 function buildContextEngine(params: {
   compactCalls: Array<Parameters<ContextEngine["compact"]>[0]>;
+  afterTurnCalls?: Array<Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]>;
+  afterTurnThrows?: boolean;
 }): ContextEngine {
-  return {
+  const engine: ContextEngine = {
     info: {
       id: "legacy",
       name: "Legacy Context Engine",
@@ -39,6 +41,15 @@ function buildContextEngine(params: {
       };
     },
   };
+  if (params.afterTurnCalls) {
+    engine.afterTurn = async (afterTurnParams) => {
+      params.afterTurnCalls?.push(afterTurnParams);
+      if (params.afterTurnThrows) {
+        throw new Error("simulated ingest failure");
+      }
+    };
+  }
+  return engine;
 }
 
 async function writeSessionFile(params: { sessionFile: string; sessionId: string }) {
@@ -166,5 +177,207 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(updatedEntry?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
     expect(updatedEntry?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(updatedEntry?.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("ingests the just-completed CLI turn into the context engine via afterTurn", async () => {
+    const sessionKey = "agent:main:cli";
+    // Use SessionManager.create + appendMessage so the on-disk file is
+    // SessionManager-readable. writeSessionFile() above produces a format
+    // the existing compaction test tolerates only because that test mocks the
+    // message-consuming code path; my ingest path actually reads getBranch().
+    const sm = SessionManager.create(tmpDir, tmpDir);
+    sm.appendMessage({ role: "user", content: "hi", timestamp: 1 });
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 2,
+    });
+    const sessionFile = sm.getSessionFile();
+    const sessionId = sm.getSessionId();
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 100,
+      totalTokensFresh: true,
+    };
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const afterTurnCalls: Array<Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]> = [];
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls, afterTurnCalls }),
+      createPreparedEmbeddedPiSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      // No compaction needed (under budget).
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 100,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: vi.fn(),
+    });
+
+    await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    // Ingest must run regardless of compaction outcome.
+    expect(afterTurnCalls).toHaveLength(1);
+    expect(afterTurnCalls[0]).toMatchObject({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget: 1_000,
+    });
+    // Two messages on disk; prePromptMessageCount = 0 means both are "new"
+    // (writeSessionFile created exactly the user prompt + assistant reply).
+    expect(afterTurnCalls[0]?.messages).toHaveLength(2);
+    expect(afterTurnCalls[0]?.prePromptMessageCount).toBe(0);
+    // No compaction this turn — under budget.
+    expect(compactCalls).toHaveLength(0);
+  });
+
+  it("ingests even when contextTokens budget is unset (skips compaction but feeds the engine)", async () => {
+    const sessionKey = "agent:main:cli";
+    const sm = SessionManager.create(tmpDir, tmpDir);
+    sm.appendMessage({ role: "user", content: "hi", timestamp: 1 });
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 2,
+    });
+    const sessionFile = sm.getSessionFile();
+    const sessionId = sm.getSessionId();
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      // contextTokens deliberately omitted — no compaction will run.
+    };
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const afterTurnCalls: Array<Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]> = [];
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls, afterTurnCalls }),
+    });
+
+    await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    // Ingest fires even with no token budget configured.
+    expect(afterTurnCalls).toHaveLength(1);
+    // Compaction is skipped (no budget).
+    expect(compactCalls).toHaveLength(0);
+  });
+
+  it("does not crash when afterTurn throws — ingest failure must not break the CLI return path", async () => {
+    const sessionKey = "agent:main:cli";
+    const sm = SessionManager.create(tmpDir, tmpDir);
+    sm.appendMessage({ role: "user", content: "hi", timestamp: 1 });
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 2,
+    });
+    const sessionFile = sm.getSessionFile();
+    const sessionId = sm.getSessionId();
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+
+    const afterTurnCalls: Array<Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]> = [];
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () =>
+        buildContextEngine({ compactCalls: [], afterTurnCalls, afterTurnThrows: true }),
+    });
+
+    // Should resolve without throwing.
+    await expect(
+      runCliTurnCompactionLifecycle({
+        cfg: {} as OpenClawConfig,
+        sessionId,
+        sessionKey,
+        sessionEntry,
+        sessionAgentId: "main",
+        workspaceDir: tmpDir,
+        agentDir: tmpDir,
+        provider: "claude-cli",
+        model: "opus",
+      }),
+    ).resolves.not.toThrow();
+
+    expect(afterTurnCalls).toHaveLength(1);
+  });
+
+  it("skips ingest when context engine has no afterTurn implementation", async () => {
+    const sessionKey = "agent:main:cli";
+    const sm = SessionManager.create(tmpDir, tmpDir);
+    sm.appendMessage({ role: "user", content: "hi", timestamp: 1 });
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 2,
+    });
+    const sessionFile = sm.getSessionFile();
+    const sessionId = sm.getSessionId();
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+    };
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    setCliCompactionTestDeps({
+      // No afterTurnCalls => engine returned has no afterTurn method.
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+    });
+
+    await expect(
+      runCliTurnCompactionLifecycle({
+        cfg: {} as OpenClawConfig,
+        sessionId,
+        sessionKey,
+        sessionEntry,
+        sessionAgentId: "main",
+        workspaceDir: tmpDir,
+        agentDir: tmpDir,
+        provider: "claude-cli",
+        model: "opus",
+      }),
+    ).resolves.not.toThrow();
+    // Compaction is skipped (no budget) and afterTurn doesn't exist — no calls anywhere.
+    expect(compactCalls).toHaveLength(0);
   });
 });

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -192,12 +192,47 @@ export async function runCliTurnCompactionLifecycle(params: {
 }): Promise<SessionEntry | undefined> {
   const sessionFile = params.sessionEntry?.sessionFile;
   const contextTokenBudget = resolvePositiveInteger(params.sessionEntry?.contextTokens);
-  if (!sessionFile || !contextTokenBudget) {
+  if (!sessionFile) {
     return params.sessionEntry;
   }
 
   const contextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
   const sessionManager = cliCompactionDeps.openSessionManager(sessionFile);
+
+  // Ingest the just-completed CLI turn into the context engine. Without this,
+  // CLI-backed agents never feed the context-engine plugin (e.g. Lossless-Claw),
+  // so retrieval tools like lcm_grep / lcm_describe can never recall anything
+  // across turns. The embedded runner already ingests via
+  // tool-result-context-guard; this closes the gap for CLI runs.
+  // Runs even when contextTokenBudget is unset, since ingest is independent of
+  // compaction. Wrapped in try/catch so engine failures never break the CLI
+  // return path.
+  try {
+    const messages = getSessionBranchMessages(sessionManager);
+    if (messages.length > 0 && typeof contextEngine.afterTurn === "function") {
+      await contextEngine.afterTurn({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile,
+        messages,
+        // persistCliTurnTranscript ran immediately before; the just-appended
+        // user prompt + assistant reply are the last two messages on disk.
+        prePromptMessageCount: Math.max(0, messages.length - 2),
+        tokenBudget: contextTokenBudget,
+      });
+    }
+  } catch (error) {
+    log.warn(
+      `CLI turn ingest failed for ${params.provider}/${params.model}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (!contextTokenBudget) {
+    return params.sessionEntry;
+  }
+
   const settingsManager = await cliCompactionDeps.createPreparedEmbeddedPiSettingsManager({
     cwd: params.workspaceDir,
     agentDir: params.agentDir,


### PR DESCRIPTION
## Summary

CLI-backed agents currently never feed the context-engine plugin. They invoke `runCliTurnCompactionLifecycle`, which only calls `compact()` — never `ingest()` or `afterTurn()`. As a result, compaction no-ops because the engine has no knowledge of the just-completed turn, and recall tools (e.g. `lcm_grep`, `lcm_describe` in the Lossless-Claw plugin) return empty across sessions.

The embedded runner already feeds the engine via `tool-result-context-guard.installContextEngineLoopHook`. This PR closes the same gap for CLI runs.

## Changes

`src/agents/command/cli-compaction.ts`:
- Splits the early-return that gated on both `sessionFile` AND `contextTokenBudget`. Ingest now runs even when no token budget is configured (compaction still requires one).
- Calls `contextEngine.afterTurn(...)` with `prePromptMessageCount = total - 2` so only the most recent user prompt + assistant reply are ingested per turn (`persistCliTurnTranscript` ran immediately before, appending exactly those two).
- Wraps the ingest in try/catch so engine failures never break the CLI return path; failures are logged via the existing `agents/cli-compaction` subsystem.

`src/agents/command/cli-compaction.test.ts`:
- Existing compaction test continues to pass.
- Adds four new tests covering:
  - Ingest fires on a normal turn, with correct `prePromptMessageCount`.
  - Ingest fires even when `contextTokens` is unset (compaction is skipped, ingest is not).
  - `afterTurn` throwing is logged and swallowed — return path is preserved.
  - Engines without an `afterTurn` implementation are silently skipped.

The new tests use `SessionManager.create()` + `appendMessage()` to set up a SessionManager-readable session file, since the existing `writeSessionFile` helper writes a JSONL format that bypasses message parsing (the existing test mocks `shouldPreemptivelyCompactBeforePrompt`, so it never actually consumed messages).

## Verification

Tested end-to-end against a live gateway with the Lossless-Claw plugin enabled (`@martian-engineering/lossless-claw`):

```
Pre:  conversations:0 messages:0 message_parts:0
[run a fresh CLI agent turn]
Post: conversations:1 messages:2 message_parts:2
```

Test command:
```
$ pnpm exec vitest run src/agents/command/cli-compaction.test.ts
Tests  10 passed (10)
```

## Test plan
- [x] Unit tests pass for happy path, no-budget, throw, no-afterTurn cases
- [x] Live gateway test: fresh CLI agent run lands a row in Lossless-Claw's SQLite store
- [ ] Reviewed by maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)