### PR TITLE
fix(plugins): repair configured plugins with broken runtime entries

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   installPluginFromClawHub: vi.fn(),
   installPluginFromNpmSpec: vi.fn(),
+  getCurrentPluginMetadataSnapshot: vi.fn(() => undefined),
   listChannelPluginCatalogEntries: vi.fn(),
   listOfficialExternalPluginCatalogEntries: vi.fn(),
   loadInstalledPluginIndex: vi.fn(),
@@ -59,6 +60,10 @@ vi.mock("../../../plugins/plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: mocks.loadPluginMetadataSnapshot,
 }));
 
+vi.mock("../../../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: mocks.getCurrentPluginMetadataSnapshot,
+}));
+
 vi.mock("../../../plugins/official-external-plugin-catalog.js", () => ({
   getOfficialExternalPluginCatalogManifest: mocks.getOfficialExternalPluginCatalogManifest,
   listOfficialExternalPluginCatalogEntries: mocks.listOfficialExternalPluginCatalogEntries,
@@ -78,6 +83,7 @@ vi.mock("../../../plugins/update.js", () => ({
 describe("repairMissingConfiguredPluginInstalls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getCurrentPluginMetadataSnapshot.mockReturnValue(undefined);
     mocks.loadPluginMetadataSnapshot.mockReturnValue({
       plugins: [],
       diagnostics: [],
@@ -1931,6 +1937,87 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         brave: expect.objectContaining({ installPath: process.cwd() }),
       }),
       { env: {} },
+    );
+    expect(result.changes).toEqual(['Repaired missing configured plugin "brave".']);
+  });
+
+  it("repairs a configured external web search plugin with broken runtime entries", async () => {
+    const records = {
+      brave: {
+        source: "npm",
+        spec: "@openclaw/brave-plugin@2026.5.2",
+        installPath: process.cwd(),
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "brave",
+          origin: "global",
+          channels: [],
+          providers: [],
+        },
+      ],
+      diagnostics: [
+        {
+          level: "warn",
+          pluginId: "brave",
+          source: `${process.cwd()}/index.ts`,
+          message:
+            "installed plugin package requires compiled runtime output for TypeScript entry ./index.ts: expected ./dist/index.js",
+        },
+      ],
+    });
+    mocks.updateNpmInstalledPlugins.mockResolvedValue({
+      changed: true,
+      config: {
+        plugins: {
+          installs: {
+            brave: {
+              source: "npm",
+              spec: "@openclaw/brave-plugin@2026.5.3",
+              installPath: process.cwd(),
+            },
+          },
+        },
+      },
+      outcomes: [
+        {
+          pluginId: "brave",
+          status: "updated",
+          message: "Updated brave.",
+        },
+      ],
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        plugins: {
+          entries: {
+            brave: { enabled: true },
+          },
+        },
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginIds: ["brave"],
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({ installs: records }),
+        }),
+      }),
     );
     expect(result.changes).toEqual(['Repaired missing configured plugin "brave".']);
   });

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -77,6 +77,11 @@ const RUNTIME_PLUGIN_INSTALL_CANDIDATES: readonly DownloadableInstallCandidate[]
 
 const MISSING_CHANNEL_CONFIG_DESCRIPTOR_DIAGNOSTIC = "without channelConfigs metadata";
 const UPDATE_IN_PROGRESS_ENV = "OPENCLAW_UPDATE_IN_PROGRESS";
