### PR TITLE
fix(gateway): plumb sessionId and onYield through gateway MCP loopback path [AI-assisted]

### DIFF
--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -24,6 +24,8 @@ export class McpLoopbackToolCache {
   resolve(params: {
     cfg: OpenClawConfig;
     sessionKey: string;
+    sessionId?: string;
+    onYield?: (message: string) => Promise<void> | void;
     messageProvider: string | undefined;
     accountId: string | undefined;
     senderIsOwner: boolean | undefined;
@@ -43,6 +45,8 @@ export class McpLoopbackToolCache {
     const next = resolveGatewayScopedTools({
       cfg: params.cfg,
       sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      onYield: params.onYield,
       messageProvider: params.messageProvider,
       accountId: params.accountId,
       senderIsOwner: params.senderIsOwner,

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -4,6 +4,8 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
+import { subagentRuns } from "../agents/subagent-registry-memory.js";
+import { markSubagentRunPausedAfterYield } from "../agents/subagent-registry-run-manager.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -110,6 +112,24 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         const scopedTools = toolCache.resolve({
           cfg,
           sessionKey: requestContext.sessionKey,
+          sessionId: requestContext.sessionKey,
+          onYield: (message) => {
+            // MCP-path yield: mark parent runs as paused in the subagent registry.
+            // Unlike the embedded runner, we do not abort — claude-cli owns the model
+            // loop and ends its turn naturally when the tool result arrives.
+            for (const [, entry] of subagentRuns) {
+              if (
+                entry.requesterSessionKey === requestContext.sessionKey &&
+                !entry.pauseReason &&
+                !entry.endedReason
+              ) {
+                markSubagentRunPausedAfterYield({ entry, now: Date.now() });
+              }
+            }
+            logDebug(
+              `mcp loopback: sessions_yield processed for session=${requestContext.sessionKey} message=${message}`,
+            );
+          },
           messageProvider: requestContext.messageProvider,
           accountId: requestContext.accountId,
           senderIsOwner: requestContext.senderIsOwner,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -31,6 +31,8 @@ export function resolveGatewayScopedTools(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   messageProvider?: string;
+  sessionId?: string;
+  onYield?: (message: string) => Promise<void> | void;
   accountId?: string;
   agentTo?: string;
   agentThreadId?: string;
@@ -88,6 +90,8 @@ export function resolveGatewayScopedTools(params: {
 
   const allTools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    onYield: params.onYield,
     agentChannel: params.messageProvider ?? undefined,
     agentAccountId: params.accountId,
     agentTo: params.agentTo,


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested. Prompt summary available on request.

## Summary
- Problem: `sessions_yield` always returned `"No session context"` on the MCP/claude-cli agent runtime path
- Why it matters: Subagent yield/pause functionality was completely broken on the gateway MCP loopback path, only working on the embedded runner path
- What changed: Plumbed `sessionId` and `onYield` through `resolveGatewayScopedTools` → `McpLoopbackToolCache.resolve()` → `createOpenClawTools`
- What did NOT change (scope boundary): Embedded runner path unchanged, no new parameters added to the public API

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Gateway

## Linked Issue/PR
- Closes #77426
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `resolveGatewayScopedTools` in `src/gateway/tool-resolution.ts` never passed `sessionId` or `onYield` to `createOpenClawTools`. The embedded runner path already wires both parameters, but the gateway/MCP loopback path was missed when the `sessions_yield` fix landed for 2026.5.3-1
- Missing detection / guardrail: No integration test verified `sessions_yield` on the MCP loopback path specifically
- Contributing context (if known): The `sessions_yield` fix for 2026.5.3-1 only covered the embedded runner, missing the parallel gateway/MCP path

## Changes

1. **`src/gateway/tool-resolution.ts`** — Accept optional `sessionId` and `onYield` parameters and forward them to `createOpenClawTools`.
2. **`src/gateway/mcp-http.runtime.ts`** — Accept and pass `sessionId`/`onYield` through `McpLoopbackToolCache.resolve()`.
3. **`src/gateway/mcp-http.ts`** — Supply `sessionId` (derived from `sessionKey`) and an MCP-appropriate `onYield` callback when resolving tools.

The MCP-path `onYield` differs from the embedded runner: it marks matching subagent runs as paused via `markSubagentRunPausedAfterYield` rather than aborting a local run controller. This is architecturally correct because `claude-cli` owns the model loop and ends its turn naturally when the tool result arrives — no abort injection is needed.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Seam test
- Target test or file: Manual integration test with claude-cli agent runtime
- Scenario the test should lock in: `sessions_yield` on MCP loopback path returns `{ status: "yielded" }` instead of `{ status: "error", error: "No session context" }`
- Why this is the smallest reliable guardrail: The bug is in parameter plumbing across 3 gateway files — a seam test at the tool-resolution boundary catches missing wiring
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: Requires a running MCP loopback server with claude-cli runtime; manual verification steps provided above

### Manual verification steps
1. Configure `agents.defaults.agentRuntime.id = "claude-cli"` with any channel
2. Have a parent agent spawn a subagent via `sessions_spawn`
3. Have the parent agent call `sessions_yield`
4. Verify: `sessions_yield` returns `{ status: "yielded", message: "Turn yielded." }`
5. Verify: The subagent run record has `pauseReason: "sessions_yield"` set
6. Verify: Child completion events are queued and delivered on the next user turn

## User-visible / Behavior Changes
- `sessions_yield` now works correctly on the MCP/claude-cli agent runtime path (previously always errored with "No session context")

## Security Impact (required)
- New permissions/capabilities? No
- This change only plumbs existing parameters through an additional code path. No new privileges, no new external surface, no auth changes. The `onYield` callback operates on the same in-memory subagent registry already used by the embedded runner path.
