### PR TITLE
fix(tui): dismiss watchdog notice when response actually arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI/streaming watchdog: dismiss the `This response is taking longer than expected` notice as soon as a chat event for the same run arrives, so the message no longer sits next to the recovered response when the run was only briefly silent. Refs #67052, #69081 (closed), prior attempt #69026. Thanks @jpruit20 and @romneyda.
 - TUI/escape abort: track the in-flight runId after `chat.send` resolves so pressing Esc during the gap before the first gateway event aborts the run instead of repeatedly printing `no active run`. Fixes #1296. Thanks @Lukavyi and @romneyda.
 - Gateway/status: label Linux managed gateway services as `systemd user`, making status output explicit about the user-service scope instead of implying a system-level unit. Thanks @vincentkoc.
 - Plugins/install: remove the previous managed plugin directory when a reinstall switches sources, so stale ClawHub and npm copies no longer keep duplicate plugin ids in discovery after the new install wins. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ Docs: https://docs.openclaw.ai
 - Exec: keep configured `tools.exec.pathPrepend` entries ahead of user shell startup PATH changes on POSIX gateway runs. (#81403) Thanks @medns.
 - Gateway/sessions: allow shared-secret bearer callers to read and stream session history without an explicit scope header. (#81815) Thanks @medns.
 - Agents/embedded runner: classify HTML auth provider responses as `auth_html` and return a re-authentication hint instead of the CDN-blocked copy that `upstream_html` returns. Cloudflare Access login pages, nginx basic-auth challenges, and gateway login walls all produce HTML auth bodies that were previously misdiagnosed as transient CDN blocks. (#79900) Thanks @martingarramon.
+- TUI/streaming watchdog: dismiss the `This response is taking longer than expected` notice as soon as a chat event for the same run arrives, so the message no longer sits next to the recovered response when the run was only briefly silent. Refs #67052, #69081 (closed), prior attempt #69026. Thanks @jpruit20 and @romneyda.
 - Agents/Pi: tolerate OpenClaw-owned transcript writes while embedded prompts are released for model I/O, keeping long-running Feishu, Slack, Telegram, and cron turns from failing with false session-takeover errors. Fixes #84059. (#84250) Thanks @tianxiaochannel-oss88.
 
 ## 2026.5.20

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -150,6 +150,33 @@ describe("ChatLog", () => {
     expect(chatLog.countPendingUsers()).toBe(0);
   });
 
+  it("dismisses a pending system notice by runId", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.addPendingSystem("run-1", "taking longer than expected");
+    let rendered = chatLog.render(120).join("\n");
+    expect(rendered).toContain("taking longer than expected");
+
+    const dismissed = chatLog.dismissPendingSystem("run-1");
+    expect(dismissed).toBe(true);
+
+    rendered = chatLog.render(120).join("\n");
+    expect(rendered).not.toContain("taking longer than expected");
+    expect(chatLog.dismissPendingSystem("run-1")).toBe(false);
+  });
+
+  it("replaces an existing pending system notice for the same runId", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.addPendingSystem("run-1", "first notice");
+    chatLog.addPendingSystem("run-1", "second notice");
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered).not.toContain("first notice");
+    expect(rendered).toContain("second notice");
+    expect(chatLog.children.length).toBe(1);
+  });
+
   it("does not hide a new repeated prompt when only older history matches", () => {
     const chatLog = new ChatLog(40);
 

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -183,6 +183,33 @@ describe("ChatLog", () => {
     expect(chatLog.countPendingUsers()).toBe(0);
   });
 
+  it("dismisses a pending system notice by runId", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.addPendingSystem("run-1", "taking longer than expected");
+    let rendered = chatLog.render(120).join("\n");
+    expect(rendered).toContain("taking longer than expected");
+
+    const dismissed = chatLog.dismissPendingSystem("run-1");
+    expect(dismissed).toBe(true);
+
+    rendered = chatLog.render(120).join("\n");
+    expect(rendered).not.toContain("taking longer than expected");
+    expect(chatLog.dismissPendingSystem("run-1")).toBe(false);
+  });
+
+  it("replaces an existing pending system notice for the same runId", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.addPendingSystem("run-1", "first notice");
+    chatLog.addPendingSystem("run-1", "second notice");
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered).not.toContain("first notice");
+    expect(rendered).toContain("second notice");
+    expect(chatLog.children.length).toBe(1);
+  });
+
   it("does not hide a new repeated prompt when only older history matches", () => {
     const chatLog = new ChatLog(40);
 

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -20,6 +20,7 @@ export class ChatLog extends Container {
       createdAt: number;
     }
   >();
+  private pendingSystemNotices = new Map<string, Container>();
   private btwMessage: BtwInlineMessage | null = null;
   private toolsExpanded = false;
 
@@ -42,6 +43,11 @@ export class ChatLog extends Container {
     for (const [runId, entry] of this.pendingUsers.entries()) {
       if (entry.component === component) {
         this.pendingUsers.delete(runId);
+      }
+    }
+    for (const [runId, entry] of this.pendingSystemNotices.entries()) {
+      if (entry === component) {
+        this.pendingSystemNotices.delete(runId);
       }
     }
     if (this.btwMessage === component) {
@@ -69,6 +75,7 @@ export class ChatLog extends Container {
     this.clear();
     this.toolById.clear();
     this.streamingRuns.clear();
+    this.pendingSystemNotices.clear();
     this.btwMessage = null;
     if (!opts?.preservePendingUsers) {
       this.pendingUsers.clear();
@@ -100,6 +107,29 @@ export class ChatLog extends Container {
 
   addSystem(text: string) {
     this.append(this.createSystemMessage(text));
+  }
+
+  // Tag a system notice with a runId so a later chat event for the same run
+  // can dismiss it. Used by the streaming watchdog so the "taking longer than
+  // expected" notice goes away if the response actually arrives afterwards.
+  addPendingSystem(runId: string, text: string) {
+    const existing = this.pendingSystemNotices.get(runId);
+    if (existing) {
+      this.removeChild(existing);
+    }
+    const entry = this.createSystemMessage(text);
+    this.pendingSystemNotices.set(runId, entry);
+    this.append(entry);
+  }
+
+  dismissPendingSystem(runId: string) {
+    const existing = this.pendingSystemNotices.get(runId);
+    if (!existing) {
+      return false;
+    }
+    this.removeChild(existing);
+    this.pendingSystemNotices.delete(runId);
+    return true;
   }
 
   addUser(text: string) {

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -27,6 +27,7 @@ export class ChatLog extends Container {
       createdAt: number;
     }
   >();
+  private pendingSystemNotices = new Map<string, Container>();
   private btwMessage: BtwInlineMessage | null = null;
   private toolsExpanded = false;
   private repeatableSystemMessage: RepeatableSystemMessage | null = null;
@@ -50,6 +51,11 @@ export class ChatLog extends Container {
     for (const [runId, entry] of this.pendingUsers.entries()) {
       if (entry.component === component) {
         this.pendingUsers.delete(runId);
+      }
+    }
+    for (const [runId, entry] of this.pendingSystemNotices.entries()) {
+      if (entry === component) {
+        this.pendingSystemNotices.delete(runId);
       }
     }
     if (this.btwMessage === component) {
@@ -85,6 +91,7 @@ export class ChatLog extends Container {
     this.clear();
     this.toolById.clear();
     this.streamingRuns.clear();
+    this.pendingSystemNotices.clear();
     this.btwMessage = null;
     this.repeatableSystemMessage = null;
     if (!opts?.preservePendingUsers) {
@@ -140,6 +147,26 @@ export class ChatLog extends Container {
     const message = this.createSystemMessage(text);
     this.append(message.component);
     this.repeatableSystemMessage = opts?.coalesceConsecutive ? message : null;
+  }
+
+  addPendingSystem(runId: string, text: string) {
+    const existing = this.pendingSystemNotices.get(runId);
+    if (existing) {
+      this.removeChild(existing);
+    }
+    const entry = this.createSystemMessage(text);
+    this.pendingSystemNotices.set(runId, entry);
+    this.append(entry);
+  }
+
+  dismissPendingSystem(runId: string) {
+    const existing = this.pendingSystemNotices.get(runId);
+    if (!existing) {
+      return false;
+    }
+    this.removeChild(existing);
+    this.pendingSystemNotices.delete(runId);
+    return true;
   }
 
   addUser(text: string) {

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -154,9 +154,9 @@ export class ChatLog extends Container {
     if (existing) {
       this.removeChild(existing);
     }
-    const entry = this.createSystemMessage(text);
-    this.pendingSystemNotices.set(runId, entry);
-    this.append(entry);
+    const message = this.createSystemMessage(text);
+    this.pendingSystemNotices.set(runId, message.component);
+    this.append(message.component);
   }
 
   dismissPendingSystem(runId: string) {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -8,6 +8,8 @@ type HandlerChatLog = {
   startTool: (...args: unknown[]) => void;
   updateToolResult: (...args: unknown[]) => void;
   addSystem: (...args: unknown[]) => void;
+  addPendingSystem: (...args: unknown[]) => void;
+  dismissPendingSystem: (...args: unknown[]) => void;
   updateAssistant: (...args: unknown[]) => void;
   finalizeAssistant: (...args: unknown[]) => void;
   dropAssistant: (...args: unknown[]) => void;
@@ -21,6 +23,8 @@ type MockChatLog = {
   startTool: MockFn;
   updateToolResult: MockFn;
   addSystem: MockFn;
+  addPendingSystem: MockFn;
+  dismissPendingSystem: MockFn;
   updateAssistant: MockFn;
   finalizeAssistant: MockFn;
   dropAssistant: MockFn;
@@ -36,6 +40,8 @@ function createMockChatLog(): MockChatLog & HandlerChatLog {
     startTool: vi.fn(),
     updateToolResult: vi.fn(),
     addSystem: vi.fn(),
+    addPendingSystem: vi.fn(),
+    dismissPendingSystem: vi.fn(),
     updateAssistant: vi.fn(),
     finalizeAssistant: vi.fn(),
     dropAssistant: vi.fn(),
@@ -994,7 +1000,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
-    expect(chatLog.addSystem).toHaveBeenCalledWith(expectedTimeoutMessage);
+    expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-stuck", expectedTimeoutMessage);
 
     handlers.dispose?.();
   });
@@ -1200,7 +1206,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
     expect(loadHistory).toHaveBeenCalledTimes(1);
-    expect(chatLog.addSystem).not.toHaveBeenCalledWith(expectedTimeoutMessage);
+    expect(chatLog.addPendingSystem).not.toHaveBeenCalled();
 
     handlers.dispose?.();
   });
@@ -1227,7 +1233,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     const statusCalls = setActivityStatus.mock.calls.map((c) => c[0]);
     expect(statusCalls.filter((s) => s === "idle").length).toBe(1);
-    expect(chatLog.addSystem).not.toHaveBeenCalledWith(expectedTimeoutMessage);
+    expect(chatLog.addPendingSystem).not.toHaveBeenCalled();
     expect(state.activeChatRunId).toBeNull();
 
     handlers.dispose?.();
@@ -1248,7 +1254,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     vi.advanceTimersByTime(60_000);
 
     expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
-    expect(chatLog.addSystem).not.toHaveBeenCalled();
+    expect(chatLog.addPendingSystem).not.toHaveBeenCalled();
     expect(state.activeChatRunId).toBe("run-no-watchdog");
 
     handlers.dispose?.();
@@ -1290,7 +1296,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
-    expect(chatLog.addSystem).toHaveBeenCalledTimes(2);
+    expect(chatLog.addPendingSystem).toHaveBeenCalledTimes(2);
 
     handlers.dispose?.();
   });
@@ -1311,6 +1317,60 @@ describe("tui-event-handlers: streaming watchdog", () => {
     vi.advanceTimersByTime(10_000);
 
     expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
-    expect(chatLog.addSystem).not.toHaveBeenCalled();
+    expect(chatLog.addPendingSystem).not.toHaveBeenCalled();
+  });
+
+  it("dismisses the watchdog notice when a delta arrives after the watchdog fires", () => {
+    const { state, chatLog, handlers } = createHarness({
+      streamingWatchdogMs: 5_000,
+    });
+
+    handlers.handleChatEvent({
+      runId: "run-late",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "starting" },
+    } satisfies ChatEvent);
+
+    vi.advanceTimersByTime(5_001);
+    expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-late", expectedTimeoutMessage);
+
+    handlers.handleChatEvent({
+      runId: "run-late",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "actually here" },
+    } satisfies ChatEvent);
+
+    expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-late");
+
+    handlers.dispose?.();
+  });
+
+  it("dismisses the watchdog notice when the final arrives after the watchdog fires", () => {
+    const { state, chatLog, handlers } = createHarness({
+      streamingWatchdogMs: 5_000,
+    });
+
+    handlers.handleChatEvent({
+      runId: "run-final-late",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "starting" },
+    } satisfies ChatEvent);
+
+    vi.advanceTimersByTime(5_001);
+    expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-final-late", expectedTimeoutMessage);
+
+    handlers.handleChatEvent({
+      runId: "run-final-late",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    } satisfies ChatEvent);
+
+    expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-final-late");
+
+    handlers.dispose?.();
   });
 });

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -8,6 +8,8 @@ type HandlerChatLog = {
   startTool: (...args: unknown[]) => void;
   updateToolResult: (...args: unknown[]) => void;
   addSystem: (...args: unknown[]) => void;
+  addPendingSystem: (...args: unknown[]) => void;
+  dismissPendingSystem: (...args: unknown[]) => void;
   updateAssistant: (...args: unknown[]) => void;
   finalizeAssistant: (...args: unknown[]) => void;
   dropAssistant: (...args: unknown[]) => void;
@@ -21,6 +23,8 @@ type MockChatLog = {
   startTool: MockFn;
   updateToolResult: MockFn;
   addSystem: MockFn;
+  addPendingSystem: MockFn;
+  dismissPendingSystem: MockFn;
   updateAssistant: MockFn;
   finalizeAssistant: MockFn;
   dropAssistant: MockFn;
@@ -36,6 +40,8 @@ function createMockChatLog(): MockChatLog & HandlerChatLog {
     startTool: vi.fn(),
     updateToolResult: vi.fn(),
     addSystem: vi.fn(),
+    addPendingSystem: vi.fn(),
+    dismissPendingSystem: vi.fn(),
     updateAssistant: vi.fn(),
     finalizeAssistant: vi.fn(),
     dropAssistant: vi.fn(),
@@ -1178,7 +1184,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
-    expect(chatLog.addSystem).toHaveBeenCalledWith(expectedTimeoutMessage);
+    expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-stuck", expectedTimeoutMessage);
 
     handlers.dispose?.();
   });
@@ -1384,7 +1390,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
     expect(loadHistory).toHaveBeenCalledTimes(1);
-    expect(chatLog.addSystem).not.toHaveBeenCalledWith(expectedTimeoutMessage);
+    expect(chatLog.addPendingSystem).not.toHaveBeenCalled();
 
     handlers.dispose?.();
   });
@@ -1410,8 +1416,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
     vi.advanceTimersByTime(10_000);
 
     const statusCalls = setActivityStatus.mock.calls.map((c) => c[0]);
-    expect(statusCalls.reduce((count, s) => count + (s === "idle" ? 1 : 0), 0)).toBe(1);
-    expect(chatLog.addSystem).not.toHaveBeenCalledWith(expectedTimeoutMessage);
+    expect(statusCalls.filter((s) => s === "idle").length).toBe(1);
+    expect(chatLog.addPendingSystem).not.toHaveBeenCalled();
     expect(state.activeChatRunId).toBeNull();
 
     handlers.dispose?.();
@@ -1432,7 +1438,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     vi.advanceTimersByTime(60_000);
 
     expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
-    expect(chatLog.addSystem).not.toHaveBeenCalled();
+    expect(chatLog.addPendingSystem).not.toHaveBeenCalled();
     expect(state.activeChatRunId).toBe("run-no-watchdog");
 
     handlers.dispose?.();
@@ -1474,7 +1480,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
-    expect(chatLog.addSystem).toHaveBeenCalledTimes(2);
+    expect(chatLog.addPendingSystem).toHaveBeenCalledTimes(2);
 
     handlers.dispose?.();
   });
@@ -1495,6 +1501,60 @@ describe("tui-event-handlers: streaming watchdog", () => {
     vi.advanceTimersByTime(10_000);
 
     expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
-    expect(chatLog.addSystem).not.toHaveBeenCalled();
+    expect(chatLog.addPendingSystem).not.toHaveBeenCalled();
+  });
+
+  it("dismisses the watchdog notice when a delta arrives after the watchdog fires", () => {
+    const { state, chatLog, handlers } = createHarness({
+      streamingWatchdogMs: 5_000,
+    });
+
+    handlers.handleChatEvent({
+      runId: "run-late",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "starting" },
+    } satisfies ChatEvent);
+
+    vi.advanceTimersByTime(5_001);
+    expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-late", expectedTimeoutMessage);
+
+    handlers.handleChatEvent({
+      runId: "run-late",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "actually here" },
+    } satisfies ChatEvent);
+
+    expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-late");
+
+    handlers.dispose?.();
+  });
+
+  it("dismisses the watchdog notice when the final arrives after the watchdog fires", () => {
+    const { state, chatLog, handlers } = createHarness({
+      streamingWatchdogMs: 5_000,
+    });
+
+    handlers.handleChatEvent({
+      runId: "run-final-late",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "starting" },
+    } satisfies ChatEvent);
+
+    vi.advanceTimersByTime(5_001);
+    expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-final-late", expectedTimeoutMessage);
+
+    handlers.handleChatEvent({
+      runId: "run-final-late",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    } satisfies ChatEvent);
+
+    expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-final-late");
+
+    handlers.dispose?.();
   });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -14,6 +14,8 @@ type EventHandlerChatLog = {
     options?: { partial?: boolean; isError?: boolean },
   ) => void;
   addSystem: (text: string) => void;
