### PR TITLE
fix(chat): MEDIA: binary file delivery — proper download for xlsx/csv/zip (Sandpaw Bug #9b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/chat: serve assistant-media binary downloads (xlsx/csv/pdf/zip/etc) with `Content-Disposition: attachment` and an RFC 5987 / 6266 `filename*=UTF-8''…` value plus an ASCII fallback so non-image documents trigger a real download instead of letting the browser render them as a webpage and offer Save As "Webpage Complete". Document attachment anchors in the chat surface also receive a `download` attribute and the managed `/api/chat/media/outgoing-doc/` URL is no longer double-wrapped through `/__openclaw__/assistant-media`. (#77912)
 - Docs/Docker: document a local Compose override for Docker Desktop DNS failures in the shared-network `openclaw-cli` sidecar, keeping the default compose setup hardened while unblocking `openclaw plugins install` when users opt in. Fixes #79018. Thanks @Jason-Vaughan.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -135,7 +135,7 @@ describe("handleControlUiHttpRequest", () => {
     trustedProxies?: string[];
     remoteAddress?: string;
   }) {
-    const { res, end } = makeMockHttpResponse();
+    const { res, end, setHeader } = makeMockHttpResponse();
     const handled = await handleControlUiAssistantMediaRequest(
       {
         url: params.url,
@@ -150,7 +150,7 @@ describe("handleControlUiHttpRequest", () => {
         ...(params.trustedProxies ? { trustedProxies: params.trustedProxies } : {}),
       },
     );
-    return { res, end, handled };
+    return { res, end, setHeader, handled };
   }
 
   function createTrustedProxyAuth(): ResolvedGatewayAuth {
@@ -330,6 +330,142 @@ describe("handleControlUiHttpRequest", () => {
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
       },
+    });
+  });
+
+  // Bug #9b: documents (xlsx/csv/pdf/zip/etc.) and any non-image/non-audio/
+  // non-video local attachment must be served with `Content-Disposition:
+  // attachment` so the browser triggers a binary download instead of
+  // rendering the file as a webpage and offering Save As "Webpage Complete".
+  // Images/audio/video keep the default inline disposition because the chat
+  // surface inlines them.
+  describe("assistant-media Content-Disposition (Bug #9b)", () => {
+    it("serves .xlsx with Content-Disposition: attachment and a sanitized filename", async () => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-doc-xlsx-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "pricing.xlsx");
+          await fs.writeFile(filePath, Buffer.from("PK\u0003\u0004fake-xlsx"));
+          const { res, setHeader, handled } = await runAssistantMediaRequest({
+            url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+            method: "GET",
+            auth: { mode: "token", token: "test-token", allowTailscale: false },
+          });
+          expect(handled).toBe(true);
+          expect(res.statusCode).toBe(200);
+          const disposition = setHeader.mock.calls.find(
+            (call) => call[0] === "Content-Disposition",
+          )?.[1];
+          expect(disposition).toBe('attachment; filename="pricing.xlsx"');
+        },
+      });
+    });
+
+    it("serves .csv with Content-Disposition: attachment", async () => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-doc-csv-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "export.csv");
+          await fs.writeFile(filePath, "a,b,c\n1,2,3\n");
+          const { res, setHeader, handled } = await runAssistantMediaRequest({
+            url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+            method: "GET",
+            auth: { mode: "token", token: "test-token", allowTailscale: false },
+          });
+          expect(handled).toBe(true);
+          expect(res.statusCode).toBe(200);
+          const disposition = setHeader.mock.calls.find(
+            (call) => call[0] === "Content-Disposition",
+          )?.[1];
+          expect(disposition).toBe('attachment; filename="export.csv"');
+        },
+      });
+    });
+
+    it("serves .pdf with Content-Disposition: attachment", async () => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-doc-pdf-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "report.pdf");
+          await fs.writeFile(filePath, Buffer.from("%PDF-1.4\nfake\n%%EOF"));
+          const { res, setHeader, handled } = await runAssistantMediaRequest({
+            url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+            method: "GET",
+            auth: { mode: "token", token: "test-token", allowTailscale: false },
+          });
+          expect(handled).toBe(true);
+          expect(res.statusCode).toBe(200);
+          const disposition = setHeader.mock.calls.find(
+            (call) => call[0] === "Content-Disposition",
+          )?.[1];
+          expect(disposition).toBe('attachment; filename="report.pdf"');
+        },
+      });
+    });
+
+    it("serves .zip with Content-Disposition: attachment", async () => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-doc-zip-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "bundle.zip");
+          await fs.writeFile(filePath, Buffer.from("PK\u0003\u0004fake-zip"));
+          const { res, setHeader, handled } = await runAssistantMediaRequest({
+            url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+            method: "GET",
+            auth: { mode: "token", token: "test-token", allowTailscale: false },
+          });
+          expect(handled).toBe(true);
+          expect(res.statusCode).toBe(200);
+          const disposition = setHeader.mock.calls.find(
+            (call) => call[0] === "Content-Disposition",
+          )?.[1];
+          expect(disposition).toBe('attachment; filename="bundle.zip"');
+        },
+      });
+    });
+
+    it("does not set Content-Disposition for image attachments (kept inline)", async () => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-image-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, "photo.png");
+          await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
+          const { res, setHeader, handled } = await runAssistantMediaRequest({
+            url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+            method: "GET",
+            auth: { mode: "token", token: "test-token", allowTailscale: false },
+          });
+          expect(handled).toBe(true);
+          expect(res.statusCode).toBe(200);
+          const disposition = setHeader.mock.calls.find(
+            (call) => call[0] === "Content-Disposition",
+          );
+          expect(disposition).toBeUndefined();
+        },
+      });
+    });
+
+    it("sanitizes CR/LF/quote/backslash from filename in Content-Disposition", async () => {
+      await withAllowedAssistantMediaRoot({
+        prefix: "ui-media-doc-sanitize-",
+        fn: async (tmpRoot) => {
+          const filePath = path.join(tmpRoot, 'weird"name.csv');
+          await fs.writeFile(filePath, "a,b\n1,2\n");
+          const { res, setHeader, handled } = await runAssistantMediaRequest({
+            url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+            method: "GET",
+            auth: { mode: "token", token: "test-token", allowTailscale: false },
+          });
+          expect(handled).toBe(true);
+          expect(res.statusCode).toBe(200);
+          const disposition = setHeader.mock.calls.find(
+            (call) => call[0] === "Content-Disposition",
+          )?.[1];
+          // The double quote is replaced with `_` so the header value stays
+          // safely quoted.
+          expect(disposition).toBe('attachment; filename="weird_name.csv"');
+        },
+      });
     });
   });
 

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import http from "node:http";
 import type { IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -465,6 +467,130 @@ describe("handleControlUiHttpRequest", () => {
           // safely quoted.
           expect(disposition).toBe('attachment; filename="weird_name.csv"');
         },
+      });
+    });
+
+    // Codex P2 regression for #77912: Node's ServerResponse.setHeader
+    // throws ERR_INVALID_CHAR on header values containing non-Latin1 bytes.
+    // The original PR interpolated the sanitized basename directly into
+    // `filename="..."`, so a download for a CJK filename like `価格.xlsx`
+    // turned into a 404 inside the route try/catch. We use a real
+    // http.createServer here (not makeMockHttpResponse) because the mock's
+    // setHeader is a vi.fn() that does not enforce Node's runtime header
+    // character validation.
+    describe("non-ASCII filename header validation (real http.Server)", () => {
+      async function withRealHttpServer<T>(
+        filePath: string,
+        fn: (port: number) => Promise<T>,
+      ): Promise<T> {
+        const server = http.createServer(async (req, res) => {
+          const handled = await handleControlUiAssistantMediaRequest(req, res, {
+            auth: { mode: "token", token: "test-token", allowTailscale: false },
+          });
+          if (!handled) {
+            res.statusCode = 404;
+            res.end("unhandled");
+          }
+        });
+        await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+        try {
+          const port = (server.address() as AddressInfo).port;
+          return await fn(port);
+        } finally {
+          await new Promise<void>((resolve, reject) =>
+            server.close((err) => (err ? reject(err) : resolve())),
+          );
+        }
+      }
+
+      async function fetchHeaders(port: number, filePath: string) {
+        return await new Promise<{ statusCode: number; headers: http.IncomingHttpHeaders }>(
+          (resolve, reject) => {
+            const req = http.request(
+              {
+                host: "127.0.0.1",
+                port,
+                path: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+                method: "GET",
+              },
+              (resp) => {
+                resp.resume();
+                resp.on("end", () => {
+                  resolve({ statusCode: resp.statusCode ?? 0, headers: resp.headers });
+                });
+              },
+            );
+            req.on("error", reject);
+            req.end();
+          },
+        );
+      }
+
+      it("serves a CJK filename without ERR_INVALID_CHAR (uses RFC 5987 filename*)", async () => {
+        // 価格.xlsx (Japanese for "price.xlsx") — the previous header
+        // construction would throw ERR_INVALID_CHAR inside setHeader and
+        // turn this download into a 404.
+        await withAllowedAssistantMediaRoot({
+          prefix: "ui-media-cjk-",
+          fn: async (tmpRoot) => {
+            const filePath = path.join(tmpRoot, "価格.xlsx");
+            await fs.writeFile(filePath, Buffer.from("PK\u0003\u0004fake-xlsx"));
+            await withRealHttpServer(filePath, async (port) => {
+              const { statusCode, headers } = await fetchHeaders(port, filePath);
+              expect(statusCode).toBe(200);
+              const disposition = String(headers["content-disposition"] ?? "");
+              // ASCII fallback present for legacy clients ...
+              expect(disposition).toMatch(/^attachment; filename="[\x20-\x7E]+";/u);
+              // ... and the RFC 5987 UTF-8-encoded filename* present for
+              // modern browsers and curl.
+              expect(disposition).toContain("filename*=UTF-8''%E4%BE%A1%E6%A0%BC.xlsx");
+              // The two CJK characters (価, 格) become `_` in the
+              // ASCII fallback so legacy clients still see something
+              // meaningful.
+              expect(disposition).toMatch(/filename="__\.xlsx"/);
+            });
+          },
+        });
+      });
+
+      it("serves a Latin-1 accented filename via the ASCII fallback path", async () => {
+        // résumé.docx — Latin-1-safe but still non-ASCII; must include
+        // filename* so modern browsers prefer the precise filename.
+        await withAllowedAssistantMediaRoot({
+          prefix: "ui-media-latin1-",
+          fn: async (tmpRoot) => {
+            const filePath = path.join(tmpRoot, "résumé.docx");
+            await fs.writeFile(filePath, Buffer.from("PK\u0003\u0004fake-docx"));
+            await withRealHttpServer(filePath, async (port) => {
+              const { statusCode, headers } = await fetchHeaders(port, filePath);
+              expect(statusCode).toBe(200);
+              const disposition = String(headers["content-disposition"] ?? "");
+              expect(disposition).toContain("filename*=UTF-8''r%C3%A9sum%C3%A9.docx");
+              // ASCII fallback: percent-decoded UTF-8 bytes for `é` are 0xC3
+              // 0xA9, both Latin-1 safe but non-ASCII; the filename test
+              // pattern \x20-\x7E excludes them so they fall to `_` for the
+              // ASCII fallback. Modern clients use filename* anyway.
+              expect(disposition).toMatch(/filename="r_sum_\.docx"/);
+            });
+          },
+        });
+      });
+
+      it("keeps the legacy single-token form for pure-ASCII filenames", async () => {
+        // Codex's review noted we shouldn't churn header strings for the
+        // common ASCII case.
+        await withAllowedAssistantMediaRoot({
+          prefix: "ui-media-ascii-real-",
+          fn: async (tmpRoot) => {
+            const filePath = path.join(tmpRoot, "pricing.xlsx");
+            await fs.writeFile(filePath, Buffer.from("PK\u0003\u0004fake-xlsx"));
+            await withRealHttpServer(filePath, async (port) => {
+              const { statusCode, headers } = await fetchHeaders(port, filePath);
+              expect(statusCode).toBe(200);
+              expect(headers["content-disposition"]).toBe('attachment; filename="pricing.xlsx"');
+            });
+          },
+        });
       });
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -496,6 +496,37 @@ function safeAssistantMediaDownloadFilename(localPath: string): string {
   return cleaned || fallback;
 }
 
+/**
+ * Build an RFC 5987-compatible Content-Disposition header value for a
+ * download.
+ *
+ * Node's `ServerResponse.setHeader` validates header values against ISO-8859-1
+ * and throws `ERR_INVALID_CHAR` if a non-Latin1 byte is present. The chat
+ * surface accepts assistant filenames containing CJK / Cyrillic / accented
+ * characters (e.g. `価格.xlsx`, `résumé.docx`), so we cannot interpolate the
+ * raw filename into `filename="…"`.
+ *
+ * RFC 5987 / 6266 prescribes pairing an ASCII-only fallback `filename="…"`
+ * with a UTF-8 percent-encoded `filename*=UTF-8''…`. All modern browsers and
+ * curl prefer `filename*` when both are present.
+ */
+function buildDownloadContentDispositionHeader(safeFilename: string): string {
+  const isLatin1Safe = /^[\x20-\x7E\xA0-\xFF]*$/u.test(safeFilename);
+  const asciiFallback = safeFilename.replace(/[^\x20-\x7E]/gu, "_");
+  const utf8Encoded = encodeURIComponent(safeFilename)
+    // RFC 5987 attr-char excludes a few percent-encoding-reserved characters
+    // that encodeURIComponent leaves alone; tighten to the spec's value-chars.
+    .replace(/['()]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
+    .replace(/\*/g, "%2A");
+  if (isLatin1Safe && asciiFallback === safeFilename) {
+    // Pure ASCII filename: a single `filename="…"` is RFC-compliant and
+    // matches the previous behavior so we don't churn header strings on the
+    // common case.
+    return `attachment; filename="${safeFilename}"`;
+  }
+  return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${utf8Encoded}`;
+}
+
 async function resolveAssistantMediaAvailability(
   source: string,
   localRoots: readonly string[],
@@ -608,7 +639,11 @@ export async function handleControlUiAssistantMediaRequest(
       mediaKind === "image" || mediaKind === "audio" || mediaKind === "video";
     if (!isInlineRenderable) {
       const downloadFilename = safeAssistantMediaDownloadFilename(localPath);
-      res.setHeader("Content-Disposition", `attachment; filename="${downloadFilename}"`);
+      // RFC 5987 / 6266: encode non-ASCII filenames with an ASCII fallback +
+      // UTF-8 `filename*` so Node's setHeader does not throw ERR_INVALID_CHAR
+      // and turn the response into a 404 for filenames like `価格.xlsx` or
+      // `résumé.docx`.
+      res.setHeader("Content-Disposition", buildDownloadContentDispositionHeader(downloadFilename));
     }
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Content-Length", String(opened.stat.size));

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -14,6 +14,7 @@ import { openLocalFileSafely, FsSafeError, readSecureFile } from "../infra/fs-sa
 import { safeFileURLToPath } from "../infra/local-file-access.js";
 import { verifyPairingToken } from "../infra/pairing-token.js";
 import { isWithinDir } from "../infra/path-safety.js";
+import { mediaKindFromMime } from "../media/constants.js";
 import { assertLocalMediaAllowed, getDefaultLocalRoots } from "../media/local-media-access.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import { resolveMediaReferenceLocalPath } from "../media/media-reference.js";
@@ -484,6 +485,17 @@ function classifyAssistantMediaError(err: unknown): AssistantMediaAvailability {
   return { available: false, code: "attachment-unavailable", reason: "Attachment unavailable" };
 }
 
+function safeAssistantMediaDownloadFilename(localPath: string): string {
+  // Mirror managed-document-attachments' filename hardening: strip CR/LF,
+  // quotes, backslashes, and path separators so the value can be safely
+  // interpolated into a Content-Disposition header. Unicode is preserved so
+  // user-facing filenames render correctly on download.
+  const fallback = "download";
+  const basename = path.basename(localPath || fallback);
+  const cleaned = basename.replace(/[\r\n"\\/]/g, "_").trim();
+  return cleaned || fallback;
+}
+
 async function resolveAssistantMediaAvailability(
   source: string,
   localRoots: readonly string[],
@@ -582,10 +594,21 @@ export async function handleControlUiAssistantMediaRequest(
       buffer: sniffBuffer?.subarray(0, bytesRead),
       filePath: localPath,
     });
-    if (mime) {
-      res.setHeader("Content-Type", mime);
-    } else {
-      res.setHeader("Content-Type", "application/octet-stream");
+    const resolvedMime = mime || "application/octet-stream";
+    res.setHeader("Content-Type", resolvedMime);
+    // Bug #9b: documents (xlsx/csv/pdf/zip/etc.) must be served with
+    // `Content-Disposition: attachment` so the browser triggers a binary
+    // download instead of trying to render them as a webpage. Images, audio,
+    // and video are inlined by the chat surface and keep the default `inline`
+    // disposition; everything else (and unclassified content streamed as
+    // application/octet-stream) gets a save-to-disk hint with the original
+    // filename so Save As doesn't fall back to "Webpage Complete".
+    const mediaKind = mediaKindFromMime(resolvedMime);
+    const isInlineRenderable =
+      mediaKind === "image" || mediaKind === "audio" || mediaKind === "video";
+    if (!isInlineRenderable) {
+      const downloadFilename = safeAssistantMediaDownloadFilename(localPath);
+      res.setHeader("Content-Disposition", `attachment; filename="${downloadFilename}"`);
     }
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Content-Length", String(opened.stat.size));

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1187,7 +1187,71 @@ describe("grouped chat rendering", () => {
     expect(docLink?.getAttribute("href")).toBe(
       "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest-doc.pdf&mediaTicket=ticket-local",
     );
+    // Bug #9b: document anchors render with `download=<filename>` so clicks
+    // trigger a binary save-to-disk instead of opening the file in a new tab
+    // (which lets Safari fall back to "Save as Webpage Complete").
+    expect(docLink?.getAttribute("download")).toBe("test-doc.pdf");
     expect(container.textContent).not.toContain("test image.png");
+    vi.unstubAllGlobals();
+  });
+
+  it("renders binary document attachments (xlsx/csv/zip) with a download attribute (Bug #9b)", async () => {
+    resetAssistantAttachmentAvailabilityCacheForTest();
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("meta=1")) {
+        return {
+          ok: true,
+          json: async () => mediaTicketPayload("ticket-binary"),
+        };
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const container = document.createElement("div");
+    const renderMessage = () =>
+      renderAssistantMessage(
+        container,
+        {
+          id: "assistant-binary-attachments",
+          role: "assistant",
+          content: [
+            "Binary docs",
+            "MEDIA:/tmp/openclaw/pricing.xlsx",
+            "MEDIA:/tmp/openclaw/export.csv",
+            "MEDIA:/tmp/openclaw/bundle.zip",
+          ].join("\n"),
+          timestamp: Date.now(),
+        },
+        {
+          showToolCalls: false,
+          basePath: "/openclaw",
+          assistantAttachmentAuthToken: "session-token",
+          localMediaPreviewRoots: ["/tmp/openclaw"],
+          onRequestUpdate: renderMessage,
+        },
+      );
+
+    renderMessage();
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    const links = [
+      ...container.querySelectorAll<HTMLAnchorElement>(".chat-assistant-attachment-card__link"),
+    ];
+    expect(links.map((link) => link.getAttribute("download"))).toEqual([
+      "pricing.xlsx",
+      "export.csv",
+      "bundle.zip",
+    ]);
+    for (const link of links) {
+      // The download triggers same-origin save-to-disk; target=_blank is kept
+      // as a graceful fallback for browsers that ignore the download
+      // attribute on cross-origin or sandboxed responses.
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noreferrer");
+      expect(link.getAttribute("href")).toMatch(
+        /\/openclaw\/__openclaw__\/assistant-media\?source=%2Ftmp%2Fopenclaw%2F.+&mediaTicket=ticket-binary/,
+      );
+    }
     vi.unstubAllGlobals();
   });
 
@@ -1336,6 +1400,52 @@ describe("grouped chat rendering", () => {
     );
     expect(image?.getAttribute("src")).toBe("/media/inbound/test-image.png");
     expect(docLink?.getAttribute("href")).toBe("/__openclaw__/media/test-doc.pdf");
+    // Bug #9b: same-origin documents still render as a download anchor so the
+    // browser saves the binary instead of trying to render it inline.
+    expect(docLink?.getAttribute("download")).toBe("test-doc.pdf");
+    expect(container.textContent).not.toContain("Unavailable");
+  });
+
+  it("preserves managed outgoing-doc URLs without re-wrapping them through assistant-media (Bug #9b)", () => {
+    // Documents emitted by the gateway-managed outgoing-document pipeline
+    // already carry the right Content-Type and `Content-Disposition: attachment`.
+    // The chat surface must not double-wrap them through the
+    // /__openclaw__/assistant-media route — that endpoint is for raw local
+    // files and would discard the managed serving guarantees.
+    resetAssistantAttachmentAvailabilityCacheForTest();
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        id: "assistant-managed-outgoing-doc",
+        role: "assistant",
+        content: [
+          {
+            type: "attachment",
+            attachment: {
+              url: "/api/chat/media/outgoing-doc/agent%3Amain%3Amain/00000000-0000-4000-8000-000000000000/full",
+              kind: "document",
+              label: "pricing.xlsx",
+              mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            },
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      {
+        showToolCalls: false,
+        basePath: "/openclaw",
+        localMediaPreviewRoots: ["/tmp/openclaw"],
+      },
+    );
+
+    const docLink = container.querySelector<HTMLAnchorElement>(
+      ".chat-assistant-attachment-card__link",
+    );
+    expect(docLink?.getAttribute("href")).toBe(
+      "/api/chat/media/outgoing-doc/agent%3Amain%3Amain/00000000-0000-4000-8000-000000000000/full",
+    );
+    expect(docLink?.getAttribute("download")).toBe("pricing.xlsx");
     expect(container.textContent).not.toContain("Unavailable");
   });
 

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -799,7 +799,17 @@ function renderReplyPill(replyTarget: NormalizedMessage["replyTarget"]) {
 
 function isLocalAssistantAttachmentSource(source: string): boolean {
   const trimmed = source.trim();
-  if (/^\/(?:__openclaw__|media|api\/chat\/media\/outgoing)\//.test(trimmed)) {
+  // Bug #9b: also recognize the managed outgoing-document route
+  // (/api/chat/media/outgoing-doc/...) as a non-local URL so it isn't
+  // double-wrapped through /__openclaw__/assistant-media. The doc route
+  // already serves with the correct Content-Type and
+  // `Content-Disposition: attachment`; passing it through assistant-media
+  // would discard those guarantees.
+  if (
+    /^\/(?:__openclaw__|media|api\/chat\/media\/outgoing|api\/chat\/media\/outgoing-doc)\//.test(
+      trimmed,
+    )
+  ) {
     return false;
   }
   return (
@@ -1261,12 +1271,21 @@ function renderAssistantAttachments(
             reason: availability.status === "unavailable" ? availability.reason : undefined,
           });
         }
+        // Bug #9b: documents (xlsx/csv/pdf/zip/etc.) must download as binary
+        // files instead of opening in a new tab and triggering Safari's
+        // "Save as Webpage Complete" fallback. The `download` attribute
+        // forces same-origin save-to-disk and uses the inferred label as
+        // the suggested filename. Pair this with the gateway-side
+        // `Content-Disposition: attachment` so cross-origin or
+        // download-attribute-ignoring browsers still get the right
+        // behaviour.
         return html`
           <div class="chat-assistant-attachment-card">
             <span class="chat-assistant-attachment-card__icon">${icons.paperclip}</span>
             <a
               class="chat-assistant-attachment-card__link"
               href=${attachmentUrl}
+              download=${attachment.label}
               target="_blank"
               rel="noreferrer"
               >${attachment.label}</a


### PR DESCRIPTION
# Sandpaw Bug #9b — file delivery for non-image binary files

Bug #9 covered MIME inference (#77875) and the gateway-managed outgoing
document pipeline (#77877). Bug #9b plugs three remaining gaps in the
plain `MEDIA:` → `/__openclaw__/assistant-media` path that produced Todd
Bolyard's "Save as Webpage Complete" fallback for non-image binary files
on `go-yard.sandpaw.ai`.

## Root cause (one-liner)

`/__openclaw__/assistant-media` streamed xlsx/csv/pdf/zip with the right
`Content-Type` but no `Content-Disposition`, the chat anchor lacked a
`download` attribute, and the new managed `/api/chat/media/outgoing-doc/`
URL was being double-wrapped through assistant-media — together that lets
Safari render the response in-tab and offer Save As "Webpage Complete".

## What goes wrong without this PR

1. `/__openclaw__/assistant-media` sets the right `Content-Type` for
   `xlsx`/`csv`/`pdf`/`zip` but **no `Content-Disposition`**. Safari (and
   other browsers under various preference combinations) renders the
   response in-tab; File→Save offers "Webpage Complete" as the only
   option.
2. The document anchor in `grouped-render.ts` uses `target="_blank"` with
   **no `download` attribute**, so even browsers that respect
   `Content-Disposition` are first asked to open the file in a new tab —
   the gateway hint is the only thing keeping it from rendering.
3. The managed `/api/chat/media/outgoing-doc/` URL produced by the
   gateway (#77877) is **misclassified as a "local" source** and
   double-wrapped through `/__openclaw__/assistant-media`, discarding the
   managed `Content-Disposition: attachment` header.

## What lands

### Server side (`src/gateway/control-ui.ts`)

- `handleControlUiAssistantMediaRequest` sets
  `Content-Disposition: attachment; filename="<basename>"` for any
  response whose resolved MIME is not image/audio/video. Images, audio,
  and video keep the default inline disposition because the chat surface
  inlines them. `application/octet-stream` fallbacks also get the
  attachment hint so unclassified content still downloads cleanly.
- `safeAssistantMediaDownloadFilename` mirrors the managed-document
  sibling: strips CR/LF/quote/backslash/slash so the filename is safe
  to interpolate into the header. Unicode is preserved.

### Client side (`ui/src/ui/chat/grouped-render.ts`)

- Document-kind anchors now render with `download=<label>` alongside the
  existing `target=_blank` / `rel=noreferrer` pair, so clicks trigger
  same-origin save-to-disk with the suggested filename. `target=_blank`
  stays as a graceful fallback for browsers that ignore the `download`
  attribute on cross-origin or sandboxed responses.
- `isLocalAssistantAttachmentSource` also recognizes
  `/api/chat/media/outgoing-doc/` as a non-local URL so the managed-doc
  response from #77877 isn't double-wrapped through assistant-media and
  keeps its `Content-Disposition: attachment` header.

## Tests

### `src/gateway/control-ui.http.test.ts` (Bug #9b describe block, 6 tests)

- `.xlsx`, `.csv`, `.pdf`, `.zip` each respond 200 with the canonical
  `attachment; filename="<original>"` header.
- `.png` keeps the default inline disposition (no header set).
- Filename sanitization replaces embedded double quotes with `_`.

### `ui/src/ui/chat/grouped-render.test.ts` (3 new + 1 strengthened)

- Existing "verified local assistant attachments" test now asserts
  `download=test-doc.pdf` on the rendered anchor.
- New "binary document attachments (xlsx/csv/zip)" test renders three
  `MEDIA:` refs and asserts `download=pricing.xlsx`, `export.csv`,
  `bundle.zip` plus the standard mediaTicket-bearing href.
- "preserves same-origin assistant attachments" test now asserts
  `download=test-doc.pdf` on the same-origin `/__openclaw__/media`
  anchor.
- New "managed outgoing-doc URLs" test asserts the
  `/api/chat/media/outgoing-doc/` URL renders without re-wrapping
  through `/__openclaw__/assistant-media` and carries
  `download=pricing.xlsx`.

## Test results

- `pnpm exec vitest run src/gateway/control-ui.http.test.ts` — 156
  passed (52 × 3 environments)
- `pnpm --dir ui exec vitest run src/ui/chat/grouped-render.test.ts` —
  37 passed
- All 11 unit-environment chat UI test files (121 tests) pass
- `oxlint` clean on the four touched files
- `pnpm lint:ui:no-raw-window-open` clean

## Related

- Pairs with #77875 (UI MIME mappings, Bug #9)
- Pairs with #77877 (gateway managed document pipeline, Bug #9)
- Sandpaw repo PR `gregstiehl/sandpaw-ai#244` covers the spreadsheet
  skill side (Bug #9a)
- Reported by Todd Bolyard on `go-yard.sandpaw.ai`, 2026-05-05



## Real behavior proof

**Behavior or issue addressed**: `/__openclaw__/assistant-media` previously
served `.xlsx`/`.csv`/`.pdf`/`.zip` with the right `Content-Type` but no
`Content-Disposition` header, so Safari rendered them in-tab and offered
"Webpage Complete" as the only Save As format. After this PR every
non-image MIME gets `Content-Disposition: attachment; filename="..."`.

**Real environment tested**: macOS 25.3.0 (arm64), Node v22.22.0, branch
`fix/chat-binary-file-delivery-bug-9b` at commit `70700cf707`. Real
`~/.openclaw` state dir, real on-disk fixture files, no vitest, no mocks.
The handler is loaded directly from `src/gateway/control-ui.ts` via an
esbuild bundle and served through `http.createServer()` listening on
`127.0.0.1:8765`.

**Exact steps or command run after this patch**:

```sh
1. Build a CJS-compatible ESM bundle of the patched module:
node_modules/.bin/esbuild src/gateway/control-ui.ts \
  --bundle --platform=node --format=esm \
  --outfile=_bug9_control_ui.mjs \
  --external:sharp --external:fsevents \
  --banner:js='import { createRequire as __ccr } from "node:module"; const require = __ccr(import.meta.url);'

2. Tiny harness:
cat > _bug9_harness.mjs <<'JS'
import http from "node:http";
import { handleControlUiAssistantMediaRequest } from "./_bug9_control_ui.mjs";
http.createServer(async (req, res) => {
  const handled = await handleControlUiAssistantMediaRequest(req, res, {});
  if (!handled) { res.writeHead(404).end("not handled"); }
}).listen(8765, "127.0.0.1", () => console.log("listening"));
JS
node ./_bug9_harness.mjs &

3. Real fixture files in ~/.openclaw/workspace/bug9-proof/:
--    pricing.xlsx (PK\x03\x04), data.csv, report.pdf, bundle.zip, photo.png

4. Hit each one:
for f in pricing.xlsx data.csv report.pdf bundle.zip photo.png; do
  curl -sIv "http://127.0.0.1:8765/__openclaw__/assistant-media?source=$HOME/.openclaw/workspace/bug9-proof/$f"
done
```

**After-fix evidence**:

`.xlsx` — gets `Content-Disposition: attachment` (the fix):

```
> HEAD /__openclaw__/assistant-media?source=/Users/ada/.openclaw/workspace/bug9-proof/pricing.xlsx HTTP/1.1
< HTTP/1.1 200 OK
< Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
< Content-Disposition: attachment; filename="pricing.xlsx"
< Cache-Control: no-cache
< Content-Length: 2058
```

`.csv`:

```
< HTTP/1.1 200 OK
< Content-Type: text/csv
< Content-Disposition: attachment; filename="data.csv"
< Content-Length: 36
```

`.pdf`:

```
< HTTP/1.1 200 OK
< Content-Type: application/pdf
< Content-Disposition: attachment; filename="report.pdf"
< Content-Length: 53
```

`.zip`:

```
< HTTP/1.1 200 OK
< Content-Type: application/zip
< Content-Disposition: attachment; filename="bundle.zip"
< Content-Length: 1028
```

`.png` — does NOT get `Content-Disposition` (proves the fix is targeted):

```
< HTTP/1.1 200 OK
< Content-Type: image/png
< Cache-Control: no-cache
< Content-Length: 69
```

**Observed result after fix**:

| extension | `Content-Type`                                                     | `Content-Disposition`                  |
|-----------|--------------------------------------------------------------------|----------------------------------------|
| `.xlsx`   | `application/vnd.openxmlformats-...spreadsheetml.sheet`            | `attachment; filename="pricing.xlsx"`  |
| `.csv`    | `text/csv`                                                         | `attachment; filename="data.csv"`      |
| `.pdf`    | `application/pdf`                                                  | `attachment; filename="report.pdf"`    |
| `.zip`    | `application/zip`                                                  | `attachment; filename="bundle.zip"`    |
| `.png`    | `image/png`                                                        | *(absent — inline)*                    |

Every binary document now triggers a download with the original filename;
images stay inline as before. This is the wire-level behaviour Todd
Bolyard's browser will see on `go-yard.sandpaw.ai`.

**What was not tested**: I did not exercise the full chat anchor click in
a real browser on `go-yard.sandpaw.ai` itself — I only verified the
gateway response shape end-to-end. The grouped-render `download=` anchor
attribute change is covered by the strengthened `grouped-render.test.ts`
assertions (which run against jsdom).
