### PR TITLE
fix(cli): inject default systemPrompt for local infer model run (#76464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/infer: fix `openclaw infer model run --model openai-codex/<model>` failing with "No text output returned" by injecting a default system prompt in the local simple-completion context; `openai-codex-responses` maps `context.systemPrompt` to the Responses `instructions` field, which is required. Fixes #76464.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- CLI/infer: fix `openclaw infer model run --model openai-codex/<model>` failing with "No text output returned" by injecting a default system prompt in the local simple-completion context; `openai-codex-responses` maps `context.systemPrompt` to the Responses `instructions` field, which is required. Fixes #76464.
+- CLI/infer: fix `openclaw infer model run --model openai-codex/<model>` failing with "No text output returned" by injecting a default system prompt in the local simple-completion context; `openai-codex-responses` maps `context.systemPrompt` to the Responses `instructions` field, which is required. Fixes #76464. Thanks @lilesjtu and @hclsys.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -164,7 +164,7 @@ openclaw infer model run --local --model ollama/qwen2.5vl:7b --prompt "Describe 
 
 Notes:
 
-- Local `model run` is the narrowest CLI smoke for provider/model/auth health because it sends only the supplied prompt to the selected model.
+- Local `model run` is the narrowest CLI smoke for provider/model/auth health. It sends the supplied prompt with a minimal default system prompt (`"You are a helpful assistant."`) so providers that require a non-empty system prompt (such as `openai-codex-responses`) succeed without an agent session context.
 - Local `model run --file` keeps that lean path and attaches image content directly to the single user message. Common image files such as PNG, JPEG, and WebP work when their MIME type is detected as `image/*`; unsupported or unrecognized files fail before the provider is called.
 - `model run --file` is best when you want to test the selected multimodal text model directly. Use `infer image describe` when you want OpenClaw's image-understanding provider selection and default image-model routing.
 - The selected model must support image input; text-only models may reject the request at the provider layer.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -406,14 +406,15 @@ describe("capability cli", () => {
     );
     expect(mocks.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledWith(
       expect.objectContaining({
-        context: {
+        context: expect.objectContaining({
+          systemPrompt: "You are a helpful assistant.",
           messages: [
             expect.objectContaining({
               role: "user",
               content: "hello",
             }),
           ],
-        },
+        }),
       }),
     );
   });
@@ -438,7 +439,8 @@ describe("capability cli", () => {
 
     expect(mocks.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledWith(
       expect.objectContaining({
-        context: {
+        context: expect.objectContaining({
+          systemPrompt: "You are a helpful assistant.",
           messages: [
             expect.objectContaining({
               role: "user",
@@ -448,7 +450,7 @@ describe("capability cli", () => {
               ],
             }),
           ],
-        },
+        }),
       }),
     );
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith(

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -664,6 +664,10 @@ async function runModelRun(params: {
       auth: prepared.auth,
       cfg,
       context: {
+        // Some providers (openai-codex-responses) require a non-empty system prompt
+        // (mapped to `instructions`). Inject a minimal default so local model probes
+        // succeed without the agent session context that normally supplies it.
+        systemPrompt: "You are a helpful assistant.",
         messages: [
           {
             role: "user",


### PR DESCRIPTION
## Problem

`openclaw infer model run --model openai-codex/gpt-5.5` fails with:

```
No text output returned for provider "openai-codex" model "gpt-5.5".
```

The underlying Codex API error is `{"detail":"Instructions are required"}`.

## Root Cause

The local CLI model-run path in `runModelRun` builds a completion context with only a user message — no `systemPrompt`. The `openai-codex-responses` provider maps `context.systemPrompt` → `instructions` in the Responses API body. When `systemPrompt` is absent, `instructions` is `undefined`, omitted from the request, and the Codex backend rejects it.

The gateway agent path works because the agent carries a configured system prompt from its session, which gets passed through.

## Fix

Inject a minimal `systemPrompt: "You are a helpful assistant."` in the local completion context. This satisfies providers that require a non-empty system prompt (openai-codex-responses) while being a reasonable default for all other providers using the `infer model run` command.

## Test

Updated `capability-cli.test.ts` — both the text-only and image-file local model probe assertions now expect `systemPrompt` in the context. 53/53 tests pass.

Closes #76464