### PR TITLE
fix: display file path when model uses 'file' parameter alias (#54882)

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -43,21 +43,30 @@
       "emoji": "📖",
       "title": "Read",
       "detailKeys": [
-        "path"
+        "path",
+        "file",
+        "filePath",
+        "file_path"
       ]
     },
     "write": {
       "emoji": "✍️",
       "title": "Write",
       "detailKeys": [
-        "path"
+        "path",
+        "file",
+        "filePath",
+        "file_path"
       ]
     },
     "edit": {
       "emoji": "📝",
       "title": "Edit",
       "detailKeys": [
-        "path"
+        "path",
+        "file",
+        "filePath",
+        "file_path"
       ]
     },
     "attach": {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -607,7 +607,11 @@ export function handleToolExecutionStart(
           ? record.path
           : typeof record.file_path === "string"
             ? record.file_path
-            : "";
+            : typeof record.filePath === "string"
+              ? record.filePath
+              : typeof record.file === "string"
+                ? record.file
+                : "";
       const filePath = filePathValue.trim();
       if (!filePath) {
         const argsPreview = readStringValue(args)?.slice(0, 200);

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -178,7 +178,7 @@ function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file_path, record.filePath, record.file]) {
     if (typeof candidate !== "string") {
       continue;
     }

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -50,17 +50,17 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
     read: {
       emoji: "📖",
       title: "Read",
-      detailKeys: ["path"],
+      detailKeys: ["path", "file", "filePath", "file_path"],
     },
     write: {
       emoji: "✍️",
       title: "Write",
-      detailKeys: ["path"],
+      detailKeys: ["path", "file", "filePath", "file_path"],
     },
     edit: {
       emoji: "📝",
       title: "Edit",
-      detailKeys: ["path"],
+      detailKeys: ["path", "file", "filePath", "file_path"],
     },
     attach: {
       emoji: "📎",


### PR DESCRIPTION
## Summary

Fixes #54882

When the model calls `Read`, `Write`, or `Edit` tools using the `file` parameter alias (instead of `path`/`file_path`/`filePath`), the verbose/block-streaming tool summary shows only the emoji + label (e.g. `📖 Read`) without the file path.

The tool executes correctly — `normalizeToolParams()` properly handles all 4 aliases. This fix addresses only the display layer.

## Changes

| File | Change |
|------|--------|
| `src/agents/tool-display-common.ts` | Added `record.file` to `resolvePathArg()` candidate list |
| `src/agents/pi-embedded-subscribe.handlers.tools.ts` | Extended `handleToolExecutionStart()` to check `record.filePath` and `record.file` |
| `apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json` | Extended `detailKeys` for `read`, `write`, `edit` tools with all 4 aliases |

## Test plan

- [ ] `/verbose on` — trigger a Read tool call with `file` parameter → should show `📖 Read: from ~/path`
- [ ] Test with `path`, `file_path`, `filePath`, `file` — all should produce the same display
- [ ] Write and Edit tools should also show file path with all 4 aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)