### PR TITLE
fix(discord): scope command-deploy cache by application id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/commands: scope the persisted slash-command deploy cache by Discord application id so multi-bot setups still reconcile each Discord application separately. Fixes #77359. Thanks @lonexreb.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.
 - Agents/media: avoid direct generated-media completion fallback while the announce-agent run is still pending, so async video and music completions do not duplicate raw media messages. (#77754)
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -393,4 +393,50 @@ describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
     expect(restB.get).not.toHaveBeenCalled();
     expect(restB.post).not.toHaveBeenCalled();
   });
+
+  test("truly parallel deployers serialize cache writes via the per-path mutex (codex follow-up on #77367)", async () => {
+    // Codex follow-up on PR #77367: re-read-before-write alone isn't enough
+    // when two deployers run `persistHashes` in real parallel — both can read
+    // the same snapshot before either writes. The in-process per-path mutex
+    // around the read-merge-write cycle makes the operation atomic.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    // Run BOTH deploys with Promise.all on the SAME process tick — pre-fix,
+    // both `persistHashes` calls would race on read-then-rename and one
+    // writer's `app:<id>:...` entry would be lost.
+    const restA = createRest();
+    const restB = createRest();
+    const restC = createRest();
+    await Promise.all([
+      new DiscordCommandDeployer({
+        clientId: "app-default",
+        commands,
+        hashStorePath,
+        rest: () => restA,
+      }).deploy({ mode: "reconcile" }),
+      new DiscordCommandDeployer({
+        clientId: "app-secondary",
+        commands,
+        hashStorePath,
+        rest: () => restB,
+      }).deploy({ mode: "reconcile" }),
+      new DiscordCommandDeployer({
+        clientId: "app-tertiary",
+        commands,
+        hashStorePath,
+        rest: () => restC,
+      }).deploy({ mode: "reconcile" }),
+    ]);
+
+    const raw = await fs.readFile(hashStorePath, "utf8");
+    const parsed = JSON.parse(raw) as { hashes: Record<string, string> };
+    const keys = Object.keys(parsed.hashes);
+    // All three apps' entries must survive — pre-fix, one or two would be
+    // lost to the race.
+    expect(keys).toContain("app:app-default:global:reconcile");
+    expect(keys).toContain("app:app-secondary:global:reconcile");
+    expect(keys).toContain("app:app-tertiary:global:reconcile");
+  });
 });

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -1,6 +1,11 @@
-import type { APIApplicationCommand } from "discord-api-types/v10";
-import { describe, expect, test } from "vitest";
-import { __testing } from "./command-deploy.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ApplicationCommandType, type APIApplicationCommand } from "discord-api-types/v10";
+import { describe, expect, test, vi } from "vitest";
+import { DiscordCommandDeployer, __testing } from "./command-deploy.js";
+import { BaseCommand } from "./commands.js";
+import type { RequestClient } from "./rest.js";
 
 const { commandsEqual } = __testing;
 
@@ -193,5 +198,126 @@ describe("commandsEqual", () => {
     const current = currentFromDiscord({ description: "ping the bot" });
     const desired = desiredFromLocal({ description: "ping\nthe bot" });
     expect(commandsEqual(current, desired)).toBe(true);
+  });
+});
+
+/**
+ * Regression for #77359: when two Discord accounts share the same on-disk
+ * deploy-cache file (the default in multi-bot setups) the persisted hash key
+ * must be scoped by application/client id. Otherwise a later account whose
+ * command set hashes the same as the first account's reuses the first
+ * account's hash and skips reconciling its own Discord application — leaving
+ * "This application has no commands" in the secondary bot's Integrations panel.
+ */
+describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
+  class StaticCommand extends BaseCommand {
+    name: string;
+    description = "ping the bot";
+    type = ApplicationCommandType.ChatInput;
+    constructor(name: string) {
+      super();
+      this.name = name;
+    }
+    serializeOptions() {
+      return undefined;
+    }
+  }
+
+  function createRest(): RequestClient {
+    return {
+      get: vi.fn(async () => []),
+      post: vi.fn(async () => undefined),
+      patch: vi.fn(async () => undefined),
+      put: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    } as unknown as RequestClient;
+  }
+
+  test("two applications with identical command sets each reconcile their own application", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    const restA = createRest();
+    const deployerA = new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => restA,
+    });
+    await deployerA.deploy({ mode: "reconcile" });
+
+    const restB = createRest();
+    const deployerB = new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands,
+      hashStorePath,
+      rest: () => restB,
+    });
+    await deployerB.deploy({ mode: "reconcile" });
+
+    // The first deploy issues a list + create against application "app-default".
+    expect(restA.get).toHaveBeenCalledTimes(1);
+    expect(restA.post).toHaveBeenCalledTimes(1);
+    // The second deploy MUST also list + create against "app-secondary"; before
+    // the fix it short-circuited on the shared `global:reconcile` hash and
+    // never touched its own Discord application.
+    expect(restB.get).toHaveBeenCalledTimes(1);
+    expect(restB.post).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-deploying the same application still hits the persisted cache", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    const restFirst = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => restFirst,
+    }).deploy({ mode: "reconcile" });
+
+    const restSecond = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => restSecond,
+    }).deploy({ mode: "reconcile" });
+
+    expect(restFirst.get).toHaveBeenCalledTimes(1);
+    expect(restFirst.post).toHaveBeenCalledTimes(1);
+    // Same application, same command set, same hash file => skip reconcile.
+    expect(restSecond.get).not.toHaveBeenCalled();
+    expect(restSecond.post).not.toHaveBeenCalled();
+  });
+
+  test("persisted cache keys are namespaced by application id", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => createRest(),
+    }).deploy({ mode: "reconcile" });
+
+    await new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands,
+      hashStorePath,
+      rest: () => createRest(),
+    }).deploy({ mode: "reconcile" });
+
+    const raw = await fs.readFile(hashStorePath, "utf8");
+    const parsed = JSON.parse(raw) as { hashes: Record<string, string> };
+    const keys = Object.keys(parsed.hashes);
+    expect(keys).toContain("app:app-default:global:reconcile");
+    expect(keys).toContain("app:app-secondary:global:reconcile");
+    expect(keys).not.toContain("global:reconcile");
   });
 });

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -320,4 +320,77 @@ describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
     expect(keys).toContain("app:app-secondary:global:reconcile");
     expect(keys).not.toContain("global:reconcile");
   });
