### PR TITLE
fix(agents): route sessions_send A2A announce replies back to request…

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -981,7 +981,6 @@ describe("sessions tools", () => {
     const replyByRunId = new Map<string, string>();
     const requesterKey = "discord:group:req";
     const targetKey = "discord:group:target";
-    let sendParams: { to?: string; channel?: string; message?: string } = {};
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
       calls.push(request);
@@ -1027,14 +1026,6 @@ describe("sessions tools", () => {
         };
       }
       if (request.method === "send") {
-        const params = request.params as
-          | { to?: string; channel?: string; message?: string }
-          | undefined;
-        sendParams = {
-          to: params?.to,
-          channel: params?.channel,
-          message: params?.message,
-        };
         return { messageId: "m-announce" };
       }
       return {};
@@ -1067,17 +1058,16 @@ describe("sessions tools", () => {
     });
     await vi.waitFor(
       () => {
-        expect(calls.filter((call) => call.method === "agent")).toHaveLength(3);
+        expect(calls.filter((call) => call.method === "agent")).toHaveLength(4);
       },
       { timeout: 2_000, interval: 5 },
     );
 
     const agentCalls = calls.filter((call) => call.method === "agent");
-    expect(agentCalls).toHaveLength(3);
+    expect(agentCalls).toHaveLength(4);
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: expect.stringMatching(/^nested(?::|$)/),
-        channel: "webchat",
         inputProvenance: { kind: "inter_session" },
       });
     }
@@ -1091,11 +1081,16 @@ describe("sessions tools", () => {
         ),
     );
     expect(replySteps).toHaveLength(2);
-    expect(sendParams).toMatchObject({
-      to: "group:target",
-      channel: "discord",
-      message: "announce now",
-    });
+
+    // The announce should now be delivered back to the requester session
+    const announceCall = calls.find(
+      (call) =>
+        call.method === "agent" &&
+        (call.params as { sessionKey?: string })?.sessionKey === requesterKey &&
+        (call.params as { deliver?: boolean })?.deliver === true,
+    );
+    expect(announceCall).toBeDefined();
+    expect((announceCall?.params as { message?: string })?.message).toBe("announce now");
   });
 
   it("sessions_send skips duplicate A2A delivery for waited parent-owned native subagents", async () => {
@@ -1184,13 +1179,6 @@ describe("sessions tools", () => {
     const replyByRunId = new Map<string, string>();
     const requesterKey = "discord:group:req";
     const targetKey = "agent:main:worker";
-    let sendParams: {
-      to?: string;
-      channel?: string;
-      accountId?: string;
-      message?: string;
-      threadId?: string;
-    } = {};
 
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
@@ -1251,22 +1239,6 @@ describe("sessions tools", () => {
         };
       }
       if (request.method === "send") {
-        const params = request.params as
-          | {
-              to?: string;
-              channel?: string;
-              accountId?: string;
-              message?: string;
-              threadId?: string;
-            }
-          | undefined;
-        sendParams = {
-          to: params?.to,
-          channel: params?.channel,
-          accountId: params?.accountId,
-          message: params?.message,
-          threadId: params?.threadId,
-        };
         return { messageId: "m-threaded-announce" };
       }
       return {};
@@ -1299,17 +1271,19 @@ describe("sessions tools", () => {
     });
     await vi.waitFor(
       () => {
-        expect(calls.filter((call) => call.method === "send")).toHaveLength(1);
+        expect(calls.filter((call) => call.method === "agent")).toHaveLength(4);
       },
       { timeout: 2_000, interval: 5 },
     );
 
-    expect(sendParams).toMatchObject({
-      to: "123@g.us",
-      channel: "whatsapp",
-      accountId: "work",
-      message: "announce now",
-      threadId: "99",
-    });
+    // The announce should now be delivered back to the requester session, not to the target channel
+    const announceCall = calls.find(
+      (call) =>
+        call.method === "agent" &&
+        (call.params as { sessionKey?: string })?.sessionKey === requesterKey &&
+        (call.params as { deliver?: boolean })?.deliver === true,
+    );
+    expect(announceCall).toBeDefined();
+    expect((announceCall?.params as { message?: string })?.message).toBe("announce now");
   });
 });

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -50,6 +50,43 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     vi.restoreAllMocks();
   });
 
