### PR TITLE
fix(channels): preflight login config blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/login: reject missing or disabled `channels.<name>` config blocks before saving login auth and return the same actionable guidance from `channels.start`. Fixes #77508. Thanks @xuruiray.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Discord/gateway: measure heartbeat ACK timeouts from the actual heartbeat send, preventing late initial heartbeats from triggering false reconnect loops while the channel is still awaiting readiness. Fixes #77668. (#78087) Thanks @bryce-d-greybeard and @NikolaFC.

--- a/src/channels/config-block.ts
+++ b/src/channels/config-block.ts
@@ -1,0 +1,27 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+import { isRecord } from "../utils.js";
+
+export function resolveChannelConfigBlockError(params: {
+  cfg: OpenClawConfig;
+  channelId: string;
+  action: string;
+}): string | undefined {
+  const channels = isRecord(params.cfg.channels) ? params.cfg.channels : null;
+  if (
+    !channels ||
+    isBlockedObjectKey(params.channelId) ||
+    !Object.prototype.hasOwnProperty.call(channels, params.channelId)
+  ) {
+    return `Channel ${params.channelId} is not configured. Add channels.${params.channelId} to your config before ${params.action}.`;
+  }
+
+  const channelCfg = channels[params.channelId];
+  if (!isRecord(channelCfg)) {
+    return `Channel ${params.channelId} is not configured. Add channels.${params.channelId} to your config before ${params.action}.`;
+  }
+  if (channelCfg.enabled === false) {
+    return `Channel ${params.channelId} is disabled. Enable channels.${params.channelId} before ${params.action}.`;
+  }
+  return undefined;
+}

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -210,6 +210,31 @@ describe("channel-auth", () => {
     );
   });
 
