### PR TITLE
fix(plugins): preserve corpus supplements from service.start() during activating re-loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/memory: preserve corpus supplements registered from plugin `service.start()` callbacks across activating re-loads (e.g. lazy tool-load re-register); supplements that a plugin's `service.start()` registered were silently dropped when a subsequent `loadOpenClawPlugins` call cleared runtime state and skipped re-calling service start for already-started services. Fixes #77039. (#77060) Thanks @hclsys.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2526,6 +2526,44 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(listMemoryEmbeddingProviders()).toEqual([]);
   });
 
+  it("preserves corpus supplements registered from service.start() during activating re-loads (#77039)", () => {
+    useNoBundledPlugins();
+    const supplement = { search: async () => [], get: async () => null };
+    // Simulate a supplement that a plugin's service.start() already registered
+    // before the lazy tool-load re-register triggers a full activating reload.
+    registerMemoryCorpusSupplement("service-start-plugin", supplement);
+    expect(listMemoryCorpusSupplements()).toHaveLength(1);
+
+    const plugin = writePlugin({
+      id: "lazy-tool-trigger",
+      filename: "lazy-tool-trigger.cjs",
+      body: `module.exports = {
+        id: "lazy-tool-trigger",
+        register(api) {
+          // register() does NOT call registerMemoryCorpusSupplement — only service.start() does
+        },
+      };`,
+    });
+
+    // Activating load (shouldActivate=true) — simulates the lazy tool-load re-register path
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["lazy-tool-trigger"],
+        },
+      },
+    });
+
+    // The supplement from service.start() must survive the activating re-load
+    const supplements = listMemoryCorpusSupplements();
+    expect(supplements).toHaveLength(1);
+    expect(supplements[0]?.pluginId).toBe("service-start-plugin");
+    expect(supplements[0]?.supplement).toBe(supplement);
+  });
+
   it("does not replace the active detached task runtime during non-activating loads", () => {
     useNoBundledPlugins();
     const activeRuntime = createDetachedTaskRuntimeStub("active");

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2526,24 +2526,31 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(listMemoryEmbeddingProviders()).toEqual([]);
   });
 
