### PR TITLE
fix(media): default terminal QR to full-block mode (#77820)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/media: render terminal QR codes with full-block characters by default so the bundled `qrcode` terminal renderer does not emit a pathologically dense ANSI final row in compact half-block mode that breaks scanning in some terminals. Fixes #77820. Thanks @KrasimirKralev.
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/media: render terminal QR codes with full-block characters by default so the bundled `qrcode` terminal renderer does not emit a pathologically dense ANSI final row in compact half-block mode that breaks scanning in some terminals. Fixes #77820. Thanks @KrasimirKralev.
 - Agents/compaction: read post-compaction AGENTS.md refresh context from the queued run workspace instead of the runner process cwd, so CLI-backed follow-up turns re-inject the correct workspace startup rules after compaction. Fixes #70541. (#75532) Thanks @vyctorbrzezowski.
 - Agents/read tool: treat positive offsets beyond EOF as empty ranges instead of surfacing the upstream read error, so stale pagination cursors no longer crash tool calls while unrelated read failures still fail loud. Fixes #62466. (#75536) Thanks @vyctorbrzezowski.
 - Google/Gemini: normalize retired Gemini 3 Pro Preview refs left in Google API-key onboarding model allowlists and fallbacks, so setup-emitted config keeps testing `google/gemini-3.1-pro-preview` instead of `google/gemini-3-pro-preview`.

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -252,7 +252,7 @@ export async function pollAppRegistration(params: {
  * otherwise the pattern is corrupted and cannot be scanned.
  */
 export async function printQrCode(url: string): Promise<void> {
-  const output = await renderQrTerminal(url, { small: true });
+  const output = await renderQrTerminal(url);
   process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 }
 

--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -154,8 +154,8 @@ describe("loginWeb coverage", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith("terminal:initial-qr");
     expect(runtime.log).toHaveBeenCalledWith("terminal:restart-qr");
-    expect(renderQrTerminalMock).toHaveBeenCalledWith("initial-qr", { small: true });
-    expect(renderQrTerminalMock).toHaveBeenCalledWith("restart-qr", { small: true });
+    expect(renderQrTerminalMock).toHaveBeenCalledWith("initial-qr");
+    expect(renderQrTerminalMock).toHaveBeenCalledWith("restart-qr");
   });
 
   it("clears creds and throws when logged out", async () => {

--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -147,8 +147,8 @@ describe("loginWeb coverage", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith("terminal:initial-qr");
     expect(runtime.log).toHaveBeenCalledWith("terminal:restart-qr");
-    expect(renderQrTerminalMock).toHaveBeenCalledWith("initial-qr", { small: true });
-    expect(renderQrTerminalMock).toHaveBeenCalledWith("restart-qr", { small: true });
+    expect(renderQrTerminalMock).toHaveBeenCalledWith("initial-qr");
+    expect(renderQrTerminalMock).toHaveBeenCalledWith("restart-qr");
   });
 
   it("clears creds and throws when logged out", async () => {

--- a/extensions/whatsapp/src/login.ts
+++ b/extensions/whatsapp/src/login.ts
@@ -22,7 +22,7 @@ export async function loginWeb(
   const restoredFromBackup = await restoreCredsFromBackupIfNeeded(account.authDir);
   const onQr = (qr: string) => {
     runtime.log("Open the WhatsApp app, go to Linked Devices, then scan this QR:");
-    void renderQrTerminal(qr, { small: true })
+    void renderQrTerminal(qr)
       .then((output) => {
         runtime.log(output.endsWith("\n") ? output.slice(0, -1) : output);
       })

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -117,7 +117,7 @@ async function safeSaveCreds(
 }
 
 async function printTerminalQr(qr: string): Promise<void> {
-  const output = await renderQrTerminal(qr, { small: true });
+  const output = await renderQrTerminal(qr);
   process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 }
 

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -119,7 +119,7 @@ async function safeSaveCreds(
 }
 
 async function printTerminalQr(qr: string): Promise<void> {
-  const output = await renderQrTerminal(qr, { small: true });
+  const output = await renderQrTerminal(qr);
   process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 }
 

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -25,7 +25,7 @@ type QrCliOptions = {
 };
 
 function renderQrAscii(data: string): Promise<string> {
-  return renderQrTerminal(data, { small: true });
+  return renderQrTerminal(data);
 }
 function readDevicePairPublicUrlFromConfig(cfg: OpenClawConfig): string | undefined {
   const value = cfg.plugins?.entries?.["device-pair"]?.config?.["publicUrl"];

--- a/src/media/qr-terminal.render.test.ts
+++ b/src/media/qr-terminal.render.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { renderQrTerminal } from "./qr-terminal.ts";
+
+describe("renderQrTerminal (real qrcode runtime)", () => {
+  it("keeps per-row ANSI sequence counts in line with typical rows", async () => {
+    const sample = "https://wa.me/login/2@SAMPLE-TOKEN-1234567890ABCDEF";
+    const rendered = await renderQrTerminal(sample);
+    const ansiSgr = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
+    const escCounts = rendered
+      .split(/\r?\n/)
+      .map((line) => (line.match(ansiSgr) ?? []).length)
+      .filter((count) => count > 0);
+    expect(escCounts.length).toBeGreaterThan(0);
+    const sorted = escCounts.toSorted((a, b) => a - b);
+    const median = sorted[Math.floor(sorted.length / 2)] ?? 0;
+    const max = Math.max(...escCounts);
+    expect(median).toBeGreaterThan(0);
+    expect(max).toBeLessThanOrEqual(median * 6);
+  });
+});

--- a/src/media/qr-terminal.test.ts
+++ b/src/media/qr-terminal.test.ts
@@ -20,7 +20,7 @@ describe("renderQrTerminal", () => {
   it("delegates terminal rendering to qrcode", async () => {
     await expect(renderQrTerminal("openclaw")).resolves.toBe("ASCII-QR");
     expect(toString).toHaveBeenCalledWith("openclaw", {
-      small: true,
+      small: false,
       type: "terminal",
     });
   });

--- a/src/media/qr-terminal.test.ts
+++ b/src/media/qr-terminal.test.ts
@@ -16,7 +16,7 @@ describe("renderQrTerminal", () => {
   it("delegates terminal rendering to qrcode", async () => {
     await expect(renderQrTerminal("openclaw")).resolves.toBe("ASCII-QR");
     expect(toString).toHaveBeenCalledWith("openclaw", {
-      small: true,
+      small: false,
       type: "terminal",
     });
   });

--- a/src/media/qr-terminal.ts
+++ b/src/media/qr-terminal.ts
@@ -6,7 +6,7 @@ export async function renderQrTerminal(
 ): Promise<string> {
   const qrCode = await loadQrCodeRuntime();
   return await qrCode.toString(normalizeQrText(input), {
-    small: opts.small ?? true,
+    small: opts.small ?? false,
     type: "terminal",
   });
 }


### PR DESCRIPTION
## Summary

Default `renderQrTerminal` and OpenClaw call sites to full-block (`small: false`) terminal QR output so the final row is not a pathological ANSI hotspot from the bundled `qrcode` renderer.

## Root cause

With `{ type: "terminal", small: true }`, `node-qrcode` merges QR modules using half-block glyphs; for odd-height matrices the last terminal row takes a code path that wraps each cell in SGR sequences instead of once per row. That yields a last line with far higher escape density than other rows, which breaks scanning in strict terminals, narrow buffers, or some SSH clients (see #77820).

## Linked issue

Fixes #77820.

## Why this change is safe

Rendering still uses the same library and the same payload; only the terminal glyph strategy changes. The QR is larger vertically but escape density stays consistent row-to-row. Callers that truly need compact mode can still pass `{ small: true }`.

## Security / runtime controls

No changes to authentication, channel credentials, gateway policy, or secret handling. This only affects how QR strings are formatted for stdout/CLI logs.

## Real behavior proof

- Behavior or issue addressed: Terminal QR rendering no longer defaults to compact half-block mode that can emit a dense ANSI final row and make WhatsApp/Feishu/pairing QR scans fail in some terminals.
- Real environment tested: macOS Darwin local OpenClaw checkout, Node v26.0.0, `qrcode@1.5.4`, real `renderQrTerminal` runtime with the bundled `qrcode` package.
- Exact steps or command run after this patch: `pnpm exec tsx -e '<script imports ./src/media/qr-terminal.ts, renders https://wa.me/login/2@SAMPLE-TOKEN-1234567890ABCDEF, counts ANSI SGR sequences per non-empty terminal row>'`
- Evidence after fix: Copied terminal output from the real renderer probe:

```json
{"behavior":"default full-block terminal QR","environment":"darwin node v26.0.0","rows":35,"medianSgrPerRow":70,"maxSgrPerRow":70,"ratio":1}
```

- Observed result after fix: Default terminal QR output uses full-block rendering with stable row density; the sample produced 35 non-empty rows with median SGR per row 70 and max SGR per row 70, so there is no final-row ANSI hotspot. Earlier compact-mode output for the same sample measured median 3 and max 143.
- What was not tested: Live `openclaw channels login --channel whatsapp` phone scan was not run here; proof covers the shared terminal renderer and all updated call sites.

## Tests run

- `pnpm test src/media/qr-terminal.test.ts src/media/qr-terminal.render.test.ts extensions/whatsapp/src/login.coverage.test.ts -- --reporter=verbose`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01krdbswvw1amcfvsccjbzrzvy`, run https://github.com/openclaw/openclaw/actions/runs/25716140762
- `git diff --check origin/main...HEAD`

## Out of scope

- Upstream patch to node-qrcode for `small: true`.
- Optional env/config toggle for compact vs full-block rendering.
- Changing behavior for callers that explicitly pass `{ small: true }`.

---

- [x] Mark as AI-assisted (tooling used for implementation and validation; proof command run locally on this branch)
