### PR TITLE
fix(model-fallback): skip cooldown for invalid_request format errors

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -840,7 +840,7 @@ export async function runEmbeddedPiAgent(
         modelId?: string;
       }) => {
         const { profileId, reason } = failure;
-        if (!profileId || !reason || reason === "timeout") {
+        if (!profileId || !reason || reason === "timeout" || reason === "format") {
           return;
         }
         await markAuthProfileFailure({

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
@@ -39,4 +39,18 @@ describe("resolveAuthProfileFailureReason", () => {
       }),
     ).toBeNull();
   });
+
+  it("does not persist format errors as auth-profile health (#76829)", () => {
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "format",
+      }),
+    ).toBeNull();
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "format",
+        policy: "shared",
+      }),
+    ).toBeNull();
+  });
 });

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
@@ -6,8 +6,16 @@ export function resolveAuthProfileFailureReason(params: {
   failoverReason: FailoverReason | null;
   policy?: AuthProfileFailurePolicy;
 }): AuthProfileFailureReason | null {
-  // Helper-local runs and transport timeouts should not poison shared provider auth health.
-  if (params.policy === "local" || !params.failoverReason || params.failoverReason === "timeout") {
+  // Helper-local runs, transport timeouts, and request-format errors should
+  // not poison shared provider auth health.  Format failures (e.g.
+  // invalid_request_error due to a corrupted transcript) are request-specific
+  // data issues, not indicators of provider unavailability.
+  if (
+    params.policy === "local" ||
+    !params.failoverReason ||
+    params.failoverReason === "timeout" ||
+    params.failoverReason === "format"
+  ) {
     return null;
   }
   return params.failoverReason;


### PR DESCRIPTION
Fixes #76829

## Root Cause

When a session transcript is corrupted (e.g. blank user message), Anthropic returns a 400 `invalid_request_error` with reason `format`. The model-fallback pipeline classifies this correctly as a `format` failure, but the auth-profile failure policy still records it as a provider-level cooldown. This causes the entire provider to enter cooldown, blocking unrelated sessions and `/new` commands.

## Fix

Skip `format` failures in `resolveAuthProfileFailureReason` (same as `timeout` is already skipped), since format errors are request-specific data issues — not indicators of provider unavailability or rate limiting. Also added the same guard in the `maybeMarkAuthProfileFailure` helper in `run.ts` for defense-in-depth.

As suggested in the issue: **don't cooldown on 400 format errors**.

## Changes

- `src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts`: Return `null` for `format` reason, preventing cooldown recording
- `src/agents/pi-embedded-runner/run.ts`: Add `format` to the early-return guard in `maybeMarkAuthProfileFailure`
- `src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts`: Added test asserting format failures do not produce auth-profile failure reasons