### PR TITLE
fix: prevent event loop saturation from trajectory flush (setImmediate yield + 10MB cap + 30s timeout)

### DIFF
--- a/src/agents/queued-file-writer.ts
+++ b/src/agents/queued-file-writer.ts
@@ -130,6 +130,7 @@ export function getQueuedFileWriter(
     write: (line: string) => {
       queue = queue
         .then(() => ready)
+        .then(() => new Promise<void>((resolve) => setImmediate(resolve)))
         .then(() => safeAppendFile(filePath, line, options))
         .catch(() => undefined);
     },

--- a/src/agents/run-cleanup-timeout.ts
+++ b/src/agents/run-cleanup-timeout.ts
@@ -1,6 +1,6 @@
 import { formatErrorMessage } from "../infra/errors.js";
 
-export const AGENT_CLEANUP_STEP_TIMEOUT_MS = 10_000;
+export const AGENT_CLEANUP_STEP_TIMEOUT_MS = 30_000;
 
 type AgentCleanupLogger = {
   warn: (message: string) => void;

--- a/src/trajectory/paths.ts
+++ b/src/trajectory/paths.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveHomeRelativePath } from "../infra/home-dir.js";
 
-export const TRAJECTORY_RUNTIME_FILE_MAX_BYTES = 50 * 1024 * 1024;
+export const TRAJECTORY_RUNTIME_FILE_MAX_BYTES = 10 * 1024 * 1024;
 export const TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = 256 * 1024;
 
 type TrajectoryPointerOpenFlagConstants = Pick<


### PR DESCRIPTION
## Problem

When a session accumulates a large trajectory (50MB+, 700+ events), `pi-trajectory-flush` blocks the event loop for 25+ minutes after the 10s timeout fires. The timeout warns but doesn't stop the flush, and the event loop stays at 100% utilization with P99 delays of 34 seconds — making the gateway completely unresponsive.

```
agent cleanup timed out: step=pi-trajectory-flush timeoutMs=10000
liveness warning: eventLoopDelayP99Ms=34728.8 eventLoopUtilization=1
liveness warning: eventLoopDelayP99Ms=27799.8 eventLoopUtilization=1  ← 25 min later
```

## Root Cause

`QueuedFileWriter` chains writes into an ever-growing promise chain without ever yielding the event loop. With 700+ individual `appendFile` calls, the chain consumes 100% of the event loop. After the cleanup timeout fires (10s), the chain continues running — the `Promise.race` in `runAgentCleanupStep` only logs a warning, it doesn't abort the cleanup.

## Changes

### 1. `queued-file-writer.ts` — Yield event loop between writes

Add `setImmediate` between each queued write so the event loop gets control back:

```ts
queue = queue
  .then(() => ready)
  .then(() => new Promise<void>((resolve) => setImmediate(resolve)))  // ← yield
  .then(() => safeAppendFile(filePath, line, options))
  .catch(() => undefined);
```

This prevents the promise chain from monopolizing the event loop. Each write still happens sequentially, but other work (message dispatch, WebSocket events) can be processed between writes.

### 2. `paths.ts` — Reduce trajectory file cap

`TRAJECTORY_RUNTIME_FILE_MAX_BYTES`: 50MB → 10MB

A single session shouldn't produce 50MB of trajectory. 10MB (~140 events at 70KB avg) is sufficient for debugging while keeping flush time manageable.

### 3. `run-cleanup-timeout.ts` — Increase cleanup timeout

`AGENT_CLEANUP_STEP_TIMEOUT_MS`: 10s → 30s

With the event loop yielding (change #1), flushes complete faster. But 10s is still tight for large sessions. 30s provides adequate margin.

## Verification

- Tested locally on macOS with OpenClaw 2026.5.2
- Applied equivalent patches to compiled bundle
- Gateway restarted cleanly, Feishu WebSocket reconnected
- No event loop saturation observed after fix
- Existing unit tests pass without modification

Fixes #75839
Related: #76340, #77115, #76421