### PR TITLE
fix(zalouser): split messages at line boundaries instead of mid-word

### DIFF
--- a/extensions/zalouser/src/send.test.ts
+++ b/extensions/zalouser/src/send.test.ts
@@ -233,6 +233,29 @@ describe("zalouser send helpers", () => {
     expect(result).toEqual({ ok: true, messageId: "mid-2d-4" });
   });
 
+  it("splits at a paragraph boundary by default instead of cutting mid-word", async () => {
+    // 398 "word " groups + "word" = 1990 + 4 = 1994 chars, then "\n\n" puts the break at 1996.
+    // Total with "second paragraph" = 2012 chars, which exceeds the 2000-char limit.
+    // The default "newline" mode finds the paragraph break inside the window and splits there,
+    // while "length" mode would blindly cut at position 2000 (mid-word).
+    const firstParagraph = "word ".repeat(398) + "word";
+    const text = firstParagraph + "\n\nsecond paragraph";
+    mockSendText
+      .mockResolvedValueOnce({ ok: true, messageId: "mid-newline-1" })
+      .mockResolvedValueOnce({ ok: true, messageId: "mid-newline-2" });
+
+    const result = await sendMessageZalouser("thread-newline", text, {
+      profile: "default",
+    });
+
+    expect(text.length).toBeGreaterThan(2000);
+    expect(mockSendText).toHaveBeenCalledTimes(2);
+    const [firstCall, secondCall] = mockSendText.mock.calls;
+    expect(firstCall[1]).toBe(firstParagraph + "\n\n");
+    expect(secondCall[1]).toBe("second paragraph");
+    expect(result).toEqual({ ok: true, messageId: "mid-newline-2" });
+  });
+
   it("respects an explicit text chunk limit when splitting formatted markdown", async () => {
     const text = `**${"a".repeat(1501)}**`;
     mockSendText

--- a/extensions/zalouser/src/send.ts
+++ b/extensions/zalouser/src/send.ts
@@ -14,7 +14,7 @@ type ZalouserSendOptions = ZaloSendOptions;
 type ZalouserSendResult = ZaloSendResult;
 
 const ZALO_TEXT_LIMIT = 2000;
-const DEFAULT_TEXT_CHUNK_MODE = "length";
+const DEFAULT_TEXT_CHUNK_MODE = "newline";
 
 type StyledTextChunk = {
   text: string;


### PR DESCRIPTION
## TL;DR

Long bot responses were split mid-word because the default chunk mode cut at exactly 2000 characters with no regard for word or sentence boundaries.

---

## Problem

`DEFAULT_TEXT_CHUNK_MODE = "length"` cuts the outgoing message at exactly the 2000-character limit regardless of whether that lands in the middle of a word. In practice this was observed as a Vietnamese word like "lên" arriving as two separate messages — "lê" followed by "n" — which is unreadable.

The `"newline"` chunk mode already exists in the codebase and correctly breaks at paragraph boundaries → single newlines → whitespace → hard cut (as a last resort). It was never set as the default, so callers that did not explicitly pass `textChunkMode: "newline"` got the hard-cut behavior.

---

## Invariant

> When a message is split into chunks, each chunk boundary must fall at a natural break (paragraph, newline, or whitespace) unless no such break exists within the limit window.

---

## What this PR does

- Changes `DEFAULT_TEXT_CHUNK_MODE` from `"length"` to `"newline"` in `send.ts`
- Adds one regression test: a message with a paragraph break inside the 2000-char window is split at the break, not at position 2000

---

## Why this matters

- **User impact**: Words arrived split across two Zalo messages, making bot responses unreadable in long replies.
- **System impact**: The hard-cut behavior never had a use case — `"newline"` falls back to a hard cut when no natural break exists, so it is strictly better for all inputs.

---

## Safety

- The `splitTextRangesByPreferredBreaks` function (used by `"newline"` mode) falls back to a hard cut when no natural break point is found, so behavior for texts with no whitespace is unchanged.
- All existing tests pass unchanged: they use continuous character strings with no natural break points, which fall through to the same hard-cut behavior as before.
- No change to any other logic.

---

## Test plan

```
node scripts/run-vitest.mjs run extensions/zalouser/src/send.test.ts
```

- [x] All existing tests pass (13)
- [x] New test: paragraph break within window → split at break, not at position 2000