### PR TITLE
fix(tasks): quarantine corrupt task registry SQLite store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ Docs: https://docs.openclaw.ai
 - Config/Nix: keep startup-derived plugin enablement, gateway auth tokens, control UI origins, and owner-display secrets runtime-only instead of rewriting `openclaw.json`; in Nix mode, config writers, mutating `openclaw update`, plugin lifecycle mutators, and doctor repair/token-generation now refuse with agent-first nix-openclaw guidance. (#78047) Thanks @joshp123.
 - Agents/context engine: invalidate cached assembled context views when source history shrinks or assembly fails, preventing stale pre-reset history from being reused. Fixes #77968. (#78163) Thanks @brokemac79 and @ChrisBot2026.
 
+- Tasks: quarantine corrupt task-registry `runs.sqlite` stores, preserve DB/WAL/SHM evidence with a manifest, and recreate a fresh registry DB so startup can continue. Addresses #71689.
+
 ### Fixes
 
 - Exec approvals/node: let trusted backend node invokes complete no-device Control UI approvals after the original request connection changes, while keeping node, command, cwd, env, and allow-once replay bindings enforced. Fixes #78569. Thanks @naturedogdog.

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -46,6 +46,20 @@ describe("sqlite WAL maintenance", () => {
     expect(db.exec).toHaveBeenCalledTimes(4);
   });
 
+  it("can close timers without running a final checkpoint", () => {
+    vi.useFakeTimers();
+    const db = createMockDb();
+
+    const maintenance = configureSqliteWalMaintenance(db, { checkpointIntervalMs: 100 });
+    expect(db.exec).toHaveBeenCalledTimes(2);
+
+    expect(maintenance.close({ checkpoint: false })).toBe(true);
+    expect(db.exec).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(200);
+    expect(db.exec).toHaveBeenCalledTimes(2);
+  });
+
   it("reports checkpoint errors without throwing from background maintenance", () => {
     const db = createMockDb();
     const error = new Error("busy");

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -11,7 +11,7 @@ type SqliteWalCheckpointMode = "PASSIVE" | "FULL" | "RESTART" | "TRUNCATE";
 
 export type SqliteWalMaintenance = {
   checkpoint: () => boolean;
-  close: () => boolean;
+  close: (options?: { checkpoint?: boolean }) => boolean;
 };
 
 export type SqliteWalMaintenanceOptions = {
@@ -63,10 +63,13 @@ export function configureSqliteWalMaintenance(
 
   return {
     checkpoint,
-    close: () => {
+    close: (closeOptions = {}) => {
       if (timer) {
         clearInterval(timer);
         timer = null;
+      }
+      if (closeOptions.checkpoint === false) {
+        return true;
       }
       return checkpoint();
     },

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -1,7 +1,22 @@
-import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
 import type { DatabaseSync, StatementSync } from "node:sqlite";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { configureSqliteWalMaintenance, type SqliteWalMaintenance } from "../infra/sqlite-wal.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { resolveTaskRegistryDir, resolveTaskRegistrySqlitePath } from "./task-registry.paths.js";
 import type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
@@ -65,9 +80,16 @@ type TaskRegistryDatabase = {
 };
 
 let cachedDatabase: TaskRegistryDatabase | null = null;
+const log = createSubsystemLogger("tasks/registry/sqlite");
 const TASK_REGISTRY_DIR_MODE = 0o700;
 const TASK_REGISTRY_FILE_MODE = 0o600;
-const TASK_REGISTRY_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
+const TASK_REGISTRY_SIDECAR_SUFFIXES = ["", "-wal", "-shm"] as const;
+const TASK_REGISTRY_CORRUPTION_MESSAGE_PATTERNS = [
+  "database disk image is malformed",
+  "file is not a database",
+  "database schema is corrupt",
+  "malformed database schema",
+] as const;
 
 function normalizeNumber(value: number | bigint | null): number | undefined {
   if (typeof value === "bigint") {
@@ -437,31 +459,302 @@ function ensureTaskRegistryPermissions(pathname: string) {
   }
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getErrorName(error: unknown): string | undefined {
+  return error instanceof Error ? error.name : undefined;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return undefined;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+export function isTaskRegistrySqliteCorruptionError(error: unknown): boolean {
+  const code = getErrorCode(error);
+  const message = getErrorMessage(error).toLowerCase();
+  const hasKnownCorruptionMessage = TASK_REGISTRY_CORRUPTION_MESSAGE_PATTERNS.some((pattern) =>
+    message.includes(pattern),
+  );
+  if (!hasKnownCorruptionMessage) {
+    return false;
+  }
+  return !code || code.startsWith("ERR_SQLITE") || code.startsWith("SQLITE");
+}
+
+function closeTaskRegistryDatabase(
+  database: TaskRegistryDatabase,
+  options: { checkpoint?: boolean } = {},
+) {
+  let closeError: unknown;
+  try {
+    database.walMaintenance.close({ checkpoint: options.checkpoint });
+  } catch (error) {
+    closeError ??= error;
+  }
+  try {
+    database.db.close();
+  } catch (error) {
+    closeError ??= error;
+  }
+  if (closeError) {
+    throw closeError;
+  }
+}
+
+function closeCachedTaskRegistryDatabase(options: { checkpoint?: boolean } = {}) {
+  if (!cachedDatabase) {
+    return;
+  }
+  const database = cachedDatabase;
+  cachedDatabase = null;
+  closeTaskRegistryDatabase(database, options);
+}
+
+function openInitializedTaskRegistryDatabase(pathname: string): TaskRegistryDatabase {
+  ensureTaskRegistryPermissions(pathname);
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(pathname);
+  let walMaintenance: SqliteWalMaintenance | null = null;
+  try {
+    walMaintenance = configureSqliteWalMaintenance(db);
+    db.exec(`PRAGMA synchronous = NORMAL;`);
+    db.exec(`PRAGMA busy_timeout = 5000;`);
+    ensureSchema(db);
+    ensureTaskRegistryPermissions(pathname);
+    return {
+      db,
+      path: pathname,
+      statements: createStatements(db),
+      walMaintenance,
+    };
+  } catch (error) {
+    let preservationError: unknown;
+    if (isTaskRegistrySqliteCorruptionError(error)) {
+      try {
+        attachTaskRegistryQuarantine(
+          error,
+          copyTaskRegistrySqliteFilesToQuarantine(pathname, error),
+        );
+      } catch (copyError) {
+        preservationError = copyError;
+      }
+    }
+    try {
+      walMaintenance?.close({ checkpoint: false });
+    } catch {
+      // Best effort: the setup path already failed, and corruption fallback must not checkpoint.
+    }
+    try {
+      db.close();
+    } catch {
+      // Best effort: preserve the original setup error.
+    }
+    if (preservationError) {
+      throw preservationError;
+    }
+    throw error;
+  }
+}
+
+type TaskRegistryQuarantinedFile = {
+  name: string;
+  originalPath: string;
+  quarantinedPath: string;
+  size: number;
+  sha256: string;
+};
+
+type TaskRegistryQuarantineResult = {
+  quarantineDir: string;
+  files: TaskRegistryQuarantinedFile[];
+};
+
+function createQuarantineTimestamp(): string {
+  return new Date().toISOString().replace(/[-:.]/gu, "");
+}
+
+function hashFile(pathname: string): string {
+  return createHash("sha256").update(readFileSync(pathname)).digest("hex");
+}
+
+function createTaskRegistrySqliteCorruptionError(message: string): Error & { code: string } {
+  const error = new Error(message) as Error & { code: string };
+  error.code = "ERR_SQLITE_ERROR";
+  return error;
+}
+
+function assertTaskRegistrySqliteHeaderIfPresent(pathname: string) {
+  if (!existsSync(pathname)) {
+    return;
+  }
+  const stat = statSync(pathname);
+  if (!stat.isFile() || stat.size === 0) {
+    return;
+  }
+  const header = Buffer.alloc(16);
+  const fd = openSync(pathname, "r");
+  try {
+    const bytesRead = readSync(fd, header, 0, header.length, 0);
+    if (bytesRead !== header.length || header.toString("binary") !== "SQLite format 3\0") {
+      throw createTaskRegistrySqliteCorruptionError("file is not a database");
+    }
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function createTaskRegistryQuarantineDir(pathname: string): string {
+  const quarantineBaseDir = path.join(resolveTaskRegistryDir(process.env), "quarantine");
+  mkdirSync(quarantineBaseDir, { recursive: true, mode: TASK_REGISTRY_DIR_MODE });
+  chmodSync(quarantineBaseDir, TASK_REGISTRY_DIR_MODE);
+
+  const quarantineDir = path.join(
+    quarantineBaseDir,
+    `${path.basename(pathname)}.${createQuarantineTimestamp()}-${randomBytes(4).toString("hex")}`,
+  );
+  mkdirSync(quarantineDir, { recursive: true, mode: TASK_REGISTRY_DIR_MODE });
+  chmodSync(quarantineDir, TASK_REGISTRY_DIR_MODE);
+  return quarantineDir;
+}
+
+function copyTaskRegistrySqliteFilesToQuarantine(
+  pathname: string,
+  error: unknown,
+): TaskRegistryQuarantineResult {
+  const quarantineDir = createTaskRegistryQuarantineDir(pathname);
+  const files: TaskRegistryQuarantinedFile[] = [];
+
+  for (const suffix of TASK_REGISTRY_SIDECAR_SUFFIXES) {
+    const originalPath = `${pathname}${suffix}`;
+    if (!existsSync(originalPath)) {
+      continue;
+    }
+    const stat = statSync(originalPath);
+    if (!stat.isFile()) {
+      continue;
+    }
+    const name = `${path.basename(pathname)}${suffix}`;
+    const quarantinedPath = path.join(quarantineDir, name);
+    copyFileSync(originalPath, quarantinedPath);
+    chmodSync(quarantinedPath, TASK_REGISTRY_FILE_MODE);
+    const quarantinedStat = statSync(quarantinedPath);
+    files.push({
+      name,
+      originalPath,
+      quarantinedPath,
+      size: quarantinedStat.size,
+      sha256: hashFile(quarantinedPath),
+    });
+  }
+
+  const manifest = {
+    createdAt: new Date().toISOString(),
+    originalPath: pathname,
+    quarantineDir,
+    reason: {
+      name: getErrorName(error),
+      code: getErrorCode(error),
+      message: getErrorMessage(error),
+    },
+    files,
+  };
+  const manifestPath = path.join(quarantineDir, "manifest.json");
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify(manifest, null, 2)}
+`,
+    "utf8",
+  );
+  chmodSync(manifestPath, TASK_REGISTRY_FILE_MODE);
+  return { quarantineDir, files };
+}
+
+function removeOriginalTaskRegistrySqliteFiles(pathname: string) {
+  for (const suffix of TASK_REGISTRY_SIDECAR_SUFFIXES) {
+    rmSync(`${pathname}${suffix}`, { force: true });
+  }
+}
+
+function attachTaskRegistryQuarantine(error: unknown, quarantine: TaskRegistryQuarantineResult) {
+  if (error && typeof error === "object") {
+    (error as { taskRegistryQuarantine?: TaskRegistryQuarantineResult }).taskRegistryQuarantine =
+      quarantine;
+  }
+}
+
+function getAttachedTaskRegistryQuarantine(
+  error: unknown,
+): TaskRegistryQuarantineResult | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  return (error as { taskRegistryQuarantine?: TaskRegistryQuarantineResult })
+    .taskRegistryQuarantine;
+}
+
+function quarantineTaskRegistrySqliteFiles(
+  pathname: string,
+  error: unknown,
+): TaskRegistryQuarantineResult {
+  const quarantine =
+    getAttachedTaskRegistryQuarantine(error) ??
+    copyTaskRegistrySqliteFilesToQuarantine(pathname, error);
+
+  try {
+    if (cachedDatabase?.path === pathname) {
+      closeCachedTaskRegistryDatabase({ checkpoint: false });
+    } else if (cachedDatabase) {
+      closeCachedTaskRegistryDatabase();
+    }
+  } finally {
+    removeOriginalTaskRegistrySqliteFiles(pathname);
+  }
+
+  return quarantine;
+}
+function logTaskRegistryQuarantine(result: TaskRegistryQuarantineResult, error: unknown) {
+  log.warn("Task registry SQLite store was corrupt; quarantined and recreated", {
+    errorCode: getErrorCode(error),
+    errorMessage: getErrorMessage(error),
+    quarantineDir: result.quarantineDir,
+    files: result.files.map((file) => file.name),
+  });
+}
+
+function emptyTaskRegistrySnapshot(): TaskRegistryStoreSnapshot {
+  return {
+    tasks: new Map(),
+    deliveryStates: new Map(),
+  };
+}
+
 function openTaskRegistryDatabase(): TaskRegistryDatabase {
   const pathname = resolveTaskRegistrySqlitePath(process.env);
   if (cachedDatabase && cachedDatabase.path === pathname) {
     return cachedDatabase;
   }
   if (cachedDatabase) {
-    cachedDatabase.walMaintenance.close();
-    cachedDatabase.db.close();
-    cachedDatabase = null;
+    closeCachedTaskRegistryDatabase();
   }
-  ensureTaskRegistryPermissions(pathname);
-  const { DatabaseSync } = requireNodeSqlite();
-  const db = new DatabaseSync(pathname);
-  const walMaintenance = configureSqliteWalMaintenance(db);
-  db.exec(`PRAGMA synchronous = NORMAL;`);
-  db.exec(`PRAGMA busy_timeout = 5000;`);
-  ensureSchema(db);
-  ensureTaskRegistryPermissions(pathname);
-  cachedDatabase = {
-    db,
-    path: pathname,
-    statements: createStatements(db),
-    walMaintenance,
-  };
-  return cachedDatabase;
+  try {
+    assertTaskRegistrySqliteHeaderIfPresent(pathname);
+    cachedDatabase = openInitializedTaskRegistryDatabase(pathname);
+    return cachedDatabase;
+  } catch (error) {
+    if (!isTaskRegistrySqliteCorruptionError(error)) {
+      throw error;
+    }
+    const quarantine = quarantineTaskRegistrySqliteFiles(pathname, error);
+    cachedDatabase = openInitializedTaskRegistryDatabase(pathname);
+    logTaskRegistryQuarantine(quarantine, error);
+    return cachedDatabase;
+  }
 }
 
 function withWriteTransaction(write: (statements: TaskRegistryStatements) => void) {
@@ -478,13 +771,26 @@ function withWriteTransaction(write: (statements: TaskRegistryStatements) => voi
 }
 
 export function loadTaskRegistryStateFromSqlite(): TaskRegistryStoreSnapshot {
-  const { statements } = openTaskRegistryDatabase();
-  const taskRows = statements.selectAll.all() as TaskRegistryRow[];
-  const deliveryRows = statements.selectAllDeliveryStates.all() as TaskDeliveryStateRow[];
-  return {
-    tasks: new Map(taskRows.map((row) => [row.task_id, rowToTaskRecord(row)])),
-    deliveryStates: new Map(deliveryRows.map((row) => [row.task_id, rowToTaskDeliveryState(row)])),
-  };
+  try {
+    const { statements } = openTaskRegistryDatabase();
+    const taskRows = statements.selectAll.all() as TaskRegistryRow[];
+    const deliveryRows = statements.selectAllDeliveryStates.all() as TaskDeliveryStateRow[];
+    return {
+      tasks: new Map(taskRows.map((row) => [row.task_id, rowToTaskRecord(row)])),
+      deliveryStates: new Map(
+        deliveryRows.map((row) => [row.task_id, rowToTaskDeliveryState(row)]),
+      ),
+    };
+  } catch (error) {
+    if (!isTaskRegistrySqliteCorruptionError(error)) {
+      throw error;
+    }
+    const pathname = resolveTaskRegistrySqlitePath(process.env);
+    const quarantine = quarantineTaskRegistrySqliteFiles(pathname, error);
+    cachedDatabase = openInitializedTaskRegistryDatabase(pathname);
+    logTaskRegistryQuarantine(quarantine, error);
+    return emptyTaskRegistrySnapshot();
+  }
 }
 
 export function saveTaskRegistryStateToSqlite(snapshot: TaskRegistryStoreSnapshot) {
@@ -543,10 +849,5 @@ export function deleteTaskDeliveryStateFromSqlite(taskId: string) {
 }
 
 export function closeTaskRegistrySqliteStore() {
-  if (!cachedDatabase) {
-    return;
-  }
-  cachedDatabase.walMaintenance.close();
-  cachedDatabase.db.close();
-  cachedDatabase = null;
+  closeCachedTaskRegistryDatabase();
 }

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, statSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
@@ -17,6 +17,10 @@ import {
   configureTaskRegistryRuntime,
   type TaskRegistryObserverEvent,
 } from "./task-registry.store.js";
+import {
+  isTaskRegistrySqliteCorruptionError,
+  loadTaskRegistryStateFromSqlite,
+} from "./task-registry.store.sqlite.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
@@ -38,6 +42,85 @@ function createStoredTask(): TaskRecord {
     createdAt: 100,
     lastEventAt: 100,
   };
+}
+
+type TaskRegistryQuarantineManifest = {
+  reason: {
+    code?: string;
+    message: string;
+  };
+  files: Array<{
+    name: string;
+    size: number;
+    sha256: string;
+  }>;
+};
+
+function readSingleTaskRegistryQuarantineManifest(): {
+  dir: string;
+  manifest: TaskRegistryQuarantineManifest;
+} {
+  const quarantineBaseDir = path.join(resolveTaskRegistryDir(process.env), "quarantine");
+  const entries = readdirSync(quarantineBaseDir).filter((entry) =>
+    entry.startsWith("runs.sqlite."),
+  );
+  expect(entries).toHaveLength(1);
+  const dir = path.join(quarantineBaseDir, entries[0] ?? "");
+  const manifest = JSON.parse(
+    readFileSync(path.join(dir, "manifest.json"), "utf8"),
+  ) as TaskRegistryQuarantineManifest;
+  return { dir, manifest };
+}
+
+function expectFreshTaskRegistrySqliteDatabase(sqlitePath: string, expectedTaskCount = 0) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(sqlitePath);
+  try {
+    const quickCheck = db.prepare("PRAGMA quick_check").get() as { quick_check: string };
+    expect(quickCheck.quick_check).toBe("ok");
+    const taskRuns = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'task_runs'")
+      .get() as { name: string };
+    expect(taskRuns.name).toBe("task_runs");
+    const count = db.prepare("SELECT COUNT(*) AS count FROM task_runs").get() as { count: number };
+    expect(count.count).toBe(expectedTaskCount);
+  } finally {
+    db.close();
+  }
+}
+
+function readRequiredNumberColumn(
+  row: Record<string, unknown> | undefined,
+  column: string,
+): number {
+  const value = row?.[column];
+  if (typeof value !== "number") {
+    throw new Error(`Expected numeric sqlite column ${column}`);
+  }
+  return value;
+}
+
+function corruptTaskRunsRootPage(sqlitePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(sqlitePath);
+  let pageSize = 4096;
+  let rootPage = 2;
+  try {
+    pageSize = readRequiredNumberColumn(db.prepare("PRAGMA page_size").get(), "page_size");
+    rootPage = readRequiredNumberColumn(
+      db
+        .prepare("SELECT rootpage FROM sqlite_master WHERE type = 'table' AND name = 'task_runs'")
+        .get(),
+      "rootpage",
+    );
+  } finally {
+    db.close();
+  }
+
+  const bytes = readFileSync(sqlitePath);
+  const offset = (rootPage - 1) * pageSize;
+  bytes.fill(0xff, offset, Math.min(offset + 32, bytes.length));
+  writeFileSync(sqlitePath, bytes);
 }
 
 describe("task-registry store runtime", () => {
@@ -304,6 +387,132 @@ describe("task-registry store runtime", () => {
         expect(statSync(sqlitePath).mode & 0o777).toBe(0o600);
       },
     );
+  });
+
+  it("quarantines a malformed sqlite store and sidecars before recreating a fresh database", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-task-store-corrupt-" },
+      async () => {
+        const sqlitePath = resolveTaskRegistrySqlitePath(process.env);
+        mkdirSync(path.dirname(sqlitePath), { recursive: true });
+        writeFileSync(sqlitePath, "not sqlite at all", "utf8");
+        writeFileSync(`${sqlitePath}-wal`, "wal bytes", "utf8");
+        writeFileSync(`${sqlitePath}-shm`, "shm bytes", "utf8");
+
+        expect(findTaskByRunId("missing-corrupt-run")).toBeUndefined();
+        resetTaskRegistryForTests({ persist: false });
+
+        const { dir, manifest } = readSingleTaskRegistryQuarantineManifest();
+        expect(manifest.reason.code).toBe("ERR_SQLITE_ERROR");
+        expect(manifest.reason.message).toContain("file is not a database");
+        expect(new Set(manifest.files.map((file) => file.name))).toEqual(
+          new Set(["runs.sqlite", "runs.sqlite-wal", "runs.sqlite-shm"]),
+        );
+        expect(readFileSync(path.join(dir, "runs.sqlite"), "utf8")).toBe("not sqlite at all");
+        expect(readFileSync(path.join(dir, "runs.sqlite-wal"), "utf8")).toBe("wal bytes");
+        expect(readFileSync(path.join(dir, "runs.sqlite-shm"), "utf8")).toBe("shm bytes");
+        expectFreshTaskRegistrySqliteDatabase(sqlitePath);
+        if (process.platform !== "win32") {
+          expect(statSync(dir).mode & 0o777).toBe(0o700);
+          expect(statSync(path.join(dir, "manifest.json")).mode & 0o777).toBe(0o600);
+          expect(statSync(path.join(dir, "runs.sqlite")).mode & 0o777).toBe(0o600);
+        }
+      },
+    );
+  });
+
+  it("preserves sidecars before closing a corrupt sqlite handle", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-task-store-valid-header-corrupt-" },
+      async () => {
+        const sqlitePath = resolveTaskRegistrySqlitePath(process.env);
+        mkdirSync(path.dirname(sqlitePath), { recursive: true });
+        const bytes = Buffer.alloc(4096, 0xff);
+        Buffer.from("SQLite format 3\0", "binary").copy(bytes, 0);
+        writeFileSync(sqlitePath, bytes);
+        writeFileSync(`${sqlitePath}-wal`, "wal bytes", "utf8");
+        writeFileSync(`${sqlitePath}-shm`, "shm bytes", "utf8");
+
+        expect(findTaskByRunId("missing-corrupt-run")).toBeUndefined();
+        resetTaskRegistryForTests({ persist: false });
+
+        const { dir, manifest } = readSingleTaskRegistryQuarantineManifest();
+        expect(manifest.reason.message).toContain("file is not a database");
+        expect(new Set(manifest.files.map((file) => file.name))).toEqual(
+          new Set(["runs.sqlite", "runs.sqlite-wal", "runs.sqlite-shm"]),
+        );
+        expect(readFileSync(path.join(dir, "runs.sqlite-wal"), "utf8")).toBe("wal bytes");
+        expect(statSync(path.join(dir, "runs.sqlite-shm")).size).toBeGreaterThan(0);
+        expectFreshTaskRegistrySqliteDatabase(sqlitePath);
+      },
+    );
+  });
+
+  it("closes a corrupt cached sqlite handle before recreating and writing to the fresh store", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-task-store-scan-corrupt-" },
+      async () => {
+        const sqlitePath = resolveTaskRegistrySqlitePath(process.env);
+        createTaskRecord({
+          runtime: "cron",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          sourceId: "job-corrupt-root",
+          runId: "run-before-corruption",
+          task: "Task before corruption",
+          status: "running",
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+        });
+        resetTaskRegistryForTests({ persist: false });
+        corruptTaskRunsRootPage(sqlitePath);
+
+        const snapshot = loadTaskRegistryStateFromSqlite();
+        expect(snapshot.tasks.size).toBe(0);
+        expect(snapshot.deliveryStates.size).toBe(0);
+
+        const { manifest } = readSingleTaskRegistryQuarantineManifest();
+        expect(manifest.files.some((file) => file.name === "runs.sqlite")).toBe(true);
+
+        const recreated = createTaskRecord({
+          runtime: "cron",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          sourceId: "job-after-corruption",
+          runId: "run-after-corruption",
+          task: "Task after corruption",
+          status: "running",
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+        });
+
+        expect(findTaskByRunId("run-before-corruption")).toBeUndefined();
+        expect(findTaskByRunId("run-after-corruption")).toMatchObject({
+          taskId: recreated.taskId,
+          task: "Task after corruption",
+        });
+        resetTaskRegistryForTests({ persist: false });
+        expectFreshTaskRegistrySqliteDatabase(sqlitePath, 1);
+      },
+    );
+  });
+
+  it("classifies only known sqlite corruption messages for quarantine fallback", () => {
+    const malformed = Object.assign(new Error("database disk image is malformed"), {
+      code: "ERR_SQLITE_ERROR",
+    });
+    const busy = Object.assign(new Error("database is locked"), { code: "ERR_SQLITE_BUSY" });
+    const diskFull = Object.assign(new Error("database or disk is full"), {
+      code: "ERR_SQLITE_FULL",
+    });
+    const permission = Object.assign(new Error("unable to open database file"), {
+      code: "ERR_SQLITE_CANTOPEN",
+    });
+
+    expect(isTaskRegistrySqliteCorruptionError(malformed)).toBe(true);
+    expect(isTaskRegistrySqliteCorruptionError(busy)).toBe(false);
+    expect(isTaskRegistrySqliteCorruptionError(diskFull)).toBe(false);
+    expect(isTaskRegistrySqliteCorruptionError(permission)).toBe(false);
   });
 
   it("migrates legacy ownerless cron rows to system scope", async () => {


### PR DESCRIPTION
### Summary

This adds an availability-first fallback for a corrupt task-registry SQLite store.

When the task registry detects a narrow class of SQLite corruption/open/read errors, it now:

- preserves `runs.sqlite`, `runs.sqlite-wal`, and `runs.sqlite-shm` into a restrictive `tasks/quarantine/...` directory;
- writes a `manifest.json` with the original paths, quarantined paths, file sizes, SHA-256 hashes, and the triggering error reason;
- closes cached/partial SQLite handles only after the DB and sidecars have been copied into quarantine, avoiding loss of WAL/SHM evidence from close-time checkpoint behavior;
- removes the suspect live files;
- recreates a fresh empty task-registry DB through the normal schema/open path;
- returns an empty task-registry snapshot on corrupt restore/load so the gateway can continue starting.

The fallback intentionally does **not** run automatic salvage or in-place repair (`.recover`, `REINDEX`, `VACUUM`, dump/restore, or checkpoint-before-preserve). Quarantined files remain available for manual `.recover`, operator follow-up, or support analysis.

Addresses #71689.

### Why

A malformed task-registry SQLite image can leave the gateway warning-looping against the same broken store. This PR restores availability while preserving forensic evidence for later manual analysis.

This does not attempt to prove or fix the underlying writer/checkpoint/root-cause path. It only makes the task registry fail closed around corrupt local state and come back with a clean empty store.

### Implementation notes

- The corruption classifier is intentionally narrow: known SQLite corruption phrases such as `database disk image is malformed`, `file is not a database`, and corrupt/malformed schema strings.
- Non-corruption operational errors such as busy/locked, disk-full, and permission/open failures are not swallowed by the fallback.
- A small SQLite-header precheck catches obvious non-SQLite task-registry files before `DatabaseSync` opens them.
- `SqliteWalMaintenance.close({ checkpoint: false })` clears the maintenance timer without issuing the explicit final `wal_checkpoint`, so the corruption path can avoid checkpoint-before-preserve.
- Because `DatabaseSync.close()` itself can checkpoint and remove WAL/SHM files, the corruption fallback copies DB/sidecars to quarantine before closing a suspect handle.
- The sidecar copy order is `runs.sqlite`, then `runs.sqlite-wal`, then `runs.sqlite-shm`, matching SQLite's write sequence more closely during corruption quarantine.
- Follow-up work intentionally stays out of scope: automatic salvage, root-cause writer/checkpoint fixes, periodic `integrity_check` telemetry, and large task-payload externalization/capping.


### Real behavior proof (isolated)

- **Behavior or issue addressed**: Corrupt task-registry SQLite state at `tasks/runs.sqlite` should be detected, preserved to quarantine with DB/WAL/SHM sidecars and a manifest, then replaced with a fresh registry DB so task-registry startup/restore can continue.
- **Real environment tested**: Disposable OpenClaw source checkout on Linux/Node 22 with an isolated `OPENCLAW_STATE_DIR` and isolated `OPENCLAW_HOME`; no live Gateway, production config, or production task DB was used.
- **Exact steps or command run after this patch**: Created a real SQLite `tasks/runs.sqlite` in WAL mode, crash-left `runs.sqlite`, `runs.sqlite-wal`, and `runs.sqlite-shm`, corrupted the live `runs.sqlite` header, then ran `corepack pnpm exec tsx proof-real-behavior.ts` to invoke the real task-registry startup/restore path via `ensureTaskRegistryReady()` followed by `createTaskRecord()`.
- **Evidence after fix**: Copied terminal output from the isolated proof run:

  ```text
  [registry/sqlite] Task registry SQLite store was corrupt; quarantined and recreated
  verdict: PASS: corrupt runs.sqlite was detected; runs.sqlite/WAL/SHM were quarantined with manifest hashes; fresh task-registry DB was recreated; task-registry restore/write path continued in isolated OPENCLAW_STATE_DIR.
  manifest.reason: ERR_SQLITE_ERROR / file is not a database
  manifest.files: runs.sqlite, runs.sqlite-wal, runs.sqlite-shm
  freshTaskCount: 1
  afterSummary.total: 1
  afterSummary.byRuntime.cli: 1
  ```

- **Observed result after fix**: The quarantine manifest included preserved copies plus SHA-256 hashes for all three files (`runs.sqlite`, `runs.sqlite-wal`, `runs.sqlite-shm`); the live registry recreated a fresh DB, `PRAGMA integrity_check` returned `ok`, and a subsequent system task persisted successfully.
- **What was not tested**: No live Gateway restart/downtime path was exercised; automatic SQLite salvage/repair remains intentionally out of scope.

### Tests

- Real behavior proof script: `corepack pnpm exec tsx proof-real-behavior.ts` in an isolated `OPENCLAW_STATE_DIR` (summary above).
- `git merge-base --is-ancestor upstream/main HEAD`
- `git merge-tree --write-tree upstream/main HEAD`
- `git diff --check upstream/main...HEAD`
- `corepack pnpm exec oxfmt --check CHANGELOG.md src/infra/sqlite-wal.test.ts src/infra/sqlite-wal.ts src/tasks/task-registry.store.sqlite.ts src/tasks/task-registry.store.test.ts`
- `corepack pnpm exec oxlint CHANGELOG.md src/infra/sqlite-wal.test.ts src/infra/sqlite-wal.ts src/tasks/task-registry.store.sqlite.ts src/tasks/task-registry.store.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 corepack pnpm test src/infra/sqlite-wal.test.ts src/tasks/task-registry.store.test.ts src/tasks/task-registry.test.ts`
