### PR TITLE
fix: improve error messages for `skills update` argument validation

### DIFF
--- a/src/param-key.test.ts
+++ b/src/param-key.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { readSnakeCaseParamRaw, resolveSnakeCaseParamKey } from "./param-key.js";
+
+describe("param-key", () => {
+  it("prefers the exact key when both camelCase and snake_case exist", () => {
+    const params = {
+      maxTokens: 100,
+      max_tokens: 200,
+    };
+
+    expect(resolveSnakeCaseParamKey(params, "maxTokens")).toBe("maxTokens");
+    expect(readSnakeCaseParamRaw(params, "maxTokens")).toBe(100);
+  });
+
+  it("falls back to snake_case when the exact key is missing", () => {
+    const params = {
+      max_tokens: 200,
+    };
+
+    expect(resolveSnakeCaseParamKey(params, "maxTokens")).toBe("max_tokens");
+    expect(readSnakeCaseParamRaw(params, "maxTokens")).toBe(200);
+  });
+
+  it("returns undefined when neither key form exists", () => {
+    const params = {
+      temperature: 0.7,
+    };
+
+    expect(resolveSnakeCaseParamKey(params, "maxTokens")).toBeUndefined();
+    expect(readSnakeCaseParamRaw(params, "maxTokens")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

The `skills update` command had two argument validation guards that emitted
bare error messages with no hint about the correct syntax. Users who
mistyped the command got an error but no guidance about what to run next.

This PR improves both messages to include a concrete command example,
matching the style already used elsewhere in the CLI. It also adds three
tests that were missing — all three `update` error/guard branches had
zero test coverage before this PR.

## Changes

**`src/cli/skills-cli.ts`**
- Added `formatCliCommand` import (already used in `skills-cli.format.ts`, missing here)
- `"Provide a skill slug or use --all."` → includes example command
- `"Use either a skill slug or --all."` → clarifies "not both" + includes example command

**`src/cli/skills-cli.commands.test.ts`**
- Test: `skills update` with no slug and no `--all` → exits 1 with actionable message
- Test: `skills update calendar --all` (slug + flag together) → exits 1 with actionable message
- Test: `skills update --all` with zero tracked skills → logs cleanly, exits 0, no API call

## Why

New users running `openclaw skills update` without the required flags had
no guidance. The new messages show the exact correct command, consistent
with how other `skills` subcommands handle missing input. The three added
tests lock in all guard branches so future refactors cannot silently break them.

## Testing

```bash
npx vitest run src/cli/skills-cli.commands.test.ts
# 24 passed (was 21 before this PR)
```