### PR TITLE
fix(plugins): memoize loadInstalledPluginIndexInstallRecordsSync on hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/loader: avoid redundant synchronous install-record file reads on every `resolvePluginTools()` call by memoizing the result for the process lifetime. Fixes #77348. Thanks @jared-rebel.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
 - Memory/wiki: preserve representation from both corpora in `corpus=all` searches while backfilling unused result capacity, so memory hits are not starved by numerically higher wiki integer scores. Fixes #77337. Thanks @hclsys.
 - Telegram: clean up tool-only draft previews after assistant message boundaries so transient `Surfacing...` tool-status bubbles do not linger when no matching final preview arrives. Thanks @BunsDev.

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -315,6 +315,8 @@ export function clearActivatedPluginRuntimeState(): void {
 
 export function clearPluginRegistryLoadCache(): void {
   pluginLoaderCacheState.clearCachedRegistries();
+  memoizedInstallRecords = null;
+  memoizedInstallRecordsEnvRef = null;
   fullWorkspacePluginLoaderCacheState.clearCachedRegistries();
 }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -245,6 +245,18 @@ type CachedPluginState = {
   memoryPromptSupplements: ReturnType<typeof listMemoryPromptSupplements>;
 };
 
+let memoizedInstallRecords: Record<string, PluginInstallRecord> | null = null;
+let memoizedInstallRecordsEnvRef: NodeJS.ProcessEnv | null = null;
+
+function getMemoizedInstallRecords(env: NodeJS.ProcessEnv): Record<string, PluginInstallRecord> {
+  if (memoizedInstallRecords !== null && memoizedInstallRecordsEnvRef === env) {
+    return memoizedInstallRecords;
+  }
+  memoizedInstallRecords = loadInstalledPluginIndexInstallRecordsSync({ env });
+  memoizedInstallRecordsEnvRef = env;
+  return memoizedInstallRecords;
+}
+
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
 const pluginLoaderCacheState = new PluginLoaderCacheState<CachedPluginState>(
   MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
@@ -286,6 +298,8 @@ function createPluginCandidatesFromManifestRegistry(
 export function clearPluginLoaderCache(): void {
   pluginLoaderCacheState.clear();
   fullWorkspacePluginLoaderCacheState.clear();
+  memoizedInstallRecords = null;
+  memoizedInstallRecordsEnvRef = null;
   clearActivatedPluginRuntimeState();
 }
 
@@ -1079,7 +1093,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
   const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
   const installRecords = {
-    ...loadInstalledPluginIndexInstallRecordsSync({ env }),
+    ...getMemoizedInstallRecords(env),
     ...cfg.plugins?.installs,
   };
   const cacheKey = buildCacheKey({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -282,6 +282,18 @@ type CachedPluginState = {
   memoryPromptSupplements: ReturnType<typeof listMemoryPromptSupplements>;
 };
 
+let memoizedInstallRecords: Record<string, PluginInstallRecord> | null = null;
+let memoizedInstallRecordsEnvRef: NodeJS.ProcessEnv | null = null;
+
+function getMemoizedInstallRecords(env: NodeJS.ProcessEnv): Record<string, PluginInstallRecord> {
+  if (memoizedInstallRecords !== null && memoizedInstallRecordsEnvRef === env) {
+    return memoizedInstallRecords;
+  }
+  memoizedInstallRecords = loadInstalledPluginIndexInstallRecordsSync({ env });
+  memoizedInstallRecordsEnvRef = env;
+  return memoizedInstallRecords;
+}
+
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
 const pluginLoaderCacheState = new PluginLoaderCacheState<CachedPluginState>(
   MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
@@ -328,6 +340,8 @@ function createPluginCandidatesFromManifestRegistry(
 export function clearPluginLoaderCache(): void {
   pluginLoaderCacheState.clear();
   fullWorkspacePluginLoaderCacheState.clear();
+  memoizedInstallRecords = null;
+  memoizedInstallRecordsEnvRef = null;
   clearActivatedPluginRuntimeState();
 }
 
@@ -344,6 +358,8 @@ export function clearActivatedPluginRuntimeState(): void {
 
 export function clearPluginRegistryLoadCache(): void {
   pluginLoaderCacheState.clearCachedRegistries();
+  memoizedInstallRecords = null;
+  memoizedInstallRecordsEnvRef = null;
   fullWorkspacePluginLoaderCacheState.clearCachedRegistries();
 }
 
@@ -1230,7 +1246,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
   const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
   const installRecords = {
-    ...(options.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env })),
+    ...(options.installRecords ?? getMemoizedInstallRecords(env)),
     ...cfg.plugins?.installs,
   };
   const cacheKey = buildCacheKey({


### PR DESCRIPTION
## Summary

- Memoize `loadInstalledPluginIndexInstallRecordsSync` result in `resolvePluginLoadCacheContext` so the sync file read does not fire on every `resolvePluginTools()` call, including LRU cache hits.
- Invalidate the memoized install records alongside the plugin loader cache in `clearPluginLoaderCache` and `clearPluginRegistryLoadCache`.

Install records do not change at runtime, so the synchronous file read was redundant after the first call. This was causing unnecessary I/O on every plugin tool resolution, compounding under concurrent embedded runs.

## Relationship to #85026

PR #85026 (merged) addresses the same root cause by threading `installRecords` through `PluginLoadOptions` from the upstream `PluginMetadataSnapshot`. That covers the primary hot paths where the snapshot is available.

This PR complements #85026 by memoizing the **fallback path**: when `options.installRecords` is not provided by upstream callers, `resolvePluginLoadCacheContext` still falls back to `loadInstalledPluginIndexInstallRecordsSync({ env })`. Without memoization, any code path that invokes `resolvePluginTools()` without passing install records will trigger a redundant synchronous file read on every call.

## Real behavior proof

**Behavior or issue addressed:** `resolvePluginLoadCacheContext` falls back to `loadInstalledPluginIndexInstallRecordsSync` (a synchronous file read) whenever `options.installRecords` is not provided by the caller. This fallback still fires on every `resolvePluginTools()` call, compounding under concurrent embedded runs (#77348). PR #85026 covers the main hot paths; this PR memoizes the remaining fallback.

**Real environment tested:** Node.js v22.22.0 on Linux (same runtime as OpenClaw production). Ran a benchmark script that simulates 100 consecutive fallback invocations with a 1.6 KB install records file (50 plugin entries), measuring file read count and elapsed time before and after the memoization patch.

**Exact steps or command run after the patch:**
```bash
node memoize_benchmark.mjs
```
The script creates a mock install records JSON file, then runs 100 iterations of the original (un-memoized) read and 100 iterations of the memoized version, counting `readFileSync` calls and measuring wall-clock time.

**Evidence after fix:**
```
=== Memoize Benchmark: loadInstalledPluginIndexInstallRecordsSync ===
Iterations: 100
Install records file size: 1.6 KB

WITHOUT memoization (original behavior):
  File reads: 100
  Total time: 4.95 ms

WITH memoization (this PR):
  File reads: 1
  Total time: 0.12 ms

Reduction:
  File reads eliminated: 99 (99%)
  Time saved: 4.83 ms (98%)
```

Independent community benchmark by @holgergruenhagen on a real OpenClaw 2026.5.7 setup (Linux VPS, Discord-driven) confirmed ~30% end-to-end latency reduction: MessageCreate latency dropped from 13.30s to 7.60s, and `loadOpenClawPlugins` calls dropped from 12× (4 MISS + 8 HIT) to 2× (0 MISS + 2 HIT). See [#77379 (comment)](https://github.com/openclaw/openclaw/pull/77379#issuecomment-4432687240).

**Observed result after the fix:** After applying the memoization patch, `loadInstalledPluginIndexInstallRecordsSync` is called only once instead of on every fallback invocation. The 100-iteration benchmark shows a 99% reduction in file reads (100 → 1) and a 98% reduction in wall-clock time (4.95 ms → 0.12 ms). Cache invalidation in `clearPluginLoaderCache` and `clearPluginRegistryLoadCache` correctly resets the memo, allowing a fresh read on the next call.

**What was not tested:** Live OpenClaw gateway with actual plugin lifecycle (load, hot-reload, registry update). The benchmark validates the I/O reduction of the memoization pattern in isolation.

Closes #77348