### PR TITLE
feat(gateway): add diagnostics.pricing method for pricing cache visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/diagnostics: add `diagnostics.pricing` operator-read RPC that returns model pricing cache metadata (`cachedAt`, `age`, `ttlMs`, `size`) so operators can tell whether the pricing cache is populated, stale, or empty after a startup timeout. Thanks @ziomancer.
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Agents/verbose: use compact explain-mode tool summaries for `/verbose` and progress drafts by default, with `agents.defaults.toolProgressDetail: "raw"` and per-agent overrides for debugging raw command/detail output.
 - Agents/commands: add `/steer <message>` for queue-independent steering of the active current-session run without starting a new turn when the session is idle. (#76934)

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -322,6 +322,7 @@ enumeration of `src/gateway/server-methods/*.ts`.
   <Accordion title="System and identity">
     - `health` returns the cached or freshly probed gateway health snapshot.
     - `diagnostics.stability` returns the recent bounded diagnostic stability recorder. It keeps operational metadata such as event names, counts, byte sizes, memory readings, queue/session state, channel/plugin names, and session ids. It does not keep chat text, webhook bodies, tool outputs, raw request or response bodies, tokens, cookies, or secret values. Operator read scope is required.
+    - `diagnostics.pricing` returns model pricing cache metadata: `cachedAt` (epoch ms or `null` when empty), `age` (ms since `cachedAt` or `null`), `ttlMs` (refresh interval), and `size` (number of cached entries). It does not return individual model pricing rows. Operator read scope is required.
     - `status` returns the `/status`-style gateway summary; sensitive fields are included only for admin-scoped operator clients.
     - `gateway.identity.get` returns the gateway device identity used by relay and pairing flows.
     - `system-presence` returns the current presence snapshot for connected operator/node devices.

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -70,6 +70,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "assistant.media.get",
     "health",
     "diagnostics.stability",
+    "diagnostics.pricing",
     "doctor.memory.status",
     "doctor.memory.dreamDiary",
     "doctor.memory.remHarness",

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -84,7 +84,7 @@ type PricingModelNormalizationOptions = {
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const LITELLM_PRICING_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
-const CACHE_TTL_MS = 24 * 60 * 60_000;
+export const GATEWAY_MODEL_PRICING_CACHE_TTL_MS = 24 * 60 * 60_000;
 const FETCH_TIMEOUT_MS = 60_000;
 const MAX_PRICING_CATALOG_BYTES = 5 * 1024 * 1024;
 const log = createSubsystemLogger("gateway").child("model-pricing");
@@ -1124,7 +1124,7 @@ function scheduleRefresh(
     void refreshGatewayModelPricingCache(params).catch((error: unknown) => {
       log.warn(`pricing refresh failed: ${String(error)}`);
     });
-  }, CACHE_TTL_MS);
+  }, GATEWAY_MODEL_PRICING_CACHE_TTL_MS);
   refreshTimer.unref?.();
 }
 

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -4,6 +4,7 @@ import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 const BASE_METHODS = [
   "health",
   "diagnostics.stability",
+  "diagnostics.pricing",
   "doctor.memory.status",
   "doctor.memory.dreamDiary",
   "doctor.memory.backfillDreamDiary",

--- a/src/gateway/server-methods/diagnostics.test.ts
+++ b/src/gateway/server-methods/diagnostics.test.ts
@@ -3,10 +3,8 @@ import {
   emitDiagnosticEvent,
   resetDiagnosticEventsForTest,
 } from "../../infra/diagnostic-events.js";
-import {
-  __resetGatewayModelPricingCacheForTest,
-  replaceGatewayModelPricingCache,
-} from "../model-pricing-cache-state.js";
+import { replaceGatewayModelPricingCache } from "../model-pricing-cache-state.js";
+import { __resetGatewayModelPricingCacheForTest } from "../model-pricing-cache.js";
 import {
   resetDiagnosticStabilityRecorderForTest,
   startDiagnosticStabilityRecorder,

--- a/src/gateway/server-methods/diagnostics.test.ts
+++ b/src/gateway/server-methods/diagnostics.test.ts
@@ -4,6 +4,10 @@ import {
   resetDiagnosticEventsForTest,
 } from "../../infra/diagnostic-events.js";
 import {
+  __resetGatewayModelPricingCacheForTest,
+  replaceGatewayModelPricingCache,
+} from "../model-pricing-cache-state.js";
+import {
   resetDiagnosticStabilityRecorderForTest,
   startDiagnosticStabilityRecorder,
   stopDiagnosticStabilityRecorder,
@@ -57,6 +61,49 @@ describe("diagnostics gateway methods", () => {
       }),
       undefined,
     );
+  });
+
+  it("returns pricing cache meta when empty", async () => {
+    __resetGatewayModelPricingCacheForTest();
+    const respond = vi.fn();
+    await diagnosticsHandlers["diagnostics.pricing"]({
+      req: { type: "req", id: "1", method: "diagnostics.pricing", params: {} },
+      params: {},
+      client: null,
+      isWebchatConnect: () => false,
+      context: {} as never,
+      respond,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ cachedAt: null, age: null, size: 0 }),
+      undefined,
+    );
+  });
+
+  it("returns pricing cache meta when populated", async () => {
+    const now = Date.now();
+    replaceGatewayModelPricingCache(
+      new Map([["anthropic/claude-sonnet-4-6", { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }]]),
+      now,
+    );
+    const respond = vi.fn();
+    await diagnosticsHandlers["diagnostics.pricing"]({
+      req: { type: "req", id: "1", method: "diagnostics.pricing", params: {} },
+      params: {},
+      client: null,
+      isWebchatConnect: () => false,
+      context: {} as never,
+      respond,
+    });
+
+    const payload = respond.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.cachedAt).toBe(now);
+    expect(payload.size).toBe(1);
+    expect(typeof payload.age).toBe("number");
+    expect(typeof payload.ttlMs).toBe("number");
+    __resetGatewayModelPricingCacheForTest();
   });
 
   it("rejects invalid stability params", async () => {

--- a/src/gateway/server-methods/diagnostics.test.ts
+++ b/src/gateway/server-methods/diagnostics.test.ts
@@ -3,13 +3,16 @@ import {
   emitDiagnosticEvent,
   resetDiagnosticEventsForTest,
 } from "../../infra/diagnostic-events.js";
-import { replaceGatewayModelPricingCache } from "../model-pricing-cache-state.js";
-import { __resetGatewayModelPricingCacheForTest } from "../model-pricing-cache.js";
 import {
   resetDiagnosticStabilityRecorderForTest,
   startDiagnosticStabilityRecorder,
   stopDiagnosticStabilityRecorder,
 } from "../../logging/diagnostic-stability.js";
+import { replaceGatewayModelPricingCache } from "../model-pricing-cache-state.js";
+import {
+  GATEWAY_MODEL_PRICING_CACHE_TTL_MS,
+  __resetGatewayModelPricingCacheForTest,
+} from "../model-pricing-cache.js";
 import { diagnosticsHandlers } from "./diagnostics.js";
 
 describe("diagnostics gateway methods", () => {
@@ -75,7 +78,12 @@ describe("diagnostics gateway methods", () => {
 
     expect(respond).toHaveBeenCalledWith(
       true,
-      expect.objectContaining({ cachedAt: null, age: null, size: 0 }),
+      expect.objectContaining({
+        cachedAt: null,
+        age: null,
+        ttlMs: GATEWAY_MODEL_PRICING_CACHE_TTL_MS,
+        size: 0,
+      }),
       undefined,
     );
   });
@@ -83,7 +91,9 @@ describe("diagnostics gateway methods", () => {
   it("returns pricing cache meta when populated", async () => {
     const now = Date.now();
     replaceGatewayModelPricingCache(
-      new Map([["anthropic/claude-sonnet-4-6", { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }]]),
+      new Map([
+        ["anthropic/claude-sonnet-4-6", { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }],
+      ]),
       now,
     );
     const respond = vi.fn();
@@ -100,7 +110,7 @@ describe("diagnostics gateway methods", () => {
     expect(payload.cachedAt).toBe(now);
     expect(payload.size).toBe(1);
     expect(typeof payload.age).toBe("number");
-    expect(typeof payload.ttlMs).toBe("number");
+    expect(payload.ttlMs).toBe(GATEWAY_MODEL_PRICING_CACHE_TTL_MS);
     __resetGatewayModelPricingCacheForTest();
   });
 

--- a/src/gateway/server-methods/diagnostics.ts
+++ b/src/gateway/server-methods/diagnostics.ts
@@ -3,6 +3,7 @@ import {
   normalizeDiagnosticStabilityQuery,
 } from "../../logging/diagnostic-stability.js";
 import { getGatewayModelPricingCacheMeta } from "../model-pricing-cache-state.js";
+import { GATEWAY_MODEL_PRICING_CACHE_TTL_MS } from "../model-pricing-cache.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
@@ -29,7 +30,7 @@ export const diagnosticsHandlers: GatewayRequestHandlers = {
       {
         cachedAt: meta.cachedAt === 0 ? null : meta.cachedAt,
         age: meta.cachedAt === 0 ? null : Date.now() - meta.cachedAt,
-        ttlMs: meta.ttlMs,
+        ttlMs: GATEWAY_MODEL_PRICING_CACHE_TTL_MS,
         size: meta.size,
       },
       undefined,

--- a/src/gateway/server-methods/diagnostics.ts
+++ b/src/gateway/server-methods/diagnostics.ts
@@ -2,6 +2,7 @@ import {
   getDiagnosticStabilitySnapshot,
   normalizeDiagnosticStabilityQuery,
 } from "../../logging/diagnostic-stability.js";
+import { getGatewayModelPricingCacheMeta } from "../model-pricing-cache-state.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
@@ -20,5 +21,18 @@ export const diagnosticsHandlers: GatewayRequestHandlers = {
         ),
       );
     }
+  },
+  "diagnostics.pricing": async ({ respond }) => {
+    const meta = getGatewayModelPricingCacheMeta();
+    respond(
+      true,
+      {
+        cachedAt: meta.cachedAt || null,
+        age: meta.cachedAt ? Date.now() - meta.cachedAt : null,
+        ttlMs: meta.ttlMs,
+        size: meta.size,
+      },
+      undefined,
+    );
   },
 };

--- a/src/gateway/server-methods/diagnostics.ts
+++ b/src/gateway/server-methods/diagnostics.ts
@@ -27,8 +27,8 @@ export const diagnosticsHandlers: GatewayRequestHandlers = {
     respond(
       true,
       {
-        cachedAt: meta.cachedAt || null,
-        age: meta.cachedAt ? Date.now() - meta.cachedAt : null,
+        cachedAt: meta.cachedAt === 0 ? null : meta.cachedAt,
+        age: meta.cachedAt === 0 ? null : Date.now() - meta.cachedAt,
         ttlMs: meta.ttlMs,
         size: meta.size,
       },


### PR DESCRIPTION
## Summary

- Adds a `diagnostics.pricing` gateway method that returns model pricing cache state: `cachedAt`, `age`, `ttlMs`, `size`
- Registered under `READ_SCOPE` alongside `diagnostics.stability` — no new auth surface
- Wires the existing `getGatewayModelPricingCacheMeta()` (in `model-pricing-cache-state.ts`) into the diagnostics handler pattern

Operators currently have no way to tell whether the pricing cache is populated, stale, or empty after a startup timeout. This came up across multiple issues where `[model-pricing] pricing bootstrap failed: TimeoutError` left users unable to determine cache state (#53639, #59348, #67653).

## Test plan

- [x] `pnpm vitest run src/gateway/server-methods/diagnostics.test.ts` — 8 tests pass (2 new pricing + 4 existing stability + 2 pricing-cache)
- [x] `pnpm tsgo` — typecheck clean
- [x] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)