### PR TITLE
[codex] Fix explicit custom web_search provider routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Video generation: wait up to 20 minutes for slow fal/MiniMax queue-backed jobs, stop forwarding unsupported Google Veo generated-audio options, and normalize MiniMax `720P` requests to its supported `768P` resolution with the usual override warning/details instead of failing fallback.
+- Web search: honor explicit `tools.web.search.provider` and `web_search` provider routing even when stale runtime metadata points at another provider or the active runtime registry is missing the configured provider.
 - Video generation: accept provider-specific aspect-ratio and resolution hints at the tool boundary, normalize `720P` to MiniMax's supported `768P`, and stop sending Google `generateAudio` on Gemini video requests so provider fallback can recover from model-specific parameter differences. Thanks @vincentkoc.
 - OpenAI/Google Meet: fail realtime voice connection attempts when the socket closes before `session.updated`, avoiding stuck Meet joins waiting on a bridge that never became ready. Thanks @vincentkoc.
 - Google Meet: fork the caller's current agent transcript into agent-mode meeting consultant sessions, so Meet replies inherit the context from the tool call that joined the meeting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4703,7 +4703,6 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Doctor/plugins: remove stale managed install records for bundled plugins even when the bundled plugin is not explicitly configured, so doctor cleanup cannot leave orphaned install metadata behind. Thanks @vincentkoc.
 - Web fetch: scope provider fallback cache entries by the selected fetch provider so config reloads cannot reuse another provider's cached fallback payload. Thanks @vincentkoc.
 - Web search: honor late-bound `tools.web.search.enabled: false` during tool execution so config reloads cannot leave an already-created `web_search` tool runnable. Thanks @vincentkoc.
-- Web search: honor explicit `tools.web.search.provider` and `web_search` provider routing even when stale runtime metadata points at another provider or the active runtime registry is missing the configured provider.
 - Plugins/packages: reject inferred built runtime entries that exist but fail package-boundary checks instead of falling back to TypeScript source for installed packages. Thanks @vincentkoc.
 - Plugins/loader: do not retry native-loaded JavaScript plugin modules through the source transformer after native evaluation has already reached a missing dependency, avoiding duplicate top-level side effects. Thanks @vincentkoc.
 - Plugins/packages: reject blank `openclaw.runtimeExtensions` entries instead of silently ignoring them and falling back to inferred TypeScript runtime entries. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4703,6 +4703,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Doctor/plugins: remove stale managed install records for bundled plugins even when the bundled plugin is not explicitly configured, so doctor cleanup cannot leave orphaned install metadata behind. Thanks @vincentkoc.
 - Web fetch: scope provider fallback cache entries by the selected fetch provider so config reloads cannot reuse another provider's cached fallback payload. Thanks @vincentkoc.
 - Web search: honor late-bound `tools.web.search.enabled: false` during tool execution so config reloads cannot leave an already-created `web_search` tool runnable. Thanks @vincentkoc.
+- Web search: honor explicit `tools.web.search.provider` and `web_search` provider routing even when stale runtime metadata points at another provider or the active runtime registry is missing the configured provider.
 - Plugins/packages: reject inferred built runtime entries that exist but fail package-boundary checks instead of falling back to TypeScript source for installed packages. Thanks @vincentkoc.
 - Plugins/loader: do not retry native-loaded JavaScript plugin modules through the source transformer after native evaluation has already reached a missing dependency, avoiding duplicate top-level side effects. Thanks @vincentkoc.
 - Plugins/packages: reject blank `openclaw.runtimeExtensions` entries instead of silently ignoring them and falling back to inferred TypeScript runtime entries. Thanks @vincentkoc.

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -301,7 +301,10 @@ fails config validation instead of silently falling back to auto-detection. If a
 configured provider only has stale plugin evidence, such as a leftover
 `plugins.entries.<plugin>` block after uninstalling a third-party plugin,
 OpenClaw keeps startup resilient and reports a warning so you can reinstall the
-plugin or run `openclaw doctor --fix` to clean up the stale config.
+plugin or run `openclaw doctor --fix` to clean up the stale config. When
+`web_search` runs, an explicit `tools.web.search.provider` is a hard route: if
+that provider cannot be loaded at runtime, the call fails instead of silently
+auto-detecting another provider.
 
 `web_fetch` fallback provider selection is separate:
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -91,6 +91,10 @@ export function createWebSearchTool(options?: {
           lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
           runtimeWebSearch: options?.runtimeWebSearch,
         });
