### PR TITLE
feat(plugins): allow community plugins to use openKeyedStore with man…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/SDK: allow community plugins to use `api.runtime.state.openKeyedStore` for restart-safe keyed state by declaring `"contracts": { "usesKeyedStore": true }` in their manifest. Community plugins are subject to a 500-entry-per-namespace limit (vs 1,000 for bundled plugins) while keeping the same per-plugin total limit of 1,000 live rows. Bundled plugins retain implicit access. Fixes #76433.
 - Plugins/onboarding: let Manual setup install optional official plugins, including ClawHub-backed diagnostics with npm fallback, and expose the external Codex plugin as a selectable provider setup choice. Thanks @vincentkoc.
 - Plugins/CLI: include package dependency install state in `openclaw plugins list --json` so scripts can spot missing plugin dependencies without runtime-loading plugins.
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Plugins/SDK: allow community plugins to use `api.runtime.state.openKeyedStore` for restart-safe keyed state by declaring `"contracts": { "usesKeyedStore": true }` in their manifest. Community plugins are subject to a 500-entry-per-namespace limit (vs 1,000 for bundled plugins) while keeping the same per-plugin total limit of 1,000 live rows. Bundled plugins retain implicit access. Fixes #76433.
 - Plugins/onboarding: let Manual setup install optional official plugins, including ClawHub-backed diagnostics with npm fallback, and expose the external Codex plugin as a selectable provider setup choice. Thanks @vincentkoc.
+- Plugins/SDK: allow plugins to use `api.runtime.state.openKeyedStore` with the store owner bound internally to the runtime plugin id and no plugin-controlled namespace.
 - Plugins/CLI: include package dependency install state in `openclaw plugins list --json` so scripts can spot missing plugin dependencies without runtime-loading plugins.
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.
 - Plugins/update: on the beta OpenClaw update channel, default-line npm and ClawHub plugin updates try `@beta` first and fall back to default/latest when no plugin beta release exists.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f829dd720df7c9c8eb9d59eda3b3f879bff278f74b4c00d8d788c1483865b649  plugin-sdk-api-baseline.json
-1b3504c8f9ddd00801f095f94f417d469b47370064478eae389d33f4b8e10c76  plugin-sdk-api-baseline.jsonl
+b35306be86208f63df751d58b2bbf7348559d9a59062eb825b265afefcb247b2  plugin-sdk-api-baseline.json
+f22ea140a4d5ed6e85d1b93e6e258246fc1bfbe92c66282806a68be077ea16a8  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -425,8 +425,25 @@ Provider and channel execution paths must use the active runtime config snapshot
     Keyed stores survive restarts and are isolated by the runtime-bound plugin id. Limits: `maxEntries` per namespace, 1,000 live rows per plugin, JSON values under 64KB, and optional TTL expiry.
 
     <Warning>
-    Bundled plugins only in this release.
+    Community plugins must declare `"contracts": { "usesKeyedStore": true }` in their `openclaw.plugin.json` manifest to access this API. Bundled plugins have implicit access.
+
+    Community plugins are subject to stricter limits:
+    - Maximum 500 entries per namespace (vs 1,000 for bundled plugins)
+    - Same per-plugin total limit of 1,000 live rows
+    - Same 64KB JSON value size limit
     </Warning>
+
+    **Example manifest declaration for community plugins:**
+
+    ```json
+    {
+      "id": "my-plugin",
+      "name": "My Plugin",
+      "contracts": {
+        "usesKeyedStore": true
+      }
+    }
+    ```
 
   </Accordion>
   <Accordion title="api.runtime.tools">

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -411,7 +411,6 @@ Provider and channel execution paths must use the active runtime config snapshot
     ```typescript
     const stateDir = api.runtime.state.resolveStateDir(process.env);
     const store = api.runtime.state.openKeyedStore<MyRecord>({
-      namespace: "my-feature",
       maxEntries: 200,
       defaultTtlMs: 15 * 60_000,
     });
@@ -422,28 +421,9 @@ Provider and channel execution paths must use the active runtime config snapshot
     await store.clear();
     ```
 
-    Keyed stores survive restarts and are isolated by the runtime-bound plugin id. Limits: `maxEntries` per namespace, 1,000 live rows per plugin, JSON values under 64KB, and optional TTL expiry.
+    Keyed stores survive restarts and are isolated by the runtime-bound plugin id. The SDK does not accept an owner id or namespace, so one plugin cannot read, write, list, consume, or clear another plugin's state. Limits: default 100 entries, optional `maxEntries` up to 1,000 live rows per plugin, JSON values under 64KB, and optional TTL expiry.
 
-    <Warning>
-    Community plugins must declare `"contracts": { "usesKeyedStore": true }` in their `openclaw.plugin.json` manifest to access this API. Bundled plugins have implicit access.
-
-    Community plugins are subject to stricter limits:
-    - Maximum 500 entries per namespace (vs 1,000 for bundled plugins)
-    - Same per-plugin total limit of 1,000 live rows
-    - Same 64KB JSON value size limit
-    </Warning>
-
-    **Example manifest declaration for community plugins:**
-
-    ```json
-    {
-      "id": "my-plugin",
-      "name": "My Plugin",
-      "contracts": {
-        "usesKeyedStore": true
-      }
-    }
-    ```
+    Omit `maxEntries` to use the default row budget.
 
   </Accordion>
   <Accordion title="api.runtime.tools">

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -3,10 +3,10 @@ import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 import { getOptionalDiscordRuntime } from "./runtime.js";
 
 const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
-const PERSISTENT_COMPONENT_NAMESPACE = "discord.components";
-const PERSISTENT_MODAL_NAMESPACE = "discord.modals";
 const PERSISTENT_COMPONENT_MAX_ENTRIES = 500;
 const PERSISTENT_MODAL_MAX_ENTRIES = 500;
+const PERSISTENT_COMPONENT_KEY_PREFIX = "component";
+const PERSISTENT_MODAL_KEY_PREFIX = "modal";
 const DISCORD_COMPONENT_ENTRIES_KEY = Symbol.for("openclaw.discord.componentEntries");
 const DISCORD_MODAL_ENTRIES_KEY = Symbol.for("openclaw.discord.modalEntries");
 
@@ -76,7 +76,6 @@ function getPersistentComponentStore(): DiscordRegistryStore<DiscordComponentEnt
     persistentComponentStore = runtime.state.openKeyedStore<
       PersistedDiscordRegistryEntry<DiscordComponentEntry>
     >({
-      namespace: PERSISTENT_COMPONENT_NAMESPACE,
       maxEntries: PERSISTENT_COMPONENT_MAX_ENTRIES,
       defaultTtlMs: DEFAULT_COMPONENT_TTL_MS,
     });
@@ -102,7 +101,6 @@ function getPersistentModalStore(): DiscordRegistryStore<DiscordModalEntry> | un
     persistentModalStore = runtime.state.openKeyedStore<
       PersistedDiscordRegistryEntry<DiscordModalEntry>
     >({
-      namespace: PERSISTENT_MODAL_NAMESPACE,
       maxEntries: PERSISTENT_MODAL_MAX_ENTRIES,
       defaultTtlMs: DEFAULT_COMPONENT_TTL_MS,
     });
