### PR TITLE
fix(embed): arm lastBlockReplyText only after block reply emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Agents/embed: only mark `lastBlockReplyText` after a text_end block reply is actually emitted, so message_end keeps its safety delivery when directive parsing suppresses an earlier chunk (fixes dropped channel replies including Telegram forum topics where logs showed skipping message_end sends). Fixes #77833.
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.
@@ -328,6 +327,7 @@ Docs: https://docs.openclaw.ai
 - CLI/update: stop dev-channel source updates immediately when `git fetch` fails, so tag conflicts cannot keep preflight, rebase, or build steps running against stale refs while the Gateway is still on the old runtime. (#77845) Thanks @obviyus.
 - Config/recovery: chmod restored `openclaw.json` back to owner-only (`0600`) after suspicious-read backup recovery on POSIX hosts, so a previously world-readable config mode cannot persist into a freshly restored credential-bearing config. (#77488) Thanks @drobison00.
 - Memory/dreaming: persist last dreaming-ingestion calendar day per daily note in `daily-ingestion.json` so unchanged notes are still re-ingested once per dreaming day for promotion signals toward deep thresholds. Fixes #76225. (#76359) Thanks @neeravmakwana.
+- Agents/embed: keep message_end safety delivery armed when a silent text_end chunk produces no block reply, fixing dropped Telegram/forum replies. Fixes #77833. (#77840) Thanks @neeravmakwana.
 
 ## 2026.5.3-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/embed: only mark `lastBlockReplyText` after a text_end block reply is actually emitted, so message_end keeps its safety delivery when directive parsing suppresses an earlier chunk (fixes dropped channel replies including Telegram forum topics where logs showed skipping message_end sends). Fixes #77833.
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -125,6 +125,31 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts).toEqual(["Hello block"]);
   });
 
+  it("message_end block-replies visible text when text_end streamed only silent NO_REPLY chunks", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextEnd({ emit, content: "NO_REPLY" });
+    await Promise.resolve();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Final visible reply." }],
+      } as AssistantMessage,
+    });
+    await Promise.resolve();
+
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("Final visible reply.");
+  });
+
   it("does not duplicate when message_end flushes and a late text_end arrives", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -127,7 +127,7 @@ describe("subscribeEmbeddedPiSession", () => {
 
   it("message_end block-replies visible text when text_end streamed only silent NO_REPLY chunks", async () => {
     const onBlockReply = vi.fn();
-    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
 
     emit({ type: "message_start", message: { role: "assistant" } });
     emitAssistantTextEnd({ emit, content: "NO_REPLY" });
@@ -148,6 +148,7 @@ describe("subscribeEmbeddedPiSession", () => {
       expect(onBlockReply).toHaveBeenCalledTimes(1);
     });
     expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("Final visible reply.");
+    expect(subscription.assistantTexts).toEqual(["Final visible reply."]);
   });
 
   it("does not duplicate when message_end flushes and a late text_end arrives", async () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -733,8 +733,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       return;
     }
 
-    pushAssistantText(chunk);
     if (!params.onBlockReply) {
+      pushAssistantText(chunk);
       return;
     }
     const splitResult = replyDirectiveAccumulator.consume(chunk);
@@ -749,11 +749,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       replyToTag,
       replyToCurrent,
     } = splitResult;
-    // Skip empty payloads, but always emit if audioAsVoice is set (to propagate the flag)
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       return;
     }
-    state.lastBlockReplyText = chunk;
+    pushAssistantText(chunk);
     emitBlockReply(
       {
         text: cleanedText,
@@ -769,6 +768,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
           options?.final === true || Boolean(mediaUrls?.length || audioAsVoice),
       },
     );
+    state.lastBlockReplyText = chunk;
   };
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -733,7 +733,6 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       return;
     }
 
-    state.lastBlockReplyText = chunk;
     pushAssistantText(chunk);
     if (!params.onBlockReply) {
       return;
@@ -754,6 +753,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       return;
     }
+    state.lastBlockReplyText = chunk;
     emitBlockReply(
       {
         text: cleanedText,


### PR DESCRIPTION
## Summary

`emitBlockChunk` set `lastBlockReplyText` before `replyDirectiveAccumulator.consume()` confirmed a renderable outbound payload and before `emitBlockReply` ran. When `consume()` returned `null` (for example silent `NO_REPLY`-only streamed text) or the cleaned payload was empty, `handleMessageEnd` still saw `lastBlockReplyText !== null`, logged *Skipping message_end safety send for text_end channel*, and skipped the fallback path—so channels such as Telegram never received a reply even though the transcript showed a completed assistant message.

This change records `lastBlockReplyText` only immediately before an actual block reply emission (after the same empty-payload guard as before).

## Root cause

Stale `lastBlockReplyText` was treated as proof of delivery for `text_end` break mode when no `onBlockReply` payload had been produced.

## Linked issue

Fixes #77833.

## Why this is safe

- No change to allowlists, mention rules, routing, or outbound transport; only when the embed layer marks a block chunk as having been delivered vs when it only attempted streaming ingestion.
- Existing duplicate-suppression stays based on emitted chunks; silently skipped/non-renderable directive chunks no longer falsely arm the message_end suppressor.

## Security / runtime controls

Unchanged: channel admission, auth, session policy, tooling allowlists, Telegram API parameters, and message-content policy enforcement beyond this delivery bookkeeping marker.

## Real behavior proof

- Not exercised in Docker against a live Telegram supergroup forum in this iteration.
- Automated: regression test `message_end block-replies visible text when text_end streamed only silent NO_REPLY chunks` in `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts`.
- Validation: `pnpm exec vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts`, `git diff --check`, `pnpm check:changed` (core lane for touched files).

## Out of scope / follow-ups

- Broader end-to-end proof on ARM64 Docker + Telegram forum routing.
- Any separate issue if compaction (`assistantTexts`) should reconcile silent streamed chunks differently from outbound delivery markers.
