### PR TITLE
fix(telegram): allow /steer without sub-agent id (#76512)

### DIFF
--- a/src/auto-reply/reply/commands-subagents-steer.test.ts
+++ b/src/auto-reply/reply/commands-subagents-steer.test.ts
@@ -39,4 +39,42 @@ describe("subagents steer action", () => {
       reply: { text: "send failed: dispatch failed" },
     });
   });
+
+  it("auto-selects sole active subagent when target is not a valid id", async () => {
+    subagentControlMocks.steerControlledSubagentRun.mockResolvedValue({
+      status: "accepted",
+      runId: "run-auto-1",
+    });
+    const ctx = buildSubagentsDispatchContext({
+      handledPrefix: "/steer",
+      restTokens: ["please", "check", "the", "logs"],
+    });
+    const result = await handleSubagentsSendAction(ctx, true);
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "steered do thing (run run-auto)." },
+    });
+    expect(subagentControlMocks.steerControlledSubagentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "please check the logs" }),
+    );
+  });
+
+  it("auto-selects sole active subagent when only one token (no explicit message)", async () => {
+    subagentControlMocks.steerControlledSubagentRun.mockResolvedValue({
+      status: "accepted",
+      runId: "run-auto-2",
+    });
+    const ctx = buildSubagentsDispatchContext({
+      handledPrefix: "/steer",
+      restTokens: ["hurry"],
+    });
+    const result = await handleSubagentsSendAction(ctx, true);
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "steered do thing (run run-auto)." },
+    });
+    expect(subagentControlMocks.steerControlledSubagentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "hurry" }),
+    );
+  });
 });

--- a/src/auto-reply/reply/commands-subagents/action-send.ts
+++ b/src/auto-reply/reply/commands-subagents/action-send.ts
@@ -4,6 +4,7 @@ import {
 } from "../commands-subagents-control.runtime.js";
 import type { CommandHandlerResult } from "../commands-types.js";
 import { formatRunLabel } from "../subagents-utils.js";
+import type { SubagentRunRecord } from "../../../agents/subagent-registry.types.js";
 import {
   type SubagentsCommandContext,
   COMMAND,
@@ -11,6 +12,46 @@ import {
   resolveSubagentEntryForToken,
   stopWithText,
 } from "./shared.js";
+
+/**
+ * When steer is requested without an explicit target, attempt to auto-select the
+ * sole active subagent so `/steer <message>` works without specifying an id.
+ */
+function tryAutoSelectSteerTarget(
+  runs: SubagentRunRecord[],
+): SubagentRunRecord | undefined {
+  const active = runs.filter((r) => !r.endedAt);
+  if (active.length === 1) {
+    return active[0];
+  }
+  return undefined;
+}
+
+async function steerAutoSelected(
+  ctx: SubagentsCommandContext,
+  entry: SubagentRunRecord,
+  fullMessage: string,
+): Promise<CommandHandlerResult> {
+  const controller = resolveCommandSubagentController(ctx.params, ctx.requesterKey);
+  const result = await steerControlledSubagentRun({
+    cfg: ctx.params.cfg,
+    controller,
+    entry,
+    message: fullMessage,
+  });
+  if (result.status === "accepted") {
+    return stopWithText(
+      `steered ${formatRunLabel(entry)} (run ${result.runId.slice(0, 8)}).`,
+    );
+  }
+  if (result.status === "done" && result.text) {
+    return stopWithText(result.text);
+  }
+  if (result.status === "error") {
+    return stopWithText(`send failed: ${result.error ?? "error"}`);
+  }
+  return stopWithText(`⚠️ ${result.error ?? "send failed"}`);
+}
 
 export async function handleSubagentsSendAction(
   ctx: SubagentsCommandContext,
@@ -20,6 +61,13 @@ export async function handleSubagentsSendAction(
   const target = restTokens[0];
   const message = restTokens.slice(1).join(" ").trim();
   if (!target || !message) {
+    // For /steer, allow omitting the target when there is exactly one active subagent.
+    if (steerRequested && target) {
+      const autoEntry = tryAutoSelectSteerTarget(runs);
+      if (autoEntry) {
+        return steerAutoSelected(ctx, autoEntry, restTokens.join(" ").trim());
+      }
+    }
     return stopWithText(
       steerRequested
         ? handledPrefix === COMMAND
@@ -30,6 +78,14 @@ export async function handleSubagentsSendAction(
   }
 
   const targetResolution = resolveSubagentEntryForToken(runs, target);
+  // For /steer, if target resolution fails, try auto-selecting the sole active subagent
+  // and treat the entire input (including the failed target token) as the message.
+  if ("reply" in targetResolution && steerRequested) {
+    const autoEntry = tryAutoSelectSteerTarget(runs);
+    if (autoEntry) {
+      return steerAutoSelected(ctx, autoEntry, restTokens.join(" ").trim());
+    }
+  }
   if ("reply" in targetResolution) {
     return targetResolution.reply;
   }


### PR DESCRIPTION
Fixes #76512

## Root Cause

`/steer <message>` (without an explicit subagent id) was always failing because `handleSubagentsSendAction` unconditionally required the first token to be a valid subagent target. When only free-text was provided, the first word was parsed as an id and failed resolution, producing the "first character not a valid ID" error.

## Fix

When `/steer` is invoked and either:
1. Only one token is provided (no explicit message portion), or
2. The first token fails subagent target resolution

...and there is exactly **one active subagent**, the entire input is now treated as the steering message and auto-dispatched to that subagent. This matches the expected behavior where `/steer some guidance` should steer the current session's running subagent without requiring an explicit id.

If multiple subagents are active, the existing behavior (requiring an explicit target) is preserved.

## Testing

Added two test cases covering both auto-select paths (single-token and multi-token with unresolvable first token).