### PR TITLE
fix(sandbox): bump config hash when buildSandboxCreateArgs flags change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback: suppress duplicate current-turn user-message transcript writes after embedded fallback retries while still sending the retry prompt to the model. (#63696) Thanks @dashhuang.
 - Channels/Telegram: force a fresh final message when a visible non-preview bubble (tool/block/error) was delivered after the active answer preview, so multi-step assistant replies no longer end up with the final answer above intermediate output. Fixes #76529. Thanks @jack-stormentswe.
 - Channels/Telegram: require an observed Telegram send, edit, or fallback before treating a forum-topic final as delivered, so final replies generated in transcript no longer disappear from Telegram topics. Fixes #76554. (#76764) Thanks @bubucilo and @obviyus.
+- Agents/sandbox: include a `createArgsEpoch` constant in the sandbox and browser-sandbox config hashes so existing containers recreate when `buildSandboxCreateArgs` adds, removes, or changes container flags. Without the epoch, deployments such as `scope: "agent"` with `prune.maxAgeDays: 0` keep running their previously created container indefinitely and never pick up new flags. Pairs with #74083 to make the `--init`/tini reaper rollout reach long-running sandboxes. Refs #68691.
 
 ## 2026.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback: suppress duplicate current-turn user-message transcript writes after embedded fallback retries while still sending the retry prompt to the model. (#63696) Thanks @dashhuang.
 - Channels/Telegram: force a fresh final message when a visible non-preview bubble (tool/block/error) was delivered after the active answer preview, so multi-step assistant replies no longer end up with the final answer above intermediate output. Fixes #76529. Thanks @jack-stormentswe.
 - Channels/Telegram: require an observed Telegram send, edit, or fallback before treating a forum-topic final as delivered, so final replies generated in transcript no longer disappear from Telegram topics. Fixes #76554. (#76764) Thanks @bubucilo and @obviyus.
-- Agents/sandbox: include a `createArgsEpoch` constant in the sandbox and browser-sandbox config hashes so existing containers recreate when `buildSandboxCreateArgs` adds, removes, or changes container flags. Without the epoch, deployments such as `scope: "agent"` with `prune.maxAgeDays: 0` keep running their previously created container indefinitely and never pick up new flags. Pairs with #74083 to make the `--init`/tini reaper rollout reach long-running sandboxes. Refs #68691.
+- Agents/sandbox: include a `createArgsEpoch` constant in the sandbox and browser-sandbox config hashes so future PRs that change `buildSandboxCreateArgs` container flags can recreate existing containers by bumping the epoch. Adds the mechanism only, with a neutral bootstrap value; flag-changing PRs bump the epoch in the same release as the flag itself. Refs #68691. Thanks @aaajiao.
 
 ## 2026.5.2
 

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -21,7 +21,11 @@ import {
 import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import { computeSandboxBrowserConfigHash } from "./config-hash.js";
 import { resolveSandboxBrowserDockerCreateConfig } from "./config.js";
-import { DEFAULT_SANDBOX_BROWSER_IMAGE, SANDBOX_BROWSER_SECURITY_HASH_EPOCH } from "./constants.js";
+import {
+  DEFAULT_SANDBOX_BROWSER_IMAGE,
+  SANDBOX_BROWSER_SECURITY_HASH_EPOCH,
+  SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
+} from "./constants.js";
 import {
   buildSandboxCreateArgs,
   dockerContainerState,
@@ -201,6 +205,7 @@ export async function ensureSandboxBrowser(params: {
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
   });
 
   const now = Date.now();

--- a/src/agents/sandbox/config-hash.test.ts
+++ b/src/agents/sandbox/config-hash.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { computeSandboxBrowserConfigHash, computeSandboxConfigHash } from "./config-hash.js";
+import { SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./constants.js";
 import type { SandboxDockerConfig } from "./types.js";
 import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
 
@@ -61,6 +62,7 @@ describe("computeSandboxConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxConfigHash({
       ...shared,
@@ -91,6 +93,7 @@ describe("computeSandboxConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxConfigHash({
       ...shared,
@@ -125,6 +128,7 @@ describe("computeSandboxBrowserConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,
@@ -157,6 +161,7 @@ describe("computeSandboxBrowserConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,
@@ -165,6 +170,35 @@ describe("computeSandboxBrowserConfigHash", () => {
     const right = computeSandboxBrowserConfigHash({
       ...shared,
       securityEpoch: "epoch-v2",
+    });
+    expect(left).not.toBe(right);
+  });
+
+  it("changes when docker create args epoch changes", () => {
+    const shared = {
+      docker: createDockerConfig(),
+      browser: {
+        cdpPort: 9222,
+        cdpSourceRange: undefined,
+        vncPort: 5900,
+        noVncPort: 6080,
+        headless: false,
+        enableNoVnc: true,
+        autoStartTimeoutMs: 12000,
+      },
+      securityEpoch: "epoch-v1",
+      workspaceAccess: "rw" as const,
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    };
+    const left = computeSandboxBrowserConfigHash({
+      ...shared,
+      createArgsEpoch: "2026-04-pre-init",
+    });
+    const right = computeSandboxBrowserConfigHash({
+      ...shared,
+      createArgsEpoch: "2026-05-init-tini",
     });
     expect(left).not.toBe(right);
   });
@@ -185,6 +219,7 @@ describe("computeSandboxBrowserConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,
@@ -213,6 +248,7 @@ describe("computeSandboxBrowserConfigHash", () => {
       workspaceAccess: "rw" as const,
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,

--- a/src/agents/sandbox/config-hash.test.ts
+++ b/src/agents/sandbox/config-hash.test.ts
@@ -194,11 +194,11 @@ describe("computeSandboxBrowserConfigHash", () => {
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,
-      createArgsEpoch: "2026-04-pre-init",
+      createArgsEpoch: "epoch-v1",
     });
     const right = computeSandboxBrowserConfigHash({
       ...shared,
-      createArgsEpoch: "2026-05-init-tini",
+      createArgsEpoch: "epoch-v2",
     });
     expect(left).not.toBe(right);
   });

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -7,6 +7,7 @@ type SandboxHashInput = {
   workspaceDir: string;
   agentWorkspaceDir: string;
   mountFormatVersion: number;
+  createArgsEpoch: string;
 };
 
 type SandboxBrowserHashInput = {
@@ -26,6 +27,7 @@ type SandboxBrowserHashInput = {
   workspaceDir: string;
   agentWorkspaceDir: string;
   mountFormatVersion: number;
+  createArgsEpoch: string;
 };
 
 function normalizeForHash(value: unknown): unknown {

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -45,9 +45,14 @@ export const SANDBOX_BROWSER_SECURITY_HASH_EPOCH = "2026-04-05-cdp-source-range"
 // flags in a way that requires existing sandboxes to be recreated. Date-tag the
 // change so readers can trace which release introduced the bump.
 //
+// IMPORTANT: only bump this in the same PR (or follow-up PR) that ships the
+// actual create-args change. Bumping speculatively before a flag lands will
+// recreate containers under a hash that claims the new behaviour without it,
+// and a later same-string bump will then NOT recreate them again.
+//
 // History:
-//   2026-05-init-tini  add --init so tini reaps zombie processes (#74083 / #68691)
-export const SANDBOX_DOCKER_CREATE_ARGS_EPOCH = "2026-05-init-tini";
+//   2026-05-bootstrap  first value; mechanism only, no flag change yet
+export const SANDBOX_DOCKER_CREATE_ARGS_EPOCH = "2026-05-bootstrap";
 
 export const DEFAULT_SANDBOX_BROWSER_PREFIX = "openclaw-sbx-browser-";
 export const DEFAULT_SANDBOX_BROWSER_NETWORK = "openclaw-sandbox-browser";

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -41,6 +41,14 @@ export const DEFAULT_SANDBOX_BROWSER_IMAGE = "openclaw-sandbox-browser:bookworm-
 export const DEFAULT_SANDBOX_COMMON_IMAGE = "openclaw-sandbox-common:bookworm-slim";
 export const SANDBOX_BROWSER_SECURITY_HASH_EPOCH = "2026-04-05-cdp-source-range";
 
+// Bump when buildSandboxCreateArgs adds, removes, or changes container creation
+// flags in a way that requires existing sandboxes to be recreated. Date-tag the
+// change so readers can trace which release introduced the bump.
+//
+// History:
+//   2026-05-init-tini  add --init so tini reaps zombie processes (#74083 / #68691)
+export const SANDBOX_DOCKER_CREATE_ARGS_EPOCH = "2026-05-init-tini";
+
 export const DEFAULT_SANDBOX_BROWSER_PREFIX = "openclaw-sbx-browser-";
 export const DEFAULT_SANDBOX_BROWSER_NETWORK = "openclaw-sandbox-browser";
 export const DEFAULT_SANDBOX_BROWSER_CDP_PORT = 9222;

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { computeSandboxConfigHash } from "./config-hash.js";
+import { SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./constants.js";
 import { collectDockerFlagValues } from "./test-args.js";
 import type { SandboxConfig } from "./types.js";
 import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
@@ -202,6 +203,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     });
     const newHash = computeSandboxConfigHash({
       docker: newCfg.docker,
@@ -209,6 +211,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     });
     expect(newHash).not.toBe(oldHash);
 
@@ -261,6 +264,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     });
 
     spawnState.inspectRunning = false;

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -166,7 +166,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import { markOpenClawExecEnv } from "../../infra/openclaw-exec-env.js";
 import { defaultRuntime } from "../../runtime.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
-import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
+import { DEFAULT_SANDBOX_IMAGE, SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./constants.js";
 import { readRegistryEntry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
@@ -405,6 +405,7 @@ export function buildSandboxCreateArgs(params: {
   args.push("--label", `openclaw.sessionKey=${params.scopeKey}`);
   args.push("--label", `openclaw.createdAtMs=${createdAtMs}`);
   args.push("--label", `openclaw.mountFormatVersion=${SANDBOX_MOUNT_FORMAT_VERSION}`);
+  args.push("--label", `openclaw.createArgsEpoch=${SANDBOX_DOCKER_CREATE_ARGS_EPOCH}`);
   if (params.configHash) {
     args.push("--label", `openclaw.configHash=${params.configHash}`);
   }
@@ -566,6 +567,7 @@ export async function ensureSandboxContainer(params: {
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
   });
   const now = Date.now();
   const state = await dockerContainerState(containerName);


### PR DESCRIPTION
## Summary

Adds a `SANDBOX_DOCKER_CREATE_ARGS_EPOCH` constant and a `createArgsEpoch` field to both `SandboxHashInput` and `SandboxBrowserHashInput`, so the existing config-hash recreate path also fires when `buildSandboxCreateArgs` adds, removes, or changes container creation flags.

**This PR adds the mechanism only.** It does not ship any flag change itself. Whichever PR adds the first real flag change (for example #74083 adding `--init`) bumps the epoch from the bootstrap value in the same release as the flag.

## Why

`buildSandboxCreateArgs` already drives container recreation via the labelled `openclaw.configHash`, but the hash inputs only capture mount layout (`mountFormatVersion`) and browser security flags (`securityEpoch`). Other docker create flags are invisible to the hash. So adding any new flag in a future PR (`--init`, cgroup limits, sysctls, capabilities, namespace flags, etc.) does NOT invalidate the hash, and existing containers keep running with their old flags forever.

The most-affected pattern is exactly the one #68691 reports: long-running sandbox containers (`scope: "agent"` + `prune.maxAgeDays: 0`) stay alive for weeks and never recreate naturally. Without an epoch in the hash, they never pick up new flags.

## What this PR adds

1. **`SANDBOX_DOCKER_CREATE_ARGS_EPOCH`** in `src/agents/sandbox/constants.ts`, set to a neutral bootstrap value (`"2026-05-bootstrap"`) and date-tagged so reviewers can tell at a glance which release introduced the bump.
2. **Header comment on the constant** explicitly telling future contributors to bump the epoch in the same PR (or a follow-up PR) as the actual flag change, never speculatively. Pre-bumping under a name like `"init-tini"` would let containers be recreated with a hash claiming the new behaviour while the actual create args still lack it.
3. **`createArgsEpoch: string`** in both `SandboxHashInput` and `SandboxBrowserHashInput`. Mirrors the existing `securityEpoch` / `mountFormatVersion` pattern.
4. **Both call sites updated** (`docker.ts:ensureSandboxContainer`, `browser.ts:ensureSandboxBrowser`) to pass the new constant.
5. **`openclaw.createArgsEpoch=...` container label** stamped at create time, alongside the existing `openclaw.mountFormatVersion` label, for diagnostics.
6. **Tests** (`config-hash.test.ts`, `docker.config-hash-recreate.test.ts`) updated; new test "changes when docker create args epoch changes" mirrors the existing security-epoch test using neutral `"epoch-v1"`/`"epoch-v2"` sentinels.
7. **CHANGELOG** entry under `## Unreleased > ### Fixes` describing the mechanism, with `Thanks @aaajiao.` per repo convention.

## Reusability

When future PRs add or change container flags, the contributor only needs to bump the `SANDBOX_DOCKER_CREATE_ARGS_EPOCH` string in the same change and add a one-line history entry to the comment. No new types, no new test scaffolding, no risk of forgetting to invalidate the hash.

## Relationship to #74083 (and #68691)

Originally I had named this epoch after the `--init` rollout. Per clawsweeper P1 review, that was wrong — it would let this PR claim a feature ship that lives in a separate PR. The current value is neutral; the `--init` rollout in #74083 is responsible for bumping the epoch when it lands. With both merged in the same release, the long-running-container pattern reported in #68691 is fully addressed.

## Test plan

- [x] `pnpm test src/agents/sandbox/config-hash.test.ts` — existing + new tests pass locally
- [x] `pnpm test src/agents/sandbox/docker.config-hash-recreate.test.ts` — recreate path still asserts hash mismatch triggers `docker rm -f`
- [ ] Maintainer-side: full CI pass (note: the unrelated `checks-node-agentic-cli` failures in `plugins-location-bridges.test.ts` reproduce on upstream/main — see commit `5ecd01ff9` — and have no overlap with sandbox)
- [ ] Live verification: a future flag change (such as #74083) bumps the epoch and a long-running `scope: "agent"` sandbox is recreated on next agent run

🤖 Generated with [Claude Code](https://claude.com/claude-code)