### PR TITLE
feat(bluebubbles): add per-DM systemPrompt via direct.<handle>.systemPrompt config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.
 - Gateway/startup: keep model-catalog test helpers, run-session lookup code, QR pairing helpers, and TypeBox memory-tool schema construction out of hot startup import paths, reducing default gateway benchmark plugin-load and memory pressure.
 - Control UI/performance: record browser long animation frame or long task entries in the debug event log when supported, making slow dashboard renders easier to attribute from the UI.
+- BlueBubbles/DM: add `direct.<handle>.systemPrompt` and `direct.”*”.systemPrompt` per-DM system-prompt config, mirroring the existing `groups.<id>.systemPrompt` pattern so operators can inject per-contact or catch-all DM behavioral directives without affecting group-chat handling. Exact sender handle takes precedence over the wildcard. Fixes #77009. (#77086) Thanks @hclsys.
 - Slack/streaming: add `streaming.progress.render: "rich"` for Block Kit progress drafts backed by structured progress line data.
 - Slack/streaming: keep the newest rich progress lines when Block Kit limits trim long progress drafts. Thanks @vincentkoc.
 - Channels/streaming: cap progress-draft tool lines by default so edited progress boxes avoid jumpy reflow from long wrapped lines.

--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -255,7 +255,30 @@ Each entry under `channels.bluebubbles.groups.*` accepts an optional `systemProm
 }
 ```
 
-The key matches whatever BlueBubbles reports as `chatGuid` / `chatIdentifier` / numeric `chatId` for the group, and a `"*"` wildcard entry provides a default for every group without an exact match (same pattern used by `requireMention` and per-group tool policies). Exact matches always win over the wildcard. DMs ignore this field; use agent-level or account-level prompt customization instead.
+The key matches whatever BlueBubbles reports as `chatGuid` / `chatIdentifier` / numeric `chatId` for the group, and a `"*"` wildcard entry provides a default for every group without an exact match (same pattern used by `requireMention` and per-group tool policies). Exact matches always win over the wildcard.
+
+### Per-DM system prompt
+
+DMs support the same per-sender system prompt injection via `channels.bluebubbles.direct`. Use the sender's handle (phone number or email) as the key, or `"*"` as a catch-all wildcard for all DMs:
+
+```json5
+{
+  channels: {
+    bluebubbles: {
+      direct: {
+        "+15551234567": {
+          systemPrompt: "This contact prefers concise bullet-point answers. Keep replies under 5 lines.",
+        },
+        "*": {
+          systemPrompt: "Always sign off DMs with your name.",
+        },
+      },
+    },
+  },
+}
+```
+
+An exact handle match takes precedence over the `"*"` wildcard. The injected directive is appended to the agent system prompt on every DM turn from that sender, mirroring the `groups.<id>.systemPrompt` pattern.
 
 #### Worked example: threaded replies and tapback reactions (Private API)
 

--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -38,6 +38,16 @@ const bluebubblesGroupConfigSchema = z.object({
   systemPrompt: z.string().optional(),
 });
 
