### PR TITLE
fix(runtime): prevent fast-path snapshot refresh from clobbering active web tool metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ Docs: https://docs.openclaw.ai
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.
 - Config/BlueBubbles: remove the duplicate core-owned BlueBubbles config schema while preserving plugin-owned `dmPolicy` allowFrom validation for channel and account configs. Fixes #69238. Thanks @omarshahine.
 - Tavily: resolve dedicated `tavily_search` and `tavily_extract` tool credentials from the active runtime config snapshot, so `exec` SecretRef-backed API keys do not reach the tools unresolved. (#78610) Thanks @VACInc.
+- Runtime/Secrets: preserve active web tool metadata across fast-path config-write refreshes, so plugin-provided tools remain visible when a stripped snapshot lacks a web surface. Fixes #77826. (#77859) Thanks @openperf.
 - Gateway/sessions: clear cached skills snapshots during `/new` and `sessions.reset` so long-lived channel sessions rebuild the visible skill list after skills change. (#78873) Thanks @Evizero.
 - fix(auto-reply): gate inline skill tool dispatch [AI]. (#78517) Thanks @pgondhi987.
 - Canvas plugin: keep legacy root `canvasHost` configs valid until `openclaw doctor --fix` migrates them into `plugins.entries.canvas.config.host`, move Canvas/A2UI clients to gateway protocol v4 plugin surfaces, and refresh the generated A2UI bundle hash so normal builds stay clean.
@@ -225,6 +226,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/Sessions: make the compaction count a compact `N Checkpoint(s)` disclosure and show expanded session-level details with modern checkpoint history cards across responsive table layouts. Thanks @BunsDev.
 - Control UI/performance: keep chat and channel tabs responsive while history payloads and channel probes are slow, label partial channel status, and record slow chat/config render timings in the event log. Thanks @BunsDev.
 - ACP: preserve streamed chunk boundaries in background-task progress summaries so CJK text, paths, URLs, and identifiers are no longer split with synthetic spaces. Fixes #78312. Thanks @amknight.
+
 - Control UI/sessions: fire the documented `/new` command and lifecycle hooks only for explicit Control UI session creation, restoring session-memory and custom hook capture without changing SDK parent-session creates. Fixes #76957. Thanks @BunsDev.
 - Exec approvals: fall back to a guarded copy when Windows rejects rename-overwrite for `exec-approvals.json`, while preserving symlink, hard-link, and owner-only permission safeguards. Fixes #77785. (#77907) Thanks @Alex-Alaniz and @MilleniumGenAI.
 - Slack: preserve Socket Mode SDK error context and structured Slack API fields in reconnect logs, so startup failures no longer collapse to a bare `unknown error`.

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -199,6 +199,7 @@ describe("createOpenClawTools browser plugin integration", () => {
       config: staleRuntimeConfig,
       authStores: [],
       warnings: [],
+      webToolsFromFastPath: false,
       webTools: {
         search: {
           providerSource: "none",

--- a/src/gateway/server-aux-handlers.test.ts
+++ b/src/gateway/server-aux-handlers.test.ts
@@ -37,6 +37,7 @@ function createSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapshot 
     config,
     authStores: [],
     warnings: [],
+    webToolsFromFastPath: false,
     webTools: {
       search: { providerSource: "none", diagnostics: [] },
       fetch: { providerSource: "none", diagnostics: [] },

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -47,6 +47,7 @@ function preparedSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapsho
     config,
     authStores: [],
     warnings: [],
+    webToolsFromFastPath: false,
     webTools: {
       search: {
         providerSource: "none",

--- a/src/secrets/runtime-web-tools-state.test.ts
+++ b/src/secrets/runtime-web-tools-state.test.ts
@@ -1,13 +1,20 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { clearConfigCache } from "../config/config.js";
 import {
-  clearActiveRuntimeWebToolsMetadata,
+  activateSecretsRuntimeSnapshot,
+  clearSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot,
+} from "./runtime.js";
+import { asConfig } from "./runtime.test-support.js";
+import {
   getActiveRuntimeWebToolsMetadata,
   setActiveRuntimeWebToolsMetadata,
 } from "./runtime-web-tools-state.js";
 
 describe("runtime web tools state", () => {
   afterEach(() => {
-    clearActiveRuntimeWebToolsMetadata();
+    clearSecretsRuntimeSnapshot();
+    clearConfigCache();
   });
 
   it("exposes active runtime web tool metadata as a defensive clone", () => {
@@ -39,5 +46,263 @@ describe("runtime web tools state", () => {
     const second = getActiveRuntimeWebToolsMetadata();
     expect(second?.search.providerConfigured).toBe("gemini");
     expect(second?.search.selectedProvider).toBe("gemini");
+  });
+
+  it("preserves active web tools metadata when a fast-path refresh fires for a snapshot whose prior source config had a web surface", async () => {
+    // Activate an initial snapshot with a configured web surface.
+    const initial = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: {
+          web: {
+            search: { provider: "gemini" },
+          },
+        },
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "WEB_SEARCH_GEMINI_API_KEY" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: { WEB_SEARCH_GEMINI_API_KEY: "gemini-key" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map([["google", "bundled"]]),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    activateSecretsRuntimeSnapshot(initial);
+
+    const before = getActiveRuntimeWebToolsMetadata();
+    expect(before?.search.providerConfigured).toBe("gemini");
+
+    // Simulate a stripped-config refresh that has no web surface and no SecretRefs
+    // (fast path fires, returns empty webTools).
+    const stripped = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({ gateway: { port: 18789 } }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map(),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    expect(stripped.webToolsFromFastPath).toBe(true);
+    activateSecretsRuntimeSnapshot(stripped);
+
+    // Active webTools must be preserved — the fast-path result must not clobber.
+    const after = getActiveRuntimeWebToolsMetadata();
+    expect(after?.search.providerConfigured).toBe("gemini");
+  });
+
+  it("clears active web tools metadata when the full resolver runs and finds no web surface", async () => {
+    const initial = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: { web: { search: { provider: "gemini" } } },
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "WEB_SEARCH_GEMINI_API_KEY" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: { WEB_SEARCH_GEMINI_API_KEY: "gemini-key" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map([["google", "bundled"]]),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    activateSecretsRuntimeSnapshot(initial);
+
+    // Config with a SecretRef but no web surface: full resolver runs.
+    const noWeb = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+              models: [],
+            },
+          },
+        },
+      }),
+      env: { OPENAI_API_KEY: "sk-test" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map(),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    expect(noWeb.webToolsFromFastPath).toBe(false);
+    activateSecretsRuntimeSnapshot(noWeb);
+
+    // Full resolver ran with no web config → webTools must be cleared.
+    const after = getActiveRuntimeWebToolsMetadata();
+    expect(after?.search.providerSource).toBe("none");
+  });
+
+  it("preserves active web tools metadata across two successive fast-path refreshes", async () => {
+    // Establish an initial full-resolver snapshot with a configured web surface.
+    const initial = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: { web: { search: { provider: "gemini" } } },
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "WEB_SEARCH_GEMINI_API_KEY" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: { WEB_SEARCH_GEMINI_API_KEY: "gemini-key" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map([["google", "bundled"]]),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    activateSecretsRuntimeSnapshot(initial);
+    expect(getActiveRuntimeWebToolsMetadata()?.search.providerConfigured).toBe("gemini");
+
+    // First fast-path refresh with a stripped config (no web surface, no SecretRefs).
+    const stripped1 = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({ gateway: { port: 18789 } }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map(),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    expect(stripped1.webToolsFromFastPath).toBe(true);
+    activateSecretsRuntimeSnapshot(stripped1);
+    expect(getActiveRuntimeWebToolsMetadata()?.search.providerConfigured).toBe("gemini");
+
+    // Second fast-path refresh — must still preserve; the first stripped activation
+    // must not have poisoned the durability signal.
+    const stripped2 = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({ gateway: { port: 18790 } }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map(),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    expect(stripped2.webToolsFromFastPath).toBe(true);
+    activateSecretsRuntimeSnapshot(stripped2);
+
+    // Metadata must still reflect the original full-resolver result.
+    const after = getActiveRuntimeWebToolsMetadata();
+    expect(after?.search.providerConfigured).toBe("gemini");
+    expect(after?.search.providerSource).toBe("configured");
+  });
+
+  it("clears active web tools metadata when a fast-path refresh carries an explicit empty web container", async () => {
+    const initial = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: { web: { search: { provider: "gemini" } } },
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "WEB_SEARCH_GEMINI_API_KEY" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: { WEB_SEARCH_GEMINI_API_KEY: "gemini-key" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map([["google", "bundled"]]),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    activateSecretsRuntimeSnapshot(initial);
+    expect(getActiveRuntimeWebToolsMetadata()?.search.providerConfigured).toBe("gemini");
+
+    // A writer that explicitly sets tools.web = {} (empty container, no SecretRefs)
+    // takes the fast path but carries a web container — treat as authoritative clear.
+    const explicitEmpty = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({ tools: { web: {} } }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map(),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    expect(explicitEmpty.webToolsFromFastPath).toBe(true);
+    activateSecretsRuntimeSnapshot(explicitEmpty);
+
+    // Explicit container present → not a stripped write → metadata must be cleared.
+    const after = getActiveRuntimeWebToolsMetadata();
+    expect(after?.search.providerSource).toBe("none");
+    expect(after?.search.providerConfigured).toBeUndefined();
+  });
+
+  it("defers web tools metadata clear until full-resolver runs when removal write takes the fast path", async () => {
+    const initial = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: { web: { search: { provider: "gemini" } } },
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "WEB_SEARCH_GEMINI_API_KEY" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: { WEB_SEARCH_GEMINI_API_KEY: "gemini-key" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map([["google", "bundled"]]),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    activateSecretsRuntimeSnapshot(initial);
+    expect(getActiveRuntimeWebToolsMetadata()?.search.providerConfigured).toBe("gemini");
+
+    // Stripped write (no tools.web key at all, no SecretRefs) → fast path.
+    // Metadata is preserved because the container is simply absent, not explicitly cleared.
+    const stripped = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({ gateway: { port: 18791 } }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map(),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    expect(stripped.webToolsFromFastPath).toBe(true);
+    activateSecretsRuntimeSnapshot(stripped);
+    expect(getActiveRuntimeWebToolsMetadata()?.search.providerConfigured).toBe("gemini");
+
+    // Full-resolver write with a SecretRef but no web surface → authoritatively clears.
+    const noWeb = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+              models: [],
+            },
+          },
+        },
+      }),
+      env: { OPENAI_API_KEY: "sk-test" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadablePluginOrigins: new Map(),
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    expect(noWeb.webToolsFromFastPath).toBe(false);
+    activateSecretsRuntimeSnapshot(noWeb);
+
+    // Full resolver ran with no web config → deferred clear completes.
+    const after = getActiveRuntimeWebToolsMetadata();
+    expect(after?.search.providerSource).toBe("none");
+    expect(after?.search.providerConfigured).toBeUndefined();
   });
 });

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -169,4 +169,43 @@ describe("secrets runtime fast path", () => {
 
     expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
   });
+
+  it("marks webToolsFromFastPath as true when the fast path is used", async () => {
+    const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        gateway: { auth: { mode: "token", token: "plain-token" } },
+      }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: emptyAuthStore,
+    });
+
+    expect(snapshot.webToolsFromFastPath).toBe(true);
+    expect(runtimePrepareImportMock).not.toHaveBeenCalled();
+  });
+
+  it("marks webToolsFromFastPath as false when the full resolver is used", async () => {
+    const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({}),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => ({
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      }),
+    });
+
+    expect(snapshot.webToolsFromFastPath).toBe(false);
+    expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -37,6 +37,7 @@ export type PreparedSecretsRuntimeSnapshot = {
   authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
   warnings: SecretResolverWarning[];
   webTools: RuntimeWebToolsMetadata;
+  webToolsFromFastPath: boolean;
 };
 
 type SecretsRuntimeRefreshContext = {
@@ -61,6 +62,7 @@ const RUNTIME_PATH_ENV_KEYS = [
 
 let activeSnapshot: PreparedSecretsRuntimeSnapshot | null = null;
 let activeRefreshContext: SecretsRuntimeRefreshContext | null = null;
+let lastFullResolverSourceConfig: OpenClawConfig | null = null;
 const preparedSnapshotRefreshContext = new WeakMap<
   PreparedSecretsRuntimeSnapshot,
   SecretsRuntimeRefreshContext
@@ -88,6 +90,7 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
     })),
     warnings: snapshot.warnings.map((warning) => ({ ...warning })),
     webTools: structuredClone(snapshot.webTools),
+    webToolsFromFastPath: snapshot.webToolsFromFastPath,
   };
 }
 
@@ -103,6 +106,7 @@ function cloneRefreshContext(context: SecretsRuntimeRefreshContext): SecretsRunt
 function clearActiveSecretsRuntimeState(): void {
   activeSnapshot = null;
   activeRefreshContext = null;
+  lastFullResolverSourceConfig = null;
   clearActiveRuntimeWebToolsMetadata();
   setRuntimeConfigSnapshotRefreshHandler(null);
   clearRuntimeConfigSnapshot();
@@ -285,6 +289,15 @@ function hasRuntimeWebToolConfigSurface(config: OpenClawConfig): boolean {
   });
 }
 
+function hasRuntimeWebToolConfigContainers(config: OpenClawConfig): boolean {
+  const web = config.tools?.web;
+  if (web && typeof web === "object" && !Array.isArray(web)) {
+    return true;
+  }
+  const entries = config.plugins?.entries;
+  return !!entries && typeof entries === "object" && !Array.isArray(entries);
+}
+
 function hasSecretRefCandidate(
   value: unknown,
   defaults: Parameters<typeof coerceSecretRef>[1],
@@ -355,6 +368,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       authStores,
       warnings: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
+      webToolsFromFastPath: true,
     };
     preparedSnapshotRefreshContext.set(snapshot, {
       env: runtimeEnv,
@@ -429,6 +443,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       resolvedConfig,
       context,
     }),
+    webToolsFromFastPath: false,
   };
   preparedSnapshotRefreshContext.set(snapshot, {
     env: runtimeEnv,
@@ -450,11 +465,27 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
       loadAuthStore: loadAuthProfileStoreForSecretsRuntime,
       loadablePluginOrigins: new Map<string, PluginOrigin>(),
     } satisfies SecretsRuntimeRefreshContext);
+
+  // Key off lastFullResolverSourceConfig, not activeSnapshot.sourceConfig — fast-path activations must not overwrite it.
+  const shouldPreserveWebTools =
+    next.webToolsFromFastPath &&
+    lastFullResolverSourceConfig !== null &&
+    hasRuntimeWebToolConfigSurface(lastFullResolverSourceConfig) &&
+    !hasRuntimeWebToolConfigContainers(next.sourceConfig);
+
   setRuntimeConfigSnapshot(next.config, next.sourceConfig);
   replaceRuntimeAuthProfileStoreSnapshots(next.authStores);
   activeSnapshot = next;
   activeRefreshContext = cloneRefreshContext(refreshContext);
-  setActiveRuntimeWebToolsMetadata(next.webTools);
+
+  if (!next.webToolsFromFastPath) {
+    lastFullResolverSourceConfig = next.sourceConfig;
+  }
+
+  if (!shouldPreserveWebTools) {
+    setActiveRuntimeWebToolsMetadata(next.webTools);
+  }
+
   setRuntimeConfigSnapshotRefreshHandler({
     refresh: async ({ sourceConfig }) => {
       if (!activeSnapshot || !activeRefreshContext) {

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -289,6 +289,7 @@ describe("web search runtime", () => {
       config: resolvedConfig,
       authStores: [],
       warnings: [],
+      webToolsFromFastPath: false,
       webTools: {
         search: {
           providerSource: "auto-detect",
@@ -398,6 +399,7 @@ describe("web search runtime", () => {
       config: {},
       authStores: [],
       warnings: [],
+      webToolsFromFastPath: false,
       webTools: {
         search: {
           providerSource: "auto-detect",


### PR DESCRIPTION
### Summary

- **Problem**: After any config write (`doctor --fix`, `plugins registry --refresh`, or any concurrent agent config write), `web_search`, `web_fetch`, `image_generate`, `memory_*`, and other plugin-provided tools silently disappear from every subsequent tool list. The bug fires reliably on first config write post-startup and persists until gateway restart.

- **Root Cause**: `prepareSecretsRuntimeSnapshot` in `src/secrets/runtime.ts` has a fast path (`canUseSecretsRuntimeFastPath`) that returns `webTools: createEmptyRuntimeWebToolsMetadata()` when the source config has no web surface and no SecretRef candidates. `finalizeRuntimeSnapshotWrite` in `src/config/runtime-snapshot.ts` passes `nextSourceConfig` — a potentially stripped or partial slice from the config writer — to the refresh handler registered by `activateSecretsRuntimeSnapshot`. If that slice lacks a web surface, the fast path fires, and `activateSecretsRuntimeSnapshot` previously called `setActiveRuntimeWebToolsMetadata(next.webTools)` unconditionally, treating "fast-path unknown" the same as "resolver-confirmed absent." A naïve guard keying off `activeSnapshot.sourceConfig` is insufficient: that field is overwritten on every activation including fast-path ones, so after the first stripped-config refresh it no longer reflects the web surface from the last full-resolver run, and a second consecutive partial refresh bypasses the guard and clobbers the metadata anyway.

- **Fix**: Introduce a module-level `lastFullResolverSourceConfig` variable that is only updated when the full resolver actually runs (`webToolsFromFastPath === false`), and reset alongside other runtime state in `clearActiveSecretsRuntimeState`. In `activateSecretsRuntimeSnapshot`, compute `shouldPreserveWebTools` before any state mutations, then skip `setActiveRuntimeWebToolsMetadata` when the conditions are met. Because `lastFullResolverSourceConfig` is never overwritten by fast-path activations, the preservation signal is durable across any number of successive partial refreshes. A full-resolver run always updates the variable and unconditionally overwrites the metadata, so authoritative no-web configs are still cleared correctly.

  The guard additionally checks `hasRuntimeWebToolConfigContainers` on the incoming snapshot's source config. A fast-path refresh that carries an explicit `tools.web` or `plugins.entries` container — even if empty — is treated as an authoritative clear rather than a stripped partial write. This correctly handles writers that deliberately remove web configuration by writing `tools.web: {}`.

- **What changed**:
  - `src/secrets/runtime.ts`:
    - `webToolsFromFastPath` is now `boolean` (non-optional) so undefined-provenance snapshots cannot silently update `lastFullResolverSourceConfig`
    - Added `hasRuntimeWebToolConfigContainers` to distinguish absent container (preserve) from explicit empty container (authoritative clear)
    - `shouldPreserveWebTools` guard uses `=== true` and `=== false` symmetrically; adds `!hasRuntimeWebToolConfigContainers(next.sourceConfig)` condition
    - `lastFullResolverSourceConfig` module-level variable and its reset in `clearActiveSecretsRuntimeState`
  - `src/secrets/runtime-web-tools-state.test.ts`: five integration tests — single fast-path refresh preserves; full-resolver with no web clears; two successive fast-path refreshes preserve (durability regression); explicit empty container clears immediately; deferred-clear path resolves on first full-resolver pass
  - `src/secrets/runtime.fast-path.test.ts`: two unit tests asserting `webToolsFromFastPath` field value for each code path
  - `CHANGELOG.md`: entry moved to `### Fixes`

- **What did NOT change (scope boundary)**: `canUseSecretsRuntimeFastPath` and `hasRuntimeWebToolConfigSurface` logic are untouched. `runtime-web-tools-state.ts`, `runtime-snapshot.ts`, `io.ts`, and `mutate.ts` are untouched. The public contract of `getActiveRuntimeWebToolsMetadata` and all its consumers are unchanged. The fast path continues to skip the heavy resolver import for clean startup paths.

---

### Reproduction

1. Configure the gateway with `tools.web.search.provider: gemini` and a valid API key under `plugins.entries.google.config.webSearch.apiKey`.
2. Start the gateway. Open a chat session and confirm `web_search` appears in the tool list.
3. Trigger any config write — e.g. `openclaw plugins registry --refresh`, `openclaw doctor --fix`, or write any unrelated config key via the API.
4. Open a new chat session and inspect the tool list.

**Before fix**: `web_search`, `web_fetch`, `image_generate`, `memory_*`, `lobster` all absent after step 3.
**After fix**: tool list is identical to step 2 regardless of how many config writes occur.

---

### Risk / Mitigation

- **Stripped write (no web container)**: metadata preserved until a full-resolver pass explicitly clears it. This is intentional — a partial write that omits `tools.web` entirely should not be interpreted as "remove web tools."
- **Explicit empty container** (`tools.web: {}`): treated as authoritative clear via `hasRuntimeWebToolConfigContainers`, so deliberate removal works correctly.
- **Full-resolver write with no web surface**: `lastFullResolverSourceConfig` is updated and metadata is cleared. Authoritative removals via SecretRef-bearing writes are always honored.
- The five integration tests cover all three paths and the multi-refresh durability invariant.

---

### Change Type

- [x] Bug fix

---

### Scope

- [x] Gateway / orchestration
- [x] Skills / tool execution

---

### Linked Issue

Fixes #77826