### PR TITLE
[codex] fix(telegram): sync native commands to private and group scopes [AI]

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -175,13 +175,15 @@ describe("bot-native-command-menu", () => {
 
     expect(callOrder).toEqual([
       "delete:default",
+      "delete:all_private_chats",
       "delete:all_group_chats",
       "set:default",
+      "set:all_private_chats",
       "set:all_group_chats",
     ]);
   });
 
-  it("registers the menu in default and group chat scopes", async () => {
+  it("registers the menu in default, private chat, and group chat scopes", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
     const commands = [{ command: "cmd", description: "Command" }];
@@ -195,10 +197,13 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(2);
+      expect(setMyCommands).toHaveBeenCalledTimes(3);
     });
 
     expect(setMyCommands).toHaveBeenCalledWith(commands);
+    expect(setMyCommands).toHaveBeenCalledWith(commands, {
+      scope: { type: "all_private_chats" },
+    });
     expect(setMyCommands).toHaveBeenCalledWith(commands, {
       scope: { type: "all_group_chats" },
     });
@@ -239,7 +244,7 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(2);
+      expect(setMyCommands).toHaveBeenCalledTimes(3);
     });
 
     // Second sync with the same commands — hash is cached, should skip.
@@ -252,8 +257,9 @@ describe("bot-native-command-menu", () => {
       botIdentity: "bot-a",
     });
 
-    // setMyCommands should NOT have been called again for either scope.
-    expect(setMyCommands).toHaveBeenCalledTimes(2);
+    // setMyCommands should NOT have been called again for any scope.
+    expect(setMyCommands).toHaveBeenCalledTimes(3);
+    expect(runtimeLog).toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync");
   });
 
   it("does not reuse cached hash across different bot identities", async () => {
@@ -271,7 +277,7 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "token-bot-a",
     });
-    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(3));
 
     syncMenuCommandsWithMocks({
       deleteMyCommands,
@@ -281,7 +287,7 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "token-bot-b",
     });
-    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(6));
   });
 
   it("does not cache empty-menu hash when deleteMyCommands fails", async () => {
@@ -301,7 +307,7 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "bot-a",
     });
-    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(3));
 
     syncMenuCommandsWithMocks({
       deleteMyCommands,
@@ -311,7 +317,44 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "bot-a",
     });
-    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(4));
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(6));
+  });
+
+  it("deletes commands in all scopes and does not set commands for an empty menu", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+    const accountId = `test-empty-delete-success-${Date.now()}`;
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(3));
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() =>
+      expect(runtimeLog).toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync"),
+    );
+
+    expect(deleteMyCommands).toHaveBeenCalledWith();
+    expect(deleteMyCommands).toHaveBeenCalledWith({ scope: { type: "all_private_chats" } });
+    expect(deleteMyCommands).toHaveBeenCalledWith({ scope: { type: "all_group_chats" } });
+    expect(deleteMyCommands).toHaveBeenCalledTimes(3);
+    expect(setMyCommands).not.toHaveBeenCalled();
   });
 
   it("retries with fewer commands on BOT_COMMANDS_TOO_MUCH", async () => {
@@ -337,15 +380,18 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(3);
+      expect(setMyCommands).toHaveBeenCalledTimes(4);
     });
     const firstPayload = setMyCommands.mock.calls[0]?.[0] as Array<unknown>;
     const secondPayload = setMyCommands.mock.calls[1]?.[0] as Array<unknown>;
     const thirdPayload = setMyCommands.mock.calls[2]?.[0] as Array<unknown>;
+    const fourthPayload = setMyCommands.mock.calls[3]?.[0] as Array<unknown>;
     expect(firstPayload).toHaveLength(100);
     expect(secondPayload).toHaveLength(80);
     expect(thirdPayload).toHaveLength(80);
