### PR TITLE
fix(mattermost): include thread files in inbound media

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -130,6 +130,58 @@ describe("mattermost monitor resources", () => {
     );
   });
 
+  it("collects earlier thread file ids and skips current/duplicate files", async () => {
+    const request = vi.fn(async (path: string) => {
+      expect(path).toBe("/posts/root-1/thread");
+      return {
+        order: ["root-1", "reply-1", "current"],
+        posts: {
+          "root-1": { id: "root-1", file_ids: [" file-root ", "file-dup"] },
+          "reply-1": { id: "reply-1", file_ids: ["file-reply", "file-dup"] },
+          current: { id: "current", file_ids: ["file-current", "file-ignored"] },
+        },
+      };
+    });
+
+    const resources = createMattermostMonitorResources({
+      accountId: "default",
+      callbackUrl: "https://openclaw.test/callback",
+      client: { request } as never,
+      logger: {},
+      mediaMaxBytes: 1024,
+      fetchRemoteMedia: vi.fn(),
+      saveMediaBuffer: vi.fn(),
+      mediaKindFromMime: () => "document",
+    });
+
+    await expect(
+      resources.resolveMattermostThreadFileIds(" root-1 ", "current", ["file-current"]),
+    ).resolves.toEqual(["file-root", "file-dup", "file-reply"]);
+  });
+
+  it("fails open when thread file lookup fails", async () => {
+    const logger = { debug: vi.fn() };
+    const resources = createMattermostMonitorResources({
+      accountId: "default",
+      callbackUrl: "https://openclaw.test/callback",
+      client: {
+        request: vi.fn(async () => {
+          throw new Error("boom");
+        }),
+      } as never,
+      logger,
+      mediaMaxBytes: 1024,
+      fetchRemoteMedia: vi.fn(),
+      saveMediaBuffer: vi.fn(),
+      mediaKindFromMime: () => "document",
+    });
+
+    await expect(resources.resolveMattermostThreadFileIds("root-1")).resolves.toEqual([]);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("failed to fetch thread files"),
+    );
+  });
+
   it("proxies typing indicators to the mattermost client helper", async () => {
     const client = {} as never;
 

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -61,7 +61,7 @@ export function createMattermostMonitorResources(params: {
   const resolveMattermostMedia = async (
     fileIds?: string[] | null,
   ): Promise<MattermostMediaInfo[]> => {
-    const ids = (fileIds ?? []).map((id) => id?.trim()).filter(Boolean);
+    const ids = [...new Set((fileIds ?? []).map((id) => id?.trim()).filter(Boolean))];
     if (ids.length === 0) {
       return [];
     }
@@ -96,6 +96,49 @@ export function createMattermostMonitorResources(params: {
       }
     }
     return out;
+  };
+
+  const resolveMattermostThreadFileIds = async (
+    threadRootId?: string | null,
+    currentPostId?: string | null,
+    currentFileIds?: string[] | null,
+  ): Promise<string[]> => {
+    const rootId = threadRootId?.trim();
+    if (!rootId) {
+      return [];
+    }
+    try {
+      const thread = await client.request<{
+        order?: string[];
+        posts?: Record<string, { id?: string | null; file_ids?: string[] | null }>;
+      }>(`/posts/${rootId}/thread`);
+      const postsById = thread.posts ?? {};
+      const orderedPosts = Array.isArray(thread.order)
+        ? thread.order.map((id) => postsById[id]).filter(Boolean)
+        : Object.values(postsById);
+      const seen = new Set((currentFileIds ?? []).map((id) => id?.trim()).filter(Boolean));
+      const out: string[] = [];
+      for (const item of orderedPosts) {
+        if (!item) {
+          continue;
+        }
+        if (currentPostId && item.id === currentPostId) {
+          continue;
+        }
+        for (const fileId of item.file_ids ?? []) {
+          const id = fileId?.trim();
+          if (!id || seen.has(id)) {
+            continue;
+          }
+          seen.add(id);
+          out.push(id);
+        }
+      }
+      return out;
+    } catch (err) {
+      logger.debug?.(`mattermost: failed to fetch thread files ${rootId}: ${String(err)}`);
+      return [];
+    }
   };
 
   const sendTypingIndicator = async (channelId: string, parentId?: string) => {
@@ -175,6 +218,7 @@ export function createMattermostMonitorResources(params: {
 
   return {
     resolveMattermostMedia,
+    resolveMattermostThreadFileIds,
     sendTypingIndicator,
     resolveChannelInfo,
     resolveUserInfo,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -822,6 +822,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
   const {
     resolveMattermostMedia,
+    resolveMattermostThreadFileIds,
     sendTypingIndicator,
     resolveChannelInfo,
     resolveUserInfo,
@@ -1495,7 +1496,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           recordPendingHistory();
           return;
         }
-        const mediaList = await resolveMattermostMedia(post.file_ids);
+        const threadFileIds = await resolveMattermostThreadFileIds(
+          threadRootId,
+          post.id,
+          post.file_ids,
+        );
+        const mediaList = await resolveMattermostMedia([
+          ...(post.file_ids ?? []),
+          ...threadFileIds,
+        ]);
         const mediaPlaceholder = buildMattermostAttachmentPlaceholder(mediaList);
         const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
         const baseText = [bodySource, mediaPlaceholder].filter(Boolean).join("\n").trim();

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1236,6 +1236,22 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       logVerboseMessage("mattermost: drop post (missing message id)");
       return;
     }
+
+    if (
+      post.id &&
+      (!normalizeOptionalString(post.root_id) ||
+        !(Array.isArray(post.file_ids) && post.file_ids.length > 0))
+    ) {
+      try {
+        const hydratedPost = await client.request<MattermostPost>(`/posts/${post.id}`);
+        if (hydratedPost && typeof hydratedPost === "object") {
+          post = { ...post, ...hydratedPost };
+        }
+      } catch (err) {
+        logVerboseMessage(`mattermost: post hydration failed post=${post.id}: ${String(err)}`);
+      }
+    }
+
     const replayResult = await processMattermostReplayGuardedPost({
       accountId: account.accountId,
       messageIds: allMessageIds,


### PR DESCRIPTION
## Summary
- collect file IDs from earlier Mattermost thread posts when processing an inbound thread reply
- pass those thread files through the existing inbound media download path so agents can inspect root/reply attachments even when the triggering mention has no files
- dedupe current and repeated file IDs, and fail open if the thread lookup fails

## Related
- Complements #76634, which focuses on resolving Mattermost reply roots before sending thread replies
- Complements #73061, which hydrates thread starter text/placeholders
- Related to #59576, but this fixes the thread-context case where files live on the root or earlier replies rather than the current WebSocket post

## Validation
- `node_modules/oxfmt/bin/oxfmt --check extensions/mattermost/src/mattermost/monitor-resources.ts extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor-resources.test.ts`
- `git diff --check`

## Notes
- Attempted `npx -y vitest@latest run extensions/mattermost/src/mattermost/monitor-resources.test.ts`, but the ad-hoc test run was SIGKILLed after repeated Rolldown plugin timing warnings in the temporary clone.