+  it("delivers announce reply back to requester session for A2A communication", async () => {
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:director1:main",
+      displayKey: "agent:director1:main",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 0,
+      requesterSessionKey: "agent:main:main",
+      requesterChannel: "webchat",
+      roundOneReply: "Worker completed successfully",
+    });
+
+    const agentCall = gatewayCalls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    const agentParams = agentCall?.params as Record<string, unknown>;
+    expect(agentParams.sessionKey).toBe("agent:main:main");
+    expect(agentParams.channel).toBe("webchat");
+    expect(agentParams.deliver).toBe(true);
+    expect(typeof agentParams.message).toBe("string");
+  });
+
+  it("falls back to target channel delivery when no requester session", async () => {
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:discord:group:dev",
+      displayKey: "agent:main:discord:group:dev",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 0,
+      roundOneReply: "Worker completed successfully",
+    });
+
+    const sendCall = gatewayCalls.find((call) => call.method === "send");
+    expect(sendCall).toBeDefined();
+    const sendParams = sendCall?.params as Record<string, unknown>;
+    expect(sendParams.channel).toBe("discord");
+  });
+
   it("passes threadId through to gateway send for Telegram forum topics", async () => {
     await runSessionsSendA2AFlow({
       targetSessionKey: "agent:main:telegram:group:-100123:topic:554",
@@ -68,7 +105,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(sendParams.threadId).toBe("554");
   });
 
-  it("omits threadId for non-topic sessions", async () => {
+  it("omits threadId for non-topic sessions when no requester", async () => {
     await runSessionsSendA2AFlow({
       targetSessionKey: "agent:main:discord:group:dev",
       displayKey: "agent:main:discord:group:dev",
@@ -112,27 +149,30 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
         lastAccountId: "scout",
       } satisfies SessionListRow,
     },
-  ])("uses Discord session $source for announce accountId", async ({ accountId, session }) => {
-    sessionListRows = [session];
+  ])(
+    "uses Discord session $source for announce accountId when no requester",
+    async ({ accountId, session }) => {
+      sessionListRows = [session];
 
-    await runSessionsSendA2AFlow({
-      targetSessionKey: session.key,
-      displayKey: session.key,
-      message: "Test message",
-      announceTimeoutMs: 10_000,
-      maxPingPongTurns: 0,
-      roundOneReply: "Worker completed successfully",
-    });
+      await runSessionsSendA2AFlow({
+        targetSessionKey: session.key,
+        displayKey: session.key,
+        message: "Test message",
+        announceTimeoutMs: 10_000,
+        maxPingPongTurns: 0,
+        roundOneReply: "Worker completed successfully",
+      });
 
-    expect(gatewayCalls.some((call) => call.method === "sessions.list")).toBe(true);
-    const sendCall = gatewayCalls.find((call) => call.method === "send");
-    expect(sendCall).toBeDefined();
-    expect(sendCall?.params).toMatchObject({
-      channel: "discord",
-      to: "channel:target-room",
-      accountId,
-    });
-  });
+      expect(gatewayCalls.some((call) => call.method === "sessions.list")).toBe(true);
+      const sendCall = gatewayCalls.find((call) => call.method === "send");
+      expect(sendCall).toBeDefined();
+      expect(sendCall?.params).toMatchObject({
+        channel: "discord",
+        to: "channel:target-room",
+        accountId,
+      });
+    },
+  );
 
   it.each(["NO_REPLY", "HEARTBEAT_OK", "ANNOUNCE_SKIP", "REPLY_SKIP"])(
     "does not re-inject exact control reply %s into agent-to-agent flow",
@@ -154,7 +194,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
   );
 
   it.each(["NO_REPLY", "HEARTBEAT_OK"])(
-    "suppresses exact announce control reply %s before channel delivery",
+    "suppresses exact announce control reply %s before delivery",
     async (announceReply) => {
       vi.mocked(runAgentStep).mockResolvedValueOnce(announceReply);
 
@@ -174,6 +214,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
         }),
       );
       expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+      expect(gatewayCalls.find((call) => call.method === "agent")).toBeUndefined();
     },
   );
 });

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -133,13 +133,50 @@ export async function runSessionsSendA2AFlow(params: {
       sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",
     });
+
+    // Send the announce reply back to the requester's session instead of the target's channel
     if (
+      params.requesterSessionKey &&
+      announceReply &&
+      announceReply.trim() &&
+      !isAnnounceSkip(announceReply) &&
+      !isNonDeliverableSessionsReply(announceReply)
+    ) {
+      try {
+        const inputProvenance = {
+          kind: "inter_session" as const,
+          sourceSessionKey: params.targetSessionKey,
+          sourceChannel: targetChannel,
+          sourceTool: "sessions_send",
+        };
+        await sessionsSendA2ADeps.callGateway({
+          method: "agent",
+          params: {
+            message: announceReply.trim(),
+            sessionKey: params.requesterSessionKey,
+            idempotencyKey: crypto.randomUUID(),
+            deliver: true,
+            channel: params.requesterChannel ?? "webchat",
+            lane: resolveNestedAgentLaneForSession(params.requesterSessionKey),
+            inputProvenance,
+          },
+          timeoutMs: 10_000,
+        });
+      } catch (err) {
+        log.warn("sessions_send announce delivery to requester failed", {
+          runId: runContextId,
+          requesterSessionKey: params.requesterSessionKey,
+          error: formatErrorMessage(err),
+        });
+      }
+    } else if (
       announceTarget &&
       announceReply &&
       announceReply.trim() &&
       !isAnnounceSkip(announceReply) &&
       !isNonDeliverableSessionsReply(announceReply)
     ) {
+      // Fallback: if no requester session, send to target's channel (original behavior)
       try {
         await sessionsSendA2ADeps.callGateway({
           method: "send",


### PR DESCRIPTION
Fixes inter-agent communication bug where sessions_send replies were not being delivered back to the requesting agent's session.

Problem: When agent A sends a message to agent B via sessions_send, agent B processes the message but the reply stays in agent B's own session instead of being delivered back to agent A. This causes sessions_send to timeout since the reply never reaches the requester.

Root Cause: The A2A announce flow was sending replies to the target agent's channel instead of back to the requester's session.

Solution: Modified the announce delivery logic to prioritize sending replies back to the requester's session via the agent method with deliver: true, while maintaining backward compatibility with a fallback to channel delivery when no requester session exists.

Impact:

Inter-agent communication now works correctly
Replies are delivered to the requesting agent's session
sessions_send no longer times out waiting for replies
Multi-agent coordination and cron job result reporting now function as expected
Fixes #76484