### PR TITLE
fix(ui): format structured tool results instead of "[object Object]

### DIFF
--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -276,3 +276,44 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     vi.useRealTimers();
   });
 });
+
+describe("app-tool-stream tool output shaping", () => {
+  beforeAll(() => {
+    const globalWithWindow = globalThis as typeof globalThis & {
+      window?: Window & typeof globalThis;
+    };
+    if (!globalWithWindow.window) {
+      globalWithWindow.window = globalThis as unknown as Window & typeof globalThis;
+    }
+  });
+
+  it("encodes object-shaped tool results as string toolresult text in the synthesized message", () => {
+    const host = createHost({ chatRunId: "run-1" });
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "tool", {
+        phase: "start",
+        toolCallId: "tc-json",
+        name: "status",
+        args: {},
+      }),
+    );
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 2, "tool", {
+        phase: "result",
+        toolCallId: "tc-json",
+        name: "status",
+        result: { ok: true, nested: { id: 2 } },
+      }),
+    );
+    const entry = host.toolStreamById.get("tc-json");
+    expect(entry).toBeDefined();
+    const chunks = entry!.message.content as Array<{ type?: string; text?: unknown }>;
+    const toolResult = chunks.find((c) => c.type === "toolresult");
+    expect(typeof toolResult?.text).toBe("string");
+    expect(toolResult?.text).toContain('"ok": true');
+    expect(toolResult?.text).toContain('"nested"');
+    expect(String(toolResult?.text)).not.toMatch(/\[object Object\]/);
+  });
+});

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -182,11 +182,12 @@ function buildToolStreamMessage(entry: ToolStreamEntry): Record<string, unknown>
     name: entry.name,
     arguments: entry.args ?? {},
   });
-  if (entry.output) {
+  const resultText = formatToolOutput(entry.output);
+  if (resultText != null) {
     content.push({
       type: "toolresult",
       name: entry.name,
-      text: entry.output,
+      text: resultText,
     });
   }
   return {
@@ -517,7 +518,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       sessionKey,
       name,
       args,
-      output: output || undefined,
+      output: output !== undefined ? output : undefined,
       startedAt: typeof payload.ts === "number" ? payload.ts : now,
       updatedAt: now,
       message: {},
@@ -530,7 +531,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       entry.args = args;
     }
     if (output !== undefined) {
-      entry.output = output || undefined;
+      entry.output = output;
     }
     entry.updatedAt = now;
   }

--- a/ui/src/ui/chat/tool-cards.node.test.ts
+++ b/ui/src/ui/chat/tool-cards.node.test.ts
@@ -53,6 +53,36 @@ describe("tool-card extraction", () => {
     expect(cards[0]?.inputText).toContain('"retry": 0');
   });
 
+  it("pretty-prints toolresult text when the API delivers a structured object", () => {
+    const cards = extractToolCards(
+      {
+        role: "assistant",
+        toolCallId: "call-obj",
+        content: [
+          {
+            type: "toolcall",
+            id: "call-obj",
+            name: "status",
+            arguments: {},
+          },
+          {
+            type: "toolresult",
+            id: "call-obj",
+            name: "status",
+            text: { ok: true, role: "gateway" },
+          },
+        ],
+      },
+      "msg:obj",
+    );
+
+    expect(cards).toHaveLength(1);
+    expect(typeof cards[0]?.outputText).toBe("string");
+    expect(cards[0]?.outputText).toContain('"ok": true');
+    expect(cards[0]?.outputText).toContain('"role": "gateway"');
+    expect(cards[0]?.outputText).not.toMatch(/\[object Object\]/);
+  });
+
   it("preserves string args verbatim and keeps empty-output cards", () => {
     const cards = extractToolCards(
       {

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { extractCanvasFromText } from "../../../../src/chat/canvas-render.js";
 import { resolveCanvasIframeUrl } from "../canvas-url.ts";
 import { resolveEmbedSandbox, type EmbedSandboxMode } from "../embed-sandbox.ts";
+import { formatUnknownText } from "../format.ts";
 import { icons } from "../icons.ts";
 import type { SidebarContent } from "../sidebar-content.ts";
 import { formatToolDetail, resolveToolDisplay } from "../tool-display.ts";
@@ -45,8 +46,14 @@ function extractToolText(item: Record<string, unknown>): string | undefined {
   if (typeof item.text === "string") {
     return item.text;
   }
+  if (item.text != null && typeof item.text === "object") {
+    return formatUnknownText(item.text, { pretty: true });
+  }
   if (typeof item.content === "string") {
     return item.content;
+  }
+  if (item.content != null && typeof item.content === "object" && !Array.isArray(item.content)) {
+    return formatUnknownText(item.content, { pretty: true });
   }
   if (Array.isArray(item.content)) {
     const parts = item.content.flatMap((entry) => {


### PR DESCRIPTION
## Problem
The Control UI could render structured tool output as `[object Object]` when `toolresult` blocks carried non-string `text` / `content`, or when stream-synthesized messages stored raw object values.
## Change
- Format object-shaped `toolresult.text` and object-shaped non-array `content` with the existing `formatUnknownText(..., { pretty: true })`.
- Normalize streamed tool output through `formatToolOutput(entry.output)`.
- Preserve empty-string outputs by avoiding truthy checks that drop `""`.
## Tests
- Added coverage for object-shaped `toolresult.text`.
- Added coverage for object-shaped stream results.
- Verified synthesized message content contains stringified JSON, not `[object Object]`.
## Verification
- `cd ui && npm run build` passed.
- `cd ui && npm test` ran unit tests successfully, but the full command exited non-zero because Playwright Chromium is not installed in this local environment.
## Local test note
Vitest’s Playwright project could not launch Chromium from `~/.cache/ms-playwright`. This appears to be an environment issue, not a failure in the updated code or assertions.
## Maintainer note
The empty-string behavior changed intentionally from truthy omission to explicit preservation. If preferred, this can be adjusted to hide empty outputs while still fixing object formatting.
