### PR TITLE
fix(doctor): exit non-zero on final invalid config (#77804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Doctor: exit non-zero when the final config validation step still reports `Invalid config:` issues, so CI/CD pipelines and wrapper scripts can detect an unhealthy configuration instead of being falsely reassured by a `0` exit code while doctor printed validation failures. Fixes #77804. Thanks @koshaji.
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerMaintenanceCommands } from "./register.maintenance.js";
 
 const mocks = vi.hoisted(() => ({
@@ -37,6 +37,8 @@ vi.mock("../../runtime.js", () => ({
 }));
 
 describe("registerMaintenanceCommands doctor action", () => {
+  const previousExitCode = process.exitCode;
+
   async function runMaintenanceCli(args: string[]) {
     const program = new Command();
     registerMaintenanceCommands(program);
@@ -45,6 +47,11 @@ describe("registerMaintenanceCommands doctor action", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
   });
 
   it("exits with code 0 after successful doctor run", async () => {
@@ -60,6 +67,17 @@ describe("registerMaintenanceCommands doctor action", () => {
       }),
     );
     expect(runtime.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("propagates a non-zero process.exitCode set during doctor run (#77804)", async () => {
+    doctorCommand.mockImplementation(async () => {
+      process.exitCode = 1;
+    });
+
+    await runMaintenanceCli(["doctor", "--non-interactive"]);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.exit).not.toHaveBeenCalledWith(0);
   });
 
   it("exits with code 1 when doctor fails", async () => {

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -36,7 +36,7 @@ export function registerMaintenanceCommands(program: Command) {
           generateGatewayToken: Boolean(opts.generateGatewayToken),
           deep: Boolean(opts.deep),
         });
-        defaultRuntime.exit(0);
+        defaultRuntime.exit(typeof process.exitCode === "number" ? process.exitCode : 0);
       });
     });
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveDoctorHealthContributions,
   shouldSkipLegacyUpdateDoctorConfigWrite,
@@ -7,6 +7,7 @@ import {
 const mocks = vi.hoisted(() => ({
   maybeRunConfiguredPluginInstallReleaseStep: vi.fn(),
   note: vi.fn(),
+  readConfigFileSnapshot: vi.fn(),
 }));
 
 vi.mock("../commands/doctor/shared/release-configured-plugin-installs.js", () => ({
@@ -21,10 +22,15 @@ vi.mock("../version.js", () => ({
   VERSION: "2026.5.2-test",
 }));
 
+vi.mock("../config/config.js", () => ({
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+}));
+
 describe("doctor health contributions", () => {
   beforeEach(() => {
     mocks.maybeRunConfiguredPluginInstallReleaseStep.mockReset();
     mocks.note.mockReset();
+    mocks.readConfigFileSnapshot.mockReset();
   });
 
   it("runs release configured plugin install repair before plugin registry and final config writes", () => {
@@ -138,5 +144,89 @@ describe("doctor health contributions", () => {
         },
       }),
     ).toBe(false);
+  });
+
+  describe("doctor:final-config-validation", () => {
+    const previousExitCode = process.exitCode;
+
+    afterEach(() => {
+      process.exitCode = previousExitCode;
+    });
+
+    function getFinalConfigValidation() {
+      const contribution = resolveDoctorHealthContributions().find(
+        (entry) => entry.id === "doctor:final-config-validation",
+      );
+      if (!contribution) {
+        throw new Error("doctor:final-config-validation contribution not registered");
+      }
+      return contribution;
+    }
+
+    function buildCtx(): Parameters<ReturnType<typeof getFinalConfigValidation>["run"]>[0] {
+      const errors: string[] = [];
+      return {
+        runtime: {
+          error: (msg: string) => errors.push(msg),
+        },
+      } as unknown as Parameters<ReturnType<typeof getFinalConfigValidation>["run"]>[0];
+    }
+
+    it("sets exitCode=1 and reports issues when final snapshot is invalid", async () => {
+      process.exitCode = 0;
+      mocks.readConfigFileSnapshot.mockResolvedValue({
+        exists: true,
+        valid: false,
+        issues: [
+          {
+            path: "models.providers.bailian.models.0.compat.thinkingFormat",
+            message: "Invalid input",
+          },
+        ],
+      });
+
+      await getFinalConfigValidation().run(buildCtx());
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("leaves exitCode untouched when final snapshot is valid", async () => {
+      process.exitCode = 0;
+      mocks.readConfigFileSnapshot.mockResolvedValue({
+        exists: true,
+        valid: true,
+        issues: [],
+      });
+
+      await getFinalConfigValidation().run(buildCtx());
+
+      expect(process.exitCode).toBe(0);
+    });
+
+    it("leaves exitCode untouched when config does not exist", async () => {
+      process.exitCode = 0;
+      mocks.readConfigFileSnapshot.mockResolvedValue({
+        exists: false,
+        valid: false,
+        issues: [],
+      });
+
+      await getFinalConfigValidation().run(buildCtx());
+
+      expect(process.exitCode).toBe(0);
+    });
+
+    it("does not lower a non-zero exitCode set earlier in the run", async () => {
+      process.exitCode = 2;
+      mocks.readConfigFileSnapshot.mockResolvedValue({
+        exists: true,
+        valid: false,
+        issues: [{ path: "x", message: "y" }],
+      });
+
+      await getFinalConfigValidation().run(buildCtx());
+
+      expect(process.exitCode).toBe(2);
+    });
   });
 });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -620,6 +620,9 @@ async function runFinalConfigValidationHealth(_ctx: DoctorHealthFlowContext): Pr
       const path = issue.path || "<root>";
       _ctx.runtime.error(`- ${path}: ${issue.message}`);
     }
+    if (!process.exitCode) {
+      process.exitCode = 1;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

`openclaw doctor` prints `Invalid config: …` when the final config validation step finds problems, but the process still exits `0`, falsely reassuring CI/CD pipelines and wrapper scripts that the config is healthy. Issue #77804 reports the exact mix of "Doctor complete." (success framing) followed by `Invalid config: …` returning `$LASTEXITCODE = 0` on Windows PowerShell, but the same path is taken on every platform.

The bug is two-step:

1. `runFinalConfigValidationHealth` in `src/flows/doctor-health-contributions.ts` detected the invalid snapshot but never set `process.exitCode`.
2. The `doctor` action in `src/cli/program/register.maintenance.ts` hardcoded `defaultRuntime.exit(0)` after `doctorCommand` returned, which would have overridden any `process.exitCode` set inside the flow anyway.

This PR fixes both halves:

- `runFinalConfigValidationHealth` now sets `process.exitCode = 1` after emitting the `Invalid config:` lines, only when the current `process.exitCode` is falsy (so it does not lower a non-zero code already set earlier in the run).
- The `doctor` registration now exits via `defaultRuntime.exit(process.exitCode ?? 0)` instead of `defaultRuntime.exit(0)`, so the signal from the flow is honored. All other surrounding behavior is unchanged.

`outro("Doctor complete.")` wording is preserved per AGENTS.md additive philosophy. No new flag, no new option, no behavior change for valid configs. Companion issue #77802 (doctor --fix atomicity / last-known-good auto-restore) is intentionally out of scope here — that touches `recovery-policy.ts` and is a separate design call; I commented on the issue to surface that.

## Real behavior proof

- **Behavior or issue addressed**: `openclaw doctor` exits `0` even though it printed `Invalid config: …` at the end of the run, masking unhealthy configs from CI/CD and wrapper scripts. Tracked in #77804.
- **Real environment tested**: macOS Darwin 25.4.0 / Node v25.9.0 (arm64) on a real openclaw checkout, running the full `node openclaw.mjs doctor` launcher against a real `~/.openclaw-77804repro/openclaw.json` written to disk with an invalid `bailian` provider shape.
- **Exact steps or command run after this patch**:
  ```sh
  mkdir -p ~/.openclaw-77804repro
  cat > ~/.openclaw-77804repro/openclaw.json <<'JSON'
  { "models": { "providers": { "bailian": { "models": { "qwen-plus": { "compat": { "thinkingFormat": "not-a-real-format" } } } } } } }
  JSON
  node openclaw.mjs --profile 77804repro --no-color doctor --non-interactive --no-workspace-suggestions
  echo "EXIT=$?"
  ```
- **Evidence after fix**: live runtime stdout captured before and after the patch was applied to the same launcher and same on-disk config.

  Before the patch — exit `0`, masking the failure:
  ```
  Run "openclaw --profile 77804repro doctor --fix" to apply changes.
  Invalid config:
  - models.providers.bailian.baseUrl: Invalid input: expected string, received undefined
  - models.providers.bailian.models: Invalid input: expected array, received object
  │
  └  Doctor complete.
  EXIT=0
  ```

  After the patch — same `Invalid config:` block, but exit `1`:
  ```
  Run "openclaw --profile 77804repro doctor --fix" to apply changes.
  Invalid config:
  - models.providers.bailian.baseUrl: Invalid input: expected string, received undefined
  - models.providers.bailian.models: Invalid input: expected array, received object
  │
  └  Doctor complete.
  EXIT=1
  ```
- **Observed result after fix**: `node openclaw.mjs doctor` against a real openclaw.json that fails final validation now terminates with shell exit code `1` while preserving the existing user-facing output, including the "Doctor complete." closing line. CI/CD pipelines and shell wrappers that branch on the exit code (`if openclaw doctor; then …`) will now see the failure they previously missed.
- **What was not tested**: No Windows PowerShell live run was performed locally — the issue reporter is on PowerShell on Windows 10. The fix path is platform-agnostic (`process.exitCode` semantics are identical across Node-supported OSes), and the policy is exercised by Vitest, but a Windows live run was not feasible in this environment.

Fixes #77804.