-    expect(setMyCommands.mock.calls[2]?.[1]).toEqual({ scope: { type: "all_group_chats" } });
+    expect(fourthPayload).toHaveLength(80);
+    expect(setMyCommands.mock.calls[2]?.[1]).toEqual({ scope: { type: "all_private_chats" } });
+    expect(setMyCommands.mock.calls[3]?.[1]).toEqual({ scope: { type: "all_group_chats" } });
     expect(runtimeLog).toHaveBeenCalledWith(
       "Telegram rejected 100 commands (BOT_COMMANDS_TOO_MUCH); retrying with 80.",
     );
@@ -376,7 +422,7 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(3);
+      expect(setMyCommands).toHaveBeenCalledTimes(4);
     });
     expect(runtimeLog).toHaveBeenCalledWith(
       "Telegram rejected 10 commands (BOT_COMMANDS_TOO_MUCH); retrying with 8.",

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -464,7 +464,7 @@ describe("bot-native-command-menu", () => {
 
     // setMyCommands should NOT have been called again for any scope.
     expect(setMyCommands).toHaveBeenCalledTimes(3);
-    expect(runtimeLog).toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync");
+    expect(runtimeLog).not.toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync");
   });
 
   it("does not reuse cached hash across different bot identities", async () => {
@@ -551,9 +551,8 @@ describe("bot-native-command-menu", () => {
       botIdentity: "bot-a",
     });
 
-    await vi.waitFor(() =>
-      expect(runtimeLog).toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync"),
-    );
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(3));
+    expect(runtimeLog).not.toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync");
 
     expect(deleteMyCommands).toHaveBeenCalledWith();
     expect(deleteMyCommands).toHaveBeenCalledWith({ scope: { type: "all_private_chats" } });

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -293,13 +293,15 @@ describe("bot-native-command-menu", () => {
 
     expect(callOrder).toEqual([
       "delete:default",
+      "delete:all_private_chats",
       "delete:all_group_chats",
       "set:default",
+      "set:all_private_chats",
       "set:all_group_chats",
     ]);
   });
 
-  it("registers the menu in default and group chat scopes", async () => {
+  it("registers the menu in default, private chat, and group chat scopes", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
     const commands = [{ command: "cmd", description: "Command" }];
@@ -313,10 +315,13 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(2);
+      expect(setMyCommands).toHaveBeenCalledTimes(3);
     });
 
     expect(setMyCommands).toHaveBeenCalledWith(commands);
+    expect(setMyCommands).toHaveBeenCalledWith(commands, {
+      scope: { type: "all_private_chats" },
+    });
     expect(setMyCommands).toHaveBeenCalledWith(commands, {
       scope: { type: "all_group_chats" },
     });
@@ -347,17 +352,27 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(4);
+      expect(setMyCommands).toHaveBeenCalledTimes(6);
     });
 
     expect(setMyCommandsPayload(setMyCommands, 0)).toEqual([
       { command: "cmd", description: "Default" },
     ]);
-    expect(setMyCommandsPayload(setMyCommands, 2)).toEqual([
+    expect(setMyCommandsCall(setMyCommands, 1).at(1)).toEqual({
+      scope: { type: "all_private_chats" },
+    });
+    expect(setMyCommandsCall(setMyCommands, 2).at(1)).toEqual({
+      scope: { type: "all_group_chats" },
+    });
+    expect(setMyCommandsPayload(setMyCommands, 3)).toEqual([
       { command: "cmd", description: "한국어" },
     ]);
-    expect(setMyCommandsCall(setMyCommands, 2).at(1)).toEqual({ language_code: "ko" });
-    expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({
+    expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({ language_code: "ko" });
+    expect(setMyCommandsCall(setMyCommands, 4).at(1)).toEqual({
+      scope: { type: "all_private_chats" },
+      language_code: "ko",
+    });
+    expect(setMyCommandsCall(setMyCommands, 5).at(1)).toEqual({
       scope: { type: "all_group_chats" },
       language_code: "ko",
     });
@@ -385,10 +400,10 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(4);
+      expect(setMyCommands).toHaveBeenCalledTimes(6);
     });
 
-    const localizedPayload = setMyCommandsPayload(setMyCommands, 2);
+    const localizedPayload = setMyCommandsPayload(setMyCommands, 3);
     expect(localizedPayload[0]).toMatchObject({ command: "long" });
     expect((localizedPayload[0] as { description: string }).description).toHaveLength(256);
   });
@@ -435,7 +450,7 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(2);
+      expect(setMyCommands).toHaveBeenCalledTimes(3);
     });
 
     syncMenuCommandsWithMocks({
@@ -447,7 +462,9 @@ describe("bot-native-command-menu", () => {
       botIdentity: "bot-a",
     });
 
-    expect(setMyCommands).toHaveBeenCalledTimes(2);
+    // setMyCommands should NOT have been called again for any scope.
+    expect(setMyCommands).toHaveBeenCalledTimes(3);
+    expect(runtimeLog).toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync");
   });
 
   it("does not reuse cached hash across different bot identities", async () => {
@@ -465,7 +482,7 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "token-bot-a",
     });
