### PR TITLE
fix: prune all history images when current turn has fresh attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Bug fixes
+
+- **Multimodal:** Prune all history images when the current turn carries fresh attachments, preventing stale image data from contaminating new image analysis. The aggressive pruning is now applied to both the prompt-build hook path and the provider replay transform, keeping the session transcript intact per pruning docs. (#76732, fixes #66702)
+
 ### Highlights
 
 - Plugins/file-transfer: add bundled file-transfer plugin with `file_fetch`, `dir_list`, `dir_fetch`, and `file_write` agent tools for binary file ops on paired nodes; default-deny per-node path policy under `plugins.entries.file-transfer.config.nodes` with operator approval, symlink traversal refused by default (opt-in `followSymlinks`), and a 16 MB byte ceiling per round-trip. (#74742) Thanks @omarshahine.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2614,8 +2614,20 @@ export async function runEmbeddedAttempt(
           trigger: params.trigger,
           ...buildAgentHookContextChannelFields(params),
         };
+        // Idempotent cleanup: prune old image blocks to limit context
+        // growth. Only mutates turns older than a few assistant replies;
+        // the delay also reduces prompt-cache churn.
+        //
+        // When the current prompt already carries fresh images, prune
+        // aggressively (preserveRecentCompletedTurns: 0) so that stale
+        // image data cannot contaminate the new analysis.
+        const currentTurnHasImages =
+          (params.images?.length ?? 0) > 0 || (params.imageOrder?.length ?? 0) > 0;
         const promptBuildMessages =
-          pruneProcessedHistoryImages(activeSession.messages) ?? activeSession.messages;
+          pruneProcessedHistoryImages(
+            activeSession.messages,
+            currentTurnHasImages ? { preserveRecentCompletedTurns: 0 } : undefined,
+          ) ?? activeSession.messages;
         const hookResult = isRawModelRun
           ? undefined
           : await resolvePromptBuildHookResult({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -321,6 +321,7 @@ import {
 import {
   installHistoryImagePruneContextTransform,
   pruneProcessedHistoryImages,
+  setActiveTurnHasFreshImages,
 } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { buildAttemptReplayMetadata } from "./incomplete-turn.js";
@@ -2623,6 +2624,7 @@ export async function runEmbeddedAttempt(
         // image data cannot contaminate the new analysis.
         const currentTurnHasImages =
           (params.images?.length ?? 0) > 0 || (params.imageOrder?.length ?? 0) > 0;
+        setActiveTurnHasFreshImages(currentTurnHasImages);
         const promptBuildMessages =
           pruneProcessedHistoryImages(
             activeSession.messages,

--- a/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
@@ -309,13 +309,17 @@ describe("pruneProcessedHistoryImages", () => {
       assistantTurn(),
     ];
 
-    const didMutate = pruneProcessedHistoryImages(messages, {
+    const result = pruneProcessedHistoryImages(messages, {
       preserveRecentCompletedTurns: 0,
     });
 
-    expect(didMutate).toBe(true);
-    const content = expectArrayMessageContent(messages[0], "expected recent user content");
-    expect(content[1]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
+    expect(result).not.toBeNull();
+    // Original messages are left intact (pruning returns a clone)
+    const originalContent = expectArrayMessageContent(messages[0], "original intact");
+    expect(originalContent[1]).toMatchObject({ type: "image", data: "abc" });
+    // Returned clone has the image replaced with the pruned marker
+    const prunedContent = expectArrayMessageContent(result![0], "pruned result");
+    expect(prunedContent[1]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
   });
 
   it("does not change messages when no assistant turn exists", () => {

--- a/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
@@ -300,6 +300,24 @@ describe("pruneProcessedHistoryImages", () => {
     expect(originalOldContent[1]).toMatchObject({ type: "image", data: "abc" });
   });
 
+  it("prunes even recent history images when current turn already has images", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "user",
+        content: [{ type: "text", text: "recent" }, { ...image }],
+      }),
+      assistantTurn(),
+    ];
+
+    const didMutate = pruneProcessedHistoryImages(messages, {
+      preserveRecentCompletedTurns: 0,
+    });
+
+    expect(didMutate).toBe(true);
+    const content = expectArrayMessageContent(messages[0], "expected recent user content");
+    expect(content[1]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
+  });
+
   it("does not change messages when no assistant turn exists", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -23,6 +23,8 @@ type PrunableContextAgent = {
 const PRESERVE_RECENT_COMPLETED_TURNS = 3;
 
 interface HistoryImagePruneOptions {
+  /** Number of most-recent completed turns to preserve.
+   * Must be >= 0. Values < 0 are clamped to 0. */
   preserveRecentCompletedTurns?: number;
 }
 
@@ -59,10 +61,14 @@ function resolvePruneBeforeIndex(
     completedTurnStarts.push(currentTurnStart);
   }
 
-  const preserveRecentCompletedTurns =
-    options?.preserveRecentCompletedTurns ?? PRESERVE_RECENT_COMPLETED_TURNS;
+  const preserveRecentCompletedTurns = Math.max(
+    0,
+    options?.preserveRecentCompletedTurns ?? PRESERVE_RECENT_COMPLETED_TURNS,
+  );
 
-  if (preserveRecentCompletedTurns <= 0) {
+  if (preserveRecentCompletedTurns === 0) {
+    // Prune all completed turns — caller has fresh images and wants no
+    // stale visual baggage from history.
     return completedTurnStarts.length > 0 ? messages.length : -1;
   }
 
@@ -165,14 +171,26 @@ export function pruneProcessedHistoryImages(
   return prunedMessages;
 }
 
+/** Current-turn image state shared between attempt.ts and the provider
+ *  replay transform so both paths prune consistently. */
+let activeTurnHasFreshImages = false;
+
+export function setActiveTurnHasFreshImages(value: boolean): void {
+  activeTurnHasFreshImages = value;
+}
+
 export function installHistoryImagePruneContextTransform(agent: PrunableContextAgent): () => void {
   const originalTransformContext = agent.transformContext;
+  // The session transcript (activeSession.messages) is intentionally left
+  // intact — only the replay/prompt view is pruned, per the pruning docs
+  // (docs/concepts/session-pruning.md).
   agent.transformContext = async (messages: AgentMessage[], signal?: AbortSignal) => {
     const transformed = originalTransformContext
       ? await originalTransformContext.call(agent, messages, signal)
       : messages;
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
-    return pruneProcessedHistoryImages(sourceMessages) ?? sourceMessages;
+    const options = activeTurnHasFreshImages ? { preserveRecentCompletedTurns: 0 } : undefined;
+    return pruneProcessedHistoryImages(sourceMessages, options) ?? sourceMessages;
   };
   return () => {
     agent.transformContext = originalTransformContext;

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -22,7 +22,14 @@ type PrunableContextAgent = {
  */
 const PRESERVE_RECENT_COMPLETED_TURNS = 3;
 
-function resolvePruneBeforeIndex(messages: AgentMessage[]): number {
+interface HistoryImagePruneOptions {
+  preserveRecentCompletedTurns?: number;
+}
+
+function resolvePruneBeforeIndex(
+  messages: AgentMessage[],
+  options?: HistoryImagePruneOptions,
+): number {
   const completedTurnStarts: number[] = [];
   let currentTurnStart = -1;
   let currentTurnHasAssistantReply = false;
@@ -52,10 +59,17 @@ function resolvePruneBeforeIndex(messages: AgentMessage[]): number {
     completedTurnStarts.push(currentTurnStart);
   }
 
-  if (completedTurnStarts.length <= PRESERVE_RECENT_COMPLETED_TURNS) {
+  const preserveRecentCompletedTurns =
+    options?.preserveRecentCompletedTurns ?? PRESERVE_RECENT_COMPLETED_TURNS;
+
+  if (preserveRecentCompletedTurns <= 0) {
+    return completedTurnStarts.length > 0 ? messages.length : -1;
+  }
+
+  if (completedTurnStarts.length <= preserveRecentCompletedTurns) {
     return -1;
   }
-  return completedTurnStarts[completedTurnStarts.length - PRESERVE_RECENT_COMPLETED_TURNS];
+  return completedTurnStarts[completedTurnStarts.length - preserveRecentCompletedTurns];
 }
 
 function pruneHistoryMediaReferenceText(text: string): string {
@@ -80,8 +94,11 @@ function cloneMessageWithContent(
  * same boundary because detectAndLoadPromptImages treats them as fresh prompt
  * image references when old history is replayed into a later prompt.
  */
-export function pruneProcessedHistoryImages(messages: AgentMessage[]): AgentMessage[] | null {
-  const pruneBeforeIndex = resolvePruneBeforeIndex(messages);
+export function pruneProcessedHistoryImages(
+  messages: AgentMessage[],
+  options?: HistoryImagePruneOptions,
+): AgentMessage[] | null {
+  const pruneBeforeIndex = resolvePruneBeforeIndex(messages, options);
   if (pruneBeforeIndex < 0) {
     return null;
   }


### PR DESCRIPTION
## Problem

When sending a new image for analysis, stale image data from previous conversation turns can contaminate the model's interpretation of the current image. Reported in #66702.

## Solution

- Add `HistoryImagePruneOptions` interface with `preserveRecentCompletedTurns` parameter
- Thread option through `resolvePruneBeforeIndex` → `pruneProcessedHistoryImages` → caller in `attempt.ts`
- When current turn has fresh images, pass `preserveRecentCompletedTurns: 0` to strip all historical image data
- No new images: existing conservative default (preserve 3 turns) applies

Backward-compatible. Existing tests unchanged.

Fixes #66702