### PR TITLE
docs: Add gateway exposure runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Models config + CLI: [Models](https://docs.openclaw.ai/concepts/models). Auth pr
 
 OpenClaw connects to real messaging surfaces. Treat inbound DMs as **untrusted input**.
 
-Full security guide: [Security](https://docs.openclaw.ai/gateway/security)
+Full security guide: [Security](https://docs.openclaw.ai/gateway/security).
+Before remote exposure, use the [Gateway exposure runbook](https://docs.openclaw.ai/gateway/security/exposure-runbook).
 
 Default behavior on Telegram/WhatsApp/Signal/iMessage/Microsoft Teams/Discord/Google Chat/Slack:
 
@@ -159,7 +160,7 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 - Default: tools run on the host for the `main` session, so the agent has full access when it is just you.
 - Group/channel safety: set `agents.defaults.sandbox.mode: "non-main"` to run non-`main` sessions inside sandboxes. Docker is the default sandbox backend; SSH and OpenShell backends are also available.
 - Typical sandbox default: allow `bash`, `process`, `read`, `write`, `edit`, `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`; deny `browser`, `canvas`, `nodes`, `cron`, `discord`, `gateway`.
-- Before exposing anything remotely, read [Security](https://docs.openclaw.ai/gateway/security), [Sandboxing](https://docs.openclaw.ai/gateway/sandboxing), and [Configuration](https://docs.openclaw.ai/gateway/configuration).
+- Before exposing anything remotely, read [Security](https://docs.openclaw.ai/gateway/security), [Gateway exposure runbook](https://docs.openclaw.ai/gateway/security/exposure-runbook), [Sandboxing](https://docs.openclaw.ai/gateway/sandboxing), and [Configuration](https://docs.openclaw.ai/gateway/configuration).
 
 ## Operator quick refs
 
@@ -173,7 +174,7 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 - New here: [Getting started](https://docs.openclaw.ai/start/getting-started), [Onboarding](https://docs.openclaw.ai/start/wizard), [Updating](https://docs.openclaw.ai/install/updating)
 - Channel setup: [Channels index](https://docs.openclaw.ai/channels), [WhatsApp](https://docs.openclaw.ai/channels/whatsapp), [Telegram](https://docs.openclaw.ai/channels/telegram), [Discord](https://docs.openclaw.ai/channels/discord), [Slack](https://docs.openclaw.ai/channels/slack)
 - Apps + nodes: [macOS](https://docs.openclaw.ai/platforms/macos), [iOS](https://docs.openclaw.ai/platforms/ios), [Android](https://docs.openclaw.ai/platforms/android), [Nodes](https://docs.openclaw.ai/nodes)
-- Config + security: [Configuration](https://docs.openclaw.ai/gateway/configuration), [Security](https://docs.openclaw.ai/gateway/security), [Sandboxing](https://docs.openclaw.ai/gateway/sandboxing)
+- Config + security: [Configuration](https://docs.openclaw.ai/gateway/configuration), [Security](https://docs.openclaw.ai/gateway/security), [Exposure runbook](https://docs.openclaw.ai/gateway/security/exposure-runbook), [Sandboxing](https://docs.openclaw.ai/gateway/sandboxing)
 - Remote + web: [Gateway](https://docs.openclaw.ai/gateway), [Remote access](https://docs.openclaw.ai/gateway/remote), [Tailscale](https://docs.openclaw.ai/gateway/tailscale), [Web surfaces](https://docs.openclaw.ai/web)
 - Tools + automation: [Tools](https://docs.openclaw.ai/tools), [Skills](https://docs.openclaw.ai/tools/skills), [Cron jobs](https://docs.openclaw.ai/automation/cron-jobs), [Webhooks](https://docs.openclaw.ai/automation/webhook), [Gmail Pub/Sub](https://docs.openclaw.ai/automation/gmail-pubsub)
 - Internals: [Architecture](https://docs.openclaw.ai/concepts/architecture), [Agent](https://docs.openclaw.ai/concepts/agent), [Session model](https://docs.openclaw.ai/concepts/session), [Gateway protocol](https://docs.openclaw.ai/reference/rpc)

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -48,6 +48,10 @@
     "target": "Gateway 网关"
   },
   {
+    "source": "Gateway exposure runbook",
+    "target": "Gateway 暴露运行手册"
+  },
+  {
     "source": "Gateway RPC reference",
     "target": "Gateway RPC 参考"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1499,6 +1499,7 @@
                     "pages": [
                       "gateway/security/index",
                       "gateway/security/audit-checks",
+                      "gateway/security/exposure-runbook",
                       "gateway/operator-scopes",
                       "gateway/sandboxing",
                       "gateway/openshell",

--- a/docs/gateway/security/exposure-runbook.md
+++ b/docs/gateway/security/exposure-runbook.md
@@ -1,0 +1,216 @@
+---
+summary: "Pre-flight and rollback checklist before exposing an OpenClaw Gateway beyond loopback"
+title: "Gateway exposure runbook"
+sidebarTitle: "Exposure runbook"
+read_when:
+  - Exposing the Gateway over LAN, tailnet, Tailscale Serve, Funnel, or a reverse proxy
+  - Reviewing a deployment before allowing real messaging users
+  - Rolling back a risky remote access or DM configuration
+---
+
+<Warning>
+Expose the Gateway only after you can explain who can reach it, how they are
+authenticated, which agents they can trigger, and which tools those agents can
+use. When in doubt, return to loopback-only access and re-run the audit.
+</Warning>
+
+This runbook turns the broader [Security](/gateway/security) guidance into an
+operator checklist for remote access and messaging exposure.
+
+## 1. Choose the exposure pattern
+
+Prefer the narrowest pattern that satisfies the workflow.
+
+| Pattern | Recommended when | Required controls |
+| --- | --- | --- |
+| Loopback + SSH tunnel | Personal use, admin access, debugging | Keep `gateway.bind: "loopback"` and tunnel `127.0.0.1:18789` |
+| Loopback + Tailscale Serve | Personal tailnet access to Control UI/WebSocket | Keep Gateway loopback-only; rely on Tailscale identity headers only for supported surfaces |
+| Tailnet/LAN bind | Dedicated private network with known devices | Gateway auth, firewall allowlist, no public port-forward |
+| Trusted reverse proxy | Organization SSO/OIDC in front of Gateway | `trusted-proxy` auth, strict `trustedProxies`, header overwrite/strip rules, explicit allowed users |
+| Public internet | Rare, high-risk deployments | Identity-aware proxy, TLS, rate limits, strict allowlists, sandboxed non-main sessions |
+
+Avoid direct public port-forwarding to the Gateway. If you need public access,
+put an identity-aware proxy in front of it and make the proxy the only network
+path to the Gateway.
+
+## 2. Pre-flight inventory
+
+Record these before changing bind, proxy, Tailscale, or channel policy:
+
+- Gateway host, OS user, and state directory.
+- Gateway URL and bind mode.
+- Auth mode, token/password source, or trusted proxy identity source.
+- All enabled channels and whether they accept DMs, groups, or webhooks.
+- Agents reachable from non-local senders.
+- Tool profile, sandbox mode, and elevated tool policy for each reachable agent.
+- External credentials available to those agents.
+- Backup location for `~/.openclaw/openclaw.json` and credentials.
+
+If more than one person can message the bot, treat this as a shared delegated
+tool authority, not as per-user host isolation.
+
+## 3. Baseline checks
+
+Run these before opening access:
+
+```bash
+openclaw doctor
+openclaw security audit
+openclaw security audit --deep
+openclaw health
+```
+
+Resolve critical findings first. Warnings may be acceptable only when they are
+intentional and documented for the deployment.
+
+For remote CLI validation, pass credentials explicitly:
+
+```bash
+openclaw gateway probe --url ws://127.0.0.1:18789 --token "$OPENCLAW_GATEWAY_TOKEN"
+```
+
+Do not assume local config credentials apply to an explicit remote URL.
+
+## 4. Minimum safe baseline
+
+Use this shape as the starting point for exposed deployments:
+
+```json5
+{
+  gateway: {
+    bind: "loopback",
+    auth: {
+      mode: "token",
+      token: "replace-with-a-long-random-token",
+    },
+  },
+  session: {
+    dmScope: "per-channel-peer",
+  },
+  agents: {
+    defaults: {
+      sandbox: { mode: "non-main" },
+    },
+  },
+  tools: {
+    profile: "messaging",
+    exec: { security: "deny", ask: "always" },
+    elevated: { enabled: false },
+  },
+}
+```
+
+Then widen one control at a time. For example, add a specific channel allowlist
+before enabling write-capable tools, or enable a reverse proxy before accepting
+remote Control UI traffic.
+
+## 5. DM and group exposure
+
+Messaging channels are untrusted input surfaces. Before allowing DMs or groups:
+
+- Prefer `dmPolicy: "pairing"` or strict `allowFrom` lists.
+- Avoid `dmPolicy: "open"` unless every sender is trusted.
+- Do not combine `"*"` allowlists with broad tool access.
+- Require mentions in groups unless the room is tightly controlled.
+- Use `session.dmScope: "per-channel-peer"` when multiple people can DM the bot.
+- Route shared channels to agents with minimal tools and no personal credentials.
+
+Pairing approves the sender to trigger the bot. It does not make that sender a
+separate host security boundary.
+
+## 6. Reverse proxy checks
+
+For identity-aware proxies:
+
+- The proxy must authenticate users before forwarding to the Gateway.
+- Direct access to the Gateway port must be blocked by firewall or network
+  policy.
+- `gateway.trustedProxies` must contain only the proxy source IPs.
+- The proxy must strip or overwrite client-supplied identity and forwarding
+  headers.
+- `gateway.auth.trustedProxy.allowUsers` should list expected users when the
+  proxy serves more than one audience.
+- Same-host loopback proxy mode should use `allowLoopback` only when local
+  processes are trusted and the proxy owns the identity headers.
+
+Run `openclaw security audit --deep` after proxy changes. Trusted-proxy findings
+are intentionally high-signal because the proxy becomes the authentication
+boundary.
+
+## 7. Tool and sandbox review
+
+Before exposing an agent to remote senders:
+
+- Confirm which sessions run on host versus sandbox.
+- Deny or require approval for host exec.
+- Keep elevated tools disabled unless a specific, trusted sender needs them.
+- Avoid browser, canvas, node, cron, gateway, and session-spawn tools for open
+  or semi-open messaging surfaces.
+- Keep bind mounts narrow and avoid credential, home, Docker socket, and system
+  paths.
+- Use separate gateways, OS users, or hosts for materially different trust
+  boundaries.
+
+If remote users are not fully trusted, isolation must come from separate
+deployments, not only from prompts or session labels.
+
+## 8. Post-change validation
+
+After each exposure change:
+
+1. Re-run `openclaw security audit --deep`.
+2. Test a successful authorized connection.
+3. Test that an unauthorized sender or browser session is denied.
+4. Confirm logs redact secrets.
+5. Confirm DM/group routing reaches only the intended agent.
+6. Confirm high-impact tools ask for approval or are denied.
+7. Document the accepted residual warnings.
+
+Do not proceed to the next exposure change until the current one is understood.
+
+## 9. Rollback plan
+
+If the Gateway may be overexposed:
+
+```json5
+{
+  gateway: {
+    bind: "loopback",
+  },
+  channels: {
+    whatsapp: { dmPolicy: "disabled" },
+    telegram: { dmPolicy: "disabled" },
+    discord: { dmPolicy: "disabled" },
+    slack: { dmPolicy: "disabled" },
+  },
+  tools: {
+    exec: { security: "deny", ask: "always" },
+    elevated: { enabled: false },
+  },
+}
+```
+
+Then:
+
+1. Stop public forwarding, Tailscale Funnel, or reverse proxy routes.
+2. Rotate Gateway tokens/passwords and affected integration credentials.
+3. Remove `"*"` and unexpected senders from allowlists.
+4. Review recent audit logs, run history, tool calls, and config changes.
+5. Re-run `openclaw security audit --deep`.
+6. Re-enable access with the narrowest pattern that satisfies the workflow.
+
+## 10. Review checklist
+
+Use this checklist in deployment reviews:
+
+- Gateway remains loopback-only unless there is a documented reason.
+- Non-loopback access has auth, firewalling, and no public direct route.
+- Trusted-proxy deployments have strict proxy IPs and header controls.
+- DMs use pairing or allowlists, not open access by default.
+- Groups require mentions or explicit allowlists.
+- Shared channels do not reach personal credentials.
+- Non-main sessions run in sandbox mode.
+- Host exec and elevated tools are denied or approval-gated.
+- Logs redact secrets.
+- Critical audit findings are resolved.
+- Rollback steps are tested and documented.

--- a/docs/gateway/security/exposure-runbook.md
+++ b/docs/gateway/security/exposure-runbook.md
@@ -104,6 +104,11 @@ Then widen one control at a time. For example, add a specific channel allowlist
 before enabling write-capable tools, or enable a reverse proxy before accepting
 remote Control UI traffic.
 
+The strict `exec.security: "deny"` baseline blocks all exec calls, including
+benign diagnostics. If diagnostics or low-risk commands are required, relax this
+only after choosing the specific senders, agents, commands, and approval mode
+that match your threat model.
+
 ## 5. DM and group exposure
 
 Messaging channels are untrusted input surfaces. Before allowing DMs or groups:

--- a/docs/gateway/security/exposure-runbook.md
+++ b/docs/gateway/security/exposure-runbook.md
@@ -21,13 +21,13 @@ operator checklist for remote access and messaging exposure.
 
 Prefer the narrowest pattern that satisfies the workflow.
 
-| Pattern | Recommended when | Required controls |
-| --- | --- | --- |
-| Loopback + SSH tunnel | Personal use, admin access, debugging | Keep `gateway.bind: "loopback"` and tunnel `127.0.0.1:18789` |
-| Loopback + Tailscale Serve | Personal tailnet access to Control UI/WebSocket | Keep Gateway loopback-only; rely on Tailscale identity headers only for supported surfaces |
-| Tailnet/LAN bind | Dedicated private network with known devices | Gateway auth, firewall allowlist, no public port-forward |
-| Trusted reverse proxy | Organization SSO/OIDC in front of Gateway | `trusted-proxy` auth, strict `trustedProxies`, header overwrite/strip rules, explicit allowed users |
-| Public internet | Rare, high-risk deployments | Identity-aware proxy, TLS, rate limits, strict allowlists, sandboxed non-main sessions |
+| Pattern                    | Recommended when                                | Required controls                                                                                   |
+| -------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Loopback + SSH tunnel      | Personal use, admin access, debugging           | Keep `gateway.bind: "loopback"` and tunnel `127.0.0.1:18789`                                        |
+| Loopback + Tailscale Serve | Personal tailnet access to Control UI/WebSocket | Keep Gateway loopback-only; rely on Tailscale identity headers only for supported surfaces          |
+| Tailnet/LAN bind           | Dedicated private network with known devices    | Gateway auth, firewall allowlist, no public port-forward                                            |
+| Trusted reverse proxy      | Organization SSO/OIDC in front of Gateway       | `trusted-proxy` auth, strict `trustedProxies`, header overwrite/strip rules, explicit allowed users |
+| Public internet            | Rare, high-risk deployments                     | Identity-aware proxy, TLS, rate limits, strict allowlists, sandboxed non-main sessions              |
 
 Avoid direct public port-forwarding to the Gateway. If you need public access,
 put an identity-aware proxy in front of it and make the proxy the only network

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -43,6 +43,10 @@ policies to allowlists, restores `logging.redactSensitive: "tools"`, tightens
 state/config/include-file permissions, and uses Windows ACL resets instead of
 POSIX `chmod` when running on Windows.
 
+If you are about to expose the Gateway beyond loopback, use the
+[Gateway exposure runbook](/gateway/security/exposure-runbook) before and after
+the change.
+
 It flags common footguns (Gateway auth exposure, browser control exposure, elevated allowlists, filesystem permissions, permissive exec approvals, and open-channel tool exposure).
 
 OpenClaw is both a product and an experiment: you’re wiring frontier-model behavior into real messaging surfaces and real tools. **There is no “perfectly secure” setup.** The goal is to be deliberate about:

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -25,6 +25,10 @@ OpenClaw security guidance assumes a **personal assistant** deployment: one trus
 
 This page explains hardening **within that model**. It does not claim hostile multi-tenant isolation on one shared gateway.
 
+Before changing remote access, DM policy, reverse proxy, or public exposure,
+use the [Gateway exposure runbook](/gateway/security/exposure-runbook) as a
+pre-flight and rollback checklist.
+
 ## Quick check: `openclaw security audit`
 
 See also: [Formal Verification (Security Models)](/security/formal-verification)
@@ -42,10 +46,6 @@ openclaw security audit --json
 policies to allowlists, restores `logging.redactSensitive: "tools"`, tightens
 state/config/include-file permissions, and uses Windows ACL resets instead of
 POSIX `chmod` when running on Windows.
-
-If you are about to expose the Gateway beyond loopback, use the
-[Gateway exposure runbook](/gateway/security/exposure-runbook) before and after
-the change.
 
 It flags common footguns (Gateway auth exposure, browser control exposure, elevated allowlists, filesystem permissions, permissive exec approvals, and open-channel tool exposure).
 


### PR DESCRIPTION
## Summary
- add a gateway exposure runbook for pre-flight checks, safe access patterns, and rollback
- include DM/group, reverse proxy, tool, sandbox, and audit review guidance
- add the runbook to the Mintlify docs navigation and README security links
- format the new runbook table and add the zh-CN glossary entry required by docs validation

## Validation
- `node scripts/format-docs.mjs`
- `node scripts/check-docs-mdx.mjs docs\gateway\security\exposure-runbook.md README.md`
- `node scripts/check-docs-i18n-glossary.mjs`
- `node scripts/docs-link-audit.mjs`
- parsed `docs/docs.json` and `docs/.i18n/glossary.zh-CN.json` with PowerShell `ConvertFrom-Json`
- `git diff --check -- docs\gateway\security\exposure-runbook.md docs\.i18n\glossary.zh-CN.json README.md docs\docs.json docs\gateway\security\index.md`

## Real behavior proof

- **Behavior or issue addressed:** The gateway exposure runbook PR was failing the repository docs gate because the new runbook table did not match docs formatter output. A follow-up validation also identified the missing zh-CN glossary entry for the new page title.
- **Real environment tested:** Local OpenClaw checkout on Windows using the repository scripts with the pinned dependency set installed from `pnpm-lock.yaml` and Node 24 for script execution.
- **Exact steps or command run after this patch:**

```powershell
node scripts/format-docs.mjs
node scripts/check-docs-mdx.mjs docs\gateway\security\exposure-runbook.md README.md
node scripts/check-docs-i18n-glossary.mjs
node scripts/docs-link-audit.mjs
Get-Content docs\docs.json -Raw | ConvertFrom-Json | Out-Null
Get-Content docs\.i18n\glossary.zh-CN.json -Raw | ConvertFrom-Json | Out-Null
git diff --check -- docs\gateway\security\exposure-runbook.md docs\.i18n\glossary.zh-CN.json README.md docs\docs.json docs\gateway\security\index.md
```

- **Evidence after fix:** Copied terminal output from the local OpenClaw checkout:

```text
Docs formatting clean (598 files).
Docs MDX check passed (2 files, 117ms).
checked_internal_links=4226
broken_links=0
docs JSON files parsed
```

- **Observed result after fix:** The runbook table is now in formatter output form, the new title has a zh-CN glossary mapping, MDX parsing passed for the touched Markdown surfaces, the docs link audit found zero broken internal links, and the touched files have no whitespace errors.
- **What was not tested:** Linux CI remains the final repository gate for the complete all-docs workflow.