### PR TITLE
Fix/cron duplicate name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: enforce unique job names in `cron add` and `cron edit` operations, preventing silent duplicate-name acceptance that could lead to dual-fire risk when both jobs remain enabled. Fixes #76160.
 - Codex/app-server: resolve managed binaries from bundled `dist` chunks and from the `@openai/codex` package bin when installs do not provide a nearby `.bin/codex` shim, avoiding false missing-binary startup failures.
 - Plugins/source checkout: discover source-only plugins such as Codex from the `extensions/*` workspace while using npm package excludes as the packaged-core boundary, removing the stale core-bundle metadata path.
 - Plugins/ClawHub: install ClawPack artifacts from the explicit npm-pack `.tgz` resolver path and persist artifact kind, npm integrity, shasum, and tarball metadata for update and diagnostics flows. Thanks @vincentkoc.

--- a/src/cron/service.duplicate-names.test.ts
+++ b/src/cron/service.duplicate-names.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+import type { CronJobCreate } from "./types.js";
+
+describe("cron duplicate name validation", () => {
+  const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-duplicate-names-" });
+
+  const createTestService = async () => {
+    const { storePath } = await makeStorePath();
+    const service = new CronService({
+      cronEnabled: true,
+      storePath,
+      defaultAgentId: "test-agent",
+      nowMs: () => Date.now(),
+      log: logger,
+      emit: () => {},
+    });
+    await service.start();
+    return service;
+  };
+
+  const createJobInput = (name: string, overrides?: Partial<CronJobCreate>): CronJobCreate => ({
+    name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "test message" },
+    ...overrides,
+  });
+
+  describe("cron.add", () => {
+    it("allows adding a job with a unique name", async () => {
+      const service = await createTestService();
+
+      const job = await service.add(createJobInput("unique-job"));
+      expect(job.name).toBe("unique-job");
+    });
+
+    it("rejects adding a job with a duplicate name", async () => {
+      const service = await createTestService();
+
+      await service.add(createJobInput("duplicate-job"));
+
+      await expect(service.add(createJobInput("duplicate-job"))).rejects.toThrow(
+        /a cron job named 'duplicate-job' already exists/,
+      );
+    });
+
+    it("includes the existing job ID in the error message", async () => {
+      const service = await createTestService();
+
+      const existingJob = await service.add(createJobInput("existing-job"));
+
+      await expect(service.add(createJobInput("existing-job"))).rejects.toThrow(
+        new RegExp(`id=${existingJob.id}`),
+      );
+    });
+
+    it("allows adding jobs with different names", async () => {
+      const service = await createTestService();
+
+      const job1 = await service.add(createJobInput("job-one"));
+      const job2 = await service.add(createJobInput("job-two"));
+
+      expect(job1.name).toBe("job-one");
+      expect(job2.name).toBe("job-two");
+      expect(job1.id).not.toBe(job2.id);
+    });
+
+    it("checks disabled jobs for name collisions", async () => {
+      const service = await createTestService();
+
+      await service.add(createJobInput("disabled-job", { enabled: false }));
+
+      await expect(service.add(createJobInput("disabled-job"))).rejects.toThrow(
+        /a cron job named 'disabled-job' already exists/,
+      );
+    });
+  });
+
+  describe("cron.update", () => {
+    it("allows updating a job without changing its name", async () => {
+      const service = await createTestService();
+
+      const job = await service.add(createJobInput("update-test"));
+      const updated = await service.update(job.id, { description: "updated description" });
+
+      expect(updated.name).toBe("update-test");
+      expect(updated.description).toBe("updated description");
+    });
+
+    it("allows renaming a job to a unique name", async () => {
+      const service = await createTestService();
+
+      const job = await service.add(createJobInput("old-name"));
+      const updated = await service.update(job.id, { name: "new-name" });
+
+      expect(updated.name).toBe("new-name");
+    });
+
+    it("rejects renaming a job to an existing name", async () => {
+      const service = await createTestService();
+
+      await service.add(createJobInput("existing-name"));
+      const job2 = await service.add(createJobInput("job-to-rename"));
+
+      await expect(service.update(job2.id, { name: "existing-name" })).rejects.toThrow(
+        /a cron job named 'existing-name' already exists/,
+      );
+    });
+
+    it("includes the conflicting job ID in the error message", async () => {
+      const service = await createTestService();
+
+      const existingJob = await service.add(createJobInput("taken-name"));
+      const job2 = await service.add(createJobInput("rename-me"));
+
+      await expect(service.update(job2.id, { name: "taken-name" })).rejects.toThrow(
+        new RegExp(`id=${existingJob.id}`),
+      );
+    });
+
+    it("allows renaming a job to its own name (no-op)", async () => {
+      const service = await createTestService();
+
+      const job = await service.add(createJobInput("same-name"));
+      const updated = await service.update(job.id, { name: "same-name" });
+
+      expect(updated.name).toBe("same-name");
+    });
+
+    it("checks disabled jobs for name collisions when renaming", async () => {
+      const service = await createTestService();
+
+      await service.add(createJobInput("disabled-target", { enabled: false }));
+      const job2 = await service.add(createJobInput("active-job"));
+
+      await expect(service.update(job2.id, { name: "disabled-target" })).rejects.toThrow(
+        /a cron job named 'disabled-target' already exists/,
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles case-sensitive name matching", async () => {
+      const service = await createTestService();
+
+      await service.add(createJobInput("MyJob"));
+      const job2 = await service.add(createJobInput("myjob"));
+
+      expect(job2.name).toBe("myjob");
+    });
+
+    it("handles names with special characters", async () => {
+      const service = await createTestService();
+
+      await service.add(createJobInput("job-with-dashes"));
+      await expect(service.add(createJobInput("job-with-dashes"))).rejects.toThrow(
+        /a cron job named 'job-with-dashes' already exists/,
+      );
+    });
+
+    it("rejects empty string names", async () => {
+      const service = await createTestService();
+
+      await expect(service.add(createJobInput(""))).rejects.toThrow(/cron job name is required/);
+    });
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -245,6 +245,10 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
   return job;
 }
 
+export function findJobByName(state: CronServiceState, name: string): CronJob | undefined {
+  return state.store?.jobs.find((j) => j.name === name);
+}
+
 export function isJobEnabled(job: Pick<CronJob, "enabled">): boolean {
   return job.enabled ?? true;
 }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -13,6 +13,7 @@ import {
   assertSupportedJobSpec,
   computeJobNextRunAtMs,
   createJob,
+  findJobByName,
   findJobOrThrow,
   hasScheduledNextRunAtMs,
   isJobEnabled,
@@ -316,6 +317,16 @@ export async function add(state: CronServiceState, input: CronJobCreate) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
     await ensureLoaded(state);
+
+    // Check for duplicate job name
+    const existingJob = findJobByName(state, input.name);
+    if (existingJob) {
+      throw new Error(
+        `a cron job named '${input.name}' already exists (id=${existingJob.id}). ` +
+          `Use 'cron rm ${existingJob.id}' to remove it first, or choose a different name.`,
+      );
+    }
+
     const job = createJob(state, input);
     state.store?.jobs.push(job);
 
@@ -352,6 +363,18 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     warnIfDisabled(state, "update");
     await ensureLoaded(state, { skipRecompute: true });
     const job = findJobOrThrow(state, id);
+
+    // Check for duplicate job name if renaming
+    if (patch.name !== undefined && patch.name !== job.name) {
+      const existingJob = findJobByName(state, patch.name);
+      if (existingJob && existingJob.id !== id) {
+        throw new Error(
+          `a cron job named '${patch.name}' already exists (id=${existingJob.id}). ` +
+            `Use 'cron rm ${existingJob.id}' to remove it first, or choose a different name.`,
+        );
+      }
+    }
+
     const now = state.deps.nowMs();
     const nextJob = structuredClone(job);
     applyJobPatch(nextJob, patch, { defaultAgentId: state.deps.defaultAgentId });


### PR DESCRIPTION
Fixes #76160

\`openclaw cron add\` and \`cron edit\` now enforce unique job names, preventing silent duplicate-name acceptance that could lead to dual-fire risk when both jobs remain enabled.

## Problem

Previously, the cron service silently accepted jobs with duplicate names:
- Two \`cron add\` calls with the same name created two distinct rows with different IDs
- \`cron edit\` could rename a job onto an existing name
- Default \`cron list\` only showed one job when their \`enabled\` states differed, hiding the divergence
- If both jobs remained enabled, they would fire twice per cycle with potentially divergent prompts

## Solution

Added name uniqueness validation in the service layer:
- **\`cron.add\`**: Checks for existing job with the same name before creating
- **\`cron.update\`**: Checks for name collision when renaming (allows no-op self-rename)
- **Disabled jobs**: Included in uniqueness check to prevent the exact scenario from the bug report
- **Error messages**: Clear, actionable format with existing job ID and removal instructions

## Implementation

- \`src/cron/service/ops.ts\`: Added \`findJobByName()\` checks in \`add()\` and \`update()\`
- \`src/cron/service/jobs.ts\`: Added \`findJobByName()\` helper function
- \`src/cron/service.duplicate-names.test.ts\`: Comprehensive test suite (13 test cases)

All entry points (CLI, agent tool, gateway RPC) funnel through the service layer, so validation is enforced everywhere.

## Testing

Added dedicated test suite covering:
- Adding jobs with duplicate names (enabled and disabled)
- Renaming jobs to existing names (enabled and disabled)
- Edge cases (case sensitivity, special characters, empty names)
- No-op renames (renaming to same name)
- Error message validation

## Breaking Changes

None. This is a bug fix that prevents invalid state. Operators who were accidentally creating duplicate names will now receive clear error messages with instructions to resolve the conflict.

## Related

- Supersedes closed PR #76180
- Found during production config audit in markthebest12/openclaw-infra#1305" --base main