-    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(3));
 
     syncMenuCommandsWithMocks({
       deleteMyCommands,
@@ -475,7 +492,7 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "token-bot-b",
     });
-    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(6));
   });
 
   it("does not cache empty-menu hash when deleteMyCommands fails", async () => {
@@ -495,7 +512,7 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "bot-a",
     });
-    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(3));
 
     syncMenuCommandsWithMocks({
       deleteMyCommands,
@@ -505,7 +522,44 @@ describe("bot-native-command-menu", () => {
       accountId,
       botIdentity: "bot-a",
     });
-    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(4));
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(6));
+  });
+
+  it("deletes commands in all scopes and does not set commands for an empty menu", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+    const accountId = `test-empty-delete-success-${Date.now()}`;
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(3));
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() =>
+      expect(runtimeLog).toHaveBeenCalledWith("telegram: command menu unchanged; skipping sync"),
+    );
+
+    expect(deleteMyCommands).toHaveBeenCalledWith();
+    expect(deleteMyCommands).toHaveBeenCalledWith({ scope: { type: "all_private_chats" } });
+    expect(deleteMyCommands).toHaveBeenCalledWith({ scope: { type: "all_group_chats" } });
+    expect(deleteMyCommands).toHaveBeenCalledTimes(3);
+    expect(setMyCommands).not.toHaveBeenCalled();
   });
 
   it("retries with fewer commands on BOT_COMMANDS_TOO_MUCH", async () => {
@@ -531,15 +585,20 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(3);
+      expect(setMyCommands).toHaveBeenCalledTimes(4);
     });
     const firstPayload = setMyCommandsPayload(setMyCommands, 0);
     const secondPayload = setMyCommandsPayload(setMyCommands, 1);
     const thirdPayload = setMyCommandsPayload(setMyCommands, 2);
+    const fourthPayload = setMyCommandsPayload(setMyCommands, 3);
     expect(firstPayload).toHaveLength(100);
     expect(secondPayload).toHaveLength(80);
     expect(thirdPayload).toHaveLength(80);
+    expect(fourthPayload).toHaveLength(80);
     expect(setMyCommandsCall(setMyCommands, 2).at(1)).toEqual({
+      scope: { type: "all_private_chats" },
+    });
+    expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({
       scope: { type: "all_group_chats" },
     });
     expect(runtimeLog).toHaveBeenCalledWith(
@@ -571,12 +630,30 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(5);
+      expect(setMyCommands).toHaveBeenCalledTimes(7);
     });
     expect(setMyCommandsPayload(setMyCommands, 0)).toHaveLength(100);
     expect(setMyCommandsPayload(setMyCommands, 1)).toHaveLength(80);
