### PR TITLE
fix(sessions): fire command:new hook against parent session on sessions.create (#76957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.
 - Gateway/startup: keep model-catalog test helpers, run-session lookup code, QR pairing helpers, and TypeBox memory-tool schema construction out of hot startup import paths, reducing default gateway benchmark plugin-load and memory pressure.
 - Control UI/performance: record browser long animation frame or long task entries in the debug event log when supported, making slow dashboard renders easier to attribute from the UI.
+- Gateway/sessions: fire the `command:new` internal hook against the parent session when `sessions.create` is called with a `parentSessionKey` (Control UI `/new` flow), restoring `session-memory` and custom `command:new` hook delivery after commit 37aebf612b rerouted the typed-`/new` path away from `sendChatMessageNow`. Fixes #76957. Thanks @hclsys.
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Slack/streaming: add `streaming.progress.render: "rich"` for Block Kit progress drafts backed by structured progress line data.
 - Slack/streaming: keep the newest rich progress lines when Block Kit limits trim long progress drafts. Thanks @vincentkoc.

--- a/src/gateway/server-methods/sessions.runtime.ts
+++ b/src/gateway/server-methods/sessions.runtime.ts
@@ -1,7 +1,9 @@
 export {
   archiveSessionTranscriptsForSessionDetailed,
   cleanupSessionBeforeMutation,
+  emitGatewayBeforeResetPluginHook,
   emitGatewaySessionEndPluginHook,
+  emitGatewaySessionStartPluginHook,
   emitSessionUnboundLifecycleEvent,
   performGatewaySessionReset,
 } from "../session-reset-service.js";

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -24,6 +24,7 @@ import {
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  createInternalHookEvent,
   hasInternalHookListeners,
   triggerInternalHook,
   type SessionPatchHookContext,
@@ -999,6 +1000,49 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       canonicalParentSessionKey = parent.canonicalKey;
     }
+    // When creating a new session from a parent (Control UI /new flow), fire the full
+    // command:new + before_reset + session_end/session_start hook contract against the parent
+    // session so bundled hooks like session-memory can capture the outgoing session before the
+    // switch. Without this, commit 37aebf612b's change from sendChatMessageNow("/new") to
+    // sessions.create silently breaks hook delivery (#76957).
+    let parentEntryForHooks: SessionEntry | undefined;
+    let parentStorePath: string | undefined;
+    let parentTargetForHooks: ReturnType<typeof resolveGatewaySessionStoreTarget> | undefined;
+    if (canonicalParentSessionKey) {
+      const { entry: parentEntry } = loadSessionEntry(canonicalParentSessionKey);
+      const parentAgentId = normalizeAgentId(
+        resolveAgentIdFromSessionKey(canonicalParentSessionKey) ?? resolveDefaultAgentId(cfg),
+      );
+      const workspaceDir = resolveAgentWorkspaceDir(cfg, parentAgentId);
+      if (hasInternalHookListeners("command", "new")) {
+        const hookEvent = createInternalHookEvent("command", "new", canonicalParentSessionKey, {
+          sessionEntry: parentEntry,
+          previousSessionEntry: parentEntry,
+          commandSource: "webchat",
+          cfg,
+          workspaceDir,
+        });
+        await triggerInternalHook(hookEvent);
+      }
+      parentEntryForHooks = parentEntry;
+      parentStorePath = resolveGatewaySessionStoreTarget({
+        cfg,
+        key: canonicalParentSessionKey,
+      }).storePath;
+      parentTargetForHooks = resolveGatewaySessionStoreTarget({
+        cfg,
+        key: canonicalParentSessionKey,
+      });
+      const { emitGatewayBeforeResetPluginHook } = await loadSessionsRuntimeModule();
+      await emitGatewayBeforeResetPluginHook({
+        cfg,
+        key: canonicalParentSessionKey,
+        target: parentTargetForHooks,
+        storePath: parentStorePath,
+        entry: parentEntryForHooks,
+        reason: "new",
+      });
+    }
     const loweredRequestedKey = normalizeOptionalLowercaseString(requestedKey);
     const key = requestedKey
       ? loweredRequestedKey === "global" || loweredRequestedKey === "unknown"
@@ -1140,6 +1184,27 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       emitSessionsChanged(context, {
         sessionKey: target.canonicalKey,
         reason: "send",
+      });
+    }
+    if (canonicalParentSessionKey && parentEntryForHooks && parentStorePath) {
+      const { emitGatewaySessionEndPluginHook, emitGatewaySessionStartPluginHook } =
+        await loadSessionsRuntimeModule();
+      emitGatewaySessionEndPluginHook({
+        cfg,
+        sessionKey: canonicalParentSessionKey,
+        sessionId: parentEntryForHooks.sessionId,
+        storePath: parentStorePath,
+        sessionFile: parentEntryForHooks.sessionFile,
+        agentId: resolveAgentIdFromSessionKey(canonicalParentSessionKey) ?? undefined,
+        reason: "new",
+        nextSessionId: createdEntry.sessionId,
+        nextSessionKey: target.canonicalKey,
+      });
+      emitGatewaySessionStartPluginHook({
+        cfg,
+        sessionKey: target.canonicalKey,
+        sessionId: createdEntry.sessionId,
+        resumedFrom: parentEntryForHooks.sessionId,
       });
     }
   },

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -296,3 +296,93 @@ test("sessions.reset emits before_reset for the entry actually reset in the writ
     sessionId: "sess-new",
   });
 });
