### PR TITLE
Improve hosted Docker runtime baseline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,27 +155,73 @@ WORKDIR /app
 # so it must be installed explicitly here. Without it `/etc/ssl/certs/`
 # stays empty and every HTTPS outbound dies at TLS handshake with
 # `error setting certificate file`.
+#
+# Keep this as a practical hosted-agent baseline, not a bare Node image.
+# Agents regularly need Python/data scripting, common archive/search tools, and
+# SSH for private Git remotes. Keep compiler/browser-heavy packages behind
+# explicit build args so the default GHCR release stays close to the slim image.
+# `python-is-python3` also makes the command agents
+# naturally try (`python`) work instead of failing despite Python being present.
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates procps hostname curl git lsof openssl python3 && \
+      ca-certificates \
+      curl \
+      file \
+      gh \
+      git \
+      hostname \
+      jq \
+      lsof \
+      openssh-client \
+      openssl \
+      procps \
+      python-is-python3 \
+      python3 \
+      python3-bs4 \
+      python3-pip \
+      python3-requests \
+      python3-venv \
+      ripgrep \
+      sqlite3 \
+      unzip \
+      wget \
+      zip && \
     update-ca-certificates
 
-RUN chown node:node /app
+RUN groupadd --gid 1001 openclaw && \
+    useradd --uid 1001 --gid 1001 --home-dir /home/openclaw --create-home --shell /bin/bash openclaw
 
-COPY --from=runtime-assets --chown=node:node /app/dist ./dist
-COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules
-COPY --from=runtime-assets --chown=node:node /app/package.json .
-COPY --from=runtime-assets --chown=node:node /app/patches ./patches
-COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
-COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}
-COPY --from=runtime-assets --chown=node:node /app/skills ./skills
-COPY --from=runtime-assets --chown=node:node /app/docs ./docs
-COPY --from=runtime-assets --chown=node:node /app/qa ./qa
+ENV NPM_CONFIG_PREFIX=/home/openclaw/.local \
+    NPM_CONFIG_CACHE=/home/openclaw/.npm \
+    PIP_CACHE_DIR=/home/openclaw/.cache/pip \
+    OPENCLAW_DISABLE_BONJOUR=1 \
+    OPENCLAW_LENIENT_CHANNEL_CONFIG=1 \
+    OPENCLAW_NO_AUTO_UPDATE=1 \
+    OPENCLAW_NO_UPDATE_CHECK=1 \
+    PATH=/home/openclaw/.local/bin:$PATH
+
+RUN install -d -m 0755 -o openclaw -g openclaw \
+      /home/openclaw/.cache \
+      /home/openclaw/.cache/pip \
+      /home/openclaw/.local \
+      /home/openclaw/.npm && \
+    install -d -m 0700 -o openclaw -g openclaw /home/openclaw/.ssh && \
+    chown openclaw:openclaw /app
+
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/dist ./dist
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/node_modules ./node_modules
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/package.json .
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/patches ./patches
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/openclaw.mjs .
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/skills ./skills
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/docs ./docs
+COPY --from=runtime-assets --chown=openclaw:openclaw /app/qa ./qa
 
 # Keep pnpm available in the runtime image for container-local workflows.
-# Use a shared Corepack home so the non-root `node` user does not need a
+# Use a shared Corepack home so the non-root `openclaw` user does not need a
 # first-run network fetch when invoking pnpm.
 ENV COREPACK_HOME=/usr/local/share/corepack
 RUN install -d -m 0755 "$COREPACK_HOME" && \
@@ -211,10 +257,10 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
     if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
-      mkdir -p /home/node/.cache/ms-playwright && \
-      PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
+      mkdir -p /home/openclaw/.cache/ms-playwright && \
+      PLAYWRIGHT_BROWSERS_PATH=/home/openclaw/.cache/ms-playwright \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      chown -R node:node /home/node/.cache/ms-playwright; \
+      chown -R openclaw:openclaw /home/openclaw/.cache/ms-playwright; \
     fi
 
 # Optionally install Docker CLI for sandbox container management.
@@ -260,17 +306,22 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs
 
-# Pre-create the default state dir so first-run Docker named volumes mounted
-# here inherit node ownership instead of root-owned state.
-RUN install -d -m 0700 -o node -g node /home/node/.openclaw && \
-    stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'
+# Pre-create the default hosted state dir so first-run Docker named volumes
+# mounted here inherit openclaw/1001 ownership instead of root-owned state.
+# `/root/.openclaw` remains a compatibility symlink for old wrappers or
+# accidentally-root HOME values; `/root` must be executable for UID 1001 to
+# traverse the symlink.
+RUN install -d -m 0700 -o openclaw -g openclaw /home/openclaw/.openclaw && \
+    stat -c '%U:%G %u:%g %a' /home/openclaw/.openclaw | grep -qx 'openclaw:openclaw 1001:1001 700' && \
+    chmod 711 /root && \
+    ln -s /home/openclaw/.openclaw /root/.openclaw
 
 ENV NODE_ENV=production
 
-# Security hardening: Run as non-root user
-# The node:24-bookworm image includes a 'node' user (uid 1000)
+# Security hardening: Run as non-root user.
+# Hosted Heyron containers mount persistent data owned by UID 1001.
 # This reduces the attack surface by preventing container escape via root privileges
-USER node
+USER openclaw
 
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - path: .env
         required: false
     environment:
-      HOME: /home/node
+      HOME: /home/openclaw
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
       OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: ${OPENCLAW_ALLOW_INSECURE_PRIVATE_WS:-}
@@ -26,10 +26,25 @@ services:
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY:-}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY:-}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE:-}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-none}
       TZ: ${OPENCLAW_TZ:-UTC}
+    cap_drop:
+      - NET_RAW
+      - NET_ADMIN
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: ${OPENCLAW_GATEWAY_MEMORY:-3g}
+    memswap_limit: ${OPENCLAW_GATEWAY_MEMORY_SWAP:-6g}
+    cpus: "${OPENCLAW_GATEWAY_CPUS:-1.5}"
+    pids_limit: ${OPENCLAW_GATEWAY_PIDS_LIMIT:-384}
+    logging:
+      driver: json-file
+      options:
+        max-size: ${OPENCLAW_GATEWAY_LOG_MAX_SIZE:-10m}
+        max-file: "${OPENCLAW_GATEWAY_LOG_MAX_FILE:-3}"
     volumes:
-      - ${OPENCLAW_CONFIG_DIR:-${HOME:-/tmp}/.openclaw}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR:-${HOME:-/tmp}/.openclaw/workspace}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR:-${HOME:-/tmp}/.openclaw}:/home/openclaw/.openclaw
+      - ${OPENCLAW_WORKSPACE_DIR:-${HOME:-/tmp}/.openclaw/workspace}:/home/openclaw/.openclaw/workspace
       ## Uncomment the lines below to enable sandbox isolation
       ## (agents.defaults.sandbox). Requires Docker CLI in the image
       ## (build with --build-arg OPENCLAW_INSTALL_DOCKER_CLI=1) or use
@@ -83,7 +98,7 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      HOME: /home/node
+      HOME: /home/openclaw
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
       OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: ${OPENCLAW_ALLOW_INSECURE_PRIVATE_WS:-}
@@ -93,8 +108,8 @@ services:
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE:-}
       TZ: ${OPENCLAW_TZ:-UTC}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR:-${HOME:-/tmp}/.openclaw}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR:-${HOME:-/tmp}/.openclaw/workspace}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR:-${HOME:-/tmp}/.openclaw}:/home/openclaw/.openclaw
+      - ${OPENCLAW_WORKSPACE_DIR:-${HOME:-/tmp}/.openclaw/workspace}:/home/openclaw/.openclaw/workspace
     stdin_open: true
     tty: true
     init: true

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -164,6 +164,42 @@ describe("GatewayPlugin", () => {
     expect(gateway.sockets).toHaveLength(2);
   });
 
