### PR TITLE
fix(telegram): allow callback acknowledgement text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: add optional `channels.telegram.callbackAck.text`/`showAlert` so inline keyboard clicks can show immediate Telegram feedback instead of only clearing the spinner. Fixes #76622.
 - Google Meet: refresh realtime browser state during status and retry delayed speech after Meet finishes joining, so a just-opened in-call tab no longer leaves speech stuck behind stale `not-in-call` health.
 - Google Meet: grant Meet media permissions through the Playwright browser context when CDP grants do not affect the attached Chrome page, and report in-call microphone/speaker permission problems instead of marking realtime speech ready.
 - Google Chat: update the setup example to use the accepted `groups.<space>.enabled` key instead of the legacy `allow` alias, with a schema regression for the documented group shape. Thanks @vincentkoc.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -429,6 +429,23 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 }
 ```
 
+    Optional immediate click acknowledgement:
+
+```json5
+{
+  channels: {
+    telegram: {
+      callbackAck: {
+        text: "Got it", // shown as a Telegram toast after inline button clicks
+        showAlert: false, // true shows a modal alert instead
+      },
+    },
+  },
+}
+```
+
+    Leave `callbackAck.text` unset or empty to preserve the default behavior: clear Telegram's loading spinner without showing a toast.
+
     Scopes:
 
     - `off`

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -156,6 +156,18 @@ export const registerTelegramHandlers = ({
   const mediaGroupBuffer = new Map<string, MediaGroupEntry>();
   let mediaGroupProcessing: Promise<void> = Promise.resolve();
 
+  const buildCallbackAckPayload = () => {
+    const ack = telegramCfg.callbackAck;
+    const text = typeof ack?.text === "string" ? ack.text.trim() : "";
+    if (!text) {
+      return undefined;
+    }
+    return {
+      text,
+      ...(ack?.showAlert === true ? { show_alert: true } : {}),
+    };
+  };
+
   type TextFragmentEntry = {
     key: string;
     messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
@@ -1219,10 +1231,17 @@ export const registerTelegramHandlers = ({
     if (shouldSkipUpdate(ctx)) {
       return;
     }
+    const callbackAckPayload = buildCallbackAckPayload();
     const answerCallbackQuery =
       typeof (ctx as { answerCallbackQuery?: unknown }).answerCallbackQuery === "function"
-        ? () => ctx.answerCallbackQuery()
-        : () => bot.api.answerCallbackQuery(callback.id);
+        ? () =>
+            callbackAckPayload
+              ? ctx.answerCallbackQuery(callbackAckPayload)
+              : ctx.answerCallbackQuery()
+        : () =>
+            callbackAckPayload
+              ? bot.api.answerCallbackQuery(callback.id, callbackAckPayload)
+              : bot.api.answerCallbackQuery(callback.id);
     // Answer immediately to prevent Telegram from retrying while we process
     await withTelegramApiErrorLogging({
       operation: "answerCallbackQuery",

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -655,6 +655,45 @@ describe("createTelegramBot", () => {
     expect(payload.Body).toContain("cmd:option_a");
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-1");
   });
+
+  it("passes configured callback acknowledgement text to Telegram inline button clicks", async () => {
+    loadConfig.mockReturnValue({
+      commands: { text: false, native: true },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          callbackAck: { text: "Got it", showAlert: true },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-ack-1",
+        data: "cmd:option_a",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-ack-1", {
+      text: "Got it",
+      show_alert: true,
+    });
+  });
+
   it("preserves native command source for prefixed callback_query payloads", async () => {
     loadConfig.mockReturnValue({
       commands: { text: false, native: true },

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -62,6 +62,13 @@ export type TelegramInlineButtonsScope = "off" | "dm" | "group" | "all" | "allow
 export type TelegramStreamingMode = "off" | "partial" | "block" | "progress";
 export type TelegramExecApprovalTarget = "dm" | "channel" | "both";
 
+export type TelegramCallbackAckConfig = {
+  /** Optional toast text shown immediately after inline button clicks. Omit/empty = clear spinner only. */
+  text?: string;
+  /** Show the acknowledgement as a modal alert instead of a toast. Default: false. */
+  showAlert?: boolean;
+};
+
 export type TelegramExecApprovalConfig = {
   /** Enable mode for Telegram exec approvals on this account. Default: auto when approvers can be resolved; false disables. */
   enabled?: import("./types.approvals.js").NativeExecApprovalEnableMode;
@@ -156,6 +163,8 @@ export type TelegramAccountConfig = {
   mediaGroupFlushMs?: number;
   /** Telegram polling watchdog threshold in milliseconds. Default: 120000. */
   pollingStallThresholdMs?: number;
+  /** Optional visible acknowledgement for inline keyboard callback clicks. */
+  callbackAck?: TelegramCallbackAckConfig;
   /** Retry policy for outbound Telegram API calls. */
   retry?: OutboundRetryConfig;
   /** Network transport overrides for Telegram. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -271,6 +271,16 @@ export const TelegramAccountSchemaBase = z
         "Buffer window in milliseconds for Telegram media groups/albums before dispatching them as one inbound message. Default: 500.",
       ),
     pollingStallThresholdMs: z.number().int().min(30_000).max(600_000).optional(),
+    callbackAck: z
+      .object({
+        text: z.string().max(200).optional(),
+        showAlert: z.boolean().optional(),
+      })
+      .strict()
+      .optional()
+      .describe(
+        "Optional visible acknowledgement for inline keyboard callback clicks. text is shown as an immediate Telegram toast; showAlert displays it as a modal alert.",
+      ),
     retry: RetryConfigSchema,
     network: z
       .object({


### PR DESCRIPTION
## Summary

- Add optional `channels.telegram.callbackAck` config for Telegram inline keyboard callbacks
- Pass configured ack text immediately to `answerCallbackQuery` as a Telegram toast, with optional `showAlert`
- Document the new config and add regression coverage for callback ack payloads

Fixes #76622.

## Reproduction

On current main, Telegram callback handling acknowledges inline button clicks with only the callback id / no options payload, so Telegram clears the spinner but shows no toast:

- `extensions/telegram/src/bot-handlers.runtime.ts` called `ctx.answerCallbackQuery()` or `bot.api.answerCallbackQuery(callback.id)`
- existing tests asserted only `answerCallbackQuerySpy("cbq-1")`

## Validation

- `pnpm install --frozen-lockfile` (restored missing local deps after fresh pull)
- `pnpm vitest run extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.create-telegram-bot.test.ts src/config/types.telegram.ts src/config/zod-schema.providers-core.ts docs/channels/telegram.md CHANGELOG.md`
- `pnpm check:changed`
