### PR TITLE
fix(feishu): normalize reaction message IDs for API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: normalize synthetic reaction message IDs before adding or removing typing indicators, so reaction-triggered replies do not send suffixed IDs back to Feishu `message_id` fields. Fixes #34528. Thanks @yfge.
 - Onboard/channels: recover externalized channel plugins from stale `channels.<id>` config by falling back to `ensureChannelSetupPluginInstalled` via the trusted catalog when the plugin is missing on disk, so leftover `appId`/token entries no longer dead-end onboard with "<channel> plugin not available." (#78328) Thanks @sliverp.
 - Dependencies: override transitive `ip-address` to `10.2.0` so the runtime lockfile no longer includes the vulnerable `10.1.0` build flagged by Dependabot alert 109. Thanks @vincentkoc.
 - Feishu: hydrate missing native topic starter thread IDs before session routing so first turns and follow-ups stay in the same topic session. Fixes #78262. Thanks @joeyzenghuan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Feishu: normalize synthetic reaction message IDs before adding or removing typing indicators, so reaction-triggered replies do not send suffixed IDs back to Feishu `message_id` fields. Fixes #34528. Thanks @yfge.
 - Onboard/channels: recover externalized channel plugins from stale `channels.<id>` config by falling back to `ensureChannelSetupPluginInstalled` via the trusted catalog when the plugin is missing on disk, so leftover `appId`/token entries no longer dead-end onboard with "<channel> plugin not available." (#78328) Thanks @sliverp.
 - Dependencies: override transitive `ip-address` to `10.2.0` so the runtime lockfile no longer includes the vulnerable `10.1.0` build flagged by Dependabot alert 109. Thanks @vincentkoc.
 - Feishu: hydrate missing native topic starter thread IDs before session routing so first turns and follow-ups stay in the same topic session. Fixes #78262. Thanks @joeyzenghuan.

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -17,6 +17,7 @@ import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { normalizeFeishuOpenMessageId } from "./message-id.js";
 import { getFeishuRuntime } from "./runtime.js";
 import {
   assertFeishuMessageApiSuccess,
@@ -519,7 +520,10 @@ export async function sendImageFeishu(params: {
   replyInThread?: boolean;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, imageKey, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, imageKey, replyInThread, accountId } = params;
+  const replyToMessageId = params.replyToMessageId
+    ? normalizeFeishuOpenMessageId(params.replyToMessageId)
+    : undefined;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
     to,
@@ -575,7 +579,10 @@ export async function sendFileFeishu(params: {
   replyInThread?: boolean;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, fileKey, replyInThread, accountId } = params;
+  const replyToMessageId = params.replyToMessageId
+    ? normalizeFeishuOpenMessageId(params.replyToMessageId)
+    : undefined;
   const msgType = params.msgType ?? "file";
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,

--- a/extensions/feishu/src/message-id.test.ts
+++ b/extensions/feishu/src/message-id.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { normalizeFeishuOpenMessageId } from "./message-id.js";
+
+describe("normalizeFeishuOpenMessageId", () => {
+  it("trims synthetic reaction suffixes before Feishu API use", () => {
+    expect(normalizeFeishuOpenMessageId(" om_123:reaction:+1:uuid-1 ")).toBe("om_123");
+  });
+
+  it("leaves already-normalized open message IDs unchanged", () => {
+    expect(normalizeFeishuOpenMessageId(" om_123 ")).toBe("om_123");
+  });
+});

--- a/extensions/feishu/src/message-id.test.ts
+++ b/extensions/feishu/src/message-id.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from "vitest";
 import { normalizeFeishuOpenMessageId } from "./message-id.js";
 
 describe("normalizeFeishuOpenMessageId", () => {
-  it("trims synthetic reaction suffixes before Feishu API use", () => {
-    expect(normalizeFeishuOpenMessageId(" om_123:reaction:+1:uuid-1 ")).toBe("om_123");
+  it("keeps already-normalized message ids unchanged", () => {
+    expect(normalizeFeishuOpenMessageId("om_message")).toBe("om_message");
   });
 
-  it("leaves already-normalized open message IDs unchanged", () => {
-    expect(normalizeFeishuOpenMessageId(" om_123 ")).toBe("om_123");
+  it("trims whitespace around already-normalized message ids", () => {
+    expect(normalizeFeishuOpenMessageId("  om_message  ")).toBe("om_message");
+  });
+
+  it("strips synthetic reaction suffixes", () => {
+    expect(normalizeFeishuOpenMessageId("om_message:reaction:THUMBSUP:uuid-1")).toBe("om_message");
   });
 });

--- a/extensions/feishu/src/message-id.ts
+++ b/extensions/feishu/src/message-id.ts
@@ -1,0 +1,18 @@
+const FEISHU_SYNTHETIC_REACTION_SEPARATOR = ":reaction:";
+
+/**
+ * Return the Open Message ID accepted by Feishu APIs.
+ *
+ * Feishu reaction notifications are represented internally as synthetic message
+ * events by appending `:reaction:<emoji>:<uuid>` to the reacted message ID. That
+ * suffix is useful for OpenClaw turn/dedupe identity, but Feishu APIs only
+ * accept the base open_message_id.
+ */
+export function normalizeFeishuOpenMessageId(messageId: string): string {
+  const trimmed = messageId.trim();
+  const reactionIndex = trimmed.indexOf(FEISHU_SYNTHETIC_REACTION_SEPARATOR);
+  if (reactionIndex <= 0) {
+    return trimmed;
+  }
+  return trimmed.slice(0, reactionIndex);
+}

--- a/extensions/feishu/src/pins.ts
+++ b/extensions/feishu/src/pins.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { normalizeFeishuOpenMessageId } from "./message-id.js";
 
 type FeishuPin = {
   messageId: string;
@@ -37,6 +38,7 @@ export async function createPinFeishu(params: {
   messageId: string;
   accountId?: string;
 }): Promise<FeishuPin | null> {
+  const messageId = normalizeFeishuOpenMessageId(params.messageId);
   const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -45,7 +47,7 @@ export async function createPinFeishu(params: {
   const client = createFeishuClient(account);
   const response = await client.im.pin.create({
     data: {
-      message_id: params.messageId,
+      message_id: messageId,
     },
   });
   assertFeishuPinApiSuccess(response, "pin create");
@@ -57,6 +59,7 @@ export async function removePinFeishu(params: {
   messageId: string;
   accountId?: string;
 }): Promise<void> {
+  const messageId = normalizeFeishuOpenMessageId(params.messageId);
   const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -65,7 +68,7 @@ export async function removePinFeishu(params: {
   const client = createFeishuClient(account);
   const response = await client.im.pin.delete({
     path: {
-      message_id: params.messageId,
+      message_id: messageId,
     },
   });
   assertFeishuPinApiSuccess(response, "pin delete");

--- a/extensions/feishu/src/reactions.ts
+++ b/extensions/feishu/src/reactions.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { normalizeFeishuOpenMessageId } from "./message-id.js";
 
 type FeishuReaction = {
   reactionId: string;
@@ -34,7 +35,8 @@ export async function addReactionFeishu(params: {
   emojiType: string;
   accountId?: string;
 }): Promise<{ reactionId: string }> {
-  const { cfg, messageId, emojiType, accountId } = params;
+  const { cfg, emojiType, accountId } = params;
+  const messageId = normalizeFeishuOpenMessageId(params.messageId);
   const client = resolveConfiguredFeishuClient({ cfg, accountId });
 
   const response = (await client.im.messageReaction.create({
@@ -69,7 +71,8 @@ export async function removeReactionFeishu(params: {
   reactionId: string;
   accountId?: string;
 }): Promise<void> {
-  const { cfg, messageId, reactionId, accountId } = params;
+  const { cfg, reactionId, accountId } = params;
+  const messageId = normalizeFeishuOpenMessageId(params.messageId);
   const client = resolveConfiguredFeishuClient({ cfg, accountId });
 
   const response = (await client.im.messageReaction.delete({
@@ -91,7 +94,8 @@ export async function listReactionsFeishu(params: {
   emojiType?: string;
   accountId?: string;
 }): Promise<FeishuReaction[]> {
-  const { cfg, messageId, emojiType, accountId } = params;
+  const { cfg, emojiType, accountId } = params;
+  const messageId = normalizeFeishuOpenMessageId(params.messageId);
   const client = resolveConfiguredFeishuClient({ cfg, accountId });
 
   const response = (await client.im.messageReaction.list({

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -107,6 +107,27 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
     );
   });
 
+  it("normalizes synthetic reaction message IDs before replying", async () => {
+    replyMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_reply" },
+    });
+
+    const result = await sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "hello",
+      replyToMessageId: "om_parent:reaction:THUMBSUP:fixed-uuid",
+    });
+
+    expect(replyMock).toHaveBeenCalledWith({
+      path: { message_id: "om_parent" },
+      data: expect.objectContaining({ msg_type: "post" }),
+    });
+    expect(createMock).not.toHaveBeenCalled();
+    expect(result.messageId).toBe("om_reply");
+  });
+
   it("falls back to create for withdrawn card replies", async () => {
     replyMock.mockResolvedValue({
       code: 231003,

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -169,6 +169,36 @@ describe("getMessageFeishu", () => {
     );
   });
 
+  it("normalizes synthetic reaction message IDs before message lookups", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_reacted",
+            chat_id: "oc_1",
+            msg_type: "text",
+            body: { content: JSON.stringify({ text: "reacted message" }) },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_reacted:reaction:THUMBSUP:fixed-uuid",
+    });
+
+    expect(mockClientGet).toHaveBeenCalledWith({ path: { message_id: "om_reacted" } });
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_reacted",
+        chatId: "oc_1",
+        content: "reacted message",
+      }),
+    );
+  });
+
   it("falls through empty interactive card element arrays and locale variants", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,
@@ -485,6 +515,22 @@ describe("editMessageFeishu", () => {
       data: {
         content: JSON.stringify({ schema: "2.0" }),
       },
+    });
+    expect(result).toEqual({ messageId: "om_card", contentType: "interactive" });
+  });
+
+  it("normalizes synthetic reaction message IDs before edits", async () => {
+    mockClientPatch.mockResolvedValueOnce({ code: 0 });
+
+    const result = await editMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card:reaction:THUMBSUP:fixed-uuid",
+      card: { schema: "2.0" },
+    });
+
+    expect(mockClientPatch).toHaveBeenCalledWith({
+      path: { message_id: "om_card" },
+      data: { content: JSON.stringify({ schema: "2.0" }) },
     });
     expect(result).toEqual({ messageId: "om_card", contentType: "interactive" });
   });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -10,6 +10,7 @@ import { createFeishuClient } from "./client.js";
 import { createFeishuApiError, requestFeishuApi } from "./comment-shared.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent, buildMentionedMessage } from "./mention.js";
+import { normalizeFeishuOpenMessageId } from "./message-id.js";
 import { parsePostContent } from "./post.js";
 import {
   assertFeishuMessageApiSuccess,
@@ -166,10 +167,11 @@ async function sendReplyOrFallbackDirect(
       )
     : null;
 
+  const replyToMessageId = normalizeFeishuOpenMessageId(params.replyToMessageId);
   let response: { code?: number; msg?: string; data?: { message_id?: string } };
   try {
     response = await client.im.message.reply({
-      path: { message_id: params.replyToMessageId },
+      path: { message_id: replyToMessageId },
       data: {
         content: params.content,
         msg_type: params.msgType,
@@ -393,7 +395,8 @@ export async function getMessageFeishu(params: {
   messageId: string;
   accountId?: string;
 }): Promise<FeishuMessageInfo | null> {
-  const { cfg, messageId, accountId } = params;
+  const { cfg, accountId } = params;
+  const messageId = normalizeFeishuOpenMessageId(params.messageId);
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -619,7 +622,8 @@ export async function editMessageFeishu(params: {
   card?: Record<string, unknown>;
   accountId?: string;
 }): Promise<{ messageId: string; contentType: "post" | "interactive" }> {
-  const { cfg, messageId, text, card, accountId } = params;
+  const { cfg, text, card, accountId } = params;
+  const messageId = normalizeFeishuOpenMessageId(params.messageId);
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -671,7 +675,8 @@ export async function updateCardFeishu(params: {
   card: Record<string, unknown>;
   accountId?: string;
 }): Promise<void> {
-  const { cfg, messageId, card, accountId } = params;
+  const { cfg, card, accountId } = params;
+  const messageId = normalizeFeishuOpenMessageId(params.messageId);
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -5,6 +5,7 @@
 import type { Client } from "@larksuiteoapi/node-sdk";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { getFeishuUserAgent } from "./client.js";
+import { normalizeFeishuOpenMessageId } from "./message-id.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
@@ -271,7 +272,7 @@ export class FeishuStreamingSession {
     const sendMode = resolveStreamingCardSendMode(sendOptions);
     if (sendMode === "reply") {
       sendRes = await this.client.im.message.reply({
-        path: { message_id: sendOptions.replyToMessageId! },
+        path: { message_id: normalizeFeishuOpenMessageId(sendOptions.replyToMessageId!) },
         data: {
           msg_type: "interactive",
           content: cardContent,

--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -1,5 +1,33 @@
-import { describe, expect, it } from "vitest";
-import { isFeishuBackoffError, getBackoffCodeFromResponse, FeishuBackoffError } from "./typing.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
+
+const resolveFeishuRuntimeAccountMock = vi.hoisted(() => vi.fn());
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const shouldLogVerboseMock = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("./accounts.js", () => ({
+  resolveFeishuRuntimeAccount: resolveFeishuRuntimeAccountMock,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    logging: {
+      shouldLogVerbose: shouldLogVerboseMock,
+    },
+  }),
+}));
+
+import {
+  addTypingIndicator,
+  FeishuBackoffError,
+  getBackoffCodeFromResponse,
+  isFeishuBackoffError,
+  removeTypingIndicator,
+} from "./typing.js";
 
 describe("isFeishuBackoffError", () => {
   it("returns true for HTTP 429 (AxiosError shape)", () => {
@@ -123,22 +151,102 @@ describe("FeishuBackoffError", () => {
   });
 
   it("survives catch-and-rethrow pattern", () => {
-    // Simulates the exact pattern in addTypingIndicator/removeTypingIndicator:
-    // thrown inside try, caught by catch, isFeishuBackoffError must match
     let caught: unknown;
     try {
       try {
         throw new FeishuBackoffError(99991403);
       } catch (err) {
         if (isFeishuBackoffError(err)) {
-          throw err; // re-thrown — this is the fix
+          throw err;
         }
-        // would be silently swallowed with plain Error
         caught = "swallowed";
       }
     } catch (err) {
       caught = err;
     }
     expect(caught).toBeInstanceOf(FeishuBackoffError);
+  });
+});
+
+describe("typing indicator message id normalization", () => {
+  const reactionCreateMock = vi.fn();
+  const reactionDeleteMock = vi.fn();
+  const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+  const cfg = {} as ClawdbotConfig;
+  const syntheticMessageId = "om_dc132ca13c4c274d9a8d54aabfcafe00:reaction:thumbsup:uuid-1";
+  const normalizedMessageId = "om_dc132ca13c4c274d9a8d54aabfcafe00";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveFeishuRuntimeAccountMock.mockReturnValue({
+      configured: true,
+      accountId: "default",
+      appId: "app-id",
+      appSecret: "secret",
+    });
+    createFeishuClientMock.mockReturnValue({
+      im: {
+        messageReaction: {
+          create: reactionCreateMock,
+          delete: reactionDeleteMock,
+        },
+      },
+    });
+    reactionCreateMock.mockResolvedValue({
+      code: 0,
+      data: { reaction_id: "typing-reaction-1" },
+    });
+    reactionDeleteMock.mockResolvedValue({ code: 0, data: {} });
+  });
+
+  it("normalizes synthetic reaction ids before adding typing indicators", async () => {
+    const state = await addTypingIndicator({
+      cfg,
+      messageId: syntheticMessageId,
+      runtime,
+    });
+
+    expect(reactionCreateMock).toHaveBeenCalledWith({
+      path: { message_id: normalizedMessageId },
+      data: { reaction_type: { emoji_type: "Typing" } },
+    });
+    expect(state).toEqual({
+      messageId: normalizedMessageId,
+      reactionId: "typing-reaction-1",
+    });
+  });
+
+  it("uses the normalized id again when removing typing indicators", async () => {
+    await removeTypingIndicator({
+      cfg,
+      state: {
+        messageId: normalizedMessageId,
+        reactionId: "typing-reaction-1",
+      },
+      runtime,
+    });
+
+    expect(reactionDeleteMock).toHaveBeenCalledWith({
+      path: {
+        message_id: normalizedMessageId,
+        reaction_id: "typing-reaction-1",
+      },
+    });
+  });
+
+  it("returns a normalized state even when the account is not configured", async () => {
+    resolveFeishuRuntimeAccountMock.mockReturnValue({ configured: false });
+
+    const state = await addTypingIndicator({
+      cfg,
+      messageId: syntheticMessageId,
+      runtime,
+    });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(state).toEqual({
+      messageId: normalizedMessageId,
+      reactionId: null,
+    });
   });
 });

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { normalizeFeishuOpenMessageId } from "./message-id.js";
 import { getFeishuRuntime } from "./runtime.js";
 
 // Feishu emoji types for typing indicator
@@ -111,16 +112,17 @@ export async function addTypingIndicator(params: {
   runtime?: RuntimeEnv;
 }): Promise<TypingIndicatorState> {
   const { cfg, messageId, accountId, runtime } = params;
+  const normalizedMessageId = normalizeFeishuOpenMessageId(messageId);
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
-    return { messageId, reactionId: null };
+    return { messageId: normalizedMessageId, reactionId: null };
   }
 
   const client = createFeishuClient(account);
 
   try {
     const response = await client.im.messageReaction.create({
-      path: { message_id: messageId },
+      path: { message_id: normalizedMessageId },
       data: {
         reaction_type: { emoji_type: TYPING_EMOJI },
       },
@@ -140,7 +142,7 @@ export async function addTypingIndicator(params: {
 
     const typedResponse: FeishuMessageReactionCreateResponse = response;
     const reactionId = typedResponse.data?.reaction_id ?? null;
-    return { messageId, reactionId };
+    return { messageId: normalizedMessageId, reactionId };
   } catch (err) {
     if (isFeishuBackoffError(err)) {
       if (getFeishuRuntime().logging.shouldLogVerbose()) {
@@ -152,7 +154,7 @@ export async function addTypingIndicator(params: {
     if (getFeishuRuntime().logging.shouldLogVerbose()) {
       runtime?.log?.(`[feishu] failed to add typing indicator: ${String(err)}`);
     }
-    return { messageId, reactionId: null };
+    return { messageId: normalizedMessageId, reactionId: null };
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes #34528 by separating Feishu synthetic reaction event IDs from Open Message IDs used for Feishu API calls.
- Adds `normalizeFeishuOpenMessageId` and applies it to replies, reads, edits, card updates, media replies, reactions, pins, and streaming-card replies.
- Adds regression coverage for reaction-suffixed reply targets, lookups, and edits.

## Background
Feishu reaction notifications use synthetic OpenClaw message IDs like `om_xxx:reaction:THUMBSUP:<uuid>` so reaction turns remain unique. Those IDs were later passed back into Feishu endpoints that only accept the base `open_message_id`, causing 400 responses such as `Invalid ids: [om_xxx:reaction:...]`.

## Verification
- `pnpm test extensions/feishu/src/send.test.ts extensions/feishu/src/send.reply-fallback.test.ts`
- `pnpm test extensions/feishu/src/media.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/feishu/src/message-id.ts extensions/feishu/src/send.ts extensions/feishu/src/send.test.ts extensions/feishu/src/send.reply-fallback.test.ts extensions/feishu/src/reactions.ts extensions/feishu/src/pins.ts extensions/feishu/src/media.ts extensions/feishu/src/streaming-card.ts`
- `node scripts/run-oxlint.mjs extensions/feishu/src/message-id.ts extensions/feishu/src/send.ts extensions/feishu/src/send.test.ts extensions/feishu/src/send.reply-fallback.test.ts extensions/feishu/src/reactions.ts extensions/feishu/src/pins.ts extensions/feishu/src/media.ts extensions/feishu/src/streaming-card.ts`
- `pnpm check:changed` (typecheck passed; lint failed on pre-existing unrelated `extensions/diagnostics-otel/src/service.ts` switch exhaustiveness after untracked local workspace directories forced all lanes)

## Impact
Reaction events still keep unique synthetic IDs inside OpenClaw, while Feishu API calls now use valid base Open Message IDs. This prevents reaction-triggered reads/replies/actions from failing with Feishu invalid ID errors.
