### PR TITLE
fix(media): skip fsync on EPERM to allow .docx uploads on Windows (#76844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Media/store: skip fsync after writing temporary media files when the OS raises EPERM, letting `.docx` and other office files upload on Windows without a crash. Fixes #76844. Thanks @hclsys.
 - Gateway/usage: serve `usage.cost` and `sessions.usage` from a durable transcript aggregate cache with lock-safe background refreshes and localized stale-cache status, so large usage views avoid repeated full scans. (#76650) Thanks @Marvinthebored.
 - Plugins/hooks: let `plugins.entries.<id>.hooks.timeoutMs` and `plugins.entries.<id>.hooks.timeouts` bound plugin typed hooks from operator config, so slow hooks can be tuned without patching installed plugin code. Fixes #76778. Thanks @vincentkoc.
 - Telegram: add `channels.telegram.mediaGroupFlushMs` at the top level and per account so operators can tune album buffering instead of being stuck with the hard-coded 500ms media-group flush window. Fixes #76149. Thanks @vincentkoc.

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -342,6 +342,28 @@ describe("media store", () => {
       },
     },
     {
+      name: "saves buffer when fsync raises EPERM (Windows behavior) (#76844)",
+      run: async () => {
+        await withTempStore(async (store) => {
+          const originalOpen = fs.open.bind(fs);
+          vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+            const handle = await originalOpen(...(args as Parameters<typeof fs.open>));
+            const eperm = new Error("operation not permitted") as NodeJS.ErrnoException;
+            eperm.code = "EPERM";
+            vi.spyOn(handle, "sync").mockRejectedValue(eperm);
+            return handle;
+          });
+          const saved = await store.saveMediaBuffer(
+            Buffer.from("docx-content"),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "inbound",
+          );
+          const stat = await fs.stat(saved.path);
+          expect(stat.isFile()).toBe(true);
+        });
+      },
+    },
+    {
       name: "rejects traversal media subdirs before saving buffers",
       run: async () => {
         await withTempStore(async (store, home) => {

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -345,9 +345,9 @@ describe("media store", () => {
       name: "saves buffer when fsync raises EPERM (Windows behavior) (#76844)",
       run: async () => {
         await withTempStore(async (store) => {
-          const originalOpen = fs.open.bind(fs);
+          const originalOpen = fs.open.bind(fs) as typeof fs.open;
           vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-            const handle = await originalOpen(...(args as Parameters<typeof fs.open>));
+            const handle = await originalOpen(...args);
             const eperm = new Error("operation not permitted") as NodeJS.ErrnoException;
             eperm.code = "EPERM";
             vi.spyOn(handle, "sync").mockRejectedValue(eperm);

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -364,6 +364,28 @@ describe("media store", () => {
       },
     },
     {
+      name: "saves buffer when fsync raises EACCES (Windows restricted handle) (#76844)",
+      run: async () => {
+        await withTempStore(async (store) => {
+          const originalOpen = fs.open.bind(fs) as typeof fs.open;
+          vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+            const handle = await originalOpen(...args);
+            const eacces = new Error("permission denied") as NodeJS.ErrnoException;
+            eacces.code = "EACCES";
+            vi.spyOn(handle, "sync").mockRejectedValue(eacces);
+            return handle;
+          });
+          const saved = await store.saveMediaBuffer(
+            Buffer.from("pdf-content"),
+            "application/pdf",
+            "inbound",
+          );
+          const stat = await fs.stat(saved.path);
+          expect(stat.isFile()).toBe(true);
+        });
+      },
+    },
+    {
       name: "rejects traversal media subdirs before saving buffers",
       run: async () => {
         await withTempStore(async (store, home) => {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -352,8 +352,8 @@ async function writeSavedMediaBuffer(params: {
       const handle = await fs.open(tempDest, "r");
       try {
         await handle.sync().catch((err: NodeJS.ErrnoException) => {
-          // Windows raises EPERM for fsync on certain file descriptors; treat as best-effort.
-          if (err.code !== "EPERM") {
+          // Windows raises EPERM or EACCES for fsync on certain file descriptors; treat as best-effort.
+          if (err.code !== "EPERM" && err.code !== "EACCES") {
             throw err;
           }
         });

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -353,7 +353,9 @@ async function writeSavedMediaBuffer(params: {
       try {
         await handle.sync().catch((err: NodeJS.ErrnoException) => {
           // Windows raises EPERM for fsync on certain file descriptors; treat as best-effort.
-          if (err.code !== "EPERM") throw err;
+          if (err.code !== "EPERM") {
+            throw err;
+          }
         });
       } finally {
         await handle.close();

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -351,7 +351,10 @@ async function writeSavedMediaBuffer(params: {
       await fs.writeFile(tempDest, params.buffer, { mode: MEDIA_FILE_MODE });
       const handle = await fs.open(tempDest, "r");
       try {
-        await handle.sync();
+        await handle.sync().catch((err: NodeJS.ErrnoException) => {
+          // Windows raises EPERM for fsync on certain file descriptors; treat as best-effort.
+          if (err.code !== "EPERM") throw err;
+        });
       } finally {
         await handle.close();
       }


### PR DESCRIPTION
## Problem

Uploading `.docx` (and other Office Open XML) files via WebChat on Windows fails with:

```
Failed to save intercepted media to disk: EPERM: operation not permitted, fsync
```

Windows raises `EPERM` from `fsync` for certain file descriptors. The media buffer write path opens the temp file read-only after writing (`fs.open(tempDest, "r")`) and then calls `handle.sync()`. That call fails with `EPERM` for files detected as `application/zip` (`.docx`, `.xlsx`, `.pptx`) on Windows 10/11 + Node ≥ 20, throwing a `MediaOffloadError` before the rename to the final destination.

Fixes #76844.

## Root cause

`src/media/store.ts` — `writeSavedMediaBuffer`:

```typescript
const handle = await fs.open(tempDest, "r");
try {
  await handle.sync();  // ← throws EPERM on Windows for .docx
} finally {
  await handle.close();
}
```

The write is already complete before `sync()` is called, so skipping the flush on EPERM does not lose data. Other error codes (`ENOSPC`, `EIO`, …) continue to propagate.

## Fix

Catch `EPERM` from `handle.sync()` and treat it as best-effort, matching the pattern already used by `trySyncDirectory` in `src/infra/json-file.ts`.

```typescript
await handle.sync().catch((err: NodeJS.ErrnoException) => {
  // Windows raises EPERM for fsync on certain file descriptors; treat as best-effort.
  if (err.code !== "EPERM") throw err;
});
```

## Test

New regression test mocks `fs.open` so `handle.sync()` rejects with `EPERM` and verifies the file is saved successfully. 35/35 `src/media/store.test.ts` pass.

## PRE-IMPLEMENT AUDIT

1. **Existing-helper check**: `trySyncDirectory` in `json-file.ts` is directory-sync only (not file handles); no reuse possible. Used same pattern.
2. **Shared-helper caller check**: `writeSavedMediaBuffer` is private to `store.ts`, called at 2 internal sites; no contract change.
3. **Rival scan**: No open PR touches `src/media/store.ts` for this EPERM issue.