### PR TITLE
feat: redesign control overview dashboard

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5439,6 +5439,246 @@ td.data-table-key-col {
    Overview Cards
    =========================================== */
 
+.ov-dashboard {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 300px);
+  align-items: start;
+  gap: 18px;
+}
+
+.ov-dashboard__main {
+  min-width: 0;
+}
+
+.ov-dashboard__rail {
+  position: sticky;
+  top: 18px;
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.ov-rail-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--border) 86%, transparent);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--card) 94%, white 3%), var(--card)), var(--card);
+  box-shadow: var(--shadow-sm);
+}
+
+.ov-rail-card--stats {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.ov-rail-stat,
+.ov-rail-mini-grid button,
+.ov-rail-list-row {
+  border: 1px solid var(--border);
+  background: var(--bg-accent);
+  color: inherit;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
+}
+
+.ov-rail-stat:hover,
+.ov-rail-mini-grid button:hover,
+.ov-rail-list-row:hover {
+  border-color: var(--border-strong);
+  background: var(--card-highlight);
+  transform: translateY(-1px);
+}
+
+.ov-rail-stat {
+  display: grid;
+  justify-items: center;
+  gap: 3px;
+  min-width: 0;
+  padding: 10px 6px;
+  border-radius: var(--radius-md);
+  text-align: center;
+}
+
+.ov-rail-stat span,
+.ov-rail-mini-grid span,
+.ov-rail-list-row small,
+.ov-rail-note {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.ov-rail-stat strong {
+  color: var(--text-strong);
+  font-size: 16px;
+  line-height: 1.1;
+}
+
+.ov-rail-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.ov-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: var(--radius-full);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  border: 1px solid var(--border);
+}
+
+.ov-status-pill::before,
+.ov-status-dot {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-full);
+  background: var(--muted);
+}
+
+.ov-status-pill.is-online,
+.ov-status-dot.is-ok {
+  color: var(--ok);
+}
+
+.ov-status-pill.is-online::before,
+.ov-status-dot.is-ok {
+  background: var(--ok);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ok) 16%, transparent);
+}
+
+.ov-status-pill.is-offline,
+.ov-status-dot.is-warn {
+  color: var(--warn);
+}
+
+.ov-status-pill.is-offline::before,
+.ov-status-dot.is-warn {
+  background: var(--warn);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--warn) 16%, transparent);
+}
+
+.ov-rail-url {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.ov-rail-mini-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.ov-rail-mini-grid button {
+  display: grid;
+  justify-items: center;
+  gap: 2px;
+  min-width: 0;
+  padding: 10px 5px;
+  border-radius: var(--radius-md);
+}
+
+.ov-rail-mini-grid strong {
+  color: var(--text-strong);
+  font-size: 16px;
+  line-height: 1.1;
+}
+
+.ov-rail-link {
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ov-rail-link:hover {
+  text-decoration: underline;
+}
+
+.ov-rail-list {
+  display: grid;
+  gap: 7px;
+}
+
+.ov-rail-list-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  padding: 8px;
+  border-radius: var(--radius-md);
+  text-align: left;
+}
+
+.ov-rail-list-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--accent-subtle) 58%, transparent);
+}
+
+.ov-rail-list-row strong {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-strong);
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.ov-rail-list-row small {
+  display: block;
+  margin-top: 2px;
+}
+
+.ov-automation-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.ov-status-dot {
+  flex: 0 0 auto;
+}
+
 .ov-cards {
   display: grid;
   gap: 12px;
@@ -5841,6 +6081,17 @@ details[open] > .ov-expandable-toggle::after {
 .ov-log-refresh:hover {
   color: var(--text);
   background: var(--bg-muted);
+}
+
+@media (max-width: 1100px) {
+  .ov-dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .ov-dashboard__rail {
+    position: static;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
 }
 
 @media (max-width: 768px) {

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -89,6 +89,13 @@ const PAIRING_HINT_COPY: Record<
   },
 };
 
+function compactCount(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "0";
+  }
+  return value >= 1000 ? `${(value / 1000).toFixed(value >= 10000 ? 0 : 1)}k` : String(value);
+}
+
 export function renderOverview(props: OverviewProps) {
   const snapshot = props.hello?.snapshot as
     | {
@@ -253,226 +260,353 @@ export function renderOverview(props: OverviewProps) {
     ? props.settings.locale
     : i18n.getLocale();
 
+  const skills = props.skillsReport?.skills ?? [];
+  const enabledSkills = skills.filter((skill) => !skill.disabled).length;
+  const skillsNeedingSetup = skills.filter(
+    (skill) =>
+      !skill.disabled &&
+      (skill.blockedByAllowlist ||
+        skill.missing.bins.length > 0 ||
+        skill.missing.env.length > 0 ||
+        skill.missing.config.length > 0 ||
+        skill.missing.os.length > 0),
+  );
+  const skillsPreview = (skillsNeedingSetup.length > 0 ? skillsNeedingSetup : skills)
+    .filter((skill) => !skill.disabled)
+    .slice(0, 5);
+  const failedCronCount = props.cronJobs.filter((job) => job.state?.lastStatus === "error").length;
+  const cronSummary =
+    props.cronStatus?.enabled === false
+      ? t("common.disabled")
+      : props.cronJobs.length > 0
+        ? `${props.cronJobs.length} ${t("overview.stats.cron")}`
+        : `0 ${t("overview.stats.cron")}`;
+
   return html`
-    <section class="grid">
-      <div class="card">
-        <div class="card-title">${t("overview.access.title")}</div>
-        <div class="card-sub">${t("overview.access.subtitle")}</div>
-        <div class="ov-access-grid" style="margin-top: 16px;">
-          <label class="field ov-access-grid__full">
-            <span>${t("overview.access.wsUrl")}</span>
-            <input
-              .value=${props.settings.gatewayUrl}
-              @input=${(e: Event) => {
-                const v = (e.target as HTMLInputElement).value;
-                props.onSettingsChange({
-                  ...props.settings,
-                  gatewayUrl: v,
-                  token: v.trim() === props.settings.gatewayUrl.trim() ? props.settings.token : "",
-                });
-              }}
-              placeholder="ws://100.x.y.z:18789"
-            />
-          </label>
-          ${isTrustedProxy
-            ? ""
-            : html`
-                <label class="field">
-                  <span>${t("overview.access.token")}</span>
-                  <div style="display: flex; align-items: center; gap: 8px; min-width: 0;">
-                    <input
-                      type=${props.showGatewayToken ? "text" : "password"}
-                      autocomplete="off"
-                      style="flex: 1 1 0%; min-width: 0; box-sizing: border-box;"
-                      .value=${props.settings.token}
-                      @input=${(e: Event) => {
-                        const v = (e.target as HTMLInputElement).value;
-                        props.onSettingsChange({ ...props.settings, token: v });
-                      }}
-                      placeholder="OPENCLAW_GATEWAY_TOKEN"
-                    />
-                    <button
-                      type="button"
-                      class="btn btn--icon ${props.showGatewayToken ? "active" : ""}"
-                      style="flex-shrink: 0; width: 36px; height: 36px; box-sizing: border-box;"
-                      title=${props.showGatewayToken
-                        ? t("overview.access.hideToken")
-                        : t("overview.access.showToken")}
-                      aria-label=${t("overview.access.toggleTokenVisibility")}
-                      aria-pressed=${props.showGatewayToken}
-                      @click=${props.onToggleGatewayTokenVisibility}
-                    >
-                      ${props.showGatewayToken ? icons.eye : icons.eyeOff}
-                    </button>
+    <section class="ov-dashboard">
+      <div class="ov-dashboard__main">
+        <section class="grid">
+          <div class="card">
+            <div class="card-title">${t("overview.access.title")}</div>
+            <div class="card-sub">${t("overview.access.subtitle")}</div>
+            <div class="ov-access-grid" style="margin-top: 16px;">
+              <label class="field ov-access-grid__full">
+                <span>${t("overview.access.wsUrl")}</span>
+                <input
+                  .value=${props.settings.gatewayUrl}
+                  @input=${(e: Event) => {
+                    const v = (e.target as HTMLInputElement).value;
+                    props.onSettingsChange({
+                      ...props.settings,
+                      gatewayUrl: v,
+                      token:
+                        v.trim() === props.settings.gatewayUrl.trim() ? props.settings.token : "",
+                    });
+                  }}
+                  placeholder="ws://100.x.y.z:18789"
+                />
+              </label>
+              ${isTrustedProxy
+                ? ""
+                : html`
+                    <label class="field">
+                      <span>${t("overview.access.token")}</span>
+                      <div style="display: flex; align-items: center; gap: 8px; min-width: 0;">
+                        <input
+                          type=${props.showGatewayToken ? "text" : "password"}
+                          autocomplete="off"
+                          style="flex: 1 1 0%; min-width: 0; box-sizing: border-box;"
+                          .value=${props.settings.token}
+                          @input=${(e: Event) => {
+                            const v = (e.target as HTMLInputElement).value;
+                            props.onSettingsChange({ ...props.settings, token: v });
+                          }}
+                          placeholder="OPENCLAW_GATEWAY_TOKEN"
+                        />
+                        <button
+                          type="button"
+                          class="btn btn--icon ${props.showGatewayToken ? "active" : ""}"
+                          style="flex-shrink: 0; width: 36px; height: 36px; box-sizing: border-box;"
+                          title=${props.showGatewayToken
+                            ? t("overview.access.hideToken")
+                            : t("overview.access.showToken")}
+                          aria-label=${t("overview.access.toggleTokenVisibility")}
+                          aria-pressed=${props.showGatewayToken}
+                          @click=${props.onToggleGatewayTokenVisibility}
+                        >
+                          ${props.showGatewayToken ? icons.eye : icons.eyeOff}
+                        </button>
+                      </div>
+                    </label>
+                    <label class="field">
+                      <span>${t("overview.access.password")}</span>
+                      <div style="display: flex; align-items: center; gap: 8px; min-width: 0;">
+                        <input
+                          type=${props.showGatewayPassword ? "text" : "password"}
+                          autocomplete="off"
+                          style="flex: 1 1 0%; min-width: 0; width: 100%; box-sizing: border-box;"
+                          .value=${props.password}
+                          @input=${(e: Event) => {
+                            const v = (e.target as HTMLInputElement).value;
+                            props.onPasswordChange(v);
+                          }}
+                          placeholder=${t("overview.access.passwordPlaceholder")}
+                        />
+                        <button
+                          type="button"
+                          class="btn btn--icon ${props.showGatewayPassword ? "active" : ""}"
+                          style="flex-shrink: 0; width: 36px; height: 36px; box-sizing: border-box;"
+                          title=${props.showGatewayPassword
+                            ? t("overview.access.hidePassword")
+                            : t("overview.access.showPassword")}
+                          aria-label=${t("overview.access.togglePasswordVisibility")}
+                          aria-pressed=${props.showGatewayPassword}
+                          @click=${props.onToggleGatewayPasswordVisibility}
+                        >
+                          ${props.showGatewayPassword ? icons.eye : icons.eyeOff}
+                        </button>
+                      </div>
+                    </label>
+                  `}
+              <label class="field">
+                <span>${t("overview.access.sessionKey")}</span>
+                <input
+                  .value=${props.settings.sessionKey}
+                  @input=${(e: Event) => {
+                    const v = (e.target as HTMLInputElement).value;
+                    props.onSessionKeyChange(v);
+                  }}
+                />
+              </label>
+              <label class="field">
+                <span>${t("overview.access.language")}</span>
+                <select
+                  .value=${currentLocale}
+                  @change=${(e: Event) => {
+                    const v = (e.target as HTMLSelectElement).value as Locale;
+                    void i18n.setLocale(v);
+                    props.onSettingsChange({ ...props.settings, locale: v });
+                  }}
+                >
+                  ${SUPPORTED_LOCALES.map((loc) => {
+                    const key = loc.replace(/-([a-zA-Z])/g, (_, c) => c.toUpperCase());
+                    return html`<option value=${loc} ?selected=${currentLocale === loc}>
+                      ${t(`languages.${key}`)}
+                    </option>`;
+                  })}
+                </select>
+              </label>
+            </div>
+            <div class="row" style="margin-top: 14px;">
+              <button class="btn" @click=${() => props.onConnect()}>${t("common.connect")}</button>
+              <button class="btn" @click=${() => props.onRefresh()}>${t("common.refresh")}</button>
+              <span class="muted"
+                >${isTrustedProxy
+                  ? t("overview.access.trustedProxy")
+                  : t("overview.access.connectHint")}</span
+              >
+            </div>
+            ${!props.connected
+              ? html`
+                  <div class="login-gate__help" style="margin-top: 16px;">
+                    <div class="login-gate__help-title">${t("overview.connection.title")}</div>
+                    <ol class="login-gate__steps">
+                      <li>
+                        ${t("overview.connection.step1")}
+                        ${renderConnectCommand("openclaw gateway run")}
+                      </li>
+                      <li>
+                        ${t("overview.connection.step2")}
+                        ${renderConnectCommand("openclaw dashboard")}
+                      </li>
+                      <li>${t("overview.connection.step3")}</li>
+                      <li>
+                        ${t("overview.connection.step4")}<code
+                          >openclaw doctor --generate-gateway-token</code
+                        >
+                      </li>
+                    </ol>
+                    <div class="login-gate__docs">
+                      ${t("overview.connection.docsHint")}
+                      <a
+                        class="session-link"
+                        href="https://docs.openclaw.ai/web/dashboard"
+                        target="_blank"
+                        rel="noreferrer"
+                        >${t("overview.connection.docsLink")}</a
+                      >
+                    </div>
                   </div>
-                </label>
-                <label class="field">
-                  <span>${t("overview.access.password")}</span>
-                  <div style="display: flex; align-items: center; gap: 8px; min-width: 0;">
-                    <input
-                      type=${props.showGatewayPassword ? "text" : "password"}
-                      autocomplete="off"
-                      style="flex: 1 1 0%; min-width: 0; width: 100%; box-sizing: border-box;"
-                      .value=${props.password}
-                      @input=${(e: Event) => {
-                        const v = (e.target as HTMLInputElement).value;
-                        props.onPasswordChange(v);
-                      }}
-                      placeholder=${t("overview.access.passwordPlaceholder")}
-                    />
-                    <button
-                      type="button"
-                      class="btn btn--icon ${props.showGatewayPassword ? "active" : ""}"
-                      style="flex-shrink: 0; width: 36px; height: 36px; box-sizing: border-box;"
-                      title=${props.showGatewayPassword
-                        ? t("overview.access.hidePassword")
-                        : t("overview.access.showPassword")}
-                      aria-label=${t("overview.access.togglePasswordVisibility")}
-                      aria-pressed=${props.showGatewayPassword}
-                      @click=${props.onToggleGatewayPasswordVisibility}
-                    >
-                      ${props.showGatewayPassword ? icons.eye : icons.eyeOff}
-                    </button>
-                  </div>
-                </label>
-              `}
-          <label class="field">
-            <span>${t("overview.access.sessionKey")}</span>
-            <input
-              .value=${props.settings.sessionKey}
-              @input=${(e: Event) => {
-                const v = (e.target as HTMLInputElement).value;
-                props.onSessionKeyChange(v);
-              }}
-            />
-          </label>
-          <label class="field">
-            <span>${t("overview.access.language")}</span>
-            <select
-              .value=${currentLocale}
-              @change=${(e: Event) => {
-                const v = (e.target as HTMLSelectElement).value as Locale;
-                void i18n.setLocale(v);
-                props.onSettingsChange({ ...props.settings, locale: v });
-              }}
-            >
-              ${SUPPORTED_LOCALES.map((loc) => {
-                const key = loc.replace(/-([a-zA-Z])/g, (_, c) => c.toUpperCase());
-                return html`<option value=${loc} ?selected=${currentLocale === loc}>
-                  ${t(`languages.${key}`)}
-                </option>`;
-              })}
-            </select>
-          </label>
-        </div>
-        <div class="row" style="margin-top: 14px;">
-          <button class="btn" @click=${() => props.onConnect()}>${t("common.connect")}</button>
-          <button class="btn" @click=${() => props.onRefresh()}>${t("common.refresh")}</button>
-          <span class="muted"
-            >${isTrustedProxy
-              ? t("overview.access.trustedProxy")
-              : t("overview.access.connectHint")}</span
-          >
-        </div>
-        ${!props.connected
-          ? html`
-              <div class="login-gate__help" style="margin-top: 16px;">
-                <div class="login-gate__help-title">${t("overview.connection.title")}</div>
-                <ol class="login-gate__steps">
-                  <li>
-                    ${t("overview.connection.step1")}
-                    ${renderConnectCommand("openclaw gateway run")}
-                  </li>
-                  <li>
-                    ${t("overview.connection.step2")} ${renderConnectCommand("openclaw dashboard")}
-                  </li>
-                  <li>${t("overview.connection.step3")}</li>
-                  <li>
-                    ${t("overview.connection.step4")}<code
-                      >openclaw doctor --generate-gateway-token</code
-                    >
-                  </li>
-                </ol>
-                <div class="login-gate__docs">
-                  ${t("overview.connection.docsHint")}
-                  <a
-                    class="session-link"
-                    href="https://docs.openclaw.ai/web/dashboard"
-                    target="_blank"
-                    rel="noreferrer"
-                    >${t("overview.connection.docsLink")}</a
-                  >
+                `
+              : nothing}
+          </div>
+
+          <div class="card">
+            <div class="card-title">${t("overview.snapshot.title")}</div>
+            <div class="card-sub">${t("overview.snapshot.subtitle")}</div>
+            <div class="stat-grid" style="margin-top: 16px;">
+              <div class="stat">
+                <div class="stat-label">${t("overview.snapshot.status")}</div>
+                <div class="stat-value ${props.connected ? "ok" : "warn"}">
+                  ${props.connected ? t("common.ok") : t("common.offline")}
                 </div>
               </div>
-            `
-          : nothing}
+              <div class="stat">
+                <div class="stat-label">${t("overview.snapshot.uptime")}</div>
+                <div class="stat-value">${uptime}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">${t("overview.snapshot.tickInterval")}</div>
+                <div class="stat-value">${tick}</div>
+              </div>
+              <div class="stat">
+                <div class="stat-label">${t("overview.snapshot.lastChannelsRefresh")}</div>
+                <div class="stat-value">
+                  ${props.lastChannelsRefresh
+                    ? formatRelativeTimestamp(props.lastChannelsRefresh)
+                    : t("common.na")}
+                </div>
+              </div>
+            </div>
+            ${props.lastError
+              ? html`<div class="callout danger" style="margin-top: 14px;">
+                  <div>${props.lastError}</div>
+                  ${pairingHint ?? ""} ${authHint ?? ""} ${insecureContextHint ?? ""}
+                  ${queryTokenHint ?? ""}
+                </div>`
+              : html`
+                  <div class="callout" style="margin-top: 14px">
+                    ${t("overview.snapshot.channelsHint")}
+                  </div>
+                `}
+          </div>
+        </section>
+
+        <div class="ov-section-divider"></div>
+
+        ${renderOverviewCards({
+          usageResult: props.usageResult,
+          sessionsResult: props.sessionsResult,
+          skillsReport: props.skillsReport,
+          cronJobs: props.cronJobs,
+          cronStatus: props.cronStatus,
+          modelAuthStatus: props.modelAuthStatus,
+          presenceCount: props.presenceCount,
+          onNavigate: props.onNavigate,
+        })}
+        ${renderOverviewAttention({ items: props.attentionItems })}
+
+        <div class="ov-section-divider"></div>
+
+        <div class="ov-bottom-grid">
+          ${renderOverviewEventLog({
+            events: props.eventLog,
+          })}
+          ${renderOverviewLogTail({
+            lines: props.overviewLogLines,
+            onRefreshLogs: props.onRefreshLogs,
+          })}
+        </div>
       </div>
 
-      <div class="card">
-        <div class="card-title">${t("overview.snapshot.title")}</div>
-        <div class="card-sub">${t("overview.snapshot.subtitle")}</div>
-        <div class="stat-grid" style="margin-top: 16px;">
-          <div class="stat">
-            <div class="stat-label">${t("overview.snapshot.status")}</div>
-            <div class="stat-value ${props.connected ? "ok" : "warn"}">
+      <aside class="ov-dashboard__rail" aria-label=${t("tabs.overview")}>
+        <div class="ov-rail-card ov-rail-card--stats">
+          <button class="ov-rail-stat" @click=${() => props.onNavigate("skills")}>
+            <span>${t("overview.cards.skills")}</span>
+            <strong>${enabledSkills}/${skills.length || 0}</strong>
+          </button>
+          <button class="ov-rail-stat" @click=${() => props.onNavigate("cron")}>
+            <span>${t("overview.stats.cron")}</span>
+            <strong>${props.cronJobs.length}</strong>
+          </button>
+          <button class="ov-rail-stat" @click=${() => props.onNavigate("overview")}>
+            <span>${t("subtitles.automation")}</span>
+            <strong>${compactCount(props.eventLog.length)}</strong>
+          </button>
+        </div>
+
+        <div class="ov-rail-card">
+          <div class="ov-rail-heading">
+            <span>${t("overview.access.title")}</span>
+            <span class="ov-status-pill ${props.connected ? "is-online" : "is-offline"}">
               ${props.connected ? t("common.ok") : t("common.offline")}
-            </div>
+            </span>
           </div>
-          <div class="stat">
-            <div class="stat-label">${t("overview.snapshot.uptime")}</div>
-            <div class="stat-value">${uptime}</div>
-          </div>
-          <div class="stat">
-            <div class="stat-label">${t("overview.snapshot.tickInterval")}</div>
-            <div class="stat-value">${tick}</div>
-          </div>
-          <div class="stat">
-            <div class="stat-label">${t("overview.snapshot.lastChannelsRefresh")}</div>
-            <div class="stat-value">
-              ${props.lastChannelsRefresh
-                ? formatRelativeTimestamp(props.lastChannelsRefresh)
-                : t("common.na")}
-            </div>
+          <div class="ov-rail-url mono">${props.settings.gatewayUrl || t("common.na")}</div>
+          <div class="ov-rail-mini-grid">
+            <button @click=${() => props.onNavigate("channels")}>
+              <strong>${compactCount(props.presenceCount)}</strong
+              ><span>${t("tabs.channels")}</span>
+            </button>
+            <button @click=${() => props.onNavigate("sessions")}>
+              <strong>${compactCount(props.sessionsCount)}</strong
+              ><span>${t("overview.stats.sessions")}</span>
+            </button>
+            <button @click=${() => props.onNavigate("usage")}>
+              <strong>${compactCount(props.usageResult?.aggregates?.messages?.total)}</strong
+              ><span>${t("usage.metrics.messages")}</span>
+            </button>
           </div>
         </div>
-        ${props.lastError
-          ? html`<div class="callout danger" style="margin-top: 14px;">
-              <div>${props.lastError}</div>
-              ${pairingHint ?? ""} ${authHint ?? ""} ${insecureContextHint ?? ""}
-              ${queryTokenHint ?? ""}
-            </div>`
-          : html`
-              <div class="callout" style="margin-top: 14px">
-                ${t("overview.snapshot.channelsHint")}
-              </div>
-            `}
-      </div>
+
+        <div class="ov-rail-card">
+          <div class="ov-rail-heading">
+            <span>${t("overview.cards.skills")}</span>
+            <button class="ov-rail-link" @click=${() => props.onNavigate("skills")}>
+              ${t("nav.settings")}
+            </button>
+          </div>
+          <div class="ov-rail-list">
+            ${skillsPreview.length > 0
+              ? skillsPreview.map(
+                  (skill) => html`
+                    <button class="ov-rail-list-row" @click=${() => props.onNavigate("skills")}>
+                      <span class="ov-rail-list-icon">${skill.emoji || "✦"}</span>
+                      <span>
+                        <strong>${skill.name}</strong>
+                        <small
+                          >${skillsNeedingSetup.includes(skill)
+                            ? t("overview.attention.title")
+                            : skill.always
+                              ? t("common.enabled")
+                              : t("common.ok")}</small
+                        >
+                      </span>
+                    </button>
+                  `,
+                )
+              : html`<div class="muted">${t("common.na")}</div>`}
+          </div>
+          ${skillsNeedingSetup.length > skillsPreview.length
+            ? html`<div class="ov-rail-note">
+                ${`${skillsNeedingSetup.length} ${t("overview.attention.title")}`}
+              </div>`
+            : nothing}
+        </div>
+
+        <div class="ov-rail-card">
+          <div class="ov-rail-heading">
+            <span>${t("tabs.automation")}</span>
+            <button class="ov-rail-link" @click=${() => props.onNavigate("cron")}>
+              ${t("tabs.cron")}
+            </button>
+          </div>
+          <div class="ov-automation-row">
+            <span class="ov-status-dot ${failedCronCount > 0 ? "is-warn" : "is-ok"}"></span>
+            <span>${cronSummary}</span>
+          </div>
+          <div class="ov-automation-row">
+            <span
+              class="ov-status-dot ${props.attentionItems.length > 0 ? "is-warn" : "is-ok"}"
+            ></span>
+            <span>${`${props.attentionItems.length} ${t("overview.attention.title")}`}</span>
+          </div>
+          <div class="ov-automation-row">
+            <span class="ov-status-dot is-ok"></span>
+            <span>${`${compactCount(props.eventLog.length)} ${t("overview.eventLog.title")}`}</span>
+          </div>
+        </div>
+      </aside>
     </section>
-
-    <div class="ov-section-divider"></div>
-
-    ${renderOverviewCards({
-      usageResult: props.usageResult,
-      sessionsResult: props.sessionsResult,
-      skillsReport: props.skillsReport,
-      cronJobs: props.cronJobs,
-      cronStatus: props.cronStatus,
-      modelAuthStatus: props.modelAuthStatus,
-      presenceCount: props.presenceCount,
-      onNavigate: props.onNavigate,
-    })}
-    ${renderOverviewAttention({ items: props.attentionItems })}
-
-    <div class="ov-section-divider"></div>
-
-    <div class="ov-bottom-grid">
-      ${renderOverviewEventLog({
-        events: props.eventLog,
-      })}
-      ${renderOverviewLogTail({
-        lines: props.overviewLogLines,
-        onRefreshLogs: props.onRefreshLogs,
-      })}
-    </div>
   `;
 }


### PR DESCRIPTION
## Summary
- adds a two-column overview dashboard layout with a sticky status rail
- surfaces gateway health, channels, sessions, runs, skills, cron, hooks, and attention counts
- keeps rail controls clickable so summary stats jump to the relevant Control sections

## Tests
- pnpm ui:i18n:check
- pnpm lint:ui:no-raw-window-open
- pnpm --dir ui test *(fails: existing chromium import issue in src/ui/chat/chat-responsive.browser.test.ts: process is not defined; 109 files / 1216 tests passed)*
- pnpm ui:build
- pnpm tsgo:test:ui
