### PR TITLE
fix(sessions): bump sessions_list gateway timeout to 60s

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -306,6 +306,7 @@ describe("sessions tools", () => {
     });
     expect(callGatewayMock).toHaveBeenNthCalledWith(1, {
       method: "sessions.list",
+      timeoutMs: 60_000,
       params: {
         activeMinutes: undefined,
         agentId: "main",

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -162,6 +162,25 @@ describe("sessions-list-tool", () => {
     });
   });
 
+  it("passes an explicit gateway timeout to sessions.list (default-10s would 500 on large stores)", async () => {
+    let observedOpts: { method?: string; timeoutMs?: number } | undefined;
+    mocks.gatewayCall.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; timeoutMs?: number };
+      if (request.method === "sessions.list") {
+        observedOpts = request;
+        return { path: "/tmp/sessions.json", sessions: [] };
+      }
+      return {};
+    });
+    const tool = createSessionsListTool({ config: {} as never });
+
+    await tool.execute("call-timeout", {});
+
+    expect(observedOpts?.method).toBe("sessions.list");
+    expect(typeof observedOpts?.timeoutMs).toBe("number");
+    expect((observedOpts?.timeoutMs ?? 0) >= 30_000).toBe(true);
+  });
+
   it("keeps live session setting metadata in sessions_list results", async () => {
     mocks.gatewayCall.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string };

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -118,8 +118,18 @@ export function createSessionsListTool(opts?: {
       const a2aPolicy = createAgentToAgentPolicy(cfg);
       const hydrateTranscriptFieldsAfterFiltering = includeDerivedTitles || includeLastMessage;
 
+      // sessions.list does sync transcript I/O for derived titles and
+      // last-message previews on top of per-row model/cost normalization;
+      // the default 10s gatewayCall budget is too tight on stores with
+      // hundreds of sessions (see #76421, #76931). Other tool callers
+      // (sessions-send, nodes, message, cron, gateway) already pass
+      // explicit timeoutMs for the same class of work; match that pattern
+      // here so /tools/invoke does not 500 with `tool execution failed:
+      // GatewayTransportError: gateway timeout after 10000ms` while the
+      // broader row-enrichment perf work proceeds.
       const list = await gatewayCall<{ sessions: Array<SessionListRow>; path: string }>({
         method: "sessions.list",
+        timeoutMs: 60_000,
         params: {
           limit,
           activeMinutes,


### PR DESCRIPTION
## Summary

Bump the `sessions_list` tool's underlying `gatewayCall` timeout from the 10 s default to 60 s, so HTTP `/tools/invoke` callers stop seeing `tool execution failed: GatewayTransportError: gateway timeout after 10000ms` on hosts with a few hundred sessions.

The bug surfaces today as a 500 from `POST /tools/invoke` with body `{"tool":"sessions_list"}`. The same `sessions.list` server method completes fine over WebSocket (~16-21 s reported in #76931, ~19 s observed locally). The wall time is dominated by per-row enrichment in `listSessionsFromStoreAsync` and `buildGatewaySessionRow`, so the call-site needs more headroom than the 10 s default in `resolveGatewayCallTimeout`.

This is a defensive band-aid on the call site while the broader row-enrichment perf work in #76931 (and the event-loop-stall class in #76421) proceeds. It does not change the server method, the tool schema, or any narrower-scope callers (`sessions-announce-target`, `plugin-sdk/session-visibility`, the per-session `chat.history` calls inside `sessions-list-tool`).

## What bug / behavior

- Endpoint: `POST /tools/invoke` body `{"tool":"sessions_list","arguments":{}}`
- Symptom: `HTTP 500 ok:false error:{type:tool_error, message:"tool execution failed"}` after ~10 s
- Server log line: `tools-invoke: tool execution failed: GatewayTransportError: gateway timeout after 10000ms`
- Refs: #76421, #76931

## Why this is the fix

- `src/gateway/call.ts` `resolveGatewayCallTimeout` defaults to `1e4` (10 s) when no `timeoutMs` is passed. `sessions-list-tool.ts` was relying on that default. Sibling tools that drive comparably bounded gateway work already pass explicit `timeoutMs`:
  - `sessions-send-tool.a2a.ts` (announce / cleanup)
  - `nodes-tool-commands.ts` (location / invoke)
  - `message-tool.ts`, `cron-tool.ts`, `gateway-tool.ts` (tool schema exposes `timeoutMs`)
- This brings `sessions_list` in line with that pattern.
- 60 s leaves ~3 × headroom over the 16-21 s wall times reported in #76931, which means real timeouts still surface (rather than masking a server hang for minutes).
- It does not address the underlying per-row work — that is the maintainer-tracked work in #76931. This is a complementary defensive change so the symptom stops showing up to operators while that work lands.

## Verification

Local, scoped:

```text
pnpm test src/agents/tools/sessions-list-tool.test.ts
  Tests  4 passed (4)         (1 new assertion locking in timeoutMs >= 30s)

pnpm test src/agents/openclaw-tools.sessions.test.ts src/agents/tools/sessions.test.ts src/agents/tools/sessions-list-tool.test.ts
  Tests  49 passed (49)        (existing exact-match assertion updated to expect timeoutMs: 60_000)

pnpm test src/agents/openclaw-tools.session-status.test.ts
  Tests  46 passed (46)        (different caller, unaffected — uses spawnedBy filter, not changed here)

pnpm test src/agents/tools/sessions-send-tool.a2a.test.ts src/commands/sessions.default-agent-store.test.ts
  Tests  11 passed (11)

pnpm exec oxfmt --check src/agents/tools/sessions-list-tool.ts src/agents/tools/sessions-list-tool.test.ts src/agents/openclaw-tools.sessions.test.ts
  All matched files use the correct format.
```

Manual reproduction of the original symptom on `2026.5.2 (8b2a6e5)` against a `main` agent with 311 done sessions: 3/3 `POST /tools/invoke` probes returned `HTTP 500` in ~10.5 s before the change. Pruning 119 cold sessions (sessions.json 5.2 MB → 3.2 MB) on its own did **not** drop the wall time below 10 s — confirming OP's "per-row enrichment dominates" finding.

I do not have OpenClaw maintainer-tier Testbox access, so the broader `pnpm check` / `pnpm test` sweeps were not run from here. I would defer to maintainers for the full gate.

## Test plan
- [x] Targeted test files green locally (`pnpm test ...`)
- [x] Formatter (`oxfmt`) clean on the touched files
- [ ] Maintainer Testbox `pnpm check:changed`
- [ ] Maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
