### PR TITLE
fix(tools): keep media tools live with alsoAllow

### DIFF
--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -13,6 +13,8 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import { clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveOptionalMediaToolFactoryPlan } from "./openclaw-tools.media-factory-plan.js";
+import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
+import { collectExplicitAllowlist } from "./tool-policy.js";
 import * as pdfModelConfigModule from "./tools/pdf-tool.model-config.js";
 
 type CreateOpenClawToolsOptions = Parameters<
@@ -226,6 +228,37 @@ describe("optional media tool factory planning", () => {
       videoGenerate: true,
       musicGenerate: true,
       pdf: true,
+    });
+  });
+
+  it("preserves implicit allow-all media factories for alsoAllow-only tool policies", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          imageGenerationModel: { primary: "image-owner/model" },
+          videoGenerationModel: { primary: "video-owner/model" },
+          musicGenerationModel: { primary: "music-owner/model" },
+        },
+      },
+    };
+    installSnapshot(config, []);
+
+    const toolAllowlist = collectExplicitAllowlist([
+      pickSandboxToolPolicy({ alsoAllow: ["group:memory"] }),
+    ]);
+    expect(toolAllowlist).not.toContain("*");
+
+    expect(
+      resolveOptionalMediaToolFactoryPlan({
+        config,
+        authStore: createAuthStore(),
+        toolAllowlist,
+      }),
+    ).toEqual({
+      imageGenerate: true,
+      videoGenerate: true,
+      musicGenerate: true,
+      pdf: false,
     });
   });
 

