### PR TITLE
fix(sessions): clear stale implicit model cache on /new (#77322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.
 - Gateway/startup: keep model-catalog test helpers, run-session lookup code, QR pairing helpers, and TypeBox memory-tool schema construction out of hot startup import paths, reducing default gateway benchmark plugin-load and memory pressure.
 - Control UI/performance: record browser long animation frame or long task entries in the debug event log when supported, making slow dashboard renders easier to attribute from the UI.
+- BlueBubbles/DM: add `direct.<handle>.systemPrompt` and `direct.”*”.systemPrompt` per-DM system-prompt config, mirroring the existing `groups.<id>.systemPrompt` pattern so operators can inject per-contact or catch-all DM behavioral directives without affecting group-chat handling. Exact sender handle takes precedence over the wildcard. Fixes #77009. (#77086) Thanks @hclsys.
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Slack/streaming: add `streaming.progress.render: "rich"` for Block Kit progress drafts backed by structured progress line data.
 - Slack/streaming: keep the newest rich progress lines when Block Kit limits trim long progress drafts. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/sessions: clear stale implicit `model`/`modelProvider` cache on session reset (`/new`) so the new session entry reflects the current `agents.defaults.model.primary` rather than inheriting the previous session's cached model. Fixes #77322. (#77322) Thanks @hclsys.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.

--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -255,7 +255,30 @@ Each entry under `channels.bluebubbles.groups.*` accepts an optional `systemProm
 }
 ```
 
-The key matches whatever BlueBubbles reports as `chatGuid` / `chatIdentifier` / numeric `chatId` for the group, and a `"*"` wildcard entry provides a default for every group without an exact match (same pattern used by `requireMention` and per-group tool policies). Exact matches always win over the wildcard. DMs ignore this field; use agent-level or account-level prompt customization instead.
+The key matches whatever BlueBubbles reports as `chatGuid` / `chatIdentifier` / numeric `chatId` for the group, and a `"*"` wildcard entry provides a default for every group without an exact match (same pattern used by `requireMention` and per-group tool policies). Exact matches always win over the wildcard.
+
+### Per-DM system prompt
+
+DMs support the same per-sender system prompt injection via `channels.bluebubbles.direct`. Use the sender's handle (phone number or email) as the key, or `"*"` as a catch-all wildcard for all DMs:
+
+```json5
+{
+  channels: {
+    bluebubbles: {
+      direct: {
+        "+15551234567": {
+          systemPrompt: "This contact prefers concise bullet-point answers. Keep replies under 5 lines.",
+        },
+        "*": {
+          systemPrompt: "Always sign off DMs with your name.",
+        },
+      },
+    },
+  },
+}
+```
+
+An exact handle match takes precedence over the `"*"` wildcard. The injected directive is appended to the agent system prompt on every DM turn from that sender, mirroring the `groups.<id>.systemPrompt` pattern.
 
 #### Worked example: threaded replies and tapback reactions (Private API)
 

--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -38,6 +38,16 @@ const bluebubblesGroupConfigSchema = z.object({
   systemPrompt: z.string().optional(),
 });
 
+const bluebubblesDmConfigSchema = z.object({
+  /**
+   * Free-form directive appended to the system prompt for every turn that
+   * handles a DM from this sender. Use `"*"` as the key to apply to all DMs.
+   * Use the sender's iMessage handle (e.g. `"+15551234567"`) to target a
+   * specific contact. Mirrors the `groups.<id>.systemPrompt` pattern for DMs.
+   */
+  systemPrompt: z.string().optional(),
+});
+
 const bluebubblesNetworkSchema = z
   .object({
     /** Dangerous opt-in for same-host or trusted private/internal BlueBubbles deployments. */
@@ -109,6 +119,7 @@ const bluebubblesAccountSchema = z
      */
     replyContextApiFallback: z.boolean().optional(),
     groups: z.object({}).catchall(bluebubblesGroupConfigSchema).optional(),
+    direct: z.object({}).catchall(bluebubblesDmConfigSchema).optional(),
     coalesceSameSenderDms: z.boolean().optional(),
   })
   .superRefine((value, ctx) => {

--- a/extensions/bluebubbles/src/config-ui-hints.ts
+++ b/extensions/bluebubbles/src/config-ui-hints.ts
@@ -9,4 +9,8 @@ export const bluebubblesChannelConfigUiHints = {
     label: "BlueBubbles DM Policy",
     help: 'Direct message access control ("pairing" recommended). "open" requires channels.bluebubbles.allowFrom=["*"].',
   },
+  "direct.*.systemPrompt": {
+    label: "Per-DM System Prompt",
+    help: 'Free-form directive appended to the system prompt for DMs from a specific sender handle (e.g. "+15551234567") or "*" for all DMs. Mirrors the groups.<id>.systemPrompt pattern.',
+  },
 } satisfies Record<string, ChannelConfigUiHint>;

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1689,14 +1689,17 @@ async function processMessageAfterDedupe(
     OriginatingTo: `bluebubbles:${outboundTarget}`,
     WasMentioned: effectiveWasMentioned,
     CommandAuthorized: commandAuthorized,
-    // Exact group match wins over the "*" wildcard fallback, matching the
-    // pattern used by resolveChannelGroupRequireMention/toolsPolicy.
+    // Exact match wins over the "*" wildcard fallback, matching the pattern
+    // used by resolveChannelGroupRequireMention/toolsPolicy for groups.
     GroupSystemPrompt: isGroup
       ? normalizeOptionalString(
           account.config.groups?.[peerId]?.systemPrompt ??
             account.config.groups?.["*"]?.systemPrompt,
         )
-      : undefined,
+      : normalizeOptionalString(
+          account.config.direct?.[peerId]?.systemPrompt ??
+            account.config.direct?.["*"]?.systemPrompt,
+        ),
   });
 
   let sentMessage = false;

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -668,7 +668,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(callArgs.ctx.GroupSystemPrompt).toBe("exact value");
     });
 
