### PR TITLE
fix(doctor): include allow-only official plugin ids in release repair set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
+- Doctor/plugins: include `plugins.allow`-only official plugin ids in the release configured-plugin repair set, so `doctor --fix` installs official external plugins that are configured but not yet loaded instead of removing them as stale allow entries. Fixes #77155. Thanks @hclsys.
 - Memory/wiki: preserve representation from both corpora in `corpus=all` searches while backfilling unused result capacity, so memory hits are not starved by numerically higher wiki integer scores. Fixes #77337. Thanks @hclsys.
 - Telegram: clean up tool-only draft previews after assistant message boundaries so transient `Surfacing...` tool-status bubbles do not linger when no matching final preview arrives. Thanks @BunsDev.
 - Cron: surface failed isolated-run diagnostics in `cron show`, status, and run history when requested tools are unavailable, so blocked cron runs report the actual tool-policy failure instead of a misleading green result. Fixes #75763. Thanks @RyanSandoval.

--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   detectPluginAutoEnableCandidates: vi.fn(),
   repairMissingPluginInstallsForIds: vi.fn(),
   resolveProviderInstallCatalogEntries: vi.fn(),
+  getOfficialExternalPluginCatalogEntry: vi.fn(),
 }));
 
 vi.mock("../../../config/plugin-auto-enable.js", () => ({
@@ -18,6 +19,14 @@ vi.mock("./missing-configured-plugin-install.js", () => ({
   repairMissingPluginInstallsForIds: mocks.repairMissingPluginInstallsForIds,
 }));
 
+vi.mock(import("../../../plugins/official-external-plugin-catalog.js"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getOfficialExternalPluginCatalogEntry: mocks.getOfficialExternalPluginCatalogEntry,
+  };
+});
+
 describe("configured plugin install release step", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -27,6 +36,7 @@ describe("configured plugin install release step", () => {
       changes: [],
       warnings: [],
     });
+    mocks.getOfficialExternalPluginCatalogEntry.mockReturnValue(undefined);
   });
 
   it("runs only for configs last touched before 2026.5.2", async () => {
@@ -371,5 +381,54 @@ describe("configured plugin install release step", () => {
       completed: false,
       touchedConfig: false,
     });
+  });
+
+  it("includes allow-only official plugin ids in the repair set", async () => {
+    mocks.getOfficialExternalPluginCatalogEntry.mockImplementation((pluginId: string) => {
+      if (pluginId === "lobster") {
+        return { id: "lobster", name: "@openclaw/lobster" };
+      }
+      return undefined;
+    });
+
+    const { collectReleaseConfiguredPluginIds } =
+      await import("./release-configured-plugin-installs.js");
+    const result = collectReleaseConfiguredPluginIds({
+      cfg: {
+        plugins: {
+          allow: ["lobster", "unofficial-custom"],
+        },
+      },
+      env: {},
+    });
+
+    expect(result.pluginIds).toEqual(["lobster"]);
+    expect(result.pluginIds).not.toContain("unofficial-custom");
+  });
+
+  it("skips allow-only plugin ids that are already covered by a material entry", async () => {
+    mocks.getOfficialExternalPluginCatalogEntry.mockImplementation((pluginId: string) => {
+      if (pluginId === "lobster") {
+        return { id: "lobster", name: "@openclaw/lobster" };
+      }
+      return undefined;
+    });
+
+    const { collectReleaseConfiguredPluginIds } =
+      await import("./release-configured-plugin-installs.js");
+    const result = collectReleaseConfiguredPluginIds({
+      cfg: {
+        plugins: {
+          allow: ["lobster"],
+          entries: {
+            lobster: { enabled: true },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(result.pluginIds).toEqual(["lobster"]);
+    expect(mocks.getOfficialExternalPluginCatalogEntry).not.toHaveBeenCalledWith("lobster");
   });
 });

--- a/src/commands/doctor/shared/release-configured-plugin-installs.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.ts
@@ -6,6 +6,7 @@ import { detectPluginAutoEnableCandidates } from "../../../config/plugin-auto-en
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { compareOpenClawVersions } from "../../../config/version.js";
 import { isTruthyEnvValue } from "../../../infra/env.js";
+import { getOfficialExternalPluginCatalogEntry } from "../../../plugins/official-external-plugin-catalog.js";
 import { resolveProviderInstallCatalogEntries } from "../../../plugins/provider-install-catalog.js";
 import { resolveWebSearchInstallCatalogEntry } from "../../../plugins/web-search-install-catalog.js";
 import { VERSION } from "../../../version.js";
@@ -249,6 +250,30 @@ function collectAcpRuntimePluginIds(cfg: OpenClawConfig): string[] {
   return ["acpx"];
 }
 
+function collectAllowOnlyOfficialPluginIds(cfg: OpenClawConfig): string[] {
+  const allow = cfg.plugins?.allow;
+  if (!Array.isArray(allow) || allow.length === 0) {
+    return [];
+  }
+  const materialEntryIds = new Set(
+    collectMaterialPluginEntryIds(cfg).map((id) => id.toLowerCase()),
+  );
+  const ids: string[] = [];
+  for (const rawPluginId of allow) {
+    if (typeof rawPluginId !== "string") {
+      continue;
+    }
+    const pluginId = rawPluginId.trim();
+    if (!pluginId || materialEntryIds.has(pluginId.toLowerCase())) {
+      continue;
+    }
+    if (getOfficialExternalPluginCatalogEntry(pluginId)) {
+      ids.push(pluginId);
+    }
+  }
+  return ids;
+}
+
 function addEligiblePluginId(cfg: OpenClawConfig, pluginIds: Set<string>, pluginId: string): void {
   const normalized = pluginId.trim();
   if (!normalized || isDenied(cfg, normalized) || isDisabled(cfg, normalized)) {
@@ -307,6 +332,9 @@ export function collectReleaseConfiguredPluginIds(params: {
     addEligiblePluginId(params.cfg, pluginIds, pluginId);
   }
   for (const pluginId of collectAcpRuntimePluginIds(params.cfg)) {
+    addEligiblePluginId(params.cfg, pluginIds, pluginId);
+  }
+  for (const pluginId of collectAllowOnlyOfficialPluginIds(params.cfg)) {
     addEligiblePluginId(params.cfg, pluginIds, pluginId);
   }
   for (const channelId of collectConfiguredChannelIds(params.cfg, env)) {


### PR DESCRIPTION
## Summary

Fixes #77155 — `doctor --fix` silently removes plugins that appear in `plugins.allow` but not in `plugins.entries` (allow-only).

## Root Cause

`collectReleaseConfiguredPluginIds` collected plugin ids from `plugins.entries` (material entries), slots, channels, providers, and runtimes — but not from `plugins.allow`. Allow-only entries (e.g. `lobster` in `plugins.allow` with no `plugins.entries.lobster`) were never passed to `repairMissingPluginInstallsForIds`, so they weren't installed during the one-time 2026.5.2 release repair. Stale-config cleanup then removed them from `plugins.allow` because they weren't in the installed plugin registry — silently breaking cron jobs that depend on those plugins.

## Fix

Added `collectAllowOnlyOfficialPluginIds` which reads `plugins.allow`, filters out ids already covered by a material `plugins.entries` entry, and gates each remaining id against `getOfficialExternalPluginCatalogEntry`. Only official external catalog entries are included — arbitrary allow-list ids for unofficial/workspace plugins are intentionally excluded to avoid installing unknown packages during `doctor --fix`.

## Changes

- `src/commands/doctor/shared/release-configured-plugin-installs.ts`: added `collectAllowOnlyOfficialPluginIds` + call in `collectReleaseConfiguredPluginIds`
- `src/commands/doctor/shared/release-configured-plugin-installs.test.ts`: 2 new regression tests
- `CHANGELOG.md`: entry under Fixes

## Test plan

- [ ] `pnpm exec vitest run src/commands/doctor/shared/release-configured-plugin-installs.test.ts` — 12/12 pass
- [ ] `pnpm exec oxlint src/commands/doctor/shared/release-configured-plugin-installs.ts src/commands/doctor/shared/release-configured-plugin-installs.test.ts` — 0 warnings, 0 errors
- [ ] New test: allow-only official plugin (`lobster`) → included in repair set
- [ ] New test: allow-only unofficial plugin → excluded from repair set  
- [ ] New test: allow-only id already covered by material entry → not double-added, catalog not queried for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)