### PR TITLE
fix: gracefully handle broken provider modules in media understanding registry

### DIFF
--- a/src/media-understanding/provider-registry.test.ts
+++ b/src/media-understanding/provider-registry.test.ts
@@ -123,4 +123,33 @@ describe("media-understanding provider registry", () => {
 
     expect(getMediaUnderstandingProvider("avOnly", registry)).toBeUndefined();
   });
+
+  it("gracefully handles broken provider modules and continues with config-based providers", () => {
+    // Simulate a broken bundled provider module (e.g. codex in Nix builds with
+    // unresolved `import 'openclaw'`) crashing the entire registry build.
+    resolvePluginCapabilityProvidersMock.mockImplementation(() => {
+      throw new Error(
+        "Cannot find package 'openclaw' imported from /nix/store/.../codex/provider.js",
+      );
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            models: [{ id: "gemini-2.5-flash", input: ["text", "image"] }],
+          },
+        },
+      },
+    } as never;
+
+    // Should not throw — returns registry with config-based fallbacks
+    const registry = buildMediaUnderstandingRegistry(undefined, cfg);
+
+    expect(registry).toBeDefined();
+    // google should be auto-registered from resolveImageCapableConfigProviderIds
+    expect(getMediaUnderstandingProvider("google", registry)?.id).toBe("google");
+    expect(getMediaUnderstandingProvider("google", registry)?.capabilities).toEqual(["image"]);
+    expect(getMediaUnderstandingProvider("google", registry)?.describeImage).toBeDefined();
+  });
 });

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -1,9 +1,12 @@
 import type { OpenClawConfig } from "../config/types.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
 import { resolveImageCapableConfigProviderIds } from "./config-provider-models.js";
 import { describeImageWithModel, describeImagesWithModel } from "./image-runtime.js";
 import { normalizeMediaProviderId } from "./provider-id.js";
 import type { MediaUnderstandingProvider } from "./types.js";
+
+const log = createSubsystemLogger("media-understanding").child("provider-registry");
 
 function mergeProviderIntoRegistry(
   registry: Map<string, MediaUnderstandingProvider>,
@@ -32,10 +35,22 @@ export function buildMediaUnderstandingRegistry(
   cfg?: OpenClawConfig,
 ): Map<string, MediaUnderstandingProvider> {
   const registry = new Map<string, MediaUnderstandingProvider>();
-  for (const provider of resolvePluginCapabilityProviders({
-    key: "mediaUnderstandingProviders",
-    cfg,
-  })) {
+  let pluginProviders: MediaUnderstandingProvider[];
+  try {
+    pluginProviders = resolvePluginCapabilityProviders({
+      key: "mediaUnderstandingProviders",
+      cfg,
+    });
+  } catch (err) {
+    log.warn(
+      "resolvePluginCapabilityProviders failed, continuing with config-based providers only",
+      {
+        error: String(err),
+      },
+    );
+    pluginProviders = [];
+  }
+  for (const provider of pluginProviders) {
     mergeProviderIntoRegistry(registry, provider);
   }
   // Auto-register media-understanding for config providers with image-capable models (#51392)


### PR DESCRIPTION
## Problem

When a bundled provider module (e.g. codex) has unresolved imports in Nix builds — specifically `Cannot find package 'openclaw'` imported from `codex/provider.js` — the call to `resolvePluginCapabilityProviders()` in `buildMediaUnderstandingRegistry()` throws, which kills the **entire** media understanding registry. This makes ALL image analysis fail, even for unrelated providers like Google Gemini that would work fine on their own.

## Root Cause

`buildMediaUnderstandingRegistry()` calls `resolvePluginCapabilityProviders()` eagerly with no error handling. A single broken bundled provider module crashes the registry build before any providers can be registered. The fallback chain in `runWithImageModelFallback` then has zero candidates to try.

## Fix

Wrap `resolvePluginCapabilityProviders()` in a `try/catch` in `provider-registry.ts`:
- On success: normal behavior, all plugin providers loaded
- On failure: log a warning via subsystem logger, continue with an empty plugin provider list
- Config-based providers (from `resolveImageCapableConfigProviderIds`) are still registered as fallback

This means that even if codex is broken, Google Gemini (or any other image-capable model in config) still works.

## Changes

- `src/media-understanding/provider-registry.ts` — try/catch around `resolvePluginCapabilityProviders()`, with structured warning log
- `src/media-understanding/provider-registry.test.ts` — added test for graceful degradation (all 6 tests pass: 5 existing + 1 new)

## Testing

```
 ✓ |media-understanding| provider-registry.test.ts (6 tests) 48ms
   Test Files  1 passed (1)
        Tests  6 passed (6)
```

Verified on a Nix-built deployment where codex has a broken `import 'openclaw'` — before the fix, all image tool calls failed. After the fix, image analysis works via config-based providers.

## Related

- Related to #66702 (image contamination — different bug but same code area)
- The underlying codex Nix build issue (`Cannot find package 'openclaw'`) is a separate packaging problem; this fix makes the registry resilient to it
