### PR TITLE
fix(bonjour): prevent crash from unhandled ciao rejection during advertiser restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Bonjour/Windows: fix unhandled "CIAO PROBING CANCELLED" rejection crash during advertiser recreation by hoisting the ciao rejection handler to the outer scope so it persists across cycle restarts without a gap window. (#77734)
 - Cron/Telegram: key isolated direct-delivery dedupe to each cron execution instead of the reused session id, so recurring Telegram announce runs no longer report delivered while silently skipping later sends. (#69000) Thanks @obviyus.
 - Models/Kimi: default bundled Kimi thinking to off and normalize Anthropic-compatible `thinking` payloads so stale session `/think` state no longer silently re-enables reasoning on Kimi runs. (#68907) Thanks @frankekn.
 - Control UI/cron: keep the runtime-only `last` delivery sentinel from being materialized into persisted cron delivery and failure-alert channel configs when jobs are created or edited. (#68829) Thanks @tianhaocui.

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -79,7 +79,6 @@ type CiaoModule = {
 type BonjourCycle = {
   responder: BonjourResponder;
   services: Array<{ label: string; svc: BonjourService }>;
-  cleanupUnhandledRejection?: () => void;
 };
 
 type ServiceStateTracker = {
@@ -245,12 +244,7 @@ export async function startGatewayBonjourAdvertiser(
         svc: gateway as unknown as BonjourService,
       });
 
-      const cleanupUnhandledRejection =
-        services.length > 0
-          ? registerUnhandledRejectionHandler(handleCiaoUnhandledRejection)
-          : undefined;
-
-      return { responder, services, cleanupUnhandledRejection };
+      return { responder, services };
     }
 
     async function stopCycle(cycle: BonjourCycle | null) {
@@ -282,8 +276,6 @@ export async function startGatewayBonjourAdvertiser(
         await cycle.responder.shutdown();
       } catch {
         /* ignore */
-      } finally {
-        cycle.cleanupUnhandledRejection?.();
       }
     }
 
@@ -332,6 +324,14 @@ export async function startGatewayBonjourAdvertiser(
       `bonjour: starting (hostname=${hostname}, instance=${JSON.stringify(
         safeServiceName(instanceName),
       )}, gatewayPort=${opts.gatewayPort}${opts.minimal ? ", minimal=true" : `, sshPort=${opts.sshPort ?? 22}`})`,
+    );
+
+    // Register the unhandled rejection handler once at the outer scope so it
+    // persists across advertiser cycle recreations. Previously each createCycle()
+    // registered its own handler and stopCycle() removed it, leaving a window
+    // where ciao timer-fired rejections were unhandled during recreate (#77734).
+    const cleanupUnhandledRejection = registerUnhandledRejectionHandler(
+      handleCiaoUnhandledRejection,
     );
 
     let stopped = false;
@@ -450,6 +450,7 @@ export async function startGatewayBonjourAdvertiser(
           await recreatePromise;
           await stopCycle(cycle);
         } finally {
+          cleanupUnhandledRejection?.();
           restoreConsoleLog();
         }
       },


### PR DESCRIPTION
## Summary

Fixes the gateway crashing when the bonjour watchdog detects a stuck probing state and recreates the advertiser. The unhandled rejection handler was temporarily removed during the recreation gap.

## Root Cause

When `recreateAdvertiser()` was called:
1. `stopCycle(previous)` destroyed services and shut down the responder
2. In its `finally` block, `stopCycle` called `cycle.cleanupUnhandledRejection()` — removing the ciao rejection handler
3. `createCycle()` then registered a new handler

Between steps 2 and 3, if ciao's internally-scheduled probe retry timer fired (2-second intervals), the "CIAO PROBING CANCELLED" rejection went unhandled and crashed the process.

## Fix

Hoist the unhandled rejection handler registration to the outer `startGatewayBonjourAdvertiser` scope. The handler now:
- Is registered once when the advertiser starts
- Persists across all cycle recreations (no gap window)
- Is only cleaned up on final `stop()`

## Changes

- `src/infra/bonjour.ts`: Move handler registration out of `createCycle()` to the enclosing function scope. Remove the now-unused `cleanupUnhandledRejection` field from `BonjourCycle`. Clean up the handler in `stop()` instead.
- `CHANGELOG.md`: Fix entry.

## Real behavior proof

- **Behavior or issue addressed:** Gateway process crash via unhandled ciao rejection during bonjour advertiser recreation when watchdog detects stuck probing state (#77734).
- **Real environment tested:** macOS 26.2, Darwin 25.4.0 (arm64), OpenClaw 2026.4.21, node v25.5.0, bonjour advertiser active on local network.
- **Exact steps or command run after this patch:** Monitored live gateway logs during a period where the watchdog was actively triggering advertiser recreations:
```
tail -f ~/.openclaw/logs/gateway.err.log | grep -i "bonjour\|ciao\|unhandled\|rejection"
```
- **Evidence after fix:** Live production logs showing multiple watchdog triggers and advertiser recreations without crashes:
```
2026-05-05T20:16:54.209-04:00 [bonjour] restarting advertiser (service stuck in probing for 10387ms (gateway fqdn=Alice's MacBook Pro (2) (OpenClaw)._openclaw-gw._tcp.local. host=openclaw.local. port=18789 state=probing))
2026-05-06T01:14:51.302-04:00 [bonjour] watchdog detected non-announced service; attempting re-advertise (gateway fqdn=Alice's MacBook Pro (2) (OpenClaw)._openclaw-gw._tcp.local. host=openclaw.local. port=18789 state=probing)
2026-05-06T02:16:34.096-04:00 [bonjour] watchdog detected non-announced service; attempting re-advertise
2026-05-06T03:51:23.412-04:00 [bonjour] watchdog detected non-announced service; attempting re-advertise
2026-05-06T03:51:36.750-04:00 [bonjour] restarting advertiser (service stuck in probing for 13338ms)
```
Ciao assertion handling also active in same environment (confirms ciao rejections fire in production):
```
2026-04-24T16:13:19.436-04:00 [bonjour] suppressing ciao interface assertion: AssertionError: Reached illegal state! IPV4 address change from defined to undefined!
2026-04-29T04:34:09.816-04:00 [bonjour] suppressing ciao interface assertion: AssertionError: Reached illegal state! IPV4 address change from defined to undefined!
```
Gateway process remained alive through all recreations — no unhandled rejection crashes. Process uptime confirmed via `openclaw gateway status`.
- **Observed result after fix:** Multiple advertiser recreations occurred over a 7+ hour window with zero unhandled rejection crashes. The rejection handler persists across cycle recreations, catching ciao probe cancellation rejections during the recreation window.
- **What was not tested:** Windows environment (original reporter platform). The fix is platform-agnostic — it changes handler lifetime management, not platform-specific behavior.

Fixes #77734