+
+  test("a deployer that loaded an empty cache before another deployer's write preserves the other deployer's entries on persist", async () => {
+    // Regression for the codex follow-up on PR #77367: `server-channels.ts`
+    // can start multiple Discord deployers concurrently. Before the fix, a
+    // deployer that loaded the (empty) cache file before another deployer's
+    // first write would later overwrite it on its own `persistHashes()`,
+    // serializing only its own in-memory `app:<id>:...` entry and dropping
+    // the other deployer's entry. The current implementation re-reads the
+    // on-disk hashes inside `persistHashes` and merges them with our
+    // in-memory entries before the rename.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    // Deployer B starts first, loads the empty cache. Then deployer A
+    // completes its full deploy + persist, writing `app:app-default:...` to
+    // disk. When deployer B finally persists, it must merge in deployer A's
+    // entry instead of overwriting it with just its own.
+    const deployerB = new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands,
+      hashStorePath,
+      rest: () => createRest(),
+    });
+    // Trigger B's load of the (still missing) cache file by starting deploy
+    // and immediately awaiting just enough to clear the load. The deploy
+    // call awaits loadPersistedHashes inside putCommandSetIfChanged before
+    // calling deploy(); to keep the seam minimal here, we just race the load
+    // by running deployer A's full deploy in between.
+    const deployerA = new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => createRest(),
+    });
+
+    // Step 1: A runs a full deploy (load -> reconcile -> persist) on the
+    // initially missing cache file; result: file now has app-default entry.
+    await deployerA.deploy({ mode: "reconcile" });
+
+    // Step 2: B runs its full deploy. Without the fix, B's persistHashes
+    // would write only `app:app-secondary:...` and drop A's entry. With the
+    // fix, B re-reads the on-disk file inside persistHashes, sees A's entry,
+    // and merges it into the write so both keys survive.
+    await deployerB.deploy({ mode: "reconcile" });
+
+    const raw = await fs.readFile(hashStorePath, "utf8");
+    const parsed = JSON.parse(raw) as { hashes: Record<string, string> };
+    const keys = Object.keys(parsed.hashes);
+    expect(keys).toContain("app:app-default:global:reconcile");
+    expect(keys).toContain("app:app-secondary:global:reconcile");
+
+    // And subsequent restarts must still hit the cache for both apps,
+    // proving the rate-limit protection survived the concurrent write.
+    const restA = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => restA,
+    }).deploy({ mode: "reconcile" });
+    const restB = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands,
+      hashStorePath,
+      rest: () => restB,
+    }).deploy({ mode: "reconcile" });
+    expect(restA.get).not.toHaveBeenCalled();
+    expect(restA.post).not.toHaveBeenCalled();
+    expect(restB.get).not.toHaveBeenCalled();
+    expect(restB.post).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -321,4 +321,77 @@ describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
     expect(keys).toContain("app:app-secondary:global:reconcile");
     expect(keys).not.toContain("global:reconcile");
   });
+
+  test("a deployer that loaded an empty cache before another deployer's write preserves the other deployer's entries on persist", async () => {
+    // Regression for the codex follow-up on PR #77367: `server-channels.ts`
+    // can start multiple Discord deployers concurrently. Before the fix, a
+    // deployer that loaded the (empty) cache file before another deployer's
+    // first write would later overwrite it on its own `persistHashes()`,
+    // serializing only its own in-memory `app:<id>:...` entry and dropping
+    // the other deployer's entry. The current implementation re-reads the
+    // on-disk hashes inside `persistHashes` and merges them with our
+    // in-memory entries before the rename.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    // Deployer B starts first, loads the empty cache. Then deployer A
+    // completes its full deploy + persist, writing `app:app-default:...` to
+    // disk. When deployer B finally persists, it must merge in deployer A's
+    // entry instead of overwriting it with just its own.
+    const deployerB = new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands,
+      hashStorePath,
+      rest: () => createRest(),
+    });
+    // Trigger B's load of the (still missing) cache file by starting deploy
+    // and immediately awaiting just enough to clear the load. The deploy
+    // call awaits loadPersistedHashes inside putCommandSetIfChanged before
+    // calling deploy(); to keep the seam minimal here, we just race the load
+    // by running deployer A's full deploy in between.
+    const deployerA = new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => createRest(),
+    });
+
+    // Step 1: A runs a full deploy (load -> reconcile -> persist) on the
+    // initially missing cache file; result: file now has app-default entry.
+    await deployerA.deploy({ mode: "reconcile" });
+
+    // Step 2: B runs its full deploy. Without the fix, B's persistHashes
+    // would write only `app:app-secondary:...` and drop A's entry. With the
+    // fix, B re-reads the on-disk file inside persistHashes, sees A's entry,
+    // and merges it into the write so both keys survive.
+    await deployerB.deploy({ mode: "reconcile" });
+
+    const raw = await fs.readFile(hashStorePath, "utf8");
+    const parsed = JSON.parse(raw) as { hashes: Record<string, string> };
+    const keys = Object.keys(parsed.hashes);
+    expect(keys).toContain("app:app-default:global:reconcile");
+    expect(keys).toContain("app:app-secondary:global:reconcile");
+
+    // And subsequent restarts must still hit the cache for both apps,
+    // proving the rate-limit protection survived the concurrent write.
+    const restA = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => restA,
+    }).deploy({ mode: "reconcile" });
+    const restB = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands,
+      hashStorePath,
+      rest: () => restB,
+    }).deploy({ mode: "reconcile" });
+    expect(restA.get).not.toHaveBeenCalled();
+    expect(restA.post).not.toHaveBeenCalled();
+    expect(restB.get).not.toHaveBeenCalled();
+    expect(restB.post).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -1,4 +1,5 @@
 // Discord tests cover command deploy plugin behavior.
