### PR TITLE
fix(acp): expose listSessions for SDK v0.16+ dispatcher (#48279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP/translator: expose `listSessions` on `AcpGatewayAgent` so SDK v0.16+ dispatcher routes `session/list` to the new canonical method instead of returning `"Method not found": session/list` (OpenClaw is pinned at SDK `0.21.0`). The legacy `unstable_listSessions` name is kept as a thin alias delegating to the same private implementation, so embedded callers still on SDK `< 0.16.0` continue to work. Fixes #48279. Thanks @thezzisu.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
 - Memory/wiki: preserve representation from both corpora in `corpus=all` searches while backfilling unused result capacity, so memory hits are not starved by numerically higher wiki integer scores. Fixes #77337. Thanks @hclsys.
 - Telegram: clean up tool-only draft previews after assistant message boundaries so transient `Surfacing...` tool-status bubbles do not linger when no matching final preview arrives. Thanks @BunsDev.

--- a/src/acp/translator.list-sessions.test.ts
+++ b/src/acp/translator.list-sessions.test.ts
@@ -1,0 +1,214 @@
+import type { ListSessionsRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import { createInMemorySessionStore } from "./session.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+/**
+ * Regression coverage for the `session/list` JSON-RPC route across ACP
+ * TypeScript SDK v0.16.0+ (see [Github #48279]).
+ *
+ * SDK v0.16.0 renamed `unstable_listSessions` to `listSessions`. The SDK
+ * dispatcher routes `session/list` by looking up `listSessions` on the
+ * agent handler, so an agent that only implements `unstable_listSessions`
+ * silently produces `"Method not found": session/list` for every call
+ * under SDK ≥ 0.16.0 (OpenClaw is pinned at `0.21.0`).
+ *
+ * These tests pin both the new canonical name and the legacy alias so a
+ * future SDK rename, or an accidental drop of the alias before all
+ * downstream callers migrate, fails in this file rather than silently in
+ * production.
+ */
+
+type GatewayRequest = GatewayClient["request"];
+
+function createListSessionsRequest(
+  overrides: Partial<ListSessionsRequest> = {},
+): ListSessionsRequest {
+  return {
+    cwd: "/tmp/openclaw-test",
+    ...overrides,
+  } as ListSessionsRequest;
+}
+
+function buildAgent(request: GatewayRequest): AcpGatewayAgent {
+  const sessionStore = createInMemorySessionStore();
+  return new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+    sessionStore,
+  });
+}
+
+function createGatewayStub(
+  sessions: Array<{
+    key: string;
+    displayName?: string;
+    label?: string;
+    kind?: string;
+    channel?: string;
+    updatedAt?: number;
+  }>,
+): { request: GatewayRequest; calls: Parameters<GatewayRequest>[] } {
+  const calls: Parameters<GatewayRequest>[] = [];
+  const request = (async (...args: Parameters<GatewayRequest>) => {
+    calls.push(args);
+    if (args[0] === "sessions.list") {
+      return { sessions };
+    }
+    return { ok: true };
+  }) as GatewayRequest;
+  return { request, calls };
+}
+
+describe("AcpGatewayAgent listSessions (#48279)", () => {
+  it("exposes `listSessions` as a method (SDK v0.16+ dispatcher contract)", () => {
+    // The SDK v0.16+ dispatcher routes `session/list` by looking up the
+    // method name `listSessions` on the agent handler. If a future
+    // refactor accidentally removes or renames the public method, this
+    // assertion fails here rather than producing
+    // `"Method not found": session/list` in production.
+    const agent = buildAgent(createGatewayStub([]).request);
+    expect(typeof (agent as unknown as { listSessions?: unknown }).listSessions).toBe("function");
+  });
+
+  it("preserves `unstable_listSessions` as a backward-compat alias", () => {
+    // SDK versions `< 0.16.0` dispatched to `unstable_listSessions`. The
+    // alias is intentionally kept so embedded consumers still on the
+    // older SDK keep working without a parallel implementation drifting
+    // out of sync.
+    const agent = buildAgent(createGatewayStub([]).request);
+    expect(
+      typeof (agent as unknown as { unstable_listSessions?: unknown }).unstable_listSessions,
+    ).toBe("function");
+  });
+
+  it("returns the gateway-supplied sessions mapped to ACP shape via the new name", async () => {
+    const { request, calls } = createGatewayStub([
+      {
+        key: "agent:main:telegram:direct:user-1",
+        displayName: "User One",
+        kind: "direct",
+        channel: "telegram",
+        updatedAt: 1_700_000_000_000,
+      },
+      {
+        key: "agent:main:slack:dm:user-2",
+        label: "User Two",
+        kind: "dm",
+        channel: "slack",
+      },
+      {
+        key: "agent:main:headless",
+        kind: "headless",
+      },
+    ]);
+    const agent = buildAgent(request);
+
+    const response = await agent.listSessions(createListSessionsRequest());
+
+    expect(calls).toEqual([["sessions.list", { limit: 100 }]]);
+    expect(response.nextCursor).toBeNull();
+    expect(response.sessions).toEqual([
+      {
+        sessionId: "agent:main:telegram:direct:user-1",
+        cwd: "/tmp/openclaw-test",
+        title: "User One",
+        updatedAt: new Date(1_700_000_000_000).toISOString(),
+        _meta: {
+          sessionKey: "agent:main:telegram:direct:user-1",
+          kind: "direct",
+          channel: "telegram",
+        },
+      },
+      {
+        sessionId: "agent:main:slack:dm:user-2",
+        cwd: "/tmp/openclaw-test",
+        title: "User Two",
+        updatedAt: undefined,
+        _meta: {
+          sessionKey: "agent:main:slack:dm:user-2",
+          kind: "dm",
+          channel: "slack",
+        },
+      },
+      {
+        // No displayName / label → falls back to the session key for the title.
+        sessionId: "agent:main:headless",
+        cwd: "/tmp/openclaw-test",
+        title: "agent:main:headless",
+        updatedAt: undefined,
+        _meta: {
+          sessionKey: "agent:main:headless",
+          kind: "headless",
+          channel: undefined,
+        },
+      },
+    ]);
+  });
+
+  it("the alias and the canonical method return identical responses for the same input", async () => {
+    const fixture = [
+      {
+        key: "agent:main:webchat",
+        displayName: "Web",
+        kind: "webchat",
+        channel: "webchat",
+        updatedAt: 1_710_000_000_000,
+      },
+    ];
+    const stub1 = createGatewayStub(fixture);
+    const agent1 = buildAgent(stub1.request);
+    const viaCanonical = await agent1.listSessions(createListSessionsRequest());
+
+    const stub2 = createGatewayStub(fixture);
+    const agent2 = buildAgent(stub2.request);
+    const viaAlias = await agent2.unstable_listSessions(createListSessionsRequest());
+
+    expect(viaAlias).toEqual(viaCanonical);
+    expect(stub1.calls).toEqual(stub2.calls);
+  });
+
+  it("honors a custom limit passed in `_meta.limit`", async () => {
+    const { request, calls } = createGatewayStub([]);
+    const agent = buildAgent(request);
+
+    await agent.listSessions(
+      createListSessionsRequest({
+        _meta: { limit: 25 },
+      } as Partial<ListSessionsRequest>),
+    );
+
+    expect(calls).toEqual([["sessions.list", { limit: 25 }]]);
+  });
+
+  it("defaults the limit to 100 when `_meta.limit` is missing", async () => {
+    const { request, calls } = createGatewayStub([]);
+    const agent = buildAgent(request);
+
+    await agent.listSessions(createListSessionsRequest());
+
+    expect(calls).toEqual([["sessions.list", { limit: 100 }]]);
+  });
+
+  it("falls back to `process.cwd()` when the request omits cwd", async () => {
+    const { request } = createGatewayStub([{ key: "agent:main:webchat", kind: "webchat" }]);
+    const agent = buildAgent(request);
+
+    const response = await agent.listSessions({
+      // SDK schema marks cwd as required, but defensive runtime callers
+      // can omit it. The implementation uses `process.cwd()` as the
+      // fallback so the response always has a cwd field.
+    } as ListSessionsRequest);
+
+    expect(response.sessions[0]?.cwd).toBe(process.cwd());
+  });
+
+  it("returns an empty session list with `nextCursor: null` when the gateway has no sessions", async () => {
+    const { request } = createGatewayStub([]);
+    const agent = buildAgent(request);
+
+    const response = await agent.listSessions(createListSessionsRequest());
+
+    expect(response).toEqual({ sessions: [], nextCursor: null });
+  });
+});

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -605,7 +605,42 @@ export class AcpGatewayAgent implements Agent {
     return { configOptions, modes };
   }
 
+  /**
+   * Handle `session/list` requests from the ACP TypeScript SDK.
+   *
+   * SDK v0.16.0 renamed `unstable_listSessions` to `listSessions`
+   * ([release notes](https://github.com/agentclientprotocol/typescript-sdk/releases/tag/v0.16.0)),
+   * and the SDK's dispatcher routes the JSON-RPC `session/list` method by
+   * looking for a function named `listSessions` on the agent handler.
+   * OpenClaw's pinned SDK version is `0.21.0`, so the dispatcher already
+   * expects the new name; the prior `unstable_listSessions`-only
+   * implementation matched no SDK-side route and produced
+   * `"Method not found": session/list` on every call (see [Github #48279]).
+   *
+   * `listSessions` is the canonical entrypoint going forward. The
+   * `unstable_listSessions` alias below is preserved as a thin shim so
+   * any caller still binding the older name (e.g. an embedded SDK
+   * version `< 0.16.0` in a downstream consumer) continues to work
+   * without a parallel implementation drifting out of sync.
+   */
+  async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
+    return this._listSessionsImpl(params);
+  }
+
+  /**
+   * Backward-compatible alias for {@link listSessions}.
+   *
+   * Kept for embedded callers still on ACP TypeScript SDK `< 0.16.0`,
+   * which dispatched `session/list` to the `unstable_listSessions`
+   * method. Newer SDK versions never look for this name. Both methods
+   * delegate to {@link _listSessionsImpl} so the two surfaces cannot
+   * drift out of sync.
+   */
   async unstable_listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
+    return this._listSessionsImpl(params);
+  }
+
+  private async _listSessionsImpl(params: ListSessionsRequest): Promise<ListSessionsResponse> {
     const limit = readNumber(params._meta, ["limit"]) ?? 100;
     const result = await this.gateway.request<SessionsListResult>("sessions.list", { limit });
     const cwd = params.cwd ?? process.cwd();


### PR DESCRIPTION
```
### Summary

Reported by @thezzisu in #48279: every ACP `session/list` request fails
with `"Method not found": session/list` because OpenClaw's
`AcpGatewayAgent` only implements `unstable_listSessions`, while the
ACP TypeScript SDK v0.16.0 renamed the dispatch target to
`listSessions`. OpenClaw's pinned SDK version is `0.21.0`, so the
dispatcher always looks for the new name and never finds a handler.

clawsweeper-bot's review confirms this is the right fix shape:

> Expose `listSessions` on `AcpGatewayAgent` using the existing
> Gateway-backed session-list logic, keep `unstable_listSessions` as a
> thin alias if compatibility is desired, and add dispatcher-level
> regression coverage for `session/list` so future ACP SDK method-name
> changes fail in tests.

The prior fix attempt #48292 was closed unmerged after sprawling into
unrelated `QMD_BINARY_CHECK_CACHE` work, `closeAllMemoryIndexManagers`
adds, and a UI form-coerce fix — Aisle flagged 4 security issues on
the bundled changes. This PR re-does **only** the listSessions rename
with the backward-compat alias clawsweeper recommended, no other files
touched outside the dedicated test.

### Fix

`src/acp/translator.ts`:

1. `listSessions(params)` is the new canonical method (matches SDK
   v0.16+ dispatcher).
2. `unstable_listSessions(params)` becomes a thin alias delegating to
   the same private `_listSessionsImpl(params)`. Kept for embedded
   consumers still on SDK `< 0.16.0`.
3. Both public methods delegate to a single private
   `_listSessionsImpl(params)` so the two surfaces cannot drift out of
   sync if the implementation evolves.

No call-site changes elsewhere — the rename is dispatcher-side, not
caller-side, and existing internal call sites (if any) keep working
through the alias.

### Tests

`src/acp/translator.list-sessions.test.ts` (new file, 8 cases):

- **Dispatcher contract — canonical**: asserts
  `typeof agent.listSessions === "function"` so any future refactor
  that drops or renames the method fails here rather than silently in
  production with `"Method not found": session/list`.
- **Dispatcher contract — alias**: asserts
  `typeof agent.unstable_listSessions === "function"` so the
  backward-compat alias is preserved.
- **Response shape via canonical name**: full mapping check (3
  sessions with mixed displayName/label/missing-title cases) →
  asserts gateway request shape `["sessions.list", { limit: 100 }]`,
  `nextCursor: null`, and the per-session ACP envelope.
- **Alias parity**: asserts the alias and the canonical method return
  identical responses for the same input fixture (proves the
  delegation has not drifted).
- **Custom limit**: `_meta.limit: 25` → gateway request carries
  `{ limit: 25 }`.
- **Default limit**: `_meta` missing → gateway request carries
  `{ limit: 100 }`.
- **cwd fallback**: request without `cwd` → response uses
  `process.cwd()`.
- **Empty-list shape**: gateway returns no sessions → response is
  `{ sessions: [], nextCursor: null }`.

### Verification

- `pnpm test src/acp/translator.list-sessions.test.ts` → 8/8 pass.
- `pnpm test src/acp` → 1/1 pass (no other ACP test files exist; the
  full ACP suite under this changed-gate lane runs cleanly).
- `pnpm exec oxfmt --check --threads=1 src/acp/translator.ts src/acp/translator.list-sessions.test.ts` → clean.

Fixes #48279.
```