### PR TITLE
fix(active-memory): skip colon-containing session-store channels to prevent crash with QQ c2c agent IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Plugins/active-memory: skip session-store channel entries that contain `:` when resolving the recall subagent's channel, so QQ c2c agent IDs (e.g. `c2c:10D4F7C2…`) and other scoped conversation IDs do not reach bundled-plugin `dirName` validation and crash the recall run. The same guard already applied to explicit `channelId` params (#76704); this extends it to store-derived channels. (#77396)
+- Plugins/active-memory: skip session-store channel entries that contain `:` when resolving the recall subagent's channel, so QQ c2c agent IDs (e.g. `c2c:10D4F7C2…`) and other scoped conversation IDs do not reach bundled-plugin `dirName` validation and crash the recall run. The same guard already applied to explicit `channelId` params (#76704); this extends it to store-derived channels. (#77396) Thanks @hclsys.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/active-memory: skip session-store channel entries that contain `:` when resolving the recall subagent's channel, so QQ c2c agent IDs (e.g. `c2c:10D4F7C2…`) and other scoped conversation IDs do not reach bundled-plugin `dirName` validation and crash the recall run. The same guard already applied to explicit `channelId` params (#76704); this extends it to store-derived channels. (#77396)
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -2753,6 +2753,33 @@ describe("active-memory plugin", () => {
     });
   });
 
+  it("skips colon-containing session-store channels for embedded recall (#77396)", async () => {
+    hoisted.sessionStore["agent:main:qqbot:direct:12345"] = {
+      sessionId: "session-a",
+      updatedAt: 25,
+      channel: "c2c:10D4F7C2",
+      origin: {
+        provider: "qqbot",
+      },
+    };
+
+    await hooks.before_prompt_build(
+      { prompt: "what wings should i order? scoped stored channel", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:qqbot:direct:12345",
+        messageProvider: "qqbot",
+        channelId: "qqbot",
+      },
+    );
+
+    expect(runEmbeddedPiAgent.mock.calls.at(-1)?.[0]).toMatchObject({
+      messageChannel: "qqbot",
+      messageProvider: "qqbot",
+    });
+  });
+
   it("preserves an explicit real channel hint over a stale stored wrapper channel", async () => {
     hoisted.sessionStore["agent:main:telegram:direct:12345"] = {
       sessionId: "session-a",

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -560,9 +560,17 @@ function resolveRecallRunChannelContext(params: {
       store,
       sessionKey: resolvedSessionKey,
     }).existing;
-    const strongEntryChannel =
+    const rawStrongEntryChannel =
       normalizeOptionalString(sessionEntry?.lastChannel) ??
       normalizeOptionalString(sessionEntry?.channel);
+    // Channel IDs containing ":" are scoped conversation IDs (e.g. QQ c2c
+    // "c2c:10D4F7C2..."), not runnable channel names. The same guard that
+    // applies to explicit channelId (#76704) must also apply to channels
+    // read from the session store (#77396).
+    const strongEntryChannel =
+      rawStrongEntryChannel && !rawStrongEntryChannel.includes(":")
+        ? rawStrongEntryChannel
+        : undefined;
     const weakEntryChannel = normalizeOptionalString(sessionEntry?.origin?.provider);
     return resolveReturnValue({
       resolvedChannel: strongEntryChannel ?? weakEntryChannel,


### PR DESCRIPTION
## Problem

When a session's `lastChannel` or `channel` field contains `:` (e.g. QQ c2c agent IDs like `c2c:10D4F7C2...`), `resolveRecallRunChannelContext` used it as-is as the resolved channel. This value then flowed through `runEmbeddedPiAgent` → `session-conversation.ts` → `normalizeBundledPluginDirName`, which rejects any name containing `:`, crashing the recall run entirely.

## Fix

Apply the same colon guard that already exists for explicit `channelId` params (added in #76704) to channels read from the session store (`sessionEntry.lastChannel` / `sessionEntry.channel`). A raw channel containing `:` is treated as a scoped conversation ID rather than a runnable channel name, and the code falls back to `sessionEntry.origin?.provider` (the weak channel).

```typescript
// Before
const strongEntryChannel =
  normalizeOptionalString(sessionEntry?.lastChannel) ??
  normalizeOptionalString(sessionEntry?.channel);

// After
const rawStrongEntryChannel =
  normalizeOptionalString(sessionEntry?.lastChannel) ??
  normalizeOptionalString(sessionEntry?.channel);
const strongEntryChannel =
  rawStrongEntryChannel && !rawStrongEntryChannel.includes(":")
    ? rawStrongEntryChannel
    : undefined;
```

## Test plan

- [x] All existing `extensions/active-memory/` tests pass (109/109)
- [x] `pnpm oxlint extensions/active-memory/index.ts` — 0 warnings, 0 errors
- Manually verified the guard matches the pattern used for `explicitChannel` at line ~543

Fixes #77396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)