### PR TITLE
fix(macos): match text-only voice wake deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS Voice Wake: match appended text-only interim transcripts without word timings so the wake trigger can start Talk Mode before final recognition arrives. Fixes #76662. Thanks @Fuma2013.
 - Web fetch: late-bind `web_fetch` config and provider fallback metadata from the active runtime snapshot, matching `web_search` so long-lived tools do not use stale fetch provider settings. Thanks @vincentkoc.
 - Plugins/discovery: demote the source-only TypeScript runtime check on already-installed `origin: "global"` plugin packages from a config-blocking error to a warning and let the runtime fall through to the TypeScript source via jiti, so a single broken installed package no longer blocks `plugins install` for unrelated plugins; install-time rejection of newly-installed source-only packages is unchanged. Thanks @romneyda.
 - Providers/OpenAI Codex: stop the OAuth progress spinner before showing the manual redirect paste prompt, so callback timeouts do not spam `Browser callback did not finish` across terminals.

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRecognitionDebugSupport.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRecognitionDebugSupport.swift
@@ -65,6 +65,60 @@ enum VoiceWakeRecognitionDebugSupport {
             trigger: VoiceWakeTextUtils.matchedTriggerWord(transcript: transcript, triggers: triggers))
     }
 
+    static func appendedTextOnlyFallbackMatch(
+        transcript: String,
+        previousTranscript: String?,
+        triggers: [String],
+        config: WakeWordGateConfig,
+        allowTriggerOnly: Bool,
+        trimWake: (String, [String]) -> String) -> WakeWordGateMatch?
+    {
+        guard let appended = self.appendedTranscriptDelta(
+            transcript: transcript,
+            previousTranscript: previousTranscript)
+        else { return nil }
+
+        if let match = self.textOnlyFallbackMatch(
+            transcript: appended,
+            triggers: triggers,
+            config: config,
+            trimWake: trimWake)
+        {
+            return match
+        }
+
+        guard allowTriggerOnly else { return nil }
+        return self.triggerOnlyFallbackMatch(
+            transcript: appended,
+            triggers: triggers,
+            trimWake: trimWake)
+    }
+
+    private static func appendedTranscriptDelta(
+        transcript: String,
+        previousTranscript: String?) -> String?
+    {
+        guard !transcript.isEmpty else { return nil }
+        guard let previousTranscript, !previousTranscript.isEmpty else { return transcript }
+        guard transcript.hasPrefix(previousTranscript) else { return nil }
+
+        let rawDelta = transcript.dropFirst(previousTranscript.count)
+        guard !rawDelta.isEmpty else { return nil }
+        guard self.hasBoundaryBetween(prefix: previousTranscript, suffix: rawDelta) else { return nil }
+
+        let delta = rawDelta.trimmingCharacters(in: .whitespacesAndNewlines)
+        return delta.isEmpty ? nil : String(delta)
+    }
+
+    private static func hasBoundaryBetween(prefix: String, suffix: Substring) -> Bool {
+        guard let before = prefix.unicodeScalars.last, let after = suffix.unicodeScalars.first else { return true }
+        return !self.isASCIIWordScalar(before) || !self.isASCIIWordScalar(after)
+    }
+
+    private static func isASCIIWordScalar(_ scalar: UnicodeScalar) -> Bool {
+        scalar.isASCII && CharacterSet.alphanumerics.contains(scalar)
+    }
+
     static func transcriptSummary(
         transcript: String,
         triggers: [String],

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -290,6 +290,7 @@ actor VoiceWakeRuntime {
         guard let transcript = update.transcript else { return }
 
         let now = Date()
+        let previousTranscript = self.isCapturing ? nil : self.lastTranscript
         if !transcript.isEmpty {
             self.lastHeard = now
             if !self.isCapturing {
@@ -347,6 +348,16 @@ actor VoiceWakeRuntime {
                 transcript: transcript,
                 triggers: config.triggers,
                 config: gateConfig,
+                trimWake: Self.trimmedAfterTrigger)
+            usedFallback = match != nil
+        }
+        if match == nil, !update.isFinal, Self.hasNoUsableTiming(update.segments) {
+            match = VoiceWakeRecognitionDebugSupport.appendedTextOnlyFallbackMatch(
+                transcript: transcript,
+                previousTranscript: previousTranscript,
+                triggers: config.triggers,
+                config: gateConfig,
+                allowTriggerOnly: config.triggersTalkMode,
                 trimWake: Self.trimmedAfterTrigger)
             usedFallback = match != nil
         }
@@ -795,6 +806,10 @@ actor VoiceWakeRuntime {
         return text
     }
 
+    private static func hasNoUsableTiming(_ segments: [WakeWordSegment]) -> Bool {
+        segments.allSatisfy { $0.start <= 0 && $0.duration <= 0 }
+    }
+
     private static func commandAfterTrigger(
         transcript: String,
         segments: [WakeWordSegment],
@@ -826,6 +841,25 @@ actor VoiceWakeRuntime {
 
     static func _testMatchedTriggerWord(_ text: String, triggers: [String]) -> String? {
         self.matchedTriggerWordText(transcript: text, triggers: triggers)
+    }
+
+    static func _testAppendedTextOnlyFallbackMatch(
+        transcript: String,
+        previousTranscript: String?,
+        triggers: [String],
+        allowTriggerOnly: Bool = false) -> WakeWordGateMatch?
+    {
+        VoiceWakeRecognitionDebugSupport.appendedTextOnlyFallbackMatch(
+            transcript: transcript,
+            previousTranscript: previousTranscript,
+            triggers: triggers,
+            config: WakeWordGateConfig(triggers: triggers),
+            allowTriggerOnly: allowTriggerOnly,
+            trimWake: self.trimmedAfterTrigger)
+    }
+
+    static func _testHasNoUsableTiming(_ segments: [WakeWordSegment]) -> Bool {
+        self.hasNoUsableTiming(segments)
     }
 
     static func _testAttributedColor(isFinal: Bool) -> NSColor {

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeRuntimeTests.swift
@@ -110,6 +110,59 @@ struct VoiceWakeRuntimeTests {
         #expect(match == nil)
     }
 
+    @Test func `appended text only fallback matches interim trigger command without timings`() {
+        let match = VoiceWakeRuntime._testAppendedTextOnlyFallbackMatch(
+            transcript: "ambient speech nero turn on talk mode",
+            previousTranscript: "ambient speech",
+            triggers: ["nero"])
+        #expect(match?.trigger == "nero")
+        #expect(match?.command == "turn on talk mode")
+    }
+
+    @Test func `appended text only fallback can activate trigger only talk mode`() {
+        let match = VoiceWakeRuntime._testAppendedTextOnlyFallbackMatch(
+            transcript: "ambient speech nero",
+            previousTranscript: "ambient speech",
+            triggers: ["nero"],
+            allowTriggerOnly: true)
+        #expect(match?.trigger == "nero")
+        #expect(match?.command == "")
+    }
+
+    @Test func `appended text only fallback leaves trigger only disabled outside talk mode`() {
+        let match = VoiceWakeRuntime._testAppendedTextOnlyFallbackMatch(
+            transcript: "ambient speech nero",
+            previousTranscript: "ambient speech",
+            triggers: ["nero"],
+            allowTriggerOnly: false)
+        #expect(match == nil)
+    }
+
+    @Test func `appended text only fallback rejects larger word suffix matches`() {
+        let match = VoiceWakeRuntime._testAppendedTextOnlyFallbackMatch(
+            transcript: "ambient computers",
+            previousTranscript: "ambient ",
+            triggers: ["computer"],
+            allowTriggerOnly: true)
+        #expect(match == nil)
+    }
+
+    @Test func `appended text only fallback requires boundary from previous text`() {
+        let match = VoiceWakeRuntime._testAppendedTextOnlyFallbackMatch(
+            transcript: "somecomputer",
+            previousTranscript: "some",
+            triggers: ["computer"],
+            allowTriggerOnly: true)
+        #expect(match == nil)
+    }
+
+    @Test func `no usable timing requires all segments to lack start and duration`() {
+        let zeroSegments = [WakeWordSegment(text: "nero", start: 0, duration: 0)]
+        let timedSegments = [WakeWordSegment(text: "nero", start: 0, duration: 0.2)]
+        #expect(VoiceWakeRuntime._testHasNoUsableTiming(zeroSegments))
+        #expect(!VoiceWakeRuntime._testHasNoUsableTiming(timedSegments))
+    }
+
     @Test func `trims after chinese trigger keeps post speech`() {
         let triggers = ["小爪", "openclaw"]
         let text = "嘿 小爪 帮我打开设置"


### PR DESCRIPTION
## Summary
- Add a bounded text-only fallback for interim macOS SpeechRecognition updates that have no usable word timings.
- Match only the newly appended transcript delta so ordinary earlier speech mentioning the wake word is still rejected.
- Preserve trigger-only Talk Mode activation while keeping false-positive boundary coverage.

Fixes #76662

## Tests
- `swift test --package-path apps/macos --filter VoiceWakeRuntimeTests`
- `swift test --package-path apps/swabble --filter WakeWordGateTests`
- `corepack pnpm check:changed` (via temporary local pnpm shim; passes, with pre-existing SwiftLint warnings in `TalkModeRuntime.swift`)
