### PR TITLE
fix(heartbeat): default tool-loop detection ON for heartbeat runs

### DIFF
--- a/src/agents/pi-tools.heartbeat-loop-detection.test.ts
+++ b/src/agents/pi-tools.heartbeat-loop-detection.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveToolLoopDetectionConfig } from "./pi-tools.js";
+
+/**
+ * Heartbeat runs are the canonical \"unbounded loop\" failure surface for
+ * tool-calling models that emit pseudo-final tokens (`HEARTBEAT_OK`,
+ * `NO_REPLY`) in the same response as tool calls.  Issue #21597 documents a
+ * heartbeat-only session burning 47 million assistant tokens in one day
+ * because the agent kept calling tools instead of terminating.
+ *
+ * The existing {@link detectToolCallLoop} framework already handles this
+ * once enabled, but `tools.loopDetection.enabled` defaults to `false`, which
+ * means by default a heartbeat tick is unprotected.  These tests pin the
+ * heartbeat-trigger override behavior in {@link resolveToolLoopDetectionConfig}.
+ */
+describe("resolveToolLoopDetectionConfig (heartbeat trigger override)", () => {
+  it("returns undefined for a non-heartbeat run with no config (no change in behavior)", () => {
+    const result = resolveToolLoopDetectionConfig({});
+    expect(result).toBeUndefined();
+  });
+
+  it("enables loop detection for heartbeat runs when the user has not configured it", () => {
+    const result = resolveToolLoopDetectionConfig({ trigger: "heartbeat" });
+    expect(result).toBeDefined();
+    expect(result?.enabled).toBe(true);
+  });
+
+  it("uses default thresholds when heartbeat enables loop detection implicitly", () => {
+    const result = resolveToolLoopDetectionConfig({ trigger: "heartbeat" });
+    // The override only flips `enabled`; thresholds stay at the
+    // resolveLoopDetectionConfig defaults so behavior remains predictable.
+    expect(result).toEqual({ enabled: true });
+  });
+
+  it("respects an explicit user opt-out even on heartbeat runs", () => {
+    // If the user has gone out of their way to set loopDetection.enabled = false
+    // we honor that — heartbeat should not silently override an explicit choice.
+    const cfg: OpenClawConfig = {
+      tools: { loopDetection: { enabled: false } },
+    } as OpenClawConfig;
+    const result = resolveToolLoopDetectionConfig({ cfg, trigger: "heartbeat" });
+    expect(result?.enabled).toBe(false);
+  });
+
+  it("respects an explicit user opt-in and preserves their thresholds", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        loopDetection: {
+          enabled: true,
+          warningThreshold: 5,
+          criticalThreshold: 12,
+        },
+      },
+    } as OpenClawConfig;
+    const result = resolveToolLoopDetectionConfig({ cfg, trigger: "heartbeat" });
+    expect(result).toEqual({
+      enabled: true,
+      warningThreshold: 5,
+      criticalThreshold: 12,
+    });
+  });
+
+  it("does not enable loop detection for non-heartbeat triggers", () => {
+    // Cron / user / memory triggers keep the existing opt-in behavior — we
+    // only relax the default for the heartbeat path because that is the
+    // documented failure mode in #21597.
+    for (const trigger of ["user", "cron", "memory", "manual", undefined]) {
+      const result = resolveToolLoopDetectionConfig({ trigger });
+      expect(result?.enabled, `trigger=${trigger ?? "undefined"}`).toBeUndefined();
+    }
+  });
+
+  it("merges agent-scoped config with global config before applying the heartbeat default", () => {
+    // Ensures the heartbeat override does not bypass the existing agent/global
+    // merge.  The override only inspects `enabled` after the merge.
+    const cfg: OpenClawConfig = {
+      tools: {
+        loopDetection: {
+          historySize: 50,
+          detectors: { genericRepeat: true, knownPollNoProgress: false, pingPong: true },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "amber",
+            tools: {
+              loopDetection: {
+                warningThreshold: 7,
+                detectors: { knownPollNoProgress: true },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveToolLoopDetectionConfig({
+      cfg,
+      agentId: "amber",
+      trigger: "heartbeat",
+    });
+
+    // Heartbeat default flipped enabled to true...
+    expect(result?.enabled).toBe(true);
+    // ...without dropping the merged user values.
+    expect(result?.historySize).toBe(50);
+    expect(result?.warningThreshold).toBe(7);
+    expect(result?.detectors).toEqual({
+      genericRepeat: true,
+      knownPollNoProgress: true,
+      pingPong: true,
+    });
+  });
+});

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -233,6 +233,14 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
 export function resolveToolLoopDetectionConfig(params: {
   cfg?: OpenClawConfig;
   agentId?: string;
+  /**
+   * What initiated this run. Heartbeat runs default loop detection ON
+   * unless the user has explicitly opted out (see {@link applyHeartbeatLoopDetectionDefault}).
+   * Without this, a heartbeat that emits the same `HEARTBEAT_OK`-shaped
+   * tool-call response on every turn keeps cycling until context overflow,
+   * burning tens of thousands of tokens per tick (see issue #21597).
+   */
+  trigger?: string;
 }): ToolLoopDetectionConfig | undefined {
   const global = params.cfg?.tools?.loopDetection;
   const agent =
@@ -240,6 +248,14 @@ export function resolveToolLoopDetectionConfig(params: {
       ? resolveAgentConfig(params.cfg, params.agentId)?.tools?.loopDetection
       : undefined;
 
+  const merged = mergeLoopDetectionConfigs(global, agent);
+  return applyHeartbeatLoopDetectionDefault(merged, params.trigger);
+}
+
+function mergeLoopDetectionConfigs(
+  global: ToolLoopDetectionConfig | undefined,
+  agent: ToolLoopDetectionConfig | undefined,
+): ToolLoopDetectionConfig | undefined {
   if (!agent) {
     return global;
   }
@@ -255,6 +271,29 @@ export function resolveToolLoopDetectionConfig(params: {
       ...agent.detectors,
     },
   };
+}
+
+/**
+ * Heartbeat runs are the canonical "unbounded loop" failure surface (issue
+ * #21597): the model emits an effectively-final response (e.g. `HEARTBEAT_OK`)
+ * along with tool calls, the runtime treats the tool calls as the real signal
+ * and re-prompts, the model imitates its own previous turn, and the cycle
+ * continues until context overflow.  The {@link detectToolCallLoop} framework
+ * already handles this once enabled, so for heartbeat triggers we flip the
+ * default from off to on.  Any explicit `enabled` value (true or false) wins;
+ * this only fills in the unset case.
+ */
+function applyHeartbeatLoopDetectionDefault(
+  config: ToolLoopDetectionConfig | undefined,
+  trigger: string | undefined,
+): ToolLoopDetectionConfig | undefined {
+  if (trigger !== "heartbeat") {
+    return config;
+  }
+  if (config?.enabled !== undefined) {
+    return config;
+  }
+  return { ...(config ?? {}), enabled: true };
 }
 
 export const __testing = {
@@ -828,7 +867,11 @@ export function createOpenClawCodingTools(options?: {
       sessionId: options?.sessionId,
       runId: options?.runId,
       ...(options?.trace ? { trace: options.trace } : {}),
-      loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
+      loopDetection: resolveToolLoopDetectionConfig({
+        cfg: options?.config,
+        agentId,
+        trigger: options?.trigger,
+      }),
     }),
   );
   options?.recordToolPrepStage?.("tool-hooks");

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -293,7 +293,7 @@ function applyHeartbeatLoopDetectionDefault(
   if (config?.enabled !== undefined) {
     return config;
   }
-  return { ...(config ?? {}), enabled: true };
+  return { ...config, enabled: true };
 }
 
 export const __testing = {


### PR DESCRIPTION
## Summary

Heartbeat runs are the documented "unbounded loop" failure surface for tool-calling models. Issue #21597 documents a heartbeat-only session burning **47,659,109 assistant tokens in one day** because the agent kept emitting tool calls instead of terminating.

The detection framework already exists in `detectToolCallLoop`, with sensible thresholds (warn=10, critical=20, circuit-breaker=30) and multiple detectors (`genericRepeat`, `knownPollNoProgress`, `pingPong`). The blocker is the default: `tools.loopDetection.enabled` defaults to `false`, so heartbeats are unprotected unless the user has explicitly opted in. Most users haven't.

This PR flips the default for heartbeat runs only. The agent runner already passes `options.trigger="heartbeat"` through `pi-tools`; `resolveToolLoopDetectionConfig` now inspects that trigger and returns `{ enabled: true }` when the user hasn't set an explicit value.

## What I observed in the wild

Local Qwen 27B (vLLM, openai-completions) heartbeat tick on a 4.4 MB / 3300-message session:

```
17:32:14 USER  | [OpenClaw heartbeat poll]
17:32:44 ASST  | text="No changes. All clear.\n\nHEARTBEAT_OK\n\n"
                 + toolCall: gog gmail messages search "is:unread"
                 + toolCall: gog gmail messages search "from:ask.edu.kw"
                 + toolCall: gog cal events --from today --to tomorrow
17:32:46 TRES  | (3 empty results)
17:33:16 ASST  | text="No changes. All clear.\n\nHEARTBEAT_OK\n\n"
                 + (same 3 toolCalls)
17:33:18 TRES  | ...
[repeats for 14 minutes, 22 turns, until context overflow]
```

The model emits a pseudo-final `HEARTBEAT_OK` text block alongside three tool calls in the same response, the runtime takes the tool calls as the live signal, the model imitates its own previous turn from history, and the cycle continues. With loop detection enabled this is exactly what the existing `genericRepeat` detector catches (same tool + same params, no progress in result), so the framework already does the right thing — it just isn't on.

## Surface area

- Optional new `trigger` parameter on `resolveToolLoopDetectionConfig`.
- Threads `options.trigger` from `createOpenClawCodingTools` to the resolver (the field already exists on the options bag and is documented as "What initiated this run").
- Splits the existing global + agent merge into a small helper so the heartbeat-default override is a separate, testable step (`applyHeartbeatLoopDetectionDefault`).

```diff
 export function resolveToolLoopDetectionConfig(params: {
   cfg?: OpenClawConfig;
   agentId?: string;
+  trigger?: string;
 }): ToolLoopDetectionConfig | undefined {
-  const global = params.cfg?.tools?.loopDetection;
-  const agent = ...;
-  if (!agent) return global;
-  if (!global) return agent;
-  return { ...global, ...agent, detectors: { ...global.detectors, ...agent.detectors } };
+  const merged = mergeLoopDetectionConfigs(global, agent);
+  return applyHeartbeatLoopDetectionDefault(merged, params.trigger);
 }
```

## Compatibility

- **No public-API change.** The new `trigger` parameter is optional. Existing two-argument call shape (`{ cfg, agentId }`) still works and produces identical results.
- **Non-heartbeat triggers are unaffected.** `user`, `cron`, `memory`, `manual`, and `undefined` all keep the existing opt-in behavior.
- **Explicit user choices win.** If `tools.loopDetection.enabled` is set to `true` *or* `false` (in global or agent config), that value is honored. The override only fills in the unset case.
- **Default thresholds unchanged.** When the heartbeat default kicks in, it returns `{ enabled: true }` only — `historySize`, `warningThreshold`, `criticalThreshold`, `globalCircuitBreakerThreshold`, and `detectors` are still resolved by the existing `resolveLoopDetectionConfig` defaults.
- **Existing 40 `tool-loop-detection` tests still pass.**

## Tests

7 new tests in `src/agents/pi-tools.heartbeat-loop-detection.test.ts`:

- `returns undefined for a non-heartbeat run with no config (no change in behavior)`
- `enables loop detection for heartbeat runs when the user has not configured it`
- `uses default thresholds when heartbeat enables loop detection implicitly`
- `respects an explicit user opt-out even on heartbeat runs`
- `respects an explicit user opt-in and preserves their thresholds`
- `does not enable loop detection for non-heartbeat triggers` (user, cron, memory, manual, undefined)
- `merges agent-scoped config with global config before applying the heartbeat default`

```
src/agents/pi-tools.heartbeat-loop-detection.test.ts (7 tests) ✓
src/agents/tool-loop-detection.test.ts                (40 tests) ✓
Test Files  2 passed (2)
     Tests  47 passed (47)
```

## Files touched

| File | Change |
|---|---|
| `src/agents/pi-tools.ts` | +44/-1: thread `trigger` through resolver, add `applyHeartbeatLoopDetectionDefault` |
| `src/agents/pi-tools.heartbeat-loop-detection.test.ts` | New file. 7 tests covering the override behavior. |

## Refs

- Closes the immediate exposure described in #21597.
- Does not implement the broader `disableTools: true` heartbeat hard-guard or per-run token ceiling that the issue also proposed — those remain reasonable follow-ups but are larger surfaces. This PR is the minimal correct change: turn on the loop detection that already exists, where it matters most.