+  it("does not identify on a replacement socket from a stale HELLO wait", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    await sharedGatewayIdentifyLimiter.wait({ shardId: 0, maxConcurrency: 1 });
+    const gateway = new TestGatewayPlugin({
+      autoInteractions: false,
+      url: "wss://gateway.example.test",
+    });
+    const errorSpy = vi.fn();
+    gateway.emitter.on("error", errorSpy);
+
+    gateway.connect(false);
+    const staleSocket = gateway.sockets[0];
+    staleSocket?.emit("open");
+    staleSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Hello,
+        d: { heartbeat_interval: 45_000 },
+        s: null,
+      }),
+    );
+
+    gateway.connect(false);
+    const replacementSocket = gateway.sockets[1];
+    replacementSocket?.emit("open");
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(staleSocket?.send).not.toHaveBeenCalled();
+    expect(replacementSocket?.send).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(gateway.connectCalls).toEqual([false, false]);
+    expect(gateway.sockets).toHaveLength(2);
+  });
+
   it("preserves MESSAGE_CREATE author payloads for inbound dispatch", async () => {
     const gateway = new GatewayPlugin({ autoInteractions: false });
     const dispatchGatewayEvent = vi.fn(async (_event: string, _data: unknown) => {});

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -251,7 +251,7 @@ export class GatewayPlugin extends Plugin {
             true,
           );
         } else {
-          void this.identifyWithConcurrency().catch((error: unknown) => {
+          void this.identifyWithConcurrency(this.ws).catch((error: unknown) => {
             this.emitter.emit(
               "error",
               error instanceof Error ? error : new Error(String(error), { cause: error }),
@@ -332,18 +332,18 @@ export class GatewayPlugin extends Plugin {
     );
   }
 
-  private async identifyWithConcurrency(): Promise<void> {
+  private async identifyWithConcurrency(socket: ws.WebSocket | null): Promise<void> {
     await sharedGatewayIdentifyLimiter.wait({
       shardId: this.shardId,
       maxConcurrency: this.gatewayInfo?.session_start_limit.max_concurrency,
     });
-    const socket = this.ws;
-    if (!socket || socket.readyState !== READY_STATE_OPEN) {
+    if (!socket || socket !== this.ws) {
+      return;
+    }
+    if (socket.readyState !== READY_STATE_OPEN) {
       const error = new Error("Discord gateway socket closed before IDENTIFY could be sent");
       this.emitter.emit("error", error);
-      if (socket) {
-        this.scheduleReconnect(false);
-      }
+      this.scheduleReconnect(false);
       return;
     }
     this.identify();

--- a/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
@@ -84,6 +84,22 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
     expectRecordedRoute({ to: "telegram:1234" });
   });
 
+  it("persists regular group last route without forcing replies back to a prior DM", async () => {
+    const ctx = await buildCtx({
+      message: {
+        chat: { id: -5167418353, type: "supergroup", title: "Test Group", is_forum: false },
+        text: "@bot hello",
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(recordInboundSessionMock).toHaveBeenCalled();
+
+    expectRecordedRoute({ to: "telegram:-5167418353" });
+  });
+
   it("passes threadId to updateLastRoute for forum topic group messages", async () => {
     const ctx = await buildCtx({
       message: {

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -416,9 +416,9 @@ export async function buildTelegramInboundContextPayload(params: {
     route,
     sessionKey: route.sessionKey,
   });
-  const shouldPersistGroupLastRouteThread = isGroup && route.matchedBy !== "binding.channel";
+  const shouldPersistGroupLastRoute = isGroup && route.matchedBy !== "binding.channel";
   const updateLastRouteThreadId = isGroup
-    ? shouldPersistGroupLastRouteThread && resolvedThreadId != null
+    ? shouldPersistGroupLastRoute && resolvedThreadId != null
       ? String(resolvedThreadId)
       : undefined
     : dmThreadId != null
@@ -426,7 +426,7 @@ export async function buildTelegramInboundContextPayload(params: {
       : undefined;
 
   const updateLastRoute =
-    !isGroup || updateLastRouteThreadId != null
+    !isGroup || shouldPersistGroupLastRoute
       ? {
           sessionKey: updateLastRouteSessionKey,
           channel: "telegram" as const,

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -350,9 +350,9 @@ services:
 YAML
 
   if [[ -n "$home_volume" ]]; then
-    gateway_home_mount="${home_volume}:/home/node"
-    gateway_config_mount="${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw"
-    gateway_workspace_mount="${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace"
+    gateway_home_mount="${home_volume}:/home/openclaw"
+    gateway_config_mount="${OPENCLAW_CONFIG_DIR}:/home/openclaw/.openclaw"
+    gateway_workspace_mount="${OPENCLAW_WORKSPACE_DIR}:/home/openclaw/.openclaw/workspace"
     validate_mount_spec "$gateway_home_mount"
     validate_mount_spec "$gateway_config_mount"
     validate_mount_spec "$gateway_workspace_mount"
@@ -515,8 +515,8 @@ else
   fi
 fi
 
-# Ensure bind-mounted data directories are writable by the container's `node`
-# user (uid 1000). Host-created dirs inherit the host user's uid which may
+# Ensure bind-mounted data directories are writable by the container's `openclaw`
+# user (uid 1001). Host-created dirs inherit the host user's uid which may
 # differ, causing EACCES when the container tries to mkdir/write.
 # Running a brief root container to chown is the portable Docker idiom --
 # it works regardless of the host uid and doesn't require host-side root.
@@ -528,8 +528,8 @@ echo "==> Fixing data-directory permissions"
 # After fixing the config dir, only the OpenClaw metadata subdirectory
 # (.openclaw/) inside the workspace gets chowned, not the user's project files.
 run_prestart_gateway --user root --entrypoint sh openclaw-gateway -c \
-  'find /home/node/.openclaw -xdev -exec chown node:node {} +; \
-   [ -d /home/node/.openclaw/workspace/.openclaw ] && chown -R node:node /home/node/.openclaw/workspace/.openclaw || true'
+  'find /home/openclaw/.openclaw -xdev -exec chown openclaw:openclaw {} +; \
+   [ -d /home/openclaw/.openclaw/workspace/.openclaw ] && chown -R openclaw:openclaw /home/openclaw/.openclaw/workspace/.openclaw || true'
 
 echo ""
 if [[ -n "$SKIP_ONBOARDING" ]]; then

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -336,7 +336,7 @@ export function buildConfiguredAllowlistKeys(params: {
   cfg: OpenClawConfig | undefined;
   defaultProvider: string;
 }): Set<string> | null {
-  const rawAllowlist = Object.keys(params.cfg?.agents?.defaults?.models ?? {});
+  const rawAllowlist = collectAgentDefaultModelRefs(params.cfg);
   if (rawAllowlist.length === 0) {
     return null;
   }
@@ -353,6 +353,25 @@ export function buildConfiguredAllowlistKeys(params: {
     }
   }
   return keys.size > 0 ? keys : null;
+}
+
+function collectAgentDefaultModelRefs(cfg: OpenClawConfig | undefined): string[] {
+  const modelMap = cfg?.agents?.defaults?.models;
+  if (!modelMap || typeof modelMap !== "object" || Array.isArray(modelMap)) {
+    return [];
+  }
+
+  const refs: string[] = [];
+  for (const [key, value] of Object.entries(modelMap as Record<string, unknown>)) {
+    if (key === "allowlist") {
+      if (Array.isArray(value)) {
+        refs.push(...value.filter((entry): entry is string => typeof entry === "string"));
+      }
+      continue;
+    }
+    refs.push(key);
+  }
+  return refs;
 }
 
 export function buildModelAliasIndex(
@@ -612,10 +631,7 @@ export function buildAllowedModelSetWithFallbacks(params: {
     primary: params.catalog,
     secondary: configuredCatalog,
   }).map((entry) => applyModelCatalogMetadata({ entry, metadata }));
-  const rawAllowlist = (() => {
-    const modelMap = params.cfg.agents?.defaults?.models ?? {};
-    return Object.keys(modelMap);
-  })();
+  const rawAllowlist = collectAgentDefaultModelRefs(params.cfg);
   const allowAny = rawAllowlist.length === 0;
   const defaultModel = params.defaultModel?.trim();
   const defaultRef =

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -651,6 +651,62 @@ describe("model-selection", () => {
       ]);
     });
 
+    it("ignores legacy models.allowlist=null instead of treating it as the only allowlisted model", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter/google/gemini-2.5-flash-image-preview" },
+            models: {
+              allowlist: null,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [
+          {
+            provider: "openrouter",
+            id: "google/gemini-2.5-flash-image-preview",
+            name: "Gemini Image Preview",
+          },
+        ],
+        defaultProvider: "openrouter",
+        defaultModel: "google/gemini-2.5-flash-image-preview",
+      });
+
+      expect(result.allowAny).toBe(true);
+      expect(result.allowedKeys.has("openrouter/google/gemini-2.5-flash-image-preview")).toBe(true);
+    });
+
+    it("accepts legacy models.allowlist arrays as model refs", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              allowlist: ["openrouter/google/gemini-2.5-flash-image-preview"],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [
+          {
+            provider: "openrouter",
+            id: "google/gemini-2.5-flash-image-preview",
+            name: "Gemini Image Preview",
+          },
+        ],
+        defaultProvider: "openrouter",
+      });
+
+      expect(result.allowAny).toBe(false);
+      expect(result.allowedKeys.has("openrouter/google/gemini-2.5-flash-image-preview")).toBe(true);
+    });
+
     it("overlays configured provider metadata and alias onto matching catalog entries", () => {
       const cfg: OpenClawConfig = {
         agents: {
@@ -889,6 +945,39 @@ describe("model-selection", () => {
       expect(result).toEqual({
         key: "anthropic/claude-sonnet-4-6",
         ref: { provider: "anthropic", model: "claude-sonnet-4-6" },
+      });
+    });
+
+    it("allows cron-style model overrides when legacy models.allowlist is null", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter/google/gemini-2.5-flash-image-preview" },
+            models: {
+              allowlist: null,
+            },
+          },
+        },
+        models: {
+          providers: {
+            openrouter: {
+              models: [{ id: "google/gemini-2.5-flash-image-preview" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "openrouter/google/gemini-2.5-flash-image-preview",
+        defaultProvider: "openrouter",
+        defaultModel: "google/gemini-2.5-flash-image-preview",
+      });
+
+      expect(result).toEqual({
+        key: "openrouter/google/gemini-2.5-flash-image-preview",
+        ref: { provider: "openrouter", model: "google/gemini-2.5-flash-image-preview" },
       });
     });
 

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -243,10 +243,15 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
-  it("does not add synthetic completion text when the run still has a tool error", () => {
-    expectNoPayloads({
+  it("surfaces a tool error instead of synthetic completion text when the run still has a tool error", () => {
+    const payloads = buildPayloads({
       toolMetas: [{ toolName: "browser", meta: "open https://example.com" }],
       lastToolError: { toolName: "browser", error: "url required" },
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Browser",
+      absentDetail: "url required",
     });
   });
 
@@ -304,10 +309,15 @@ describe("buildEmbeddedRunPayloads", () => {
   });
 
   it.each(["url required", "url missing", "invalid parameter: url"])(
-    "suppresses recoverable non-mutating tool error: %s",
+    "surfaces recoverable non-mutating tool error when no assistant reply exists: %s",
     (error) => {
-      expectNoPayloads({
+      const payloads = buildPayloads({
         lastToolError: { toolName: "browser", error },
+      });
+
+      expectSingleToolErrorPayload(payloads, {
+        title: "Browser",
+        absentDetail: error,
       });
     },
   );

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -38,16 +38,6 @@ type ToolErrorWarningPolicy = {
   includeDetails: boolean;
 };
 
-const RECOVERABLE_TOOL_ERROR_KEYWORDS = [
-  "required",
-  "missing",
-  "invalid",
-  "must be",
-  "must have",
-  "needs",
-  "requires",
-] as const;
-
 const MUTATING_FAILURE_ACTION_PATTERN =
   "(?:write|edit|update|save|create|delete|remove|modify|change|apply|patch|move|rename|send|reply|message|tool|action|operation)";
 
@@ -69,11 +59,6 @@ const MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN = new RegExp(
 );
 const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
 const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/u;
-
-function isRecoverableToolError(error: string | undefined): boolean {
-  const errorLower = normalizeOptionalLowercaseString(error) ?? "";
-  return RECOVERABLE_TOOL_ERROR_KEYWORDS.some((keyword) => errorLower.includes(keyword));
-}
 
 function hasExplicitMutatingToolFailureAcknowledgement(text: string): boolean {
   const normalizedText = normalizeTextForComparison(text);
@@ -165,7 +150,7 @@ function resolveToolErrorWarningPolicy(params: {
     return { showWarning: false, includeDetails };
   }
   return {
-    showWarning: !params.hasUserFacingReply && !isRecoverableToolError(params.lastToolError.error),
+    showWarning: !params.hasUserFacingReply,
     includeDetails,
   };
 }
@@ -416,7 +401,7 @@ export function buildEmbeddedRunPayloads(params: {
     });
 
     // Surface mutating failures unless the assistant explicitly acknowledged the failed action.
-    // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.
+    // For non-mutating tool errors, surface the failure when the model produced no user-facing reply.
     if (warningPolicy.showWarning) {
       const toolSummary = formatToolAggregate(
         params.lastToolError.toolName,

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -88,6 +88,10 @@ const transcriptMocks = vi.hoisted(() => ({
   persistAcpDispatchTranscript: vi.fn(async (_params: unknown) => undefined),
 }));
 
+const preAgentHookMocks = vi.hoisted(() => ({
+  emitPreAgentMessageHooks: vi.fn(),
+}));
+
 const bindingServiceMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(sessionKey: string) => SessionBindingRecord[]>(() => []),
   unbind: vi.fn<(input: unknown) => Promise<SessionBindingRecord[]>>(async () => []),
@@ -179,6 +183,10 @@ vi.mock("../../logging/diagnostic.js", () => ({
 vi.mock("./dispatch-acp-transcript.runtime.js", () => ({
   persistAcpDispatchTranscript: (params: unknown) =>
     transcriptMocks.persistAcpDispatchTranscript(params),
+}));
+
+vi.mock("./message-preprocess-hooks.js", () => ({
+  emitPreAgentMessageHooks: (params: unknown) => preAgentHookMocks.emitPreAgentMessageHooks(params),
 }));
 
 const sessionKey = "agent:codex-acp:session-1";
@@ -386,6 +394,7 @@ describe("tryDispatchAcpReply", () => {
     sessionMetaMocks.readAcpSessionEntry.mockReset();
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue(null);
     transcriptMocks.persistAcpDispatchTranscript.mockClear();
+    preAgentHookMocks.emitPreAgentMessageHooks.mockClear();
     bindingServiceMocks.listBySession.mockReset();
     bindingServiceMocks.listBySession.mockReturnValue([]);
     bindingServiceMocks.unbind.mockReset();
@@ -448,6 +457,39 @@ describe("tryDispatchAcpReply", () => {
     expect(call?.text).toContain("message(action=send)");
     expect(call?.text).toContain("The target defaults to the current source channel");
     expect(call?.text).toContain("reply privately unless you send explicitly");
+  });
+
+  it("emits pre-agent message hooks before ACP runTurn handles the turn", async () => {
+    setReadyAcpResolution();
+
+    const cfg = createAcpTestConfig();
+    await runDispatch({
+      bodyForAgent: "run acp",
+      cfg,
+      ctxOverrides: {
+        MessageSid: "discord-msg-1",
+        SenderId: "discord-user-1",
+      },
+    });
+
+    expect(preAgentHookMocks.emitPreAgentMessageHooks).toHaveBeenCalledOnce();
+    expect(preAgentHookMocks.emitPreAgentMessageHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        isFastTestEnv: process.env.OPENCLAW_TEST_FAST === "1",
+        ctx: expect.objectContaining({
+          SessionKey: sessionKey,
+          Provider: "discord",
+          Surface: "discord",
+          BodyForAgent: "run acp",
+          MessageSid: "discord-msg-1",
+          SenderId: "discord-user-1",
+        }),
+      }),
+    );
+    expect(preAgentHookMocks.emitPreAgentMessageHooks.mock.invocationCallOrder[0]).toBeLessThan(
+      managerMocks.runTurn.mock.invocationCallOrder[0],
+    );
   });
 
   it("starts reply lifecycle for tool-only ACP turns while suppressing automatic delivery", async () => {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -492,6 +492,29 @@ describe("tryDispatchAcpReply", () => {
     );
   });
 
+  it("waits for pre-agent message hooks before starting ACP runTurn", async () => {
+    setReadyAcpResolution();
+    let resolveHook: (() => void) | undefined;
+    preAgentHookMocks.emitPreAgentMessageHooks.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveHook = resolve;
+        }),
+    );
+
+    const dispatchPromise = runDispatch({ bodyForAgent: "run acp" });
+    await vi.waitFor(() => {
+      expect(preAgentHookMocks.emitPreAgentMessageHooks).toHaveBeenCalledOnce();
+    });
+
+    expect(managerMocks.runTurn).not.toHaveBeenCalled();
+
+    resolveHook?.();
+    await dispatchPromise;
+
+    expect(managerMocks.runTurn).toHaveBeenCalledOnce();
+  });
+
   it("starts reply lifecycle for tool-only ACP turns while suppressing automatic delivery", async () => {
     setReadyAcpResolution();
     mockVisibleTextTurn("hidden final");

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -38,6 +38,7 @@ import {
   type AcpDispatchDeliveryCoordinator,
 } from "./dispatch-acp-delivery.js";
 import { hasInboundMedia } from "./inbound-media.js";
+import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
 
 const dispatchAcpManagerRuntimeLoader = createLazyImportLoader(
@@ -468,6 +469,12 @@ export async function tryDispatchAcpReply(params: {
         );
       }
     }
+
+    emitPreAgentMessageHooks({
+      ctx: params.ctx,
+      cfg: params.cfg,
+      isFastTestEnv: process.env.OPENCLAW_TEST_FAST === "1",
+    });
 
     const promptText = resolveAcpPromptText(params.ctx);
     const mediaAttachments = hasInboundMedia(params.ctx)

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -470,7 +470,7 @@ export async function tryDispatchAcpReply(params: {
       }
     }
 
-    emitPreAgentMessageHooks({
+    await emitPreAgentMessageHooks({
       ctx: params.ctx,
       cfg: params.cfg,
       isFastTestEnv: process.env.OPENCLAW_TEST_FAST === "1",

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -272,7 +272,7 @@ export async function getReplyFromConfig(
       cfg,
     });
   }
-  emitPreAgentMessageHooks({
+  await emitPreAgentMessageHooks({
     ctx: finalized,
     cfg,
     isFastTestEnv,

--- a/src/auto-reply/reply/message-preprocess-hooks.test.ts
+++ b/src/auto-reply/reply/message-preprocess-hooks.test.ts
@@ -35,13 +35,11 @@ describe("emitPreAgentMessageHooks", () => {
       actions.push(event.action);
     });
 
-    emitPreAgentMessageHooks({
+    await emitPreAgentMessageHooks({
       ctx: makeCtx(),
       cfg: {} as OpenClawConfig,
       isFastTestEnv: false,
     });
-    await Promise.resolve();
-    await Promise.resolve();
 
     expect(actions).toEqual(["transcribed", "preprocessed"]);
   });
@@ -52,27 +50,44 @@ describe("emitPreAgentMessageHooks", () => {
       actions.push(event.action);
     });
 
-    emitPreAgentMessageHooks({
+    await emitPreAgentMessageHooks({
       ctx: makeCtx({ Transcript: undefined }),
       cfg: {} as OpenClawConfig,
       isFastTestEnv: false,
     });
-    await Promise.resolve();
-    await Promise.resolve();
 
     expect(actions).toEqual(["preprocessed"]);
+  });
+
+  it("awaits preprocessed hook mutations before returning", async () => {
+    const ctx = makeCtx({ Body: "raw", BodyForAgent: "original", Transcript: undefined });
+    registerInternalHook("message:preprocessed", async (event) => {
+      await Promise.resolve();
+      event.context.body = "rewritten raw";
+      event.context.bodyForAgent = "rewritten for agent";
+      event.context.transcript = "late transcript";
+    });
+
+    await emitPreAgentMessageHooks({
+      ctx,
+      cfg: {} as OpenClawConfig,
+      isFastTestEnv: false,
+    });
+
+    expect(ctx.Body).toBe("rewritten raw");
+    expect(ctx.BodyForAgent).toBe("rewritten for agent");
+    expect(ctx.Transcript).toBe("late transcript");
   });
 
   it("skips hook emission in fast-test mode", async () => {
     const handler = vi.fn();
     registerInternalHook("message", handler);
 
-    emitPreAgentMessageHooks({
+    await emitPreAgentMessageHooks({
       ctx: makeCtx(),
       cfg: {} as OpenClawConfig,
       isFastTestEnv: true,
     });
-    await Promise.resolve();
 
     expect(handler).not.toHaveBeenCalled();
   });
@@ -81,12 +96,11 @@ describe("emitPreAgentMessageHooks", () => {
     const handler = vi.fn();
     registerInternalHook("message", handler);
 
-    emitPreAgentMessageHooks({
+    await emitPreAgentMessageHooks({
       ctx: makeCtx({ SessionKey: " " }),
       cfg: {} as OpenClawConfig,
       isFastTestEnv: false,
     });
-    await Promise.resolve();
 
     expect(handler).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/message-preprocess-hooks.ts
+++ b/src/auto-reply/reply/message-preprocess-hooks.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import {
   deriveInboundMessageHookContext,
@@ -9,11 +8,26 @@ import {
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { FinalizedMsgContext } from "../templating.js";
 
-export function emitPreAgentMessageHooks(params: {
+function applyPreprocessedContextMutations(
+  ctx: FinalizedMsgContext,
+  context: Record<string, unknown>,
+): void {
+  if (typeof context.body === "string") {
+    ctx.Body = context.body;
+  }
+  if (typeof context.bodyForAgent === "string") {
+    ctx.BodyForAgent = context.bodyForAgent;
+  }
+  if (typeof context.transcript === "string") {
+    ctx.Transcript = context.transcript;
+  }
+}
+
+export async function emitPreAgentMessageHooks(params: {
   ctx: FinalizedMsgContext;
   cfg: OpenClawConfig;
   isFastTestEnv: boolean;
-}): void {
+}): Promise<void> {
   if (params.isFastTestEnv) {
     return;
   }
@@ -24,28 +38,22 @@ export function emitPreAgentMessageHooks(params: {
 
   const canonical = deriveInboundMessageHookContext(params.ctx);
   if (canonical.transcript) {
-    fireAndForgetHook(
-      triggerInternalHook(
-        createInternalHookEvent(
-          "message",
-          "transcribed",
-          sessionKey,
-          toInternalMessageTranscribedContext(canonical, params.cfg),
-        ),
+    await triggerInternalHook(
+      createInternalHookEvent(
+        "message",
+        "transcribed",
+        sessionKey,
+        toInternalMessageTranscribedContext(canonical, params.cfg),
       ),
-      "get-reply: message:transcribed internal hook failed",
     );
   }
 
-  fireAndForgetHook(
-    triggerInternalHook(
-      createInternalHookEvent(
-        "message",
-        "preprocessed",
-        sessionKey,
-        toInternalMessagePreprocessedContext(canonical, params.cfg),
-      ),
-    ),
-    "get-reply: message:preprocessed internal hook failed",
+  const preprocessedEvent = createInternalHookEvent(
+    "message",
+    "preprocessed",
+    sessionKey,
+    toInternalMessagePreprocessedContext(canonical, params.cfg),
   );
+  await triggerInternalHook(preprocessedEvent);
+  applyPreprocessedContextMutations(params.ctx, preprocessedEvent.context);
 }

--- a/src/channels/plugins/outbound/load.test.ts
+++ b/src/channels/plugins/outbound/load.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockedRegistryAdapter = vi.hoisted<{ value: unknown }>(() => ({ value: undefined }));
+const mockedBundledAdapter = vi.hoisted<{ value: unknown }>(() => ({ value: undefined }));
+
+vi.mock("../registry-loader.js", () => ({
+  createChannelRegistryLoader: () => async () => mockedRegistryAdapter.value,
+}));
+
+vi.mock("../bundled.js", () => ({
+  getBundledChannelPlugin: vi.fn((id: string) =>
+    id === "discord" && mockedBundledAdapter.value
+      ? { outbound: mockedBundledAdapter.value }
+      : undefined,
+  ),
+}));
+
+const { loadChannelOutboundAdapter } = await import("./load.js");
+
+describe("loadChannelOutboundAdapter", () => {
+  it("falls back to bundled channel outbound adapters when the active registry is missing channel plugins", async () => {
+    const bundledAdapter = { sendText: vi.fn() };
+    mockedRegistryAdapter.value = undefined;
+    mockedBundledAdapter.value = bundledAdapter;
+
+    await expect(loadChannelOutboundAdapter("discord")).resolves.toBe(bundledAdapter);
+  });
+});

--- a/src/channels/plugins/outbound/load.ts
+++ b/src/channels/plugins/outbound/load.ts
@@ -1,3 +1,4 @@
+import { getBundledChannelPlugin } from "../bundled.js";
 import type { ChannelId } from "../channel-id.types.js";
 import type { ChannelOutboundAdapter } from "../outbound.types.js";
 import { createChannelRegistryLoader } from "../registry-loader.js";
@@ -15,7 +16,7 @@ const loadOutboundAdapterFromRegistry = createChannelRegistryLoader<ChannelOutbo
 export async function loadChannelOutboundAdapter(
   id: ChannelId,
 ): Promise<ChannelOutboundAdapter | undefined> {
-  return loadOutboundAdapterFromRegistry(id);
+  return (await loadOutboundAdapterFromRegistry(id)) ?? getBundledChannelPlugin(id)?.outbound;
 }
 
 export type { LoadChannelOutboundAdapter };

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -167,6 +167,60 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("moves drifted global message-tool visibility back to group-only visibility", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        telegram: {
+          enabled: true,
+        },
+      },
+      messages: {
+        groupChat: {},
+        visibleReplies: "message_tool",
+      },
+    });
+
+    expect(res.config.messages?.visibleReplies).toBeUndefined();
+    expect(res.config.messages?.groupChat).toEqual({
+      visibleReplies: "message_tool",
+    });
+    expect(res.changes).toContain(
+      'Moved drifted messages.visibleReplies "message_tool" → messages.groupChat.visibleReplies so direct chats keep automatic replies.',
+    );
+  });
+
+  it("does not rewrite explicit global message-tool visibility when group rules are explicit", () => {
+    expect(
+      normalizeCompatibilityConfigValues({
+        channels: {
+          discord: {},
+        },
+        messages: {
+          groupChat: {
+            mentionPatterns: ["@openclaw"],
+          },
+          visibleReplies: "message_tool",
+        },
+      }).config.messages,
+    ).toEqual({
+      groupChat: {
+        mentionPatterns: ["@openclaw"],
+      },
+      visibleReplies: "message_tool",
+    });
+
+    expect(
+      normalizeCompatibilityConfigValues({
+        channels: {
+          discord: {},
+        },
+        messages: {
+          visibleReplies: "message_tool",
+        },
+      }).config.messages?.visibleReplies,
+    ).toBe("message_tool");
+  });
+
   it("does not set group visible replies without channels or when already explicit", () => {
     expect(
       normalizeCompatibilityConfigValues({

--- a/src/commands/doctor/shared/legacy-config-compatibility-base.ts
+++ b/src/commands/doctor/shared/legacy-config-compatibility-base.ts
@@ -8,6 +8,7 @@ import {
   normalizeLegacyRuntimeModelRefs,
   normalizeLegacyNanoBananaSkill,
   normalizeLegacyTalkConfig,
+  normalizeGlobalVisibleRepliesMessageToolDrift,
   normalizeMissingGroupVisibleRepliesDefault,
   seedMissingDefaultAccountsFromSingleAccountBase,
 } from "./legacy-config-core-normalizers.js";
@@ -42,6 +43,7 @@ export function normalizeBaseCompatibilityConfigValues(
   next = normalizeLegacyOpenAIModelProviderApi(next, changes);
   next = normalizeLegacyRuntimeModelRefs(next, changes);
   next = normalizeLegacyCrossContextMessageConfig(next, changes);
+  next = normalizeGlobalVisibleRepliesMessageToolDrift(next, changes);
   next = normalizeMissingGroupVisibleRepliesDefault(next, changes);
   next = normalizeLegacyMediaProviderOptions(next, changes);
   return normalizeLegacyMistralModelMaxTokens(next, changes);

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -22,6 +22,38 @@ function hasConfiguredChannels(cfg: OpenClawConfig): boolean {
   return Object.keys(channels).some((channelId) => channelId !== "defaults");
 }
 
+export function normalizeGlobalVisibleRepliesMessageToolDrift(
+  cfg: OpenClawConfig,
+  changes: string[],
+): OpenClawConfig {
+  const messages = cfg.messages;
+  const groupChat = messages?.groupChat;
+  if (
+    !hasConfiguredChannels(cfg) ||
+    messages?.visibleReplies !== "message_tool" ||
+    !isRecord(groupChat) ||
+    groupChat.visibleReplies !== undefined ||
+    Object.keys(groupChat).length !== 0
+  ) {
+    return cfg;
+  }
+
+  const nextMessages = { ...messages };
+  delete nextMessages.visibleReplies;
+  nextMessages.groupChat = {
+    ...groupChat,
+    visibleReplies: "message_tool",
+  };
+  changes.push(
+    'Moved drifted messages.visibleReplies "message_tool" → messages.groupChat.visibleReplies so direct chats keep automatic replies.',
+  );
+
+  return {
+    ...cfg,
+    messages: nextMessages,
+  };
+}
+
 export function normalizeMissingGroupVisibleRepliesDefault(
   cfg: OpenClawConfig,
   changes: string[],

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -3600,8 +3600,20 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
               },
               models: {
                 type: "object",
-                propertyNames: {
-                  type: "string",
+                properties: {
+                  allowlist: {
+                    anyOf: [
+                      {
+                        type: "array",
+                        items: {
+                          type: "string",
+                        },
+                      },
+                      {
+                        type: "null",
+                      },
+                    ],
+                  },
                 },
                 additionalProperties: {
                   type: "object",

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { __testing, validateConfigObjectRaw } from "./validation.js";
+import {
+  __testing,
+  validateConfigObjectRaw,
+  validateConfigObjectWithPlugins,
+} from "./validation.js";
 
 function mapFirstIssue(
   schema: { safeParse: (value: unknown) => { success: true } | { success: false; error: unknown } },
@@ -17,6 +21,31 @@ function mapFirstIssue(
 }
 
 describe("config validation allowed-values metadata", () => {
+  it("normalizes bundled channel legacy config before channel schema validation", () => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        channels: {
+          telegram: {
+            enabled: true,
+            botToken: "123456789:abcdefghijklmnopqrstuvwxyzABCDEFGHIJK",
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupPolicy: "allowlist",
+            streaming: "partial",
+          },
+        },
+      },
+      {
+        loadPluginMetadataSnapshot: () => ({ manifestRegistry: { plugins: [], diagnostics: [] } }),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.channels?.telegram?.streaming).toEqual({ mode: "partial" });
+    }
+  });
+
   it("adds allowed values for invalid union paths", () => {
     const result = validateConfigObjectRaw({
       update: { channel: "nightly" },

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -176,6 +176,52 @@ describe("validateConfigObjectWithPlugins channel metadata (applyDefaults: true)
       );
     }
   });
+
+  it("downgrades invalid channel config to a disabled channel when lenient channel config is enabled", async () => {
+    mockLoadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: [
+        createPluginManifestRecord({
+          id: "telegram",
+          channels: ["telegram"],
+          channelConfigs: {
+            telegram: {
+              schema: {
+                type: "object",
+                properties: {
+                  enabled: { type: "boolean" },
+                },
+                additionalProperties: false,
+              },
+              uiHints: {},
+            },
+          },
+        }),
+      ],
+    });
+
+    const result = validateConfigObjectWithPlugins(
+      {
+        channels: {
+          telegram: { allowedUsers: ["legacy"] },
+        },
+      },
+      { env: { OPENCLAW_LENIENT_CHANNEL_CONFIG: "1" } },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "channels.telegram",
+          message: expect.stringContaining("channel disabled"),
+        }),
+      ]),
+    );
+    if (result.ok) {
+      expect(result.config.channels?.telegram).toEqual({ enabled: false });
+    }
+  });
 });
 
 describe("validateConfigObjectRawWithPlugins channel metadata", () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/ids.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
 import { withBundledPluginAllowlistCompat } from "../plugins/bundled-compat.js";
 import {
@@ -780,6 +781,7 @@ function validateConfigObjectWithPluginsBase(
 
   const issues: ConfigValidationIssue[] = [];
   const warnings: ConfigValidationIssue[] = [];
+  const lenientChannelConfig = isTruthyEnvValue(opts.env?.OPENCLAW_LENIENT_CHANNEL_CONFIG);
   const hasExplicitPluginsConfig =
     isRecord(raw) && Object.prototype.hasOwnProperty.call(raw, "plugins");
 
@@ -1236,6 +1238,19 @@ function validateConfigObjectWithPluginsBase(
     (mutatedConfig.channels as Record<string, unknown>)[channelId] = nextValue;
   };
 
+  const removeChannelConfig = (channelId: string) => {
+    if (!channelsCloned) {
+      mutatedConfig = {
+        ...mutatedConfig,
+        channels: {
+          ...mutatedConfig.channels,
+        },
+      };
+      channelsCloned = true;
+    }
+    delete (mutatedConfig.channels as Record<string, unknown>)[channelId];
+  };
+
   const replacePluginEntryConfig = (pluginId: string, nextValue: Record<string, unknown>) => {
     if (!pluginsCloned) {
       mutatedConfig = {
@@ -1288,6 +1303,12 @@ function validateConfigObjectWithPluginsBase(
             ...issue,
             message: `${issue.message} (stale channel plugin config ignored; run openclaw doctor --fix to remove stale config, or install the plugin)`,
           });
+        } else if (lenientChannelConfig) {
+          warnings.push({
+            ...issue,
+            message: `${issue.message} (ignored because OPENCLAW_LENIENT_CHANNEL_CONFIG is enabled)`,
+          });
+          removeChannelConfig(trimmed);
         } else {
           issues.push(issue);
         }
@@ -1307,13 +1328,24 @@ function validateConfigObjectWithPluginsBase(
       });
       if (!result.ok) {
         for (const error of result.errors) {
-          issues.push({
+          const issue = {
             path:
               error.path === "<root>" ? `channels.${trimmed}` : `channels.${trimmed}.${error.path}`,
             message: `invalid config: ${error.message}`,
             allowedValues: error.allowedValues,
             allowedValuesHiddenCount: error.allowedValuesHiddenCount,
-          });
+          };
+          if (lenientChannelConfig) {
+            warnings.push({
+              ...issue,
+              message: `${issue.message} (channel disabled because OPENCLAW_LENIENT_CHANNEL_CONFIG is enabled)`,
+            });
+          } else {
+            issues.push(issue);
+          }
+        }
+        if (lenientChannelConfig) {
+          replaceChannelConfig(trimmed, { enabled: false });
         }
         continue;
       }

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/ids.js";
+import { loadBundledChannelDoctorContractApi } from "../channels/plugins/doctor-contract-api.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
 import { withBundledPluginAllowlistCompat } from "../plugins/bundled-compat.js";
@@ -1279,6 +1280,19 @@ function validateConfigObjectWithPluginsBase(
 
   const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
 
+  const applyBundledChannelCompatibilityMigration = (channelId: string): void => {
+    const normalizeCompatibilityConfig =
+      loadBundledChannelDoctorContractApi(channelId)?.normalizeCompatibilityConfig;
+    if (!normalizeCompatibilityConfig) {
+      return;
+    }
+    const mutation = normalizeCompatibilityConfig({ cfg: mutatedConfig });
+    if (!mutation || mutation.changes.length === 0) {
+      return;
+    }
+    mutatedConfig = mutation.config;
+  };
+
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {
       const trimmed = key.trim();
@@ -1319,10 +1333,13 @@ function validateConfigObjectWithPluginsBase(
       if (!channelSchema) {
         continue;
       }
+      applyBundledChannelCompatibilityMigration(trimmed);
       const result = validateJsonSchemaValue({
         schema: channelSchema,
         cacheKey: `channel:${trimmed}`,
-        value: config.channels[trimmed],
+        value: isRecord(mutatedConfig.channels)
+          ? mutatedConfig.channels[trimmed]
+          : config.channels[trimmed],
         applyDefaults: true, // Always apply defaults for AJV schema validation;
         // writeConfigFile persists persistCandidate, not validated.config (#61841)
       });

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -55,6 +55,32 @@ describe("agent defaults schema", () => {
     ).not.toThrow();
   });
 
+  it("accepts legacy models.allowlist=null as hosted-image compatibility", () => {
+    const result = AgentDefaultsSchema.parse({
+      models: {
+        allowlist: null,
+        "openrouter/google/gemini-2.5-flash-image-preview": {},
+      },
+    })!;
+
+    expect(result.models).toEqual({
+      allowlist: null,
+      "openrouter/google/gemini-2.5-flash-image-preview": {},
+    });
+  });
+
+  it("accepts legacy models.allowlist arrays", () => {
+    const result = AgentDefaultsSchema.parse({
+      models: {
+        allowlist: ["openrouter/google/gemini-2.5-flash-image-preview"],
+      },
+    })!;
+
+    expect(result.models).toEqual({
+      allowlist: ["openrouter/google/gemini-2.5-flash-image-preview"],
+    });
+  });
+
   it("accepts experimental.localModelLean", () => {
     const result = AgentDefaultsSchema.parse({
       experimental: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -47,6 +47,28 @@ export const SilentReplyRewriteConfigSchema = z
   })
   .strict();
 
+const AgentDefaultModelEntrySchema = z
+  .object({
+    alias: z.string().optional(),
+    /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
+    params: z.record(z.string(), z.unknown()).optional(),
+    /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
+    streaming: z.boolean().optional(),
+  })
+  .strict();
+
+const AgentDefaultModelsSchema = z
+  .object({
+    /**
+     * Legacy/hosted-image compatibility: some generated configs wrote
+     * agents.defaults.models.allowlist. The canonical shape is still a map
+     * keyed by provider/model, but accepting this prevents cron model
+     * validation from breaking on already-provisioned hosted images.
+     */
+    allowlist: z.union([z.array(z.string()), z.null()]).optional(),
+  })
+  .catchall(AgentDefaultModelEntrySchema);
+
 export const AgentDefaultsSchema = z
   .object({
     /** Global default provider params applied to all models before per-model and per-agent overrides. */
@@ -62,20 +84,7 @@ export const AgentDefaultsSchema = z
     pdfModel: AgentModelSchema.optional(),
     pdfMaxBytesMb: z.number().positive().optional(),
     pdfMaxPages: z.number().int().positive().optional(),
-    models: z
-      .record(
-        z.string(),
-        z
-          .object({
-            alias: z.string().optional(),
-            /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
-            params: z.record(z.string(), z.unknown()).optional(),
-            /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
-            streaming: z.boolean().optional(),
-          })
-          .strict(),
-      )
-      .optional(),
+    models: AgentDefaultModelsSchema.optional(),
     workspace: z.string().optional(),
     skills: z.array(z.string()).optional(),
     silentReply: SilentReplyPolicyConfigSchema.optional(),

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -6,10 +6,47 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
+const dockerComposePath = join(repoRoot, "docker-compose.yml");
+const dockerSetupPath = join(repoRoot, "scripts/docker/setup.sh");
 const packageJsonPath = join(repoRoot, "package.json");
 
 function collapseDockerContinuations(dockerfile: string): string {
   return dockerfile.replace(/\\\r?\n[ \t]*/g, " ");
+}
+
+const hostedAgentRuntimePackages = [
+  "ca-certificates",
+  "curl",
+  "file",
+  "gh",
+  "git",
+  "hostname",
+  "jq",
+  "lsof",
+  "openssh-client",
+  "openssl",
+  "procps",
+  "python-is-python3",
+  "python3",
+  "python3-bs4",
+  "python3-pip",
+  "python3-requests",
+  "python3-venv",
+  "ripgrep",
+  "sqlite3",
+  "unzip",
+  "wget",
+  "zip",
+];
+
+function runtimeInstallSection(dockerfile: string): string {
+  const runtimeIndex = dockerfile.indexOf(
+    "FROM ${OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE} AS base-runtime",
+  );
+  const userCreateIndex = dockerfile.indexOf("RUN groupadd --gid 1001 openclaw");
+  expect(runtimeIndex).toBeGreaterThan(-1);
+  expect(userCreateIndex).toBeGreaterThan(runtimeIndex);
+  return dockerfile.slice(runtimeIndex, userCreateIndex);
 }
 
 describe("Dockerfile", () => {
@@ -36,13 +73,11 @@ describe("Dockerfile", () => {
     const runtimeIndex = collapsed.indexOf(
       "FROM ${OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE} AS base-runtime",
     );
-    const caInstallIndex = collapsed.indexOf(
-      "ca-certificates procps hostname curl git lsof openssl python3",
-    );
+    const section = runtimeInstallSection(collapsed);
+    const caInstallIndex = section.indexOf("ca-certificates");
 
     expect(runtimeIndex).toBeGreaterThan(-1);
-    expect(caInstallIndex).toBeGreaterThan(runtimeIndex);
-    expect(caInstallIndex).toBeLessThan(collapsed.indexOf("RUN chown node:node /app"));
+    expect(caInstallIndex).toBeGreaterThan(-1);
     expect(collapsed).toMatch(/apt-get install -y --no-install-recommends\s+ca-certificates/);
     expect(collapsed).toContain("update-ca-certificates");
   });
@@ -52,14 +87,93 @@ describe("Dockerfile", () => {
     const runtimeIndex = dockerfile.indexOf(
       "FROM ${OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE} AS base-runtime",
     );
-    const pythonInstallIndex = dockerfile.indexOf(
-      "ca-certificates procps hostname curl git lsof openssl python3",
-    );
+    const section = runtimeInstallSection(dockerfile);
+    const pythonInstallIndex = section.indexOf("python3");
 
     expect(runtimeIndex).toBeGreaterThan(-1);
-    expect(pythonInstallIndex).toBeGreaterThan(runtimeIndex);
-    expect(pythonInstallIndex).toBeLessThan(dockerfile.indexOf("RUN chown node:node /app"));
-    expect(dockerfile).toContain("ca-certificates procps hostname curl git lsof openssl python3");
+    expect(pythonInstallIndex).toBeGreaterThan(-1);
+    expect(dockerfile).toContain("python-is-python3");
+    expect(dockerfile).toContain("python3-pip");
+    expect(dockerfile).toContain("python3-venv");
+  });
+
+  it("installs practical hosted-agent runtime tools in the slim runtime stage", async () => {
+    const dockerfile = collapseDockerContinuations(await readFile(dockerfilePath, "utf8"));
+
+    for (const pkg of hostedAgentRuntimePackages) {
+      expect(dockerfile).toContain(pkg);
+    }
+  });
+
+  it("pre-creates writable package manager homes for the non-root runtime user", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+
+    expect(dockerfile).toContain("NPM_CONFIG_PREFIX=/home/openclaw/.local");
+    expect(dockerfile).toContain("NPM_CONFIG_CACHE=/home/openclaw/.npm");
+    expect(dockerfile).toContain("PIP_CACHE_DIR=/home/openclaw/.cache/pip");
+    expect(dockerfile).toContain("install -d -m 0755 -o openclaw -g openclaw");
+    expect(dockerfile).toContain("/home/openclaw/.npm");
+    expect(dockerfile).toContain("install -d -m 0700 -o openclaw -g openclaw /home/openclaw/.ssh");
+  });
+
+  it("runs hosted containers as openclaw uid 1001 with root-home compatibility", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+
+    expect(dockerfile).toContain("groupadd --gid 1001 openclaw");
+    expect(dockerfile).toContain("useradd --uid 1001 --gid 1001");
+    expect(dockerfile).toContain("/home/openclaw --create-home");
+    expect(dockerfile).toContain("USER openclaw");
+    expect(dockerfile).not.toContain("USER node");
+    expect(dockerfile).toContain(
+      "install -d -m 0700 -o openclaw -g openclaw /home/openclaw/.openclaw",
+    );
+    expect(dockerfile).toContain("grep -qx 'openclaw:openclaw 1001:1001 700'");
+    expect(dockerfile).toContain("chmod 711 /root");
+    expect(dockerfile).toContain("ln -s /home/openclaw/.openclaw /root/.openclaw");
+  });
+
+  it("keeps Docker Compose paths aligned with the openclaw uid-1001 home", async () => {
+    const compose = await readFile(dockerComposePath, "utf8");
+
+    expect(compose).toContain("HOME: /home/openclaw");
+    expect(compose).toContain(":/home/openclaw/.openclaw");
+    expect(compose).toContain(":/home/openclaw/.openclaw/workspace");
+    expect(compose).not.toContain("/home/node");
+  });
+
+  it("keeps Docker Compose gateway resource guardrails enabled by default", async () => {
+    const compose = await readFile(dockerComposePath, "utf8");
+
+    expect(compose).toContain("NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-none}");
+    expect(compose).toContain("cap_drop:\n      - NET_RAW\n      - NET_ADMIN");
+    expect(compose).toContain("security_opt:\n      - no-new-privileges:true");
+    expect(compose).toContain("mem_limit: ${OPENCLAW_GATEWAY_MEMORY:-3g}");
+    expect(compose).toContain("memswap_limit: ${OPENCLAW_GATEWAY_MEMORY_SWAP:-6g}");
+    expect(compose).toContain('cpus: "${OPENCLAW_GATEWAY_CPUS:-1.5}"');
+    expect(compose).toContain("pids_limit: ${OPENCLAW_GATEWAY_PIDS_LIMIT:-384}");
+    expect(compose).toContain("max-size: ${OPENCLAW_GATEWAY_LOG_MAX_SIZE:-10m}");
+    expect(compose).toContain('max-file: "${OPENCLAW_GATEWAY_LOG_MAX_FILE:-3}"');
+  });
+
+  it("keeps Docker setup chown repair aligned with the openclaw uid-1001 home", async () => {
+    const setup = await readFile(dockerSetupPath, "utf8");
+
+    expect(setup).toContain("user (uid 1001)");
+    expect(setup).toContain("${home_volume}:/home/openclaw");
+    expect(setup).toContain("${OPENCLAW_CONFIG_DIR}:/home/openclaw/.openclaw");
+    expect(setup).toContain("find /home/openclaw/.openclaw -xdev -exec chown openclaw:openclaw");
+    expect(setup).not.toContain("/home/node");
+    expect(setup).not.toContain("node:node");
+    expect(setup).not.toContain("uid 1000");
+  });
+
+  it("enables hosted runtime guards in the slim runtime image", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+
+    expect(dockerfile).toContain("OPENCLAW_DISABLE_BONJOUR=1");
+    expect(dockerfile).toContain("OPENCLAW_LENIENT_CHANNEL_CONFIG=1");
+    expect(dockerfile).toContain("OPENCLAW_NO_AUTO_UPDATE=1");
+    expect(dockerfile).toContain("OPENCLAW_NO_UPDATE_CHECK=1");
   });
 
   it("installs optional browser dependencies after pnpm install", async () => {
@@ -74,6 +188,7 @@ describe("Dockerfile", () => {
       "node /app/node_modules/playwright-core/cli.js install --with-deps chromium",
     );
     expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
+    expect(dockerfile).toContain("PLAYWRIGHT_BROWSERS_PATH=/home/openclaw/.cache/ms-playwright");
   });
 
   it("verifies matrix-sdk-crypto native addons without hardcoded pnpm virtual-store paths", async () => {
@@ -116,10 +231,10 @@ describe("Dockerfile", () => {
       `npm install --prefix "${BUNDLED_PLUGIN_ROOT_DIR}/$ext" --omit=dev --silent`,
     );
     expect(dockerfile).toContain(
-      "COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules",
+      "COPY --from=runtime-assets --chown=openclaw:openclaw /app/node_modules ./node_modules",
     );
     expect(dockerfile).toContain(
-      "COPY --from=runtime-assets --chown=node:node /app/patches ./patches",
+      "COPY --from=runtime-assets --chown=openclaw:openclaw /app/patches ./patches",
     );
   });
 
@@ -131,7 +246,7 @@ describe("Dockerfile", () => {
 
     expect(Object.keys(packageJson.pnpm?.patchedDependencies ?? {})).not.toHaveLength(0);
     expect(dockerfile).toContain(
-      "COPY --from=runtime-assets --chown=node:node /app/patches ./patches",
+      "COPY --from=runtime-assets --chown=openclaw:openclaw /app/patches ./patches",
     );
   });
 
@@ -182,23 +297,23 @@ describe("Dockerfile", () => {
     );
   });
 
-  it("pre-creates the OpenClaw home before switching to the node user", async () => {
+  it("pre-creates the OpenClaw home before switching to the openclaw user", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const runtimeStageIndex = dockerfile.lastIndexOf("FROM base-runtime");
     const stateDirIndex = dockerfile.indexOf(
-      "RUN install -d -m 0700 -o node -g node /home/node/.openclaw && \\",
+      "RUN install -d -m 0700 -o openclaw -g openclaw /home/openclaw/.openclaw && \\",
       runtimeStageIndex,
     );
-    const userIndex = dockerfile.indexOf("USER node", runtimeStageIndex);
+    const userIndex = dockerfile.indexOf("USER openclaw", runtimeStageIndex);
 
     expect(runtimeStageIndex).toBeGreaterThan(-1);
     expect(stateDirIndex).toBeGreaterThan(-1);
     expect(userIndex).toBeGreaterThan(-1);
     expect(stateDirIndex).toBeGreaterThan(runtimeStageIndex);
     expect(stateDirIndex).toBeLessThan(userIndex);
-    expect(dockerfile).not.toContain("mkdir -p /home/node/.openclaw");
+    expect(dockerfile).not.toContain("mkdir -p /home/openclaw/.openclaw");
     expect(dockerfile).toContain(
-      "stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'",
+      "stat -c '%U:%G %u:%g %a' /home/openclaw/.openclaw | grep -qx 'openclaw:openclaw 1001:1001 700'",
     );
   });
 });

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -68,6 +68,7 @@ describe("update-startup", () => {
     tempDir = await suiteRootTracker.make("case");
     envSnapshot = captureEnv([
       "OPENCLAW_NO_AUTO_UPDATE",
+      "OPENCLAW_NO_UPDATE_CHECK",
       "OPENCLAW_STATE_DIR",
       "NODE_ENV",
       "VITEST",
@@ -199,6 +200,21 @@ describe("update-startup", () => {
         : {}),
     });
   }
+
+  it("skips startup update checks when OPENCLAW_NO_UPDATE_CHECK is set", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.OPENCLAW_NO_UPDATE_CHECK = "1";
+    mockPackageUpdateStatus("latest", "2.0.0");
+
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "stable" } },
+      log: { info: vi.fn() },
+      isNixMode: false,
+    });
+
+    expect(resolveOpenClawPackageRoot).not.toHaveBeenCalled();
+    expect(checkUpdateStatus).not.toHaveBeenCalled();
+  });
 
   it.each([
     {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -72,6 +72,9 @@ function shouldSkipCheck(allowInTests: boolean): boolean {
   if (allowInTests) {
     return false;
   }
+  if (isTruthyEnvValue(process.env.OPENCLAW_NO_UPDATE_CHECK)) {
+    return true;
+  }
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return true;
   }

--- a/src/media/media-reference.test.ts
+++ b/src/media/media-reference.test.ts
@@ -59,6 +59,26 @@ describe("media reference helpers", () => {
     }
   });
 
+  it("resolves inbound media route paths", async () => {
+    const stateDir = resolveStateDir();
+    const id = `ref-route-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;
+    const filePath = path.join(stateDir, "media", "inbound", id);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, Buffer.from("png"));
+
+    try {
+      await expect(resolveInboundMediaReference(`/media/inbound/${id}`)).resolves.toMatchObject({
+        id,
+        normalizedSource: `/media/inbound/${id}`,
+        physicalPath: filePath,
+        sourceType: "uri",
+      });
+      await expect(resolveMediaReferenceLocalPath(`media/inbound/${id}`)).resolves.toBe(filePath);
+    } finally {
+      await fs.rm(filePath, { force: true });
+    }
+  });
+
   it("maps canonical inbound media URIs to local paths for direct file readers", async () => {
     const stateDir = resolveStateDir();
     const id = `ref-local-path-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;

--- a/src/media/media-reference.ts
+++ b/src/media/media-reference.ts
@@ -130,6 +130,32 @@ async function resolveInboundMediaUri(
   };
 }
 
+async function resolveInboundMediaRoutePath(
+  normalizedSource: string,
+): Promise<InboundMediaReference | null> {
+  const match = /^(?:\/?media\/inbound\/)([^/\\]+)$/i.exec(normalizedSource);
+  if (!match) {
+    return null;
+  }
+  let id: string;
+  try {
+    id = decodeURIComponent(match[1]);
+  } catch (err) {
+    throw new MediaReferenceError("invalid-path", `Invalid media reference: ${normalizedSource}`, {
+      cause: err,
+    });
+  }
+  if (!id || id.includes("/") || id.includes("\\")) {
+    throw new MediaReferenceError("invalid-path", `Invalid media reference: ${normalizedSource}`);
+  }
+  return {
+    id,
+    normalizedSource,
+    physicalPath: await resolveInboundMediaPath(id, normalizedSource),
+    sourceType: "uri",
+  };
+}
+
 export async function resolveInboundMediaReference(
   source: string,
 ): Promise<InboundMediaReference | null> {
@@ -141,6 +167,11 @@ export async function resolveInboundMediaReference(
   const uriSource = await resolveInboundMediaUri(normalizedSource);
   if (uriSource) {
     return uriSource;
+  }
+
+  const routePathSource = await resolveInboundMediaRoutePath(normalizedSource);
+  if (routePathSource) {
+    return routePathSource;
   }
 
   const localPath = maybeLocalPathFromSource(normalizedSource);

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -335,6 +335,7 @@ describe("web search runtime", () => {
         id: "alpha",
         credentialPath: "tools.web.search.alpha.apiKey",
         autoDetectOrder: 1,
+        getConfiguredCredentialValue: () => "alpha-configured",
         getCredentialValue: () => "alpha-configured",
         createTool: ({ runtimeMetadata }) => ({
           description: "alpha",
@@ -351,6 +352,7 @@ describe("web search runtime", () => {
         id: "beta",
         credentialPath: "tools.web.search.beta.apiKey",
         autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "beta-configured",
         getCredentialValue: () => "beta-configured",
         createTool: ({ runtimeMetadata }) => ({
           description: "beta",
@@ -479,7 +481,9 @@ describe("web search runtime", () => {
 
   it("does not prebuild fallback provider tools before attempting the selected provider", async () => {
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([
-      createGoogleSearchProvider(),
+      createGoogleSearchProvider({
+        getConfiguredCredentialValue: () => "google-key",
+      }),
       createWebSearchTestProvider({
         pluginId: "broken-fallback",
         id: "broken-fallback",
@@ -655,6 +659,44 @@ describe("web search runtime", () => {
     ).resolves.toEqual({
       provider: "google",
       result: { query: "prefer-config", provider: "google" },
+    });
+  });
+
+  it("skips unconfigured credential-backed providers during auto fallback", async () => {
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createGoogleSearchProvider({
+        createTool: () => ({
+          description: "google",
+          parameters: {},
+          execute: async () => {
+            throw new Error("google should not run without credentials");
+          },
+        }),
+      }),
+      createDuckDuckGoSearchProvider(),
+      createCustomSearchProvider({
+        id: "searxng",
+        pluginId: "searxng",
+        credentialPath: "plugins.entries.searxng.config.webSearch.baseUrl",
+        autoDetectOrder: 200,
+        createTool: () => ({
+          description: "searxng",
+          parameters: {},
+          execute: async () => {
+            throw new Error("SearXNG base URL is not configured");
+          },
+        }),
+      }),
+    ]);
+
+    await expect(
+      runWebSearch({
+        config: {},
+        args: { query: "skip-unconfigured" },
+      }),
+    ).resolves.toEqual({
+      provider: "duckduckgo",
+      result: { query: "skip-unconfigured", provider: "duckduckgo" },
     });
   });
 

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -348,6 +348,14 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
   let sawUnavailableProvider = false;
 
   for (const candidate of candidates) {
+    if (
+      allowFallback &&
+      providerRequiresCredential(candidate) &&
+      !hasEntryCredential(candidate, config, search)
+    ) {
+      sawUnavailableProvider = true;
+      continue;
+    }
     try {
       const definition = candidate.createTool({
         config,

--- a/ui/src/ui/canvas-url.test.ts
+++ b/ui/src/ui/canvas-url.test.ts
@@ -19,6 +19,17 @@ describe("resolveCanvasIframeUrl", () => {
     );
   });
 
+  it("preserves reverse-proxy path prefixes on scoped canvas hosts", () => {
+    expect(
+      resolveCanvasIframeUrl(
+        "/__openclaw__/canvas/documents/cv_demo/index.html",
+        "https://hosted.example.test/proxy/path/__openclaw__/cap/cap_123",
+      ),
+    ).toBe(
+      "https://hosted.example.test/proxy/path/__openclaw__/cap/cap_123/__openclaw__/canvas/documents/cv_demo/index.html",
+    );
+  });
+
   it("rejects non-canvas same-origin paths", () => {
     expect(resolveCanvasIframeUrl("/not-canvas/snake.html")).toBeUndefined();
   });

--- a/ui/src/ui/canvas-url.ts
+++ b/ui/src/ui/canvas-url.ts
@@ -15,6 +15,14 @@ function isExternalHttpUrl(entry: URL): boolean {
   return entry.protocol === "http:" || entry.protocol === "https:";
 }
 
+function isCanvasCapabilityScopedPath(pathname: string): boolean {
+  return (
+    pathname === CANVAS_CAPABILITY_PATH_PREFIX ||
+    pathname.startsWith(`${CANVAS_CAPABILITY_PATH_PREFIX}/`) ||
+    pathname.includes(`${CANVAS_CAPABILITY_PATH_PREFIX}/`)
+  );
+}
+
 function sanitizeCanvasEntryUrl(
   rawEntryUrl: string,
   allowExternalEmbedUrls = false,
@@ -55,7 +63,7 @@ export function resolveCanvasIframeUrl(
   try {
     const scopedHostUrl = new URL(canvasHostUrl);
     const scopedPrefix = scopedHostUrl.pathname.replace(/\/+$/, "");
-    if (!scopedPrefix.startsWith(CANVAS_CAPABILITY_PATH_PREFIX)) {
+    if (!isCanvasCapabilityScopedPath(scopedPrefix)) {
       return safeEntryUrl;
     }
     const entry = new URL(safeEntryUrl, scopedHostUrl.origin);

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1173,32 +1173,51 @@ describe("grouped chat rendering", () => {
     vi.unstubAllGlobals();
   });
 
-  it("preserves same-origin assistant attachments without local preview rewriting", () => {
+  it("proxies inbound media-store assistant attachments through the authenticated media route", async () => {
     resetAssistantAttachmentAvailabilityCacheForTest();
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("meta=1")) {
+        return {
+          ok: true,
+          json: async () => ({ available: true }),
+        };
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
     const container = document.createElement("div");
-    renderAssistantMessage(
-      container,
-      {
-        id: "assistant-same-origin-media-inline",
-        role: "assistant",
-        content:
-          "Inline\nMEDIA:/media/inbound/test-image.png\nMEDIA:/__openclaw__/media/test-doc.pdf",
-        timestamp: Date.now(),
-      },
-      {
-        showToolCalls: false,
-        basePath: "/openclaw",
-        localMediaPreviewRoots: ["/tmp/openclaw"],
-      },
-    );
+    const renderMessage = () =>
+      renderAssistantMessage(
+        container,
+        {
+          id: "assistant-same-origin-media-inline",
+          role: "assistant",
+          content:
+            "Inline\nMEDIA:/media/inbound/test-image.png\nMEDIA:/__openclaw__/media/test-doc.pdf",
+          timestamp: Date.now(),
+        },
+        {
+          showToolCalls: false,
+          basePath: "/openclaw",
+          assistantAttachmentAuthToken: "session-token",
+          localMediaPreviewRoots: ["/tmp/openclaw"],
+          onRequestUpdate: renderMessage,
+        },
+      );
+
+    renderMessage();
+    await flushAssistantAttachmentAvailabilityChecks();
 
     const image = container.querySelector<HTMLImageElement>(".chat-message-image");
     const docLink = container.querySelector<HTMLAnchorElement>(
       ".chat-assistant-attachment-card__link",
     );
-    expect(image?.getAttribute("src")).toBe("/media/inbound/test-image.png");
+    expect(image?.getAttribute("src")).toBe(
+      "/openclaw/__openclaw__/assistant-media?source=%2Fmedia%2Finbound%2Ftest-image.png&token=session-token",
+    );
     expect(docLink?.getAttribute("href")).toBe("/__openclaw__/media/test-doc.pdf");
     expect(container.textContent).not.toContain("Unavailable");
+    vi.unstubAllGlobals();
   });
 
   it("renders blocked local assistant files as unavailable with a reason", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -779,7 +779,10 @@ function renderReplyPill(replyTarget: NormalizedMessage["replyTarget"]) {
 
 function isLocalAssistantAttachmentSource(source: string): boolean {
   const trimmed = source.trim();
-  if (/^\/(?:__openclaw__|media|api\/chat\/media\/outgoing)\//.test(trimmed)) {
+  if (isInboundMediaStoreSource(trimmed)) {
+    return true;
+  }
+  if (/^\/(?:__openclaw__|api\/chat\/media\/outgoing)\//.test(trimmed)) {
     return false;
   }
   return (
@@ -790,10 +793,20 @@ function isLocalAssistantAttachmentSource(source: string): boolean {
   );
 }
 
+function isInboundMediaStoreSource(source: string): boolean {
+  const trimmed = source.trim();
+  return (
+    /^media:\/\/inbound\/[^/\\]+$/i.test(trimmed) || /^\/?media\/inbound\/[^/\\]+$/i.test(trimmed)
+  );
+}
+
 function normalizeLocalAttachmentPath(source: string): string | null {
   const trimmed = source.trim();
   if (!isLocalAssistantAttachmentSource(trimmed)) {
     return null;
+  }
+  if (isInboundMediaStoreSource(trimmed)) {
+    return trimmed;
   }
   if (trimmed.startsWith("file://")) {
     try {
@@ -855,6 +868,9 @@ function isLocalAttachmentPreviewAllowed(
       : [];
   if (comparableSources.length === 0) {
     return false;
+  }
+  if (normalizedSource && isInboundMediaStoreSource(normalizedSource)) {
+    return true;
   }
   return localMediaPreviewRoots.some((root) => {
     const normalizedRoot = canonicalizeLocalPathForComparison(root.trim());


### PR DESCRIPTION
## Summary
- improve the hosted Docker runtime baseline with Python/pip/venv, common CLI tools, writable npm/pip homes, and optional browser/Docker-CLI build args
- add hosted runtime guards for Docker deployments: disable mDNS/Bonjour, lenient channel config validation, and hosted no-auto-update/no-update-check defaults
- keep local Chromium out of the default GHCR image; browser access remains via Browserless/CDP with `playwright-core`
- emit ACP pre-agent message hooks for runtime event handling

## Validation
- `pnpm vitest run src/dockerfile.test.ts src/config/validation.channel-metadata.test.ts src/infra/update-startup.test.ts extensions/discord/index.test.ts extensions/discord/src/channel.test.ts extensions/discord/src/client.proxy.test.ts extensions/discord/src/monitor.gateway.test.ts extensions/discord/src/outbound-adapter.test.ts` — 8 files / 103 tests passed
- `git diff --check` — clean
- built on c4: `openclaw:heyron-ghcr-wed-slim-candidate`
- smoke: env guards present, Python 3.11.2, requests/bs4/sqlite3 imports OK, venv OK, `playwright-core` present, no baked local browser cache
- candidate size: 3.39GB versus current GHCR 3.05GB; rejected local-browser candidate was 5.1GB
