### PR TITLE
fix(whatsapp): route QR heading and ASCII art through injected runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/WhatsApp: route QR heading and ASCII art through the injected `runtime` in `loginWeb` instead of writing directly to `process.stdout`, so gateway-side and non-terminal runtimes receive QR output instead of having it bypassed. Fixes #76213. Thanks @hclsys.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -109,6 +109,24 @@ describe("loginWeb coverage", () => {
     expect(secondSock.ws.close).toHaveBeenCalled();
   });
 
+  it("forwards QR callback to restart socket after 515 (#76213)", async () => {
+    waitForWaConnectionMock
+      .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
+      .mockResolvedValueOnce(undefined);
+
+    const runtime = { log: vi.fn(), error: vi.fn() } as never;
+    await loginWeb(false, waitForWaConnectionMock as never, runtime);
+
+    expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+    const restartCallOpts = createWaSocketMock.mock.calls[1]?.[2] as
+      | { onQr?: (qr: string) => void }
+      | undefined;
+    expect(restartCallOpts?.onQr).toBeDefined();
+    // Invoking onQr should route through runtime.log, not process.stdout
+    restartCallOpts?.onQr?.("test-qr-payload");
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Scan this QR in WhatsApp"));
+  });
+
   it("clears creds and throws when logged out", async () => {
     waitForWaConnectionMock.mockRejectedValueOnce({
       output: { statusCode: 401 },

--- a/extensions/whatsapp/src/login.ts
+++ b/extensions/whatsapp/src/login.ts
@@ -20,22 +20,25 @@ export async function loginWeb(
   const account = resolveWhatsAppAccount({ cfg, accountId });
   const socketTiming = resolveWhatsAppSocketTiming(cfg);
   const restoredFromBackup = await restoreCredsFromBackupIfNeeded(account.authDir);
+  // Route QR heading and ASCII art through the runtime so non-default
+  // runtimes (e.g. gateway-side) receive the output instead of having it
+  // written directly to process.stdout via console.log. Hoisted so the
+  // same handler reaches both the initial socket and any restart socket
+  // created by the 515 restart path in waitForWhatsAppLoginResult.
+  const onQr = (qr: string) => {
+    runtime.log("Scan this QR in WhatsApp (Linked Devices):");
+    void renderQrTerminal(qr, { small: true })
+      .then((art) => {
+        runtime.log(art.endsWith("\n") ? art.slice(0, -1) : art);
+      })
+      .catch((err) => {
+        runtime.error(`failed rendering WhatsApp QR: ${String(err)}`);
+      });
+  };
   let sock = await createWaSocket(false, verbose, {
     authDir: account.authDir,
     ...socketTiming,
-    onQr: (qr: string) => {
-      // Route QR heading and ASCII art through the runtime so non-default
-      // runtimes (e.g. gateway-side) receive the output instead of having it
-      // written directly to process.stdout via console.log.
-      runtime.log("Scan this QR in WhatsApp (Linked Devices):");
-      void renderQrTerminal(qr, { small: true })
-        .then((art) => {
-          runtime.log(art.endsWith("\n") ? art.slice(0, -1) : art);
-        })
-        .catch((err) => {
-          runtime.error(`failed rendering WhatsApp QR: ${String(err)}`);
-        });
-    },
+    onQr,
   });
   logInfo("Waiting for WhatsApp connection...", runtime);
   try {
@@ -47,6 +50,7 @@ export async function loginWeb(
       runtime,
       waitForConnection,
       socketTiming,
+      onQr,
       onSocketReplaced: (replacementSock) => {
         sock = replacementSock;
       },

--- a/extensions/whatsapp/src/login.ts
+++ b/extensions/whatsapp/src/login.ts
@@ -6,6 +6,7 @@ import { logInfo } from "openclaw/plugin-sdk/text-runtime";
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { restoreCredsFromBackupIfNeeded } from "./auth-store.js";
 import { closeWaSocketSoon, waitForWhatsAppLoginResult } from "./connection-controller.js";
+import { renderQrTerminal } from "./qr-terminal.js";
 import { createWaSocket, waitForWaConnection } from "./session.js";
 import { resolveWhatsAppSocketTiming } from "./socket-timing.js";
 
@@ -19,9 +20,22 @@ export async function loginWeb(
   const account = resolveWhatsAppAccount({ cfg, accountId });
   const socketTiming = resolveWhatsAppSocketTiming(cfg);
   const restoredFromBackup = await restoreCredsFromBackupIfNeeded(account.authDir);
-  let sock = await createWaSocket(true, verbose, {
+  let sock = await createWaSocket(false, verbose, {
     authDir: account.authDir,
     ...socketTiming,
+    onQr: (qr: string) => {
+      // Route QR heading and ASCII art through the runtime so non-default
+      // runtimes (e.g. gateway-side) receive the output instead of having it
+      // written directly to process.stdout via console.log.
+      runtime.log("Scan this QR in WhatsApp (Linked Devices):");
+      void renderQrTerminal(qr, { small: true })
+        .then((art) => {
+          runtime.log(art.endsWith("\n") ? art.slice(0, -1) : art);
+        })
+        .catch((err) => {
+          runtime.error(`failed rendering WhatsApp QR: ${String(err)}`);
+        });
+    },
   });
   logInfo("Waiting for WhatsApp connection...", runtime);
   try {


### PR DESCRIPTION
## Root cause

`loginWeb` was calling `createWaSocket(printQr: true, ...)`. Inside `session.ts`, the `connection.update` handler for QR events writes:

1. The heading `"Scan this QR in WhatsApp (Linked Devices):"` via `console.log`
2. The ASCII QR art via `printTerminalQr` → `process.stdout.write`

Both bypass the `runtime` parameter injected into `loginWeb`.

## Fix

Switch to `printQr: false` with an explicit `onQr` callback that routes both the heading and the rendered ASCII art through `runtime.log`. Uses the existing `renderQrTerminal` export from `qr-terminal.ts` (already used in `login-qr.ts`).

Before:
```ts
let sock = await createWaSocket(true, verbose, { authDir, ...socketTiming });
```

After:
```ts
let sock = await createWaSocket(false, verbose, {
  authDir,
  ...socketTiming,
  onQr: (qr: string) => {
    runtime.log("Scan this QR in WhatsApp (Linked Devices):");
    void renderQrTerminal(qr, { small: true })
      .then((art) => runtime.log(art.endsWith("\n") ? art.slice(0, -1) : art))
      .catch((err) => runtime.error(`failed rendering WhatsApp QR: ${String(err)}`));
  },
});
```

All other `createWaSocket` callers already pass `printQr: false`.

## Tests

`extensions/whatsapp/src/login.test.ts`, `login-qr.test.ts`, `login.coverage.test.ts` — 18/18 pass.

Fixes #76213.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)