### PR TITLE
fix(web-chat): stop action icons from overlapping short messages (#58702)

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -238,7 +238,7 @@ img.chat-avatar {
   background: transparent;
 }
 
-.chat-bubble.has-copy {
+.chat-bubble.has-copy:hover {
   padding-right: 70px;
 }
 
@@ -279,10 +279,14 @@ img.chat-avatar {
   pointer-events: auto;
 }
 
-@media (hover: none) {
+@media (hover: none) and (pointer: coarse) {
   .chat-bubble-actions {
     opacity: 1;
     pointer-events: auto;
+  }
+
+  .chat-bubble.has-copy {
+    padding-right: 70px;
   }
 }
 


### PR DESCRIPTION
## Problem

After upgrading to 2026.3.31, the chat bubble action icons (copy/expand) stopped respecting hover — they'd permanently sit on top of message text on some devices. Short messages were visually clipped even when icons weren't visible.

Two root causes:

**1. `@media (hover: none)` too broad**
The media query correctly makes icons always-visible on touch-only devices, but `hover: none` also fires on hybrid pointer/touch devices (touch laptops, Surface, some MacBook trackpad configurations). Adding `and (pointer: coarse)` scopes it to actual finger-touch-only devices.

**2. `.chat-bubble.has-copy` padding always applied**
`padding-right: 70px` was unconditionally applied whenever a bubble had actions, even on hover-capable devices where icons are hidden. On short single-line messages, this unnecessarily narrowed the visible text area. Moved to `:hover` selector so the padding only kicks in when icons actually appear. The touch block gets the unconditional padding since icons are always visible there.

## Changes

`ui/src/styles/chat/grouped.css`

```diff
- .chat-bubble.has-copy {
+ .chat-bubble.has-copy:hover {
    padding-right: 70px;
  }

- @media (hover: none) {
+ @media (hover: none) and (pointer: coarse) {
    .chat-bubble-actions {
      opacity: 1;
      pointer-events: auto;
    }
+
+  .chat-bubble.has-copy {
+    padding-right: 70px;
+  }
  }
```

## Test plan

- [ ] Desktop (mouse): icons hidden by default, appear on hover, short messages use full width
- [ ] Touch laptop / hybrid device: icons hidden by default, appear on hover (not permanently)
- [ ] Actual touch-only device (phone/tablet): icons permanently visible, padding prevents overlap
- [ ] Short one-liner messages: text no longer clipped when not hovering

Fixes #58702

🤖 Generated with [Claude Code](https://claude.com/claude-code)