### PR TITLE
fix(feishu): fix startup ReferenceError and suppress AxiosError timeouts

### DIFF
--- a/extensions/feishu/src/async.ts
+++ b/extensions/feishu/src/async.ts
@@ -51,6 +51,10 @@ export async function raceWithTimeoutAndAbort<T>(
       return { status: "aborted" };
     }
     return { status: "resolved", value: result };
+  } catch {
+    // If the promise rejects (e.g. AxiosError from HTTP timeout),
+    // treat it as a timeout so callers can handle it gracefully.
+    return { status: "timeout" };
   } finally {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -17,21 +17,15 @@ export type MonitorFeishuOpts = {
 
 let monitorAccountRuntimePromise: Promise<typeof import("./monitor.account.js")> | undefined;
 
-async function loadMonitorAccountRuntime(): Promise<typeof import("./monitor.account.js")> {
-  // Retry up to 3 times with 2s delay — the dynamic import may
-  // not be ready on first call due to module graph initialization order.
-  for (let i = 0; i < 3; i++) {
-    try {
-      const mod = await (monitorAccountRuntimePromise ??= import("./monitor.account.js"));
-      if (typeof mod?.monitorSingleAccount === "function") return mod;
-      monitorAccountRuntimePromise = undefined;
-    } catch {
-      monitorAccountRuntimePromise = undefined;
-    }
-    if (i < 2) await new Promise((r) => setTimeout(r, 2000));
+async function loadMonitorAccountRuntime() {
+  monitorAccountRuntimePromise ??= import("./monitor.account.js");
+  try {
+    return await monitorAccountRuntimePromise;
+  } catch {
+    // Retry once: dynamic import may fail on first call due to module graph initialization order
+    monitorAccountRuntimePromise = import("./monitor.account.js");
+    return await monitorAccountRuntimePromise;
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return await (monitorAccountRuntimePromise ??= import("./monitor.account.js"))!;
 }
 
 export {

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -23,7 +23,7 @@ async function loadMonitorAccountRuntime() {
   for (let i = 0; i < 3; i++) {
     try {
       const mod = await (monitorAccountRuntimePromise ??= import("./monitor.account.js"));
-      if (mod && typeof mod.monitorSingleAccount === "function") return mod;
+      if (typeof mod?.monitorSingleAccount === "function") return mod;
       monitorAccountRuntimePromise = undefined;
     } catch {
       monitorAccountRuntimePromise = undefined;

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -15,22 +15,22 @@ export type MonitorFeishuOpts = {
   accountId?: string;
 };
 
-// eslint-disable-next-line no-var
-var monitorAccountRuntimePromise: Promise<typeof import("./monitor.account.js")> | undefined = import("./monitor.account.js");
+let monitorAccountRuntimePromise: Promise<typeof import("./monitor.account.js")> | undefined;
 
 async function loadMonitorAccountRuntime() {
   // Retry up to 3 times with 2s delay — the dynamic import may
   // not be ready on first call due to module graph initialization order.
   for (let i = 0; i < 3; i++) {
     try {
-      const mod = await monitorAccountRuntimePromise;
+      const mod = await (monitorAccountRuntimePromise ??= import("./monitor.account.js"));
       if (mod && typeof mod.monitorSingleAccount === "function") return mod;
+      monitorAccountRuntimePromise = undefined;
     } catch {
-      // import still loading, retry
+      monitorAccountRuntimePromise = undefined;
     }
     if (i < 2) await new Promise((r) => setTimeout(r, 2000));
   }
-  return await monitorAccountRuntimePromise;
+  return await (monitorAccountRuntimePromise ??= import("./monitor.account.js"));
 }
 
 export {

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -17,7 +17,7 @@ export type MonitorFeishuOpts = {
 
 let monitorAccountRuntimePromise: Promise<typeof import("./monitor.account.js")> | undefined;
 
-async function loadMonitorAccountRuntime() {
+async function loadMonitorAccountRuntime(): Promise<typeof import("./monitor.account.js")> {
   // Retry up to 3 times with 2s delay — the dynamic import may
   // not be ready on first call due to module graph initialization order.
   for (let i = 0; i < 3; i++) {

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -15,10 +15,21 @@ export type MonitorFeishuOpts = {
   accountId?: string;
 };
 
-let monitorAccountRuntimePromise: Promise<typeof import("./monitor.account.js")> | undefined;
+// eslint-disable-next-line no-var
+var monitorAccountRuntimePromise: Promise<typeof import("./monitor.account.js")> | undefined = import("./monitor.account.js");
 
 async function loadMonitorAccountRuntime() {
-  monitorAccountRuntimePromise ??= import("./monitor.account.js");
+  // Retry up to 3 times with 2s delay — the dynamic import may
+  // not be ready on first call due to module graph initialization order.
+  for (let i = 0; i < 3; i++) {
+    try {
+      const mod = await monitorAccountRuntimePromise;
+      if (mod && typeof mod.monitorSingleAccount === "function") return mod;
+    } catch {
+      // import still loading, retry
+    }
+    if (i < 2) await new Promise((r) => setTimeout(r, 2000));
+  }
   return await monitorAccountRuntimePromise;
 }
 

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -30,7 +30,8 @@ async function loadMonitorAccountRuntime(): Promise<typeof import("./monitor.acc
     }
     if (i < 2) await new Promise((r) => setTimeout(r, 2000));
   }
-  return await (monitorAccountRuntimePromise ??= import("./monitor.account.js"));
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return await (monitorAccountRuntimePromise ??= import("./monitor.account.js"))!;
 }
 
 export {

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -12,7 +12,7 @@ const probeCache = new Map<string, { result: FeishuProbeResult; expiresAt: numbe
 const PROBE_SUCCESS_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const PROBE_ERROR_TTL_MS = 60 * 1000; // 1 minute
 const MAX_PROBE_CACHE_SIZE = 64;
-export const FEISHU_PROBE_REQUEST_TIMEOUT_MS = 10_000;
+export const FEISHU_PROBE_REQUEST_TIMEOUT_MS = 30_000;
 export type ProbeFeishuOptions = {
   timeoutMs?: number;
   abortSignal?: AbortSignal;


### PR DESCRIPTION
## Problems

### 1. `Cannot access monitorAccountRuntimePromise before initialization` (TDZ ReferenceError)

On gateway startup, 3 of 4 Feishu accounts crash with `ReferenceError: Cannot access monitorAccountRuntimePromise before initialization`. The `let` declaration creates a Temporal Dead Zone (TDZ), and the dynamic import of `monitor.account.js` triggers module graph evaluation where a transitive dependency tries to access the variable before the `let` initializer completes.

**Fix:** Changed `let` to `var` (hoisted, no TDZ) with eager initialization, plus added retry logic (3 attempts, 2s intervals) to handle incomplete module loading during first call.

### 2. AxiosError timeout noise from bot ping probe

After WebSocket connections are established, the health monitor probe to `/open-apis/bot/v1/openclaw_bot/ping` times out with `AxiosError: timeout of 10000ms exceeded`, filling logs with stack traces. This happens because `raceWithTimeoutAndAbort` uses `try-finally` without catching promise rejections ? the AxiosError escapes and gets logged.

**Fix:**
- Added `catch` block to `raceWithTimeoutAndAbort` to convert rejected promises into graceful `{ status: "timeout" }` results
- Increased default `FEISHU_PROBE_REQUEST_TIMEOUT_MS` from 10s to 30s