### PR TITLE
fix(ui): rehydrate chat history after model switch to prevent blank messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/WebChat: rehydrate chat history after switching model from the chat header, so older assistant messages render correctly instead of appearing blank after the session list re-renders. Fixes #76582. Thanks @hclsys.
 - Gateway/update: recover an installed-but-unloaded macOS LaunchAgent after package updates, rerun Gateway health/version/channel readiness checks, and print restart, reinstall, and rollback guidance before reporting update failure. (#76790) Thanks @jonathanlindsay.
 - Google Meet: route stateful CLI session commands through the gateway-owned runtime so joined realtime sessions survive after the starting CLI process exits. Fixes #76344. Thanks @coltonharris-wq.
 - Memory/status: split builtin sqlite-vec store readiness from embedding-provider readiness in `memory status --deep` and `openclaw status`, so local vector-store failures no longer look like provider failures and provider failures no longer hide a healthy local vector store.

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -7,6 +7,7 @@ import {
   resolveChatModelSelectState,
 } from "../chat-model-select-state.ts";
 import { refreshVisibleToolsEffectiveForCurrentSession } from "../controllers/agents.ts";
+import { type ChatState, loadChatHistory } from "../controllers/chat.ts";
 import { loadSessions } from "../controllers/sessions.ts";
 import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
 import { parseAgentSessionKey } from "../session-key.ts";
@@ -289,6 +290,9 @@ async function switchChatModel(state: AppViewState, nextModel: string) {
     });
     void refreshVisibleToolsEffectiveForCurrentSessionLazy(state);
     await refreshSessionOptions(state);
+    // Rehydrate chat history after the session metadata refresh so Lit re-renders
+    // messages from the server instead of losing older assistant message text.
+    void loadChatHistory(state as unknown as ChatState);
   } catch (err) {
     // Roll back so the picker reflects the actual server model.
     state.chatModelOverrides = { ...state.chatModelOverrides, [targetSessionKey]: prevOverride };

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -42,6 +42,7 @@ const loadSessionsMock = vi.hoisted(() =>
     }
   }),
 );
+const loadChatHistoryMock = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock("../icons.ts", () => ({
   icons: {},
@@ -153,6 +154,10 @@ vi.mock("../controllers/agents.ts", () => ({
 
 vi.mock("../controllers/sessions.ts", () => ({
   loadSessions: loadSessionsMock,
+}));
+
+vi.mock("../controllers/chat.ts", () => ({
+  loadChatHistory: loadChatHistoryMock,
 }));
 
 vi.mock("./agents-utils.ts", () => ({
@@ -434,6 +439,7 @@ describe("chat compaction divider", () => {
 
 afterEach(() => {
   loadSessionsMock.mockClear();
+  loadChatHistoryMock.mockClear();
   refreshVisibleToolsEffectiveForCurrentSessionMock.mockClear();
   resetChatViewState();
   resetChatAttachmentPayloadStoreForTest();
@@ -797,7 +803,6 @@ describe("chat session controls", () => {
       key: "main",
       model: "openai/gpt-5-mini",
     });
-    expect(request).not.toHaveBeenCalledWith("chat.history", expect.anything());
     await flushTasks();
     expect(loadSessionsMock).toHaveBeenCalledTimes(1);
     expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5-mini");
@@ -807,6 +812,9 @@ describe("chat session controls", () => {
       sessionKey: "main",
     });
     expect(state.toolsEffectiveResultKey).toBe("main:main:model=openai/gpt-5-mini");
+    // Model switch must rehydrate chat history to prevent older assistant
+    // messages rendering blank after the sessions-list re-render (#76582).
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
   });
 
   it("clears the session model override back to the default model", async () => {


### PR DESCRIPTION
## Root cause

`switchChatModel` calls `sessions.patch` → `refreshSessionOptions` (which calls `loadSessions`). This updates `sessionsResult` and triggers a Lit re-render. The re-render pipeline drops older assistant message text because the local `chatMessages` state is not refreshed from the server after the session metadata changes.

The previous test (`chat.test.ts:805`) actually encoded the broken behavior by asserting `expect(request).not.toHaveBeenCalledWith("chat.history", ...)`.

## Fix

Two files changed:

**`ui/src/ui/chat/session-controls.ts`** — import `loadChatHistory` and call it after `refreshSessionOptions` succeeds:
```ts
import { type ChatState, loadChatHistory } from "../controllers/chat.ts";
// ...
await refreshSessionOptions(state);
// Rehydrate chat history so Lit re-renders messages from the server
// instead of losing older assistant message text.
void loadChatHistory(state as unknown as ChatState);
```

**`ui/src/ui/views/chat.test.ts`** — add `loadChatHistoryMock`, mock `../controllers/chat.ts`, update the model-switch test to assert `loadChatHistoryMock` is called once (removing the previous assertion that it was NOT called).

## Tests

22/22 pass (`ui/src/ui/views/chat.test.ts`).

Fixes #76582.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)