### PR TITLE
fix(ui): relax tweakcn theme ID pattern to accept short IDs

### DIFF
--- a/ui/src/ui/custom-theme.ts
+++ b/ui/src/ui/custom-theme.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { normalizeOptionalString } from "./string-coerce.ts";
 
 const TWEAKCN_HOSTS = new Set(["tweakcn.com", "www.tweakcn.com"]);
-const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/;
+const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 const CUSTOM_THEME_STYLE_ID = "openclaw-custom-theme";
 const MAX_TWEAKCN_THEME_BYTES = 200_000;
 const MAX_CSS_TOKEN_LENGTH = 240;


### PR DESCRIPTION
The regex `THEME_ID_PATTERN` in `ui/src/ui/custom-theme.ts` used `{7,127}` as the quantifier for the trailing characters, meaning the minimum total length was 8 characters (1 mandatory leading char + 7 trailing). Valid tweakcn themes with shorter IDs like `twitter` (7 chars) were rejected.

Changed the quantifier from `{7,127}` to `{0,127}`, allowing theme IDs of any length ≥ 1 character while still rejecting empty strings.

**Verification:**
- Tested with node: `"twitter"` now matches correctly
- Empty string still correctly rejected
- Longer IDs like `"my-theme"` continue to match as before

Closes #76403