### PR TITLE
fix(commands): restore LLM fallthrough on bare /new and /reset [AI-assisted]

### DIFF
--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -432,7 +432,7 @@ describe("handleCommands reset hooks", () => {
     expect(resetMocks.resetConfiguredBindingTargetInPlace).not.toHaveBeenCalled();
   });
 
-  it("acknowledges bare /reset without falling through to model execution", async () => {
+  it("falls through on bare /reset so the LLM turn runs the persona greeting", async () => {
     const params = buildResetParams("/reset", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
@@ -440,16 +440,13 @@ describe("handleCommands reset hooks", () => {
 
     const result = await maybeHandleResetCommand(params);
 
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: { text: "✅ Session reset." },
-    });
+    expect(result).toBeNull();
     expect(triggerInternalHookMock).toHaveBeenCalledWith(
       expect.objectContaining({ type: "command", action: "reset" }),
     );
   });
 
-  it("acknowledges bare /new without falling through to model execution", async () => {
+  it("falls through on bare /new so the LLM turn runs the persona greeting", async () => {
     const params = buildResetParams("/new", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
@@ -457,10 +454,7 @@ describe("handleCommands reset hooks", () => {
 
     const result = await maybeHandleResetCommand(params);
 
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: { text: "✅ New session started." },
-    });
+    expect(result).toBeNull();
     expect(triggerInternalHookMock).toHaveBeenCalledWith(
       expect.objectContaining({ type: "command", action: "new" }),
     );

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -167,16 +167,15 @@ export async function maybeHandleResetCommand(
     workspaceDir: params.workspaceDir,
   });
   if (!resetTail) {
-    return {
-      shouldContinue: false,
-      ...(hookResult.routedReply
-        ? {}
-        : {
-            reply: {
-              text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
-            },
-          }),
-    };
+    // When a hook already routed a reply, honor it and stop.
+    // Otherwise fall through (return null) so the LLM turn runs and the
+    // persona greeting fires — this restores the 4.x behavior where bare
+    // /new and /reset trigger an agent-driven greeting instead of a canned
+    // acknowledgment text.
+    if (hookResult.routedReply) {
+      return { shouldContinue: false };
+    }
+    return null;
   }
   return null;
 }


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: Bare `/new` and `/reset` commands were short-circuited in 2026.5.3 to return a canned acknowledgment, skipping the LLM turn entirely, breaking the persona greeting
- Why it matters: In 4.x, bare reset commands fell through to the agent loop so the persona greeting fires — users expected this behavior
- What changed: Removed the canned-reply branch for bare resets, returning `null` to restore LLM fallthrough
- What did NOT change (scope boundary): Hook-routed replies still honored, `/new <tail>` fallthrough unchanged

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] CLI

## Linked Issue/PR
- Closes #77733
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: In `src/auto-reply/reply/commands-reset.ts`, the `!resetTail` branch (added in 5.3) returned `{ shouldContinue: false, reply: { text: "..." } }` for bare `/new` and `/reset`, preventing the request from reaching the LLM turn
- Missing detection / guardrail: No test verified that bare resets still fall through to the LLM turn for persona greeting
- Contributing context (if known): The canned reply was added in 5.3 as a UX improvement but broke the established 4.x behavior

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/auto-reply/reply/commands-reset-hooks.test.ts`
- Scenario the test should lock in: Bare `/reset` and `/new` return `null` (fallthrough to LLM turn); hook-routed replies still return `{ shouldContinue: false }`
- Why this is the smallest reliable guardrail: Unit tests on the reset command handler directly verify fallthrough vs short-circuit behavior
- Existing test that already covers this (if any): Test suite updated — 12/12 tests pass
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- Bare `/new` and `/reset` now trigger the persona greeting again (restores 4.x behavior) instead of showing a canned "✅ New session started." message

## Security Impact (required)
- New permissions/capabilities? No
- This restores prior behavior — no new code paths, no auth changes, no new inputs accepted.
