### PR TITLE
fix(web-tools): exempt fake-IP DNS ranges from trusted/self-hosted SSRF policy

### DIFF
--- a/src/agents/tools/web-guarded-fetch.ts
+++ b/src/agents/tools/web-guarded-fetch.ts
@@ -7,10 +7,24 @@ import {
 } from "../../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
-const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {};
+// Allow fake-IP DNS proxy ranges (RFC 2544 benchmark 198.18.0.0/15 and IPv6
+// ULA fc00::/7) so trusted public web-tool endpoints (Tavily, Brave, Exa,
+// hosted Firecrawl, etc.) work behind sing-box / Clash / Surge fake-IP
+// setups. The trusted path still rejects RFC1918 private networks, link-
+// local, loopback, and cloud-metadata hostnames — only the fake-IP-only
+// special-use ranges are exempted, matching how the public web_fetch policy
+// was extended in #74571. Without this, every web-search provider that
+// routes through the same trusted-endpoint helper still fails with "Blocked:
+// resolves to private/internal/special-use IP address" for every foreign
+// domain on a fake-IP proxy.
+const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
+  allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
+};
 const WEB_TOOLS_SELF_HOSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
   dangerouslyAllowPrivateNetwork: true,
   allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
 };
 
 type WebToolGuardedFetchOptions = Omit<


### PR DESCRIPTION
## Summary

The trusted-endpoint helper used by Tavily / Brave / Exa / hosted Firecrawl search providers passes a policy of `{}` to `fetchWithSsrFGuard`. On fake-IP proxy setups (sing-box / Clash / Surge), every public domain resolves to the 198.18.0.0/15 RFC 2544 benchmark range or fc00::/7 IPv6 ULA, which is unconditionally blocked unless the policy opts in.

#74571 extended the public `tools.web.fetch.ssrfPolicy` to accept `allowRfc2544BenchmarkRange` / `allowIpv6UniqueLocalRange`, but the parallel **hardcoded** trusted/self-hosted web-tool policies in `web-guarded-fetch.ts:10-14` still pass `{}` and a partial exemption respectively, so users on fake-IP proxies still see:

```
[security] blocked URL fetch (url-fetch) targetOrigin=https://api.tavily.com reason=Blocked: resolves to private/internal/special-use IP address
```

…even after configuring `tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange: true` in their config — because `web_search` providers don't read user config, they use the hardcoded trusted policy.

## Change

```diff
-const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {};
+const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
+  allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
+};
 const WEB_TOOLS_SELF_HOSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
   dangerouslyAllowPrivateNetwork: true,
   allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
 };
```

The trusted path still rejects RFC1918 private networks, link-local, loopback, and cloud-metadata hostnames — only the fake-IP-only special-use ranges are exempted, matching how `tools.web.fetch.ssrfPolicy` was extended in #74571.

## Test plan

- [x] Local repro: `pnpm openclaw infer web search --query "test"` failed with `SsrFBlockedError` on a Surge fake-IP setup before the patch
- [x] After the patch + rebuild, the same call returns Tavily results
- [x] Re-ran `web_fetch` against various non-fake-IP destinations — still blocked as expected (no regression on real public IPs)
- [ ] CI: `pnpm test src/agents/tools/web-guarded-fetch.test.ts` (added cases would be welcome — happy to add if the maintainers prefer it in this PR)

## Refs

- Refs #74351 (the original fake-IP IPv6 ULA report)
- Companion to #74571 — that PR fixed the user-config path; this fix covers the parallel hardcoded trusted/self-hosted path that #74571 didn't touch

## Open question for maintainers (separate, not blocking this fix)

The same fake-IP exemption is currently **impossible to configure** for two other ssrf-policy paths:

- `browser.ssrfPolicy` — schema rejects `allowRfc2544BenchmarkRange` and `allowIpv6UniqueLocalRange`
- `models.providers.*.request` — same rejection

Real-world impact for fake-IP proxy users (we see this on `api.openai.com`, `generativelanguage.googleapis.com`, image-describe pulling remote reference images, etc):

```
[security] blocked URL fetch (url-fetch) target=https://api.openai.com/v1/audio/transcriptions reason=Blocked: ...
[security] blocked URL fetch (url-fetch) target=https://generativelanguage.googleapis.com/... reason=Blocked: ...
[tools] image failed: Failed to fetch media from https://pbs.twimg.com/media/... : Blocked: ...
```

Should those schemas be extended to mirror `tools.web.fetch.ssrfPolicy`, or is the deliberate design that browser navigation and provider HTTP must rely solely on `dangerouslyAllowPrivateNetwork` plus DNS-level fake-IP exemptions outside OpenClaw?

Happy to follow up with separate PRs if the schema extension is desired — wanted to surface the question while you're already in the fake-IP context. Not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)