### PR TITLE
fix(realtime): strip originator header from browser WebRTC SDP offer (#76435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Control UI/Talk: fix Talk (OpenAI Realtime WebRTC) CORS failure by stripping server-side-only attribution headers (`originator`, `version`, `User-Agent`) from browser offer headers; `api.openai.com/v1/realtime/calls` only allows `authorization` and `content-type` in its CORS preflight, so forwarding these headers caused the browser SDP exchange to fail. Fixes #76435.
+- Control UI/Talk: fix Talk (OpenAI Realtime WebRTC) CORS failure by stripping server-side-only attribution headers (`originator`, `version`, `User-Agent`) from browser offer headers; `api.openai.com/v1/realtime/calls` only allows `authorization` and `content-type` in its CORS preflight, so forwarding these headers caused the browser SDP exchange to fail. Fixes #76435. Thanks @hclsys.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Talk: fix Talk (OpenAI Realtime WebRTC) CORS failure by stripping server-side-only attribution headers (`originator`, `version`, `User-Agent`) from browser offer headers; `api.openai.com/v1/realtime/calls` only allows `authorization` and `content-type` in its CORS preflight, so forwarding these headers caused the browser SDP exchange to fail. Fixes #76435.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -192,19 +192,12 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       transport: "webrtc-sdp",
       clientSecret: "client-secret-123",
       offerUrl: "https://api.openai.com/v1/realtime/calls",
-      offerHeaders: {
-        version: "2026.3.22",
-      },
     });
-    // originator and User-Agent are server-side attribution headers; they must not be
-    // forwarded to the browser so that the browser's direct SDP POST to
-    // api.openai.com passes the CORS preflight (#76435).
-    expect((session as { offerHeaders?: Record<string, string> }).offerHeaders).not.toHaveProperty(
-      "originator",
-    );
-    expect((session as { offerHeaders?: Record<string, string> }).offerHeaders).not.toHaveProperty(
-      "User-Agent",
-    );
+    // originator, version, and User-Agent are server-side attribution headers; they
+    // must not be forwarded to the browser so that the browser's direct SDP POST to
+    // api.openai.com passes the CORS preflight (only authorization,content-type
+    // allowed — #76435). All three are filtered, leaving no browser offer headers.
+    expect((session as { offerHeaders?: Record<string, string> }).offerHeaders).toBeUndefined();
   });
 
   it("resolves keychain OPENAI_API_KEY refs before creating browser sessions", async () => {

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -193,10 +193,15 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       clientSecret: "client-secret-123",
       offerUrl: "https://api.openai.com/v1/realtime/calls",
       offerHeaders: {
-        originator: "openclaw",
         version: "2026.3.22",
       },
     });
+    // originator and User-Agent are server-side attribution headers; they must not be
+    // forwarded to the browser so that the browser's direct SDP POST to
+    // api.openai.com passes the CORS preflight (#76435).
+    expect((session as { offerHeaders?: Record<string, string> }).offerHeaders).not.toHaveProperty(
+      "originator",
+    );
     expect((session as { offerHeaders?: Record<string, string> }).offerHeaders).not.toHaveProperty(
       "User-Agent",
     );

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -731,9 +731,10 @@ function resolveOpenAIRealtimeBrowserOfferHeaders(): Record<string, string> | un
     transport: "http",
     defaultHeaders: {},
   });
-  // Strip headers that are server-side-only attribution signals: browser direct
-  // fetches to api.openai.com fail CORS preflight when these are present.
-  const SERVER_ONLY_HEADERS = new Set(["user-agent", "originator"]);
+  // Strip server-side-only attribution headers: browser direct fetches to
+  // api.openai.com fail CORS preflight when these are present (only
+  // authorization,content-type are allowed by the endpoint's CORS policy).
+  const SERVER_ONLY_HEADERS = new Set(["user-agent", "originator", "version"]);
   const browserHeaders = Object.fromEntries(
     Object.entries(headers ?? {}).filter(([key]) => !SERVER_ONLY_HEADERS.has(key.toLowerCase())),
   );

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -731,8 +731,11 @@ function resolveOpenAIRealtimeBrowserOfferHeaders(): Record<string, string> | un
     transport: "http",
     defaultHeaders: {},
   });
+  // Strip headers that are server-side-only attribution signals: browser direct
+  // fetches to api.openai.com fail CORS preflight when these are present.
+  const SERVER_ONLY_HEADERS = new Set(["user-agent", "originator"]);
   const browserHeaders = Object.fromEntries(
-    Object.entries(headers ?? {}).filter(([key]) => key.toLowerCase() !== "user-agent"),
+    Object.entries(headers ?? {}).filter(([key]) => !SERVER_ONLY_HEADERS.has(key.toLowerCase())),
   );
   return Object.keys(browserHeaders).length > 0 ? browserHeaders : undefined;
 }


### PR DESCRIPTION
## Problem

When using Talk (OpenAI Realtime WebRTC), the browser's direct SDP POST to `api.openai.com/v1/realtime/calls` fails with a CORS error:

```
Request header field originator is not allowed by Access-Control-Allow-Headers in preflight response.
```

## Root Cause

`resolveOpenAIRealtimeBrowserOfferHeaders` already stripped `user-agent` (browsers can't set it), but left `originator` in the browser `offerHeaders`. The browser then forwards `originator` in the SDP fetch, which OpenAI's CORS policy rejects at preflight.

`originator` is an attribution header intended for server-side (Gateway-proxied) calls only. It should not be forwarded on browser→OpenAI direct connections.

## Fix

Extend the server-only filter set in `resolveOpenAIRealtimeBrowserOfferHeaders` to include `originator` alongside `user-agent`. The gateway-side token minting call (which succeeds fine) still sends the full attribution headers.

## Test

Updated `realtime-voice-provider.test.ts` — the browser session test now asserts `originator` is absent from `offerHeaders` (same as the existing `User-Agent` assertion). 11/11 tests pass.

Closes #76435