### PR TITLE
fix(memory-core): clean up orphaned temp files from writePhaseSignalStore and writeStore

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -848,16 +848,24 @@ async function writePhaseSignalStore(
   const phaseSignalPath = resolvePhaseSignalPath(workspaceDir);
   await ensureShortTermArtifactsDir(workspaceDir);
   const tmpPath = `${phaseSignalPath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
-  await fs.writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
-  await fs.rename(tmpPath, phaseSignalPath);
+  try {
+    await fs.writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+    await fs.rename(tmpPath, phaseSignalPath);
+  } finally {
+    await fs.unlink(tmpPath).catch(() => {});
+  }
 }
 
 async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
   const storePath = resolveStorePath(workspaceDir);
   await ensureShortTermArtifactsDir(workspaceDir);
   const tmpPath = `${storePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
-  await fs.writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
-  await fs.rename(tmpPath, storePath);
+  try {
+    await fs.writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+    await fs.rename(tmpPath, storePath);
+  } finally {
+    await fs.unlink(tmpPath).catch(() => {});
+  }
 }
 
 export function isShortTermMemoryPath(filePath: string): boolean {


### PR DESCRIPTION
## Summary

`writePhaseSignalStore` and `writeStore` use write-then-rename for atomic updates but never clean up the temporary file. If `rename` fails, the `.tmp` file is left orphaned.

- **Problem:** On rename failure (cross-filesystem, permission, etc.) the `.tmp` file persists in the short-term artifacts directory with no cleanup.
- **Why it matters:** Over long-running deployments, orphaned `.tmp` files accumulate as litter in the workspace directory.
- **What changed:** Wrapped `writeFile` + `rename` in `try...finally` that runs `fs.unlink(tmpPath).catch(() => {})`. If rename succeeded, unlink is a no-op (file already moved). If rename failed, the tmp file is cleaned up.
- **What did NOT change:** The write-then-rename atomic pattern, the file naming, any caller behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #77888

## Root Cause

- **Root cause:** write-then-rename pattern had no cleanup path for the temporary file. If `rename` failed, the `.tmp` file was left behind with no mechanism to remove it.
- **Missing detection / guardrail:** No cleanup of stale `.tmp` files existed in repair or sweep paths.

## Regression Test Plan

- **Coverage level that should have caught this:** Unit test
- **Target test or file:** `extensions/memory-core/src/short-term-promotion.test.ts`
- **Scenario the test should lock in:** Mock `fs.rename` to throw, verify `.tmp` file is unlinked in finally.
- **Existing test that already covers this:** None
- **If no new test is added, why not:** The try...finally pattern is structurally self-evident — the finally block unconditionally cleans up the tmp path. All 44 existing tests pass.

## User-visible / Behavior Changes

None.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** `writePhaseSignalStore` and `writeStore` orphan `.tmp` files when `rename()` fails — no cleanup exists in the write-then-rename pattern.
- **Real environment tested:** macOS 15.x, Node 24, OpenClaw main branch with the fix applied.
- **Exact steps or command run after this patch:** `node proof-test.cjs` — simulation script that writes a tmp file, then throws on rename to trigger the cleanup path. Output captured below.
- **Evidence after fix:** Terminal output from the simulation:

```
=== BEFORE: rename fails + NO cleanup  → orphan .tmp ===
  rename: FAILED
  tmp files left: signal.json.2026.1778668665574.<uuid>.tmp

=== AFTER:  rename fails + WITH cleanup → cleaned ===
  rename: FAILED
  tmp files left: NONE

=== AFTER:  rename OK + WITH cleanup    → normal ===
  rename: OK
  tmp files left: NONE
```

- **Observed result after fix:** With the `try...finally { fs.unlink }` block, zero `.tmp` files remain after a rename failure. Without the fix, the `.tmp` file is orphaned permanently. The successful rename path is unaffected — `unlink` is a no-op on the already-moved file.
- **What was not tested:** Cross-filesystem rename behavior (requires separate mount points); behavior under process kill during the write-then-rename window (requires external orchestration).
