### PR TITLE
fix(gateway): route transcript reads through claude-cli store for CLI sessions [AI]

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -135,6 +135,9 @@ export async function runPreparedCliAgent(
           sessionKey: params.sessionKey,
           agentId: params.agentId,
           config: params.config,
+          modelProvider: params.provider,
+          cliSessionId: params.cliSessionId ?? params.cliSessionBinding?.sessionId,
+          workspaceDir: params.workspaceDir,
         })
       : [];
   const llmInputEvent = {

--- a/src/agents/cli-runner/claude-cli-paths.ts
+++ b/src/agents/cli-runner/claude-cli-paths.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+
+const CLAUDE_CLI_PROVIDER = "claude-cli";
+const CLAUDE_PROJECTS_DIRNAME = path.join(".claude", "projects");
+const MAX_SANITIZED_PROJECT_LENGTH = 200;
+
+function simpleHash36(input: string): string {
+  let hash = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 31 + input.charCodeAt(index)) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+function sanitizeClaudeCliProjectKey(workspaceDir: string): string {
+  const sanitized = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+  if (sanitized.length <= MAX_SANITIZED_PROJECT_LENGTH) {
+    return sanitized;
+  }
+  return `${sanitized.slice(0, MAX_SANITIZED_PROJECT_LENGTH)}-${simpleHash36(workspaceDir)}`;
+}
+
+function canonicalizeWorkspaceDir(workspaceDir: string): string {
+  const resolved = path.resolve(workspaceDir).normalize("NFC");
+  try {
+    return fs.realpathSync.native(resolved).normalize("NFC");
+  } catch {
+    return resolved;
+  }
+}
+
+/**
+ * Resolve the directory the Claude CLI uses to store this workspace's session
+ * transcripts. Mirrors the path-construction rules used by the `claude` binary:
+ *   `~/.claude/projects/<sanitized-workspace>/`.
+ *
+ * Used by both `doctor` health checks and the read-through transcript resolver
+ * for sessions whose modelProvider is `claude-cli`.
+ */
+export function resolveClaudeCliProjectDirForWorkspace(params: {
+  workspaceDir: string;
+  homeDir?: string;
+}): string {
+  const homeDir = normalizeOptionalString(params.homeDir) || process.env.HOME || os.homedir();
+  const canonicalWorkspaceDir = canonicalizeWorkspaceDir(params.workspaceDir);
+  return path.join(
+    homeDir,
+    CLAUDE_PROJECTS_DIRNAME,
+    sanitizeClaudeCliProjectKey(canonicalWorkspaceDir),
+  );
+}
+
+/**
+ * Resolve the canonical transcript file owned by the Claude CLI for a given
+ * session, when (and only when) the session is running under the `claude-cli`
+ * model provider AND has a populated CLI session id.
+ *
+ * Returns `undefined` when the session is not CLI-bound, when required inputs
+ * are missing, or when the resolved file does not yet exist on disk (callers
+ * should fall back to the openclaw-store `sessionFile` candidate in that case).
+ *
+ * Read-only path resolution: this function never creates files or directories.
+ */
+export function resolveActiveCliTranscriptPath(params: {
+  modelProvider?: string;
+  cliSessionId?: string;
+  workspaceDir?: string;
+  homeDir?: string;
+}): string | undefined {
+  const provider = normalizeOptionalString(params.modelProvider);
+  if (provider !== CLAUDE_CLI_PROVIDER) {
+    return undefined;
+  }
+  const cliSessionId = normalizeOptionalString(params.cliSessionId);
+  if (!cliSessionId) {
+    return undefined;
+  }
+  const workspaceDir = normalizeOptionalString(params.workspaceDir);
+  if (!workspaceDir) {
+    return undefined;
+  }
+  const projectDir = resolveClaudeCliProjectDirForWorkspace({
+    workspaceDir,
+    homeDir: params.homeDir,
+  });
+  const candidate = path.join(projectDir, `${cliSessionId}.jsonl`);
+  try {
+    const stat = fs.statSync(candidate);
+    if (!stat.isFile()) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return candidate;
+}

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -304,6 +304,9 @@ export async function prepareCliRunContext(
       sessionKey: params.sessionKey,
       agentId: params.agentId,
       config: params.config,
+      modelProvider: params.provider,
+      cliSessionId: params.cliSessionId ?? params.cliSessionBinding?.sessionId,
+      workspaceDir: params.workspaceDir,
     });
     return openClawHistoryMessages;
   };
@@ -410,6 +413,9 @@ export async function prepareCliRunContext(
           sessionKey: params.sessionKey,
           agentId: params.agentId,
           config: params.config,
+          modelProvider: params.provider,
+          cliSessionId: params.cliSessionId ?? params.cliSessionBinding?.sessionId,
+          workspaceDir: params.workspaceDir,
         }),
         prompt: preparedPrompt,
       });

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -187,6 +187,63 @@ describe("loadCliSessionHistoryMessages", () => {
     }
   });
 
