### PR TITLE
fix(exec): block unisolated heavy validation commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,6 +416,18 @@ Docs: https://docs.openclaw.ai
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)
 - Agents/fallback: fail fast on session write-lock timeouts instead of trying fallback models for local file contention. Fixes #66646. Thanks @sallyom.
 - Browser/SSRF: stop closing user-owned Chrome tabs when a read-only operation (snapshot/screenshot/interactions) is rejected by the SSRF guard — only OpenClaw-initiated navigations now close on policy denial. Thanks @scotthuang.
+- Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
+- Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.
+- Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
+- Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @jacobtomlinson.
+- Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
+- OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
+- CLI/update: keep pnpm package updates on the running custom global install root and pass pnpm's `--global-dir` so `openclaw update` does not create a second default-prefix install when `OPENCLAW_HOME` or the shell points at a custom OpenClaw directory. Fixes #78377. Thanks @amknight.
+- Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.
+- PDF/Codex: include extraction-fallback instructions for `openai-codex/*` PDF tool requests so Codex Responses receives its required system prompt. Fixes #77872. Thanks @anyech.
+- Gateway/startup: keep the Gateway running when a configured optional plugin-owned capability such as a web_search provider or channel points at a known installable plugin that is currently unavailable; startup now logs a config warning and leaves `openclaw doctor --fix` to install or enable the plugin. (#78642) Thanks @joshavant.
+- Exec: refuse unisolated heavy validation commands at Gateway exec preflight unless an approved isolation wrapper or emergency bypass is present.
+- Onboard/channels: recover externalized channel plugins from stale `channels.<id>` config by falling back to `ensureChannelSetupPluginInstalled` via the trusted catalog when the plugin is missing on disk, so leftover `appId`/token entries no longer dead-end onboard with "<channel> plugin not available." (#78328) Thanks @sliverp.
 - Agents/Gateway: throttle and cap live exec command-output events so noisy tool runs cannot flood Gateway WebSocket clients or starve RPC handling. (#78645) Thanks @joshavant.
 - Memory Wiki: skip empty and whitespace-only source pages when refreshing generated Related blocks, preventing blank pages from being rewritten into Related-only stubs. Fixes #78121. Thanks @amknight.
 - Telegram: keep duplicate message-tool-only Codex turns from posting generic silent-reply fallback text, so private finals stay private after inbound dedupe. Thanks @rubencu.

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -24,6 +24,7 @@ const isWin = process.platform === "win32";
 
 const describeNonWin = isWin ? describe.skip : describe;
 const describeWin = isWin ? describe : describe.skip;
+const analyzeHeavyExecCommand = __testing.analyzeHeavyExecCommand;
 const parseOpenClawChannelsLoginShellCommand = __testing.parseOpenClawChannelsLoginShellCommand;
 const validateExecScriptPreflight = __testing.validateScriptFileForShellBleed;
 const createPreflightTool = () =>
@@ -66,6 +67,93 @@ async function expectSymlinkSwapDuringPreflightToAvoidErrors(params: {
     expect(swapped).toBe(true);
   });
 }
+
+describe("exec heavy-command guard", () => {
+  it("classifies package-manager and compiler-style validation as heavy", () => {
+    expect(analyzeHeavyExecCommand("corepack pnpm install --frozen-lockfile")).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "corepack pnpm install" },
+    });
+    expect(analyzeHeavyExecCommand("pnpm lint:core")).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "pnpm lint:core" },
+    });
+    expect(analyzeHeavyExecCommand("corepack pnpm exec vitest run src/foo.test.ts")).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "corepack pnpm exec vitest" },
+    });
+    expect(analyzeHeavyExecCommand("tsgolint src")).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "tsgolint" },
+    });
+  });
+
+  it("detects heavy commands inside shell wrappers and chained commands", () => {
+    expect(
+      analyzeHeavyExecCommand("cd /tmp/openclaw && git diff --check && corepack pnpm lint:core"),
+    ).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "corepack pnpm lint:core" },
+    });
+    expect(
+      analyzeHeavyExecCommand(
+        "bash -lc 'cd /tmp/openclaw && corepack pnpm install --frozen-lockfile'",
+      ),
+    ).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "corepack pnpm install" },
+    });
+  });
+
+  it("classifies broader diagnostic commands as maybe-heavy", () => {
+    expect(analyzeHeavyExecCommand("git diff --stat")).toMatchObject({
+      heavy: true,
+      hit: { classification: "maybe", reason: "git diff --stat" },
+    });
+    expect(analyzeHeavyExecCommand("rg -n pattern -S .")).toMatchObject({
+      heavy: true,
+      hit: { classification: "maybe", reason: "broad ripgrep" },
+    });
+    expect(analyzeHeavyExecCommand("grep -rn pattern src")).toMatchObject({
+      heavy: true,
+      hit: { classification: "maybe", reason: "recursive grep" },
+    });
+    expect(analyzeHeavyExecCommand("grep error src/file.ts")).toMatchObject({ heavy: false });
+  });
+
+  it("allows light commands and explicitly isolated heavy commands", () => {
+    expect(analyzeHeavyExecCommand("git status --short")).toMatchObject({ heavy: false });
+    expect(analyzeHeavyExecCommand("openclaw-heavy-run -- corepack pnpm lint:core")).toMatchObject({
+      heavy: false,
+      wrapped: true,
+    });
+    expect(
+      analyzeHeavyExecCommand(
+        "systemd-run --user --scope -p MemoryMax=6G -- corepack pnpm lint:core",
+      ),
+    ).toMatchObject({ heavy: false, wrapped: true });
+  });
+
+  it("blocks unisolated always-heavy commands before execution", async () => {
+    const tool = createPreflightTool();
+
+    await expect(
+      tool.execute("call-unisolated-heavy", {
+        command: "cd /tmp/openclaw && corepack pnpm lint:core",
+      }),
+    ).rejects.toThrow(/exec heavy-command guard: refused unisolated always-heavy command/);
+  });
+
+  it("does not fail closed on maybe-heavy diagnostics", async () => {
+    const tool = createPreflightTool();
+
+    await expect(
+      tool.execute("call-maybe-heavy", {
+        command: "git diff --stat -- src/agents/bash-tools.exec.ts",
+      }),
+    ).resolves.toMatchObject({ details: { status: "completed" } });
+  });
+});
 
 describe("exec interactive OpenClaw channel login guard", () => {
   it("recognizes direct and package-runner channel login commands before execution", () => {

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -82,6 +82,20 @@ describe("exec heavy-command guard", () => {
       heavy: true,
       hit: { classification: "always", reason: "corepack pnpm exec vitest" },
     });
+    expect(analyzeHeavyExecCommand("pnpm --dir ui test")).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "pnpm test" },
+    });
+    expect(
+      analyzeHeavyExecCommand("corepack pnpm --filter ./ui exec vitest run src/foo.test.ts"),
+    ).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "corepack pnpm exec vitest" },
+    });
+    expect(analyzeHeavyExecCommand("npm --prefix ui run lint")).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "npm run lint" },
+    });
     expect(analyzeHeavyExecCommand("tsgolint src")).toMatchObject({
       heavy: true,
       hit: { classification: "always", reason: "tsgolint" },

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -21,6 +21,8 @@ vi.mock("../utils/delivery-context.js", () => ({
 }));
 
 const isWin = process.platform === "win32";
+const originalApprovedHeavyWrappers = process.env.OPENCLAW_EXEC_HEAVY_APPROVED_WRAPPERS;
+const originalPath = process.env.PATH;
 
 const describeNonWin = isWin ? describe.skip : describe;
 const describeWin = isWin ? describe : describe.skip;
@@ -32,6 +34,16 @@ const createPreflightTool = () =>
 
 afterEach(() => {
   __setFsSafeTestHooksForTest();
+  if (originalApprovedHeavyWrappers === undefined) {
+    delete process.env.OPENCLAW_EXEC_HEAVY_APPROVED_WRAPPERS;
+  } else {
+    process.env.OPENCLAW_EXEC_HEAVY_APPROVED_WRAPPERS = originalApprovedHeavyWrappers;
+  }
+  if (originalPath === undefined) {
+    delete process.env.PATH;
+  } else {
+    process.env.PATH = originalPath;
+  }
 });
 
 async function expectSymlinkSwapDuringPreflightToAvoidErrors(params: {
@@ -135,17 +147,56 @@ describe("exec heavy-command guard", () => {
     expect(analyzeHeavyExecCommand("grep error src/file.ts")).toMatchObject({ heavy: false });
   });
 
-  it("allows light commands and explicitly isolated heavy commands", () => {
-    expect(analyzeHeavyExecCommand("git status --short")).toMatchObject({ heavy: false });
+  it("allows light commands and verified explicitly isolated heavy commands", async () => {
+    await withTempDir("openclaw-heavy-run-wrapper-", async (tmp) => {
+      const wrapperPath = path.join(tmp, "openclaw-heavy-run");
+      await fs.writeFile(wrapperPath, '#!/bin/sh\nexec "$@"\n', "utf-8");
+      await fs.chmod(wrapperPath, 0o755);
+      process.env.OPENCLAW_EXEC_HEAVY_APPROVED_WRAPPERS = wrapperPath;
+      process.env.PATH = `${tmp}${path.delimiter}${originalPath ?? ""}`;
+
+      expect(analyzeHeavyExecCommand("git status --short")).toMatchObject({ heavy: false });
+      expect(
+        analyzeHeavyExecCommand("openclaw-heavy-run -- corepack pnpm lint:core"),
+      ).toMatchObject({
+        heavy: false,
+        wrapped: true,
+      });
+      expect(
+        analyzeHeavyExecCommand(`python3 ${wrapperPath} -- corepack pnpm lint:core`),
+      ).toMatchObject({
+        heavy: false,
+        wrapped: true,
+      });
+      expect(
+        analyzeHeavyExecCommand(
+          "systemd-run --user --scope -p MemoryMax=6G -- corepack pnpm lint:core",
+        ),
+      ).toMatchObject({ heavy: false, wrapped: true });
+    });
+  });
+
+  it("classifies payloads behind unverified wrapper-shaped commands", () => {
+    delete process.env.OPENCLAW_EXEC_HEAVY_APPROVED_WRAPPERS;
+
     expect(analyzeHeavyExecCommand("openclaw-heavy-run -- corepack pnpm lint:core")).toMatchObject({
-      heavy: false,
-      wrapped: true,
+      heavy: true,
+      hit: { classification: "always", reason: "corepack pnpm lint:core" },
     });
     expect(
       analyzeHeavyExecCommand(
-        "systemd-run --user --scope -p MemoryMax=6G -- corepack pnpm lint:core",
+        "systemd-run --user --scope -p TimeoutStopSec=60 -- corepack pnpm lint:core",
       ),
-    ).toMatchObject({ heavy: false, wrapped: true });
+    ).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "corepack pnpm lint:core" },
+    });
+    expect(
+      analyzeHeavyExecCommand("systemd-run --user --scope -- MemoryMax=6G corepack pnpm lint:core"),
+    ).toMatchObject({
+      heavy: true,
+      hit: { classification: "always", reason: "corepack pnpm lint:core" },
+    });
   });
 
   it("blocks unisolated always-heavy commands before execution", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { buildCommandPayloadCandidates } from "../infra/command-analysis/risks.js";
@@ -1177,36 +1178,151 @@ function stripEnvAssignmentsForHeavyDetection(argv: string[]): string[] {
   return argv.slice(index);
 }
 
-function isOpenClawHeavyRunWrapper(argv: string[]): boolean {
+const EXEC_HEAVY_APPROVED_WRAPPERS_ENV = "OPENCLAW_EXEC_HEAVY_APPROVED_WRAPPERS";
+
+function shellQuoteCommandCandidateArg(arg: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/u.test(arg) ? arg : `'${arg.replace(/'/gu, "'\\''")}'`;
+}
+
+function joinCommandCandidateArgv(argv: string[]): string {
+  return argv.map(shellQuoteCommandCandidateArg).join(" ");
+}
+
+function parseApprovedHeavyWrapperPaths(): Set<string> {
+  const raw = process.env[EXEC_HEAVY_APPROVED_WRAPPERS_ENV]?.trim();
+  if (!raw) {
+    return new Set();
+  }
+  const approved = new Set<string>();
+  for (const candidate of raw.split(/[,\n]/u).map((value) => value.trim())) {
+    if (!candidate) {
+      continue;
+    }
+    try {
+      approved.add(fs.realpathSync.native(path.resolve(candidate)));
+    } catch {
+      // Missing or unreadable allowlist entries are deliberately not trusted.
+    }
+  }
+  return approved;
+}
+
+function resolveExecutableRealpath(token: string | undefined): string | null {
+  if (!token) {
+    return null;
+  }
+  const candidates =
+    path.isAbsolute(token) || token.includes("/") || token.includes("\\")
+      ? [path.resolve(token)]
+      : (process.env.PATH ?? "")
+          .split(path.delimiter)
+          .filter(Boolean)
+          .map((dir) => path.join(dir, token));
+  for (const candidate of candidates) {
+    try {
+      return fs.realpathSync.native(candidate);
+    } catch {
+      // Keep looking through PATH; absence means the wrapper is not verified.
+    }
+  }
+  return null;
+}
+
+function openClawHeavyRunWrapperDetails(
+  argv: string[],
+): { wrapperToken: string; payload: string[] } | null {
   const stripped = stripEnvAssignmentsForHeavyDetection(argv);
   const executable = normalizeCommandBaseName(stripped[0]);
+  let wrapperIndex = -1;
   if (executable === "openclaw-heavy-run") {
-    return true;
+    wrapperIndex = 0;
+  } else if (
+    (executable === "python" || executable === "python3" || executable === "node") &&
+    normalizeCommandBaseName(stripped[1]) === "openclaw-heavy-run"
+  ) {
+    wrapperIndex = 1;
   }
-  if (executable === "python" || executable === "python3" || executable === "node") {
-    return normalizeCommandBaseName(stripped[1]) === "openclaw-heavy-run";
+  if (wrapperIndex < 0) {
+    return null;
   }
-  return false;
+  let payloadIndex = wrapperIndex + 1;
+  if (stripped[payloadIndex] === "--") {
+    payloadIndex += 1;
+  }
+  return { wrapperToken: stripped[wrapperIndex] ?? "", payload: stripped.slice(payloadIndex) };
+}
+
+function isOpenClawHeavyRunWrapper(argv: string[]): boolean {
+  const details = openClawHeavyRunWrapperDetails(argv);
+  if (!details) {
+    return false;
+  }
+  const wrapperRealpath = resolveExecutableRealpath(details.wrapperToken);
+  if (!wrapperRealpath) {
+    return false;
+  }
+  return parseApprovedHeavyWrapperPaths().has(wrapperRealpath);
+}
+
+function unapprovedOpenClawHeavyRunPayload(argv: string[]): string | null {
+  const details = openClawHeavyRunWrapperDetails(argv);
+  if (!details || isOpenClawHeavyRunWrapper(argv) || details.payload.length === 0) {
+    return null;
+  }
+  return joinCommandCandidateArgv(details.payload);
+}
+
+type SystemdRunMemoryScopeAnalysis = {
+  hasMemoryScope: boolean;
+  payload: string[];
+};
+
+function analyzeSystemdRunMemoryScope(argv: string[]): SystemdRunMemoryScopeAnalysis | null {
+  const stripped = stripEnvAssignmentsForHeavyDetection(argv);
+  if (normalizeCommandBaseName(stripped[0]) !== "systemd-run") {
+    return null;
+  }
+  const separatorIndex = stripped.indexOf("--");
+  const wrapperArgs = separatorIndex >= 0 ? stripped.slice(1, separatorIndex) : stripped.slice(1);
+  const payload = separatorIndex >= 0 ? stripped.slice(separatorIndex + 1) : [];
+  let hasScope = false;
+  let hasMemoryMax = false;
+  for (let index = 0; index < wrapperArgs.length; index += 1) {
+    const arg = wrapperArgs[index] ?? "";
+    if (arg === "--scope") {
+      hasScope = true;
+      continue;
+    }
+    if (/^MemoryMax=/u.test(arg)) {
+      hasMemoryMax = true;
+      continue;
+    }
+    if (arg === "-p" || arg === "--property") {
+      const value = wrapperArgs[index + 1] ?? "";
+      if (/^MemoryMax=/u.test(value)) {
+        hasMemoryMax = true;
+      }
+      index += 1;
+      continue;
+    }
+    const propertyValue = arg.match(/^--property=(.+)$/u)?.[1] ?? "";
+    if (/^MemoryMax=/u.test(propertyValue)) {
+      hasMemoryMax = true;
+    }
+  }
+  return { hasMemoryScope: hasScope && hasMemoryMax, payload };
 }
 
 function isExplicitSystemdMemoryScope(argv: string[]): boolean {
-  const stripped = stripEnvAssignmentsForHeavyDetection(argv);
-  if (normalizeCommandBaseName(stripped[0]) !== "systemd-run") {
-    return false;
+  return analyzeSystemdRunMemoryScope(argv)?.hasMemoryScope ?? false;
+}
+
+function unapprovedSystemdRunPayload(argv: string[]): string | null {
+  const analysis = analyzeSystemdRunMemoryScope(argv);
+  if (!analysis || analysis.hasMemoryScope || analysis.payload.length === 0) {
+    return null;
   }
-  return (
-    stripped.includes("--scope") &&
-    stripped.some(
-      (arg) => arg === "-p" || /^--property(?:=|$)/u.test(arg) || /^MemoryMax=/u.test(arg),
-    ) &&
-    stripped.some((arg, index) => {
-      if (/^MemoryMax=/u.test(arg)) {
-        return true;
-      }
-      const prev = stripped[index - 1];
-      return (prev === "-p" || prev === "--property") && /^MemoryMax=/u.test(arg);
-    })
-  );
+  return joinCommandCandidateArgv(analysis.payload);
 }
 
 const PACKAGE_MANAGER_LEADING_VALUE_OPTIONS = new Set([
@@ -1366,6 +1482,12 @@ function analyzeHeavyExecCommand(command: string): HeavyExecCommandAnalysis {
       sawHeavyRunWrapper = true;
       continue;
     }
+    const unapprovedWrapperPayload =
+      unapprovedOpenClawHeavyRunPayload(argv) ?? unapprovedSystemdRunPayload(argv);
+    if (unapprovedWrapperPayload && !seen.has(unapprovedWrapperPayload.trim())) {
+      queue.push(unapprovedWrapperPayload);
+      continue;
+    }
     const hit = classifyHeavyArgv(argv);
     if (hit) {
       return { heavy: true, wrapped: sawHeavyRunWrapper, hit };
@@ -1397,6 +1519,7 @@ function rejectUnisolatedHeavyExecCommand(command: string): void {
       `Matched command: ${truncateMiddle(analysis.hit.candidate, 180)}`,
       "Run heavy OpenClaw/upstream validation through a configured resource-isolation wrapper, for example:",
       "openclaw-heavy-run -- <command>",
+      `Approved wrapper paths must resolve from ${EXEC_HEAVY_APPROVED_WRAPPERS_ENV}.`,
       "If the guard exits 75/defer, stop and report instead of bypassing.",
       "Set OPENCLAW_EXEC_HEAVY_ENFORCEMENT=off only for an explicitly approved emergency bypass.",
     ].join("\n"),

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1209,19 +1209,57 @@ function isExplicitSystemdMemoryScope(argv: string[]): boolean {
   );
 }
 
+const PACKAGE_MANAGER_LEADING_VALUE_OPTIONS = new Set([
+  "-C",
+  "--cache",
+  "--config",
+  "--configfile",
+  "--cwd",
+  "--dir",
+  "--filter",
+  "--package",
+  "--prefix",
+  "--registry",
+  "--store-dir",
+  "--userconfig",
+  "--workspace",
+]);
+
+function stripPackageManagerLeadingOptions(args: string[]): string[] {
+  let index = 0;
+  while (index < args.length) {
+    const arg = args[index] ?? "";
+    if (arg === "--") {
+      index += 1;
+      break;
+    }
+    if (!arg.startsWith("-") || arg === "-") {
+      break;
+    }
+
+    const optionName = arg.includes("=") ? arg.slice(0, arg.indexOf("=")) : arg;
+    index += 1;
+    if (!arg.includes("=") && PACKAGE_MANAGER_LEADING_VALUE_OPTIONS.has(optionName)) {
+      index += 1;
+    }
+  }
+  return args.slice(index);
+}
+
 function packageManagerHeavyReason(packageManager: string, args: string[]): string | null {
-  const first = normalizeLowercaseStringOrEmpty(args[0] ?? "");
+  const commandArgs = stripPackageManagerLeadingOptions(args);
+  const first = normalizeLowercaseStringOrEmpty(commandArgs[0] ?? "");
   if (!first) {
     return null;
   }
   if (first === "exec" || first === "dlx") {
-    const executable = normalizeCommandBaseName(args[1]);
+    const executable = normalizeCommandBaseName(commandArgs[1]);
     return DIRECT_HEAVY_EXECUTABLES.has(executable)
       ? `${packageManager} ${first} ${executable}`
       : null;
   }
   if (first === "run") {
-    const script = normalizeLowercaseStringOrEmpty(args[1] ?? "");
+    const script = normalizeLowercaseStringOrEmpty(commandArgs[1] ?? "");
     return isHeavyPackageScriptName(script) ? `${packageManager} run ${script}` : null;
   }
   if (PACKAGE_MANAGER_HEAVY_DIRECT_COMMANDS.has(first) || isHeavyPackageScriptName(first)) {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1134,6 +1134,237 @@ function parseOpenClawChannelsLoginShellCommand(raw: string): boolean {
   );
 }
 
+type HeavyExecCommandClassification = "always" | "maybe";
+
+type HeavyExecCommandHit = {
+  classification: HeavyExecCommandClassification;
+  reason: string;
+  candidate: string;
+};
+
+type HeavyExecCommandAnalysis = {
+  heavy: boolean;
+  wrapped: boolean;
+  hit?: HeavyExecCommandHit;
+};
+
+const PACKAGE_MANAGER_HEAVY_DIRECT_COMMANDS = new Set([
+  "add",
+  "build",
+  "build:docker",
+  "build:strict-smoke",
+  "ci",
+  "install",
+  "lint",
+  "lint:all",
+  "lint:core",
+  "lint:extensions",
+  "test",
+  "test:all",
+  "typecheck",
+  "update",
+]);
+
+const PACKAGE_MANAGER_HEAVY_PREFIXES = ["build", "check", "lint", "test", "tsgo", "typecheck"];
+
+const DIRECT_HEAVY_EXECUTABLES = new Set(["jest", "mocha", "oxlint", "tsgo", "tsgolint", "vitest"]);
+
+function stripEnvAssignmentsForHeavyDetection(argv: string[]): string[] {
+  let index = 0;
+  while (index < argv.length && isShellEnvAssignmentToken(argv[index])) {
+    index += 1;
+  }
+  return argv.slice(index);
+}
+
+function isOpenClawHeavyRunWrapper(argv: string[]): boolean {
+  const stripped = stripEnvAssignmentsForHeavyDetection(argv);
+  const executable = normalizeCommandBaseName(stripped[0]);
+  if (executable === "openclaw-heavy-run") {
+    return true;
+  }
+  if (executable === "python" || executable === "python3" || executable === "node") {
+    return normalizeCommandBaseName(stripped[1]) === "openclaw-heavy-run";
+  }
+  return false;
+}
+
+function isExplicitSystemdMemoryScope(argv: string[]): boolean {
+  const stripped = stripEnvAssignmentsForHeavyDetection(argv);
+  if (normalizeCommandBaseName(stripped[0]) !== "systemd-run") {
+    return false;
+  }
+  return (
+    stripped.includes("--scope") &&
+    stripped.some(
+      (arg) => arg === "-p" || /^--property(?:=|$)/u.test(arg) || /^MemoryMax=/u.test(arg),
+    ) &&
+    stripped.some((arg, index) => {
+      if (/^MemoryMax=/u.test(arg)) {
+        return true;
+      }
+      const prev = stripped[index - 1];
+      return (prev === "-p" || prev === "--property") && /^MemoryMax=/u.test(arg);
+    })
+  );
+}
+
+function packageManagerHeavyReason(packageManager: string, args: string[]): string | null {
+  const first = normalizeLowercaseStringOrEmpty(args[0] ?? "");
+  if (!first) {
+    return null;
+  }
+  if (first === "exec" || first === "dlx") {
+    const executable = normalizeCommandBaseName(args[1]);
+    return DIRECT_HEAVY_EXECUTABLES.has(executable)
+      ? `${packageManager} ${first} ${executable}`
+      : null;
+  }
+  if (first === "run") {
+    const script = normalizeLowercaseStringOrEmpty(args[1] ?? "");
+    return isHeavyPackageScriptName(script) ? `${packageManager} run ${script}` : null;
+  }
+  if (PACKAGE_MANAGER_HEAVY_DIRECT_COMMANDS.has(first) || isHeavyPackageScriptName(first)) {
+    return `${packageManager} ${first}`;
+  }
+  return null;
+}
+
+function isHeavyPackageScriptName(script: string): boolean {
+  if (!script) {
+    return false;
+  }
+  return PACKAGE_MANAGER_HEAVY_PREFIXES.some((prefix) => {
+    return script === prefix || script.startsWith(`${prefix}:`) || script.startsWith(`${prefix}-`);
+  });
+}
+
+function isRecursiveGrepFlag(arg: string): boolean {
+  return (
+    arg === "-r" ||
+    arg === "-R" ||
+    arg === "--recursive" ||
+    arg === "--dereference-recursive" ||
+    /^-[^-]*[rR][A-Za-z]*$/u.test(arg)
+  );
+}
+
+function classifyHeavyArgv(argv: string[]): HeavyExecCommandHit | null {
+  const stripped = stripEnvAssignmentsForHeavyDetection(argv);
+  const executable = normalizeCommandBaseName(stripped[0]);
+  if (
+    !executable ||
+    isOpenClawHeavyRunWrapper(stripped) ||
+    isExplicitSystemdMemoryScope(stripped)
+  ) {
+    return null;
+  }
+
+  if (executable === "corepack") {
+    const packageManager = normalizeCommandBaseName(stripped[1]);
+    if (["pnpm", "npm", "yarn", "bun"].includes(packageManager)) {
+      const reason = packageManagerHeavyReason(`corepack ${packageManager}`, stripped.slice(2));
+      return reason ? { classification: "always", reason, candidate: stripped.join(" ") } : null;
+    }
+  }
+
+  if (["pnpm", "npm", "yarn", "bun"].includes(executable)) {
+    const reason = packageManagerHeavyReason(executable, stripped.slice(1));
+    return reason ? { classification: "always", reason, candidate: stripped.join(" ") } : null;
+  }
+
+  if (DIRECT_HEAVY_EXECUTABLES.has(executable)) {
+    return { classification: "always", reason: executable, candidate: stripped.join(" ") };
+  }
+
+  if (executable === "rg") {
+    if (stripped.includes("-S") || stripped.includes("--no-ignore")) {
+      return { classification: "maybe", reason: "broad ripgrep", candidate: stripped.join(" ") };
+    }
+  }
+
+  if (executable === "grep" && stripped.some(isRecursiveGrepFlag)) {
+    return { classification: "maybe", reason: "recursive grep", candidate: stripped.join(" ") };
+  }
+
+  if (executable === "git" && stripped[1] === "diff" && stripped.includes("--stat")) {
+    return { classification: "maybe", reason: "git diff --stat", candidate: stripped.join(" ") };
+  }
+
+  return null;
+}
+
+function collectExecCommandCandidates(rawCommand: string): string[] {
+  const raw = rawCommand.trim();
+  const analysis = analyzeShellCommand({ command: raw });
+  return analysis.ok
+    ? analysis.segments.flatMap((segment) => buildCommandPayloadCandidates(segment.argv))
+    : raw
+        .split(/\r?\n/u)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .flatMap((line) => {
+          const argv = splitShellArgs(line);
+          return argv ? buildCommandPayloadCandidates(argv) : [line];
+        });
+}
+
+function analyzeHeavyExecCommand(command: string): HeavyExecCommandAnalysis {
+  const queue = collectExecCommandCandidates(command);
+  const seen = new Set<string>();
+  let sawHeavyRunWrapper = false;
+  while (queue.length > 0) {
+    const candidate = queue.shift() ?? "";
+    const normalizedCandidate = candidate.trim();
+    if (!normalizedCandidate || seen.has(normalizedCandidate)) {
+      continue;
+    }
+    seen.add(normalizedCandidate);
+    const argv = splitShellArgs(normalizedCandidate);
+    if (!argv) {
+      continue;
+    }
+    if (isOpenClawHeavyRunWrapper(argv) || isExplicitSystemdMemoryScope(argv)) {
+      sawHeavyRunWrapper = true;
+      continue;
+    }
+    const hit = classifyHeavyArgv(argv);
+    if (hit) {
+      return { heavy: true, wrapped: sawHeavyRunWrapper, hit };
+    }
+    // A shell-wrapper payload may itself contain a chain such as
+    // `cd /repo && corepack pnpm lint:core`; recurse into it after the wrapper
+    // unwrapping step so the inner heavy segment is still detected.
+    const nestedCandidates = collectExecCommandCandidates(normalizedCandidate);
+    for (const nested of nestedCandidates) {
+      if (!seen.has(nested.trim())) {
+        queue.push(nested);
+      }
+    }
+  }
+  return { heavy: false, wrapped: sawHeavyRunWrapper };
+}
+
+function rejectUnisolatedHeavyExecCommand(command: string): void {
+  if (process.env.OPENCLAW_EXEC_HEAVY_ENFORCEMENT === "off") {
+    return;
+  }
+  const analysis = analyzeHeavyExecCommand(command);
+  if (!analysis.heavy || !analysis.hit || analysis.hit.classification !== "always") {
+    return;
+  }
+  throw new Error(
+    [
+      `exec heavy-command guard: refused unisolated ${analysis.hit.classification}-heavy command (${analysis.hit.reason}).`,
+      `Matched command: ${truncateMiddle(analysis.hit.candidate, 180)}`,
+      "Run heavy OpenClaw/upstream validation through a configured resource-isolation wrapper, for example:",
+      "openclaw-heavy-run -- <command>",
+      "If the guard exits 75/defer, stop and report instead of bypassing.",
+      "Set OPENCLAW_EXEC_HEAVY_ENFORCEMENT=off only for an explicitly approved emergency bypass.",
+    ].join("\n"),
+  );
+}
+
 function rejectUnsafeControlShellCommand(command: string): void {
   const rawCommand = command.trim();
   const analysis = analyzeShellCommand({ command: rawCommand });
@@ -1398,6 +1629,9 @@ export function createExecTool(
         workdir = resolveWorkdir(rawWorkdir, warnings);
       }
       rejectUnsafeControlShellCommand(params.command);
+      if (host === "gateway" && !sandbox) {
+        rejectUnisolatedHeavyExecCommand(params.command);
+      }
 
       const inheritedBaseEnv = coerceEnv(process.env);
       const hostEnvResult =
@@ -1683,6 +1917,7 @@ export function createExecTool(
 export const execTool = createExecTool();
 
 export const __testing = {
+  analyzeHeavyExecCommand,
   parseOpenClawChannelsLoginShellCommand,
   validateScriptFileForShellBleed,
 };


### PR DESCRIPTION
### Summary

- add an exec-tool preflight guard for known-heavy validation commands before local Gateway execution
- fail closed for unisolated package-manager install/lint/build/typecheck/test commands and direct `tsgo` / `tsgolint` / `oxlint` / broad test runners
- classify broader diagnostics such as `rg -S`, recursive `grep`, and `git diff --stat` as maybe-heavy without fail-closing them yet
- allow commands already isolated via `openclaw-heavy-run` or an explicit resource-limited `systemd-run --user --scope -p MemoryMax=...`
- expose `analyzeHeavyExecCommand` in `__testing` and cover direct, chained, shell-wrapped, maybe-heavy, light, isolated, and execute-path blocking cases

Closes #77121.

### Why

Agents can autonomously generate heavyweight upstream validation commands during issue/PR follow-up. When those commands run through local Gateway `exec`, they share the live Gateway service resource domain. Existing mitigations help adjacent surfaces, but do not prevent arbitrary agent-generated heavy validation from starting unisolated:

- #70419 improves Linux OOM victim selection for child processes, but it does not prevent heavy commands from entering the Gateway unit cgroup.
- #71652 guards local `tsgo` scripts under pressure, but does not cover arbitrary agent `exec` commands such as `pnpm install` or `pnpm lint:core`.
- #43176 caps broad `find` scans, which is complementary but covers a different command class.

This PR adds a narrower fail-closed guard at the `exec` entry point.

### Behavior

Blocked unless isolated:

- `pnpm` / `npm` / `yarn` / `bun` / `corepack` install, update, lint, build, typecheck, or test scripts
- direct `tsgo`, `tsgolint`, `oxlint`, `vitest`, `jest`, `mocha`
- shell-wrapped/chained variants, for example `bash -lc 'cd repo && corepack pnpm lint:core'`

Detected but not blocked yet:

- maybe-heavy broad diagnostics such as `rg -S`, recursive `grep`, and `git diff --stat`

Allowed:

- light commands such as `git status --short`
- commands wrapped by `openclaw-heavy-run -- <command>`
- explicit resource-scoped commands such as `systemd-run --user --scope -p MemoryMax=... -- <command>`

Emergency bypass:

- `OPENCLAW_EXEC_HEAVY_ENFORCEMENT=off`

### Test plan

Run through a resource-isolated wrapper locally:

```bash
[workspace]/.github/scripts/openclaw-heavy-run --   corepack pnpm exec vitest run src/agents/bash-tools.exec.script-preflight.test.ts
```

Result:

```text
2 files passed
126 tests passed
8 skipped
```

Also passed:

```bash
git diff --check
```

### Notes / scope boundaries

- This PR intentionally does not introduce a new built-in process supervisor or cgroup manager.
- This PR intentionally does not replace #70419, #71652, #75820, or #43176; it complements them at the agent `exec` entry point.
- The command-class heuristic is conservative for known-heavy validation commands. Maybe-heavy diagnostics are classified for observability/tests but are not fail-closed yet to avoid excessive operator friction.
- The refusal message intentionally names a generic configured resource-isolation wrapper rather than a local filesystem path.

## Files changed

```text
d56991f8 fix(exec): block unisolated heavy validation commands
 .../bash-tools.exec.script-preflight.test.ts       |  88 ++++++++
 src/agents/bash-tools.exec.ts                      | 235 +++++++++++++++++++++
 2 files changed, 323 insertions(+)
```

## Local diff summary

```text
.../bash-tools.exec.script-preflight.test.ts       |  88 ++++++++
 src/agents/bash-tools.exec.ts                      | 235 +++++++++++++++++++++
 2 files changed, 323 insertions(+)
```

## Real behavior proof

- **Behavior addressed:** Gateway exec preflight classifies unisolated always-heavy validation commands as heavy while recognizing the approved `openclaw-heavy-run` wrapper as isolated.
- **Real environment tested:** Local OpenClaw source checkout on Linux using the actual exec preflight analyzer from `src/agents/bash-tools.exec.ts`.
- **Exact steps or command run after this patch:** Ran a `node --import tsx` terminal smoke against the real analyzer for an unwrapped `corepack pnpm exec vitest ...` command and the same command routed through `.github/scripts/openclaw-heavy-run -- ...`.
- **Evidence after fix:** Terminal capture from the smoke:

  ```text
  unwrapped: {"heavy":true,"wrapped":false,"hit":{"classification":"always","reason":"corepack pnpm exec vitest","candidate":"corepack pnpm exec vitest run src/agents/bash-tools.exec.script-preflight.test.ts"}}
  wrapped: {"heavy":false,"wrapped":true}
  ```

- **Observed result after fix:** The unwrapped heavy command is detected as always-heavy and not wrapped; the approved wrapper is recognized and no longer reports a heavy unisolated hit.
- **What was not tested:** No live Gateway exec call was run; the proof exercises the real preflight analyzer in an isolated source checkout, with the targeted exec preflight regression suite run separately.
