### PR TITLE
fix(tool-policy): deny write no longer silently hides apply_patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/tools: stop treating `tools.deny: ["write"]` as an implicit `apply_patch` deny; operators who want to block patch writes should deny `apply_patch` or `group:fs` explicitly. Fixes #76749. (#76795) Thanks @Nek-12 and @hclsys.
 - Gateway/update: recover an installed-but-unloaded macOS LaunchAgent after package updates, rerun Gateway health/version/channel readiness checks, and print restart, reinstall, and rollback guidance before reporting update failure. (#76790) Thanks @jonathanlindsay.
 - Google Meet: route stateful CLI session commands through the gateway-owned runtime so joined realtime sessions survive after the starting CLI process exits. Fixes #76344. Thanks @coltonharris-wq.
 - Memory/status: split builtin sqlite-vec store readiness from embedding-provider readiness in `memory status --deep` and `openclaw status`, so local vector-store failures no longer look like provider failures and provider failures no longer hide a healthy local vector store.

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -54,6 +54,14 @@ Global tool allow/deny policy (deny wins). Case-insensitive, supports `*` wildca
 }
 ```
 
+`write` and `apply_patch` are separate tool ids. `allow: ["write"]` also enables `apply_patch` for compatible models, but `deny: ["write"]` does not deny `apply_patch`. To block all file mutation, deny `group:fs` or list each mutating tool explicitly:
+
+```json5
+{
+  tools: { deny: ["write", "edit", "apply_patch"] },
+}
+```
+
 ### `tools.byProvider`
 
 Further restrict tools for specific providers or models. Order: base profile → provider profile → allow/deny.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -264,6 +264,7 @@ Notes:
 
 - Only available for OpenAI/OpenAI Codex models.
 - Tool policy still applies; `allow: ["write"]` implicitly allows `apply_patch`.
+- `deny: ["write"]` does not deny `apply_patch`; deny `apply_patch` explicitly or use `deny: ["group:fs"]` when patch writes should also be blocked.
 - Config lives under `tools.exec.applyPatch`.
 - `tools.exec.applyPatch.enabled` defaults to `true`; set it to `false` to disable the tool for OpenAI models.
 - `tools.exec.applyPatch.workspaceOnly` defaults to `true` (workspace-contained). Set it to `false` only if you intentionally want `apply_patch` to write/delete outside the workspace directory.

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -37,8 +37,8 @@ describe("pi-tools.policy", () => {
     expect(isToolAllowedByPolicyName("apply_patch", { allow: ["write"] })).toBe(true);
   });
 
-  it("blocks apply_patch when write is denylisted", () => {
-    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write"] })).toBe(false);
+  it("keeps apply_patch when write is denylisted", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write"] })).toBe(true);
   });
 });
 

--- a/src/agents/tool-policy-match.ts
+++ b/src/agents/tool-policy-match.ts
@@ -16,9 +16,6 @@ function makeToolPolicyMatcher(policy: SandboxToolPolicy) {
     if (matchesAnyGlobPattern(normalized, deny)) {
       return false;
     }
-    if (normalized === "apply_patch" && matchesAnyGlobPattern("write", deny)) {
-      return false;
-    }
     if (allow.length === 0) {
       return true;
     }

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
 import { isToolAllowed, resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { TOOL_POLICY_CONFORMANCE } from "./tool-policy.conformance.js";
 import {
   applyOwnerOnlyToolPolicy,
@@ -262,5 +263,25 @@ describe("resolveSandboxToolPolicyForAgent", () => {
     const resolved = resolveSandboxToolPolicyForAgent(cfg, undefined);
     expect(resolved.allow).toEqual(["read"]);
     expect(resolved.deny).toEqual(["image"]);
+  });
+});
+
+describe("isToolAllowedByPolicyName — apply_patch / write deny decoupling (#76749)", () => {
+  it("does not deny apply_patch when write is denied", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write"] })).toBe(true);
+  });
+
+  it("still denies apply_patch when apply_patch is explicitly denied", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["apply_patch"] })).toBe(false);
+  });
+
+  it("still allows apply_patch via write in the allow list", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { allow: ["write"], deny: [] })).toBe(true);
+  });
+
+  it("denies apply_patch when both write and apply_patch are denied", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write", "apply_patch"] })).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
Fixes #76749.

## Problem

`makeToolPolicyMatcher` contained an asymmetric coupling: if `write` appeared in the **deny** list, `apply_patch` was also silently denied — even when the caller never listed `apply_patch` in deny.

The allow side already has symmetric coupling (allow `write` ⇒ allow `apply_patch`). This made the deny side inconsistent and surprising.

## Fix

Remove the three lines that caused `deny: ["write"]` to also block `apply_patch`:

```ts
// removed:
if (normalized === "apply_patch" && matchesAnyGlobPattern("write", deny)) {
  return false;
}
```

The allow coupling at the bottom of the function is preserved — `allow: ["write"]` still grants `apply_patch`.

## Tests

Four regression tests added to `tool-policy.test.ts`:
- `deny: ["write"]` leaves `apply_patch` accessible ← the bug
- `deny: ["apply_patch"]` still denies directly
- `allow: ["write"]` still grants `apply_patch`
- `deny: ["write", "apply_patch"]` still denies when both explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)