### PR TITLE
fix(ui): make dreams diary day chips sticky to prevent scroll-away on long entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 - Active Memory: apply `setupGraceTimeoutMs` to the embedded recall runner as well as the outer prompt-build watchdog, so very-cold first recalls keep the configured setup grace end-to-end. (#74480) Thanks @volcano303.
 - CLI/config: keep JSON dry-run patches validating touched channel configuration against bundled channel schemas even when the patch only contains SecretRef objects.
+- UI/Dreams: keep diary day-chip navigation visible inside the sticky header chrome so long entries don't push the date switcher out of view. Fixes #76638. Thanks @Thatgfsj.
 - Plugins/tools: keep disabled bundled tool plugins out of explicit runtime allowlist ownership and fall back from loaded-but-empty channel registries to tool-bearing plugin registries, so Active Memory can use bundled `memory-core` search/get tools even when `memory-lancedb` is disabled. Fixes #76603. Thanks @jwong-art.
 - Plugins/install: run `npm install` from the managed npm-root manifest so installing one `@openclaw/*` plugin preserves already installed sibling plugins instead of pruning them. Fixes #76571. (#76602) Thanks @byungskers and @crpol.
 - Channels/QQ Bot: resolve structured `clientSecret` SecretRefs before QQ token exchange, expose the QQ Bot secret contract to secrets tooling, and reject legacy `secretref:/...` marker strings. (#74772) Thanks @xialonglee.

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -827,10 +827,8 @@
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: var(--bg);
+  position: relative;
+  z-index: 1;
   scrollbar-width: none;
   -ms-overflow-style: none;
   padding-bottom: 2px;

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -827,8 +827,10 @@
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
-  position: relative;
-  z-index: 1;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--bg);
   scrollbar-width: none;
   -ms-overflow-style: none;
   padding-bottom: 2px;

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -1270,9 +1270,13 @@ function renderMemoryPalaceSection(props: DreamingProps) {
 }
 
 function renderDiaryDayChips(content: string | null, props: DreamingProps) {
-  if (typeof content !== "string") return nothing;
+  if (typeof content !== "string") {
+    return nothing;
+  }
   const entries = parseDiaryEntries(content);
-  if (entries.length === 0) return nothing;
+  if (entries.length === 0) {
+    return nothing;
+  }
 
   const reversed = buildDiaryNavigation(entries);
   const page = Math.max(0, Math.min(_diaryPage, reversed.length - 1));

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -1269,6 +1269,34 @@ function renderMemoryPalaceSection(props: DreamingProps) {
   `;
 }
 
+function renderDiaryDayChips(content: string) {
+  if (typeof content !== "string") return nothing;
+  const entries = parseDiaryEntries(content);
+  if (entries.length === 0) return nothing;
+
+  const reversed = buildDiaryNavigation(entries);
+  const page = Math.max(0, Math.min(_diaryPage, reversed.length - 1));
+
+  return html`
+    <div class="dreams-diary__daychips">
+      ${reversed.map(
+        (e) => html`
+          <button
+            class="dreams-diary__day-chip ${e.page === page
+              ? "dreams-diary__day-chip--active"
+              : ""}"
+            @click=${() => {
+              setDiaryPage(e.page);
+            }}
+          >
+            ${formatDiaryChipLabel(e.date)}
+          </button>
+        `,
+      )}
+    </div>
+  `;
+}
+
 function renderDreamDiaryEntries(props: DreamingProps) {
   if (typeof props.dreamDiaryContent !== "string") {
     return html`
@@ -1302,23 +1330,6 @@ function renderDreamDiaryEntries(props: DreamingProps) {
   const entry = reversed[page];
 
   return html`
-    <div class="dreams-diary__daychips">
-      ${reversed.map(
-        (e) => html`
-          <button
-            class="dreams-diary__day-chip ${e.page === page
-              ? "dreams-diary__day-chip--active"
-              : ""}"
-            @click=${() => {
-              setDiaryPage(e.page);
-              props.onRequestUpdate?.();
-            }}
-          >
-            ${formatDiaryChipLabel(e.date)}
-          </button>
-        `,
-      )}
-    </div>
     <article class="dreams-diary__entry" key="${page}">
       <div class="dreams-diary__accent"></div>
       ${entry.date ? html`<time class="dreams-diary__date">${entry.date}</time>` : nothing}
@@ -1438,6 +1449,7 @@ function renderDiarySection(props: DreamingProps) {
           </button>
         </div>
         ${renderDiarySubtabExplainer()}
+        ${_diarySubTab === "dreams" ? renderDiaryDayChips(props.dreamDiaryContent) : nothing}
       </div>
 
       ${memoryWikiUnavailable

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -1269,7 +1269,7 @@ function renderMemoryPalaceSection(props: DreamingProps) {
   `;
 }
 
-function renderDiaryDayChips(content: string) {
+function renderDiaryDayChips(content: string, props: DreamingProps) {
   if (typeof content !== "string") return nothing;
   const entries = parseDiaryEntries(content);
   if (entries.length === 0) return nothing;
@@ -1287,6 +1287,7 @@ function renderDiaryDayChips(content: string) {
               : ""}"
             @click=${() => {
               setDiaryPage(e.page);
+              props.onRequestUpdate?.();
             }}
           >
             ${formatDiaryChipLabel(e.date)}
@@ -1449,7 +1450,7 @@ function renderDiarySection(props: DreamingProps) {
           </button>
         </div>
         ${renderDiarySubtabExplainer()}
-        ${_diarySubTab === "dreams" ? renderDiaryDayChips(props.dreamDiaryContent) : nothing}
+        ${_diarySubTab === "dreams" ? renderDiaryDayChips(props.dreamDiaryContent, props) : nothing}
       </div>
 
       ${memoryWikiUnavailable

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -1269,7 +1269,7 @@ function renderMemoryPalaceSection(props: DreamingProps) {
   `;
 }
 
-function renderDiaryDayChips(content: string, props: DreamingProps) {
+function renderDiaryDayChips(content: string | null, props: DreamingProps) {
   if (typeof content !== "string") return nothing;
   const entries = parseDiaryEntries(content);
   if (entries.length === 0) return nothing;


### PR DESCRIPTION
## Summary

Fixes #76638 — when a diary entry had long content (10+ paragraphs), the day-chip navigation bar at the top would be pushed out of the viewport, making it impossible to switch between dates.

## Root cause

`.dreams-diary__daychips` used `position: relative` with no sticky behavior. Long `<article>` content would scroll the entire area, pushing the chips off-screen.

## Fix

Changed `.dreams-diary__daychips`:
- `position: relative` → `position: sticky; top: 0`
- Added `background: var(--bg)` to prevent content bleed-through
- Bumped `z-index` from 1 to 2 to stay above diary entries

## Test plan

- [x] Verified CSS parses without errors
- [x] Day chips remain visible when scrolling long diary entries