### PR TITLE
fix(auto-reply): clear runtime model cache on reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply: clear stale runtime model cache fields when `/new` or `/reset` creates a fresh channel session, so changed model defaults apply after reset unless the user kept an explicit override. Fixes #77322. Thanks @mjamiv.
 - Google/Gemini: default new API-key onboarding to stable `google/gemini-2.5-flash` instead of the preview Pro route, reducing surprise daily quota exhaustion. Fixes #79670. Thanks @HugeBunny.
 - Amazon Bedrock: expose Claude thinking profiles through the lightweight provider policy surface so `/think:adaptive` validates before the Bedrock runtime plugin is loaded. Fixes #79754. Thanks @phoenixyy and @hclsys.
 - Codex/transcripts: mirror dynamic tool calls and outputs into Codex app-server transcripts so tool activity is visible alongside assistant text instead of being elided, with per-item output capped at 12,000 characters. (#79952) Thanks @scoootscooob.

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3065,6 +3065,65 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     expect(result.sessionEntry.totalTokensFresh).toBe(true);
   });
 
+  it("clears stale runtime model cache fields on /new and /reset (#77322)", async () => {
+    const storePath = await createStorePath("openclaw-reset-runtime-model-cache-");
+    const sessionKey = "agent:main:telegram:direct:runtime-model-cache";
+    const existingSessionId = "existing-session-runtime-model-cache";
+    const runtimeModelCache = {
+      modelProvider: "openai",
+      model: "gpt-5.4-mini",
+      contextTokens: 400_000,
+      verboseLevel: "on",
+    } as const;
+    const cases = [
+      { name: "new clears stale runtime model cache", body: "/new" },
+      { name: "reset clears stale runtime model cache", body: "/reset" },
+    ] as const;
+
+    for (const testCase of cases) {
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { ...runtimeModelCache },
+      });
+
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "6761477233",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(true);
+      expect(result.resetTriggered, testCase.name).toBe(true);
+      expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
+      expect(result.sessionEntry.modelProvider, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.model, testCase.name).toBeUndefined();
+      // Unrelated behavior overrides still carry across the reset.
+      expect(result.sessionEntry.verboseLevel, testCase.name).toBe(runtimeModelCache.verboseLevel);
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].modelProvider, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].model, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].contextTokens, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].verboseLevel, testCase.name).toBe(runtimeModelCache.verboseLevel);
+    }
+  });
+
   it("preserves spawned session ownership metadata across /new and /reset", async () => {
     const storePath = await createStorePath("openclaw-reset-spawned-metadata-");
     const sessionKey = "subagent:owned-child";

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3073,6 +3073,21 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       modelProvider: "openai",
       model: "gpt-5.4-mini",
       contextTokens: 400_000,
+      cacheRead: 1_000,
+      cacheWrite: 2_000,
+      fallbackNoticeSelectedModel: "openai/gpt-5.4-mini",
+      fallbackNoticeActiveModel: "minimax/m2.7",
+      fallbackNoticeReason: "rate limit",
+      systemPromptReport: {
+        source: "run",
+        generatedAt: 1,
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        systemPrompt: { chars: 1, projectContextChars: 0, nonProjectContextChars: 1 },
+        injectedWorkspaceFiles: [],
+        skills: { promptChars: 0, entries: [] },
+        tools: { listChars: 0, schemaChars: 0, entries: [] },
+      },
       verboseLevel: "on",
     } as const;
     const explicitUserOverride = {
@@ -3126,6 +3141,12 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
       expect(result.sessionEntry.modelProvider, testCase.name).toBeUndefined();
       expect(result.sessionEntry.model, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.cacheRead, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.cacheWrite, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeSelectedModel, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeActiveModel, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeReason, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.systemPromptReport, testCase.name).toBeUndefined();
       expect(result.sessionEntry.providerOverride, testCase.name).toBe(
         explicitUserOverride.providerOverride,
       );
@@ -3144,6 +3165,12 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       >;
       expect(stored[sessionKey].modelProvider, testCase.name).toBeUndefined();
       expect(stored[sessionKey].model, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].cacheRead, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].cacheWrite, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].fallbackNoticeSelectedModel, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].fallbackNoticeActiveModel, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].fallbackNoticeReason, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].systemPromptReport, testCase.name).toBeUndefined();
       expect(stored[sessionKey].providerOverride, testCase.name).toBe(
         explicitUserOverride.providerOverride,
       );

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3075,6 +3075,11 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       contextTokens: 400_000,
       verboseLevel: "on",
     } as const;