+  addPendingSystem: (runId: string, text: string) => void;
+  dismissPendingSystem: (runId: string) => void;
   updateAssistant: (text: string, runId: string) => void;
   finalizeAssistant: (text: string, runId: string) => void;
   dropAssistant: (runId: string) => void;
@@ -131,7 +133,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
       flushPendingHistoryRefreshIfIdle();
-      chatLog.addSystem(STREAMING_WATCHDOG_USER_MESSAGE);
+      chatLog.addPendingSystem(runId, STREAMING_WATCHDOG_USER_MESSAGE);
       tui.requestRender();
     }, streamingWatchdogMs);
     const maybeUnref = (streamingWatchdogTimer as { unref?: () => void }).unref;
@@ -361,6 +363,10 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (reconnectPendingRunId === evt.runId) {
       reconnectPendingRunId = null;
     }
+    // Any chat event for a run that previously tripped the streaming watchdog
+    // is proof the response is no longer stuck — drop the stale notice so it
+    // doesn't sit alongside the recovered content.
+    chatLog.dismissPendingSystem(evt.runId);
     noteSessionRun(evt.runId);
     if (!state.activeChatRunId && !isLocalBtwRunId?.(evt.runId)) {
       state.activeChatRunId = evt.runId;

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -14,6 +14,8 @@ type EventHandlerChatLog = {
     options?: { partial?: boolean; isError?: boolean },
   ) => void;
   addSystem: (text: string) => void;
+  addPendingSystem: (runId: string, text: string) => void;
+  dismissPendingSystem: (runId: string) => void;
   updateAssistant: (text: string, runId: string) => void;
   finalizeAssistant: (text: string, runId: string) => void;
   dropAssistant: (runId: string) => void;
@@ -132,7 +134,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
       flushPendingHistoryRefreshIfIdle();
-      chatLog.addSystem(STREAMING_WATCHDOG_USER_MESSAGE);
+      chatLog.addPendingSystem(runId, STREAMING_WATCHDOG_USER_MESSAGE);
       tui.requestRender();
     }, streamingWatchdogMs);
     const maybeUnref = (streamingWatchdogTimer as { unref?: () => void }).unref;
