### PR TITLE
Add Android APK GitHub workflows

### DIFF
--- a/.github/workflows/android-apk-build.yml
+++ b/.github/workflows/android-apk-build.yml
@@ -1,0 +1,176 @@
+name: Android APK Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: "Android flavor to build"
+        required: true
+        default: "thirdParty"
+        type: choice
+        options:
+          - play
+          - thirdParty
+      build_type:
+        description: "Build type"
+        required: true
+        default: "debug"
+        type: choice
+        options:
+          - debug
+          - release
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/android-apk-build.yml"
+      - "apps/android/**"
+      - "apps/shared/**"
+      - "package.json"
+      - "bun.lock"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-apk-build-${{ github.ref }}-${{ github.event.inputs.variant || 'thirdParty' }}-${{ github.event.inputs.build_type || 'debug' }}
+  cancel-in-progress: true
+
+jobs:
+  build-apk:
+    name: Build ${{ github.event.inputs.variant || 'thirdParty' }} ${{ github.event.inputs.build_type || 'debug' }} APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
+      ANDROID_HOME: /usr/local/lib/android/sdk
+      OPENCLAW_ANDROID_STORE_FILE: ${{ secrets.OPENCLAW_ANDROID_STORE_FILE }}
+      OPENCLAW_ANDROID_STORE_PASSWORD: ${{ secrets.OPENCLAW_ANDROID_STORE_PASSWORD }}
+      OPENCLAW_ANDROID_KEY_ALIAS: ${{ secrets.OPENCLAW_ANDROID_KEY_ALIAS }}
+      OPENCLAW_ANDROID_KEY_PASSWORD: ${{ secrets.OPENCLAW_ANDROID_KEY_PASSWORD }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          yes | sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null
+          sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --install \
+            "platform-tools" \
+            "platforms;android-36" \
+            "build-tools;36.0.0"
+
+      - name: Restore Gradle cache
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Configure release signing
+        if: ${{ github.event.inputs.build_type == 'release' }}
+        working-directory: apps/android
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for name in \
+            OPENCLAW_ANDROID_STORE_FILE \
+            OPENCLAW_ANDROID_STORE_PASSWORD \
+            OPENCLAW_ANDROID_KEY_ALIAS \
+            OPENCLAW_ANDROID_KEY_PASSWORD
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is required for release APK builds"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+          mkdir -p "$(dirname "$OPENCLAW_ANDROID_STORE_FILE")"
+          if [ -n "${OPENCLAW_ANDROID_KEYSTORE_BASE64:-}" ]; then
+            printf '%s' "$OPENCLAW_ANDROID_KEYSTORE_BASE64" | base64 --decode > "$OPENCLAW_ANDROID_STORE_FILE"
+          fi
+
+          if [ ! -f "$OPENCLAW_ANDROID_STORE_FILE" ]; then
+            echo "::error::Release keystore file does not exist at $OPENCLAW_ANDROID_STORE_FILE"
+            exit 1
+          fi
+
+          {
+            echo "OPENCLAW_ANDROID_STORE_FILE=$OPENCLAW_ANDROID_STORE_FILE"
+            echo "OPENCLAW_ANDROID_STORE_PASSWORD=$OPENCLAW_ANDROID_STORE_PASSWORD"
+            echo "OPENCLAW_ANDROID_KEY_ALIAS=$OPENCLAW_ANDROID_KEY_ALIAS"
+            echo "OPENCLAW_ANDROID_KEY_PASSWORD=$OPENCLAW_ANDROID_KEY_PASSWORD"
+          } >> gradle.properties
+        env:
+          OPENCLAW_ANDROID_KEYSTORE_BASE64: ${{ secrets.OPENCLAW_ANDROID_KEYSTORE_BASE64 }}
+
+      - name: Resolve build task
+        id: task
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          variant="${{ github.event.inputs.variant || 'thirdParty' }}"
+          build_type="${{ github.event.inputs.build_type || 'debug' }}"
+
+          case "$variant:$build_type" in
+            play:debug)
+              task=":app:assemblePlayDebug"
+              output_dir="app/build/outputs/apk/play/debug"
+              ;;
+            thirdParty:debug)
+              task=":app:assembleThirdPartyDebug"
+              output_dir="app/build/outputs/apk/thirdParty/debug"
+              ;;
+            play:release)
+              task=":app:assemblePlayRelease"
+              output_dir="app/build/outputs/apk/play/release"
+              ;;
+            thirdParty:release)
+              task=":app:assembleThirdPartyRelease"
+              output_dir="app/build/outputs/apk/thirdParty/release"
+              ;;
+            *)
+              echo "::error::Unsupported Android APK build target: $variant:$build_type"
+              exit 1
+              ;;
+          esac
+
+          echo "task=$task" >> "$GITHUB_OUTPUT"
+          echo "output_dir=$output_dir" >> "$GITHUB_OUTPUT"
+          echo "variant=$variant" >> "$GITHUB_OUTPUT"
+          echo "build_type=$build_type" >> "$GITHUB_OUTPUT"
+
+      - name: Build APK
+        working-directory: apps/android
+        shell: bash
+        run: ./gradlew --no-daemon --build-cache "${{ steps.task.outputs.task }}"
+
+      - name: Check APK output
+        working-directory: apps/android
+        shell: bash
+        run: |
+          set -euo pipefail
+          find "${{ steps.task.outputs.output_dir }}" -name "*.apk" -type f -print -exec sha256sum {} \;
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openclaw-${{ steps.task.outputs.variant }}-${{ steps.task.outputs.build_type }}-apk
+          path: apps/android/${{ steps.task.outputs.output_dir }}/*.apk
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,0 +1,88 @@
+name: Upstream Watch
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 13 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: upstream-watch
+  cancel-in-progress: false
+
+jobs:
+  check-upstream:
+    name: Check openclaw/openclaw main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out fork
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Fetch upstream
+        shell: bash
+        run: |
+          set -euo pipefail
+          git remote add upstream https://github.com/openclaw/openclaw.git
+          git fetch --no-tags upstream main
+
+      - name: Open issue when fork is behind
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git merge-base --is-ancestor upstream/main HEAD; then
+            echo "Fork includes upstream/main."
+            exit 0
+          fi
+
+          upstream_sha="$(git rev-parse --short=12 upstream/main)"
+          fork_sha="$(git rev-parse --short=12 HEAD)"
+          behind_count="$(git rev-list --count HEAD..upstream/main)"
+          title="OpenClaw upstream update available"
+
+          existing="$(
+            gh issue list \
+              --repo "$REPO" \
+              --state open \
+              --search "$title in:title" \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          body="$(
+            cat <<EOF
+          The fork is behind \`openclaw/openclaw:main\`.
+
+          - Fork HEAD: \`$fork_sha\`
+          - Upstream HEAD: \`$upstream_sha\`
+          - Upstream commits not in this fork: \`$behind_count\`
+
+          Suggested update path:
+
+          \`\`\`bash
+          git remote add upstream https://github.com/openclaw/openclaw.git 2>/dev/null || true
+          git fetch upstream main
+          git checkout main
+          git merge upstream/main
+          git push origin main
+          \`\`\`
+          EOF
+          )"
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+            echo "Updated existing issue #$existing."
+          else
+            gh issue create --repo "$REPO" --title "$title" --body "$body"
+            echo "Created upstream update issue."
+          fi

--- a/apps/android/GITHUB_APK_BUILDS.md
+++ b/apps/android/GITHUB_APK_BUILDS.md
@@ -1,0 +1,37 @@
+# GitHub APK Builds
+
+Use the `Android APK Build` workflow in a fork to build downloadable APK artifacts from GitHub.
+
+## Recommended Fork Setup
+
+1. Fork `openclaw/openclaw` to your GitHub owner, for example `brannum/openclaw`.
+2. Keep `origin` pointed at your fork and add the official repository as `upstream`.
+3. Push these workflow files to the fork's `main` branch.
+4. Open **Actions** > **Android APK Build** > **Run workflow**.
+5. Download the `openclaw-...-apk` artifact from the completed workflow run.
+
+## Build Choices
+
+- `thirdParty` keeps the SMS and call-log features enabled.
+- `play` disables SMS and call-log features for Google Play policy compatibility.
+- `debug` builds are easiest for private sideloading and do not need release signing secrets.
+- `release` builds require a private Android keystore configured through GitHub Secrets.
+
+## Release Signing Secrets
+
+For signed release APKs, add these repository secrets:
+
+- `OPENCLAW_ANDROID_KEYSTORE_BASE64`: optional base64-encoded keystore file content.
+- `OPENCLAW_ANDROID_STORE_FILE`: path where the workflow should write or read the keystore, such as `app/release.keystore`.
+- `OPENCLAW_ANDROID_STORE_PASSWORD`: keystore password.
+- `OPENCLAW_ANDROID_KEY_ALIAS`: signing key alias.
+- `OPENCLAW_ANDROID_KEY_PASSWORD`: signing key password.
+
+Do not commit keystore files or signing passwords to the repository.
+
+## Upstream Updates
+
+The `Upstream Watch` workflow runs daily and compares the fork with `openclaw/openclaw:main`.
+When upstream has commits that are not in the fork, it opens or comments on an issue with the current fork SHA, upstream SHA, and merge commands.
+
+This workflow reports source updates only. Dependency update tools such as Dependabot are still separate from upstream fork tracking.


### PR DESCRIPTION
## Summary
- add a manually runnable Android APK build workflow for play/thirdParty debug/release variants
- upload APK artifacts with SHA-256 logging
- add a fork upstream-watch workflow and APK build instructions

## Verification
- `./gradlew --no-daemon :app:assembleThirdPartyDebug` from `apps/android` passed locally
