### PR TITLE
fix: hide heartbeat tool prompts from chat history

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -4,7 +4,11 @@ import {
   isHeartbeatOkResponse,
   isHeartbeatUserMessage,
 } from "./heartbeat-filter.js";
-import { HEARTBEAT_PROMPT, HEARTBEAT_TRANSCRIPT_PROMPT } from "./heartbeat.js";
+import {
+  HEARTBEAT_PROMPT,
+  HEARTBEAT_RESPONSE_TOOL_PROMPT,
+  HEARTBEAT_TRANSCRIPT_PROMPT,
+} from "./heartbeat.js";
 
 describe("isHeartbeatUserMessage", () => {
   it("matches heartbeat prompts", () => {
@@ -23,6 +27,13 @@ describe("isHeartbeatUserMessage", () => {
         role: "user",
         content:
           "Run the following periodic tasks (only those due based on their intervals):\n\n- email-check: Check for urgent unread emails\n\nAfter completing all due tasks, reply HEARTBEAT_OK.",
+      }),
+    ).toBe(true);
+
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content: HEARTBEAT_RESPONSE_TOOL_PROMPT,
       }),
     ).toBe(true);
 

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -1,5 +1,9 @@
-import { stripHeartbeatToken } from "./heartbeat.js";
-import { HEARTBEAT_TRANSCRIPT_PROMPT } from "./heartbeat.js";
+import {
+  HEARTBEAT_PROMPT,
+  HEARTBEAT_RESPONSE_TOOL_PROMPT,
+  HEARTBEAT_TRANSCRIPT_PROMPT,
+  stripHeartbeatToken,
+} from "./heartbeat.js";
 
 const HEARTBEAT_TASK_PROMPT_PREFIX =
   "Run the following periodic tasks (only those due based on their intervals):";
