### PR TITLE
fix(ui): reduce sessions list refresh cost

### DIFF
--- a/src/agents/model-selection-cli.ts
+++ b/src/agents/model-selection-cli.ts
@@ -3,18 +3,43 @@ import { resolveRuntimeCliBackends } from "../plugins/cli-backends.runtime.js";
 import { resolvePluginSetupCliBackendRuntime } from "../plugins/setup-registry.runtime.js";
 import { normalizeProviderId } from "./model-selection-normalize.js";
 
+const cliProviderResultCache = new Map<string, boolean>();
+
+export const __testing = {
+  resetCliProviderCache(): void {
+    cliProviderResultCache.clear();
+  },
+};
+
+function buildCliProviderCacheKey(provider: string, cfg?: OpenClawConfig): string {
+  const configuredBackendKeys = Object.keys(cfg?.agents?.defaults?.cliBackends ?? {})
+    .map((key) => normalizeProviderId(key))
+    .sort()
+    .join(",");
+  return `${provider}|${configuredBackendKeys}`;
+}
+
 export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   const normalized = normalizeProviderId(provider);
+  const cacheKey = buildCliProviderCacheKey(normalized, cfg);
+  const cached = cliProviderResultCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const backends = cfg?.agents?.defaults?.cliBackends ?? {};
+  let result = false;
   if (Object.keys(backends).some((key) => normalizeProviderId(key) === normalized)) {
-    return true;
+    result = true;
+  } else {
+    const cliBackends = resolveRuntimeCliBackends();
+    if (cliBackends.some((backend) => normalizeProviderId(backend.id) === normalized)) {
+      result = true;
+    } else if (resolvePluginSetupCliBackendRuntime({ backend: normalized, config: cfg })) {
+      result = true;
+    }
   }
-  const cliBackends = resolveRuntimeCliBackends();
-  if (cliBackends.some((backend) => normalizeProviderId(backend.id) === normalized)) {
-    return true;
-  }
-  if (resolvePluginSetupCliBackendRuntime({ backend: normalized, config: cfg })) {
-    return true;
-  }
-  return false;
+
+  cliProviderResultCache.set(cacheKey, result);
+  return result;
 }

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import { __testing as setupRegistryRuntimeTesting } from "../plugins/setup-registry.runtime.js";
+import { __testing as modelSelectionCliTesting } from "./model-selection-cli.js";
 import {
   buildAllowedModelSet,
   inferUniqueProviderFromConfiguredModels,
@@ -157,6 +158,7 @@ describe("model-selection", () => {
 
   describe("isCliProvider", () => {
     beforeEach(() => {
+      modelSelectionCliTesting.resetCliProviderCache();
       setupRegistryRuntimeTesting.resetRuntimeState();
       setupRegistryRuntimeTesting.setRuntimeModuleForTest({
         resolvePluginSetupCliBackend: ({ backend }) =>
@@ -170,6 +172,7 @@ describe("model-selection", () => {
     });
 
     afterEach(() => {
+      modelSelectionCliTesting.resetCliProviderCache();
       setupRegistryRuntimeTesting.resetRuntimeState();
     });
 
@@ -179,6 +182,23 @@ describe("model-selection", () => {
 
     it("returns false for provider ids", () => {
       expect(isCliProvider("example-cli", {} as OpenClawConfig)).toBe(false);
+    });
+
+    it("caches setup registry cli backend lookups", () => {
+      const resolvePluginSetupCliBackend = vi.fn(({ backend }) =>
+        backend === "claude-cli"
+          ? {
+              pluginId: "anthropic",
+              backend: { id: "claude-cli", config: { command: "claude" } },
+            }
+          : undefined,
+      );
+      setupRegistryRuntimeTesting.setRuntimeModuleForTest({ resolvePluginSetupCliBackend });
+
+      expect(isCliProvider("claude-cli", {} as OpenClawConfig)).toBe(true);
+      expect(isCliProvider("claude-cli", {} as OpenClawConfig)).toBe(true);
+
+      expect(resolvePluginSetupCliBackend).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -78,6 +78,7 @@ export type ChatSendOptions = {
 };
 
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
+export const CHAT_SESSIONS_REFRESH_LIMIT = 5;
 export {
   handleChatDraftChange,
   handleChatInputHistoryKey,

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -7,6 +7,7 @@ const applySessionsChangedEventMock = vi.fn();
 
 vi.mock("./app-chat.ts", () => ({
   CHAT_SESSIONS_ACTIVE_MINUTES: 10,
+  CHAT_SESSIONS_REFRESH_LIMIT: 5,
   flushChatQueueForEvent: vi.fn(),
   refreshChatAvatar: vi.fn(),
 }));

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -5,6 +5,7 @@ import {
 import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
 import {
   CHAT_SESSIONS_ACTIVE_MINUTES,
+  CHAT_SESSIONS_REFRESH_LIMIT,
   clearPendingQueueItemsForRun,
   flushChatQueueForEvent,
   refreshChatAvatar,
@@ -584,6 +585,7 @@ function handleTerminalChatEvent(
     if (state === "final") {
       void loadSessions(host as unknown as SessionsState, {
         activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+        limit: CHAT_SESSIONS_REFRESH_LIMIT,
       });
     }
   }


### PR DESCRIPTION
## Summary

- cache `isCliProvider` results by normalized provider and configured CLI backend keys
- cap the Control UI chat-turn session refresh to a small recent-session window
- add a regression test for cached setup CLI backend lookup

Fixes #77056. Related to #76562.

## Why

On a Control UI instance with a large session store, normal chat completion refreshes were putting avoidable pressure on `sessions.list`. Local diagnostics showed repeated CLI-provider classification during row building and overly broad chat-side session refresh windows as meaningful contributors.

This keeps the explicit Sessions page/search flows intact while making the routine chat-turn refresh cheaper.

## Testing

- `git diff --check`
- `npm test -- --runInBand src/agents/model-selection.test.ts ui/src/ui/app-gateway.sessions.node.test.ts` could not run in this local worktree because dependencies are not installed (`Cannot find module 'vitest/package.json'`).
