### PR TITLE
fix(install): show progress during npm install in non-interactive mode

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -758,6 +758,7 @@ run_npm_global_install() {
         return $?
     fi
 
+    ui_info "Installing OpenClaw package"
     "${cmd[@]}" >"$log" 2>&1
 }
 


### PR DESCRIPTION
## Problem

When running `curl -fsSL https://openclaw.ai/install.sh | bash`, gum is disabled because stdin is a pipe (`is_non_interactive_shell` returns true). Without gum, `run_npm_global_install` silently redirects all output to a temp log file (line 751):

```bash
"${cmd[@]}" >"$log" 2>&1
```

Users see **no feedback** during the npm install step, which can take 60+ seconds. The gum branch already shows "Installing OpenClaw package" via `run_with_spinner`, but the no-gum fallback is completely silent.

## Fix

Add `ui_info "Installing OpenClaw package"` before the silent npm command in the no-gum branch, matching the pattern from PR #71720 that was applied to `run_quiet_step`.

Closes #82305

## Real behavior proof
Behavior addressed: in non-interactive mode (piped stdin, no gum), the npm install step now shows a progress message instead of running silently for 60+ seconds.
Real environment tested: Linux x86_64, OpenClaw 2026.5.12 already installed, Node v26.0.0, npm 11.12.1. Ran `bash scripts/install.sh --install-method npm < /dev/null` to simulate `curl | bash` non-interactive mode.
Exact steps or command run after this patch: (1) checked out upstream/main install.sh, ran `bash scripts/install.sh --install-method npm < /dev/null 2>&1` and captured output; (2) applied the one-line fix, ran the same command again and captured output; (3) compared the install section output.
Evidence after fix: terminal output copied below.

Before (upstream/main, no progress line):
```console
$ bash scripts/install.sh --install-method npm < /dev/null 2>&1 | grep -A2 "Installing OpenClaw v"
· Installing OpenClaw v2026.5.12
✓ OpenClaw npm package installed
✓ OpenClaw installed
```

After (with `ui_info` added):
```console
$ bash scripts/install.sh --install-method npm < /dev/null 2>&1 | grep -A3 "Installing OpenClaw v"
· Installing OpenClaw v2026.5.12
· Installing OpenClaw package
✓ OpenClaw npm package installed
✓ OpenClaw installed
```

Full install section before:
```
[2/3] Installing OpenClaw
✓ Git already installed
· Installing OpenClaw v2026.5.12
✓ OpenClaw npm package installed
✓ OpenClaw installed
```

Full install section after:
```
[2/3] Installing OpenClaw
✓ Git already installed
· Installing OpenClaw v2026.5.12
· Installing OpenClaw package
✓ OpenClaw npm package installed
✓ OpenClaw installed
```

Observed result after fix: the "Installing OpenClaw package" progress line now appears between the version announcement and the completion checkmark, matching the text shown by the gum spinner branch in interactive mode. No other output changed.
What was not tested: gum/spinner interactive path (gum is only available when stdin is a tty, which this non-interactive proof intentionally disables). The gum branch already shows this text via `run_with_spinner` and is unchanged by this PR.