### PR TITLE
feat(sessions): auto-label dashboard sessions created via WebUI /new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
+- Sessions/WebUI: auto-label dashboard sessions created by `/new` with `"WebUI chat"` so `openclaw sessions` shows a readable entry instead of a bare UUID-keyed row; explicit `label` params still take precedence. Fixes #76848. (#77022) Thanks @hclsys.
 - Agents/commands: add `/steer <message>` for queue-independent steering of the active current-session run without starting a new turn when the session is idle. (#76934)
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Doctor/config: `doctor --fix` now commits safe legacy migrations even when unrelated validation issues (e.g. a missing plugin) prevent full validation from passing, so `agents.defaults.llm` and other known-legacy keys are always cleaned up by `doctor --fix` regardless of other config problems. Fixes #76798. (#76800) Thanks @hclsys.

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1000,6 +1000,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       canonicalParentSessionKey = parent.canonicalKey;
     }
     const loweredRequestedKey = normalizeOptionalLowercaseString(requestedKey);
+    const isDashboardAutoKey = !requestedKey;
     const key = requestedKey
       ? loweredRequestedKey === "global" || loweredRequestedKey === "unknown"
         ? loweredRequestedKey
@@ -1018,7 +1019,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         storeKey: target.canonicalKey,
         patch: {
           key: target.canonicalKey,
-          label: normalizeOptionalString(p.label),
+          label:
+            normalizeOptionalString(p.label) ?? (isDashboardAutoKey ? "WebUI chat" : undefined),
           model: normalizeOptionalString(p.model),
         },
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -187,6 +187,36 @@ test("sessions.create rejects unknown parentSessionKey", async () => {
   );
 });
 
+test("sessions.create auto-labels dashboard sessions when no label is provided (#76848)", async () => {
+  await createSessionStoreDir();
+
+  const created = await directSessionReq<{
+    key?: string;
+    entry?: { label?: string };
+  }>("sessions.create", {
+    agentId: "ops",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.key).toMatch(/^agent:ops:dashboard:/);
+  expect(created.payload?.entry?.label).toBe("WebUI chat");
+});
+
+test("sessions.create preserves explicit label over auto-label (#76848)", async () => {
+  await createSessionStoreDir();
+
+  const created = await directSessionReq<{
+    key?: string;
+    entry?: { label?: string };
+  }>("sessions.create", {
+    agentId: "ops",
+    label: "My custom label",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.label).toBe("My custom label");
+});
+
 test("sessions.create can start the first agent turn from an initial task", async () => {
   await createSessionStoreDir();
   // Register "ops" so the deleted-agent guard added in #65986 does not


### PR DESCRIPTION
Fixes #76848.

## Problem

When Control UI `/new` creates a new session, `sessions.create` is called without a `key` — the gateway auto-generates `agent:main:dashboard:<uuid>`. No `label` is passed, so the session entry has `label: undefined`. The `openclaw sessions` CLI shows only the raw UUID-keyed row, which is unreadable when multiple WebUI sessions exist.

## Fix

In `sessions.create`, when no explicit key is requested (dashboard auto-key path) and no `label` param is provided, default the label to `"WebUI chat"`. Explicit `label` params still take precedence (operator-built clients or the existing auto-label on checkpoint branches are unaffected).

```typescript
label:
  normalizeOptionalString(p.label) ??
  (isDashboardAutoKey ? "WebUI chat" : undefined),
```

## Testing

Added two regression tests to `server.sessions.create.test.ts`:
1. `sessions.create auto-labels dashboard sessions when no label is provided` — verifies `entry.label === "WebUI chat"` for a no-key, no-label call
2. `sessions.create preserves explicit label over auto-label` — verifies explicit label param wins

All 8 tests pass.

## Scope

- `src/gateway/server-methods/sessions.ts` — 4 lines changed
- `src/gateway/server.sessions.create.test.ts` — 30 lines added
- `CHANGELOG.md` — 1 line added