### PR TITLE
fix(agents): preserve subagent context with systemPromptOverride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/subagents: preserve runtime task context when `systemPromptOverride` is configured, so native subagent and CLI runs keep both the role prompt override and the task handoff context.
 - fix: harden backend message action gateway routing [AI]. (#76374) Thanks @pgondhi987.
 - Gate QQBot streaming command auth [AI]. (#76375) Thanks @pgondhi987.
 - Plugins/release: make the published npm runtime verifier reject blank `openclaw.runtimeExtensions` entries instead of treating them as absent and passing via inferred outputs. Thanks @vincentkoc.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -482,7 +482,7 @@ Optional CLI backends for text-only fallback runs (no tool calls). Useful as a b
 
 ### `agents.defaults.systemPromptOverride`
 
-Replace the entire OpenClaw-assembled system prompt with a fixed string. Set at the default level (`agents.defaults.systemPromptOverride`) or per agent (`agents.list[].systemPromptOverride`). Per-agent values take precedence; an empty or whitespace-only value is ignored. Useful for controlled prompt experiments.
+Use a fixed string as the base system prompt instead of the OpenClaw-assembled base prompt. Runtime extra context, such as subagent task context, may still be appended. Set at the default level (`agents.defaults.systemPromptOverride`) or per agent (`agents.list[].systemPromptOverride`). Per-agent values take precedence; an empty or whitespace-only value is ignored. Useful for controlled prompt experiments.
 
 ```json5
 {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -24,6 +24,10 @@ vi.mock("../../plugin-sdk/anthropic-cli.js", () => ({
   isClaudeCliProvider: (providerId: string) => providerId === "claude-cli",
 }));
 
+vi.mock("global-agent", () => ({
+  bootstrap: vi.fn(),
+}));
+
 vi.mock("../../tts/tts.js", () => ({
   buildTtsSystemPromptHint: vi.fn(() => undefined),
 }));
@@ -478,6 +482,32 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.systemPrompt).toBe("base extra system");
       expect(context.systemPrompt).not.toContain("hook exploded");
       expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges extraSystemPrompt into a configured systemPromptOverride", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-override-extra-system",
+        extraSystemPrompt: "## Spawn Context\nOC_EXTRA_PROMPT_OVERRIDE_SPIKE_SENTINEL",
+        config: createCliBackendConfig({
+          systemPromptOverride: "STATIC_ROLE_PROMPT_OVERRIDE_SPIKE",
+        }),
+      });
+
+      expect(context.systemPrompt).toContain("STATIC_ROLE_PROMPT_OVERRIDE_SPIKE");
+      expect(context.systemPrompt).toContain("## Spawn Context");
+      expect(context.systemPrompt).toContain("OC_EXTRA_PROMPT_OVERRIDE_SPIKE_SENTINEL");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -44,6 +44,7 @@ import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { resolveSkillsPromptForRun } from "../skills.js";
 import { resolveSystemPromptOverride } from "../system-prompt-override.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
+import { appendExtraSystemPromptToSystemPrompt } from "../system-prompt.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { buildSystemPrompt, normalizeCliModel } from "./helpers.js";
@@ -324,28 +325,32 @@ export async function prepareCliRunContext(
     config: params.config,
     agentId: sessionAgentId,
   });
-  const builtSystemPrompt =
-    resolveSystemPromptOverride({
-      config: params.config,
-      agentId: sessionAgentId,
-    }) ??
-    buildSystemPrompt({
-      workspaceDir,
-      config: params.config,
-      defaultThinkLevel: params.thinkLevel,
-      extraSystemPrompt,
-      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-      silentReplyPromptMode: params.silentReplyPromptMode,
-      ownerNumbers: params.ownerNumbers,
-      heartbeatPrompt,
-      docsPath: openClawReferences.docsPath ?? undefined,
-      sourcePath: openClawReferences.sourcePath ?? undefined,
-      skillsPrompt,
-      tools: [],
-      contextFiles,
-      modelDisplay,
-      agentId: sessionAgentId,
-    });
+  const systemPromptOverride = resolveSystemPromptOverride({
+    config: params.config,
+    agentId: sessionAgentId,
+  });
+  const builtSystemPrompt = systemPromptOverride
+    ? appendExtraSystemPromptToSystemPrompt({
+        systemPrompt: systemPromptOverride,
+        extraSystemPrompt,
+      })
+    : buildSystemPrompt({
+        workspaceDir,
+        config: params.config,
+        defaultThinkLevel: params.thinkLevel,
+        extraSystemPrompt,
+        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+        silentReplyPromptMode: params.silentReplyPromptMode,
+        ownerNumbers: params.ownerNumbers,
+        heartbeatPrompt,
+        docsPath: openClawReferences.docsPath ?? undefined,
+        sourcePath: openClawReferences.sourcePath ?? undefined,
+        skillsPrompt,
+        tools: [],
+        contextFiles,
+        modelDisplay,
+        agentId: sessionAgentId,
+      });
   const transformedSystemPrompt =
     backendResolved.transformSystemPrompt?.({
       config: params.config,

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -60,6 +60,10 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve };
 }
 
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1;
+}
+
 function mockResolvedModel() {
   resolveModelMock.mockReset();
   resolveModelMock.mockReturnValue({
@@ -307,6 +311,46 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
         senderE164: "+15551234567",
       }),
     );
+  });
+
+  it("appends extraSystemPrompt to configured systemPromptOverride during compaction prompt rebuild", () => {
+    const buildDefaultSystemPrompt = vi.fn(() => "default prompt should not be used");
+    const overrideSentinel = "OC_COMPACTION_OVERRIDE_BASE_SENTINEL";
+    const extraSentinel = "OC_COMPACTION_EXTRA_PROMPT_SENTINEL";
+    const contextHeader = "## Group Chat Context";
+
+    const rebuiltPrompt = compactTesting.buildCompactionSystemPrompt({
+      systemPromptOverride: overrideSentinel,
+      buildDefaultSystemPrompt,
+      extraSystemPrompt: extraSentinel,
+      promptMode: "full",
+    });
+
+    expect(rebuiltPrompt).toContain(overrideSentinel);
+    expect(countOccurrences(rebuiltPrompt, extraSentinel)).toBe(1);
+    expect(countOccurrences(rebuiltPrompt, contextHeader)).toBe(1);
+    expect(buildDefaultSystemPrompt).not.toHaveBeenCalled();
+    expect(rebuiltPrompt.indexOf(overrideSentinel)).toBeLessThan(
+      rebuiltPrompt.indexOf(extraSentinel),
+    );
+  });
+
+  it("does not duplicate extraSystemPrompt when compaction uses the default system prompt", () => {
+    const extraSentinel = "OC_COMPACTION_EXTRA_PROMPT_SENTINEL";
+    const contextHeader = "## Group Chat Context";
+    const defaultPrompt = ["DEFAULT_PROMPT", contextHeader, extraSentinel].join("\n");
+    const buildDefaultSystemPrompt = vi.fn(() => defaultPrompt);
+
+    const rebuiltPrompt = compactTesting.buildCompactionSystemPrompt({
+      buildDefaultSystemPrompt,
+      extraSystemPrompt: extraSentinel,
+      promptMode: "full",
+    });
+
+    expect(buildDefaultSystemPrompt).toHaveBeenCalledTimes(1);
+    expect(rebuiltPrompt).toBe(defaultPrompt);
+    expect(countOccurrences(rebuiltPrompt, extraSentinel)).toBe(1);
+    expect(countOccurrences(rebuiltPrompt, contextHeader)).toBe(1);
   });
 
   it("uses the session model fallback chain when implicit compaction fails", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -103,6 +103,7 @@ import {
   resolveSkillsPromptForRun,
 } from "../skills.js";
 import { resolveSystemPromptOverride } from "../system-prompt-override.js";
+import { appendExtraSystemPromptToSystemPrompt } from "../system-prompt.js";
 import {
   classifyCompactionReason,
   formatUnknownCompactionReasonDetail,
@@ -378,6 +379,23 @@ function fallbackFailureToCompactionResult(err: unknown): EmbeddedPiCompactResul
     compacted: false,
     reason,
   };
+}
+
+function buildCompactionSystemPrompt(params: {
+  systemPromptOverride?: string;
+  buildDefaultSystemPrompt: () => string;
+  extraSystemPrompt?: string;
+  promptMode?: Parameters<typeof appendExtraSystemPromptToSystemPrompt>[0]["promptMode"];
+}): string {
+  if (params.systemPromptOverride) {
+    return appendExtraSystemPromptToSystemPrompt({
+      systemPrompt: params.systemPromptOverride,
+      extraSystemPrompt: params.extraSystemPrompt,
+      promptMode: params.promptMode,
+    });
+  }
+
+  return params.buildDefaultSystemPrompt();
 }
 
 /**
@@ -843,48 +861,52 @@ async function compactEmbeddedPiSessionDirectOnce(
     const promptContribution =
       runtimePlan.prompt.resolveSystemPromptContribution(promptContributionContext);
     const buildSystemPromptOverride = (defaultThinkLevel: ThinkLevel) => {
-      const builtSystemPrompt =
-        resolveSystemPromptOverride({
+      const builtSystemPrompt = buildCompactionSystemPrompt({
+        systemPromptOverride: resolveSystemPromptOverride({
           config: params.config,
           agentId: sessionAgentId,
-        }) ??
-        buildEmbeddedSystemPrompt({
-          workspaceDir: effectiveWorkspace,
-          defaultThinkLevel,
-          reasoningLevel: params.reasoningLevel ?? "off",
-          extraSystemPrompt: params.extraSystemPrompt,
-          ownerNumbers: params.ownerNumbers,
-          ownerDisplay: ownerDisplay.ownerDisplay,
-          ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
-          reasoningTagHint,
-          heartbeatPrompt: resolveHeartbeatPromptForSystemPrompt({
-            config: params.config,
-            agentId: sessionAgentId,
-            defaultAgentId,
+        }),
+        buildDefaultSystemPrompt: () =>
+          buildEmbeddedSystemPrompt({
+            workspaceDir: effectiveWorkspace,
+            defaultThinkLevel,
+            reasoningLevel: params.reasoningLevel ?? "off",
+            extraSystemPrompt: params.extraSystemPrompt,
+            ownerNumbers: params.ownerNumbers,
+            ownerDisplay: ownerDisplay.ownerDisplay,
+            ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
+            reasoningTagHint,
+            heartbeatPrompt: resolveHeartbeatPromptForSystemPrompt({
+              config: params.config,
+              agentId: sessionAgentId,
+              defaultAgentId,
+            }),
+            skillsPrompt,
+            docsPath: openClawReferences.docsPath ?? undefined,
+            sourcePath: openClawReferences.sourcePath ?? undefined,
+            ttsHint,
+            promptMode,
+            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+            acpEnabled: isAcpRuntimeSpawnAvailable({
+              config: params.config,
+              sandboxed: sandboxInfo?.enabled === true,
+            }),
+            runtimeInfo,
+            reactionGuidance,
+            messageToolHints,
+            sandboxInfo,
+            tools: effectiveTools,
+            modelAliasLines: buildModelAliasLines(params.config),
+            userTimezone,
+            userTime,
+            userTimeFormat,
+            contextFiles,
+            memoryCitationsMode: params.config?.memory?.citations,
+            promptContribution,
           }),
-          skillsPrompt,
-          docsPath: openClawReferences.docsPath ?? undefined,
-          sourcePath: openClawReferences.sourcePath ?? undefined,
-          ttsHint,
-          promptMode,
-          sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-          acpEnabled: isAcpRuntimeSpawnAvailable({
-            config: params.config,
-            sandboxed: sandboxInfo?.enabled === true,
-          }),
-          runtimeInfo,
-          reactionGuidance,
-          messageToolHints,
-          sandboxInfo,
-          tools: effectiveTools,
-          modelAliasLines: buildModelAliasLines(params.config),
-          userTimezone,
-          userTime,
-          userTimeFormat,
-          contextFiles,
-          memoryCitationsMode: params.config?.memory?.citations,
-          promptContribution,
-        });
+        extraSystemPrompt: params.extraSystemPrompt,
+        promptMode,
+      });
       return createSystemPromptOverride(
         transformProviderSystemPrompt({
           provider,
@@ -1398,6 +1420,7 @@ export const __testing = {
   buildBeforeCompactionHookMetrics,
   hardenManualCompactionBoundary,
   resolveCompactionProviderStream,
+  buildCompactionSystemPrompt,
   prepareCompactionSessionAgent,
   runBeforeCompactionHooks,
   runAfterCompactionHooks,

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -8,6 +8,7 @@ import {
   clearMemoryPluginState,
   registerMemoryPromptSection,
 } from "../../../plugins/memory-state.js";
+import { buildSubagentSystemPrompt } from "../../subagent-system-prompt.js";
 import {
   type AttemptContextEngine,
   buildLoopPromptCacheInfo,
@@ -340,6 +341,90 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     const contextCompiled = trajectoryEvents.find((event) => event.type === "context.compiled");
     expect(contextCompiled?.data?.prompt).toBe("Continue the OpenClaw runtime event.");
     expect(contextCompiled?.data?.systemPrompt).toContain("internal heartbeat event");
+  });
+
+  it("records merged override and extraSystemPrompt in compiled context", async () => {
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        config: {
+          agents: {
+            defaults: {
+              systemPromptOverride: "STATIC_ROLE_PROMPT_OVERRIDE_SPIKE",
+            },
+          },
+        },
+        extraSystemPrompt: "## Spawn Context\nOC_EXTRA_PROMPT_OVERRIDE_SPIKE_SENTINEL",
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    const trajectoryEvents = (
+      await fs.readFile(path.join(tempPaths[0] ?? "", "session.trajectory.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as TrajectoryEvent);
+    const contextCompiled = trajectoryEvents.find((event) => event.type === "context.compiled");
+    const systemPrompt = contextCompiled?.data?.systemPrompt;
+
+    expect(systemPrompt).toContain("STATIC_ROLE_PROMPT_OVERRIDE_SPIKE");
+    expect(systemPrompt).toContain("## Spawn Context");
+    expect(systemPrompt).toContain("OC_EXTRA_PROMPT_OVERRIDE_SPIKE_SENTINEL");
+  });
+
+  it("preserves native subagent role and task context for target role overrides", async () => {
+    const task = "Smoke test only. Reply with exactly: OC_NATIVE_SUBAGENT_TASK_SPIKE_SENTINEL";
+    const childSystemPrompt = buildSubagentSystemPrompt({
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex-verifier:subagent:child",
+      task,
+    });
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:codex-verifier:subagent:child",
+      tempPaths,
+      attemptOverrides: {
+        config: {
+          agents: {
+            list: [
+              {
+                id: "codex-verifier",
+                systemPromptOverride: "STATIC_VERIFIER_ROLE_PROMPT_SPIKE",
+              },
+            ],
+          },
+        } satisfies OpenClawConfig,
+        extraSystemPrompt: childSystemPrompt,
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    const trajectoryEvents = (
+      await fs.readFile(path.join(tempPaths[0] ?? "", "session.trajectory.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as TrajectoryEvent);
+    const contextCompiled = trajectoryEvents.find((event) => event.type === "context.compiled");
+    const systemPrompt = contextCompiled?.data?.systemPrompt;
+
+    expect(systemPrompt).toContain("STATIC_VERIFIER_ROLE_PROMPT_SPIKE");
+    expect(systemPrompt).toContain("## Your Role");
+    expect(systemPrompt).toContain("OC_NATIVE_SUBAGENT_TASK_SPIKE_SENTINEL");
   });
 
   it("skips blank visible prompts with replay history before provider submission", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -233,6 +233,10 @@ vi.mock("../../subagent-spawn.js", () => ({
   spawnSubagentDirect: (...args: unknown[]) => hoisted.spawnSubagentDirectMock(...args),
 }));
 
+vi.mock("global-agent", () => ({
+  bootstrap: vi.fn(),
+}));
+
 vi.mock("../../sandbox.js", () => ({
   resolveSandboxContext: (...args: unknown[]) => hoisted.resolveSandboxContextMock(...args),
 }));
@@ -255,7 +259,8 @@ vi.mock("../../../plugins/provider-runtime.js", () => ({
   resolveProviderReasoningOutputModeWithPlugin: () => undefined,
   resolveProviderSystemPromptContribution: () => undefined,
   resolveProviderTextTransforms: () => undefined,
-  transformProviderSystemPrompt: ({ systemPrompt }: { systemPrompt: string }) => systemPrompt,
+  transformProviderSystemPrompt: ({ context }: { context: { systemPrompt: string } }) =>
+    context.systemPrompt,
 }));
 
 vi.mock("../../../infra/machine-name.js", () => ({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -155,6 +155,7 @@ import {
 import { resolveSystemPromptOverride } from "../../system-prompt-override.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
+import { appendExtraSystemPromptToSystemPrompt } from "../../system-prompt.js";
 import { resolveAgentTimeoutMs } from "../../timeout.js";
 import {
   buildEmptyExplicitToolAllowlistError,
@@ -1284,48 +1285,53 @@ export async function runEmbeddedAttempt(
         context: promptContributionContext,
       });
 
-    const builtAppendPrompt =
-      resolveSystemPromptOverride({
-        config: params.config,
-        agentId: sessionAgentId,
-      }) ??
-      buildEmbeddedSystemPrompt({
-        workspaceDir: effectiveWorkspace,
-        defaultThinkLevel: params.thinkLevel,
-        reasoningLevel: params.reasoningLevel ?? "off",
-        extraSystemPrompt: params.extraSystemPrompt,
-        ownerNumbers: params.ownerNumbers,
-        ownerDisplay: ownerDisplay.ownerDisplay,
-        ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
-        reasoningTagHint,
-        heartbeatPrompt,
-        skillsPrompt: effectiveSkillsPrompt,
-        docsPath: openClawReferences.docsPath ?? undefined,
-        sourcePath: openClawReferences.sourcePath ?? undefined,
-        ttsHint,
-        workspaceNotes: workspaceNotes?.length ? workspaceNotes : undefined,
-        reactionGuidance,
-        promptMode: effectivePromptMode,
-        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-        silentReplyPromptMode: params.silentReplyPromptMode,
-        acpEnabled: isAcpRuntimeSpawnAvailable({
-          config: params.config,
-          sandboxed: sandboxInfo?.enabled === true,
-        }),
-        nativeCommandGuidanceLines: listRegisteredPluginAgentPromptGuidance(),
-        runtimeInfo,
-        messageToolHints,
-        sandboxInfo,
-        tools: effectiveTools,
-        modelAliasLines: buildModelAliasLines(params.config),
-        userTimezone,
-        userTime,
-        userTimeFormat,
-        contextFiles,
-        includeMemorySection: !activeContextEngine || activeContextEngine.info.id === "legacy",
-        memoryCitationsMode: params.config?.memory?.citations,
-        promptContribution,
-      });
+    const configuredSystemPromptOverride = resolveSystemPromptOverride({
+      config: params.config,
+      agentId: sessionAgentId,
+    });
+    const builtAppendPrompt = configuredSystemPromptOverride
+      ? appendExtraSystemPromptToSystemPrompt({
+          systemPrompt: configuredSystemPromptOverride,
+          extraSystemPrompt: params.extraSystemPrompt,
+          promptMode: effectivePromptMode,
+        })
+      : buildEmbeddedSystemPrompt({
+          workspaceDir: effectiveWorkspace,
+          defaultThinkLevel: params.thinkLevel,
+          reasoningLevel: params.reasoningLevel ?? "off",
+          extraSystemPrompt: params.extraSystemPrompt,
+          ownerNumbers: params.ownerNumbers,
+          ownerDisplay: ownerDisplay.ownerDisplay,
+          ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
+          reasoningTagHint,
+          heartbeatPrompt,
+          skillsPrompt: effectiveSkillsPrompt,
+          docsPath: openClawReferences.docsPath ?? undefined,
+          sourcePath: openClawReferences.sourcePath ?? undefined,
+          ttsHint,
+          workspaceNotes: workspaceNotes?.length ? workspaceNotes : undefined,
+          reactionGuidance,
+          promptMode: effectivePromptMode,
+          sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+          silentReplyPromptMode: params.silentReplyPromptMode,
+          acpEnabled: isAcpRuntimeSpawnAvailable({
+            config: params.config,
+            sandboxed: sandboxInfo?.enabled === true,
+          }),
+          nativeCommandGuidanceLines: listRegisteredPluginAgentPromptGuidance(),
+          runtimeInfo,
+          messageToolHints,
+          sandboxInfo,
+          tools: effectiveTools,
+          modelAliasLines: buildModelAliasLines(params.config),
+          userTimezone,
+          userTime,
+          userTimeFormat,
+          contextFiles,
+          includeMemorySection: !activeContextEngine || activeContextEngine.info.id === "legacy",
+          memoryCitationsMode: params.config?.memory?.citations,
+          promptContribution,
+        });
     const appendPrompt = isRawModelRun
       ? ""
       : transformProviderSystemPrompt({

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -4,10 +4,51 @@ import { typedCases } from "../test-utils/typed-cases.js";
 import { buildSubagentSystemPrompt } from "./subagent-system-prompt.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./system-prompt-cache-boundary.js";
 import {
+  appendExtraSystemPromptToSystemPrompt,
   buildAgentSystemPrompt,
   buildAgentUserPromptPrefix,
   buildRuntimeLine,
 } from "./system-prompt.js";
+
+describe("appendExtraSystemPromptToSystemPrompt", () => {
+  it("preserves the override prompt when there is no extra prompt", () => {
+    expect(
+      appendExtraSystemPromptToSystemPrompt({
+        systemPrompt: "  Static role prompt  ",
+      }),
+    ).toBe("Static role prompt");
+  });
+
+  it("appends extra prompt context with the default context header", () => {
+    const prompt = appendExtraSystemPromptToSystemPrompt({
+      systemPrompt: "Static role prompt",
+      extraSystemPrompt: "Runtime context",
+    });
+
+    expect(prompt).toBe("Static role prompt\n\n## Group Chat Context\n\nRuntime context");
+  });
+
+  it("uses the subagent context header in minimal prompt mode", () => {
+    const prompt = appendExtraSystemPromptToSystemPrompt({
+      systemPrompt: "Static role prompt",
+      extraSystemPrompt: "Runtime context",
+      promptMode: "minimal",
+    });
+
+    expect(prompt).toBe("Static role prompt\n\n## Subagent Context\n\nRuntime context");
+  });
+
+  it("does not append duplicate extra prompt content", () => {
+    const prompt = appendExtraSystemPromptToSystemPrompt({
+      systemPrompt: "Static role prompt\n\n## Subagent Context\n\nRuntime context",
+      extraSystemPrompt: "Runtime context",
+      promptMode: "minimal",
+    });
+
+    expect(prompt.match(/Runtime context/g)).toHaveLength(1);
+    expect(prompt.match(/## Subagent Context/g)).toHaveLength(1);
+  });
+});
 
 describe("buildAgentSystemPrompt", () => {
   it("formats owner section for plain, hash, and missing owner lists", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -44,6 +44,25 @@ import type { PromptMode, SilentReplyPromptMode } from "./system-prompt.types.js
  */
 type OwnerIdDisplay = "raw" | "hash";
 
+export function appendExtraSystemPromptToSystemPrompt(params: {
+  systemPrompt: string;
+  extraSystemPrompt?: string;
+  promptMode?: PromptMode;
+}): string {
+  const basePrompt = params.systemPrompt.trim();
+  const extraSystemPrompt = params.extraSystemPrompt?.trim();
+  if (!extraSystemPrompt) {
+    return basePrompt;
+  }
+  const contextHeader =
+    params.promptMode === "minimal" ? "## Subagent Context" : "## Group Chat Context";
+  const extraPromptBlock = [contextHeader, extraSystemPrompt].join("\n\n");
+  if (basePrompt.includes(extraPromptBlock)) {
+    return basePrompt;
+  }
+  return [basePrompt, extraPromptBlock].filter(Boolean).join("\n\n");
+}
+
 const CONTEXT_FILE_ORDER = new Map<string, number>([
   ["agents.md", 10],
   ["soul.md", 20],

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -226,7 +226,7 @@ export type AgentDefaultsConfig = {
   silentReplyRewrite?: SilentReplyRewriteShape;
   /** Optional repository root for system prompt runtime line (overrides auto-detect). */
   repoRoot?: string;
-  /** Optional full system prompt replacement. Primarily for prompt debugging and controlled experiments. */
+  /** Optional base system prompt override. Runtime extra context may still be appended. */
   systemPromptOverride?: string;
   /** Provider-independent prompt overlays applied by model family. */
   promptOverlays?: PromptOverlaysConfig;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -79,7 +79,7 @@ export type AgentConfig = {
   name?: string;
   workspace?: string;
   agentDir?: string;
-  /** Optional per-agent full system prompt replacement. */
+  /** Optional per-agent base system prompt override. Runtime extra context may still be appended. */
   systemPromptOverride?: AgentDefaultsConfig["systemPromptOverride"];
   /** Optional per-agent agent runtime policy override. */
   agentRuntime?: AgentRuntimePolicyConfig;


### PR DESCRIPTION
## Summary

- Problem: `systemPromptOverride` was treated as a complete replacement in CLI and embedded agent prompt paths, so runtime `extraSystemPrompt` context could be dropped.
- Why it matters: native subagents and context-engine runs could keep the configured role prompt but lose the task/handoff context needed to complete the run.
- What changed: append runtime extra system context to configured prompt overrides, add a shared helper, and cover CLI runner, embedded runner, context-engine, compaction, and prompt merge behavior.
- What did NOT change: provider selection, model defaults, tool allowlists, sandbox policy, and auth/secret resolution behavior.

This is a hotfix targeting the `2026.5.3` release line to ensure native subagents function correctly when overrides are present.

## Change Type

- [x] Bug fix
- [x] Docs

## Scope

- [x] Gateway / orchestration
- [x] API / contracts

## Root Cause

Prompt override resolution used the configured `systemPromptOverride` as the final system prompt in several run paths instead of using it as the base prompt and then preserving runtime extra context.

The default generated prompt path already accepted `extraSystemPrompt`, but override paths bypassed that merge. There was no regression coverage for override prompts combined with native subagent/task `extraSystemPrompt` context.

## User-visible / Behavior Changes

Agents configured with `systemPromptOverride` still use that configured base prompt, but runtime extra context such as subagent task context can now be appended instead of being dropped.

```text
Before:
systemPromptOverride + runtime extra context -> override prompt only -> missing task context

After:
systemPromptOverride + runtime extra context -> override prompt + context block -> role and task context preserved
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Regression Test Plan

New/updated coverage exercises the prompt merge seams where override prompts previously bypassed runtime context:

- `src/agents/system-prompt.test.ts`
- `src/agents/cli-runner/prepare.test.ts`
- `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `src/agents/pi-embedded-runner/compact.hooks.test.ts`

Scenarios covered include configured prompt override plus runtime extra context in shared helper, CLI runner, embedded context-engine path, and compaction path, including empty/missing extra context and duplicate appended context.

## Validation

Release-tip PR branch validation:

- `pnpm exec vitest run src/agents/system-prompt.test.ts src/agents/cli-runner/prepare.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts`
  - 7 test files passed
  - 255 tests passed
- `pnpm check:changed`
  - passed
- `git diff --check`
  - clean

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: prompt overrides receive appended runtime context, which changes the previous strict replacement interpretation.
  - Mitigation: docs and config comments now describe the override as a base prompt; appending is limited to runtime extra context and duplicate context blocks are avoided.

## AI Assistance

- AI-assisted: Yes.
- Testing degree: tested with targeted regression coverage and changed-check gate.
- Author understanding: this fix preserves configured role prompts while keeping runtime task context in affected prompt construction paths.
- Prompts/session logs: not included to avoid publishing private operator context.
