### PR TITLE
fix(web-chat): prevent blank chat pane after assistant response (#67035)

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -593,7 +593,9 @@ function handleTerminalChatEvent(
   // replace the now-cleared streaming state.
   if (hadToolEvents && state === "final") {
     const completedRunId = runId ?? null;
-    void loadChatHistory(host as unknown as ChatState).finally(() => {
+    const chatStateHostForTools = host as unknown as ChatState;
+    chatStateHostForTools.chatLoading = true;
+    void loadChatHistory(chatStateHostForTools).finally(() => {
       if (completedRunId && host.chatRunId && host.chatRunId !== completedRunId) {
         return;
       }
@@ -658,11 +660,15 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     deferredReloadHost.pendingSessionMessageReloadSessionKey = null;
   }
   if (finalEventNeedsHistoryReload && !historyReloaded && !terminalEventIsForDifferentActiveRun) {
-    void loadChatHistory(host as unknown as ChatState);
+    const chatStateHost = host as unknown as ChatState;
+    chatStateHost.chatLoading = true;
+    void loadChatHistory(chatStateHost);
     return;
   }
   if (shouldReplayDeferredSessionMessageReload && !historyReloaded) {
-    void loadChatHistory(host as unknown as ChatState);
+    const chatStateHost = host as unknown as ChatState;
+    chatStateHost.chatLoading = true;
+    void loadChatHistory(chatStateHost);
   }
 }
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -386,6 +386,7 @@ function maybeResetToolStream(state: ChatState) {
 
 export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
+    state.chatLoading = false;
     return;
   }
   const sessionKey = state.sessionKey;


### PR DESCRIPTION
## Problem

After a turn completes, the chat UI could render blank — showing nothing where the assistant's response should be — until the user manually refreshed the page. The content was there in gateway history, just not displayed.

## Root cause

Two gaps in the `chatLoading` flag lifecycle when history reloads are triggered by terminal chat events:

**Gap 1 — pre-set missing before `void` calls**
In `handleTerminalChatEvent` and `handleChatGatewayEvent`, `loadChatHistory` is called with `void` (fire-and-forget). `chatLoading = true` is set inside the async function synchronously before the first `await`, but there's no guarantee a reactive render won't fire in the gap between the call site and function entry. Explicitly pre-setting `chatLoading = true` at each call site eliminates this window.

**Gap 2 — early-exit path never cleared `chatLoading`**
If `loadChatHistory` returned early due to `!state.client || !state.connected`, any `chatLoading = true` that had been pre-set externally was never reset. This left the UI stuck showing a loading state instead of cached messages. Adding `state.chatLoading = false` to the early-exit branch fixes this.

Together these close the render window where:
`chatStream = null` → `chatMessages` not yet updated → `chatLoading` still false → `isEmpty = true` → blank pane.

## Changes

`ui/src/ui/app-gateway.ts` — pre-set `chatLoading = true` at all three `void loadChatHistory()` call sites (tool-turn path in `handleTerminalChatEvent`, final-event-needs-reload path, and deferred session-message reload path).

`ui/src/ui/controllers/chat.ts` — reset `chatLoading = false` in the early-return path so pre-set loading flag doesn't get stuck.

## Test plan

- [ ] Send a message and confirm response appears without refresh
- [ ] Tool-call turn: response and tool results appear without refresh
- [ ] Send a message while briefly offline, reconnect — no stuck loading spinner
- [ ] Silent-reply / heartbeat turns: no blank flash in visible sessions

Fixes #67035

🤖 Generated with [Claude Code](https://claude.com/claude-code)