### PR TITLE
[codex] feat(ui): render HTML assistant responses in sandboxed iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Channels/streaming: cap progress-draft tool lines by default so edited progress boxes avoid jumpy reflow from long wrapped lines.
 - Agents/verbose: use compact explain-mode tool summaries for `/verbose` and progress drafts by default, with `agents.defaults.toolProgressDetail: "raw"` and per-agent overrides for debugging raw command/detail output.
 - Control UI/chat: add an agent-first filter to the chat session picker, keep chat controls/composer responsive across phone/tablet/desktop widths, keep desktop chat controls on one row, avoid duplicate avatar refreshes during initial chat load, and hide that row while scrolling down the transcript. Thanks @BunsDev.
+- Control UI/chat: render complete assistant HTML responses as sandboxed iframe previews with collapsible source while keeping snippets and streaming text on the markdown path.
 - Control UI/chat: collapse consecutive duplicate text messages into one bubble with a count so no-op heartbeat acknowledgements stay compact without hiding nearby context.
 - Agents/subagents: preserve every grouped child result when direct completion fallback has to bypass the requester-agent announce turn. Thanks @vincentkoc.
 - TTS/telephony: honor provider voice/model overrides in telephony synthesis providers so Google Meet agent speech logs match the backend that actually produced the audio. Thanks @vincentkoc.

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -25,6 +25,60 @@
   overflow-wrap: break-word;
 }
 
