### PR TITLE
Fix channel setup and streaming preview regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels: preserve `streaming.preview.toolProgress: false` for WhatsApp, LINE, and Slack without requiring `streaming.mode`, and avoid onboarding crashes when channel setup text prompts return an empty value. Fixes #67366 and #73795. Thanks @koshaji.
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-43c6f668cd8301f485c64e6a663dc1b19d38c146ce2572943e2dc961973e0c6f  plugin-sdk-api-baseline.json
-1d877d94bebb634d90d929fe0581ba4bccf4d12d8342d179ae9bf1053e68c013  plugin-sdk-api-baseline.jsonl
+7bbba0d352f566019fb3d7759c69b84eee4c27c453833ac5410b58bfae098803  plugin-sdk-api-baseline.json
+1132a8663c21402cf415b46e36d2a86f6351320726b41c3491d0dbb247ca4d33  plugin-sdk-api-baseline.jsonl

--- a/extensions/line/src/config-schema.test.ts
+++ b/extensions/line/src/config-schema.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { LineConfigSchema } from "./config-schema.js";
+
+describe("line config schema", () => {
+  it("preserves streaming preview toolProgress without streaming mode", () => {
+    const result = LineConfigSchema.safeParse({
+      streaming: { preview: { toolProgress: false } },
+      accounts: {
+        work: {
+          streaming: { preview: { toolProgress: false } },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.streaming?.preview?.toolProgress).toBe(false);
+      expect(result.data.streaming?.mode).toBeUndefined();
+      expect(result.data.accounts?.work?.streaming?.preview?.toolProgress).toBe(false);
+      expect(result.data.accounts?.work?.streaming?.mode).toBeUndefined();
+    }
+  });
+});

--- a/extensions/line/src/config-schema.ts
+++ b/extensions/line/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import {
+  buildChannelConfigSchema,
+  ChannelPreviewStreamingConfigSchema,
+} from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "openclaw/plugin-sdk/zod";
 
 const DmPolicySchema = z.enum(["open", "allowlist", "pairing", "disabled"]);
@@ -27,6 +30,7 @@ const LineCommonConfigSchema = z.object({
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),
   responsePrefix: z.string().optional(),
+  streaming: ChannelPreviewStreamingConfigSchema.optional(),
   mediaMaxMb: z.number().optional(),
   webhookPath: z.string().optional(),
   threadBindings: ThreadBindingsSchema.optional(),

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -1,5 +1,6 @@
 import type { webhook } from "@line/bot-sdk";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
+import { resolveChannelStreamingSuppressDefaultToolProgressMessages } from "openclaw/plugin-sdk/channel-streaming";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { hasFinalInboundReplyDispatch } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
@@ -256,6 +257,8 @@ export async function monitorLineProvider(
                 ...replyPipeline,
               },
               replyOptions: {
+                suppressDefaultToolProgressMessages:
+                  resolveChannelStreamingSuppressDefaultToolProgressMessages(bot.account.config),
                 onModelSelected,
               },
               delivery: {

--- a/extensions/line/src/types.ts
+++ b/extensions/line/src/types.ts
@@ -1,4 +1,5 @@
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
+import type { ChannelPreviewStreamingConfig } from "openclaw/plugin-sdk/channel-streaming";
 
 export type LineTokenSource = "config" | "env" | "file" | "none";
 
@@ -26,6 +27,7 @@ interface LineAccountBaseConfig {
   dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
   groupPolicy?: "open" | "allowlist" | "disabled";
   responsePrefix?: string;
+  streaming?: ChannelPreviewStreamingConfig;
   mediaMaxMb?: number;
   webhookPath?: string;
   threadBindings?: LineThreadBindingsConfig;

--- a/extensions/slack/src/config-schema.test.ts
+++ b/extensions/slack/src/config-schema.test.ts
@@ -37,6 +37,23 @@ describe("slack config schema", () => {
     }
   });
 
+  it("preserves preview tool progress settings without streaming mode", () => {
+    const res = SlackConfigSchema.safeParse({
+      streaming: { preview: { toolProgress: false } },
+      accounts: {
+        ops: {
+          streaming: { preview: { toolProgress: false } },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.streaming?.preview?.toolProgress).toBe(false);
+      expect(res.data.accounts?.ops?.streaming?.preview?.toolProgress).toBe(false);
+    }
+  });
+
   it('rejects dmPolicy="open" without allowFrom "*"', () => {
     expectSlackConfigIssue(
       {

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -725,6 +725,27 @@ describe("Slack native command argument menus", () => {
     expect(call.ctx?.Body).toBe("/usage tokens");
   });
 
+  it("suppresses default tool progress when Slack preview toolProgress is disabled", async () => {
+    const harness = createArgMenusHarness();
+    const account = {
+      accountId: "acct",
+      config: {
+        commands: { native: true, nativeSkills: false },
+        streaming: { preview: { toolProgress: false } },
+      },
+    };
+    await registerCommands(harness.ctx, account);
+    const handler = requireHandler(harness.commands, "/agentstatus", "/agentstatus");
+
+    await runCommandHandler(handler);
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    const call = dispatchMock.mock.calls[0]?.[0] as {
+      replyOptions?: { suppressDefaultToolProgressMessages?: boolean };
+    };
+    expect(call.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+  });
+
   it("tracks accepted slash command activity", async () => {
     const trackingHarness = createArgMenusHarness();
     const trackEvent = vi.fn();

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -1,6 +1,7 @@
 import type { SlackActionMiddlewareArgs, SlackCommandMiddlewareArgs } from "@slack/bolt";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
+import { resolveChannelStreamingSuppressDefaultToolProgressMessages } from "openclaw/plugin-sdk/channel-streaming";
 import {
   formatCommandArgMenuTitle,
   resolveStoredModelOverride,
@@ -764,6 +765,8 @@ export async function registerSlackMonitorSlashCommands(params: {
         },
         replyOptions: {
           skillFilter: channelConfig?.skills,
+          suppressDefaultToolProgressMessages:
+            resolveChannelStreamingSuppressDefaultToolProgressMessages(account.config),
           onModelSelected,
         },
       });

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -6,6 +6,7 @@ import {
   resolveUserPath,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/account-core";
+import type { ChannelPreviewStreamingConfig } from "openclaw/plugin-sdk/channel-streaming";
 import type { DmPolicy, GroupPolicy, ReplyToMode } from "openclaw/plugin-sdk/config-types";
 import { resolveOAuthDir } from "openclaw/plugin-sdk/state-paths";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
@@ -37,6 +38,7 @@ export type ResolvedWhatsAppAccount = {
   historyLimit?: number;
   textChunkLimit?: number;
   chunkMode?: "length" | "newline";
+  streaming?: ChannelPreviewStreamingConfig;
   mediaMaxMb?: number;
   blockStreaming?: boolean;
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
@@ -148,6 +150,7 @@ export function resolveWhatsAppAccount(params: {
     historyLimit: merged.historyLimit,
     textChunkLimit: merged.textChunkLimit,
     chunkMode: merged.chunkMode,
+    streaming: merged.streaming,
     mediaMaxMb: merged.mediaMaxMb,
     blockStreaming: merged.blockStreaming,
     ackReaction: merged.ackReaction,

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -173,6 +173,7 @@ export async function monitorWebChannel(
         groupPolicy: account.groupPolicy,
         textChunkLimit: account.textChunkLimit,
         chunkMode: account.chunkMode,
+        streaming: account.streaming,
         mediaMaxMb: account.mediaMaxMb,
         blockStreaming: account.blockStreaming,
         groups: account.groups,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -166,6 +166,7 @@ function getCapturedReplyOptions() {
     capturedDispatchParams as {
       replyOptions?: {
         disableBlockStreaming?: boolean;
+        suppressDefaultToolProgressMessages?: boolean;
         sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
       };
     }
@@ -625,6 +626,40 @@ describe("whatsapp inbound dispatch", () => {
     });
 
     expect(getCapturedReplyOptions()?.disableBlockStreaming).toBeUndefined();
+  });
+
+  it("suppresses default tool progress when WhatsApp preview toolProgress is disabled", async () => {
+    await dispatchBufferedReply({
+      cfg: {
+        channels: {
+          whatsapp: {
+            streaming: { preview: { toolProgress: false } },
+          },
+        },
+      } as never,
+    });
+
+    expect(getCapturedReplyOptions()?.suppressDefaultToolProgressMessages).toBe(true);
+  });
+
+  it("suppresses default tool progress from WhatsApp account streaming overrides", async () => {
+    await dispatchBufferedReply({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              work: {
+                streaming: { preview: { toolProgress: false } },
+              },
+            },
+          },
+        },
+      } as never,
+      msg: makeMsg({ accountId: "work" }),
+      route: makeRoute({ accountId: "work" }),
+    });
+
+    expect(getCapturedReplyOptions()?.suppressDefaultToolProgressMessages).toBe(true);
   });
 
   it("leaves WhatsApp direct reply mode unset by default", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -1,4 +1,6 @@
+import { resolveChannelStreamingSuppressDefaultToolProgressMessages } from "openclaw/plugin-sdk/channel-streaming";
 import { hasVisibleInboundReplyDispatch } from "openclaw/plugin-sdk/inbound-reply-dispatch";
+import { resolveMergedWhatsAppAccountConfig } from "../../account-config.js";
 import {
   type DeliverableWhatsAppOutboundPayload,
   normalizeWhatsAppOutboundPayload,
@@ -330,6 +332,10 @@ export async function dispatchWhatsAppBufferedReply(params: {
   const disableBlockStreaming = sourceRepliesAreToolOnly
     ? true
     : resolveWhatsAppDisableBlockStreaming(params.cfg);
+  const effectiveWhatsAppAccountConfig = resolveMergedWhatsAppAccountConfig({
+    cfg: params.cfg,
+    accountId: params.route.accountId ?? params.msg.accountId,
+  });
   let didSendReply = false;
   let didLogHeartbeatStrip = false;
 
@@ -417,6 +423,8 @@ export async function dispatchWhatsAppBufferedReply(params: {
     },
     replyOptions: {
       disableBlockStreaming,
+      suppressDefaultToolProgressMessages:
+        resolveChannelStreamingSuppressDefaultToolProgressMessages(effectiveWhatsAppAccountConfig),
       ...(sourceReplyDeliveryMode ? { sourceReplyDeliveryMode } : {}),
       onModelSelected: params.onModelSelected,
     },

--- a/src/channels/plugins/setup-wizard-helpers.test.ts
+++ b/src/channels/plugins/setup-wizard-helpers.test.ts
@@ -505,6 +505,24 @@ describe("promptSingleChannelToken", () => {
     expect(result).toEqual(expected);
     expect(prompter.text).toHaveBeenCalledTimes(expectTextCalls);
   });
+
+  it("does not throw when replacement token prompt returns undefined", async () => {
+    const prompter = {
+      confirm: vi.fn(async () => false),
+      text: vi.fn(async () => undefined),
+    };
+
+    const result = await runPromptSingleToken({
+      prompter: prompter as unknown as ReturnType<typeof createTokenPrompter>,
+      accountConfigured: true,
+      canUseEnv: false,
+      hasConfigToken: true,
+    });
+
+    expect(result).toEqual({ useEnv: false, token: "" });
+    expect(prompter.confirm).toHaveBeenCalledTimes(1);
+    expect(prompter.text).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("promptSingleChannelSecretInput", () => {

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -961,12 +961,12 @@ export async function promptSingleChannelToken(params: {
   inputPrompt: string;
 }): Promise<{ useEnv: boolean; token: string | null }> {
   const promptToken = async (): Promise<string> =>
-    (
+    normalizeOptionalString(
       await params.prompter.text({
         message: params.inputPrompt,
         validate: (value) => (value?.trim() ? undefined : "Required"),
-      })
-    ).trim();
+      }),
+    ) ?? "";
 
   if (params.canUseEnv) {
     const keepEnv = await params.prompter.confirm({

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -455,7 +455,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
               });
             },
           });
-          const trimmedValue = rawValue.trim();
+          const trimmedValue = normalizeOptionalString(rawValue) ?? "";
           if (!trimmedValue && textInput.required === false) {
             if (textInput.applyEmptyValue) {
               next = await applyWizardTextInputValue({

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -608,6 +608,32 @@ describe("setupChannels", () => {
     expect(reloadChannelSetupPluginRegistry).not.toHaveBeenCalled();
   });
 
+  it("does not crash when setup wizard text input returns undefined", async () => {
+    const note = vi.fn(async (_message?: string, _title?: string) => {});
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "whatsapp";
+      }
+      return "__done__";
+    });
+    const text = vi.fn(async () => undefined);
+
+    const prompter = createPrompter({
+      note,
+      select: select as unknown as WizardPrompter["select"],
+      text: text as unknown as WizardPrompter["text"],
+    });
+
+    const cfg = await runSetupChannels({} as OpenClawConfig, prompter, {
+      quickstartDefaults: true,
+    });
+
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Your personal WhatsApp number" }),
+    );
+    expect((cfg.channels?.whatsapp as { account?: string } | undefined)?.account).toBeUndefined();
+  });
+
   it("shows explicit dmScope config command in channel primer", async () => {
     const note = vi.fn(async (_message?: string, _title?: string) => {});
     const select = vi.fn(async () => "__done__");

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -7171,6 +7171,134 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         responsePrefix: {
           type: "string",
         },
+        streaming: {
+          type: "object",
+          properties: {
+            mode: {
+              type: "string",
+              enum: ["off", "partial", "block", "progress"],
+            },
+            chunkMode: {
+              type: "string",
+              enum: ["length", "newline"],
+            },
+            preview: {
+              type: "object",
+              properties: {
+                chunk: {
+                  type: "object",
+                  properties: {
+                    minChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    maxChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    breakPreference: {
+                      anyOf: [
+                        {
+                          type: "string",
+                          const: "paragraph",
+                        },
+                        {
+                          type: "string",
+                          const: "newline",
+                        },
+                        {
+                          type: "string",
+                          const: "sentence",
+                        },
+                      ],
+                    },
+                  },
+                  additionalProperties: false,
+                },
+                toolProgress: {
+                  type: "boolean",
+                },
+                commandText: {
+                  type: "string",
+                  enum: ["raw", "status"],
+                },
+              },
+              additionalProperties: false,
+            },
+            progress: {
+              type: "object",
+              properties: {
+                label: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "boolean",
+                      const: false,
+                    },
+                  ],
+                },
+                labels: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                },
+                maxLines: {
+                  type: "integer",
+                  exclusiveMinimum: 0,
+                  maximum: 9007199254740991,
+                },
+                render: {
+                  type: "string",
+                  enum: ["text", "rich"],
+                },
+                toolProgress: {
+                  type: "boolean",
+                },
+                commandText: {
+                  type: "string",
+                  enum: ["raw", "status"],
+                },
+              },
+              additionalProperties: false,
+            },
+            block: {
+              type: "object",
+              properties: {
+                enabled: {
+                  type: "boolean",
+                },
+                coalesce: {
+                  type: "object",
+                  properties: {
+                    minChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    maxChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    idleMs: {
+                      type: "integer",
+                      minimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                  },
+                  additionalProperties: false,
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        },
         mediaMaxMb: {
           type: "number",
         },
@@ -7269,6 +7397,134 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               responsePrefix: {
                 type: "string",
+              },
+              streaming: {
+                type: "object",
+                properties: {
+                  mode: {
+                    type: "string",
+                    enum: ["off", "partial", "block", "progress"],
+                  },
+                  chunkMode: {
+                    type: "string",
+                    enum: ["length", "newline"],
+                  },
+                  preview: {
+                    type: "object",
+                    properties: {
+                      chunk: {
+                        type: "object",
+                        properties: {
+                          minChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          breakPreference: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "paragraph",
+                              },
+                              {
+                                type: "string",
+                                const: "newline",
+                              },
+                              {
+                                type: "string",
+                                const: "sentence",
+                              },
+                            ],
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                      toolProgress: {
+                        type: "boolean",
+                      },
+                      commandText: {
+                        type: "string",
+                        enum: ["raw", "status"],
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                  progress: {
+                    type: "object",
+                    properties: {
+                      label: {
+                        anyOf: [
+                          {
+                            type: "string",
+                          },
+                          {
+                            type: "boolean",
+                            const: false,
+                          },
+                        ],
+                      },
+                      labels: {
+                        type: "array",
+                        items: {
+                          type: "string",
+                        },
+                      },
+                      maxLines: {
+                        type: "integer",
+                        exclusiveMinimum: 0,
+                        maximum: 9007199254740991,
+                      },
+                      render: {
+                        type: "string",
+                        enum: ["text", "rich"],
+                      },
+                      toolProgress: {
+                        type: "boolean",
+                      },
+                      commandText: {
+                        type: "string",
+                        enum: ["raw", "status"],
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                  block: {
+                    type: "object",
+                    properties: {
+                      enabled: {
+                        type: "boolean",
+                      },
+                      coalesce: {
+                        type: "object",
+                        properties: {
+                          minChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          idleMs: {
+                            type: "integer",
+                            minimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                },
+                additionalProperties: false,
               },
               mediaMaxMb: {
                 type: "number",
@@ -16959,6 +17215,134 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           type: "string",
           enum: ["length", "newline"],
         },
+        streaming: {
+          type: "object",
+          properties: {
+            mode: {
+              type: "string",
+              enum: ["off", "partial", "block", "progress"],
+            },
+            chunkMode: {
+              type: "string",
+              enum: ["length", "newline"],
+            },
+            preview: {
+              type: "object",
+              properties: {
+                chunk: {
+                  type: "object",
+                  properties: {
+                    minChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    maxChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    breakPreference: {
+                      anyOf: [
+                        {
+                          type: "string",
+                          const: "paragraph",
+                        },
+                        {
+                          type: "string",
+                          const: "newline",
+                        },
+                        {
+                          type: "string",
+                          const: "sentence",
+                        },
+                      ],
+                    },
+                  },
+                  additionalProperties: false,
+                },
+                toolProgress: {
+                  type: "boolean",
+                },
+                commandText: {
+                  type: "string",
+                  enum: ["raw", "status"],
+                },
+              },
+              additionalProperties: false,
+            },
+            progress: {
+              type: "object",
+              properties: {
+                label: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "boolean",
+                      const: false,
+                    },
+                  ],
+                },
+                labels: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                },
+                maxLines: {
+                  type: "integer",
+                  exclusiveMinimum: 0,
+                  maximum: 9007199254740991,
+                },
+                render: {
+                  type: "string",
+                  enum: ["text", "rich"],
+                },
+                toolProgress: {
+                  type: "boolean",
+                },
+                commandText: {
+                  type: "string",
+                  enum: ["raw", "status"],
+                },
+              },
+              additionalProperties: false,
+            },
+            block: {
+              type: "object",
+              properties: {
+                enabled: {
+                  type: "boolean",
+                },
+                coalesce: {
+                  type: "object",
+                  properties: {
+                    minChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    maxChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    idleMs: {
+                      type: "integer",
+                      minimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                  },
+                  additionalProperties: false,
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        },
         blockStreaming: {
           type: "boolean",
         },
@@ -17247,6 +17631,134 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               chunkMode: {
                 type: "string",
                 enum: ["length", "newline"],
+              },
+              streaming: {
+                type: "object",
+                properties: {
+                  mode: {
+                    type: "string",
+                    enum: ["off", "partial", "block", "progress"],
+                  },
+                  chunkMode: {
+                    type: "string",
+                    enum: ["length", "newline"],
+                  },
+                  preview: {
+                    type: "object",
+                    properties: {
+                      chunk: {
+                        type: "object",
+                        properties: {
+                          minChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          breakPreference: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "paragraph",
+                              },
+                              {
+                                type: "string",
+                                const: "newline",
+                              },
+                              {
+                                type: "string",
+                                const: "sentence",
+                              },
+                            ],
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                      toolProgress: {
+                        type: "boolean",
+                      },
+                      commandText: {
+                        type: "string",
+                        enum: ["raw", "status"],
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                  progress: {
+                    type: "object",
+                    properties: {
+                      label: {
+                        anyOf: [
+                          {
+                            type: "string",
+                          },
+                          {
+                            type: "boolean",
+                            const: false,
+                          },
+                        ],
+                      },
+                      labels: {
+                        type: "array",
+                        items: {
+                          type: "string",
+                        },
+                      },
+                      maxLines: {
+                        type: "integer",
+                        exclusiveMinimum: 0,
+                        maximum: 9007199254740991,
+                      },
+                      render: {
+                        type: "string",
+                        enum: ["text", "rich"],
+                      },
+                      toolProgress: {
+                        type: "boolean",
+                      },
+                      commandText: {
+                        type: "string",
+                        enum: ["raw", "status"],
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                  block: {
+                    type: "object",
+                    properties: {
+                      enabled: {
+                        type: "boolean",
+                      },
+                      coalesce: {
+                        type: "object",
+                        properties: {
+                          minChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          idleMs: {
+                            type: "integer",
+                            minimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                },
+                additionalProperties: false,
               },
               blockStreaming: {
                 type: "boolean",

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -1,6 +1,7 @@
 import type { ReactionLevel } from "../utils/reaction-level.js";
 import type {
   BlockStreamingCoalesceConfig,
+  ChannelPreviewStreamingConfig,
   ContextVisibilityMode,
   DmPolicy,
   GroupPolicy,
@@ -82,6 +83,8 @@ type WhatsAppSharedConfig = {
   textChunkLimit?: number;
   /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
   chunkMode?: "length" | "newline";
+  /** Preview/progress streaming behavior. */
+  streaming?: ChannelPreviewStreamingConfig;
   /** Maximum media file size in MB. Default: 50. */
   mediaMaxMb?: number;
   /** Disable block streaming for this account. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -97,7 +97,7 @@ const ChannelStreamingProgressSchema = z
     commandText: z.enum(["raw", "status"]).optional(),
   })
   .strict();
-const ChannelPreviewStreamingConfigSchema = z
+export const ChannelPreviewStreamingConfigSchema = z
   .object({
     mode: UnifiedStreamingModeSchema.optional(),
     chunkMode: TextChunkModeSchema.optional(),

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -97,6 +97,25 @@ describe("WhatsApp prompt config Zod validation", () => {
     }
   });
 
+  it("preserves streaming preview toolProgress without streaming mode", () => {
+    const result = WhatsAppConfigSchema.safeParse({
+      streaming: { preview: { toolProgress: false } },
+      accounts: {
+        work: {
+          streaming: { preview: { toolProgress: false } },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.streaming?.preview?.toolProgress).toBe(false);
+      expect(result.data.streaming?.mode).toBeUndefined();
+      expect(result.data.accounts?.work?.streaming?.preview?.toolProgress).toBe(false);
+      expect(result.data.accounts?.work?.streaming?.mode).toBeUndefined();
+    }
+  });
+
   it("accepts deprecated exposeErrorText as a no-op compatibility key", () => {
     const result = WhatsAppConfigSchema.safeParse({
       exposeErrorText: false,

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -15,6 +15,7 @@ import {
   MarkdownConfigSchema,
   ReplyToModeSchema,
 } from "./zod-schema.core.js";
+import { ChannelPreviewStreamingConfigSchema } from "./zod-schema.providers-core.js";
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
@@ -85,6 +86,7 @@ function buildWhatsAppCommonShape(params: { useDefaults: boolean }) {
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
+    streaming: ChannelPreviewStreamingConfigSchema.optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     groups: WhatsAppGroupsSchema,

--- a/src/plugin-sdk/channel-config-schema.ts
+++ b/src/plugin-sdk/channel-config-schema.ts
@@ -6,6 +6,7 @@ export {
   buildJsonChannelConfigSchema,
   buildNestedDmConfigSchema,
 } from "../channels/plugins/config-schema.js";
+export { ChannelPreviewStreamingConfigSchema } from "../config/zod-schema.providers-core.js";
 export {
   BlockStreamingCoalesceSchema,
   ContextVisibilityModeSchema,

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -163,6 +163,17 @@ describe("channel-streaming", () => {
         { draftStreamActive: false },
       ),
     ).toBe(false);
+    expect(
+      resolveChannelStreamingSuppressDefaultToolProgressMessages({
+        streaming: { preview: { toolProgress: false } },
+      }),
+    ).toBe(true);
+    expect(
+      resolveChannelStreamingSuppressDefaultToolProgressMessages(
+        { streaming: { preview: { toolProgress: false } } },
+        { draftStreamActive: false, previewStreamingEnabled: false },
+      ),
+    ).toBe(true);
   });
 
   it("uses auto progress labels when no explicit label is configured", () => {

--- a/src/plugin-sdk/channel-streaming.ts
+++ b/src/plugin-sdk/channel-streaming.ts
@@ -569,6 +569,13 @@ export function resolveChannelStreamingSuppressDefaultToolProgressMessages(
     previewStreamingEnabled?: boolean;
   },
 ): boolean {
+  const config = getChannelStreamingConfigObject(entry);
+  if (
+    asBoolean(config?.preview?.toolProgress) === false ||
+    asBoolean(config?.progress?.toolProgress) === false
+  ) {
+    return true;
+  }
   if (options?.draftStreamActive === false || options?.previewStreamingEnabled === false) {
     return false;
   }


### PR DESCRIPTION
## Summary
- Guard setup wizard token/text prompt normalization so undefined prompt responses do not crash onboarding
- Preserve `streaming.preview.toolProgress: false` without requiring `streaming.mode`
- Wire default tool-progress suppression through WhatsApp, LINE, and Slack config/runtime paths
- Regenerate bundled channel config metadata and Plugin SDK API baseline for the intentional schema/export changes

Fixes #67366
Fixes #73795
Related to #76575

## Verification
- `pnpm config:channels:check`
- `pnpm plugin-sdk:api:check`
- `pnpm test extensions/slack/src/config-schema.test.ts extensions/slack/src/monitor/slash.test.ts extensions/line/src/config-schema.test.ts src/plugin-sdk/channel-streaming.test.ts src/config/zod-schema.providers-whatsapp.test.ts extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts src/channels/plugins/setup-wizard-helpers.test.ts src/commands/onboard-channels.e2e.test.ts`
- `pnpm exec oxfmt --check --threads=1 ...` on touched files

## Real behavior proof
- **Behavior or issue addressed:** `streaming.preview.toolProgress: false` should be accepted and preserved for WhatsApp, LINE, and Slack channel configs without requiring `streaming.mode`; setup wizard prompt handling should not crash on empty/undefined text prompt results.
- **Real environment tested:** Local OpenClaw checkout on macOS, Node 22.22.0, branch `fix/contribution-batch-issues`, using the actual `pnpm openclaw` CLI against a temporary `OPENCLAW_CONFIG_PATH`.
- **Exact steps or command run after this patch:** Created a temporary `openclaw.json` containing WhatsApp, LINE, and Slack `streaming.preview.toolProgress: false`, then ran `OPENCLAW_CONFIG_PATH=<temp>/openclaw.json pnpm openclaw config validate` and `OPENCLAW_CONFIG_PATH=<temp>/openclaw.json pnpm openclaw config get channels.{whatsapp,line,slack}.streaming.preview.toolProgress`.
- **Evidence after fix:** Terminal output from the real CLI run:

```text
Config valid: /tmp/openclaw-proof-nBRVzf/openclaw.json
false
false
false
```

- **Observed result after fix:** The temporary config validated successfully, and `config get` returned `false` for `channels.whatsapp.streaming.preview.toolProgress`, `channels.line.streaming.preview.toolProgress`, and `channels.slack.streaming.preview.toolProgress`, proving the generated runtime metadata no longer strips or rejects the setting.
- **What was not tested:** Live WhatsApp, LINE, or Slack message delivery was not exercised in this local proof; the runtime dispatch behavior is covered by the focused channel tests listed above.

## Notes
- Investigated the Telegram PPTX/media issue path; current `main` already includes the relevant best-effort fsync EPERM handling and Telegram media filename/MIME plumbing, so this PR leaves that path unchanged.
- `pnpm check:changed` was blocked locally by missing `node_modules/web-tree-sitter`, although the dependency is present in package metadata/lockfile.