### PR TITLE
fix(zalouser): surface send errors and recover from oversized style payloads

### DIFF
--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -770,13 +770,19 @@ async function deliverZalouserReply(params: {
     text: reply.text,
     sendText: async (chunk) => {
       try {
-        await sendMessageZalouser(chatId, chunk, {
+        const result = await sendMessageZalouser(chatId, chunk, {
           profile,
           isGroup,
           textMode: "markdown",
           textChunkMode: chunkMode,
           textChunkLimit,
         });
+        if (!result.ok) {
+          runtime.error(
+            `Zalouser message send failed (ok=false): ${result.error ?? "unknown error"} chatId=${chatId}`,
+          );
+          return;
+        }
         statusSink?.({ lastOutboundAt: Date.now() });
       } catch (err) {
         runtime.error(`Zalouser message send failed: ${String(err)}`);
@@ -784,7 +790,7 @@ async function deliverZalouserReply(params: {
     },
     sendMedia: async ({ mediaUrl, caption }) => {
       logVerbose(core, runtime, `Sending media to ${chatId}`);
-      await sendMessageZalouser(chatId, caption ?? "", {
+      const result = await sendMessageZalouser(chatId, caption ?? "", {
         profile,
         mediaUrl,
         isGroup,
@@ -792,6 +798,12 @@ async function deliverZalouserReply(params: {
         textChunkMode: chunkMode,
         textChunkLimit,
       });
+      if (!result.ok) {
+        runtime.error(
+          `Zalouser media send failed (ok=false): ${result.error ?? "unknown error"} chatId=${chatId}`,
+        );
+        return;
+      }
       statusSink?.({ lastOutboundAt: Date.now() });
     },
     onMediaError: (error) => {

--- a/extensions/zalouser/src/send.test.ts
+++ b/extensions/zalouser/src/send.test.ts
@@ -361,6 +361,57 @@ describe("zalouser send helpers", () => {
     expect(result).toEqual({ ok: true, error: undefined });
   });
 
+  it("retries without styles when Zalo rejects with error code 112", async () => {
+    mockSendText
+      .mockResolvedValueOnce({ ok: false, errorCode: 112, error: "params too large (code: 112)" })
+      .mockResolvedValueOnce({ ok: true, messageId: "mid-retry" });
+
+    const result = await sendMessageZalouser("thread-retry", "**hello**", {
+      profile: "default",
+      textMode: "markdown",
+    });
+
+    expect(mockSendText).toHaveBeenCalledTimes(2);
+    expect(mockSendText).toHaveBeenNthCalledWith(
+      1,
+      "thread-retry",
+      "hello",
+      expect.objectContaining({ textStyles: [{ start: 0, len: 5, st: TextStyle.Bold }] }),
+    );
+    expect(mockSendText).toHaveBeenNthCalledWith(
+      2,
+      "thread-retry",
+      "hello",
+      expect.objectContaining({ textStyles: undefined }),
+    );
+    expect(result).toEqual({ ok: true, messageId: "mid-retry" });
+  });
+
+  it("propagates the error when retry without styles also fails", async () => {
+    mockSendText
+      .mockResolvedValueOnce({ ok: false, errorCode: 112, error: "params too large (code: 112)" })
+      .mockResolvedValueOnce({ ok: false, errorCode: 500, error: "server error" });
+
+    const result = await sendMessageZalouser("thread-retry-fail", "**hello**", {
+      profile: "default",
+      textMode: "markdown",
+    });
+
+    expect(mockSendText).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: false, errorCode: 500, error: "server error" });
+  });
+
+  it("does not retry on error code 112 when there are no styles", async () => {
+    mockSendText.mockResolvedValueOnce({ ok: false, errorCode: 112, error: "error (code: 112)" });
+
+    const result = await sendMessageZalouser("thread-no-retry", "plain text", {
+      profile: "default",
+    });
+
+    expect(mockSendText).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: false, errorCode: 112, error: "error (code: 112)" });
+  });
+
   it("delegates delivered+seen helpers to JS transport", async () => {
     mockSendDelivered.mockResolvedValueOnce();
     mockSendSeen.mockResolvedValueOnce();

--- a/extensions/zalouser/src/send.ts
+++ b/extensions/zalouser/src/send.ts
@@ -52,7 +52,15 @@ export async function sendMessageZalouser(
             mediaUrl: undefined,
             textStyles: chunk.styles,
           };
-    const result = await sendZaloTextMessage(threadId, chunk.text, chunkOptions);
+    let result = await sendZaloTextMessage(threadId, chunk.text, chunkOptions);
+    if (!result.ok && result.errorCode === 112 && chunkOptions.textStyles?.length) {
+      // Zalo rejected the request, likely because the params payload is too large
+      // when combined with styling data. Retry without styles.
+      result = await sendZaloTextMessage(threadId, chunk.text, {
+        ...chunkOptions,
+        textStyles: undefined,
+      });
+    }
     if (!result.ok) {
       return result;
     }

--- a/extensions/zalouser/src/types.ts
+++ b/extensions/zalouser/src/types.ts
@@ -72,6 +72,7 @@ export type ZaloSendResult = {
   ok: boolean;
   messageId?: string;
   error?: string;
+  errorCode?: number;
 };
 
 export type ZaloGroupContext = {

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -212,6 +212,10 @@ function normalizeProfile(profile?: string | null): string {
 
 function toErrorMessage(error: unknown): string {
   if (error instanceof Error) {
+    const code = (error as Error & { code?: unknown }).code;
+    if (typeof code === "number" || typeof code === "string") {
+      return `${error.message} (code: ${code})`;
+    }
     return error.message;
   }
   return String(error);
@@ -1332,7 +1336,9 @@ export async function sendZaloTextMessage(
         );
         return { ok: true, messageId: extractSendMessageId(response) };
       } catch (error) {
-        return { ok: false, error: toErrorMessage(error) };
+        const code = (error as Error & { code?: unknown }).code;
+        const errorCode = typeof code === "number" ? code : undefined;
+        return { ok: false, error: toErrorMessage(error), errorCode };
       }
     },
     { shouldPersist: (result) => result.ok },


### PR DESCRIPTION
## TL;DR

Zalo delivery failures were completely invisible: the monitor never checked send results, error codes were lost, and messages silently disappeared when styled payloads exceeded Zalo's size limit.

---

## Problem

Three compounding gaps caused messages to vanish without any log trace:

1. `sendZaloTextMessage` caught errors but discarded the numeric `error_code` from Zalo's response — callers could not distinguish a transient network error from a Zalo-specific rejection.
2. The `sendText` and `sendMedia` callbacks in the monitor called `sendMessageZalouser` without checking the returned result, so `ok=false` responses were silently dropped.
3. Zalo rejects messages with `error_code=112` when the combined params payload (message text + `textProperties` JSON for styling) exceeds its server-side size limit. Empirically: a ~1420-char Vietnamese message combined with 56+ style ranges (~1871 chars of JSON) triggers this. The message was never delivered and no error appeared in logs.

---

## Invariant

> When Zalo rejects a styled message with error code 112, the message text must still be delivered (without styles), and the failure must be logged if delivery ultimately fails.

---

## What this PR does

- Adds `errorCode?: number` to `ZaloSendResult` so callers can branch on specific Zalo error codes
- Enhances `toErrorMessage` to include the numeric code in the string so it appears in logs
- Extracts the numeric error code from caught errors in `sendZaloTextMessage` and attaches it to the result
- Adds a retry-without-styles path in `sendMessageZalouser` on error code 112: if the styled send fails with 112, the message is re-sent as plain text
- Makes `sendText` and `sendMedia` in the monitor check `result.ok` and emit a structured error log when delivery fails

---

## Why this matters

- **User impact**: Long bot responses with markdown formatting silently failed to reach Zalo users. The bot appeared to respond on the web UI but nothing arrived in the chat.
- **System impact**: Failures were completely unobservable — no logs, no error propagation — making debugging impossible without adding instrumentation manually.

---

## Safety

- No change to message delivery path when everything succeeds
- The retry only triggers on the specific error code 112 with styled content; all other errors are forwarded unchanged
- Existing tests unchanged; 3 new regression tests added

---

## Test plan

```
node scripts/run-vitest.mjs run extensions/zalouser/src/send.test.ts
```

- [x] All existing tests pass (13)
- [x] New test: retries without styles on error code 112
- [x] New test: propagates error when retry also fails
- [x] New test: does not retry when there are no styles