### PR TITLE
Keep runtime plugin repair active during updates

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -1007,6 +1007,66 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result).toEqual({ changes: [], warnings: [] });
   });
 
+  it("installs missing runtime plugins during the package update doctor pass", async () => {
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "codex",
+      targetDir: "/tmp/openclaw-plugins/codex",
+      version: "2026.5.3",
+      npmResolution: {
+        name: "@openclaw/codex",
+        version: "2026.5.3",
+        resolvedSpec: "@openclaw/codex@2026.5.3",
+        integrity: "sha512-codex",
+        resolvedAt: "2026-05-01T00:00:00.000Z",
+      },
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.4",
+            agentRuntime: { id: "codex" },
+          },
+        },
+      },
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+      },
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "@openclaw/codex",
+        expectedPluginId: "codex",
+        trustedSourceLinkedOfficialInstall: true,
+      }),
+    );
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        codex: expect.objectContaining({
+          source: "npm",
+          spec: "@openclaw/codex",
+          installPath: "/tmp/openclaw-plugins/codex",
+          version: "2026.5.3",
+        }),
+      }),
+      {
+        env: {
+          OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        },
+      },
+    );
+    expect(result).toEqual({
+      changes: ['Installed missing configured plugin "codex" from @openclaw/codex.'],
+      warnings: [],
+    });
+  });
+
   it("does not install configured plugins when plugins are globally disabled", async () => {
     mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -67,6 +67,9 @@ const RUNTIME_PLUGIN_INSTALL_CANDIDATES: readonly DownloadableInstallCandidate[]
 
 const MISSING_CHANNEL_CONFIG_DESCRIPTOR_DIAGNOSTIC = "without channelConfigs metadata";
 const UPDATE_IN_PROGRESS_ENV = "OPENCLAW_UPDATE_IN_PROGRESS";
+const UPDATE_DOCTOR_IMMEDIATE_PLUGIN_IDS = new Set(
+  RUNTIME_PLUGIN_INSTALL_CANDIDATES.map((candidate) => candidate.pluginId),
+);
 
 function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
   return (
@@ -366,7 +369,12 @@ function collectUpdateDeferredPluginIds(params: {
   configuredChannelOwnerPluginIds?: ReadonlyMap<string, ReadonlySet<string>>;
   blockedPluginIds?: ReadonlySet<string>;
 }): Set<string> {
-  const pluginIds = new Set(params.configuredPluginIds);
+  // Runtime harness plugins must exist before the restarted Gateway can process turns.
+  const pluginIds = new Set(
+    [...params.configuredPluginIds].filter(
+      (pluginId) => !UPDATE_DOCTOR_IMMEDIATE_PLUGIN_IDS.has(pluginId),
+    ),
+  );
   for (const candidate of collectDownloadableInstallCandidates({
     cfg: params.cfg,
     env: params.env,
@@ -376,6 +384,9 @@ function collectUpdateDeferredPluginIds(params: {
     configuredChannelOwnerPluginIds: params.configuredChannelOwnerPluginIds,
     blockedPluginIds: params.blockedPluginIds,
   })) {
+    if (UPDATE_DOCTOR_IMMEDIATE_PLUGIN_IDS.has(candidate.pluginId)) {
+      continue;
+    }
     pluginIds.add(candidate.pluginId);
   }
   return pluginIds;

--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -271,11 +271,9 @@ describe("configured plugin install release step", () => {
     expect(result.completed).toBe(true);
   });
 
-  it("does not stamp config during update-time deferred install repair", async () => {
+  it("does not stamp config during update-time runtime install repair", async () => {
     mocks.repairMissingPluginInstallsForIds.mockResolvedValue({
-      changes: [
-        'Deferred missing configured plugin "codex" install repair until post-update doctor.',
-      ],
+      changes: ['Installed missing configured plugin "codex".'],
       warnings: [],
     });
 
@@ -302,9 +300,7 @@ describe("configured plugin install release step", () => {
       }),
     );
     expect(result).toEqual({
-      changes: [
-        'Deferred missing configured plugin "codex" install repair until post-update doctor.',
-      ],
+      changes: ['Installed missing configured plugin "codex".'],
       warnings: [],
       completed: false,
       touchedConfig: false,


### PR DESCRIPTION
Summary
- Exclude runtime harness plugins from the update-doctor deferral set so Codex can be reinstalled before gateway restart.
- Preserve update-time deferral for channel and ordinary plugin payload repair.
- Add regression coverage for Codex runtime repair during package update doctor passes.

Verification
- pnpm test src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/commands/doctor/shared/release-configured-plugin-installs.test.ts
- pnpm check:changed
- pnpm test:changed

Not tested
- Live npm package update from a published release.