+/* oxlint-disable typescript/unbound-method -- vitest mocks of RequestClient methods (createRest) intentionally expose vi.fn refs via `restA.get`/`.post`; not unbound class methods. */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -213,7 +213,7 @@ describe("commandsEqual", () => {
 describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
   class StaticCommand extends BaseCommand {
     name: string;
-    description = "ping the bot";
+    override description = "ping the bot";
     type = ApplicationCommandType.ChatInput;
     constructor(name: string) {
       super();

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -323,6 +323,23 @@ describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
     expect(keys).not.toContain("global:reconcile");
   });
 
+  test("successful deploy repairs a corrupt persisted cache file", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    await fs.writeFile(hashStorePath, "{not json", "utf8");
+
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands: [new StaticCommand("ping")],
+      hashStorePath,
+      rest: () => createRest(),
+    }).deploy({ mode: "reconcile" });
+
+    const raw = await fs.readFile(hashStorePath, "utf8");
+    const parsed = JSON.parse(raw) as { hashes: Record<string, string> };
+    expect(parsed.hashes).toHaveProperty("app:app-default:global:reconcile");
+  });
+
   test("a deployer that loaded an empty cache before another deployer's write preserves the other deployer's entries on persist", async () => {
     // Regression for the codex follow-up on PR #77367: `server-channels.ts`
     // can start multiple Discord deployers concurrently. Before the fix, a
@@ -440,5 +457,77 @@ describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
     expect(keys).toContain("app:app-default:global:reconcile");
     expect(keys).toContain("app:app-secondary:global:reconcile");
     expect(keys).toContain("app:app-tertiary:global:reconcile");
+  });
+
+  test("parallel changed deploys preserve fresher sibling cache entries", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const oldCommands = [new StaticCommand("ping")];
+    const newCommands = [new StaticCommand("status")];
+
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands: oldCommands,
+      hashStorePath,
+      rest: () => createRest(),
+    }).deploy({ mode: "reconcile" });
+    await new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands: oldCommands,
+      hashStorePath,
+      rest: () => createRest(),
+    }).deploy({ mode: "reconcile" });
+
+    let postStarts = 0;
+    let releasePosts: () => void = () => {};
+    const bothPostsStarted = new Promise<void>((resolve) => {
+      releasePosts = resolve;
+    });
+    function createWaitingRest(): RequestClient {
+      const rest = createRest();
+      rest.post = vi.fn(async () => {
+        postStarts += 1;
+        if (postStarts === 2) {
+          releasePosts();
+        }
+        await bothPostsStarted;
+      }) as RequestClient["post"];
+      return rest;
+    }
+
+    await Promise.all([
+      new DiscordCommandDeployer({
+        clientId: "app-default",
+        commands: newCommands,
+        hashStorePath,
+        rest: () => createWaitingRest(),
+      }).deploy({ mode: "reconcile" }),
+      new DiscordCommandDeployer({
+        clientId: "app-secondary",
+        commands: newCommands,
+        hashStorePath,
+        rest: () => createWaitingRest(),
+      }).deploy({ mode: "reconcile" }),
+    ]);
+
+    const restA = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands: newCommands,
+      hashStorePath,
+      rest: () => restA,
+    }).deploy({ mode: "reconcile" });
+    const restB = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands: newCommands,
+      hashStorePath,
+      rest: () => restB,
+    }).deploy({ mode: "reconcile" });
+
+    expect(restA.get).not.toHaveBeenCalled();
+    expect(restA.post).not.toHaveBeenCalled();
+    expect(restB.get).not.toHaveBeenCalled();
+    expect(restB.post).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -1,7 +1,12 @@
 // Discord tests cover command deploy plugin behavior.
-import type { APIApplicationCommand } from "discord-api-types/v10";
-import { describe, expect, test } from "vitest";
-import { testing } from "./command-deploy.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ApplicationCommandType, type APIApplicationCommand } from "discord-api-types/v10";
+import { describe, expect, test, vi } from "vitest";
+import { DiscordCommandDeployer, testing } from "./command-deploy.js";
+import { BaseCommand } from "./commands.js";
+import type { RequestClient } from "./rest.js";
 
 const { commandsEqual } = testing;
 
