### PR TITLE
docs(providers/openai): note OpenAI Realtime requires Platform credits, not Codex/ChatGPT subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/providers/openai: clarify that OpenAI Realtime voice goes through the OpenAI Platform Realtime API and requires Platform credits — Codex/ChatGPT subscription quota does not cover this route. Fixes #76498. Thanks @lonexreb.
 - Docker/Gateway: harden the gateway container by dropping `NET_RAW` and `NET_ADMIN` capabilities and enabling `no-new-privileges` in the bundled `docker-compose.yml`. Thanks @VintageAyu.
 - Telegram: accept plugin-owned numeric forum-topic targets in the agent message tool and keep reply-dispatch provider chunks behind a real stable runtime alias during in-place package updates. Fixes #77137. Thanks @richardmqq.
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1851,6 +1851,7 @@ Docs: https://docs.openclaw.ai
 - Agents/read tool: treat positive offsets beyond EOF as empty ranges instead of surfacing the upstream read error, so stale pagination cursors no longer crash tool calls while unrelated read failures still fail loud. Fixes #62466. (#75536) Thanks @vyctorbrzezowski.
 - Google/Gemini: normalize retired Gemini 3 Pro Preview refs left in Google API-key onboarding model allowlists and fallbacks, so setup-emitted config keeps testing `google/gemini-3.1-pro-preview` instead of `google/gemini-3-pro-preview`.
 - Telegram/context: bound selected topic context to the active session so messages from before `/new` or `/reset` are not replayed into later turns. (#80848) Thanks @VACInc.
+- Docs/providers/openai: clarify that OpenAI Realtime voice goes through the OpenAI Platform Realtime API and requires Platform credits — Codex/ChatGPT subscription quota does not cover this route. Fixes #76498. Thanks @lonexreb.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids when resolving exact configured proxy-provider refs, so `kilocode/google/gemini-3-pro-preview` resolves to `kilocode/google/gemini-3.1-pro-preview` for Gemini 3.1 testing.
 - CLI: strip generic OSC terminal escape payloads from sanitized output fields, preventing clipboard/title escape bodies from leaking into commitment tables and other terminal-safe text. Thanks @shakkernerd.
 - Codex app-server: match connector-backed plugin approval elicitations by stable connector id so enabled destructive actions no longer fall through to display-name-only rejection.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -73,19 +73,38 @@ through PI, `openclaw doctor` warns and leaves the route unchanged.
 
 ## OpenClaw feature coverage
 
-| OpenAI capability         | OpenClaw surface                                           | Status                                                 |
-| ------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ |
-| Chat / Responses          | `openai/<model>` model provider                            | Yes                                                    |
-| Codex subscription models | `openai-codex/<model>` with `openai-codex` OAuth           | Yes                                                    |
-| Codex app-server harness  | `openai/<model>` with `agentRuntime.id: codex`             | Yes                                                    |
-| Server-side web search    | Native OpenAI Responses tool                               | Yes, when web search is enabled and no provider pinned |
-| Images                    | `image_generate`                                           | Yes                                                    |
-| Videos                    | `video_generate`                                           | Yes                                                    |
-| Text-to-speech            | `messages.tts.provider: "openai"` / `tts`                  | Yes                                                    |
-| Batch speech-to-text      | `tools.media.audio` / media understanding                  | Yes                                                    |
-| Streaming speech-to-text  | Voice Call `streaming.provider: "openai"`                  | Yes                                                    |
-| Realtime voice            | Voice Call `realtime.provider: "openai"` / Control UI Talk | Yes                                                    |
-| Embeddings                | memory embedding provider                                  | Yes                                                    |
+| OpenAI capability         | OpenClaw surface                                           | Status                                                                     |
+| ------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Chat / Responses          | `openai/<model>` model provider                            | Yes                                                                        |
+| Codex subscription models | `openai-codex/<model>` with `openai-codex` OAuth           | Yes                                                                        |
+| Codex app-server harness  | `openai/<model>` with `agentRuntime.id: codex`             | Yes                                                                        |
+| Server-side web search    | Native OpenAI Responses tool                               | Yes, when web search is enabled and no provider pinned                     |
+| Images                    | `image_generate`                                           | Yes                                                                        |
+| Videos                    | `video_generate`                                           | Yes                                                                        |
+| Text-to-speech            | `messages.tts.provider: "openai"` / `tts`                  | Yes                                                                        |
+| Batch speech-to-text      | `tools.media.audio` / media understanding                  | Yes                                                                        |
+| Streaming speech-to-text  | Voice Call `streaming.provider: "openai"`                  | Yes                                                                        |
+| Realtime voice            | Voice Call `realtime.provider: "openai"` / Control UI Talk | Yes (requires OpenAI Platform API credits, not Codex/ChatGPT subscription) |
+| Embeddings                | memory embedding provider                                  | Yes                                                                        |
+
+<Note>
+  OpenAI Realtime voice (used by Voice Call's `realtime.provider: "openai"` and
+  Control UI Talk with `talk.provider: "openai"`) goes through the public
+  **OpenAI Platform Realtime API** — it requires an `OPENAI_API_KEY` whose
+  organization has funded Platform credits. Codex/ChatGPT subscription quota
+  does **not** apply: an account with healthy Codex OAuth that runs
+  `openai-codex/*` chat models without issue can still hit
+  `insufficient_quota` / "You exceeded your current quota" on the first
+  Realtime turn if the same OpenAI organization has no Platform billing set
+  up. The `openai-codex` provider is not registered as a realtime voice
+  provider for the same reason.
+
+Fix: top up Platform credits at
+[platform.openai.com/account/billing](https://platform.openai.com/account/billing)
+and configure `OPENAI_API_KEY` (or `talk.providers.openai.apiKey` for Control UI Talk, or `plugins.entries.voice-call.config.realtime.providers.openai.apiKey` for Voice Call) with a key from that organization. For chat
+turns you can still use `openai-codex/*` against the same OpenClaw install —
+Realtime is the one route that needs Platform billing.
+</Note>
 
 ## Memory embeddings
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -81,20 +81,42 @@ explicit runtime config.
 
 ## OpenClaw feature coverage
 
-| OpenAI capability         | OpenClaw surface                                                                 | Status                                                 |
-| ------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| Chat / Responses          | `openai/<model>` model provider                                                  | Yes                                                    |
-| Codex subscription models | `openai/<model>` with `openai-codex` OAuth                                       | Yes                                                    |
-| Legacy Codex model refs   | `openai-codex/<model>` or `codex-cli/<model>`                                    | Repaired by doctor to `openai/<model>`                 |
-| Codex app-server harness  | `openai/<model>` with omitted runtime or provider/model `agentRuntime.id: codex` | Yes                                                    |
-| Server-side web search    | Native OpenAI Responses tool                                                     | Yes, when web search is enabled and no provider pinned |
-| Images                    | `image_generate`                                                                 | Yes                                                    |
-| Videos                    | `video_generate`                                                                 | Yes                                                    |
-| Text-to-speech            | `messages.tts.provider: "openai"` / `tts`                                        | Yes                                                    |
-| Batch speech-to-text      | `tools.media.audio` / media understanding                                        | Yes                                                    |
-| Streaming speech-to-text  | Voice Call `streaming.provider: "openai"`                                        | Yes                                                    |
-| Realtime voice            | Voice Call `realtime.provider: "openai"` / Control UI Talk                       | Yes                                                    |
-| Embeddings                | memory embedding provider                                                        | Yes                                                    |
+| OpenAI capability         | OpenClaw surface                                                                              | Status                                                                 |
+| ------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Chat / Responses          | `openai/<model>` model provider                                                               | Yes                                                                    |
+| Codex subscription models | `openai/<model>` with `openai-codex` OAuth                                                    | Yes                                                                    |
+| Legacy Codex model refs   | `openai-codex/<model>` or `codex-cli/<model>`                                                 | Repaired by doctor to `openai/<model>`                                 |
+| Codex app-server harness  | `openai/<model>` with omitted runtime or provider/model `agentRuntime.id: codex`              | Yes                                                                    |
+| Server-side web search    | Native OpenAI Responses tool                                                                  | Yes, when web search is enabled and no provider pinned                 |
+| Images                    | `image_generate`                                                                              | Yes                                                                    |
+| Videos                    | `video_generate`                                                                              | Yes                                                                    |
+| Text-to-speech            | `messages.tts.provider: "openai"` / `tts`                                                     | Yes                                                                    |
+| Batch speech-to-text      | `tools.media.audio` / media understanding                                                     | Yes                                                                    |
+| Streaming speech-to-text  | Voice Call `streaming.provider: "openai"`                                                     | Yes                                                                    |
+| Realtime voice            | Voice Call `realtime.provider: "openai"` / Control UI Talk `talk.realtime.provider: "openai"` | Yes (requires OpenAI Platform credits, not Codex/ChatGPT subscription) |
+| Embeddings                | memory embedding provider                                                                     | Yes                                                                    |
+
+<Note>
+  OpenAI Realtime voice (used by Voice Call's `realtime.provider: "openai"` and
+  Control UI Talk with `talk.realtime.provider: "openai"`) goes through the
+  public **OpenAI Platform Realtime API**, which is billed against OpenAI
+  Platform credits rather than Codex/ChatGPT subscription quota. An account
+  with healthy Codex OAuth that runs `openai-codex/*` chat models without
+  issue can still hit `insufficient_quota` / "You exceeded your current
+  quota" on the first Realtime turn if the same OpenAI organization has no
+  Platform billing set up.
+
+Fix: top up Platform credits at
+[platform.openai.com/account/billing](https://platform.openai.com/account/billing)
+for the organization backing your realtime credentials. Realtime accepts
+either a Platform `OPENAI_API_KEY` (configured via `talk.realtime.providers.openai.apiKey`
+for Control UI Talk, or `plugins.entries.voice-call.config.realtime.providers.openai.apiKey`
+for Voice Call) or an `openai-codex` OAuth profile whose underlying
+organization has Platform billing — both routes mint Realtime client secrets
+through the Platform API, so either way the org needs funded Platform
+credits. For chat turns you can still use `openai-codex/*` against the same
+OpenClaw install; Realtime is the one route that needs Platform billing.
+</Note>
 
 ## Memory embeddings
 


### PR DESCRIPTION
## Summary

Adds an inline clarification to `docs/providers/openai.md` that OpenAI Realtime voice (used by Voice Call `realtime.provider: "openai"` and Control UI Talk with `talk.realtime.provider: "openai"`) is billed against OpenAI Platform credits rather than Codex/ChatGPT subscription quota. Documents both supported auth routes — direct Platform `OPENAI_API_KEY` and the `openai-codex` OAuth fallback that mints Realtime client secrets through the Platform API.

## Why

From #76498: a user with healthy Codex OAuth (where `openai-codex/*` chat worked fine) hit `You exceeded your current quota` on the first Realtime turn, even though the ChatGPT/Codex usage dashboard still showed remaining quota. The Realtime route goes through the public OpenAI Platform Realtime API, so the underlying organization needs funded Platform credits — independent of which auth path mints the client secret. Nothing in the docs surfaced that distinction, so troubleshooting was guesswork.

## Changes

- `docs/providers/openai.md`
  - Append a qualifier to the **Realtime voice** row of the OpenClaw feature coverage matrix: `Yes (requires OpenAI Platform credits, not Codex/ChatGPT subscription)`, with the surface column updated to include the correct `talk.realtime.provider: "openai"` Control UI Talk key.
  - Add a `<Note>` block under the matrix that:
    - Names the affected surfaces with current config keys (`realtime.provider: "openai"` for Voice Call, `talk.realtime.provider: "openai"` for Control UI Talk)
    - Explains why Codex/ChatGPT subscription quota does not apply (different billing path)
    - Names the exact symptom (`insufficient_quota` / "You exceeded your current quota" on the first Realtime turn even when chat works)
    - Documents both supported auth routes: a Platform `OPENAI_API_KEY` (via `talk.realtime.providers.openai.apiKey` or `plugins.entries.voice-call.config.realtime.providers.openai.apiKey`) **or** an `openai-codex` OAuth profile whose underlying organization has Platform billing — both routes mint Realtime client secrets through the Platform API, so either way the org needs funded Platform credits
    - Gives the concrete fix (top up Platform credits at platform.openai.com/account/billing)
- `CHANGELOG.md` — Unreleased > Changes entry.

## Test plan

- [x] `pnpm exec oxfmt --check --threads=1 docs/providers/openai.md CHANGELOG.md` — clean
- [x] `git diff --check` — clean
- [x] No code changes; docs-only.
- [x] Mintlify-compatible: kept the `<Note>` JSX block, no em-dashes inside headings.
- [x] Rebased onto current `origin/main` (HEAD `8dc213227b`); preserves the `codex-cli/<model>` legacy-row addition that landed on main.

Closes #76498.

## Real behavior proof

- **Behavior or issue addressed:** Fixes #76498. Users with healthy `openai-codex` OAuth who tried OpenAI Realtime voice got `insufficient_quota` on the first Realtime turn even though their Codex subscription worked fine for chat. The Realtime route is billed against OpenAI Platform credits regardless of whether the credential is a direct Platform API key or an `openai-codex` OAuth profile — both mint client secrets through the Platform API. The original docs didn't mention this; users had no signposting from "Codex works" to "but Realtime needs Platform billing on the same org."
- **Real environment tested:** The patched `docs/providers/openai.md` as rendered by Mintlify (the production docs hosting layer at `docs.openclaw.ai`). Config keys verified against current `main`:
  - `talk.realtime.provider` / `talk.realtime.providers.openai.apiKey` — `src/gateway/server-methods/talk-shared.ts:112` (Talk realtime config reads `config.talk?.realtime`, not the top-level Talk speech provider map).
  - `openai-codex` OAuth fallback — `extensions/openai/realtime-voice-provider.ts:304` calls `resolveProviderAuthProfileApiKey({ provider: "openai-codex" })` when no direct key is present; native bridge at `extensions/openai/realtime-voice-provider.ts:645` falls through to OAuth-backed client-secret creation.
  - Test coverage — `extensions/openai/realtime-voice-provider.test.ts:282` covers minting an ephemeral Realtime secret from an `openai-codex` OAuth token when no direct API key is configured.
- **Exact steps or command run after this patch (HEAD `768259819e`, rebased onto `origin/main` at `8dc213227b`):**
  ```
  $ pnpm exec oxfmt --check --threads=1 docs/providers/openai.md CHANGELOG.md
  Checking formatting...

  All matched files use the correct format.

  $ git diff --check
  (clean)

  $ git diff --stat origin/main..HEAD
   CHANGELOG.md             |  1 +
   docs/providers/openai.md | 50 ++++++++++++++++++++++++++++++++++--------------
   2 files changed, 37 insertions(+), 14 deletions(-)
  ```
- **Evidence after fix (current HEAD `768259819e`):** The rendered `<Note>` block at `docs/providers/openai.md:99` now contains the corrected, OAuth-aware remediation:

  > OpenAI Realtime voice (used by Voice Call's `realtime.provider: "openai"` and Control UI Talk with `talk.realtime.provider: "openai"`) goes through the public **OpenAI Platform Realtime API**, which is billed against OpenAI Platform credits rather than Codex/ChatGPT subscription quota. An account with healthy Codex OAuth that runs `openai-codex/*` chat models without issue can still hit `insufficient_quota` / "You exceeded your current quota" on the first Realtime turn if the same OpenAI organization has no Platform billing set up.
  >
  > Fix: top up Platform credits at platform.openai.com/account/billing for the organization backing your realtime credentials. Realtime accepts either a Platform `OPENAI_API_KEY` (configured via `talk.realtime.providers.openai.apiKey` for Control UI Talk, or `plugins.entries.voice-call.config.realtime.providers.openai.apiKey` for Voice Call) or an `openai-codex` OAuth profile whose underlying organization has Platform billing — both routes mint Realtime client secrets through the Platform API, so either way the org needs funded Platform credits. For chat turns you can still use `openai-codex/*` against the same OpenClaw install; Realtime is the one route that needs Platform billing.

  The Realtime voice row in the capability table at `docs/providers/openai.md:96` carries the updated `Yes (requires OpenAI Platform credits, not Codex/ChatGPT subscription)` status note and includes `talk.realtime.provider: "openai"` for Control UI Talk in the surface column.
- **Observed result after fix:** A user hitting `insufficient_quota` on their first Realtime turn while their `openai-codex/*` chat keeps working can now find the explanation by reading the OpenAI provider docs — the capability table flags the Platform-credits requirement on the Realtime row, and the `<Note>` block tells them both (a) which org's billing they need to top up and (b) which config keys to point at the funded credential, including the OAuth path. Pre-fix, the docs page did not mention the billing split at all and operators had no signposting from "Codex works" to "but Realtime needs Platform billing."
- **What was not tested:** Live `insufficient_quota` reproduction against a real OpenAI organization without Platform billing — the bug is a documentation gap, not a code regression; the underlying API contract (Codex subscription ≠ Platform credits) is established by OpenAI's billing system and verified by the original reporter in #76498.

