### PR TITLE
fix: harden subagent completion announce cleanup races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/subagents: harden completion announce cleanup against browser cleanup delays, stale active child sessions with frozen replies, and late success signals that could overwrite terminal errors.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.
 - Gateway/responses: emit every client tool call from `/v1/responses` JSON and SSE responses when the agent invokes multiple client tools in a single turn, so multi-tool plans, graph orchestration calls, and similar batched flows no longer drop every call but the last. Fixes #52288. Thanks @CharZhou and @bonelli.

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -31,7 +31,7 @@ Not every agent run creates a task. Heartbeat turns and normal interactive chat 
 - Completion is push-driven: detached work can notify directly or wake the
   requester session/heartbeat when it finishes, so status polling loops are
   usually the wrong shape.
-- Isolated cron runs and subagent completions best-effort clean up tracked browser tabs/processes for their child session before final cleanup bookkeeping.
+- Isolated cron runs and subagent completions best-effort clean up tracked browser tabs/processes for their child session. Subagent browser cleanup runs in the background and does not block completion delivery.
 - Isolated cron delivery suppresses stale interim parent replies while descendant subagent work is still draining, and it prefers final descendant output when that arrives before delivery.
 - Completion notifications are delivered directly to a channel or queued for the next heartbeat.
 - `openclaw tasks list` shows all tasks; `openclaw tasks audit` surfaces issues.
@@ -253,7 +253,7 @@ openclaw tasks notify <lookup> state_changes
 
     Completion cleanup is also runtime-aware:
 
-    - Subagent completion best-effort closes tracked browser tabs/processes for the child session before announce cleanup continues.
+    - Subagent completion starts announce cleanup first, then best-effort closes tracked browser tabs/processes for the child session in the background so browser cleanup cannot delay completion delivery.
     - Isolated cron completion best-effort closes tracked browser tabs/processes for the cron session before the run fully tears down.
     - Isolated cron delivery waits out descendant subagent follow-up when needed and suppresses stale parent acknowledgement text instead of announcing it.
     - Subagent completion delivery prefers the latest visible assistant text; if that is empty it falls back to sanitized latest tool/toolResult text, and timeout-only tool-call runs can collapse to a short partial-progress summary. Terminal failed runs announce failure status without replaying captured reply text.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -76,7 +76,7 @@ requester chat when the run finishes.
     - The spawn command is non-blocking; it returns a run id immediately.
     - On completion, the sub-agent announces a summary/result message back to the requester chat channel.
     - Completion is push-based. Once spawned, do **not** poll `/subagents list`, `sessions_list`, or `sessions_history` in a loop just to wait for it to finish; inspect status only on-demand for debugging or intervention.
-    - On completion, OpenClaw best-effort closes tracked browser tabs/processes opened by that sub-agent session before the announce cleanup flow continues.
+    - On completion, OpenClaw starts the announce cleanup flow without waiting on tracked browser tab/process cleanup. Browser cleanup runs best-effort in the background so stale browser state does not delay completion delivery.
 
   </Accordion>
   <Accordion title="Manual-spawn delivery resilience">
@@ -276,7 +276,7 @@ app-server, and other configured native runtimes.
 - Auto-archive is best-effort; pending timers are lost if the gateway restarts.
 - `runTimeoutSeconds` does **not** auto-archive; it only stops the run. The session remains until auto-archive.
 - Auto-archive applies equally to depth-1 and depth-2 sessions.
-- Browser cleanup is separate from archive cleanup: tracked browser tabs/processes are best-effort closed when the run finishes, even if the transcript/session record is kept.
+- Browser cleanup is separate from archive cleanup: tracked browser tabs/processes are best-effort closed after the run finishes, even if the transcript/session record is kept. This cleanup does not block completion delivery.
 
 ## Nested sub-agents
 

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -363,6 +363,43 @@ describe("subagent announce seam flow", () => {
     expect(agentSpy).not.toHaveBeenCalled();
   });
 
