### PR TITLE
fix(agents): persist delivered assistant text [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - fix(gateway): clamp unbound websocket auth scopes [AI]. (#77413) Thanks @pgondhi987.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.
+- Agents/transcripts: persist delivered final assistant text when a tool-using turn produced `assistantTexts` without a matching stored assistant message, so the next user turn keeps the answer the user already saw in durable context.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
 - Claude CLI: honor non-off `/think` levels by passing Claude Code's session-scoped `--effort` flag through the CLI backend seam, so chat bridges no longer show an inert thinking control. Fixes #77303. Thanks @Petr1t.
 - Agents/subagents: refresh deferred final-delivery payloads when same-session completion output changes, so retried parent notifications use the final child summary instead of stale progress text. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2120,6 +2120,7 @@ Docs: https://docs.openclaw.ai
 - Active Memory: send a bounded latest-message search query to the recall worker so channel/runtime metadata does not become the memory search string. Fixes #65309. Thanks @joeykrug, @westley3601, @pimenov, and @tasi333.
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.
 - Providers/OpenRouter: keep DeepSeek V4 `reasoning_effort` on OpenRouter-supported values, mapping stale `max` thinking overrides to `xhigh` so `openrouter/deepseek/deepseek-v4-pro` no longer fails with OpenRouter's invalid-effort 400. Fixes #77350. (#77423) Thanks @krllagent, @mushuiyu886, and @sallyom.
+- Agents/transcripts: persist delivered final assistant text when a tool-using turn produced `assistantTexts` without a matching stored assistant message, so the next user turn keeps the answer the user already saw in durable context.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
 - Claude CLI: honor non-off `/think` levels by passing Claude Code's session-scoped `--effort` flag through the CLI backend seam, so chat bridges no longer show an inert thinking control. Fixes #77303. Thanks @Petr1t.
 - Agents/subagents: refresh deferred final-delivery payloads when same-session completion output changes, so retried parent notifications use the final child summary instead of stale progress text. Thanks @vincentkoc.

--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -57,6 +57,12 @@ Separate from transcript hygiene, session files are repaired (if needed) before 
 - `repairSessionFileIfNeeded` in `src/agents/session-file-repair.ts`
 - Called from `run/attempt.ts` and `compact.ts` (embedded runner)
 
+After a successful turn, the embedded runner also reconciles delivered final
+assistant text back into the durable transcript when streaming or tool-call
+sequencing produced `assistantTexts` without a matching stored assistant
+message. This keeps the next user turn anchored to the answer the user already
+saw without changing provider-specific outbound replay hygiene.
+
 ---
 
 ## Global rule: image sanitization

--- a/src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts
@@ -107,6 +107,53 @@ describe("assistant text transcript persistence", () => {
     ).toHaveLength(1);
   });
 
+  it("treats short streamed chunks as covered by a persisted full assistant message", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    sessionManager.appendMessage(textAssistant("All checks passed.\n\nDone.", 2));
+
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Done."],
+        messagesSnapshot: getPersistedMessages(sessionManager),
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual([]);
+  });
+
+  it("persists short final replies that only appear inside earlier assistant text", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    sessionManager.appendMessage(textAssistant("I'll get this done.", 2));
+    sessionManager.appendMessage(toolResult(3));
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Done."],
+        messagesSnapshot,
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual(["Done."]);
+
+    const reconciled = reconcileAssistantTextsWithTranscript({
+      sessionManager,
+      messagesSnapshot,
+      prePromptMessageCount: 0,
+      assistantTexts: ["Done."],
+      provider: "openai-codex",
+      modelId: "gpt-test",
+      timestamp: 4,
+    });
+
+    expect(reconciled).toBeDefined();
+    const assistantMessages = getPersistedMessages(sessionManager).filter(
+      (message) => message.role === "assistant",
+    );
+    expect(assistantMessages).toHaveLength(2);
+    expect(JSON.stringify(assistantMessages[1])).toContain("Done.");
+  });
+
   it("persists only visible text from delivery directive payloads", () => {
     expect(
       resolveUnpersistedAssistantTexts({

--- a/src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts
@@ -1,0 +1,122 @@
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { makeAgentAssistantMessage } from "../../test-helpers/agent-message-fixtures.js";
+import {
+  reconcileAssistantTextsWithTranscript,
+  resolveUnpersistedAssistantTexts,
+} from "./assistant-text-persistence.js";
+
+type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
+
+function getPersistedMessages(sessionManager: SessionManager) {
+  return sessionManager
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AppendMessage }).message);
+}
+
+function textAssistant(text: string, timestamp: number): AppendMessage {
+  return makeAgentAssistantMessage({
+    content: [{ type: "text", text }],
+    timestamp,
+  }) as AppendMessage;
+}
+
+function toolUseAssistant(timestamp: number): AppendMessage {
+  return makeAgentAssistantMessage({
+    content: [{ type: "toolCall", id: "call_1", name: "web_search", arguments: {} }],
+    stopReason: "toolUse",
+    timestamp,
+  }) as AppendMessage;
+}
+
+function toolResult(timestamp: number): AppendMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call_1",
+    toolName: "web_search",
+    content: [{ type: "text", text: "tool output" }],
+    isError: false,
+    timestamp,
+  } as AppendMessage;
+}
+
+describe("assistant text transcript persistence", () => {
+  it("persists delivered assistant text before the next unrelated user turn", () => {
+    const sessionManager = SessionManager.inMemory();
+    const userA = { role: "user", content: "question A", timestamp: 1 } as const;
+    sessionManager.appendMessage(userA);
+    sessionManager.appendMessage(toolUseAssistant(2));
+    sessionManager.appendMessage(toolResult(3));
+
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+    const reconciled = reconcileAssistantTextsWithTranscript({
+      sessionManager,
+      messagesSnapshot,
+      prePromptMessageCount: 0,
+      assistantTexts: ["Answer A was delivered to the requester."],
+      provider: "openai-codex",
+      modelId: "gpt-test",
+      timestamp: 4,
+    });
+
+    expect(reconciled).toBeDefined();
+    sessionManager.appendMessage({
+      role: "user",
+      content: "question B",
+      timestamp: 5,
+    });
+
+    const persisted = getPersistedMessages(sessionManager);
+    expect(persisted.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+      "user",
+    ]);
+    expect(JSON.stringify(persisted[3])).toContain("Answer A was delivered");
+    expect(JSON.stringify(persisted[4])).toContain("question B");
+  });
+
+  it("does not duplicate assistant text already persisted by the session manager", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    sessionManager.appendMessage(textAssistant("Answer A already persisted.", 2));
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Answer A already persisted."],
+        messagesSnapshot,
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual([]);
+    expect(
+      reconcileAssistantTextsWithTranscript({
+        sessionManager,
+        messagesSnapshot,
+        prePromptMessageCount: 0,
+        assistantTexts: ["Answer A already persisted."],
+        provider: "openai-codex",
+        modelId: "gpt-test",
+      }),
+    ).toBeUndefined();
+    expect(
+      getPersistedMessages(sessionManager).filter((message) => message.role === "assistant"),
+    ).toHaveLength(1);
+  });
+
+  it("persists only visible text from delivery directive payloads", () => {
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: [
+          "Here is the spreadsheet.\nMEDIA:./exports/report.xlsx",
+          "NO_REPLY\nMEDIA:./exports/audio.opus\n[[audio_as_voice]]",
+        ],
+        messagesSnapshot: [],
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual(["Here is the spreadsheet."]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts
@@ -1,0 +1,241 @@
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { makeAgentAssistantMessage } from "../../test-helpers/agent-message-fixtures.js";
+import {
+  reconcileAssistantTextsWithTranscript,
+  resolveUnpersistedAssistantTexts,
+} from "./assistant-text-persistence.js";
+
+type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
+
+function getPersistedMessages(sessionManager: SessionManager) {
+  return sessionManager
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AppendMessage }).message);
+}
+
+function textAssistant(text: string, timestamp: number): AppendMessage {
+  return makeAgentAssistantMessage({
+    content: [{ type: "text", text }],
+    timestamp,
+  }) as AppendMessage;
+}
+
+function toolUseAssistant(timestamp: number): AppendMessage {
+  return makeAgentAssistantMessage({
+    content: [{ type: "toolCall", id: "call_1", name: "web_search", arguments: {} }],
+    stopReason: "toolUse",
+    timestamp,
+  }) as AppendMessage;
+}
+
+function toolResult(timestamp: number): AppendMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call_1",
+    toolName: "web_search",
+    content: [{ type: "text", text: "tool output" }],
+    isError: false,
+    timestamp,
+  } as AppendMessage;
+}
+
+describe("assistant text transcript persistence", () => {
+  it("persists delivered assistant text before the next unrelated user turn", () => {
+    const sessionManager = SessionManager.inMemory();
+    const userA = { role: "user", content: "question A", timestamp: 1 } as const;
+    sessionManager.appendMessage(userA);
+    sessionManager.appendMessage(toolUseAssistant(2));
+    sessionManager.appendMessage(toolResult(3));
+
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+    const reconciled = reconcileAssistantTextsWithTranscript({
+      sessionManager,
+      mutableMessagesSnapshot: messagesSnapshot,
+      prePromptMessageCount: 0,
+      assistantTexts: ["Answer A was delivered to the requester."],
+      api: "openai-responses",
+      provider: "openai-codex",
+      modelId: "gpt-test",
+      timestamp: 4,
+    });
+
+    expect(reconciled).toBeDefined();
+    sessionManager.appendMessage({
+      role: "user",
+      content: "question B",
+      timestamp: 5,
+    });
+
+    const persisted = getPersistedMessages(sessionManager);
+    expect(persisted.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+      "user",
+    ]);
+    expect(JSON.stringify(persisted[3])).toContain("Answer A was delivered");
+    expect(JSON.stringify(persisted[4])).toContain("question B");
+  });
+
+  it("does not duplicate assistant text already persisted by the session manager", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    sessionManager.appendMessage(textAssistant("Answer A already persisted.", 2));
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Answer A already persisted."],
+        messagesSnapshot,
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual([]);
+    expect(
+      reconcileAssistantTextsWithTranscript({
+        sessionManager,
+        mutableMessagesSnapshot: messagesSnapshot,
+        prePromptMessageCount: 0,
+        assistantTexts: ["Answer A already persisted."],
+        api: "openai-responses",
+        provider: "openai-codex",
+        modelId: "gpt-test",
+      }),
+    ).toBeUndefined();
+    expect(
+      getPersistedMessages(sessionManager).filter((message) => message.role === "assistant"),
+    ).toHaveLength(1);
+  });
+
+  it("treats short streamed chunks as covered by a persisted full assistant message", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    sessionManager.appendMessage(textAssistant("All checks passed.\n\nDone.", 2));
+
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Done."],
+        messagesSnapshot: getPersistedMessages(sessionManager),
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual([]);
+  });
+
+  it("persists short final replies that only appear inside earlier assistant text", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    sessionManager.appendMessage(textAssistant("I'll get this done.", 2));
+    sessionManager.appendMessage(toolResult(3));
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Done."],
+        messagesSnapshot,
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual(["Done."]);
+
+    const reconciled = reconcileAssistantTextsWithTranscript({
+      sessionManager,
+      mutableMessagesSnapshot: messagesSnapshot,
+      prePromptMessageCount: 0,
+      assistantTexts: ["Done."],
+      api: "openai-responses",
+      provider: "openai-codex",
+      modelId: "gpt-test",
+      timestamp: 4,
+    });
+
+    expect(reconciled).toBeDefined();
+    const assistantMessages = getPersistedMessages(sessionManager).filter(
+      (message) => message.role === "assistant",
+    );
+    expect(assistantMessages).toHaveLength(2);
+    expect(JSON.stringify(assistantMessages[1])).toContain("Done.");
+  });
+
+  it("preserves the real model API on the reconciled assistant mirror", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+
+    const reconciled = reconcileAssistantTextsWithTranscript({
+      sessionManager,
+      mutableMessagesSnapshot: messagesSnapshot,
+      prePromptMessageCount: 0,
+      assistantTexts: ["Anthropic answer delivered."],
+      api: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-test",
+      timestamp: 2,
+    });
+
+    expect(reconciled?.api).toBe("anthropic-messages");
+    expect(reconciled?.provider).toBe("anthropic");
+    expect(reconciled?.model).toBe("claude-test");
+  });
+
+  it("uses prePromptMessageCount as the current-attempt persistence boundary", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    sessionManager.appendMessage(textAssistant("Earlier answer.", 2));
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Earlier answer."],
+        messagesSnapshot,
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual([]);
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Earlier answer."],
+        messagesSnapshot,
+        prePromptMessageCount: messagesSnapshot.length,
+      }),
+    ).toEqual(["Earlier answer."]);
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: ["Earlier answer."],
+        messagesSnapshot,
+        prePromptMessageCount: messagesSnapshot.length + 1,
+      }),
+    ).toEqual(["Earlier answer."]);
+  });
+
+  it("appends reconciled mirrors to the mutable snapshot for downstream consumers", () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "question A", timestamp: 1 });
+    const messagesSnapshot = getPersistedMessages(sessionManager);
+
+    const reconciled = reconcileAssistantTextsWithTranscript({
+      sessionManager,
+      mutableMessagesSnapshot: messagesSnapshot,
+      prePromptMessageCount: 0,
+      assistantTexts: ["Answer A was delivered."],
+      api: "openai-responses",
+      provider: "openai-codex",
+      modelId: "gpt-test",
+      timestamp: 2,
+    });
+
+    expect(messagesSnapshot.at(-1)).toBe(reconciled);
+  });
+
+  it("persists only visible text from delivery directive payloads", () => {
+    expect(
+      resolveUnpersistedAssistantTexts({
+        assistantTexts: [
+          "Here is the spreadsheet.\nMEDIA:./exports/report.xlsx",
+          "NO_REPLY\nMEDIA:./exports/audio.opus\n[[audio_as_voice]]",
+        ],
+        messagesSnapshot: [],
+        prePromptMessageCount: 0,
+      }),
+    ).toEqual(["Here is the spreadsheet."]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/assistant-text-persistence.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-text-persistence.ts
@@ -1,13 +1,22 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { AssistantMessage, Usage } from "@mariozechner/pi-ai";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import { normalizeTextForComparison } from "../../pi-embedded-helpers.js";
 import { extractAssistantVisibleText, isAssistantMessage } from "../../pi-embedded-utils.js";
-import { makeZeroUsageSnapshot, type NormalizedUsage } from "../../usage.js";
+import { makeZeroUsageSnapshot } from "../../usage.js";
 
 type SessionManagerAppender = Pick<SessionManager, "appendMessage">;
+
+const SHORT_SUBSTRING_COVERAGE_MAX_LENGTH = 16;
+
+function normalizedTextSegments(text: string): string[] {
+  return text
+    .split(/(?:\r?\n)+|(?<=[.!?])\s+/u)
+    .map((segment) => normalizeTextForComparison(segment))
+    .filter(Boolean);
+}
 
 function persistedTextCoversAssistantText(persisted: string, candidate: string): boolean {
   const persistedNormalized = normalizeTextForComparison(persisted);
@@ -18,7 +27,10 @@ function persistedTextCoversAssistantText(persisted: string, candidate: string):
   if (persistedNormalized === candidateNormalized) {
     return true;
   }
-  return candidateNormalized.length >= 20 && persistedNormalized.includes(candidateNormalized);
+  if (candidateNormalized.length <= SHORT_SUBSTRING_COVERAGE_MAX_LENGTH) {
+    return normalizedTextSegments(persisted).includes(candidateNormalized);
+  }
+  return persistedNormalized.includes(candidateNormalized);
 }
 
 function toPersistableAssistantText(text: string): string | undefined {
@@ -49,25 +61,6 @@ export function resolveUnpersistedAssistantTexts(params: {
     );
 }
 
-function toAssistantUsageSnapshot(usage?: NormalizedUsage): Usage {
-  const zero = makeZeroUsageSnapshot();
-  if (!usage) {
-    return zero;
-  }
-  const input = usage.input ?? 0;
-  const output = usage.output ?? 0;
-  const cacheRead = usage.cacheRead ?? 0;
-  const cacheWrite = usage.cacheWrite ?? 0;
-  return {
-    ...zero,
-    input,
-    output,
-    cacheRead,
-    cacheWrite,
-    totalTokens: usage.total ?? input + output + cacheRead + cacheWrite,
-  };
-}
-
 export function reconcileAssistantTextsWithTranscript(params: {
   sessionManager: SessionManagerAppender;
   messagesSnapshot: AgentMessage[];
@@ -75,7 +68,6 @@ export function reconcileAssistantTextsWithTranscript(params: {
   assistantTexts: readonly string[];
   provider: string;
   modelId: string;
-  usage?: NormalizedUsage;
   timestamp?: number;
 }): AssistantMessage | undefined {
   const text = normalizeOptionalString(
@@ -95,7 +87,7 @@ export function reconcileAssistantTextsWithTranscript(params: {
     api: "openai-responses",
     provider: params.provider,
     model: params.modelId,
-    usage: toAssistantUsageSnapshot(params.usage),
+    usage: makeZeroUsageSnapshot(),
     stopReason: "stop",
     timestamp: params.timestamp ?? Date.now(),
   };

--- a/src/agents/pi-embedded-runner/run/assistant-text-persistence.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-text-persistence.ts
@@ -1,0 +1,105 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, Usage } from "@mariozechner/pi-ai";
+import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
+import { normalizeOptionalString } from "../../../shared/string-coerce.js";
+import { normalizeTextForComparison } from "../../pi-embedded-helpers.js";
+import { extractAssistantVisibleText, isAssistantMessage } from "../../pi-embedded-utils.js";
+import { makeZeroUsageSnapshot, type NormalizedUsage } from "../../usage.js";
+
+type SessionManagerAppender = Pick<SessionManager, "appendMessage">;
+
+function persistedTextCoversAssistantText(persisted: string, candidate: string): boolean {
+  const persistedNormalized = normalizeTextForComparison(persisted);
+  const candidateNormalized = normalizeTextForComparison(candidate);
+  if (!persistedNormalized || !candidateNormalized) {
+    return false;
+  }
+  if (persistedNormalized === candidateNormalized) {
+    return true;
+  }
+  return candidateNormalized.length >= 20 && persistedNormalized.includes(candidateNormalized);
+}
+
+function toPersistableAssistantText(text: string): string | undefined {
+  return normalizeOptionalString(parseReplyDirectives(text).text);
+}
+
+export function resolveUnpersistedAssistantTexts(params: {
+  assistantTexts: readonly string[];
+  messagesSnapshot: readonly AgentMessage[];
+  prePromptMessageCount: number;
+}): string[] {
+  const currentAttemptMessages = params.messagesSnapshot.slice(
+    Math.max(0, params.prePromptMessageCount),
+  );
+  const persistedAssistantTexts = currentAttemptMessages
+    .filter(isAssistantMessage)
+    .map((message) => normalizeOptionalString(extractAssistantVisibleText(message)) ?? "")
+    .filter(Boolean);
+
+  return params.assistantTexts
+    .map((text) => toPersistableAssistantText(text) ?? "")
+    .filter(Boolean)
+    .filter(
+      (text) =>
+        !persistedAssistantTexts.some((persisted) =>
+          persistedTextCoversAssistantText(persisted, text),
+        ),
+    );
+}
+
+function toAssistantUsageSnapshot(usage?: NormalizedUsage): Usage {
+  const zero = makeZeroUsageSnapshot();
+  if (!usage) {
+    return zero;
+  }
+  const input = usage.input ?? 0;
+  const output = usage.output ?? 0;
+  const cacheRead = usage.cacheRead ?? 0;
+  const cacheWrite = usage.cacheWrite ?? 0;
+  return {
+    ...zero,
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    totalTokens: usage.total ?? input + output + cacheRead + cacheWrite,
+  };
+}
+
+export function reconcileAssistantTextsWithTranscript(params: {
+  sessionManager: SessionManagerAppender;
+  messagesSnapshot: AgentMessage[];
+  prePromptMessageCount: number;
+  assistantTexts: readonly string[];
+  provider: string;
+  modelId: string;
+  usage?: NormalizedUsage;
+  timestamp?: number;
+}): AssistantMessage | undefined {
+  const text = normalizeOptionalString(
+    resolveUnpersistedAssistantTexts({
+      assistantTexts: params.assistantTexts,
+      messagesSnapshot: params.messagesSnapshot,
+      prePromptMessageCount: params.prePromptMessageCount,
+    }).join("\n\n"),
+  );
+  if (!text) {
+    return undefined;
+  }
+
+  const message: AssistantMessage = {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: params.provider,
+    model: params.modelId,
+    usage: toAssistantUsageSnapshot(params.usage),
+    stopReason: "stop",
+    timestamp: params.timestamp ?? Date.now(),
+  };
+  params.sessionManager.appendMessage(message);
+  params.messagesSnapshot.push(message);
+  return message;
+}

--- a/src/agents/pi-embedded-runner/run/assistant-text-persistence.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-text-persistence.ts
@@ -1,0 +1,108 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { SessionManager } from "@earendil-works/pi-coding-agent";
+import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
+import { normalizeOptionalString } from "../../../shared/string-coerce.js";
+import { normalizeTextForComparison } from "../../pi-embedded-helpers.js";
+import { extractAssistantVisibleText, isAssistantMessage } from "../../pi-embedded-utils.js";
+import { makeZeroUsageSnapshot } from "../../usage.js";
+
+type SessionManagerAppender = Pick<SessionManager, "appendMessage">;
+
+const SHORT_SUBSTRING_COVERAGE_MAX_LENGTH = 16;
+
+function normalizedTextSegments(text: string): string[] {
+  return text
+    .split(/(?:\r?\n)+|(?<=[.!?])\s+/u)
+    .map((segment) => normalizeTextForComparison(segment))
+    .filter(Boolean);
+}
+
+function persistedTextCoversAssistantText(persisted: string, candidate: string): boolean {
+  const persistedNormalized = normalizeTextForComparison(persisted);
+  const candidateNormalized = normalizeTextForComparison(candidate);
+  if (!persistedNormalized || !candidateNormalized) {
+    return false;
+  }
+  if (persistedNormalized === candidateNormalized) {
+    return true;
+  }
+  if (candidateNormalized.length <= SHORT_SUBSTRING_COVERAGE_MAX_LENGTH) {
+    return normalizedTextSegments(persisted).includes(candidateNormalized);
+  }
+  return candidateNormalized.length >= 20 && persistedNormalized.includes(candidateNormalized);
+}
+
+function toPersistableAssistantText(text: string): string | undefined {
+  return normalizeOptionalString(parseReplyDirectives(text).text);
+}
+
+export function resolveUnpersistedAssistantTexts(params: {
+  assistantTexts: readonly string[];
+  messagesSnapshot: readonly AgentMessage[];
+  /**
+   * The message count captured at prompt entry for this attempt. Only messages
+   * appended at or after this boundary can prove that the current delivered
+   * assistant text was already durably persisted.
+   */
+  prePromptMessageCount: number;
+}): string[] {
+  const currentAttemptMessages = params.messagesSnapshot.slice(
+    Math.max(0, params.prePromptMessageCount),
+  );
+  const persistedAssistantTexts = currentAttemptMessages
+    .filter(isAssistantMessage)
+    .map((message) => normalizeOptionalString(extractAssistantVisibleText(message)) ?? "")
+    .filter(Boolean);
+
+  return params.assistantTexts
+    .map((text) => toPersistableAssistantText(text) ?? "")
+    .filter(Boolean)
+    .filter(
+      (text) =>
+        !persistedAssistantTexts.some((persisted) =>
+          persistedTextCoversAssistantText(persisted, text),
+        ),
+    );
+}
+
+export function reconcileAssistantTextsWithTranscript(params: {
+  sessionManager: SessionManagerAppender;
+  /**
+   * Mutable turn snapshot. The reconciled assistant mirror is appended here so
+   * downstream after-turn consumers see the same assistant text that was written
+   * to the durable transcript.
+   */
+  mutableMessagesSnapshot: AgentMessage[];
+  prePromptMessageCount: number;
+  assistantTexts: readonly string[];
+  api: AssistantMessage["api"];
+  provider: string;
+  modelId: string;
+  timestamp?: number;
+}): AssistantMessage | undefined {
+  const text = normalizeOptionalString(
+    resolveUnpersistedAssistantTexts({
+      assistantTexts: params.assistantTexts,
+      messagesSnapshot: params.mutableMessagesSnapshot,
+      prePromptMessageCount: params.prePromptMessageCount,
+    }).join("\n\n"),
+  );
+  if (!text) {
+    return undefined;
+  }
+
+  const message: AssistantMessage = {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: params.api,
+    provider: params.provider,
+    model: params.modelId,
+    usage: makeZeroUsageSnapshot(),
+    stopReason: "stop",
+    timestamp: params.timestamp ?? Date.now(),
+  };
+  params.sessionManager.appendMessage(message);
+  params.mutableMessagesSnapshot.push(message);
+  return message;
+}

--- a/src/agents/pi-embedded-runner/run/assistant-text-persistence.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-text-persistence.ts
@@ -30,7 +30,7 @@ function persistedTextCoversAssistantText(persisted: string, candidate: string):
   if (candidateNormalized.length <= SHORT_SUBSTRING_COVERAGE_MAX_LENGTH) {
     return normalizedTextSegments(persisted).includes(candidateNormalized);
   }
-  return candidateNormalized.length >= 20 && persistedNormalized.includes(candidateNormalized);
+  return persistedNormalized.includes(candidateNormalized);
 }
 
 function toPersistableAssistantText(text: string): string | undefined {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,4 +1,6 @@
-import { streamSimple } from "@earendil-works/pi-ai";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { streamSimple, type AssistantMessage } from "@earendil-works/pi-ai";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../context-engine-capabilities.js", () => ({
@@ -128,6 +130,48 @@ describe("buildEmbeddedAttemptToolRunContext", () => {
     expect(context.jobId).toBe("job-1");
     expect(context.memoryFlushWritePath).toBe("memory/log.md");
     expect(context.runtimeToolAllowlist).toEqual(["memory_search", "memory_get"]);
+  });
+});
+
+describe("reconcileAssistantTranscriptAndPreserveLastAssistant", () => {
+  it("keeps real assistant usage while appending a zero-usage transcript mirror", () => {
+    const sessionManager = SessionManager.inMemory();
+    const realLastAssistant = {
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      usage: { input: 100, output: 25, totalTokens: 125 },
+      stopReason: "toolUse",
+      timestamp: 2,
+    } as AssistantMessage;
+
+    sessionManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
+    sessionManager.appendMessage(realLastAssistant);
+    const messagesSnapshot = sessionManager
+      .getEntries()
+      .filter((entry) => entry.type === "message")
+      .map((entry) => (entry as { message: AgentMessage }).message);
+
+    const preserved = attemptTesting.reconcileAssistantTranscriptAndPreserveLastAssistant({
+      sessionManager,
+      mutableMessagesSnapshot: messagesSnapshot,
+      prePromptMessageCount: 0,
+      assistantTexts: ["Final answer delivered after the tool call."],
+      api: "openai-responses",
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      lastAssistant: realLastAssistant,
+    });
+
+    const mirror = messagesSnapshot.at(-1) as AssistantMessage;
+    expect(preserved).toBe(realLastAssistant);
+    expect(preserved?.usage).toEqual(realLastAssistant.usage);
+    expect((preserved?.usage as { totalTokens?: number }).totalTokens).toBe(125);
+    expect(mirror).not.toBe(realLastAssistant);
+    expect(JSON.stringify(mirror.content)).toContain("Final answer delivered");
+    expect((mirror.usage as { totalTokens?: number }).totalTokens).toBe(0);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3222,20 +3222,21 @@ export async function runEmbeddedAttempt(
           prePromptMessageCount,
         });
         attemptUsage = getUsageTotals();
-        if (!promptError && !aborted && !yieldAborted && !timedOutDuringCompaction) {
-          const reconciledAssistant = reconcileAssistantTextsWithTranscript({
+        if (
+          !promptError &&
+          !aborted &&
+          !yieldAborted &&
+          !timedOutDuringCompaction &&
+          !compactionOccurredThisAttempt
+        ) {
+          reconcileAssistantTextsWithTranscript({
             sessionManager,
             messagesSnapshot,
             prePromptMessageCount,
             assistantTexts,
             provider: params.provider,
             modelId: params.modelId,
-            usage: normalizeUsage(currentAttemptAssistant?.usage) ?? attemptUsage,
           });
-          if (reconciledAssistant) {
-            lastAssistant = reconciledAssistant;
-            currentAttemptAssistant = reconciledAssistant;
-          }
         }
         cacheBreak = cacheObservabilityEnabled
           ? completePromptCacheObservation({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -232,6 +232,7 @@ import { splitSdkTools } from "../tool-split.js";
 import { mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
+import { reconcileAssistantTextsWithTranscript } from "./assistant-text-persistence.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
 import {
@@ -3221,6 +3222,21 @@ export async function runEmbeddedAttempt(
           prePromptMessageCount,
         });
         attemptUsage = getUsageTotals();
+        if (!promptError && !aborted && !yieldAborted && !timedOutDuringCompaction) {
+          const reconciledAssistant = reconcileAssistantTextsWithTranscript({
+            sessionManager,
+            messagesSnapshot,
+            prePromptMessageCount,
+            assistantTexts,
+            provider: params.provider,
+            modelId: params.modelId,
+            usage: normalizeUsage(currentAttemptAssistant?.usage) ?? attemptUsage,
+          });
+          if (reconciledAssistant) {
+            lastAssistant = reconciledAssistant;
+            currentAttemptAssistant = reconciledAssistant;
+          }
+        }
         cacheBreak = cacheObservabilityEnabled
           ? completePromptCacheObservation({
               sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -277,6 +277,7 @@ import { splitSdkTools } from "../tool-split.js";
 import { mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
+import { reconcileAssistantTextsWithTranscript } from "./assistant-text-persistence.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 import {
   applyEmbeddedAttemptToolsAllow,
@@ -4313,6 +4314,27 @@ export async function runEmbeddedAttempt(
             prePromptMessageCount,
           });
           attemptUsage = getUsageTotals();
+          lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
+          if (
+            !promptError &&
+            !aborted &&
+            !yieldAborted &&
+            !timedOutDuringCompaction &&
+            !compactionOccurredThisAttempt
+          ) {
+            const reconciledAssistant = reconcileAssistantTextsWithTranscript({
+              sessionManager,
+              mutableMessagesSnapshot: messagesSnapshot,
+              prePromptMessageCount,
+              assistantTexts,
+              api: params.model.api,
+              provider: params.provider,
+              modelId: params.modelId,
+            });
+            if (reconciledAssistant) {
+              lastAssistant = reconciledAssistant;
+            }
+          }
           cacheBreak = cacheObservabilityEnabled
             ? completePromptCacheObservation({
                 sessionId: params.sessionId,
@@ -4320,7 +4342,6 @@ export async function runEmbeddedAttempt(
                 usage: attemptUsage,
               })
             : null;
-          lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
           const promptCacheObservation =
             cacheObservabilityEnabled &&
             (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -784,9 +784,32 @@ async function cancelQueuedSteeringMessage(
 
 export const testing = {
   cancelQueuedSteeringMessage,
+  reconcileAssistantTranscriptAndPreserveLastAssistant,
   resolveAttemptStreamAuthProfileId,
   steerAndWaitForTranscriptCommit,
 };
+
+function reconcileAssistantTranscriptAndPreserveLastAssistant(params: {
+  sessionManager: Pick<SessionManager, "appendMessage">;
+  mutableMessagesSnapshot: AgentMessage[];
+  prePromptMessageCount: number;
+  assistantTexts: readonly string[];
+  api: AssistantMessage["api"];
+  provider: string;
+  modelId: string;
+  lastAssistant: AssistantMessage | undefined;
+}): AssistantMessage | undefined {
+  reconcileAssistantTextsWithTranscript({
+    sessionManager: params.sessionManager,
+    mutableMessagesSnapshot: params.mutableMessagesSnapshot,
+    prePromptMessageCount: params.prePromptMessageCount,
+    assistantTexts: params.assistantTexts,
+    api: params.api,
+    provider: params.provider,
+    modelId: params.modelId,
+  });
+  return params.lastAssistant;
+}
 
 function resolveAttemptStreamAuthProfileId(
   params: Pick<EmbeddedRunAttemptParams, "authProfileId" | "runtimePlan">,
@@ -3190,9 +3213,8 @@ export async function runEmbeddedAttempt(
         prompt: string,
         options?: Parameters<typeof activeSession.prompt>[1],
       ): Promise<void> =>
-        withOwnedSessionTranscriptWrites(
-          ownedTranscriptWriteContext,
-          async () => abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options))),
+        withOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, async () =>
+          abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options))),
         );
       const onBlockReply = params.onBlockReply
         ? bindOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, params.onBlockReply)
@@ -4322,18 +4344,16 @@ export async function runEmbeddedAttempt(
             !timedOutDuringCompaction &&
             !compactionOccurredThisAttempt
           ) {
-            const reconciledAssistant = reconcileAssistantTextsWithTranscript({
-              sessionManager,
+            lastAssistant = reconcileAssistantTranscriptAndPreserveLastAssistant({
+              sessionManager: activeSessionManager,
               mutableMessagesSnapshot: messagesSnapshot,
               prePromptMessageCount,
               assistantTexts,
               api: params.model.api,
               provider: params.provider,
               modelId: params.modelId,
+              lastAssistant,
             });
-            if (reconciledAssistant) {
-              lastAssistant = reconciledAssistant;
-            }
           }
           cacheBreak = cacheObservabilityEnabled
             ? completePromptCacheObservation({


### PR DESCRIPTION
## Summary
- Problem: tool-using embedded-agent turns can deliver final assistant text through `assistantTexts` without a matching durable assistant text message.
- Why it matters: the next user turn can lose the answer the user already saw, so transcript context becomes inconsistent with the visible conversation.
- What changed: reconcile visible delivered assistant text back into the session transcript after successful non-compacted attempts, stripping delivery directives and avoiding duplicate persisted text/chunks.
- Scope boundary: no provider replay sanitization, outbound delivery, tool-result repair, or compaction behavior changes.

Related #77447, #77448.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Delivered assistant text from tool-using embedded-agent turns was visible to the user but could be missing from durable transcript state, so later turns lost context the user had already seen.
- Real environment tested: Local OpenClaw checkout on macOS rebased on current `origin/main` at commits `1227486ee2` and `9b2b46f229`, using the repo runner against the actual embedded-runner transcript reconciliation path.
- Exact steps or command run after this patch: `node scripts/test-projects.mjs src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts src/agents/pi-embedded-runner/usage-reporting.test.ts` and `git diff --check HEAD~1..HEAD`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local checkout:

```text
$ node scripts/test-projects.mjs src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts src/agents/pi-embedded-runner/usage-reporting.test.ts
unit-fast: 1 file passed, 8 tests passed
agents: 2 files passed, 152 tests passed
[test] passed 2 Vitest shards in 27.97s

$ git diff --check HEAD~1..HEAD
(no output)
```

- Observed result after fix: Missing delivered assistant text is appended as durable assistant prose before the next unrelated user turn, while already-persisted text, covered streamed chunks, `MEDIA:` directives, and `NO_REPLY` payloads are not duplicated as visible prose. The attempt keeps the real model `lastAssistant` for accounting: the regression preserves a non-zero `totalTokens=125` usage snapshot while the durable transcript mirror remains zero-usage.
- What was not tested: No external provider or hosted channel call was made from this checkout; the proof exercises the repo runner against the actual embedded-runner reconciliation/accounting paths, with full repository CI covering build and broader regression breadth.
- Before evidence (optional but encouraged): Before the patch, the durable transcript could remain `user -> assistant(toolCall) -> toolResult -> next user` even though the user had seen a final assistant answer. Before the follow-up fix, the zero-usage transcript mirror could also replace `lastAssistant`, risking bad usage/accounting metadata.

## Root Cause
- `assistantTexts` is the user-visible final text source for some streaming/tool-call flows, but session persistence can already contain only the tool-call assistant/tool-result sequence. Nothing reconciled the delivered final text back into the durable transcript before the next turn.

## Testing
- node scripts/test-projects.mjs src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/assistant-text-persistence.test.ts src/agents/pi-embedded-runner/usage-reporting.test.ts
- git diff --check HEAD~1..HEAD

## User-visible / Behavior Changes
Successful tool-using turns now keep delivered final assistant text in durable context for later turns. Delivery directives such as `MEDIA:` and silent `NO_REPLY` payloads are not persisted as assistant prose.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
