### PR TITLE
fix(whatsapp): use per-channel-peer dmScope for inbound direct messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: keep directly requested plugin tools invokable under restrictive tool profiles while preserving explicit deny lists and the HTTP safety deny list, preventing catalog/invoke mismatches that surface as "Tool not available". Thanks @BunsDev.
 - Gateway/update: allow beta binaries to refresh gateway services when the config was last written by the matching stable release version, avoiding false newer-config downgrade blocks during beta channel updates.
 - Channels: keep Matrix and Mattermost bundled in the core package instead of advertising external npm installs before those channels are cut over. Thanks @vincentkoc.
+- Channels/WhatsApp: route inbound direct messages to per-contact session keys (`agent:<agentId>:whatsapp:direct:<peerId>`) instead of collapsing all DMs to the agent main session, so distinct contacts no longer share session files or model context. Thanks @chinar-amrutkar.
 - Bonjour: disable LAN mDNS advertising after a repeated stuck-announcing recovery instead of repeatedly restarting ciao and saturating the Gateway event loop.
 - Channels/setup: label installable channel picker hints as remote npm installs and hide remote install hints for bundled plugins that already ship with OpenClaw.
 - CLI/plugins: stop treating the non-plugin `auth` command root as a bundled plugin id, so restrictive `plugins.allow` configs no longer tell users to add stale `auth` plugin entries.

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -155,8 +155,7 @@ OpenClaw recommends running WhatsApp on a separate number when possible. (The ch
 - Outbound sends require an active WhatsApp listener for the target account.
 - Status and broadcast chats are ignored (`@status`, `@broadcast`).
 - The reconnect watchdog follows WhatsApp Web transport activity, not only inbound app-message volume: quiet linked-device sessions stay up while transport frames continue, but a transport stall forces reconnect well before the later remote disconnect path.
-- Direct chats use DM session rules (`session.dmScope`; default `main` collapses DMs to the agent main session).
-- Group sessions are isolated (`agent:<agentId>:whatsapp:group:<jid>`).
+- Direct chats use per-contact session isolation (`agent:<agentId>:whatsapp:direct:<peerId>`), so distinct contacts do not share session files or model context. Group sessions are isolated (`agent:<agentId>:whatsapp:group:<jid>`).
 - WhatsApp Channels/Newsletters can be explicit outbound targets with their native `@newsletter` JID. Outbound newsletter sends use channel session metadata (`agent:<agentId>:whatsapp:channel:<jid>`) rather than DM session semantics.
 - WhatsApp Web transport honors standard proxy environment variables on the gateway host (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` / lowercase variants). Prefer host-level proxy config over channel-specific WhatsApp proxy settings.
 - When `messages.removeAckAfterReply` is enabled, OpenClaw clears the WhatsApp ack reaction after a visible reply is delivered.

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
@@ -181,4 +181,55 @@ describe("web auto-reply last-route", () => {
 
     await store.cleanup();
   });
+
+  it("uses distinct session keys for different direct chat contacts", async () => {
+    const now = Date.now();
+    const store = await makeSessionStore({});
+
+    const { handler, backgroundTasks } = createLastRouteHarness(store.storePath);
+
+    await handler(
+      buildInboundMessage({
+        id: "m1",
+        from: "+15551112222",
+        conversationId: "+15551112222",
+        chatType: "direct",
+        chatId: "direct:+15551112222",
+        timestamp: now,
+        senderE164: "+15551112222",
+      }),
+    );
+
+    await awaitBackgroundTasks(backgroundTasks);
+
+    const firstCall = updateLastRouteInBackgroundMock.mock.calls[0];
+    const firstSessionKey = firstCall[0]?.sessionKey as string | undefined;
+
+    updateLastRouteInBackgroundMock.mockClear();
+
+    await handler(
+      buildInboundMessage({
+        id: "m2",
+        from: "+15553334444",
+        conversationId: "+15553334444",
+        chatType: "direct",
+        chatId: "direct:+15553334444",
+        timestamp: now + 1,
+        senderE164: "+15553334444",
+      }),
+    );
+
+    await awaitBackgroundTasks(backgroundTasks);
+
+    const secondCall = updateLastRouteInBackgroundMock.mock.calls[0];
+    const secondSessionKey = secondCall[0]?.sessionKey as string | undefined;
+
+    expect(firstSessionKey).toBeDefined();
+    expect(secondSessionKey).toBeDefined();
+    expect(firstSessionKey).not.toBe(secondSessionKey);
+    expect(firstSessionKey).toMatch(/^agent:main:whatsapp:direct:\+15551112222$/);
+    expect(secondSessionKey).toMatch(/^agent:main:whatsapp:direct:\+15553334444$/);
+
+    await store.cleanup();
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -816,7 +816,7 @@ describe("whatsapp inbound dispatch", () => {
     expect(updateLastRoute).toHaveBeenCalledTimes(1);
   });
 
-  it("does not update main last route for isolated DM scope sessions", () => {
+  it("records last-route for per-contact session when using scoped dmScope", () => {
     const updateLastRoute = vi.fn();
 
     updateWhatsAppMainLastRoute({
@@ -826,14 +826,20 @@ describe("whatsapp inbound dispatch", () => {
       dmRouteTarget: "+3000",
       pinnedMainDmRecipient: null,
       route: makeRoute({
-        sessionKey: "agent:main:whatsapp:dm:+1000:peer:+3000",
-        mainSessionKey: "agent:main:whatsapp:direct:+1000",
+        sessionKey: "agent:main:whatsapp:direct:+3000",
+        mainSessionKey: "agent:main:main",
       }),
       updateLastRoute,
       warn: () => {},
     });
 
-    expect(updateLastRoute).not.toHaveBeenCalled();
+    expect(updateLastRoute).toHaveBeenCalledTimes(1);
+    expect(updateLastRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:whatsapp:direct:+3000",
+        to: "+3000",
+      }),
+    );
   });
 
   it("does not update main last route for non-owner sender when main DM scope is pinned", () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -824,7 +824,7 @@ describe("whatsapp inbound dispatch", () => {
       cfg: {} as never,
       ctx: { Body: "hello" },
       dmRouteTarget: "+3000",
-      pinnedMainDmRecipient: null,
+      pinnedMainDmRecipient: "+1000", // owner different from dmRouteTarget
       route: makeRoute({
         sessionKey: "agent:main:whatsapp:direct:+3000",
         mainSessionKey: "agent:main:main",

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -256,6 +256,25 @@ export function updateWhatsAppMainLastRoute(params: {
     return;
   }
 
+  // Record last-route for per-contact session when using scoped dmScope
+  if (
+    params.dmRouteTarget &&
+    params.route.sessionKey !== params.route.mainSessionKey &&
+    shouldUpdateMainLastRoute
+  ) {
+    params.updateLastRoute({
+      cfg: params.cfg,
+      backgroundTasks: params.backgroundTasks,
+      storeAgentId: params.route.agentId,
+      sessionKey: params.route.sessionKey,
+      channel: "whatsapp",
+      to: params.dmRouteTarget,
+      accountId: params.route.accountId,
+      ctx: params.ctx,
+      warn: params.warn,
+    });
+  }
+
   if (
     params.dmRouteTarget &&
     inboundLastRouteSessionKey === params.route.mainSessionKey &&

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -256,12 +256,10 @@ export function updateWhatsAppMainLastRoute(params: {
     return;
   }
 
-  // Record last-route for per-contact session when using scoped dmScope
-  if (
-    params.dmRouteTarget &&
-    params.route.sessionKey !== params.route.mainSessionKey &&
-    shouldUpdateMainLastRoute
-  ) {
+  // Record last-route for per-contact session when using scoped dmScope.
+  // Always record per-contact sessions regardless of pinnedMainDmRecipient,
+  // since the pin guard only applies to main session updates.
+  if (params.dmRouteTarget && params.route.sessionKey !== params.route.mainSessionKey) {
     params.updateLastRoute({
       cfg: params.cfg,
       backgroundTasks: params.backgroundTasks,

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -94,6 +94,7 @@ export function createWebOnMessageHandler(params: {
         kind: msg.chatType === "group" ? "group" : "direct",
         id: peerId,
       },
+      dmScopeOverride: "per-channel-peer",
     });
     const route =
       msg.chatType === "group" ? resolveWhatsAppGroupSessionRoute(baseRoute) : baseRoute;

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -41,6 +41,11 @@ export type ResolveAgentRouteInput = {
   teamId?: string | null;
   /** Discord member role IDs — used for role-based agent routing. */
   memberRoleIds?: string[];
+  /**
+   * Override the dmScope from cfg.session.dmScope for this specific call.
+   * Useful when a channel plugin needs per-chat isolation regardless of global config.
+   */
+  dmScopeOverride?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
 };
 
 export type ResolvedAgentRoute = {
@@ -620,7 +625,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const teamId = normalizeId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
-  const dmScope = input.cfg.session?.dmScope ?? "main";
+  const dmScope = input.dmScopeOverride ?? input.cfg.session?.dmScope ?? "main";
   const identityLinks = input.cfg.session?.identityLinks;
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp plugin routes all inbound direct messages to the same `agent:${agentId}:main` session key regardless of contact, causing distinct chats to share session/.jsonl files and model context.
- Why it matters: Multi-tenant SaaS setups with one WhatsApp account per agent lose conversation isolation between contacts.
- What changed: Added `dmScopeOverride` to `ResolveAgentRouteInput` so callers can force per-chat session scoping; WhatsApp now passes `dmScopeOverride: "per-channel-peer"` when resolving inbound routes.
- What did NOT change: Group chat routing already uses `resolveWhatsAppGroupSessionRoute` with proper group scoping.

## Change Type

- [x] Bug fix
- [ ] Refactor required for the fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #76263

## Root Cause

- Root cause: `resolveAgentRoute` uses `cfg.session?.dmScope ?? "main"`. With `"main"`, all direct chats collapse to `agent:${agentId}:main` regardless of peer. WhatsApp passed a correct peer object but the global dmScope was the bottleneck.
- Missing detection: No guardrail existed to prevent channel plugins from inheriting a globally-shared dmScope when they require per-chat isolation.
- Contributing context: Telegram explicitly passes `dmScope: "per-account-channel-peer"` and works correctly. WhatsApp had no analogous override.

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient (routing + session-key tests cover the mechanism; WhatsApp specific integration test would catch the behavior)
- Target test or file: `extensions/whatsapp/src/auto-reply/monitor/on-message.ts` — add integration test verifying distinct `peerId` values produce distinct `route.sessionKey` values
- Scenario the test should lock in: Two inbound direct messages from different E.164 numbers → `sessionKey` values differ and contain the peer ID
- Existing test that already covers this (if any): `src/routing/session-key.ts` tests for `dmScope: "per-channel-peer"` exist but no WhatsApp-specific seam test
- If no new test added, why not: The fix is minimal and follows the established Telegram pattern; a WhatsApp integration test would be a separate work item

## User-Visible / Behavior Changes

- WhatsApp direct messages now get chat-scoped session keys: `agent:${agentId}:whatsapp:direct:${peerId}` instead of `agent:${agentId}:main`
- Existing sessions are not migrated — new messages from a given contact will use a fresh scoped key; old `main` session continues independently