-  it("preserves corpus supplements registered via register(api) across activating re-loads (#77039)", () => {
+  it("preserves corpus supplements that were not re-registered on a second activating load (#77039)", () => {
     useNoBundledPlugins();
-    // Plugin registers its supplement through register(api). A second activating load calls
-    // clearActivatedPluginRuntimeState() before re-running register(api), temporarily wiping
-    // the supplement. The restore loop must put it back for still-active plugins.
+    // Reproduces the service.start() scenario: on first load the plugin registers a corpus
+    // supplement; on second activating load clearActivatedPluginRuntimeState() wipes it and
+    // register(api) does NOT re-add it (module-level flag prevents double registration, just
+    // as service.start() only fires once and register() doesn't call registerMemoryCorpusSupplement
+    // on subsequent loads).  Without the restore loop the supplement stays gone; with it, the
+    // loader detects the still-active plugin didn't re-register and puts the supplement back.
     const plugin = writePlugin({
       id: "corpus-supplement-plugin",
       filename: "corpus-supplement-plugin.cjs",
-      body: `module.exports = {
-        id: "corpus-supplement-plugin",
-        kind: "memory",
-        register(api) {
-          api.registerMemoryCorpusSupplement({
-            search: async () => [],
-            get: async () => null,
-          });
-        },
-      };`,
+      body: `let registered = false;
+module.exports = {
+  id: "corpus-supplement-plugin",
+  kind: "memory",
+  register(api) {
+    if (!registered) {
+      registered = true;
+      api.registerMemoryCorpusSupplement({
+        search: async () => [],
+        get: async () => null,
+      });
+    }
+  },
+};`,
     });
     const pluginConfig = {
       cache: false,
@@ -2557,11 +2564,13 @@ module.exports = { id: "throws-after-import", register() {} };`,
       },
     };
 
-    // First load: supplement registered via register(api).
+    // First load: supplement registered (register() fires, flag unset).
     loadOpenClawPlugins(pluginConfig);
     expect(listMemoryCorpusSupplements()).toHaveLength(1);
 
-    // Second activating load: restore loop must preserve the supplement for still-active plugin.
+    // Second activating load: clearActivatedPluginRuntimeState() wipes the supplement;
+    // register() fires again but the flag prevents re-registration.
+    // The restore loop must put the supplement back for this still-active plugin.
     loadOpenClawPlugins(pluginConfig);
     const supplements = listMemoryCorpusSupplements();
     expect(supplements).toHaveLength(1);

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2526,42 +2526,88 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(listMemoryEmbeddingProviders()).toEqual([]);
   });
 
-  it("preserves corpus supplements registered from service.start() during activating re-loads (#77039)", () => {
+  it("preserves corpus supplements registered via register(api) across activating re-loads (#77039)", () => {
     useNoBundledPlugins();
-    const supplement = { search: async () => [], get: async () => null };
-    // Simulate a supplement that a plugin's service.start() already registered
-    // before the lazy tool-load re-register triggers a full activating reload.
-    registerMemoryCorpusSupplement("service-start-plugin", supplement);
+    // Plugin registers its supplement through register(api). A second activating load calls
+    // clearActivatedPluginRuntimeState() before re-running register(api), temporarily wiping
+    // the supplement. The restore loop must put it back for still-active plugins.
+    const plugin = writePlugin({
+      id: "corpus-supplement-plugin",
+      filename: "corpus-supplement-plugin.cjs",
+      body: `module.exports = {
+        id: "corpus-supplement-plugin",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCorpusSupplement({
+            search: async () => [],
+            get: async () => null,
+          });
+        },
+      };`,
+    });
+    const pluginConfig = {
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["corpus-supplement-plugin"],
+          slots: { memory: "corpus-supplement-plugin" },
+        },
+      },
+    };
+
+    // First load: supplement registered via register(api).
+    loadOpenClawPlugins(pluginConfig);
     expect(listMemoryCorpusSupplements()).toHaveLength(1);
 
+    // Second activating load: restore loop must preserve the supplement for still-active plugin.
+    loadOpenClawPlugins(pluginConfig);
+    const supplements = listMemoryCorpusSupplements();
+    expect(supplements).toHaveLength(1);
+    expect(supplements[0]?.pluginId).toBe("corpus-supplement-plugin");
+  });
+
+  it("does not restore corpus supplements for omitted plugins during activating re-loads (#77039)", () => {
+    useNoBundledPlugins();
+    // A plugin that had a supplement in a prior load must NOT have it restored
+    // when it is absent from the new activating load.
     const plugin = writePlugin({
-      id: "lazy-tool-trigger",
-      filename: "lazy-tool-trigger.cjs",
+      id: "corpus-supplement-plugin",
+      filename: "corpus-supplement-plugin.cjs",
       body: `module.exports = {
-        id: "lazy-tool-trigger",
+        id: "corpus-supplement-plugin",
+        kind: "memory",
         register(api) {
-          // register() does NOT call registerMemoryCorpusSupplement — only service.start() does
+          api.registerMemoryCorpusSupplement({
+            search: async () => [],
+            get: async () => null,
+          });
         },
       };`,
     });
 
-    // Activating load (shouldActivate=true) — simulates the lazy tool-load re-register path
+    // First load: supplement is live.
     loadOpenClawPlugins({
       cache: false,
       workspaceDir: plugin.dir,
       config: {
         plugins: {
           load: { paths: [plugin.file] },
-          allow: ["lazy-tool-trigger"],
+          allow: ["corpus-supplement-plugin"],
+          slots: { memory: "corpus-supplement-plugin" },
         },
       },
     });
+    expect(listMemoryCorpusSupplements()).toHaveLength(1);
 
-    // The supplement from service.start() must survive the activating re-load
-    const supplements = listMemoryCorpusSupplements();
-    expect(supplements).toHaveLength(1);
-    expect(supplements[0]?.pluginId).toBe("service-start-plugin");
-    expect(supplements[0]?.supplement).toBe(supplement);
+    // Second load: plugin omitted — supplement must NOT be restored.
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: { plugins: { load: { paths: [] }, allow: [] } },
+    });
+    expect(listMemoryCorpusSupplements()).toHaveLength(0);
   });
 
   it("does not replace the active detached task runtime during non-activating loads", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2528,12 +2528,11 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
   it("preserves corpus supplements that were not re-registered on a second activating load (#77039)", () => {
     useNoBundledPlugins();
-    // Reproduces the service.start() scenario: on first load the plugin registers a corpus
-    // supplement; on second activating load clearActivatedPluginRuntimeState() wipes it and
-    // register(api) does NOT re-add it (module-level flag prevents double registration, just
-    // as service.start() only fires once and register() doesn't call registerMemoryCorpusSupplement
-    // on subsequent loads).  Without the restore loop the supplement stays gone; with it, the
-    // loader detects the still-active plugin didn't re-register and puts the supplement back.
+    // Reproduces the service.start() scenario: the plugin registers a service (idempotent)
+    // and on first load it also registers a corpus supplement. On the second activating load
+    // clearActivatedPluginRuntimeState() wipes the supplement; register() fires again but
+    // the supplement flag prevents double registration (matching service.start() semantics).
+    // The restore loop sees the plugin still has a registered service and puts the supplement back.
     const plugin = writePlugin({
       id: "corpus-supplement-plugin",
       filename: "corpus-supplement-plugin.cjs",
@@ -2542,6 +2541,8 @@ module.exports = {
   id: "corpus-supplement-plugin",
   kind: "memory",
   register(api) {
+    // registerService is idempotent — simulates an always-registered service.
+    api.registerService({ id: "corpus-supplement-plugin-svc", start: async () => {}, stop: async () => {} });
     if (!registered) {
       registered = true;
       api.registerMemoryCorpusSupplement({
@@ -2616,6 +2617,56 @@ module.exports = {
       workspaceDir: plugin.dir,
       config: { plugins: { load: { paths: [] }, allow: [] } },
     });
+    expect(listMemoryCorpusSupplements()).toHaveLength(0);
+  });
+
+  it("does not restore corpus supplement when a loaded plugin drops it between activating loads (#77039)", () => {
+    useNoBundledPlugins();
+    // A plugin that registers a supplement on the first load, but on the second load its
+    // register() runs again and intentionally omits the call (simulated with a counter).
+    // Without the service-ownership guard, the restore loop would incorrectly re-add the
+    // stale supplement because the plugin is still loaded. With the guard it is skipped
+    // because the plugin has no registered service (supplements from service.start() are
+    // the only legitimate restore case).
+    const plugin = writePlugin({
+      id: "corpus-supplement-drop-plugin",
+      filename: "corpus-supplement-drop-plugin.cjs",
+      body: `let calls = 0;
+module.exports = {
+  id: "corpus-supplement-drop-plugin",
+  kind: "memory",
+  register(api) {
+    calls++;
+    if (calls === 1) {
+      api.registerMemoryCorpusSupplement({
+        search: async () => [],
+        get: async () => null,
+      });
+    }
+    // Second call: intentionally no supplement (simulates a plugin update that dropped it).
+  },
+};`,
+    });
+    const pluginConfig = {
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["corpus-supplement-drop-plugin"],
+          slots: { memory: "corpus-supplement-drop-plugin" },
+        },
+      },
+    };
+
+    // First load: supplement registered via register().
+    loadOpenClawPlugins(pluginConfig);
+    expect(listMemoryCorpusSupplements()).toHaveLength(1);
+
+    // Second load: register() fires again, calls === 2, no supplement registered.
+    // The restore loop must NOT bring the stale supplement back because the plugin
+    // has no registered service (service-owned supplements are the only legitimate case).
+    loadOpenClawPlugins(pluginConfig);
     expect(listMemoryCorpusSupplements()).toHaveLength(0);
   });
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2424,14 +2424,16 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
 
     if (shouldActivate && preLoadCorpusSupplements.length > 0) {
-      // Only restore supplements for plugins that are still active in the new registry.
-      // Disabled, failed, or omitted plugins must not keep their supplements alive.
-      const activePluginIdSet = new Set(
-        registry.plugins.filter((p) => p.status === "loaded").map((p) => p.id),
-      );
+      // Only restore supplements for plugins that are still active in the new registry AND
+      // have a registered service. Supplements registered via service.start() callbacks are
+      // the only legitimate case: register() is idempotent so service.start() only fires
+      // once, but register() itself always runs on every load. A loaded plugin whose
+      // register() ran without calling registerMemoryCorpusSupplement intentionally dropped
+      // it — restoring it would keep a stale adapter alive (#77039, addresses clawsweeper P2).
+      const servicePluginIdSet = new Set(registry.services.map((s) => s.pluginId));
       const reRegisteredPluginIds = new Set(listMemoryCorpusSupplements().map((r) => r.pluginId));
       for (const prev of preLoadCorpusSupplements) {
-        if (activePluginIdSet.has(prev.pluginId) && !reRegisteredPluginIds.has(prev.pluginId)) {
+        if (servicePluginIdSet.has(prev.pluginId) && !reRegisteredPluginIds.has(prev.pluginId)) {
           registerMemoryCorpusSupplement(prev.pluginId, prev.supplement);
         }
       }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2424,9 +2424,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
 
     if (shouldActivate && preLoadCorpusSupplements.length > 0) {
+      // Only restore supplements for plugins that are still active in the new registry.
+      // Disabled, failed, or omitted plugins must not keep their supplements alive.
+      const activePluginIdSet = new Set(
+        registry.plugins.filter((p) => p.status === "loaded").map((p) => p.id),
+      );
       const reRegisteredPluginIds = new Set(listMemoryCorpusSupplements().map((r) => r.pluginId));
       for (const prev of preLoadCorpusSupplements) {
-        if (!reRegisteredPluginIds.has(prev.pluginId)) {
+        if (activePluginIdSet.has(prev.pluginId) && !reRegisteredPluginIds.has(prev.pluginId)) {
           registerMemoryCorpusSupplement(prev.pluginId, prev.supplement);
         }
       }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -96,6 +96,7 @@ import {
   getMemoryCapabilityRegistration,
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
+  registerMemoryCorpusSupplement,
   restoreMemoryPluginState,
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
@@ -1530,6 +1531,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   try {
     // Clear previously registered plugin state before reloading.
     // Skip for non-activating (snapshot) loads to avoid wiping commands from other plugins.
+    // Capture corpus supplements first: service.start() callbacks register supplements after
+    // register() returns, so they survive the current load but won't be re-called during a
+    // lazy re-register (registerService is idempotent). Restore any supplement whose plugin
+    // did not re-register one during this load pass. (#77039)
+    const preLoadCorpusSupplements = shouldActivate ? listMemoryCorpusSupplements() : [];
     if (shouldActivate) {
       clearActivatedPluginRuntimeState();
     }
@@ -2414,6 +2420,15 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             failedPlugins,
           )}). Run 'openclaw plugins list' for details.`,
         );
+      }
+    }
+
+    if (shouldActivate && preLoadCorpusSupplements.length > 0) {
+      const reRegisteredPluginIds = new Set(listMemoryCorpusSupplements().map((r) => r.pluginId));
+      for (const prev of preLoadCorpusSupplements) {
+        if (!reRegisteredPluginIds.has(prev.pluginId)) {
+          registerMemoryCorpusSupplement(prev.pluginId, prev.supplement);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Corpus supplements registered from a plugin's `service.start()` callback were silently wiped when `loadOpenClawPlugins` ran with `shouldActivate=true` on a subsequent call (e.g. lazy `memory_search` tool load re-trigger)
- `clearActivatedPluginRuntimeState()` wipes all supplements at the start of every activating load; since `registerService` is idempotent, `service.start()` is never re-called, so supplements from it are permanently lost
- Fix: capture `preLoadCorpusSupplements` before clearing; after the registration loop, restore any supplement whose plugin did not re-register via `register()` in the new pass

## Root cause (verified by source trace)

`loader.ts:1505` — `clearActivatedPluginRuntimeState()` → `clearMemoryPluginState()` wipes supplements.
`registry.ts:1403` — `registerService` returns early (idempotent guard) if same service ID was already registered; `service.start()` not called again.
Result: supplement lost with no error.

## Test plan

- [x] New regression test: `preserves corpus supplements registered from service.start() during activating re-loads (#77039)` — verifies a pre-load supplement survives a full activating reload where the plugin's `register()` does not call `registerMemoryCorpusSupplement`
- [x] `pnpm exec vitest run src/plugins/loader.test.ts` — 124/124 pass
- [x] `pnpm exec vitest run src/plugins/loader*.test.ts` — 177/177 pass
- [x] `pnpm exec tsc --noEmit --project tsconfig.core.json` — no new errors
- [x] `pnpm exec oxlint src/plugins/loader.ts src/plugins/loader.test.ts` — clean
- [x] `pnpm exec oxfmt --threads=1 src/plugins/loader.ts src/plugins/loader.test.ts` — formatted

Fixes #77039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)