### PR TITLE
fix(doctor): clarify mcp allowlist diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Doctor/config: identify allowlisted MCP tool patterns from configured `mcp.servers.*` entries, so restrictive tool policies no longer report them as generic missing plugin tools. Thanks @ecochran76.
 - Codex/app-server: resolve managed binaries from bundled `dist` chunks and from the `@openai/codex` package bin when installs do not provide a nearby `.bin/codex` shim, avoiding false missing-binary startup failures.
 - Plugins/ClawHub: use the ClawHub artifact resolver response as the install decision before downloading, keeping legacy ZIP fallback and future ClawPack npm-pack installs on the same explicit resolver path. Thanks @vincentkoc.
 - Plugins/ClawHub: keep bare plugin package specs on npm for the launch cutover and reserve ClawHub resolution for explicit `clawhub:` specs until ClawHub pack readiness is deployed. Thanks @vincentkoc.

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -74,6 +74,7 @@ describe("tool-policy-pipeline", () => {
     });
     expect(warnings.length).toBe(1);
     expect(warnings[0]).toContain("unknown entries (wat)");
+    expect(warnings[0]).toContain("plugin or MCP server is enabled and connected");
   });
 
   test("suppresses built-in profile warnings for unavailable gated core tools", () => {

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -179,7 +179,7 @@ function describeUnknownAllowlistSuffix(params: {
       ? "Some entries are shipped core tools but unavailable in the current runtime/provider/model/config; other entries won't match any tool unless the plugin is enabled."
       : params.hasGatedCoreEntries
         ? "These entries are shipped core tools but unavailable in the current runtime/provider/model/config."
-        : "These entries won't match any tool unless the plugin is enabled.";
+        : "These entries won't match any tool unless the plugin or MCP server is enabled and connected.";
   return preface ? `${preface} ${detail}` : detail;
 }
 

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
@@ -87,6 +87,35 @@ describe("collectPluginToolAllowlistWarnings", () => {
     ]);
   });
 
+  it("warns when a configured MCP server tool pattern is unavailable under restrictive plugins.allow", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        plugins: { allow: ["slack", "openai"] },
+        mcp: {
+          servers: {
+            messaging: {
+              command: "messaging-mcp",
+              args: ["mcp"],
+            },
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "support-agent",
+              tools: { alsoAllow: ["messaging__*"] },
+            },
+          ],
+        },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toEqual([
+      '- agents.list[0].tools.alsoAllow references MCP tool pattern "messaging__*" for configured mcp.servers.messaging. If it is unavailable at runtime, make sure bundle MCP is not denied by tool policy and the MCP server starts cleanly.',
+    ]);
+  });
+
   it("does not warn when the owning plugin is allowed", () => {
     const warnings = collectPluginToolAllowlistWarnings({
       cfg: {

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
@@ -1,3 +1,4 @@
+import { sanitizeServerName, TOOL_NAME_SEPARATOR } from "../../../agents/pi-bundle-mcp-names.js";
 import { normalizeToolName } from "../../../agents/tool-policy-shared.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizePluginId } from "../../../plugins/config-state.js";
@@ -92,6 +93,25 @@ function collectKnownPluginIds(registry: PluginManifestRegistry): Set<string> {
   return new Set(registry.plugins.map((plugin) => normalizePluginId(plugin.id)));
 }
 
+function collectConfiguredMcpServerNames(cfg: OpenClawConfig): Map<string, string> {
+  const servers = hasRecord(cfg.mcp) && hasRecord(cfg.mcp.servers) ? cfg.mcp.servers : undefined;
+  const result = new Map<string, string>();
+  const usedNames = new Set<string>();
+  for (const serverName of Object.keys(servers ?? {})) {
+    const safeName = sanitizeServerName(serverName, usedNames);
+    result.set(normalizeToolName(safeName), serverName);
+  }
+  return result;
+}
+
+function extractMcpServerPrefix(toolName: string): string | undefined {
+  const separatorIndex = toolName.indexOf(TOOL_NAME_SEPARATOR);
+  if (separatorIndex <= 0) {
+    return undefined;
+  }
+  return toolName.slice(0, separatorIndex);
+}
+
 function formatPluginList(pluginIds: readonly string[]): string {
   if (pluginIds.length === 1) {
     return `"${pluginIds[0]}"`;
@@ -153,8 +173,10 @@ export function collectPluginToolAllowlistWarnings(params: {
     }).manifestRegistry;
   const knownPluginIds = collectKnownPluginIds(registry);
   const toolOwners = collectToolOwners(registry);
+  const configuredMcpServers = collectConfiguredMcpServerNames(params.cfg);
   const missingPluginIssues = new Map<string, Set<string>>();
   const missingToolOwnerIssues = new Map<string, Set<string>>();
+  const mcpServerToolIssues = new Map<string, Set<string>>();
 
   for (const { source, entry } of exactEntries) {
     const pluginId = normalizePluginId(entry);
@@ -168,6 +190,16 @@ export function collectPluginToolAllowlistWarnings(params: {
     );
     if (owners.length > 0 && owners.length === (toolOwners.get(entry) ?? []).length) {
       addIssue(missingToolOwnerIssues, `${entry}\u0000${owners.join("\u0000")}`, source);
+      continue;
+    }
+
+    const mcpServerPrefix = extractMcpServerPrefix(entry);
+    if (mcpServerPrefix && configuredMcpServers.has(mcpServerPrefix)) {
+      addIssue(
+        mcpServerToolIssues,
+        `${entry}\u0000${configuredMcpServers.get(mcpServerPrefix)}`,
+        source,
+      );
     }
   }
 
@@ -188,6 +220,18 @@ export function collectPluginToolAllowlistWarnings(params: {
     }
     warnings.push(
       `- ${formatSourceLabels(issueSources)} references tool "${toolName}", owned by plugin ${formatPluginList(ownerPluginIds)}, but plugins.allow does not include the owning plugin. Add ${formatPluginList(ownerPluginIds)} to plugins.allow or remove plugins.allow.`,
+    );
+  }
+
+  for (const [issueKey, issueSources] of [...mcpServerToolIssues.entries()].toSorted(
+    (left, right) => left[0].localeCompare(right[0]),
+  )) {
+    const [toolName, serverName] = issueKey.split("\u0000");
+    if (!toolName || !serverName) {
+      continue;
+    }
+    warnings.push(
+      `- ${formatSourceLabels(issueSources)} references MCP tool pattern "${toolName}" for configured mcp.servers.${serverName}. If it is unavailable at runtime, make sure bundle MCP is not denied by tool policy and the MCP server starts cleanly.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Doctor/tool-policy diagnostics can currently misclassify allowlisted MCP tool name patterns as generic missing plugin tools, even when the corresponding `mcp.servers.<name>` entry is configured.

This PR makes the diagnostics recognize configured MCP server prefixes using the same sanitized server-name convention as bundle MCP tool names. When a restrictive tool allowlist references a configured MCP server pattern such as `messaging__*`, doctor now reports MCP-specific guidance instead of only saying the plugin may be disabled.

## Scope

- Recognize configured `mcp.servers.*` prefixes in doctor allowlist warnings.
- Update the generic unknown-tool suffix to mention MCP servers as well as plugins.
- Add focused tests for the doctor warning and tool-policy warning wording.

## Non-goals

- Does not start MCP servers.
- Does not change runtime MCP materialization.
- Does not broaden tool permissions.
- Does not change plugin allow semantics.
- Does not change generated config schema or docs baselines.

## Security

Diagnostics-only. This does not expose new tools, add permissions, alter credential handling, or change MCP process startup behavior.

## Validation

```sh
pnpm test src/agents/tool-policy-pipeline.test.ts src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/tool-policy-pipeline.ts src/agents/tool-policy-pipeline.test.ts src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
git diff --check
```