+const BROKEN_RUNTIME_ENTRY_DIAGNOSTICS = [
+  "requires compiled runtime output",
+  "runtime extension entry not found",
+  "runtime setup entry not found",
+] as const;
 
 function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
   return (
@@ -414,16 +419,75 @@ function collectConfiguredPluginIdsWithMissingChannelConfigDescriptors(params: {
   return stalePluginIds;
 }
 
+function isBrokenRuntimeEntryDiagnostic(message: string): boolean {
+  return BROKEN_RUNTIME_ENTRY_DIAGNOSTICS.some((needle) => message.includes(needle));
+}
+
+function isPathInsideOrEqual(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function resolveInstallRecordPath(
+  record: PluginInstallRecord | undefined,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const rawPath =
+    typeof record?.installPath === "string" && record.installPath.trim()
+      ? record.installPath
+      : typeof record?.sourcePath === "string" && record.sourcePath.trim()
+        ? record.sourcePath
+        : undefined;
+  return rawPath ? resolveUserPath(rawPath, env) : undefined;
+}
+
+function collectConfiguredPluginIdsWithBrokenRuntimeEntries(params: {
+  snapshot: PluginMetadataSnapshot;
+  configuredPluginIds: ReadonlySet<string>;
+  records: Record<string, PluginInstallRecord>;
+  env: NodeJS.ProcessEnv;
+}): Set<string> {
+  const stalePluginIds = new Set<string>();
+  const configuredInstallPaths = Object.entries(params.records)
+    .filter(([pluginId]) => params.configuredPluginIds.has(pluginId))
+    .flatMap(([pluginId, record]) => {
+      const installPath = resolveInstallRecordPath(record, params.env);
+      return installPath ? [{ pluginId, installPath }] : [];
+    });
+
+  for (const diagnostic of params.snapshot.diagnostics) {
+    if (!isBrokenRuntimeEntryDiagnostic(diagnostic.message)) {
+      continue;
+    }
+    const pluginId = diagnostic.pluginId?.trim();
+    if (pluginId && params.configuredPluginIds.has(pluginId)) {
+      stalePluginIds.add(pluginId);
+      continue;
+    }
+    const source = diagnostic.source?.trim();
+    if (!source) {
+      continue;
+    }
+    const resolvedSource = resolveUserPath(source, params.env);
+    for (const entry of configuredInstallPaths) {
+      if (isPathInsideOrEqual(entry.installPath, resolvedSource)) {
+        stalePluginIds.add(entry.pluginId);
+      }
+    }
+  }
+
+  return stalePluginIds;
+}
+
 function isInstalledRecordMissingOnDisk(
   record: PluginInstallRecord | undefined,
   env: NodeJS.ProcessEnv,
 ): boolean {
-  const installPath = record?.installPath?.trim();
+  const installPath = resolveInstallRecordPath(record, env);
   if (!installPath) {
     return true;
   }
-  const resolved = resolveUserPath(installPath, env);
-  return !existsSync(path.join(resolved, "package.json"));
+  return !existsSync(path.join(installPath, "package.json"));
 }
 
 function isUpdatePackageDoctorPass(env: NodeJS.ProcessEnv): boolean {
@@ -655,13 +719,20 @@ async function repairMissingPluginInstalls(params: {
         ] as const,
     ),
   ]);
+  const records = await loadInstalledPluginIndexInstallRecords({ env });
   const configuredPluginIdsWithStaleDescriptors =
     collectConfiguredPluginIdsWithMissingChannelConfigDescriptors({
       snapshot,
       configuredPluginIds: params.pluginIds,
       configuredChannelIds: params.channelIds,
     });
-  const records = await loadInstalledPluginIndexInstallRecords({ env });
+  const configuredPluginIdsWithBrokenRuntimeEntries =
+    collectConfiguredPluginIdsWithBrokenRuntimeEntries({
+      snapshot,
+      configuredPluginIds: params.pluginIds,
+      records,
+      env,
+    });
   const changes: string[] = [];
   const warnings: string[] = [];
   const deferredPluginIds = new Set<string>();
@@ -714,7 +785,8 @@ async function repairMissingPluginInstalls(params: {
       !bundledPluginsById.has(pluginId) &&
       ((params.pluginIds.has(pluginId) &&
         (!knownIds.has(pluginId) || isInstalledRecordMissingOnDisk(nextRecords[pluginId], env))) ||
-        configuredPluginIdsWithStaleDescriptors.has(pluginId)),
+        configuredPluginIdsWithStaleDescriptors.has(pluginId) ||
+        configuredPluginIdsWithBrokenRuntimeEntries.has(pluginId)),
   );
 
   if (missingRecordedPluginIds.length > 0) {


### PR DESCRIPTION
## Summary
- detect configured plugins whose metadata diagnostics report broken runtime entries
- repair those persisted install records through the existing npm plugin update path
- treat `sourcePath` as a fallback install path when checking persisted plugin records

## Why
A configured Brave web search plugin can remain recorded as installed while its package only has source runtime entries, e.g. `@openclaw/brave-plugin@2026.5.2` expecting compiled `dist/index.js`. Doctor should update that configured plugin instead of considering the install healthy only because `package.json` exists.

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts` -> 40 passed
- `pnpm exec oxfmt --check --threads=1 src/commands/doctor/shared/missing-configured-plugin-install.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts`
- `git diff --check upstream/main...HEAD`

## Real behavior proof
- **Behavior or issue addressed**: A configured Brave web search plugin with a persisted install record but broken runtime entry is treated as repairable, so doctor can update the installed npm plugin instead of leaving built-in `web_search` without a provider.
- **Real environment tested**: kevinlasnh live Ubuntu main OpenClaw gateway on OpenClaw 2026.5.3 with Brave configured as the built-in web search provider.
- **Exact steps or command run after this patch**: Updated the live `@openclaw/brave-plugin` package to the compiled runtime build, restarted the main gateway, then ran a Brave-only main agent smoke test that forbade `exec` and Tavily fallback and allowed only built-in `web_search`.
- **Evidence after fix**: Copied live output from the real gateway smoke:

```text
OpenClaw 2026.5.3 (06d46f7)
plugins inspect brave: Status=loaded, Version=2026.5.3, webSearchProviderIds=["brave"], diagnostics=[]
gateway health: ok=true, Telegram running=true, lastError=null
main Brave-only smoke: final=MAIN_BRAVE_ONLY_OK
toolSummary.calls=1
toolSummary.tools=["web_search"]
toolSummary.failures=0
```

- **Observed result after fix**: The live main gateway used built-in `web_search` successfully through Brave with zero tool failures, confirming the broken runtime entry state was repaired in a real OpenClaw setup.
- **What was not tested**: No additional real-environment gaps known; local targeted doctor tests are supplemental.

## Note
- `pnpm exec oxlint src/commands/doctor/shared/missing-configured-plugin-install.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts` still reports the existing `__testing` naming rule in this file; this PR does not add that export.