### PR TITLE
[codex] Fix missing channel plugin diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/OpenAI: default direct OpenAI Responses models to the SSE transport instead of WebSocket auto-selection, preventing pi runtime chat turns from hanging on servers where the WebSocket path stalls while the OpenAI HTTP stream works. Thanks @vincentkoc.
+- Doctor/config: report missing catalog-backed channel plugin entries as repairable installs, so upgrades with Discord or WhatsApp config point to `openclaw doctor --fix` instead of telling users to remove valid plugin config. Fixes #77483.
 - CLI/update: disable and skip plugins that fail package-update plugin sync, so a broken npm/ClawHub/git/marketplace plugin cannot turn a successful OpenClaw package update into a failed update result. Thanks @vincentkoc.
 - CLI/update: use an absolute POSIX npm script shell during package-manager updates, so restricted PATH environments can still run dependency lifecycle scripts while updating from `--tag main`. Fixes #77530. Thanks @PeterTremonti.
 - Diagnostics: grant the internal diagnostics event bus to official installed diagnostics exporter plugins, so npm-installed `@openclaw/diagnostics-prometheus` can emit metrics without broadening the capability to arbitrary global plugins. Fixes #76628. Thanks @RayWoo.

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -497,6 +497,45 @@ describe("config plugin validation", () => {
     });
   });
 
+  it("points missing installable plugin entries at doctor repair", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        channels: {
+          discord: { token: "xxx" },
+          whatsapp: {},
+        },
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+            whatsapp: { enabled: true },
+          },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    expect(res.warnings ?? []).toContainEqual({
+      path: "plugins.entries.discord",
+      message:
+        "plugin not installed: discord (Discord; run openclaw doctor --fix or openclaw plugins install @openclaw/discord; config preserved)",
+    });
+    expect(res.warnings ?? []).toContainEqual({
+      path: "plugins.entries.whatsapp",
+      message:
+        "plugin not installed: whatsapp (WhatsApp; run openclaw doctor --fix or openclaw plugins install @openclaw/whatsapp; config preserved)",
+    });
+  });
+
   it("uses persisted installed-plugin records as stale channel evidence", async () => {
     const installedPluginIndexPath = path.join(suiteHome, ".openclaw", "plugins", "installs.json");
     await mkdirSafe(path.dirname(installedPluginIndexPath));

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -13,6 +13,11 @@ import { loadInstalledPluginIndexInstallRecordsSync } from "../plugins/installed
 import { resolveManifestCommandAliasOwnerInRegistry } from "../plugins/manifest-command-aliases.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import {
+  getOfficialExternalPluginCatalogEntry,
+  resolveOfficialExternalPluginInstall,
+  resolveOfficialExternalPluginLabel,
+} from "../plugins/official-external-plugin-catalog.js";
+import {
   loadPluginMetadataSnapshot,
   type PluginMetadataSnapshot,
 } from "../plugins/plugin-metadata-snapshot.js";
@@ -1473,10 +1478,23 @@ function validateConfigObjectWithPluginsBase(
       blockedDiagnosticSourceMatchesPluginId(diagnostic, pluginId),
     );
   };
+  const formatInstallablePluginWarning = (pluginId: string): string | null => {
+    const catalogEntry = getOfficialExternalPluginCatalogEntry(pluginId);
+    if (!catalogEntry) {
+      return null;
+    }
+    const install = resolveOfficialExternalPluginInstall(catalogEntry);
+    const installSpec = install?.npmSpec ?? install?.clawhubSpec;
+    if (!installSpec) {
+      return null;
+    }
+    const label = resolveOfficialExternalPluginLabel(catalogEntry);
+    return `plugin not installed: ${pluginId} (${label}; run openclaw doctor --fix or openclaw plugins install ${installSpec}; config preserved)`;
+  };
   const pushMissingPluginIssue = (
     path: string,
     pluginId: string,
-    opts?: { warnOnly?: boolean },
+    opts?: { warnOnly?: boolean; doctorRepairable?: boolean },
   ) => {
     if (LEGACY_REMOVED_PLUGIN_IDS.has(pluginId)) {
       warnings.push({
@@ -1497,9 +1515,14 @@ function validateConfigObjectWithPluginsBase(
       return;
     }
     if (opts?.warnOnly) {
+      const installablePluginWarning = opts.doctorRepairable
+        ? formatInstallablePluginWarning(pluginId)
+        : null;
       warnings.push({
         path,
-        message: `plugin not found: ${pluginId} (stale config entry ignored; remove it from plugins config)`,
+        message:
+          installablePluginWarning ??
+          `plugin not found: ${pluginId} (stale config entry ignored; remove it from plugins config)`,
       });
       return;
     }
@@ -1516,7 +1539,10 @@ function validateConfigObjectWithPluginsBase(
     for (const pluginId of Object.keys(entries)) {
       if (!knownIds.has(pluginId)) {
         // Keep gateway startup resilient when plugins are removed/renamed across upgrades.
-        pushMissingPluginIssue(`plugins.entries.${pluginId}`, pluginId, { warnOnly: true });
+        pushMissingPluginIssue(`plugins.entries.${pluginId}`, pluginId, {
+          warnOnly: true,
+          doctorRepairable: true,
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary
- Treat missing catalog-backed `plugins.entries.*` channel plugins as repairable installs instead of stale config.
- Keep `plugins.allow` on the existing stale-config warning path because `openclaw doctor --fix` does not repair allow-only references.
- Use neutral `plugin not installed` wording so third-party catalog entries are not labeled as OpenClaw-official.
- Add regression coverage for Discord and WhatsApp upgrade-style config.

## Root Cause
After bundled channel plugins were externalized, upgraded configs can still contain valid `plugins.entries.discord` or `plugins.entries.whatsapp` references while the plugin package is absent from the current manifest registry. Validation previously treated those entries the same as truly stale plugin IDs and told users to remove valid config, even though doctor already has an install repair path for missing configured plugin entries.

## Behavior Change
For missing installable plugin entries, config validation now reports:

```text
plugin not installed: discord (Discord; run openclaw doctor --fix or openclaw plugins install @openclaw/discord; config preserved)
```

Unknown or allow-only plugin references still use the old stale-config warning, avoiding a repair suggestion that doctor cannot complete.

## Verification
- `pnpm test src/config/config.plugin-validation.test.ts -- --reporter=dot`
- `pnpm test src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/commands/doctor/shared/stale-plugin-config.test.ts -- --reporter=dot`
- `pnpm exec oxfmt --check --threads=1 src/config/validation.ts src/config/config.plugin-validation.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `pnpm check:changed`

## Notes
Blacksmith Testbox changed-gate attempts did not reach repo commands because both fresh leases shut down while queued: `tbx_01kqtga2jvntf4ft6vdzxrkwpb`, `tbx_01kqtgbp3r99jr04v5zfte47nf`. Local `pnpm check:changed` initially exposed a stale local dependency tree missing `web-tree-sitter`; `pnpm install` repaired `node_modules` with no tracked file changes, then `pnpm check:changed` passed.

Fixes #77483
