### PR TITLE
docs: clarify `/reset` is not an alias for `/new`

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -124,7 +124,7 @@ Current source-of-truth:
 
 <AccordionGroup>
   <Accordion title="Sessions and runs">
-    - `/new [model]` starts a new session; `/reset` is the reset alias.
+    - `/new [model]` starts a new session. `/reset` resets the current session in place; it is not an alias for `/new`.
     - Control UI intercepts typed `/new` to create and switch to a fresh dashboard session; typed `/reset` still runs the Gateway's in-place reset.
     - `/reset soft [message]` keeps the current transcript, drops reused CLI backend session ids, and reruns startup/system-prompt loading in-place.
     - `/compact [instructions]` compacts the session context. See [Compaction](/concepts/compaction).

--- a/src/acp/commands.ts
+++ b/src/acp/commands.ts
@@ -20,8 +20,8 @@ const BASE_AVAILABLE_COMMANDS: AvailableCommand[] = [
   { name: "restart", description: "Restart the gateway (if enabled)." },
   { name: "activation", description: "Set group activation (mention|always)." },
   { name: "send", description: "Set send mode (on|off|inherit)." },
-  { name: "reset", description: "Reset the session (/new)." },
-  { name: "new", description: "Reset the session (/reset)." },
+  { name: "reset", description: "Reset the current session in place." },
+  { name: "new", description: "Start a new session." },
   {
     name: "think",
     description: "Set thinking level (off|minimal|low|medium|high|xhigh).",


### PR DESCRIPTION
Fixes #76592.

This updates the slash command docs and native command summaries so `/new` and `/reset` are no longer presented as interchangeable aliases.

- `/new [model]` starts a new session.
- `/reset` resets the current session in place.

The old wording called `/reset` the reset alias, which made it sound interchangeable with `/new`.

## Real behavior proof

**Behavior or issue addressed:** The PR removes user-facing alias-like wording for `/new` and `/reset`. After this patch, the docs say `/new` starts a new session and `/reset` resets the current session in place; ACP/native command summaries now say the same thing.

**Real environment tested:** macOS 26.3.1 OpenClaw runtime host with OpenClaw `2026.5.3-1 (2eae30e)` available, plus this PR branch checked out locally at `893e25f76e285c74b37a79cac2b579aa6936bc90`.

**Exact steps or command run after this patch:** Ran terminal commands against the patched branch to read the exact user-facing strings that changed:

```text
sed -n '125,128p' docs/tools/slash-commands.md
sed -n '23,24p' src/acp/commands.ts
```

**Evidence after fix:** Terminal output from the patched branch:

```text
$ sed -n '125,128p' docs/tools/slash-commands.md
    - `/new [model]` starts a new session. `/reset` resets the current session in place; it is not an alias for `/new`.
    - Control UI intercepts typed `/new` to create and switch to a fresh dashboard session; typed `/reset` still runs the Gateway's in-place reset.

$ sed -n '23,24p' src/acp/commands.ts
  { name: "reset", description: "Reset the current session in place." },
  { name: "new", description: "Start a new session." },
```

**Observed result after fix:** The after-fix output shows both affected user-facing surfaces now distinguish `/new` from `/reset` and no longer describe either command as the other's alias.

**What was not tested:** No additional gaps.

This is a docs/user-facing command-copy fix only. It does not change command dispatch behavior.

## Testing

- Ran `git diff --check`.
- Verified the updated docs line and ACP command summaries with the terminal output shown above.
- Did not run `pnpm build`, `pnpm check`, or `pnpm test` because this changes only documentation and command descriptions.

AI-assisted: yes. I used Codex to locate the contradictory wording, prepare the docs patch, and align the related command summaries after review feedback.