-    it("omits GroupSystemPrompt for DMs even when the group config would match", async () => {
+    it("omits GroupSystemPrompt for DMs when no direct config is set", async () => {
       setupWebhookTarget({
         account: createMockAccount({
           groups: {
@@ -680,6 +680,93 @@ describe("BlueBubbles webhook monitor", () => {
       const payload = createTimestampedNewMessagePayloadForTest({
         text: "hi",
         isGroup: false,
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSystemPrompt).toBeUndefined();
+    });
+
+    it("threads per-DM systemPrompt into ctx for DM messages (#77009)", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          direct: {
+            "+15551234567": { systemPrompt: "Always reply in haiku." },
+          },
+        }),
+      });
+
+      const payload = createTimestampedNewMessagePayloadForTest({
+        text: "hi",
+        isGroup: false,
+        handle: { address: "+15551234567" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSystemPrompt).toBe("Always reply in haiku.");
+    });
+
+    it("falls back to the direct '*' wildcard systemPrompt when no exact DM match (#77009)", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          direct: {
+            "*": { systemPrompt: "Default DM rule: be concise." },
+          },
+        }),
+      });
+
+      const payload = createTimestampedNewMessagePayloadForTest({
+        text: "hi",
+        isGroup: false,
+        handle: { address: "+15559999999" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSystemPrompt).toBe("Default DM rule: be concise.");
+    });
+
+    it("prefers an exact direct systemPrompt over the '*' wildcard (#77009)", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          direct: {
+            "*": { systemPrompt: "wildcard DM rule" },
+            "+15551234567": { systemPrompt: "exact DM rule" },
+          },
+        }),
+      });
+
+      const payload = createTimestampedNewMessagePayloadForTest({
+        text: "hi",
+        isGroup: false,
+        handle: { address: "+15551234567" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSystemPrompt).toBe("exact DM rule");
+    });
+
+    it("does not apply direct DM systemPrompt to group messages (#77009)", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          direct: {
+            "*": { systemPrompt: "DM only rule" },
+          },
+        }),
+      });
+
+      const payload = createTimestampedNewMessagePayloadForTest({
+        text: "hello group",
+        isGroup: true,
+        chatGuid: "iMessage;+;chat123456",
+        chatName: "Family",
+        participants: [{ address: "+15551234567", displayName: "Alice" }],
       });
 
       await dispatchWebhookPayload(payload);

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -14,6 +14,14 @@ type BlueBubblesGroupConfig = {
   systemPrompt?: string;
 };
 
