### PR TITLE
perf(agents): cache runtime bootstrap and model discovery

### DIFF
--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -3,6 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { saveJsonFile } from "../../infra/json-file.js";
+import { stableStringify } from "../stable-stringify.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import {
   AUTH_STORE_LOCK_OPTIONS,
@@ -156,12 +157,37 @@ function readAuthStoreMtimeMs(authPath: string): number | null {
   }
 }
 
-function readCachedAuthProfileStore(params: {
+function buildAuthStoreCacheKey(params: {
   authPath: string;
+  options?: LoadAuthProfileStoreOptions;
+}): string {
+  return stableStringify({
+    version: 2,
+    authPath: params.authPath,
+    config: params.options?.config
+      ? {
+          models: params.options.config.models ?? null,
+          plugins: params.options.config.plugins ?? null,
+        }
+      : null,
+    externalCli: params.options?.externalCli?.mode ?? null,
+    externalCliProviderIds: params.options?.externalCliProviderIds
+      ? Array.from(params.options.externalCliProviderIds).toSorted()
+      : null,
+    externalCliProfileIds: params.options?.externalCliProfileIds
+      ? Array.from(params.options.externalCliProfileIds).toSorted()
+      : null,
+    syncExternalCli: params.options?.syncExternalCli ?? null,
+    allowKeychainPrompt: params.options?.allowKeychainPrompt ?? null,
+  });
+}
+
+function readCachedAuthProfileStore(params: {
+  cacheKey: string;
   authMtimeMs: number | null;
   stateMtimeMs: number | null;
 }): AuthProfileStore | null {
-  const cached = loadedAuthStoreCache.get(params.authPath);
+  const cached = loadedAuthStoreCache.get(params.cacheKey);
   if (
     !cached ||
     cached.authMtimeMs !== params.authMtimeMs ||
@@ -176,12 +202,12 @@ function readCachedAuthProfileStore(params: {
 }
 
 function writeCachedAuthProfileStore(params: {
-  authPath: string;
+  cacheKey: string;
   authMtimeMs: number | null;
   stateMtimeMs: number | null;
   store: AuthProfileStore;
 }): void {
-  loadedAuthStoreCache.set(params.authPath, {
+  loadedAuthStoreCache.set(params.cacheKey, {
     authMtimeMs: params.authMtimeMs,
     stateMtimeMs: params.stateMtimeMs,
     syncedAtMs: Date.now(),
@@ -361,9 +387,10 @@ function loadAuthProfileStoreForAgent(
   const statePath = resolveAuthStatePath(agentDir);
   const authMtimeMs = readAuthStoreMtimeMs(authPath);
   const stateMtimeMs = readAuthStoreMtimeMs(statePath);
+  const cacheKey = buildAuthStoreCacheKey({ authPath, options });
   if (!readOnly) {
     const cached = readCachedAuthProfileStore({
-      authPath,
+      cacheKey,
       authMtimeMs,
       stateMtimeMs,
     });
@@ -375,7 +402,7 @@ function loadAuthProfileStoreForAgent(
   if (asStore) {
     if (!readOnly) {
       writeCachedAuthProfileStore({
-        authPath,
+        cacheKey,
         authMtimeMs: readAuthStoreMtimeMs(authPath),
         stateMtimeMs: readAuthStoreMtimeMs(statePath),
         store: asStore,
@@ -419,7 +446,7 @@ function loadAuthProfileStoreForAgent(
 
   if (!readOnly) {
     writeCachedAuthProfileStore({
-      authPath,
+      cacheKey,
       authMtimeMs: readAuthStoreMtimeMs(authPath),
       stateMtimeMs: readAuthStoreMtimeMs(statePath),
       store,
@@ -594,7 +621,7 @@ export function saveAuthProfileStore(
   saveJsonFile(authPath, payload);
   savePersistedAuthProfileState(localStore, agentDir);
   writeCachedAuthProfileStore({
-    authPath,
+    cacheKey: buildAuthStoreCacheKey({ authPath }),
     authMtimeMs: readAuthStoreMtimeMs(authPath),
     stateMtimeMs: readAuthStoreMtimeMs(statePath),
     store: localStore,

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,3 +1,4 @@
+import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
 type BootstrapSnapshot = {
@@ -5,7 +6,15 @@ type BootstrapSnapshot = {
   files: WorkspaceBootstrapFile[];
 };
 
+export type BootstrapContextSnapshot = {
+  bootstrapFiles: WorkspaceBootstrapFile[];
+  contextFiles: EmbeddedContextFile[];
+};
+
+const BOOTSTRAP_CONTEXT_CACHE_LIMIT = 128;
+
 const cache = new Map<string, BootstrapSnapshot>();
+const contextCache = new Map<string, BootstrapContextSnapshot>();
 
 function bootstrapFilesEqual(
   previous: WorkspaceBootstrapFile[],
@@ -27,6 +36,48 @@ function bootstrapFilesEqual(
   });
 }
 
+function cloneContextSnapshot(snapshot: BootstrapContextSnapshot): BootstrapContextSnapshot {
+  return {
+    bootstrapFiles: snapshot.bootstrapFiles.map((file) => ({ ...file })),
+    contextFiles: snapshot.contextFiles.map((file) => ({ ...file })),
+  };
+}
+
+function rememberContextSnapshot(key: string, snapshot: BootstrapContextSnapshot): void {
+  if (contextCache.has(key)) {
+    contextCache.delete(key);
+  }
+  contextCache.set(key, cloneContextSnapshot(snapshot));
+  while (contextCache.size > BOOTSTRAP_CONTEXT_CACHE_LIMIT) {
+    const oldest = contextCache.keys().next().value;
+    if (typeof oldest !== "string") {
+      break;
+    }
+    contextCache.delete(oldest);
+  }
+}
+
+export function readCachedBootstrapContext(key: string): BootstrapContextSnapshot | undefined {
+  if (process.env.OPENCLAW_DISABLE_BOOTSTRAP_CONTEXT_CACHE === "1") {
+    return undefined;
+  }
+  const cached = contextCache.get(key);
+  if (!cached) {
+    return undefined;
+  }
+  // Refresh LRU order and protect cached arrays/objects from per-run mutation.
+  contextCache.delete(key);
+  contextCache.set(key, cached);
+  return cloneContextSnapshot(cached);
+}
+
+export function writeCachedBootstrapContext(key: string, snapshot: BootstrapContextSnapshot): void {
+  if (process.env.OPENCLAW_DISABLE_BOOTSTRAP_CONTEXT_CACHE === "1") {
+    return;
+  }
+  rememberContextSnapshot(key, snapshot);
+}
+
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
@@ -44,11 +95,21 @@ export async function getOrLoadBootstrapFiles(params: {
   }
 
   cache.set(params.sessionKey, { workspaceDir: params.workspaceDir, files });
+  clearBootstrapContextSnapshotsForSession(params.sessionKey);
   return files;
+}
+
+export function clearBootstrapContextSnapshotsForSession(sessionKey: string): void {
+  for (const key of Array.from(contextCache.keys())) {
+    if (key.includes(`\"sessionKey\":${JSON.stringify(sessionKey)}`)) {
+      contextCache.delete(key);
+    }
+  }
 }
 
 export function clearBootstrapSnapshot(sessionKey: string): void {
   cache.delete(sessionKey);
+  clearBootstrapContextSnapshotsForSession(sessionKey);
 }
 
 export function clearBootstrapSnapshotOnSessionRollover(params: {
@@ -64,4 +125,11 @@ export function clearBootstrapSnapshotOnSessionRollover(params: {
 
 export function clearAllBootstrapSnapshots(): void {
   cache.clear();
+  contextCache.clear();
 }
+
+export const __testing = {
+  readCachedBootstrapContext,
+  writeCachedBootstrapContext,
+  clearBootstrapContextSnapshotsForSession,
+};

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -2,9 +2,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getInternalHookRegistryVersion } from "../hooks/internal-hooks.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
-import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
+import {
+  getOrLoadBootstrapFiles,
+  readCachedBootstrapContext,
+  writeCachedBootstrapContext,
+} from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import { shouldIncludeHeartbeatGuidanceForSystemPrompt } from "./heartbeat-system-prompt.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -13,6 +18,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 } from "./pi-embedded-helpers.js";
+import { stableStringify } from "./stable-stringify.js";
 import {
   DEFAULT_HEARTBEAT_FILENAME,
   filterBootstrapFilesForSession,
@@ -226,7 +232,83 @@ function filterHeartbeatBootstrapFile(
   return files.filter((file) => file.name !== DEFAULT_HEARTBEAT_FILENAME);
 }
 
-export async function resolveBootstrapFilesForRun(params: {
+async function readWorkspaceMtimeSignature(workspaceDir: string): Promise<string> {
+  try {
+    const stat = await fs.stat(workspaceDir);
+    return `${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return "missing";
+  }
+}
+
+function buildBootstrapFilesSignature(files: WorkspaceBootstrapFile[]): string {
+  return stableStringify(
+    files.map((file) => ({
+      name: file.name,
+      path: file.path,
+      missing: file.missing === true,
+      contentLength: file.content?.length ?? 0,
+      content: file.content ?? "",
+    })),
+  );
+}
+
+async function buildBootstrapContextCacheKey(params: {
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  contextMode?: BootstrapContextMode;
+  runKind?: BootstrapContextRunKind;
+  channelId?: string;
+  rawFiles: WorkspaceBootstrapFile[];
+}): Promise<string> {
+  const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey ?? params.sessionId,
+    config: params.config,
+    agentId: params.agentId,
+  });
+  return stableStringify({
+    version: 1,
+    sessionKey: params.sessionKey ?? params.sessionId ?? "",
+    workspaceDir: path.resolve(params.workspaceDir),
+    workspaceMtime: await readWorkspaceMtimeSignature(params.workspaceDir),
+    contextMode: params.contextMode ?? "full",
+    runKind: params.runKind ?? "default",
+    agentId: sessionAgentId ?? params.agentId ?? "",
+    defaultAgentId: defaultAgentId ?? "",
+    channelId: params.channelId ?? "",
+    contextInjection: params.config?.agents?.defaults?.contextInjection ?? null,
+    bootstrapConfig: {
+      maxChars: params.config?.agents?.defaults?.bootstrapMaxChars ?? null,
+      totalMaxChars: params.config?.agents?.defaults?.bootstrapTotalMaxChars ?? null,
+      truncationWarning: params.config?.agents?.defaults?.bootstrapPromptTruncationWarning ?? null,
+    },
+    heartbeatGuidance: params.config?.agents?.defaults?.heartbeat ?? null,
+    maxChars: resolveBootstrapMaxChars(params.config),
+    totalMaxChars: resolveBootstrapTotalMaxChars(params.config),
+    rawFiles: buildBootstrapFilesSignature(params.rawFiles),
+    hookRegistryVersion: getInternalHookRegistryVersion(),
+    plugins: params.config?.plugins ?? null,
+  });
+}
+
+async function loadRawBootstrapFilesForRun(params: {
+  workspaceDir: string;
+  sessionKey?: string;
+  sessionId?: string;
+}): Promise<WorkspaceBootstrapFile[]> {
+  return params.sessionKey
+    ? await getOrLoadBootstrapFiles({
+        workspaceDir: params.workspaceDir,
+        sessionKey: params.sessionKey,
+      })
+    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+}
+
+async function resolveBootstrapFilesFromRaw(params: {
+  rawFiles: WorkspaceBootstrapFile[];
   workspaceDir: string;
   config?: OpenClawConfig;
   sessionKey?: string;
@@ -238,14 +320,8 @@ export async function resolveBootstrapFilesForRun(params: {
 }): Promise<WorkspaceBootstrapFile[]> {
   const excludeHeartbeatBootstrapFile = shouldExcludeHeartbeatBootstrapFile(params);
   const sessionKey = params.sessionKey ?? params.sessionId;
-  const rawFiles = params.sessionKey
-    ? await getOrLoadBootstrapFiles({
-        workspaceDir: params.workspaceDir,
-        sessionKey: params.sessionKey,
-      })
-    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
   const bootstrapFiles = applyContextModeFilter({
-    files: filterBootstrapFilesForSession(rawFiles, sessionKey),
+    files: filterBootstrapFilesForSession(params.rawFiles, sessionKey),
     contextMode: params.contextMode,
     runKind: params.runKind,
   });
@@ -265,6 +341,20 @@ export async function resolveBootstrapFilesForRun(params: {
   );
 }
 
+export async function resolveBootstrapFilesForRun(params: {
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  warn?: (message: string) => void;
+  contextMode?: BootstrapContextMode;
+  runKind?: BootstrapContextRunKind;
+}): Promise<WorkspaceBootstrapFile[]> {
+  const rawFiles = await loadRawBootstrapFilesForRun(params);
+  return resolveBootstrapFilesFromRaw({ ...params, rawFiles });
+}
+
 export async function resolveBootstrapContextForRun(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
@@ -274,17 +364,27 @@ export async function resolveBootstrapContextForRun(params: {
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
+  channelId?: string;
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
 }> {
-  const bootstrapFiles = await resolveBootstrapFilesForRun(params);
+  const rawFiles = await loadRawBootstrapFilesForRun(params);
+  const cacheKey = await buildBootstrapContextCacheKey({ ...params, rawFiles });
+  const cached = readCachedBootstrapContext(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const bootstrapFiles = await resolveBootstrapFilesFromRaw({ ...params, rawFiles });
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
     maxChars: resolveBootstrapMaxChars(params.config),
     totalMaxChars: resolveBootstrapTotalMaxChars(params.config),
     warn: params.warn,
   });
-  return { bootstrapFiles, contextFiles };
+  const snapshot = { bootstrapFiles, contextFiles };
+  writeCachedBootstrapContext(cacheKey, snapshot);
+  return snapshot;
 }
 
 export { isWorkspaceBootstrapPending };

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -991,7 +991,8 @@ export function resolveModel(
   };
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = options?.authStorage ?? discoverAuthStorage(resolvedAgentDir);
-  const modelRegistry = options?.modelRegistry ?? discoverModels(authStorage, resolvedAgentDir);
+  const modelRegistry =
+    options?.modelRegistry ?? discoverModels(authStorage, resolvedAgentDir, { config: cfg });
   const runtimeHooks = resolveRuntimeHooks(options);
   const model = resolveModelWithRegistry({
     provider: normalizedRef.provider,
@@ -1053,7 +1054,7 @@ export async function resolveModelAsync(
   const modelRegistry =
     options?.modelRegistry ??
     emptyDiscoveryStores?.modelRegistry ??
-    discoverModels(authStorage, resolvedAgentDir);
+    discoverModels(authStorage, resolvedAgentDir, { config: cfg });
   const runtimeHooks = resolveRuntimeHooks(options);
   const explicitModel = resolveExplicitModelWithRegistry({
     provider: normalizedRef.provider,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -982,6 +982,7 @@ export async function runEmbeddedAttempt(
           }),
           contextMode: params.bootstrapContextMode,
           runKind: params.bootstrapContextRunKind,
+          channelId: params.currentChannelId ?? params.messageChannel ?? params.messageProvider,
         }),
     });
     prepStages.mark("bootstrap-context");

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import * as PiCodingAgent from "@mariozechner/pi-coding-agent";
@@ -5,6 +6,7 @@ import type {
   AuthStorage as PiAuthStorage,
   ModelRegistry as PiModelRegistry,
 } from "@mariozechner/pi-coding-agent";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeModelCompat } from "../plugins/provider-model-compat.js";
 import {
   applyProviderResolvedModelCompatWithPlugins,
@@ -12,6 +14,7 @@ import {
   normalizeProviderResolvedModelWithPlugin,
 } from "../plugins/provider-runtime.js";
 import { isRecord } from "../utils.js";
+import { resolveAuthStatePath, resolveAuthStorePath } from "./auth-profiles/paths.js";
 import type { PiCredentialMap } from "./pi-auth-credentials.js";
 import {
   resolvePiCredentialsForDiscovery,
@@ -19,6 +22,7 @@ import {
   type DiscoverAuthStorageOptions,
 } from "./pi-auth-discovery.js";
 import { normalizeProviderId } from "./provider-id.js";
+import { stableStringify } from "./stable-stringify.js";
 
 const PiAuthStorageClass = PiCodingAgent.AuthStorage;
 const PiModelRegistryClass = PiCodingAgent.ModelRegistry;
@@ -36,7 +40,81 @@ type DiscoveredProviderRuntimeModelLike = Omit<ProviderRuntimeModelLike, "api"> 
 type DiscoverModelsOptions = {
   providerFilter?: string;
   normalizeModels?: boolean;
+  config?: OpenClawConfig;
 };
+
+type FileFingerprint = { mtimeMs: number | null; size: number | null };
+
+const PI_DISCOVERY_CACHE_LIMIT = 64;
+const piDiscoveryCache = new Map<string, PiModelRegistry>();
+
+function fileFingerprint(filePath: string): FileFingerprint {
+  try {
+    const stat = fs.statSync(filePath);
+    return { mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch {
+    return { mtimeMs: null, size: null };
+  }
+}
+
+function buildPiDiscoveryCacheKey(params: {
+  agentDir: string;
+  modelsJsonPath: string;
+  options?: DiscoverModelsOptions;
+}): string {
+  const provider = params.options?.providerFilter
+    ? normalizeProviderId(params.options.providerFilter)
+    : "";
+  const mainAuthPath = resolveAuthStorePath();
+  const agentAuthPath = resolveAuthStorePath(params.agentDir);
+  return stableStringify({
+    version: 2,
+    agentDir: path.resolve(params.agentDir),
+    provider,
+    normalizeModels: params.options?.normalizeModels !== false,
+    config: {
+      models: params.options?.config?.models ?? null,
+      plugins: params.options?.config?.plugins ?? null,
+    },
+    auth: {
+      main: fileFingerprint(mainAuthPath),
+      mainState: fileFingerprint(resolveAuthStatePath()),
+      agent: fileFingerprint(agentAuthPath),
+      agentState: fileFingerprint(resolveAuthStatePath(params.agentDir)),
+    },
+    modelsJson: fileFingerprint(params.modelsJsonPath),
+  });
+}
+
+function readCachedPiDiscovery(key: string): PiModelRegistry | undefined {
+  if (process.env.OPENCLAW_DISABLE_MODEL_DISCOVERY_CACHE === "1") {
+    return undefined;
+  }
+  const cached = piDiscoveryCache.get(key);
+  if (!cached) {
+    return undefined;
+  }
+  piDiscoveryCache.delete(key);
+  piDiscoveryCache.set(key, cached);
+  return cached;
+}
+
+function writeCachedPiDiscovery(key: string, registry: PiModelRegistry): void {
+  if (process.env.OPENCLAW_DISABLE_MODEL_DISCOVERY_CACHE === "1") {
+    return;
+  }
+  if (piDiscoveryCache.has(key)) {
+    piDiscoveryCache.delete(key);
+  }
+  piDiscoveryCache.set(key, registry);
+  while (piDiscoveryCache.size > PI_DISCOVERY_CACHE_LIMIT) {
+    const oldest = piDiscoveryCache.keys().next().value;
+    if (typeof oldest !== "string") {
+      break;
+    }
+    piDiscoveryCache.delete(oldest);
+  }
+}
 
 type InMemoryAuthStorageBackendLike = {
   withLock<T>(
@@ -236,12 +314,15 @@ export function discoverModels(
   agentDir: string,
   options?: DiscoverModelsOptions,
 ): PiModelRegistry {
-  return createOpenClawModelRegistry(
-    authStorage,
-    path.join(agentDir, "models.json"),
-    agentDir,
-    options,
-  );
+  const modelsJsonPath = path.join(agentDir, "models.json");
+  const cacheKey = buildPiDiscoveryCacheKey({ agentDir, modelsJsonPath, options });
+  const cached = readCachedPiDiscovery(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const registry = createOpenClawModelRegistry(authStorage, modelsJsonPath, agentDir, options);
+  writeCachedPiDiscovery(cacheKey, registry);
+  return registry;
 }
 
 export {

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -196,7 +196,20 @@ const internalHooksEnabledState = resolveGlobalSingleton<{ enabled: boolean }>(
   INTERNAL_HOOKS_ENABLED_KEY,
   () => ({ enabled: true }),
 );
+const INTERNAL_HOOK_REGISTRY_VERSION_KEY = Symbol.for("openclaw.internalHookRegistryVersion");
+const internalHookRegistryVersion = resolveGlobalSingleton<{ value: number }>(
+  INTERNAL_HOOK_REGISTRY_VERSION_KEY,
+  () => ({ value: 0 }),
+);
 const log = createSubsystemLogger("internal-hooks");
+
+function bumpInternalHookRegistryVersion(): void {
+  internalHookRegistryVersion.value += 1;
+}
+
+export function getInternalHookRegistryVersion(): number {
+  return internalHookRegistryVersion.value;
+}
 
 /**
  * Register a hook handler for a specific event type or event:action combination
@@ -222,6 +235,7 @@ export function registerInternalHook(eventKey: string, handler: InternalHookHand
     handlers.set(eventKey, []);
   }
   handlers.get(eventKey)!.push(handler);
+  bumpInternalHookRegistryVersion();
 }
 
 /**
@@ -239,6 +253,7 @@ export function unregisterInternalHook(eventKey: string, handler: InternalHookHa
   const index = eventHandlers.indexOf(handler);
   if (index !== -1) {
     eventHandlers.splice(index, 1);
+    bumpInternalHookRegistryVersion();
   }
 
   // Clean up empty handler arrays
@@ -251,7 +266,10 @@ export function unregisterInternalHook(eventKey: string, handler: InternalHookHa
  * Clear all registered hooks (useful for testing)
  */
 export function clearInternalHooks(): void {
-  handlers.clear();
+  if (handlers.size > 0) {
+    handlers.clear();
+    bumpInternalHookRegistryVersion();
+  }
 }
 
 export function setInternalHooksEnabled(enabled: boolean): void {

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -167,6 +167,9 @@ export function capturePluginToolDescriptor(params: {
 export function readCachedPluginToolDescriptors(
   cacheKey: string,
 ): readonly CachedPluginToolDescriptor[] | undefined {
+  if (process.env.OPENCLAW_DISABLE_TOOL_CACHE === "1") {
+    return undefined;
+  }
   return descriptorCache.get(cacheKey);
 }
 
@@ -174,6 +177,9 @@ export function writeCachedPluginToolDescriptors(params: {
   cacheKey: string;
   descriptors: readonly CachedPluginToolDescriptor[];
 }): void {
+  if (process.env.OPENCLAW_DISABLE_TOOL_CACHE === "1") {
+    return;
+  }
   if (
     !descriptorCache.has(params.cacheKey) &&
     descriptorCache.size >= PLUGIN_TOOL_DESCRIPTOR_CACHE_LIMIT


### PR DESCRIPTION
## Summary
- add runtime LRU cache for resolved bootstrap context snapshots with hook/config/session invalidation
- add PI model discovery LRU cache keyed by auth/model/config fingerprints
- include auth store option-sensitive cache keys and tool descriptor cache kill switch

## Validation
- pnpm install --frozen-lockfile
- pnpm exec vitest run src/agents/bootstrap-files.test.ts src/agents/auth-profiles.store-cache.test.ts src/agents/pi-embedded-runner/model.test.ts src/plugins/tool-descriptor-cache.test.ts src/hooks/internal-hooks.test.ts
- pnpm test attempted: local baseline failures reproduced on origin/main for onboarding-plugin-install, voice-call, system-prompt-params; full run later SIGKILLed by OS
- node --max-old-space-size=8192 node_modules/typescript/bin/tsc --noEmit attempted: existing test type errors reproduced on origin/main