### PR TITLE
fix(bluebubbles): handle helper disconnects and self-chat echoes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- BlueBubbles: keep helper-disconnect `imsg` fallback sends non-actionable, preserve user-authored self-chat prompts, and report disconnected Private API helpers from the channel plugin status collector. Thanks @neilofneils404.
 - Discord/streaming: show live reasoning text in progress drafts instead of a bare `Reasoning` status line.
 - Doctor/status: warn when `OPENCLAW_GATEWAY_TOKEN` would shadow a different active `gateway.auth.token` source for local CLI commands, while avoiding false positives when config points at the same env token. Fixes #74271. Thanks @yelog.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.
@@ -104,6 +105,7 @@ Docs: https://docs.openclaw.ai
 - CLI/plugins: handle closed stdin during `plugins uninstall` confirmation prompt and exit 1 with actionable `--force` guidance instead of crashing with Node exit 13 unsettled top-level await. Fixes #73562. (#73566) Thanks @ai-hpc.
 - CLI/gateway: pause non-TTY stdin after full CLI command completion and stop `openclaw agent` from falling back to embedded mode after gateway request/auth failures, so parent help commands exit cleanly and scoped delivery probes surface the real Gateway error immediately. Thanks @vincentkoc.
 - Gateway/model catalog: cache empty read-only model catalog results until reload, so TUI and control-plane refresh loops cannot hammer plugin metadata reads when no usable models are currently discovered. Thanks @vincentkoc.
+
 - Google Meet: fork the caller's current agent transcript into agent-mode meeting consultant sessions, so Meet replies inherit the context from the tool call that joined the meeting.
 - Google Meet: log the concrete agent-mode TTS provider, model, voice, output format, and sample rate after speech synthesis, so Meet logs show which voice backend spoke each reply.
 - Google Meet: log the resolved audio provider model when starting Chrome and paired-node Meet talk-back bridges, so agent-mode joins show the STT model and bidi joins show the realtime voice model.

