### PR TITLE
fix(exec): hide policy controls from model args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/chat history: preserve oversized transcript turns as explicit omitted-message placeholders while avoiding large JSONL parse stalls. Thanks @Marvinthebored and @vincentkoc.
 - Gateway/models: keep read-only model-list responses on registry-compatible fallbacks and metadata defaults, so empty or minimal persisted model files do not hide built-ins or custom model capabilities. Thanks @Marvinthebored.
 - CLI/doctor: load the configured memory-slot plugin when resolving memory diagnostics so bundled `memory-core` no longer triggers a false “no active memory plugin” warning on standalone `doctor` / `status` runs. Fixes #76367. Thanks @neeravmakwana.
+- Exec: hide host/security policy controls from model-call args so models cannot override configured exec defaults such as `security`, `ask`, `host`, `node`, or elevated routing. Fixes #75811.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Heartbeats/Codex: stop sending the legacy `HEARTBEAT_OK` prompt instruction when heartbeat turns have the structured `heartbeat_respond` tool, while keeping the text sentinel for legacy automatic heartbeat replies. Thanks @pashpashpash.
 - Agent runtimes: fail explicit plugin runtime selections honestly when the requested harness is unavailable instead of silently falling back to the embedded PI runtime. Thanks @pashpashpash.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -40,31 +40,12 @@ Override the configured exec timeout for this call. Set `timeout: 0` only when t
 Run in a pseudo-terminal when available. Use for TTY-only CLIs, coding agents, and terminal UIs.
 </ParamField>
 
-<ParamField path="host" type="'auto' | 'sandbox' | 'gateway' | 'node'" default="auto">
-Where to execute. `auto` resolves to `sandbox` when a sandbox runtime is active and `gateway` otherwise.
-</ParamField>
-
-<ParamField path="security" type="'deny' | 'allowlist' | 'full'">
-Enforcement mode for `gateway` / `node` execution.
-</ParamField>
-
-<ParamField path="ask" type="'off' | 'on-miss' | 'always'">
-Approval prompt behavior for `gateway` / `node` execution.
-</ParamField>
-
-<ParamField path="node" type="string">
-Node id/name when `host=node`.
-</ParamField>
-
-<ParamField path="elevated" type="boolean" default="false">
-Request elevated mode — escape the sandbox onto the configured host path. `security=full` is forced only when elevated resolves to `full`.
-</ParamField>
-
 Notes:
 
+- Exec policy controls (`host`, `security`, `ask`, `node`, and elevated host access) are not tool-call parameters. Set them in config or with `/exec` session defaults.
 - `host` defaults to `auto`: sandbox when sandbox runtime is active for the session, otherwise gateway.
-- `host` only accepts `auto`, `sandbox`, `gateway`, or `node`. It is not a hostname selector; hostname-like values are rejected before the command runs.
-- `auto` is the default routing strategy, not a wildcard. Per-call `host=node` is allowed from `auto`; per-call `host=gateway` is only allowed when no sandbox runtime is active.
+- `host` only accepts `auto`, `sandbox`, `gateway`, or `node`. It is not a hostname selector.
+- `auto` is the default routing strategy, not a wildcard. To force gateway or node routing, set `tools.exec.host`, `exec.host`, or use `/exec host=...`.
 - With no extra config, `host=auto` still "just works": no sandbox means it resolves to `gateway`; a live sandbox means it stays in the sandbox.
 - `elevated` escapes the sandbox onto the configured host path: `gateway` by default, or `node` when `tools.exec.host=node` (or the session default is `host=node`). It is only available when elevated access is enabled for the current session/provider.
 - `gateway`/`node` approvals are controlled by `~/.openclaw/exec-approvals.json`.

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -51,31 +51,28 @@ describe("exec foreground failures", () => {
     expect((result.details as { durationMs?: number }).durationMs).toEqual(expect.any(Number));
   });
 
