### PR TITLE
test(agents): cover isOpenAIGpt54MiniModel helper variants

### DIFF
--- a/src/agents/openai-reasoning-effort.test.ts
+++ b/src/agents/openai-reasoning-effort.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isOpenAIGpt54MiniModel,
   resolveOpenAIReasoningEffortForModel,
   resolveOpenAISupportedReasoningEfforts,
 } from "./openai-reasoning-effort.js";
@@ -76,5 +77,62 @@ describe("OpenAI reasoning effort support", () => {
         effort: "off",
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("isOpenAIGpt54MiniModel", () => {
+  it.each([
+    { id: "gpt-5.4-mini", expected: true, reason: "exact id" },
+    {
+      id: "gpt-5.4-mini-2026-05-01",
+      expected: true,
+      reason: "dated alias (YYYY-MM-DD suffix stripped by normalizeModelId)",
+    },
+    {
+      id: "gpt-5.4-mini-preview",
+      expected: true,
+      reason: "non-date suffix preserved by normalize",
+    },
+    { id: "gpt-5.4-mini-codex", expected: true, reason: "non-date suffix kept" },
+    { id: "GPT-5.4-MINI", expected: true, reason: "uppercase normalized to lowercase" },
+    {
+      id: "  gpt-5.4-mini  ",
+      expected: true,
+      reason: "surrounding whitespace trimmed by normalize",
+    },
+    { id: "gpt-5.4-mini2", expected: false, reason: "no separator after mini" },
+    { id: "gpt-5.4", expected: false, reason: "missing -mini" },
+    { id: "gpt-5.4-pro", expected: false, reason: "sibling family" },
+    { id: "gpt-5.4-mini-pro", expected: true, reason: "non-date suffix" },
+    { id: "gpt-5", expected: false, reason: "different family" },
+    {
+      id: "gpt-5.4-pro-2026-05-01",
+      expected: false,
+      reason: "date-stamped sibling family (strip + regex independence)",
+    },
+    { id: "", expected: false, reason: "empty string" },
+  ])("$reason: $id -> $expected", ({ id, expected }) => {
+    expect(isOpenAIGpt54MiniModel({ provider: "openai", id })).toBe(expected);
+  });
+
+  it("returns false for non-string id values without throwing", () => {
+    expect(isOpenAIGpt54MiniModel({ provider: "openai", id: undefined })).toBe(false);
+    expect(isOpenAIGpt54MiniModel({ provider: "openai", id: null })).toBe(false);
+    expect(isOpenAIGpt54MiniModel({ provider: "openai", id: 42 })).toBe(false);
+    expect(isOpenAIGpt54MiniModel({ provider: "openai", id: { name: "gpt-5.4-mini" } })).toBe(
+      false,
+    );
+    expect(isOpenAIGpt54MiniModel({ provider: "openai" })).toBe(false);
+  });
+
+  it("ignores other model fields (regex matches strictly on id)", () => {
+    expect(
+      isOpenAIGpt54MiniModel({
+        provider: "openai-codex",
+        id: "gpt-5",
+        api: "openai-completions",
+        baseUrl: "https://api.openai.com",
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Locks in the contract of `isOpenAIGpt54MiniModel` (exported but not directly unit-tested in #76727). Combined matrix exercises the lowercase + date-strip in `normalizeModelId` and the `/^gpt-5\.4-mini(?:-|$)/u` regex.

## Notes
- Test-only; no production change.
- Cases cover: dated aliases, non-date suffixes (preview, codex, pro), uppercase, whitespace, sibling families (`gpt-5.4`, `gpt-5.4-pro`, `gpt-5`), no-separator fakes (`gpt-5.4-mini2`), strip+regex independence (`gpt-5.4-pro-2026-05-01`), non-string ids (no throw), extra-fields isolation.

## Test plan
- `pnpm test -- src/agents/openai-reasoning-effort.test.ts` → 22/22 pass.

Happy to drop any rows you'd rather not lock in as part of the contract.

Refs #76727