### PR TITLE
fix(openai): keep split SSE frames flowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Codex plugin: mirror the experimental upstream app-server protocol and format generated TypeScript before drift checks, keeping OpenClaw's `experimentalApi` bridge compatible with latest Codex while preserving formatter gates.
 - Telegram/media: derive no-caption inbound media placeholders from saved MIME metadata instead of the Telegram `photo` shape, so non-image and mixed attachments no longer reach the model as `<media:image>`. Fixes #69793. Thanks @aspalagin.
 - Agents/cache: keep per-turn runtime context out of ordinary chat system prompts while still delivering hidden current-turn context, restoring prompt-cache reuse on chat continuations. Fixes #77431. Thanks @Udjin79.
+- Agents/OpenAI: keep reading split SSE frames until a complete sanitized event is ready, preventing OpenAI Responses streams from starving when event headers and readable data arrive in separate chunks. Fixes #76305. Thanks @andhai and @vincentkoc.
 - Gateway/startup: include resolved thinking and fast-mode defaults in the `agent model` startup log line, defaulting unset startup thinking to `medium` without mixing in reasoning visibility.
 - Gateway/watch: suppress sync-I/O trace output during `pnpm gateway:watch --benchmark` unless explicitly requested, so CPU profiling no longer floods the terminal with stack traces.
 - Gateway/watch: when benchmark sync-I/O tracing is explicitly enabled, tee trace blocks to the benchmark output log and filter them from the terminal pane while keeping normal Gateway logs visible.

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -312,6 +312,54 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("does not stall when a readable SSE frame is split across chunks", async () => {
+    const encoder = new TextEncoder();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode("event: message\n"));
+            controller.enqueue(encoder.encode('data: {"ok": true}\n\n'));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+      finalUrl: "https://api.openai.com/v1/responses",
+      release: vi.fn(async () => undefined),
+    });
+
+    const { buildGuardedModelFetch } = await import("./provider-transport-fetch.js");
+    const model = {
+      id: "gpt-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+
+    const response = await buildGuardedModelFetch(model)("https://api.openai.com/v1/responses", {
+      method: "POST",
+    });
+    const itemsPromise = (async () => {
+      const items = [];
+      for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+        items.push(item);
+      }
+      return items;
+    })();
+
+    const items = await Promise.race([
+      itemsPromise,
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 200)),
+    ]);
+
+    expect(items).not.toBe("timeout");
+    if (items === "timeout") {
+      return;
+    }
+    expect(items).toEqual([{ ok: true }]);
+  });
+
   it("drops whitespace-only SSE data frames with CRLF delimiters", async () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response('event: message\r\ndata:   \r\n\r\ndata: {"ok": true}\r\n\r\n', {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -58,15 +58,14 @@ function sanitizeOpenAISdkSseResponse(response: Response): Response {
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let buffer = "";
 
-  const enqueueSanitized = (
+  const flushSanitizedBlocks = (
     controller: ReadableStreamDefaultController<Uint8Array>,
-    text: string,
-  ) => {
-    buffer += text;
+  ): boolean => {
+    let emitted = false;
     for (;;) {
       const boundary = findSseEventBoundary(buffer);
       if (!boundary) {
-        return;
+        return emitted;
       }
       const block = buffer.slice(0, boundary.index);
       const separator = buffer.slice(boundary.index, boundary.index + boundary.length);
@@ -75,6 +74,7 @@ function sanitizeOpenAISdkSseResponse(response: Response): Response {
       // messages. Drop those malformed keepalive-style blocks before it parses.
       if (hasReadableSseData(block)) {
         controller.enqueue(encoder.encode(`${block}${separator}`));
+        emitted = true;
       }
     }
   };
@@ -85,20 +85,26 @@ function sanitizeOpenAISdkSseResponse(response: Response): Response {
     },
     async pull(controller) {
       try {
-        const chunk = await reader?.read();
-        if (!chunk || chunk.done) {
-          const tail = decoder.decode();
-          if (tail) {
-            enqueueSanitized(controller, tail);
+        for (;;) {
+          if (flushSanitizedBlocks(controller)) {
+            return;
           }
-          if (buffer && hasReadableSseData(buffer)) {
-            controller.enqueue(encoder.encode(buffer));
+          const chunk = await reader?.read();
+          if (!chunk || chunk.done) {
+            const tail = decoder.decode();
+            if (tail) {
+              buffer += tail;
+            }
+            flushSanitizedBlocks(controller);
+            if (buffer && hasReadableSseData(buffer)) {
+              controller.enqueue(encoder.encode(buffer));
+            }
+            buffer = "";
+            controller.close();
+            return;
           }
-          buffer = "";
-          controller.close();
-          return;
+          buffer += decoder.decode(chunk.value, { stream: true });
         }
-        enqueueSanitized(controller, decoder.decode(chunk.value, { stream: true }));
       } catch (error) {
         controller.error(error);
       }


### PR DESCRIPTION
## Summary
- keep reading the OpenAI SSE response stream until the sanitizer can emit at least one complete readable event
- avoid returning early when the first chunk only contains a partial frame boundary
- add a regression test covering a readable SSE frame split across chunk boundaries

## Root cause
`sanitizeOpenAISdkSseResponse()` returned from `pull()` as soon as it failed to find a complete SSE boundary in the current buffer. When OpenAI delivered an event header in one chunk and the readable `data:` line in the next chunk, the sanitizer produced no output and stopped pulling, which could starve the embedded Responses path until it hit the LLM idle timeout.

## Testing
- verified the live Lab bundle end-to-end after patching the installed sanitizer: embedded `openai/gpt-4o-mini` runs returned normally with sanitization still enabled
- ran `node scripts/run-vitest.mjs run src/agents/provider-transport-fetch.test.ts`

Fixes #76305
Related to #76174