-  it("rejects invalid host values before launching a command", async () => {
+  it("ignores operator-only policy fields supplied in tool-call args", async () => {
     const tool = createExecTool({
+      host: "gateway",
       security: "full",
       ask: "off",
       allowBackground: false,
     });
-    for (const testCase of [
-      {
-        host: "spark-ff13",
-        message: 'Invalid exec host "spark-ff13". Allowed values: auto, sandbox, gateway, node.',
-      },
-      {
-        host: 42,
-        message:
-          "Invalid exec host value type number. Allowed values: auto, sandbox, gateway, node.",
-      },
-    ]) {
-      const malformedArgs = {
-        command: "echo should-not-run",
-        host: testCase.host,
-      } as unknown as Parameters<typeof tool.execute>[1];
+    const args = {
+      command: "echo policy-ok",
+      host: "spark-ff13",
+      security: "deny",
+      ask: "always",
+      elevated: true,
+      node: "not-a-real-node",
+    } as unknown as Parameters<typeof tool.execute>[1];
 
-      await expect(tool.execute("call-invalid-host", malformedArgs)).rejects.toThrow(
-        testCase.message,
-      );
-    }
+    const result = await tool.execute("call-model-policy-fields", args);
+
+    expect(result.details).toMatchObject({
+      status: "completed",
+      exitCode: 0,
+    });
+    expect((result.content[0] as { text?: string }).text).toContain("policy-ok");
   });
 });

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -595,7 +595,7 @@ describe("exec approvals", () => {
     expect(runCwd).toBeUndefined();
   });
 
