### PR TITLE
fix(feishu): handle empty message content safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: handle group messages with missing content without crashing mention parsing, debounce, or empty-message handling. Fixes #66657.
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.
 - Codex app-server: preserve prompt-local current-turn context through context-engine prompt projection, so replied-to Telegram messages stay visible to the Codex model input.

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -247,7 +247,7 @@ export function parseFeishuMessageEvent(
   botOpenId?: string,
   _botName?: string,
 ): FeishuMessageContext {
-  const rawContent = parseMessageContent(event.message.content, event.message.message_type);
+  const rawContent = parseMessageContent(event.message.content ?? "", event.message.message_type);
   const mentionedBot = checkBotMentioned(event, botOpenId);
   const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
   // Strip the bot's own mention so slash commands like @Bot /help retain
@@ -887,7 +887,8 @@ export async function handleFeishuMessage(params: {
       }
     }
 
-    const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
+    const content = ctx.content ?? "";
+    const preview = content.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel = isGroup
       ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
       : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
@@ -919,7 +920,7 @@ export async function handleFeishuMessage(params: {
     // user turn to the session causes downstream LLM providers (e.g. MiniMax)
     // to reject the request with "messages must not be empty" errors. Logging
     // the skip avoids silent loss without polluting the agent session.
-    if (!ctx.content.trim() && mediaList.length === 0) {
+    if (!content.trim() && mediaList.length === 0) {
       log(
         `feishu[${account.accountId}]: skipping empty message (no text, no media) from ${ctx.senderOpenId}`,
       );

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -217,11 +217,13 @@ export function createFeishuMessageReceiveHandler({
   };
 
   const resolveDebounceText = (event: FeishuMessageEvent): string => {
-    return resolveText({
-      event,
-      botOpenId: getBotOpenId(accountId),
-      botName: getBotName(accountId),
-    }).trim();
+    return (
+      resolveText({
+        event,
+        botOpenId: getBotOpenId(accountId),
+        botName: getBotName(accountId),
+      }) ?? ""
+    ).trim();
   };
 
   const recordSuppressedMessageIds = async (

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -69,4 +69,26 @@ describe("getFeishuSequentialKey", () => {
       }),
     ).toBe("feishu:default:oc_dm_chat:btw");
   });
+
+  it("handles events with missing content and mention metadata", () => {
+    const event = createTextEvent({ text: "hello" });
+    delete (event.message as { content?: string }).content;
+    event.message.mentions = [
+      {
+        key: "@_user_1",
+        id: {
+          open_id: "ou_bot_1",
+        },
+        name: "OpenClaw",
+      },
+    ];
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+        botOpenId: "ou_bot_1",
+      }),
+    ).toBe("feishu:default:oc_dm_chat");
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: Feishu group or direct message events can arrive with runtime-missing `message.content`, especially around empty or mention-only messages.
- Why it matters: Some Feishu message paths assumed content was always a string and could call `.replace()` or `.trim()` before the empty-message guard ran, causing crashes such as `Cannot read properties of undefined`.
- What changed:
  - Normalize missing Feishu message content at the parser boundary before mention normalization.
  - Guard the handler preview path before `.replace()`.
  - Guard the debounce text path before `.trim()`.
  - Add regression coverage for missing `message.content` with mention metadata.
  - Add the required changelog entry.
- What did NOT change:
  - No dependency changes.
  - No permission, secret, network, CI, or code-execution surface changes.
  - No intentional change to normal non-empty Feishu message behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #66657
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Feishu message parsing and receive/dispatch paths assumed `message.content` was always present and string-like. When a runtime event had missing content plus mention metadata, content could be used before downstream optional chaining guards ran.
- Missing detection / guardrail: Existing tests covered empty JSON text such as `{"text":""}`, but did not cover runtime-missing `message.content` with mention metadata through the parser/mention normalization path.
- Contributing context (if known): The original guard was added near downstream `.trim()` usage, but earlier paths such as mention normalization, handler preview, and debounce could still read content first.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/feishu/src/sequential-key.test.ts`
- Scenario the test should lock in:
  - A Feishu text event with runtime-missing `message.content` and mention metadata should not crash before sequential-key resolution.
  - The parser boundary should normalize missing content before mention normalization.
- Why this is the smallest reliable guardrail:
  - The regression directly covers the previously unsafe source-level path: `getFeishuSequentialKey()` calls `parseFeishuMessageEvent()`, which reaches content parsing and mention normalization before resolving the lane.
- Existing test that already covers this (if any):
  - Existing Feishu tests covered empty parsed text, but not missing runtime `message.content` with mention metadata.
- If no new test is added, why not:
  - N/A. A regression test was added.

## User-visible / Behavior Changes

Feishu empty or mention-only messages with missing runtime content should no longer crash parsing, debounce, sequential-key resolution, or dispatch preview paths.

Expected behavior after this change:

- Missing `message.content` is normalized to an empty string at the parser boundary.
- Mention normalization receives a string.
- Handler preview does not call `.replace()` on missing content.
- Debounce does not call `.trim()` on missing content.
- Empty messages without media are skipped safely instead of crashing.

## Diagram (if applicable)

```text
Before:
Feishu event
  -> message.content missing
  -> parseMessageContent(undefined)
  -> normalizeMentions(non-string)
  -> .replace() / .trim() crash before downstream guard

After:
Feishu event
  -> message.content missing
  -> parser boundary normalizes to ""
  -> parseMessageContent("")
  -> normalizeMentions("")
  -> sequential key / debounce / handler preview continue safely
  -> empty message is skipped when there is no text and no media
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: WSL Ubuntu
- Runtime/container: Node.js 22.22.2, pnpm 10.33.2
- Integration/channel: Feishu
- Relevant config (redacted): N/A for local source-level runtime proof

### Steps

1. Create a Feishu text event.
2. Remove `event.message.content` at runtime.
3. Add mention metadata to `event.message.mentions`.
4. Pass the event through `parseFeishuMessageEvent()`.
5. Pass the same event through `getFeishuSequentialKey()`.
6. Verify the parser and mention normalization path completes without throwing.
7. Verify the stable Feishu chat lane is returned.

### Expected

- Missing `message.content` is treated as empty text.
- `normalizeMentions()` receives a string.
- `getFeishuSequentialKey()` returns the base chat lane.
- Handler preview and debounce paths are guarded against missing content.

### Actual

- Before the full fix, downstream optional chaining guarded only later `.trim()` sites, while parser/mention normalization and preview/debounce paths could still read missing content first.
- After the fix, parser-boundary normalization and defensive preview/debounce guards prevent those paths from calling string methods on missing content.

## Real behavior proof

### behavior

Feishu events with runtime-missing `message.content` and mention metadata no longer crash the Feishu parser, mention normalization, sequential-key resolution, debounce text resolution, or handler preview paths.

The fixed behavior is that missing message content is normalized to an empty string before mention normalization, then empty messages without media are safely skipped instead of causing `.replace()` or `.trim()` to run on `undefined`.

### environment

- OS: WSL Ubuntu
- Runtime: Node.js 22.22.2
- Package manager: pnpm 10.33.2
- Integration/channel: Feishu
- Setup used for proof: local OpenClaw checkout running the production Feishu parser and sequential-key code with a redacted Feishu event shape
- Live Feishu tenant: not available

### steps

1. Ran the current PR branch locally after the fix.
2. Created a redacted Feishu text event with `message.content` intentionally missing.
3. Added Feishu mention metadata to the event.
4. Executed the real OpenClaw Feishu parser via `parseFeishuMessageEvent()`.
5. Executed the real sequential-key path via `getFeishuSequentialKey()`.
6. Confirmed the parser returned string content and the sequential-key path completed without throwing.

### evidence

Command run:

```text
pnpm exec tsx feishu-real-proof.ts
```

Redacted input shape:

```text
message_type: "text"
chat_type: "group"
message.content: <missing>
message.mentions:
  - key: "@_user_1"
    id.open_id: "<redacted_bot_open_id>"
    name: "<redacted>"
```

After-fix terminal output:

```text
Feishu real-behavior local proof
Input shape: {
  message_type: 'text',
  chat_type: 'group',
  hasContent: false,
  mentions: 1
}
Parsed content: ""
Parsed content type: string
Mentioned bot: true
Has any mention: true
Sequential key: feishu:default:oc_group_redacted
Result: PASS - missing message.content did not crash parser, mention normalization, or sequential-key resolution
```

Relevant after-fix parser boundary:

```ts
const rawContent = parseMessageContent(event.message.content ?? "", event.message.message_type);
```

Supplemental local validation:

```text
pnpm test extensions/feishu/src/sequential-key.test.ts extensions/feishu/src/bot.stripBotMention.test.ts extensions/feishu/src/bot.test.ts

Test Files  3 passed (3)
Tests       81 passed (81)
```

Formatter validation:

```text
pnpm exec oxfmt --check --threads=1 extensions/feishu/src/sequential-key.ts extensions/feishu/src/sequential-key.test.ts extensions/feishu/src/bot.ts extensions/feishu/src/bot-content.ts extensions/feishu/src/bot.stripBotMention.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/monitor.message-handler.ts extensions/feishu/src/monitor.account.ts CHANGELOG.md

All matched files use the correct format.
```

### observedResult

- `parseFeishuMessageEvent()` completed without throwing when `message.content` was missing.
- `parsed.content` was returned as a string.
- `normalizeMentions()` did not receive `undefined`.
- `getFeishuSequentialKey()` returned the stable Feishu chat lane.
- The missing-content + mention metadata path no longer crashes before downstream guards.
- Handler preview and debounce were updated to avoid calling string methods on missing content.

### notTested

I did not verify against a live Feishu tenant because I do not have Feishu test credentials or access to the original provider payload. The proof above uses a local OpenClaw runtime execution of the production Feishu parser and sequential-key code with redacted Feishu event data matching the missing-content shape from the issue.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence provided in this PR:

- Local OpenClaw runtime execution of the production Feishu parser and sequential-key code with a redacted missing-content Feishu event.
- Regression test covering runtime-missing `message.content` with mention metadata.
- Local test output showing 81 Feishu tests passed.
- Formatter output showing all matched files use the correct format.
- Diff showing parser-boundary normalization, handler preview guard, debounce guard, and changelog entry.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran a local proof script against the production Feishu parser and sequential-key code.
  - Confirmed missing `message.content` with mention metadata is normalized safely.
  - Ran the Feishu regression/unit test set locally.
  - Confirmed missing `message.content` with mention metadata is covered by `sequential-key.test.ts`.
  - Confirmed parser-boundary normalization is applied before mention normalization.
  - Confirmed handler preview uses a safe `content` variable before `.replace()`.
  - Confirmed debounce guards resolved text before `.trim()`.
  - Confirmed `CHANGELOG.md` includes the Feishu fix entry.
- Edge cases checked:
  - Missing `message.content`.
  - Mention metadata present.
  - Empty content path with no media.
  - Sequential-key resolution after parser normalization.
- What you did **not** verify:
  - I did not verify a live Feishu tenant replay because I do not have Feishu test credentials or the original provider payload.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

Risk: The real provider payload shape for #66657 may differ from the source-level reproduced missing-content event.

Mitigation:
- The fix normalizes missing content at the parser boundary and adds defensive guards in preview and debounce paths, so it is intentionally tolerant of absent content.
- The regression covers the unsafe missing-content + mention metadata path identified by review.
- The local proof executes the production Feishu parser and sequential-key code with redacted missing-content event data.
- A maintainer with Feishu test credentials can still replay the original live payload if strict external runtime proof is required.