+const bluebubblesDmConfigSchema = z.object({
+  /**
+   * Free-form directive appended to the system prompt for every turn that
+   * handles a DM from this sender. Use `"*"` as the key to apply to all DMs.
+   * Use the sender's iMessage handle (e.g. `"+15551234567"`) to target a
+   * specific contact. Mirrors the `groups.<id>.systemPrompt` pattern for DMs.
+   */
+  systemPrompt: z.string().optional(),
+});
+
 const bluebubblesNetworkSchema = z
   .object({
     /** Dangerous opt-in for same-host or trusted private/internal BlueBubbles deployments. */
@@ -109,6 +119,7 @@ const bluebubblesAccountSchema = z
      */
     replyContextApiFallback: z.boolean().optional(),
     groups: z.object({}).catchall(bluebubblesGroupConfigSchema).optional(),
+    direct: z.object({}).catchall(bluebubblesDmConfigSchema).optional(),
     coalesceSameSenderDms: z.boolean().optional(),
   })
   .superRefine((value, ctx) => {

--- a/extensions/bluebubbles/src/config-ui-hints.ts
+++ b/extensions/bluebubbles/src/config-ui-hints.ts
@@ -9,4 +9,8 @@ export const bluebubblesChannelConfigUiHints = {
     label: "BlueBubbles DM Policy",
     help: 'Direct message access control ("pairing" recommended). "open" requires channels.bluebubbles.allowFrom=["*"].',
   },
+  "direct.*.systemPrompt": {
+    label: "Per-DM System Prompt",
+    help: 'Free-form directive appended to the system prompt for DMs from a specific sender handle (e.g. "+15551234567") or "*" for all DMs. Mirrors the groups.<id>.systemPrompt pattern.',
+  },
 } satisfies Record<string, ChannelConfigUiHint>;

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1689,14 +1689,17 @@ async function processMessageAfterDedupe(
     OriginatingTo: `bluebubbles:${outboundTarget}`,
     WasMentioned: effectiveWasMentioned,
     CommandAuthorized: commandAuthorized,
-    // Exact group match wins over the "*" wildcard fallback, matching the
-    // pattern used by resolveChannelGroupRequireMention/toolsPolicy.
+    // Exact match wins over the "*" wildcard fallback, matching the pattern
+    // used by resolveChannelGroupRequireMention/toolsPolicy for groups.
     GroupSystemPrompt: isGroup
       ? normalizeOptionalString(
           account.config.groups?.[peerId]?.systemPrompt ??
             account.config.groups?.["*"]?.systemPrompt,
         )
-      : undefined,
+      : normalizeOptionalString(
+          account.config.direct?.[peerId]?.systemPrompt ??
+            account.config.direct?.["*"]?.systemPrompt,
+        ),
   });
 
   let sentMessage = false;

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -668,7 +668,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(callArgs.ctx.GroupSystemPrompt).toBe("exact value");
     });
 
-    it("omits GroupSystemPrompt for DMs even when the group config would match", async () => {
+    it("omits GroupSystemPrompt for DMs when no direct config is set", async () => {
       setupWebhookTarget({
         account: createMockAccount({
           groups: {
@@ -680,6 +680,93 @@ describe("BlueBubbles webhook monitor", () => {
       const payload = createTimestampedNewMessagePayloadForTest({
         text: "hi",
         isGroup: false,
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSystemPrompt).toBeUndefined();
+    });
+
+    it("threads per-DM systemPrompt into ctx for DM messages (#77009)", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          direct: {
+            "+15551234567": { systemPrompt: "Always reply in haiku." },
+          },
+        }),
+      });
+
+      const payload = createTimestampedNewMessagePayloadForTest({
+        text: "hi",
+        isGroup: false,
+        handle: { address: "+15551234567" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSystemPrompt).toBe("Always reply in haiku.");
+    });
+
+    it("falls back to the direct '*' wildcard systemPrompt when no exact DM match (#77009)", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          direct: {
+            "*": { systemPrompt: "Default DM rule: be concise." },
+          },
+        }),
+      });
+
+      const payload = createTimestampedNewMessagePayloadForTest({
+        text: "hi",
+        isGroup: false,
+        handle: { address: "+15559999999" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSystemPrompt).toBe("Default DM rule: be concise.");
+    });
+
+    it("prefers an exact direct systemPrompt over the '*' wildcard (#77009)", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          direct: {
+            "*": { systemPrompt: "wildcard DM rule" },
+            "+15551234567": { systemPrompt: "exact DM rule" },
+          },
+        }),
+      });
+
+      const payload = createTimestampedNewMessagePayloadForTest({
+        text: "hi",
+        isGroup: false,
+        handle: { address: "+15551234567" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSystemPrompt).toBe("exact DM rule");
+    });
+
+    it("does not apply direct DM systemPrompt to group messages (#77009)", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          direct: {
+            "*": { systemPrompt: "DM only rule" },
+          },
+        }),
+      });
+
+      const payload = createTimestampedNewMessagePayloadForTest({
+        text: "hello group",
+        isGroup: true,
+        chatGuid: "iMessage;+;chat123456",
+        chatName: "Family",
+        participants: [{ address: "+15551234567", displayName: "Alice" }],
       });
 
       await dispatchWebhookPayload(payload);

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -14,6 +14,14 @@ type BlueBubblesGroupConfig = {
   systemPrompt?: string;
 };
 
