### PR TITLE
fix(claude-cli): fork session on resume to avoid concurrent collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/claude-cli: append `--fork-session` to the default Claude CLI resume args so each `claude --resume {sessionId}` starts a fresh session id rather than reusing the original, preventing concurrent transcript-write collisions when multiple call sites (auto-reply, queued steers, subagent spawns) resume the same session in close succession; the new session id is captured from the stream-json `init` event and written back through `cliSessionBindings` on each turn. Thanks @dae-sun.
 - Web fetch: late-bind `web_fetch` config and provider fallback metadata from the active runtime snapshot, matching `web_search` so long-lived tools do not use stale fetch provider settings. Thanks @vincentkoc.
 - Discord: clear stale startup probe bot/application status when the async bot probe throws, not just when it returns a degraded probe result. Thanks @vincentkoc.
 - Web search: scope explicit bundled `web_search` provider runtime loading through manifest ownership, so selecting DuckDuckGo/Gemini/etc. does not import unrelated bundled providers or log their optional dependency failures. Thanks @vincentkoc.

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -52,6 +52,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
         "mcp__openclaw__*",
         "--resume",
         "{sessionId}",
+        "--fork-session",
       ],
       output: "jsonl",
       liveSession: "claude-stdio",

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -209,6 +209,8 @@ describe("normalizeClaudeBackendConfig", () => {
     expect(backend.config.args).toContain("user");
     expect(backend.config.resumeArgs).toContain("--setting-sources");
     expect(backend.config.resumeArgs).toContain("user");
+    expect(backend.config.resumeArgs).toContain("--fork-session");
+    expect(backend.config.args).not.toContain("--fork-session");
     expect(backend.config.clearEnv).toEqual([...CLAUDE_CLI_CLEAR_ENV]);
     expect(backend.config.clearEnv).toContain("ANTHROPIC_API_TOKEN");
     expect(backend.config.clearEnv).toContain("ANTHROPIC_BASE_URL");
@@ -224,5 +226,18 @@ describe("normalizeClaudeBackendConfig", () => {
     expect(backend.config.clearEnv).toContain("OTEL_METRICS_EXPORTER");
     expect(backend.config.clearEnv).toContain("OTEL_EXPORTER_OTLP_PROTOCOL");
     expect(backend.config.clearEnv).toContain("OTEL_SDK_DISABLED");
+  });
+
+  it("orders --fork-session after --resume {sessionId} in default resume args so each resume forks its own session id", () => {
+    const backend = buildAnthropicCliBackend();
+    const resumeArgs = backend.config.resumeArgs ?? [];
+
+    const resumeIndex = resumeArgs.indexOf("--resume");
+    const forkIndex = resumeArgs.indexOf("--fork-session");
+
+    expect(resumeIndex).toBeGreaterThanOrEqual(0);
+    expect(forkIndex).toBeGreaterThanOrEqual(0);
+    expect(resumeArgs[resumeIndex + 1]).toBe("{sessionId}");
+    expect(forkIndex).toBeGreaterThan(resumeIndex + 1);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: when multiple call sites (auto-reply, queued steers, subagent spawns) `claude --resume {sessionId}` the same Claude CLI session in close succession, they all write to the same transcript file and collide. Symptoms: dropped/empty replies, partial transcripts, occasional crash loops on busy Slack threads.
- Why it matters: any moderately busy install that resumes the same session id from more than one driver in the same window will silently lose model output; the failure is timing-dependent and easy to miss in quiet test envs.
- What changed: append `--fork-session` to the default Claude CLI `resumeArgs` in `buildAnthropicCliBackend`, positioned after `--resume {sessionId}` so the resume target is preserved before the fork. The existing runtime already captures the new session id from the stream-json `init` event and writes it back through `cliSessionBindings` on each turn, so toggling the flag is sufficient.
- What did NOT change (scope boundary): no change to initial-launch `args`, no new bindings code, no change to `cli-session-history` plumbing, no change to non-Claude CLI backends.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

(touched: `extensions/anthropic/cli-backend.ts` + matching test/CHANGELOG.)

## Linked Issue/PR

- Closes N/A (no upstream issue filed; happy to open one if maintainers prefer)
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `claude --resume {sessionId}` reuses the same session id, which means each concurrent resume of the same id appends to the same transcript file. When more than one driver (auto-reply / queued steer / subagent fan-out) resumes within the same write window, their transcript writes interleave and either lose output or trip the CLI's own consistency checks.
- Missing detection / guardrail: `cli-shared.test.ts` covered every flag in default `resumeArgs` except `--fork-session`, so a regression that strips it (we did exactly this earlier in our integration) compiles, type-checks, and unit-tests cleanly while breaking concurrent resumes in production.
- Contributing context: `cliSessionBindings` already persists the freshly forked session id captured from the stream-json `init` event, so once the flag is set the rest of the resume pipeline is correct. The bug was purely the missing flag in the default resume args.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/anthropic/cli-shared.test.ts` (the `normalizeClaudeBackendConfig` suite)
- Scenario the test should lock in: (a) `--fork-session` is present in default `resumeArgs`, (b) it is **not** added to initial `args` (which would re-fork on every cold launch), and (c) it is ordered **after** `--resume {sessionId}` so the resume target is bound before the fork.
- Why this is the smallest reliable guardrail: the bug is a one-token omission in a static argv array. Asserting on that array is deterministic and fast (no Claude CLI fixtures needed), and the ordering check pins the operationally important property (resume id must be parsed as the resume target, not as the fork target).
- Existing test that already covers this: none — the existing default-args case asserted other resume flags but not `--fork-session`.
- If no new test is added, why not: N/A — test is included.

## User-visible / Behavior Changes

Each resume now starts with a freshly forked session id. The forked id is captured + persisted via the existing `cliSessionBindings` flow, so callers that read the bound session id from the gateway after a turn will see the newly forked id from then on. This is the documented Claude CLI semantics for `--fork-session` and matches the implicit assumption in `cli-session-history.claude.ts` (`entry?.cliSessionBindings?.[CLAUDE_CLI_PROVIDER]?.sessionId`). No config keys, no new defaults to surface.

## Diagram

```text
Before (collision window):
  driver A: claude --resume S1 ──┐
  driver B: claude --resume S1 ──┤── all write transcript-S1.jsonl  => interleaved / lost output
  driver C: claude --resume S1 ──┘

After (--fork-session on resume):
  driver A: claude --resume S1 --fork-session ──> transcript-S2.jsonl  (S2 bound back via init)
  driver B: claude --resume S2 --fork-session ──> transcript-S3.jsonl  (S3 bound back via init)
  driver C: claude --resume S3 --fork-session ──> transcript-S4.jsonl  (no shared file)
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (still the same `claude` invocation, only an extra argv token)
- Command/tool execution surface changed? `No` (default Claude CLI flag, documented upstream)
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (tested on the same Slack-heavy install where the regression first showed up)
- Runtime/container: local node + bundled openclaw runtime
- Model/provider: Anthropic Claude CLI (`claude`) backend
- Integration/channel (if any): Slack (multi-driver: auto-reply + queued steers + subagent spawns hitting the same session id)
- Relevant config (redacted): default `buildAnthropicCliBackend()` config; no per-agent `resumeArgs` override

### Steps

1. From the affected install, drive 3+ concurrent resumes against one session id (auto-reply + queued steer + subagent spawn within the same write window).
2. Observe transcript-write collisions / dropped replies on the busy thread.
3. Apply this PR (re-add `--fork-session` to default `resumeArgs`).
4. Repeat step 1.

### Expected

- Step 2 shows interleaved/empty replies; step 4 shows clean per-turn replies and a fresh session id captured into `cliSessionBindings` on every turn.

### Actual

- Matches expected. We had previously dropped this flag thinking the problem was elsewhere; the regression came right back, which confirmed `--fork-session` is the actual fix.

## Evidence

- [x] Failing test/log before + passing after — production reproduction described above; new unit test (`orders --fork-session after --resume {sessionId}` in `cli-shared.test.ts`) fails on a no-flag default.
- [x] Trace/log snippets — see "In-tree code path" below; raw production transcripts contain channel PII and are not safe to share, so I'm citing the verifiable in-tree call sites that the fix rides on instead.
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

### In-tree code path

The fix is a one-token argv change because the rest of the resume pipeline already supports session-id rotation. Reviewers can confirm without running the CLI:

- `extensions/anthropic/cli-backend.ts:55` — argv now contains `"--fork-session"` immediately after `"--resume", "{sessionId}"`.
- `src/agents/cli-output.ts:289-294` and `:389-395` — every parsed CLI stream line is passed through `pickCliSessionId(parsed, backend)` (with `sessionIdFields = ["session_id", "sessionId"]` per `cli-output.ts:254-256`), so the forked id from the stream-json `init` event (`{type: "init", session_id: "..."}`, see fixture in `src/agents/cli-runner.spawn.test.ts:699,718,774`) is captured on every turn.
- `src/gateway/cli-session-history.claude.ts:49-64` (`resolveClaudeCliBindingSessionId`) — reads the freshly bound id from `entry?.cliSessionBindings?.[CLAUDE_CLI_PROVIDER]?.sessionId` first, with legacy fallbacks. So the next resume target is whatever the previous turn's `init` event reported, not the original.

In other words: capture, persistence, and read paths for the rotated session id are all already in place. The PR just removes the missing-flag regression that was causing every resume to land on the same id.

Local check evidence (rebased onto current `origin/main`):

```
node_modules/.bin/vitest run extensions/anthropic/cli-shared.test.ts
  Test Files  1 passed (1)  Tests  14 passed (14)

node_modules/.bin/oxfmt --check --threads=1 \
    extensions/anthropic/cli-backend.ts \
    extensions/anthropic/cli-shared.test.ts \
    CHANGELOG.md
  All matched files use the correct format.

node_modules/.bin/oxlint --deny-warnings \
    extensions/anthropic/cli-backend.ts \
    extensions/anthropic/cli-shared.test.ts
  Found 0 warnings and 0 errors.

git diff --check origin/main..HEAD   # clean
```

## Human Verification

- Verified scenarios:
  - Default `buildAnthropicCliBackend()` produces `resumeArgs` containing `--fork-session` after `--resume {sessionId}` and initial `args` without it.
  - Multi-driver Slack repro recovers (no dropped replies, no interleaved transcripts).
- Edge cases checked:
  - Initial cold launch (`args`) does not get the flag — first turn still produces a normal session id, not a fork-of-nothing.
  - Existing `cliSessionBindings` capture path (`cli-session-history.claude.ts`) reads the new forked id correctly via the stream-json `init` event.
- What I did **not** verify:
  - Non-Slack channels (Discord/Telegram/Matrix) under the same multi-driver pressure — change is at the Anthropic backend layer and channel-agnostic, but I only repro'd on Slack.
  - Maintainer Testbox / Crabbox `pnpm check:changed` runs (not available to contributors); local oxfmt/oxlint/vitest stand in.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — initial `args` are unchanged; only resume behavior gains `--fork-session`. Existing `cliSessionBindings` machinery already supports session-id rotation.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: integrators that hard-pin to the original session id across turns (i.e., reading the id once at session creation and reusing it forever for transcript inspection) will see the bound id rotate after the first resume.
  - Mitigation: this matches the documented `--fork-session` semantics, and the canonical access pattern in-tree (`entry?.cliSessionBindings?.[CLAUDE_CLI_PROVIDER]?.sessionId`) already reads the freshly bound id per turn rather than caching one. Anyone hard-pinning is reading a snapshot they should be re-resolving anyway.
