### PR TITLE
Fix subagent startup lifecycle signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/subagents: emit first-progress and startup-failed lifecycle signals so silently aborted child runs are reported as startup failures instead of looking like hangs. Fixes #58776.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.
 - Gateway/responses: emit every client tool call from `/v1/responses` JSON and SSE responses when the agent invokes multiple client tools in a single turn, so multi-tool plans, graph orchestration calls, and similar batched flows no longer drop every call but the last. Fixes #52288. Thanks @CharZhou and @bonelli.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -404,9 +404,13 @@ Announce context is normalized to a stable internal event block:
 | Follow-up      | Instruction describing when to reply vs stay silent                                                           |
 
 Terminal failed runs report failure status without replaying captured
-reply text. On timeout, if the child only got through tool calls, announce
-can collapse that history into a short partial-progress summary instead
-of replaying raw tool output.
+reply text. Embedded child runs emit a `first-progress` lifecycle signal
+on first visible assistant text or tool call; if an aborted run reaches
+termination before that signal, OpenClaw emits `startup-failed` and reports
+it as a startup failure instead of leaving the parent to infer a hang. On
+timeout, if the child only got through tool calls, announce can collapse
+that history into a short partial-progress summary instead of replaying raw
+tool output.
 
 ### Stats line
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import { handleAgentEnd } from "./pi-embedded-subscribe.handlers.lifecycle.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import { emitFirstProgressOnce } from "./pi-embedded-subscribe.lifecycle-progress.js";
 
 vi.mock("../infra/agent-events.js", () => ({
   emitAgentEvent: vi.fn(),
 }));
+
+beforeEach(() => {
+  vi.mocked(emitAgentEvent).mockClear();
+});
 
 function createContext(
   lastAssistant: unknown,
@@ -60,6 +66,36 @@ async function handleAgentEndAndReadWarnMeta(ctx: EmbeddedPiSubscribeContext) {
   expect(warn.mock.calls[0]?.[0]).toBe("embedded run agent end");
   return warn.mock.calls[0]?.[1];
 }
+
+describe("embedded lifecycle progress", () => {
+  it("emits first-progress once", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
+    ctx.state.firstProgressEmitted = false;
+
+    emitFirstProgressOnce(ctx, "tool", { name: "read", toolCallId: "tc-1" });
+    emitFirstProgressOnce(ctx, "assistant");
+
+    expect(emitAgentEvent).toHaveBeenCalledTimes(1);
+    expect(emitAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        stream: "lifecycle",
+        data: expect.objectContaining({
+          phase: "first-progress",
+          source: "tool",
+          name: "read",
+          toolCallId: "tc-1",
+        }),
+      }),
+    );
+    expect(onAgentEvent).toHaveBeenCalledTimes(1);
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: { phase: "first-progress", source: "tool", name: "read", toolCallId: "tc-1" },
+    });
+  });
+});
 
 describe("handleAgentEnd", () => {
   it("logs the resolved error message when run ends with assistant error", async () => {
@@ -537,6 +573,39 @@ describe("handleAgentEnd", () => {
         phase: "error",
         error: "LLM request failed: connection refused by the provider endpoint.",
       },
+    });
+  });
+
+  it("emits startup-failed before terminal end when an aborted run never made progress", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
+    ctx.state.terminalStopReason = "aborted";
+    ctx.state.firstProgressEmitted = false;
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenNthCalledWith(1, {
+      stream: "lifecycle",
+      data: { phase: "startup-failed", reason: "startup_aborted", stopReason: "aborted" },
+    });
+    expect(onAgentEvent).toHaveBeenNthCalledWith(2, {
+      stream: "lifecycle",
+      data: { phase: "end", stopReason: "aborted" },
+    });
+  });
+
+  it("does not emit startup-failed for aborted runs after first progress", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
+    ctx.state.terminalStopReason = "aborted";
+    ctx.state.firstProgressEmitted = true;
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledTimes(1);
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: { phase: "end", stopReason: "aborted" },
     });
   });
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -115,6 +115,27 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
       ...(ctx.state.terminalStopReason ? { stopReason: ctx.state.terminalStopReason } : {}),
       ...(ctx.state.yielded === true ? { yielded: true } : {}),
     };
