### PR TITLE
fix(plugins): preserve hook context mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/hooks: preserve plugin hook context mutations while keeping `pluginConfig` scoped to the active handler, so `agent:bootstrap` plugins can add bootstrap files without leaking config. Fixes #75245. Thanks @xuruiray.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Discord/gateway: measure heartbeat ACK timeouts from the actual heartbeat send, preventing late initial heartbeats from triggering false reconnect loops while the channel is still awaiting readiness. Fixes #77668. (#78087) Thanks @bryce-d-greybeard and @NikolaFC.

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { listAgentHarnessIds } from "../agents/harness/registry.js";
+import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import {
   clearRuntimeConfigSnapshot,
@@ -11,6 +12,7 @@ import { getContextEngineFactory, listContextEngineIds } from "../context-engine
 import {
   clearInternalHooks,
   createInternalHookEvent,
+  type AgentBootstrapHookContext,
   getRegisteredEventKeys,
   triggerInternalHook,
 } from "../hooks/internal-hooks.js";
@@ -2181,6 +2183,81 @@ module.exports = { id: "throws-after-import", register() {} };`,
     await triggerInternalHook(event);
     expect(event.messages).toEqual(["plugin-config-visible"]);
     expect(event.context).toEqual({});
+
+    clearInternalHooks();
+  });
+
+  it("preserves plugin hook context mutations for agent bootstrap hooks", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "bootstrap-context-mutator",
+      filename: "bootstrap-context-mutator.cjs",
+      body: `module.exports = {
+        id: "bootstrap-context-mutator",
+        register(api) {
+          api.registerHook(
+            "agent:bootstrap",
+            (event) => {
+              const marker = event.context.pluginConfig?.marker;
+              if (marker !== "plugin-config-visible") {
+                throw new Error("plugin config missing from hook context");
+              }
+              event.context.bootstrapFiles = [
+                ...event.context.bootstrapFiles,
+                {
+                  name: "PLUGIN.md",
+                  path: event.context.workspaceDir + "/PLUGIN.md",
+                  content: marker,
+                  missing: false,
+                },
+              ];
+            },
+            { name: "bootstrap-context-mutator" },
+          );
+        },
+      };`,
+    });
+    updatePluginManifest(plugin, {
+      configSchema: { type: "object" },
+    });
+
+    clearInternalHooks();
+
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["bootstrap-context-mutator"],
+          entries: {
+            "bootstrap-context-mutator": {
+              config: {
+                marker: "plugin-config-visible",
+              },
+            },
+          },
+        },
+      },
+      onlyPluginIds: ["bootstrap-context-mutator"],
+    });
+
+    const baseFile: WorkspaceBootstrapFile = {
+      name: "AGENTS.md",
+      path: path.join(plugin.dir, "AGENTS.md"),
+      content: "base",
+      missing: false,
+    };
+    const event = createInternalHookEvent("agent", "bootstrap", "agent:main:test:dm:peer", {
+      workspaceDir: plugin.dir,
+      bootstrapFiles: [baseFile],
+    });
+    await triggerInternalHook(event);
+
+    const context = event.context as AgentBootstrapHookContext & { pluginConfig?: unknown };
+    expect(context.bootstrapFiles.map((file) => file.name)).toEqual(["AGENTS.md", "PLUGIN.md"]);
+    expect(context.bootstrapFiles[1]?.content).toBe("plugin-config-visible");
+    expect("pluginConfig" in context).toBe(false);
 
     clearInternalHooks();
   });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -657,9 +657,19 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }> = [];
     for (const event of normalizedEvents) {
       const wrappedHandler: typeof handler = async (evt) => {
-        // Shallow-copy to avoid mutating the shared event object
-        // passed to all handlers sequentially by triggerInternalHook
-        return handler({ ...evt, context: { ...evt.context, pluginConfig } });
+        const { context } = evt;
+        const hadPluginConfig = Object.prototype.hasOwnProperty.call(context, "pluginConfig");
+        const previousPluginConfig = context.pluginConfig;
+        context.pluginConfig = pluginConfig;
+        try {
+          return await handler({ ...evt, context });
+        } finally {
+          if (hadPluginConfig) {
+            context.pluginConfig = previousPluginConfig;
+          } else {
+            delete context.pluginConfig;
+          }
+        }
       };
       registerInternalHook(event, wrappedHandler);
       nextRegistrations.push({ event, handler: wrappedHandler });


### PR DESCRIPTION
Fixes #75245.

## Summary
- preserve the original internal hook context while injecting pluginConfig for the active plugin handler
- restore or remove pluginConfig after the handler so config stays scoped
- add a loader regression test for agent:bootstrap plugins mutating bootstrapFiles

## Testing
- pnpm test src/agents/bootstrap-hooks.test.ts src/agents/bootstrap-files.test.ts src/plugins/loader.test.ts
- pnpm exec oxfmt --check --threads=1 src/plugins/registry.ts src/agents/bootstrap-hooks.test.ts src/agents/bootstrap-files.test.ts src/plugins/loader.test.ts CHANGELOG.md
- pnpm check:changed

## Real behavior proof
- **Behavior or issue addressed**: Plugin `agent:bootstrap` hooks can mutate the original hook context while `pluginConfig` remains visible only during the active plugin handler.
- **Real environment tested**: Local OpenClaw plugin loader/runtime from this PR branch (`OpenClaw 2026.5.4`, commit `b92440d`) using a temporary on-disk plugin with an `agent:bootstrap` hook.
- **Exact steps or command run after this patch**:
  ```sh
  node --import tsx --input-type=module
  # Created a temp plugin with openclaw.plugin.json, loaded it via plugins.load.paths,
  # triggered agent:bootstrap, and printed the mutated bootstrapFiles plus post-hook context state.
  ```
- **Evidence after fix**: Console output from the node command:
  ```text
  loadedPlugins=bootstrap-context-mutator:loaded
  hooks=bootstrap-context-mutator:agent:bootstrap
  diagnostics=
  hook running marker=plugin-config-visible
  bootstrapFiles=AGENTS.md:base,PLUGIN.md:plugin-config-visible
  pluginConfigPresentAfterHook=false
  ```
- **Observed result after fix**: The real plugin hook appended `PLUGIN.md` to `bootstrapFiles`, read `pluginConfig.marker` during execution, and `pluginConfig` was removed from the shared context after the hook returned.
- **What was not tested**: No packaged third-party plugin was installed from npm; the proof uses a temporary local plugin loaded through the normal OpenClaw plugin loader path.

