### PR TITLE
Fix/nodes paired token row responsive

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -536,6 +536,11 @@ openclaw-app {
   position: relative;
   z-index: 1;
   min-height: 100vh;
+  /* Prevent long unbroken strings anywhere in the subtree from stretching past the viewport. */
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: hidden;
 }
 
 @media (display-mode: standalone) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1951,18 +1951,30 @@
   display: grid;
   gap: 8px;
   container-type: inline-size;
+  min-width: 0;
 }
 
 .list-item {
+  box-sizing: border-box;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(200px, 260px);
   gap: 16px;
   align-items: start;
+  /* Grid items default to min-width: auto (= min-content), so long strings can
+     forbid shrinking and never wrap — force participation in layout width. */
+  min-width: 0;
+  max-width: 100%;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   padding: 12px;
   background: var(--card);
   transition: border-color var(--duration-fast) ease;
+}
+
+/* Paired device rows only use .list-main; keep a single fluid column instead of
+   reserving an empty 200–260px track that squeezes readable width. */
+.list-item.nodes-device-paired {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .list-item-clickable {
@@ -2012,51 +2024,81 @@
   width: 100%;
 }
 
-/* Nodes → Devices → Paired: long role/scope strings must wrap; keep actions visible */
+/* Nodes → Devices → Paired: long ids / scope lines must wrap; keep actions visible */
 .nodes-device-paired .list-main {
   min-width: 0;
 }
 
-.nodes-device-paired .list-sub {
+/* Grid/flex children default to min-width:auto; allow the card to shrink with the viewport */
+.nodes-device-paired .list-main > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.nodes-device-paired .list-title {
+  white-space: normal;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
+/* Heading is the raw device id when no separate display name is set */
+.nodes-device-paired .list-title.nodes-device-paired__device-id {
+  word-break: break-all;
+}
+
+.nodes-device-paired .list-sub {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* Unbroken hex device ids */
+.nodes-device-paired__device-id {
+  word-break: break-all;
+}
+
+.nodes-device-paired__meta {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.nodes-device-token-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 6px;
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+}
+
+/* Always stack meta above actions — flex side-by-side still allowed long “detail” lines
+   to measure as one min-content-wide row and spill past the card on some widths. */
 .nodes-device-token-row {
   box-sizing: border-box;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 8px;
   width: 100%;
+  max-width: 100%;
   min-width: 0;
 }
 
 .nodes-device-token-row__detail {
-  flex: 1 1 12rem;
   min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .nodes-device-token-row__actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 6px;
-  flex: 0 1 auto;
-}
-
-/* When the devices list column is narrow, stack token meta above actions */
-@container (max-width: 520px) {
-  .nodes-device-token-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .nodes-device-token-row__actions {
-    justify-content: flex-start;
-  }
 }
 
 /* Debug event log payloads should use full width like other debug sections. */
@@ -2251,7 +2293,7 @@
 
 @container (max-width: 560px) {
   .list-item {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .list-meta {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2012,6 +2012,53 @@
   width: 100%;
 }
 
+/* Nodes → Devices → Paired: long role/scope strings must wrap; keep actions visible */
+.nodes-device-paired .list-main {
+  min-width: 0;
+}
+
+.nodes-device-paired .list-sub {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.nodes-device-token-row {
+  box-sizing: border-box;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+}
+
+.nodes-device-token-row__detail {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.nodes-device-token-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  flex: 0 1 auto;
+}
+
+/* When the devices list column is narrow, stack token meta above actions */
+@container (max-width: 520px) {
+  .nodes-device-token-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nodes-device-token-row__actions {
+    justify-content: flex-start;
+  }
+}
+
 /* Debug event log payloads should use full width like other debug sections. */
 .debug-event-log__item {
   grid-template-columns: minmax(0, 1fr);

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -21,6 +21,8 @@
   animation: dashboard-enter 0.3s var(--ease-out);
   transition: grid-template-columns var(--shell-focus-duration) var(--shell-focus-ease);
   overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
 }
 
 @supports (height: 100dvh) {
@@ -1200,7 +1202,7 @@
   }
 
   .list-item {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/ui/src/ui/views/nodes.ts
+++ b/ui/src/ui/views/nodes.ts
@@ -172,7 +172,7 @@ function renderPairedDevice(device: PairedDevice, props: NodesProps) {
   const scopes = `scopes: ${formatList(device.scopes)}`;
   const tokens = Array.isArray(device.tokens) ? device.tokens : [];
   return html`
-    <div class="list-item">
+    <div class="list-item nodes-device-paired">
       <div class="list-main">
         <div class="list-title">${name}</div>
         <div class="list-sub">${device.deviceId}${ip}</div>
@@ -197,9 +197,11 @@ function renderTokenRow(deviceId: string, token: DeviceTokenSummary, props: Node
     token.rotatedAtMs ?? token.createdAtMs ?? token.lastUsedAtMs ?? null,
   );
   return html`
-    <div class="row" style="justify-content: space-between; gap: 8px;">
-      <div class="list-sub">${token.role} · ${status} · ${scopes} · ${when}</div>
-      <div class="row" style="justify-content: flex-end; gap: 6px; flex-wrap: wrap;">
+    <div class="nodes-device-token-row">
+      <div class="list-sub nodes-device-token-row__detail">
+        ${token.role} · ${status} · ${scopes} · ${when}
+      </div>
+      <div class="nodes-device-token-row__actions">
         <button
           class="btn btn--sm"
           @click=${() => props.onDeviceRotate(deviceId, token.role, token.scopes)}

--- a/ui/src/ui/views/nodes.ts
+++ b/ui/src/ui/views/nodes.ts
@@ -1,4 +1,5 @@
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
+import { styleMap } from "lit/directives/style-map.js";
 import {
   resolvePendingDeviceApprovalState,
   type DevicePairingAccessSummary,
@@ -12,6 +13,39 @@ import { renderExecApprovals, resolveExecApprovalsState } from "./nodes-exec-app
 import { resolveConfigAgents, resolveNodeTargets, type NodeTargetOption } from "./nodes-shared.ts";
 export type { NodesProps } from "./nodes.types.ts";
 import type { NodesProps } from "./nodes.types.ts";
+
+/** Inline so wrapping survives any stylesheet order / stale bundles; grid+flex min-sizing can't suppress these. */
+const NODES_WRAP_BREAK_ALL: Readonly<Record<string, string>> = {
+  overflowWrap: "anywhere",
+  wordBreak: "break-all",
+  maxWidth: "100%",
+  minWidth: "0",
+  whiteSpace: "normal",
+};
+
+const NODES_WRAP_SOFT: Readonly<Record<string, string>> = {
+  overflowWrap: "anywhere",
+  wordBreak: "break-word",
+  maxWidth: "100%",
+  minWidth: "0",
+  whiteSpace: "normal",
+};
+
+/** Inserts `<wbr>` so lines can break even when CSS min-content / caching fights `word-break`. */
+function htmlChunkWithBreaks(text: string, chunkSize: number): TemplateResult {
+  const n = Math.max(8, Math.floor(chunkSize));
+  if (text.length <= n) {
+    return html`${text}`;
+  }
+  const parts: Array<string | TemplateResult> = [];
+  for (let i = 0; i < text.length; i += n) {
+    if (i > 0) {
+      parts.push(html`<wbr />`);
+    }
+    parts.push(text.slice(i, i + n));
+  }
+  return html`${parts}`;
+}
 
 export function renderNodes(props: NodesProps) {
   const bindingState = resolveBindingsState(props);
@@ -166,22 +200,51 @@ function renderPendingDevice(req: PendingDevice, props: NodesProps, paired?: Pai
 }
 
 function renderPairedDevice(device: PairedDevice, props: NodesProps) {
-  const name = normalizeOptionalString(device.displayName) || device.deviceId;
+  const displayName = normalizeOptionalString(device.displayName);
+  const technicalId = String(device.deviceId ?? "").trim();
   const ip = device.remoteIp ? ` · ${device.remoteIp}` : "";
+  const titleLabel = displayName || technicalId;
+  const showTechnicalIdRow = Boolean(displayName) && displayName.trim() !== technicalId;
   const roles = `roles: ${formatList(device.roles)}`;
   const scopes = `scopes: ${formatList(device.scopes)}`;
   const tokens = Array.isArray(device.tokens) ? device.tokens : [];
+  const titleHexClass = showTechnicalIdRow || !technicalId ? "" : "nodes-device-paired__device-id";
+  const titleUsesBreakAll = Boolean(technicalId) && !showTechnicalIdRow;
+  const titleInline = titleUsesBreakAll ? NODES_WRAP_BREAK_ALL : NODES_WRAP_SOFT;
+  const titleText = `${titleLabel}${showTechnicalIdRow ? "" : ip}`;
+  const idRowText = `${technicalId}${ip}`;
+  const rolesScopesText = `${roles} · ${scopes}`;
   return html`
     <div class="list-item nodes-device-paired">
       <div class="list-main">
-        <div class="list-title">${name}</div>
-        <div class="list-sub">${device.deviceId}${ip}</div>
-        <div class="muted" style="margin-top: 6px;">${roles} · ${scopes}</div>
+        <div class="list-title ${titleHexClass}" style=${styleMap(titleInline)}>
+          ${titleUsesBreakAll || titleText.length > 48
+            ? htmlChunkWithBreaks(titleText, 14)
+            : html`${titleText}`}
+        </div>
+        ${showTechnicalIdRow
+          ? html`<div
+              class="list-sub nodes-device-paired__device-id"
+              style=${styleMap(NODES_WRAP_BREAK_ALL)}
+            >
+              ${htmlChunkWithBreaks(idRowText, 14)}
+            </div>`
+          : nothing}
+        <div
+          class="muted nodes-device-paired__meta"
+          style=${styleMap({ ...NODES_WRAP_BREAK_ALL, marginTop: "6px" })}
+        >
+          ${htmlChunkWithBreaks(rolesScopesText, 28)}
+        </div>
         ${tokens.length === 0
-          ? html` <div class="muted" style="margin-top: 6px">Tokens: none</div> `
+          ? html`
+              <div class="muted nodes-device-paired__meta" style="margin-top: 6px">
+                Tokens: none
+              </div>
+            `
           : html`
               <div class="muted" style="margin-top: 10px;">Tokens</div>
-              <div style="display: flex; flex-direction: column; gap: 8px; margin-top: 6px;">
+              <div class="nodes-device-token-list">
                 ${tokens.map((token) => renderTokenRow(device.deviceId, token, props))}
               </div>
             `}
@@ -196,10 +259,11 @@ function renderTokenRow(deviceId: string, token: DeviceTokenSummary, props: Node
   const when = formatRelativeTimestamp(
     token.rotatedAtMs ?? token.createdAtMs ?? token.lastUsedAtMs ?? null,
   );
+  const detailText = `${token.role} · ${status} · ${scopes} · ${when}`;
   return html`
     <div class="nodes-device-token-row">
-      <div class="list-sub nodes-device-token-row__detail">
-        ${token.role} · ${status} · ${scopes} · ${when}
+      <div class="list-sub nodes-device-token-row__detail" style=${styleMap(NODES_WRAP_BREAK_ALL)}>
+        ${htmlChunkWithBreaks(detailText, 28)}
       </div>
       <div class="nodes-device-token-row__actions">
         <button

--- a/ui/src/ui/views/nodes.ts
+++ b/ui/src/ui/views/nodes.ts
@@ -201,10 +201,10 @@ function renderPendingDevice(req: PendingDevice, props: NodesProps, paired?: Pai
 
 function renderPairedDevice(device: PairedDevice, props: NodesProps) {
   const displayName = normalizeOptionalString(device.displayName);
-  const technicalId = String(device.deviceId ?? "").trim();
+  const technicalId = device.deviceId.trim();
   const ip = device.remoteIp ? ` · ${device.remoteIp}` : "";
   const titleLabel = displayName || technicalId;
-  const showTechnicalIdRow = Boolean(displayName) && displayName.trim() !== technicalId;
+  const showTechnicalIdRow = Boolean(displayName && displayName.trim() !== technicalId);
   const roles = `roles: ${formatList(device.roles)}`;
   const scopes = `scopes: ${formatList(device.scopes)}`;
   const tokens = Array.isArray(device.tokens) ? device.tokens : [];


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: On the Control UI **Nodes** page, **Devices → Paired** rows did not respect narrow viewports. Long device IDs, roles/scopes lines, and token detail strings stayed effectively unbounded horizontally, while **Rotate** / **Revoke** could be pushed off-card or clipped on mobile-like widths.
- Why it matters: Users managing paired devices on small windows, split-screen, or touch devices need readable metadata and fully visible actions without horizontal spill or truncated button labels.
- What changed: **Layout & CSS** — grid/stacked token rows, `minmax(0, 1fr)` / `min-width: 0` on list and paired-device columns, shell/content width guards, nodes-specific rules for wrapping paired metadata and token details. **Markup** — paired device and token rows use explicit classes, inline wrap helpers, and `htmlChunkWithBreaks()` + `<wbr />` for long unbroken hex so lines break reliably.
- What did NOT change (scope boundary): Gateway APIs, auth, pairing protocols, or non-**Nodes**/devices UI. No new permissions or device-management behavior beyond presentation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #77311


## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Default grid/flex **min-content** sizing for long uninterrupted strings (hex IDs, comma-separated scopes) let the “detail” column claim width, squeezing or overflowing the action column. **Paired** rows also used a layout that did not consistently stack or constrain text on small breakpoints.
- Missing detection / guardrail: No viewport/container query or `min-width: 0` chain on the paired-device token row; long strings were not broken for layout at narrow widths.
- Contributing context (if known): Control UI is built to `dist/control-ui`; reviewers should confirm the gateway serves a **fresh** build (`pnpm ui:build`) when validating layout fixes.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/nodes.devices.test.ts` (or equivalent under the repo’s vitest layout)
- Scenario the test should lock in: Paired device markup includes wrap-friendly structure/classes and token rows render without assuming a single-line flex row for long scope strings.
- Why this is the smallest reliable guardrail: Catches regressions in the Lit templates and class names that drive the responsive CSS without requiring a full browser screenshot suite.
- Existing test that already covers this (if any): `nodes.devices.test.ts` (run after changes).
- If no new test is added, why not: _Fill in if you add assertions for classes / snapshot; otherwise note that visual narrow-width behavior is verified manually._

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- **Nodes → Devices → Paired**: Long device IDs and scope/token lines wrap or break within the card; **Rotate** and **Revoke** remain usable on narrow viewports (typically stacked below detail text when space is tight).

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[narrow viewport] -> [long id + scopes on one line] -> [Rotate/Revoke clipped off card]

After:
[narrow viewport] -> [text wraps / breaks with wbr + min-width:0] -> [actions on next row or in bounded column, fully visible]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (or your verified OS)
- Runtime/container: Gateway + built Control UI (`pnpm ui:build`)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Valid gateway token for Control UI

### Steps

1. Build UI: `pnpm ui:build` from repo root (`openclaw/` with workspace).
2. Run gateway and open Control UI (e.g. `http://127.0.0.1:18789/`), authenticate.
3. Go to **Nodes** (`/nodes`), expand **Devices → Paired** with at least one device and tokens.
4. Resize the window to a narrow width (or mobile emulation) and scroll paired rows.

### Expected

- No horizontal overflow off the card; long hex and scope lists wrap or break.
- **Rotate** and **Revoke** are fully visible and tappable.

### Actual

- _Fill after verification: matches expected._

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Narrow viewport on `/nodes`, Devices → Paired with long device id and long operator scopes; token rows with Rotate/Revoke.
- Edge cases checked: _e.g. paired device with display name vs raw id-only title; revoked vs active token._
- What you did **not** verify: _e.g. every breakpoint; other tabs under Nodes._

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Visual regression on wide desktops if grid/flex assumptions differ for locale or font scaling.
  - Mitigation: Confirmed on desktop width; uses progressive stacking only in constrained containers / breakpoints.
- Risk: Served UI still appears old if `dist/control-ui` is not rebuilt or gateway points at a different root.
  - Mitigation: Document `pnpm ui:build` in verification; hash-suffixed assets update on rebuild.
