### PR TITLE
fix: declare sharp as root optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1749,6 +1749,7 @@
     "vitest": "^4.1.5"
   },
   "optionalDependencies": {
+    "sharp": "^0.34.5",
     "sqlite-vec": "0.1.9"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
     optionalDependencies:
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       sqlite-vec:
         specifier: 0.1.9
         version: 0.1.9


### PR DESCRIPTION
Fixes #77760.

## Summary
- Mirror bundled `media-understanding-core`'s `sharp` runtime dependency in root `optionalDependencies`.
- Add the matching root importer entry to `pnpm-lock.yaml` so package installs include `sharp` for the runtime path that imports it.

## Why
`media-understanding-core` imports `sharp` at runtime, but the root package did not declare it. Nested bundled extension `package.json` dependencies are not installed as part of a normal root package install, so image/media optimization can fail in fresh installs or after updates.

## Verification
- Confirmed root optional `sharp` matches the bundled `media-understanding-core` dependency range.
- Ran `git diff --check`.
- Ran lockfile-only install for the prepared patch.

## Real behavior proof

**Behavior or issue addressed:**
The root OpenClaw package needs to make `sharp` available from the package root because bundled `media-understanding-core` imports it at runtime. Without the root manifest entry, fresh package installs or updates can miss `sharp` even though runtime code imports it.

**Real environment tested:**
Live OpenClaw install on Linux VPS, Node.js runtime, OpenClaw installed under a user-local global npm path. Sensitive local usernames and exact state paths are redacted below.

**Exact steps or command run after this patch:**
After installing `sharp` in the same root package path this PR declares, I verified runtime resolution from the bundled media-understanding import location, checked plugin health, checked gateway connectivity, and ran the local post-update guard.

```bash
node - <<'NODE'
const { createRequire } = require('module');
const r = createRequire('<openclaw-install>/dist/extensions/media-understanding-core/image-ops.js');
console.log(r.resolve('sharp'));
NODE

OPENCLAW_STATE_DIR=<state-dir> openclaw plugins doctor
openclaw gateway status
node /path/to/openclaw_sharp_guard.mjs
```

**Evidence after fix:**
Copied live terminal output from the real setup:

```text
$ node - <<'NODE'
const { createRequire } = require('module');
const r = createRequire('<openclaw-install>/dist/extensions/media-understanding-core/image-ops.js');
console.log(r.resolve('sharp'));
NODE
<openclaw-install>/node_modules/sharp/lib/index.js

$ OPENCLAW_STATE_DIR=<state-dir> openclaw plugins doctor
No plugin issues detected.

$ openclaw gateway status
Connectivity probe: ok
Listening: 127.0.0.1:<port>

$ node /path/to/openclaw_sharp_guard.mjs
{
  "status": "ok",
  "changed": false,
  "action": "none",
  "sharp": "<openclaw-install>/node_modules/sharp/lib/index.js"
}
```

**Observed result after fix:**
`sharp` resolves from the OpenClaw root package `node_modules`, plugin doctor reports no plugin issues, the gateway connectivity probe is ok, and the post-update guard reports no repair is needed because `sharp` is present in the runtime path.

**What was not tested:**
I did not publish or install a package tarball built from this PR. The live proof validates the runtime behavior this manifest change is intended to make durable; CI validates the package and lockfile changes.
