### PR TITLE
[AI-assisted] fix(deepseek): export resolveThinkingProfile from provider policy surface

### DIFF
--- a/extensions/deepseek/index.ts
+++ b/extensions/deepseek/index.ts
@@ -1,27 +1,12 @@
-import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
 import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
-import { isDeepSeekV4ModelId } from "./models.js";
 import { applyDeepSeekConfig, DEEPSEEK_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildDeepSeekProvider } from "./provider-catalog.js";
 import { createDeepSeekV4ThinkingWrapper } from "./stream.js";
+import { resolveDeepSeekV4ThinkingProfile } from "./thinking-profile.js";
 
 const PROVIDER_ID = "deepseek";
-const V4_THINKING_LEVEL_IDS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
-
-function buildDeepSeekV4ThinkingLevel(id: (typeof V4_THINKING_LEVEL_IDS)[number]) {
-  return { id };
-}
-
-const DEEPSEEK_V4_THINKING_PROFILE = {
-  levels: V4_THINKING_LEVEL_IDS.map(buildDeepSeekV4ThinkingLevel),
-  defaultLevel: "high",
-} satisfies ProviderThinkingProfile;
-
-function resolveDeepSeekV4ThinkingProfile(modelId: string): ProviderThinkingProfile | undefined {
-  return isDeepSeekV4ModelId(modelId) ? DEEPSEEK_V4_THINKING_PROFILE : undefined;
-}
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,

--- a/extensions/deepseek/provider-policy-api.ts
+++ b/extensions/deepseek/provider-policy-api.ts
@@ -1,6 +1,7 @@
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { DEEPSEEK_MODEL_CATALOG } from "./models.js";
+import { resolveDeepSeekV4ThinkingProfile } from "./thinking-profile.js";
 
 type ModelDefinitionDraft = Partial<ModelDefinitionConfig> &
   Pick<ModelDefinitionConfig, "id" | "name">;
@@ -94,4 +95,11 @@ export function normalizeConfig(params: {
   }
 
   return { ...providerConfig, models: nextModels as ModelDefinitionConfig[] };
+}
+
+export function resolveThinkingProfile(params: { provider: string; modelId: string }) {
+  if (params.provider.trim().toLowerCase() !== "deepseek") {
+    return null;
+  }
+  return resolveDeepSeekV4ThinkingProfile(params.modelId) ?? null;
 }

--- a/extensions/deepseek/thinking-profile.ts
+++ b/extensions/deepseek/thinking-profile.ts
@@ -1,0 +1,19 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+import { isDeepSeekV4ModelId } from "./models.js";
+
+const V4_THINKING_LEVEL_IDS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+function buildDeepSeekV4ThinkingLevel(id: (typeof V4_THINKING_LEVEL_IDS)[number]) {
+  return { id };
+}
+
+const DEEPSEEK_V4_THINKING_PROFILE = {
+  levels: V4_THINKING_LEVEL_IDS.map(buildDeepSeekV4ThinkingLevel),
+  defaultLevel: "high",
+} satisfies ProviderThinkingProfile;
+
+export function resolveDeepSeekV4ThinkingProfile(
+  modelId: string,
+): ProviderThinkingProfile | undefined {
+  return isDeepSeekV4ModelId(modelId) ? DEEPSEEK_V4_THINKING_PROFILE : undefined;
+}


### PR DESCRIPTION
## Summary

Fixes #77139 — DeepSeek V4 `/think` picker in the Control UI omits `xhigh` and `max` thinking levels for native `deepseek/deepseek-v4-pro`.

## Root Cause

`resolveThinkingProfile` was registered at runtime via `extensions/deepseek/index.ts` but was **not exported** from the lightweight bundled provider policy surface (`extensions/deepseek/provider-policy-api.ts`). When the Control UI hits the fallback path in `src/plugins/provider-thinking.ts:85` — which calls `resolveBundledProviderPolicySurface("deepseek")?.resolveThinkingProfile?.(...)` — it found no `resolveThinkingProfile` export and fell back to the default five-level profile, missing `xhigh` and `max`.

For comparison, `extensions/anthropic/provider-policy-api.ts` already exports `resolveThinkingProfile`, which is why Anthropic models work correctly through the same fallback path.

## Changes

1. **`extensions/deepseek/thinking-profile.ts`** (new) — Extracts the V4 thinking profile constant and `resolveDeepSeekV4ThinkingProfile()` into a shared module so both the runtime entry and the policy surface can import it without duplication.

2. **`extensions/deepseek/index.ts`** — Imports `resolveDeepSeekV4ThinkingProfile` from the new shared module instead of defining it inline.

3. **`extensions/deepseek/provider-policy-api.ts`** — Exports `resolveThinkingProfile` that delegates to `resolveDeepSeekV4ThinkingProfile`, making `xhigh` and `max` available through the bundled policy surface fallback path.

## Regression Test Plan

- Existing `extensions/deepseek/index.test.ts` (10 tests) — pass ✅
- Existing `extensions/deepseek/provider-policy-api.test.ts` (10 tests) — pass ✅
- Manual: open Control UI for a `deepseek/deepseek-v4-pro` session, type `/think`, and confirm `xhigh` and `max` appear in the picker.

## Security Impact

None. This change only wires an existing thinking profile through an additional code path. No new permissions, no auth changes, no data flow changes.
