### PR TITLE
fix(cron): let timeoutSeconds raise agent watchdogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: let explicit `timeoutSeconds` raise CLI no-output and embedded model-idle watchdog budgets for cron agent runs, while preserving configured CLI watchdog caps. Fixes #76289.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -889,4 +889,27 @@ describe("resolveCliNoOutputTimeoutMs", () => {
     });
     expect(timeoutMs).toBe(42_000);
   });
+
+  it("lets explicit cron timeouts raise the default resume watchdog budget", () => {
+    const timeoutMs = resolveCliNoOutputTimeoutMs({
+      backend: {
+        command: "codex",
+      },
+      timeoutMs: 600_000,
+      trigger: "cron",
+      useResume: true,
+    });
+    expect(timeoutMs).toBe(480_000);
+  });
+
+  it("keeps non-cron resume runs on the shorter no-output watchdog profile", () => {
+    const timeoutMs = resolveCliNoOutputTimeoutMs({
+      backend: {
+        command: "codex",
+      },
+      timeoutMs: 600_000,
+      useResume: true,
+    });
+    expect(timeoutMs).toBe(180_000);
+  });
 });

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -913,6 +913,25 @@ describe("resolveCliNoOutputTimeoutMs", () => {
     expect(timeoutMs).toBe(180_000);
   });
 
+  it("preserves configured cron resume watchdog ratio", () => {
+    const timeoutMs = resolveCliNoOutputTimeoutMs({
+      backend: {
+        command: "codex",
+        reliability: {
+          watchdog: {
+            resume: {
+              noOutputTimeoutRatio: 0.2,
+            },
+          },
+        },
+      },
+      timeoutMs: 600_000,
+      trigger: "cron",
+      useResume: true,
+    });
+    expect(timeoutMs).toBe(120_000);
+  });
+
   it("preserves configured cron resume watchdog caps", () => {
     const timeoutMs = resolveCliNoOutputTimeoutMs({
       backend: {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -912,4 +912,23 @@ describe("resolveCliNoOutputTimeoutMs", () => {
     });
     expect(timeoutMs).toBe(180_000);
   });
+
+  it("preserves configured cron resume watchdog caps", () => {
+    const timeoutMs = resolveCliNoOutputTimeoutMs({
+      backend: {
+        command: "codex",
+        reliability: {
+          watchdog: {
+            resume: {
+              maxMs: 120_000,
+            },
+          },
+        },
+      },
+      timeoutMs: 600_000,
+      trigger: "cron",
+      useResume: true,
+    });
+    expect(timeoutMs).toBe(120_000);
+  });
 });

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -383,6 +383,7 @@ export async function executePreparedCliRun(
           backend,
           timeoutMs: params.timeoutMs,
           useResume,
+          trigger: params.trigger,
         });
         const hasJsonlOutput = backend.output === "jsonl";
         if (shouldUseClaudeLiveSession(context)) {

--- a/src/agents/cli-runner/reliability.ts
+++ b/src/agents/cli-runner/reliability.ts
@@ -15,6 +15,7 @@ function pickWatchdogProfile(
   noOutputTimeoutRatio: number;
   minMs: number;
   maxMs: number;
+  maxMsConfigured: boolean;
 } {
   const defaults = useResume ? CLI_RESUME_WATCHDOG_DEFAULTS : CLI_FRESH_WATCHDOG_DEFAULTS;
   const configured = useResume
@@ -35,13 +36,11 @@ function pickWatchdogProfile(
     }
     return Math.max(CLI_WATCHDOG_MIN_TIMEOUT_MS, Math.floor(value));
   })();
-  const maxMs = (() => {
-    const value = configured?.maxMs;
-    if (typeof value !== "number" || !Number.isFinite(value)) {
-      return defaults.maxMs;
-    }
-    return Math.max(CLI_WATCHDOG_MIN_TIMEOUT_MS, Math.floor(value));
-  })();
+  const configuredMaxMs = configured?.maxMs;
+  const maxMsConfigured = typeof configuredMaxMs === "number" && Number.isFinite(configuredMaxMs);
+  const maxMs = maxMsConfigured
+    ? Math.max(CLI_WATCHDOG_MIN_TIMEOUT_MS, Math.floor(configuredMaxMs))
+    : defaults.maxMs;
 
   return {
     noOutputTimeoutMs:
@@ -52,6 +51,7 @@ function pickWatchdogProfile(
     noOutputTimeoutRatio: ratio,
     minMs: Math.min(minMs, maxMs),
     maxMs: Math.max(minMs, maxMs),
+    maxMsConfigured,
   };
 }
 