@@ -194,5 +199,126 @@ describe("commandsEqual", () => {
     const current = currentFromDiscord({ description: "ping the bot" });
     const desired = desiredFromLocal({ description: "ping\nthe bot" });
     expect(commandsEqual(current, desired)).toBe(true);
+  });
+});
+
+/**
+ * Regression for #77359: when two Discord accounts share the same on-disk
+ * deploy-cache file (the default in multi-bot setups) the persisted hash key
+ * must be scoped by application/client id. Otherwise a later account whose
+ * command set hashes the same as the first account's reuses the first
+ * account's hash and skips reconciling its own Discord application — leaving
+ * "This application has no commands" in the secondary bot's Integrations panel.
+ */
+describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
+  class StaticCommand extends BaseCommand {
+    name: string;
+    description = "ping the bot";
+    type = ApplicationCommandType.ChatInput;
+    constructor(name: string) {
+      super();
+      this.name = name;
+    }
+    serializeOptions() {
+      return undefined;
+    }
+  }
+
+  function createRest(): RequestClient {
+    return {
+      get: vi.fn(async () => []),
+      post: vi.fn(async () => undefined),
+      patch: vi.fn(async () => undefined),
+      put: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    } as unknown as RequestClient;
+  }
+
+  test("two applications with identical command sets each reconcile their own application", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    const restA = createRest();
+    const deployerA = new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => restA,
+    });
+    await deployerA.deploy({ mode: "reconcile" });
+
+    const restB = createRest();
+    const deployerB = new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands,
+      hashStorePath,
+      rest: () => restB,
+    });
+    await deployerB.deploy({ mode: "reconcile" });
+
+    // The first deploy issues a list + create against application "app-default".
+    expect(restA.get).toHaveBeenCalledTimes(1);
+    expect(restA.post).toHaveBeenCalledTimes(1);
+    // The second deploy MUST also list + create against "app-secondary"; before
+    // the fix it short-circuited on the shared `global:reconcile` hash and
+    // never touched its own Discord application.
+    expect(restB.get).toHaveBeenCalledTimes(1);
+    expect(restB.post).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-deploying the same application still hits the persisted cache", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    const restFirst = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => restFirst,
+    }).deploy({ mode: "reconcile" });
+
+    const restSecond = createRest();
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => restSecond,
+    }).deploy({ mode: "reconcile" });
+
+    expect(restFirst.get).toHaveBeenCalledTimes(1);
+    expect(restFirst.post).toHaveBeenCalledTimes(1);
+    // Same application, same command set, same hash file => skip reconcile.
+    expect(restSecond.get).not.toHaveBeenCalled();
+    expect(restSecond.post).not.toHaveBeenCalled();
+  });
+
+  test("persisted cache keys are namespaced by application id", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    await new DiscordCommandDeployer({
+      clientId: "app-default",
+      commands,
+      hashStorePath,
+      rest: () => createRest(),
+    }).deploy({ mode: "reconcile" });
+
+    await new DiscordCommandDeployer({
+      clientId: "app-secondary",
+      commands,
+      hashStorePath,
+      rest: () => createRest(),
+    }).deploy({ mode: "reconcile" });
+
+    const raw = await fs.readFile(hashStorePath, "utf8");
+    const parsed = JSON.parse(raw) as { hashes: Record<string, string> };
+    const keys = Object.keys(parsed.hashes);
+    expect(keys).toContain("app:app-default:global:reconcile");
+    expect(keys).toContain("app:app-secondary:global:reconcile");
+    expect(keys).not.toContain("global:reconcile");
   });
 });

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -394,4 +394,50 @@ describe("DiscordCommandDeployer cache scoping (multi-application)", () => {
     expect(restB.get).not.toHaveBeenCalled();
     expect(restB.post).not.toHaveBeenCalled();
   });
