### PR TITLE
fix(plugins): grant internalDiagnostics to global-origin official diagnostics plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/services: grant `internalDiagnostics` capability to `diagnostics-otel` and `diagnostics-prometheus` when installed globally via `openclaw plugins install`, not only when bundled; fixes "internal diagnostics capability unavailable" after official diagnostics plugins were externalized in 2026.5.2. Fixes #77206.
 - Doctor/plugins: remove stale managed npm plugin shadow entries from the managed package lock as well as `package.json` and `node_modules`, so future npm operations do not keep referencing repaired bundled-plugin shadows. Thanks @vincentkoc.
 - Plugins/runtime state: keep the key being registered when namespace eviction runs in the same millisecond as existing entries, so `register` and `registerIfAbsent` do not report success while evicting their own fresh value. Thanks @vincentkoc.
 - Control UI/Talk: make failed Talk startup errors dismissable and clear the stale Talk error state when dismissed, so missing realtime voice provider configuration does not leave a permanent chat banner. Fixes #77071. Thanks @ijoshdavis.

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -215,4 +215,41 @@ describe("startPluginServices", () => {
 
     expect(untrustedContexts[0]?.internalDiagnostics).toBeUndefined();
   });
+
+  it("grants internal diagnostics to global-origin official diagnostics plugins", async () => {
+    const otelContexts: OpenClawPluginServiceContext[] = [];
+    const otelService = createTrackingService("diagnostics-otel", { contexts: otelContexts });
+    await startPluginServices({
+      registry: createRegistry([otelService], "diagnostics-otel", "global"),
+      config: createServiceConfig(),
+    });
+
+    expect(otelContexts[0]?.internalDiagnostics?.onEvent).toBeTypeOf("function");
+    expect(otelContexts[0]?.internalDiagnostics?.emit).toBeTypeOf("function");
+
+    const promContexts: OpenClawPluginServiceContext[] = [];
+    const promService = createTrackingService("diagnostics-prometheus", {
+      contexts: promContexts,
+    });
+    await startPluginServices({
+      registry: createRegistry([promService], "diagnostics-prometheus", "global"),
+      config: createServiceConfig(),
+    });
+
+    expect(promContexts[0]?.internalDiagnostics?.onEvent).toBeTypeOf("function");
+    expect(promContexts[0]?.internalDiagnostics?.emit).toBeTypeOf("function");
+  });
+
+  it("does not grant internal diagnostics to config-origin diagnostics plugins", async () => {
+    const configContexts: OpenClawPluginServiceContext[] = [];
+    const configService = createTrackingService("diagnostics-otel", {
+      contexts: configContexts,
+    });
+    await startPluginServices({
+      registry: createRegistry([configService], "diagnostics-otel", "config"),
+      config: createServiceConfig(),
+    });
+
+    expect(configContexts[0]?.internalDiagnostics).toBeUndefined();
+  });
 });

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -25,7 +25,7 @@ function createServiceContext(params: {
   service?: PluginServiceRegistration;
 }): OpenClawPluginServiceContext {
   const grantsInternalDiagnostics =
-    params.service?.origin === "bundled" &&
+    (params.service?.origin === "bundled" || params.service?.origin === "global") &&
     params.service.pluginId === params.service.service.id &&
     (params.service.service.id === "diagnostics-otel" ||
       params.service.service.id === "diagnostics-prometheus");


### PR DESCRIPTION
## Summary

Fixes #77206 — `diagnostics-otel` and `diagnostics-prometheus` fail with "internal diagnostics capability unavailable" after upgrading to 2026.5.2 because they were externalized from the bundled extensions directory.

## Root Cause

`createServiceContext` in `src/plugins/services.ts` gates `internalDiagnostics` on `origin === "bundled"`. After externalization, these plugins are installed via `openclaw plugins install @openclaw/diagnostics-otel`, which registers them with `origin: "global"`. The gate fails and the capability is never injected.

## Fix

Widen the origin check to accept both `"bundled"` and `"global"` origins for the two known diagnostics plugin IDs. The existing guards remain intact:

- `pluginId === service.id` — prevents capability leak across plugin boundaries
- Explicit service ID allowlist — only `diagnostics-otel` and `diagnostics-prometheus`
- `"workspace"` and `"config"` origins remain denied (untrusted)

## Changes

- `src/plugins/services.ts` — 1-line origin gate change
- `src/plugins/services.test.ts` — add test coverage for `global` origin grant and `config` origin denial
- `CHANGELOG.md` — add fix entry

## Security

The `internalDiagnostics` capability is only granted to plugins that match ALL of:
1. Origin is `"bundled"` or `"global"` (installed via npm, not workspace-local)
2. `pluginId === service.id` (service registered by its own plugin)
3. Service ID is exactly `"diagnostics-otel"` or `"diagnostics-prometheus"`

This means an attacker would need to publish to the `@openclaw` npm scope AND match the exact plugin/service IDs, which is controlled by the OpenClaw team.