### PR TITLE
fix: LM Studio thinking blocks invisible with Responses API

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4430,4 +4430,149 @@ describe("openai transport stream", () => {
       __testing.processOpenAICompletionsStream(mockStream(), output, model, stream),
     ).rejects.toThrow("Exceeded tool-call argument buffer limit");
   });
+
+  describe("response.reasoning_text.done handling", () => {
+    const model = {
+      id: "lmstudio/qwen3",
+      name: "Qwen3",
+      api: "openai-responses" as const,
+      provider: "lmstudio",
+      baseUrl: "http://localhost:9191/v1",
+      reasoning: true,
+      input: ["text" as const],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32768,
+      maxTokens: 8192,
+    };
+
+    function makeOutput() {
+      return {
+        role: "assistant" as const,
+        content: [] as Array<Record<string, unknown>>,
+        api: "openai-responses" as const,
+        provider: "lmstudio",
+        model: "lmstudio/qwen3",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 0,
+      };
+    }
+
+    it("LM Studio path: inserts thinking block when no prior output_item.added reasoning item", async () => {
+      const output = makeOutput();
+      const events: unknown[] = [];
+      const stream = { push: (e: unknown) => events.push(e) };
+
+      async function* mockStream() {
+        yield { type: "response.created", response: { id: "resp_lms_1" } };
+        yield { type: "response.reasoning_text.done", text: "I should answer 4." };
+        yield {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_1" },
+        };
+        yield { type: "response.output_text.delta", delta: "4" };
+        yield {
+          type: "response.output_item.done",
+          item: { type: "message", content: [{ type: "output_text", text: "4" }] },
+        };
+        yield {
+          type: "response.completed",
+          response: {
+            id: "resp_lms_1",
+            status: "completed",
+            usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+          },
+        };
+      }
+
+      await __testing.processResponsesStream(mockStream(), output, stream, model);
+
+      const thinkingBlock = output.content.find((b) => b["type"] === "thinking");
+      expect(thinkingBlock).toBeDefined();
+      expect(thinkingBlock?.["thinking"]).toBe("I should answer 4.");
+      expect(output.content[0]?.["type"]).toBe("thinking");
+
+      const thinkingStart = events.find((e) => (e as { type: string }).type === "thinking_start");
+      const thinkingEnd = events.find((e) => (e as { type: string }).type === "thinking_end");
+      expect(thinkingStart).toBeDefined();
+      expect(thinkingEnd).toBeDefined();
+    });
+
+    it("standard path: finalizes active reasoning block when output_item.added(reasoning) precedes reasoning_text.done", async () => {
+      const output = makeOutput();
+      const events: unknown[] = [];
+      const stream = { push: (e: unknown) => events.push(e) };
+
+      async function* mockStream() {
+        yield { type: "response.created", response: { id: "resp_std_1" } };
+        yield {
+          type: "response.output_item.added",
+          item: { type: "reasoning", id: "rs_1", summary: [] },
+        };
+        yield {
+          type: "response.reasoning_text.done",
+          item_id: "rs_1",
+          output_index: 0,
+          content_index: 0,
+          text: "Let me think about this.",
+        };
+        yield {
+          type: "response.completed",
+          response: {
+            id: "resp_std_1",
+            status: "completed",
+            usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+          },
+        };
+      }
+
+      await __testing.processResponsesStream(mockStream(), output, stream, model);
+
+      const thinkingBlocks = output.content.filter((b) => b["type"] === "thinking");
+      expect(thinkingBlocks).toHaveLength(1);
+      expect(thinkingBlocks[0]?.["thinking"]).toBe("Let me think about this.");
+
+      const thinkingEndEvents = events.filter(
+        (e) => (e as { type: string }).type === "thinking_end",
+      );
+      expect(thinkingEndEvents).toHaveLength(1);
+    });
+
+    it("does not produce duplicate thinking blocks when both paths fire", async () => {
+      const output = makeOutput();
+      const events: unknown[] = [];
+      const stream = { push: (e: unknown) => events.push(e) };
+
+      async function* mockStream() {
+        yield { type: "response.created", response: { id: "resp_dup_1" } };
+        yield {
+          type: "response.output_item.added",
+          item: { type: "reasoning", id: "rs_1", summary: [] },
+        };
+        yield { type: "response.reasoning_text.done", item_id: "rs_1", text: "Thinking done." };
+        // A second reasoning_text.done should be ignored since a thinking block already exists
+        yield { type: "response.reasoning_text.done", text: "Duplicate thinking." };
+        yield {
+          type: "response.completed",
+          response: {
+            id: "resp_dup_1",
+            status: "completed",
+            usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+          },
+        };
+      }
+
+      await __testing.processResponsesStream(mockStream(), output, stream, model);
+
+      const thinkingBlocks = output.content.filter((b) => b["type"] === "thinking");
+      expect(thinkingBlocks).toHaveLength(1);
+    });
+  });
 });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -505,14 +505,12 @@ async function processResponsesStream(
             partial: output,
           });
           currentBlock = null;