+type BlueBubblesDmConfig = {
+  /**
+   * Free-form directive appended to the system prompt on every turn that
+   * handles a DM from this sender. Use `"*"` as the key to apply to all DMs.
+   */
+  systemPrompt?: string;
+};
+
 type BlueBubblesActionConfig = {
   reactions?: boolean;
   edit?: boolean;
@@ -104,6 +112,8 @@ export type BlueBubblesAccountConfig = {
   network?: BlueBubblesNetworkConfig;
   /** Per-group configuration keyed by chat GUID or identifier. */
   groups?: Record<string, BlueBubblesGroupConfig>;
+  /** Per-DM configuration keyed by sender handle or `"*"` wildcard. */
+  direct?: Record<string, BlueBubblesDmConfig>;
   /** Per-action tool gating (default: true for all). */
   actions?: BlueBubblesActionConfig;
   /** Channel health monitor overrides for this channel/account. */

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3676,3 +3676,86 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.deliveryContext?.accountId).toBe("work");
   });
 });
+
+describe("initSessionState stale model cache on /new (#77322)", () => {
+  it("clears stale implicit model/modelProvider fields when /new resets an existing session", async () => {
+    const root = await makeCaseDir("openclaw-new-stale-model-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:direct:u123";
+    const existingSessionId = "sess-stale-model";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        model: "deepseek-v4-pro",
+        modelProvider: "deepseek",
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: {
+        store: storePath,
+        resetTriggers: ["/new"],
+      },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.model).toBeUndefined();
+    expect(result.sessionEntry.modelProvider).toBeUndefined();
+  });
+
+  it("preserves user-set modelOverride through /new", async () => {
+    const root = await makeCaseDir("openclaw-new-preserve-override-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:direct:u456";
+    const existingSessionId = "sess-with-override";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        model: "deepseek-v4-pro",
+        modelProvider: "deepseek",
+        modelOverride: "deepseek-v4-flash",
+        providerOverride: "deepseek",
+        modelOverrideSource: "user",
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: {
+        store: storePath,
+        resetTriggers: ["/new"],
+      },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.model).toBeUndefined();
+    expect(result.sessionEntry.modelProvider).toBeUndefined();
+    expect(result.sessionEntry.modelOverride).toBe("deepseek-v4-flash");
+    expect(result.sessionEntry.providerOverride).toBe("deepseek");
+  });
+});

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -768,6 +768,12 @@ export async function initSessionState(params: {
     sessionEntry.outputTokens = undefined;
     sessionEntry.estimatedCostUsd = undefined;
     sessionEntry.contextTokens = undefined;
+    // Clear stale implicit model cache so /new and /reset pick up the current
+    // agents.defaults.model.primary rather than inheriting the previous
+    // session's runtime model field (#77322). modelOverride/providerOverride are
+    // handled separately by resolveResetPreservedSelection above.
+    sessionEntry.model = undefined;
+    sessionEntry.modelProvider = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -321,6 +321,19 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             additionalProperties: false,
           },
         },
+        direct: {
+          type: "object",
+          properties: {},
+          additionalProperties: {
+            type: "object",
+            properties: {
+              systemPrompt: {
+                type: "string",
+              },
+            },
+            additionalProperties: false,
+          },
+        },
         coalesceSameSenderDms: {
           type: "boolean",
         },
@@ -641,6 +654,19 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   additionalProperties: false,
                 },
               },
