### PR TITLE
fix(mattermost): resolve reply root before sending thread replies

### DIFF
--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -261,6 +261,99 @@ describe("sendMessageMattermost", () => {
     );
   });
 
+  it("resolves child replyToId to the Mattermost thread root before posting", async () => {
+    const client = {
+      request: vi.fn().mockResolvedValue({
+        id: "child-post",
+        channel_id: "town-square",
+        root_id: "root-post",
+      }),
+    };
+    mockState.createMattermostClient.mockReturnValue(client);
+
+    await sendMessageMattermost("channel:town-square", "threaded", {
+      cfg: TEST_CFG,
+      replyToId: "child-post",
+    });
+
+    expect(client.request).toHaveBeenCalledWith("/posts/child-post");
+    expect(mockState.createMattermostPost).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        channelId: "town-square",
+        rootId: "root-post",
+      }),
+    );
+  });
+
+  it("preserves top-level replyToId as the Mattermost root when the post is in channel", async () => {
+    const client = {
+      request: vi.fn().mockResolvedValue({
+        id: "root-post",
+        channel_id: "town-square",
+        root_id: "",
+      }),
+    };
+    mockState.createMattermostClient.mockReturnValue(client);
+
+    await sendMessageMattermost("channel:town-square", "threaded", {
+      cfg: TEST_CFG,
+      replyToId: "root-post",
+    });
+
+    expect(mockState.createMattermostPost).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        channelId: "town-square",
+        rootId: "root-post",
+      }),
+    );
+  });
+
+  it("drops replyToId when the referenced Mattermost post is in another channel", async () => {
+    const client = {
+      request: vi.fn().mockResolvedValue({
+        id: "other-child",
+        channel_id: "other-channel",
+        root_id: "other-root",
+      }),
+    };
+    mockState.createMattermostClient.mockReturnValue(client);
+
+    await sendMessageMattermost("channel:town-square", "not cross threaded", {
+      cfg: TEST_CFG,
+      replyToId: "other-child",
+    });
+
+    expect(mockState.createMattermostPost).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        channelId: "town-square",
+        rootId: undefined,
+      }),
+    );
+  });
+
+  it("drops replyToId when Mattermost cannot resolve the referenced post", async () => {
+    const client = {
+      request: vi.fn().mockRejectedValue(new Error("Mattermost API 404: post not found")),
+    };
+    mockState.createMattermostClient.mockReturnValue(client);
+
+    await sendMessageMattermost("channel:town-square", "top level fallback", {
+      cfg: TEST_CFG,
+      replyToId: "missing-post",
+    });
+
+    expect(mockState.createMattermostPost).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        channelId: "town-square",
+        rootId: undefined,
+      }),
+    );
+  });
+
   it("builds interactive button props when buttons are provided", async () => {
     mockState.resolveMattermostAccount.mockReturnValue({
       accountId: "default",

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -19,6 +19,7 @@ import {
   normalizeMattermostBaseUrl,
   uploadMattermostFile,
   type MattermostUser,
+  type MattermostClient,
   type CreateDmChannelRetryOptions,
 } from "./client.js";
 import {
@@ -393,6 +394,31 @@ export async function resolveMattermostSendChannelId(
   return (await resolveMattermostSendContext(to, opts)).channelId;
 }
 
+async function resolveMattermostPostRootIdForSend(
+  client: MattermostClient,
+  channelId: string,
+  replyToId?: string,
+): Promise<string | undefined> {
+  const trimmed = normalizeOptionalString(replyToId);
+  if (!trimmed) {
+    return undefined;
+  }
+
+  try {
+    const post = await client.request<{
+      id?: string | null;
+      channel_id?: string | null;
+      root_id?: string | null;
+    }>(`/posts/${encodeURIComponent(trimmed)}`);
+    if (post.channel_id && post.channel_id !== channelId) {
+      return undefined;
+    }
+    return normalizeOptionalString(post.root_id) ?? normalizeOptionalString(post.id);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function sendMessageMattermost(
   to: string,
   text: string,
@@ -465,10 +491,12 @@ export async function sendMessageMattermost(
     throw new Error("Mattermost message is empty");
   }
 
+  const rootId = await resolveMattermostPostRootIdForSend(client, channelId, opts.replyToId);
+
   const post = await createMattermostPost(client, {
     channelId,
     message,
-    rootId: opts.replyToId,
+    rootId,
     fileIds,
     props,
   });


### PR DESCRIPTION
## Summary
- resolve Mattermost replyTo post IDs before using them as root_id
- map child reply posts to their actual thread root
- avoid sending stale or cross-channel replyTo IDs as root_id
- add Mattermost send tests for child roots, top-level roots, cross-channel refs, and lookup failures

## Verification
- pnpm exec oxfmt --write extensions/mattermost/src/mattermost/send.ts extensions/mattermost/src/mattermost/send.test.ts
- node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/mattermost/src/mattermost/send.test.ts