### PR TITLE
fix(anthropic): strip temperature for adaptive-thinking models (#76861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Anthropic: strip `temperature` from requests to adaptive-thinking Anthropic models (`claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`) so agents with explicit `params.temperature` no longer get a `FailoverError: temperature is deprecated for this model` on every turn. Fixes #76861. Thanks @hclsys.
 - Agents/models: forward model `maxTokens` as the default output-token limit for OpenAI-compatible Responses and Completions transports when no runtime override is provided, preventing provider defaults from silently truncating larger outputs. (#76645) Thanks @joeyfrasier.
 - Control UI/Skills: fix skill detail modal silently failing to open in all browsers by deferring `showModal()` until the dialog element is connected to the DOM; the Lit `ref` callback fired before connection causing a `DOMException: HTMLDialogElement.showModal: Dialog element is not connected` on every skill click. Thanks @nickmopen.
 - Gateway/update: run `doctor --non-interactive --fix` after Control UI global package updates before reporting success, so legacy config is migrated before the gateway restart. Thanks @stevenchouai.

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -902,4 +902,40 @@ describe("anthropic transport stream", () => {
       output_config: { effort: "xhigh" },
     });
   });
+
+  it("strips temperature for adaptive-thinking Anthropic models to avoid API rejection (#76861)", async () => {
+    for (const modelId of ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"] as const) {
+      const model = makeAnthropicTransportModel({
+        id: modelId,
+        reasoning: false,
+        maxTokens: 8192,
+      });
+
+      await runTransportStream(
+        model,
+        { messages: [{ role: "user", content: "Hello." }] } as AnthropicStreamContext,
+        { apiKey: "sk-ant-api", temperature: 0 } as AnthropicStreamOptions,
+      );
+
+      const payload = latestAnthropicRequest().payload;
+      expect(payload, `${modelId} must not receive temperature`).not.toHaveProperty("temperature");
+    }
+  });
+
+  it("forwards temperature for non-adaptive Anthropic models with thinking disabled", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-3-7-sonnet-20250219",
+      name: "Claude 3.7 Sonnet",
+      reasoning: false,
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      { messages: [{ role: "user", content: "Hello." }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api", temperature: 0.5 } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({ temperature: 0.5 });
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -765,7 +765,11 @@ function buildAnthropicParams(
       },
     ];
   }
-  if (options?.temperature !== undefined && !options.thinkingEnabled) {
+  if (
+    options?.temperature !== undefined &&
+    !options.thinkingEnabled &&
+    !supportsAdaptiveThinking(model.id)
+  ) {
     params.temperature = options.temperature;
   }
   if (context.tools) {


### PR DESCRIPTION
## Summary

Fixes #76861.

Anthropic's `claude-opus-4-7`, `claude-opus-4-6`, and `claude-sonnet-4-6` reject the `temperature` parameter with a `FailoverError: temperature is deprecated for this model` when an agent has explicit `params.temperature` set. The transport already skipped temperature when `thinkingEnabled` is true, but in non-thinking runs `thinkingEnabled` is explicitly `false` while sampling params are still rejected by the API.

**Root cause:** `buildAnthropicParams` in `anthropic-transport-stream.ts` only guarded temperature on `!thinkingEnabled`. But for adaptive-thinking models, even with `thinking: { type: "disabled" }`, the Anthropic API rejects `temperature`.

**Fix:** Gate temperature forwarding on `!supportsAdaptiveThinking(model.id)` (which already correctly identifies these model families). Non-adaptive models (e.g. `claude-3-7-sonnet`) are unaffected.

## Changes

- `src/agents/anthropic-transport-stream.ts`: Add `!supportsAdaptiveThinking(model.id)` to the temperature guard
- `src/agents/anthropic-transport-stream.test.ts`: Two regression tests — (1) adaptive models receive no `temperature` in payload, (2) non-adaptive models still receive `temperature`
- `CHANGELOG.md`: Unreleased fix entry

## Test plan

- [ ] `pnpm test src/agents/anthropic-transport-stream.test.ts` — 25 tests pass
- [ ] Agent with `params.temperature: 0` and `anthropic/claude-opus-4-7` should no longer fail with FailoverError

🤖 Generated with [Claude Code](https://claude.com/claude-code)