+type BlueBubblesDmConfig = {
+  /**
+   * Free-form directive appended to the system prompt on every turn that
+   * handles a DM from this sender. Use `"*"` as the key to apply to all DMs.
+   */
+  systemPrompt?: string;
+};
+
 type BlueBubblesActionConfig = {
   reactions?: boolean;
   edit?: boolean;
@@ -104,6 +112,8 @@ export type BlueBubblesAccountConfig = {
   network?: BlueBubblesNetworkConfig;
   /** Per-group configuration keyed by chat GUID or identifier. */
   groups?: Record<string, BlueBubblesGroupConfig>;
+  /** Per-DM configuration keyed by sender handle or `"*"` wildcard. */
+  direct?: Record<string, BlueBubblesDmConfig>;
   /** Per-action tool gating (default: true for all). */
   actions?: BlueBubblesActionConfig;
   /** Channel health monitor overrides for this channel/account. */

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -321,6 +321,19 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             additionalProperties: false,
           },
         },
+        direct: {
+          type: "object",
+          properties: {},
+          additionalProperties: {
+            type: "object",
+            properties: {
+              systemPrompt: {
+                type: "string",
+              },
+            },
+            additionalProperties: false,
+          },
+        },
         coalesceSameSenderDms: {
           type: "boolean",
         },
@@ -641,6 +654,19 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   additionalProperties: false,
                 },
               },
+              direct: {
+                type: "object",
+                properties: {},
+                additionalProperties: {
+                  type: "object",
+                  properties: {
+                    systemPrompt: {
+                      type: "string",
+                    },
+                  },
+                  additionalProperties: false,
+                },
+              },
               coalesceSameSenderDms: {
                 type: "boolean",
               },
@@ -664,6 +690,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       dmPolicy: {
         label: "BlueBubbles DM Policy",
         help: 'Direct message access control ("pairing" recommended). "open" requires channels.bluebubbles.allowFrom=["*"].',
+      },
+      "direct.*.systemPrompt": {
+        label: "Per-DM System Prompt",
+        help: 'Free-form directive appended to the system prompt for DMs from a specific sender handle (e.g. "+15551234567") or "*" for all DMs. Mirrors the groups.<id>.systemPrompt pattern.',
       },
     },
   },


### PR DESCRIPTION
## Summary

- Adds `direct.<handle>.systemPrompt` and `direct."*".systemPrompt` config for BlueBubbles DMs, mirroring the existing `groups.<id>.systemPrompt` pattern
- Telegram and WhatsApp both support per-DM system prompts; BlueBubbles was asymmetric (#60665/#69198 added per-group only)
- Exact sender handle takes precedence over `"*"` wildcard, same logic as group config
- Group messages are unaffected when only `direct` config is set

## Commits

1. `feat(bluebubbles): add per-DM systemPrompt config schema` — `bluebubblesDmConfigSchema` + `direct` field in account schema and TypeScript type
2. `feat(bluebubbles): resolve per-DM systemPrompt from direct config` — wire into `monitor-processing.ts` context builder
3. `feat(bluebubbles): add ui-hint and regression tests for per-DM systemPrompt` — 4 new tests + ui-hint entry
4. `chore: add CHANGELOG entry for per-DM systemPrompt (#77009)`

## Test plan

- [x] `pnpm exec vitest run extensions/bluebubbles/src/monitor.test.ts` — 89/89 pass
- [x] `pnpm exec vitest run extensions/bluebubbles/` — 589/589 pass
- [x] `pnpm exec oxlint` on all changed files — 0 warnings/errors
- [x] `pnpm exec oxfmt` — formatted

New regression tests:
- exact handle match sets `GroupSystemPrompt`
- `"*"` wildcard fallback sets `GroupSystemPrompt`
- exact handle beats wildcard
- group messages unaffected by `direct` config

Fixes #77009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)