@@ -398,6 +400,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (reconnectPendingRunId === evt.runId) {
       reconnectPendingRunId = null;
     }
+    chatLog.dismissPendingSystem(evt.runId);
     noteSessionRun(evt.runId);
     if (!state.activeChatRunId && !isLocalBtwRunId?.(evt.runId)) {
       state.activeChatRunId = evt.runId;


### PR DESCRIPTION
## Summary

The TUI streaming watchdog adds **"This response is taking longer than expected. Send another message to continue."** to the chat log after 30 s without a delta. When a chat delta or `final` then arrives — common for runs that were slow but not actually stuck — the notice persists next to the recovered response and contradicts what the user sees.

This change tracks the notice by `runId` and dismisses it from `handleChatEvent` whenever any further chat event for that run is processed, so the message disappears the moment the response continues. The watchdog's internal cleanup (`activeChatRunId` reset, status idle, deferred history reload) is unchanged, so genuinely stuck runs still show the notice and recover identically.

## Implementation

- `src/tui/components/chat-log.ts` — new `addPendingSystem(runId, text)` / `dismissPendingSystem(runId)` pair, keyed by `runId` (mirrors the existing `pendingUsers` map at `addPendingUser` / `dropPendingUser`). `clearAll` and `dropComponentReferences` updated.
- `src/tui/tui-event-handlers.ts` — watchdog timer routes through `addPendingSystem(runId, …)`, and `handleChatEvent` calls `dismissPendingSystem(evt.runId)` after early-return checks but before `noteSessionRun`, so any delta / final / aborted / error for the run drops a stale notice.
- Tests cover the happy-path display, dismissal on a late delta, dismissal on a late final, and the chat-log component contract.

## Related

- Refs #67052 ("TUI streaming indicator stays active long after response content finishes") — same surface, adjacent UX bug; this PR addresses the user-visible notice rather than the streaming-status indicator timing, so #67052 stays open.
- Refs #69081 (closed) — the watchdog desync issue whose tool/lifecycle proof-of-life fix already shipped on `main`.
- Prior attempt #69026 by @jpruit20 raised the threshold to 120 s and suppressed the notice entirely; this PR is the narrower fix that keeps the warning useful for genuinely stuck runs. #69026 can be closed in favor of this once merged.

## Verification

- `pnpm test src/tui/tui-event-handlers.test.ts src/tui/components/chat-log.test.ts` — 61 passed (including 2 new dismissal tests + 2 new chat-log tests).
- `pnpm exec oxfmt --check --threads=1 src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts src/tui/components/chat-log.ts src/tui/components/chat-log.test.ts CHANGELOG.md` — clean.
- `node scripts/run-oxlint.mjs src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts src/tui/components/chat-log.ts src/tui/components/chat-log.test.ts` — 0 warnings, 0 errors.
- `pnpm check:changed` — exit 0 (core + core-tests lanes selected).

## Test plan

- [ ] CI green
- [ ] Manual TUI: trigger a run that exceeds 30 s without a delta, see the notice; let the run continue and confirm the notice disappears once a delta/final arrives
- [ ] Manual TUI: trigger a genuinely stuck run (kill gateway mid-run); confirm the notice still appears and persists