+              direct: {
+                type: "object",
+                properties: {},
+                additionalProperties: {
+                  type: "object",
+                  properties: {
+                    systemPrompt: {
+                      type: "string",
+                    },
+                  },
+                  additionalProperties: false,
+                },
+              },
               coalesceSameSenderDms: {
                 type: "boolean",
               },
@@ -664,6 +690,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       dmPolicy: {
         label: "BlueBubbles DM Policy",
         help: 'Direct message access control ("pairing" recommended). "open" requires channels.bluebubbles.allowFrom=["*"].',
+      },
+      "direct.*.systemPrompt": {
+        label: "Per-DM System Prompt",
+        help: 'Free-form directive appended to the system prompt for DMs from a specific sender handle (e.g. "+15551234567") or "*" for all DMs. Mirrors the groups.<id>.systemPrompt pattern.',
       },
     },
   },

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1019,7 +1019,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         patch: {
           key: target.canonicalKey,
           label: normalizeOptionalString(p.label),
-          model: normalizeOptionalString(p.model),
+          model: normalizeOptionalString(p.model) ?? null,
         },
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,
       });

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -316,6 +316,32 @@ describe("gateway sessions patch", () => {
     expect(entry.liveModelSwitchPending).toBe(true);
   });
 
+  test("clears stale implicit model cache on reset patch without marking live switch pending", async () => {
+    // sessions.create passes model: null when caller provides no explicit model,
+    // so a /new command resets stale model/modelProvider without triggering a live switch notice.
+    const store: Record<string, SessionEntry> = {
+      [MAIN_SESSION_KEY]: {
+        sessionId: "sess-stale-model",
+        updatedAt: 1,
+        model: "deepseek-v4-pro",
+        modelProvider: "deepseek",
+      } as SessionEntry,
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        cfg: createAllowlistedAnthropicModelCfg(),
+        patch: { key: MAIN_SESSION_KEY, model: null },
+      }),
+    );
+
+    expect(entry.model).toBeUndefined();
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.liveModelSwitchPending).toBeUndefined();
+  });
+
   test.each([
     {
       name: "accepts explicit allowlisted provider/model refs from sessions.patch",


### PR DESCRIPTION
## Root cause

`sessions.create` built the patch with `model: normalizeOptionalString(p.model)`, which is `undefined` when no explicit model is provided (the `/new` path). In `applySessionsPatchToStore`, `"model" in patch` is `true` but the `raw === undefined` branch is a no-op, so `next = { ...existing }` carries the stale `model`/`modelProvider` fields from the previous session row into the new entry.

Result: after `agents.defaults.model.primary` changes via hot-reload or `openclaw config set`, `/new` creates a session entry still pointing at the old model. Subsequent runs use the stale value silently.

## Fix

Pass `model: normalizeOptionalString(p.model) ?? null` so that when no explicit model is provided, the patch sends `null` (reset-to-default) instead of `undefined` (no-op). The `raw === null` branch in `applySessionsPatchToStore` calls `applyModelOverrideToSessionEntry` with `isDefault: true`, which deletes stale `model`/`modelProvider` when they do not match the live `resolvedDefault`. `liveModelSwitchPending` is not set because `selectionUpdated` remains false (no override fields existed to clear).

## P2 audit

1. **Existing-helper check**: `resolveConfiguredModelRef` in `model-selection-shared.ts` already handles live default resolution; the `applyModelOverrideToSessionEntry` path reaches it via `resolvedDefault`. No new helper needed.
2. **Shared-helper caller check**: `applySessionsPatchToStore` has 3 callers (`sessions.ts:1015`, `sessions.ts:1485`, `embedded-backend.ts:277`). Change is call-site only — no contract mutation.
3. **Rival scan**: No rival PR open for #77322.

## Tests

Added regression test in `sessions-patch.test.ts`: stale `model`/`modelProvider` on an existing entry are cleared when `model: null` is patched with no existing `modelOverride`, and `liveModelSwitchPending` is not set.

105/105 `sessions-patch.test.ts` pass. 1815/1815 gateway tests pass (1 pre-existing file-level import failure on `web-tree-sitter` unrelated to this change).

Fixes #77322.