### PR TITLE
docs: document Docker migration workflow and local overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,87 @@ openclaw onboard --install-daemon
 
 OpenClaw Onboard installs the Gateway daemon (launchd/systemd user service) so it stays running.
 
+## Docker setup (optional)
+
+Use Docker if you want a containerized gateway, are validating the Docker flow, or want to reuse an existing OpenClaw config/workspace on the same machine without keeping the host-managed gateway service.
+
+Full runbook: [Docker guide](https://docs.openclaw.ai/install/docker)
+
+### Quick setup
+
+Prerequisites:
+
+- Docker Desktop (or Docker Engine) with Docker Compose v2
+- Enough RAM/disk for the image build and logs
+
+From the repo root:
+
+```bash
+./scripts/docker/setup.sh
+```
+
+To use a published image instead of building locally:
+
+```bash
+export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest"
+./scripts/docker/setup.sh
+```
+
+The setup script runs onboarding, writes the gateway token to `.env`, and starts `openclaw-gateway` with Docker Compose. After startup, open `http://127.0.0.1:18789/` and use the configured shared secret from `.env`.
+
+### Reuse an existing host install
+
+If OpenClaw already runs as a host-managed gateway on the same machine, stop that service first so it does not reclaim the gateway port:
+
+```bash
+openclaw gateway stop
+openclaw gateway uninstall
+```
+
+Then point Docker at the existing config and workspace before running setup:
+
+```bash
+export OPENCLAW_CONFIG_DIR="$HOME/.openclaw"
+export OPENCLAW_WORKSPACE_DIR="$HOME/.openclaw/workspace"
+
+# Optional: preserve absolute-path workspace mounts from an existing config
+export OPENCLAW_EXTRA_MOUNTS="$HOME/.openclaw/workspace:$HOME/.openclaw/workspace"
+
+./scripts/docker/setup.sh
+```
+
+`OPENCLAW_EXTRA_MOUNTS` is the compatibility path for configs that already pin `agents.defaults.workspace` or another runtime path to an absolute host location.
+
+### Local Docker configuration files
+
+- `.env` stores local runtime environment variables such as `OPENCLAW_GATEWAY_TOKEN`
+- `docker-compose.extra.yml` is generated when setup needs extra bind mounts or a named home volume
+- Both files are local deployment artifacts and should not be committed
+
+If `docker-compose.extra.yml` exists, include it in future Compose commands:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.extra.yml up -d openclaw-gateway
+docker compose -f docker-compose.yml -f docker-compose.extra.yml logs -f openclaw-gateway
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm openclaw-cli gateway probe
+```
+
+### Common Docker environment variables
+
+- `OPENCLAW_CONFIG_DIR`: host directory mounted at `/home/node/.openclaw`
+- `OPENCLAW_WORKSPACE_DIR`: host directory mounted at `/home/node/.openclaw/workspace`
+- `OPENCLAW_IMAGE`: use a remote image instead of building locally
+- `OPENCLAW_EXTRA_MOUNTS`: extra bind mounts as `source:target[:opts]`
+
+For the full variable list, manual container flow, and VM/runtime persistence notes, see the [Docker guide](https://docs.openclaw.ai/install/docker).
+
+### Health checks
+
+```bash
+curl -fsS http://127.0.0.1:18789/healthz
+curl -fsS http://127.0.0.1:18789/readyz
+```
+
 ## Quick start (TL;DR)
 
 Runtime: **Node 24 (recommended) or Node 22.14+**.

--- a/docker-compose.extra.yml
+++ b/docker-compose.extra.yml
@@ -1,0 +1,14 @@
+services:
+  openclaw-gateway:
+    volumes:
+      - /Users/abdullah/.openclaw:/Users/abdullah/.openclaw
+  openclaw-cli:
+    environment:
+      OPENCLAW_GATEWAY_TOKEN: ""
+      OPENCLAW_STATE_DIR: /home/node/.openclaw-cli
+      OPENCLAW_CONFIG_PATH: /home/node/.openclaw/openclaw.json
+    volumes:
+      - /Users/abdullah/.openclaw:/Users/abdullah/.openclaw
+      - openclaw_cli_state:/home/node/.openclaw-cli
+volumes:
+  openclaw_cli_state:

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -23,6 +23,47 @@ Docker is **optional**. Use it only if you want a containerized gateway or to va
   [Security hardening for network exposure](/gateway/security),
   especially Docker `DOCKER-USER` firewall policy.
 
+## Migrating an existing host install
+
+If OpenClaw already runs as a host-managed gateway on the same machine, move it
+into Docker in this order:
+
+1. Stop and uninstall the host service so launchd/systemd/schtasks does not
+   reclaim the gateway port:
+
+   ```bash
+   openclaw gateway stop
+   openclaw gateway uninstall
+   ```
+
+2. Reuse the existing config and workspace directories by exporting
+   `OPENCLAW_CONFIG_DIR` and `OPENCLAW_WORKSPACE_DIR` before running
+   `./scripts/docker/setup.sh`.
+
+3. If your existing config pins `agents.defaults.workspace` or another runtime
+   path to an absolute host path outside `/home/node/.openclaw/workspace`, mount
+   that path into the container at the same location so the config keeps
+   working unchanged:
+
+   ```bash
+   export OPENCLAW_EXTRA_MOUNTS="/srv/openclaw/workspace:/srv/openclaw/workspace"
+   ./scripts/docker/setup.sh
+   ```
+
+   This compatibility mount is especially useful when moving a long-lived local
+   install into Docker without rewriting existing absolute-path workspace
+   settings.
+
+4. If you set `OPENCLAW_EXTRA_MOUNTS` or `OPENCLAW_HOME_VOLUME`, the setup
+   script writes `docker-compose.extra.yml`. Keep using the same compose file
+   set for later `up`, `logs`, `exec`, and `run` commands.
+
+<Note>
+The generated `.env` and `docker-compose.extra.yml` files are local deployment
+artifacts. They may contain secrets or machine-specific mount paths, so do not
+commit them.
+</Note>
+
 ## Containerized gateway
 
 <Steps>
@@ -39,6 +80,9 @@ Docker is **optional**. Use it only if you want a containerized gateway or to va
     export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest"
     ./scripts/docker/setup.sh
     ```
+
+    Using a published image is also the safer migration path when the checkout
+    on disk is older than the gateway version you are already running.
 
     Pre-built images are published at the
     [GitHub Container Registry](https://github.com/openclaw/openclaw/pkgs/container/openclaw).
@@ -124,6 +168,8 @@ The setup script accepts these optional environment variables:
 
 | Variable                                   | Purpose                                                         |
 | ------------------------------------------ | --------------------------------------------------------------- |
+| `OPENCLAW_CONFIG_DIR`                      | Reuse or override the host directory mounted at `/home/node/.openclaw` |
+| `OPENCLAW_WORKSPACE_DIR`                   | Reuse or override the host directory mounted at `/home/node/.openclaw/workspace` |
 | `OPENCLAW_IMAGE`                           | Use a remote image instead of building locally                  |
 | `OPENCLAW_DOCKER_APT_PACKAGES`             | Install extra apt packages during build (space-separated)       |
 | `OPENCLAW_EXTENSIONS`                      | Include selected bundled plugin helpers at build time           |
@@ -181,6 +227,19 @@ http://<gateway-host>:18789/api/diagnostics/prometheus
 The route is protected by Gateway authentication. Do not expose a separate
 public `/metrics` port or unauthenticated reverse-proxy path. See
 [Prometheus metrics](/gateway/prometheus).
+
+### Day-two Docker commands
+
+If the setup script generated `docker-compose.extra.yml`, include it in all
+later Compose commands:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.extra.yml up -d openclaw-gateway
+docker compose -f docker-compose.yml -f docker-compose.extra.yml logs -f openclaw-gateway
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm openclaw-cli gateway probe
+```
+
+Without the extra overlay, use plain `docker compose ...` from the repo root.
 
 ### Health checks
 


### PR DESCRIPTION
## Summary

- Problem: the repo root README did not summarize the Docker setup and migration flow, and this migrated setup also depended on a local Docker overlay for absolute-path compatibility.
- Why it matters: it makes the Docker migration path discoverable from the repo root and preserves a working migrated configuration on this branch.
- What changed: added a Docker setup section to `README.md`, expanded `docs/install/docker.md` with migration and day-two guidance, and committed `docker-compose.extra.yml` used by this migrated setup.
- What did NOT change (scope boundary): no OpenClaw runtime/source code paths were changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related #76843
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- Root `README.md` now includes Docker setup, migration, configuration, and health-check steps.
- `docs/install/docker.md` now documents migration of an existing host install into Docker and day-two Docker commands.
- This branch includes a committed `docker-compose.extra.yml` overlay with absolute-path compatibility mounts for the migrated local setup.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - The overlay exposes the same `~/.openclaw` host directory at an additional in-container absolute path for compatibility with an existing config that uses host-style paths.
  - Mitigation: no new host directory is added beyond the already-mounted OpenClaw state dir; this is a second mount target for the same path.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Docker Compose with `ghcr.io/openclaw/openclaw:latest`
- Model/provider: N/A
- Integration/channel (if any): local Dockerized OpenClaw gateway migration
- Relevant config (redacted): `agents.defaults.workspace` points to an absolute host path under `~/.openclaw/workspace`; overlay mounts `~/.openclaw` at both `/home/node/.openclaw` and `/Users/abdullah/.openclaw`

### Steps

1. Start from an existing local OpenClaw state directory and Dockerized gateway setup.
2. Use the documented Docker setup/migration flow from the repo root and install docs.
3. Start or restart the gateway through Docker Compose / LaunchAgent and verify the compatibility mount paths resolve cleanly.

### Expected

- Docker setup/migration instructions are discoverable from the root README.
- The migrated Docker gateway works with configs that still reference absolute host-style OpenClaw paths.

### Actual

- Verified as expected on this branch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Notes:
- Verified `docker compose ... config`, `gateway status --json`, `gateway probe`, and health endpoints.
- Verified LaunchAgent-based startup and a simulated restart path.
- Conversation: https://app.warp.dev/conversation/3715bd9b-2bd7-4f53-8981-7353e208c458

## Human Verification (required)

- Verified scenarios:
  - root README Docker section renders correctly
  - install docs include migration/day-two Docker steps
  - overlay-backed gateway startup succeeds
  - LaunchAgent restart simulation brings the gateway back healthy
- Edge cases checked:
  - absolute-path compatibility mount for `/Users/abdullah/.openclaw/agents`
  - dedicated CLI state still works with the overlay present
- What you did **not** verify:
  - a full cold macOS reboot sequence

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) Yes
- If yes, exact upgrade steps:
  - Follow the Docker migration instructions in `README.md` / `docs/install/docker.md`.
  - If the existing config references host-style absolute OpenClaw paths, include the compatibility overlay / extra mounts so those paths also exist inside the container.

## Risks and Mitigations

- Risk:
  - `docker-compose.extra.yml` is machine-specific and contains absolute local paths.
  - Mitigation:
    - this is called out explicitly in the PR so reviewers can decide whether to keep it on-branch, split it out, or drop it before merge.

Co-Authored-By: Oz <oz-agent@warp.dev>
