### PR TITLE
fix(memory-core): re-throw unexpected I/O errors in readPhaseSignalStore to prevent silent phase signal data loss

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -834,10 +834,13 @@ async function readPhaseSignalStore(
     return normalizePhaseSignalStore(JSON.parse(raw) as unknown, nowIso);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
-    if (code === "ENOENT" || err instanceof SyntaxError) {
+    if (code === "ENOENT") {
       return emptyPhaseSignalStore(nowIso);
     }
-    return emptyPhaseSignalStore(nowIso);
+    if (err instanceof SyntaxError) {
+      return emptyPhaseSignalStore(nowIso);
+    }
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary

`readPhaseSignalStore` silently swallows non-ENOENT I/O errors, returns an empty store, and the caller writes it back to disk — permanently losing all dreaming phase signal history.

- **Problem:** All errors (EACCES, EIO, EBUSY, EMFILE, ENOSPC) were caught and treated identically to ENOENT, returning an empty store that overwrites the on-disk file.
- **Why it matters:** Phase signal data (lightHits/remHits counts) accumulates across dreaming cycles and is critical for short-term memory promotion ranking. Silent data loss causes promotion candidates to be missed.
- **What changed:** Split the catch block: ENOENT → empty store (file doesn't exist), SyntaxError → empty store (corrupt data), everything else → re-throw so the caller's workspace-level try/catch in `dreaming.ts:555` handles it (logs the error, increments `failedWorkspaces`, skips the write).
- **What did NOT change:** The ENOENT and SyntaxError recovery paths — both still return `emptyPhaseSignalStore`. No changes to the callers, the lock mechanism, or the write path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #77881
- Related # N/A

## Root Cause

- **Root cause:** The original catch block used a single combined condition `if (code === "ENOENT" || err instanceof SyntaxError)` followed by a fallback `return emptyPhaseSignalStore(nowIso)` that caught all other errors. There was no re-throw path for unexpected I/O errors.
- **Missing detection / guardrail:** No test covers I/O error scenarios on `readPhaseSignalStore`; the existing tests mock the filesystem or use temp directories where EACCES/EIO never occur.
- **Contributing context:** The caller `recordDreamingPhaseSignals` does a read → mutate → write cycle under `withShortTermLock`. Returning an empty store on read failure means the subsequent write overwrites the disk with empty/sparse data.

## Regression Test Plan

- **Coverage level that should have caught this:** Unit test
- **Target test or file:** `extensions/memory-core/src/short-term-promotion.test.ts`
- **Scenario the test should lock in:** `readPhaseSignalStore` throws on EACCES (not ENOENT/SyntaxError), the error propagates to caller, phase signal file is not overwritten.
- **Why this is the smallest reliable guardrail:** The read path is a pure function of the filesystem — a unit test mocking `fs.readFile` to throw EACCES verifies the throw path exists.
- **Existing test that already covers this:** None
- **If no new test is added, why not:** EACCES/EIO are inherently hard to trigger in cross-platform unit tests without filesystem mocking. The behavioral fix (throw vs swallow) is simple enough that the code shape is the guard.

## User-visible / Behavior Changes

None. In normal operation (file exists and is valid JSON) the behavior is identical. The only change is on unexpected I/O errors, which now surface via the existing dreaming error log instead of being silently lost.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

**Environment**
- OS: macOS 15.x
- Runtime/container: Node 22, local
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: N/A (code-level bug)

**Steps**
1. Apply a permission restriction to the phase signal file: `chmod 000 <phase-signal-path>`
2. Trigger a dreaming cycle (or call `recordDreamingPhaseSignals` directly)
3. Observe behavior

**Expected**
Error logged: `memory-core: dreaming promotion failed for workspace ...`, `failedWorkspaces` incremented, phase signal file NOT overwritten

**Actual (before fix)**
No error log, phase signal file overwritten with empty store, all historical lightHits/remHits lost

**Evidence**
N/A — code-level change verified by review of the catch block structure. The fix removes the unconditional `return emptyPhaseSignalStore(nowIso)` fallback and replaces it with `throw err`.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** `readPhaseSignalStore` now throws on non-ENOENT/non-SyntaxError I/O errors instead of returning `emptyPhaseSignalStore` and silently overwriting disk.
- **Real environment tested:** macOS 15.x, Node 22, OpenClaw main branch at 1d6de8da9f with the 3-line fix applied.
- **Exact steps or command run after this patch:** `pnpm test extensions/memory-core/src/short-term-promotion.test.ts`
- **Evidence after fix:** All 44 existing tests pass:

```
✅ Test Files  1 passed (1)
     Tests  44 passed (44)
  Duration  1.50s
```

- **Observed result after fix:** Existing tests covering ENOENT (missing file → empty store) and SyntaxError (corrupt JSON → empty store) continue to pass. The changed behavior (EACCES → throw) is structurally verifiable: `return emptyPhaseSignalStore(nowIso)` → `throw err` at line 840.
- **What was not tested:** Live EACCES on a real filesystem (requires root or chmod 000, cross-platform). The fix is a 3-line structural change to the catch block.
- **Before evidence:** The original catch block treated all errors identically to ENOENT, returning an empty store that overwrote on-disk data.

## Human Verification

- Verified scenarios: Code review of the catch block and caller chain (`recordDreamingPhaseSignals` → `runLightDreaming`/`runRemDreaming` → `runDreamingSweepPhases` → `dreaming.ts:555` try/catch)
- Edge cases checked: ENOENT (still returns empty store), SyntaxError (still returns empty store), any other Error (now throws)
- What you did not verify: Live reproduction with EACCES on a real filesystem

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Throwing on unexpected I/O errors could cause the dreaming sweep to abort earlier than before.
  - **Mitigation:** The caller (`dreaming.ts:555`) already has a per-workspace try/catch that logs the error and continues to the next workspace. Throwing is strictly better than silent data loss.

