### PR TITLE
fix(plugin-runtime): use named chokidar imports to fix Node 22 ESM resolution

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -33,7 +33,7 @@ const watchMock = vi.fn(() => {
 let refreshModule: typeof import("./refresh.js");
 
 vi.mock("chokidar", () => ({
-  default: { watch: watchMock },
+  watch: watchMock,
 }));
 
 vi.mock("./plugin-skills.js", () => ({

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import chokidar, { type FSWatcher } from "chokidar";
+import { watch as chokidarWatch, type FSWatcher } from "chokidar";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -139,7 +139,7 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
     void existing.watcher.close().catch(() => {});
   }
 
-  const watcher = chokidar.watch(watchTargets, {
+  const watcher = chokidarWatch(watchTargets, {
     ignoreInitial: true,
     awaitWriteFinish: {
       stabilityThreshold: debounceMs,

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -9,7 +9,7 @@ import {
   clearTimeout as clearNativeTimeout,
   setTimeout as scheduleNativeTimeout,
 } from "node:timers";
-import chokidar from "chokidar";
+import { watch as chokidarWatch } from "chokidar";
 import { type WebSocket, WebSocketServer } from "ws";
 import { resolveStateDir } from "../config/paths.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -34,7 +34,7 @@ export type CanvasHostOpts = {
   listenHost?: string;
   allowInTests?: boolean;
   liveReload?: boolean;
-  watchFactory?: typeof chokidar.watch;
+  watchFactory?: ChokidarWatch;
   webSocketServerClass?: typeof WebSocketServer;
 };
 
@@ -55,7 +55,7 @@ export type CanvasHostHandlerOpts = {
   basePath?: string;
   allowInTests?: boolean;
   liveReload?: boolean;
-  watchFactory?: typeof chokidar.watch;
+  watchFactory?: ChokidarWatch;
   webSocketServerClass?: typeof WebSocketServer;
 };
 
@@ -222,9 +222,8 @@ function resolveDefaultCanvasRoot(): string {
 }
 
 function resolveDefaultWatchFactory(): ChokidarWatch {
-  const importedWatch = (chokidar as { watch?: ChokidarWatch } | undefined)?.watch;
-  if (typeof importedWatch === "function") {
-    return importedWatch.bind(chokidar);
+  if (typeof chokidarWatch === "function") {
+    return chokidarWatch;
   }
 
   const require = createRequire(import.meta.url);

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1,5 +1,10 @@
-import chokidar from "chokidar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const chokidarWatchMock = vi.hoisted(() => vi.fn());
+vi.mock("chokidar", () => ({
+  watch: chokidarWatchMock,
+}));
+
 import {
   getSkillsSnapshotVersion,
   resetSkillsRefreshStateForTest,
@@ -590,7 +595,7 @@ function createReloaderHarness(
   } = {},
 ) {
   const watcher = createWatcherMock();
-  vi.spyOn(chokidar, "watch").mockReturnValue(watcher as unknown as never);
+  chokidarWatchMock.mockReturnValue(watcher as unknown as never);
   const onHotReload = vi.fn(async () => {});
   const onRestart = vi.fn();
   let writeListener: ((event: ConfigWriteNotification) => void) | null = null;

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import chokidar from "chokidar";
+import { watch as chokidarWatch } from "chokidar";
 import { bumpSkillsSnapshotVersion } from "../agents/skills/refresh-state.js";
 import type { ConfigWriteNotification } from "../config/io.js";
 import { formatConfigIssueLines, formatConfigIssueSummary } from "../config/issue-format.js";
@@ -515,7 +515,7 @@ export function startGatewayConfigReloader(opts: {
     }
   };
 
-  const watcher = chokidar.watch(opts.watchPath, {
+  const watcher = chokidarWatch(opts.watchPath, {
     ignoreInitial: true,
     awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
     usePolling: Boolean(process.env.VITEST),


### PR DESCRIPTION
fix(plugin-runtime): use named chokidar imports to fix Node 22 ESM resolution

The default-import shape `import chokidar from "chokidar"` fails at module-load
time under chokidar 5.x's ESM exports map in Node 22.x bundling
configurations:

    Cannot find package 'chokidar' imported from .../dist/manager-*.js
    Did you mean to import "chokidar/index.js"?

This blocks subcommands that exercise the watcher startup path (notably
plugin-runtime stagers that mirror chokidar from the OpenClaw runtime-deps
tree). Reproduces on openclaw 2026.4.27, Node v22.22.1, macOS 14.x. Refs
#73176 (the original report; closed prematurely on 2026-04-28 but the
regression persists in 2026.4.26 and 2026.4.27 as documented in the
follow-up comment from w3i-William on the issue thread).

Switch to named imports per chokidar 5.x's documented usage:

    import { watch as chokidarWatch, type FSWatcher } from "chokidar";

Named imports survive future chokidar majors and don't depend on the
package's `exports` map happening to expose `index.js` directly. The
aliased local name (`chokidarWatch`) preserves call-site readability where
the previous code wrote `chokidar.watch(...)` and avoids a future collision
with an unrelated `watch` symbol.

The existing `createRequire("chokidar")` runtime fallback inside
`src/canvas-host/server.ts:resolveDefaultWatchFactory` is left intact (still
defends against the same-class failure at runtime).

Test-side updates (required, since the spy/mock targets the same module):

  - `src/gateway/config-reload.test.ts`: switch from
    `vi.spyOn(chokidar, "watch")` (which can't redefine a property on a
    frozen ESM namespace) to a hoisted `vi.mock("chokidar", ...)` factory
    sharing a `vi.hoisted(() => vi.fn())` mock with the harness setup.
  - `src/agents/skills/refresh.test.ts`:
    `vi.mock("chokidar", () => ({ watch }))` instead of
    `{ default: { watch } }`.

Verified locally on Mac mini (macOS 25.4.0 arm64, Node v22.22.1, pnpm 10.33.2):

  - `pnpm install --frozen-lockfile` -- clean
  - `npx tsc --noEmit -p tsconfig.core.json` -- clean
    (NODE_OPTIONS=--max-old-space-size=8192 needed locally; CI presumably
    sets this already)
  - `npx tsc --noEmit -p tsconfig.core.test.json` -- clean
  - canvas-host tests (`vitest.unit-fast.config.ts` --
    `src/canvas-host/server.test.ts` + `server.state-dir.test.ts`):
    7/7 pass
  - config-reload tests (`vitest.gateway-core.config.ts` --
    `src/gateway/config-reload.test.ts`): 73/73 pass
  - skills/refresh tests (`vitest.agents-support.config.ts` --
    `src/agents/skills/refresh.test.ts`): 5/5 pass
