### PR TITLE
meta(issue-template): add dedicated docs bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_bug_report.yml
@@ -1,0 +1,75 @@
+name: Docs bug report
+description: Report documentation defects (incorrect, missing, outdated, or contradictory docs).
+title: "[Docs Bug]: "
+labels:
+  - bug
+  - docs
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Report a documentation defect with concrete evidence from current docs behavior/content.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-sentence statement of what is wrong in the docs.
+      placeholder: The WhatsApp config example defines duplicate top-level keys in one JSON5 block.
+    validations:
+      required: true
+  - type: input
+    id: doc_paths
+    attributes:
+      label: Affected docs path(s)
+      description: Repo-relative docs file path(s).
+      placeholder: docs/gateway/config-channels.md
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce / verify
+      description: Minimal steps to observe the docs defect in the current docs.
+      placeholder: |
+        1. Open docs/gateway/config-channels.md
+        2. Go to the WhatsApp example block
+        3. Observe duplicate top-level key definitions
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected docs behavior/content
+      description: What the docs should say/show instead.
+      placeholder: The example should use a single merged top-level object with no duplicate keys.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual docs behavior/content
+      description: What the docs currently say/show.
+      placeholder: The snippet defines the same top-level key twice in one object.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is affected and practical consequence.
+      placeholder: Users who copy-paste the snippet can end up with ambiguous config behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Links/snippets/screenshots proving the docs defect.
+      placeholder: Include exact file links and line ranges.
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional information
+      description: Optional context, related issues/PRs, or constraints.

--- a/.github/ISSUE_TEMPLATE/docs_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_bug_report.yml
@@ -9,6 +9,7 @@ body:
     attributes:
       value: |
         Report a documentation defect with concrete evidence from current docs behavior/content.
+        Please only report one documentation defect per submission.
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_bug_report.yml
@@ -21,9 +21,9 @@ body:
   - type: input
     id: doc_paths
     attributes:
-      label: Affected docs path(s)
-      description: Repo-relative docs file path(s).
-      placeholder: docs/gateway/config-channels.md
+      label: Affected docs path(s) or URL(s)
+      description: Repo-relative docs file path(s) or published docs URL(s).
+      placeholder: docs/gateway/config-channels.md or https://docs.openclaw.ai/gateway/config-channels
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Summary
- add a dedicated docs bug issue form at `.github/ISSUE_TEMPLATE/docs_bug_report.yml`
- keep existing runtime bug form unchanged
- label docs defects as `bug` + `docs`

## Why
Issue #76664 requests a docs-focused intake path so docs-only defects do not require runtime/model/provider placeholders.

## Scope
- metadata-only change in issue templates
- no runtime code paths changed

Closes #76664

## Validation
- YAML parsed successfully (`yaml.safe_load`)
- `git diff --check`

## Real behavior proof
- **Behavior or issue addressed:** Docs-only bugs lacked a dedicated issue form.
- **Real environment tested:** GitHub web issue chooser on `openclaw/openclaw` default branch.
- **Exact steps or command run after this patch:**
  1. Open `https://github.com/openclaw/openclaw/issues/new/choose`
  2. Open `https://github.com/openclaw/openclaw/issues/new?template=docs_bug_report.yml`
- **Evidence after fix:** Attached screenshots plus PR comment with authenticated UI proof: https://github.com/openclaw/openclaw/pull/76668#issuecomment-4528709187
- **Observed result after fix:** Current `main` does not yet expose `Docs bug report`; this PR adds `.github/ISSUE_TEMPLATE/docs_bug_report.yml`, which is the required change for chooser visibility after merge.
- **What was not tested:** Post-merge chooser rendering on default branch (cannot be validated pre-merge).