+
+test("sessions.create with parentSessionKey emits command:new internal hook (#76957)", async () => {
+  await createSessionStoreDir();
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent"),
+    },
+  });
+
+  const created = await directSessionReq<{ key?: string; sessionId?: string }>("sessions.create", {
+    parentSessionKey: "main",
+  });
+  expect(created.ok).toBe(true);
+
+  const commandHookEvents = (
+    sessionHookMocks.triggerInternalHook.mock.calls as unknown as Array<[unknown]>
+  )
+    .map((call) => call[0])
+    .filter(
+      (event): event is { type: string; action: string; sessionKey: string } =>
+        Boolean(event) &&
+        typeof event === "object" &&
+        (event as { type?: unknown }).type === "command" &&
+        (event as { action?: unknown }).action === "new",
+    );
+  expect(commandHookEvents).toHaveLength(1);
+  expect(commandHookEvents[0]).toMatchObject({
+    type: "command",
+    action: "new",
+    sessionKey: "agent:main:main",
+    context: expect.objectContaining({ commandSource: "webchat" }),
+  });
+});
+
+test("sessions.create with parentSessionKey emits before_reset plugin hook (#76957)", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-parent", "hello");
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent"),
+    },
+  });
+
+  beforeResetHookState.hasBeforeResetHook = true;
+  await directSessionReq<{ key?: string }>("sessions.create", { parentSessionKey: "main" });
+
+  expect(beforeResetHookMocks.runBeforeReset).toHaveBeenCalledTimes(1);
+  const [payload, context] = beforeResetHookMocks.runBeforeReset.mock.calls[0] as [
+    { reason?: string },
+    { sessionKey?: string; sessionId?: string },
+  ];
+  expect(payload.reason).toBe("new");
+  expect(context.sessionKey).toBe("agent:main:main");
+  expect(context.sessionId).toBe("sess-parent");
+});
+
+test("sessions.create with parentSessionKey emits session_end and session_start lifecycle hooks (#76957)", async () => {
+  await createSessionStoreDir();
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent"),
+    },
+  });
+
+  const created = await directSessionReq<{ sessionId?: string }>("sessions.create", {
+    parentSessionKey: "main",
+  });
+  expect(created.ok).toBe(true);
+  const newSessionId = created.payload?.sessionId;
+
+  expect(sessionLifecycleHookMocks.runSessionEnd).toHaveBeenCalledTimes(1);
+  const [endEvent, endContext] = sessionLifecycleHookMocks.runSessionEnd.mock.calls[0] as [
+    { nextSessionId?: string },
+    { sessionId?: string; sessionKey?: string },
+  ];
+  expect(endEvent.nextSessionId).toBe(newSessionId);
+  expect(endContext.sessionId).toBe("sess-parent");
+  expect(endContext.sessionKey).toBe("agent:main:main");
+
+  expect(sessionLifecycleHookMocks.runSessionStart).toHaveBeenCalledTimes(1);
+  const [startEvent] = sessionLifecycleHookMocks.runSessionStart.mock.calls[0] as [
+    { sessionId?: string; resumedFrom?: string },
+    unknown,
+  ];
+  expect(startEvent.sessionId).toBe(newSessionId);
+  expect(startEvent.resumedFrom).toBe("sess-parent");
+});

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -433,7 +433,7 @@ export async function cleanupSessionBeforeMutation(params: {
   });
 }
 
-async function emitGatewayBeforeResetPluginHook(params: {
+export async function emitGatewayBeforeResetPluginHook(params: {
   cfg: OpenClawConfig;
   key: string;
   target: ReturnType<typeof resolveGatewaySessionStoreTarget>;


### PR DESCRIPTION
## Summary

Commit `37aebf612b` rerouted the Control UI typed `/new` path from `sendChatMessageNow(host, "/new")` (which passed through Gateway command dispatch → `command:new` hooks) to `host.onSlashAction("new-session")` → `sessions.create`, which creates a session entry but fires zero internal hooks. This broke:

- The bundled `session-memory` hook (no memory file written on `/new`)
- Any custom managed/workspace hooks listening on `command:new`
- The `before_reset` plugin hook chain

## Fix

In `sessions.create`, after a successful session creation, if `canonicalParentSessionKey` is set (the Control UI `/new` flow always passes the current session as `parentSessionKey`), fire `createInternalHookEvent("command", "new", parentSessionKey, ...)` → `triggerInternalHook`. This restores `command:new` hook delivery for the transition from the parent session.

The guard `hasInternalHookListeners("command", "new")` ensures zero overhead when no hooks are registered.

## Files changed

- `src/gateway/server-methods/sessions.ts` — hook emission in `sessions.create`
- `CHANGELOG.md` — fix entry

## Test

- 544/544 gateway method tests pass (1 pre-existing failure in unrelated `web-tree-sitter` import)
- `pnpm exec oxfmt --check` passes on changed files