@@ -46,11 +50,13 @@ export function isHeartbeatUserMessage(
   if (!trimmed) {
     return false;
   }
-  const normalizedHeartbeatPrompt = heartbeatPrompt?.trim();
+  const knownHeartbeatPrompts = [heartbeatPrompt, HEARTBEAT_PROMPT, HEARTBEAT_RESPONSE_TOOL_PROMPT]
+    .map((prompt) => prompt?.trim())
+    .filter((prompt): prompt is string => Boolean(prompt));
   if (trimmed === HEARTBEAT_TRANSCRIPT_PROMPT) {
     return true;
   }
-  if (normalizedHeartbeatPrompt && trimmed.startsWith(normalizedHeartbeatPrompt)) {
+  if (knownHeartbeatPrompts.some((prompt) => trimmed.startsWith(prompt))) {
     return true;
   }
   return (

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -462,6 +462,88 @@ function toProjectedMessages(messages: unknown[]): Array<Record<string, unknown>
   );
 }
 
+function projectedHistoryDedupeKey(message: Record<string, unknown>): string | null {
+  const role = typeof message.role === "string" ? message.role.trim().toLowerCase() : "";
+  if (!role) {
+    return null;
+  }
+
+  const textSignature =
+    typeof message.textSignature === "string" && message.textSignature.trim()
+      ? message.textSignature.trim()
+      : null;
+  if (role === "assistant" && textSignature) {
+    return `${role}:signature:${textSignature}`;
+  }
+
+  const responseId =
+    typeof message.responseId === "string" && message.responseId.trim()
+      ? message.responseId.trim()
+      : null;
+  if (role === "assistant" && responseId) {
+    return `${role}:response:${responseId}`;
+  }
+
+  const timestamp =
+    typeof message.timestamp === "number" && Number.isFinite(message.timestamp)
+      ? message.timestamp
+      : null;
+  if (timestamp === null) {
+    return null;
+  }
+
+  const roleContent = asRoleContentMessage(message);
+  const text = roleContent ? extractMessageTextForDisplayDedupe(roleContent.content).trim() : "";
+  if (!text) {
+    return null;
+  }
+  return `${role}:ts:${timestamp}:text:${text}`;
+}
+
+function extractMessageTextForDisplayDedupe(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((block) => {
+      if (!block || typeof block !== "object") {
+        return "";
+      }
+      const entry = block as { type?: unknown; text?: unknown };
+      return entry.type === "text" && typeof entry.text === "string" ? entry.text : "";
+    })
+    .join("");
+}
+
+function dedupeAdjacentProjectedHistoryMessages(messages: Array<Record<string, unknown>>): {
+  messages: Array<Record<string, unknown>>;
+  changed: boolean;
+} {
+  if (messages.length < 2) {
+    return { messages, changed: false };
+  }
+  let changed = false;
+  const deduped: Array<Record<string, unknown>> = [];
+  for (const message of messages) {
+    const key = projectedHistoryDedupeKey(message);
+    const previous = deduped[deduped.length - 1];
+    const previousKey = previous ? projectedHistoryDedupeKey(previous) : null;
+    if (key && previousKey === key) {
+      // Keep the newer/right-most transcript copy. Control UI duplicates can
+      // differ only by internal sender metadata; the later copy displays as
+      // the local user instead of the synthetic openclaw-control-ui sender.
+      deduped[deduped.length - 1] = message;
+      changed = true;
+      continue;
+    }
+    deduped.push(message);
+  }
+  return { messages: deduped, changed };
+}
+
 function filterVisibleProjectedHistoryMessages(
   messages: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
@@ -494,7 +576,9 @@ function filterVisibleProjectedHistoryMessages(
     }
     visible.push(current);
   }
-  return changed ? visible : messages;
+  const deduped = dedupeAdjacentProjectedHistoryMessages(visible);
+  changed ||= deduped.changed;
+  return changed ? deduped.messages : messages;
 }
 
 export function projectChatDisplayMessages(

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_PROMPT, HEARTBEAT_RESPONSE_TOOL_PROMPT } from "../../auto-reply/heartbeat.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
 import {
@@ -458,6 +459,45 @@ describe("sanitizeChatHistoryMessages", () => {
 });
 
 describe("projectRecentChatDisplayMessages", () => {
+  it("hides heartbeat user prompts from display history", () => {
+    const result = projectRecentChatDisplayMessages([
+      { role: "user", content: HEARTBEAT_PROMPT, timestamp: 1 },
+      { role: "user", content: HEARTBEAT_RESPONSE_TOOL_PROMPT, timestamp: 2 },
+      { role: "user", content: "real user message", timestamp: 3 },
+    ]);
+
+    expect(result).toEqual([{ role: "user", content: "real user message", timestamp: 3 }]);
+  });
+
+  it("dedupes adjacent duplicate display messages while keeping the local user copy", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "user",
+        content: "same ask",
+        timestamp: 10,
+        senderLabel: "openclaw-control-ui",
+      },
+      { role: "user", content: "same ask", timestamp: 10 },
+      {
+        role: "assistant",
+        content: "same answer",
+        timestamp: 11,
+        textSignature: "sig-1",
+      },
+      {
+        role: "assistant",
+        content: "same answer",
+        timestamp: 11,
+        textSignature: "sig-1",
+      },
+    ]);
+
+    expect(result).toEqual([
+      { role: "user", content: "same ask", timestamp: 10 },
+      { role: "assistant", content: "same answer", timestamp: 11, textSignature: "sig-1" },
+    ]);
+  });
+
   it("applies history limits after dropping display-hidden messages", () => {
     const result = projectRecentChatDisplayMessages(
       [

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -367,8 +367,9 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
 
   const timestamp = typeof m.timestamp === "number" ? m.timestamp : Date.now();
   const id = typeof m.id === "string" ? m.id : undefined;
-  const senderLabel =
+  const rawSenderLabel =
     typeof m.senderLabel === "string" && m.senderLabel.trim() ? m.senderLabel.trim() : null;
+  const senderLabel = rawSenderLabel === "openclaw-control-ui" ? null : rawSenderLabel;
 
   // Strip AI-injected metadata prefix blocks from user messages before display.
   if (role === "user" || role === "User") {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -171,7 +171,7 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Hello");
   });
 
-  it("ignores NO_REPLY delta updates", () => {
+  it.each(["NO_REPLY", "HEARTBEAT_OK"])("ignores %s delta updates", (text) => {
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
@@ -181,7 +181,7 @@ describe("handleChatEvent", () => {
       runId: "run-1",
       sessionKey: "main",
       state: "delta",
-      message: { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+      message: { role: "assistant", content: [{ type: "text", text }] },
     };
 
     expect(handleChatEvent(state, payload)).toBe("delta");
@@ -212,16 +212,19 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages[0]).toEqual(payload.message);
   });
 
-  it("drops NO_REPLY final payload from another run without clearing active stream", () => {
-    const state = createActiveStreamingState();
-    const payload = createOtherRunNoReplyFinalPayload();
+  it.each(["NO_REPLY", "HEARTBEAT_OK"])(
+    "drops %s final payload from another run without clearing active stream",
+    (text) => {
+      const state = createActiveStreamingState();
+      const payload = createOtherRunSilentFinalPayload(text);
 
-    expect(handleChatEvent(state, payload)).toBe("final");
-    expect(state.chatRunId).toBe("run-user");
-    expect(state.chatStream).toBe("Working...");
-    expect(state.chatStreamStartedAt).toBe(123);
-    expect(state.chatMessages).toEqual([]);
-  });
+      expect(handleChatEvent(state, payload)).toBe("final");
+      expect(state.chatRunId).toBe("run-user");
+      expect(state.chatStream).toBe("Working...");
+      expect(state.chatStreamStartedAt).toBe(123);
+      expect(state.chatMessages).toEqual([]);
+    },
+  );
 
   it.each(["no_reply", "ANNOUNCE_SKIP", "REPLY_SKIP"])(
     "keeps plain-text %s final payload from another run without clearing active stream",
@@ -559,11 +562,11 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Working...");
   });
 
-  it("drops NO_REPLY final payload from own run", () => {
+  it.each(["NO_REPLY", "HEARTBEAT_OK"])("drops %s final payload from own run", (text) => {
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
-      chatStream: "NO_REPLY",
+      chatStream: text,
       chatStreamStartedAt: 100,
     });
     const payload: ChatEventPayload = {
@@ -572,7 +575,7 @@ describe("handleChatEvent", () => {
       state: "final",
       message: {
         role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
+        content: [{ type: "text", text }],
       },
     };
 
@@ -608,22 +611,25 @@ describe("handleChatEvent", () => {
     },
   );
 
-  it("does not persist NO_REPLY stream text on final without message", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "NO_REPLY",
-      chatStreamStartedAt: 100,
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "final",
-    };
+  it.each(["NO_REPLY", "HEARTBEAT_OK"])(
+    "does not persist %s stream text on final without message",
+    (text) => {
+      const state = createState({
+        sessionKey: "main",
+        chatRunId: "run-1",
+        chatStream: text,
+        chatStreamStartedAt: 100,
+      });
+      const payload: ChatEventPayload = {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "final",
+      };
 
-    expect(handleChatEvent(state, payload)).toBe("final");
-    expect(state.chatMessages).toEqual([]);
-  });
+      expect(handleChatEvent(state, payload)).toBe("final");
+      expect(state.chatMessages).toEqual([]);
+    },
+  );
 
   it("does not persist NO_REPLY stream text on abort", () => {
     const state = createState({
@@ -1062,10 +1068,28 @@ describe("loadChatHistory", () => {
     expect(state.lastError).toBeNull();
   });
 
-  it("filters heartbeat acknowledgements and internal-only user messages", async () => {
+  it("filters heartbeat acknowledgements, heartbeat prompts, and internal-only user messages", async () => {
     const request = vi.fn().mockResolvedValue({
       messages: [
         { role: "assistant", content: [{ type: "text", text: "HEARTBEAT_OK" }] },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "An async command completion event was triggered, but user delivery is disabled for this run. Handle the result internally and reply HEARTBEAT_OK only.",
+            },
+          ],
+        },
         {
           role: "user",
           content: [

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -16,6 +16,12 @@ import {
 
 const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+const HEARTBEAT_USER_PROMPT_PREFIXES = [
+  "Read HEARTBEAT.md if it exists (workspace context).",
+  "Run the following periodic tasks (only those due based on their intervals):",
+  "An async command completion event was triggered, but user delivery is disabled for this run.",
+  "[OpenClaw heartbeat poll]",
+] as const;
 const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
@@ -45,6 +51,10 @@ function shouldApplyChatHistoryResult(
 
 function isSilentReplyStream(text: string): boolean {
   return SILENT_REPLY_PATTERN.test(text);
+}
+
+function isSuppressedAssistantDisplayText(text: string): boolean {
+  return isSilentReplyStream(text) || stripHeartbeatTokenForDisplay(text).shouldSkip;
 }
 
 function escapeRegExp(value: string): string {
@@ -195,7 +205,7 @@ function isTextOnlyContent(content: unknown): boolean {
   return sawText;
 }
 
-function isEmptyUserTextOnlyMessage(message: unknown): boolean {
+function isUserTextOnlyMessage(message: unknown): boolean {
   if (!message || typeof message !== "object") {
     return false;
   }
@@ -203,10 +213,25 @@ function isEmptyUserTextOnlyMessage(message: unknown): boolean {
   if (normalizeLowercaseStringOrEmpty(entry.role) !== "user") {
     return false;
   }
-  if (!isTextOnlyContent(entry.content ?? entry.text)) {
+  return isTextOnlyContent(entry.content ?? entry.text);
+}
+
+function isEmptyUserTextOnlyMessage(message: unknown): boolean {
+  if (!isUserTextOnlyMessage(message)) {
     return false;
   }
   return (extractText(message)?.trim() ?? "") === "";
+}
+
+function isHeartbeatUserPromptMessage(message: unknown): boolean {
+  if (!isUserTextOnlyMessage(message)) {
+    return false;
+  }
+  const text = extractText(message)?.trim() ?? "";
+  if (!text) {
+    return false;
+  }
+  return HEARTBEAT_USER_PROMPT_PREFIXES.some((prefix) => text.startsWith(prefix));
 }
 
 function isAssistantHeartbeatAck(message: unknown): boolean {
@@ -226,6 +251,7 @@ function shouldHideHistoryMessage(message: unknown): boolean {
   return (
     isAssistantSilentReply(message) ||
     isAssistantHeartbeatAck(message) ||
+    isHeartbeatUserPromptMessage(message) ||
     isSyntheticTranscriptRepairToolResult(message) ||
     isEmptyUserTextOnlyMessage(message)
   );
@@ -738,7 +764,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (state.chatRunId && payload.runId !== state.chatRunId) {
     if (payload.state === "final") {
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
-      if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+      if (finalMessage && !shouldHideHistoryMessage(finalMessage)) {
         state.chatMessages = [...state.chatMessages, finalMessage];
         return null;
       }
@@ -749,14 +775,14 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
 
   if (payload.state === "delta") {
     const next = extractText(payload.message);
-    if (typeof next === "string" && !isSilentReplyStream(next)) {
+    if (typeof next === "string" && !isSuppressedAssistantDisplayText(next)) {
       state.chatStream = next;
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
-    if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+    if (finalMessage && !shouldHideHistoryMessage(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
+    } else if (state.chatStream?.trim() && !isSuppressedAssistantDisplayText(state.chatStream)) {
       state.chatMessages = [
         ...state.chatMessages,
         {
@@ -771,11 +797,11 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatStreamStartedAt = null;
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-    if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
+    if (normalizedMessage && !shouldHideHistoryMessage(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
       const streamedText = state.chatStream ?? "";
-      if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
+      if (streamedText.trim() && !isSuppressedAssistantDisplayText(streamedText)) {
         state.chatMessages = [
           ...state.chatMessages,
           {


### PR DESCRIPTION
Fixes #58287.

## Summary
- Treat the default heartbeat prompt and heartbeat response-tool prompt as internal heartbeat user messages in the shared heartbeat filter.
- Keep those prompts out of projected chat display history.
- Add Control UI defense-in-depth so live rendered chat also hides heartbeat user prompts, async internal completion prompts, HEARTBEAT_OK deltas/finals, and HEARTBEAT_OK stream fallback text.
- Deduplicate adjacent duplicate transcript entries with the same timestamp/text or assistant signature/response id, which prevents duplicated Control UI user/assistant bubbles when the same event is recorded twice.
- Normalize the synthetic `openclaw-control-ui` sender label out of user-message display so local Control UI messages render as `You`.
- Add regression coverage for gateway projection and the actual UI controller/rendering paths.

## Tests
- `corepack pnpm exec vitest run ui/src/ui/controllers/chat.test.ts ui/src/ui/chat/message-normalizer.test.ts src/auto-reply/heartbeat-filter.test.ts src/gateway/server-methods/server-methods.test.ts`