### PR TITLE
feat(cli): list pending exec approvals (#9987)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Status: show compact Gateway process uptime and host system uptime in `/status`, making restart and host-lifetime checks visible from chat. Thanks @vincentkoc.
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.
 - Gateway/Windows: bind the default loopback gateway listener only to `127.0.0.1` on Windows so libuv's dual-stack `::1` behavior cannot wedge localhost HTTP requests. (#69701, fixes #69674) Thanks @SARAMALI15792.
+- CLI/approvals: add `openclaw approvals pending [--json]` to list unresolved exec approval requests from the Gateway, including the approval id, agent, host, command preview, wait time, and TTL. Fixes #9987. Thanks @hclsys.
 - Slack/streaming: add `streaming.progress.render: "rich"` for Block Kit progress drafts backed by structured progress line data.
 - Slack/streaming: keep the newest rich progress lines when Block Kit limits trim long progress drafts. Thanks @vincentkoc.
 - Channels/streaming: cap progress-draft tool lines by default so edited progress boxes avoid jumpy reflow from long wrapped lines.

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -63,6 +63,9 @@ or `openclaw approvals set --node <id|name|ip>`.
 openclaw approvals get
 openclaw approvals get --node <id|name|ip>
 openclaw approvals get --gateway
+
+openclaw approvals pending
+openclaw approvals pending --json
 ```
 
 `openclaw approvals get` now shows the effective exec policy for local, gateway, and node targets:
@@ -77,6 +80,19 @@ Precedence is intentional:
 - requested `tools.exec` policy can narrow or broaden intent, but the effective result is still derived from the host rules
 - `--node` combines the node host approvals file with gateway `tools.exec` policy, because both still apply at runtime
 - if gateway config is unavailable, the CLI falls back to the node approvals snapshot and notes that the final runtime policy could not be computed
+
+`openclaw approvals pending` queries the running Gateway for unresolved exec approval
+requests. Use it when a headless agent or chat surface reports an approval id and
+you need to inspect the requested command from a terminal:
+
+```bash
+openclaw approvals pending
+openclaw approvals pending --json
+```
+
+The table output shows the approval id prefix, agent, host, command preview,
+wait time, and time remaining. The JSON output returns the raw
+`exec.approval.list` records for monitoring and scripting.
 
 ## Replace approvals from a file
 
@@ -176,6 +192,10 @@ Targeting notes:
 `allowlist add|remove` also supports:
 
 - `--agent <id>` (defaults to `*`)
+
+`pending` queries the running Gateway only, so it supports shared Gateway RPC
+options (`--url`, `--token`, `--timeout`, `--json`) but not `--node` or
+`--gateway`.
 
 ## Notes
 

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -24,7 +24,9 @@ const mocks = vi.hoisted(() => {
     }),
   };
   return {
-    callGatewayFromCli: vi.fn(async (method: string, _opts: unknown, params?: unknown) => {
+    callGatewayFromCli: vi.fn<
+      (method: string, _opts: unknown, params?: unknown) => Promise<unknown>
+    >(async (method: string, _opts: unknown, params?: unknown) => {
       if (method.endsWith(".get")) {
         if (method === "config.get") {
           return {
@@ -210,6 +212,65 @@ describe("exec approvals CLI", () => {
       }),
       0,
     );
+  });
+
+  it("lists pending approval requests", async () => {
+    const now = Date.now();
+    callGatewayFromCli.mockImplementation(async (method: string, _opts: unknown) => {
+      if (method === "exec.approval.list") {
+        return [
+          {
+            id: "8332daed-1111-4444-8888-000000000000",
+            request: {
+              command: "cat << 'EOF'\nhello\nEOF",
+              commandPreview: "cat << 'EOF' ... EOF",
+              agentId: "main",
+              host: "gateway",
+            },
+            createdAtMs: now - 45_000,
+            expiresAtMs: now + 1_755_000,
+          },
+        ];
+      }
+      return { method };
+    });
+
+    await runApprovalsCommand(["approvals", "pending"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "exec.approval.list",
+      expect.objectContaining({ timeout: "10000" }),
+      {},
+    );
+    const output = defaultRuntime.log.mock.calls.map((args) => String(args[0])).join("\n");
+    expect(output).toContain("8332daed");
+    expect(output).toContain("main");
+    expect(output).toContain("gateway");
+    expect(output).toContain("cat << 'EOF' ... EOF");
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("prints pending approval requests as json", async () => {
+    const pending = [
+      {
+        id: "approval-json-1",
+        request: {
+          command: "/usr/bin/file /tmp/media.ogg",
+          agentId: "main",
+          host: "node",
+        },
+        createdAtMs: 1,
+        expiresAtMs: 2,
+      },
+    ];
+    callGatewayFromCli.mockImplementation(async (method: string) =>
+      method === "exec.approval.list" ? pending : { method },
+    );
+
+    await runApprovalsCommand(["approvals", "pending", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(pending, 0);
+    expect(runtimeErrors).toHaveLength(0);
   });
 
   it("reports wildcard host policy sources in effective policy output", async () => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -12,6 +12,7 @@ import {
   saveExecApprovals,
   type ExecApprovalsAgent,
   type ExecApprovalsFile,
+  type ExecApprovalRequestPayload,
 } from "../infra/exec-approvals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { defaultRuntime } from "../runtime.js";
@@ -45,6 +46,13 @@ type EffectivePolicyReport = {
   note?: string;
 };
 const APPROVALS_GET_DEFAULT_TIMEOUT_MS = 60_000;
+
+type PendingExecApproval = {
+  id: string;
+  request: ExecApprovalRequestPayload;
+  createdAtMs: number;
+  expiresAtMs: number;
+};
 
 type ExecApprovalsCliOpts = NodesRpcOpts & {
   node?: string;
@@ -360,6 +368,49 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
   );
 }
 
+function formatPendingApprovalCommand(request: ExecApprovalRequestPayload): string {
+  const raw = normalizeOptionalString(request.commandPreview) ?? request.command;
+  const safe = sanitizeForLog(raw);
+  return safe.length > 160 ? `${safe.slice(0, 157)}...` : safe;
+}
+
+function formatPendingApprovalId(id: string): string {
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+function renderPendingApprovals(records: PendingExecApproval[]) {
+  const muted = (text: string) => (isRich() ? theme.muted(text) : text);
+  if (records.length === 0) {
+    defaultRuntime.log(muted("No pending exec approvals."));
+    return;
+  }
+
+  const now = Date.now();
+  const rows = records.map((record) => ({
+    ID: formatPendingApprovalId(record.id),
+    Agent: normalizeOptionalString(record.request.agentId) ?? "unknown",
+    Host: normalizeOptionalString(record.request.host) ?? "unknown",
+    Command: formatPendingApprovalCommand(record.request),
+    Waiting: formatTimeAgo(now - record.createdAtMs, { suffix: false }),
+    TTL: formatTimeAgo(record.expiresAtMs - now, { suffix: false }),
+  }));
+
+  defaultRuntime.log(
+    renderTable({
+      width: getTerminalTableWidth(),
+      columns: [
+        { key: "ID", header: "ID", minWidth: 8 },
+        { key: "Agent", header: "Agent", minWidth: 8 },
+        { key: "Host", header: "Host", minWidth: 8 },
+        { key: "Command", header: "Command", minWidth: 24, flex: true },
+        { key: "Waiting", header: "Waiting", minWidth: 8 },
+        { key: "TTL", header: "TTL", minWidth: 6 },
+      ],
+      rows,
+    }).trimEnd(),
+  );
+}
+
 async function saveSnapshot(
   opts: ExecApprovalsCliOpts,
   nodeId: string | null,
@@ -520,6 +571,28 @@ export function registerExecApprovalsCli(program: Command) {
       }
     });
   nodesCallOpts(getCmd, { timeoutMs: APPROVALS_GET_DEFAULT_TIMEOUT_MS });
+
+  const pendingCmd = approvals
+    .command("pending")
+    .description("List pending exec approval requests")
+    .action(async (opts: ExecApprovalsCliOpts) => {
+      try {
+        const records = (await callGatewayFromCli(
+          "exec.approval.list",
+          opts,
+          {},
+        )) as unknown as PendingExecApproval[];
+        if (opts.json) {
+          defaultRuntime.writeJson(records, 0);
+          return;
+        }
+        renderPendingApprovals(records);
+      } catch (err) {
+        defaultRuntime.error(formatCliError(err));
+        defaultRuntime.exit(1);
+      }
+    });
+  nodesCallOpts(pendingCmd);
 
   const setCmd = approvals
     .command("set")


### PR DESCRIPTION
Fixes #9987

Summary:
- add `openclaw approvals pending` to list pending exec approval requests from the gateway
- show approval id prefix, agent, host, command preview, waiting time, and TTL in table output
- add `--json` for raw `exec.approval.list` records
- document the command and add a changelog entry

Validation:
- `pnpm test src/cli/exec-approvals-cli.test.ts`
- `pnpm exec oxlint src/cli/exec-approvals-cli.ts src/cli/exec-approvals-cli.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cli/exec-approvals-cli.ts src/cli/exec-approvals-cli.test.ts docs/cli/approvals.md CHANGELOG.md`
- `pnpm check:changed`

Audits:
- existing helper reused: `exec.approval.list`
- shared callers: no shared helper contract changed
- broader rival: no active #9987 rival PR found

## Real behavior proof
- **Behavior or issue addressed**: `openclaw approvals pending` now lists unresolved exec approval requests from the Gateway, including table output and `--json` output backed by the existing `exec.approval.list` RPC.
- **Real environment tested**: Local OpenClaw checkout on branch `feat/9987-approvals-pending-cli`; Node/Vitest CLI runner from this repository.
- **Exact steps or command run after this patch**: `pnpm test src/cli/exec-approvals-cli.test.ts`
- **Evidence after fix**: Terminal output from the after-patch run:

```text
[test] starting test/vitest/vitest.cli.config.ts
Test Files  1 passed (1)
Tests  13 passed (13)
[test] passed 1 Vitest shard in 3.20s
```

- **Observed result after fix**: The CLI approvals shard passed, including pending-approval table/json output coverage for the new command.
- **What was not tested**: Did not connect to a live Gateway with real pending exec approvals; verification used the repository's CLI coverage for the Gateway RPC response shape.
