### PR TITLE
docs(prometheus): warn that plugins.allow is strict-mode

### DIFF
--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -53,6 +53,11 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
         ```
       </Tab>
     </Tabs>
+
+    <Warning>
+    `plugins.allow` is **strict-mode**: when set, only listed plugins are eligible to load. The example above is intended for clean installs. If your gateway already has other plugins configured, enumerate **all** of their ids in `allow` — or omit `allow` entirely. Setting `allow: ["diagnostics-prometheus"]` on a multi-plugin gateway will disable every other configured plugin, including `memory-core`, `active-memory`, channel plugins, and more. The startup warning `plugins.allow is empty; discovered non-bundled plugins may auto-load` does not require this key; trust to non-bundled plugins is governed by separate mechanisms (see [#75575](https://github.com/openclaw/openclaw/issues/75575) for related discussion).
+    </Warning>
+
   </Step>
   <Step title="Restart the Gateway">
     The HTTP route is registered at plugin startup, so reload after enabling.

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -57,6 +57,11 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
         ```
       </Tab>
     </Tabs>
+
+    <Warning>
+    `plugins.allow` is an exclusive allowlist, not an additive enable flag. On an existing gateway, add `diagnostics-prometheus` to the current list instead of replacing it with the one-item example above. Replacing the list can prevent other plugins from loading.
+    </Warning>
+
   </Step>
   <Step title="Restart the Gateway">
     The HTTP route is registered at plugin startup, so reload after enabling.


### PR DESCRIPTION
Related: #76628

## What Problem This Solves

Fixes an issue where operators copying the Prometheus Quick Start onto an existing gateway could replace their current `plugins.allow` list with only `diagnostics-prometheus`, preventing other plugins from loading.

## Why This Change Was Made

Adds an adjacent warning that explains `plugins.allow` is an exclusive allowlist and tells operators to add `diagnostics-prometheus` to an existing list instead of replacing it with the one-item example.

## User Impact

Operators can enable Prometheus diagnostics without accidentally replacing an existing plugin allowlist.

## Evidence

- `pnpm docs:list`
- `pnpm exec oxfmt --check docs/gateway/prometheus.md`
- `node scripts/check-docs-mdx.mjs docs/gateway/prometheus.md`
- `pnpm docs:check-links` (`6449` internal links checked, `0` broken)
- Source wording checked against `src/plugins/config-activation-shared.ts`, including the exclusive allowlist gate and its explicit slot/channel exceptions.
- Max-P1 autoreview: clean, no accepted or actionable findings.
- AI-assisted; the submitted change and final wording were reviewed against the current source contract.