+.chat-bubble.chat-bubble--html-preview {
+  width: min(100%, 760px);
+}
+
+.chat-html-preview {
+  box-sizing: border-box;
+  display: grid;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.chat-html-preview__header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.chat-html-preview__badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.chat-html-preview__meta {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.chat-html-preview__frame {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  min-height: 420px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: white;
+}
+
+.chat-html-preview__source {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.chat-html-preview__source pre {
+  box-sizing: border-box;
+  max-width: 100%;
+  max-height: 18rem;
+  overflow: auto;
+}
+
 .chat-text :where(p, ul, ol, pre, blockquote, table) {
   margin: 0;
 }

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -9,9 +9,20 @@ import {
   renderStreamingGroup,
   resetAssistantAttachmentAvailabilityCacheForTest,
 } from "./grouped-render.ts";
+import {
+  HTML_PREVIEW_CSP,
+  HTML_PREVIEW_SANDBOX,
+  type HtmlDocumentPreview,
+} from "./html-preview.ts";
 import { normalizeMessage } from "./message-normalizer.ts";
 
 const localStorageValues = vi.hoisted(() => new Map<string, string>());
+const htmlPreviewMock = vi.hoisted(() => ({
+  actualDetectHtmlDocumentPreview: null as
+    | ((markdown: string) => HtmlDocumentPreview | null)
+    | null,
+  detectHtmlDocumentPreview: vi.fn<(markdown: string) => HtmlDocumentPreview | null>(),
+}));
 
 vi.mock("../../local-storage.ts", () => ({
   getSafeLocalStorage: () => ({
@@ -89,7 +100,53 @@ vi.mock("../tool-display.ts", () => ({
   }),
 }));
 
+vi.mock("./html-preview.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./html-preview.ts")>();
+  htmlPreviewMock.actualDetectHtmlDocumentPreview = actual.detectHtmlDocumentPreview;
+  htmlPreviewMock.detectHtmlDocumentPreview.mockImplementation(actual.detectHtmlDocumentPreview);
+  return {
+    ...actual,
+    detectHtmlDocumentPreview: htmlPreviewMock.detectHtmlDocumentPreview,
+  };
+});
+
 type RenderMessageGroupOptions = Parameters<typeof renderMessageGroup>[1];
+
+const COMPLETE_HTML_DOCUMENT =
+  "<!doctype html><html><head><title>Report</title><style>body{font-family:Arial}</style></head><body><h1>Report</h1><script>window.evil=true</script></body></html>";
+const HTML_PREVIEW_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${HTML_PREVIEW_CSP}">`;
+
+function expectHtmlPreview(container: HTMLElement, source = COMPLETE_HTML_DOCUMENT) {
+  const preview = container.querySelector<HTMLElement>(".chat-html-preview");
+  expect(preview).not.toBeNull();
+
+  const frame = preview!.querySelector<HTMLIFrameElement>("iframe.chat-html-preview__frame");
+  expect(frame).not.toBeNull();
+  expect(frame!.getAttribute("title")).toBe("Rendered HTML response");
+  expect(frame!.hasAttribute("sandbox")).toBe(true);
+  expect(frame!.getAttribute("sandbox")).toBe("");
+  expect(frame!.getAttribute("sandbox")).toBe(HTML_PREVIEW_SANDBOX);
+  expect((frame!.getAttribute("sandbox") ?? "").split(/\s+/)).not.toContain("allow-scripts");
+  expect(frame!.getAttribute("csp")).toBe(HTML_PREVIEW_CSP);
+  expect(frame!.getAttribute("csp")).not.toContain("script-src");
+  expect(frame!.getAttribute("referrerpolicy")).toBe("no-referrer");
+  expect(frame!.getAttribute("loading")).toBe("lazy");
+  const srcdoc = frame!.getAttribute("srcdoc") ?? "";
+  expect(srcdoc).toContain(HTML_PREVIEW_CSP_META);
+  expect(srcdoc.replace(HTML_PREVIEW_CSP_META, "")).toBe(source);
+
+  const sourceCode = preview!.querySelector<HTMLElement>(".chat-html-preview__source code");
+  expect(sourceCode?.textContent).toBe(source);
+}
+
+function resetHtmlPreviewDetectorMock() {
+  htmlPreviewMock.detectHtmlDocumentPreview.mockReset();
+  if (htmlPreviewMock.actualDetectHtmlDocumentPreview) {
+    htmlPreviewMock.detectHtmlDocumentPreview.mockImplementation(
+      htmlPreviewMock.actualDetectHtmlDocumentPreview,
+    );
+  }
+}
 
 function renderAssistantMessage(
   container: HTMLElement,
@@ -388,6 +445,7 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  resetHtmlPreviewDetectorMock();
 });
 
 describe("grouped chat rendering", () => {
@@ -655,6 +713,141 @@ describe("grouped chat rendering", () => {
 
     const avatar = named.querySelector<HTMLElement>(".chat-avatar.user");
     expect(avatar?.tagName).toBe("DIV");
+  });
+
+  it("renders complete assistant HTML documents as sandboxed previews with source", () => {
+    const container = document.createElement("div");
+    htmlPreviewMock.detectHtmlDocumentPreview.mockClear();
+
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: COMPLETE_HTML_DOCUMENT,
+      timestamp: Date.now(),
+    });
+
+    const bubble = container.querySelector<HTMLElement>(".chat-bubble");
+    expect(bubble?.classList.contains("chat-bubble--html-preview")).toBe(true);
+    expectHtmlPreview(container);
+    expect(container.querySelector(".chat-text")).toBeNull();
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).toHaveBeenCalledTimes(1);
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).toHaveBeenCalledWith(COMPLETE_HTML_DOCUMENT);
+  });
+
+  it("keeps assistant HTML snippets on the markdown text path", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: "<strong>Important</strong>",
+      timestamp: Date.now(),
+    });
+
+    expect(container.querySelector(".chat-html-preview")).toBeNull();
+    expect(container.querySelector(".chat-bubble--html-preview")).toBeNull();
+    const text = container.querySelector<HTMLElement>(".chat-text");
+    expect(text).not.toBeNull();
+    expect(text?.textContent).toContain("Important");
+  });
+
+  it("keeps streaming complete assistant HTML on the markdown text path", () => {
+    const container = document.createElement("div");
+    render(renderStreamingGroup(COMPLETE_HTML_DOCUMENT, Date.now()), container);
+
+    expect(container.querySelector(".chat-html-preview")).toBeNull();
+    expect(container.querySelector(".chat-text")).not.toBeNull();
+  });
+
+  it("keeps complete user HTML documents on the markdown text path", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: COMPLETE_HTML_DOCUMENT,
+        timestamp: Date.now(),
+      },
+      "user",
+    );
+
+    expect(container.querySelector(".chat-html-preview")).toBeNull();
+    const text = container.querySelector<HTMLElement>(".chat-text");
+    expect(text).not.toBeNull();
+    expect(text?.textContent).toContain("Report");
+  });
+
+  it.each(["system", "developer"])(
+    "keeps complete %s HTML documents on the markdown text path",
+    (role) => {
+      const container = document.createElement("div");
+      htmlPreviewMock.detectHtmlDocumentPreview.mockClear();
+      renderGroupedMessage(
+        container,
+        {
+          role,
+          content: COMPLETE_HTML_DOCUMENT,
+          timestamp: Date.now(),
+        },
+        role,
+      );
+
+      const bubble = container.querySelector<HTMLElement>(".chat-bubble");
+      expect(bubble?.classList.contains("chat-bubble--html-preview")).toBe(false);
+      expect(container.querySelector(".chat-html-preview")).toBeNull();
+      const text = container.querySelector<HTMLElement>(".chat-text");
+      expect(text).not.toBeNull();
+      expect(text?.textContent).toContain("Report");
+      expect(htmlPreviewMock.detectHtmlDocumentPreview).not.toHaveBeenCalled();
+    },
+  );
+
+  it("renders expanded complete tool-result HTML documents as sandboxed previews", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        id: "tool-html",
+        role: "tool",
+        toolCallId: "call-html",
+        toolName: "browser.open",
+        content: COMPLETE_HTML_DOCUMENT,
+        timestamp: Date.now(),
+      },
+      "tool",
+      {
+        isToolMessageExpanded: () => true,
+      },
+    );
+
+    const toolBody = container.querySelector<HTMLElement>(".chat-tool-msg-body");
+    expect(toolBody).not.toBeNull();
+    expectHtmlPreview(toolBody!);
+    expect(toolBody!.querySelector(".chat-text")).toBeNull();
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).toHaveBeenCalledTimes(1);
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).toHaveBeenCalledWith(COMPLETE_HTML_DOCUMENT);
+  });
+
+  it("keeps collapsed complete tool-result HTML hidden and skips preview detection", () => {
+    const container = document.createElement("div");
+    htmlPreviewMock.detectHtmlDocumentPreview.mockClear();
+
+    renderGroupedMessage(
+      container,
+      {
+        id: "tool-html-collapsed",
+        role: "tool",
+        toolCallId: "call-html-collapsed",
+        toolName: "browser.open",
+        content: COMPLETE_HTML_DOCUMENT,
+        timestamp: Date.now(),
+      },
+      "tool",
+      {
+        isToolMessageExpanded: () => false,
+      },
+    );
+
+    expect(container.querySelector(".chat-html-preview")).toBeNull();
+    expect(container.querySelector(".chat-text")).toBeNull();
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).not.toHaveBeenCalled();
   });
 
   it("keeps inline tool cards collapsed by default and renders expanded state", () => {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -9,12 +9,23 @@ import {
   renderStreamingGroup,
   resetAssistantAttachmentAvailabilityCacheForTest,
 } from "./grouped-render.ts";
+import {
+  HTML_PREVIEW_CSP,
+  HTML_PREVIEW_SANDBOX,
+  type HtmlDocumentPreview,
+} from "./html-preview.ts";
 import { normalizeMessage } from "./message-normalizer.ts";
 
 const localStorageValues = vi.hoisted(() => new Map<string, string>());
 const markdownRenderMock = vi.hoisted(() =>
   vi.fn((value: string, _options?: { codeBlockChrome?: "copy" | "none" }) => value),
 );
+const htmlPreviewMock = vi.hoisted(() => ({
+  actualDetectHtmlDocumentPreview: null as
+    | ((markdown: string) => HtmlDocumentPreview | null)
+    | null,
+  detectHtmlDocumentPreview: vi.fn<(markdown: string) => HtmlDocumentPreview | null>(),
+}));
 
 vi.mock("../../local-storage.ts", () => ({
   getSafeLocalStorage: () => ({
@@ -111,6 +122,16 @@ vi.mock("../tool-display.ts", () => ({
   }),
 }));
 
+vi.mock("./html-preview.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./html-preview.ts")>();
+  htmlPreviewMock.actualDetectHtmlDocumentPreview = actual.detectHtmlDocumentPreview;
+  htmlPreviewMock.detectHtmlDocumentPreview.mockImplementation(actual.detectHtmlDocumentPreview);
+  return {
+    ...actual,
+    detectHtmlDocumentPreview: htmlPreviewMock.detectHtmlDocumentPreview,
+  };
+});
+
 type RenderMessageGroupOptions = Parameters<typeof renderMessageGroup>[1];
 
 function expectElement<T extends Element>(
@@ -147,6 +168,42 @@ function requireFetchCallForUrl(fetchMock: ReturnType<typeof vi.fn>, expectedUrl
 function expectSameOriginGet(init: RequestInit | undefined) {
   expect(init?.credentials).toBe("same-origin");
   expect(init?.method).toBe("GET");
+}
+
+const COMPLETE_HTML_DOCUMENT =
+  "<!doctype html><html><head><title>Report</title><style>body{font-family:Arial}</style></head><body><h1>Report</h1><script>window.evil=true</script></body></html>";
+const HTML_PREVIEW_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${HTML_PREVIEW_CSP}">`;
+
+function expectHtmlPreview(container: HTMLElement, source = COMPLETE_HTML_DOCUMENT) {
+  const preview = container.querySelector<HTMLElement>(".chat-html-preview");
+  expect(preview).not.toBeNull();
+
+  const frame = preview!.querySelector<HTMLIFrameElement>("iframe.chat-html-preview__frame");
+  expect(frame).not.toBeNull();
+  expect(frame!.getAttribute("title")).toBe("Rendered HTML response");
+  expect(frame!.hasAttribute("sandbox")).toBe(true);
+  expect(frame!.getAttribute("sandbox")).toBe("");
+  expect(frame!.getAttribute("sandbox")).toBe(HTML_PREVIEW_SANDBOX);
+  expect((frame!.getAttribute("sandbox") ?? "").split(/\s+/)).not.toContain("allow-scripts");
+  expect(frame!.getAttribute("csp")).toBe(HTML_PREVIEW_CSP);
+  expect(frame!.getAttribute("csp")).not.toContain("script-src");
+  expect(frame!.getAttribute("referrerpolicy")).toBe("no-referrer");
+  expect(frame!.getAttribute("loading")).toBe("lazy");
+  const srcdoc = frame!.srcdoc;
+  expect(srcdoc).toContain(HTML_PREVIEW_CSP_META);
+  expect(srcdoc.replace(HTML_PREVIEW_CSP_META, "")).toBe(source);
+
+  const sourceCode = preview!.querySelector<HTMLElement>(".chat-html-preview__source code");
+  expect(sourceCode?.textContent).toBe(source);
+}
+
+function resetHtmlPreviewDetectorMock() {
+  htmlPreviewMock.detectHtmlDocumentPreview.mockReset();
+  if (htmlPreviewMock.actualDetectHtmlDocumentPreview) {
+    htmlPreviewMock.detectHtmlDocumentPreview.mockImplementation(
+      htmlPreviewMock.actualDetectHtmlDocumentPreview,
+    );
+  }
 }
 
 function renderAssistantMessage(
@@ -505,6 +562,7 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  resetHtmlPreviewDetectorMock();
 });
 
 describe("grouped chat rendering", () => {
@@ -1031,6 +1089,141 @@ describe("grouped chat rendering", () => {
     renderMessageGroups(container, [group], { showToolCalls: false });
 
     expect(container.querySelector(".chat-activity-group")).toBeNull();
+  });
+
+  it("renders complete assistant HTML documents as sandboxed previews with source", () => {
+    const container = document.createElement("div");
+    htmlPreviewMock.detectHtmlDocumentPreview.mockClear();
+
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: COMPLETE_HTML_DOCUMENT,
+      timestamp: Date.now(),
+    });
+
+    const bubble = container.querySelector<HTMLElement>(".chat-bubble");
+    expect(bubble?.classList.contains("chat-bubble--html-preview")).toBe(true);
+    expectHtmlPreview(container);
+    expect(container.querySelector(".chat-text")).toBeNull();
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).toHaveBeenCalledTimes(1);
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).toHaveBeenCalledWith(COMPLETE_HTML_DOCUMENT);
+  });
+
+  it("keeps assistant HTML snippets on the markdown text path", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: "<strong>Important</strong>",
+      timestamp: Date.now(),
+    });
+
+    expect(container.querySelector(".chat-html-preview")).toBeNull();
+    expect(container.querySelector(".chat-bubble--html-preview")).toBeNull();
+    const text = container.querySelector<HTMLElement>(".chat-text");
+    expect(text).not.toBeNull();
+    expect(text?.textContent).toContain("Important");
+  });
+
+  it("keeps streaming complete assistant HTML on the markdown text path", () => {
+    const container = document.createElement("div");
+    render(renderStreamingGroup(COMPLETE_HTML_DOCUMENT, Date.now()), container);
+
+    expect(container.querySelector(".chat-html-preview")).toBeNull();
+    expect(container.querySelector(".chat-text")).not.toBeNull();
+  });
+
+  it("keeps complete user HTML documents on the markdown text path", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: COMPLETE_HTML_DOCUMENT,
+        timestamp: Date.now(),
+      },
+      "user",
+    );
+
+    expect(container.querySelector(".chat-html-preview")).toBeNull();
+    const text = container.querySelector<HTMLElement>(".chat-text");
+    expect(text).not.toBeNull();
+    expect(text?.textContent).toContain("Report");
+  });
+
+  it.each(["system", "developer"])(
+    "keeps complete %s HTML documents on the markdown text path",
+    (role) => {
+      const container = document.createElement("div");
+      htmlPreviewMock.detectHtmlDocumentPreview.mockClear();
+      renderGroupedMessage(
+        container,
+        {
+          role,
+          content: COMPLETE_HTML_DOCUMENT,
+          timestamp: Date.now(),
+        },
+        role,
+      );
+
+      const bubble = container.querySelector<HTMLElement>(".chat-bubble");
+      expect(bubble?.classList.contains("chat-bubble--html-preview")).toBe(false);
+      expect(container.querySelector(".chat-html-preview")).toBeNull();
+      const text = container.querySelector<HTMLElement>(".chat-text");
+      expect(text).not.toBeNull();
+      expect(text?.textContent).toContain("Report");
+      expect(htmlPreviewMock.detectHtmlDocumentPreview).not.toHaveBeenCalled();
+    },
+  );
+
+  it("renders expanded complete tool-result HTML documents as sandboxed previews", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        id: "tool-html",
+        role: "tool",
+        toolCallId: "call-html",
+        toolName: "browser.open",
+        content: COMPLETE_HTML_DOCUMENT,
+        timestamp: Date.now(),
+      },
+      "tool",
+      {
+        isToolMessageExpanded: () => true,
+      },
+    );
+
+    const toolBody = container.querySelector<HTMLElement>(".chat-tool-msg-body");
+    expect(toolBody).not.toBeNull();
+    expectHtmlPreview(toolBody!);
+    expect(toolBody!.querySelector(".chat-text")).toBeNull();
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).toHaveBeenCalledTimes(1);
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).toHaveBeenCalledWith(COMPLETE_HTML_DOCUMENT);
+  });
+
+  it("keeps collapsed complete tool-result HTML hidden and skips preview detection", () => {
+    const container = document.createElement("div");
+    htmlPreviewMock.detectHtmlDocumentPreview.mockClear();
+
+    renderGroupedMessage(
+      container,
+      {
+        id: "tool-html-collapsed",
+        role: "tool",
+        toolCallId: "call-html-collapsed",
+        toolName: "browser.open",
+        content: COMPLETE_HTML_DOCUMENT,
+        timestamp: Date.now(),
+      },
+      "tool",
+      {
+        isToolMessageExpanded: () => false,
+      },
+    );
+
+    expect(container.querySelector(".chat-html-preview")).toBeNull();
+    expect(container.querySelector(".chat-text")).toBeNull();
+    expect(htmlPreviewMock.detectHtmlDocumentPreview).not.toHaveBeenCalled();
   });
 
   it("keeps inline tool cards collapsed by default and renders expanded state", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -19,6 +19,13 @@ import { resolveLocalUserName } from "../user-identity.ts";
 export { resolveAssistantTextAvatar } from "../views/agents-utils.ts";
 import { renderChatAvatar } from "./chat-avatar.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
+import {
+  buildHtmlPreviewSrcdoc,
+  detectHtmlDocumentPreview,
+  HTML_PREVIEW_CSP,
+  HTML_PREVIEW_SANDBOX,
+  type HtmlDocumentPreview,
+} from "./html-preview.ts";
 import { extractThinkingCached, formatReasoningMarkdown } from "./message-extract.ts";
 import { isToolResultMessage, normalizeMessage } from "./message-normalizer.ts";
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
@@ -84,6 +91,32 @@ function renderChatTimestamp(timestamp: number) {
     <time class="chat-group-timestamp" datetime=${display.dateTime} title=${display.title}>
       ${display.label}
     </time>
+  `;
+}
+
+function renderHtmlDocumentPreview(preview: HtmlDocumentPreview) {
+  return html`
+    <div class="chat-html-preview">
+      <div class="chat-html-preview__header">
+        <span class="chat-html-preview__badge">HTML preview</span>
+        ${preview.truncated
+          ? html`<span class="chat-html-preview__meta">Preview truncated</span>`
+          : nothing}
+      </div>
+      <iframe
+        class="chat-html-preview__frame"
+        title="Rendered HTML response"
+        sandbox=${HTML_PREVIEW_SANDBOX}
+        csp=${HTML_PREVIEW_CSP}
+        referrerpolicy="no-referrer"
+        loading="lazy"
+        srcdoc=${buildHtmlPreviewSrcdoc(preview.html)}
+      ></iframe>
+      <details class="chat-html-preview__source">
+        <summary>Source</summary>
+        <pre><code>${preview.html}</code></pre>
+      </details>
+    </div>
   `;
 }
 
@@ -1435,13 +1468,32 @@ function renderGroupedMessage(
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
+  const isToolMessage = normalizedRole === "tool" || isToolResult;
+  const toolMessageDisclosureId = `toolmsg:${messageKey}`;
+  const toolMessageExpanded = opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false;
+  let cachedHtmlDocumentPreview: HtmlDocumentPreview | null | undefined;
+  const getHtmlDocumentPreview = (): HtmlDocumentPreview | null => {
+    if (cachedHtmlDocumentPreview !== undefined) {
+      return cachedHtmlDocumentPreview;
+    }
+    cachedHtmlDocumentPreview =
+      markdown && !opts.isStreaming && (normalizedRole === "assistant" || isToolMessage)
+        ? detectHtmlDocumentPreview(markdown)
+        : null;
+    return cachedHtmlDocumentPreview;
+  };
+  const htmlDocumentPreview = isToolMessage
+    ? toolMessageExpanded
+      ? getHtmlDocumentPreview()
+      : null
+    : getHtmlDocumentPreview();
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
 
-  const isToolMessage = normalizedRole === "tool" || isToolResult;
   const bubbleClasses = [
     "chat-bubble",
+    htmlDocumentPreview ? "chat-bubble--html-preview" : "",
     isToolMessage ? "chat-bubble--tool-shell" : "",
     opts.isStreaming ? "streaming" : "",
     "fade-in",
@@ -1462,8 +1514,6 @@ function renderGroupedMessage(
     return nothing;
   }
 
-  const toolMessageDisclosureId = `toolmsg:${messageKey}`;
-  const toolMessageExpanded = opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false;
   const toolNames = [...new Set(toolCards.map((c) => c.name))];
   const toolSummaryLabel =
     toolNames.length <= 3
@@ -1528,24 +1578,26 @@ function renderGroupedMessage(
                             ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
                           </div>`
                         : nothing}
-                      ${jsonResult
-                        ? html`<details
-                            class="chat-json-collapse"
-                            ?open=${Boolean(opts.autoExpandToolCalls)}
-                          >
-                            <summary class="chat-json-summary">
-                              <span class="chat-json-badge">JSON</span>
-                              <span class="chat-json-label"
-                                >${jsonSummaryLabel(jsonResult.parsed)}</span
-                              >
-                            </summary>
-                            <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
-                          </details>`
-                        : markdown
-                          ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                              ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
-                            </div>`
-                          : nothing}
+                      ${htmlDocumentPreview
+                        ? renderHtmlDocumentPreview(htmlDocumentPreview)
+                        : jsonResult
+                          ? html`<details
+                              class="chat-json-collapse"
+                              ?open=${Boolean(opts.autoExpandToolCalls)}
+                            >
+                              <summary class="chat-json-summary">
+                                <span class="chat-json-badge">JSON</span>
+                                <span class="chat-json-label"
+                                  >${jsonSummaryLabel(jsonResult.parsed)}</span
+                                >
+                              </summary>
+                              <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+                            </details>`
+                          : markdown
+                            ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+                                ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
+                              </div>`
+                            : nothing}
                       ${hasToolCards
                         ? singleToolCard && !markdown && !hasImages
                           ? renderExpandedToolCardContent(
@@ -1595,19 +1647,21 @@ function renderGroupedMessage(
                   ${block.rawText ? renderRawOutputToggle(block.rawText) : nothing}`,
                 )}`
               : nothing}
-            ${jsonResult
-              ? html`<details class="chat-json-collapse">
-                  <summary class="chat-json-summary">
-                    <span class="chat-json-badge">JSON</span>
-                    <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
-                  </summary>
-                  <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
-                </details>`
-              : markdown
-                ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                    ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
-                  </div>`
-                : nothing}
+            ${htmlDocumentPreview
+              ? renderHtmlDocumentPreview(htmlDocumentPreview)
+              : jsonResult
+                ? html`<details class="chat-json-collapse">
+                    <summary class="chat-json-summary">
+                      <span class="chat-json-badge">JSON</span>
+                      <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
+                    </summary>
+                    <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+                  </details>`
+                : markdown
+                  ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+                      ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
+                    </div>`
+                  : nothing}
             ${hasToolCards
               ? renderInlineToolCards(toolCards, {
                   messageKey,

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -20,6 +20,13 @@ import { resolveLocalUserName } from "../user-identity.ts";
 export { resolveAssistantTextAvatar } from "../views/agents-utils.ts";
 import { renderChatAvatar } from "./chat-avatar.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
+import {
+  buildHtmlPreviewSrcdoc,
+  detectHtmlDocumentPreview,
+  HTML_PREVIEW_CSP,
+  HTML_PREVIEW_SANDBOX,
+  type HtmlDocumentPreview,
+} from "./html-preview.ts";
 import { extractThinkingCached, formatReasoningMarkdown } from "./message-extract.ts";
 import { isToolResultMessage, normalizeMessage } from "./message-normalizer.ts";
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
@@ -89,6 +96,32 @@ function renderChatTimestamp(timestamp: number) {
     <time class="chat-group-timestamp" datetime=${display.dateTime} title=${display.title}>
       ${display.label}
     </time>
+  `;
+}
+
+function renderHtmlDocumentPreview(preview: HtmlDocumentPreview) {
+  return html`
+    <div class="chat-html-preview">
+      <div class="chat-html-preview__header">
+        <span class="chat-html-preview__badge">HTML preview</span>
+        ${preview.truncated
+          ? html`<span class="chat-html-preview__meta">Preview truncated</span>`
+          : nothing}
+      </div>
+      <iframe
+        class="chat-html-preview__frame"
+        title="Rendered HTML response"
+        sandbox=${HTML_PREVIEW_SANDBOX}
+        csp=${HTML_PREVIEW_CSP}
+        referrerpolicy="no-referrer"
+        loading="lazy"
+        .srcdoc=${buildHtmlPreviewSrcdoc(preview.html)}
+      ></iframe>
+      <details class="chat-html-preview__source">
+        <summary>Source</summary>
+        <pre><code>${preview.html}</code></pre>
+      </details>
+    </div>
   `;
 }
 
@@ -1665,13 +1698,32 @@ function renderGroupedMessage(
     !m.openclawMessageToolMirror &&
     (transcriptMeta?.truncated === true || markdown?.includes("\n...(truncated)...")),
   );
+  const isToolMessage = normalizedRole === "tool" || isToolResult;
+  const toolMessageDisclosureId = `toolmsg:${messageKey}`;
+  const toolMessageExpanded = opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false;
+  let cachedHtmlDocumentPreview: HtmlDocumentPreview | null | undefined;
+  const getHtmlDocumentPreview = (): HtmlDocumentPreview | null => {
+    if (cachedHtmlDocumentPreview !== undefined) {
+      return cachedHtmlDocumentPreview;
+    }
+    cachedHtmlDocumentPreview =
+      markdown && !opts.isStreaming && (normalizedRole === "assistant" || isToolMessage)
+        ? detectHtmlDocumentPreview(markdown)
+        : null;
+    return cachedHtmlDocumentPreview;
+  };
+  const htmlDocumentPreview = isToolMessage
+    ? toolMessageExpanded
+      ? getHtmlDocumentPreview()
+      : null
+    : getHtmlDocumentPreview();
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
 
-  const isToolMessage = normalizedRole === "tool" || isToolResult;
   const bubbleClasses = [
     "chat-bubble",
+    htmlDocumentPreview ? "chat-bubble--html-preview" : "",
     isToolMessage ? "chat-bubble--tool-shell" : "",
     hasActions ? "has-copy" : "",
     opts.isStreaming ? "streaming" : "",
@@ -1693,8 +1745,6 @@ function renderGroupedMessage(
     return nothing;
   }
 
-  const toolMessageDisclosureId = `toolmsg:${messageKey}`;
-  const toolMessageExpanded = opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false;
   const toolNames = [...new Set(toolCards.map((c) => c.name))];
   const singleToolCard = toolCards.length === 1 ? toolCards[0] : null;
   const toolMessageHasError = toolCards.some(isToolCardError);
@@ -1799,26 +1849,28 @@ function renderGroupedMessage(
                             ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
                           </div>`
                         : nothing}
-                      ${jsonResult
-                        ? html`<details
-                            class="chat-json-collapse"
-                            ?open=${Boolean(opts.autoExpandToolCalls)}
-                          >
-                            <summary class="chat-json-summary">
-                              <span class="chat-json-badge">JSON</span>
-                              <span class="chat-json-label"
-                                >${jsonSummaryLabel(jsonResult.parsed)}</span
-                              >
-                            </summary>
-                            <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
-                          </details>`
-                        : markdown
-                          ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                              ${unsafeHTML(
-                                toSanitizedMarkdownHtml(markdown, markdownRenderOptions),
-                              )}
-                            </div>`
-                          : nothing}
+                      ${htmlDocumentPreview
+                        ? renderHtmlDocumentPreview(htmlDocumentPreview)
+                        : jsonResult
+                          ? html`<details
+                              class="chat-json-collapse"
+                              ?open=${Boolean(opts.autoExpandToolCalls)}
+                            >
+                              <summary class="chat-json-summary">
+                                <span class="chat-json-badge">JSON</span>
+                                <span class="chat-json-label"
+                                  >${jsonSummaryLabel(jsonResult.parsed)}</span
+                                >
+                              </summary>
+                              <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+                            </details>`
+                          : markdown
+                            ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+                                ${unsafeHTML(
+                                  toSanitizedMarkdownHtml(markdown, markdownRenderOptions),
+                                )}
+                              </div>`
+                            : nothing}
                       ${hasToolCards
                         ? singleToolCard && !markdown && !hasImages
                           ? renderExpandedToolCardContent(
@@ -1871,19 +1923,21 @@ function renderGroupedMessage(
                   ${block.rawText ? renderRawOutputToggle(block.rawText) : nothing}`,
                 )}`
               : nothing}
-            ${jsonResult
-              ? html`<details class="chat-json-collapse">
-                  <summary class="chat-json-summary">
-                    <span class="chat-json-badge">JSON</span>
-                    <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
-                  </summary>
-                  <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
-                </details>`
-              : markdown
-                ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                    ${unsafeHTML(toSanitizedMarkdownHtml(markdown, markdownRenderOptions))}
-                  </div>`
-                : nothing}
+            ${htmlDocumentPreview
+              ? renderHtmlDocumentPreview(htmlDocumentPreview)
+              : jsonResult
+                ? html`<details class="chat-json-collapse">
+                    <summary class="chat-json-summary">
+                      <span class="chat-json-badge">JSON</span>
+                      <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
+                    </summary>
+                    <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+                  </details>`
+                : markdown
+                  ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+                      ${unsafeHTML(toSanitizedMarkdownHtml(markdown, markdownRenderOptions))}
+                    </div>`
+                  : nothing}
             ${hasToolCards
               ? renderInlineToolCards(toolCards, {
                   messageKey,

--- a/ui/src/ui/chat/html-preview.test.ts
+++ b/ui/src/ui/chat/html-preview.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHtmlPreviewSrcdoc,
+  HTML_PREVIEW_CSP,
+  HTML_PREVIEW_SANDBOX,
+  detectHtmlDocumentPreview,
+} from "./html-preview.ts";
+
+const HTML_PREVIEW_LIMIT = 750_000;
+const HTML_PREVIEW_TRUNCATION_COMMENT = `\n<!-- OpenClaw: HTML preview truncated at ${HTML_PREVIEW_LIMIT} characters. -->`;
+const HTML_PREVIEW_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${HTML_PREVIEW_CSP}">`;
+
+function createHtmlDocumentWithLength(length: number): string {
+  const prefix = "<html><body>";
+  const suffix = "</body></html>";
+  const fillerLength = length - prefix.length - suffix.length;
+  if (fillerLength < 0) {
+    throw new Error(`Cannot create an HTML document with only ${length} characters.`);
+  }
+  return `${prefix}${"x".repeat(fillerLength)}${suffix}`;
+}
+
+describe("detectHtmlDocumentPreview", () => {
+  it("detects complete HTML documents", () => {
+    const result = detectHtmlDocumentPreview(
+      '<html><head><style>body{font-family:Arial}</style></head><body><img src="data:image/svg+xml;base64,PHN2Zy8+"></body></html>',
+    );
+    expect(result?.truncated).toBe(false);
+    expect(result?.html).toContain("<body>");
+  });
+
+  it.each(["html", "htm"] as const)(
+    "detects whole-message %s fenced HTML documents",
+    (language) => {
+      const result = detectHtmlDocumentPreview(
+        `\`\`\`${language}\n<!doctype html><html><body><h1>Report</h1></body></html>\n\`\`\``,
+      );
+      expect(result?.html).toBe("<!doctype html><html><body><h1>Report</h1></body></html>");
+    },
+  );
+
+  it("detects whole-message fenced HTML documents with CRLF line endings", () => {
+    const html = "<!doctype html><html><body><h1>Report</h1></body></html>";
+    const result = detectHtmlDocumentPreview(`\`\`\`html\r\n${html}\r\n\`\`\``);
+    expect(result?.html).toBe(html);
+  });
+
+  it("preserves fenced HTML document content", () => {
+    const html = "\n<!doctype html><html><body>\n  <h1>Report</h1>\n</body></html>\n";
+    const result = detectHtmlDocumentPreview(`\`\`\`html\n${html}\n\`\`\``);
+    expect(result?.html).toBe(html);
+  });
+
+  it("detects paired head and body documents", () => {
+    const result = detectHtmlDocumentPreview(
+      "<head><title>Report</title></head>\n\n<body><h1>Report</h1></body>",
+    );
+    expect(result?.html).toContain("<head>");
+    expect(result?.html).toContain("<body>");
+  });
+
+  it("does not strip or preview non-whole-message HTML fences", () => {
+    expect(
+      detectHtmlDocumentPreview(
+        "Before\n```html\n<!doctype html><html><body><h1>Report</h1></body></html>\n```",
+      ),
+    ).toBeNull();
+    expect(
+      detectHtmlDocumentPreview(
+        "```html\n<!doctype html><html><body><h1>Report</h1></body></html>\n```\nAfter",
+      ),
+    ).toBeNull();
+  });
+
+  it("does not truncate documents at the preview limit", () => {
+    const html = createHtmlDocumentWithLength(HTML_PREVIEW_LIMIT);
+    const result = detectHtmlDocumentPreview(html);
+    expect(result).toEqual({ html, truncated: false });
+  });
+
+  it("truncates documents over the preview limit", () => {
+    const html = createHtmlDocumentWithLength(HTML_PREVIEW_LIMIT + 1);
+    const result = detectHtmlDocumentPreview(html);
+    expect(result?.truncated).toBe(true);
+    expect(result?.html).toContain(HTML_PREVIEW_TRUNCATION_COMMENT.trim());
+    expect(result?.html).toBe(
+      `${html.slice(0, HTML_PREVIEW_LIMIT)}${HTML_PREVIEW_TRUNCATION_COMMENT}`,
+    );
+    expect(result?.html).toHaveLength(HTML_PREVIEW_LIMIT + HTML_PREVIEW_TRUNCATION_COMMENT.length);
+  });
+
+  it("does not treat small raw HTML snippets as full documents", () => {
+    expect(detectHtmlDocumentPreview("<strong>Important</strong>")).toBeNull();
+    expect(detectHtmlDocumentPreview("Use <html> literally in docs.")).toBeNull();
+    expect(detectHtmlDocumentPreview("Example: <html><body>x</body></html> done")).toBeNull();
+    expect(detectHtmlDocumentPreview("Example: <head></head><body>x</body> done")).toBeNull();
+    expect(detectHtmlDocumentPreview("<html> is the root element...")).toBeNull();
+    expect(detectHtmlDocumentPreview("<html><body>x")).toBeNull();
+    expect(detectHtmlDocumentPreview("<!doctype html>")).toBeNull();
+  });
+
+  it("uses a scriptless sandbox policy for previews", () => {
+    expect(HTML_PREVIEW_SANDBOX).toBe("");
+    expect(HTML_PREVIEW_CSP).toBe(
+      "default-src 'none'; img-src data: blob:; media-src data: blob:; font-src data:; style-src 'unsafe-inline'",
+    );
+    expect(HTML_PREVIEW_CSP).not.toContain("script-src");
+  });
+
+  it("injects CSP metadata into preview srcdoc documents", () => {
+    expect(
+      buildHtmlPreviewSrcdoc("<html><head><title>Report</title></head><body></body></html>"),
+    ).toBe(`<html><head>${HTML_PREVIEW_CSP_META}<title>Report</title></head><body></body></html>`);
+
+    expect(buildHtmlPreviewSrcdoc("<html><body><h1>Report</h1></body></html>")).toBe(
+      `<html><head>${HTML_PREVIEW_CSP_META}</head><body><h1>Report</h1></body></html>`,
+    );
+
+    expect(buildHtmlPreviewSrcdoc("<head></head><body><h1>Report</h1></body>")).toBe(
+      `<head>${HTML_PREVIEW_CSP_META}</head><body><h1>Report</h1></body>`,
+    );
+  });
+
+  it("does not inject CSP metadata into commented head markers", () => {
+    expect(
+      buildHtmlPreviewSrcdoc(
+        '<!doctype html><html><!-- <head> marker --><body><img src="https://example.test/leak.png"></body></html>',
+      ),
+    ).toBe(
+      `<!doctype html><html><head>${HTML_PREVIEW_CSP_META}</head><!-- <head> marker --><body><img src="https://example.test/leak.png"></body></html>`,
+    );
+
+    expect(
+      buildHtmlPreviewSrcdoc(
+        "<html><!-- leading comment --><head><title>Report</title></head><body></body></html>",
+      ),
+    ).toBe(
+      `<html><!-- leading comment --><head>${HTML_PREVIEW_CSP_META}<title>Report</title></head><body></body></html>`,
+    );
+  });
+
+  it("does not inject CSP metadata into script head markers", () => {
+    expect(
+      buildHtmlPreviewSrcdoc(
+        '<html><script>const marker = "<head>";</script><body><img src="https://example.test/script-head.png"></body></html>',
+      ),
+    ).toBe(
+      `<html><head>${HTML_PREVIEW_CSP_META}</head><script>const marker = "<head>";</script><body><img src="https://example.test/script-head.png"></body></html>`,
+    );
+  });
+});

--- a/ui/src/ui/chat/html-preview.test.ts
+++ b/ui/src/ui/chat/html-preview.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHtmlPreviewSrcdoc,
+  HTML_PREVIEW_CSP,
+  HTML_PREVIEW_SANDBOX,
+  HTML_PREVIEW_TRUNCATION_COMMENT,
+  MAX_HTML_PREVIEW_CHARS,
+  detectHtmlDocumentPreview,
+} from "./html-preview.ts";
+
+const HTML_PREVIEW_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${HTML_PREVIEW_CSP}">`;
+
+function createHtmlDocumentWithLength(length: number): string {
+  const prefix = "<html><body>";
+  const suffix = "</body></html>";
+  const fillerLength = length - prefix.length - suffix.length;
+  if (fillerLength < 0) {
+    throw new Error(`Cannot create an HTML document with only ${length} characters.`);
+  }
+  return `${prefix}${"x".repeat(fillerLength)}${suffix}`;
+}
+
+describe("detectHtmlDocumentPreview", () => {
+  it("detects complete HTML documents", () => {
+    const result = detectHtmlDocumentPreview(
+      '<html><head><style>body{font-family:Arial}</style></head><body><img src="data:image/svg+xml;base64,PHN2Zy8+"></body></html>',
+    );
+    expect(result?.truncated).toBe(false);
+    expect(result?.html).toContain("<body>");
+  });
+
+  it.each(["html", "htm"] as const)(
+    "detects whole-message %s fenced HTML documents",
+    (language) => {
+      const result = detectHtmlDocumentPreview(
+        `\`\`\`${language}\n<!doctype html><html><body><h1>Report</h1></body></html>\n\`\`\``,
+      );
+      expect(result?.html).toBe("<!doctype html><html><body><h1>Report</h1></body></html>");
+    },
+  );
+
+  it("detects whole-message fenced HTML documents with CRLF line endings", () => {
+    const html = "<!doctype html><html><body><h1>Report</h1></body></html>";
+    const result = detectHtmlDocumentPreview(`\`\`\`html\r\n${html}\r\n\`\`\``);
+    expect(result?.html).toBe(html);
+  });
+
+  it("detects whole-message fenced HTML documents without a trailing newline", () => {
+    const html = "<!doctype html><html><body><h1>Report</h1></body></html>";
+    const result = detectHtmlDocumentPreview(`\`\`\`html\n${html}\`\`\``);
+    expect(result?.html).toBe(html);
+  });
+
+  it("preserves fenced HTML document content", () => {
+    const html = "\n<!doctype html><html><body>\n  <h1>Report</h1>\n</body></html>\n";
+    const result = detectHtmlDocumentPreview(`\`\`\`html\n${html}\n\`\`\``);
+    expect(result?.html).toBe(html);
+  });
+
+  it("detects paired head and body documents", () => {
+    const result = detectHtmlDocumentPreview(
+      "<head><title>Report</title></head>\n\n<body><h1>Report</h1></body>",
+    );
+    expect(result?.html).toContain("<head>");
+    expect(result?.html).toContain("<body>");
+  });
+
+  it("does not strip or preview non-whole-message HTML fences", () => {
+    expect(
+      detectHtmlDocumentPreview(
+        "Before\n```html\n<!doctype html><html><body><h1>Report</h1></body></html>\n```",
+      ),
+    ).toBeNull();
+    expect(
+      detectHtmlDocumentPreview(
+        "```html\n<!doctype html><html><body><h1>Report</h1></body></html>\n```\nAfter",
+      ),
+    ).toBeNull();
+  });
+
+  it("does not truncate documents at the preview limit", () => {
+    const html = createHtmlDocumentWithLength(MAX_HTML_PREVIEW_CHARS);
+    const result = detectHtmlDocumentPreview(html);
+    expect(result).toEqual({ html, truncated: false });
+  });
+
+  it("truncates documents over the preview limit", () => {
+    const html = createHtmlDocumentWithLength(MAX_HTML_PREVIEW_CHARS + 1);
+    const result = detectHtmlDocumentPreview(html);
+    expect(result?.truncated).toBe(true);
+    expect(result?.html).toContain(HTML_PREVIEW_TRUNCATION_COMMENT.trim());
+    expect(result?.html).toBe(
+      `${html.slice(0, MAX_HTML_PREVIEW_CHARS)}${HTML_PREVIEW_TRUNCATION_COMMENT}`,
+    );
+    expect(result?.html).toHaveLength(
+      MAX_HTML_PREVIEW_CHARS + HTML_PREVIEW_TRUNCATION_COMMENT.length,
+    );
+  });
+
+  it("does not treat small raw HTML snippets as full documents", () => {
+    expect(detectHtmlDocumentPreview("<strong>Important</strong>")).toBeNull();
+    expect(detectHtmlDocumentPreview("Use <html> literally in docs.")).toBeNull();
+    expect(detectHtmlDocumentPreview("Example: <html><body>x</body></html> done")).toBeNull();
+    expect(detectHtmlDocumentPreview("Example: <head></head><body>x</body> done")).toBeNull();
+    expect(detectHtmlDocumentPreview("<html> is the root element...")).toBeNull();
+    expect(detectHtmlDocumentPreview("<html><body>x")).toBeNull();
+    expect(detectHtmlDocumentPreview("<!doctype html>")).toBeNull();
+  });
+
+  it("uses a scriptless sandbox policy for previews", () => {
+    expect(HTML_PREVIEW_SANDBOX).toBe("");
+    expect(HTML_PREVIEW_CSP).toBe(
+      "default-src 'none'; navigate-to 'none'; base-uri 'none'; form-action 'none'; img-src data: blob:; media-src data: blob:; font-src data:; style-src 'unsafe-inline'",
+    );
+    expect(HTML_PREVIEW_CSP).toContain("navigate-to 'none'");
+    expect(HTML_PREVIEW_CSP).toContain("base-uri 'none'");
+    expect(HTML_PREVIEW_CSP).toContain("form-action 'none'");
+    expect(HTML_PREVIEW_CSP).not.toContain("script-src");
+  });
+
+  it("injects CSP metadata into preview srcdoc documents", () => {
+    expect(
+      buildHtmlPreviewSrcdoc("<html><head><title>Report</title></head><body></body></html>"),
+    ).toBe(`<html><head>${HTML_PREVIEW_CSP_META}<title>Report</title></head><body></body></html>`);
+
+    expect(buildHtmlPreviewSrcdoc("<html><body><h1>Report</h1></body></html>")).toBe(
+      `<html><head>${HTML_PREVIEW_CSP_META}</head><body><h1>Report</h1></body></html>`,
+    );
+
+    expect(buildHtmlPreviewSrcdoc("<head></head><body><h1>Report</h1></body>")).toBe(
+      `<head>${HTML_PREVIEW_CSP_META}</head><body><h1>Report</h1></body>`,
+    );
+  });
+
+  it("keeps CSP metadata outside quoted html start-tag attributes", () => {
+    expect(
+      buildHtmlPreviewSrcdoc(
+        '<html data-x=">"><body><img src="https://example.test/leak.png"></body></html>',
+      ),
+    ).toBe(
+      `<html data-x=">"><head>${HTML_PREVIEW_CSP_META}</head><body><img src="https://example.test/leak.png"></body></html>`,
+    );
+  });
+
+  it("keeps CSP metadata outside quoted head start-tag attributes", () => {
+    expect(
+      buildHtmlPreviewSrcdoc(
+        '<html><head data-x=">"><title>Report</title></head><body></body></html>',
+      ),
+    ).toBe(
+      `<html><head data-x=">">${HTML_PREVIEW_CSP_META}<title>Report</title></head><body></body></html>`,
+    );
+  });
+
+  it("does not inject CSP metadata into commented head markers", () => {
+    expect(
+      buildHtmlPreviewSrcdoc(
+        '<!doctype html><html><!-- <head> marker --><body><img src="https://example.test/leak.png"></body></html>',
+      ),
+    ).toBe(
+      `<!doctype html><html><head>${HTML_PREVIEW_CSP_META}</head><!-- <head> marker --><body><img src="https://example.test/leak.png"></body></html>`,
+    );
+
+    expect(
+      buildHtmlPreviewSrcdoc(
+        "<html><!-- leading comment --><head><title>Report</title></head><body></body></html>",
+      ),
+    ).toBe(
+      `<html><!-- leading comment --><head>${HTML_PREVIEW_CSP_META}<title>Report</title></head><body></body></html>`,
+    );
+  });
+
+  it("injects CSP before base, navigation, and form egress controls", () => {
+    const srcdoc = buildHtmlPreviewSrcdoc(
+      '<html><head><base href="https://example.test/"><meta http-equiv="refresh" content="0;url=https://example.test/refresh"></head><body><a href="https://example.test/link">link</a><form action="https://example.test/post"></form></body></html>',
+    );
+    expect(srcdoc).toBe(
+      `<html><head>${HTML_PREVIEW_CSP_META}<base href="https://example.test/"><meta http-equiv="refresh" content="0;url=https://example.test/refresh"></head><body><a href="https://example.test/link">link</a><form action="https://example.test/post"></form></body></html>`,
+    );
+    expect(srcdoc).toContain("navigate-to 'none'");
+    expect(srcdoc).toContain("base-uri 'none'");
+    expect(srcdoc).toContain("form-action 'none'");
+  });
+
+  it("does not inject CSP metadata into script head markers", () => {
+    expect(
+      buildHtmlPreviewSrcdoc(
+        '<html><script>const marker = "<head>";</script><body><img src="https://example.test/script-head.png"></body></html>',
+      ),
+    ).toBe(
+      `<html><head>${HTML_PREVIEW_CSP_META}</head><script>const marker = "<head>";</script><body><img src="https://example.test/script-head.png"></body></html>`,
+    );
+  });
+});

--- a/ui/src/ui/chat/html-preview.ts
+++ b/ui/src/ui/chat/html-preview.ts
@@ -1,0 +1,132 @@
+export const HTML_PREVIEW_SANDBOX = "";
+export const HTML_PREVIEW_CSP =
+  "default-src 'none'; img-src data: blob:; media-src data: blob:; font-src data:; style-src 'unsafe-inline'";
+
+const MAX_HTML_PREVIEW_CHARS = 750_000;
+
+export type HtmlDocumentPreview = {
+  html: string;
+  truncated: boolean;
+};
+
+export function detectHtmlDocumentPreview(markdown: string): HtmlDocumentPreview | null {
+  const candidate = stripMarkdownHtmlFence(markdown);
+  if (!looksLikeCompleteHtmlDocument(candidate)) {
+    return null;
+  }
+  if (candidate.length <= MAX_HTML_PREVIEW_CHARS) {
+    return { html: candidate, truncated: false };
+  }
+  return {
+    html: `${candidate.slice(
+      0,
+      MAX_HTML_PREVIEW_CHARS,
+    )}\n<!-- OpenClaw: HTML preview truncated at ${MAX_HTML_PREVIEW_CHARS} characters. -->`,
+    truncated: true,
+  };
+}
+
+export function buildHtmlPreviewSrcdoc(html: string): string {
+  const meta = `<meta http-equiv="Content-Security-Policy" content="${escapeHtmlAttribute(
+    HTML_PREVIEW_CSP,
+  )}">`;
+  const htmlOpen = findHtmlStartTag(html, "html");
+  if (htmlOpen) {
+    const firstTagAfterHtml = findFirstHtmlStartTag(html, htmlOpen.end);
+    if (firstTagAfterHtml?.tagName === "head") {
+      return `${html.slice(0, firstTagAfterHtml.end)}${meta}${html.slice(firstTagAfterHtml.end)}`;
+    }
+    return `${html.slice(0, htmlOpen.end)}<head>${meta}</head>${html.slice(htmlOpen.end)}`;
+  }
+
+  const firstTag = findFirstHtmlStartTag(html);
+  if (firstTag?.tagName === "head") {
+    return `${html.slice(0, firstTag.end)}${meta}${html.slice(firstTag.end)}`;
+  }
+
+  return `${meta}${html}`;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+function findFirstHtmlStartTag(
+  html: string,
+  startIndex = 0,
+  endIndex = html.length,
+): { tagName: string; index: number; end: number } | null {
+  let index = Math.max(0, startIndex);
+  const searchEnd = Math.min(Math.max(index, endIndex), html.length);
+
+  while (index < searchEnd) {
+    const open = html.indexOf("<", index);
+    if (open === -1 || open >= searchEnd) {
+      return null;
+    }
+    if (html.startsWith("<!--", open)) {
+      const commentEnd = html.indexOf("-->", open + 4);
+      index = commentEnd === -1 ? searchEnd : commentEnd + 3;
+      continue;
+    }
+
+    const close = html.indexOf(">", open + 1);
+    if (close === -1 || close >= searchEnd) {
+      return null;
+    }
+
+    const tagText = html.slice(open + 1, close).trimStart();
+    const nameMatch = /^([a-z][^\s/>]*)/i.exec(tagText);
+    if (nameMatch?.[1] && !tagText.startsWith("/")) {
+      return { tagName: nameMatch[1].toLowerCase(), index: open, end: close + 1 };
+    }
+    index = close + 1;
+  }
+
+  return null;
+}
+
+function findHtmlStartTag(
+  html: string,
+  tagName: "body" | "head" | "html",
+  startIndex = 0,
+  endIndex = html.length,
+): { index: number; end: number } | null {
+  const normalizedTagName = tagName.toLowerCase();
+  let index = Math.max(0, startIndex);
+  const searchEnd = Math.min(Math.max(index, endIndex), html.length);
+
+  while (index < searchEnd) {
+    const tag = findFirstHtmlStartTag(html, index, searchEnd);
+    if (!tag) {
+      return null;
+    }
+    if (tag.tagName === normalizedTagName) {
+      return { index: tag.index, end: tag.end };
+    }
+    index = tag.end;
+  }
+
+  return null;
+}
+
+function stripMarkdownHtmlFence(markdown: string): string {
+  const trimmed = markdown.trim();
+  const lineBreak = "(?:\\r\\n|\\n|\\r)";
+  const match = new RegExp(
+    `^\\\`\\\`\\\`(?:html|htm)[^\\S\\r\\n]*${lineBreak}([\\s\\S]*?)${lineBreak}\\\`\\\`\\\`$`,
+    "i",
+  ).exec(trimmed);
+  return match?.[1] ?? trimmed;
+}
+
+function looksLikeCompleteHtmlDocument(candidate: string): boolean {
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const documentShape =
+    "(?:<html(?:\\s[^>]*)?>[\\s\\S]*<\\/html>|<head(?:\\s[^>]*)?>[\\s\\S]*<\\/head>\\s*<body(?:\\s[^>]*)?>[\\s\\S]*<\\/body>)";
+  return new RegExp(`^(?:<!doctype\\s+html\\s*>\\s*)?${documentShape}$`, "i").test(trimmed);
+}

--- a/ui/src/ui/chat/html-preview.ts
+++ b/ui/src/ui/chat/html-preview.ts
@@ -1,0 +1,155 @@
+export const HTML_PREVIEW_SANDBOX = "";
+export const HTML_PREVIEW_CSP =
+  "default-src 'none'; navigate-to 'none'; base-uri 'none'; form-action 'none'; img-src data: blob:; media-src data: blob:; font-src data:; style-src 'unsafe-inline'";
+
+export const MAX_HTML_PREVIEW_CHARS = 750_000;
+export const HTML_PREVIEW_TRUNCATION_COMMENT = `\n<!-- OpenClaw: HTML preview truncated at ${MAX_HTML_PREVIEW_CHARS} characters. -->`;
+
+export type HtmlDocumentPreview = {
+  html: string;
+  truncated: boolean;
+};
+
+export function detectHtmlDocumentPreview(markdown: string): HtmlDocumentPreview | null {
+  const candidate = stripMarkdownHtmlFence(markdown);
+  if (!looksLikeCompleteHtmlDocument(candidate)) {
+    return null;
+  }
+  if (candidate.length <= MAX_HTML_PREVIEW_CHARS) {
+    return { html: candidate, truncated: false };
+  }
+  return {
+    html: `${candidate.slice(0, MAX_HTML_PREVIEW_CHARS)}${HTML_PREVIEW_TRUNCATION_COMMENT}`,
+    truncated: true,
+  };
+}
+
+export function buildHtmlPreviewSrcdoc(html: string): string {
+  const meta = `<meta http-equiv="Content-Security-Policy" content="${escapeHtmlAttribute(
+    HTML_PREVIEW_CSP,
+  )}">`;
+  const htmlOpen = findHtmlStartTag(html, "html");
+  if (htmlOpen) {
+    const firstTagAfterHtml = findFirstHtmlStartTag(html, htmlOpen.end);
+    if (firstTagAfterHtml?.tagName === "head") {
+      return `${html.slice(0, firstTagAfterHtml.end)}${meta}${html.slice(firstTagAfterHtml.end)}`;
+    }
+    return `${html.slice(0, htmlOpen.end)}<head>${meta}</head>${html.slice(htmlOpen.end)}`;
+  }
+
+  const firstTag = findFirstHtmlStartTag(html);
+  if (firstTag?.tagName === "head") {
+    return `${html.slice(0, firstTag.end)}${meta}${html.slice(firstTag.end)}`;
+  }
+
+  return `${meta}${html}`;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function findFirstHtmlStartTag(
+  html: string,
+  startIndex = 0,
+  endIndex = html.length,
+): { tagName: string; index: number; end: number } | null {
+  let index = Math.max(0, startIndex);
+  const searchEnd = Math.min(Math.max(index, endIndex), html.length);
+
+  while (index < searchEnd) {
+    const open = html.indexOf("<", index);
+    if (open === -1 || open >= searchEnd) {
+      return null;
+    }
+    if (html.startsWith("<!--", open)) {
+      const commentEnd = html.indexOf("-->", open + 4);
+      index = commentEnd === -1 ? searchEnd : commentEnd + 3;
+      continue;
+    }
+
+    const close = findStartTagClose(html, open, searchEnd);
+    if (close === null) {
+      return null;
+    }
+
+    const tagText = html.slice(open + 1, close).trimStart();
+    const nameMatch = /^([a-z][^\s/>]*)/i.exec(tagText);
+    if (nameMatch?.[1] && !tagText.startsWith("/")) {
+      return { tagName: nameMatch[1].toLowerCase(), index: open, end: close + 1 };
+    }
+    index = close + 1;
+  }
+
+  return null;
+}
+
+function findStartTagClose(html: string, open: number, searchEnd: number): number | null {
+  let quote: '"' | "'" | null = null;
+  for (let index = open + 1; index < searchEnd; index += 1) {
+    const char = html[index];
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === ">") {
+      return index;
+    }
+  }
+  return null;
+}
+
+function findHtmlStartTag(
+  html: string,
+  tagName: "body" | "head" | "html",
+  startIndex = 0,
+  endIndex = html.length,
+): { index: number; end: number } | null {
+  const normalizedTagName = tagName.toLowerCase();
+  let index = Math.max(0, startIndex);
+  const searchEnd = Math.min(Math.max(index, endIndex), html.length);
+
+  while (index < searchEnd) {
+    const tag = findFirstHtmlStartTag(html, index, searchEnd);
+    if (!tag) {
+      return null;
+    }
+    if (tag.tagName === normalizedTagName) {
+      return { index: tag.index, end: tag.end };
+    }
+    index = tag.end;
+  }
+
+  return null;
+}
+
+function stripMarkdownHtmlFence(markdown: string): string {
+  const trimmed = markdown.trim();
+  const lineBreak = "(?:\\r\\n|\\n|\\r)";
+  const match = new RegExp(
+    `^\\\`\\\`\\\`(?:html|htm)[^\\S\\r\\n]*${lineBreak}([\\s\\S]*?)(?:${lineBreak})?\\\`\\\`\\\`$`,
+    "i",
+  ).exec(trimmed);
+  return match?.[1] ?? trimmed;
+}
+
+function looksLikeCompleteHtmlDocument(candidate: string): boolean {
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const documentShape =
+    "(?:<html(?:\\s[^>]*)?>[\\s\\S]*<\\/html>|<head(?:\\s[^>]*)?>[\\s\\S]*<\\/head>\\s*<body(?:\\s[^>]*)?>[\\s\\S]*<\\/body>)";
+  return new RegExp(`^(?:<!doctype\\s+html\\s*>\\s*)?${documentShape}$`, "i").test(trimmed);
+}


### PR DESCRIPTION
## Summary

Complete assistant-generated HTML documents now render in Control UI chat as sandboxed previews instead of raw inline markup. The source stays available in a disclosure, and expanded tool-result HTML uses the same preview path.

AI-assisted by Codex GPT-5.5.

## What Changed

- Added `ui/src/ui/chat/html-preview.ts` to detect complete HTML documents, strip whole-message `html`/`htm` fences, cap very large previews, and inject a CSP meta tag into iframe `srcdoc`.
- Updated grouped chat rendering to show previews only for completed assistant messages and expanded tool outputs.
- Added chat preview styles for the iframe, header, truncation label, and source disclosure.
- Added focused tests for detection, CSP injection, truncation, role gates, streaming gates, and tool expansion behavior.

## Scope Boundaries

- Does not preview HTML snippets, prose containing HTML, incomplete documents, or non-whole-message fences.
- Does not preview user, system, developer, or streaming assistant messages.
- Does not change JSON rendering, markdown rendering, collapsed tool output behavior, or existing canvas/embed behavior.

## Security

- The iframe uses an empty `sandbox` attribute, leaving scripts, same-origin access, forms, popups, and top navigation disabled.
- The preview CSP is:

```text
default-src 'none'; navigate-to 'none'; base-uri 'none'; form-action 'none'; img-src data: blob:; media-src data: blob:; font-src data:; style-src 'unsafe-inline'
```

- The renderer uses Lit `.srcdoc` property binding instead of setting a large `srcdoc` attribute.
- Source remains visible under the `Source` disclosure so rendered output is not the only view of the content.

## Verification

Verified on rebased head `f3a017d9a059cceb6f6a10806c0f954cb22f46be` against base `84b025eb622176483ebb1615a88059a4368b3775`.

- `node scripts/run-vitest.mjs ui/src/ui/chat/html-preview.test.ts ui/src/ui/chat/grouped-render.test.ts` passed: 2 files, 74 tests.
- `./node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/chat/html-preview.ts ui/src/ui/chat/html-preview.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts ui/src/styles/chat/text.css` passed.
- `git diff --check origin/main...HEAD` produced no output.

Broader local checks were run earlier in the branch:

- `pnpm build` passed.
- `pnpm check` passed.
- A full `pnpm test` run was attempted but hit unrelated local host/environment failures outside this PR's diff.

## Real behavior proof

- **Behavior or issue addressed:** Complete assistant-generated HTML documents render as sandboxed iframe previews instead of raw inline markup, while the original source remains available in a disclosure.
- **Real environment tested:** Local Chromium through Playwright against current PR head `f3a017d9a059cceb6f6a10806c0f954cb22f46be`; Control UI served by the real Vite dev server using `ui/vite.config.ts`; Gateway traffic supplied by the Control UI E2E harness.
- **Exact steps or command run after this patch:** From the PR worktree, ran a `pnpm exec tsx` browser probe that started the Control UI Vite server, loaded `/chat`, installed the E2E Gateway harness with one complete assistant HTML document in history, waited for `.chat-html-preview iframe.chat-html-preview__frame`, and queried the live DOM attributes.
- **Evidence after fix:** Current-head terminal output from the Chromium browser probe:

```json
{
  "head": "f3a017d9a059cceb6f6a10806c0f954cb22f46be",
  "base": "84b025eb622176483ebb1615a88059a4368b3775",
  "previewCount": 1,
  "frameTitle": "Rendered HTML response",
  "sandboxAttribute": "",
  "cspAttribute": "default-src 'none'; navigate-to 'none'; base-uri 'none'; form-action 'none'; img-src data: blob:; media-src data: blob:; font-src data:; style-src 'unsafe-inline'",
  "referrerPolicy": "no-referrer",
  "loading": "lazy",
  "srcdocHasCspMeta": true,
  "srcdocHasNavigateToNone": true,
  "srcdocHasBaseUriNone": true,
  "srcdocHasFormActionNone": true,
  "sourceDisclosurePresent": true,
  "sourceDisclosureOpen": false,
  "sourceTextMatchesOriginalHtml": true,
  "rawHtmlShownAsChatText": false,
  "htmlPreviewElementVisible": true,
  "consoleErrorCount": 0,
  "pageErrorCount": 0
}
```

Supplemental before/after browser artifact from the earlier branch state: https://gist.github.com/wolph/207291436a424d13572b8964821f982e
- **Observed result after fix:** The current-head browser run rendered exactly one visible HTML preview iframe, the iframe sandbox attribute was empty, the final CSP included `navigate-to 'none'`, `base-uri 'none'`, and `form-action 'none'`, the disclosure source matched the original HTML, and the raw doctype markup was not shown as normal chat text.
- **What was not tested:** I did not record a new screenshot/video artifact for the current-head run; the current-head evidence is the copied Playwright/Chromium terminal capture above.

## Review Status

- Copilot review threads were addressed and resolved.
- The remaining merge decision is maintainer acceptance of the sandboxed iframe preview boundary and normal required-check handling.