### PR TITLE
fix(doctor): resolve gateway token SecretRef before warning unavailable

### DIFF
--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -142,6 +142,7 @@ async function runAuthProfileHealth(ctx: DoctorHealthFlowContext): Promise<void>
 async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { resolveSecretInputRef } = await import("../config/types.secrets.js");
   const { resolveGatewayAuth } = await import("../gateway/auth.js");
+  const { resolveGatewayAuthToken } = await import("../gateway/auth-token-resolution.js");
   const { note } = await import("../terminal/note.js");
   const { randomToken } = await import("../commands/onboard-helpers.js");
   if (resolveDoctorMode(ctx.cfg) !== "local" || !ctx.sourceConfigValid) {
@@ -168,9 +169,21 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     return;
   }
   if (gatewayTokenRef) {
+    const resolved = await resolveGatewayAuthToken({
+      cfg: ctx.cfg,
+      env: process.env,
+      envFallback: "never",
+    });
+    if (resolved.token) {
+      // SecretRef resolves successfully — no action needed.
+      return;
+    }
+    const reason = resolved.unresolvedRefReason
+      ? `Gateway token SecretRef could not be resolved: ${resolved.unresolvedRefReason}`
+      : "Gateway token is managed via SecretRef and is currently unavailable.";
     note(
       [
-        "Gateway token is managed via SecretRef and is currently unavailable.",
+        reason,
         "Doctor will not overwrite gateway.auth.token with a plaintext value.",
         "Resolve/rotate the external secret source, then rerun doctor.",
       ].join("\n"),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -169,17 +169,24 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     return;
   }
   if (gatewayTokenRef) {
-    const resolved = await resolveGatewayAuthToken({
-      cfg: ctx.cfg,
-      env: process.env,
-      envFallback: "never",
-    });
-    if (resolved.token) {
-      // SecretRef resolves successfully — no action needed.
-      return;
+    // Skip exec SecretRef resolution in doctor to avoid running arbitrary
+    // commands during a health check. Env and file refs are safe to resolve.
+    let unresolvedReason: string | undefined;
+    if (gatewayTokenRef.source === "exec") {
+      // Cannot verify without executing — defer to user.
+    } else {
+      const resolved = await resolveGatewayAuthToken({
+        cfg: ctx.cfg,
+        env: process.env,
+        envFallback: "never",
+      });
+      if (resolved.token) {
+        return;
+      }
+      unresolvedReason = resolved.unresolvedRefReason;
     }
-    const reason = resolved.unresolvedRefReason
-      ? `Gateway token SecretRef could not be resolved: ${resolved.unresolvedRefReason}`
+    const reason = unresolvedReason
+      ? `Gateway token SecretRef could not be resolved: ${unresolvedReason}`
       : "Gateway token is managed via SecretRef and is currently unavailable.";
     note(
       [


### PR DESCRIPTION
## Problem

`openclaw doctor` unconditionally warns that `gateway.auth.token` is unavailable when configured as a SecretRef, even when the SecretRef resolves successfully.

**Root cause:** `runGatewayAuthHealth()` checks whether the token value *is* a SecretRef (`gatewayTokenRef`) but never attempts to resolve it. The synchronous `resolveGatewayAuth()` path deliberately skips SecretRef values, so `auth.token` is always `undefined` for SecretRef-backed tokens, making `needsToken` always `true`.

## Fix

Before emitting the warning, call `resolveGatewayAuthToken()` which actually materializes SecretRef values:

- If resolution succeeds → return silently (no warning)
- If resolution fails → include the `unresolvedRefReason` in the diagnostic message instead of a generic "unavailable" warning
- **Security gate:** exec-type SecretRefs are NOT resolved during doctor (avoids running arbitrary commands in a health check). Only env and file SecretRefs are resolved. For exec, the original warning is preserved.

This uses the same resolution path as `resolveGatewayTokenForDriftCheck()` in `gateway-token-drift.ts`, which already handles this correctly.

## Real behavior proof

**Environment constraint:** The contributor environment uses plaintext token auth (no SecretRef), making the exact reproduction scenario unavailable locally. The fix is verified through:

1. **Code path analysis:** `resolveGatewayAuthToken()` is the same function used by `gateway-token-drift.ts` (already in production). Its behavior with env/file SecretRefs is well-tested via `doctor-gateway-auth-token.test.ts`.

2. **Static verification of the fix:**
   - Before fix: `if (gatewayTokenRef) { note("unavailable") }` — unconditional warning
   - After fix: `if (gatewayTokenRef) { resolve → return if ok → warn if not }` — conditional
   - The exec gate prevents the security concern raised in Codex review

3. **Boundary cases covered:**
   - `gatewayTokenRef.source === "exec"` → skips resolution, warns as before ✓
   - `gatewayTokenRef.source === "env"` or `"file"` → resolves, suppresses warning on success ✓
   - Resolution throws → catch in `resolveConfiguredSecretInputString`, returns `unresolvedRefReason` ✓

A maintainer with a SecretRef-configured setup can verify by running `openclaw doctor` before/after and confirming the false warning is suppressed.

Fixes #77687