+      const configuredProviderId =
+        typeof config?.tools?.web?.search?.provider === "string"
+          ? config.tools.web.search.provider.trim().toLowerCase()
+          : "";
       if (isWebSearchDisabled(config)) {
         throw new Error("web_search is disabled.");
       }
@@ -98,6 +102,7 @@ export function createWebSearchTool(options?: {
         config,
         sandboxed: options?.sandboxed,
         runtimeWebSearch,
+        providerId: configuredProviderId || undefined,
         preferRuntimeProviders,
         args: asToolParamsRecord(args),
         signal,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -100,6 +100,10 @@ export function createWebSearchTool(options?: {
           lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
           runtimeWebSearch: options?.runtimeWebSearch,
         });
+      const configuredProviderId =
+        typeof config?.tools?.web?.search?.provider === "string"
+          ? config.tools.web.search.provider.trim().toLowerCase()
+          : "";
       if (isWebSearchDisabled(config)) {
         throw new Error("web_search is disabled.");
       }
@@ -108,6 +112,7 @@ export function createWebSearchTool(options?: {
         agentDir: options?.agentDir,
         sandboxed: options?.sandboxed,
         runtimeWebSearch,
+        providerId: configuredProviderId || undefined,
         preferRuntimeProviders,
         args: asToolParamsRecord(args),
         signal,

--- a/src/agents/tools/web-tool-runtime-context.test.ts
+++ b/src/agents/tools/web-tool-runtime-context.test.ts
@@ -127,6 +127,23 @@ describe("web tool runtime context", () => {
     expect(mocks.resolveManifestContractOwnerPluginId).not.toHaveBeenCalled();
   });
 
+  it("keeps fetch provider ids aligned with runtime metadata precedence", () => {
+    resolveWebFetchToolRuntimeContext({
+      config: { tools: { web: { fetch: { provider: "firecrawl" } } } },
+      runtimeWebFetch: {
+        providerConfigured: "perplexity-fetch",
+        providerSource: "configured",
+        selectedProvider: "perplexity-fetch",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+    });
+
+    const ownerLookup = latestOwnerLookupParams();
+    expect(ownerLookup.contract).toBe("webFetchProviders");
+    expect(ownerLookup.value).toBe("perplexity-fetch");
+  });
+
   it("keeps runtime providers disabled for bundled fetch owners", async () => {
     mocks.resolveManifestContractOwnerPluginId.mockReturnValue("firecrawl");
 

--- a/src/agents/tools/web-tool-runtime-context.ts
+++ b/src/agents/tools/web-tool-runtime-context.ts
@@ -67,8 +67,8 @@ function resolveWebToolRuntimeContext<TMetadata extends WebProviderRuntimeMetada
       ? (getActiveSecretsRuntimeSnapshot()?.config ?? params.capturedConfig)
       : params.capturedConfig;
   const providerSelectionId =
-    resolveRuntimeWebProviderId(runtimeMetadata) ||
-    resolveConfiguredWebProviderId(config, params.kind);
+    resolveConfiguredWebProviderId(config, params.kind) ||
+    resolveRuntimeWebProviderId(runtimeMetadata);
   return {
     config,
     preferRuntimeProviders: shouldPreferRuntimeProviders({

--- a/src/agents/tools/web-tool-runtime-context.ts
+++ b/src/agents/tools/web-tool-runtime-context.ts
@@ -70,8 +70,8 @@ function resolveWebToolRuntimeContext<TMetadata extends WebProviderRuntimeMetada
       ? (getActiveSecretsRuntimeConfigSnapshot()?.config ?? params.capturedConfig)
       : params.capturedConfig;
   const providerSelectionId =
-    resolveRuntimeWebProviderId(runtimeMetadata) ||
-    resolveConfiguredWebProviderId(config, params.kind);
+    resolveConfiguredWebProviderId(config, params.kind) ||
+    resolveRuntimeWebProviderId(runtimeMetadata);
   return {
     config,
     preferRuntimeProviders: shouldPreferRuntimeProviders({

--- a/src/agents/tools/web-tool-runtime-context.ts
+++ b/src/agents/tools/web-tool-runtime-context.ts
@@ -34,6 +34,18 @@ function resolveRuntimeWebProviderId(metadata: WebProviderRuntimeMetadata | unde
   return metadata?.selectedProvider ?? metadata?.providerConfigured ?? "";
 }
 
+function resolveWebProviderSelectionId(params: {
+  config: OpenClawConfig | undefined;
+  kind: WebProviderKind;
+  runtimeMetadata: WebProviderRuntimeMetadata | undefined;
+}): string {
+  const configuredProviderId = resolveConfiguredWebProviderId(params.config, params.kind);
+  const runtimeProviderId = resolveRuntimeWebProviderId(params.runtimeMetadata);
+  return params.kind === "search"
+    ? configuredProviderId || runtimeProviderId
+    : runtimeProviderId || configuredProviderId;
+}
+
 function shouldPreferRuntimeProviders(params: {
   config?: OpenClawConfig;
   kind: WebProviderKind;
@@ -69,9 +81,11 @@ function resolveWebToolRuntimeContext<TMetadata extends WebProviderRuntimeMetada
     params.lateBindRuntimeConfig === true
       ? (getActiveSecretsRuntimeConfigSnapshot()?.config ?? params.capturedConfig)
       : params.capturedConfig;
-  const providerSelectionId =
-    resolveConfiguredWebProviderId(config, params.kind) ||
-    resolveRuntimeWebProviderId(runtimeMetadata);
+  const providerSelectionId = resolveWebProviderSelectionId({
+    config,
+    kind: params.kind,
+    runtimeMetadata,
+  });
   return {
     config,
     preferRuntimeProviders: shouldPreferRuntimeProviders({

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -11,6 +11,7 @@ const runWebSearchCalls = vi.hoisted(
   () =>
     [] as Array<{
       config?: unknown;
+      providerId?: string;
       preferRuntimeProviders?: boolean;
       runtimeWebSearch?: unknown;
     }>,
@@ -49,9 +50,11 @@ vi.mock("../../web-search/runtime.js", async () => {
     await import("../../secrets/runtime-web-tools-state.js");
   const resolveRuntimeDefinition = (options?: {
     config?: unknown;
+    providerId?: string;
     runtimeWebSearch?: { selectedProvider?: string; providerConfigured?: string };
   }) => {
     const providerId =
+      options?.providerId ??
       options?.runtimeWebSearch?.selectedProvider ??
       options?.runtimeWebSearch?.providerConfigured ??
       getActiveRuntimeWebToolsMetadata()?.search?.selectedProvider ??
@@ -80,11 +83,13 @@ vi.mock("../../web-search/runtime.js", async () => {
     runWebSearch: async (options: {
       config?: unknown;
       args: Record<string, unknown>;
+      providerId?: string;
       preferRuntimeProviders?: boolean;
       runtimeWebSearch?: unknown;
     }) => {
       runWebSearchCalls.push({
         config: options.config,
+        providerId: options.providerId,
         preferRuntimeProviders: options.preferRuntimeProviders,
         runtimeWebSearch: options.runtimeWebSearch,
       });
@@ -304,6 +309,86 @@ describe("web tools defaults", () => {
     expect(runWebSearchCalls[0]?.config).toBe(runtimeConfig);
     expect(runWebSearchCalls[0]?.runtimeWebSearch).toMatchObject({
       selectedProvider: "fresh",
+    });
+  });
+
+  it("lets explicit config win over stale runtime web_search metadata", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.webSearchProviders.push(
+      {
+        pluginId: "stale-search",
+        pluginName: "Stale Search",
+        source: "test",
+        provider: {
+          id: "stale",
+          label: "Stale Search",
+          hint: "Stale runtime provider",
+          envVars: [],
+          placeholder: "stale-...",
+          signupUrl: "https://example.com/stale",
+          autoDetectOrder: 1,
+          credentialPath: "tools.web.search.stale.apiKey",
+          getCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          createTool: () => ({
+            description: "stale runtime tool",
+            parameters: {},
+            execute: async () => ({ provider: "stale" }),
+          }),
+        },
+      },
+      {
+        pluginId: "custom-search",
+        pluginName: "Custom Search",
+        source: "test",
+        provider: {
+          id: "custom",
+          label: "Custom Search",
+          hint: "Custom runtime provider",
+          envVars: ["CUSTOM_SEARCH_API_KEY"],
+          placeholder: "custom-...",
+          signupUrl: "https://example.com/signup",
+          autoDetectOrder: 2,
+          credentialPath: "plugins.entries.custom-search.config.webSearch.apiKey",
+          getCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          createTool: () => ({
+            description: "custom runtime tool",
+            parameters: {},
+            execute: async () => ({ provider: "custom" }),
+          }),
+        },
+      },
+    );
+    setActivePluginRegistry(registry);
+
+    const tool = createWebSearchTool({
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "custom",
+            },
+          },
+        },
+      },
+      sandboxed: true,
+      runtimeWebSearch: {
+        providerConfigured: "stale",
+        providerSource: "configured",
+        selectedProvider: "stale",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+    });
+
+    const result = await tool?.execute?.("call-explicit-custom-provider", {});
+
+    expect(result?.details).toMatchObject({ provider: "custom" });
+    expect(runWebSearchCalls).toHaveLength(1);
+    expect(runWebSearchCalls[0]?.providerId).toBe("custom");
+    expect(runWebSearchCalls[0]?.runtimeWebSearch).toMatchObject({
+      selectedProvider: "stale",
     });
   });
 });

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -13,6 +13,7 @@ const runWebSearchCalls = vi.hoisted(
   () =>
     [] as Array<{
       config?: unknown;
+      providerId?: string;
       preferRuntimeProviders?: boolean;
       runtimeWebSearch?: unknown;
     }>,
@@ -51,11 +52,13 @@ vi.mock("../../web-search/runtime.js", async () => {
     await import("../../secrets/runtime-web-tools-state.js");
   const resolveRuntimeDefinition = (options?: {
     config?: unknown;
+    providerId?: string;
     runtimeWebSearch?: { selectedProvider?: string; providerConfigured?: string };
   }) => {
     // The mock mirrors production provider resolution order closely enough to
     // catch stale construction-time metadata in late-bound tool instances.
     const providerId =
+      options?.providerId ??
       options?.runtimeWebSearch?.selectedProvider ??
       options?.runtimeWebSearch?.providerConfigured ??
       getActiveRuntimeWebToolsMetadata()?.search?.selectedProvider ??
@@ -84,11 +87,13 @@ vi.mock("../../web-search/runtime.js", async () => {
     runWebSearch: async (options: {
       config?: unknown;
       args: Record<string, unknown>;
+      providerId?: string;
       preferRuntimeProviders?: boolean;
       runtimeWebSearch?: unknown;
     }) => {
       runWebSearchCalls.push({
         config: options.config,
+        providerId: options.providerId,
         preferRuntimeProviders: options.preferRuntimeProviders,
         runtimeWebSearch: options.runtimeWebSearch,
       });
@@ -312,5 +317,85 @@ describe("web tools defaults", () => {
       (runWebSearchCalls[0]?.runtimeWebSearch as { selectedProvider?: string } | undefined)
         ?.selectedProvider,
     ).toBe("fresh");
+  });
+
+  it("lets explicit config win over stale runtime web_search metadata", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.webSearchProviders.push(
+      {
+        pluginId: "stale-search",
+        pluginName: "Stale Search",
+        source: "test",
+        provider: {
+          id: "stale",
+          label: "Stale Search",
+          hint: "Stale runtime provider",
+          envVars: [],
+          placeholder: "stale-...",
+          signupUrl: "https://example.com/stale",
+          autoDetectOrder: 1,
+          credentialPath: "tools.web.search.stale.apiKey",
+          getCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          createTool: () => ({
+            description: "stale runtime tool",
+            parameters: {},
+            execute: async () => ({ provider: "stale" }),
+          }),
+        },
+      },
+      {
+        pluginId: "custom-search",
+        pluginName: "Custom Search",
+        source: "test",
+        provider: {
+          id: "custom",
+          label: "Custom Search",
+          hint: "Custom runtime provider",
+          envVars: ["CUSTOM_SEARCH_API_KEY"],
+          placeholder: "custom-...",
+          signupUrl: "https://example.com/signup",
+          autoDetectOrder: 2,
+          credentialPath: "plugins.entries.custom-search.config.webSearch.apiKey",
+          getCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          createTool: () => ({
+            description: "custom runtime tool",
+            parameters: {},
+            execute: async () => ({ provider: "custom" }),
+          }),
+        },
+      },
+    );
+    setActivePluginRegistry(registry);
+
+    const tool = createWebSearchTool({
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "custom",
+            },
+          },
+        },
+      },
+      sandboxed: true,
+      runtimeWebSearch: {
+        providerConfigured: "stale",
+        providerSource: "configured",
+        selectedProvider: "stale",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+    });
+
+    const result = await tool?.execute?.("call-explicit-custom-provider", {});
+
+    expect(result?.details).toMatchObject({ provider: "custom" });
+    expect(runWebSearchCalls).toHaveLength(1);
+    expect(runWebSearchCalls[0]?.providerId).toBe("custom");
+    expect(runWebSearchCalls[0]?.runtimeWebSearch).toMatchObject({
+      selectedProvider: "stale",
+    });
   });
 });

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -689,6 +689,58 @@ describe("web search runtime", () => {
     ).rejects.toThrow("google aborted");
   });
 
+  it("uses plugin provider discovery when an explicit provider is missing from runtime providers", async () => {
+    const staleProvider = createWebSearchTestProvider({
+      pluginId: "stale-search",
+      id: "stale",
+      credentialPath: "",
+      autoDetectOrder: 1,
+      requiresCredential: false,
+    });
+    const customProvider = createCustomSearchProvider({
+      requiresCredential: false,
+      createTool: () => ({
+        description: "custom",
+        parameters: {},
+        execute: async (args) => ({
+          ...args,
+          provider: "custom",
+        }),
+      }),
+    });
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([staleProvider]);
+    resolvePluginWebSearchProvidersMock.mockReturnValue([customProvider, staleProvider]);
+
+    await expect(
+      runWebSearch({
+        config: {
+          tools: {
+            web: {
+              search: {
+                provider: "custom",
+              },
+            },
+          },
+        },
+        providerId: "custom",
+        runtimeWebSearch: {
+          providerConfigured: "stale",
+          selectedProvider: "stale",
+          providerSource: "configured",
+          diagnostics: [],
+        },
+        preferRuntimeProviders: true,
+        args: { query: "explicit-custom" },
+      }),
+    ).resolves.toEqual({
+      provider: "custom",
+      result: {
+        query: "explicit-custom",
+        provider: "custom",
+      },
+    });
+  });
+
   it("fails fast when an explicit provider cannot create a tool", async () => {
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([
       createGoogleSearchProvider({

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -1050,6 +1050,58 @@ describe("web search runtime", () => {
     ).rejects.toThrow("google aborted");
   });
 
+  it("uses plugin provider discovery when an explicit provider is missing from runtime providers", async () => {
+    const staleProvider = createWebSearchTestProvider({
+      pluginId: "stale-search",
+      id: "stale",
+      credentialPath: "",
+      autoDetectOrder: 1,
+      requiresCredential: false,
+    });
+    const customProvider = createCustomSearchProvider({
+      requiresCredential: false,
+      createTool: () => ({
+        description: "custom",
+        parameters: {},
+        execute: async (args) => ({
+          ...args,
+          provider: "custom",
+        }),
+      }),
+    });
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([staleProvider]);
+    resolvePluginWebSearchProvidersMock.mockReturnValue([customProvider, staleProvider]);
+
+    await expect(
+      runWebSearch({
+        config: {
+          tools: {
+            web: {
+              search: {
+                provider: "custom",
+              },
+            },
+          },
+        },
+        providerId: "custom",
+        runtimeWebSearch: {
+          providerConfigured: "stale",
+          selectedProvider: "stale",
+          providerSource: "configured",
+          diagnostics: [],
+        },
+        preferRuntimeProviders: true,
+        args: { query: "explicit-custom" },
+      }),
+    ).resolves.toEqual({
+      provider: "custom",
+      result: {
+        query: "explicit-custom",
+        provider: "custom",
+      },
+    });
+  });
+
   it("fails fast when an explicit provider cannot create a tool", async () => {
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([
       createGoogleSearchProvider({

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -718,7 +718,7 @@ describe("web search runtime", () => {
     ).rejects.toThrow("web_search is disabled or no provider is available.");
   });
 
-  it("ignores auto-detected runtime metadata after config names an unknown provider", async () => {
+  it("fails closed instead of using auto-detected runtime metadata after config names an unknown provider", async () => {
     const createTool = vi.fn(() => createCustomSearchTool());
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([
       createGoogleSearchProvider({
@@ -759,7 +759,7 @@ describe("web search runtime", () => {
         config: structuredClone(config),
         args: { query: "runtime-config-typo" },
       }),
-    ).rejects.toThrow("web_search is disabled or no provider is available.");
+    ).rejects.toThrow('Unknown web_search provider "missing-id".');
     expect(createTool).not.toHaveBeenCalled();
   });
 
@@ -1083,7 +1083,6 @@ describe("web search runtime", () => {
             },
           },
         },
-        providerId: "custom",
         runtimeWebSearch: {
           providerConfigured: "stale",
           selectedProvider: "stale",
@@ -1157,7 +1156,7 @@ describe("web search runtime", () => {
         },
         args: { query: "config-typo" },
       }),
-    ).rejects.toThrow("web_search is disabled or no provider is available.");
+    ).rejects.toThrow('Unknown web_search provider "missing-id".');
   });
 
   it("honors preferRuntimeProviders during execution", async () => {

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -338,6 +338,25 @@ function resolveWebSearchCandidates(
           ...loadScope,
         }),
   ).filter(Boolean);
+  const explicitProviderId = options?.providerId?.trim();
+  if (
+    explicitProviderId &&
+    options?.preferRuntimeProviders &&
+    !providers.some((entry) => entry.id === explicitProviderId)
+  ) {
+    const merged = new Map(providers.map((provider) => [provider.id, provider] as const));
+    for (const provider of resolvePluginWebSearchProviders({
+      config,
+      bundledAllowlistCompat: true,
+    })) {
+      merged.set(provider.id, provider);
+    }
+    providers.splice(
+      0,
+      providers.length,
+      ...sortWebSearchProvidersForAutoDetect([...merged.values()]).filter(Boolean),
+    );
+  }
   if (providers.length === 0) {
     return [];
   }
@@ -351,7 +370,6 @@ function resolveWebSearchCandidates(
     (value, index, array): value is string => Boolean(value) && array.indexOf(value) === index,
   );
 
-  const explicitProviderId = options?.providerId?.trim();
   if (explicitProviderId && !providers.some((entry) => entry.id === explicitProviderId)) {
     throw new Error(`Unknown web_search provider "${explicitProviderId}".`);
   }

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -4,6 +4,12 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  hasWebProviderEntryCredential,
+  providerRequiresCredential,
+  readWebProviderEnvValue,
+  resolveWebProviderConfig,
+} from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { hasAuthProfileForProvider } from "../agents/tools/model-config.helpers.js";
 import {
@@ -22,12 +28,6 @@ import {
 import { sortWebSearchProvidersForAutoDetect } from "../plugins/web-search-providers.shared.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
 import type { RuntimeWebSearchMetadata } from "../secrets/runtime-web-tools.types.js";
-import {
-  hasWebProviderEntryCredential,
-  providerRequiresCredential,
-  readWebProviderEnvValue,
-  resolveWebProviderConfig,
-} from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import type {
   ResolveWebSearchDefinitionParams,
   RunWebSearchParams,
@@ -324,6 +324,10 @@ function loadSortedWebSearchProviders(
     preferRuntimeProviders?: boolean;
   },
 ): PluginWebSearchProviderEntry[] {
+  const explicitProviderId = resolveExplicitWebSearchProviderId({
+    search: params.search,
+    providerId: params.providerId,
+  });
   const loadScope = resolveWebSearchProviderLoadScope({
     config: params.config,
     search: params.search,
@@ -331,17 +335,35 @@ function loadSortedWebSearchProviders(
     providerId: params.providerId,
     includeRuntimeSelection: Boolean(params.preferRuntimeProviders),
   });
-  return sortWebSearchProvidersForAutoDetect(
-    params.preferRuntimeProviders
-      ? resolveRuntimeWebSearchProviders({
-          config: params.config,
-          ...loadScope,
-        })
-      : resolvePluginWebSearchProviders({
-          config: params.config,
-          ...loadScope,
-        }),
-  );
+  if (!params.preferRuntimeProviders) {
+    return sortWebSearchProvidersForAutoDetect(
+      resolvePluginWebSearchProviders({
+        config: params.config,
+        ...loadScope,
+      }),
+    );
+  }
+  const runtimeProviders = resolveRuntimeWebSearchProviders({
+    config: params.config,
+    ...loadScope,
+  });
+  if (
+    !explicitProviderId ||
+    runtimeProviders.some((provider) => provider.id === explicitProviderId)
+  ) {
+    return sortWebSearchProvidersForAutoDetect(runtimeProviders);
+  }
+  const explicitLoadScope = resolveWebSearchProviderLoadScope({
+    config: params.config,
+    search: params.search,
+    providerId: params.providerId,
+    includeRuntimeSelection: false,
+  });
+  const pluginProviders = resolvePluginWebSearchProviders({
+    config: params.config,
+    ...explicitLoadScope,
+  });
+  return sortWebSearchProvidersForAutoDetect([...pluginProviders, ...runtimeProviders]);
 }
 
 function resolveWebSearchCandidates(
@@ -359,14 +381,17 @@ function resolveWebSearchCandidates(
     providerId: options?.providerId,
     preferRuntimeProviders: options?.preferRuntimeProviders,
   }).filter(Boolean);
-  const explicitProviderId = options?.providerId?.trim();
+  const explicitProviderId = resolveExplicitWebSearchProviderId({
+    search,
+    providerId: options?.providerId,
+  });
   if (providers.length === 0) {
     return [];
   }
 
   const preferredIds = uniqueStrings(
     [
-      options?.providerId,
+      explicitProviderId,
       resolveRuntimePreferredWebSearchProviderId({
         config,
         search,
@@ -421,7 +446,7 @@ function hasExplicitWebSearchSelection(params: {
     params.search && "provider" in params.search && typeof params.search.provider === "string"
       ? normalizeLowercaseStringOrEmpty(params.search.provider)
       : "";
-  if (configuredProviderId && availableProviderIds.has(configuredProviderId)) {
+  if (configuredProviderId) {
     return true;
   }
   const runtimeConfiguredId = normalizeOptionalLowercaseString(

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -359,6 +359,7 @@ function resolveWebSearchCandidates(
     providerId: options?.providerId,
     preferRuntimeProviders: options?.preferRuntimeProviders,
   }).filter(Boolean);
+  const explicitProviderId = options?.providerId?.trim();
   if (providers.length === 0) {
     return [];
   }
@@ -377,7 +378,6 @@ function resolveWebSearchCandidates(
     ].filter((value): value is string => Boolean(value)),
   );
 
-  const explicitProviderId = options?.providerId?.trim();
   if (explicitProviderId && !providers.some((entry) => entry.id === explicitProviderId)) {
     throw new Error(`Unknown web_search provider "${explicitProviderId}".`);
   }


### PR DESCRIPTION
## Summary

Fixes `web_search` routing when `tools.web.search.provider` explicitly names a custom or installed web-search provider.

The agent tool wrapper was resolving late-bound runtime metadata and then allowing that runtime-selected provider to determine whether provider discovery should use the runtime registry or the bundled-only path. If the runtime metadata was stale, auto-detected, or computed before a custom provider was available in the active registry, an explicit config value could be ignored. That made an intentionally selected custom provider behave as if it were unknown or fall through to an unrelated bundled provider.

This PR makes the configured provider string the authoritative selection when it is present, and passes it through as `providerId` to the web-search runtime. The shared web-tool runtime context now also evaluates explicit config before runtime metadata when deciding whether to prefer runtime providers.

## Why This Is Needed

`tools.web.search.provider` is a user-facing explicit routing setting. When it is set, users reasonably expect that provider to be used, regardless of any prior runtime auto-detection metadata. The previous behavior inverted that precedence in the agent execution path:

- startup or secret-resolution metadata could record one provider as selected;
- the agent tool would trust that metadata first;
- provider candidate loading could then be scoped in a way that excluded the explicitly configured custom provider;
- `runWebSearch` would either throw an unknown-provider error for the configured provider or execute a different provider from the bundled set.

That is both surprising and risky. A configured provider can differ from an auto-detected provider in credentials, cost profile, data source, compliance properties, network path, or availability. Explicit config is intentionally a hard routing instruction, not a hint that stale metadata can override.

## What Changed

- `createWebSearchTool` now reads the configured `tools.web.search.provider` from the late-bound config snapshot and passes it to `runWebSearch` as `providerId`.
- `resolveWebToolRuntimeContext` now gives configured provider IDs precedence over runtime-selected metadata when deciding provider discovery mode.
- `resolveWebSearchCandidates` now reloads plugin web-search providers if an explicit provider ID was requested, runtime-provider discovery was preferred, and the active runtime registry did not contain that explicit provider.
- `docs/tools/web.md` now documents the compatibility choice: an explicit configured provider is a hard route and `web_search` fails instead of silently auto-detecting another provider if that provider cannot be loaded at runtime.

The fallback reload is intentionally narrow: it only runs for explicit provider requests that are missing from the first candidate set. Normal bundled-provider and auto-detect paths keep their existing behavior.

## Impact

Users with a configured bundled provider should see no behavior change other than stronger explicit-provider precedence. Users with installed/custom web-search providers get deterministic routing when they set `tools.web.search.provider`.

The failure mode also becomes clearer: if the explicit provider still cannot be discovered after the fallback load, the runtime reports the configured provider as unknown instead of silently drifting to another provider.

## Real behavior proof

- **Behavior or issue addressed:** Agent `web_search` should honor an explicit `tools.web.search.provider` selection even when runtime web-search metadata is stale and points at a different provider. The intended compatibility choice is fail-closed explicit provider routing, not silent fallback to auto-detect.
- **Real environment tested:** Local OpenClaw repo runtime on Linux in this isolated PR worktree, using production TypeScript modules via `pnpm exec tsx`; no gateway restart, no host config writes, and no real credentials.
- **Exact steps or command run after this patch:** Ran a production-module terminal proof that installed a synthetic active plugin registry with `stale` and `custom` web-search providers, configured `tools.web.search.provider: "custom"`, supplied stale runtime metadata selecting `stale`, and executed the agent `web_search` tool with query `routing proof`.
- **Evidence after fix:** Terminal output from the production-module proof:

```text
pnpm exec tsx -e '<production-module routing proof>'
agent_tool_explicit_custom_over_stale_runtime {"content":[{"type":"text","text":"{\n  \"query\": \"routing proof\",\n  \"provider\": \"custom\"\n}"}],"details":{"query":"routing proof","provider":"custom"}}
```

- **Observed result after fix:** The agent tool returned provider `custom`, proving the explicit configured provider won over stale runtime metadata selecting `stale`.
- **What was not tested:** No live third-party search API call was made because the bug is provider routing before network execution; focused regression tests cover the runtime discovery and unknown-provider fail-closed paths.

## Validation

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/tools/web.md src/agents/tools/web-search.ts src/agents/tools/web-tool-runtime-context.ts src/agents/tools/web-tools.enabled-defaults.test.ts src/web-search/runtime.ts src/web-search/runtime.test.ts`
- `pnpm test src/agents/tools/web-search.test.ts src/agents/tools/web-tools.enabled-defaults.test.ts src/web-search/runtime.test.ts`
- `pnpm changed:lanes --json` selected `core`, `coreTests`, and `docs`.
- `OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed` was attempted because Testbox is not authenticated here; it completed conflict-marker, changelog attribution, dependency/patch guards, core typecheck, core test typecheck, core lint, runtime sidecar loader, and runtime import-cycle checks, then left an idle node process with no active child work and was stopped to avoid leaving it behind.
- `pnpm check:docs`

Testbox was attempted first but is unavailable in this environment:

```text
blacksmith testbox warmup ci-check-testbox.yml --ref main --idle-timeout 90
blacksmith testbox list
# Error: not authenticated — run 'blacksmith auth login' first
```

Known unrelated broad-check note: `pnpm plugin-sdk:api:check` currently reports `docs/.generated/plugin-sdk-api-baseline.sha256` hash drift even though this branch has no generated file changes and does not touch Plugin SDK exports.
