### PR TITLE
fix(telegram): defer update_id offset ack until after handler completes (#77000)

### DIFF
--- a/extensions/telegram/src/bot-update-tracker.ts
+++ b/extensions/telegram/src/bot-update-tracker.ts
@@ -140,7 +140,10 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
     }
     if (typeof updateId === "number") {
       pendingUpdateIds.add(updateId);
-      acceptUpdateId(updateId);
+      // Do NOT call acceptUpdateId here. That would advance the Telegram offset
+      // before the reply is delivered, so a restart between begin and finish
+      // would permanently lose this update's reply. Instead, accept (and persist)
+      // the update id only after finishUpdate confirms the handler completed.
     }
     return {
       accepted: true,
@@ -166,6 +169,12 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
         if (highestCompletedUpdateId === null || update.updateId > highestCompletedUpdateId) {
           highestCompletedUpdateId = update.updateId;
         }
+        // Accept (and persist) the update id so Telegram advances the offset past
+        // it on the next getUpdates call. This is deferred from beginUpdate so
+        // that the offset is only advanced after the handler has run — if the
+        // gateway restarts between begin and finish the update will be
+        // re-delivered and reprocessed rather than silently dropped.
+        acceptUpdateId(update.updateId);
       } else {
         failedUpdateIds.add(update.updateId);
       }


### PR DESCRIPTION
## Fix: Telegram update_id acked before outbound sendMessage confirms

### Problem
Telegram update_id was being acknowledged (and the offset persisted to disk) in `beginUpdate`, **before** the handler ran and **before** `sendMessage` confirmed delivery. If the gateway restarted between these events, the offset had already advanced past the message, Telegram would not resend it, but the transcript showed the assistant had written a reply — permanently losing the reply.

### Timeline (before fix)
1. 16:01:46 - User message arrives (update_id 79669836)
2. 16:02:43 - Gateway acks offset (advances past 79669836), session recorded
3. 16:03:55 - Assistant final text written to session.jsonl
4. 16:03:45 - Gateway restart (queue lost, offset already past message)
5. User never sees reply

### Solution
Move `acceptUpdateId` from `beginUpdate` to `finishUpdate` (when `completed=true`). Now the offset only advances after the handler finishes. If the gateway restarts before `finishUpdate` runs, the update is re-delivered by Telegram and reprocessed (reply may duplicate, which is preferable to silent loss).

### Changed file
- `extensions/telegram/src/bot-update-tracker.ts`

Fixes #77000