--- a/extensions/bluebubbles/src/channel.status.test.ts
+++ b/extensions/bluebubbles/src/channel.status.test.ts
@@ -41,6 +41,7 @@ describe("bluebubblesPlugin.status.probeAccount", () => {
     expect(probeBlueBubblesMock).toHaveBeenCalledWith({
       baseUrl: "http://localhost:1234",
       password: "test-password",
+      accountId: "default",
       timeoutMs: 5000,
       allowPrivateNetwork: true,
     });
@@ -68,6 +69,7 @@ describe("bluebubblesPlugin.status.probeAccount", () => {
     expect(probeBlueBubblesMock).toHaveBeenCalledWith({
       baseUrl: "http://localhost:1234",
       password: "test-password",
+      accountId: "default",
       timeoutMs: 5000,
       allowPrivateNetwork: false,
     });

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -229,6 +229,7 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount, BlueBu
           (await loadBlueBubblesChannelRuntime()).probeBlueBubbles({
             baseUrl: account.baseUrl,
             password: account.config.password ?? null,
+            accountId: account.accountId,
             timeoutMs,
             allowPrivateNetwork: resolveBlueBubblesEffectiveAllowPrivateNetwork({
               baseUrl: account.baseUrl,

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -867,17 +867,17 @@ async function processMessageAfterDedupe(
   };
 
   if (message.fromMe) {
+    const cachedOutboundBeforeFromMe = cacheMessageId
+      ? resolveReplyContextFromCache({
+          accountId: account.accountId,
+          replyToId: cacheMessageId,
+          chatGuid: message.chatGuid,
+          chatIdentifier: message.chatIdentifier,
+          chatId: message.chatId,
+        })
+      : null;
     // Cache from-me messages so reply context can resolve sender/body.
     cacheInboundMessage();
-    // BlueBubbles self-chats can emit our outbound twice: first as `fromMe`,
-    // then as a reflected inbound copy from the same handle. Cache any explicit
-    // self-chat `fromMe` copy so the reflected duplicate does not become a new
-    // user turn. This is intentionally broader than assistant-only sends:
-    // outgoing messages are not inbound prompts, and letting their reflections
-    // through creates self-reply loops.
-    if (isSelfChatMessage) {
-      rememberBlueBubblesSelfChatCopy(selfChatLookup);
-    }
     if (cacheMessageId) {
       const pending = consumePendingOutboundMessageId({
         accountId: account.accountId,
@@ -886,6 +886,16 @@ async function processMessageAfterDedupe(
         chatId: message.chatId,
         body: rawBody,
       });
+      const matchesCachedAssistantOutbound =
+        cachedOutboundBeforeFromMe?.senderLabel === "me" &&
+        cachedOutboundBeforeFromMe.body === rawBody;
+      if (isSelfChatMessage && (pending || matchesCachedAssistantOutbound)) {
+        // BlueBubbles self-chats can emit assistant outbounds twice: first as
+        // `fromMe`, then as a reflected inbound copy from the same handle. Only
+        // mark confirmed pending/cached assistant sends; user-authored self-chat
+        // prompts must still dispatch when no assistant outbound matched.
+        rememberBlueBubblesSelfChatCopy(selfChatLookup);
+      }
       if (pending) {
         const displayId = getShortIdForUuid(cacheMessageId) || cacheMessageId;
         const previewSource = pending.snippetRaw || rawBody;

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -878,10 +878,13 @@ async function processMessageAfterDedupe(
   if (message.fromMe) {
     // Cache from-me messages so reply context can resolve sender/body.
     cacheInboundMessage();
-    const confirmedAssistantOutbound =
-      confirmedOutboundCacheEntry?.senderLabel === "me" &&
-      normalizeSnippet(confirmedOutboundCacheEntry.body ?? "") === normalizeSnippet(rawBody);
-    if (isSelfChatMessage && confirmedAssistantOutbound) {
+    // BlueBubbles self-chats can emit our outbound twice: first as `fromMe`,
+    // then as a reflected inbound copy from the same handle. Cache any explicit
+    // self-chat `fromMe` copy so the reflected duplicate does not become a new
+    // user turn. This is intentionally broader than assistant-only sends:
+    // outgoing messages are not inbound prompts, and letting their reflections
+    // through creates self-reply loops.
+    if (isSelfChatMessage) {
       rememberBlueBubblesSelfChatCopy(selfChatLookup);
     }
     if (cacheMessageId) {

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -848,15 +848,6 @@ async function processMessageAfterDedupe(
   };
 
   const cacheMessageId = message.messageId?.trim();
-  const confirmedOutboundCacheEntry = cacheMessageId
-    ? resolveReplyContextFromCache({
-        accountId: account.accountId,
-        replyToId: cacheMessageId,
-        chatGuid: message.chatGuid,
-        chatIdentifier: message.chatIdentifier,
-        chatId: message.chatId,
-      })
-    : null;
   let messageShortId: string | undefined;
   const cacheInboundMessage = () => {
     if (!cacheMessageId) {

--- a/extensions/bluebubbles/src/monitor-self-chat-cache.test.ts
+++ b/extensions/bluebubbles/src/monitor-self-chat-cache.test.ts
@@ -36,6 +36,25 @@ describe("BlueBubbles self-chat cache", () => {
     ).toBe(true);
   });
 
+  it("matches reflected copies with small BlueBubbles timestamp skew", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));
+
+    rememberBlueBubblesSelfChatCopy({
+      ...directLookup,
+      body: "hello skew",
+      timestamp: 10_000,
+    });
+
+    expect(
+      hasBlueBubblesSelfChatCopy({
+        ...directLookup,
+        body: "hello skew",
+        timestamp: 9_000,
+      }),
+    ).toBe(true);
+  });
+
   it("canonicalizes DM scope across chatIdentifier and chatGuid", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));

--- a/extensions/bluebubbles/src/monitor-self-chat-cache.ts
+++ b/extensions/bluebubbles/src/monitor-self-chat-cache.ts
@@ -16,7 +16,9 @@ type SelfChatLookup = SelfChatCacheKeyParts & {
 };
 
 const SELF_CHAT_TTL_MS = 10_000;
+const SELF_CHAT_TIMESTAMP_BUCKET_MS = 5_000;
 const MAX_SELF_CHAT_CACHE_ENTRIES = 512;
+const MAX_SELF_CHAT_CACHE_KEYS = MAX_SELF_CHAT_CACHE_ENTRIES * 3;
 const CLEANUP_MIN_INTERVAL_MS = 1_000;
 const MAX_SELF_CHAT_BODY_CHARS = 32_768;
 const cache = new Map<string, number>();
@@ -80,7 +82,7 @@ function cleanupExpired(now = Date.now()): void {
 }
 
 function enforceSizeCap(): void {
-  while (cache.size > MAX_SELF_CHAT_CACHE_ENTRIES) {
+  while (cache.size > MAX_SELF_CHAT_CACHE_KEYS) {
     const oldestKey = cache.keys().next().value;
     if (typeof oldestKey !== "string") {
       break;
@@ -89,32 +91,39 @@ function enforceSizeCap(): void {
   }
 }
 
-function buildKey(lookup: SelfChatLookup): string | null {
+function buildKeyForBucket(lookup: SelfChatLookup, bucket: number): string | null {
   const body = normalizeBody(lookup.body);
-  if (!body || !isUsableTimestamp(lookup.timestamp)) {
+  if (!body) {
     return null;
   }
-  return `${buildScope(lookup)}:${lookup.timestamp}:${digestText(body)}`;
+  return `${buildScope(lookup)}:${bucket}:${digestText(body)}`;
+}
+
+function buildKeys(lookup: SelfChatLookup): string[] {
+  if (!isUsableTimestamp(lookup.timestamp)) {
+    return [];
+  }
+  const bucket = Math.floor(lookup.timestamp / SELF_CHAT_TIMESTAMP_BUCKET_MS);
+  return [bucket - 1, bucket, bucket + 1]
+    .map((candidate) => buildKeyForBucket(lookup, candidate))
+    .filter((candidate): candidate is string => typeof candidate === "string");
 }
 
 export function rememberBlueBubblesSelfChatCopy(lookup: SelfChatLookup): void {
   cleanupExpired();
-  const key = buildKey(lookup);
-  if (!key) {
-    return;
+  const keys = buildKeys(lookup);
+  for (const key of keys) {
+    cache.set(key, Date.now());
   }
-  cache.set(key, Date.now());
   enforceSizeCap();
 }
 
 export function hasBlueBubblesSelfChatCopy(lookup: SelfChatLookup): boolean {
   cleanupExpired();
-  const key = buildKey(lookup);
-  if (!key) {
-    return false;
-  }
-  const seenAt = cache.get(key);
-  return typeof seenAt === "number" && Date.now() - seenAt <= SELF_CHAT_TTL_MS;
+  return buildKeys(lookup).some((key) => {
+    const seenAt = cache.get(key);
+    return typeof seenAt === "number" && Date.now() - seenAt <= SELF_CHAT_TTL_MS;
+  });
 }
 
 export function resetBlueBubblesSelfChatCache(): void {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2661,7 +2661,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
     });
 
-    it("does not drop user-authored self-chat prompts without a confirmed assistant outbound", async () => {
+    it("drops reflected self-chat prompts after an explicit fromMe copy", async () => {
       setupWebhookTarget();
 
       const timestamp = Date.now();
@@ -2686,10 +2686,10 @@ describe("BlueBubbles webhook monitor", () => {
 
       await dispatchWebhookPayload(reflectedPayload);
 
-      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
 
-    it("does not treat a pending text-only match as confirmed assistant outbound", async () => {
+    it("drops reflected self-chat copies when the send result only confirmed a pending text match", async () => {
       setupWebhookTarget();
 
       const { sendMessageBlueBubbles } = await import("./send.js");
@@ -2731,7 +2731,7 @@ describe("BlueBubbles webhook monitor", () => {
 
       await dispatchWebhookPayload(reflectedPayload);
 
-      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
 
     it("does not treat chatGuid-inferred sender ids as self-chat evidence", async () => {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2661,7 +2661,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
     });
 
-    it("drops reflected self-chat prompts after an explicit fromMe copy", async () => {
+    it("preserves user-authored self-chat prompts after an explicit fromMe copy", async () => {
       setupWebhookTarget();
 
       const timestamp = Date.now();
@@ -2686,7 +2686,7 @@ describe("BlueBubbles webhook monitor", () => {
 
       await dispatchWebhookPayload(reflectedPayload);
 
-      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
     });
 
     it("drops reflected self-chat copies when the send result only confirmed a pending text match", async () => {

--- a/extensions/bluebubbles/src/probe.test.ts
+++ b/extensions/bluebubbles/src/probe.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { probeBlueBubbles } from "./probe.js";
+import { createBlueBubblesFetchGuardPassthroughInstaller } from "./test-harness.js";
+import { _setFetchGuardForTesting } from "./types.js";
+
+const mockFetch = vi.fn();
+const installFetchGuardPassthrough = createBlueBubblesFetchGuardPassthroughInstaller();
+
+describe("probeBlueBubbles", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    installFetchGuardPassthrough();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    _setFetchGuardForTesting(null);
+    vi.unstubAllGlobals();
+  });
+
+  it("projects server info into the probe result", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(""),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            data: {
+              private_api: true,
+              helper_connected: false,
+              os_version: "26.5.0",
+              server_version: "1.9.9",
+              proxy_service: "cloudflare",
+              detected_icloud: "neil@example.invalid",
+            },
+          }),
+      });
+
+    const result = await probeBlueBubbles({
+      baseUrl: "http://localhost:1234",
+      password: "test-password",
+      accountId: "probe-test",
+      allowPrivateNetwork: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 200,
+      privateApi: true,
+      helperConnected: false,
+      osVersion: "26.5.0",
+      serverVersion: "1.9.9",
+      proxyService: "cloudflare",
+      detectedIcloud: "neil@example.invalid",
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/ping"),
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/server/info"),
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -6,6 +6,12 @@ import { normalizeSecretInputString } from "./secret-input.js";
 
 export type BlueBubblesProbe = BaseProbeResult & {
   status?: number | null;
+  privateApi?: boolean | null;
+  helperConnected?: boolean | null;
+  serverVersion?: string;
+  osVersion?: string;
+  proxyService?: string;
+  detectedIcloud?: string;
 };
 
 type BlueBubblesServerInfo = {
@@ -133,9 +139,37 @@ export function isMacOS26OrHigher(accountId?: string): boolean {
   return major !== null && major >= 26;
 }
 
+function projectServerInfoForProbe(info: BlueBubblesServerInfo | null): Partial<BlueBubblesProbe> {
+  if (!info) {
+    return {};
+  }
+  const out: Partial<BlueBubblesProbe> = {
+    privateApi: typeof info.private_api === "boolean" ? info.private_api : null,
+    helperConnected: typeof info.helper_connected === "boolean" ? info.helper_connected : null,
+  };
+  const serverVersion = normalizeOptionalString(info.server_version);
+  const osVersion = normalizeOptionalString(info.os_version);
+  const proxyService = normalizeOptionalString(info.proxy_service);
+  const detectedIcloud = normalizeOptionalString(info.detected_icloud);
+  if (serverVersion) {
+    out.serverVersion = serverVersion;
+  }
+  if (osVersion) {
+    out.osVersion = osVersion;
+  }
+  if (proxyService) {
+    out.proxyService = proxyService;
+  }
+  if (detectedIcloud) {
+    out.detectedIcloud = detectedIcloud;
+  }
+  return out;
+}
+
 export async function probeBlueBubbles(params: {
   baseUrl?: string | null;
   password?: string | null;
+  accountId?: string;
   timeoutMs?: number;
   allowPrivateNetwork?: boolean;
 }): Promise<BlueBubblesProbe> {
@@ -158,7 +192,14 @@ export async function probeBlueBubbles(params: {
     if (!res.ok) {
       return { ok: false, status: res.status, error: `HTTP ${res.status}` };
     }
-    return { ok: true, status: res.status };
+    const info = await fetchBlueBubblesServerInfo({
+      baseUrl,
+      password,
+      accountId: params.accountId,
+      timeoutMs: params.timeoutMs,
+      allowPrivateNetwork: params.allowPrivateNetwork,
+    });
+    return { ok: true, status: res.status, ...projectServerInfoForProbe(info) };
   } catch (err) {
     return {
       ok: false,

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -847,7 +847,7 @@ describe("send", () => {
         password: "test",
       });
 
-      expect(result.messageId).toBe("imsg-fallback");
+      expect(result.messageId).toBe("ok");
       expect(mockExecFile).toHaveBeenCalledWith(
         "imsg",
         ["send", "--to", "+15550008888", "--service", "auto", "--text", "Hello"],
@@ -1003,7 +1003,7 @@ describe("send", () => {
         cfg: { channels: { bluebubbles: { serverUrl: "http://localhost:1234", password: "pw" } } },
       });
 
-      expect(result.messageId).toBe("imsg-fallback");
+      expect(result.messageId).toBe("ok");
       expect(mockExecFile).toHaveBeenCalledWith(
         "imsg",
         ["send", "--to", "+15551234567", "--service", "auto", "--text", "Hello fallback"],

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-mocks.js";
 import {
@@ -16,6 +17,13 @@ import {
 } from "./test-harness.js";
 import { _setFetchGuardForTesting, type BlueBubblesSendTarget } from "./types.js";
 
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn((_command, _args, _options, callback) => {
+    callback(null, "sent", "");
+  }),
+}));
+
+const mockExecFile = vi.mocked(execFile);
 const mockFetch = vi.fn();
 const privateApiStatusMock = vi.mocked(getCachedBlueBubblesPrivateApiStatus);
 const fetchServerInfoMock = vi.mocked(fetchBlueBubblesServerInfo);
@@ -647,6 +655,7 @@ describe("send", () => {
   describe("sendMessageBlueBubbles", () => {
     beforeEach(() => {
       mockFetch.mockReset();
+      mockExecFile.mockClear();
       fetchServerInfoMock.mockReset();
       fetchServerInfoMock.mockResolvedValue(null);
     });
@@ -821,6 +830,32 @@ describe("send", () => {
       expect(body.message).toBe("Hello new chat");
     });
 
+    it("falls back to imsg when new chat creation hits a disconnected helper", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve("iMessage Private API Helper is not connected!"),
+        });
+
+      const result = await sendMessageBlueBubbles("+15550008888", "Hello", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+      });
+
+      expect(result.messageId).toBe("imsg-fallback");
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "imsg",
+        ["send", "--to", "+15550008888", "--service", "auto", "--text", "Hello"],
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
     it("throws when creating a new chat requires Private API", async () => {
       mockFetch
         .mockResolvedValueOnce({
@@ -944,6 +979,39 @@ describe("send", () => {
     // explicitly as apple-script rather than omitting `method`; BB Server's
     // behavior on an omitted field is version-dependent and silently drops
     // on some setups, which is the worse failure mode. (#64480)
+    it("falls back to imsg when BlueBubbles Private API helper is disconnected", async () => {
+      mockResolvedHandleTarget();
+      privateApiStatusMock.mockReturnValue(true);
+      isMacOS26OrHigherMock.mockReturnValue(true);
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              status: 500,
+              message: "Message Send Error",
+              error: {
+                type: "iMessage Error",
+                message: "iMessage Private API Helper is not connected!",
+              },
+            }),
+          ),
+      });
+
+      const result = await sendMessageBlueBubbles("+15551234567", "Hello fallback", {
+        cfg: { channels: { bluebubbles: { serverUrl: "http://localhost:1234", password: "pw" } } },
+      });
+
+      expect(result.messageId).toBe("imsg-fallback");
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "imsg",
+        ["send", "--to", "+15551234567", "--service", "auto", "--text", "Hello fallback"],
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
     it("falls back to apple-script on macOS 26 when Private API is disabled", async () => {
       mockBlueBubblesPrivateApiStatusOnce(
         privateApiStatusMock,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -1,4 +1,6 @@
+import { execFile } from "node:child_process";
 import crypto from "node:crypto";
+import { promisify } from "node:util";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -38,6 +40,8 @@ export type BlueBubblesSendResult = {
 };
 
 /** Maps short effect names to full Apple effect IDs */
+const execFileAsync = promisify(execFile);
+
 const EFFECT_MAP: Record<string, string> = {
   // Bubble effects
   slam: "com.apple.MobileSMS.expressivesend.impact",
@@ -116,6 +120,74 @@ function resolvePrivateApiDecision(params: {
     throwEffectDisabledError,
     warningMessage: `Private API status unknown; sending without ${requested}. Run a status probe to restore private-api features.`,
   };
+}
+
+function isPrivateApiHelperDisconnectedErrorText(errorText: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(errorText);
+  return (
+    normalized.includes("private api helper is not connected") ||
+    normalized.includes("bluebubbleshelper is not running")
+  );
+}
+
+function isPrivateApiHelperDisconnectedError(status: number, errorText: string): boolean {
+  return status === 500 && isPrivateApiHelperDisconnectedErrorText(errorText);
+}
+
+function resolveConfiguredImsgCliPath(cfg?: OpenClawConfig): string {
+  const channels = cfg?.channels;
+  const imessage = channels && typeof channels === "object" ? channels.imessage : undefined;
+  if (imessage && typeof imessage === "object") {
+    const cliPath = normalizeOptionalString((imessage as { cliPath?: unknown }).cliPath);
+    if (cliPath) {
+      return cliPath;
+    }
+  }
+  return "imsg";
+}
+
+function resolveImsgFallbackTarget(
+  target: BlueBubblesSendTarget,
+  chatGuid: string,
+): { to: string; service: "imessage" | "sms" | "auto" } | null {
+  if (target.kind === "handle") {
+    return { to: target.address, service: target.service ?? "auto" };
+  }
+  const handle = extractHandleFromChatGuid(chatGuid) ?? extractChatIdentifierFromChatGuid(chatGuid);
+  if (!handle) {
+    return null;
+  }
+  const service = chatGuid.startsWith("SMS;-")
+    ? "sms"
+    : chatGuid.startsWith("iMessage;-")
+      ? "imessage"
+      : "auto";
+  return { to: handle, service };
+}
+
+async function sendViaImsgFallback(params: {
+  target: BlueBubblesSendTarget;
+  chatGuid: string;
+  text: string;
+  cfg?: OpenClawConfig;
+}): Promise<BlueBubblesSendResult | null> {
+  const fallback = resolveImsgFallbackTarget(params.target, params.chatGuid);
+  if (!fallback) {
+    return null;
+  }
+  try {
+    await execFileAsync(
+      resolveConfiguredImsgCliPath(params.cfg),
+      ["send", "--to", fallback.to, "--service", fallback.service, "--text", params.text],
+      {
+        timeout: DEFAULT_SEND_TIMEOUT_MS,
+        maxBuffer: 64 * 1024,
+      },
+    );
+    return { messageId: "imsg-fallback" };
+  } catch {
+    return null;
+  }
 }
 
 async function parseBlueBubblesMessageResponse(res: Response): Promise<BlueBubblesSendResult> {
@@ -523,14 +595,33 @@ export async function sendMessageBlueBubbles(
     // If target is a phone number/handle and no existing chat found,
     // auto-create a new DM chat using the /api/v1/chat/new endpoint
     if (target.kind === "handle") {
-      return createNewChatWithMessage({
-        baseUrl,
-        password,
-        address: target.address,
-        message: strippedText,
-        timeoutMs: effectiveSendTimeoutMs,
-        allowPrivateNetwork,
-      });
+      try {
+        return await createNewChatWithMessage({
+          baseUrl,
+          password,
+          address: target.address,
+          message: strippedText,
+          timeoutMs: effectiveSendTimeoutMs,
+          allowPrivateNetwork,
+        });
+      } catch (err) {
+        const errorText = err instanceof Error ? err.message : String(err);
+        if (isPrivateApiHelperDisconnectedErrorText(errorText)) {
+          const fallback = await sendViaImsgFallback({
+            target,
+            chatGuid: "",
+            text: strippedText,
+            cfg: opts.cfg,
+          });
+          if (fallback) {
+            warnBlueBubbles(
+              "BlueBubbles Private API helper is disconnected; sent via local imsg fallback.",
+            );
+            return fallback;
+          }
+        }
+        throw err;
+      }
     }
     throw new Error(
       "BlueBubbles send failed: chatGuid not found for target. Use a chat_guid target or ensure the chat exists.",
@@ -612,6 +703,20 @@ export async function sendMessageBlueBubbles(
   });
   if (!res.ok) {
     const errorText = await res.text();
+    if (isPrivateApiHelperDisconnectedError(res.status, errorText)) {
+      const fallback = await sendViaImsgFallback({
+        target,
+        chatGuid,
+        text: strippedText,
+        cfg: opts.cfg,
+      });
+      if (fallback) {
+        warnBlueBubbles(
+          "BlueBubbles Private API helper is disconnected; sent via local imsg fallback.",
+        );
+        return fallback;
+      }
+    }
     throw new Error(`BlueBubbles send failed (${res.status}): ${errorText || "unknown"}`);
   }
   return parseBlueBubblesMessageResponse(res);

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -184,7 +184,7 @@ async function sendViaImsgFallback(params: {
         maxBuffer: 64 * 1024,
       },
     );
-    return { messageId: "imsg-fallback" };
+    return { messageId: "ok" };
   } catch {
     return null;
   }

--- a/extensions/bluebubbles/src/status-issues.test.ts
+++ b/extensions/bluebubbles/src/status-issues.test.ts
@@ -52,4 +52,32 @@ describe("collectBlueBubblesStatusIssues", () => {
       }),
     );
   });
+
+  it("reports disconnected Private API helper from probe server info", () => {
+    const issues = collectBlueBubblesStatusIssues([
+      {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        running: true,
+        probe: {
+          ok: true,
+          status: 200,
+          privateApi: true,
+          helperConnected: false,
+          osVersion: "26.5.0",
+        },
+      },
+    ]);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        channel: "bluebubbles",
+        accountId: "default",
+        kind: "runtime",
+        message: "BlueBubbles Private API is enabled, but the helper is disconnected.",
+      }),
+    ]);
+    expect(issues[0]?.fix).toContain("imsg fallback");
+  });
 });

--- a/extensions/bluebubbles/src/status-issues.ts
+++ b/extensions/bluebubbles/src/status-issues.ts
@@ -16,6 +16,9 @@ type BlueBubblesProbeResult = {
   ok?: boolean;
   status?: number | null;
   error?: string | null;
+  privateApi?: boolean | null;
+  helperConnected?: boolean | null;
+  osVersion?: string | null;
 };
 
 function asString(value: unknown): string | null {
@@ -45,11 +48,17 @@ function readBlueBubblesProbeResult(value: unknown): BlueBubblesProbeResult | nu
   if (!record) {
     return null;
   }
-  return {
-    ok: typeof record.ok === "boolean" ? record.ok : undefined,
+  const result: BlueBubblesProbeResult = {
     status: typeof record.status === "number" ? record.status : null,
     error: asString(record.error) ?? null,
+    privateApi: typeof record.privateApi === "boolean" ? record.privateApi : null,
+    helperConnected: typeof record.helperConnected === "boolean" ? record.helperConnected : null,
+    osVersion: asString(record.osVersion) ?? null,
   };
+  if (typeof record.ok === "boolean") {
+    result.ok = record.ok;
+  }
+  return result;
 }
 
 export function collectBlueBubblesStatusIssues(accounts: ChannelAccountSnapshot[]) {
@@ -85,6 +94,16 @@ export function collectBlueBubblesStatusIssues(accounts: ChannelAccountSnapshot[
           kind: "runtime",
           message: `BlueBubbles server unreachable${errorDetail}`,
           fix: "Check that the BlueBubbles server is running and accessible. Verify serverUrl and password in your config.",
+        });
+      }
+
+      if (probe?.ok !== false && probe?.privateApi === true && probe.helperConnected === false) {
+        issues.push({
+          channel: "bluebubbles",
+          accountId,
+          kind: "runtime",
+          message: "BlueBubbles Private API is enabled, but the helper is disconnected.",
+          fix: "Open BlueBubbles Private API settings and restart the Messages helper/server. If it stays disconnected, verify the BlueBubbles Private API prerequisites (SIP and Library Validation) before expecting helper-only features. Until it reconnects, sends may use the local imsg fallback and Private API-only features such as reply threading/effects are unavailable.",
         });
       }
 

--- a/src/infra/channels-status-issues.test.ts
+++ b/src/infra/channels-status-issues.test.ts
@@ -46,4 +46,58 @@ describe("collectChannelStatusIssues", () => {
     expect(collectTelegramIssues).toHaveBeenCalledWith(telegramAccounts);
     expect(collectSlackIssues).toHaveBeenCalledWith(slackAccounts);
   });
+
+  it("surfaces BlueBubbles helper disconnect from gateway payload when plugin collectors are unavailable", () => {
+    listChannelPluginsMock.mockReturnValue([]);
+
+    expect(
+      collectChannelStatusIssues({
+        channelAccounts: {
+          bluebubbles: [
+            {
+              accountId: "default",
+              probe: {
+                ok: true,
+                privateApi: true,
+                helperConnected: false,
+              },
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        channel: "bluebubbles",
+        accountId: "default",
+        kind: "runtime",
+        message: "BlueBubbles Private API is enabled, but the helper is disconnected.",
+      }),
+    ]);
+  });
+
+  it("does not duplicate BlueBubbles helper issues when a plugin collector handled the channel", () => {
+    const collectBlueBubblesIssues = vi.fn(() => [{ code: "bluebubbles.plugin" }]);
+    const bluebubblesAccounts = [
+      {
+        accountId: "default",
+        probe: {
+          ok: true,
+          privateApi: true,
+          helperConnected: false,
+        },
+      },
+    ];
+    listChannelPluginsMock.mockReturnValue([
+      { id: "bluebubbles", status: { collectStatusIssues: collectBlueBubblesIssues } },
+    ]);
+
+    expect(
+      collectChannelStatusIssues({
+        channelAccounts: {
+          bluebubbles: bluebubblesAccounts,
+        },
+      }),
+    ).toEqual([{ code: "bluebubbles.plugin" }]);
+    expect(collectBlueBubblesIssues).toHaveBeenCalledWith(bluebubblesAccounts);
+  });
 });

--- a/src/infra/channels-status-issues.test.ts
+++ b/src/infra/channels-status-issues.test.ts
@@ -47,35 +47,7 @@ describe("collectChannelStatusIssues", () => {
     expect(collectSlackIssues).toHaveBeenCalledWith(slackAccounts);
   });
 
-  it("surfaces BlueBubbles helper disconnect from gateway payload when plugin collectors are unavailable", () => {
-    listChannelPluginsMock.mockReturnValue([]);
-
-    expect(
-      collectChannelStatusIssues({
-        channelAccounts: {
-          bluebubbles: [
-            {
-              accountId: "default",
-              probe: {
-                ok: true,
-                privateApi: true,
-                helperConnected: false,
-              },
-            },
-          ],
-        },
-      }),
-    ).toEqual([
-      expect.objectContaining({
-        channel: "bluebubbles",
-        accountId: "default",
-        kind: "runtime",
-        message: "BlueBubbles Private API is enabled, but the helper is disconnected.",
-      }),
-    ]);
-  });
-
-  it("does not duplicate BlueBubbles helper issues when a plugin collector handled the channel", () => {
+  it("keeps BlueBubbles helper issues plugin-owned", () => {
     const collectBlueBubblesIssues = vi.fn(() => [{ code: "bluebubbles.plugin" }]);
     const bluebubblesAccounts = [
       {

--- a/src/infra/channels-status-issues.ts
+++ b/src/infra/channels-status-issues.ts
@@ -4,9 +4,47 @@ import type {
   ChannelStatusIssue,
 } from "../channels/plugins/types.public.js";
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function collectBlueBubblesPayloadIssues(accounts: unknown): ChannelStatusIssue[] {
+  if (!Array.isArray(accounts)) {
+    return [];
+  }
+  const issues: ChannelStatusIssue[] = [];
+  for (const account of accounts) {
+    const record = asRecord(account);
+    if (!record) {
+      continue;
+    }
+    const probe = asRecord(record.probe);
+    if (!probe) {
+      continue;
+    }
+    if (probe.ok !== false && probe.privateApi === true && probe.helperConnected === false) {
+      issues.push({
+        channel: "bluebubbles",
+        accountId: asString(record.accountId) ?? "default",
+        kind: "runtime",
+        message: "BlueBubbles Private API is enabled, but the helper is disconnected.",
+        fix: "Open BlueBubbles Private API settings and restart the Messages helper/server. If it stays disconnected, verify the BlueBubbles Private API prerequisites (SIP and Library Validation). Until it reconnects, sends may use the local imsg fallback and Private API-only features such as reply threading/effects are unavailable.",
+      });
+    }
+  }
+  return issues;
+}
+
 export function collectChannelStatusIssues(payload: Record<string, unknown>): ChannelStatusIssue[] {
   const issues: ChannelStatusIssue[] = [];
   const accountsByChannel = payload.channelAccounts as Record<string, unknown> | undefined;
+  const channelsWithPluginCollectors = new Set<string>();
   for (const plugin of listChannelPlugins()) {
     const collect = plugin.status?.collectStatusIssues;
     if (!collect) {
@@ -17,7 +55,15 @@ export function collectChannelStatusIssues(payload: Record<string, unknown>): Ch
       continue;
     }
 
+    channelsWithPluginCollectors.add(plugin.id);
     issues.push(...collect(raw as ChannelAccountSnapshot[]));
+  }
+
+  // CLI status often formats gateway-provided payloads without loading every
+  // bundled plugin locally. Keep high-value runtime caveats visible even when
+  // the plugin-specific collector is unavailable in the CLI process.
+  if (!channelsWithPluginCollectors.has("bluebubbles")) {
+    issues.push(...collectBlueBubblesPayloadIssues(accountsByChannel?.bluebubbles));
   }
   return issues;
 }

--- a/src/infra/channels-status-issues.ts
+++ b/src/infra/channels-status-issues.ts
@@ -4,47 +4,9 @@ import type {
   ChannelStatusIssue,
 } from "../channels/plugins/types.public.js";
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function asString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function collectBlueBubblesPayloadIssues(accounts: unknown): ChannelStatusIssue[] {
-  if (!Array.isArray(accounts)) {
-    return [];
-  }
-  const issues: ChannelStatusIssue[] = [];
-  for (const account of accounts) {
-    const record = asRecord(account);
-    if (!record) {
-      continue;
-    }
-    const probe = asRecord(record.probe);
-    if (!probe) {
-      continue;
-    }
-    if (probe.ok !== false && probe.privateApi === true && probe.helperConnected === false) {
-      issues.push({
-        channel: "bluebubbles",
-        accountId: asString(record.accountId) ?? "default",
-        kind: "runtime",
-        message: "BlueBubbles Private API is enabled, but the helper is disconnected.",
-        fix: "Open BlueBubbles Private API settings and restart the Messages helper/server. If it stays disconnected, verify the BlueBubbles Private API prerequisites (SIP and Library Validation). Until it reconnects, sends may use the local imsg fallback and Private API-only features such as reply threading/effects are unavailable.",
-      });
-    }
-  }
-  return issues;
-}
-
 export function collectChannelStatusIssues(payload: Record<string, unknown>): ChannelStatusIssue[] {
   const issues: ChannelStatusIssue[] = [];
   const accountsByChannel = payload.channelAccounts as Record<string, unknown> | undefined;
-  const channelsWithPluginCollectors = new Set<string>();
   for (const plugin of listChannelPlugins()) {
     const collect = plugin.status?.collectStatusIssues;
     if (!collect) {
@@ -55,15 +17,8 @@ export function collectChannelStatusIssues(payload: Record<string, unknown>): Ch
       continue;
     }
 
-    channelsWithPluginCollectors.add(plugin.id);
     issues.push(...collect(raw as ChannelAccountSnapshot[]));
   }
 
-  // CLI status often formats gateway-provided payloads without loading every
-  // bundled plugin locally. Keep high-value runtime caveats visible even when
-  // the plugin-specific collector is unavailable in the CLI process.
-  if (!channelsWithPluginCollectors.has("bluebubbles")) {
-    issues.push(...collectBlueBubblesPayloadIssues(accountsByChannel?.bluebubbles));
-  }
   return issues;
 }


### PR DESCRIPTION
## Summary
- suppress local self-chat echoes from BlueBubbles monitoring so Cass does not reflect on her own outbound messages
- surface BlueBubbles Private API helper disconnects as degraded status instead of generic failures
- add guarded `imsg` fallback behavior for helper-disconnected new-chat sends where supported
- add shared channel-status issue collection for helper warnings

## Validation
- `pnpm check:no-conflict-markers`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-bluebubbles.config.ts extensions/bluebubbles/src/*.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/infra/channels-status-issues.test.ts`

## Real behavior proof
- **Behavior or issue addressed**: BlueBubbles self-chat handling now avoids suppressing user-authored self-chat prompts, helper-disconnected `imsg` fallback sends are non-actionable, and helper-disconnect status is reported from the BlueBubbles plugin path instead of duplicated in core fallback policy.
- **Real environment tested**: Local OpenClaw checkout on SpicyTaco (macOS/Darwin), PR branch `cass/bluebubbles-helper-fixes-20260504` at `2c052c8985` after rebase onto `origin/main` `8aa7b7a4ca`.
- **Exact steps or command run after this patch**: `pnpm check:no-conflict-markers && pnpm test extensions/bluebubbles/src/monitor.test.ts extensions/bluebubbles/src/monitor-self-chat-cache.test.ts extensions/bluebubbles/src/send.test.ts extensions/bluebubbles/src/probe.test.ts extensions/bluebubbles/src/status-issues.test.ts && pnpm test src/infra/channels-status-issues.test.ts`
- **Evidence after fix**: Terminal capture from the local OpenClaw checkout after the fix:

  ```text
  2c052c8985 fix(bluebubbles): address helper fallback review
  > openclaw@2026.5.5 check:no-conflict-markers /private/tmp/openclaw-pr77420
  > node scripts/check-no-conflict-markers.mjs

  ✓ extension-bluebubbles extensions/bluebubbles/src/send.test.ts (71 tests)
  ✓ extension-bluebubbles extensions/bluebubbles/src/monitor-self-chat-cache.test.ts (7 tests)
  ✓ extension-bluebubbles extensions/bluebubbles/src/probe.test.ts (1 test)
  ✓ extension-bluebubbles extensions/bluebubbles/src/status-issues.test.ts (3 tests)
  ✓ extension-bluebubbles extensions/bluebubbles/src/monitor.test.ts (85 tests)
  Test Files  5 passed (5)
  Tests       167 passed (167)

  ✓ infra src/infra/channels-status-issues.test.ts (3 tests)
  Test Files  1 passed (1)
  Tests       3 passed (3)

  [bluebubbles] BlueBubbles Private API helper is disconnected; sent via local imsg fallback.
  [test] passed 1 Vitest shard in 4.93s
  [test] passed 1 Vitest shard in 2.12s
  ```

- **Observed result after fix**: The changed BlueBubbles monitor/send/status paths pass locally, including helper-disconnected fallback logging and plugin-owned status issue coverage.
- **What was not tested**: I did not send a live BlueBubbles/iMessage from this PR branch; the after-fix behavior was verified in the local OpenClaw extension/infra harness with terminal output above.
