### PR TITLE
docs: clarify new and reset command semantics

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -124,8 +124,9 @@ Current source-of-truth:
 
 <AccordionGroup>
   <Accordion title="Sessions and runs">
-    - `/new [model]` starts a new session; `/reset` is the reset alias.
-    - Control UI intercepts typed `/new` to create and switch to a fresh dashboard session, except when `session.dmScope: "main"` is configured and the current parent is the agent's main session; in that case `/new` resets the main session in place. Typed `/reset` still runs the Gateway's in-place reset.
+    - `/new [model]` starts a new session flow.
+    - Control UI intercepts typed `/new` to create and switch to a fresh dashboard session, except when `session.dmScope: "main"` is configured and the current parent is the agent's main session; in that case `/new` resets the main session in place.
+    - Typed `/reset` runs the Gateway's in-place reset for the current session.
     - `/reset soft [message]` keeps the current transcript, drops reused CLI backend session ids, and reruns startup/system-prompt loading in-place.
     - `/compact [instructions]` compacts the session context. See [Compaction](/concepts/compaction).
     - `/stop` aborts the current run.


### PR DESCRIPTION
## Summary

- Problem: The slash-command docs described `/reset` as an alias for `/new`, even though the commands have different behavior depending on the surface.
- Why it matters: Users may incorrectly assume `/new` and `/reset` are equivalent everywhere, or that `/new` always preserves an accessible previous session.
- What changed: Removed the misleading alias wording and clarified the difference between Control UI handling and Gateway reset handling.
- What did NOT change (scope boundary): No runtime behavior, command handling, Gateway logic, Control UI behavior, or TUI behavior was changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76592
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): The same documentation section already distinguished `/new` and `/reset` later in the text, but the summary line still incorrectly described `/reset` as an alias.

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: N/A — documentation-only change.
- Scenario the test should lock in: N/A.
- Why this is the smallest reliable guardrail: The issue was caused by misleading documentation wording, so the smallest reliable fix is to update the affected docs text.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: Documentation-only change.

## User-visible / Behavior Changes

The documentation now clearly distinguishes the relevant behavior:

- `/new [model]`: starts a new session flow.
- Control UI intercepts typed `/new` to create and switch to a fresh dashboard session, except when `session.dmScope: "main"` is configured and the current parent is the agent's main session; in that case `/new` resets the main session in place.
- `/reset`: runs the Gateway's in-place reset for the current session.

No runtime behavior changes.

## Diagram (if applicable)

```text
Before:
User reads docs -> sees /reset described as alias for /new -> may assume both commands behave the same everywhere

After:
User reads docs -> sees /new, Control UI handling, and Gateway reset handling described separately -> understands that /reset runs the Gateway's in-place reset
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: WSL Ubuntu
- Runtime/container: Node.js 22.22.2, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): Docs only
- Relevant config (redacted): N/A

### Steps

1. Open `docs/tools/slash-commands.md`.
2. Find the "Sessions and runs" section.
3. Check the `/new [model]`, Control UI `/new`, and `/reset` descriptions.

### Expected

- `/new [model]` is documented as starting a new session flow.
- Control UI behavior is documented separately, including the `session.dmScope: "main"` exception.
- `/reset` is documented as running the Gateway's in-place reset for the current session.
- `/reset` is not described as an alias for `/new`.
- The docs do not claim that `/new` always preserves an accessible previous session.

### Actual

- Before this change, the docs stated that `/reset` was the reset alias for `/new`.
- After this change, the docs distinguish `/new`, Control UI handling, and Gateway `/reset` handling separately.
- After this change, the docs avoid promising that `/new` always preserves an accessible previous session.

## Real behavior proof

**Behavior or issue addressed:** The PR removes the misleading wording that described `/reset` as the reset alias for `/new`. After this patch, the docs describe `/new`, Control UI `/new` handling, and Gateway `/reset` handling separately.

**Real environment tested:** WSL Ubuntu with Node.js 22.22.2 and pnpm 10.33.2, on the patched branch `docs/clarify-new-reset-semantics`.

**Exact steps or command run after this patch:** Ran terminal commands against the patched branch to read the changed docs text and verify the docs check:

```bash
sed -n '124,132p' docs/tools/slash-commands.md
git diff --check
pnpm docs:check-mdx
```

**Evidence after fix:** Terminal output from the patched branch:

```text
$ sed -n '124,132p' docs/tools/slash-commands.md

<AccordionGroup>
  <Accordion title="Sessions and runs">

    - `/new [model]` starts a new session flow.
    - Control UI intercepts typed `/new` to create and switch to a fresh dashboard session, except when `session.dmScope: "main"` is configured and the current parent is the agent's main session; in that case `/new` resets the main session in place.
    - Typed `/reset` runs the Gateway's in-place reset for the current session.
    - `/reset soft [message]` keeps the current transcript, drops reused CLI backend session ids, and reruns startup/system-prompt loading in-place.
    - `/compact [instructions]` compacts the session context. See [Compaction](/concepts/compaction).

$ git diff --check

$ pnpm docs:check-mdx

> openclaw@2026.5.10-beta.1 docs:check-mdx /home/thiagosoares/Projects/openclaw
> node scripts/check-docs-mdx.mjs docs README.md

Docs MDX check passed (637 files, 5265ms).
```

**Observed result after fix:** The after-fix output shows the docs no longer describe `/reset` as an alias for `/new` and preserve the `session.dmScope: "main"` Control UI exception.

**What was not tested:** Runtime command behavior was not tested because this PR only changes documentation text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence provided in this PR:

- Before: the docs described `/reset` as the reset alias for `/new`.
- After: the docs describe `/new`, Control UI handling, and Gateway `/reset` handling separately.
- Manual verification using `git diff --check`.
- Manual verification using `pnpm docs:check-mdx`.
- Manual verification that the misleading "reset alias" wording no longer appears.
- After-fix terminal proof is included in the `Real behavior proof` section above.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed the documentation change in `docs/tools/slash-commands.md`.
  - Confirmed `/reset` is no longer described as an alias for `/new`.
  - Confirmed the docs no longer claim that `/new` always preserves an accessible previous session.
  - Confirmed the docs distinguish Control UI `/new` behavior from Gateway `/reset` behavior.
  - Ran `git diff --check`.
  - Ran `pnpm docs:check-mdx`.
- Edge cases checked:
  - Searched for the misleading "reset alias" wording after the change.
- What you did **not** verify:
  - Runtime command behavior, because this PR only changes documentation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
