### PR TITLE
fix(kimi): strip anthropic cache markers

### DIFF
--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -281,6 +281,82 @@ describe("kimi tool-call markup wrapper", () => {
     });
   });
 
+  it("strips Anthropic cache_control markers before Kimi requests are sent", () => {
+    const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream({
+      system: [{ type: "text", text: "stable", cache_control: { type: "ephemeral", ttl: "1h" } }],
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hello", cache_control: { type: "ephemeral" } },
+            {
+              type: "tool_result",
+              tool_use_id: "tool_1",
+              content: [
+                {
+                  type: "text",
+                  text: "done",
+                  cache_control: { type: "ephemeral" },
+                },
+              ],
+              cache_control: { type: "ephemeral" },
+            },
+            {
+              type: "tool_use",
+              id: "tool_2",
+              name: "persist",
+              input: {
+                cache_control: "tool argument",
+                nested: { cache_control: "nested argument" },
+              },
+              cache_control: { type: "ephemeral" },
+            },
+            { type: "text", text: "bye" },
+          ],
+        },
+      ],
+    });
+
+    const wrapped = createKimiThinkingWrapper(baseStreamFn, "enabled");
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "kimi",
+        id: "kimi-code",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(getCapturedPayload()).toEqual({
+      system: [{ type: "text", text: "stable" }],
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hello" },
+            {
+              type: "tool_result",
+              tool_use_id: "tool_1",
+              content: [{ type: "text", text: "done" }],
+            },
+            {
+              type: "tool_use",
+              id: "tool_2",
+              name: "persist",
+              input: {
+                cache_control: "tool argument",
+                nested: { cache_control: "nested argument" },
+              },
+            },
+            { type: "text", text: "bye" },
+          ],
+        },
+      ],
+      thinking: { type: "enabled" },
+    });
+  });
+
   it("lets explicit model params keep Kimi thinking disabled even when session thinking is on", () => {
     const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream();
 

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -394,7 +394,49 @@ export function createKimiThinkingWrapper(
       delete payloadObj.reasoning;
       delete payloadObj.reasoning_effort;
       delete payloadObj.reasoningEffort;
+      stripAnthropicCacheControlMarkers(payloadObj);
     });
+}
+
+function stripContentBlockCacheControl(block: unknown): void {
+  if (!block || typeof block !== "object") {
+    return;
+  }
+
+  const record = block as Record<string, unknown>;
+  delete record.cache_control;
+
+  if (record.type === "tool_result" && Array.isArray(record.content)) {
+    for (const nestedBlock of record.content) {
+      stripContentBlockCacheControl(nestedBlock);
+    }
+  }
+}
+
+function stripContentArrayCacheControl(value: unknown): void {
+  if (!Array.isArray(value)) {
+    return;
+  }
+
+  for (const block of value) {
+    stripContentBlockCacheControl(block);
+  }
+}
+
+function stripAnthropicCacheControlMarkers(payloadObj: Record<string, unknown>): void {
+  stripContentArrayCacheControl(payloadObj.system);
+
+  if (!Array.isArray(payloadObj.messages)) {
+    return;
+  }
+
+  for (const message of payloadObj.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+
+    stripContentArrayCacheControl((message as Record<string, unknown>).content);
+  }
 }
 
 export function wrapKimiProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn {


### PR DESCRIPTION
## Summary

Kimi Code can return `stop_reason=stop` with `content: []` when Anthropic `cache_control` prompt-cache markers reach its Anthropic-compatible endpoint. #76612 has a source-level path for that failure: core builds Anthropic Messages params first, then the Kimi provider wrapper runs its payload patch.

This keeps the repair in the Kimi provider boundary. The wrapper now strips Anthropic `cache_control` markers from Kimi request system blocks, message content blocks, and nested `tool_result` content before the request is sent, while leaving Kimi tool-call input fields intact.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue

- Closes #76612
- [x] This PR fixes a bug or regression

## Root Cause

Kimi uses the shared `anthropic-messages` transport. When inherited or explicit `cacheRetention` is present, the shared Anthropic payload policy can add `cache_control` markers before provider-owned wrappers run. Kimi's wrapper already patches Kimi-specific thinking fields, but it did not remove those Anthropic cache markers before the payload reached `api.kimi.com`.

## What changed

1. `extensions/kimi-coding/stream.ts` strips `cache_control` markers inside Kimi's existing payload patch.
2. `extensions/kimi-coding/stream.test.ts` covers the final payload shape sent by the wrapper and preserves unrelated ids, content ordering, nested tool-result content, and `tool_use.input.cache_control` values.

## What did NOT change

- Generic Anthropic, Vertex, Bedrock, OpenRouter, and custom `anthropic-messages` cache behavior.
- Kimi tool-call markup rewriting.
- Kimi thinking enablement rules.
- `CHANGELOG.md`, per current contributor guidance.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.2, pnpm 11.1.0
- Model/provider: `kimi/kimi-code`
- Integration/channel: Kimi provider wrapper
- Relevant config: inherited or explicit `cacheRetention`

### Expected

Kimi requests do not include Anthropic `cache_control` markers.

### Actual

Before this change, Kimi's payload patch left `cache_control` markers in the request body when the shared Anthropic transport added them.

## Real behavior proof

**Behavior addressed:** Kimi-bound Anthropic Messages request payloads should not include Anthropic `cache_control` markers on system, text, `tool_result`, or `tool_use` content blocks after the Kimi provider wrapper runs.

**Real environment tested:** Local OpenClaw checkout on the PR branch, macOS, Node v22.22.2, pnpm 11.1.0.

**Exact steps or command run after this patch:** Ran the actual Kimi provider wrapper from this checkout with `node --import tsx`, using a request-shaped Anthropic Messages payload containing `cache_control` markers on system, text, `tool_result`, and `tool_use` blocks.

**Evidence after fix:**

```text
OpenClaw Kimi wrapper proof
cache_control in request content blocks: absent
tool input cache_control preserved: tool argument
nested tool input preserved: nested argument
tool_result id preserved: tool_1
thinking type: enabled
reasoning field present: false
```

**Observed result after fix:** The wrapper strips Anthropic request cache markers from Kimi-bound content blocks while preserving non-Anthropic tool input fields named `cache_control`.

**What was not tested:** No live Kimi API request was made.

## Tests

```text
node scripts/test-projects.mjs extensions/kimi-coding/stream.test.ts
[test] passed 1 Vitest shard in 3.42s

pnpm exec oxfmt --check --threads=1 extensions/kimi-coding/stream.ts extensions/kimi-coding/stream.test.ts
All matched files use the correct format.

node scripts/changed-lanes.mjs --json
lanes: extensions, extensionTests

node scripts/check-changed.mjs
passed
```

## Human Verification

Verified the Kimi wrapper test captures the request payload after the provider patch runs. The regression case covers `system` blocks, user text blocks, nested `tool_result` content, adjacent structure, and preservation of `tool_use.input.cache_control` fields. I did not run a live Kimi API request.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: removing cache markers too broadly from other providers.
  - Mitigation: the stripping is local to `extensions/kimi-coding/stream.ts` and runs only through the Kimi provider wrapper.