@@ -71,7 +71,8 @@ export function resolveCliNoOutputTimeoutMs(params: {
   const noOutputTimeoutRatio = isCronRun
     ? Math.max(profile.noOutputTimeoutRatio, CLI_FRESH_WATCHDOG_DEFAULTS.noOutputTimeoutRatio)
     : profile.noOutputTimeoutRatio;
-  const maxMs = isCronRun ? Math.max(profile.maxMs, cap) : profile.maxMs;
+  const maxMs =
+    isCronRun && !profile.maxMsConfigured ? Math.max(profile.maxMs, cap) : profile.maxMs;
   const computed = Math.floor(params.timeoutMs * noOutputTimeoutRatio);
   const bounded = Math.min(maxMs, Math.max(profile.minMs, computed));
   return Math.min(bounded, cap);

--- a/src/agents/cli-runner/reliability.ts
+++ b/src/agents/cli-runner/reliability.ts
@@ -59,6 +59,7 @@ export function resolveCliNoOutputTimeoutMs(params: {
   backend: CliBackendConfig;
   timeoutMs: number;
   useResume: boolean;
+  trigger?: string;
 }): number {
   const profile = pickWatchdogProfile(params.backend, params.useResume);
   // Keep watchdog below global timeout in normal cases.
@@ -66,8 +67,13 @@ export function resolveCliNoOutputTimeoutMs(params: {
   if (profile.noOutputTimeoutMs !== undefined) {
     return Math.min(profile.noOutputTimeoutMs, cap);
   }
-  const computed = Math.floor(params.timeoutMs * profile.noOutputTimeoutRatio);
-  const bounded = Math.min(profile.maxMs, Math.max(profile.minMs, computed));
+  const isCronRun = params.trigger === "cron";
+  const noOutputTimeoutRatio = isCronRun
+    ? Math.max(profile.noOutputTimeoutRatio, CLI_FRESH_WATCHDOG_DEFAULTS.noOutputTimeoutRatio)
+    : profile.noOutputTimeoutRatio;
+  const maxMs = isCronRun ? Math.max(profile.maxMs, cap) : profile.maxMs;
+  const computed = Math.floor(params.timeoutMs * noOutputTimeoutRatio);
+  const bounded = Math.min(maxMs, Math.max(profile.minMs, computed));
   return Math.min(bounded, cap);
 }
 

--- a/src/agents/cli-runner/reliability.ts
+++ b/src/agents/cli-runner/reliability.ts
@@ -16,19 +16,19 @@ function pickWatchdogProfile(
   minMs: number;
   maxMs: number;
   maxMsConfigured: boolean;
+  noOutputTimeoutRatioConfigured: boolean;
 } {
   const defaults = useResume ? CLI_RESUME_WATCHDOG_DEFAULTS : CLI_FRESH_WATCHDOG_DEFAULTS;
   const configured = useResume
     ? backend.reliability?.watchdog?.resume
     : backend.reliability?.watchdog?.fresh;
 
-  const ratio = (() => {
-    const value = configured?.noOutputTimeoutRatio;
-    if (typeof value !== "number" || !Number.isFinite(value)) {
-      return defaults.noOutputTimeoutRatio;
-    }
-    return Math.max(0.05, Math.min(0.95, value));
-  })();
+  const configuredRatio = configured?.noOutputTimeoutRatio;
+  const noOutputTimeoutRatioConfigured =
+    typeof configuredRatio === "number" && Number.isFinite(configuredRatio);
+  const ratio = noOutputTimeoutRatioConfigured
+    ? Math.max(0.05, Math.min(0.95, configuredRatio))
+    : defaults.noOutputTimeoutRatio;
   const minMs = (() => {
     const value = configured?.minMs;
     if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -52,6 +52,7 @@ function pickWatchdogProfile(
     minMs: Math.min(minMs, maxMs),
     maxMs: Math.max(minMs, maxMs),
     maxMsConfigured,
+    noOutputTimeoutRatioConfigured,
   };
 }
 
@@ -68,7 +69,9 @@ export function resolveCliNoOutputTimeoutMs(params: {
     return Math.min(profile.noOutputTimeoutMs, cap);
   }
   const isCronRun = params.trigger === "cron";
-  const noOutputTimeoutRatio = isCronRun
+  const shouldLiftDefaultResumeRatio =
+    isCronRun && params.useResume && !profile.noOutputTimeoutRatioConfigured;
+  const noOutputTimeoutRatio = shouldLiftDefaultResumeRatio
     ? Math.max(profile.noOutputTimeoutRatio, CLI_FRESH_WATCHDOG_DEFAULTS.noOutputTimeoutRatio)
     : profile.noOutputTimeoutRatio;
   const maxMs =

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -30,6 +30,10 @@ describe("resolveLlmIdleTimeoutMs", () => {
     expect(resolveLlmIdleTimeoutMs({ runTimeoutMs: 900_000 })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
   });
 
+  it("lets explicit cron run timeouts raise the model idle watchdog budget", () => {
+    expect(resolveLlmIdleTimeoutMs({ trigger: "cron", runTimeoutMs: 600_000 })).toBe(600_000);
+  });
+
   it("uses an explicit run timeout override when shorter than the default idle watchdog", () => {
     expect(resolveLlmIdleTimeoutMs({ runTimeoutMs: 30_000 })).toBe(30_000);
   });

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -61,6 +61,9 @@ export function resolveLlmIdleTimeoutMs(params?: {
   }
 
   if (typeof runTimeoutMs === "number" && Number.isFinite(runTimeoutMs) && runTimeoutMs > 0) {
+    if (params?.trigger === "cron") {
+      return clampTimeoutMs(runTimeoutMs);
+    }
     return clampImplicitTimeoutMs(runTimeoutMs);
   }
 


### PR DESCRIPTION
## Summary
- Fixes cron runs where `timeoutSeconds` could still be preempted by shorter agent-level watchdogs.
- CLI-backed cron resume runs now let the explicit cron timeout raise the default no-output watchdog budget instead of staying on the 180s resume ceiling.
- Embedded cron runs now let the explicit run timeout raise the model idle watchdog budget instead of clamping it to the default idle timeout.

## Changes
- Pass the run trigger into CLI no-output watchdog resolution.
- For cron CLI runs without an explicit backend watchdog override, use the longer fresh-run ratio and allow the computed budget up to the cron run deadline.
- For embedded cron runs with an explicit run timeout, use that timeout as the idle watchdog budget.
- Add focused regression coverage for cron CLI and embedded timeout resolution while preserving non-cron behavior.

## Testing
- `pnpm test src/agents/cli-runner.reliability.test.ts src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts`
- `pnpm test src/cron/isolated-agent/run.skill-filter.test.ts`
- `pnpm check:changed`

Fixes openclaw/openclaw#76289
