### PR TITLE
fix(diagnostics): suppress liveness warnings during startup-grace window (#76365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/diagnostics: suppress liveness event/warning emission during the `startupGraceMs` window while still running the sampler so event-loop-delay metrics and baselines are reset each heartbeat; prevents startup spikes from being falsely reported by the first post-grace sample. Fixes #76365.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Gateway/diagnostics: suppress liveness event/warning emission during the `startupGraceMs` window while still running the sampler so event-loop-delay metrics and baselines are reset each heartbeat; prevents startup spikes from being falsely reported by the first post-grace sample. Fixes #76365.
+- Gateway/diagnostics: suppress liveness event/warning emission during the `startupGraceMs` window while still running the sampler so event-loop-delay metrics and baselines are reset each heartbeat; prevents startup spikes from being falsely reported by the first post-grace sample. Fixes #76365. Thanks @hclsys.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -552,7 +552,10 @@ export async function startGatewayServer(
   const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
   setDiagnosticsEnabledForProcess(diagnosticsEnabled);
   if (diagnosticsEnabled) {
-    startDiagnosticHeartbeat(undefined, { getConfig: getRuntimeConfig });
+    startDiagnosticHeartbeat(undefined, {
+      getConfig: getRuntimeConfig,
+      startupGraceMs: 60_000,
+    });
   }
   setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(cfgAtStart) });
   setPreRestartDeferralCheck(

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -587,7 +587,7 @@ describe("stuck session diagnostics threshold", () => {
     const events: string[] = [];
     const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
     const sampleLiveness = vi.fn(() => ({
-      reasons: ["event_loop_delay"] as const,
+      reasons: ["event_loop_delay"],
       intervalMs: 30_000,
       eventLoopDelayP99Ms: 1_500,
       eventLoopDelayMaxMs: 2_000,

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -582,6 +582,41 @@ describe("stuck session diagnostics threshold", () => {
     expect(events.filter((event) => event === "diagnostic.liveness.warning")).toHaveLength(2);
   });
 
+  it("suppresses liveness warnings during startupGraceMs window (#76365)", () => {
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    const events: string[] = [];
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
+
+    try {
+      startDiagnosticHeartbeat(
+        { diagnostics: { enabled: true } },
+        {
+          emitMemorySample: createEmitMemorySampleMock(),
+          sampleLiveness: () => ({
+            reasons: ["event_loop_delay"],
+            intervalMs: 30_000,
+            eventLoopDelayP99Ms: 1_500,
+            eventLoopDelayMaxMs: 2_000,
+          }),
+          startupGraceMs: 60_000,
+        },
+      );
+
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      // Still within the 60s grace window — no liveness warning should fire
+      vi.advanceTimersByTime(30_000);
+      expect(events.filter((e) => e === "diagnostic.liveness.warning")).toHaveLength(0);
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("liveness warning:"));
+
+      // Advance past grace window — liveness warning should now fire
+      vi.advanceTimersByTime(60_000);
+      expect(events.filter((e) => e === "diagnostic.liveness.warning")).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("liveness warning:"));
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it("does not start the heartbeat when diagnostics are disabled by config", () => {
     const emitMemorySample = createEmitMemorySampleMock();
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -582,29 +582,32 @@ describe("stuck session diagnostics threshold", () => {
     expect(events.filter((event) => event === "diagnostic.liveness.warning")).toHaveLength(2);
   });
 
-  it("suppresses liveness warnings during startupGraceMs window (#76365)", () => {
+  it("suppresses liveness warnings during startupGraceMs window but still calls sampler (#76365)", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
     const events: string[] = [];
     const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
+    const sampleLiveness = vi.fn(() => ({
+      reasons: ["event_loop_delay"] as const,
+      intervalMs: 30_000,
+      eventLoopDelayP99Ms: 1_500,
+      eventLoopDelayMaxMs: 2_000,
+    }));
 
     try {
       startDiagnosticHeartbeat(
         { diagnostics: { enabled: true } },
         {
           emitMemorySample: createEmitMemorySampleMock(),
-          sampleLiveness: () => ({
-            reasons: ["event_loop_delay"],
-            intervalMs: 30_000,
-            eventLoopDelayP99Ms: 1_500,
-            eventLoopDelayMaxMs: 2_000,
-          }),
+          sampleLiveness,
           startupGraceMs: 60_000,
         },
       );
 
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
-      // Still within the 60s grace window — no liveness warning should fire
+      // Still within the 60s grace window — sampler must be called (for metric resets)
+      // but no liveness warning should be emitted
       vi.advanceTimersByTime(30_000);
+      expect(sampleLiveness).toHaveBeenCalled();
       expect(events.filter((e) => e === "diagnostic.liveness.warning")).toHaveLength(0);
       expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("liveness warning:"));
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -758,10 +758,13 @@ export function startDiagnosticHeartbeat(
     const now = Date.now();
     pruneDiagnosticSessionStates(now, true);
     const work = getDiagnosticWorkSnapshot();
+    // Always run the sampler so it can reset event-loop-delay metrics and update
+    // baselines; suppressing it during grace would let startup spikes carry over
+    // into the first post-grace sample. Discard the result during grace so that
+    // liveness events/warnings are not emitted while the startup window is open.
     const inStartupGrace = livenessGraceUntil > 0 && now < livenessGraceUntil;
-    const livenessSample = inStartupGrace
-      ? null
-      : (opts?.sampleLiveness ?? sampleDiagnosticLiveness)(now, work);
+    const rawLivenessSample = (opts?.sampleLiveness ?? sampleDiagnosticLiveness)(now, work);
+    const livenessSample = inStartupGrace ? null : rawLivenessSample;
     const shouldEmitLivenessEvent =
       livenessSample !== null && shouldEmitDiagnosticLivenessEvent(now);
     const shouldEmitLivenessWarning =

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -106,6 +106,8 @@ type StartDiagnosticHeartbeatOptions = {
   emitMemorySample?: EmitDiagnosticMemorySample;
   sampleLiveness?: SampleDiagnosticLiveness;
   recoverStuckSession?: RecoverStuckSession;
+  /** Suppress liveness warnings for this many ms after heartbeat starts (mirrors channel-health-monitor startup grace). */
+  startupGraceMs?: number;
 };
 
 let diagnosticLivenessMonitor: EventLoopDelayMonitor | null = null;
@@ -741,6 +743,8 @@ export function startDiagnosticHeartbeat(
     return;
   }
   startDiagnosticLivenessSampler();
+  const livenessGraceUntil =
+    opts?.startupGraceMs != null && opts.startupGraceMs > 0 ? Date.now() + opts.startupGraceMs : 0;
   heartbeatInterval = setInterval(() => {
     let heartbeatConfig = config;
     if (!heartbeatConfig) {
@@ -754,7 +758,10 @@ export function startDiagnosticHeartbeat(
     const now = Date.now();
     pruneDiagnosticSessionStates(now, true);
     const work = getDiagnosticWorkSnapshot();
-    const livenessSample = (opts?.sampleLiveness ?? sampleDiagnosticLiveness)(now, work);
+    const inStartupGrace = livenessGraceUntil > 0 && now < livenessGraceUntil;
+    const livenessSample = inStartupGrace
+      ? null
+      : (opts?.sampleLiveness ?? sampleDiagnosticLiveness)(now, work);
     const shouldEmitLivenessEvent =
       livenessSample !== null && shouldEmitDiagnosticLivenessEvent(now);
     const shouldEmitLivenessWarning =


### PR DESCRIPTION
Fixes #76365.

## Root cause

`startDiagnosticHeartbeat` (in `src/logging/diagnostic.ts`) starts the liveness sampler immediately after gateway start with no startup-grace window. `channel-health-monitor.ts` already has a `startupGraceMs` guard (default 60s, the value logged at startup), but the diagnostic heartbeat had no equivalent. During normal cold-start operations (`models.list`, `sessions.list` taking 20-24s), the event loop delay spikes to ~15s, triggering false WARN-level liveness events.

## Fix

- Add `startupGraceMs` option to `StartDiagnosticHeartbeatOptions`; when set, liveness sampling is skipped until the grace window elapses
- `server.impl.ts` passes `startupGraceMs: 60_000` (matching the default startup-grace already printed in the `[gateway/health-monitor] started` log line)

## Changes

| File | Change |
|------|--------|
| `src/logging/diagnostic.ts` | Add `startupGraceMs` to options; skip `sampleLiveness` while `now < graceUntil` |
| `src/gateway/server.impl.ts` | Pass `startupGraceMs: 60_000` to `startDiagnosticHeartbeat` |
| `src/logging/diagnostic.test.ts` | New test: warnings suppressed within grace, fire after expiry |

## Tests

23 passing (including 1 new test for startup grace behavior).