+  it("fails explicit login before saving auth when the channel config block is missing", async () => {
+    mocks.loadConfig.mockReturnValue({});
+
+    await expect(
+      runChannelLogin({ channel: "whatsapp", account: "acct-1" }, runtime),
+    ).rejects.toThrow(
+      "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in.",
+    );
+
+    expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("fails explicit login before saving auth when the channel config block is disabled", async () => {
+    mocks.loadConfig.mockReturnValue({ channels: { whatsapp: { enabled: false } } });
+
+    await expect(
+      runChannelLogin({ channel: "whatsapp", account: "acct-1" }, runtime),
+    ).rejects.toThrow("Channel whatsapp is disabled. Enable channels.whatsapp before logging in.");
+
+    expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
   it("auto-picks the single configured channel that supports login when opts are empty", async () => {
     await runChannelLogin({}, runtime);
 

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -243,6 +243,31 @@ describe("channel-auth", () => {
     );
   });
 
+  it("fails explicit login before saving auth when the channel config block is missing", async () => {
+    mocks.loadConfig.mockReturnValue({});
+
+    await expect(
+      runChannelLogin({ channel: "whatsapp", account: "acct-1" }, runtime),
+    ).rejects.toThrow(
+      "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in.",
+    );
+
+    expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("fails explicit login before saving auth when the channel config block is disabled", async () => {
+    mocks.loadConfig.mockReturnValue({ channels: { whatsapp: { enabled: false } } });
+
+    await expect(
+      runChannelLogin({ channel: "whatsapp", account: "acct-1" }, runtime),
+    ).rejects.toThrow("Channel whatsapp is disabled. Enable channels.whatsapp before logging in.");
+
+    expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
   it("auto-picks the single configured channel that supports login when opts are empty", async () => {
     await runChannelLogin({}, runtime);
 

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -1,3 +1,4 @@
+import { resolveChannelConfigBlockError } from "../channels/config-block.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import {
   getChannelPlugin,
@@ -223,6 +224,14 @@ export async function runChannelLogin(
     throw new Error(`Channel ${channelInput} does not support login`);
   }
   // Auth-only flow: do not mutate channel config here.
+  const configBlockError = resolveChannelConfigBlockError({
+    cfg,
+    channelId: plugin.id,
+    action: "logging in",
+  });
+  if (configBlockError) {
+    throw new Error(configBlockError);
+  }
   setVerbose(Boolean(opts.verbose));
   const { accountId } = resolveAccountContext(plugin, opts, cfg);
   await login({

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -1,3 +1,4 @@
+import { resolveChannelConfigBlockError } from "../channels/config-block.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import {
   getChannelPlugin,
@@ -241,6 +242,14 @@ export async function runChannelLogin(
     );
   }
   // Auth-only flow: do not mutate channel config here.
+  const configBlockError = resolveChannelConfigBlockError({
+    cfg,
+    channelId: plugin.id,
+    action: "logging in",
+  });
+  if (configBlockError) {
+    throw new Error(configBlockError);
+  }
   setVerbose(Boolean(opts.verbose));
   const { accountId } = resolveAccountContext(plugin, opts, cfg);
   await login({

--- a/src/gateway/server-methods/channels.start.test.ts
+++ b/src/gateway/server-methods/channels.start.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../protocol/index.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
@@ -67,7 +68,7 @@ function createOptions(
 describe("channelsHandlers channels.start", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.getRuntimeConfig.mockReturnValue({ channels: { whatsapp: {} } });
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
     mocks.getChannelPlugin.mockReturnValue({
       id: "whatsapp",
@@ -116,7 +117,7 @@ describe("channelsHandlers channels.start", () => {
     );
 
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
-      config: {},
+      config: { channels: { whatsapp: {} } },
       env: process.env,
     });
     expect(startChannel).toHaveBeenCalledWith("whatsapp", "default-account");
@@ -129,6 +130,41 @@ describe("channelsHandlers channels.start", () => {
       },
       undefined,
     );
+  });
+
+  it("rejects starts for channels missing a config block", async () => {
+    const startChannel = vi.fn();
+    const respond = vi.fn();
+    mocks.getRuntimeConfig.mockReturnValue({});
+
+    await channelsHandlers["channels.start"](
+      createOptions(
+        { channel: "whatsapp" },
+        {
+          respond,
+          context: {
+            getRuntimeConfig: mocks.getRuntimeConfig,
+            startChannel,
+            getRuntimeSnapshot: vi.fn(
+              (): ChannelRuntimeSnapshot => ({
+                channels: {},
+                channelAccounts: {},
+              }),
+            ),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    const call = respond.mock.calls[0] as
+      | [boolean, unknown, { code: number; message: string }]
+      | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.code).toBe(ErrorCodes.INVALID_REQUEST);
+    expect(call?.[2]?.message).toContain(
+      "Channel whatsapp is not configured. Add channels.whatsapp to your config before starting it.",
+    );
+    expect(startChannel).not.toHaveBeenCalled();
   });
 
   it("reports started=false when the channel runtime remains stopped", async () => {

--- a/src/gateway/server-methods/channels.start.test.ts
+++ b/src/gateway/server-methods/channels.start.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../protocol/index.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
@@ -7,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
   getChannelPlugin: vi.fn(),
+  normalizeChannelId: vi.fn((value: string): string | null => value),
 }));
 
 vi.mock("../../config/config.js", () => ({
@@ -21,7 +23,7 @@ vi.mock("../../config/plugin-auto-enable.js", () => ({
 vi.mock("../../channels/plugins/index.js", () => ({
   listChannelPlugins: vi.fn(),
   getChannelPlugin: mocks.getChannelPlugin,
-  normalizeChannelId: (value: string) => value,
+  normalizeChannelId: mocks.normalizeChannelId,
 }));
 
 import { channelsHandlers } from "./channels.js";
@@ -67,8 +69,9 @@ function createOptions(
 describe("channelsHandlers channels.start", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.getRuntimeConfig.mockReturnValue({ channels: { whatsapp: {} } });
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
+    mocks.normalizeChannelId.mockImplementation((value: string) => value);
     mocks.getChannelPlugin.mockReturnValue({
       id: "whatsapp",
       gateway: { startAccount: vi.fn() },
@@ -116,7 +119,7 @@ describe("channelsHandlers channels.start", () => {
     );
 
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
-      config: {},
+      config: { channels: { whatsapp: {} } },
       env: process.env,
     });
     expect(startChannel).toHaveBeenCalledWith("whatsapp", "default-account");
@@ -129,6 +132,44 @@ describe("channelsHandlers channels.start", () => {
       },
       undefined,
     );
+  });
+
+  it("rejects starts for channels missing a config block", async () => {
+    const startChannel = vi.fn();
+    const respond = vi.fn();
+    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.normalizeChannelId.mockReturnValue(null);
+
+    await channelsHandlers["channels.start"](
+      createOptions(
+        { channel: "whatsapp" },
+        {
+          respond,
+          context: {
+            getRuntimeConfig: mocks.getRuntimeConfig,
+            startChannel,
+            getRuntimeSnapshot: vi.fn(
+              (): ChannelRuntimeSnapshot => ({
+                channels: {},
+                channelAccounts: {},
+              }),
+            ),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    const call = respond.mock.calls[0] as
+      | [boolean, unknown, { code: number; message: string }]
+      | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.code).toBe(ErrorCodes.INVALID_REQUEST);
+    expect(call?.[2]?.message).toContain(
+      "Channel whatsapp is not configured. Add channels.whatsapp to your config before starting it.",
+    );
+    expect(mocks.normalizeChannelId).not.toHaveBeenCalled();
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(startChannel).not.toHaveBeenCalled();
   });
 
   it("reports started=false when the channel runtime remains stopped", async () => {

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -1,3 +1,4 @@
+import { resolveChannelConfigBlockError } from "../../channels/config-block.js";
 import { buildChannelUiCatalog } from "../../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import {
@@ -497,6 +498,15 @@ export const channelsHandlers: GatewayRequestHandlers = {
         config: context.getRuntimeConfig(),
         env: process.env,
       }).config;
+      const configBlockError = resolveChannelConfigBlockError({
+        cfg,
+        channelId,
+        action: "starting it",
+      });
+      if (configBlockError) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, configBlockError));
+        return;
+      }
       const payload = await startChannelAccount({
         channelId,
         accountId: (params as { accountId?: string | null }).accountId,

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -1,14 +1,16 @@
+import { resolveChannelConfigBlockError } from "../../channels/config-block.js";
 import { buildChannelUiCatalog } from "../../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import {
   type ChannelId,
   getChannelPlugin,
   listChannelPlugins,
-  normalizeChannelId,
+  normalizeChannelId as normalizeRegisteredChannelId,
 } from "../../channels/plugins/index.js";
 import { buildChannelAccountSnapshot } from "../../channels/plugins/status.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
+import { normalizeChannelId as normalizeCatalogChannelId } from "../../channels/registry.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -300,7 +302,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
     const timeoutMs = resolveChannelsStatusTimeoutMs({ probe, timeoutMsRaw });
     const rawChannel = (params as { channel?: unknown }).channel;
     const requestedChannel =
-      typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : undefined;
+      typeof rawChannel === "string" ? normalizeRegisteredChannelId(rawChannel) : undefined;
     const cfg = applyPluginAutoEnable({
       config: context.getRuntimeConfig(),
       env: process.env,
@@ -552,37 +554,60 @@ export const channelsHandlers: GatewayRequestHandlers = {
       return;
     }
     const rawChannel = (params as { channel?: unknown }).channel;
-    const channelId = typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : null;
-    if (!channelId) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid channels.start channel"),
-      );
-      return;
-    }
-    const plugin = getChannelPlugin(channelId);
-    if (!plugin) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `unknown channel: ${formatForLog(rawChannel)}`),
-      );
-      return;
-    }
-    if (!plugin.gateway?.startAccount) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `channel ${channelId} does not support start`),
-      );
-      return;
-    }
     try {
       const cfg = applyPluginAutoEnable({
         config: context.getRuntimeConfig(),
         env: process.env,
       }).config;
+      const catalogChannelId =
+        typeof rawChannel === "string" ? normalizeCatalogChannelId(rawChannel) : null;
+      if (catalogChannelId) {
+        const configBlockError = resolveChannelConfigBlockError({
+          cfg,
+          channelId: catalogChannelId,
+          action: "starting it",
+        });
+        if (configBlockError) {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, configBlockError));
+          return;
+        }
+      }
+      const channelId =
+        typeof rawChannel === "string" ? normalizeRegisteredChannelId(rawChannel) : null;
+      if (!channelId) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid channels.start channel"),
+        );
+        return;
+      }
+      const plugin = getChannelPlugin(channelId);
+      if (!plugin) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `unknown channel: ${formatForLog(rawChannel)}`),
+        );
+        return;
+      }
+      if (!plugin.gateway?.startAccount) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `channel ${channelId} does not support start`),
+        );
+        return;
+      }
+      const configBlockError = resolveChannelConfigBlockError({
+        cfg,
+        channelId,
+        action: "starting it",
+      });
+      if (configBlockError) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, configBlockError));
+        return;
+      }
       const payload = await startChannelAccount({
         channelId,
         accountId: (params as { accountId?: string | null }).accountId,
@@ -608,7 +633,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
       return;
     }
     const rawChannel = (params as { channel?: unknown }).channel;
-    const channelId = typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : null;
+    const channelId =
+      typeof rawChannel === "string" ? normalizeRegisteredChannelId(rawChannel) : null;
     if (!channelId) {
       respond(
         false,
@@ -654,7 +680,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
       return;
     }
     const rawChannel = (params as { channel?: unknown }).channel;
-    const channelId = typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : null;
+    const channelId =
+      typeof rawChannel === "string" ? normalizeRegisteredChannelId(rawChannel) : null;
     if (!channelId) {
       respond(
         false,


### PR DESCRIPTION
Fixes #77508.

## Summary
- add a shared channel config-block preflight for missing or disabled channels
- fail explicit channel login before saving auth when channels.<name> is absent or disabled
- return the same actionable guidance from channels.start before starting a runtime

## Testing
- pnpm test src/cli/channel-auth.test.ts src/gateway/server-methods/channels.start.test.ts
- pnpm exec oxfmt --check --threads=1 src/channels/config-block.ts src/cli/channel-auth.ts src/cli/channel-auth.test.ts src/gateway/server-methods/channels.ts src/gateway/server-methods/channels.start.test.ts CHANGELOG.md
- pnpm check:changed

## Real behavior proof
- **Behavior or issue addressed**: Explicit channel login now rejects a missing channel config block before attempting provider auth, matching the new channel config-block preflight behavior.
- **Real environment tested**: Local OpenClaw CLI from this PR branch (`OpenClaw 2026.5.4`, commit `5097ba8`) with a temporary empty `HOME` / `OPENCLAW_CONFIG_DIR`.
- **Exact steps or command run after this patch**:
  ```sh
  tmp=$(mktemp -d)
  HOME="$tmp" OPENCLAW_HOME="$tmp" OPENCLAW_CONFIG_DIR="$tmp/.openclaw" pnpm openclaw channels login --channel whatsapp
  ```
- **Evidence after fix**:
  ```text
  > openclaw@2026.5.4 openclaw /Users/xurui/.config/superpowers/worktrees/openclaw/codex-77508-channel-login-config-preflight
  > node scripts/run-node.mjs channels login --channel whatsapp

  Channel login failed: Error: Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in.
  ```
- **Observed result after fix**: The CLI failed before provider login/auth and returned actionable `channels.whatsapp` config guidance instead of proceeding to save auth.
- **What was not tested**: Live WhatsApp QR auth was not run; this proof covers the pre-auth missing-config failure path.
