### PR TITLE
fix(secrets): search dist/ subdir in resolvePluginContractApiPath for npm-compiled channel plugins

### DIFF
--- a/src/secrets/channel-contract-api.external.test.ts
+++ b/src/secrets/channel-contract-api.external.test.ts
@@ -98,6 +98,54 @@ describe("external channel secret contract api", () => {
     expect(api?.collectRuntimeConfigAssignments).toBeTypeOf("function");
   });
 
+  it("loads secret-contract-api from dist/ subdirectory for npm-compiled channel plugins", () => {
+    const rootDir = makeTrackedTempDir("openclaw-channel-dist-contract", tempDirs);
+    const distDir = path.join(rootDir, "dist");
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(distDir, "secret-contract-api.cjs"),
+      `
+module.exports = {
+  secretTargetRegistryEntries: [
+    {
+      id: "channels.discord.token",
+      targetType: "channels.discord.token",
+      configFile: "openclaw.json",
+      pathPattern: "channels.discord.token",
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true
+    }
+  ],
+  collectRuntimeConfigAssignments(params) {}
+};
+`,
+      "utf8",
+    );
+    const record = {
+      id: "discord",
+      origin: "global" as const,
+      channels: ["discord"],
+      channelConfigs: {},
+      rootDir,
+    };
+    loadPluginMetadataSnapshotMock.mockReturnValue({ plugins: [record] });
+
+    const api = loadChannelSecretContractApi({
+      channelId: "discord",
+      config: { channels: { discord: {} } },
+      env: {},
+      loadablePluginOrigins: new Map([["discord", "global"]]),
+    });
+
+    expect(api?.secretTargetRegistryEntries).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "channels.discord.token" })]),
+    );
+    expect(api?.collectRuntimeConfigAssignments).toBeTypeOf("function");
+  });
+
   it("skips external channel records outside the loadable plugin origin set", () => {
     const record = writeExternalChannelPlugin({ pluginId: "discord", channelId: "discord" });
     loadPluginMetadataSnapshotMock.mockReturnValue({

--- a/src/secrets/channel-contract-api.ts
+++ b/src/secrets/channel-contract-api.ts
@@ -87,16 +87,21 @@ function orderedContractApiExtensions(): readonly string[] {
 }
 
 function resolvePluginContractApiPath(rootDir: string): string | null {
-  for (const extension of orderedContractApiExtensions()) {
-    const candidate = path.join(rootDir, `secret-contract-api${extension}`);
-    if (fs.existsSync(candidate)) {
-      return candidate;
+  const searchDirs = [rootDir, path.join(rootDir, "dist")];
+  for (const dir of searchDirs) {
+    for (const extension of orderedContractApiExtensions()) {
+      const candidate = path.join(dir, `secret-contract-api${extension}`);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
     }
   }
-  for (const extension of orderedContractApiExtensions()) {
-    const candidate = path.join(rootDir, `contract-api${extension}`);
-    if (fs.existsSync(candidate)) {
-      return candidate;
+  for (const dir of searchDirs) {
+    for (const extension of orderedContractApiExtensions()) {
+      const candidate = path.join(dir, `contract-api${extension}`);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
     }
   }
   return null;


### PR DESCRIPTION
## Problem

`resolvePluginContractApiPath()` in `src/secrets/channel-contract-api.ts` only searched the plugin `rootDir` directly for `secret-contract-api.*` / `contract-api.*` files. npm packages conventionally compile TypeScript output to a `dist/` subdirectory, so any installed npm channel plugin (including `@openclaw/discord`) that places its contract under `dist/` was never discovered. The result: Discord channel tokens were never resolved into the runtime snapshot, and **all Discord accounts silently failed to start on every gateway boot**.

## Fix

Extend `resolvePluginContractApiPath` to search `[rootDir, rootDir/dist]` for both contract file names. `rootDir` is still preferred — `dist/` is only checked as a fallback.

## Tests

- Added regression test to `channel-contract-api.external.test.ts`: a plugin with only `dist/secret-contract-api.cjs` (no root-level file) is discovered and its `secretTargetRegistryEntries` are returned correctly.
- All 3 external channel contract tests pass.

## PRE-IMPLEMENT AUDIT
1. Existing-helper: `resolvePluginContractApiPath` is private and has no dist-aware variant elsewhere. PASS.
2. Shared-helper: Only one call site (`loadExternalChannelSecretContractFromRecord`). PASS.
3. Rival scan: No rival PR found. PASS.

Fixes #77241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)