### PR TITLE
fix(cli): emit agent-tool diagnostic instead of plugins.allow suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
+- CLI/diagnostics: emit an agent-tool hint instead of a `plugins.allow` suggestion when a missing CLI argument matches a plugin's `contracts.tools` entry, so users running an agent tool name at the shell see a clear "use from an agent session" message rather than a misleading allowlist error. Fixes #77214. Thanks @hclsys.
 - Memory/wiki: preserve representation from both corpora in `corpus=all` searches while backfilling unused result capacity, so memory hits are not starved by numerically higher wiki integer scores. Fixes #77337. Thanks @hclsys.
 - Telegram: clean up tool-only draft previews after assistant message boundaries so transient `Surfacing...` tool-status bubbles do not linger when no matching final preview arrives. Thanks @BunsDev.
 - Cron: surface failed isolated-run diagnostics in `cron show`, status, and run history when requested tools are unavailable, so blocked cron runs report the actual tool-policy failure instead of a misleading green result. Fixes #75763. Thanks @RyanSandoval.

--- a/src/cli/run-main-policy.ts
+++ b/src/cli/run-main-policy.ts
@@ -102,6 +102,7 @@ export function resolveMissingPluginCommandMessage(
       config?: OpenClawConfig;
       registry?: PluginManifestCommandAliasRegistry;
     }) => PluginManifestCommandAliasRecord | undefined;
+    resolveToolOwner?: (toolName: string) => string | undefined;
   },
 ): string | null {
   const normalizedPluginId = normalizeLowercaseStringOrEmpty(pluginId);
@@ -171,6 +172,13 @@ export function resolveMissingPluginCommandMessage(
   if (allow.length > 0 && !allow.includes(normalizedPluginId)) {
     if (parentPluginId && allow.includes(parentPluginId)) {
       return null;
+    }
+    const toolOwnerPluginId = options?.resolveToolOwner?.(normalizedPluginId);
+    if (toolOwnerPluginId) {
+      return (
+        `"${normalizedPluginId}" is an agent tool registered by the "${toolOwnerPluginId}" plugin, ` +
+        `not a CLI subcommand. Use it from an agent session (model tool-use), not the CLI.`
+      );
     }
     return (
       `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -367,4 +367,36 @@ describe("resolveMissingPluginCommandMessage", () => {
     expect(message).toContain('"memory-wiki"');
     expect(message).toContain("plugins.allow");
   });
+
+  it("surfaces tool-owner message when allow excludes an agent tool name", () => {
+    const message = resolveMissingPluginCommandMessage(
+      "wecom_mcp",
+      {
+        plugins: {
+          allow: ["quietchat"],
+        },
+      },
+      {
+        resolveToolOwner: (toolName) => (toolName === "wecom_mcp" ? "wecom" : undefined),
+      },
+    );
+    expect(message).toContain('"wecom_mcp" is an agent tool');
+    expect(message).toContain('"wecom"');
+    expect(message).not.toContain("plugins.allow");
+  });
+
+  it("falls through to plugins.allow message when resolveToolOwner returns undefined", () => {
+    const message = resolveMissingPluginCommandMessage(
+      "unknown_tool",
+      {
+        plugins: {
+          allow: ["quietchat"],
+        },
+      },
+      {
+        resolveToolOwner: (_toolName) => undefined,
+      },
+    );
+    expect(message).toContain('`plugins.allow` excludes "unknown_tool"');
+  });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -639,13 +639,14 @@ export async function runCli(argv: string[] = process.argv) {
               (command) => command.name() === primary || command.aliases().includes(primary),
             )
           ) {
-            const { resolveManifestCommandAliasOwner } =
+            const { resolveManifestCommandAliasOwner, resolveManifestToolOwner } =
               await import("../plugins/manifest-command-aliases.runtime.js");
             const missingPluginCommandMessage = resolveMissingPluginCommandMessageFromPolicy(
               primary,
               config,
               {
                 resolveCommandAliasOwner: resolveManifestCommandAliasOwner,
+                resolveToolOwner: (toolName) => resolveManifestToolOwner({ toolName, config }),
               },
             );
             if (missingPluginCommandMessage) {

--- a/src/plugins/manifest-command-aliases.runtime.ts
+++ b/src/plugins/manifest-command-aliases.runtime.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import {
   resolveManifestCommandAliasOwnerInRegistry,
   type PluginManifestCommandAliasRegistry,
@@ -24,4 +25,31 @@ export function resolveManifestCommandAliasOwner(params: {
     command: params.command,
     registry,
   });
+}
+
+export function resolveManifestToolOwner(params: {
+  toolName: string | undefined;
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): string | undefined {
+  const normalized = normalizeOptionalLowercaseString(params.toolName);
+  if (!normalized) {
+    return undefined;
+  }
+  const { manifestRegistry } = loadManifestMetadataRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  for (const plugin of manifestRegistry.plugins) {
+    const toolNames = plugin.contracts?.tools;
+    if (
+      Array.isArray(toolNames) &&
+      toolNames.some((t) => normalizeOptionalLowercaseString(t) === normalized)
+    ) {
+      return plugin.id;
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Root cause

`resolveMissingPluginCommandMessage` in `src/cli/run-main-policy.ts` falls straight through to the `plugins.allow` suggestion branch when the user types an unrecognized subcommand. It has no awareness of `contracts.tools` — the tool names a plugin registers for agent model-use. So `openclaw wecom_mcp` (a tool name, not a CLI command) produces:

> The \`openclaw wecom_mcp\` command is unavailable because \`plugins.allow\` excludes "wecom_mcp". Add "wecom_mcp" to \`plugins.allow\` if you want that bundled plugin CLI surface.

That's wrong: `wecom_mcp` is never a CLI subcommand, and adding it to `plugins.allow` does nothing useful.

## Fix

- **`src/plugins/manifest-command-aliases.runtime.ts`** — adds `resolveManifestToolOwner`, which loads the manifest registry and searches each plugin's `contracts.tools` array for a matching tool name.
- **`src/cli/run-main-policy.ts`** — adds `resolveToolOwner?: (toolName: string) => string | undefined` to the options of `resolveMissingPluginCommandMessage`; calls it just before the `plugins.allow` branch. If it returns a plugin ID, emits a targeted diagnostic instead.
- **`src/cli/run-main.ts`** — wires `resolveToolOwner: (toolName) => resolveManifestToolOwner({ toolName, config })` at the runtime call site alongside the existing `resolveCommandAliasOwner`.

## Example output after fix

```
"wecom_mcp" is an agent tool registered by the "wecom" plugin, not a CLI subcommand. Use it from an agent session (model tool-use), not the CLI.
```

## Tests

Two new unit tests in `src/cli/run-main.test.ts`:
- emits agent-tool message when `resolveToolOwner` identifies the tool owner
- falls through to `plugins.allow` message when `resolveToolOwner` returns undefined

All 29 existing tests continue to pass.

Fixes #77214.