+    expect(setMyCommandsPayload(setMyCommands, 2)).toHaveLength(80);
     expect(setMyCommandsPayload(setMyCommands, 3)).toHaveLength(80);
-    expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({ language_code: "ko" });
+    expect(setMyCommandsPayload(setMyCommands, 4)).toHaveLength(80);
+    expect(setMyCommandsPayload(setMyCommands, 5)).toHaveLength(80);
+    expect(setMyCommandsPayload(setMyCommands, 6)).toHaveLength(80);
+    expect(setMyCommandsCall(setMyCommands, 2).at(1)).toEqual({
+      scope: { type: "all_private_chats" },
+    });
+    expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({
+      scope: { type: "all_group_chats" },
+    });
+    expect(setMyCommandsCall(setMyCommands, 4).at(1)).toEqual({ language_code: "ko" });
+    expect(setMyCommandsCall(setMyCommands, 5).at(1)).toEqual({
+      scope: { type: "all_private_chats" },
+      language_code: "ko",
+    });
+    expect(setMyCommandsCall(setMyCommands, 6).at(1)).toEqual({
+      scope: { type: "all_group_chats" },
+      language_code: "ko",
+    });
   });
 
   it.each([
@@ -600,7 +677,7 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalledTimes(3);
+      expect(setMyCommands).toHaveBeenCalledTimes(4);
     });
     expect(runtimeLog).toHaveBeenCalledWith(
       "Telegram rejected 10 commands (BOT_COMMANDS_TOO_MUCH); retrying with 8.",

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import type { Bot } from "grammy";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString, readStringValue } from "openclaw/plugin-sdk/text-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -18,6 +17,7 @@ type TelegramMenuCommand = {
 
 type TelegramCommandMenuScope =
   | { label: "default"; options?: undefined }
