### PR TITLE
fix(comfy): match Comfy Cloud API completion status values

### DIFF
--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -460,10 +460,10 @@ async function waitForCloudCompletion(params: {
       errorPrefix: "Comfy status lookup failed",
     });
 
-    if (status.status === "completed") {
+    if (status.status === "completed" || status.status === "success") {
       return;
     }
-    if (status.status === "failed" || status.status === "cancelled") {
+    if (status.status === "failed" || status.status === "error" || status.status === "cancelled") {
       throw new Error(
         `Comfy workflow ${status.status}: ${status.error ?? status.message ?? params.promptId}`,
       );


### PR DESCRIPTION
## Summary

Comfy Cloud API returns `"success"` for completed workflows, but OpenClaw only checked for `"completed"`. This caused workflows that succeeded on Comfy Cloud to time out after 300s in OpenClaw.

Additionally, Comfy Cloud uses `"error"` as a terminal failure status, which was not handled.

## Changes

- Accept `"success"` as a completion status (in addition to `"completed"`)
- Treat `"error"` as a terminal failure status (in addition to `"failed"` and `"cancelled"`)

## Test plan

- [ ] Comfy Cloud image generation completes without 300s timeout
- [ ] Failed/error workflows still throw appropriate errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)