-  it("routes explicit host=node to node invoke when elevated default is on under auto host", async () => {
+  it("routes configured host=node to node invoke when elevated default is on", async () => {
     const calls: string[] = [];
 
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
@@ -613,7 +613,7 @@ describe("exec approvals", () => {
     });
 
     const tool = createExecTool({
-      host: "auto",
+      host: "node",
       ask: "off",
       security: "full",
       approvalRunningNoticeMs: 0,
@@ -622,7 +622,6 @@ describe("exec approvals", () => {
 
     const result = await tool.execute("call-auto-node-elevated-default", {
       command: "echo gateway-ok",
-      host: "node",
     });
 
     expect(result.details.status).toBe("completed");
@@ -644,7 +643,7 @@ describe("exec approvals", () => {
       elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
     });
 
-    const result = await tool.execute("call3", { command: "echo ok", elevated: true });
+    const result = await tool.execute("call3", { command: "echo ok" });
     expect(result.details.status).toBe("completed");
     expect(calls).not.toContain("exec.approval.request");
   });
@@ -905,7 +904,7 @@ describe("exec approvals", () => {
 
     const tool = createElevatedAllowlistExecTool();
 
-    const result = await tool.execute("call4", { command: "echo ok", elevated: true });
+    const result = await tool.execute("call4", { command: "echo ok" });
     expectPendingApprovalText(result, { command: "echo ok", host: "gateway" });
     await approvalSeen;
     expect(calls).toContain("exec.approval.request");
@@ -1165,11 +1164,9 @@ describe("exec approvals", () => {
 
     const first = await tool.execute("call-seq-1", {
       command: "printf approval-one",
-      elevated: true,
     });
     const second = await tool.execute("call-seq-2", {
       command: "printf approval-two",
-      elevated: true,
     });
 
     expect(first.details.status).toBe("approval-pending");

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -6,8 +6,6 @@ import {
   type ExecHost,
   type ExecSecurity,
   loadExecApprovals,
-  maxAsk,
-  minSecurity,
   requireValidExecTarget,
 } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
@@ -38,8 +36,6 @@ import {
   type ExecProcessOutcome,
   applyPathPrepend,
   applyShellPath,
-  normalizeExecAsk,
-  normalizeExecSecurity,
   normalizePathPrepend,
   resolveExecTarget,
   resolveApprovalRunningNoticeMs,
@@ -1452,11 +1448,6 @@ export function createExecTool(
         background?: boolean;
         timeout?: number;
         pty?: boolean;
-        elevated?: boolean;
-        host?: string;
-        security?: string;
-        ask?: string;
-        node?: string;
       };
 
       if (!params.command) {
@@ -1497,14 +1488,7 @@ export function createExecTool(
               ? "ask"
               : "off";
       const effectiveDefaultMode = elevatedAllowed ? elevatedDefaultMode : "off";
-      const elevatedMode =
-        typeof params.elevated === "boolean"
-          ? params.elevated
-            ? elevatedDefaultMode === "full"
-              ? "full"
-              : "ask"
-            : "off"
-          : effectiveDefaultMode;
+      const elevatedMode = effectiveDefaultMode;
       const elevatedRequested = elevatedMode !== "off";
       if (elevatedRequested) {
         if (!elevatedDefaults?.enabled || !elevatedDefaults.allowed) {
@@ -1545,7 +1529,7 @@ export function createExecTool(
       if (elevatedRequested) {
         logInfo(`exec: elevated command ${truncateMiddle(params.command, 120)}`);
       }
-      const requestedTarget = requireValidExecTarget(params.host);
+      const requestedTarget = requireValidExecTarget(undefined);
       const target = resolveExecTarget({
         configuredTarget: defaults?.host,
         requestedTarget,
@@ -1557,15 +1541,13 @@ export function createExecTool(
       const approvalDefaults = loadExecApprovals().defaults;
       const configuredSecurity =
         defaults?.security ?? approvalDefaults?.security ?? (host === "sandbox" ? "deny" : "full");
-      const requestedSecurity = normalizeExecSecurity(params.security);
-      let security = minSecurity(configuredSecurity, requestedSecurity ?? configuredSecurity);
+      let security = configuredSecurity;
       if (elevatedRequested && elevatedMode === "full") {
         security = "full";
       }
       // Keep local exec defaults in sync with exec-approvals.json when tools.exec.* is unset.
       const configuredAsk = defaults?.ask ?? approvalDefaults?.ask ?? "off";
-      const requestedAsk = normalizeExecAsk(params.ask);
-      let ask = maxAsk(configuredAsk, requestedAsk ?? configuredAsk);
+      let ask = configuredAsk;
       const bypassApprovals = elevatedRequested && elevatedMode === "full";
       if (bypassApprovals) {
         ask = "off";
@@ -1688,7 +1670,7 @@ export function createExecTool(
           workdir,
           env,
           requestedEnv: params.env,
-          requestedNode: params.node?.trim(),
+          requestedNode: undefined,
           boundNode: defaults?.node?.trim(),
           sessionKey: defaults?.sessionKey,
           turnSourceChannel: defaults?.messageProvider,

--- a/src/agents/bash-tools.schemas.test.ts
+++ b/src/agents/bash-tools.schemas.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { execSchema } from "./bash-tools.schemas.js";
+
+describe("exec tool schema", () => {
+  it("does not expose operator-only policy fields to the model", () => {
+    const properties = (execSchema as { properties?: Record<string, unknown> }).properties ?? {};
+
+    expect(properties).toHaveProperty("command");
+    for (const field of ["security", "ask", "host", "elevated", "node"]) {
+      expect(properties).not.toHaveProperty(field);
+    }
+  });
+});

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -1,9 +1,6 @@
 import { Type } from "typebox";
-import { optionalStringEnum } from "./schema/typebox.js";
 
-const EXEC_TOOL_HOST_VALUES = ["auto", "sandbox", "gateway", "node"] as const;
-
-export const execSchema = Type.Object({
+export const execModelSchema = Type.Object({
   command: Type.String({ description: "Shell command to execute" }),
   workdir: Type.Optional(Type.String({ description: "Working directory (defaults to cwd)" })),
   env: Type.Optional(Type.Record(Type.String(), Type.String())),
@@ -24,30 +21,9 @@ export const execSchema = Type.Object({
         "Run in a pseudo-terminal (PTY) when available (TTY-required CLIs, coding agents)",
     }),
   ),
-  elevated: Type.Optional(
-    Type.Boolean({
-      description: "Run on the host with elevated permissions (if allowed)",
-    }),
-  ),
-  host: optionalStringEnum(EXEC_TOOL_HOST_VALUES, {
-    description: "Exec host/target (auto|sandbox|gateway|node).",
-  }),
-  security: Type.Optional(
-    Type.String({
-      description: "Exec security mode (deny|allowlist|full).",
-    }),
-  ),
-  ask: Type.Optional(
-    Type.String({
-      description: "Exec ask mode (off|on-miss|always).",
-    }),
-  ),
-  node: Type.Optional(
-    Type.String({
-      description: "Node id/name for host=node.",
-    }),
-  ),
 });
+
+export const execSchema = execModelSchema;
 
 export const processSchema = Type.Object({
   action: Type.String({ description: "Process action" }),

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -449,7 +449,6 @@ const EXPECTED_TOTAL_LINES_THREE = 3;
 type DisallowedElevationCase = LabeledCase & {
   defaultLevel: "off" | "on";
   overrides?: Partial<ExecToolConfig>;
-  requestElevated?: boolean;
   expectedError?: string;
   expectedOutputIncludes?: string;
 };
@@ -463,14 +462,13 @@ const NOOP_NOTIFY_CASES: NotifyNoopCase[] = [
   }),
 ];
 const DISALLOWED_ELEVATION_CASES: DisallowedElevationCase[] = [
-  withLabel("rejects elevated requests when not allowed", {
+  withLabel("ignores model-supplied elevated requests when not allowed", {
     defaultLevel: "off",
     overrides: {
       messageProvider: "telegram",
       sessionKey: DEFAULT_NOTIFY_SESSION_KEY,
     },
-    requestElevated: true,
-    expectedError: "Context: provider=telegram session=agent:main:main",
+    expectedOutputIncludes: "hi",
   }),
   withLabel("does not default to elevated when not allowed", {
     defaultLevel: "on",
@@ -525,15 +523,12 @@ const expectNotifyNoopEvents = (
 const runDisallowedElevationCase = async ({
   defaultLevel,
   overrides,
-  requestElevated,
   expectedError,
   expectedOutputIncludes,
 }: DisallowedElevationCase) => {
   const customBash = createDisallowedElevatedExecTool(defaultLevel, overrides);
   if (expectedError) {
-    await expect(
-      executeExecCommand(customBash, ECHO_HI_COMMAND, { elevated: requestElevated }),
-    ).rejects.toThrow(expectedError);
+    await expect(executeExecCommand(customBash, ECHO_HI_COMMAND)).rejects.toThrow(expectedError);
     return;
   }
 

--- a/src/agents/pi-tools-agent-config.exec.test.ts
+++ b/src/agents/pi-tools-agent-config.exec.test.ts
@@ -93,7 +93,7 @@ describe("Agent-specific exec tool defaults", () => {
     expect(resultDetails?.status).toBe("completed");
   });
 
-  it("fails closed when exec host=sandbox is requested without sandbox runtime", async () => {
+  it("ignores model-requested exec host=sandbox without sandbox runtime", async () => {
     const tools = createOpenClawCodingTools({
       config: {},
       sessionKey: "agent:main:main",
@@ -102,12 +102,12 @@ describe("Agent-specific exec tool defaults", () => {
     });
     const execTool = tools.find((tool) => tool.name === "exec");
     expect(execTool).toBeDefined();
-    await expect(
-      execTool!.execute("call-fail-closed", {
-        command: "echo done",
-        host: "sandbox",
-      }),
-    ).rejects.toThrow(/requires a sandbox runtime/);
+    const result = await execTool!.execute("call-ignored-host", {
+      command: "echo done",
+      host: "sandbox",
+    });
+    const resultDetails = result?.details as { status?: string } | undefined;
+    expect(resultDetails?.status).toBe("completed");
   });
 
   it("should apply agent-specific exec host defaults over global defaults", async () => {
@@ -130,12 +130,12 @@ describe("Agent-specific exec tool defaults", () => {
     });
     const mainDetails = mainResult?.details as { status?: string } | undefined;
     expect(mainDetails?.status).toBe("completed");
-    await expect(
-      mainExecTool!.execute("call-main", {
-        command: "echo done",
-        host: "sandbox",
-      }),
-    ).rejects.toThrow("exec host not allowed");
+    const mainOverrideResult = await mainExecTool!.execute("call-main", {
+      command: "echo done",
+      host: "sandbox",
+    });
+    const mainOverrideDetails = mainOverrideResult?.details as { status?: string } | undefined;
+    expect(mainOverrideDetails?.status).toBe("completed");
 
     const helperTools = createOpenClawCodingTools({
       config: cfg,
@@ -151,13 +151,13 @@ describe("Agent-specific exec tool defaults", () => {
     });
     const helperDetails = helperResult?.details as { status?: string } | undefined;
     expect(helperDetails?.status).toBe("completed");
-    await expect(
-      helperExecTool!.execute("call-helper", {
-        command: "echo done",
-        host: "sandbox",
-        yieldMs: 1000,
-      }),
-    ).rejects.toThrow(/requires a sandbox runtime/);
+    const helperOverrideResult = await helperExecTool!.execute("call-helper", {
+      command: "echo done",
+      host: "sandbox",
+      yieldMs: 1000,
+    });
+    const helperOverrideDetails = helperOverrideResult?.details as { status?: string } | undefined;
+    expect(helperOverrideDetails?.status).toBe("completed");
   });
 
   it("applies explicit agentId exec defaults when sessionKey is opaque", async () => {

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -365,7 +365,6 @@ export async function handleBashChatCommand(params: {
       background: shouldBackgroundImmediately,
       yieldMs: shouldBackgroundImmediately ? undefined : foregroundMs,
       timeout: timeoutSec,
-      elevated: true,
     });
 
     if (result.details?.status === "running") {

--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -254,10 +254,8 @@ describe("diagnostics command", () => {
     expect(
       String((execCalls[0]?.defaults as { approvalWarningText?: string }).approvalWarningText),
     ).toContain("https://docs.openclaw.ai/gateway/diagnostics");
-    expect(execCalls[0]?.params).toMatchObject({
-      security: "allowlist",
-      ask: "always",
-    });
+    expect(execCalls[0]?.params).not.toHaveProperty("security");
+    expect(execCalls[0]?.params).not.toHaveProperty("ask");
     const command = (execCalls[0]?.params as { command?: string }).command ?? "";
     expect(command).toContain("gateway");
     expect(command).toContain("diagnostics");

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -323,8 +323,6 @@ async function requestGatewayDiagnosticsExportApproval(
     });
     const result = await execTool.execute("chat-diagnostics-gateway-export", {
       command,
-      security: "allowlist",
-      ask: "always",
       background: true,
       timeout: timeoutSec,
     });

--- a/src/auto-reply/reply/commands-export-trajectory.test.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.test.ts
@@ -325,10 +325,10 @@ describe("buildExportTrajectoryCommandReply", () => {
       accountId: "account-1",
     });
     expect(execCalls[0]?.params).toMatchObject({
-      security: "allowlist",
-      ask: "always",
       background: true,
     });
+    expect(execCalls[0]?.params).not.toHaveProperty("security");
+    expect(execCalls[0]?.params).not.toHaveProperty("ask");
     const command = (execCalls[0]?.params as { command?: string }).command ?? "";
     expect(command).toContain("sessions");
     expect(command).toContain("export-trajectory");

--- a/src/auto-reply/reply/commands-export-trajectory.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.ts
@@ -270,8 +270,6 @@ async function requestTrajectoryExportApproval(
     });
     const result = await execTool.execute("chat-export-trajectory", {
       command: request.command,
-      security: "allowlist",
-      ask: "always",
       background: true,
       timeout: timeoutSec,
     });


### PR DESCRIPTION
## Summary

- Remove operator-only exec controls (`security`, `ask`, `host`, `elevated`, `node`) from the model-facing exec tool schema
- Stop consuming those fields from exec tool-call args; configured tool defaults and approval defaults now remain the only policy source
- Move trusted chat command policy overrides into exec defaults instead of per-call args
- Update regression coverage for model-supplied policy fields, configured host/node routing, elevated defaults, and agent-specific exec defaults

Fixes #75811.

## Security

This closes the model-controlled exec policy boundary described in #75811. Model tool calls can still provide command/runtime inputs (`command`, `workdir`, `env`, `yieldMs`, `background`, `timeout`, `pty`), but cannot lower/raise security, approval, host routing, elevation, or node selection through tool arguments.

## Test plan

- pnpm test src/agents/bash-tools.schemas.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec.approval-id.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/pi-tools-agent-config.exec.test.ts src/agents/pi-tools.schema.test.ts
- pnpm test src/agents/bash-tools.test.ts src/agents/bash-tools.exec.approval-id.test.ts
- pnpm test src/agents/bash-tools.schemas.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.exec.approval-id.test.ts src/agents/pi-tools-agent-config.exec.test.ts src/auto-reply/reply/bash-command.stop.test.ts
- pnpm exec oxfmt --check --threads=1 src/agents/bash-tools.schemas.ts src/agents/bash-tools.schemas.test.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.exec.approval-id.test.ts src/agents/pi-tools-agent-config.exec.test.ts src/agents/bash-tools.test.ts src/auto-reply/reply/bash-command.ts src/auto-reply/reply/commands-diagnostics.ts src/auto-reply/reply/commands-export-trajectory.ts
- pnpm tsgo:core
- pnpm tsgo:core:test
- pnpm check:changed
