### PR TITLE
fix(agents): honor hook bootstrap content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,7 @@ Docs: https://docs.openclaw.ai
 - Security/Windows: block `LOCALAPPDATA` from workspace `.env` and resolve Windows update-flow portable Git path prepends from the trusted process-local `LOCALAPPDATA` only, so workspace-supplied values cannot redirect `git` discovery during `openclaw update`. (#77470) Thanks @drobison00.
 - Browser/SSRF: enforce the existing current-tab URL navigation policy before tab-scoped debug, export, and read routes (console, page errors, network requests, trace start/stop, response body, screenshot, snapshot, storage, etc.) collect from an already-selected tab, so blocked tabs return a policy error instead of being read first and redacted only at response time. (#75731) Thanks @eleqtrizit.
 - Security/Windows: route the `.cmd`/`.bat` process wrapper through the shared Windows install-root resolver instead of `process.env.ComSpec`, so workspace dotenv-blocked `SystemRoot`/`WINDIR` overrides and unsafe values like UNC paths or path-lists cannot redirect `cmd.exe` selection on Windows. (#77472) Thanks @drobison00.
+- Agents/bootstrap: honor `BOOTSTRAP.md` content injected by `agent:bootstrap` hooks when deciding whether bootstrap is pending, so hook-provided required setup instructions are included in the system prompt. (#77501) Thanks @ificator.
 
 ## 2026.5.3-1
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -279,12 +279,23 @@ export async function resolveBootstrapContextForRun(params: {
   contextFiles: EmbeddedContextFile[];
 }> {
   const bootstrapFiles = await resolveBootstrapFilesForRun(params);
+  const contextFiles = buildBootstrapContextForFiles(bootstrapFiles, params);
+  return { bootstrapFiles, contextFiles };
+}
+
+export function buildBootstrapContextForFiles(
+  bootstrapFiles: WorkspaceBootstrapFile[],
+  params: {
+    config?: OpenClawConfig;
+    warn?: (message: string) => void;
+  },
+): EmbeddedContextFile[] {
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
     maxChars: resolveBootstrapMaxChars(params.config),
     totalMaxChars: resolveBootstrapTotalMaxChars(params.config),
     warn: params.warn,
   });
-  return { bootstrapFiles, contextFiles };
+  return contextFiles;
 }
 
 export { isWorkspaceBootstrapPending };

--- a/src/agents/pi-embedded-runner/run/attempt-bootstrap-routing.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-bootstrap-routing.ts
@@ -1,5 +1,6 @@
 import type { BootstrapMode } from "../../bootstrap-mode.js";
 import { resolveBootstrapMode } from "../../bootstrap-mode.js";
+import { DEFAULT_BOOTSTRAP_FILENAME, type WorkspaceBootstrapFile } from "../../workspace.js";
 
 export type AttemptBootstrapRoutingInput = {
   workspaceBootstrapPending: boolean;
@@ -24,6 +25,7 @@ export type AttemptWorkspaceBootstrapRoutingInput = Omit<
   "workspaceBootstrapPending"
 > & {
   isWorkspaceBootstrapPending: (workspaceDir: string) => Promise<boolean>;
+  bootstrapFiles?: readonly WorkspaceBootstrapFile[];
 };
 
 export function resolveBootstrapContextTargets(params: {
@@ -58,14 +60,28 @@ function resolveAttemptBootstrapRouting(
   };
 }
 
+export function hasBootstrapFileContent(files?: readonly WorkspaceBootstrapFile[]): boolean {
+  return (
+    files?.some(
+      (file) =>
+        file.name === DEFAULT_BOOTSTRAP_FILENAME &&
+        !file.missing &&
+        typeof file.content === "string" &&
+        file.content.trim().length > 0,
+    ) ?? false
+  );
+}
+
 export async function resolveAttemptWorkspaceBootstrapRouting(
   params: AttemptWorkspaceBootstrapRoutingInput,
 ): Promise<AttemptBootstrapRouting> {
   const workspaceBootstrapPending = await params.isWorkspaceBootstrapPending(
     params.resolvedWorkspace,
   );
+  const hasHookBootstrapContent = hasBootstrapFileContent(params.bootstrapFiles);
   return resolveAttemptBootstrapRouting({
     ...params,
-    workspaceBootstrapPending,
+    workspaceBootstrapPending: workspaceBootstrapPending || hasHookBootstrapContent,
+    hasBootstrapFileAccess: params.hasBootstrapFileAccess || hasHookBootstrapContent,
   });
 }

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-routing.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  hasBootstrapFileContent,
   resolveBootstrapContextTargets,
   resolveAttemptWorkspaceBootstrapRouting,
 } from "./attempt-bootstrap-routing.js";
@@ -44,6 +45,67 @@ describe("runEmbeddedAttempt bootstrap routing", () => {
     expect(routing.bootstrapMode).toBe("limited");
     expect(routing.includeBootstrapInSystemContext).toBe(false);
     expect(routing.includeBootstrapInRuntimeContext).toBe(false);
+  });
+
+  it("treats hook-provided BOOTSTRAP.md content as pending bootstrap context", async () => {
+    const routing = await resolveAttemptWorkspaceBootstrapRouting({
+      isWorkspaceBootstrapPending: vi.fn(async () => false),
+      bootstrapFiles: [
+        {
+          name: "BOOTSTRAP.md",
+          path: "/tmp/openclaw-workspace/BOOTSTRAP.md",
+          content: "Ask who I am before continuing.",
+          missing: false,
+        },
+      ],
+      trigger: "user",
+      isPrimaryRun: true,
+      isCanonicalWorkspace: true,
+      effectiveWorkspace: "/tmp/openclaw-workspace",
+      resolvedWorkspace: "/tmp/openclaw-workspace",
+      hasBootstrapFileAccess: true,
+    });
+
+    expect(routing.bootstrapMode).toBe("full");
+    expect(routing.includeBootstrapInSystemContext).toBe(true);
+    expect(routing.includeBootstrapInRuntimeContext).toBe(false);
+  });
+
+  it("uses hook-provided BOOTSTRAP.md content even when normal file reads are unavailable", async () => {
+    const routing = await resolveAttemptWorkspaceBootstrapRouting({
+      isWorkspaceBootstrapPending: vi.fn(async () => false),
+      bootstrapFiles: [
+        {
+          name: "BOOTSTRAP.md",
+          path: "/tmp/openclaw-workspace/BOOTSTRAP.md",
+          content: "Ask who I am before continuing.",
+          missing: false,
+        },
+      ],
+      trigger: "user",
+      isPrimaryRun: true,
+      isCanonicalWorkspace: true,
+      effectiveWorkspace: "/tmp/openclaw-workspace",
+      resolvedWorkspace: "/tmp/openclaw-workspace",
+      hasBootstrapFileAccess: false,
+    });
+
+    expect(routing.bootstrapMode).toBe("full");
+    expect(routing.includeBootstrapInSystemContext).toBe(true);
+    expect(routing.includeBootstrapInRuntimeContext).toBe(false);
+  });
+
+  it("does not treat empty hook-provided BOOTSTRAP.md as pending bootstrap context", () => {
+    expect(
+      hasBootstrapFileContent([
+        {
+          name: "BOOTSTRAP.md",
+          path: "/tmp/openclaw-workspace/BOOTSTRAP.md",
+          content: "   ",
+          missing: false,
+        },
+      ]),
+    ).toBe(false);
   });
 
   it("keeps BOOTSTRAP.md in Project Context for full bootstrap turns", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -316,6 +316,54 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(systemPrompt).toContain("Ask who I am.");
   });
 
+  it("includes hook-adjusted bootstrap files preloaded before routing", async () => {
+    const workspaceDir = "/tmp/openclaw-hook-workspace";
+    hoisted.resolveBootstrapFilesForRunMock.mockResolvedValueOnce([
+      {
+        name: "BOOTSTRAP.md",
+        path: `${workspaceDir}/BOOTSTRAP.md`,
+        content: "Ask who I am before continuing.",
+        missing: false,
+      },
+    ]);
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        config: {
+          agents: {
+            defaults: {
+              systemPromptOverride: "Custom override prompt.",
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "visible ask",
+        transcriptPrompt: "visible ask",
+        trigger: "user",
+        workspaceDir,
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    expect(hoisted.resolveBootstrapFilesForRunMock).toHaveBeenCalledOnce();
+    expect(hoisted.resolveBootstrapContextForRunMock).not.toHaveBeenCalled();
+    const systemPrompt =
+      hoisted.systemPromptOverrideTexts.find((text) => text.includes("Custom override prompt.")) ??
+      "";
+
+    expect(systemPrompt).toContain("## Bootstrap Pending");
+    expect(systemPrompt).toContain("BOOTSTRAP.md is included below in Project Context");
+    expect(systemPrompt).toContain(`## ${workspaceDir}/BOOTSTRAP.md`);
+    expect(systemPrompt).toContain("Ask who I am before continuing.");
+  });
+
   it("adds explicit reply context to the current model input without exposing generic runtime context", async () => {
     let seenPrompt: string | undefined;
 

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -69,6 +69,9 @@ type AttemptSpawnWorkspaceHoisted = {
   installContextEngineLoopHookMock: UnknownMock;
   flushPendingToolResultsAfterIdleMock: AsyncUnknownMock;
   releaseWsSessionMock: UnknownMock;
+  resolveBootstrapFilesForRunMock: Mock<
+    (...args: unknown[]) => Promise<WorkspaceBootstrapFile[]>
+  >;
   resolveBootstrapContextForRunMock: Mock<() => Promise<BootstrapContext>>;
   isWorkspaceBootstrapPendingMock: Mock<(workspaceDir: string) => Promise<boolean>>;
   resolveContextInjectionModeMock: Mock<() => "always" | "continuation-skip">;
@@ -139,6 +142,12 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     bootstrapFiles: [],
     contextFiles: [],
   }));
+  const resolveBootstrapFilesForRunMock = vi.fn<
+    (...args: unknown[]) => Promise<WorkspaceBootstrapFile[]>
+  >(async () => {
+    const context = await resolveBootstrapContextForRunMock();
+    return context.bootstrapFiles;
+  });
   const isWorkspaceBootstrapPendingMock = vi.fn<(workspaceDir: string) => Promise<boolean>>(
     async () => false,
   );
@@ -188,6 +197,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     installContextEngineLoopHookMock,
     flushPendingToolResultsAfterIdleMock,
     releaseWsSessionMock,
+    resolveBootstrapFilesForRunMock,
     resolveBootstrapContextForRunMock,
     isWorkspaceBootstrapPendingMock,
     resolveContextInjectionModeMock,
@@ -286,6 +296,7 @@ vi.mock("../../bootstrap-files.js", async () => {
     ...actual,
     makeBootstrapWarn: () => () => {},
     isWorkspaceBootstrapPending: hoisted.isWorkspaceBootstrapPendingMock,
+    resolveBootstrapFilesForRun: hoisted.resolveBootstrapFilesForRunMock,
     resolveBootstrapContextForRun: hoisted.resolveBootstrapContextForRunMock,
     resolveContextInjectionMode: hoisted.resolveContextInjectionModeMock,
     hasCompletedBootstrapTurn: hoisted.hasCompletedBootstrapTurnMock,
@@ -820,6 +831,10 @@ export function resetEmbeddedAttemptHarness(
   hoisted.resolveBootstrapContextForRunMock.mockReset().mockResolvedValue({
     bootstrapFiles: [],
     contextFiles: [],
+  });
+  hoisted.resolveBootstrapFilesForRunMock.mockReset().mockImplementation(async () => {
+    const context = await hoisted.resolveBootstrapContextForRunMock();
+    return context.bootstrapFiles;
   });
   hoisted.isWorkspaceBootstrapPendingMock.mockReset().mockResolvedValue(false);
   hoisted.resolveContextInjectionModeMock.mockReset().mockReturnValue("always");

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -62,10 +62,11 @@ import {
 } from "../../bootstrap-budget.js";
 import {
   FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+  buildBootstrapContextForFiles,
   hasCompletedBootstrapTurn,
   isWorkspaceBootstrapPending,
   makeBootstrapWarn,
-  resolveBootstrapContextForRun,
+  resolveBootstrapFilesForRun,
   resolveContextInjectionMode,
 } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
@@ -945,8 +946,26 @@ export async function runEmbeddedAttempt(
     emitCorePluginToolStageSummary("core-plugin-tools", corePluginToolStages.snapshot());
     const toolsEnabled = supportsModelTools(params.model);
     const bootstrapHasFileAccess = toolsEnabled && toolsRaw.some((tool) => tool.name === "read");
+    const bootstrapWarn = makeBootstrapWarn({
+      sessionLabel,
+      workspaceDir: resolvedWorkspace,
+      warn: (message) => log.warn(message),
+    });
+    const preloadedBootstrapFiles =
+      isRawModelRun || contextInjectionMode === "never"
+        ? undefined
+        : await resolveBootstrapFilesForRun({
+            workspaceDir: resolvedWorkspace,
+            config: params.config,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            warn: bootstrapWarn,
+            contextMode: params.bootstrapContextMode,
+            runKind: params.bootstrapContextRunKind,
+          });
     const bootstrapRouting = await resolveAttemptWorkspaceBootstrapRouting({
       isWorkspaceBootstrapPending,
+      bootstrapFiles: preloadedBootstrapFiles,
       bootstrapContextRunKind: params.bootstrapContextRunKind,
       trigger: params.trigger,
       sessionKey: params.sessionKey,
@@ -970,20 +989,26 @@ export async function runEmbeddedAttempt(
       bootstrapMode,
       sessionFile: params.sessionFile,
       hasCompletedBootstrapTurn,
-      resolveBootstrapContextForRun: async () =>
-        await resolveBootstrapContextForRun({
-          workspaceDir: resolvedWorkspace,
-          config: params.config,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          warn: makeBootstrapWarn({
-            sessionLabel,
+      resolveBootstrapContextForRun: async () => {
+        const bootstrapFiles =
+          preloadedBootstrapFiles ??
+          (await resolveBootstrapFilesForRun({
             workspaceDir: resolvedWorkspace,
-            warn: (message) => log.warn(message),
+            config: params.config,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            warn: bootstrapWarn,
+            contextMode: params.bootstrapContextMode,
+            runKind: params.bootstrapContextRunKind,
+          }));
+        return {
+          bootstrapFiles,
+          contextFiles: buildBootstrapContextForFiles(bootstrapFiles, {
+            config: params.config,
+            warn: bootstrapWarn,
           }),
-          contextMode: params.bootstrapContextMode,
-          runKind: params.bootstrapContextRunKind,
-        }),
+        };
+      },
     });
     prepStages.mark("bootstrap-context");
     const remappedContextFiles = remapInjectedContextFilesToWorkspace({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `agent:bootstrap` hooks can inject `BOOTSTRAP.md` content, but embedded-runner bootstrap routing decided whether bootstrap was pending before hook-adjusted files were considered.
- Why it matters: hook-provided required setup instructions could be omitted from the system prompt when the workspace did not already have pending filesystem bootstrap state.
- What changed: preload hook-adjusted bootstrap files before routing, treat non-empty hook-provided `BOOTSTRAP.md` as pending and accessible bootstrap content, and reuse the preloaded files when building Project Context.
- What did NOT change (scope boundary): no changes to hook contracts, bootstrap file formats, or non-workspace/raw model run behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `resolveAttemptWorkspaceBootstrapRouting()` only used filesystem/workspace bootstrap pending state, while `agent:bootstrap` hook output was resolved later by Project Context generation.
- Missing detection / guardrail: routing tests did not cover hook-injected `BOOTSTRAP.md` content before this change.
- Contributing context (if known): continuation/context-injection logic already preserves full bootstrap mode, but the route into full mode did not account for hook-provided bootstrap content.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-routing.test.ts`
- Scenario the test should lock in: non-empty `BOOTSTRAP.md` content injected by `agent:bootstrap` selects full bootstrap mode and is included in system Project Context, including when normal file read access is unavailable.
- Why this is the smallest reliable guardrail: the bug lived at the seam between hook-resolved bootstrap files and embedded-runner routing, so the routing spawn test exercises the affected path without a broader E2E.
- Existing test that already covers this (if any): `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts` covers that full bootstrap mode bypasses continuation-skip behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Hook-provided required bootstrap instructions are now included in the system prompt when `agent:bootstrap` injects non-empty `BOOTSTRAP.md` content.

## Diagram (if applicable)

```text
Before:
agent:bootstrap -> BOOTSTRAP.md content -> routing had already decided pending=false -> required setup could be omitted

After:
agent:bootstrap -> BOOTSTRAP.md content -> routing sees pending=true -> Project Context includes required setup
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows_NT
- Runtime/container: Node 22.14.0 via nvs, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Configure an `agent:bootstrap` hook that returns non-empty `BOOTSTRAP.md` content for a workspace without filesystem-pending bootstrap state.
2. Start an embedded workspace attempt that resolves bootstrap routing and Project Context.
3. Inspect the generated system Project Context.

### Expected

- Hook-provided `BOOTSTRAP.md` content makes bootstrap pending and required setup instructions are included in the system prompt.

### Actual

- Before this PR, routing could decide bootstrap was not pending before hook output was considered, so hook-provided instructions could be omitted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification run:

```text
pnpm test src\agents\pi-embedded-runner\run\attempt.spawn-workspace.bootstrap-routing.test.ts src\agents\pi-embedded-runner\run\attempt.spawn-workspace.context-injection.test.ts -- --reporter=verbose
```

Changed-gate proof:

```text
pnpm check:changed -- --staged
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: hook-provided non-empty `BOOTSTRAP.md` triggers full bootstrap mode; hook-provided content remains usable when normal file reads are unavailable; empty hook-provided `BOOTSTRAP.md` does not mark bootstrap pending.
- Edge cases checked: continuation/full-bootstrap behavior covered by existing context-injection regression test; preloaded bootstrap files are reused so hooks are not double-run for context generation.
- What you did **not** verify: full repository test suite and live/provider scenarios.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: resolving hook-adjusted bootstrap files before routing could add duplicate hook work.
  - Mitigation: the resolved bootstrap files are reused for Project Context generation.
- Risk: empty hook-provided `BOOTSTRAP.md` could accidentally force bootstrap.
  - Mitigation: routing only treats non-empty trimmed bootstrap content as pending, with regression coverage.
