### PR TITLE
feat(cli-runner): opt-in flag to reseed from raw transcript when no compaction exists

### DIFF
--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -410,6 +410,8 @@ export async function prepareCliRunContext(
           sessionKey: params.sessionKey,
           agentId: params.agentId,
           config: params.config,
+          allowRawTranscriptReseed:
+            backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true,
         }),
         prompt: preparedPrompt,
       });

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -249,6 +249,72 @@ describe("loadCliSessionReseedMessages", () => {
     }
   });
 
+  it("reseeds from raw transcript tail when allowRawTranscriptReseed is opted in", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const sessionFile = createSessionTranscript({
+      rootDir: stateDir,
+      sessionId: "session-opt-in",
+      messages: ["earlier turn", "later turn"],
+    });
+
+    try {
+      const reseed = await loadCliSessionReseedMessages({
+        sessionId: "session-opt-in",
+        sessionFile,
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        allowRawTranscriptReseed: true,
+      });
+      expect(reseed).toMatchObject([
+        { role: "user", content: "earlier turn" },
+        { role: "user", content: "later turn" },
+      ]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to raw transcript tail when compaction summary is empty and opt-in is set", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const sessionFile = createSessionTranscript({
+      rootDir: stateDir,
+      sessionId: "session-empty-summary",
+      messages: ["pre-compaction", "post-compaction"],
+    });
+    // Insert a compaction entry with an empty summary between the two messages.
+    const original = fs.readFileSync(sessionFile, "utf-8").trimEnd().split("\n");
+    const reordered = [
+      ...original.slice(0, 2),
+      JSON.stringify({
+        type: "compaction",
+        id: "compaction-empty",
+        parentId: "msg-0",
+        timestamp: new Date(2).toISOString(),
+        summary: "   ",
+      }),
+      ...original.slice(2),
+    ].join("\n");
+    fs.writeFileSync(sessionFile, `${reordered}\n`, "utf-8");
+
+    try {
+      const reseed = await loadCliSessionReseedMessages({
+        sessionId: "session-empty-summary",
+        sessionFile,
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        allowRawTranscriptReseed: true,
+      });
+      expect(reseed).toMatchObject([
+        { role: "user", content: "pre-compaction" },
+        { role: "user", content: "post-compaction" },
+      ]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("reseeds fresh CLI sessions from the latest compaction summary and post-compaction tail", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -190,20 +190,43 @@ export async function loadCliSessionReseedMessages(params: {
   sessionKey?: string;
   agentId?: string;
   config?: OpenClawConfig;
+  /**
+   * Opt-in fallback: when no compaction summary exists yet (or its summary is
+   * empty), return the most recent raw transcript messages so a freshly
+   * resumed CLI session has continuity instead of waking up empty. Default
+   * `false` preserves the long-standing safety property — pre-compaction
+   * transcripts may contain raw context the operator does not want bleeding
+   * into a resumed session. Operators with single-user, single-consumer
+   * setups (where the agent is the only reader of its own transcripts) can
+   * set this to `true` to trade that filter for restart continuity.
+   */
+  allowRawTranscriptReseed?: boolean;
 }): Promise<unknown[]> {
   const entries = await loadCliSessionEntries(params);
   const latestCompactionIndex = entries.findLastIndex((entry) => {
     const candidate = entry as HistoryEntry;
     return candidate.type === "compaction" && typeof candidate.summary === "string";
   });
+
+  const fallbackToRawTail = (): unknown[] => {
+    if (!params.allowRawTranscriptReseed) {
+      return [];
+    }
+    const allMessages = entries.flatMap((entry) => {
+      const candidate = entry as HistoryEntry;
+      return candidate.type === "message" ? [candidate.message] : [];
+    });
+    return limitAgentHookHistoryMessages(allMessages, MAX_CLI_SESSION_HISTORY_MESSAGES);
+  };
+
   if (latestCompactionIndex < 0) {
-    return [];
+    return fallbackToRawTail();
   }
 
   const compaction = entries[latestCompactionIndex] as HistoryEntry;
   const summary = typeof compaction.summary === "string" ? compaction.summary.trim() : "";
   if (!summary) {
-    return [];
+    return fallbackToRawTail();
   }
 
   const tailMessages = entries.slice(latestCompactionIndex + 1).flatMap((entry) => {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -147,6 +147,18 @@ export type CliBackendConfig = {
   imagePathScope?: "temp" | "workspace";
   /** Serialize runs for this CLI. */
   serialize?: boolean;
+  /**
+   * Opt-in: when a freshly resumed CLI session has no compaction summary to
+   * reseed from, fall back to the most recent raw transcript messages
+   * (capped at MAX_CLI_SESSION_HISTORY_MESSAGES) so the resumed session has
+   * continuity instead of waking up empty. Default `false` preserves the
+   * long-standing safety property — pre-compaction transcripts may contain
+   * raw context the operator does not want bleeding into a resumed session.
+   * Operators with single-user, single-consumer setups (where the agent is
+   * the only reader of its own transcripts) can set this to `true` to trade
+   * that filter for restart continuity.
+   */
+  reseedFromRawTranscriptWhenUncompacted?: boolean;
   /** Runtime reliability tuning for this backend's process lifecycle. */
   reliability?: {
     /** Live-session output caps for CLIs that stream JSONL through a long-lived process. */


### PR DESCRIPTION
## Summary

Today `loadCliSessionReseedMessages` returns `[]` for any CLI session that has not yet compacted, even after a gateway restart. This is the intentional safety property asserted by the existing test [`"does not reseed fresh CLI sessions from raw transcript history before compaction"`](https://github.com/openclaw/openclaw/blob/main/src/agents/cli-runner/session-history.test.ts#L229) — pre-compaction transcripts may contain raw operator context that should not bleed into a resumed session, and compaction is treated as the filtering boundary. The literal `"raw secret"` test data makes that intent unambiguous.

The cost of that safety default is restart amnesia for operators in trusted single-user / single-consumer environments: a gateway restart that invalidates the resumeSession (mcp/system-prompt hash mismatch is routine) drops all prior thread state with no way to opt back in.

## Change

This PR adds an opt-in `CliBackendConfig` field `reseedFromRawTranscriptWhenUncompacted` (default `false`) plus a matching `allowRawTranscriptReseed?: boolean` parameter on `loadCliSessionReseedMessages`. The default behavior is unchanged — pre-compaction transcripts still short-circuit to `[]` when the flag is not set, and the existing safety test passes untouched. When opted in, the function falls back to the most recent `MAX_CLI_SESSION_HISTORY_MESSAGES` from the raw transcript, mirroring what `loadCliSessionHistoryMessages` already does for hooks.

`prepare.ts` reads the flag off `backendResolved.config.reseedFromRawTranscriptWhenUncompacted` and threads it through, so a per-backend setting like:

```jsonc
{
  "agents": {
    "defaults": {
      "cliBackends": {
        "claude-cli": {
          "reseedFromRawTranscriptWhenUncompacted": true
        }
      }
    }
  }
}
```

…controls the behavior without any code changes from the operator.

## Why this matters in practice

A team running OpenClaw on a single operator's workstation (where the agent is the only consumer of its own transcripts) currently has to maintain a vendored patch over this function to survive gateway restarts. An opt-in flag removes the need for that vendored patch upstream-permanently while preserving the safety default for everyone else.

## Tests

Three test cases cover this code path:

- *Existing*: `"does not reseed fresh CLI sessions from raw transcript history before compaction"` — unchanged. Asserts `[]` is still returned by default. Still passes.
- *New*: `"reseeds from raw transcript tail when allowRawTranscriptReseed is opted in"` — asserts the opt-in returns the recent message tail in the no-compaction case.
- *New*: `"falls back to raw transcript tail when compaction summary is empty and opt-in is set"` — asserts the opt-in branch also covers the existing `if (!summary) return [];` short-circuit.

## Considered alternative

A larger architectural option is *"force a compaction at restart time, then reseed the compacted summary"* — that preserves the safety boundary AND solves the amnesia problem without an opt-in flag at all. More invasive (needs a compaction trigger on `gateway:startup` or just-before-resume). I'd be happy to file that as a follow-up issue if maintainers prefer that direction long-term; this PR is the smallest change that unblocks the use case while being explicit about the safety tradeoff via the flag name and docstring.
