### PR TITLE
fix(media): dedupe identical path/url in inbound media-note formatter (#47587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/media: dedupe identical path/url in inbound media-note formatter so albums no longer render `path | path` for local-only attachments. Fixes #47587. Thanks @yzjJosh.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -6,16 +6,19 @@ import {
 } from "./media-understanding.test-fixtures.js";
 
 describe("buildInboundMediaNote", () => {
-  it("formats single MediaPath as a media note", () => {
+  it("formats single MediaPath as a media note (collapses redundant duplicate URL, #47587)", () => {
+    // When the channel mirrors the local path into MediaUrl (e.g. Telegram
+    // album media), the formatter should not render `path | path`. The URL
+    // suffix is only useful when it adds new information beyond the path.
     const note = buildInboundMediaNote({
       MediaPath: "/tmp/a.png",
       MediaType: "image/png",
       MediaUrl: "/tmp/a.png",
     });
-    expect(note).toBe("[media attached: /tmp/a.png (image/png) | /tmp/a.png]");
+    expect(note).toBe("[media attached: /tmp/a.png (image/png)]");
   });
 
-  it("formats multiple MediaPaths as numbered media notes", () => {
+  it("formats multiple MediaPaths as numbered media notes (collapses duplicate URLs, #47587)", () => {
     const note = buildInboundMediaNote({
       MediaPaths: ["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"],
       MediaUrls: ["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"],
@@ -23,9 +26,9 @@ describe("buildInboundMediaNote", () => {
     expect(note).toBe(
       [
         "[media attached: 3 files]",
-        "[media attached 1/3: /tmp/a.png | /tmp/a.png]",
-        "[media attached 2/3: /tmp/b.png | /tmp/b.png]",
-        "[media attached 3/3: /tmp/c.png | /tmp/c.png]",
+        "[media attached 1/3: /tmp/a.png]",
+        "[media attached 2/3: /tmp/b.png]",
+        "[media attached 3/3: /tmp/c.png]",
       ].join("\n"),
     );
   });
@@ -290,5 +293,42 @@ describe("buildInboundMediaNote", () => {
       MediaTypes: ["audio/ogg"],
     });
     expect(note).toBe("[media attached: /tmp/voice.ogg (audio/ogg)]");
+  });
+
+  it("preserves URL suffix when it differs from the local path (#47587)", () => {
+    // Single attachment: distinct path and URL must both render.
+    const single = buildInboundMediaNote({
+      MediaPath: "/tmp/a.png",
+      MediaType: "image/png",
+      MediaUrl: "https://example.com/a.png",
+    });
+    expect(single).toBe(
+      "[media attached: /tmp/a.png (image/png) | https://example.com/a.png]",
+    );
+
+    // Mixed array: some indices have identical path/url (Telegram local-only),
+    // others carry a real remote URL. Each entry should be deduped independently.
+    const mixed = buildInboundMediaNote({
+      MediaPaths: ["/tmp/local.png", "/tmp/remote.png"],
+      MediaUrls: ["/tmp/local.png", "https://example.com/remote.png"],
+    });
+    expect(mixed).toBe(
+      [
+        "[media attached: 2 files]",
+        "[media attached 1/2: /tmp/local.png]",
+        "[media attached 2/2: /tmp/remote.png | https://example.com/remote.png]",
+      ].join("\n"),
+    );
+  });
+
+  it("dedupes after sanitization: trailing whitespace/control chars in URL still match (#47587)", () => {
+    // Sanitization runs before equality, so visually-identical inputs that
+    // differ only by trailing whitespace are treated as duplicates.
+    const note = buildInboundMediaNote({
+      MediaPath: "/tmp/a.png",
+      MediaType: "image/png",
+      MediaUrl: "/tmp/a.png   ",
+    });
+    expect(note).toBe("[media attached: /tmp/a.png (image/png)]");
   });
 });

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -331,9 +331,7 @@ describe("buildInboundMediaNote", () => {
       MediaType: "image/png",
       MediaUrl: "https://example.com/a.png",
     });
-    expect(single).toBe(
-      "[media attached: /tmp/a.png (image/png) | https://example.com/a.png]",
-    );
+    expect(single).toBe("[media attached: /tmp/a.png (image/png) | https://example.com/a.png]");
 
     // Mixed array: some indices have identical path/url (Telegram local-only),
     // others carry a real remote URL. Each entry should be deduped independently.

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -8,13 +8,16 @@ import {
 } from "./media-understanding.test-fixtures.js";
 
 describe("buildInboundMediaNote", () => {
-  it("formats single MediaPath as a media note", () => {
+  it("formats single MediaPath as a media note (collapses redundant duplicate URL, #47587)", () => {
+    // When the channel mirrors the local path into MediaUrl (e.g. Telegram
+    // album media), the formatter should not render `path | path`. The URL
+    // suffix is only useful when it adds new information beyond the path.
     const note = buildInboundMediaNote({
       MediaPath: "/tmp/a.png",
       MediaType: "image/png",
       MediaUrl: "/tmp/a.png",
     });
-    expect(note).toBe("[media attached: /tmp/a.png (image/png) | /tmp/a.png]");
+    expect(note).toBe("[media attached: /tmp/a.png (image/png)]");
   });
 
   it("renders managed inbound media-store paths as media URIs", () => {
@@ -29,7 +32,7 @@ describe("buildInboundMediaNote", () => {
     );
   });
 
-  it("formats multiple MediaPaths as numbered media notes", () => {
+  it("formats multiple MediaPaths as numbered media notes (collapses duplicate URLs, #47587)", () => {
     const note = buildInboundMediaNote({
       MediaPaths: ["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"],
       MediaUrls: ["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"],
@@ -37,9 +40,9 @@ describe("buildInboundMediaNote", () => {
     expect(note).toBe(
       [
         "[media attached: 3 files]",
-        "[media attached 1/3: /tmp/a.png | /tmp/a.png]",
-        "[media attached 2/3: /tmp/b.png | /tmp/b.png]",
-        "[media attached 3/3: /tmp/c.png | /tmp/c.png]",
+        "[media attached 1/3: /tmp/a.png]",
+        "[media attached 2/3: /tmp/b.png]",
+        "[media attached 3/3: /tmp/c.png]",
       ].join("\n"),
     );
   });
@@ -304,5 +307,42 @@ describe("buildInboundMediaNote", () => {
       MediaTypes: ["audio/ogg"],
     });
     expect(note).toBe("[media attached: /tmp/voice.ogg (audio/ogg)]");
+  });
+
+  it("preserves URL suffix when it differs from the local path (#47587)", () => {
+    // Single attachment: distinct path and URL must both render.
+    const single = buildInboundMediaNote({
+      MediaPath: "/tmp/a.png",
+      MediaType: "image/png",
+      MediaUrl: "https://example.com/a.png",
+    });
+    expect(single).toBe(
+      "[media attached: /tmp/a.png (image/png) | https://example.com/a.png]",
+    );
+
+    // Mixed array: some indices have identical path/url (Telegram local-only),
+    // others carry a real remote URL. Each entry should be deduped independently.
+    const mixed = buildInboundMediaNote({
+      MediaPaths: ["/tmp/local.png", "/tmp/remote.png"],
+      MediaUrls: ["/tmp/local.png", "https://example.com/remote.png"],
+    });
+    expect(mixed).toBe(
+      [
+        "[media attached: 2 files]",
+        "[media attached 1/2: /tmp/local.png]",
+        "[media attached 2/2: /tmp/remote.png | https://example.com/remote.png]",
+      ].join("\n"),
+    );
+  });
+
+  it("dedupes after sanitization: trailing whitespace/control chars in URL still match (#47587)", () => {
+    // Sanitization runs before equality, so visually-identical inputs that
+    // differ only by trailing whitespace are treated as duplicates.
+    const note = buildInboundMediaNote({
+      MediaPath: "/tmp/a.png",
+      MediaType: "image/png",
+      MediaUrl: "/tmp/a.png   ",
+    });
+    expect(note).toBe("[media attached: /tmp/a.png (image/png)]");
   });
 });

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -20,15 +20,30 @@ describe("buildInboundMediaNote", () => {
     expect(note).toBe("[media attached: /tmp/a.png (image/png)]");
   });
 
-  it("renders managed inbound media-store paths as media URIs", () => {
+  it("renders managed inbound media-store paths as media URIs (collapses duplicate URL, #47587)", () => {
     const inboundPath = path.join(getMediaDir(), "inbound", "photo---abc123.png");
     const note = buildInboundMediaNote({
       MediaPath: inboundPath,
       MediaType: "image/png",
       MediaUrl: inboundPath,
     });
+    // Both MediaPath and MediaUrl normalize to the same media://inbound/ URI,
+    // so the duplicate URL suffix is collapsed per #47587. Channels that
+    // surface a genuinely different URL (e.g. a remote handle) still get the
+    // ` | <url>` suffix - see the next test case.
+    expect(note).toBe("[media attached: media://inbound/photo---abc123.png (image/png)]");
+  });
+
+  it("renders managed inbound media-store paths with distinct remote URL", () => {
+    const inboundPath = path.join(getMediaDir(), "inbound", "photo---abc123.png");
+    const note = buildInboundMediaNote({
+      MediaPath: inboundPath,
+      MediaType: "image/png",
+      MediaUrl: "https://cdn.example.com/photo---abc123.png",
+    });
+    // Genuinely different URL (remote CDN) is preserved as the suffix.
     expect(note).toBe(
-      "[media attached: media://inbound/photo---abc123.png (image/png) | media://inbound/photo---abc123.png]",
+      "[media attached: media://inbound/photo---abc123.png (image/png) | https://cdn.example.com/photo---abc123.png]",
     );
   });
 

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -27,7 +27,10 @@ function formatMediaAttachedLine(params: {
   const typeRaw = sanitizeInlineMediaNoteValue(params.type);
   const typePart = typeRaw ? ` (${typeRaw})` : "";
   const urlRaw = sanitizeInlineMediaNoteValue(params.url);
-  const urlPart = urlRaw ? ` | ${urlRaw}` : "";
+  // When the channel mirrors the local path into MediaUrl (Telegram album
+  // media is the canonical case), rendering ` | ${url}` adds no information
+  // and clutters the prompt with `path | path` duplication (issue #47587).
+  const urlPart = urlRaw && urlRaw !== path ? ` | ${urlRaw}` : "";
   return `${prefix}${path}${typePart}${urlPart}]`;
 }
 

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -51,7 +51,10 @@ function formatMediaAttachedLine(params: {
   const typeRaw = sanitizeInlineMediaNoteValue(params.type);
   const typePart = typeRaw ? ` (${typeRaw})` : "";
   const urlRaw = sanitizeInlineMediaNoteValue(params.url);
-  const urlPart = urlRaw ? ` | ${urlRaw}` : "";
+  // When the channel mirrors the local path into MediaUrl (Telegram album
+  // media is the canonical case), rendering ` | ${url}` adds no information
+  // and clutters the prompt with `path | path` duplication (issue #47587).
+  const urlPart = urlRaw && urlRaw !== path ? ` | ${urlRaw}` : "";
   return `${prefix}${path}${typePart}${urlPart}]`;
 }
 


### PR DESCRIPTION
## Summary

Telegram album media (and any channel that mirrors local paths into `MediaUrl`) caused the prompt-side media note to render `path | path` for each attachment, polluting context with redundant data and confusing models that treat the URL suffix as a remote handle. This PR makes `formatMediaAttachedLine` skip the URL suffix when it is byte-equal to the local path after sanitization, so single-image and album notes render cleanly while genuinely-distinct local-path/remote-URL pairs still render both.

## Root Cause

- `src/auto-reply/media-note.ts:formatMediaAttachedLine`: unconditionally appended ` | ${urlRaw}` whenever `params.url` was non-empty after sanitization, even when `urlRaw === path`. There was no path-vs-URL equality check.
- Execution path: `Telegram bot-message-context.session.ts:384-388` sets `MediaUrl/MediaUrls` to the same local file paths it sets in `MediaPath/MediaPaths` (Telegram has no separate remote URL for inbound album media) → `buildInboundMediaNote` (`media-note.ts:103`) builds entries where `entry.path === entry.url` → `formatMediaAttachedLine` renders `[media attached: /tmp/a.png (image/png) | /tmp/a.png]`.
- This follows the conservative direction in clawsweeper's review on #47587: *"fix duplicate local path/url media-note rendering, and point users who need all album images described to `tools.media.image.attachments` with `mode: \"all\"`. ... De-duplicating identical local path/url rendering is maintainable, while changing the shared first-image default is unnecessary because multi-image processing already has documented config."*

## Changes

- `src/auto-reply/media-note.ts`: in `formatMediaAttachedLine`, skip the ` | ${urlRaw}` suffix when sanitized URL equals sanitized path. Sanitization runs before equality so `"/tmp/a.png"` and `"/tmp/a.png   "` collapse consistently. Single-line behavior change with brief comment citing #47587.
- `src/auto-reply/media-note.test.ts`: updated the two existing `formats single MediaPath` and `formats multiple MediaPaths` tests at lines 9-31 to assert the corrected (deduped) output. Added two new regression tests:
  - "preserves URL suffix when it differs from the local path" — covers the mixed-array case where some entries are Telegram-style identical and others carry a real remote URL.
  - "dedupes after sanitization" — covers whitespace/control-char variants of the same path.

## Real behavior proof

- **Behavior or issue addressed**: Telegram inbound album messages (and any channel that mirrors local file paths into `MediaUrl`) cause `buildInboundMediaNote` to render every attachment as `[media attached: <path> (<type>) | <same path>]`, doubling the token cost of every inbound media line and confusing models that read the `| <suffix>` as a remote URL. After this fix the same input renders `[media attached: <path> (<type>)]` with **no** trailing `| <path>` duplicate; genuinely-distinct local-path / remote-URL pairs (e.g. when a channel actually has a remote URL) still render both halves. Issue: https://github.com/openclaw/openclaw/issues/47587
- **Real environment tested**: Local OpenClaw checkout at `../openclaw-47587` on Windows 11 + Node 22.14, exercising the patched **production** `buildInboundMediaNote` export from `src/auto-reply/media-note.ts` directly through `node --import tsx`. No mocks, no test runner — the same function the auto-reply path calls. PR head: `db978572a493ebbb22881089b090e435573ab208`.
- **Exact steps or command run after this patch**: `git checkout fix/telegram-media-note-dedupe-path-url && node --import tsx ./smoke-pr77279.ts`, where `smoke-pr77279.ts` imports `buildInboundMediaNote` from `./src/auto-reply/media-note.js` and feeds it four representative `MsgContext` shapes: (1) Telegram album single-image with identical path/url (the #47587 reproducer), (2) genuinely-distinct path vs URL, (3) mixed-array where some attachments dedupe and others stay distinct, (4) no-URL audio (must not emit trailing pipe).
- **Evidence after fix**: Terminal output captured locally on PR head `db978572a4` (Windows 11 + Node 22.14, the patched `src/auto-reply/media-note.ts` exercised through its real exports via `node --import tsx`).

~~~text
$ node --import tsx ./smoke-pr77279.ts
=== Telegram album: identical path & url (the #47587 reproducer) ===
output:
[media attached: /tmp/openclaw/inbound/AgADBQ_0123_photo.jpg (image/jpeg)]

=== Distinct path vs url (must keep both) ===
output:
[media attached: /tmp/openclaw/inbound/photo.jpg (image/jpeg) | https://t.me/c/123/456]

=== Mixed: some align, some distinct ===
output:
[media attached: 2 files]
[media attached 1/2: /tmp/openclaw/inbound/a.jpg (image/jpeg)]
[media attached 2/2: /tmp/openclaw/inbound/b.jpg (image/jpeg) | https://t.me/c/123/456]

=== No url (must NOT emit ' | ' suffix) ===
output:
[media attached: /tmp/openclaw/inbound/silent.mp3 (audio/mpeg)]

=== Substring check on Telegram-style output ===
contains literal path-pipe-path duplicate: false
occurrences of /tmp/openclaw/inbound/AgADBQ_0123_photo.jpg in output: 1
~~~

- **Observed result after fix**: The Telegram-album reproducer renders **exactly one** occurrence of the path string in the line (`occurrences=1`) and the literal substring `<path> | <path>` is absent (`contains literal path-pipe-path duplicate: false`). The distinct-URL case renders **both** halves (`(image/jpeg) | https://t.me/c/123/456`), confirming the fix only dedupes when the URL is byte-equal to the path. The mixed case correctly dedupes the first entry (where `path === url`) and preserves the second (where `url` is a different `https://...` value). The no-URL audio case produces no trailing `| ` separator. Each of these four cases is observable behavior from the production function, not a derived assertion.
- **What was not tested**: A live inbound Telegram album roundtrip through `auto-reply/reply` against a real Telegram Bot API is not reproduced on the contributor machine (would need a paired bot token + group chat). The fix is a pure-function change inside `formatMediaAttachedLine`; downstream consumers (`auto-reply/reply.ts`, prompt builders) read the returned string verbatim, so the only behavioural change is the removed `| <path>` suffix on duplicate-mirror channels. Maintainers may apply `proof: override` if a live Telegram recording is required.

## Test

- `pnpm test src/auto-reply/media-note.test.ts` — updated 2 existing cases + added 2 new regression cases (4 total assertions for #47587 scope).
- `pnpm test src/auto-reply/reply.media-note.test.ts` — unchanged; this sister test already uses prefix `toContain` / `indexOf` semantics that survive the dedup change.
- `pnpm tsgo` — clean (lsp_diagnostics on changed files: no errors).
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/media-note.ts src/auto-reply/media-note.test.ts` — formatting preserved.

## Notes

- Scope: single issue, smallest complete fix at the shared formatter (1 production line + brief comment). Telegram's `bot-message-context.session.ts:384-388` is left as-is — fixing it at the formatter handles every channel that mirrors path→url uniformly (not just Telegram).
- Compatibility: prompts that previously contained `[media attached: PATH | PATH]` now contain `[media attached: PATH]` — no consumer parses this header for round-trip data, and the URL-suffix semantics for genuinely-remote URLs are preserved unchanged.
- Defers per clawsweeper's direction: the shared multi-image default (`mode: "first"`, `maxAttachments: 1`) is intentionally left alone; users who want all album images transcribed already have `tools.media.image.attachments` with `mode: "all"`.
- This follows the conservative direction in clawsweeper's review on #47587: "De-duplicating identical local path/url rendering is maintainable, while changing the shared first-image default is unnecessary because multi-image processing already has documented config."

Closes #47587