+  it("does not wait on an active child session when frozen reply text is already available", async () => {
+    loadSessionStoreMock.mockImplementation(() => ({
+      "agent:main:subagent:test": {
+        sessionId: "child-session-active",
+        updatedAt: Date.now(),
+      },
+    }));
+    isEmbeddedPiRunActiveMock.mockReturnValue(true);
+    waitForEmbeddedPiRunEndMock.mockResolvedValue(false);
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-frozen-reply-active-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "deliver frozen reply",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "frozen final answer",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(waitForEmbeddedPiRunEndMock).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({ sessionKey: "agent:main:main" }),
+      }),
+    );
+  });
+
   it("keeps completion direct announce session-only when requester origin is webchat", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:webchat",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -264,7 +264,8 @@ export async function runSubagentAnnounceFlow(params: {
     const settleTimeoutMs = Math.min(Math.max(params.timeoutMs, 1), 120_000);
     let reply = params.roundOneReply;
     let outcome: SubagentRunOutcome | undefined = params.outcome;
-    if (childSessionId && isEmbeddedPiRunActive(childSessionId)) {
+    const hasFrozenReply = typeof reply === "string" && reply.trim().length > 0;
+    if (!hasFrozenReply && childSessionId && isEmbeddedPiRunActive(childSessionId)) {
       const settled = await waitForEmbeddedPiRunEnd(childSessionId, settleTimeoutMs);
       if (!settled && isEmbeddedPiRunActive(childSessionId)) {
         shouldDeleteChildSession = false;

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CallGatewayOptions } from "../gateway/call.js";
-import { SUBAGENT_ENDED_REASON_COMPLETE } from "./subagent-lifecycle-events.js";
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+} from "./subagent-lifecycle-events.js";
 import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
@@ -226,14 +229,20 @@ describe("subagent registry lifecycle hardening", () => {
     expect(persist).toHaveBeenCalled();
   });
 
-  it("cleans up tracked browser sessions before subagent cleanup flow", async () => {
+  it("starts subagent cleanup flow without waiting on tracked browser session cleanup", async () => {
     const persist = vi.fn();
     const entry = createRunEntry({
       expectsCompletionMessage: true,
     });
     const runSubagentAnnounceFlow = vi.fn(async () => true);
 
-    const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
+    const controller = createLifecycleController({
+      entry,
+      persist,
+      runSubagentAnnounceFlow,
+      cleanupBrowserSessionsForLifecycleEnd:
+        browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd,
+    });
 
     await expect(
       controller.completeSubagentRun({
@@ -245,16 +254,20 @@ describe("subagent registry lifecycle hardening", () => {
       }),
     ).resolves.toBeUndefined();
 
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childSessionKey: entry.childSessionKey,
+      }),
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
     expect(browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd).toHaveBeenCalledWith(
       {
         sessionKeys: [entry.childSessionKey],
         onWarn: expect.any(Function),
       },
-    );
-    expect(runSubagentAnnounceFlow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        childSessionKey: entry.childSessionKey,
-      }),
     );
   });
 
@@ -278,11 +291,13 @@ describe("subagent registry lifecycle hardening", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd).toHaveBeenCalledWith(
-      {
+    await vi.waitFor(() =>
+      expect(
+        browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd,
+      ).toHaveBeenCalledWith({
         sessionKeys: [entry.childSessionKey],
         onWarn: expect.any(Function),
-      },
+      }),
     );
     expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
     expect(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId).not.toHaveBeenCalledWith(
@@ -460,6 +475,69 @@ describe("subagent registry lifecycle hardening", () => {
       endedAt: 4_250,
       elapsedMs: 2_250,
     });
+    expect(persist).toHaveBeenCalled();
+  });
+
+  it("does not overwrite a terminal error with a later success completion", async () => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      endedReason: SUBAGENT_ENDED_REASON_ERROR,
+      outcome: { status: "error", error: "terminated", startedAt: 2_000, endedAt: 3_000 },
+      frozenResultText: null,
+      frozenResultCapturedAt: 3_000,
+    });
+
+    const controller = createLifecycleController({ entry, persist });
+
+    await expect(
+      controller.completeSubagentRun({
+        runId: entry.runId,
+        endedAt: 4_000,
+        outcome: { status: "ok" },
+        reason: SUBAGENT_ENDED_REASON_COMPLETE,
+        triggerCleanup: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(entry.endedReason).toBe(SUBAGENT_ENDED_REASON_ERROR);
+    expect(entry.outcome).toMatchObject({ status: "error", error: "terminated" });
+    expect(taskExecutorMocks.completeTaskRunByRunId).not.toHaveBeenCalled();
+    expect(taskExecutorMocks.failTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        error: "terminated",
+      }),
+    );
+    expect(persist).toHaveBeenCalled();
+  });
+
+  it("allows a later success to replace an earlier error after a restart", async () => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      startedAt: 3_100,
+      endedReason: SUBAGENT_ENDED_REASON_ERROR,
+      outcome: { status: "error", error: "rate limit", startedAt: 2_000, endedAt: 3_000 },
+    });
+
+    const controller = createLifecycleController({ entry, persist });
+
+    await expect(
+      controller.completeSubagentRun({
+        runId: entry.runId,
+        endedAt: 4_000,
+        outcome: { status: "ok" },
+        reason: SUBAGENT_ENDED_REASON_COMPLETE,
+        triggerCleanup: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(entry.endedReason).toBe(SUBAGENT_ENDED_REASON_COMPLETE);
+    expect(entry.outcome).toMatchObject({ status: "ok", startedAt: 3_100, endedAt: 4_000 });
+    expect(taskExecutorMocks.completeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endedAt: 4_000,
+      }),
+    );
     expect(persist).toHaveBeenCalled();
   });
 

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -16,6 +16,7 @@ import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatc
 import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
 import {
@@ -580,9 +581,15 @@ export function createSubagentRegistryLifecycleController(params: {
     scheduleResumeSubagentRun(runId, entry, deferredDecision.resumeDelayMs);
   };
 
-  const startSubagentAnnounceCleanupFlow = (runId: string, entry: SubagentRunRecord): boolean => {
+  const startSubagentAnnounceCleanupFlow = (
+    runId: string,
+    entry: SubagentRunRecord,
+    options?: { skipBeginCleanup?: boolean },
+  ): boolean => {
+    const ensureCleanupLease = () =>
+      options?.skipBeginCleanup === true ? true : beginSubagentCleanup(runId);
     if (typeof entry.completionAnnouncedAt === "number") {
-      if (!beginSubagentCleanup(runId)) {
+      if (!ensureCleanupLease()) {
         return false;
       }
       void finalizeSubagentCleanup(runId, entry.cleanup, true, {
@@ -598,7 +605,7 @@ export function createSubagentRegistryLifecycleController(params: {
       });
       return true;
     }
-    if (!beginSubagentCleanup(runId)) {
+    if (!ensureCleanupLease()) {
       return false;
     }
     if (entry.expectsCompletionMessage === false) {
@@ -730,16 +737,33 @@ export function createSubagentRegistryLifecycleController(params: {
       entry.endedAt = endedAt;
       mutated = true;
     }
-    const outcome = withSubagentOutcomeTiming(completeParams.outcome, {
+    const incomingOutcome = withSubagentOutcomeTiming(completeParams.outcome, {
       startedAt: entry.startedAt,
       endedAt,
     });
+    const priorErrorEndedAt = entry.outcome?.status === "error" ? entry.outcome.endedAt : undefined;
+    const restartedAfterTerminalError =
+      typeof priorErrorEndedAt === "number" &&
+      typeof entry.startedAt === "number" &&
+      entry.startedAt > priorErrorEndedAt;
+    const priorEndedReason = entry.endedReason;
+    const priorTerminalError =
+      priorEndedReason === SUBAGENT_ENDED_REASON_ERROR || entry.outcome?.status === "error";
+    const preserveTerminalError =
+      completeParams.reason === SUBAGENT_ENDED_REASON_COMPLETE &&
+      incomingOutcome.status === "ok" &&
+      !restartedAfterTerminalError &&
+      priorTerminalError;
+    const outcome = preserveTerminalError ? (entry.outcome ?? incomingOutcome) : incomingOutcome;
+    const reason = preserveTerminalError
+      ? (priorEndedReason ?? SUBAGENT_ENDED_REASON_ERROR)
+      : completeParams.reason;
     if (shouldUpdateRunOutcome(entry.outcome, outcome)) {
       entry.outcome = outcome;
       mutated = true;
     }
-    if (entry.endedReason !== completeParams.reason) {
-      entry.endedReason = completeParams.reason;
+    if (entry.endedReason !== reason) {
+      entry.endedReason = reason;
       mutated = true;
     }
     if (entry.pauseReason !== undefined) {
@@ -782,7 +806,7 @@ export function createSubagentRegistryLifecycleController(params: {
       !suppressedForSteerRestart &&
       params.shouldEmitEndedHookForRun({
         entry,
-        reason: completeParams.reason,
+        reason,
       });
     const shouldDeferEndedHook =
       shouldEmitEndedHook &&
@@ -792,7 +816,7 @@ export function createSubagentRegistryLifecycleController(params: {
     if (!shouldDeferEndedHook && shouldEmitEndedHook) {
       await params.emitSubagentEndedHookForRun({
         entry,
-        reason: completeParams.reason,
+        reason,
         sendFarewell: completeParams.sendFarewell,
         accountId: completeParams.accountId,
       });
@@ -802,12 +826,14 @@ export function createSubagentRegistryLifecycleController(params: {
       return;
     }
 
-    const cleanupBrowserSessions =
-      params.cleanupBrowserSessionsForLifecycleEnd ??
-      (await loadCleanupBrowserSessionsForLifecycleEnd());
-    await cleanupBrowserSessions({
-      sessionKeys: [entry.childSessionKey],
-      onWarn: (msg) => params.warn(msg, { runId: entry.runId }),
+    const preclaimedCleanup = !entry.cleanupCompletedAt && entry.cleanupHandled !== true;
+    if (preclaimedCleanup) {
+      entry.cleanupHandled = true;
+      params.persist();
+    }
+
+    startSubagentAnnounceCleanupFlow(completeParams.runId, entry, {
+      skipBeginCleanup: preclaimedCleanup,
     });
 
     await retireRunModeBundleMcpRuntime({
@@ -816,7 +842,23 @@ export function createSubagentRegistryLifecycleController(params: {
       reason: "subagent-run-complete",
     });
 
-    startSubagentAnnounceCleanupFlow(completeParams.runId, entry);
+    void (async () => {
+      try {
+        const cleanupBrowserSessions =
+          params.cleanupBrowserSessionsForLifecycleEnd ??
+          (await loadCleanupBrowserSessionsForLifecycleEnd());
+        await cleanupBrowserSessions({
+          sessionKeys: [entry.childSessionKey],
+          onWarn: (msg) => params.warn(msg, { runId: entry.runId }),
+        });
+      } catch (err) {
+        params.warn("failed browser cleanup during subagent lifecycle end", {
+          err,
+          runId: entry.runId,
+          childSessionKey: entry.childSessionKey,
+        });
+      }
+    })();
   };
 
   return {


### PR DESCRIPTION
## Summary

Fixes a set of subagent completion lifecycle races that can leave completed child runs stuck behind cleanup/announce sequencing or overwrite a terminal error with a later success signal.

The patch makes three related changes:

- Do not block completion announce delivery on browser-session cleanup. The cleanup is now started after the announce/cleanup flow is leased and runs best-effort in the background, with warnings captured instead of blocking the lifecycle path.
- Skip waiting for an active embedded child session when a frozen final reply is already available. If we already captured the reply text, the requester can be notified immediately instead of waiting on a stale/active child run check.
- Preserve a terminal error outcome if a later completion signal reports success for the same run, unless the run was actually restarted after the error. This prevents cleanup/finalization races from turning a failed run into a successful task after the fact.

## Why this matters

The lifecycle path has a few asynchronous pieces that can finish in different orders:

1. child session/browser cleanup
2. completion announce delivery back to the requester
3. task finalization bookkeeping
4. embedded child-run settle checks
5. terminal lifecycle hooks

Before this patch, a slow or stuck browser cleanup could delay the announce/cleanup flow. Separately, if a child run had already produced frozen reply text but still appeared active, the announce flow could wait unnecessarily. And in a failure path, a later `complete` event could overwrite the already-recorded terminal error.

That combination makes subagent completion feel flaky from the user's side: the work is done, but the parent session may not receive the completion promptly, or the persisted final task state can become misleading.

## Implementation notes

### Lifecycle cleanup lease

`completeSubagentRun` now preclaims cleanup when `triggerCleanup` is true and cleanup has not already completed/been handled. That lease is passed into `startSubagentAnnounceCleanupFlow` as `skipBeginCleanup`, avoiding a second `beginSubagentCleanup` race while still protecting duplicate cleanup attempts.

If cleanup is not actually triggered, or announce is suppressed for steer-restart, the preclaim is released so the record does not stay permanently handled.

### Browser cleanup no longer blocks announce cleanup

Previously browser cleanup was awaited before starting the subagent announce cleanup flow. This patch starts the announce cleanup flow first, retires run-mode bundle MCP runtime as before, and then launches browser cleanup as a best-effort async task:

- uses injected `cleanupBrowserSessionsForLifecycleEnd` when provided
- lazy-loads the browser cleanup helper otherwise
- logs warning context on failure
- does not reject or delay completion delivery

### Frozen reply short-circuit

`runSubagentAnnounceFlow` now checks whether `roundOneReply` already contains non-empty frozen reply text. If it does, the flow does not wait for `waitForEmbeddedPiRunEnd` even if `isEmbeddedPiRunActive` reports true. The frozen reply is already the durable completion payload; waiting only increases the chance of a stale active-state race.

### Terminal error preservation

When a run already has a terminal error outcome/reason, a later successful completion signal no longer overwrites it unless the entry's `startedAt` proves the run restarted after the error's `endedAt`. The ended hook and persisted outcome use the preserved effective reason/outcome.

## Tests

Added/updated coverage for:

- announcing without waiting for browser cleanup
- skipping announce delivery when completion messages are disabled
- delete-mode cleanup when completion messages are disabled
- preserving terminal errors against later success completion
- allowing success to replace error only after a restart
- using frozen reply text without waiting on an active embedded child session

Verification run locally:

```bash
pnpm test src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-announce.test.ts
```

Result: 2 files passed, 29 tests passed.
