### PR TITLE
fix(process): avoid spawn EBADF by defaulting to pipe stdin for non-TTY gateways

### DIFF
--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -3,6 +3,7 @@ import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { killProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
+import type { SpawnFallback } from "../../spawn-utils.js";
 import { resolveWindowsCommandShim } from "../../windows-command.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
@@ -38,7 +39,7 @@ export async function createChildAdapter(params: {
     env: baseEnv,
   });
 
-  const stdinMode = params.stdinMode ?? (params.input !== undefined ? "pipe-closed" : "inherit");
+  const stdinMode = params.stdinMode ?? (params.input !== undefined ? "pipe-closed" : process.stdin.isTTY ? "inherit" : "pipe");
 
   // In service-managed mode keep children attached so systemd/launchd can
   // stop the full process tree reliably. Outside service mode preserve the
@@ -62,14 +63,20 @@ export async function createChildAdapter(params: {
   const spawned = await spawnWithFallback({
     argv: [preparedSpawn.command, ...preparedSpawn.args],
     options,
-    fallbacks: useDetached
-      ? [
-          {
-            label: "no-detach",
-            options: { detached: false },
-          },
-        ]
-      : [],
+    fallbacks: (() => {
+      const fbs: SpawnFallback[] = [];
+      if (useDetached) {
+        fbs.push({
+          label: "no-detach",
+          options: { detached: false },
+        });
+      }
+      fbs.push({
+        label: "pipe-stdin",
+        options: { detached: false, stdio: ["pipe", "pipe", "pipe"] },
+      });
+      return fbs;
+    })(),
   });
 
   const child = spawned.child as ChildProcessWithoutNullStreams;


### PR DESCRIPTION
## Summary

When the gateway runs as a service (launchd/systemd), stdin is `/dev/null` and `"inherit"` mode exposes child processes to the parent's fd table. Combined with fd leaks from plugins (e.g. thousands of open markdown files from claude-mem/lossless-claw), `spawn` fails with `EBADF` because the kernel cannot handle the inflated fd table during `posix_spawn`.

**Fixes #77750**

## Changes

1. **Default `stdinMode` to `"pipe"` when `process.stdin` is not a TTY** — in interactive mode (TTY), behavior is unchanged. When running as a service, this avoids inheriting `/dev/null` and the parent's fd table.

2. **Always include a `pipe-stdin` fallback** — adds a final fallback (`detached: false` + `["pipe", "pipe", "pipe"]` stdio) so even if the first spawn fails with `EBADF`, the retry uses the safest configuration regardless of the original `stdinMode`.

3. **Import `SpawnFallback` type** — needed for the typed fallback array construction.

## Test plan

- [x] Tested on macOS 26.1 with openclaw gateway running via launchd
- [x] Before: `spawn EBADF` on every exec tool call (gateway had 14k fd leak)
- [x] After restart + patch: exec calls succeed, no EBADF errors
- [x] After restart: fd count normal (58), gateway API responding (HTTP 200)
- [x] Reproduced the pre-patch path: confirmed that with `inherit` stdin + high fd count, spawn fails; with `pipe` stdin it succeeds

## AI-Assisted

This PR was written with Claude Code assistance. The human (loyu) verified the fix on their own machine — real gateway logs confirm the EBADF errors and the fix resolves them.