+  | { label: "all_private_chats"; options: { scope: { type: "all_private_chats" } } }
   | { label: "all_group_chats"; options: { scope: { type: "all_group_chats" } } };
 
 type TelegramPluginCommandSpec = {
@@ -27,6 +27,7 @@ type TelegramPluginCommandSpec = {
 
 const TELEGRAM_COMMAND_MENU_SCOPES: readonly TelegramCommandMenuScope[] = [
   { label: "default" },
+  { label: "all_private_chats", options: { scope: { type: "all_private_chats" } } },
   { label: "all_group_chats", options: { scope: { type: "all_group_chats" } } },
 ];
 
@@ -308,7 +309,7 @@ export function syncTelegramMenuCommands(params: {
     const currentHash = hashCommandList(commandsToRegister);
     const cachedHash = readCachedCommandHash(accountId, botIdentity);
     if (cachedHash === currentHash) {
-      logVerbose("telegram: command menu unchanged; skipping sync");
+      runtime.log?.("telegram: command menu unchanged; skipping sync");
       return;
     }
 

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Bot } from "grammy";
 import type { LanguageCode } from "grammy/types";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeOptionalString,
@@ -26,6 +25,7 @@ export type TelegramMenuCommand = {
 
 type TelegramCommandMenuScope =
   | { label: "default"; options?: undefined }
+  | { label: "all_private_chats"; options: { scope: { type: "all_private_chats" } } }
   | { label: "all_group_chats"; options: { scope: { type: "all_group_chats" } } };
 
 type TelegramPluginCommandSpec = {
@@ -36,6 +36,7 @@ type TelegramPluginCommandSpec = {
 
 const TELEGRAM_COMMAND_MENU_SCOPES: readonly TelegramCommandMenuScope[] = [
   { label: "default" },
+  { label: "all_private_chats", options: { scope: { type: "all_private_chats" } } },
   { label: "all_group_chats", options: { scope: { type: "all_group_chats" } } },
 ];
 
@@ -504,7 +505,7 @@ export function syncTelegramMenuCommands(params: {
     const currentHash = hashCommandList(commandsToRegister);
     const cachedHash = readCachedCommandHash(accountId, botIdentity);
     if (cachedHash === currentHash) {
-      logVerbose("telegram: command menu unchanged; skipping sync");
+      runtime.log?.("telegram: command menu unchanged; skipping sync");
       return;
     }
 

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { Bot } from "grammy";
 import type { LanguageCode } from "grammy/types";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeOptionalString,
@@ -505,7 +506,7 @@ export function syncTelegramMenuCommands(params: {
     const currentHash = hashCommandList(commandsToRegister);
     const cachedHash = readCachedCommandHash(accountId, botIdentity);
     if (cachedHash === currentHash) {
-      runtime.log?.("telegram: command menu unchanged; skipping sync");
+      logVerbose("telegram: command menu unchanged; skipping sync");
       return;
     }
 

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -160,6 +160,33 @@ describe("registerTelegramNativeCommands", () => {
     resetPluginCommandMocks();
   });
 
+  it("clears native command menus in every Telegram scope when explicitly disabled", async () => {
+    const { bot, setMyCommands } = createCommandBot();
+
+    registerTelegramNativeCommands(
+      createNativeCommandTestParams(
+        { commands: { native: false } },
+        {
+          bot,
+          nativeEnabled: false,
+          nativeSkillsEnabled: false,
+          nativeDisabledExplicit: true,
+        },
+      ),
+    );
+
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalledTimes(3);
+    });
+    expect(setMyCommands).toHaveBeenCalledWith([]);
+    expect(setMyCommands).toHaveBeenCalledWith([], {
+      scope: { type: "all_private_chats" },
+    });
+    expect(setMyCommands).toHaveBeenCalledWith([], {
+      scope: { type: "all_group_chats" },
+    });
+  });
+
   it("scopes skill commands when account binding exists", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1382,6 +1382,11 @@ export const registerTelegramNativeCommands = ({
       fn: () => bot.api.setMyCommands([]),
     }).catch(() => {});
     withTelegramApiErrorLogging({
+      operation: "setMyCommands(all_private_chats)",
+      runtime,
+      fn: () => bot.api.setMyCommands([], { scope: { type: "all_private_chats" } }),
+    }).catch(() => {});
+    withTelegramApiErrorLogging({
       operation: "setMyCommands(all_group_chats)",
       runtime,
       fn: () => bot.api.setMyCommands([], { scope: { type: "all_group_chats" } }),

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1562,6 +1562,11 @@ export const registerTelegramNativeCommands = ({
       fn: () => bot.api.setMyCommands([]),
     }).catch(() => {});
     withTelegramApiErrorLogging({
+      operation: "setMyCommands(all_private_chats)",
+      runtime,
+      fn: () => bot.api.setMyCommands([], { scope: { type: "all_private_chats" } }),
+    }).catch(() => {});
+    withTelegramApiErrorLogging({
       operation: "setMyCommands(all_group_chats)",
       runtime,
       fn: () => bot.api.setMyCommands([], { scope: { type: "all_group_chats" } }),

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -2264,6 +2264,9 @@ describe("createTelegramBot", () => {
 
     expect(setMyCommandsSpy).toHaveBeenCalledWith([]);
     expect(setMyCommandsSpy).toHaveBeenCalledWith([], {
+      scope: { type: "all_private_chats" },
+    });
+    expect(setMyCommandsSpy).toHaveBeenCalledWith([], {
       scope: { type: "all_group_chats" },
     });
   });


### PR DESCRIPTION
## Summary

Telegram native slash-command menus are now synced and cleared for default, private-chat, and group-chat scopes. This prevents private chats from retaining stale command menus when the bot updates or disables native commands.

AI-assisted by Codex GPT-5.5.

## What Changed

- Added `all_private_chats` to the shared Telegram command-menu scope list.
- Added private-chat cleanup to the explicit native-disabled command cleanup path.
- Kept command construction, authorization, transport behavior, and config unchanged.
- Kept unchanged-menu skip logging on the verbose-only path, matching the pre-existing rate-limit guard behavior.
- Added focused regression coverage for scope ordering, empty-menu cleanup, cache skips, localized command variants, retry behavior, native-disabled cleanup, and unchanged-menu logging.

## Scope Boundaries

- No new permissions or secrets.
- No dependency, package, or CI changes.
- No change to the commands themselves; only the Telegram Bot API scopes used to set and clear native command menus changed.

## Verification

Verified on rebased head `6798383d1ae9bace7d6cce5a4552f47b13401e58` against base `84b025eb622176483ebb1615a88059a4368b3775`.

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-native-command-menu.test.ts` passed: 1 file, 26 tests.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-native-command-menu.test.ts extensions/telegram/src/bot-native-commands.test.ts` passed: 2 files, 51 tests.
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/bot-native-command-menu.ts extensions/telegram/src/bot-native-command-menu.test.ts extensions/telegram/src/bot-native-commands.ts extensions/telegram/src/bot-native-commands.test.ts` passed.
- `git diff --check origin/main...HEAD` produced no output.

## Real behavior proof

- **Behavior or issue addressed:** Telegram native command menu sync now deletes and sets commands for `default`, `all_private_chats`, and `all_group_chats`; empty-menu cleanup also clears the private-chat scope.
- **Real environment tested:** Local Node 24 runtime against current PR head `6798383d1ae9bace7d6cce5a4552f47b13401e58`, executing the production `syncTelegramMenuCommands` path with a Bot API capture adapter for `deleteMyCommands` and `setMyCommands` calls.
- **Exact steps or command run after this patch:** From the PR worktree, ran a `pnpm exec tsx` probe that imported `extensions/telegram/src/bot-native-command-menu.ts`, invoked `syncTelegramMenuCommands` once with a non-empty command list and once with an empty command list, and captured the emitted Telegram Bot API method/options sequence.
- **Evidence after fix:** Current-head terminal output from the Bot API call-sequence probe:

```json
{
  "head": "6798383d1ae9bace7d6cce5a4552f47b13401e58",
  "base": "84b025eb622176483ebb1615a88059a4368b3775",
  "registrationCalls": [
    { "method": "deleteMyCommands", "scope": "default" },
    { "method": "deleteMyCommands", "scope": "all_private_chats" },
    { "method": "deleteMyCommands", "scope": "all_group_chats" },
    { "method": "setMyCommands", "scope": "default", "commandCount": 1, "languageCode": null },
    { "method": "setMyCommands", "scope": "all_private_chats", "commandCount": 1, "languageCode": null },
    { "method": "setMyCommands", "scope": "all_group_chats", "commandCount": 1, "languageCode": null }
  ],
  "cleanupCalls": [
    { "method": "deleteMyCommands", "scope": "default" },
    { "method": "deleteMyCommands", "scope": "all_private_chats" },
    { "method": "deleteMyCommands", "scope": "all_group_chats" }
  ],
  "runtimeLogs": [],
  "runtimeErrors": []
}
```

The proof from my telegram client:
<img width="301" height="199" alt="image" src="https://github.com/user-attachments/assets/a6030f7e-ff74-43fc-8dd9-95777efa00af" />

- **Observed result after fix:** The production sync path emitted delete-then-set calls for default, private-chat, and group-chat scopes, and the empty-menu path emitted deletes for all three scopes without setting any commands.
- **What was not tested:** I did not run a live Telegram Bot API token or Telegram Desktop visual proof in this workspace. That still needs Mantis/maintainer proof if the project requires remote Telegram UI confirmation.

## Review Status

- No inline review threads remain open.
- The latest ClawSweeper review finding about unchanged-menu skip logging was addressed in `6798383d1ae9bace7d6cce5a4552f47b13401e58`.
- ClawSweeper may still ask for live Telegram proof or an explicit maintainer proof override before merge.