+    if (ctx.state.terminalStopReason === "aborted" && !ctx.state.firstProgressEmitted) {
+      const startupFailureData = {
+        phase: "startup-failed",
+        reason: "startup_aborted",
+        stopReason: ctx.state.terminalStopReason,
+        endedAt: Date.now(),
+      };
+      emitAgentEvent({
+        runId: ctx.params.runId,
+        stream: "lifecycle",
+        data: startupFailureData,
+      });
+      void ctx.params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase: "startup-failed",
+          reason: "startup_aborted",
+          stopReason: ctx.state.terminalStopReason,
+        },
+      });
+    }
     if (isError) {
       emitAgentEvent({
         runId: ctx.params.runId,

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -25,6 +25,7 @@ import type {
   EmbeddedPiSubscribeContext,
   EmbeddedPiSubscribeState,
 } from "./pi-embedded-subscribe.handlers.types.js";
+import { emitFirstProgressOnce } from "./pi-embedded-subscribe.lifecycle-progress.js";
 import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import { appendRawStream } from "./pi-embedded-subscribe.raw-stream.js";
 import { warnIfAssistantEmittedToolText } from "./pi-embedded-subscribe.tool-text-diagnostics.js";
@@ -620,6 +621,9 @@ export function handleMessageUpdate(
         data,
       });
       ctx.state.emittedAssistantUpdate = true;
+      if (cleanedText.trim()) {
+        emitFirstProgressOnce(ctx, "assistant");
+      }
       if (ctx.params.onPartialReply && ctx.state.shouldEmitPartialReplies) {
         void ctx.params.onPartialReply(data);
       }
@@ -751,6 +755,9 @@ export function handleMessageEnd(
       data,
     });
     ctx.state.emittedAssistantUpdate = true;
+    if (cleanedText.trim()) {
+      emitFirstProgressOnce(ctx, "assistant");
+    }
     ctx.state.lastStreamedAssistantCleaned = cleanedText;
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -46,6 +46,7 @@ function createTestContext(): {
       itemActiveIds: new Set<string>(),
       itemStartedCount: 0,
       itemCompletedCount: 0,
+      firstProgressEmitted: false,
       pendingMessagingTargets: new Map<string, MessagingToolSend>(),
       pendingMessagingTexts: new Map<string, string>(),
       pendingMessagingMediaUrls: new Map<string, string[]>(),

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -30,6 +30,7 @@ import type {
   ToolCallSummary,
   ToolHandlerContext,
 } from "./pi-embedded-subscribe.handlers.types.js";
+import { emitFirstProgressOnce } from "./pi-embedded-subscribe.lifecycle-progress.js";
 import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import {
   extractToolResultMediaArtifact,
@@ -622,6 +623,7 @@ export function handleToolExecutionStart(
     ctx.log.debug(
       `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
     );
+    emitFirstProgressOnce(ctx, "tool", { name: toolName, toolCallId });
 
     const shouldEmitToolEvents = ctx.shouldEmitToolResult();
     emitAgentEvent({

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -60,6 +60,7 @@ export type EmbeddedPiSubscribeState = {
   lastStreamedAssistant?: string;
   lastStreamedAssistantCleaned?: string;
   emittedAssistantUpdate: boolean;
+  firstProgressEmitted: boolean;
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   reasoningStreamOpen: boolean;
@@ -210,6 +211,7 @@ type ToolHandlerState = Pick<
   | "messagingToolSentMediaUrls"
   | "messagingToolSentTargets"
   | "heartbeatToolResponse"
+  | "firstProgressEmitted"
   | "successfulCronAdds"
   | "deterministicApprovalPromptSent"
 >;

--- a/src/agents/pi-embedded-subscribe.lifecycle-progress.ts
+++ b/src/agents/pi-embedded-subscribe.lifecycle-progress.ts
@@ -1,0 +1,31 @@
+import { emitAgentEvent } from "../infra/agent-events.js";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+
+export function emitFirstProgressOnce(
+  ctx: {
+    params: Pick<EmbeddedPiSubscribeContext["params"], "runId" | "onAgentEvent">;
+    state: Pick<EmbeddedPiSubscribeContext["state"], "firstProgressEmitted">;
+  },
+  source: "assistant" | "tool",
+  meta: Record<string, unknown> = {},
+): void {
+  if (ctx.state.firstProgressEmitted) {
+    return;
+  }
+  ctx.state.firstProgressEmitted = true;
+  const data = {
+    phase: "first-progress",
+    source,
+    ...meta,
+    progressedAt: Date.now(),
+  };
+  emitAgentEvent({
+    runId: ctx.params.runId,
+    stream: "lifecycle",
+    data,
+  });
+  void ctx.params.onAgentEvent?.({
+    stream: "lifecycle",
+    data: { phase: "first-progress", source, ...meta },
+  });
+}

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -145,6 +145,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     lastStreamedAssistant: undefined,
     lastStreamedAssistantCleaned: undefined,
     emittedAssistantUpdate: false,
+    firstProgressEmitted: false,
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
     reasoningStreamOpen: false,

--- a/src/agents/pi-tool-handler-state.test-helpers.ts
+++ b/src/agents/pi-tool-handler-state.test-helpers.ts
@@ -10,6 +10,7 @@ export function createBaseToolHandlerState() {
     itemStartedCount: 0,
     itemCompletedCount: 0,
     lastToolError: undefined,
+    firstProgressEmitted: false,
     pendingMessagingTexts: new Map<string, string>(),
     pendingMessagingTargets: new Map<string, unknown>(),
     pendingMessagingMediaUrls: new Map<string, string[]>(),

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -468,6 +468,54 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
+  it("announces startup-failed lifecycle events as errors", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-startup-failed",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "startup failure",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-startup-failed",
+      stream: "lifecycle",
+      data: { phase: "startup-failed", reason: "startup_aborted", endedAt: 1_000 },
+    });
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          childRunId: "run-startup-failed",
+          outcome: expect.objectContaining({
+            status: "error",
+            error: "startup_aborted",
+            endedAt: 1_000,
+          }),
+        }),
+      );
+    });
+  });
+
   it("deletes delete-mode completion runs when announce cleanup gives up after retry limit", async () => {
     mocks.runSubagentAnnounceFlow.mockResolvedValue(false);
     const endedAt = Date.parse("2026-03-24T12:00:00Z");

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -922,6 +922,26 @@ function ensureListener() {
         }
         return;
       }
+      if (phase === "first-progress") {
+        clearPendingLifecycleTimeout(evt.runId);
+        return;
+      }
+      if (phase === "startup-failed") {
+        clearPendingLifecycleError(evt.runId);
+        clearPendingLifecycleTimeout(evt.runId);
+        const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+        const reason = typeof evt.data?.reason === "string" ? evt.data.reason : "startup_failed";
+        await completeSubagentRun({
+          runId: evt.runId,
+          endedAt,
+          outcome: { status: "error", error: reason },
+          reason: SUBAGENT_ENDED_REASON_ERROR,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
+        });
+        return;
+      }
       if (phase !== "end" && phase !== "error") {
         return;
       }

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -130,19 +130,25 @@ function getPendingAgentRunTimeout(runId: string) {
 
 function createSnapshotFromLifecycleEvent(params: {
   runId: string;
-  phase: "end" | "error";
+  phase: "end" | "error" | "startup-failed";
   data?: Record<string, unknown>;
 }): AgentRunSnapshot {
   const { runId, phase, data } = params;
   const startedAt =
     typeof data?.startedAt === "number" ? data.startedAt : agentRunStarts.get(runId);
   const endedAt = typeof data?.endedAt === "number" ? data.endedAt : undefined;
-  const error = typeof data?.error === "string" ? data.error : undefined;
+  const error =
+    typeof data?.error === "string"
+      ? data.error
+      : typeof data?.reason === "string"
+        ? data.reason
+        : undefined;
   const stopReason = typeof data?.stopReason === "string" ? data.stopReason : undefined;
   const livenessState = typeof data?.livenessState === "string" ? data.livenessState : undefined;
   return {
     runId,
-    status: phase === "error" ? "error" : data?.aborted ? "timeout" : "ok",
+    status:
+      phase === "error" || phase === "startup-failed" ? "error" : data?.aborted ? "timeout" : "ok",
     startedAt,
     endedAt,
     error,
@@ -176,7 +182,11 @@ function ensureAgentRunListener() {
       agentRunCache.delete(evt.runId);
       return;
     }
-    if (phase !== "end" && phase !== "error") {
+    if (phase === "first-progress") {
+      clearPendingAgentRunTimeout(evt.runId);
+      return;
+    }
+    if (phase !== "end" && phase !== "error" && phase !== "startup-failed") {
       return;
     }
     const snapshot = createSnapshotFromLifecycleEvent({

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -87,6 +87,31 @@ describe("session lifecycle state", () => {
     });
   });
 
+  it("maps startup-failed lifecycle events to failed", () => {
+    expect(
+      deriveGatewaySessionLifecycleSnapshot({
+        session: {
+          updatedAt: 1_000,
+          startedAt: 1_050,
+        },
+        event: {
+          ts: 2_000,
+          data: {
+            phase: "startup-failed",
+            endedAt: 1_550,
+          },
+        },
+      }),
+    ).toEqual({
+      updatedAt: 1_550,
+      status: "failed",
+      startedAt: 1_050,
+      endedAt: 1_550,
+      runtimeMs: 500,
+      abortedLastRun: false,
+    });
+  });
+
   it("maps aborted lifecycle end events without stopReason to timeout", () => {
     expect(
       derivePersistedSessionLifecyclePatch({

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -3,7 +3,7 @@ import type { AgentEventPayload } from "../infra/agent-events.js";
 import { loadSessionEntry } from "./session-utils.js";
 import type { GatewaySessionRow, SessionRunStatus } from "./session-utils.types.js";
 
-type LifecyclePhase = "start" | "end" | "error";
+type LifecyclePhase = "start" | "end" | "error" | "startup-failed";
 
 type LifecycleEventLike = Pick<AgentEventPayload, "ts"> & {
   data?: {
@@ -33,12 +33,14 @@ function isFiniteTimestamp(value: unknown): value is number {
 
 function resolveLifecyclePhase(event: LifecycleEventLike): LifecyclePhase | null {
   const phase = typeof event.data?.phase === "string" ? event.data.phase : "";
-  return phase === "start" || phase === "end" || phase === "error" ? phase : null;
+  return phase === "start" || phase === "end" || phase === "error" || phase === "startup-failed"
+    ? phase
+    : null;
 }
 
 function resolveTerminalStatus(event: LifecycleEventLike): SessionRunStatus {
   const phase = resolveLifecyclePhase(event);
-  if (phase === "error") {
+  if (phase === "error" || phase === "startup-failed") {
     return "failed";
   }
 


### PR DESCRIPTION
## Summary

Fixes #58776 by making embedded subagent startup state explicit instead of letting silent aborted runs look like hangs.

- emit a one-shot `first-progress` lifecycle signal on the first visible assistant text or tool call
- emit `startup-failed` when an embedded run aborts before first progress
- teach subagent completion, agent-job snapshots, and session lifecycle state to treat `startup-failed` as a terminal startup failure
- document the new lifecycle behavior and add focused tests

## Validation

- `git diff --check`
- `pnpm check:docs`
- `pnpm check:test-types`
- `pnpm test src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/openclaw-owned-tool-runtime-contract.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-lifecycle-state.test.ts packages/sdk/src/index.test.ts src/agents/subagent-registry.test.ts`
- `pnpm lint src/agents/pi-embedded-subscribe.handlers.lifecycle.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/agents/pi-embedded-subscribe.handlers.messages.ts src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-embedded-subscribe.handlers.types.ts src/agents/pi-embedded-subscribe.ts src/agents/pi-tool-handler-state.test-helpers.ts src/agents/subagent-registry.ts src/agents/subagent-registry.test.ts src/gateway/server-methods/agent-job.ts src/gateway/session-lifecycle-state.ts src/gateway/session-lifecycle-state.test.ts src/agents/openclaw-owned-tool-runtime-contract.test.ts`
