### PR TITLE
perf(gateway): cache session, node, and cron list lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -495,6 +495,8 @@ Docs: https://docs.openclaw.ai
 
 ## 2026.5.4
 
+- Gateway/performance: cache repeated session, node pairing, and cron list/preview lookups with short-lived invalidation so Control UI refreshes avoid duplicate Gateway scans while staying fresh after writes. Thanks @NikolaFC.
+
 ### Highlights
 
 - Google Meet/Voice Call: make Twilio dial-in joins speak through the realtime Gemini voice bridge with paced audio streaming, backpressure-aware buffering, barge-in queue clearing, and no TwiML fallback during realtime speech, giving Meet participants a much snappier OpenClaw voice agent. (#77064) Thanks @scoootscooob.

--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -9,11 +9,13 @@ vi.mock("./isolated-agent/delivery-target.js", () => ({
   resolveDeliveryTarget: mocks.resolveDeliveryTarget,
 }));
 
-const { resolveCronDeliveryPreview } = await import("./delivery-preview.js");
+const { clearCronDeliveryPreviewsCache, resolveCronDeliveryPreview, resolveCronDeliveryPreviews } =
+  await import("./delivery-preview.js");
 
 describe("resolveCronDeliveryPreview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearCronDeliveryPreviewsCache();
     mocks.resolveDeliveryTarget.mockResolvedValue({
       ok: true,
       channel: "telegram",
@@ -65,5 +67,54 @@ describe("resolveCronDeliveryPreview", () => {
 
     expect(preview).toEqual({ label: "not requested", detail: "not requested" });
     expect(mocks.resolveDeliveryTarget).not.toHaveBeenCalled();
+  });
+
+  it("reuses in-flight delivery preview resolution for identical job lists", async () => {
+    let release!: () => void;
+    const pending = new Promise((resolve) => {
+      release = () =>
+        resolve({
+          ok: true,
+          channel: "telegram",
+          to: "direct-123",
+          mode: "implicit",
+        });
+    });
+    mocks.resolveDeliveryTarget.mockReturnValueOnce(pending);
+    const job = makeCronJob({
+      id: "job-1",
+      agentId: "avery",
+      delivery: undefined,
+    });
+
+    const first = resolveCronDeliveryPreviews({ cfg: {} as never, jobs: [job] });
+    const second = resolveCronDeliveryPreviews({ cfg: {} as never, jobs: [job] });
+
+    expect(mocks.resolveDeliveryTarget).toHaveBeenCalledTimes(1);
+    release();
+    await expect(first).resolves.toEqual({
+      "job-1": {
+        detail: "resolved from last, main session",
+        label: "announce -> telegram:direct-123",
+      },
+    });
+    await expect(second).resolves.toEqual({
+      "job-1": {
+        detail: "resolved from last, main session",
+        label: "announce -> telegram:direct-123",
+      },
+    });
+  });
+
+  it("clears cached delivery preview results on demand", async () => {
+    const job = makeCronJob({ id: "job-1", delivery: undefined });
+
+    await resolveCronDeliveryPreviews({ cfg: {} as never, jobs: [job] });
+    await resolveCronDeliveryPreviews({ cfg: {} as never, jobs: [job] });
+    expect(mocks.resolveDeliveryTarget).toHaveBeenCalledTimes(1);
+
+    clearCronDeliveryPreviewsCache();
+    await resolveCronDeliveryPreviews({ cfg: {} as never, jobs: [job] });
+    expect(mocks.resolveDeliveryTarget).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -5,6 +5,41 @@ import { resolveDeliveryTarget } from "./isolated-agent/delivery-target.js";
 import { resolveCronDeliverySessionKey } from "./session-target.js";
 import type { CronDeliveryPreview, CronJob } from "./types.js";
 
+const CRON_DELIVERY_PREVIEWS_CACHE_TTL_MS = 1_000;
+
+type CronDeliveryPreviewsCacheEntry = {
+  expiresAt: number;
+  previews: Record<string, CronDeliveryPreview>;
+};
+
+const cronDeliveryPreviewsCache = new Map<string, CronDeliveryPreviewsCacheEntry>();
+const cronDeliveryPreviewsInFlight = new Map<
+  string,
+  Promise<Record<string, CronDeliveryPreview>>
+>();
+
+function getCronDeliveryPreviewsCacheKey(params: {
+  defaultAgentId?: string;
+  jobs: CronJob[];
+}): string {
+  return JSON.stringify({
+    defaultAgentId: params.defaultAgentId ?? null,
+    jobs: params.jobs.map((job) => ({
+      id: job.id,
+      updatedAtMs: job.updatedAtMs,
+      agentId: job.agentId,
+      sessionTarget: job.sessionTarget,
+      sessionKey: job.sessionKey,
+      delivery: job.delivery,
+    })),
+  });
+}
+
+export function clearCronDeliveryPreviewsCache(): void {
+  cronDeliveryPreviewsCache.clear();
+  cronDeliveryPreviewsInFlight.clear();
+}
+
 function formatTarget(channel?: string, to?: string | null): string {
   if (!channel) {
     return "last";
@@ -90,7 +125,20 @@ export async function resolveCronDeliveryPreviews(params: {
   defaultAgentId?: string;
   jobs: CronJob[];
 }): Promise<Record<string, CronDeliveryPreview>> {
-  const entries = await Promise.all(
+  const cacheKey = getCronDeliveryPreviewsCacheKey({
+    defaultAgentId: params.defaultAgentId,
+    jobs: params.jobs,
+  });
+  const now = Date.now();
+  const cached = cronDeliveryPreviewsCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.previews;
+  }
+  const existing = cronDeliveryPreviewsInFlight.get(cacheKey);
+  if (existing) {
+    return existing;
+  }
+  const promise = Promise.all(
     params.jobs.map(
       async (job) =>
         [
@@ -102,6 +150,18 @@ export async function resolveCronDeliveryPreviews(params: {
           }),
         ] as const,
     ),
-  );
-  return Object.fromEntries(entries);
+  )
+    .then((entries) => {
+      const previews = Object.fromEntries(entries);
+      cronDeliveryPreviewsCache.set(cacheKey, {
+        expiresAt: Date.now() + CRON_DELIVERY_PREVIEWS_CACHE_TTL_MS,
+        previews,
+      });
+      return previews;
+    })
+    .finally(() => {
+      cronDeliveryPreviewsInFlight.delete(cacheKey);
+    });
+  cronDeliveryPreviewsInFlight.set(cacheKey, promise);
+  return promise;
 }

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -21,6 +21,7 @@ import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.ru
 import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-session-lifecycle.runtime.js";
 import { deriveGatewaySessionLifecycleSnapshot } from "./session-lifecycle-state.js";
 import { loadSessionEntry } from "./session-utils.js";
+import { invalidateSessionsListResultCache } from "./sessions-list-result-cache.js";
 import { formatForLog } from "./ws-log.js";
 
 export {
@@ -355,6 +356,7 @@ export function createAgentEventHandler({
 
     if (sessionKey) {
       void persistGatewaySessionLifecycleEvent({ sessionKey, event: evt }).catch(() => undefined);
+      invalidateSessionsListResultCache();
       const sessionEventConnIds = sessionEventSubscribers.getAll();
       if (sessionEventConnIds.size > 0) {
         broadcastToConnIds(
@@ -726,6 +728,7 @@ export function createAgentEventHandler({
 
     if (sessionKey && lifecyclePhase === "start") {
       void persistGatewaySessionLifecycleEvent({ sessionKey, event: evt }).catch(() => undefined);
+      invalidateSessionsListResultCache();
       const sessionEventConnIds = sessionEventSubscribers.getAll();
       if (sessionEventConnIds.size > 0) {
         broadcastToConnIds(

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -118,6 +118,7 @@ import {
   resolveGatewayModelSupportsImages,
   resolveSessionModelRef,
 } from "../session-utils.js";
+import { invalidateSessionsListResultCache } from "../sessions-list-result-cache.js";
 import { formatForLog } from "../ws-log.js";
 import { waitForAgentJob } from "./agent-job.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
@@ -305,6 +306,7 @@ function emitSessionsChanged(
   >,
   payload: { sessionKey?: string; reason: string },
 ) {
+  invalidateSessionsListResultCache();
   const connIds = context.getSessionEventSubscriberConnIds();
   if (connIds.size === 0) {
     return;

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1,5 +1,8 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveCronDeliveryPreviews } from "../../cron/delivery-preview.js";
+import {
+  clearCronDeliveryPreviewsCache,
+  resolveCronDeliveryPreviews,
+} from "../../cron/delivery-preview.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
 import {
   readCronRunLogEntriesPage,
@@ -308,6 +311,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
+    clearCronDeliveryPreviewsCache();
     respond(true, job, undefined);
   },
   "cron.update": async ({ params, respond, context }) => {
@@ -403,6 +407,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     context.logGateway.info("cron: job updated", { jobId });
+    clearCronDeliveryPreviewsCache();
     respond(true, job, undefined);
   },
   "cron.remove": async ({ params, respond, context }) => {
@@ -430,6 +435,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     const result = await context.cron.remove(jobId);
     if (result.removed) {
       context.logGateway.info("cron: job removed", { jobId });
+      clearCronDeliveryPreviewsCache();
     }
     respond(true, result, undefined);
   },

--- a/src/gateway/server-methods/nodes.cache.test.ts
+++ b/src/gateway/server-methods/nodes.cache.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listDevicePairing } from "../../infra/device-pairing.js";
+import { listNodePairing, requestNodePairing } from "../../infra/node-pairing.js";
+import { nodeHandlers } from "./nodes.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const {
+  approveNodePairingMock,
+  listDevicePairingMock,
+  listNodePairingMock,
+  rejectNodePairingMock,
+  removePairedNodeMock,
+  renamePairedNodeMock,
+  requestNodePairingMock,
+  verifyNodeTokenMock,
+} = vi.hoisted(() => ({
+  approveNodePairingMock: vi.fn(),
+  listDevicePairingMock: vi.fn(),
+  listNodePairingMock: vi.fn(),
+  rejectNodePairingMock: vi.fn(),
+  removePairedNodeMock: vi.fn(),
+  renamePairedNodeMock: vi.fn(),
+  requestNodePairingMock: vi.fn(),
+  verifyNodeTokenMock: vi.fn(),
+}));
+
+vi.mock("../../infra/device-pairing.js", () => ({
+  listDevicePairing: listDevicePairingMock,
+}));
+
+vi.mock("../../infra/node-pairing.js", () => ({
+  approveNodePairing: approveNodePairingMock,
+  listNodePairing: listNodePairingMock,
+  rejectNodePairing: rejectNodePairingMock,
+  removePairedNode: removePairedNodeMock,
+  renamePairedNode: renamePairedNodeMock,
+  requestNodePairing: requestNodePairingMock,
+  verifyNodeToken: verifyNodeTokenMock,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function createOptions(
+  method: string,
+  params: Record<string, unknown>,
+): GatewayRequestHandlerOptions {
+  return {
+    req: { type: "req", id: `${method}-req`, method, params },
+    params,
+    client: null,
+    isWebchatConnect: () => false,
+    respond: vi.fn(),
+    context: {
+      broadcast: vi.fn(),
+      nodeRegistry: {
+        listConnected: vi.fn(() => []),
+        get: vi.fn(),
+      },
+      logGateway: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+  } as unknown as GatewayRequestHandlerOptions;
+}
+
+async function callNodeMethod(method: keyof typeof nodeHandlers, params: Record<string, unknown>) {
+  const opts = createOptions(method, params);
+  await nodeHandlers[method]?.(opts);
+  return vi.mocked(opts.respond).mock.calls[0];
+}
+
+describe("node pairing list cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not let a stale in-flight pairing read repopulate the node list cache after invalidation", async () => {
+    const staleDevices = deferred<{ paired: unknown[] }>();
+    const staleNodes = deferred<{ paired: unknown[] }>();
+
+    vi.mocked(listDevicePairing).mockReturnValueOnce(staleDevices.promise as never);
+    vi.mocked(listNodePairing).mockReturnValueOnce(staleNodes.promise as never);
+    vi.mocked(requestNodePairing).mockResolvedValueOnce({
+      status: "pending",
+      created: false,
+      request: { requestId: "req-1", nodeId: "fresh-node" },
+    } as never);
+
+    const firstListPromise = callNodeMethod("node.list", {});
+
+    const [requestOk] = await callNodeMethod("node.pair.request", {
+      nodeId: "fresh-node",
+      platform: "darwin",
+    });
+    expect(requestOk).toBe(true);
+
+    staleDevices.resolve({ paired: [] });
+    staleNodes.resolve({
+      paired: [
+        {
+          nodeId: "stale-node",
+          displayName: "Stale Node",
+          caps: [],
+          commands: [],
+        },
+      ],
+    });
+    const [firstOk] = await firstListPromise;
+    expect(firstOk).toBe(true);
+
+    vi.mocked(listDevicePairing).mockResolvedValueOnce({ paired: [] } as never);
+    vi.mocked(listNodePairing).mockResolvedValueOnce({
+      paired: [
+        {
+          nodeId: "fresh-node",
+          displayName: "Fresh Node",
+          caps: [],
+          commands: [],
+        },
+      ],
+    } as never);
+
+    const [secondOk, secondPayload] = await callNodeMethod("node.list", {});
+
+    expect(secondOk).toBe(true);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
+    expect(listNodePairingMock).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(secondPayload)).toContain("fresh-node");
+    expect(JSON.stringify(secondPayload)).not.toContain("stale-node");
+  });
+});

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { getRuntimeConfig } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { listDevicePairing } from "../../infra/device-pairing.js";
+import { listDevicePairing, type DevicePairingList } from "../../infra/device-pairing.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
   approveNodePairing,
@@ -86,6 +86,56 @@ const TALK_PTT_COMMANDS = new Set([
   "talk.ptt.once",
 ]);
 const talkPttEventSeqBySessionId = new Map<string, number>();
+
+const NODE_PAIRING_LIST_CACHE_TTL_MS = 1_000;
+
+type NodePairingListSnapshot = Awaited<ReturnType<typeof listNodePairing>>;
+type NodePairingListCacheEntry = {
+  expiresAt: number;
+  devicePairing: DevicePairingList;
+  nodePairing: NodePairingListSnapshot;
+};
+
+let nodePairingListCache: NodePairingListCacheEntry | null = null;
+let nodePairingListInFlight: Promise<NodePairingListCacheEntry> | null = null;
+let nodePairingListCacheGeneration = 0;
+
+function clearNodePairingListCache(): void {
+  nodePairingListCacheGeneration += 1;
+  nodePairingListCache = null;
+  nodePairingListInFlight = null;
+}
+
+async function loadNodePairingListsCached(): Promise<NodePairingListCacheEntry> {
+  const now = Date.now();
+  if (nodePairingListCache && nodePairingListCache.expiresAt > now) {
+    return nodePairingListCache;
+  }
+  if (nodePairingListInFlight) {
+    return nodePairingListInFlight;
+  }
+  const generation = nodePairingListCacheGeneration;
+  const promise = Promise.all([listDevicePairing(), listNodePairing()])
+    .then(([devicePairing, nodePairing]) => {
+      const entry = {
+        expiresAt: Date.now() + NODE_PAIRING_LIST_CACHE_TTL_MS,
+        devicePairing,
+        nodePairing,
+      } satisfies NodePairingListCacheEntry;
+      if (nodePairingListCacheGeneration === generation) {
+        nodePairingListCache = entry;
+      }
+      return entry;
+    })
+    .finally(() => {
+      if (nodePairingListCacheGeneration === generation) {
+        nodePairingListInFlight = null;
+      }
+    });
+  nodePairingListInFlight = promise;
+  return promise;
+}
+
 
 type NodeWakeNudgeAttempt = {
   sent: boolean;
@@ -661,6 +711,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         remoteIp: p.remoteIp,
         silent: p.silent,
       });
+      clearNodePairingListCache();
       if (result.status === "pending" && result.created) {
         context.broadcast("node.pair.requested", result.request, {
           dropIfSlow: true,
@@ -697,6 +748,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
     const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
     await respondUnavailableOnThrow(respond, async () => {
       const approved = await approveNodePairing(requestId, { callerScopes });
+      clearNodePairingListCache();
       if (!approved) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown requestId"));
         return;
@@ -739,6 +791,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
     const { requestId } = params as { requestId: string };
     await respondUnavailableOnThrow(respond, async () => {
       const rejected = await rejectNodePairing(requestId);
+      clearNodePairingListCache();
       if (!rejected) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown requestId"));
         return;
@@ -768,6 +821,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
     const { nodeId } = params as { nodeId: string };
     await respondUnavailableOnThrow(respond, async () => {
       const removed = await removePairedNode(nodeId);
+      clearNodePairingListCache();
       if (!removed) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
         return;
@@ -823,6 +877,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         return;
       }
       const updated = await renamePairedNode(nodeId, trimmed);
+      clearNodePairingListCache();
       if (!updated) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
         return;
@@ -840,10 +895,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
       return;
     }
     await respondUnavailableOnThrow(respond, async () => {
-      const [devicePairing, nodePairing] = await Promise.all([
-        listDevicePairing(),
-        listNodePairing(),
-      ]);
+      const { devicePairing, nodePairing } = await loadNodePairingListsCached();
       const catalog = createKnownNodeCatalog({
         pairedDevices: devicePairing.paired,
         pairedNodes: nodePairing.paired,
@@ -869,10 +921,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
       return;
     }
     await respondUnavailableOnThrow(respond, async () => {
-      const [devicePairing, nodePairing] = await Promise.all([
-        listDevicePairing(),
-        listNodePairing(),
-      ]);
+      const { devicePairing, nodePairing } = await loadNodePairingListsCached();
       const catalog = createKnownNodeCatalog({
         pairedDevices: devicePairing.paired,
         pairedNodes: nodePairing.paired,

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -136,7 +136,6 @@ async function loadNodePairingListsCached(): Promise<NodePairingListCacheEntry> 
   return promise;
 }
 
-
 type NodeWakeNudgeAttempt = {
   sent: boolean;
   throttled: boolean;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -16,7 +16,6 @@ import {
 import { compactEmbeddedPiSession } from "../../agents/pi-embedded.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
-import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import {
   loadSessionStore,
   runSessionsCleanup,
@@ -74,7 +73,6 @@ import {
   validateSessionsResetParams,
   validateSessionsResolveParams,
   validateSessionsSendParams,
-  type SessionsListParams,
 } from "../protocol/index.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
 import {
@@ -105,6 +103,11 @@ import {
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
 } from "../session-utils.js";
+import {
+  buildSessionsListCacheKey,
+  invalidateSessionsListResultCache,
+  loadSessionsListResultCached,
+} from "../sessions-list-result-cache.js";
 import { applySessionsPatchToStore } from "../sessions-patch.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
@@ -140,100 +143,6 @@ let sessionsRuntimeModulePromise: Promise<SessionsRuntimeModule> | undefined;
 let loggedSlowSessionsListCatalog = false;
 
 const SESSIONS_LIST_MODEL_CATALOG_TIMEOUT_MS = 750;
-const SESSIONS_LIST_RESULT_CACHE_TTL_MS = 60_000;
-const SESSIONS_LIST_RESULT_CACHE_MAX = 24;
-
-type SessionsListResult = Awaited<ReturnType<typeof listSessionsFromStoreAsync>>;
-
-const sessionsListResultCache = new Map<string, { storedAt: number; result: SessionsListResult }>();
-const sessionsListInFlight = new Map<string, Promise<SessionsListResult>>();
-
-function normalizeSessionsListCacheValue(value: unknown): string | number | boolean | undefined {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    return trimmed ? trimmed : undefined;
-  }
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return Math.floor(value);
-  }
-  if (typeof value === "boolean") {
-    return value;
-  }
-  return undefined;
-}
-
-function buildSessionsListCacheKey(params: {
-  cfg: OpenClawConfig;
-  storePath: string;
-  opts: SessionsListParams;
-}): string {
-  const p = params.opts;
-  return JSON.stringify({
-    config: resolveRuntimeConfigCacheKey(params.cfg),
-    storePath: params.storePath,
-    agentId: normalizeSessionsListCacheValue(p.agentId),
-    activeMinutes: normalizeSessionsListCacheValue(p.activeMinutes),
-    limit: normalizeSessionsListCacheValue(p.limit),
-    includeGlobal: normalizeSessionsListCacheValue(p.includeGlobal),
-    includeUnknown: normalizeSessionsListCacheValue(p.includeUnknown),
-    spawnedBy: normalizeSessionsListCacheValue(p.spawnedBy),
-    label: normalizeSessionsListCacheValue(p.label),
-    search: normalizeSessionsListCacheValue(p.search),
-    includeDerivedTitles: normalizeSessionsListCacheValue(p.includeDerivedTitles),
-    includeLastMessage: normalizeSessionsListCacheValue(p.includeLastMessage),
-    configuredAgentsOnly: normalizeSessionsListCacheValue(p.configuredAgentsOnly),
-  });
-}
-
-function clearSessionsListResultCache(): void {
-  sessionsListResultCache.clear();
-  sessionsListInFlight.clear();
-}
-
-function readCachedSessionsListResult(cacheKey: string): SessionsListResult | undefined {
-  const cached = sessionsListResultCache.get(cacheKey);
-  if (!cached) {
-    return undefined;
-  }
-  if (Date.now() - cached.storedAt > SESSIONS_LIST_RESULT_CACHE_TTL_MS) {
-    sessionsListResultCache.delete(cacheKey);
-    return undefined;
-  }
-  return cached.result;
-}
-
-function writeCachedSessionsListResult(cacheKey: string, result: SessionsListResult): void {
-  if (sessionsListResultCache.size >= SESSIONS_LIST_RESULT_CACHE_MAX) {
-    const oldestKey = sessionsListResultCache.keys().next().value;
-    if (oldestKey !== undefined) {
-      sessionsListResultCache.delete(oldestKey);
-    }
-  }
-  sessionsListResultCache.set(cacheKey, { storedAt: Date.now(), result });
-}
-
-async function loadSessionsListResultCached(
-  cacheKey: string,
-  load: () => Promise<SessionsListResult>,
-): Promise<SessionsListResult> {
-  const cached = readCachedSessionsListResult(cacheKey);
-  if (cached) {
-    return cached;
-  }
-  const inflight = sessionsListInFlight.get(cacheKey);
-  if (inflight) {
-    return await inflight;
-  }
-  const promise = load();
-  sessionsListInFlight.set(cacheKey, promise);
-  try {
-    const result = await promise;
-    writeCachedSessionsListResult(cacheKey, result);
-    return result;
-  } finally {
-    sessionsListInFlight.delete(cacheKey);
-  }
-}
 
 function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
   sessionsRuntimeModulePromise ??= import("./sessions.runtime.js");
@@ -348,7 +257,7 @@ function emitSessionsChanged(
   >,
   payload: { sessionKey?: string; reason: string; compacted?: boolean },
 ) {
-  clearSessionsListResultCache();
+  invalidateSessionsListResultCache();
   const connIds = context.getSessionEventSubscriberConnIds();
   if (connIds.size === 0) {
     return;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -16,6 +16,7 @@ import {
 import { compactEmbeddedPiSession } from "../../agents/pi-embedded.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
+import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import {
   loadSessionStore,
   runSessionsCleanup,
@@ -73,6 +74,7 @@ import {
   validateSessionsResetParams,
   validateSessionsResolveParams,
   validateSessionsSendParams,
+  type SessionsListParams,
 } from "../protocol/index.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
 import {
@@ -138,6 +140,100 @@ let sessionsRuntimeModulePromise: Promise<SessionsRuntimeModule> | undefined;
 let loggedSlowSessionsListCatalog = false;
 
 const SESSIONS_LIST_MODEL_CATALOG_TIMEOUT_MS = 750;
+const SESSIONS_LIST_RESULT_CACHE_TTL_MS = 60_000;
+const SESSIONS_LIST_RESULT_CACHE_MAX = 24;
+
+type SessionsListResult = Awaited<ReturnType<typeof listSessionsFromStoreAsync>>;
+
+const sessionsListResultCache = new Map<string, { storedAt: number; result: SessionsListResult }>();
+const sessionsListInFlight = new Map<string, Promise<SessionsListResult>>();
+
+function normalizeSessionsListCacheValue(value: unknown): string | number | boolean | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.floor(value);
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return undefined;
+}
+
+function buildSessionsListCacheKey(params: {
+  cfg: OpenClawConfig;
+  storePath: string;
+  opts: SessionsListParams;
+}): string {
+  const p = params.opts;
+  return JSON.stringify({
+    config: resolveRuntimeConfigCacheKey(params.cfg),
+    storePath: params.storePath,
+    agentId: normalizeSessionsListCacheValue(p.agentId),
+    activeMinutes: normalizeSessionsListCacheValue(p.activeMinutes),
+    limit: normalizeSessionsListCacheValue(p.limit),
+    includeGlobal: normalizeSessionsListCacheValue(p.includeGlobal),
+    includeUnknown: normalizeSessionsListCacheValue(p.includeUnknown),
+    spawnedBy: normalizeSessionsListCacheValue(p.spawnedBy),
+    label: normalizeSessionsListCacheValue(p.label),
+    search: normalizeSessionsListCacheValue(p.search),
+    includeDerivedTitles: normalizeSessionsListCacheValue(p.includeDerivedTitles),
+    includeLastMessage: normalizeSessionsListCacheValue(p.includeLastMessage),
+    configuredAgentsOnly: normalizeSessionsListCacheValue(p.configuredAgentsOnly),
+  });
+}
+
+function clearSessionsListResultCache(): void {
+  sessionsListResultCache.clear();
+  sessionsListInFlight.clear();
+}
+
+function readCachedSessionsListResult(cacheKey: string): SessionsListResult | undefined {
+  const cached = sessionsListResultCache.get(cacheKey);
+  if (!cached) {
+    return undefined;
+  }
+  if (Date.now() - cached.storedAt > SESSIONS_LIST_RESULT_CACHE_TTL_MS) {
+    sessionsListResultCache.delete(cacheKey);
+    return undefined;
+  }
+  return cached.result;
+}
+
+function writeCachedSessionsListResult(cacheKey: string, result: SessionsListResult): void {
+  if (sessionsListResultCache.size >= SESSIONS_LIST_RESULT_CACHE_MAX) {
+    const oldestKey = sessionsListResultCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      sessionsListResultCache.delete(oldestKey);
+    }
+  }
+  sessionsListResultCache.set(cacheKey, { storedAt: Date.now(), result });
+}
+
+async function loadSessionsListResultCached(
+  cacheKey: string,
+  load: () => Promise<SessionsListResult>,
+): Promise<SessionsListResult> {
+  const cached = readCachedSessionsListResult(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const inflight = sessionsListInFlight.get(cacheKey);
+  if (inflight) {
+    return await inflight;
+  }
+  const promise = load();
+  sessionsListInFlight.set(cacheKey, promise);
+  try {
+    const result = await promise;
+    writeCachedSessionsListResult(cacheKey, result);
+    return result;
+  } finally {
+    sessionsListInFlight.delete(cacheKey);
+  }
+}
 
 function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
   sessionsRuntimeModulePromise ??= import("./sessions.runtime.js");
@@ -252,6 +348,7 @@ function emitSessionsChanged(
   >,
   payload: { sessionKey?: string; reason: string; compacted?: boolean },
 ) {
+  clearSessionsListResultCache();
   const connIds = context.getSessionEventSubscriberConnIds();
   if (connIds.size === 0) {
     return;
@@ -691,16 +788,21 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const p = params;
     const cfg = context.getRuntimeConfig();
     const { storePath, store } = loadCombinedSessionStoreForGateway(cfg, { agentId: p.agentId });
-    const listStore =
-      p.configuredAgentsOnly === true ? filterSessionStoreToConfiguredAgents(cfg, store) : store;
-    const modelCatalog = await loadOptionalSessionsListModelCatalog(context);
-    const result = await listSessionsFromStoreAsync({
-      cfg,
-      storePath,
-      store: listStore,
-      modelCatalog,
-      opts: p,
-    });
+    const result = await loadSessionsListResultCached(
+      buildSessionsListCacheKey({ cfg, storePath, opts: p }),
+      async () => {
+        const listStore =
+          p.configuredAgentsOnly === true ? filterSessionStoreToConfiguredAgents(cfg, store) : store;
+        const modelCatalog = await loadOptionalSessionsListModelCatalog(context);
+        return await listSessionsFromStoreAsync({
+          cfg,
+          storePath,
+          store: listStore,
+          modelCatalog,
+          opts: p,
+        });
+      },
+    );
     respond(
       true,
       {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -701,7 +701,9 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       buildSessionsListCacheKey({ cfg, storePath, opts: p }),
       async () => {
         const listStore =
-          p.configuredAgentsOnly === true ? filterSessionStoreToConfiguredAgents(cfg, store) : store;
+          p.configuredAgentsOnly === true
+            ? filterSessionStoreToConfiguredAgents(cfg, store)
+            : store;
         const modelCatalog = await loadOptionalSessionsListModelCatalog(context);
         return await listSessionsFromStoreAsync({
           cfg,

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -14,6 +14,7 @@ import {
   readSessionMessageCountAsync,
   type GatewaySessionRow,
 } from "./session-utils.js";
+import { invalidateSessionsListResultCache } from "./sessions-list-result-cache.js";
 
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
@@ -108,6 +109,7 @@ async function handleTranscriptUpdateBroadcast(
   if (!sessionKey || update.message === undefined) {
     return;
   }
+  invalidateSessionsListResultCache();
   const connIds = new Set<string>();
   for (const connId of params.sessionEventSubscribers.getAll()) {
     connIds.add(connId);
@@ -170,6 +172,7 @@ export function createLifecycleEventBroadcastHandler(params: {
   sessionEventSubscribers: SessionEventSubscribers;
 }) {
   return (event: SessionLifecycleEvent): void => {
+    invalidateSessionsListResultCache();
     const connIds = params.sessionEventSubscribers.getAll();
     if (connIds.size === 0) {
       return;

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
+import { createLifecycleEventBroadcastHandler } from "./server-session-events.js";
+import {
+  invalidateSessionsListResultCache,
+  loadSessionsListResultCached,
+} from "./sessions-list-result-cache.js";
 import { rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
@@ -321,6 +326,87 @@ test("sessions.list does not block on slow model catalog discovery", async () =>
   } finally {
     vi.useRealTimers();
   }
+});
+
+test("sessions.list cache is invalidated by external sessions.changed lifecycle sources", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main", { displayName: "before" }),
+    },
+  });
+
+  const sessionsHandlers = await getSessionsHandlers();
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  const listSessions = async () => {
+    const respond = vi.fn();
+    await sessionsHandlers["sessions.list"]({
+      req: {
+        type: "req",
+        id: `req-sessions-list-cache-${respond.mock.calls.length}`,
+        method: "sessions.list",
+        params: {},
+      },
+      params: {},
+      respond,
+      client: null,
+      isWebchatConnect: () => false,
+      context: {
+        getRuntimeConfig,
+        loadGatewayModelCatalog: async () => [],
+      } as never,
+    });
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    return respond.mock.calls[0]?.[1] as { sessions: Array<{ key: string; displayName?: string }> };
+  };
+
+  const first = await listSessions();
+  expect(first.sessions.find((session) => session.key === "agent:main:main")?.displayName).toBe(
+    "before",
+  );
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main", { displayName: "after" }),
+    },
+  });
+  const lifecycleBroadcast = createLifecycleEventBroadcastHandler({
+    broadcastToConnIds: vi.fn(),
+    sessionEventSubscribers: { getAll: () => new Set<string>() },
+  });
+  lifecycleBroadcast({ sessionKey: "agent:main:main", reason: "updated" } as never);
+
+  const second = await listSessions();
+  expect(second.sessions.find((session) => session.key === "agent:main:main")?.displayName).toBe(
+    "after",
+  );
+});
+
+test("sessions.list in-flight results do not repopulate cache after invalidation", async () => {
+  invalidateSessionsListResultCache();
+  const stale = { sessions: [{ key: "agent:main:stale" }] } as never;
+  const fresh = { sessions: [{ key: "agent:main:fresh" }] } as never;
+  const staleLoad = createDeferred<never>();
+  const freshLoad = createDeferred<never>();
+
+  const staleRequest = loadSessionsListResultCached(
+    "test-in-flight-generation",
+    () => staleLoad.promise,
+  );
+  invalidateSessionsListResultCache();
+  const freshRequest = loadSessionsListResultCached(
+    "test-in-flight-generation",
+    () => freshLoad.promise,
+  );
+
+  staleLoad.resolve(stale);
+  expect(await staleRequest).toBe(stale);
+  freshLoad.resolve(fresh);
+  expect(await freshRequest).toBe(fresh);
+
+  const fallbackLoad = vi.fn(async () => stale);
+  expect(await loadSessionsListResultCached("test-in-flight-generation", fallbackLoad)).toBe(fresh);
+  expect(fallbackLoad).not.toHaveBeenCalled();
 });
 
 test("sessions.changed mutation events include live usage metadata", async () => {

--- a/src/gateway/sessions-list-result-cache.ts
+++ b/src/gateway/sessions-list-result-cache.ts
@@ -1,0 +1,112 @@
+import { resolveRuntimeConfigCacheKey } from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SessionsListParams } from "./protocol/index.js";
+import { listSessionsFromStoreAsync } from "./session-utils.js";
+
+const SESSIONS_LIST_RESULT_CACHE_TTL_MS = 60_000;
+const SESSIONS_LIST_RESULT_CACHE_MAX = 24;
+
+type SessionsListResult = Awaited<ReturnType<typeof listSessionsFromStoreAsync>>;
+
+type SessionsListInFlightEntry = {
+  generation: number;
+  promise: Promise<SessionsListResult>;
+};
+
+const sessionsListResultCache = new Map<string, { storedAt: number; result: SessionsListResult }>();
+const sessionsListInFlight = new Map<string, SessionsListInFlightEntry>();
+let sessionsListCacheGeneration = 0;
+
+function normalizeSessionsListCacheValue(value: unknown): string | number | boolean | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.floor(value);
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return undefined;
+}
+
+export function buildSessionsListCacheKey(params: {
+  cfg: OpenClawConfig;
+  storePath: string;
+  opts: SessionsListParams;
+}): string {
+  const p = params.opts;
+  return JSON.stringify({
+    config: resolveRuntimeConfigCacheKey(params.cfg),
+    storePath: params.storePath,
+    agentId: normalizeSessionsListCacheValue(p.agentId),
+    activeMinutes: normalizeSessionsListCacheValue(p.activeMinutes),
+    limit: normalizeSessionsListCacheValue(p.limit),
+    includeGlobal: normalizeSessionsListCacheValue(p.includeGlobal),
+    includeUnknown: normalizeSessionsListCacheValue(p.includeUnknown),
+    spawnedBy: normalizeSessionsListCacheValue(p.spawnedBy),
+    label: normalizeSessionsListCacheValue(p.label),
+    search: normalizeSessionsListCacheValue(p.search),
+    includeDerivedTitles: normalizeSessionsListCacheValue(p.includeDerivedTitles),
+    includeLastMessage: normalizeSessionsListCacheValue(p.includeLastMessage),
+    configuredAgentsOnly: normalizeSessionsListCacheValue(p.configuredAgentsOnly),
+  });
+}
+
+export function invalidateSessionsListResultCache(): void {
+  sessionsListCacheGeneration += 1;
+  sessionsListResultCache.clear();
+  sessionsListInFlight.clear();
+}
+
+function readCachedSessionsListResult(cacheKey: string): SessionsListResult | undefined {
+  const cached = sessionsListResultCache.get(cacheKey);
+  if (!cached) {
+    return undefined;
+  }
+  if (Date.now() - cached.storedAt > SESSIONS_LIST_RESULT_CACHE_TTL_MS) {
+    sessionsListResultCache.delete(cacheKey);
+    return undefined;
+  }
+  return cached.result;
+}
+
+function writeCachedSessionsListResult(cacheKey: string, result: SessionsListResult): void {
+  if (sessionsListResultCache.size >= SESSIONS_LIST_RESULT_CACHE_MAX) {
+    const oldestKey = sessionsListResultCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      sessionsListResultCache.delete(oldestKey);
+    }
+  }
+  sessionsListResultCache.set(cacheKey, { storedAt: Date.now(), result });
+}
+
+export async function loadSessionsListResultCached(
+  cacheKey: string,
+  load: () => Promise<SessionsListResult>,
+): Promise<SessionsListResult> {
+  const cached = readCachedSessionsListResult(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const inflight = sessionsListInFlight.get(cacheKey);
+  if (inflight) {
+    return await inflight.promise;
+  }
+  const generation = sessionsListCacheGeneration;
+  const promise = load();
+  sessionsListInFlight.set(cacheKey, { generation, promise });
+  try {
+    const result = await promise;
+    if (sessionsListCacheGeneration === generation) {
+      writeCachedSessionsListResult(cacheKey, result);
+    }
+    return result;
+  } finally {
+    const current = sessionsListInFlight.get(cacheKey);
+    if (current?.promise === promise) {
+      sessionsListInFlight.delete(cacheKey);
+    }
+  }
+}

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -29,11 +29,13 @@ function collectManifestModelIdNormalizationPolicies(
 }
 
 type ManifestModelIdNormalizationPolicyCache = {
+  loadedAt: number;
   configFingerprint: string;
   policies: Map<string, PluginManifestModelIdNormalizationProvider>;
 };
 
 let cachedPolicies: ManifestModelIdNormalizationPolicyCache | undefined;
+const MANIFEST_MODEL_ID_NORMALIZATION_CACHE_TTL_MS = 60_000;
 
 function resolveMetadataSnapshotForPolicies(
   params: ManifestModelIdNormalizationLookupParams = {},
@@ -69,12 +71,18 @@ function loadManifestModelIdNormalizationPolicies(
   }
   const { snapshot, cacheable } = resolveMetadataSnapshotForPolicies(params);
   const configFingerprint = snapshot.configFingerprint;
-  if (cacheable && configFingerprint && cachedPolicies?.configFingerprint === configFingerprint) {
+  const now = Date.now();
+  if (
+    cacheable &&
+    configFingerprint &&
+    cachedPolicies?.configFingerprint === configFingerprint &&
+    now - cachedPolicies.loadedAt <= MANIFEST_MODEL_ID_NORMALIZATION_CACHE_TTL_MS
+  ) {
     return cachedPolicies.policies;
   }
   const policies = collectManifestModelIdNormalizationPolicies(snapshot.plugins);
   if (cacheable && configFingerprint) {
-    cachedPolicies = { configFingerprint, policies };
+    cachedPolicies = { loadedAt: now, configFingerprint, policies };
   }
   return policies;
 }


### PR DESCRIPTION
## Summary
- add a short-lived cache for `sessions.list` results and manifest normalization lookups
- coalesce session-list cache fills and invalidate on session mutations/events
- add short-lived cache/coalescing for `node.list` / `node.describe` pairing-list reads, invalidated on node-pairing mutations
- add short-lived cache/coalescing for cron delivery preview resolution used by `cron.list`, invalidated on cron add/update/remove

## Evidence
- production profiling continued after the session/node-list fixes and still observed hot-path list calls while the gateway process was under load
- 2026-05-05 profiler sample saw `node.list` spikes up to ~8.1s and `cron.list` / `node.list` together around 1.3-1.4s during liveness-warning windows
- this PR keeps the mitigation scoped to short TTL caches plus mutation invalidation; it does not change production gateway deployment

## Local validation
- `pnpm format src/cron/delivery-preview.ts src/cron/delivery-preview.test.ts src/gateway/server-methods/cron.ts`
- `pnpm test src/cron/delivery-preview.test.ts`
- `pnpm lint:core -- src/cron/delivery-preview.ts src/cron/delivery-preview.test.ts src/gateway/server-methods/cron.ts`
- `pnpm test src/gateway/server.cron.test.ts src/cron/delivery-preview.test.ts`
- `pnpm check:changed`

## Safety
- no production restart or gateway switch performed
- no private deployment identifiers included

## Real behavior proof

- Behavior or issue addressed: Repeated Gateway `sessions.list`, node pairing list, and cron list/preview requests now reuse short-lived cached results with explicit invalidation after session, node, or cron lifecycle changes. This reduces repeated Gateway hot-path scans while preserving fresh rows after writes.
- Real environment tested: Local OpenClaw checkout on the repaired PR branch after rebasing onto current `main`; Node 22 and pnpm 10. Secrets, account names, machine paths, and deployment identifiers omitted.
- Exact steps or command run after this patch:
  1. Rebased/cherry-picked the PR payload onto current `main` and resolved only the changelog conflict.
  2. Ran `pnpm docs:list` before validation.
  3. Ran focused Gateway/cron tests covering `sessions.list`, session row cache invalidation, manifest/model row enrichment, and cron delivery preview behavior.
  4. Ran `pnpm check:changed` and `pnpm build`.
  5. Started the built Gateway on an isolated local port with `--allow-unconfigured` and checked `/health`.
- Evidence after fix:

```text
$ pnpm test src/gateway/server.sessions.list-changed.test.ts src/gateway/session-utils.subagent.test.ts src/gateway/server.sessions.store-rpc.test.ts src/gateway/server.sessions.thinking-e2e.test.ts src/cron/delivery-preview.test.ts
Test Files  5 passed
Tests  46 passed
```

```text
$ pnpm check:changed
[check:changed] lanes=core, coreTests, docs
Found 0 warnings and 0 errors.
```

```text
$ pnpm build
[build-all] write-cli-compat
```

```text
$ node dist/index.js gateway --port <local-test-port> --allow-unconfigured
$ curl http://127.0.0.1:<local-test-port>/health
{"ok":true,"status":"live"}
```

- Observed result after fix: The repaired branch builds from current `main`, the focused Gateway/cron tests pass, changed-file gates pass, and the built Gateway starts successfully and reports a live health endpoint.
- What was not tested: No live authenticated multi-channel production Gateway restart was performed as part of this PR validation; production runtime validation is tracked separately from this PR branch repair.