### PR TITLE
fix(session-status): thread runtime model override into session_status tool (#77493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Voice Call/realtime: bound the paced Twilio audio queue and close overloaded realtime streams before provider audio can pile up behind the websocket backpressure guard. Thanks @vincentkoc.
 - Google Meet: preserve `realtime.introMessage: ""` so realtime Chrome joins can stay silent instead of restoring the default spoken intro. Thanks @vincentkoc.
 - OpenAI/Codex media: advertise Codex audio transcription in runtime and manifest metadata and route active Codex chat models to the OpenAI transcription default instead of sending chat model ids to audio transcription. Thanks @vincentkoc.
+- Agents/session-status: thread the active runtime model (e.g. `heartbeat.model`) into the `session_status` tool so heartbeat runs report their actual executing model instead of the session-stored default. Fixes #77493. Thanks @hclsys.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Cron CLI: add `openclaw cron list --agent <id>`, normalize the requested agent id, and include jobs without a stored agent id under the configured default agent while keeping `cron list` unfiltered when no agent is supplied. Fixes #77118. Thanks @zhanggttry.
 - Status: show compact Gateway process uptime and host system uptime in `/status`, making restart and host-lifetime checks visible from chat. Thanks @vincentkoc.

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -1838,6 +1838,63 @@ describe("session_status tool", () => {
     expect(details.sessionKey).toBe("main");
   });
 
+  it("uses runtimeModelOverride as the displayed model for sessionKey=current (#77493)", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "heartbeat-run",
+        updatedAt: 10,
+        modelOverride: "openai-codex/gpt-5.3-codex",
+      },
+    });
+
+    const tool = createSessionStatusTool({
+      agentSessionKey: "main",
+      config: mockConfig as never,
+      runtimeModelOverride: "openai-codex/gpt-5.4-codex-spark",
+    });
+
+    await tool.execute("call-heartbeat-override", { sessionKey: "current" });
+
+    expect(buildStatusMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({
+          model: expect.objectContaining({
+            primary: "openai-codex/gpt-5.4-codex-spark",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not apply runtimeModelOverride for explicit non-current session lookups", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s-explicit",
+        updatedAt: 10,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.4",
+      },
+    });
+
+    const tool = createSessionStatusTool({
+      agentSessionKey: "main",
+      config: mockConfig as never,
+      runtimeModelOverride: "openai-codex/gpt-5.4-codex-spark",
+    });
+
+    await tool.execute("call-explicit", { sessionKey: "main" });
+
+    expect(buildStatusMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({
+          model: expect.objectContaining({
+            primary: "openai/gpt-5.4",
+          }),
+        }),
+      }),
+    );
+  });
+
   it("resets per-session model override via model=default", async () => {
     resetSessionStore({
       main: {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -615,6 +615,10 @@ export function createOpenClawTools(
       runSessionKey: options?.runSessionKey,
       config: resolvedConfig,
       sandboxed: options?.sandboxed,
+      runtimeModelOverride:
+        options?.modelProvider && options?.modelId
+          ? `${options.modelProvider}/${options.modelId}`
+          : undefined,
     }),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),
   ];

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -284,6 +284,13 @@ export function createSessionStatusTool(opts?: {
   runSessionKey?: string;
   config?: OpenClawConfig;
   sandboxed?: boolean;
+  /**
+   * Active runtime provider/model override for the current run (e.g. "openai-codex/gpt-5.2").
+   * When present and the caller requests sessionKey:"current", the status card displays this
+   * model instead of the session entry's stored default — so heartbeat runs with a
+   * per-turn model override report their actual executing model.
+   */
+  runtimeModelOverride?: string;
 }): AnyAgentTool {
   return {
     label: "Session Status",
@@ -612,10 +619,14 @@ export function createSessionStatusTool(opts?: {
           : resolved.entry;
       const providerOverrideForCard = statusSessionEntry.providerOverride?.trim();
       const providerForCard = providerOverrideForCard ?? defaultProviderForCard;
-      const primaryModelLabel =
+      const storedPrimaryModelLabel =
         providerForCard && defaultModelForCard
           ? `${providerForCard}/${defaultModelForCard}`
           : defaultModelForCard;
+      const primaryModelLabel =
+        isSemanticCurrentRequest && opts?.runtimeModelOverride
+          ? opts.runtimeModelOverride
+          : storedPrimaryModelLabel;
       const isGroup =
         statusSessionEntry.chatType === "group" ||
         statusSessionEntry.chatType === "channel" ||


### PR DESCRIPTION
## Summary

Fixes #77493: when a heartbeat run specifies `heartbeat.model`, calling `session_status` with `sessionKey:"current"` displayed the session-stored default model instead of the actively executing one.

**Root cause:** `createSessionStatusTool` reads `sessionEntry.modelOverride` (stored on the entry at session-creation time), which is never updated during a heartbeat run. The resolved heartbeat model exists in `get-reply.ts` and the pi-embedded-runner attempt context (`params.provider` / `params.modelId`) but was not threaded into the tool.

**Fix (3 changes, ~25 LOC net):**

1. `src/agents/tools/session-status-tool.ts` — add `runtimeModelOverride?: string` opt; when `isSemanticCurrentRequest && runtimeModelOverride`, use it as `primaryModelLabel` instead of the stored entry label.
2. `src/agents/openclaw-tools.ts` — pass `runtimeModelOverride: \`${modelProvider}/${modelId}\`` from the existing `options.modelProvider` / `options.modelId` already threaded through from the attempt context.
3. `src/agents/openclaw-tools.session-status.test.ts` — 2 new tests: one verifying the override applies for `sessionKey:"current"`, one verifying it does NOT apply for explicit non-current key lookups.

## Test plan

- [x] `pnpm test src/agents/openclaw-tools.session-status.test.ts` — 52 tests pass (was 50)
- [x] `node scripts/run-bundled-extension-oxlint.mjs` — 0 warnings, 0 errors
- [x] `pnpm exec oxfmt --check` on all 4 modified files — all correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real behavior proof
- **Behavior or issue addressed**: `session_status` now receives the active runtime model override from the running tool context, so heartbeat or per-run model overrides report the actual executing model instead of only the persisted session default.
- **Real environment tested**: Local OpenClaw checkout on branch `fix/77493-session-status-runtime-model`; Node/Vitest agent tool runner from this repository.
- **Exact steps or command run after this patch**: `pnpm test src/agents/openclaw-tools.session-status.test.ts`
- **Evidence after fix**: Terminal output from the after-patch run:

```text
[test] starting test/vitest/vitest.agents.config.ts
Test Files  1 passed (1)
Tests  52 passed (52)
[test] passed 1 Vitest shard in 6.07s
```

- **Observed result after fix**: The session-status tool shard passed, including the focused runtime-model override coverage that verifies the active provider/model is threaded into `session_status`.
- **What was not tested**: Did not run a live heartbeat agent against an external provider; verification used the repository's session-status tool coverage.