+  it("reads the Claude CLI project transcript when modelProvider is claude-cli", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-home-"));
+    const workspaceDirRaw = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-ws-"));
+    // macOS `os.tmpdir()` returns a `/var/folders/...` path that realpaths to
+    // `/private/var/folders/...`. The Claude CLI sanitizer canonicalizes via
+    // realpath before slugifying, so use the canonical form here so the test
+    // computes the same `<sanitized>/<cliSessionId>.jsonl` path the helper
+    // does on disk.
+    const workspaceDir = fs.realpathSync.native(workspaceDirRaw);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("HOME", homeDir);
+    // The openclaw-store sessionFile is a delivery-mirror surface that may not
+    // exist on disk for CLI-run sessions; the canonical transcript is owned by
+    // claude-cli at ~/.claude/projects/<workspace-slug>/<cliSessionId>.jsonl.
+    const openclawSessionFile = path.join(
+      stateDir,
+      "agents",
+      "main",
+      "sessions",
+      "session-cli.jsonl",
+    );
+    const cliSessionId = "11111111-2222-4333-8444-555555555555";
+    const sanitizedWorkspace = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+    const claudeProjectFile = path.join(
+      homeDir,
+      ".claude",
+      "projects",
+      sanitizedWorkspace,
+      `${cliSessionId}.jsonl`,
+    );
+    createSessionTranscript({
+      rootDir: workspaceDir,
+      sessionId: cliSessionId,
+      filePath: claudeProjectFile,
+      messages: ["claude cli history"],
+    });
+
+    try {
+      expect(
+        await loadCliSessionHistoryMessages({
+          sessionId: "session-cli",
+          sessionFile: openclawSessionFile,
+          sessionKey: "agent:main:main",
+          agentId: "main",
+          modelProvider: "claude-cli",
+          cliSessionId,
+          workspaceDir,
+        }),
+      ).toMatchObject([{ role: "user", content: "claude cli history" }]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(workspaceDirRaw, { recursive: true, force: true });
+    }
+  });
+
   it("honors custom session store roots when resolving hook history transcripts", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
     const customStoreDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-store-"));

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -11,6 +11,10 @@ import {
   limitAgentHookHistoryMessages,
   MAX_AGENT_HOOK_HISTORY_MESSAGES,
 } from "../harness/hook-history.js";
+import {
+  resolveActiveCliTranscriptPath,
+  resolveClaudeCliProjectDirForWorkspace,
+} from "./claude-cli-paths.js";
 
 export const MAX_CLI_SESSION_HISTORY_FILE_BYTES = 5 * 1024 * 1024;
 export const MAX_CLI_SESSION_HISTORY_MESSAGES = MAX_AGENT_HOOK_HISTORY_MESSAGES;
@@ -119,7 +123,10 @@ function resolveSafeCliSessionFile(params: {
   sessionKey?: string;
   agentId?: string;
   config?: OpenClawConfig;
-}): { sessionFile: string; sessionsDir: string } {
+  modelProvider?: string;
+  cliSessionId?: string;
+  workspaceDir?: string;
+}): { sessionFile: string; sessionsDirs: string[] } {
   const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
     sessionKey: params.sessionKey,
     config: params.config,
@@ -129,14 +136,32 @@ function resolveSafeCliSessionFile(params: {
     agentId: sessionAgentId ?? defaultAgentId,
     storePath: params.config?.session?.store,
   });
-  const sessionFile = resolveSessionFilePath(
+  const openclawSessionFile = resolveSessionFilePath(
     params.sessionId,
     { sessionFile: params.sessionFile },
     pathOptions,
   );
+  const openclawSessionsDir = pathOptions?.sessionsDir ?? path.dirname(openclawSessionFile);
+  // For sessions running under the claude-cli model provider, the canonical
+  // transcript is owned by the Claude CLI itself (under
+  // ~/.claude/projects/<workspace-slug>/<cliSessionId>.jsonl). Prefer that
+  // path when both inputs are populated and the file exists; fall back to the
+  // openclaw-store path otherwise. The within-base check below is widened so
+  // both directories are accepted as safe roots.
+  const claudeCliFile = resolveActiveCliTranscriptPath({
+    modelProvider: params.modelProvider,
+    cliSessionId: params.cliSessionId,
+    workspaceDir: params.workspaceDir,
+  });
+  const sessionsDirs = [openclawSessionsDir];
+  if (params.workspaceDir && params.modelProvider === "claude-cli") {
+    sessionsDirs.push(
+      resolveClaudeCliProjectDirForWorkspace({ workspaceDir: params.workspaceDir }),
+    );
+  }
   return {
-    sessionFile,
-    sessionsDir: pathOptions?.sessionsDir ?? path.dirname(sessionFile),
+    sessionFile: claudeCliFile ?? openclawSessionFile,
+    sessionsDirs,
   };
 }
 
@@ -146,16 +171,24 @@ async function loadCliSessionEntries(params: {
   sessionKey?: string;
   agentId?: string;
   config?: OpenClawConfig;
+  modelProvider?: string;
+  cliSessionId?: string;
+  workspaceDir?: string;
 }): Promise<unknown[]> {
   try {
-    const { sessionFile, sessionsDir } = resolveSafeCliSessionFile(params);
+    const { sessionFile, sessionsDirs } = resolveSafeCliSessionFile(params);
     const entryStat = await fsp.lstat(sessionFile);
     if (!entryStat.isFile() || entryStat.isSymbolicLink()) {
       return [];
     }
-    const realSessionsDir = (await safeRealpath(sessionsDir)) ?? path.resolve(sessionsDir);
     const realSessionFile = await safeRealpath(sessionFile);
-    if (!realSessionFile || !isPathWithinBase(realSessionsDir, realSessionFile)) {
+    if (!realSessionFile) {
+      return [];
+    }
+    const realSessionsDirs = await Promise.all(
+      sessionsDirs.map(async (dir) => (await safeRealpath(dir)) ?? path.resolve(dir)),
+    );
+    if (!realSessionsDirs.some((dir) => isPathWithinBase(dir, realSessionFile))) {
       return [];
     }
     const stat = await fsp.stat(realSessionFile);
@@ -176,6 +209,9 @@ export async function loadCliSessionHistoryMessages(params: {
   sessionKey?: string;
   agentId?: string;
   config?: OpenClawConfig;
+  modelProvider?: string;
+  cliSessionId?: string;
+  workspaceDir?: string;
 }): Promise<unknown[]> {
   const history = (await loadCliSessionEntries(params)).flatMap((entry) => {
     const candidate = entry as HistoryEntry;
@@ -190,6 +226,9 @@ export async function loadCliSessionReseedMessages(params: {
   sessionKey?: string;
   agentId?: string;
   config?: OpenClawConfig;
+  modelProvider?: string;
+  cliSessionId?: string;
+  workspaceDir?: string;
 }): Promise<unknown[]> {
   const entries = await loadCliSessionEntries(params);
   const latestCompactionIndex = entries.findLastIndex((entry) => {

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -6,7 +6,7 @@ import {
   resolveSessionFilePathOptions,
   resolveStorePath,
 } from "../../config/sessions.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import type { CliSessionBinding, SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import {
@@ -15,6 +15,8 @@ import {
 } from "../../gateway/session-utils.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../../shared/string-coerce.js";
+import { resolveAgentWorkspaceDir } from "../agent-scope.js";
+import { resolveActiveCliTranscriptPath } from "../cli-runner/claude-cli-paths.js";
 import {
   describeSessionsListTool,
   SESSIONS_LIST_TOOL_DISPLAY_SUMMARY,
@@ -217,31 +219,65 @@ export function createSessionsListTool(opts?: {
         const sessionFileRaw = (entry as { sessionFile?: unknown }).sessionFile;
         const sessionFile = readStringValue(sessionFileRaw);
         const resolvedAgentId = resolveAgentIdFromSessionKey(key);
+        const entryModelProvider = readStringValue(
+          (entry as { modelProvider?: unknown }).modelProvider,
+        );
+        const cliSessionBindings = (
+          entry as { cliSessionBindings?: Record<string, CliSessionBinding> }
+        ).cliSessionBindings;
+        const cliBoundSessionId = readStringValue(
+          cliSessionBindings?.[entryModelProvider ?? ""]?.sessionId,
+        );
+        const spawnedWorkspaceDir = readStringValue(
+          (entry as { spawnedWorkspaceDir?: unknown }).spawnedWorkspaceDir,
+        );
         let transcriptPath: string | undefined;
         if (sessionId) {
-          try {
-            const trimmedStorePath = storePath?.trim();
-            let effectiveStorePath: string | undefined;
-            if (trimmedStorePath && trimmedStorePath !== "(multiple)") {
-              if (trimmedStorePath.includes("{agentId}") || trimmedStorePath.startsWith("~")) {
-                effectiveStorePath = resolveStorePath(trimmedStorePath, {
-                  agentId: resolvedAgentId,
-                });
-              } else if (path.isAbsolute(trimmedStorePath)) {
-                effectiveStorePath = trimmedStorePath;
-              }
+          // For sessions running under a CLI model provider (claude-cli today),
+          // prefer the live transcript owned by the CLI itself. The
+          // openclaw-store sessionFile is a delivery-mirror surface for those
+          // sessions and may not even exist on disk; resolving to it produces
+          // the dashboard `transcriptPath: null` symptom this branch fixes.
+          if (entryModelProvider === "claude-cli" && cliBoundSessionId) {
+            try {
+              const workspaceDir =
+                spawnedWorkspaceDir ?? resolveAgentWorkspaceDir(cfg, resolvedAgentId);
+              transcriptPath = resolveActiveCliTranscriptPath({
+                modelProvider: entryModelProvider,
+                cliSessionId: cliBoundSessionId,
+                workspaceDir,
+              });
+            } catch {
+              // resolveAgentWorkspaceDir can throw for unknown agent ids; fall
+              // through to the openclaw-store path resolution below.
+              transcriptPath = undefined;
             }
-            const filePathOpts = resolveSessionFilePathOptions({
-              agentId: resolvedAgentId,
-              storePath: effectiveStorePath,
-            });
-            transcriptPath = resolveSessionFilePath(
-              sessionId,
-              sessionFile ? { sessionFile } : undefined,
-              filePathOpts,
-            );
-          } catch {
-            transcriptPath = undefined;
+          }
+          if (!transcriptPath) {
+            try {
+              const trimmedStorePath = storePath?.trim();
+              let effectiveStorePath: string | undefined;
+              if (trimmedStorePath && trimmedStorePath !== "(multiple)") {
+                if (trimmedStorePath.includes("{agentId}") || trimmedStorePath.startsWith("~")) {
+                  effectiveStorePath = resolveStorePath(trimmedStorePath, {
+                    agentId: resolvedAgentId,
+                  });
+                } else if (path.isAbsolute(trimmedStorePath)) {
+                  effectiveStorePath = trimmedStorePath;
+                }
+              }
+              const filePathOpts = resolveSessionFilePathOptions({
+                agentId: resolvedAgentId,
+                storePath: effectiveStorePath,
+              });
+              transcriptPath = resolveSessionFilePath(
+                sessionId,
+                sessionFile ? { sessionFile } : undefined,
+                filePathOpts,
+              );
+            } catch {
+              transcriptPath = undefined;
+            }
           }
         }
 

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { resolveAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import {
@@ -16,6 +15,7 @@ import type {
   TokenCredential,
 } from "../agents/auth-profiles/types.js";
 import { readClaudeCliCredentialsCached } from "../agents/cli-credentials.js";
+import { resolveClaudeCliProjectDirForWorkspace } from "../agents/cli-runner/claude-cli-paths.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveExecutablePath } from "../infra/executable-path.js";
@@ -27,9 +27,9 @@ import {
 import { note } from "../terminal/note.js";
 import { shortenHomePath } from "../utils.js";
 
+export { resolveClaudeCliProjectDirForWorkspace };
+
 const CLAUDE_CLI_PROVIDER = "claude-cli";
-const CLAUDE_PROJECTS_DIRNAME = path.join(".claude", "projects");
-const MAX_SANITIZED_PROJECT_LENGTH = 200;
 
 type ClaudeCliReadableCredential =
   | Pick<OAuthCredential, "type" | "expires">
@@ -61,44 +61,6 @@ function resolveClaudeCliCommand(cfg: OpenClawConfig): string {
     }
   }
   return "claude";
-}
-
-function simpleHash36(input: string): string {
-  let hash = 0;
-  for (let index = 0; index < input.length; index += 1) {
-    hash = (hash * 31 + input.charCodeAt(index)) >>> 0;
-  }
-  return hash.toString(36);
-}
-
-function sanitizeClaudeCliProjectKey(workspaceDir: string): string {
-  const sanitized = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
-  if (sanitized.length <= MAX_SANITIZED_PROJECT_LENGTH) {
-    return sanitized;
-  }
-  return `${sanitized.slice(0, MAX_SANITIZED_PROJECT_LENGTH)}-${simpleHash36(workspaceDir)}`;
-}
-
-function canonicalizeWorkspaceDir(workspaceDir: string): string {
-  const resolved = path.resolve(workspaceDir).normalize("NFC");
-  try {
-    return fs.realpathSync.native(resolved).normalize("NFC");
-  } catch {
-    return resolved;
-  }
-}
-
-export function resolveClaudeCliProjectDirForWorkspace(params: {
-  workspaceDir: string;
-  homeDir?: string;
-}): string {
-  const homeDir = normalizeOptionalString(params.homeDir) || process.env.HOME || os.homedir();
-  const canonicalWorkspaceDir = canonicalizeWorkspaceDir(params.workspaceDir);
-  return path.join(
-    homeDir,
-    CLAUDE_PROJECTS_DIRNAME,
-    sanitizeClaudeCliProjectKey(canonicalWorkspaceDir),
-  );
 }
 
 function probeDirectoryHealth(dirPath: string): ClaudeCliDirHealth {

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { resolveActiveCliTranscriptPath } from "../agents/cli-runner/claude-cli-paths.js";
 import {
   formatSessionArchiveTimestamp,
   parseSessionArchiveTimestamp,
@@ -13,6 +14,19 @@ import {
 } from "../config/sessions/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+
+/**
+ * Optional inputs that route candidate resolution through the Claude CLI
+ * project store when the session is bound to the `claude-cli` model provider.
+ * When `cliSessionId` and `workspaceDir` are both populated and the resolved
+ * file exists on disk, that path is added as the FIRST candidate so it wins
+ * over any openclaw-store candidate.
+ */
+export type CliTranscriptHint = {
+  modelProvider?: string;
+  cliSessionId?: string;
+  workspaceDir?: string;
+};
 
 type ArchiveFileReason = SessionArchiveReason;
 export type ArchivedSessionTranscript = {
@@ -73,6 +87,7 @@ export function resolveSessionTranscriptCandidates(
   storePath: string | undefined,
   sessionFile?: string,
   agentId?: string,
+  cliHint?: CliTranscriptHint,
 ): string[] {
   const candidates: string[] = [];
   const sessionFileState = classifySessionTranscriptCandidate(sessionId, sessionFile);
@@ -83,6 +98,23 @@ export function resolveSessionTranscriptCandidates(
       // Ignore invalid paths/IDs and keep scanning other safe candidates.
     }
   };
+
+  // Read-through to the Claude CLI project store: when the session is running
+  // under the claude-cli model provider and a CLI session id is bound to it,
+  // the canonical transcript lives in `~/.claude/projects/<workspace-slug>/`.
+  // We surface that path FIRST when it exists on disk so consumers (history
+  // reads, dashboard transcriptPath, sessions_history MCP tool, …) prefer the
+  // live file instead of the openclaw-store delivery-mirror sibling.
+  if (cliHint) {
+    const cliPath = resolveActiveCliTranscriptPath({
+      modelProvider: cliHint.modelProvider,
+      cliSessionId: cliHint.cliSessionId,
+      workspaceDir: cliHint.workspaceDir,
+    });
+    if (cliPath) {
+      candidates.push(cliPath);
+    }
+  }
 
   if (storePath) {
     const sessionsDir = path.dirname(storePath);

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -1596,6 +1596,73 @@ describe("resolveSessionTranscriptCandidates safety", () => {
     );
     expect(candidates).toContain(path.resolve(staleSessionFile));
   });
+
+  test("prefers the Claude CLI project transcript when modelProvider is claude-cli", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-hint-home-"));
+    const workspaceDirRaw = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-hint-ws-"));
+    // Match the realpath canonicalization the helper performs internally so the
+    // sanitized workspace slug matches what the helper computes on disk.
+    const workspaceDir = fs.realpathSync.native(workspaceDirRaw);
+    const cliSessionId = "33333333-3333-4333-8333-333333333333";
+    const sanitizedWorkspace = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+    const cliTranscript = path.join(
+      homeDir,
+      ".claude",
+      "projects",
+      sanitizedWorkspace,
+      `${cliSessionId}.jsonl`,
+    );
+    fs.mkdirSync(path.dirname(cliTranscript), { recursive: true });
+    fs.writeFileSync(cliTranscript, '{"type":"session"}\n', "utf-8");
+    vi.stubEnv("HOME", homeDir);
+
+    try {
+      const candidates = resolveSessionTranscriptCandidates(
+        "11111111-1111-4111-8111-111111111111",
+        "/tmp/openclaw/agents/main/sessions/sessions.json",
+        "/tmp/openclaw/agents/main/sessions/11111111-1111-4111-8111-111111111111.jsonl",
+        "main",
+        { modelProvider: "claude-cli", cliSessionId, workspaceDir },
+      );
+
+      expect(candidates[0]).toBe(cliTranscript);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(workspaceDirRaw, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  });
+
+  test("ignores the cliHint when the resolved CLI transcript does not exist", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-hint-miss-home-"));
+    const workspaceDirRaw = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-hint-miss-ws-"));
+    const workspaceDir = fs.realpathSync.native(workspaceDirRaw);
+    vi.stubEnv("HOME", homeDir);
+
+    try {
+      const candidates = resolveSessionTranscriptCandidates(
+        "11111111-1111-4111-8111-111111111111",
+        "/tmp/openclaw/agents/main/sessions/sessions.json",
+        undefined,
+        "main",
+        {
+          modelProvider: "claude-cli",
+          cliSessionId: "44444444-4444-4444-8444-444444444444",
+          workspaceDir,
+        },
+      );
+
+      expect(candidates[0]).toBe(
+        path.resolve(
+          "/tmp/openclaw/agents/main/sessions/11111111-1111-4111-8111-111111111111.jsonl",
+        ),
+      );
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(workspaceDirRaw, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  });
 });
 
 describe("archiveSessionTranscripts", () => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -13,6 +13,7 @@ import {
   archiveFileOnDisk,
   archiveSessionTranscripts,
   cleanupArchivedSessionTranscripts,
+  type CliTranscriptHint,
 } from "./session-transcript-files.fs.js";
 import {
   readSessionTranscriptIndex,
@@ -541,12 +542,25 @@ export async function readSessionMessagesAsync(
   storePath: string | undefined,
   sessionFile: string | undefined,
   opts: ReadSessionMessagesAsyncOptions,
+  cliHint?: CliTranscriptHint,
 ): Promise<unknown[]> {
   if (opts.mode === "recent") {
     const { mode: _mode, ...recentOpts } = opts;
-    return await readRecentSessionMessagesAsync(sessionId, storePath, sessionFile, recentOpts);
+    return await readRecentSessionMessagesAsync(
+      sessionId,
+      storePath,
+      sessionFile,
+      recentOpts,
+      cliHint,
+    );
   }
-  const filePath = findExistingTranscriptPath(sessionId, storePath, sessionFile);
+  const filePath = findExistingTranscriptPath(
+    sessionId,
+    storePath,
+    sessionFile,
+    undefined,
+    cliHint,
+  );
   if (!filePath) {
     return [];
   }
@@ -582,8 +596,15 @@ export async function readSessionMessageCountAsync(
   sessionId: string,
   storePath: string | undefined,
   sessionFile?: string,
+  cliHint?: CliTranscriptHint,
 ): Promise<number> {
-  const filePath = findExistingTranscriptPath(sessionId, storePath, sessionFile);
+  const filePath = findExistingTranscriptPath(
+    sessionId,
+    storePath,
+    sessionFile,
+    undefined,
+    cliHint,
+  );
   if (!filePath) {
     return 0;
   }
@@ -625,13 +646,20 @@ export async function readRecentSessionMessagesAsync(
   storePath: string | undefined,
   sessionFile?: string,
   opts?: ReadRecentSessionMessagesOptions,
+  cliHint?: CliTranscriptHint,
 ): Promise<unknown[]> {
   const maxMessages = Math.max(0, Math.floor(opts?.maxMessages ?? 0));
   if (maxMessages === 0) {
     return [];
   }
 
-  const filePath = findExistingTranscriptPath(sessionId, storePath, sessionFile);
+  const filePath = findExistingTranscriptPath(
+    sessionId,
+    storePath,
+    sessionFile,
+    undefined,
+    cliHint,
+  );
   if (!filePath) {
     return [];
   }
@@ -657,9 +685,21 @@ export async function readRecentSessionMessagesWithStatsAsync(
   storePath: string | undefined,
   sessionFile: string | undefined,
   opts: ReadRecentSessionMessagesOptions,
+  cliHint?: CliTranscriptHint,
 ): Promise<ReadRecentSessionMessagesResult> {
-  const totalMessages = await readSessionMessageCountAsync(sessionId, storePath, sessionFile);
-  const messages = await readRecentSessionMessagesAsync(sessionId, storePath, sessionFile, opts);
+  const totalMessages = await readSessionMessageCountAsync(
+    sessionId,
+    storePath,
+    sessionFile,
+    cliHint,
+  );
+  const messages = await readRecentSessionMessagesAsync(
+    sessionId,
+    storePath,
+    sessionFile,
+    opts,
+    cliHint,
+  );
   const firstSeq = Math.max(1, totalMessages - messages.length + 1);
   const messagesWithSeq = messages.map((message, index) =>
     attachOpenClawTranscriptMeta(message, { seq: firstSeq + index }),
@@ -991,8 +1031,15 @@ function findExistingTranscriptPath(
   storePath: string | undefined,
   sessionFile?: string,
   agentId?: string,
+  cliHint?: CliTranscriptHint,
 ): string | null {
-  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile, agentId);
+  const candidates = resolveSessionTranscriptCandidates(
+    sessionId,
+    storePath,
+    sessionFile,
+    agentId,
+    cliHint,
+  );
   return candidates.find((p) => fs.existsSync(p)) ?? null;
 }
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1727,6 +1727,8 @@ export function buildGatewaySessionRow(params: {
     responseUsage: entry?.responseUsage,
     modelProvider: rowModelProvider,
     model: rowModel,
+    cliSessionBindings: entry?.cliSessionBindings,
+    sessionFile: entry?.sessionFile,
     agentRuntime,
     contextTokens,
     deliveryContext: deliveryFields.deliveryContext,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -1,5 +1,9 @@
 import type { ChatType } from "../channels/chat-type.js";
-import type { SessionCompactionCheckpoint, SessionEntry } from "../config/sessions/types.js";
+import type {
+  CliSessionBinding,
+  SessionCompactionCheckpoint,
+  SessionEntry,
+} from "../config/sessions/types.js";
 import type { PluginSessionExtensionProjection } from "../plugins/host-hooks.js";
 import type {
   GatewayAgentRuntime,
@@ -82,6 +86,19 @@ export type GatewaySessionRow = {
   responseUsage?: "on" | "off" | "tokens" | "full";
   modelProvider?: string;
   model?: string;
+  /**
+   * CLI-runner session ids keyed by provider (e.g. claude-cli). Forwarded so
+   * downstream surfaces (sessions_list MCP tool, dashboards) can resolve the
+   * canonical transcript location for sessions running under a CLI provider
+   * — the CLI owns its own transcript store outside the openclaw sessions dir.
+   */
+  cliSessionBindings?: Record<string, CliSessionBinding>;
+  /**
+   * Openclaw-store transcript path (delivery-mirror surface for CLI providers).
+   * Forwarded so the sessions_list MCP tool can run the same read-through
+   * resolver the gateway uses, instead of re-deriving it from the agent id.
+   */
+  sessionFile?: string;
   agentRuntime?: GatewayAgentRuntime;
   contextTokens?: number;
   deliveryContext?: DeliveryContext;

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { loadSessionStore } from "../config/sessions.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -138,6 +139,26 @@ export async function handleSessionHistoryHttpRequest(
   const target = resolveGatewaySessionStoreTarget({ cfg, key: sessionKey });
   const store = loadSessionStore(target.storePath);
   const entry = resolveFreshestSessionEntryFromStoreKeys(store, target.storeKeys);
+  // For sessions whose model provider is `claude-cli`, the canonical transcript
+  // lives under the Claude CLI project store, not the openclaw sessions dir.
+  // Carry that hint through so reads route to the live file instead of the
+  // (possibly missing) openclaw-store delivery-mirror sibling.
+  const cliBoundSessionId =
+    entry?.modelProvider === "claude-cli"
+      ? normalizeOptionalString(entry?.cliSessionBindings?.["claude-cli"]?.sessionId)
+      : undefined;
+  let cliHint: { modelProvider: string; cliSessionId: string; workspaceDir: string } | undefined;
+  if (cliBoundSessionId && target.agentId) {
+    try {
+      cliHint = {
+        modelProvider: "claude-cli",
+        cliSessionId: cliBoundSessionId,
+        workspaceDir: resolveAgentWorkspaceDir(cfg, target.agentId),
+      };
+    } catch {
+      cliHint = undefined;
+    }
+  }
   if (!entry?.sessionId) {
     sendJson(res, 404, {
       ok: false,
@@ -161,6 +182,7 @@ export async function handleSessionHistoryHttpRequest(
           target.storePath,
           entry.sessionFile,
           resolveSessionHistoryTailReadOptions(limit),
+          cliHint,
         )
       : undefined;
   // Cursor reads still need an arbitrary historical window. The common first
@@ -168,10 +190,16 @@ export async function handleSessionHistoryHttpRequest(
   const rawSnapshot =
     boundedSnapshot?.messages ??
     (entry?.sessionId
-      ? await readSessionMessagesAsync(entry.sessionId, target.storePath, entry.sessionFile, {
-          mode: "full",
-          reason: "session history cursor pagination",
-        })
+      ? await readSessionMessagesAsync(
+          entry.sessionId,
+          target.storePath,
+          entry.sessionFile,
+          {
+            mode: "full",
+            reason: "session history cursor pagination",
+          },
+          cliHint,
+        )
       : []);
   const historySnapshot = buildSessionHistorySnapshot({
     rawMessages: rawSnapshot,
@@ -198,6 +226,7 @@ export async function handleSessionHistoryHttpRequest(
           target.storePath,
           entry.sessionFile,
           target.agentId,
+          cliHint,
         )
           .map((candidate) => canonicalizePath(candidate))
           .filter((candidate): candidate is string => typeof candidate === "string"),


### PR DESCRIPTION
# Title

`fix(gateway): route transcript reads through claude-cli store for CLI sessions [AI]`

## Summary

- Sessions running under the `claude-cli` model provider have their canonical
  transcript managed by the Claude CLI itself at
  `~/.claude/projects/<workspace-slug>/<cliSessionId>.jsonl`, but the openclaw
  resolver only ever looked at the openclaw sessions dir. This PR adds a
  read-through resolver so live transcripts are surfaced first instead of the
  openclaw delivery-mirror sibling.
- New helper `resolveActiveCliTranscriptPath` is plumbed through
  `resolveSessionTranscriptCandidates` (gateway), `loadCliSessionHistoryMessages`
  (CLI runner hook history), `readSessionMessagesAsync` /
  `readRecentSessionMessagesAsync` / `readSessionMessageCountAsync`
  (`/sessions/:key/history` SSE), and the `sessions_list` MCP tool's
  `transcriptPath` projection.
- No write churn: `entry.sessionFile` still points at the openclaw-store path
  and continues to receive delivery-mirror writes. The Claude CLI store stays
  the system of record for CLI conversations, mirroring how `claude resume`
  already operates.

## Repro / symptom

For any session whose `entry.modelProvider === "claude-cli"` and which has
`entry.cliSessionBindings["claude-cli"].sessionId` populated:

- **Dashboard** (`sessions_list` MCP tool output) reports
  `transcriptPath: null` for the live channel session, because the
  openclaw-store `sessionFile` doesn't exist on disk (CLI sessions only get
  delivery-mirror writes there, and those have stopped firing on at least one
  install since 2026-05-03).
- **`sessions_history`** MCP tool returns empty messages for the same
  sessions; the SSE `/sessions/:key/history` endpoint resolves a path inside
  the openclaw sessions dir that doesn't exist (or is a 124-byte header-only
  stub from a long-finished session).
- **Sub-agent context-load** that tries to reload parent context from
  `entry.sessionFile` gets nothing and falls back to a cold start.

Confirmed concretely on a 2026-05-04 install: live `#general` channel session
has `cliSessionBindings."claude-cli".sessionId = 147a4851-...`,
`~/.claude/projects/-Users-Frank--openclaw-workspace/147a4851-...jsonl` is 202
KB and growing, while the openclaw-store-resolved file simply does not exist.

## Root cause

`SessionEntry.sessionFile` was always the openclaw-store path
(`~/.openclaw/agents/<agentId>/sessions/<openclawSessionId>.jsonl`),
regardless of which provider runs the turn. Under `claude-cli`, the runner
shells out to the `claude` binary which writes its own transcript into the
Claude project store, and openclaw never mirrored those LLM turns. The path
resolution layer (`resolveSessionTranscriptCandidates`) only ever looked
inside the openclaw sessions dir, so for CLI-bound sessions every read
returned a stale or missing path. The schema had all the inputs
(`cliSessionBindings`, the workspace dir) but no resolver step that consumed
them.

## Fix shape

Read-through resolver, three call-sites, no write churn — recommended over a
mirror-write design because doubling disk and re-implementing claude-cli's
own resume path on the hot turn loop is heavier than it's worth, and the
Claude CLI store is already where `claude resume` looks.

1. New helper `resolveActiveCliTranscriptPath({ modelProvider, cliSessionId,
   workspaceDir })` lives in `src/agents/cli-runner/claude-cli-paths.ts`
   alongside the (hoisted) `resolveClaudeCliProjectDirForWorkspace`. Returns
   the CLI-owned path when present on disk, otherwise `undefined`.
2. `resolveSessionTranscriptCandidates` (gateway) accepts an optional
   `CliTranscriptHint` and pushes the CLI path FIRST so callers prefer it;
   safety guards (path traversal, stale-vs-current sessionFile classification)
   are unchanged.
3. `loadCliSessionHistoryMessages` accepts the same trio of inputs; its
   `isPathWithinBase` safe-base check is widened so the Claude CLI project
   dir is accepted in addition to the openclaw sessions dir for CLI sessions.
   Symlink/oversize/cross-agent guards still apply.
4. `sessions_list` MCP tool now resolves `transcriptPath` through the new
   helper for `modelProvider === "claude-cli"` rows; falls back to the
   existing openclaw-store resolution otherwise.
5. The SSE history endpoint (`/sessions/:key/history`) computes the hint from
   `entry` + agent workspace and threads it through
   `readSessionMessagesAsync` / `readRecentSessionMessagesAsync` /
   `readSessionMessageCountAsync` so the streamed history pulls from the live
   transcript.

`entry.sessionFile` is left alone (still the openclaw-store path). Archive,
maintenance, and disk-budget paths intentionally do NOT pass the hint, so
they keep operating on the openclaw store only — the CLI store stays the
CLI's responsibility.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Related: none filed yet (private install report). Happy to open one if
  maintainers want a tracking issue.
- [x] This PR fixes a bug or regression

## Test plan

Automated:

- `pnpm exec vitest run src/agents/cli-runner/session-history.test.ts` —
  passes, including new "reads the Claude CLI project transcript when
  modelProvider is claude-cli" case.
- `pnpm exec vitest run src/gateway/session-utils.fs.test.ts` — passes,
  including new "prefers the Claude CLI project transcript when
  modelProvider is claude-cli" + "ignores the cliHint when the resolved CLI
  transcript does not exist" cases.
- Targeted suite covering touched files
  (`src/commands/doctor-claude-cli.test.ts`, `src/agents/tools/sessions.test.ts`,
  `src/gateway/sessions-history-http.test.ts`,
  `src/gateway/sessions-history-http.revocation.test.ts`,
  `src/agents/cli-runner.reliability.test.ts`,
  `src/agents/cli-runner/session-history.test.ts`):
  **139 / 139 passing**.

Manual verification (what to check on a real install):

- For a live `claude-cli`-bound Discord channel session, run the
  `sessions_list` MCP tool: expect `transcriptPath` to point at
  `~/.claude/projects/<workspace-slug>/<cliSessionId>.jsonl` and the file to
  exist + be non-empty.
- Hit `/sessions/<key>/history` for the same session over SSE: expect
  history to be non-empty and to track the live `claude-cli` conversation,
  not just delivery-mirror entries.
- Spawn a sub-agent that reloads parent context from `sessionFile`:
  expect non-empty hook history.
- Confirm an openclaw-provider session (non-CLI) shows no behavior change —
  `transcriptPath` resolves identically to today.

## User-visible / Behavior Changes

- `sessions_list` MCP tool's `transcriptPath` field now points at the
  Claude CLI project transcript for CLI-bound sessions where the openclaw
  delivery-mirror sibling was previously surfaced (or `null`).
- `/sessions/:key/history` SSE returns live `claude-cli` history for CLI
  sessions where it previously returned only delivery-mirror entries (or an
  empty response when the openclaw sessionFile didn't exist).

## Compatibility / Migration

- Backward compatible: `Yes`
- Config/env changes: `No`
- Migration needed: `No`
- `SessionEntry` schema unchanged. Optional `CliTranscriptHint` parameter is
  additive and defaults to undefined (preserving existing call sites).

## Risks and Mitigations

- **Risk:** A CLI-bound session reads from a path outside the openclaw
  sessions dir.
  - **Mitigation:** `loadCliSessionHistoryMessages`'s safe-base check is
    extended (not removed) — the resolved transcript still has to live
    inside either the openclaw sessions dir or the workspace's Claude CLI
    project dir. The `resolveActiveCliTranscriptPath` helper computes the
    project dir via the same `realpath`-then-sanitize routine the doctor
    surface and the `claude` binary already use, and only returns a path
    when the file exists.
- **Risk:** Stale CLI session id on disk surfaces an unrelated transcript.
  - **Mitigation:** The CLI session id comes from
    `entry.cliSessionBindings["claude-cli"].sessionId`, written by the
    runner at session creation. The 36-char UUID-shaped filename plus the
    `existsSync` gate makes accidental collisions effectively impossible.
- **Risk:** Maintenance / archive paths now also pick up CLI transcripts.
  - **Mitigation:** Archive callers do NOT pass the hint, so they continue
    to operate on the openclaw store only.

## Notes for reviewers

- AI-assisted (Claude). Lightly tested: 139 targeted unit tests pass; full
  `pnpm test` was not executed in the constrained environment (the repo's
  full TS check OOMs at default Node heap settings on this machine), so the
  rest of the suite is unverified locally.
- I deliberately left `entry.sessionFile` and the delivery-mirror write path
  untouched; if maintainers prefer a mirror-writes design instead, happy to
  discuss but the read-through approach matches the existing openclaw
  posture (CLI store is the source of truth for CLI runs).
