### PR TITLE
fix: expose ollama thinking profile before activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Ollama/thinking: expose the lightweight Ollama provider thinking profile through the public provider-policy artifact too, so reasoning-capable Ollama models such as `ollama/deepseek-v4-pro:cloud` keep `/think max` available even before the full plugin runtime activates. Fixes #77612. Thanks @rriggs.
 - CLI/sessions: prune old unreferenced transcript, compaction checkpoint, and trajectory artifacts during normal `sessions cleanup`, so gateway restart or crash orphans do not accumulate indefinitely outside `sessions.json`. Fixes #77608. Thanks @slideshow-dingo.
 - Video generation: wait up to 20 minutes for slow fal/MiniMax queue-backed jobs, stop forwarding unsupported Google Veo generated-audio options, and normalize MiniMax `720P` requests to its supported `768P` resolution with the usual override warning/details instead of failing fallback.
 - Update/restart: probe managed Gateway restarts with the service environment and add a Docker product lane that exercises candidate-owned `openclaw update --yes --json` restarts, so SecretRef-backed local gateway auth cannot regress behind mocked restart checks. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Ollama/thinking: expose the lightweight Ollama provider thinking profile through the public provider-policy artifact too, so reasoning-capable Ollama models such as `ollama/deepseek-v4-pro:cloud` keep `/think max` available even before the full plugin runtime activates. Fixes #77612. Thanks @rriggs.
 - CLI/sessions: prune old unreferenced transcript, compaction checkpoint, and trajectory artifacts during normal `sessions cleanup`, so gateway restart or crash orphans do not accumulate indefinitely outside `sessions.json`. Fixes #77608. Thanks @slideshow-dingo.
 - Video generation: wait up to 20 minutes for slow fal/MiniMax queue-backed jobs, stop forwarding unsupported Google Veo generated-audio options, and normalize MiniMax `720P` requests to its supported `768P` resolution with the usual override warning/details instead of failing fallback.
 - Update/restart: probe managed Gateway restarts with the service environment and add a Docker product lane that exercises candidate-owned `openclaw update --yes --json` restarts, so SecretRef-backed local gateway auth cannot regress behind mocked restart checks. Thanks @vincentkoc.
