### PR TITLE
fix(ui): show inherited thinking label in chat dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Channels/streaming: cap progress-draft tool lines by default so edited progress boxes avoid jumpy reflow from long wrapped lines.
 - Control UI/chat: add an agent-first filter to the chat session picker, keep chat controls/composer responsive across phone/tablet/desktop widths, keep desktop chat controls on one row, avoid duplicate avatar refreshes during initial chat load, and hide that row while scrolling down the transcript. Thanks @BunsDev.
 - Control UI/chat: collapse consecutive duplicate text messages into one bubble with a count so repeated text-only messages stay compact without hiding nearby context.
+- Control UI/chat: label the thinking selector's inherited default separately from explicit overrides while preserving provider-supplied option labels. Thanks @Beandon13.
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.
 - Plugins/migration: emit catalog-backed install hints when `plugins.entries` or `plugins.allow` references an official external plugin that is not installed, so upgraded configs point operators to `openclaw plugins install <spec>` instead of telling them to remove valid plugin config. (#77483) Thanks @hclsys.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -123,7 +123,8 @@ Malformed local-model reasoning tags are handled conservatively. Closed `<think>
 
 - The web chat thinking selector mirrors the session's stored level from the inbound session store/config when the page loads.
 - Picking another level writes the session override immediately via `sessions.patch`; it does not wait for the next send and it is not a one-shot `thinkingOnce` override.
-- The first option is always `Default (<resolved level>)`, where the resolved default comes from the active session model's provider thinking profile plus the same fallback logic that `/status` and `session_status` use.
+- The first option is always the clear-override choice. It shows `Inherited: <resolved level>` when the session is inheriting a non-off effective default, or `Off` when the inherited default resolves to disabled thinking.
+- Explicit picker choices are labeled as overrides, while preserving provider labels when present (for example `Override: maximum` for a provider-labeled `max` option).
 - The picker uses `thinkingLevels` returned by the gateway session row/defaults, with `thinkingOptions` kept as a legacy label list. The browser UI does not keep its own provider regex list; plugins own model-specific level sets.
 - `/think:<level>` still works and updates the same stored session level, so chat directives and the picker stay in sync.
 

--- a/ui/src/ui/chat/session-controls.thinking-state.test.ts
+++ b/ui/src/ui/chat/session-controls.thinking-state.test.ts
@@ -7,11 +7,16 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
     sessionKey: "session-1",
     chatModelCatalog: [],
     sessionsResult: {
+      ts: 0,
+      path: "sessions.json",
+      count: 1,
       sessions: [
         {
           key: "session-1",
+          kind: "direct",
           modelProvider: "openai",
           model: "gpt-5",
+          updatedAt: null,
           thinkingLevel: undefined,
           thinkingDefault: "high",
           thinkingLevels: [
@@ -24,6 +29,7 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
       defaults: {
         modelProvider: "openai",
         model: "gpt-5",
+        contextTokens: null,
         thinkingDefault: "medium",
         thinkingLevels: [
           { id: "off", label: "Off" },
@@ -53,11 +59,16 @@ describe("resolveChatThinkingSelectState", () => {
     const result = resolveChatThinkingSelectState(
       createState({
         sessionsResult: {
+          ts: 0,
+          path: "sessions.json",
+          count: 1,
           sessions: [
             {
               key: "session-1",
+              kind: "direct",
               modelProvider: "openai",
               model: "gpt-5",
+              updatedAt: null,
               thinkingLevel: "low",
               thinkingDefault: "high",
               thinkingLevels: [
@@ -70,6 +81,7 @@ describe("resolveChatThinkingSelectState", () => {
           defaults: {
             modelProvider: "openai",
             model: "gpt-5",
+            contextTokens: null,
             thinkingDefault: "medium",
             thinkingLevels: [
               { id: "off", label: "Off" },
@@ -90,11 +102,16 @@ describe("resolveChatThinkingSelectState", () => {
     const result = resolveChatThinkingSelectState(
       createState({
         sessionsResult: {
+          ts: 0,
+          path: "sessions.json",
+          count: 1,
           sessions: [
             {
               key: "session-1",
+              kind: "direct",
               modelProvider: "openai",
               model: "gpt-5",
+              updatedAt: null,
               thinkingLevel: undefined,
               thinkingDefault: "off",
               thinkingLevels: [{ id: "off", label: "Off" }],
@@ -103,6 +120,7 @@ describe("resolveChatThinkingSelectState", () => {
           defaults: {
             modelProvider: "openai",
             model: "gpt-5",
+            contextTokens: null,
             thinkingDefault: "off",
             thinkingLevels: [{ id: "off", label: "Off" }],
           },

--- a/ui/src/ui/chat/session-controls.thinking-state.test.ts
+++ b/ui/src/ui/chat/session-controls.thinking-state.test.ts
@@ -50,8 +50,8 @@ describe("resolveChatThinkingSelectState", () => {
     expect(result.defaultLabel).toBe("Inherited: high");
     expect(result.options.map((entry) => entry.label)).toEqual([
       "Off",
-      "Override: low",
-      "Override: high",
+      "Override: Low",
+      "Override: High",
     ]);
   });
 
@@ -95,7 +95,47 @@ describe("resolveChatThinkingSelectState", () => {
 
     expect(result.currentOverride).toBe("low");
     expect(result.defaultLabel).toBe("Inherited: high");
-    expect(result.options.find((entry) => entry.value === "low")?.label).toBe("Override: low");
+    expect(result.options.find((entry) => entry.value === "low")?.label).toBe("Override: Low");
+  });
+
+  it("preserves provider supplied thinking level labels for overrides", () => {
+    const result = resolveChatThinkingSelectState(
+      createState({
+        sessionsResult: {
+          ts: 0,
+          path: "sessions.json",
+          count: 1,
+          sessions: [
+            {
+              key: "session-1",
+              kind: "direct",
+              modelProvider: "openai",
+              model: "gpt-5",
+              updatedAt: null,
+              thinkingLevel: undefined,
+              thinkingDefault: "max",
+              thinkingLevels: [
+                { id: "off", label: "Off" },
+                { id: "max", label: "maximum" },
+              ],
+            },
+          ],
+          defaults: {
+            modelProvider: "openai",
+            model: "gpt-5",
+            contextTokens: null,
+            thinkingDefault: "max",
+            thinkingLevels: [
+              { id: "off", label: "Off" },
+              { id: "max", label: "maximum" },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result.defaultLabel).toBe("Inherited: max");
+    expect(result.options).toContainEqual({ value: "max", label: "Override: maximum" });
   });
 
   it("renders Off when the effective default is truly off", () => {

--- a/ui/src/ui/chat/session-controls.thinking-state.test.ts
+++ b/ui/src/ui/chat/session-controls.thinking-state.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { AppViewState } from "../app-view-state.ts";
+import { resolveChatThinkingSelectState } from "./session-controls.ts";
+
+function createState(overrides: Partial<AppViewState> = {}): AppViewState {
+  return {
+    sessionKey: "session-1",
+    chatModelCatalog: [],
+    sessionsResult: {
+      sessions: [
+        {
+          key: "session-1",
+          modelProvider: "openai",
+          model: "gpt-5",
+          thinkingLevel: undefined,
+          thinkingDefault: "high",
+          thinkingLevels: [
+            { id: "off", label: "Off" },
+            { id: "low", label: "Low" },
+            { id: "high", label: "High" },
+          ],
+        },
+      ],
+      defaults: {
+        modelProvider: "openai",
+        model: "gpt-5",
+        thinkingDefault: "medium",
+        thinkingLevels: [
+          { id: "off", label: "Off" },
+          { id: "low", label: "Low" },
+          { id: "medium", label: "Medium" },
+        ],
+      },
+    },
+    ...overrides,
+  } as unknown as AppViewState;
+}
+
+describe("resolveChatThinkingSelectState", () => {
+  it("shows inherited effective thinking when no session override is set", () => {
+    const result = resolveChatThinkingSelectState(createState());
+
+    expect(result.currentOverride).toBe("");
+    expect(result.defaultLabel).toBe("Inherited: high");
+    expect(result.options.map((entry) => entry.label)).toEqual([
+      "Off",
+      "Override: low",
+      "Override: high",
+    ]);
+  });
+
+  it("keeps the blank option pointed at the inherited level when an override is active", () => {
+    const result = resolveChatThinkingSelectState(
+      createState({
+        sessionsResult: {
+          sessions: [
+            {
+              key: "session-1",
+              modelProvider: "openai",
+              model: "gpt-5",
+              thinkingLevel: "low",
+              thinkingDefault: "high",
+              thinkingLevels: [
+                { id: "off", label: "Off" },
+                { id: "low", label: "Low" },
+                { id: "high", label: "High" },
+              ],
+            },
+          ],
+          defaults: {
+            modelProvider: "openai",
+            model: "gpt-5",
+            thinkingDefault: "medium",
+            thinkingLevels: [
+              { id: "off", label: "Off" },
+              { id: "low", label: "Low" },
+              { id: "medium", label: "Medium" },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result.currentOverride).toBe("low");
+    expect(result.defaultLabel).toBe("Inherited: high");
+    expect(result.options.find((entry) => entry.value === "low")?.label).toBe("Override: low");
+  });
+
+  it("renders Off when the effective default is truly off", () => {
+    const result = resolveChatThinkingSelectState(
+      createState({
+        sessionsResult: {
+          sessions: [
+            {
+              key: "session-1",
+              modelProvider: "openai",
+              model: "gpt-5",
+              thinkingLevel: undefined,
+              thinkingDefault: "off",
+              thinkingLevels: [{ id: "off", label: "Off" }],
+            },
+          ],
+          defaults: {
+            modelProvider: "openai",
+            model: "gpt-5",
+            thinkingDefault: "off",
+            thinkingLevels: [{ id: "off", label: "Off" }],
+          },
+        },
+      }),
+    );
+
+    expect(result.defaultLabel).toBe("Off");
+    expect(result.options).toEqual([{ value: "off", label: "Off" }]);
+  });
+});

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -200,12 +200,13 @@ function formatThinkingDefaultLabel(effectiveLevel: string | undefined): string 
   return `Inherited: ${normalized}`;
 }
 
-function formatThinkingOverrideLabel(value: string): string {
+function formatThinkingOverrideLabel(value: string, label?: string): string {
   const normalized = normalizeThinkLevel(value) ?? normalizeLowercaseStringOrEmpty(value);
   if (!normalized || normalized === "off") {
     return "Off";
   }
-  return `Override: ${normalized}`;
+  const displayLabel = label?.trim() || normalized;
+  return `Override: ${displayLabel}`;
 }
 
 function resolveThinkingTargetModel(state: AppViewState): {
@@ -226,15 +227,15 @@ function buildThinkingOptions(
   const seen = new Set<string>();
   const options: ChatThinkingSelectOption[] = [];
 
-  const addOption = (value: string) => {
+  const addOption = (value: string, label?: string) => {
     const normalizedValue = normalizeThinkLevel(value) ?? normalizeLowercaseStringOrEmpty(value);
-    const resolvedLabel = formatThinkingOverrideLabel(normalizedValue);
+    const resolvedLabel = formatThinkingOverrideLabel(normalizedValue, label);
     pushUniqueTrimmedSelectOption(options, seen, normalizedValue, () => resolvedLabel);
   };
 
   for (const level of levels) {
     const normalized = normalizeThinkLevel(level.id) ?? normalizeLowercaseStringOrEmpty(level.id);
-    addOption(normalized);
+    addOption(normalized, level.label);
   }
   if (currentOverride) {
     addOption(currentOverride);

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -192,6 +192,22 @@ type ChatThinkingSelectState = {
   options: ChatThinkingSelectOption[];
 };
 
+function formatThinkingDefaultLabel(effectiveLevel: string | undefined): string {
+  const normalized = normalizeThinkLevel(effectiveLevel) ?? "off";
+  if (normalized === "off") {
+    return "Off";
+  }
+  return `Inherited: ${normalized}`;
+}
+
+function formatThinkingOverrideLabel(value: string): string {
+  const normalized = normalizeThinkLevel(value) ?? normalizeLowercaseStringOrEmpty(value);
+  if (!normalized || normalized === "off") {
+    return "Off";
+  }
+  return `Override: ${normalized}`;
+}
+
 function resolveThinkingTargetModel(state: AppViewState): {
   provider: string | null;
   model: string | null;
@@ -210,19 +226,15 @@ function buildThinkingOptions(
   const seen = new Set<string>();
   const options: ChatThinkingSelectOption[] = [];
 
-  const addOption = (value: string, label?: string) => {
-    const resolvedLabel =
-      label ??
-      value
-        .split(/[-_]/g)
-        .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
-        .join(" ");
-    pushUniqueTrimmedSelectOption(options, seen, value, () => resolvedLabel);
+  const addOption = (value: string) => {
+    const normalizedValue = normalizeThinkLevel(value) ?? normalizeLowercaseStringOrEmpty(value);
+    const resolvedLabel = formatThinkingOverrideLabel(normalizedValue);
+    pushUniqueTrimmedSelectOption(options, seen, normalizedValue, () => resolvedLabel);
   };
 
   for (const level of levels) {
     const normalized = normalizeThinkLevel(level.id) ?? normalizeLowercaseStringOrEmpty(level.id);
-    addOption(normalized, level.label);
+    addOption(normalized);
   }
   if (currentOverride) {
     addOption(currentOverride);
@@ -257,7 +269,7 @@ function resolveThinkingLevelOptions(
   }));
 }
 
-function resolveChatThinkingSelectState(state: AppViewState): ChatThinkingSelectState {
+export function resolveChatThinkingSelectState(state: AppViewState): ChatThinkingSelectState {
   const activeRow = state.sessionsResult?.sessions?.find((row) => row.key === state.sessionKey);
   const persisted = activeRow?.thinkingLevel;
   const currentOverride =
@@ -283,7 +295,7 @@ function resolveChatThinkingSelectState(state: AppViewState): ChatThinkingSelect
       : "off");
   return {
     currentOverride,
-    defaultLabel: `Default (${defaultLevel})`,
+    defaultLabel: formatThinkingDefaultLabel(defaultLevel),
     options: buildThinkingOptions(levels, currentOverride),
   };
 }

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1041,7 +1041,7 @@ describe("chat session controls", () => {
       [...(thinkingSelect?.options ?? [])]
         .find((option) => option.value === "max")
         ?.textContent?.trim(),
-    ).toBe("maximum");
+    ).toBe("Override: maximum");
   });
 
   it("labels chat thinking default from the active session row", () => {
@@ -1058,8 +1058,8 @@ describe("chat session controls", () => {
     );
 
     expect(thinkingSelect?.value).toBe("");
-    expect(thinkingSelect?.options[0]?.textContent?.trim()).toBe("Default (adaptive)");
-    expect(thinkingSelect?.title).toBe("Default (adaptive)");
+    expect(thinkingSelect?.options[0]?.textContent?.trim()).toBe("Inherited: adaptive");
+    expect(thinkingSelect?.title).toBe("Inherited: adaptive");
   });
 
   it("always renders full thinking labels", () => {
@@ -1089,14 +1089,14 @@ describe("chat session controls", () => {
 
     expect(container.querySelector('select[data-chat-thinking-select-compact="true"]')).toBeNull();
     expect(thinkingSelect?.value).toBe("");
-    expect(thinkingSelect?.title).toBe("Default (high)");
+    expect(thinkingSelect?.title).toBe("Inherited: high");
     expect([...thinkingSelect!.options].map((option) => option.textContent?.trim())).toEqual([
-      "Default (high)",
-      "off",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
+      "Inherited: high",
+      "Off",
+      "Override: low",
+      "Override: medium",
+      "Override: high",
+      "Override: xhigh",
     ]);
   });
 
@@ -1113,7 +1113,7 @@ describe("chat session controls", () => {
     );
 
     expect(thinkingSelect?.value).toBe("");
-    expect(thinkingSelect?.options[0]?.textContent?.trim()).toBe("Default (adaptive)");
-    expect(thinkingSelect?.title).toBe("Default (adaptive)");
+    expect(thinkingSelect?.options[0]?.textContent?.trim()).toBe("Inherited: adaptive");
+    expect(thinkingSelect?.title).toBe("Inherited: adaptive");
   });
 });


### PR DESCRIPTION
## Summary
- stop rendering the blank chat thinking option as `Default (off)` when the session is inheriting a non-off effective level
- label the clear-override option from the effective inherited level (`Inherited: high`) and explicit picks as overrides
- add a focused selector-state regression so inherited/default/off cases stay distinct

Closes #77581

## Real behavior proof
- Behavior or issue addressed: The chat thinking selector now makes the inherited/default level explicit while preserving provider-supplied labels for explicit override choices.
- Real environment tested: Local OpenClaw checkout from this PR branch on macOS, built through `pnpm openclaw` at head `c42033eebb608ca943a962b98b9b54f74932611f`.
- Exact steps or command run after this patch:
  ```bash
  pnpm openclaw --version
  pnpm test ui/src/ui/views/chat.test.ts ui/src/ui/chat/session-controls.thinking-state.test.ts
  ```
- Evidence after fix:
  ```text
  OpenClaw 2026.5.4 (c42033e)

  ✓ unit-ui ui/src/ui/views/chat.test.ts (28 tests)
  ✓ unit-ui ui/src/ui/chat/session-controls.thinking-state.test.ts (4 tests)

  Test Files 2 passed (2)
  Tests 32 passed (32)
  ```
- Observed result after fix: The patched Control UI selector state renders inherited labels such as `Inherited: high` and explicit choices such as `Override: maximum` while keeping provider labels intact.
- What was not tested: No browser screenshot was captured in this run; the proof covers the built local checkout and DOM-level UI selector tests.
