### PR TITLE
perf: add caching for tool policy and provider hook resolution

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -180,6 +180,8 @@ function resolveOptionalMediaToolFactoryPlan(params: {
   const explicitPdf =
     hasToolModelConfig(coercePdfModelConfig(params.config)) ||
     hasToolModelConfig(coerceImageModelConfig(params.config));
+
+  // Fast path for disabled plugins
   if (params.config?.plugins?.enabled === false) {
     return {
       imageGenerate: false,
@@ -188,10 +190,12 @@ function resolveOptionalMediaToolFactoryPlan(params: {
       pdf: false,
     };
   }
+
   const snapshot = loadCapabilityMetadataSnapshot({
     config: params.config,
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
+
   return {
     imageGenerate:
       allowImageGenerate &&

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -5,6 +5,11 @@ import { resolveChannelGroupToolsPolicy } from "../config/group-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
 import { logWarn } from "../logger.js";
+import {
+  createPluginCacheKey,
+  resolveConfigScopedRuntimeCacheValue,
+  type ConfigScopedRuntimeCache,
+} from "../plugins/plugin-cache-primitives.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import {
   parseRawSessionConversationRef,
@@ -395,7 +400,12 @@ function detectImplicitProfileGrants(params: {
   return implicit.size > 0 ? Array.from(implicit) : undefined;
 }
 
-export function resolveEffectiveToolPolicy(params: {
+// Cache for effective tool policy resolution
+const effectiveToolPolicyCache: ConfigScopedRuntimeCache<
+  ReturnType<typeof resolveEffectiveToolPolicyUncached>
+> = new WeakMap();
+
+function resolveEffectiveToolPolicyUncached(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
   agentId?: string;
@@ -470,6 +480,30 @@ export function resolveEffectiveToolPolicy(params: {
         ? providerPolicy?.alsoAllow
         : undefined,
   };
+}
+
+export function resolveEffectiveToolPolicy(params: {
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  agentId?: string;
+  modelProvider?: string;
+  modelId?: string;
+}): ReturnType<typeof resolveEffectiveToolPolicyUncached> {
+  if (!params.config) {
+    return resolveEffectiveToolPolicyUncached(params);
+  }
+  const cacheKey = createPluginCacheKey([
+    params.sessionKey ?? "",
+    params.agentId ?? "",
+    params.modelProvider ?? "",
+    params.modelId ?? "",
+  ]);
+  return resolveConfigScopedRuntimeCacheValue({
+    cache: effectiveToolPolicyCache,
+    config: params.config,
+    key: cacheKey,
+    load: () => resolveEffectiveToolPolicyUncached(params),
+  });
 }
 
 export function resolveGroupToolPolicy(params: {

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import {
+  createPluginCacheKey,
   resolveConfigScopedRuntimeCacheValue,
   type ConfigScopedRuntimeCache,
 } from "./plugin-cache-primitives.js";
@@ -22,6 +23,9 @@ import type {
 } from "./types.js";
 
 const providerRuntimePluginCache: ConfigScopedRuntimeCache<ProviderPlugin | null> = new WeakMap();
+
+// Cache for resolveProviderPluginsForHooks results to avoid repeated provider discovery
+const providerPluginsForHooksCache: ConfigScopedRuntimeCache<ProviderPlugin[]> = new WeakMap();
 
 type ProviderRuntimePluginLookupParams = {
   provider: string;
@@ -107,6 +111,40 @@ export function resolveProviderPluginsForHooks(params: {
 }): ProviderPlugin[] {
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
+
+  // Compute cache key
+  const cacheKey = createPluginCacheKey([
+    params.providerRefs?.slice().sort() ?? [],
+    params.onlyPluginIds?.slice().sort() ?? [],
+    resolvePluginControlPlaneFingerprint({
+      config: params.config,
+      env,
+      workspaceDir,
+    }),
+    workspaceDir ?? "",
+    params.applyAutoEnable ?? false,
+    params.bundledProviderAllowlistCompat ?? true,
+    params.bundledProviderVitestCompat ?? true,
+  ]);
+
+  // Use config-scoped cache when possible (falls back to uncached when no config)
+  if (params.config) {
+    return resolveConfigScopedRuntimeCacheValue({
+      cache: providerPluginsForHooksCache,
+      config: params.config,
+      key: cacheKey,
+      load: () => resolveProviderPluginsForHooksUncached(params, env, workspaceDir),
+    });
+  }
+
+  return resolveProviderPluginsForHooksUncached(params, env, workspaceDir);
+}
+
+function resolveProviderPluginsForHooksUncached(
+  params: Parameters<typeof resolveProviderPluginsForHooks>[0],
+  env: NodeJS.ProcessEnv,
+  workspaceDir: string | undefined,
+): ProviderPlugin[] {
   if (
     isPluginProvidersLoadInFlight({
       ...params,


### PR DESCRIPTION
## Summary

- Add cache for `resolveEffectiveToolPolicy` to avoid redundant policy computation
- Add cache for `resolveProviderPluginsForHooks` to speed up provider discovery
- Minor formatting improvements in `openclaw-tools.ts`

## Performance Impact

These changes improve performance by caching expensive resolution operations using the existing plugin cache infrastructure (`ConfigScopedRuntimeCache`). The cache is config-scoped, ensuring proper invalidation when configuration changes.

## Test plan

- [ ] Verify existing tests pass
- [ ] Manual testing of tool policy resolution
- [ ] Verify no memory leaks from cache usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)