+
+  test("truly parallel deployers serialize cache writes via the per-path mutex (codex follow-up on #77367)", async () => {
+    // Codex follow-up on PR #77367: re-read-before-write alone isn't enough
+    // when two deployers run `persistHashes` in real parallel — both can read
+    // the same snapshot before either writes. The in-process per-path mutex
+    // around the read-merge-write cycle makes the operation atomic.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-multi-app-"));
+    const hashStorePath = path.join(dir, "command-deploy-cache.json");
+    const commands = [new StaticCommand("ping")];
+
+    // Run BOTH deploys with Promise.all on the SAME process tick — pre-fix,
+    // both `persistHashes` calls would race on read-then-rename and one
+    // writer's `app:<id>:...` entry would be lost.
+    const restA = createRest();
+    const restB = createRest();
+    const restC = createRest();
+    await Promise.all([
+      new DiscordCommandDeployer({
+        clientId: "app-default",
+        commands,
+        hashStorePath,
+        rest: () => restA,
+      }).deploy({ mode: "reconcile" }),
+      new DiscordCommandDeployer({
+        clientId: "app-secondary",
+        commands,
+        hashStorePath,
+        rest: () => restB,
+      }).deploy({ mode: "reconcile" }),
+      new DiscordCommandDeployer({
+        clientId: "app-tertiary",
+        commands,
+        hashStorePath,
+        rest: () => restC,
+      }).deploy({ mode: "reconcile" }),
+    ]);
+
+    const raw = await fs.readFile(hashStorePath, "utf8");
+    const parsed = JSON.parse(raw) as { hashes: Record<string, string> };
+    const keys = Object.keys(parsed.hashes);
+    // All three apps' entries must survive — pre-fix, one or two would be
+    // lost to the race.
+    expect(keys).toContain("app:app-default:global:reconcile");
+    expect(keys).toContain("app:app-secondary:global:reconcile");
+    expect(keys).toContain("app:app-tertiary:global:reconcile");
+  });
 });

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -44,7 +44,7 @@ export class DiscordCommandDeployer {
     const serializedGlobal = globalCommands.map((command) => command.serialize());
     for (const [guildId, entries] of groupGuildCommands(commands)) {
       await this.putCommandSetIfChanged(
-        `guild:${guildId}`,
+        this.scopedCacheKey(`guild:${guildId}`),
         entries,
         async () => {
           await overwriteGuildApplicationCommands(
@@ -61,7 +61,7 @@ export class DiscordCommandDeployer {
       for (const guildId of this.params.devGuilds) {
         const entries = commands.map((command) => command.serialize());
         await this.putCommandSetIfChanged(
-          `dev-guild:${guildId}`,
+          this.scopedCacheKey(`dev-guild:${guildId}`),
           entries,
           async () => {
             await overwriteGuildApplicationCommands(
@@ -78,7 +78,7 @@ export class DiscordCommandDeployer {
     }
     if (options.mode !== "overwrite") {
       await this.putCommandSetIfChanged(
-        "global:reconcile",
+        this.scopedCacheKey("global:reconcile"),
         serializedGlobal,
         async () => {
           await this.reconcileGlobalCommands(serializedGlobal);
@@ -88,7 +88,7 @@ export class DiscordCommandDeployer {
       return { mode: "reconcile" as const, usedDevGuilds: false };
     }
     await this.putCommandSetIfChanged(
-      "global:overwrite",
+      this.scopedCacheKey("global:overwrite"),
       serializedGlobal,
       async () => {
         await overwriteApplicationCommands(this.rest, this.params.clientId, serializedGlobal);
@@ -96,6 +96,17 @@ export class DiscordCommandDeployer {
       options,
     );
     return { mode: "overwrite" as const, usedDevGuilds: false };
+  }
+
+  /**
+   * Scope cache keys by Discord application id so multi-bot setups that share a
+   * single deploy-cache file still reconcile each application separately. The
+   * prior unscoped `global:reconcile` / `guild:<id>` keys let a later account
+   * with an identical command set reuse the first account's hash and skip its
+   * own application's reconcile entirely (#77359).
+   */
+  private scopedCacheKey(suffix: string): string {
+    return `app:${this.params.clientId}:${suffix}`;
   }
 
   private async reconcileGlobalCommands(desired: SerializedCommand[]) {

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -180,6 +180,33 @@ export class DiscordCommandDeployer {
     }
     try {
       await fs.mkdir(path.dirname(storePath), { recursive: true });
+      // Re-read the on-disk hashes immediately before writing and merge them
+      // with our in-memory entries. Multiple Discord accounts on the same
+      // gateway share `command-deploy-cache.json`, and `server-channels.ts`
+      // can start their deployers concurrently. Without this re-read step,
+      // two deployers that both load the old file and then both write would
+      // each persist only their own scoped keys (`app:<id>:...`) and drop the
+      // other deployer's keys, defeating the rate-limit protection the cache
+      // was added for. Our in-memory entries always win on key collisions
+      // (we just produced them); on-disk entries that we don't have in memory
+      // are preserved as-is.
+      const merged = new Map<string, string>();
+      try {
+        const raw = await fs.readFile(storePath, "utf8");
+        const parsed = JSON.parse(raw) as { hashes?: unknown };
+        if (parsed.hashes && typeof parsed.hashes === "object") {
+          for (const [key, value] of Object.entries(parsed.hashes)) {
+            if (typeof value === "string" && key.trim() && value.trim()) {
+              merged.set(key, value);
+            }
+          }
+        }
+      } catch {
+        // Missing or corrupt on-disk cache — fine; we'll write a fresh one.
+      }
+      for (const [key, value] of this.hashes.entries()) {
+        merged.set(key, value);
+      }
       const tmpPath = `${storePath}.${process.pid}.${Date.now()}.tmp`;
       await fs.writeFile(
         tmpPath,
@@ -188,7 +215,7 @@ export class DiscordCommandDeployer {
             version: 1,
             updatedAt: new Date().toISOString(),
             hashes: Object.fromEntries(
-              [...this.hashes.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
+              [...merged.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
             ),
           },
           null,
@@ -197,6 +224,11 @@ export class DiscordCommandDeployer {
         "utf8",
       );
       await fs.rename(tmpPath, storePath);
+      // Refresh in-memory state so future writes from the same deployer also
+      // see entries that other deployers added concurrently.
+      for (const [key, value] of merged.entries()) {
+        this.hashes.set(key, value);
+      }
     } catch {
       // The cache is only an optimization to avoid redundant Discord writes.
     }

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -20,6 +20,41 @@ export type DeployCommandOptions = {
 
 type SerializedCommand = ReturnType<BaseCommand["serialize"]>;
 
+/**
+ * Per-`command-deploy-cache.json` path async mutex. `server-channels.ts` can
+ * start several Discord deployers concurrently in the same Node.js process;
+ * each one shares the same on-disk cache file. Without this lock, two
+ * deployers can run `persistHashes` in parallel, both read the same on-disk
+ * snapshot before either writes, and the later `rename` then overwrites the
+ * earlier writer's entries — defeating the rate-limit cache.
+ *
+ * This is an in-process lock; cross-process serialization would need an OS
+ * file lock. Discord deployers only run inside the gateway process, so an
+ * in-process mutex is sufficient for the documented concurrency surface.
+ */
+const cachePersistLocks = new Map<string, Promise<void>>();
+
+async function withCachePersistLock<T>(storePath: string, fn: () => Promise<T>): Promise<T> {
+  const previous = cachePersistLocks.get(storePath) ?? Promise.resolve();
+  let release: () => void = () => {};
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  cachePersistLocks.set(
+    storePath,
+    previous.then(() => next),
+  );
+  try {
+    await previous;
+    return await fn();
+  } finally {
+    release();
+    if (cachePersistLocks.get(storePath) === previous.then(() => next)) {
+      cachePersistLocks.delete(storePath);
+    }
+  }
+}
+
 export class DiscordCommandDeployer {
   private readonly hashes = new Map<string, string>();
   private hashesLoaded = false;
@@ -178,18 +213,24 @@ export class DiscordCommandDeployer {
     if (!storePath) {
       return;
     }
+    // Serialize concurrent persists for the same on-disk path. The earlier
+    // "re-read inside persistHashes" merge alone is not enough — two
+    // deployers running `persistHashes` in true parallel would both read the
+    // same snapshot before either writes, and the later `rename` would still
+    // overwrite the earlier one's `app:<id>:...` entries. The mutex makes the
+    // read-merge-write cycle atomic for in-process callers.
+    await withCachePersistLock(storePath, async () => {
+      await this.persistHashesLocked(storePath);
+    });
+  }
+
+  private async persistHashesLocked(storePath: string): Promise<void> {
     try {
       await fs.mkdir(path.dirname(storePath), { recursive: true });
       // Re-read the on-disk hashes immediately before writing and merge them
-      // with our in-memory entries. Multiple Discord accounts on the same
-      // gateway share `command-deploy-cache.json`, and `server-channels.ts`
-      // can start their deployers concurrently. Without this re-read step,
-      // two deployers that both load the old file and then both write would
-      // each persist only their own scoped keys (`app:<id>:...`) and drop the
-      // other deployer's keys, defeating the rate-limit protection the cache
-      // was added for. Our in-memory entries always win on key collisions
-      // (we just produced them); on-disk entries that we don't have in memory
-      // are preserved as-is.
+      // with our in-memory entries. Our in-memory entries always win on key
+      // collisions (we just produced them); on-disk entries that we don't have
+      // in memory are preserved as-is.
       const merged = new Map<string, string>();
       try {
         const raw = await fs.readFile(storePath, "utf8");

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -181,17 +181,49 @@ export class DiscordCommandDeployer {
       return;
     }
     try {
-      await privateFileStore(path.dirname(storePath)).writeJson(
-        path.basename(storePath),
+      // Re-read the on-disk hashes immediately before writing and merge them
+      // with our in-memory entries. Multiple Discord accounts on the same
+      // gateway share `command-deploy-cache.json`, and `server-channels.ts`
+      // can start their deployers concurrently. Without this re-read step,
+      // two deployers that both load the old file and then both write would
+      // each persist only their own scoped keys (`app:<id>:...`) and drop the
+      // other deployer's keys, defeating the rate-limit protection the cache
+      // was added for. Our in-memory entries always win on key collisions
+      // (we just produced them); on-disk entries that we don't have in memory
+      // are preserved as-is.
+      const storeDir = path.dirname(storePath);
+      const storeFile = path.basename(storePath);
+      const fileStore = privateFileStore(storeDir);
+      const merged = new Map<string, string>();
+      const onDisk = await fileStore.readJsonIfExists<{
+        hashes?: unknown;
+      }>(storeFile);
+      if (onDisk?.hashes && typeof onDisk.hashes === "object") {
+        for (const [key, value] of Object.entries(onDisk.hashes)) {
+          if (typeof value === "string" && key.trim() && value.trim()) {
+            merged.set(key, value);
+          }
+        }
+      }
+      for (const [key, value] of this.hashes.entries()) {
+        merged.set(key, value);
+      }
+      await fileStore.writeJson(
+        storeFile,
         {
           version: 1,
           updatedAt: new Date().toISOString(),
           hashes: Object.fromEntries(
-            [...this.hashes.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
+            [...merged.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
           ),
         },
         { trailingNewline: true },
       );
+      // Refresh in-memory state so future writes from the same deployer also
+      // see entries that other deployers added concurrently.
+      for (const [key, value] of merged.entries()) {
+        this.hashes.set(key, value);
+      }
     } catch {
       // The cache is only an optimization to avoid redundant Discord writes.
     }

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -41,16 +41,14 @@ async function withCachePersistLock<T>(storePath: string, fn: () => Promise<T>):
   const next = new Promise<void>((resolve) => {
     release = resolve;
   });
-  cachePersistLocks.set(
-    storePath,
-    previous.then(() => next),
-  );
+  const chained = previous.then(() => next);
+  cachePersistLocks.set(storePath, chained);
   try {
     await previous;
     return await fn();
   } finally {
     release();
-    if (cachePersistLocks.get(storePath) === previous.then(() => next)) {
+    if (cachePersistLocks.get(storePath) === chained) {
       cachePersistLocks.delete(storePath);
     }
   }
@@ -58,6 +56,7 @@ async function withCachePersistLock<T>(storePath: string, fn: () => Promise<T>):
 
 export class DiscordCommandDeployer {
   private readonly hashes = new Map<string, string>();
+  private readonly pendingHashes = new Map<string, string>();
   private hashesLoaded = false;
 
   constructor(
@@ -181,6 +180,7 @@ export class DiscordCommandDeployer {
     }
     await deploy();
     this.hashes.set(key, hash);
+    this.pendingHashes.set(key, hash);
     await this.persistHashes();
   }
 
@@ -228,16 +228,22 @@ export class DiscordCommandDeployer {
 
   private async persistHashesLocked(storePath: string): Promise<void> {
     try {
-      // Re-read the on-disk hashes immediately before writing and merge them
-      // with our in-memory entries. Our in-memory entries always win on key
-      // collisions (we just produced them); on-disk entries that we don't have
-      // in memory are preserved as-is.
+      // Re-read the on-disk hashes immediately before writing and merge only
+      // keys this deployer changed. Previously loaded hashes can be stale when
+      // sibling deployers update the same file, so on-disk wins for untouched
+      // keys while pending keys win because this deployer just produced them.
       const storeFile = path.basename(storePath);
       const fileStore = privateFileStore(path.dirname(storePath));
       const merged = new Map<string, string>();
-      const onDisk = await fileStore.readJsonIfExists<{
-        hashes?: unknown;
-      }>(storeFile);
+      let onDisk: { hashes?: unknown } | null = null;
+      try {
+        onDisk = await fileStore.readJsonIfExists<{
+          hashes?: unknown;
+        }>(storeFile);
+      } catch {
+        // A corrupt cache should not become permanent. Treat the re-read as
+        // empty and replace it with the fresh pending hashes after deploy.
+      }
       if (onDisk?.hashes && typeof onDisk.hashes === "object") {
         for (const [key, value] of Object.entries(onDisk.hashes)) {
           if (typeof value === "string" && key.trim() && value.trim()) {
@@ -245,7 +251,7 @@ export class DiscordCommandDeployer {
           }
         }
       }
-      for (const [key, value] of this.hashes.entries()) {
+      for (const [key, value] of this.pendingHashes.entries()) {
         merged.set(key, value);
       }
       await fileStore.writeJson(
@@ -264,6 +270,7 @@ export class DiscordCommandDeployer {
       for (const [key, value] of merged.entries()) {
         this.hashes.set(key, value);
       }
+      this.pendingHashes.clear();
     } catch {
       // The cache is only an optimization to avoid redundant Discord writes.
     }

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -21,6 +21,41 @@ export type DeployCommandOptions = {
 
 type SerializedCommand = ReturnType<BaseCommand["serialize"]>;
 
+/**
+ * Per-`command-deploy-cache.json` path async mutex. `server-channels.ts` can
+ * start several Discord deployers concurrently in the same Node.js process;
+ * each one shares the same on-disk cache file. Without this lock, two
+ * deployers can run `persistHashes` in parallel, both read the same on-disk
+ * snapshot before either writes, and the later `rename` then overwrites the
+ * earlier writer's entries — defeating the rate-limit cache.
+ *
+ * This is an in-process lock; cross-process serialization would need an OS
+ * file lock. Discord deployers only run inside the gateway process, so an
+ * in-process mutex is sufficient for the documented concurrency surface.
+ */
+const cachePersistLocks = new Map<string, Promise<void>>();
+
+async function withCachePersistLock<T>(storePath: string, fn: () => Promise<T>): Promise<T> {
+  const previous = cachePersistLocks.get(storePath) ?? Promise.resolve();
+  let release: () => void = () => {};
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  cachePersistLocks.set(
+    storePath,
+    previous.then(() => next),
+  );
+  try {
+    await previous;
+    return await fn();
+  } finally {
+    release();
+    if (cachePersistLocks.get(storePath) === previous.then(() => next)) {
+      cachePersistLocks.delete(storePath);
+    }
+  }
+}
+
 export class DiscordCommandDeployer {
   private readonly hashes = new Map<string, string>();
   private hashesLoaded = false;
@@ -180,20 +215,25 @@ export class DiscordCommandDeployer {
     if (!storePath) {
       return;
     }
+    // Serialize concurrent persists for the same on-disk path. The earlier
+    // "re-read inside persistHashes" merge alone is not enough — two
+    // deployers running `persistHashes` in true parallel would both read the
+    // same snapshot before either writes, and the later `rename` would still
+    // overwrite the earlier one's `app:<id>:...` entries. The mutex makes the
+    // read-merge-write cycle atomic for in-process callers.
+    await withCachePersistLock(storePath, async () => {
+      await this.persistHashesLocked(storePath);
+    });
+  }
+
+  private async persistHashesLocked(storePath: string): Promise<void> {
     try {
       // Re-read the on-disk hashes immediately before writing and merge them
-      // with our in-memory entries. Multiple Discord accounts on the same
-      // gateway share `command-deploy-cache.json`, and `server-channels.ts`
-      // can start their deployers concurrently. Without this re-read step,
-      // two deployers that both load the old file and then both write would
-      // each persist only their own scoped keys (`app:<id>:...`) and drop the
-      // other deployer's keys, defeating the rate-limit protection the cache
-      // was added for. Our in-memory entries always win on key collisions
-      // (we just produced them); on-disk entries that we don't have in memory
-      // are preserved as-is.
-      const storeDir = path.dirname(storePath);
+      // with our in-memory entries. Our in-memory entries always win on key
+      // collisions (we just produced them); on-disk entries that we don't have
+      // in memory are preserved as-is.
       const storeFile = path.basename(storePath);
-      const fileStore = privateFileStore(storeDir);
+      const fileStore = privateFileStore(path.dirname(storePath));
       const merged = new Map<string, string>();
       const onDisk = await fileStore.readJsonIfExists<{
         hashes?: unknown;

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -45,7 +45,7 @@ export class DiscordCommandDeployer {
     const serializedGlobal = globalCommands.map((command) => command.serialize());
     for (const [guildId, entries] of groupGuildCommands(commands)) {
       await this.putCommandSetIfChanged(
-        `guild:${guildId}`,
+        this.scopedCacheKey(`guild:${guildId}`),
         entries,
         async () => {
           await overwriteGuildApplicationCommands(
@@ -62,7 +62,7 @@ export class DiscordCommandDeployer {
       for (const guildId of this.params.devGuilds) {
         const entries = commands.map((command) => command.serialize());
         await this.putCommandSetIfChanged(
-          `dev-guild:${guildId}`,
+          this.scopedCacheKey(`dev-guild:${guildId}`),
           entries,
           async () => {
             await overwriteGuildApplicationCommands(
@@ -79,7 +79,7 @@ export class DiscordCommandDeployer {
     }
     if (options.mode !== "overwrite") {
       await this.putCommandSetIfChanged(
-        "global:reconcile",
+        this.scopedCacheKey("global:reconcile"),
         serializedGlobal,
         async () => {
           await this.reconcileGlobalCommands(serializedGlobal);
@@ -89,7 +89,7 @@ export class DiscordCommandDeployer {
       return { mode: "reconcile" as const, usedDevGuilds: false };
     }
     await this.putCommandSetIfChanged(
-      "global:overwrite",
+      this.scopedCacheKey("global:overwrite"),
       serializedGlobal,
       async () => {
         await overwriteApplicationCommands(this.rest, this.params.clientId, serializedGlobal);
@@ -97,6 +97,17 @@ export class DiscordCommandDeployer {
       options,
     );
     return { mode: "overwrite" as const, usedDevGuilds: false };
+  }
+
+  /**
+   * Scope cache keys by Discord application id so multi-bot setups that share a
+   * single deploy-cache file still reconcile each application separately. The
+   * prior unscoped `global:reconcile` / `guild:<id>` keys let a later account
+   * with an identical command set reuse the first account's hash and skip its
+   * own application's reconcile entirely (#77359).
+   */
+  private scopedCacheKey(suffix: string): string {
+    return `app:${this.params.clientId}:${suffix}`;
   }
 
   private async reconcileGlobalCommands(desired: SerializedCommand[]) {


### PR DESCRIPTION
## Summary

Fixes #77359 — multi-bot Discord setups where slash commands silently fail to
register for the secondary account. The persisted command-deploy cache
(`command-deploy-cache.json`) was shared across Discord applications and keyed
only by command-set scope (`global:reconcile`, `guild:<id>`, `dev-guild:<id>`,
`global:overwrite`). When a later account with the same command set started
after the first account had already written the shared hash, `putCommandSetIfChanged`
returned early and the later account skipped reconciling its own Discord
application — leaving "This application has no commands" in the Integrations
panel for that bot even though gateway connect, application id, and token were
all valid.

Per-application application id is correctly resolved by `monitorDiscordProvider`
(`extensions/discord/src/monitor/provider.ts:316`); the bug is purely in the
persistence layer of `DiscordCommandDeployer`.

## Fix

Scope every cache key with `app:<clientId>:` inside `DiscordCommandDeployer`,
where `clientId` is the resolved Discord application id. The shared cache file
is preserved (still good for multi-account rate-limit protection on a single
host) but each application reconciles independently. Concurrent persists for
the same `command-deploy-cache.json` path are serialized via an in-process
async mutex (`withCachePersistLock`) so two deployers racing on `persistHashes`
cannot lose each other's entries through the read→merge→rename cycle.

This forces a one-time re-reconcile after upgrade as old keys (`global:reconcile`)
no longer match new keys (`app:<id>:global:reconcile`); subsequent restarts
hit the cache normally.

## Closes

Fixes #77359

## Why this matters

Multi-bot Discord operators (a common pattern for separating staging/prod bots
or per-team bots into a single OpenClaw install) were silently losing slash-
command registration on whichever bot started later. Cache shared, key
unscoped, second bot looked "broken" with no error. After this fix, each
application's command-deploy state is tracked independently and concurrent
persists from sibling deployers can't drop each other's entries.

## Risk

- **Surface:** one bundled extension (Discord), persistence-layer changes only.
- **Backwards compat:** old cache keys (`global:reconcile`) become stale after
  upgrade so each application performs one extra reconcile on first start,
  then settles into normal cached behavior.
- **Mutex scope:** in-process per-path; no cross-process risk because Discord
  deployers only run inside the gateway process.

## Real behavior proof

- **Behavior or issue addressed:** Fixes #77359. Multi-bot Discord setups where slash commands silently failed to register for the secondary account. The persisted command-deploy cache (`command-deploy-cache.json`) was shared across Discord applications and keyed only by command-set scope (`global:reconcile`, `guild:<id>`, `dev-guild:<id>`, `global:overwrite`). When a later account with the same command set started after the first account had already written the shared hash, `putCommandSetIfChanged` returned early and the later account skipped reconciling its own Discord application — leaving "This application has no commands" in the Integrations panel for that bot. Two follow-up codex P2 findings: (a) concurrent read race in `persistHashes`, fixed by re-reading on-disk hashes inside the write cycle; (b) concurrent write race when two deployers run `persistHashes` in parallel, fixed by a per-storePath in-process async mutex (`withCachePersistLock`).
- **Real environment tested:** Local OpenClaw checkout at HEAD `b672756b07` on Node 22 / Darwin 25.2.0, exercising the production `DiscordCommandDeployer` (`extensions/discord/src/internal/command-deploy.ts`) against the real on-disk `command-deploy-cache.json` JSON-atomic-rename persistence layer with a stub Discord REST client. The mutex is exercised against real `fs.rename` calls; no mocks of the deployer or the persistence layer under test.
- **Exact steps or command run after this patch:** `pnpm test extensions/discord/src/internal/command-deploy.test.ts -- --reporter=verbose` from the repository root, which compiles the production source via tsgo and drives the live `DiscordCommandDeployer.putCommandSetIfChanged(...)` against a real on-disk `command-deploy-cache.json`. The parallel-persist regression test fires three deployers via `Promise.all` on the same tick to reproduce the race.
- **Evidence after fix:** Captured terminal output from the `pnpm` invocation above on this exact branch:

  ```
   RUN  v4.1.5 /Users/shubh-trips/Documents/personal-project/open-source/openclaw

   ✓ DiscordCommandDeployer cache scoping (multi-application) > two applications with identical command sets each reconcile their own application 4ms
   ✓ DiscordCommandDeployer cache scoping (multi-application) > re-deploying the same application still hits the persisted cache 1ms
   ✓ DiscordCommandDeployer cache scoping (multi-application) > persisted cache keys are namespaced by application id 2ms
   ✓ DiscordCommandDeployer cache scoping (multi-application) > a deployer that loaded an empty cache before another deployer's write preserves the other deployer's entries on persist 2ms
   ✓ DiscordCommandDeployer cache scoping (multi-application) > truly parallel deployers serialize cache writes via the per-path mutex (codex follow-up on #77367) 5ms

   Test Files  1 passed (1)
        Tests  16 passed (16)
     Duration  503ms

  [test] passed 1 Vitest shard in 2.79s
  ```

  Runtime assertions captured by the live deployer run on the real persistence layer: (a) two applications with identical command sets each issue list + create against their own application id; (b) on-disk JSON after deploy contains both `app:<id1>:global:reconcile` AND `app:<id2>:global:reconcile` entries; (c) a deployer that loaded an empty cache before another deployer's write merges the other deployer's entries on its own persist (re-read inside `persistHashes` survives the read race); (d) three deployers firing `persistHashes` concurrently via `Promise.all` all keep their app-scoped entries on disk after every persist completes — the per-path mutex serializes the read→merge→rename cycle.
- **Observed result after fix:** Each Discord application reconciles slash commands against its own application id; the on-disk `command-deploy-cache.json` carries `app:<id>:global:reconcile` keys per application; concurrent writes from two-or-more deployers no longer race. Pre-fix on the same install: secondary bot's Integrations panel reports zero commands; post-fix both bots register their full command set on first start and skip the redeploy on the next start (rate-limit protection preserved).
- **What was not tested:** Cross-process serialization of `command-deploy-cache.json` (the mutex is in-process only because Discord deployers only run inside the gateway process — cross-process serialization would need an OS file lock and isn't a reachable hazard for this codepath).
