### PR TITLE
fix(agents): match provider-scoped model ids in context-window-guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/context-window: match provider-scoped runtime model ids (e.g. `github-copilot/claude-opus-4.7-1m-internal`) against bare configured model ids in `resolveContextWindowInfo`, so user-configured `contextTokens`/`contextWindow` are honoured instead of silently falling back to the plugin default. Fixes #76532.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - Microsoft Teams: persist sent-message markers across Gateway restarts so follow-up replies to recent bot messages keep resolving the original conversation instead of dropping out after restart, with marker TTLs preserved on best-effort recovery. (#75585) Thanks @amknight.
 - Matrix: persist pending approval reaction targets across Gateway restarts so room approvers can still approve or deny outstanding prompts after OpenClaw comes back online. (#75586) Thanks @amknight.

--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -113,6 +113,61 @@ describe("context-window-guard", () => {
     });
   });
 
+  it("matches provider-scoped runtime modelId against bare config id", () => {
+    const cfg = openRouterModelConfig({ contextWindow: 1_000_000, contextTokens: 936_000 });
+
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "openrouter",
+      modelId: "openrouter/tiny",
+      modelContextWindow: 128_000,
+      defaultTokens: 200_000,
+    });
+
+    expect(info).toEqual({
+      source: "modelsConfig",
+      tokens: 936_000,
+    });
+  });
+
+  it("matches bare runtime modelId against provider-scoped config id", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "github-copilot": {
+            baseUrl: "http://localhost",
+            apiKey: "x",
+            models: [
+              {
+                id: "github-copilot/claude-opus-4.7-1m-internal",
+                name: "claude-opus-4.7-1m",
+                reasoning: false,
+                input: ["text"] as const,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 1_000_000,
+                contextTokens: 936_000,
+                maxTokens: 64_000,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "github-copilot",
+      modelId: "claude-opus-4.7-1m-internal",
+      modelContextWindow: 128_000,
+      defaultTokens: 200_000,
+    });
+
+    expect(info).toEqual({
+      source: "modelsConfig",
+      tokens: 936_000,
+    });
+  });
+
   it("normalizes provider aliases when reading models config context windows", () => {
     const cfg = {
       models: {

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -23,6 +23,41 @@ function normalizePositiveInt(value: unknown): number | null {
   return int > 0 ? int : null;
 }
 
+/**
+ * Matches a configured model id against a runtime model id, accounting for
+ * the runtime potentially using `provider/model` form while the config uses
+ * the bare model id (or vice-versa).
+ */
+function matchesModelIdForProvider(
+  configuredId: string | undefined,
+  runtimeModelId: string,
+  provider: string,
+): boolean {
+  if (!configuredId) return false;
+  if (configuredId === runtimeModelId) return true;
+
+  const providerPrefix = provider ? `${provider}/` : "";
+  if (!providerPrefix) return false;
+
+  // Runtime id is provider-scoped, configured id is bare
+  if (
+    runtimeModelId.startsWith(providerPrefix) &&
+    runtimeModelId.slice(providerPrefix.length) === configuredId
+  ) {
+    return true;
+  }
+
+  // Configured id is provider-scoped, runtime id is bare
+  if (
+    configuredId.startsWith(providerPrefix) &&
+    configuredId.slice(providerPrefix.length) === runtimeModelId
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 export function resolveContextWindowInfo(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -40,7 +75,9 @@ export function resolveContextWindowInfo(params: {
       | undefined;
     const providerEntry = findNormalizedProviderValue(providers, params.provider);
     const models = Array.isArray(providerEntry?.models) ? providerEntry.models : [];
-    const match = models.find((m) => m?.id === params.modelId);
+    const match = models.find((m) =>
+      matchesModelIdForProvider(m?.id, params.modelId, params.provider),
+    );
     return normalizePositiveInt(match?.contextTokens) ?? normalizePositiveInt(match?.contextWindow);
   })();
   const fromModel =


### PR DESCRIPTION
## Summary

`resolveContextWindowInfo` uses strict `m.id === params.modelId` equality to find configured model entries. When the runtime resolves a model id in `provider/model` form (e.g. `github-copilot/claude-opus-4.7-1m-internal`) but the user configured the bare id (`claude-opus-4.7-1m-internal`), the match fails silently. The guard then falls back to the plugin's default `contextWindow` (128k for `github-copilot`), capping sessions at 128k even though the user configured 1M/936k.

## Root Cause

`src/agents/context-window-guard.ts`:
```ts
const match = models.find((m) => m?.id === params.modelId);
```

`params.modelId` can arrive in `provider/model` form from `pi-embedded-runner/run.ts` and callers like `auto-reply/reply/agent-runner-execution.ts`. The existing `matchesProviderScopedModelId` helper in `pi-embedded-runner/model.ts` already handles the inverse direction (candidate has prefix, requested is bare) — this fix makes the context-window-guard symmetric.

## Fix

Add `matchesModelIdForProvider()` that handles both directions of prefix mismatch:
- Runtime id is provider-scoped, config id is bare
- Config id is provider-scoped, runtime id is bare

## Tests

Added two new test cases:
- `matches provider-scoped runtime modelId against bare config id` — the exact reproduction from the issue (runtime sends `openrouter/tiny`, config has `tiny`)
- `matches bare runtime modelId against provider-scoped config id` — the reverse direction (config has `github-copilot/claude-opus-4.7-1m-internal`, runtime sends bare)

All 24 tests pass. Formatting verified with `oxfmt`.

Fixes #76532