+    const explicitUserOverride = {
+      providerOverride: "minimax",
+      modelOverride: "m2.7",
+      modelOverrideSource: "user",
+    } as const;
     const cases = [
       { name: "new clears stale runtime model cache", body: "/new" },
       { name: "reset clears stale runtime model cache", body: "/reset" },
@@ -3085,8 +3090,16 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         storePath,
         sessionKey,
         sessionId: existingSessionId,
-        overrides: { ...runtimeModelCache },
+        overrides: { ...runtimeModelCache, ...explicitUserOverride },
       });
+      const seeded = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        SessionEntry
+      >;
+      expect(seeded[sessionKey]?.modelProvider, testCase.name).toBe(
+        runtimeModelCache.modelProvider,
+      );
+      expect(seeded[sessionKey]?.model, testCase.name).toBe(runtimeModelCache.model);
 
       const cfg = {
         session: { store: storePath, idleMinutes: 999 },
@@ -3113,12 +3126,33 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
       expect(result.sessionEntry.modelProvider, testCase.name).toBeUndefined();
       expect(result.sessionEntry.model, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.providerOverride, testCase.name).toBe(
+        explicitUserOverride.providerOverride,
+      );
+      expect(result.sessionEntry.modelOverride, testCase.name).toBe(
+        explicitUserOverride.modelOverride,
+      );
+      expect(result.sessionEntry.modelOverrideSource, testCase.name).toBe(
+        explicitUserOverride.modelOverrideSource,
+      );
       // Unrelated behavior overrides still carry across the reset.
       expect(result.sessionEntry.verboseLevel, testCase.name).toBe(runtimeModelCache.verboseLevel);
 
-      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        SessionEntry
+      >;
       expect(stored[sessionKey].modelProvider, testCase.name).toBeUndefined();
       expect(stored[sessionKey].model, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].providerOverride, testCase.name).toBe(
+        explicitUserOverride.providerOverride,
+      );
+      expect(stored[sessionKey].modelOverride, testCase.name).toBe(
+        explicitUserOverride.modelOverride,
+      );
+      expect(stored[sessionKey].modelOverrideSource, testCase.name).toBe(
+        explicitUserOverride.modelOverrideSource,
+      );
       expect(stored[sessionKey].contextTokens, testCase.name).toBeUndefined();
       expect(stored[sessionKey].verboseLevel, testCase.name).toBe(runtimeModelCache.verboseLevel);
     }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2380,6 +2380,65 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("clears stale runtime model cache fields on /new and /reset (#77322)", async () => {
+    const storePath = await createStorePath("openclaw-reset-runtime-model-cache-");
+    const sessionKey = "agent:main:telegram:direct:runtime-model-cache";
+    const existingSessionId = "existing-session-runtime-model-cache";
+    const runtimeModelCache = {
+      modelProvider: "openai",
+      model: "gpt-5.4-mini",
+      contextTokens: 400_000,
+      verboseLevel: "on",
+    } as const;
+    const cases = [
+      { name: "new clears stale runtime model cache", body: "/new" },
+      { name: "reset clears stale runtime model cache", body: "/reset" },
+    ] as const;
+
+    for (const testCase of cases) {
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { ...runtimeModelCache },
+      });
+
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "6761477233",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(true);
+      expect(result.resetTriggered, testCase.name).toBe(true);
+      expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
+      expect(result.sessionEntry.modelProvider, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.model, testCase.name).toBeUndefined();
+      // Unrelated behavior overrides still carry across the reset.
+      expect(result.sessionEntry.verboseLevel, testCase.name).toBe(runtimeModelCache.verboseLevel);
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].modelProvider, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].model, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].contextTokens, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].verboseLevel, testCase.name).toBe(runtimeModelCache.verboseLevel);
+    }
+  });
+
   it("preserves spawned session ownership metadata across /new and /reset", async () => {
     const storePath = await createStorePath("openclaw-reset-spawned-metadata-");
     const sessionKey = "subagent:owned-child";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -811,6 +811,10 @@ export async function initSessionState(params: {
     // explicit providerOverride/modelOverride values preserved above.
     sessionEntry.modelProvider = undefined;
     sessionEntry.model = undefined;
+    sessionEntry.fallbackNoticeSelectedModel = undefined;
+    sessionEntry.fallbackNoticeActiveModel = undefined;
+    sessionEntry.fallbackNoticeReason = undefined;
+    sessionEntry.systemPromptReport = undefined;
     // Clear stale context hash so the first flush in the new session is not
     // incorrectly skipped due to a hash match with the old transcript (#30115).
     sessionEntry.memoryFlushContextHash = undefined;
@@ -825,6 +829,8 @@ export async function initSessionState(params: {
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
     sessionEntry.estimatedCostUsd = undefined;
+    sessionEntry.cacheRead = undefined;
+    sessionEntry.cacheWrite = undefined;
     sessionEntry.contextTokens = undefined;
     sessionEntry.contextBudgetStatus = undefined;
     sessionEntry.goal = undefined;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -806,9 +806,9 @@ export async function initSessionState(params: {
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;
     sessionEntry.memoryFlushAt = undefined;
-    // Runtime model fields are a cache of the previous run, not a user
-    // selection. A reset should resolve the next run from current defaults or
-    // explicit preserved overrides.
+    // Runtime model fields are persisted last-run cache, not user selection.
+    // Reset must drop them so the next turn resolves current defaults or the
+    // explicit providerOverride/modelOverride values preserved above.
     sessionEntry.modelProvider = undefined;
     sessionEntry.model = undefined;
     // Clear stale context hash so the first flush in the new session is not

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -806,6 +806,11 @@ export async function initSessionState(params: {
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;
     sessionEntry.memoryFlushAt = undefined;
+    // Runtime model fields are a cache of the previous run, not a user
+    // selection. A reset should resolve the next run from current defaults or
+    // explicit preserved overrides.
+    sessionEntry.modelProvider = undefined;
+    sessionEntry.model = undefined;
     // Clear stale context hash so the first flush in the new session is not
     // incorrectly skipped due to a hash match with the old transcript (#30115).
     sessionEntry.memoryFlushContextHash = undefined;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -772,6 +772,11 @@ export async function initSessionState(params: {
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;
     sessionEntry.memoryFlushAt = undefined;
+    // Runtime model fields are a cache of the previous run, not a user
+    // selection. A reset should resolve the next run from current defaults or
+    // explicit preserved overrides.
+    sessionEntry.modelProvider = undefined;
+    sessionEntry.model = undefined;
     // Clear stale context hash so the first flush in the new session is not
     // incorrectly skipped due to a hash match with the old transcript (#30115).
     sessionEntry.memoryFlushContextHash = undefined;


### PR DESCRIPTION
Summary
- clear cached runtime model/provider fields when /new or /reset creates a fresh auto-reply channel session
- keep explicit preserved overrides and unrelated behavior overrides intact
- add a persisted-store regression for #77322 plus changelog entry

Why
- the transient reset entry was clean, but the persisted store merge kept old model/modelProvider fields and could keep using the prior model after defaults changed

## Real behavior proof

Behavior or issue addressed: `/new` and `/reset` should start a fresh channel session without carrying stale runtime model cache fields from the previous run, so a defaults change or a model retirement actually takes effect on the next turn.

Real environment tested: rebased patched OpenClaw source checkout at `/tmp/openclaw-77339`, Node v24.14.0, running a standalone `tsx` driver script that imports the production `initSessionState` from `src/auto-reply/reply/session.ts` and exercises a real on-disk persisted session store. No vitest, no mocks — just the real auto-reply session-state code path against a real `sessions.json` file in `/tmp`.

Exact steps or command run after this patch:

1. Build a small driver script that imports `initSessionState` from the patched `src/auto-reply/reply/session.ts`, seeds a real `sessions.json` with a session entry that has `modelProvider: "openai"`, `model: "gpt-5.4-mini"`, `contextTokens: 400_000`, and `verboseLevel: "on"`, calls `initSessionState` with `Body: "/new"` (and again with `Body: "/reset"`), then prints the live persisted store contents and the returned `sessionEntry` fields. The driver is not part of the diff.
2. `pnpm exec tsx scratch-77322-demo.mts`

Driver script:

```ts
import * as fs from "node:fs/promises";
import * as os from "node:os";
import * as path from "node:path";
import { initSessionState } from "./src/auto-reply/reply/session.js";

async function main() {
  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-77322-demo-"));
  const storePath = path.join(tmpRoot, "sessions.json");
  const sessionKey = "agent:main:telegram:direct:demo";
  const seedEntry = {
    sessionId: "session-before-reset",
    updatedAt: Date.now(),
    modelProvider: "openai",
    model: "gpt-5.4-mini",
    contextTokens: 400_000,
    verboseLevel: "on",
  };
  await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: seedEntry }, null, 2));
  console.log("[before /new] sessions.json:");
  console.log((await fs.readFile(storePath, "utf-8")).trim());

  const cfg = { session: { store: storePath, idleMinutes: 999 } } as any;
  const r1 = await initSessionState({
    ctx: { Body: "/new", RawBody: "/new", CommandBody: "/new",
           From: "user", To: "bot", ChatType: "direct",
           SessionKey: sessionKey, Provider: "telegram", Surface: "telegram" } as any,
    cfg, commandAuthorized: true,
  });
  console.log("\n[after /new] sessionEntry.modelProvider:", r1.sessionEntry.modelProvider);
  console.log("[after /new] sessionEntry.model:", r1.sessionEntry.model);
  console.log("[after /new] sessionEntry.verboseLevel:", r1.sessionEntry.verboseLevel);
  console.log("[after /new] sessions.json:");
  console.log((await fs.readFile(storePath, "utf-8")).trim());

  await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: seedEntry }, null, 2));
  const r2 = await initSessionState({
    ctx: { Body: "/reset", RawBody: "/reset", CommandBody: "/reset",
           From: "user", To: "bot", ChatType: "direct",
           SessionKey: sessionKey, Provider: "telegram", Surface: "telegram" } as any,
    cfg, commandAuthorized: true,
  });
  console.log("\n[after /reset] sessionEntry.modelProvider:", r2.sessionEntry.modelProvider);
  console.log("[after /reset] sessionEntry.model:", r2.sessionEntry.model);
  console.log("[after /reset] sessionEntry.verboseLevel:", r2.sessionEntry.verboseLevel);
}
main().catch((e) => { console.error(e); process.exit(1); });
```

Evidence after fix: copied live stdout from the `tsx` driver, with uuids/timestamps as emitted by the runtime (anonymized identifiers only):

```text
[before /new] sessions.json:
{
  "agent:main:telegram:direct:demo": {
    "sessionId": "session-before-reset",
    "updatedAt": 1778436597524,
    "modelProvider": "openai",
    "model": "gpt-5.4-mini",
    "contextTokens": 400000,
    "verboseLevel": "on"
  }
}

[after /new] sessionEntry.modelProvider: undefined
[after /new] sessionEntry.model: undefined
[after /new] sessionEntry.verboseLevel: on
[after /new] sessions.json:
{
  "agent:main:telegram:direct:demo": {
    "sessionId": "fa90f97a-7512-41fb-a75f-74d4a0f4aa2f",
    "updatedAt": 1778436649018,
    "verboseLevel": "on",
    "sessionStartedAt": 1778436649016,
    "lastInteractionAt": 1778436649016,
    "systemSent": false,
    "abortedLastRun": false,
    "usageFamilyKey": "agent:main:telegram:direct:demo",
    "usageFamilySessionIds": [
      "session-before-reset",
      "fa90f97a-7512-41fb-a75f-74d4a0f4aa2f"
    ],
    "chatType": "direct",
    "deliveryContext": { "channel": "telegram", "to": "bot" },
    "lastChannel": "telegram",
    "lastTo": "bot",
    "origin": { "label": "user", "provider": "telegram", "surface": "telegram",
                "chatType": "direct", "from": "user", "to": "bot" },
    "sessionFile": "<state-dir>/agents/main/sessions/fa90f97a-7512-41fb-a75f-74d4a0f4aa2f.jsonl",
    "compactionCount": 0
  }
}

[after /reset] sessionEntry.modelProvider: undefined
[after /reset] sessionEntry.model: undefined
[after /reset] sessionEntry.verboseLevel: on
```

Observed result after fix:
- `sessionId` rotates to a fresh uuid (true reset; `usageFamilySessionIds` keeps both entries for cost tracking).
- `modelProvider`, `model`, and `contextTokens` are absent from the persisted entry — the stale runtime cache is gone, so the next turn resolves from current defaults or explicit preserved overrides.
- `verboseLevel: "on"` (an unrelated behavior override) is preserved.
- Same shape on both `/new` and `/reset`.

What was not tested: full Telegram network round-trip; the proof exercises the production auto-reply session-state code path that channel commands route through (the same `initSessionState` call that runs in production for `/new` and `/reset`).

Validation
- pnpm install
- pnpm test -- src/auto-reply/reply/session.test.ts
- pnpm test src/gateway/sessions-patch.test.ts src/gateway/server.sessions.reset-models.test.ts
- pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts CHANGELOG.md
- git diff --check
- pnpm check:changed -- --base upstream/main --head HEAD
- pnpm exec tsx scratch-77322-demo.mts (the live driver above)

Fixes #77322