@@ -178,6 +176,7 @@ function readPersistedRegistryEntry<T extends { id: string }>(
 function registerPersistentRegistryEntries<T extends { id: string }>(params: {
   entries: T[];
   ttlMs: number;
+  keyPrefix: string;
   openStore: () => DiscordRegistryStore<T> | undefined;
 }): void {
   if (params.entries.length === 0) {
@@ -189,7 +188,7 @@ function registerPersistentRegistryEntries<T extends { id: string }>(params: {
   }
   for (const entry of params.entries) {
     void store
-      .register(entry.id, { version: 1, entry }, { ttlMs: params.ttlMs })
+      .register(`${params.keyPrefix}:${entry.id}`, { version: 1, entry }, { ttlMs: params.ttlMs })
       .catch(disablePersistentComponentRegistry);
   }
 }
@@ -202,24 +201,27 @@ function registerPersistentEntries(params: {
   registerPersistentRegistryEntries({
     entries: params.entries,
     ttlMs: params.ttlMs,
+    keyPrefix: PERSISTENT_COMPONENT_KEY_PREFIX,
     openStore: getPersistentComponentStore,
   });
   registerPersistentRegistryEntries({
     entries: params.modals,
     ttlMs: params.ttlMs,
+    keyPrefix: PERSISTENT_MODAL_KEY_PREFIX,
     openStore: getPersistentModalStore,
   });
 }
 
 function deletePersistentEntry<T extends { id: string }>(params: {
   id: string;
+  keyPrefix: string;
   openStore: () => DiscordRegistryStore<T> | undefined;
 }): void {
   const store = params.openStore();
   if (!store) {
     return;
   }
-  void store.delete(params.id).catch(disablePersistentComponentRegistry);
+  void store.delete(`${params.keyPrefix}:${params.id}`).catch(disablePersistentComponentRegistry);
 }
 
 function resolveComponentConsumptionIds(entry: DiscordComponentEntry): string[] {
@@ -243,13 +245,16 @@ function deletePersistentComponentConsumptionGroup(entry: DiscordComponentEntry)
     return;
   }
   for (const id of resolveComponentConsumptionIds(entry)) {
-    void store.delete(id).catch(disablePersistentComponentRegistry);
+    void store
+      .delete(`${PERSISTENT_COMPONENT_KEY_PREFIX}:${id}`)
+      .catch(disablePersistentComponentRegistry);
   }
 }
 
 async function resolvePersistentRegistryEntry<T extends { id: string }>(params: {
   id: string;
   consume?: boolean;
+  keyPrefix: string;
   openStore: () => DiscordRegistryStore<T> | undefined;
 }): Promise<T | null> {
   const store = params.openStore();
@@ -257,8 +262,8 @@ async function resolvePersistentRegistryEntry<T extends { id: string }>(params: 
     return null;
   }
   try {
-    const value =
-      params.consume === false ? await store.lookup(params.id) : await store.consume(params.id);
+    const key = `${params.keyPrefix}:${params.id}`;
+    const value = params.consume === false ? await store.lookup(key) : await store.consume(key);
     return readPersistedRegistryEntry(value);
   } catch (error) {
     disablePersistentComponentRegistry(error);
@@ -315,6 +320,7 @@ export async function resolveDiscordComponentEntryWithPersistence(params: {
   }
   const persisted = await resolvePersistentRegistryEntry({
     ...params,
+    keyPrefix: PERSISTENT_COMPONENT_KEY_PREFIX,
     openStore: getPersistentComponentStore,
   });
   if (persisted && params.consume !== false) {
@@ -337,12 +343,17 @@ export async function resolveDiscordModalEntryWithPersistence(params: {
   const inMemory = resolveDiscordModalEntry(params);
   if (inMemory) {
     if (params.consume !== false) {
-      deletePersistentEntry({ ...params, openStore: getPersistentModalStore });
+      deletePersistentEntry({
+        ...params,
+        keyPrefix: PERSISTENT_MODAL_KEY_PREFIX,
+        openStore: getPersistentModalStore,
+      });
     }
     return inMemory;
   }
   return await resolvePersistentRegistryEntry({
     ...params,
+    keyPrefix: PERSISTENT_MODAL_KEY_PREFIX,
     openStore: getPersistentModalStore,
   });
 }

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -178,35 +178,31 @@ describe("discord component registry", () => {
   });
 
   it("persists component and modal entries when runtime state is available", async () => {
-    const componentRegister = vi.fn().mockResolvedValue(undefined);
-    const modalRegister = vi.fn().mockResolvedValue(undefined);
-    const componentLookup = vi.fn().mockResolvedValue({
-      version: 1,
-      entry: { id: "btn_persisted", kind: "button", label: "Persisted" },
+    const register = vi.fn().mockResolvedValue(undefined);
+    const lookup = vi.fn(async (key: string) => {
+      if (key === "component:btn_persisted") {
+        return {
+          version: 1,
+          entry: { id: "btn_persisted", kind: "button", label: "Persisted" },
+        };
+      }
+      if (key === "modal:mdl_persisted") {
+        return {
+          version: 1,
+          entry: { id: "mdl_persisted", title: "Persisted", fields: [] },
+        };
+      }
+      return undefined;
     });
-    const modalLookup = vi.fn().mockResolvedValue({
-      version: 1,
-      entry: { id: "mdl_persisted", title: "Persisted", fields: [] },
-    });
-    const componentStore = {
-      register: componentRegister,
-      lookup: componentLookup,
+    const store = {
+      register,
+      lookup,
       consume: vi.fn(),
       delete: vi.fn(),
       entries: vi.fn(),
       clear: vi.fn(),
     };
-    const modalStore = {
-      register: modalRegister,
-      lookup: modalLookup,
-      consume: vi.fn(),
-      delete: vi.fn(),
-      entries: vi.fn(),
-      clear: vi.fn(),
-    };
-    const openKeyedStore = vi.fn((opts: { namespace: string }) =>
-      opts.namespace === "discord.components" ? componentStore : modalStore,
-    );
+    const openKeyedStore = vi.fn(() => store);
     const { setDiscordRuntime } = await import("./runtime.js");
     setDiscordRuntime({
       state: { openKeyedStore },
@@ -219,14 +215,14 @@ describe("discord component registry", () => {
       ttlMs: 1000,
     });
 
-    await vi.waitFor(() => expect(componentRegister).toHaveBeenCalledTimes(1));
-    expect(componentRegister).toHaveBeenCalledWith(
-      "btn_1",
+    await vi.waitFor(() => expect(register).toHaveBeenCalledTimes(2));
+    expect(register).toHaveBeenCalledWith(
+      "component:btn_1",
       { version: 1, entry: expect.objectContaining({ id: "btn_1" }) },
       { ttlMs: 1000 },
     );
-    expect(modalRegister).toHaveBeenCalledWith(
-      "mdl_1",
+    expect(register).toHaveBeenCalledWith(
+      "modal:mdl_1",
       { version: 1, entry: expect.objectContaining({ id: "mdl_1" }) },
       { ttlMs: 1000 },
     );
@@ -238,14 +234,14 @@ describe("discord component registry", () => {
     await expect(
       resolveDiscordModalEntryWithPersistence({ id: "mdl_persisted", consume: false }),
     ).resolves.toMatchObject({ id: "mdl_persisted" });
-    expect(componentLookup).toHaveBeenCalledWith("btn_persisted");
-    expect(modalLookup).toHaveBeenCalledWith("mdl_persisted");
+    expect(lookup).toHaveBeenCalledWith("component:btn_persisted");
+    expect(lookup).toHaveBeenCalledWith("modal:mdl_persisted");
     expect(openKeyedStore).toHaveBeenCalledTimes(4);
   });
 
   it("deletes sibling persistent component entries when a group entry is consumed", async () => {
-    const componentDelete = vi.fn().mockResolvedValue(true);
-    const componentStore = {
+    const deleteEntry = vi.fn().mockResolvedValue(true);
+    const store = {
       register: vi.fn(),
       lookup: vi.fn(),
       consume: vi.fn().mockResolvedValue({
@@ -258,17 +254,9 @@ describe("discord component registry", () => {
           consumptionGroupEntryIds: ["btn_confirm", "btn_cancel"],
         },
       }),
-      delete: componentDelete,
+      delete: deleteEntry,
     };
-    const modalStore = {
-      register: vi.fn(),
-      lookup: vi.fn(),
-      consume: vi.fn(),
-      delete: vi.fn(),
-    };
-    const openKeyedStore = vi.fn((opts: { namespace: string }) =>
-      opts.namespace === "discord.components" ? componentStore : modalStore,
-    );
+    const openKeyedStore = vi.fn(() => store);
     const { setDiscordRuntime } = await import("./runtime.js");
     setDiscordRuntime({
       state: { openKeyedStore },
@@ -282,8 +270,8 @@ describe("discord component registry", () => {
       id: "btn_confirm",
     });
 
-    await vi.waitFor(() => expect(componentDelete).toHaveBeenCalledWith("btn_cancel"));
-    expect(componentDelete).toHaveBeenCalledWith("btn_confirm");
+    await vi.waitFor(() => expect(deleteEntry).toHaveBeenCalledWith("component:btn_cancel"));
+    expect(deleteEntry).toHaveBeenCalledWith("component:btn_confirm");
   });
 
   it("falls back to the in-memory registry when persistent state cannot open", async () => {

--- a/extensions/matrix/src/approval-reactions.ts
+++ b/extensions/matrix/src/approval-reactions.ts
@@ -1,4 +1,5 @@
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-runtime";
+import { getOptionalMatrixRuntime } from "./runtime.js";
 
 const MATRIX_APPROVAL_REACTION_META = {
   "allow-once": {
@@ -21,7 +22,10 @@ const MATRIX_APPROVAL_REACTION_ORDER = [
   "deny",
 ] as const satisfies readonly ExecApprovalReplyDecision[];
 
-type MatrixApprovalReactionBinding = {
+const PERSISTENT_MAX_ENTRIES = 1000;
+const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type MatrixApprovalReactionBinding = {
   decision: ExecApprovalReplyDecision;
   emoji: string;
   label: string;
@@ -37,7 +41,24 @@ type MatrixApprovalReactionTarget = {
   allowedDecisions: readonly ExecApprovalReplyDecision[];
 };
 
+type PersistedMatrixApprovalReactionTarget = {
+  version: 1;
+  target: MatrixApprovalReactionTarget;
+};
+
+type MatrixApprovalReactionStore = {
+  register(
+    key: string,
+    value: PersistedMatrixApprovalReactionTarget,
+    opts?: { ttlMs?: number },
+  ): Promise<void>;
+  lookup(key: string): Promise<PersistedMatrixApprovalReactionTarget | undefined>;
+  delete(key: string): Promise<boolean>;
+};
+
 const matrixApprovalReactionTargets = new Map<string, MatrixApprovalReactionTarget>();
+let persistentStore: MatrixApprovalReactionStore | undefined;
+let persistentStoreDisabled = false;
 
 function buildReactionTargetKey(roomId: string, eventId: string): string | null {
   const normalizedRoomId = roomId.trim();
@@ -46,6 +67,96 @@ function buildReactionTargetKey(roomId: string, eventId: string): string | null 
     return null;
   }
   return `${normalizedRoomId}:${normalizedEventId}`;
+}
+
+function reportPersistentApprovalReactionError(error: unknown): void {
+  try {
+    getOptionalMatrixRuntime()
+      ?.logging.getChildLogger({ plugin: "matrix", feature: "approval-reaction-state" })
+      .warn("Matrix persistent approval reaction state failed", { error: String(error) });
+  } catch {
+    // Best effort only: persistent state must never break Matrix reactions.
+  }
+}
+
+function disablePersistentApprovalReactionStore(error: unknown): void {
+  persistentStoreDisabled = true;
+  persistentStore = undefined;
+  reportPersistentApprovalReactionError(error);
+}
+
+function getPersistentApprovalReactionStore(): MatrixApprovalReactionStore | undefined {
+  if (persistentStoreDisabled) {
+    return undefined;
+  }
+  if (persistentStore) {
+    return persistentStore;
+  }
+  const runtime = getOptionalMatrixRuntime();
+  if (!runtime) {
+    return undefined;
+  }
+  try {
+    persistentStore = runtime.state.openKeyedStore<PersistedMatrixApprovalReactionTarget>({
+      maxEntries: PERSISTENT_MAX_ENTRIES,
+      defaultTtlMs: DEFAULT_REACTION_TARGET_TTL_MS,
+    });
+    return persistentStore;
+  } catch (error) {
+    disablePersistentApprovalReactionStore(error);
+    return undefined;
+  }
+}
+
+function readPersistedTarget(value: unknown): MatrixApprovalReactionTarget | null {
+  const persisted = value as PersistedMatrixApprovalReactionTarget | undefined;
+  if (
+    persisted?.version !== 1 ||
+    !persisted.target ||
+    typeof persisted.target.approvalId !== "string" ||
+    !Array.isArray(persisted.target.allowedDecisions)
+  ) {
+    return null;
+  }
+  return persisted.target;
+}
+
+function rememberPersistentApprovalReactionTarget(params: {
+  key: string;
+  target: MatrixApprovalReactionTarget;
+  ttlMs?: number;
+}): void {
+  const ttlMs = params.ttlMs == null ? DEFAULT_REACTION_TARGET_TTL_MS : Math.max(1, params.ttlMs);
+  const store = getPersistentApprovalReactionStore();
+  if (!store) {
+    return;
+  }
+  void store
+    .register(params.key, { version: 1, target: params.target }, { ttlMs })
+    .catch(disablePersistentApprovalReactionStore);
+}
+
+function forgetPersistentApprovalReactionTarget(key: string): void {
+  const store = getPersistentApprovalReactionStore();
+  if (!store) {
+    return;
+  }
+  void store.delete(key).catch(disablePersistentApprovalReactionStore);
+}
+
+async function lookupPersistentApprovalReactionTarget(
+  key: string,
+): Promise<MatrixApprovalReactionTarget | null> {
+  const store = getPersistentApprovalReactionStore();
+  if (!store) {
+    return null;
+  }
+  try {
+    return readPersistedTarget(await store.lookup(key));
+  } catch (error) {
+    disablePersistentApprovalReactionStore(error);
+    return null;
+  }
 }
 
 export function listMatrixApprovalReactionBindings(
@@ -96,6 +207,7 @@ export function registerMatrixApprovalReactionTarget(params: {
   eventId: string;
   approvalId: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
+  ttlMs?: number;
 }): void {
   const key = buildReactionTargetKey(params.roomId, params.eventId);
   const approvalId = params.approvalId.trim();
@@ -110,9 +222,15 @@ export function registerMatrixApprovalReactionTarget(params: {
   if (!key || !approvalId || allowedDecisions.length === 0) {
     return;
   }
-  matrixApprovalReactionTargets.set(key, {
+  const target = {
     approvalId,
     allowedDecisions,
+  };
+  matrixApprovalReactionTargets.set(key, target);
+  rememberPersistentApprovalReactionTarget({
+    key,
+    target,
+    ttlMs: params.ttlMs,
   });
 }
 
@@ -125,18 +243,14 @@ export function unregisterMatrixApprovalReactionTarget(params: {
     return;
   }
   matrixApprovalReactionTargets.delete(key);
+  forgetPersistentApprovalReactionTarget(key);
 }
 
-export function resolveMatrixApprovalReactionTarget(params: {
-  roomId: string;
-  eventId: string;
+function resolveTarget(params: {
+  target: MatrixApprovalReactionTarget | null | undefined;
   reactionKey: string;
 }): MatrixApprovalReactionResolution | null {
-  const key = buildReactionTargetKey(params.roomId, params.eventId);
-  if (!key) {
-    return null;
-  }
-  const target = matrixApprovalReactionTargets.get(key);
+  const target = params.target;
   if (!target) {
     return null;
   }
@@ -153,6 +267,45 @@ export function resolveMatrixApprovalReactionTarget(params: {
   };
 }
 
+export function resolveMatrixApprovalReactionTarget(params: {
+  roomId: string;
+  eventId: string;
+  reactionKey: string;
+}): MatrixApprovalReactionResolution | null {
+  const key = buildReactionTargetKey(params.roomId, params.eventId);
+  if (!key) {
+    return null;
+  }
+  return resolveTarget({
+    target: matrixApprovalReactionTargets.get(key),
+    reactionKey: params.reactionKey,
+  });
+}
+
+export async function resolveMatrixApprovalReactionTargetWithPersistence(params: {
+  roomId: string;
+  eventId: string;
+  reactionKey: string;
+}): Promise<MatrixApprovalReactionResolution | null> {
+  const key = buildReactionTargetKey(params.roomId, params.eventId);
+  if (!key) {
+    return null;
+  }
+  const inMemory = resolveTarget({
+    target: matrixApprovalReactionTargets.get(key),
+    reactionKey: params.reactionKey,
+  });
+  if (inMemory) {
+    return inMemory;
+  }
+  return resolveTarget({
+    target: await lookupPersistentApprovalReactionTarget(key),
+    reactionKey: params.reactionKey,
+  });
+}
+
 export function clearMatrixApprovalReactionTargetsForTest(): void {
   matrixApprovalReactionTargets.clear();
+  persistentStore = undefined;
+  persistentStoreDisabled = false;
 }

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -1,10 +1,13 @@
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "./runtime-api.js";
 
-const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =
-  createPluginRuntimeStore<PluginRuntime>({
-    pluginId: "matrix",
-    errorMessage: "Matrix runtime not initialized",
-  });
+const {
+  setRuntime: setMatrixRuntime,
+  getRuntime: getMatrixRuntime,
+  tryGetRuntime: getOptionalMatrixRuntime,
+} = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "matrix",
+  errorMessage: "Matrix runtime not initialized",
+});
 
-export { getMatrixRuntime, setMatrixRuntime };
+export { getMatrixRuntime, getOptionalMatrixRuntime, setMatrixRuntime };

--- a/extensions/msteams/src/runtime.ts
+++ b/extensions/msteams/src/runtime.ts
@@ -1,9 +1,12 @@
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
-const { setRuntime: setMSTeamsRuntime, getRuntime: getMSTeamsRuntime } =
-  createPluginRuntimeStore<PluginRuntime>({
-    pluginId: "msteams",
-    errorMessage: "MSTeams runtime not initialized",
-  });
-export { getMSTeamsRuntime, setMSTeamsRuntime };
+const {
+  setRuntime: setMSTeamsRuntime,
+  getRuntime: getMSTeamsRuntime,
+  tryGetRuntime: getOptionalMSTeamsRuntime,
+} = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "msteams",
+  errorMessage: "MSTeams runtime not initialized",
+});
+export { getMSTeamsRuntime, getOptionalMSTeamsRuntime, setMSTeamsRuntime };

--- a/extensions/msteams/src/sent-message-cache.ts
+++ b/extensions/msteams/src/sent-message-cache.ts
@@ -1,7 +1,21 @@
-const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+import { getOptionalMSTeamsRuntime } from "./runtime.js";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const PERSISTENT_MAX_ENTRIES = 1000;
 const MSTEAMS_SENT_MESSAGES_KEY = Symbol.for("openclaw.msteamsSentMessages");
 
+type MSTeamsSentMessageRecord = {
+  sentAt: number;
+};
+
+type MSTeamsSentMessageStore = {
+  register(key: string, value: MSTeamsSentMessageRecord, opts?: { ttlMs?: number }): Promise<void>;
+  lookup(key: string): Promise<MSTeamsSentMessageRecord | undefined>;
+};
+
 let sentMessageCache: Map<string, Map<string, number>> | undefined;
+let persistentStore: MSTeamsSentMessageStore | undefined;
+let persistentStoreDisabled = false;
 
 function getSentMessageCache(): Map<string, Map<string, number>> {
   if (!sentMessageCache) {
@@ -12,6 +26,49 @@ function getSentMessageCache(): Map<string, Map<string, number>> {
     globalStore[MSTEAMS_SENT_MESSAGES_KEY] = sentMessageCache;
   }
   return sentMessageCache;
+}
+
+function makePersistentKey(conversationId: string, messageId: string): string {
+  return `${conversationId}:${messageId}`;
+}
+
+function reportPersistentSentMessageError(error: unknown): void {
+  try {
+    getOptionalMSTeamsRuntime()
+      ?.logging.getChildLogger({ plugin: "msteams", feature: "sent-message-state" })
+      .warn("Microsoft Teams persistent sent-message state failed", { error: String(error) });
+  } catch {
+    // Best effort only: persistent state must never break Teams routing.
+  }
+}
+
+function disablePersistentSentMessageStore(error: unknown): void {
+  persistentStoreDisabled = true;
+  persistentStore = undefined;
+  reportPersistentSentMessageError(error);
+}
+
+function getPersistentSentMessageStore(): MSTeamsSentMessageStore | undefined {
+  if (persistentStoreDisabled) {
+    return undefined;
+  }
+  if (persistentStore) {
+    return persistentStore;
+  }
+  const runtime = getOptionalMSTeamsRuntime();
+  if (!runtime) {
+    return undefined;
+  }
+  try {
+    persistentStore = runtime.state.openKeyedStore<MSTeamsSentMessageRecord>({
+      maxEntries: PERSISTENT_MAX_ENTRIES,
+      defaultTtlMs: TTL_MS,
+    });
+    return persistentStore;
+  } catch (error) {
+    disablePersistentSentMessageStore(error);
+    return undefined;
+  }
 }
 
 function cleanupExpired(scopeKey: string, entry: Map<string, number>, now: number): void {
@@ -25,21 +82,60 @@ function cleanupExpired(scopeKey: string, entry: Map<string, number>, now: numbe
   }
 }
 
-export function recordMSTeamsSentMessage(conversationId: string, messageId: string): void {
-  if (!conversationId || !messageId) {
-    return;
-  }
-  const now = Date.now();
+function rememberSentMessageInMemory(
+  conversationId: string,
+  messageId: string,
+  sentAt: number,
+): void {
   const store = getSentMessageCache();
   let entry = store.get(conversationId);
   if (!entry) {
     entry = new Map<string, number>();
     store.set(conversationId, entry);
   }
-  entry.set(messageId, now);
+  entry.set(messageId, sentAt);
   if (entry.size > 200) {
-    cleanupExpired(conversationId, entry, now);
+    cleanupExpired(conversationId, entry, sentAt);
   }
+}
+
+function rememberPersistentSentMessage(params: {
+  conversationId: string;
+  messageId: string;
+  sentAt: number;
+}): void {
+  const store = getPersistentSentMessageStore();
+  if (!store) {
+    return;
+  }
+  void store
+    .register(makePersistentKey(params.conversationId, params.messageId), { sentAt: params.sentAt })
+    .catch(disablePersistentSentMessageStore);
+}
+
+async function lookupPersistentSentMessage(params: {
+  conversationId: string;
+  messageId: string;
+}): Promise<number | undefined> {
+  const store = getPersistentSentMessageStore();
+  if (!store) {
+    return undefined;
+  }
+  try {
+    return (await store.lookup(makePersistentKey(params.conversationId, params.messageId)))?.sentAt;
+  } catch (error) {
+    disablePersistentSentMessageStore(error);
+    return undefined;
+  }
+}
+
+export function recordMSTeamsSentMessage(conversationId: string, messageId: string): void {
+  if (!conversationId || !messageId) {
+    return;
+  }
+  const now = Date.now();
+  rememberSentMessageInMemory(conversationId, messageId, now);
+  rememberPersistentSentMessage({ conversationId, messageId, sentAt: now });
 }
 
 export function wasMSTeamsMessageSent(conversationId: string, messageId: string): boolean {
@@ -51,6 +147,26 @@ export function wasMSTeamsMessageSent(conversationId: string, messageId: string)
   return entry.has(messageId);
 }
 
+export async function wasMSTeamsMessageSentWithPersistence(params: {
+  conversationId: string;
+  messageId: string;
+}): Promise<boolean> {
+  if (!params.conversationId || !params.messageId) {
+    return false;
+  }
+  if (wasMSTeamsMessageSent(params.conversationId, params.messageId)) {
+    return true;
+  }
+  const sentAt = await lookupPersistentSentMessage(params);
+  if (sentAt == null) {
+    return false;
+  }
+  rememberSentMessageInMemory(params.conversationId, params.messageId, sentAt);
+  return wasMSTeamsMessageSent(params.conversationId, params.messageId);
+}
+
 export function clearMSTeamsSentMessageCache(): void {
   getSentMessageCache().clear();
+  persistentStore = undefined;
+  persistentStoreDisabled = false;
 }

--- a/extensions/slack/src/sent-thread-cache.ts
+++ b/extensions/slack/src/sent-thread-cache.ts
@@ -10,7 +10,6 @@ import { getOptionalSlackRuntime } from "./runtime.js";
 const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const MAX_ENTRIES = 5000;
 const PERSISTENT_MAX_ENTRIES = 1000;
-const PERSISTENT_NAMESPACE = "slack.thread-participation";
 
 type SlackThreadParticipationRecord = {
   agentId?: string;
@@ -72,7 +71,6 @@ function getPersistentThreadParticipationStore(): SlackThreadParticipationStore 
   }
   try {
     persistentStore = runtime.state.openKeyedStore<SlackThreadParticipationRecord>({
-      namespace: PERSISTENT_NAMESPACE,
       maxEntries: PERSISTENT_MAX_ENTRIES,
       defaultTtlMs: TTL_MS,
     });

--- a/src/plugin-sdk/plugin-runtime.ts
+++ b/src/plugin-sdk/plugin-runtime.ts
@@ -10,3 +10,8 @@ export * from "../plugins/lazy-service-module.js";
 export * from "../plugins/types.js";
 export { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 export type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
+export type {
+  OpenKeyedStoreOptions,
+  PluginStateEntry,
+  PluginStateKeyedStore,
+} from "../plugin-state/plugin-state-store.types.js";

--- a/src/plugin-state/plugin-state-store.e2e.test.ts
+++ b/src/plugin-state/plugin-state-store.e2e.test.ts
@@ -26,7 +26,6 @@ describe("runtime smoke", () => {
   it("creates and exercises a keyed store directly", async () => {
     await withOpenClawTestState({ label: "e2e-smoke-load" }, async () => {
       const store = createPluginStateKeyedStore<{ ready: boolean }>("fixture-plugin", {
-        namespace: "boot",
         maxEntries: 10,
       });
       expect(store).toBeDefined();
@@ -39,7 +38,6 @@ describe("runtime smoke", () => {
   it("writes and reads a value", async () => {
     await withOpenClawTestState({ label: "e2e-smoke-rw" }, async () => {
       const store = createPluginStateKeyedStore<{ msg: string }>("fixture-plugin", {
-        namespace: "data",
         maxEntries: 10,
       });
       await store.register("greeting", { msg: "hello" });
@@ -50,7 +48,6 @@ describe("runtime smoke", () => {
   it("consumes a value exactly once", async () => {
     await withOpenClawTestState({ label: "e2e-smoke-consume" }, async () => {
       const store = createPluginStateKeyedStore<{ token: string }>("fixture-plugin", {
-        namespace: "tokens",
         maxEntries: 10,
       });
       await store.register("one-shot", { token: "abc123" });
@@ -73,7 +70,6 @@ describe("persistence", () => {
   it("survives close and reopen of the store", async () => {
     await withOpenClawTestState({ label: "e2e-persist" }, async () => {
       const storeA = createPluginStateKeyedStore<{ persisted: boolean }>("fixture-plugin", {
-        namespace: "durable",
         maxEntries: 10,
       });
       await storeA.register("key1", { persisted: true });
@@ -84,7 +80,6 @@ describe("persistence", () => {
       resetPluginStateStoreForTests();
 
       const storeB = createPluginStateKeyedStore<{ persisted: boolean }>("fixture-plugin", {
-        namespace: "durable",
         maxEntries: 10,
       });
       await expect(storeB.lookup("key1")).resolves.toEqual({ persisted: true });
@@ -103,7 +98,6 @@ describe("TTL", () => {
       vi.setSystemTime(10_000);
 
       const store = createPluginStateKeyedStore<{ v: number }>("fixture-plugin", {
-        namespace: "ttl-test",
         maxEntries: 10,
       });
       await store.register("short", { v: 1 }, { ttlMs: 500 });
@@ -136,14 +130,12 @@ describe("TTL", () => {
 // Isolation
 // ---------------------------------------------------------------------------
 describe("isolation", () => {
-  it("segregates plugins sharing namespace and key", async () => {
+  it("segregates plugins sharing a key", async () => {
     await withOpenClawTestState({ label: "e2e-isolation" }, async () => {
       const pluginA = createPluginStateKeyedStore<{ owner: string }>("plugin-a", {
-        namespace: "x",
         maxEntries: 10,
       });
       const pluginB = createPluginStateKeyedStore<{ owner: string }>("plugin-b", {
-        namespace: "x",
         maxEntries: 10,
       });
 
@@ -153,7 +145,7 @@ describe("isolation", () => {
       await expect(pluginA.lookup("same")).resolves.toEqual({ owner: "a" });
       await expect(pluginB.lookup("same")).resolves.toEqual({ owner: "b" });
 
-      // Clearing one plugin's namespace does not affect the other.
+      // Clearing one plugin's store does not affect the other.
       await pluginA.clear();
       await expect(pluginA.lookup("same")).resolves.toBeUndefined();
       await expect(pluginB.lookup("same")).resolves.toEqual({ owner: "b" });
@@ -168,7 +160,6 @@ describe("limits", () => {
   it("accepts a value at the 64 KB boundary", async () => {
     await withOpenClawTestState({ label: "e2e-limit-accept" }, async () => {
       const store = createPluginStateKeyedStore<string>("fixture-plugin", {
-        namespace: "size",
         maxEntries: 10,
       });
       // JSON.stringify wraps a string in quotes (+2 bytes).
@@ -182,7 +173,6 @@ describe("limits", () => {
   it("rejects a value one byte over 64 KB", async () => {
     await withOpenClawTestState({ label: "e2e-limit-reject" }, async () => {
       const store = createPluginStateKeyedStore<string>("fixture-plugin", {
-        namespace: "size",
         maxEntries: 10,
       });
       // 65 535 chars → 65 537 bytes of JSON → over limit.
@@ -193,41 +183,31 @@ describe("limits", () => {
     });
   });
 
-  it("enforces the per-plugin live-row cap", async () => {
+  it("evicts oldest entries at the plugin-wide live-row cap", async () => {
     await withOpenClawTestState({ label: "e2e-limit-plugin" }, async () => {
-      // Spread MAX_ENTRIES_PER_PLUGIN rows across several namespaces so
-      // namespace eviction never fires (each namespace has generous room).
-      const nsCount = 10;
-      const perNs = MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN / nsCount; // 100
       seedPluginStateEntriesForTests(
         Array.from({ length: MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN }, (_, index) => {
-          const ns = Math.floor(index / perNs);
-          const k = index % perNs;
           return {
             pluginId: "fixture-plugin",
-            namespace: `ns-${ns}`,
-            key: `k-${k}`,
-            value: { ns, k },
+            key: `k-${index}`,
+            value: { index },
           };
         }),
       );
       const store = createPluginStateKeyedStore("fixture-plugin", {
-        namespace: "ns-0",
-        maxEntries: perNs + 1,
+        maxEntries: MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN,
       });
 
-      // One more row tips over the plugin-wide limit.
-      await expect(store.register("overflow", { boom: true })).rejects.toMatchObject({
-        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
-      });
+      await expect(store.register("overflow", { boom: true })).resolves.toBeUndefined();
+      await expect(store.lookup("k-0")).resolves.toBeUndefined();
+      await expect(store.lookup("overflow")).resolves.toEqual({ boom: true });
     });
   });
 
-  it("evicts oldest entries when namespace maxEntries is exceeded", async () => {
+  it("evicts oldest entries when maxEntries is exceeded", async () => {
     await withOpenClawTestState({ label: "e2e-limit-eviction" }, async () => {
       vi.useFakeTimers();
       const store = createPluginStateKeyedStore<number>("fixture-plugin", {
-        namespace: "capped",
         maxEntries: 3,
       });
 
@@ -262,7 +242,6 @@ describe("failure safety", () => {
       db.close();
 
       const store = createPluginStateKeyedStore("fixture-plugin", {
-        namespace: "schema",
         maxEntries: 10,
       });
       const error = await store.register("k", { ok: true }).catch((e: unknown) => e);
@@ -288,7 +267,6 @@ describe("failure safety", () => {
   it("close and reopen cycle is clean", async () => {
     await withOpenClawTestState({ label: "e2e-fail-reopen" }, async () => {
       const store = createPluginStateKeyedStore<{ v: number }>("fixture-plugin", {
-        namespace: "reopen",
         maxEntries: 10,
       });
       await store.register("k", { v: 1 });

--- a/src/plugin-state/plugin-state-store.permissions.test.ts
+++ b/src/plugin-state/plugin-state-store.permissions.test.ts
@@ -38,7 +38,6 @@ describe("plugin state permission hardening", () => {
     try {
       await withOpenClawTestState({ label: "plugin-state-post-commit-chmod" }, async () => {
         const store = createPluginStateKeyedStore<{ value: number }>("fixture-plugin", {
-          namespace: "post-commit",
           maxEntries: 10,
         });
         await store.register("first", { value: 1 });

--- a/src/plugin-state/plugin-state-store.runtime.test.ts
+++ b/src/plugin-state/plugin-state-store.runtime.test.ts
@@ -62,7 +62,6 @@ describe("plugin runtime state proxy", () => {
 
       expect(api.runtime.state.resolveStateDir()).toBe(state.stateDir);
       const store = api.runtime.state.openKeyedStore<{ plugin: string }>({
-        namespace: "runtime",
         maxEntries: 10,
       });
       await store.register("k", { plugin: "discord" });
@@ -71,7 +70,6 @@ describe("plugin runtime state proxy", () => {
       registry.registry.plugins.push(telegram);
       const telegramApi = registry.createApi(telegram, { config: {} });
       const telegramStore = telegramApi.runtime.state.openKeyedStore<{ plugin: string }>({
-        namespace: "runtime",
         maxEntries: 10,
       });
       await expect(telegramStore.lookup("k")).resolves.toBeUndefined();
@@ -79,67 +77,40 @@ describe("plugin runtime state proxy", () => {
     });
   });
 
-  it("rejects community plugins without manifest declaration", () => {
-    const registry = createTestPluginRegistry();
-    const record = createPluginRecord("external-plugin", "workspace");
-    registry.registry.plugins.push(record);
-    const api = registry.createApi(record, { config: {} });
-
-    expect(() =>
-      api.runtime.state.openKeyedStore({ namespace: "runtime", maxEntries: 10 }),
-    ).toThrow('Plugin "external-plugin" cannot use openKeyedStore');
-  });
-
-  it("allows community plugins with manifest declaration", async () => {
-    await withOpenClawTestState({ label: "plugin-state-community" }, async () => {
+  it("allows workspace plugins and keeps owner isolation", async () => {
+    await withOpenClawTestState({ label: "plugin-state-runtime-workspace" }, async () => {
       const registry = createTestPluginRegistry();
-      const record = createPluginRecord("community-plugin", "workspace");
+      const external = createPluginRecord("external-state-plugin", "workspace");
+      registry.registry.plugins.push(external);
+      const api = registry.createApi(external, { config: {} });
 
-      // Add contracts with usesKeyedStore capability
-      record.contracts = {
-        usesKeyedStore: true,
-      };
+      const store = api.runtime.state.openKeyedStore<{ plugin: string }>({
+        maxEntries: 10,
+      });
+      await store.register("k", { plugin: "external-state-plugin" });
 
-      registry.registry.plugins.push(record);
-      const api = registry.createApi(record, { config: {} });
-      const store = api.runtime.state.openKeyedStore<{ data: string }>({
-        namespace: "test",
+      const sibling = createPluginRecord("sibling-state-plugin", "workspace");
+      registry.registry.plugins.push(sibling);
+      const siblingApi = registry.createApi(sibling, { config: {} });
+      const siblingStore = siblingApi.runtime.state.openKeyedStore<{ plugin: string }>({
         maxEntries: 10,
       });
 
-      await store.register("key1", { data: "community" });
-      await expect(store.lookup("key1")).resolves.toEqual({ data: "community" });
+      await expect(siblingStore.lookup("k")).resolves.toBeUndefined();
+      await expect(store.lookup("k")).resolves.toEqual({ plugin: "external-state-plugin" });
     });
   });
 
-  it("enforces stricter limits for community plugins", async () => {
-    await withOpenClawTestState({ label: "plugin-state-limits" }, async () => {
+  it("uses a default row budget when options are omitted", async () => {
+    await withOpenClawTestState({ label: "plugin-state-runtime-defaults" }, async () => {
       const registry = createTestPluginRegistry();
-      const record = createPluginRecord("community-plugin", "workspace");
-
-      // Add contracts with usesKeyedStore capability
-      record.contracts = {
-        usesKeyedStore: true,
-      };
-
+      const record = createPluginRecord("external-plugin", "workspace");
       registry.registry.plugins.push(record);
       const api = registry.createApi(record, { config: {} });
 
-      // Request 1000 entries but should be capped at 500 for community plugins
-      const store = api.runtime.state.openKeyedStore<{ index: number }>({
-        namespace: "limits",
-        maxEntries: 1000,
-      });
-
-      // Fill up to the enforced limit (500)
-      for (let i = 0; i < 500; i++) {
-        await store.register(`key${i}`, { index: i });
-      }
-
-      // The 501st entry should trigger eviction of the oldest
-      await store.register("key500", { index: 500 });
-      const entries = await store.entries();
-      expect(entries.length).toBeLessThanOrEqual(500);
+      const store = api.runtime.state.openKeyedStore<{ ok: boolean }>({});
+      await store.register("k", { ok: true });
+      await expect(store.lookup("k")).resolves.toEqual({ ok: true });
     });
   });
 });

--- a/src/plugin-state/plugin-state-store.runtime.test.ts
+++ b/src/plugin-state/plugin-state-store.runtime.test.ts
@@ -79,7 +79,7 @@ describe("plugin runtime state proxy", () => {
     });
   });
 
-  it("rejects external plugins in this release", () => {
+  it("rejects community plugins without manifest declaration", () => {
     const registry = createTestPluginRegistry();
     const record = createPluginRecord("external-plugin", "workspace");
     registry.registry.plugins.push(record);
@@ -87,6 +87,59 @@ describe("plugin runtime state proxy", () => {
 
     expect(() =>
       api.runtime.state.openKeyedStore({ namespace: "runtime", maxEntries: 10 }),
-    ).toThrow("openKeyedStore is only available for bundled plugins");
+    ).toThrow('Plugin "external-plugin" cannot use openKeyedStore');
+  });
+
+  it("allows community plugins with manifest declaration", async () => {
+    await withOpenClawTestState({ label: "plugin-state-community" }, async () => {
+      const registry = createTestPluginRegistry();
+      const record = createPluginRecord("community-plugin", "workspace");
+
+      // Add contracts with usesKeyedStore capability
+      record.contracts = {
+        usesKeyedStore: true,
+      };
+
+      registry.registry.plugins.push(record);
+      const api = registry.createApi(record, { config: {} });
+      const store = api.runtime.state.openKeyedStore<{ data: string }>({
+        namespace: "test",
+        maxEntries: 10,
+      });
+
+      await store.register("key1", { data: "community" });
+      await expect(store.lookup("key1")).resolves.toEqual({ data: "community" });
+    });
+  });
+
+  it("enforces stricter limits for community plugins", async () => {
+    await withOpenClawTestState({ label: "plugin-state-limits" }, async () => {
+      const registry = createTestPluginRegistry();
+      const record = createPluginRecord("community-plugin", "workspace");
+
+      // Add contracts with usesKeyedStore capability
+      record.contracts = {
+        usesKeyedStore: true,
+      };
+
+      registry.registry.plugins.push(record);
+      const api = registry.createApi(record, { config: {} });
+
+      // Request 1000 entries but should be capped at 500 for community plugins
+      const store = api.runtime.state.openKeyedStore<{ index: number }>({
+        namespace: "limits",
+        maxEntries: 1000,
+      });
+
+      // Fill up to the enforced limit (500)
+      for (let i = 0; i < 500; i++) {
+        await store.register(`key${i}`, { index: i });
+      }
+
+      // The 501st entry should trigger eviction of the oldest
+      await store.register("key500", { index: 500 });
+      const entries = await store.entries();
+      expect(entries.length).toBeLessThanOrEqual(500);
+    });
   });
 });

--- a/src/plugin-state/plugin-state-store.test-helpers.ts
+++ b/src/plugin-state/plugin-state-store.test-helpers.ts
@@ -4,7 +4,7 @@ import { closePluginStateSqliteStore, probePluginStateStore } from "./plugin-sta
 
 export type PluginStateSeedEntry = {
   pluginId: string;
-  namespace: string;
+  namespace?: string;
   key: string;
   value: unknown;
   createdAt?: number;
@@ -50,7 +50,7 @@ export function seedPluginStateEntriesForTests(entries: PluginStateSeedEntry[]):
       }
       insertEntry.run({
         plugin_id: entry.pluginId,
-        namespace: entry.namespace,
+        namespace: entry.namespace ?? "default",
         entry_key: entry.key,
         value_json: valueJson,
         created_at: entry.createdAt ?? now + index,

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -12,7 +12,6 @@ import {
   sweepExpiredPluginStateEntries,
 } from "./plugin-state-store.js";
 import { resolvePluginStateDir, resolvePluginStateSqlitePath } from "./plugin-state-store.paths.js";
-import { seedPluginStateEntriesForTests } from "./plugin-state-store.test-helpers.js";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -23,13 +22,11 @@ describe("plugin state keyed store", () => {
   it("registers and looks up values across store instances", async () => {
     await withOpenClawTestState({ label: "plugin-state-roundtrip" }, async () => {
       const store = createPluginStateKeyedStore<{ count: number }>("discord", {
-        namespace: "components",
         maxEntries: 10,
       });
       await store.register("interaction:1", { count: 1 });
 
       const reopened = createPluginStateKeyedStore<{ count: number }>("discord", {
-        namespace: "components",
         maxEntries: 10,
       });
       await expect(reopened.lookup("interaction:1")).resolves.toEqual({ count: 1 });
@@ -40,7 +37,6 @@ describe("plugin state keyed store", () => {
     await withOpenClawTestState({ label: "plugin-state-upsert" }, async () => {
       vi.useFakeTimers();
       const store = createPluginStateKeyedStore<{ version: number }>("discord", {
-        namespace: "components",
         maxEntries: 10,
       });
       vi.setSystemTime(1000);
@@ -61,7 +57,6 @@ describe("plugin state keyed store", () => {
   it("returns undefined for missing lookups and consumes by deleting atomically", async () => {
     await withOpenClawTestState({ label: "plugin-state-consume" }, async () => {
       const store = createPluginStateKeyedStore<{ ok: boolean }>("discord", {
-        namespace: "components",
         maxEntries: 10,
       });
 
@@ -73,20 +68,20 @@ describe("plugin state keyed store", () => {
     });
   });
 
-  it("deletes and clears only the targeted namespace", async () => {
+  it("deletes and clears only the owning plugin store", async () => {
     await withOpenClawTestState({ label: "plugin-state-clear" }, async () => {
-      const first = createPluginStateKeyedStore("discord", { namespace: "a", maxEntries: 10 });
-      const second = createPluginStateKeyedStore("discord", { namespace: "b", maxEntries: 10 });
-      await first.register("k1", { value: 1 });
-      await second.register("k2", { value: 2 });
+      const discord = createPluginStateKeyedStore("discord", { maxEntries: 10 });
+      const telegram = createPluginStateKeyedStore("telegram", { maxEntries: 10 });
+      await discord.register("k1", { value: 1 });
+      await telegram.register("k2", { value: 2 });
 
-      await expect(first.delete("k1")).resolves.toBe(true);
-      await expect(first.delete("k1")).resolves.toBe(false);
-      await first.register("k1", { value: 1 });
-      await first.clear();
+      await expect(discord.delete("k1")).resolves.toBe(true);
+      await expect(discord.delete("k1")).resolves.toBe(false);
+      await discord.register("k1", { value: 1 });
+      await discord.clear();
 
-      await expect(first.entries()).resolves.toEqual([]);
-      await expect(second.lookup("k2")).resolves.toEqual({ value: 2 });
+      await expect(discord.entries()).resolves.toEqual([]);
+      await expect(telegram.lookup("k2")).resolves.toEqual({ value: 2 });
     });
   });
 
@@ -95,7 +90,6 @@ describe("plugin state keyed store", () => {
       vi.useFakeTimers();
       vi.setSystemTime(1000);
       const store = createPluginStateKeyedStore("discord", {
-        namespace: "ttl",
         maxEntries: 10,
         defaultTtlMs: 100,
       });
@@ -113,7 +107,7 @@ describe("plugin state keyed store", () => {
   it("evicts oldest live entries over maxEntries", async () => {
     await withOpenClawTestState({ label: "plugin-state-eviction" }, async () => {
       vi.useFakeTimers();
-      const store = createPluginStateKeyedStore("discord", { namespace: "evict", maxEntries: 2 });
+      const store = createPluginStateKeyedStore("discord", { maxEntries: 2 });
       vi.setSystemTime(1000);
       await store.register("a", 1);
       vi.setSystemTime(2000);
@@ -125,48 +119,18 @@ describe("plugin state keyed store", () => {
     });
   });
 
-  it("rejects when the per-plugin live row ceiling would be exceeded without evicting siblings", async () => {
+  it("rejects maxEntries above the plugin-wide live row ceiling", async () => {
     await withOpenClawTestState({ label: "plugin-state-plugin-limit" }, async () => {
-      seedPluginStateEntriesForTests([
-        ...Array.from({ length: 999 }, (_, entryIndex) => ({
-          pluginId: "discord",
-          namespace: "limit",
-          key: `k-${entryIndex}`,
-          value: { namespaceIndex: 0, entryIndex },
-        })),
-        {
-          pluginId: "discord",
-          namespace: "sibling",
-          key: "k-0",
-          value: { namespaceIndex: 1, entryIndex: 0 },
-        },
-      ]);
-
-      const limitStore = createPluginStateKeyedStore("discord", {
-        namespace: "limit",
-        maxEntries: 1_001,
-      });
-      const siblingStore = createPluginStateKeyedStore("discord", {
-        namespace: "sibling",
-        maxEntries: 10,
-      });
-
-      await expect(limitStore.register("overflow", { overflow: true })).rejects.toMatchObject({
-        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
-      });
-      await expect(siblingStore.lookup("k-0")).resolves.toEqual({
-        namespaceIndex: 1,
-        entryIndex: 0,
-      });
-      await expect(limitStore.lookup("overflow")).resolves.toBeUndefined();
+      expect(() => createPluginStateKeyedStore("discord", { maxEntries: 1_001 })).toThrow(
+        PluginStateStoreError,
+      );
     });
   });
 
-  it("segregates plugins sharing a namespace and key", async () => {
+  it("segregates plugins sharing a key", async () => {
     await withOpenClawTestState({ label: "plugin-state-segregation" }, async () => {
-      const discord = createPluginStateKeyedStore("discord", { namespace: "same", maxEntries: 10 });
+      const discord = createPluginStateKeyedStore("discord", { maxEntries: 10 });
       const telegram = createPluginStateKeyedStore("telegram", {
-        namespace: "same",
         maxEntries: 10,
       });
       await discord.register("k", { plugin: "discord" });
@@ -178,16 +142,20 @@ describe("plugin state keyed store", () => {
     });
   });
 
-  it("validates namespaces, keys, options, and JSON values before writes", async () => {
+  it("validates keys, options, and JSON values before writes", async () => {
     await withOpenClawTestState({ label: "plugin-state-validation" }, async () => {
-      expect(() =>
-        createPluginStateKeyedStore("discord", { namespace: "../bad", maxEntries: 10 }),
-      ).toThrow(PluginStateStoreError);
-      expect(() =>
-        createPluginStateKeyedStore("discord", { namespace: "bad-max", maxEntries: 0 }),
-      ).toThrow(PluginStateStoreError);
+      expect(() => createPluginStateKeyedStore("discord", { maxEntries: 0 })).toThrow(
+        PluginStateStoreError,
+      );
+      expect(() => createPluginStateKeyedStore("discord", { maxEntries: 1_001 })).toThrow(
+        PluginStateStoreError,
+      );
 
-      const store = createPluginStateKeyedStore("discord", { namespace: "valid", maxEntries: 10 });
+      const defaultStore = createPluginStateKeyedStore("default-plugin");
+      await defaultStore.register("default-options", { ok: true });
+      await expect(defaultStore.lookup("default-options")).resolves.toEqual({ ok: true });
+
+      const store = createPluginStateKeyedStore("discord", { maxEntries: 10 });
       await expect(store.register(" ", { ok: true })).rejects.toThrow(PluginStateStoreError);
       await expect(store.register("undefined", undefined)).rejects.toThrow(PluginStateStoreError);
       await expect(store.register("infinity", Number.POSITIVE_INFINITY)).rejects.toThrow(
@@ -217,11 +185,6 @@ describe("plugin state keyed store", () => {
         PluginStateStoreError,
       );
 
-      // Namespace byte-length limit (128 bytes)
-      expect(() =>
-        createPluginStateKeyedStore("discord", { namespace: "a".repeat(129), maxEntries: 10 }),
-      ).toThrow(PluginStateStoreError);
-
       // JSON depth limit (64 levels)
       let deep: unknown = { leaf: true };
       for (let i = 0; i < 65; i += 1) {
@@ -243,12 +206,12 @@ describe("plugin state keyed store", () => {
     });
   });
 
-  it("rejects reopening the same namespace with incompatible options", async () => {
+  it("rejects reopening the same plugin store with incompatible options", async () => {
     await withOpenClawTestState({ label: "plugin-state-option-consistency" }, async () => {
-      createPluginStateKeyedStore("discord", { namespace: "same", maxEntries: 10 });
-      expect(() =>
-        createPluginStateKeyedStore("discord", { namespace: "same", maxEntries: 11 }),
-      ).toThrow(PluginStateStoreError);
+      createPluginStateKeyedStore("discord", { maxEntries: 10 });
+      expect(() => createPluginStateKeyedStore("discord", { maxEntries: 11 })).toThrow(
+        PluginStateStoreError,
+      );
     });
   });
 
@@ -256,20 +219,22 @@ describe("plugin state keyed store", () => {
     await withOpenClawTestState({ label: "plugin-state-core" }, async () => {
       const store = createCorePluginStateKeyedStore<{ stopped: boolean }>({
         ownerId: "core:channel-intent",
-        namespace: "stopped",
         maxEntries: 10,
       });
       await store.register("telegram:personal", { stopped: true });
       await expect(store.lookup("telegram:personal")).resolves.toEqual({ stopped: true });
-      expect(() =>
-        createPluginStateKeyedStore("core:not-a-plugin", { namespace: "bad", maxEntries: 10 }),
-      ).toThrow(PluginStateStoreError);
+      expect(() => createPluginStateKeyedStore("core:not-a-plugin", { maxEntries: 10 })).toThrow(
+        PluginStateStoreError,
+      );
+      expect(() => createPluginStateKeyedStore("__proto__", { maxEntries: 10 })).toThrow(
+        PluginStateStoreError,
+      );
     });
   });
 
   it("closes the cached DB handle and reopens cleanly", async () => {
     await withOpenClawTestState({ label: "plugin-state-close" }, async () => {
-      const store = createPluginStateKeyedStore("discord", { namespace: "close", maxEntries: 10 });
+      const store = createPluginStateKeyedStore("discord", { maxEntries: 10 });
       await store.register("k", { ok: true });
       closePluginStateSqliteStore();
       await expect(store.lookup("k")).resolves.toEqual({ ok: true });
@@ -278,7 +243,7 @@ describe("plugin state keyed store", () => {
 
   it.runIf(process.platform !== "win32")("hardens DB directory and file permissions", async () => {
     await withOpenClawTestState({ label: "plugin-state-permissions" }, async () => {
-      const store = createPluginStateKeyedStore("discord", { namespace: "perms", maxEntries: 10 });
+      const store = createPluginStateKeyedStore("discord", { maxEntries: 10 });
       await store.register("k", { ok: true });
 
       expect(statSync(resolvePluginStateDir()).mode & 0o777).toBe(0o700);
@@ -303,7 +268,7 @@ describe("plugin state keyed store", () => {
       db.exec("PRAGMA user_version = 2;");
       db.close();
 
-      const store = createPluginStateKeyedStore("discord", { namespace: "schema", maxEntries: 10 });
+      const store = createPluginStateKeyedStore("discord", { maxEntries: 10 });
       await expect(store.register("k", { ok: true })).rejects.toMatchObject({
         code: "PLUGIN_STATE_SCHEMA_UNSUPPORTED",
       });

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -1,5 +1,7 @@
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import {
   closePluginStateSqliteStore,
+  MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN,
   MAX_PLUGIN_STATE_VALUE_BYTES,
   pluginStateClear,
   pluginStateConsume,
@@ -36,7 +38,10 @@ export {
 const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9._-]*$/iu;
 const MAX_NAMESPACE_BYTES = 128;
 const MAX_KEY_BYTES = 512;
+const MAX_PLUGIN_ID_BYTES = 256;
 const MAX_JSON_DEPTH = 64;
+const DEFAULT_PLUGIN_STATE_NAMESPACE = "default";
+const DEFAULT_PLUGIN_STATE_MAX_ENTRIES = 100;
 
 type StoreOptionSignature = {
   maxEntries: number;
@@ -85,11 +90,31 @@ function validateKey(value: string, operation: PluginStateStoreOperation = "regi
   return trimmed;
 }
 
-function validateMaxEntries(value: number): number {
-  if (!Number.isInteger(value) || value < 1) {
-    throw invalidInput("plugin state maxEntries must be an integer >= 1", "open");
+function validatePluginStatePluginId(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || isBlockedObjectKey(trimmed)) {
+    throw invalidInput("plugin state plugin id must not be empty or reserved", "open");
   }
-  return value;
+  assertMaxBytes("plugin id", trimmed, MAX_PLUGIN_ID_BYTES, "open");
+  if (trimmed.startsWith("core:")) {
+    throw invalidInput("Plugin ids starting with 'core:' are reserved for core consumers.", "open");
+  }
+  return trimmed;
+}
+
+function validateMaxEntries(value: number | undefined): number {
+  const resolved = value ?? DEFAULT_PLUGIN_STATE_MAX_ENTRIES;
+  if (
+    !Number.isInteger(resolved) ||
+    resolved < 1 ||
+    resolved > MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN
+  ) {
+    throw invalidInput(
+      `plugin state maxEntries must be an integer from 1 to ${MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN}`,
+      "open",
+    );
+  }
+  return resolved;
 }
 
 function validateOptionalTtlMs(
@@ -202,7 +227,7 @@ function assertConsistentOptions(
     existing.defaultTtlMs !== signature.defaultTtlMs
   ) {
     throw invalidInput(
-      `plugin state namespace ${namespace} for ${pluginId} was reopened with incompatible options`,
+      `plugin state store for ${pluginId} was reopened with incompatible options`,
       "open",
     );
   }
@@ -210,9 +235,9 @@ function assertConsistentOptions(
 
 function createKeyedStoreForPluginId<T>(
   pluginId: string,
-  options: OpenKeyedStoreOptions,
+  options: OpenKeyedStoreOptions = {},
 ): PluginStateKeyedStore<T> {
-  const namespace = validateNamespace(options.namespace);
+  const namespace = validateNamespace(DEFAULT_PLUGIN_STATE_NAMESPACE);
   const maxEntries = validateMaxEntries(options.maxEntries);
   const defaultTtlMs = validateOptionalTtlMs(options.defaultTtlMs);
   assertConsistentOptions(pluginId, namespace, { maxEntries, defaultTtlMs });
@@ -256,12 +281,9 @@ function createKeyedStoreForPluginId<T>(
 
 export function createPluginStateKeyedStore<T>(
   pluginId: string,
-  options: OpenKeyedStoreOptions,
+  options: OpenKeyedStoreOptions = {},
 ): PluginStateKeyedStore<T> {
-  if (pluginId.startsWith("core:")) {
-    throw invalidInput("Plugin ids starting with 'core:' are reserved for core consumers.", "open");
-  }
-  return createKeyedStoreForPluginId<T>(pluginId, options);
+  return createKeyedStoreForPluginId<T>(validatePluginStatePluginId(pluginId), options);
 }
 
 export function createCorePluginStateKeyedStore<T>(

--- a/src/plugin-state/plugin-state-store.types.ts
+++ b/src/plugin-state/plugin-state-store.types.ts
@@ -15,8 +15,7 @@ export type PluginStateKeyedStore<T> = {
 };
 
 export type OpenKeyedStoreOptions = {
-  namespace: string;
-  maxEntries: number;
+  maxEntries?: number;
   defaultTtlMs?: number;
 };
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -411,12 +411,6 @@ export type PluginManifestContracts = {
   webSearchProviders?: string[];
   migrationProviders?: string[];
   tools?: string[];
-  /**
-   * Declares that this plugin uses the openKeyedStore API for restart-safe
-   * keyed state. Community plugins must declare this capability to access
-   * openKeyedStore. Bundled plugins have implicit access.
-   */
-  usesKeyedStore?: boolean;
 };
 
 export type PluginManifestMediaUnderstandingCapability = "image" | "audio" | "video";
@@ -771,8 +765,6 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const webSearchProviders = normalizeTrimmedStringList(value.webSearchProviders);
   const migrationProviders = normalizeTrimmedStringList(value.migrationProviders);
   const tools = normalizeTrimmedStringList(value.tools);
-  const usesKeyedStore =
-    typeof value.usesKeyedStore === "boolean" ? value.usesKeyedStore : undefined;
   const contracts = {
     ...(embeddedExtensionFactories.length > 0 ? { embeddedExtensionFactories } : {}),
     ...(agentToolResultMiddleware.length > 0 ? { agentToolResultMiddleware } : {}),
@@ -791,7 +783,6 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
     ...(webSearchProviders.length > 0 ? { webSearchProviders } : {}),
     ...(migrationProviders.length > 0 ? { migrationProviders } : {}),
     ...(tools.length > 0 ? { tools } : {}),
-    ...(usesKeyedStore !== undefined ? { usesKeyedStore } : {}),
   } satisfies PluginManifestContracts;
 
   return Object.keys(contracts).length > 0 ? contracts : undefined;

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -411,6 +411,12 @@ export type PluginManifestContracts = {
   webSearchProviders?: string[];
   migrationProviders?: string[];
   tools?: string[];
+  /**
+   * Declares that this plugin uses the openKeyedStore API for restart-safe
+   * keyed state. Community plugins must declare this capability to access
+   * openKeyedStore. Bundled plugins have implicit access.
+   */
+  usesKeyedStore?: boolean;
 };
 
 export type PluginManifestMediaUnderstandingCapability = "image" | "audio" | "video";
@@ -765,6 +771,8 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const webSearchProviders = normalizeTrimmedStringList(value.webSearchProviders);
   const migrationProviders = normalizeTrimmedStringList(value.migrationProviders);
   const tools = normalizeTrimmedStringList(value.tools);
+  const usesKeyedStore =
+    typeof value.usesKeyedStore === "boolean" ? value.usesKeyedStore : undefined;
   const contracts = {
     ...(embeddedExtensionFactories.length > 0 ? { embeddedExtensionFactories } : {}),
     ...(agentToolResultMiddleware.length > 0 ? { agentToolResultMiddleware } : {}),
@@ -783,6 +791,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
     ...(webSearchProviders.length > 0 ? { webSearchProviders } : {}),
     ...(migrationProviders.length > 0 ? { migrationProviders } : {}),
     ...(tools.length > 0 ? { tools } : {}),
+    ...(usesKeyedStore !== undefined ? { usesKeyedStore } : {}),
   } satisfies PluginManifestContracts;
 
   return Object.keys(contracts).length > 0 ? contracts : undefined;

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -8,7 +8,11 @@ import {
   passesManifestOwnerBasePolicy,
 } from "./manifest-owner-policy.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
-import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import type {
+  PluginManifestContractListKey,
+  PluginManifestRecord,
+  PluginManifestRegistry,
+} from "./manifest-registry.js";
 import {
   loadPluginRegistrySnapshot,
   normalizePluginsConfigWithRegistry,
@@ -185,7 +189,7 @@ export function resolveExternalAuthProfileProviderPluginIds(params: {
 }
 
 function resolveRegistryManifestContractPluginIds(params: {
-  contract: string;
+  contract: PluginManifestContractListKey;
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
@@ -205,9 +209,7 @@ function resolveRegistryManifestContractPluginIds(params: {
       if (onlyPluginIdSet && !onlyPluginIdSet.has(plugin.id)) {
         return false;
       }
-      const contractValue =
-        plugin.contracts?.[params.contract as keyof NonNullable<typeof plugin.contracts>];
-      return Array.isArray(contractValue) && contractValue.length > 0;
+      return (plugin.contracts?.[params.contract]?.length ?? 0) > 0;
     })
     .map((plugin) => plugin.id)
     .toSorted((left, right) => left.localeCompare(right));

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -205,10 +205,9 @@ function resolveRegistryManifestContractPluginIds(params: {
       if (onlyPluginIdSet && !onlyPluginIdSet.has(plugin.id)) {
         return false;
       }
-      return (
-        (plugin.contracts?.[params.contract as keyof NonNullable<typeof plugin.contracts>] ?? [])
-          .length > 0
-      );
+      const contractValue =
+        plugin.contracts?.[params.contract as keyof NonNullable<typeof plugin.contracts>];
+      return Array.isArray(contractValue) && contractValue.length > 0;
     })
     .map((plugin) => plugin.id)
     .toSorted((left, right) => left.localeCompare(right));

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2097,12 +2097,25 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               const record =
                 pluginRuntimeRecordById.get(pluginId) ??
                 registry.plugins.find((entry) => entry.id === pluginId);
-              if (record?.origin !== "bundled") {
-                throw new Error(
-                  "openKeyedStore is only available for bundled plugins in this release.",
-                );
+
+              // Bundled plugins have implicit access
+              if (record?.origin === "bundled") {
+                return createPluginStateKeyedStore<T>(pluginId, options);
               }
-              return createPluginStateKeyedStore<T>(pluginId, options);
+
+              // Community plugins must declare the capability in their manifest
+              if (record?.contracts?.usesKeyedStore === true) {
+                // Enforce stricter limits for community plugins
+                const enforcedOptions = {
+                  ...options,
+                  maxEntries: Math.min(options.maxEntries, 500), // Half of bundled plugin limit
+                };
+                return createPluginStateKeyedStore<T>(pluginId, enforcedOptions);
+              }
+
+              throw new Error(
+                `Plugin "${pluginId}" cannot use openKeyedStore. Community plugins must declare "contracts": { "usesKeyedStore": true } in openclaw.plugin.json. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-state`,
+              );
             },
           } satisfies PluginRuntime["state"];
         }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2093,29 +2093,8 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           const baseState = Reflect.get(target, prop, receiver);
           return {
             ...baseState,
-            openKeyedStore: <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
-              const record =
-                pluginRuntimeRecordById.get(pluginId) ??
-                registry.plugins.find((entry) => entry.id === pluginId);
-
-              // Bundled plugins have implicit access
-              if (record?.origin === "bundled") {
-                return createPluginStateKeyedStore<T>(pluginId, options);
-              }
-
-              // Community plugins must declare the capability in their manifest
-              if (record?.contracts?.usesKeyedStore === true) {
-                // Enforce stricter limits for community plugins
-                const enforcedOptions = {
-                  ...options,
-                  maxEntries: Math.min(options.maxEntries, 500), // Half of bundled plugin limit
-                };
-                return createPluginStateKeyedStore<T>(pluginId, enforcedOptions);
-              }
-
-              throw new Error(
-                `Plugin "${pluginId}" cannot use openKeyedStore. Community plugins must declare "contracts": { "usesKeyedStore": true } in openclaw.plugin.json. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-state`,
-              );
+            openKeyedStore: <T>(options?: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
+              return createPluginStateKeyedStore<T>(pluginId, options);
             },
           } satisfies PluginRuntime["state"];
         }

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -249,7 +249,7 @@ export type PluginRuntimeCore = {
   state: {
     resolveStateDir: typeof import("../../config/paths.js").resolveStateDir;
     openKeyedStore: <T>(
-      options: import("../../plugin-state/plugin-state-store.types.js").OpenKeyedStoreOptions,
+      options?: import("../../plugin-state/plugin-state-store.types.js").OpenKeyedStoreOptions,
     ) => import("../../plugin-state/plugin-state-store.types.js").PluginStateKeyedStore<T>;
   };
   tasks: {


### PR DESCRIPTION
## Summary

- **Problem**: Community plugins cannot use `api.runtime.state.openKeyedStore` for restart-safe keyed state storage due to a bundled-only origin check, forcing them to reimplement SQLite-backed state management for recovery dedup, cron alert windows, watchdog history, and pipeline checkpoints.
- **Why it matters**: The underlying implementation already provides per-plugin isolation, quotas, and validation. Community plugins need durable state for production use cases, and the API was artificially restricted despite having the necessary safety mechanisms.
- **What changed**: Added manifest-based opt-in capability (`contracts.usesKeyedStore: true`) allowing community plugins to access `openKeyedStore` with stricter limits (500 entries per namespace vs 1,000 for bundled plugins). Fixed type guard in `providers.ts` to handle boolean contract fields.
- **What did NOT change (scope boundary)**: Bundled plugins retain implicit access without manifest changes. Underlying SQLite storage, per-plugin isolation, TTL eviction, total row limits (1,000 per plugin), value size limits (64KB), and validation logic remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76433
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A - This is a feature addition, not a bug fix.

## Regression Test Plan (if applicable)

N/A - This is a feature addition, not a bug fix.

## User-visible / Behavior Changes

- Community plugins can now use `api.runtime.state.openKeyedStore` by declaring `"contracts": { "usesKeyedStore": true }` in their `openclaw.plugin.json` manifest.
- Community plugins are limited to 500 entries per namespace (bundled plugins remain at 1,000).
- Error message changed from "openKeyedStore is only available for bundled plugins in this release" to "Plugin '<id>' cannot use openKeyedStore. Community plugins must declare 'contracts': { 'usesKeyedStore': true } in openclaw.plugin.json. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-state"
- Documentation updated to reflect capability-based access model with example manifest declaration.

## Diagram (if applicable)

```text
Before:
[community plugin] -> openKeyedStore() -> [bundled-only check] -> Error

After:
[bundled plugin] -> openKeyedStore() -> [implicit access] -> store (1000 limit)
[community plugin without manifest] -> openKeyedStore() -> Error with guidance
[community plugin with manifest] -> openKeyedStore() -> [capability check] -> store (500 limit)