-        } else if (
-          !output.content.some((b) => (b as Record<string, unknown>).type === "thinking")
-        ) {
+        } else if (!output.content.some((b) => b.type === "thinking")) {
           // LM Studio path: provider skips output_item.added for reasoning and delivers
           // the full thinking text in one shot via this event. Only insert when no
           // thinking block exists yet to avoid duplicates, and only when no text blocks
           // have been emitted yet to avoid retroactively shifting stream indexes.
-          if (!output.content.some((b) => (b as Record<string, unknown>).type === "text")) {
+          if (!output.content.some((b) => b.type === "text")) {
             const thinkingBlock: Record<string, unknown> = { type: "thinking", thinking: text };
             output.content.unshift(thinkingBlock);
             stream.push({ type: "thinking_start", contentIndex: 0, partial: output });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -492,16 +492,34 @@ async function processResponsesStream(
         });
       }
     } else if (type === "response.reasoning_text.done") {
-      // Some OpenAI-compatible providers (e.g. LM Studio) deliver reasoning as a
-      // single completed event instead of the standard output_item.added →
-      // reasoning_summary_text.delta → output_item.done sequence.
       const text = stringifyUnknown(event.text);
       if (text) {
-        const thinkingBlock: Record<string, unknown> = { type: "thinking", thinking: text };
-        output.content.unshift(thinkingBlock);
-        stream.push({ type: "thinking_start", contentIndex: 0, partial: output });
-        stream.push({ type: "thinking_delta", contentIndex: 0, delta: text, partial: output });
-        stream.push({ type: "thinking_end", contentIndex: 0, content: text, partial: output });
+        if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
+          // Standard path: provider sent output_item.added(reasoning) before this event.
+          // Finalize the active reasoning block with the complete text.
+          currentBlock.thinking = text;
+          stream.push({
+            type: "thinking_end",
+            contentIndex: blockIndex(),
+            content: text,
+            partial: output,
+          });
+          currentBlock = null;
+        } else if (
+          !output.content.some((b) => (b as Record<string, unknown>).type === "thinking")
+        ) {
+          // LM Studio path: provider skips output_item.added for reasoning and delivers
+          // the full thinking text in one shot via this event. Only insert when no
+          // thinking block exists yet to avoid duplicates, and only when no text blocks
+          // have been emitted yet to avoid retroactively shifting stream indexes.
+          if (!output.content.some((b) => (b as Record<string, unknown>).type === "text")) {
+            const thinkingBlock: Record<string, unknown> = { type: "thinking", thinking: text };
+            output.content.unshift(thinkingBlock);
+            stream.push({ type: "thinking_start", contentIndex: 0, partial: output });
+            stream.push({ type: "thinking_delta", contentIndex: 0, delta: text, partial: output });
+            stream.push({ type: "thinking_end", contentIndex: 0, content: text, partial: output });
+          }
+        }
       }
     } else if (type === "response.output_text.delta" || type === "response.refusal.delta") {
       if (currentItem?.type === "message" && currentBlock?.type === "text") {
@@ -2021,4 +2039,5 @@ export const __testing = {
   sanitizeOpenAICodexResponsesParams,
   buildOpenAICompletionsClientConfig,
   processOpenAICompletionsStream,
+  processResponsesStream,
 };

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -491,6 +491,18 @@ async function processResponsesStream(
           partial: output,
         });
       }
