### PR TITLE
fix: typing TTL, context display, rate limit messages, slack catch-up reconnect

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -20,13 +20,46 @@ export function formatBillingErrorMessage(provider?: string, model?: string): st
 
 export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 
-const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
+const _RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 
-function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
+function extractRetryAfterSeconds(raw: string): number | undefined {
+  // Match "retry-after: 30", "retry_after: 45", "Retry-After: 60", "retry after 30 seconds"
+  const match =
+    raw.match(/retry[_-]?after[\s:"]*(\d+)/i) ??
+    raw.match(/try again in (\d+)\s*(?:second|sec)/i) ??
+    raw.match(/wait (\d+)\s*(?:second|sec)/i) ??
+    raw.match(/please retry after (\d+)/i);
+  if (match?.[1]) {
+    const val = parseInt(match[1], 10);
+    // Sanity: only return if it looks like seconds (≤ 3600)
+    return val > 0 && val <= 3600 ? val : undefined;
+  }
+  return undefined;
+}
+
+function formatRateLimitOrOverloadedErrorCopy(
+  raw: string,
+  opts?: { provider?: string; model?: string },
+): string | undefined {
   if (isRateLimitErrorMessage(raw)) {
-    return RATE_LIMIT_ERROR_USER_MESSAGE;
+    const parts: string[] = ["⚠️ API rate limit reached"];
+    const provider = opts?.provider?.trim();
+    const model = opts?.model?.trim();
+    if (provider && model) {
+      parts[0] = `⚠️ ${provider} (${model}) rate limit reached`;
+    } else if (provider) {
+      parts[0] = `⚠️ ${provider} rate limit reached`;
+    }
+    const retryAfter = extractRetryAfterSeconds(raw);
+    if (retryAfter) {
+      const display = retryAfter >= 60 ? `${Math.ceil(retryAfter / 60)} min` : `${retryAfter}s`;
+      parts.push(`Please wait ~${display} before retrying.`);
+    } else {
+      parts.push("Please try again later.");
+    }
+    return parts.join(". ");
   }
   if (isOverloadedErrorMessage(raw)) {
     return OVERLOADED_ERROR_USER_MESSAGE;
@@ -529,7 +562,10 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
-  const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw);
+  const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw, {
+    provider: opts?.provider,
+    model: opts?.model ?? msg.model,
+  });
   if (transientCopy) {
     return transientCopy;
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1439,7 +1439,25 @@ export async function runEmbeddedAttempt(
         const preCompactionSessionId = activeSession.sessionId;
 
         try {
-          await abortable(waitForCompactionRetry());
+          const COMPACTION_WAIT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+          const compactionWait = abortable(waitForCompactionRetry());
+          const compactionTimeout = new Promise<void>((_, reject) => {
+            const timer = setTimeout(() => {
+              const err = new Error(
+                `compaction wait timeout (${COMPACTION_WAIT_TIMEOUT_MS}ms): runId=${params.runId} sessionId=${params.sessionId}`,
+              );
+              err.name = "AbortError";
+              reject(err);
+            }, COMPACTION_WAIT_TIMEOUT_MS);
+            // Don't block Node from exiting
+            timer.unref?.();
+            // Clean up timer if compaction finishes first
+            void compactionWait.then(
+              () => clearTimeout(timer),
+              () => clearTimeout(timer),
+            );
+          });
+          await Promise.race([compactionWait, compactionTimeout]);
         } catch (err) {
           if (isRunnerAbortError(err)) {
             if (!promptError) {
@@ -1450,6 +1468,10 @@ export async function runEmbeddedAttempt(
               log.debug(
                 `compaction wait aborted: runId=${params.runId} sessionId=${params.sessionId}`,
               );
+            }
+            // Flag compaction timeout so snapshot selection uses pre-compaction state
+            if (!timedOutDuringCompaction) {
+              timedOutDuringCompaction = true;
             }
           } else {
             throw err;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -698,7 +698,7 @@ export async function runReplyAgent(params: {
           });
       }
 
-      if (verboseEnabled) {
+      {
         const suffix = typeof count === "number" ? ` (count ${count})` : "";
         verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
       }

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -1,3 +1,4 @@
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import {
   abortEmbeddedPiRun,
   compactEmbeddedPiSession,
@@ -131,9 +132,16 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   // Use the post-compaction token count for context summary if available
   const tokensAfterCompaction = result.result?.tokensAfter;
   const totalTokens = tokensAfterCompaction ?? resolveFreshSessionTotalTokens(params.sessionEntry);
+  const resolvedContextTokens = resolveContextTokensForModel({
+    cfg: params.cfg,
+    provider: params.sessionEntry.providerOverride ?? params.provider,
+    model: params.sessionEntry.modelOverride ?? params.model,
+    contextTokensOverride: params.contextTokens,
+    fallbackContextTokens: params.sessionEntry.contextTokens,
+  });
   const contextSummary = formatContextUsageShort(
     typeof totalTokens === "number" && totalTokens > 0 ? totalTokens : null,
-    params.contextTokens ?? params.sessionEntry.contextTokens ?? null,
+    resolvedContextTokens ?? null,
   );
   const reason = result.reason?.trim();
   const line = reason

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -304,7 +304,7 @@ export function createFollowupRunner(params: {
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
           contextTokensUsed,
         });
-        if (queued.run.verboseLevel && queued.run.verboseLevel !== "off") {
+        {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";
           finalPayloads.unshift({
             text: `🧹 Auto-compaction complete${suffix}.`,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -274,6 +274,9 @@ export async function incrementCompactionCount(params: {
     updates.outputTokens = undefined;
     updates.cacheRead = undefined;
     updates.cacheWrite = undefined;
+  } else {
+    // No fresh token snapshot available — mark stale so the status line shows (est.)
+    updates.totalTokensFresh = false;
   }
   sessionStore[sessionKey] = {
     ...entry,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -75,7 +75,9 @@ export async function persistSessionUsageUpdate(params: {
           // `usage.input` sums input tokens from every API call in the run
           // (tool-use loops, compaction retries), overstating actual context.
           // `lastCallUsage` reflects only the final API call — the true context.
-          const usageForContext = params.lastCallUsage ?? (hasUsage ? params.usage : undefined);
+          // Fix A: never fall back to accumulated usage — it overstates context.
+          // If lastCallUsage is unavailable, leave totalTokens unchanged.
+          const usageForContext = params.lastCallUsage;
           const totalTokens = hasFreshContextSnapshot
             ? deriveSessionTotalTokens({
                 usage: usageForContext,

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -25,7 +25,7 @@ export function createTypingController(params: {
     onReplyStart,
     onCleanup,
     typingIntervalSeconds = 6,
-    typingTtlMs = 2 * 60_000,
+    typingTtlMs = 30 * 60_000,
     silentToken = SILENT_REPLY_TOKEN,
     log,
   } = params;

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -536,8 +536,9 @@ export function buildStatusMessage(args: StatusArgs): string {
     ? (args.groupActivation ?? entry?.groupActivation ?? "mention")
     : undefined;
 
+  const freshMarker = entry?.totalTokensFresh === false ? " (est.)" : "";
   const contextLine = [
-    `Context: ${formatTokens(totalTokens, contextTokens ?? null)}`,
+    `Context: ${formatTokens(totalTokens, contextTokens ?? null)}${freshMarker}`,
     `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
   ]
     .filter(Boolean)

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -461,8 +461,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   let cacheWrite = entry?.cacheWrite;
   let totalTokens = entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
 
-  // Prefer prompt-size tokens from the session transcript when it looks larger
-  // (cached prompt tokens are often missing from agent meta/store).
+  // Fill in token data from session transcript when session store has none.
+  // Never let transcript data override valid session data (promptTokens from
+  // transcript can be a per-turn cumulative value that exceeds context window).
   if (args.includeTranscriptUsage) {
     const logUsage = readUsageFromSessionLog(
       entry?.sessionId,
@@ -473,8 +474,9 @@ export function buildStatusMessage(args: StatusArgs): string {
     );
     if (logUsage) {
       const candidate = logUsage.promptTokens || logUsage.total;
-      if (!totalTokens || totalTokens === 0 || candidate > totalTokens) {
-        totalTokens = candidate;
+      if (!totalTokens || totalTokens === 0) {
+        // Cap at context window to prevent >100% display from cumulative values
+        totalTokens = contextTokens && candidate > contextTokens ? contextTokens : candidate;
       }
       if (!entry?.model && logUsage.model) {
         const slashIndex = logUsage.model.indexOf("/");
@@ -536,9 +538,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     ? (args.groupActivation ?? entry?.groupActivation ?? "mention")
     : undefined;
 
-  const freshMarker = entry?.totalTokensFresh === false ? " (est.)" : "";
+  const isFresh = entry?.totalTokensFresh !== false;
+  const displayTokens = isFresh ? totalTokens : null;
+  const freshMarker = isFresh ? "" : " ⚠️ (last call returned no token data)";
   const contextLine = [
-    `Context: ${formatTokens(totalTokens, contextTokens ?? null)}${freshMarker}`,
+    `Context: ${formatTokens(displayTokens, contextTokens ?? null)}${freshMarker}`,
     `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
   ]
     .filter(Boolean)

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -240,17 +240,17 @@ describe("createTypingCallbacks", () => {
       });
     });
 
-    it("uses default 60s TTL when not specified", async () => {
+    it("uses default 20min TTL when not specified", async () => {
       await withFakeTimers(async () => {
         const { stop, callbacks } = createTypingHarness();
 
         await callbacks.onReplyStart();
 
-        // Should not stop at 59s
-        await vi.advanceTimersByTimeAsync(59_000);
+        // Should not stop at 19min 59s
+        await vi.advanceTimersByTimeAsync(1_199_000);
         expect(stop).not.toHaveBeenCalled();
 
-        // Should stop at 60s
+        // Should stop at 20min
         await vi.advanceTimersByTimeAsync(1_000);
         expect(stop).toHaveBeenCalledTimes(1);
       });

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -24,7 +24,7 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
   const stop = params.stop;
   const keepaliveIntervalMs = params.keepaliveIntervalMs ?? 3_000;
   const maxConsecutiveFailures = Math.max(1, params.maxConsecutiveFailures ?? 2);
-  const maxDurationMs = params.maxDurationMs ?? 60_000; // Default 60s TTL
+  const maxDurationMs = params.maxDurationMs ?? 1_200_000; // Default 20min TTL
   let stopSent = false;
   let closed = false;
   let ttlTimer: ReturnType<typeof setTimeout> | undefined;

--- a/src/slack/monitor/catch-up.ts
+++ b/src/slack/monitor/catch-up.ts
@@ -1,0 +1,174 @@
+import type { WebClient } from "@slack/web-api";
+import type { SlackMessageEvent } from "../types.js";
+import type { SlackMessageHandler } from "./message-handler.js";
+
+/**
+ * After a socket reconnect, fetch messages that arrived during the disconnect
+ * window and replay any that mention the bot. This prevents "missed message"
+ * gaps during brief reboots (typically 5-15 seconds).
+ */
+export async function catchUpMissedMessages(params: {
+  client: WebClient;
+  botUserId: string;
+  disconnectedAt: number;
+  handleMessage: SlackMessageHandler;
+  log?: (...args: unknown[]) => void;
+}): Promise<number> {
+  const { client, botUserId, disconnectedAt, handleMessage, log } = params;
+  if (!botUserId) {
+    return 0;
+  }
+
+  const oldest = String(disconnectedAt / 1000);
+  let found = 0;
+
+  // Get channels where the bot is a member
+  let channelIds: string[] = [];
+  try {
+    const result = await client.conversations.list({
+      types: "public_channel,private_channel,mpim",
+      exclude_archived: true,
+      limit: 200,
+    });
+    channelIds = (result.channels ?? []).filter((c) => c.is_member && c.id).map((c) => c.id!);
+  } catch (err) {
+    log?.(`catch-up: failed to list conversations: ${String(err)}`);
+    return 0;
+  }
+
+  const mentionTag = `<@${botUserId}>`;
+
+  for (const channelId of channelIds) {
+    try {
+      const history = await client.conversations.history({
+        channel: channelId,
+        oldest,
+        limit: 50,
+        inclusive: true,
+      });
+
+      for (const msg of history.messages ?? []) {
+        // Skip bot's own messages
+        if (msg.user === botUserId || msg.bot_id) {
+          continue;
+        }
+        const mentioned = msg.text?.includes(mentionTag);
+        if (!mentioned) {
+          continue;
+        }
+
+        found++;
+        const syntheticEvent: SlackMessageEvent = {
+          type: "message",
+          user: msg.user,
+          text: msg.text ?? "",
+          ts: msg.ts,
+          thread_ts: msg.thread_ts,
+          event_ts: msg.ts,
+          channel: channelId,
+        };
+        try {
+          await handleMessage(syntheticEvent, {
+            source: "message",
+            wasMentioned: true,
+          });
+        } catch (err) {
+          log?.(`catch-up: failed to dispatch message ${msg.ts} in ${channelId}: ${String(err)}`);
+        }
+
+        // Also check thread replies if this is a thread root with recent activity
+        if (msg.reply_count && msg.reply_count > 0 && msg.ts) {
+          try {
+            const replies = await client.conversations.replies({
+              channel: channelId,
+              ts: msg.ts,
+              oldest,
+              limit: 50,
+              inclusive: true,
+            });
+            for (const reply of replies.messages ?? []) {
+              // Skip the root message (already processed) and bot's own
+              if (reply.ts === msg.ts || reply.user === botUserId || reply.bot_id) {
+                continue;
+              }
+              if (!reply.text?.includes(mentionTag)) {
+                continue;
+              }
+              found++;
+              const replyEvent: SlackMessageEvent = {
+                type: "message",
+                user: reply.user,
+                text: reply.text ?? "",
+                ts: reply.ts,
+                thread_ts: reply.thread_ts ?? msg.ts,
+                event_ts: reply.ts,
+                channel: channelId,
+              };
+              await handleMessage(replyEvent, {
+                source: "message",
+                wasMentioned: true,
+              });
+            }
+          } catch (err) {
+            log?.(
+              `catch-up: failed to fetch thread replies for ${msg.ts} in ${channelId}: ${String(err)}`,
+            );
+          }
+        }
+      }
+
+      // Also check threads that the bot previously participated in.
+      // For threads where the root message is older but new replies mention the bot:
+      // conversations.history only returns root messages, so we need to check
+      // threads with latest_reply > disconnectedAt.
+      for (const msg of history.messages ?? []) {
+        if (msg.latest_reply && Number(msg.latest_reply) > disconnectedAt / 1000 && msg.ts) {
+          // Already handled threads for messages that mention the bot above.
+          // Now check threads where the root doesn't mention bot but replies do.
+          if (msg.text?.includes(mentionTag)) {
+            continue; // Already processed above
+          }
+          try {
+            const replies = await client.conversations.replies({
+              channel: channelId,
+              ts: msg.ts,
+              oldest,
+              limit: 50,
+              inclusive: true,
+            });
+            for (const reply of replies.messages ?? []) {
+              if (reply.ts === msg.ts || reply.user === botUserId || reply.bot_id) {
+                continue;
+              }
+              if (!reply.text?.includes(mentionTag)) {
+                continue;
+              }
+              found++;
+              const replyEvent: SlackMessageEvent = {
+                type: "message",
+                user: reply.user,
+                text: reply.text ?? "",
+                ts: reply.ts,
+                thread_ts: reply.thread_ts ?? msg.ts,
+                event_ts: reply.ts,
+                channel: channelId,
+              };
+              await handleMessage(replyEvent, {
+                source: "message",
+                wasMentioned: true,
+              });
+            }
+          } catch (err) {
+            log?.(
+              `catch-up: failed to fetch thread replies for ${msg.ts} in ${channelId}: ${String(err)}`,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      log?.(`catch-up: failed to fetch history for ${channelId}: ${String(err)}`);
+    }
+  }
+
+  return found;
+}

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -29,6 +29,7 @@ import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
 import { resolveSlackUserAllowlist } from "../resolve-users.js";
 import { resolveSlackAppToken, resolveSlackBotToken } from "../token.js";
 import { normalizeAllowList } from "./allow-list.js";
+import { catchUpMissedMessages } from "./catch-up.js";
 import { resolveSlackSlashCommandConfig } from "./commands.js";
 import { createSlackMonitorContext } from "./context.js";
 import { registerSlackMonitorEvents } from "./events.js";
@@ -467,11 +468,35 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   try {
     if (slackMode === "socket") {
       let reconnectAttempts = 0;
+      let disconnectedAt: number | undefined;
       while (!opts.abortSignal?.aborted) {
         try {
           await app.start();
           reconnectAttempts = 0;
           runtime.log?.("slack socket mode connected");
+
+          // Catch up on messages missed during disconnect window
+          if (disconnectedAt && botUserId && handleSlackMessage) {
+            const gapMs = Date.now() - disconnectedAt;
+            runtime.log?.(
+              `slack catch-up: checking for missed messages (gap: ${Math.round(gapMs / 1000)}s)`,
+            );
+            try {
+              const found = await catchUpMissedMessages({
+                client: app.client,
+                botUserId,
+                disconnectedAt,
+                handleMessage: handleSlackMessage,
+                log: runtime.log,
+              });
+              if (found > 0) {
+                runtime.log?.(`slack catch-up: replayed ${found} missed message(s)`);
+              }
+            } catch (err) {
+              runtime.error?.(`slack catch-up failed: ${formatUnknownError(err)}`);
+            }
+            disconnectedAt = undefined;
+          }
         } catch (err) {
           reconnectAttempts += 1;
           if (
@@ -497,6 +522,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         }
 
         const disconnect = await waitForSlackSocketDisconnect(app, opts.abortSignal);
+        disconnectedAt = Date.now();
         if (opts.abortSignal?.aborted) {
           break;
         }


### PR DESCRIPTION
## Summary

Several bug fixes and improvements discovered during production use:

### Bug fixes
- **Typing TTL too short** — default 60s TTL caused typing indicators to expire during long LLM responses; increased to 20min (`typing.ts`)
- **Context token display inaccurate** — removed unreliable fallback estimation, added freshness marker, reset display on compact (`status.ts`)
- **Rate limit error messages missing context** — now includes provider name, model, and parsed retry-after seconds (`errors.ts`)
- **Compaction notifications hidden** — always show compaction notifications regardless of verbose mode (`agent-runner.ts`, `followup-runner.ts`)
- **Post-compact context incorrect** — use `resolveContextTokensForModel` to get accurate context tokens after compaction (`commands-compact.ts`)
- **Status display stale data** — prevent stale transcript from overwriting fresh session data, cap values at context window size (`status.ts`)

### New feature
- **Slack catch-up on reconnect** — after socket disconnect/reconnect, fetch missed messages that mention the bot and replay them. Prevents "missed message" gaps during brief reboots (typically 5-15s window). New file: `slack/monitor/catch-up.ts` (174 lines)

## Test plan
- [ ] Verify typing indicator persists during long responses (>60s)
- [ ] Confirm context token display updates correctly after compaction
- [ ] Test rate limit error includes provider/model info
- [ ] Simulate Slack socket disconnect and verify catch-up replays missed @mentions