### PR TITLE
fix(ui): clear stale hasActiveRun on terminal chat event to fix stuck Stop button (#76874)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/WebChat: clear the stale `hasActiveRun` session row flag when a terminal chat event fires so the Stop button returns to Send without a page refresh. Fixes #76874. Thanks @hclsys.
 - Config/messages: coerce boolean `messages.visibleReplies` and `messages.groupChat.visibleReplies` values to the documented enum modes so an intuitive toggle no longer invalidates config and drops channel startup. Fixes #75390. Thanks @scottgl9.
 - Feishu: accept and honor `channels.feishu.blockStreaming` at the top level and per account, while keeping the legacy default off so Feishu cards no longer reject documented config or silently drop block replies. Fixes #75555. Thanks @vincentkoc.
 - Google Chat: normalize custom Google auth transport headers before google-auth/gaxios interceptors run, restoring webhook token verification when certificate retrieval expects Fetch `Headers`. Fixes #76742. Thanks @donbowman.

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1158,6 +1158,37 @@ describe("connectGateway", () => {
 
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
   });
+
+  it("clears stale hasActiveRun on the session row when a terminal chat event fires (#76874)", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "run-stop-stale";
+    // Simulate a session row that has hasActiveRun: true from a prior sessions.list refresh.
+    (host as unknown as Record<string, unknown>).sessionsResult = {
+      ts: 0,
+      count: 1,
+      sessions: [{ key: "main", hasActiveRun: true, kind: "agent", updatedAt: null }],
+    };
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "run-stop-stale",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+        },
+      },
+    });
+
+    expect(host.chatRunId).toBeNull();
+    const sessionsResult = (host as unknown as Record<string, unknown>).sessionsResult as {
+      sessions: Array<{ key: string; hasActiveRun?: boolean }>;
+    };
+    const row = sessionsResult?.sessions.find((s) => s.key === "main");
+    expect(row?.hasActiveRun).toBe(false);
+  });
 });
 
 describe("resolveControlUiClientVersion", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -578,6 +578,15 @@ function handleTerminalChatEvent(
     host as unknown as Parameters<typeof clearPendingQueueItemsForRun>[0],
     payload?.runId,
   );
+  // Clear stale hasActiveRun on the session row so the Stop button returns to
+  // Send without waiting for a sessions.changed event that may omit the field.
+  const sessionKeyForRun = payload?.sessionKey?.trim() ?? host.sessionKey;
+  if (sessionKeyForRun) {
+    applySessionsChangedEvent(host as unknown as SessionsState, {
+      key: sessionKeyForRun,
+      hasActiveRun: false,
+    });
+  }
   const runId = payload?.runId;
   if (runId && host.refreshSessionsAfterChat.has(runId)) {
     host.refreshSessionsAfterChat.delete(runId);


### PR DESCRIPTION
## Problem

The Control UI Stop button sometimes remains active after the assistant reply has completed, requiring a page refresh to reset. Closes #76874.

## Root cause

`hasAbortableSessionRun` returns `true` when either `chatRunId` is set **or** the current session row in `sessionsResult` has `hasActiveRun === true`. Terminal chat events correctly clear `chatRunId`, but `sessions.changed` chat lifecycle payloads omit `hasActiveRun`, so `applySessionsChangedEvent` preserves the stale `true` value — keeping the Stop button visible indefinitely.

## Fix

In `handleTerminalChatEvent`, after confirming the event is terminal and matches the active run, call `applySessionsChangedEvent` with `{ key: sessionKey, hasActiveRun: false }` to clear the flag in-memory immediately — before any subsequent sessions reload.

```diff
+  const sessionKeyForRun = payload?.sessionKey?.trim() ?? host.sessionKey;
+  if (sessionKeyForRun) {
+    applySessionsChangedEvent(host as unknown as SessionsState, {
+      key: sessionKeyForRun,
+      hasActiveRun: false,
+    });
+  }
```

## Tests

Regression test in `app-gateway.node.test.ts`: host starts with `sessionsResult.sessions[0].hasActiveRun: true` and a matching `chatRunId`; after a terminal `chat` event, asserts `hasActiveRun` is `false`. 46/46 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)