@@ -311,6 +310,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/sessions: cache selected model override resolution while building session-list rows so `openclaw sessions` and Control UI session lists stay responsive on model-heavy stores. (#77650) Thanks @ragesaq.
 - Agents/session-file-repair: drop `type: "message"` entries with a missing, `null`, or blank role during the on-disk repair pass so sessions that accumulated null-role JSONL corruption (such as the 935+ corrupt entries in #77228) get fully cleaned up rather than carried forward into the repaired file. Refs #77228. (#77288) Thanks @openperf.
 - Doctor/device pairing: stop suggesting `openclaw devices rotate --role <role>` for stale local cached device auth when that role is no longer approved by the gateway pairing record, so doctor no longer points users at a command that must be denied. (#77688) Thanks @Conan-Scott.
+- Ollama/thinking: expose the lightweight Ollama provider thinking profile through the public provider-policy artifact too, so reasoning-capable Ollama models such as `ollama/deepseek-v4-pro:cloud` keep `/think max` available even before the full plugin runtime activates. (#77617, fixes #77612) Thanks @rriggs and @yfge.
 
 ## 2026.5.3-1
 

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -27,6 +27,7 @@ import {
   promptAndConfigureOllama,
   queryOllamaModelShowInfo,
 } from "./api.js";
+import { resolveThinkingProfile as resolveOllamaThinkingProfile } from "./provider-policy-api.js";
 import {
   OLLAMA_DEFAULT_API_KEY,
   OLLAMA_PROVIDER_ID,
@@ -249,13 +250,7 @@ export default definePluginEntry({
       contributeResolvedModelCompat: ({ model }) =>
         usesOllamaOpenAICompatTransport(model) ? { supportsUsageInStreaming: true } : undefined,
       resolveReasoningOutputMode: () => "native",
-      resolveThinkingProfile: ({ reasoning }) => ({
-        levels:
-          reasoning === true
-            ? [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }]
-            : [{ id: "off" }],
-        defaultLevel: "off",
-      }),
+      resolveThinkingProfile: resolveOllamaThinkingProfile,
       wrapStreamFn: createConfiguredOllamaCompatStreamWrapper,
       createEmbeddingProvider: async ({ config, model, provider: embeddingProvider, remote }) => {
         const { provider, client } = await createOllamaEmbeddingProvider({

--- a/extensions/ollama/provider-policy-api.test.ts
+++ b/extensions/ollama/provider-policy-api.test.ts
@@ -1,6 +1,6 @@
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { describe, expect, it } from "vitest";
-import { normalizeConfig } from "./provider-policy-api.js";
+import { normalizeConfig, resolveThinkingProfile } from "./provider-policy-api.js";
 import { OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
 
 function createModel(id: string, name: string): ModelDefinitionConfig {
@@ -57,5 +57,16 @@ describe("ollama provider policy public artifact", () => {
         providerConfig: {},
       }),
     ).toEqual({});
+  });
+
+  it("exposes max thinking for reasoning-capable models without full plugin activation", () => {
+    expect(resolveThinkingProfile({ reasoning: true })).toEqual({
+      levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
+      defaultLevel: "off",
+    });
+    expect(resolveThinkingProfile({ reasoning: false })).toEqual({
+      levels: [{ id: "off" }],
+      defaultLevel: "off",
+    });
   });
 });

--- a/extensions/ollama/provider-policy-api.ts
+++ b/extensions/ollama/provider-policy-api.ts
@@ -1,7 +1,18 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
 
 type OllamaProviderConfigDraft = Partial<ModelProviderConfig>;
+
+const OLLAMA_REASONING_THINKING_PROFILE = {
+  levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
+  defaultLevel: "off",
+} satisfies ProviderThinkingProfile;
+
+const OLLAMA_NON_REASONING_THINKING_PROFILE = {
+  levels: [{ id: "off" }],
+  defaultLevel: "off",
+} satisfies ProviderThinkingProfile;
 
 /**
  * Provider policy surface for Ollama: normalize provider configs used by
@@ -37,4 +48,12 @@ export function normalizeConfig({
   }
 
   return next;
+}
+
+export function resolveThinkingProfile({
+  reasoning,
+}: {
+  reasoning?: boolean;
+}): ProviderThinkingProfile {
+  return reasoning ? OLLAMA_REASONING_THINKING_PROFILE : OLLAMA_NON_REASONING_THINKING_PROFILE;
 }


### PR DESCRIPTION
## Summary
- expose Ollama's reasoning-capable thinking profile from the lightweight provider-policy artifact
- keep `/think max` available for reasoning-capable Ollama models before the full Ollama plugin runtime activates
- add regression coverage for the public artifact path

## Changes
- add `resolveThinkingProfile()` to `extensions/ollama/provider-policy-api.ts`
- reuse that resolver from the full Ollama runtime registration
- return `off/low/medium/high/max` for reasoning-capable Ollama models and `off` otherwise
- document the fix in `CHANGELOG.md`

## Real behavior proof
- **Behavior or issue addressed**: `ollama/deepseek-v4-pro:cloud` rejected `/think max` before the Ollama plugin runtime activated.
- **Real environment tested**: local OpenClaw build from this PR worktree (`openclaw 2026.5.4`, head `ecde0494faae975180bcda243f80472b810a0f18`) with built runtime artifacts generated by `pnpm openclaw models --help`.
- **Exact steps or command run after this patch**:
  ```shell
  node --input-type=module <<'EOF_RUN'
  const thinking = await import('./dist/thinking-DtIsL--U.js');
  const catalog = [{ provider: 'ollama', id: 'deepseek-v4-pro:cloud', reasoning: true }];
  console.log(`levels=${thinking.t('ollama', 'deepseek-v4-pro:cloud', '|', catalog)}`);
  console.log(`maxSupported=${thinking.n({ provider: 'ollama', model: 'deepseek-v4-pro:cloud', level: 'max', catalog })}`);
  EOF_RUN
  ```
- **Evidence after fix**: Terminal capture from the built OpenClaw runtime:
  ```text
  levels=off|low|medium|high|max
  maxSupported=true
  ```
- **Observed result after fix**: the startup-safe provider-policy path now advertises `max` for reasoning-capable Ollama Cloud models before full plugin activation, so the `/think max` validation path no longer falls back to the base `off|minimal|low|medium|high` profile.
- **What was not tested**: live Fedora/Ollama Cloud chat round trip.

## Testing
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/ollama/index.ts extensions/ollama/provider-policy-api.ts extensions/ollama/provider-policy-api.test.ts`
- `pnpm test extensions/ollama/provider-policy-api.test.ts extensions/ollama/index.test.ts`
- Testbox `pnpm check:changed`

Fixes openclaw/openclaw#77612