+    } else if (type === "response.reasoning_text.done") {
+      // Some OpenAI-compatible providers (e.g. LM Studio) deliver reasoning as a
+      // single completed event instead of the standard output_item.added →
+      // reasoning_summary_text.delta → output_item.done sequence.
+      const text = stringifyUnknown(event.text);
+      if (text) {
+        const thinkingBlock: Record<string, unknown> = { type: "thinking", thinking: text };
+        output.content.unshift(thinkingBlock);
+        stream.push({ type: "thinking_start", contentIndex: 0, partial: output });
+        stream.push({ type: "thinking_delta", contentIndex: 0, delta: text, partial: output });
+        stream.push({ type: "thinking_end", contentIndex: 0, content: text, partial: output });
+      }
     } else if (type === "response.output_text.delta" || type === "response.refusal.delta") {
       if (currentItem?.type === "message" && currentBlock?.type === "text") {
         currentBlock.text = `${stringifyUnknown(currentBlock.text)}${stringifyUnknown(event.delta)}`;


### PR DESCRIPTION
## Problem

When using LM Studio with the `openai-responses` API, the model's reasoning/thinking content was completely invisible, even though the model was actively thinking and producing reasoning tokens.

The root cause: LM Studio (and other OpenAI-compatible providers) deliver reasoning content via a single `response.reasoning_text.done` event carrying the full thinking text. OpenClaw's `processResponsesStream` had no handler for this event, so it was silently dropped on every request.

The standard OpenAI sequence OpenClaw expected:
1. `response.output_item.added` → `{ type: "reasoning" }`
2. `response.reasoning_summary_text.delta` (incremental chunks)
3. `response.output_item.done`

What LM Studio actually sends:
1. `response.reasoning_text.done` → full thinking text in one shot

No handler = no thinking block = thinking silently lost every time.

## Fix

Adds a handler for `response.reasoning_text.done` in `processResponsesStream` (`src/agents/openai-transport-stream.ts`):

- Reads the full reasoning text from `event.text`
- Creates a `thinking` content block and inserts it at the **front** of `output.content` (before any text blocks, preserving correct think-before-respond ordering)
- Fires the complete `thinking_start` -> `thinking_delta` -> `thinking_end` event sequence so all downstream consumers receive the thinking content correctly

Two paths are handled:

1. **Standard path** (provider sent `output_item.added(reasoning)` first): reuses the active reasoning block and fires only `thinking_end` to avoid duplicates
2. **LM Studio path** (no prior reasoning item): inserts a new thinking block at the front, but only when no thinking block and no text blocks exist yet

## Why This Is Correct

`response.reasoning_text.done` is not a non-standard event. It is part of the [official OpenAI Responses API spec](https://platform.openai.com/docs/api-reference/responses/streaming) (`ResponseReasoningTextDoneEvent`). This is a gap in spec coverage that affects any provider delivering reasoning this way.

## Real Behavior Proof

**Issue addressed:** Reasoning/thinking content from LM Studio was completely invisible when using the `openai-responses` API. No thinking block was rendered even though the model was actively reasoning.

**Real environment tested:** macOS, LM Studio running `ykimport/qwen3.5-9b-opus-openclaw-distilled` (Qwen3.5 reasoning model), OpenClaw gateway local mode, `openai-responses` API.

**Exact steps or command run after this patch:**
1. Applied the fix to the installed OpenClaw runtime
2. Started OpenClaw gateway in local mode
3. Sent "what is 2+2?" to the agent
4. Observed the response in the UI

**Evidence after fix:** Full reasoning block rendered above the answer, correctly displayed in the dashed thinking container.

Before (no thinking block):

<img width="1161" height="215" alt="Before: no reasoning block" src="https://github.com/user-attachments/assets/a9f3fb78-d66b-4f74-8e51-9a7560ab2d83" />

After (thinking block visible):

<img width="1163" height="360" alt="After: reasoning block visible" src="https://github.com/user-attachments/assets/0a84e851-7cf6-4aa0-a15e-3e405775a59e" />

**Observed result after fix:** Thinking block appears correctly with full reasoning content visible. The model's reasoning text ("The user wants to solve a simple arithmetic problem. Since runtime=agent, I can use the agent's built-in reasoning... I'll compute directly: 2 + 2 = 4.") is displayed in the thinking container above the final answer.

**What was not tested:** Providers that send both `output_item.added(reasoning)` and `reasoning_text.done` in the same stream (only LM Studio's done-only path was live-tested).

## Notes

The same fix has been submitted to `badlogic/pi-mono` for `@mariozechner/pi-ai`'s
`processResponsesStream` in `packages/ai/src/providers/openai-responses-shared.ts`,
which covers the LM Studio extension's `streamSimple` path:
badlogic/pi-mono#4191