--- a/src/agents/openclaw-tools.media-factory-plan.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.ts
@@ -8,6 +8,7 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import { listProfilesForProvider } from "./auth-profiles/profile-list.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY } from "./tool-policy.js";
 import {
   hasSnapshotCapabilityAvailability,
   hasSnapshotProviderEnvAvailability,
@@ -78,7 +79,11 @@ export function isToolExplicitlyAllowedByFactoryPolicy(params: {
 export function mergeFactoryPolicyList(
   ...lists: Array<string[] | undefined>
 ): string[] | undefined {
-  const merged = lists.flatMap((list) => (Array.isArray(list) ? list : []));
+  const merged = lists.flatMap((list) =>
+    Array.isArray(list)
+      ? list.map((entry) => (entry === IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY ? "*" : entry))
+      : [],
+  );
   return merged.length > 0 ? Array.from(new Set(merged)) : undefined;
 }
 

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -18,7 +18,11 @@ import { expectReadWriteEditTools } from "./test-helpers/pi-tools-fs-helpers.js"
 import { createPiToolsSandboxContext } from "./test-helpers/pi-tools-sandbox-context.js";
 import { providerAliasCases } from "./test-helpers/provider-alias-cases.js";
 import { buildEmptyExplicitToolAllowlistError } from "./tool-allowlist-guard.js";
-import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY, normalizeToolName } from "./tool-policy.js";
+import {
+  DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
+  IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY,
+  normalizeToolName,
+} from "./tool-policy.js";
 
 const tinyPngBuffer = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=",
@@ -465,6 +469,7 @@ describe("createOpenClawCodingTools", () => {
     expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
     expect(latestCreateOpenClawToolsOptions().pluginToolAllowlist).toStrictEqual([
       "lobster",
+      IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY,
       DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
     ]);
   });

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -11,6 +11,7 @@ import {
   collectExplicitAllowlist,
   DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
   expandToolGroups,
+  IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY,
   isOwnerOnlyToolName,
   normalizeToolName,
   resolveOwnerOnlyToolApprovalClass,
@@ -156,6 +157,7 @@ describe("tool-policy", () => {
   it("uses alsoAllow entries for plugin discovery without the synthetic allow-all", () => {
     expect(collectExplicitAllowlist([pickSandboxToolPolicy({ alsoAllow: ["lobster"] })])).toEqual([
       "lobster",
+      IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY,
       DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
     ]);
     expect(

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -90,6 +90,7 @@ export type AllowlistResolution = {
 };
 
 export const DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY = "__openclaw_default_plugin_tools__";
+export const IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY = "__openclaw_implicit_core_tools__";
 
 export function collectExplicitAllowlist(policies: Array<ToolPolicyLike | undefined>): string[] {
   const entries: string[] = [];
@@ -110,6 +111,7 @@ export function collectExplicitAllowlist(policies: Array<ToolPolicyLike | undefi
       }
     }
     if (policy[IMPLICIT_ALLOW_ALL_FROM_ALSO_ALLOW] === true) {
+      entries.push(IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY);
       entries.push(DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY);
     }
   }

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -103,14 +103,14 @@ export function collectExplicitAllowlist(policies: Array<ToolPolicyLike | undefi
         continue;
       }
       const trimmed = value.trim();
-      if (trimmed === "*" && policy[IMPLICIT_ALLOW_ALL_FROM_ALSO_ALLOW] === true) {
+      if (trimmed === "*" && policy[IMPLICIT_ALLOW_ALL_FROM_ALSO_ALLOW]) {
         continue;
       }
       if (trimmed) {
         entries.push(trimmed);
       }
     }
-    if (policy[IMPLICIT_ALLOW_ALL_FROM_ALSO_ALLOW] === true) {
+    if (policy[IMPLICIT_ALLOW_ALL_FROM_ALSO_ALLOW]) {
       entries.push(IMPLICIT_CORE_TOOLS_ALLOWLIST_ENTRY);
       entries.push(DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY);
     }


### PR DESCRIPTION
## Summary

- Problem: `tools.alsoAllow` without `tools.allow` is treated as implicit allow-all in the main tool policy, but the media tool factory received a reduced allowlist that made `image_generate`, `video_generate`, and `music_generate` look disallowed.
- Why it matters: media generation tools could be catalog-visible but not live/effective even when explicit generation models and provider plugins were configured.
- What changed: the policy extraction now carries a private core-tool allow-all marker for alsoAllow-only policies, and the built-in media factory maps that marker back to `*` while preserving the existing bounded optional-plugin discovery marker.
- What did NOT change (scope boundary): optional plugin tool discovery remains bounded; this PR does not address the separate warning wording issue in #77801.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra
- [x] Agent tool policy

## Linked Issue/PR

- Closes #77841
- Related #77801
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: media generation factories now preserve implicit allow-all behavior when policy input came from `tools.alsoAllow` without `tools.allow`.
- Real environment tested: local macOS OpenClaw checkout on 2026-05-05, Node via `pnpm exec tsx`, production tool-policy and media-factory planning code with a real temporary workspace.
- Exact steps or command run after this patch: `pnpm exec tsx` ran production APIs: `pickSandboxToolPolicy(alsoAllow) -> collectExplicitAllowlist -> resolveOptionalMediaToolFactoryPlan`.
- Evidence after fix: terminal output from the real OpenClaw policy/factory path:

```text
REAL_OPENCLAW_MEDIA_TOOLS_PROOF {"workspaceBasename":"openclaw-real-tools-proof-1oLQF2","command":"pickSandboxToolPolicy(alsoAllow) -> collectExplicitAllowlist -> resolveOptionalMediaToolFactoryPlan","allowlist":["group:memory","__openclaw_implicit_core_tools__","__openclaw_default_plugin_tools__"],"hasLiteralWildcard":false,"mediaFactoryPlan":{"imageGenerate":true,"videoGenerate":true,"musicGenerate":true,"pdf":true},"memoryGroupStillRequested":true}
```

- Observed result after fix: the extracted allowlist still does not contain a literal `*`, so optional plugin discovery remains bounded, while the built-in media factory sees image/video/music generation as available under the internal core allow-all marker.
- What was not tested: a live Gateway restart with real OpenAI/Google credentials; explicit generation model config is sufficient to prove the fixed factory-planning branch without making provider calls.
- Before evidence: source inspection matched the issue: `collectExplicitAllowlist` removed the synthetic wildcard from alsoAllow-only policy, leaving a nonempty reduced allowlist that made the media factory treat generation tools as disallowed.

## Root Cause (if applicable)

- Root cause: the plugin-tool allowlist extraction intentionally removed the synthetic wildcard from alsoAllow-only policy to avoid loading all optional plugin tools, but the same reduced list was reused by built-in media factory availability checks.
- Missing detection / guardrail: tests covered restrictive allowlists and explicit model config availability, but not the alsoAllow-only policy path where core tools should remain effectively allow-all.
- Contributing context (if known): optional plugin discovery and built-in media factory planning share `pluginToolAllowlist`, but they need different interpretations of the implicit allow-all marker.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openclaw-tools.media-factory-plan.test.ts` and `src/agents/tool-policy.test.ts`
- Scenario the test should lock in: an alsoAllow-only policy exposes built-in media generation factories without reintroducing a literal wildcard into optional plugin discovery.
- Why this is the smallest reliable guardrail: it directly validates the extracted allowlist and the media factory plan without starting a full Gateway.
- Existing test that already covers this (if any): none for alsoAllow-only media generation factory planning.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

With `tools.alsoAllow` and no `tools.allow`, explicitly configured image/video/music generation tools can remain live/effective instead of appearing enabled but not live.

## Diagram (if applicable)

```text
Before:
tools.alsoAllow only -> strip synthetic * -> media factory sees group:memory -> generation tools filtered

After:
tools.alsoAllow only -> strip synthetic * for plugin discovery + carry core allow-all marker -> media factory sees * -> generation tools stay live
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node 22+/pnpm repo scripts
- Model/provider: N/A for local tests; issue config used OpenAI/Google generation providers
- Integration/channel (if any): agent tool policy / Gateway tool resolution
- Relevant config (redacted): `tools.alsoAllow: ["group:memory"]` with explicit `agents.defaults.*GenerationModel`

### Steps

1. Create an alsoAllow-only sandbox tool policy.
2. Extract the explicit allowlist through `collectExplicitAllowlist` and verify it does not contain a literal `*`.
3. Pass that allowlist to optional media factory planning with explicit image/video/music generation model config.
4. Verify image, video, and music generation factories are all available.

### Expected

- Built-in media generation factories preserve implicit allow-all semantics from alsoAllow-only policy.
- Optional plugin discovery remains bounded by the default plugin marker instead of a literal wildcard.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run:

```text
pnpm test src/agents/openclaw-tools.media-factory-plan.test.ts src/agents/tool-policy.test.ts src/agents/tools-effective-inventory.test.ts src/gateway/tools-invoke-http.test.ts
Test Files  4 passed (4)
Tests       94 passed (94)
```

Additional checks:

```text
pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/tool-policy.ts src/agents/tool-policy.test.ts src/agents/openclaw-tools.ts src/agents/openclaw-tools.media-factory-plan.test.ts
All matched files use the correct format.

git diff --check
passed
```

Known unrelated local typecheck blocker:

```text
pnpm tsgo:core
```

This currently stops on existing `src/infra/command-explainer/*` `web-tree-sitter` type export errors outside this PR's touched files.

## Human Verification (required)

- Verified scenarios: alsoAllow-only extracted allowlist lacks a literal wildcard but still enables built-in image/video/music generation factories; restrictive explicit allowlist tests still pass; gateway tool invoke tests still pass.
- Edge cases checked: optional plugin discovery keeps its existing default-plugin marker behavior; denylist and explicit restrictive allowlist coverage still pass in the same target suite.
- What you did **not** verify: a live Gateway restart with real provider credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accidentally expanding optional plugin tool loading when alsoAllow-only is used.
  - Mitigation: the literal `*` is still stripped from plugin discovery; only the built-in media factory maps the new internal core marker back to allow-all.

