### PR TITLE
Prefer direct native hook relay before gateway fallback

### DIFF
--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -1,12 +1,66 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as nativeHookRelayTesting,
+  registerNativeHookRelay,
+} from "../agents/harness/native-hook-relay.js";
 import {
   createReadableTextStream,
   createWritableTextBuffer,
   runNativeHookRelayCli,
 } from "./native-hook-relay-cli.js";
 
+afterEach(() => {
+  nativeHookRelayTesting.clearNativeHookRelaysForTests();
+});
+
 describe("native hook relay CLI", () => {
-  it("reads Codex hook JSON from stdin and forwards it to the gateway relay", async () => {
+  it("reads Codex hook JSON from stdin and forwards it through the direct relay bridge", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "relay-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const callGateway = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      {
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "pre_tool_use",
+        timeout: "1234",
+      },
+      {
+        stdin: createReadableTextStream(
+          JSON.stringify({
+            hook_event_name: "PreToolUse",
+            tool_name: "Bash",
+            tool_input: { command: "pnpm test" },
+          }),
+        ),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toBe("");
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(nativeHookRelayTesting.getNativeHookRelayInvocationsForTests()).toEqual([
+      expect.objectContaining({
+        relayId: relay.relayId,
+        event: "pre_tool_use",
+        runId: "run-1",
+      }),
+    ]);
+  });
+
+  it("falls back to the gateway relay when the direct relay bridge is unavailable", async () => {
     const callGateway = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
     const stdout = createWritableTextBuffer();
     const stderr = createWritableTextBuffer();
@@ -16,7 +70,7 @@ describe("native hook relay CLI", () => {
         provider: "codex",
         relayId: "relay-1",
         event: "pre_tool_use",
-        timeout: "1234",
+        timeout: "1",
       },
       {
         stdin: createReadableTextStream(
@@ -47,7 +101,7 @@ describe("native hook relay CLI", () => {
           tool_input: { command: "pnpm test" },
         },
       },
-      timeoutMs: 1234,
+      timeoutMs: 1,
       scopes: ["operator.admin"],
     });
   });
@@ -58,7 +112,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "permission_request" },
+      { provider: "codex", relayId: "relay-1", event: "permission_request", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -77,7 +131,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use", timeout: "1" },
       {
         stdin: createReadableTextStream("{nope"),
         stderr,
@@ -116,7 +170,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -144,7 +198,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "permission_request" },
+      { provider: "codex", relayId: "relay-1", event: "permission_request", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -173,7 +227,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "post_tool_use" },
+      { provider: "codex", relayId: "relay-1", event: "post_tool_use", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -195,7 +249,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "before_agent_finalize" },
+      { provider: "codex", relayId: "relay-1", event: "before_agent_finalize", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -7,38 +7,42 @@ import {
 
 describe("native hook relay CLI", () => {
   it("reads Codex hook JSON from stdin and forwards it to the gateway relay", async () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValueOnce(1_000).mockReturnValueOnce(1_000);
+    const invokeBridge = vi.fn(async () => {
+      throw new Error("native hook relay bridge not found");
+    });
     const callGateway = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
     const stdout = createWritableTextBuffer();
     const stderr = createWritableTextBuffer();
 
-    const exitCode = await runNativeHookRelayCli(
-      {
-        provider: "codex",
-        relayId: "relay-1",
-        generation: "generation-1",
-        event: "pre_tool_use",
-        timeout: "1234",
-      },
-      {
-        stdin: createReadableTextStream(
-          JSON.stringify({
-            hook_event_name: "PreToolUse",
-            tool_name: "Bash",
-            tool_input: { command: "pnpm test" },
-          }),
-        ),
-        stdout,
-        stderr,
-        callGateway: callGateway as never,
-      },
-    );
+    try {
+      const exitCode = await runNativeHookRelayCli(
+        {
+          provider: "codex",
+          relayId: "relay-1",
+          generation: "generation-1",
+          event: "pre_tool_use",
+          timeout: "1234",
+        },
+        {
+          stdin: createReadableTextStream(
+            JSON.stringify({
+              hook_event_name: "PreToolUse",
+              tool_name: "Bash",
+              tool_input: { command: "pnpm test" },
+            }),
+          ),
+          stdout,
+          stderr,
+          invokeBridge: invokeBridge as never,
+          callGateway: callGateway as never,
+        },
+      );
 
-    expect(exitCode).toBe(0);
-    expect(stdout.text()).toBe("");
-    expect(stderr.text()).toBe("");
-    expect(callGateway).toHaveBeenCalledWith({
-      method: "nativeHook.invoke",
-      params: {
+      expect(exitCode).toBe(0);
+      expect(stdout.text()).toBe("");
+      expect(stderr.text()).toBe("");
+      expect(invokeBridge).toHaveBeenCalledWith({
         provider: "codex",
         relayId: "relay-1",
         generation: "generation-1",
@@ -48,10 +52,68 @@ describe("native hook relay CLI", () => {
           tool_name: "Bash",
           tool_input: { command: "pnpm test" },
         },
-      },
-      timeoutMs: 1234,
-      scopes: ["operator.admin"],
+        registrationTimeoutMs: 984,
+        timeoutMs: 1234,
+      });
+      expect(callGateway).toHaveBeenCalledWith({
+        method: "nativeHook.invoke",
+        params: {
+          provider: "codex",
+          relayId: "relay-1",
+          generation: "generation-1",
+          event: "pre_tool_use",
+          rawPayload: {
+            hook_event_name: "PreToolUse",
+            tool_name: "Bash",
+            tool_input: { command: "pnpm test" },
+          },
+        },
+        timeoutMs: 1234,
+        scopes: ["operator.admin"],
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("reserves remaining timeout for the gateway relay after direct bridge wait", async () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValueOnce(10_000).mockReturnValueOnce(14_000);
+    const invokeBridge = vi.fn(async () => {
+      throw new Error("native hook relay bridge not found");
     });
+    const callGateway = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
+
+    try {
+      const exitCode = await runNativeHookRelayCli(
+        {
+          provider: "codex",
+          relayId: "relay-1",
+          generation: "generation-1",
+          event: "pre_tool_use",
+          timeout: "5000",
+        },
+        {
+          stdin: createReadableTextStream("{}"),
+          invokeBridge: invokeBridge as never,
+          callGateway: callGateway as never,
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(invokeBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          registrationTimeoutMs: 4000,
+          timeoutMs: 5000,
+        }),
+      );
+      expect(callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutMs: 1000,
+        }),
+      );
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 
   it("renders provider-compatible stdout, stderr, and exit code from the gateway response", async () => {

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -45,13 +45,14 @@ export async function runNativeHookRelayCli(
   }
 
   try {
+    const timeoutMs = normalizeTimeoutMs(opts.timeout);
     const response = await invokeNativeHookRelayBridge({
       provider,
       relayId,
       event,
       rawPayload,
-      registrationTimeoutMs: 100,
-      timeoutMs: normalizeTimeoutMs(opts.timeout),
+      registrationTimeoutMs: timeoutMs,
+      timeoutMs,
     });
     writeText(stdout, response.stdout);
     writeText(stderr, response.stderr);

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -10,6 +10,9 @@ import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
 
 const MAX_NATIVE_HOOK_STDIN_BYTES = 1024 * 1024;
+const MAX_NATIVE_HOOK_GATEWAY_FALLBACK_RESERVE_MS = 1_000;
+const MIN_NATIVE_HOOK_GATEWAY_FALLBACK_RESERVE_MS = 250;
+const NATIVE_HOOK_GATEWAY_FALLBACK_RESERVE_RATIO = 0.2;
 
 export type NativeHookRelayCliOptions = {
   provider?: string;
@@ -58,14 +61,16 @@ export async function runNativeHookRelayCli(
     return 1;
   }
 
+  let bridgeStartedAtMs = 0;
   try {
+    bridgeStartedAtMs = Date.now();
     const response = await invokeBridge({
       provider,
       relayId,
       generation,
       event,
       rawPayload,
-      registrationTimeoutMs: 100,
+      registrationTimeoutMs: computeBridgeRegistrationTimeoutMs(timeoutMs),
       timeoutMs,
     });
     writeText(stdout, response.stdout);
@@ -86,30 +91,41 @@ export async function runNativeHookRelayCli(
     }
     // Fall through to the gateway path for embedded/local gateway cases and
     // older registrations that predate the direct relay bridge.
+    const remainingTimeoutMs = Math.max(1, timeoutMs - (Date.now() - bridgeStartedAtMs));
+    try {
+      const response = await callGatewayFn<NativeHookRelayProcessResponse>({
+        method: "nativeHook.invoke",
+        params: { provider, relayId, generation, event, rawPayload },
+        timeoutMs: remainingTimeoutMs,
+        scopes: [ADMIN_SCOPE],
+      });
+      writeText(stdout, response.stdout);
+      writeText(stderr, response.stderr);
+      return response.exitCode;
+    } catch (gatewayError) {
+      writeText(stderr, formatRelayCliError("native hook relay unavailable", gatewayError));
+      const response = renderNativeHookRelayUnavailableResponse({
+        provider,
+        event,
+        preToolUseUnavailable: opts.preToolUseUnavailable,
+        message: "Native hook relay unavailable",
+      });
+      writeText(stdout, response.stdout);
+      writeText(stderr, response.stderr);
+      return response.exitCode;
+    }
   }
+}
 
-  try {
-    const response = await callGatewayFn<NativeHookRelayProcessResponse>({
-      method: "nativeHook.invoke",
-      params: { provider, relayId, generation, event, rawPayload },
-      timeoutMs,
-      scopes: [ADMIN_SCOPE],
-    });
-    writeText(stdout, response.stdout);
-    writeText(stderr, response.stderr);
-    return response.exitCode;
-  } catch (error) {
-    writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
-    const response = renderNativeHookRelayUnavailableResponse({
-      provider,
-      event,
-      preToolUseUnavailable: opts.preToolUseUnavailable,
-      message: "Native hook relay unavailable",
-    });
-    writeText(stdout, response.stdout);
-    writeText(stderr, response.stderr);
-    return response.exitCode;
-  }
+function computeBridgeRegistrationTimeoutMs(timeoutMs: number): number {
+  const fallbackReserveMs = Math.min(
+    MAX_NATIVE_HOOK_GATEWAY_FALLBACK_RESERVE_MS,
+    Math.max(
+      MIN_NATIVE_HOOK_GATEWAY_FALLBACK_RESERVE_MS,
+      Math.floor(timeoutMs * NATIVE_HOOK_GATEWAY_FALLBACK_RESERVE_RATIO),
+    ),
+  );
+  return Math.max(1, timeoutMs - fallbackReserveMs);
 }
 
 function readRequiredOption(value: string | undefined, name: string): string {


### PR DESCRIPTION
## Summary
- let `openclaw hooks relay` wait longer than the old 100ms grace for the direct localhost relay bridge before falling back to `nativeHook.invoke`
- reserve gateway fallback budget by capping the direct bridge registration wait to `timeout - reserve`, where reserve is 20% of the hook timeout bounded between 250ms and 1000ms
- pass only the remaining elapsed timeout budget into the gateway fallback
- keep the current stale-bridge/unavailable-response behavior from `main`, including fail-closed PreToolUse handling unless explicit noop fallback is requested

## Why
In a self-hosted Codex harness setup, hook delivery could abandon the direct bridge after 100ms and fall back to `nativeHook.invoke`, where gateway auth/handshake cost made the hook unreliable under startup or event-loop delay. The direct bridge is the safer in-process path for current registrations, but the gateway fallback still needs time to complete inside Codex's hook timeout when no direct bridge is registered.

## Testing
- `node_modules/.bin/oxlint src/cli/native-hook-relay-cli.ts src/cli/native-hook-relay-cli.test.ts` — passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/native-hook-relay-cli.test.ts` — 16 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/harness/native-hook-relay.test.ts` — 75 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/native-hook-relay.test.ts` — 3 passed

## Real behavior proof
- **Behavior or issue addressed:** Missing direct native hook bridge should not spend the entire Codex hook timeout before gateway fallback starts; unavailable PreToolUse still fails closed when fallback cannot authenticate.
- **Real environment tested:** Local macOS source checkout at commit `6d4b022cc5`, Node 25.4.0, isolated temporary `OPENCLAW_HOME` and `OPENCLAW_STATE_DIR`, redacted Codex `PreToolUse` payload.
- **Exact steps or command run after this patch:**

```sh
TIMEFORMAT='elapsed=%3R'; time printf '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo redacted"}}' | \
  OPENCLAW_HOME="$tmp_home" OPENCLAW_STATE_DIR="$tmp_state" \
  node_modules/.bin/tsx -e '(async () => { const { runNativeHookRelayCli } = await import("./src/cli/native-hook-relay-cli.ts"); process.exitCode = await runNativeHookRelayCli({ provider: "codex", relayId: "codex-pr-76793-redacted", generation: "generation-redacted", event: "pre_tool_use", timeout: "5000" }); })().catch((error) => { console.error(error); process.exitCode = 1; });'
```

- **Evidence after fix:** Redacted terminal output from the run above:

```text
native hook relay unavailable: gateway nativeHook.invoke requires credentials before opening a websocket
Fix: configure gateway.auth token/password, pair this device, or pass --token/--password.
Config: /tmp/openclaw-pr-76793-state.[redacted]/openclaw.json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Native hook relay unavailable"}}
elapsed=11.986
```

- **Observed result after fix:** The patched hook relay attempted fallback from a missing direct bridge and returned a provider-compatible PreToolUse deny response instead of letting the hook produce an allow/noop response. The isolated setup intentionally lacked gateway credentials, so the final unavailable response is the expected fail-closed behavior for this proof run.
- **What was not tested:** I did not include authenticated output from my real local OpenClaw config because current source rejects local config keys that my installed OpenClaw accepts (`agents.defaults.embeddedPi`, `agents.list.*.systemPromptOverride`), which contaminated that run.

AI-assisted: yes. I understand the change; it keeps the direct bridge preference while preserving fallback budget and current fail-closed PreToolUse behavior.
