### PR TITLE
fix(config): resolve file: env var references in openclaw.json

### DIFF
--- a/src/config/config-env-vars.file-ref.test.ts
+++ b/src/config/config-env-vars.file-ref.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { applyConfigEnvVars } from "./config-env-vars.js";
+import type { OpenClawConfig } from "./types.js";
+
+describe("applyConfigEnvVars file: ref resolution", () => {
+  let tmpDir: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-env-file-ref-"));
+    env = { OPENCLAW_STATE_DIR: tmpDir };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeConfig(vars: Record<string, string>): OpenClawConfig {
+    return { env: { vars } } as unknown as OpenClawConfig;
+  }
+
+  it("resolves file: ref to file content", () => {
+    const secretDir = path.join(tmpDir, "secrets");
+    fs.mkdirSync(secretDir, { recursive: true });
+    fs.writeFileSync(path.join(secretDir, "api-key.txt"), "sk-test-12345\n");
+
+    applyConfigEnvVars(makeConfig({ MY_KEY: "file:secrets/api-key.txt" }), env);
+
+    expect(env.MY_KEY).toBe("sk-test-12345");
+  });
+
+  it("trims trailing CRLF", () => {
+    fs.writeFileSync(path.join(tmpDir, "key.txt"), "value123\r\n");
+
+    applyConfigEnvVars(makeConfig({ K: "file:key.txt" }), env);
+
+    expect(env.K).toBe("value123");
+  });
+
+  it("throws on missing file", () => {
+    expect(() =>
+      applyConfigEnvVars(makeConfig({ K: "file:nonexistent.txt" }), env),
+    ).toThrow(/not found at/);
+  });
+
+  it("rejects path traversal outside state dir", () => {
+    expect(() =>
+      applyConfigEnvVars(makeConfig({ K: "file:../../../etc/passwd" }), env),
+    ).toThrow(/resolves outside/);
+  });
+
+  it("does not override existing env var", () => {
+    const secretDir = path.join(tmpDir, "secrets");
+    fs.mkdirSync(secretDir, { recursive: true });
+    fs.writeFileSync(path.join(secretDir, "k.txt"), "from-file");
+    env.MY_KEY = "already-set";
+
+    applyConfigEnvVars(makeConfig({ MY_KEY: "file:secrets/k.txt" }), env);
+
+    expect(env.MY_KEY).toBe("already-set");
+  });
+});

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -44,6 +44,7 @@ function resolveFileEnvRef(
     const code = (err as NodeJS.ErrnoException).code;
     throw new Error(
       `Config env file ref "${value}" not found at ${resolved}${code ? ` (${code})` : ""}`,
+      { cause: err },
     );
   }
 }

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -1,10 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
 import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
   normalizeEnvVarKey,
 } from "../infra/host-env-security.js";
 import { containsEnvVarReference } from "./env-substitution.js";
+import { resolveStateDir } from "./paths.js";
 import type { OpenClawConfig } from "./types.js";
+
+const FILE_REF_PREFIX = "file:";
+
+/**
+ * Resolve a `file:<relpath>` env var value by reading the referenced file.
+ * The path is resolved relative to the OpenClaw state directory (~/.openclaw).
+ * Path traversal outside the state directory is rejected.
+ */
+function resolveFileEnvRef(
+  value: string,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const relPath = value.slice(FILE_REF_PREFIX.length).trim();
+  if (!relPath) {
+    return undefined;
+  }
+  const stateDir = resolveStateDir(env);
+  const resolved = path.resolve(stateDir, relPath);
+  // Path traversal protection: resolved path must be inside stateDir
+  const normalizedStateDir = path.resolve(stateDir) + path.sep;
+  const normalizedResolved = path.resolve(resolved);
+  if (
+    normalizedResolved !== path.resolve(stateDir) &&
+    !normalizedResolved.startsWith(normalizedStateDir)
+  ) {
+    throw new Error(
+      `Config env file ref "${value}" resolves outside the OpenClaw state directory: ${normalizedResolved}`,
+    );
+  }
+  try {
+    const content = fs.readFileSync(resolved, "utf8");
+    return content.replace(/\r?\n$/, "");
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    throw new Error(
+      `Config env file ref "${value}" not found at ${resolved}${code ? ` (${code})` : ""}`,
+    );
+  }
+}
 
 function isBlockedConfigEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
@@ -85,6 +127,11 @@ export function applyConfigEnvVars(
     // (e.g. process.env.OPENCLAW_GATEWAY_TOKEN = "${VAULT_TOKEN}") which downstream auth
     // resolution would accept as valid credentials.
     if (containsEnvVarReference(value)) {
+      continue;
+    }
+    // Resolve file: references — read file content as the env var value
+    if (value.startsWith(FILE_REF_PREFIX)) {
+      env[key] = resolveFileEnvRef(value, env);
       continue;
     }
     env[key] = value;


### PR DESCRIPTION
Fixes #76947

## Problem

When `openclaw.json` configures env vars with a `file:` prefix (e.g. `"XAI_API_KEY": "file:secrets/xai-api-key.txt"`), the gateway passes the literal string `file:secrets/xai-api-key.txt` as the API key instead of reading the file content.

## Solution

Added `file:<relpath>` resolution in `applyConfigEnvVars`. When an env var value starts with `file:`, the referenced file is read (relative to the OpenClaw state directory, typically `~/.openclaw`) and its trimmed content is used as the env var value.

### Supported env value schemes

| Prefix | Behavior |
|--------|----------|
| `${VAR}` | Env var template (existing) |
| `file:<relpath>` | Read file content relative to state dir (**new**) |
| plain string | Used as-is (existing) |

### Path safety

- Paths are resolved relative to the OpenClaw state directory (`~/.openclaw`)
- Path traversal (`..`) that escapes the state directory is rejected with a clear error
- Missing or unreadable files throw an error (no silent fallback to literal value)

## Test coverage

- `file:` resolves to file content with trailing newline trimmed
- CRLF line endings handled
- Missing file throws descriptive error
- Path traversal outside state dir is rejected
- Existing env vars are not overridden