### PR TITLE
Warn on high-frequency cron schedules (<30m)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: warn for sub-30-minute `every` schedules across CLI add/edit and Gateway add/update so short-interval jobs surface session-accumulation risk without blocking valid cron creation. Fixes #38730.
 - Memory: skip managed dreaming cron reconciliation warnings for ordinary cron and heartbeat hook contexts that cannot manage Gateway cron. (#77027) Thanks @rubencu.
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.
 - Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -54,7 +54,7 @@ vi.mock("../runtime.js", () => ({
 
 type CronUpdatePatch = {
   patch?: {
-    schedule?: { kind?: string; expr?: string; tz?: string; staggerMs?: number };
+    schedule?: { kind?: string; expr?: string; everyMs?: number; tz?: string; staggerMs?: number };
     payload?: {
       kind?: string;
       message?: string;
@@ -75,7 +75,7 @@ type CronUpdatePatch = {
 };
 
 type CronAddParams = {
-  schedule?: { kind?: string; staggerMs?: number };
+  schedule?: { kind?: string; everyMs?: number; staggerMs?: number };
   payload?: {
     model?: string;
     thinking?: string;
@@ -629,6 +629,38 @@ describe("cron cli", () => {
     expect(output.params?.name).toBe("No agent JSON");
     expect(output.params?.payload?.kind).toBe("agentTurn");
     expect(output.params?.payload?.message).toBe("hello");
+  });
+
+  it("warns for high-frequency cron add schedules on stderr without corrupting JSON stdout", async () => {
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "Fast add",
+      "--every",
+      "15m",
+      "--session",
+      "main",
+      "--system-event",
+      "tick",
+      "--json",
+    ]);
+
+    expect(params?.schedule?.kind).toBe("every");
+    expect(params?.schedule?.everyMs).toBe(900_000);
+    expectRuntimeErrorContaining("high-frequency cron schedules (<30m)");
+    const stdout = stdoutText();
+    expect(stdout).not.toContain("high-frequency cron schedules");
+    expect(JSON.parse(stdout)).toMatchObject({ ok: true });
+  });
+
+  it("warns for high-frequency cron edit schedules on stderr without corrupting JSON stdout", async () => {
+    const patch = await runCronEditAndGetPatch(["--every", "15m"]);
+
+    expect(patch?.patch?.schedule?.kind).toBe("every");
+    expect(patch?.patch?.schedule?.everyMs).toBe(900_000);
+    expectRuntimeErrorContaining("high-frequency cron schedules (<30m)");
+    const stdout = stdoutText();
+    expect(stdout).not.toContain("high-frequency cron schedules");
+    expect(JSON.parse(stdout)).toMatchObject({ ok: true });
   });
 
   it("warns when --agent is blank on cron add with --message", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -1,4 +1,8 @@
 import type { Command } from "commander";
+import {
+  getHighFrequencyEveryWarningMessage,
+  isHighFrequencyEverySchedule,
+} from "../../cron/high-frequency-warning.js";
 import type { CronJob } from "../../cron/types.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -132,6 +136,9 @@ export function registerCronAddCommand(cron: Command) {
             stagger: opts.stagger,
             tz: opts.tz,
           });
+          if (isHighFrequencyEverySchedule(schedule)) {
+            defaultRuntime.error(theme.warn(getHighFrequencyEveryWarningMessage()));
+          }
 
           const wakeMode = normalizeOptionalString(opts.wake) ?? "now";
           if (wakeMode !== "now" && wakeMode !== "next-heartbeat") {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -1,4 +1,8 @@
 import type { Command } from "commander";
+import {
+  getHighFrequencyEveryWarningMessage,
+  isHighFrequencyEverySchedule,
+} from "../../cron/high-frequency-warning.js";
 import type { CronJob } from "../../cron/types.js";
 import { danger } from "../../globals.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
@@ -214,6 +218,9 @@ export function registerCronEditCommand(cron: Command) {
           });
           if (scheduleRequest.kind === "direct") {
             patch.schedule = scheduleRequest.schedule;
+            if (isHighFrequencyEverySchedule(scheduleRequest.schedule)) {
+              defaultRuntime.error(getHighFrequencyEveryWarningMessage());
+            }
           } else if (scheduleRequest.kind === "patch-existing-cron") {
             const existing = await loadCronJobForEditSchedulePatch(opts, String(id));
             if (!existing) {

--- a/src/cron/high-frequency-warning.ts
+++ b/src/cron/high-frequency-warning.ts
@@ -1,0 +1,13 @@
+import type { CronSchedule } from "./types.js";
+
+export const HIGH_FREQUENCY_EVERY_THRESHOLD_MS = 30 * 60 * 1000;
+
+export function isHighFrequencyEverySchedule(
+  schedule: CronSchedule | undefined,
+): schedule is Extract<CronSchedule, { kind: "every" }> {
+  return schedule?.kind === "every" && schedule.everyMs < HIGH_FREQUENCY_EVERY_THRESHOLD_MS;
+}
+
+export function getHighFrequencyEveryWarningMessage(): string {
+  return "Warning: high-frequency cron schedules (<30m) can accumulate sessions and silently exhaust the agent context window; prefer heartbeat or longer intervals when possible.";
+}

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveCronDeliveryPreviews } from "../../cron/delivery-preview.js";
+import {
+  getHighFrequencyEveryWarningMessage,
+  isHighFrequencyEverySchedule,
+} from "../../cron/high-frequency-warning.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
 import {
   readCronRunLogEntriesPage,
@@ -307,6 +311,13 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    if (isHighFrequencyEverySchedule(jobCreate.schedule)) {
+      context.logGateway.warn(getHighFrequencyEveryWarningMessage(), {
+        method: "cron.add",
+        name: jobCreate.name,
+        schedule: jobCreate.schedule,
+      });
+    }
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);
   },
@@ -401,6 +412,13 @@ export const cronHandlers: GatewayRequestHandlers = {
         ),
       );
       return;
+    }
+    if (isHighFrequencyEverySchedule(patch.schedule)) {
+      context.logGateway.warn(getHighFrequencyEveryWarningMessage(), {
+        jobId,
+        method: "cron.update",
+        schedule: patch.schedule,
+      });
     }
     context.logGateway.info("cron: job updated", { jobId });
     respond(true, job, undefined);

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -80,6 +80,7 @@ function createCronContext(currentJob?: CronJob) {
     },
     logGateway: {
       info: vi.fn(),
+      warn: vi.fn(),
     },
     getRuntimeConfig: () => getRuntimeConfig(),
   };
@@ -268,6 +269,53 @@ describe("cron method validation", () => {
       to: "-1001234567890",
       threadId: "456",
     });
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("warns but accepts high-frequency every schedules on cron.add", async () => {
+    const { context, respond } = await invokeCronAdd({
+      name: "fast add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 900_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expect(context.logGateway.warn).toHaveBeenCalledWith(
+      expect.stringContaining("high-frequency cron schedules (<30m)"),
+      expect.objectContaining({
+        method: "cron.add",
+        name: "fast add",
+        schedule: { kind: "every", everyMs: 900_000 },
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("warns but accepts high-frequency every schedules on cron.update", async () => {
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          schedule: { kind: "every", everyMs: 900_000 },
+        },
+      },
+      createCronJob(),
+    );
+
+    expect(context.cron.update).toHaveBeenCalledWith("cron-1", {
+      schedule: { kind: "every", everyMs: 900_000 },
+    });
+    expect(context.logGateway.warn).toHaveBeenCalledWith(
+      expect.stringContaining("high-frequency cron schedules (<30m)"),
+      expect.objectContaining({
+        jobId: "cron-1",
+        method: "cron.update",
+        schedule: { kind: "every", everyMs: 900_000 },
+      }),
+    );
     expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
   });
 


### PR DESCRIPTION
## Summary
- extract a shared high-frequency `every` warning helper
- warn on high-frequency `every` schedules in CLI `cron add` and `cron edit`
- warn on high-frequency `every` schedules in Gateway `cron.add` and `cron.update`
- align the Gateway warning call shape and add focused CLI/Gateway regression coverage

## Verification
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/cron/high-frequency-warning.ts src/cli/cron-cli/register.cron-add.ts src/cli/cron-cli/register.cron-edit.ts src/gateway/server-methods/cron.ts src/cli/cron-cli.test.ts src/gateway/server-methods/cron.validation.test.ts`
- `pnpm exec vitest run src/cli/cron-cli.test.ts src/gateway/server-methods/cron.validation.test.ts`

Replacement for #38731.

Closes #38730.