### PR TITLE
fix(config): skip root-level additionalProperties errors from bundled channel validation for plugin extension fields

### DIFF
--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import {
+  validateConfigObjectRaw,
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
@@ -298,5 +299,54 @@ describe("validateConfigObjectWithPlugins bundled allowlist compatibility", () =
     expect(result.ok).toBe(true);
     expect(loadPluginMetadataSnapshot).toHaveBeenCalledOnce();
     expect(mockLoadPluginManifestRegistry).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateConfigObjectRaw bundled channel plugin extension fields (#77887)", () => {
+  it("accepts top-level plugin extension fields in channel config without additionalProperties error", () => {
+    // The feishu bundled schema has additionalProperties:false, but plugins like
+    // openclaw-lark legitimately extend the root channel config with their own
+    // fields (replyMode, footer). The bundled schema validator must not reject them.
+    const result = validateConfigObjectRaw(
+      {
+        channels: {
+          feishu: {
+            // Required feishu fields (using schema defaults as explicit values)
+            domain: "feishu",
+            connectionMode: "websocket",
+            webhookPath: "/feishu/events",
+            dmPolicy: "pairing",
+            groupPolicy: "allowlist",
+            reactionNotifications: "own",
+            typingIndicator: true,
+            resolveSenderNames: true,
+            // Plugin extension fields (openclaw-lark) — must not be rejected
+            replyMode: "text",
+            footer: "powered by openclaw",
+          },
+        },
+      },
+      { validateBundledChannels: true },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("still rejects genuinely invalid bundled channel config field types", () => {
+    const result = validateConfigObjectRaw(
+      {
+        channels: {
+          feishu: {
+            enabled: "not-a-boolean",
+          },
+        },
+      },
+      { validateBundledChannels: true },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.some((i) => i.path.startsWith("channels.feishu"))).toBe(true);
+    }
   });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -223,6 +223,14 @@ function collectRawBundledChannelConfigIssues(config: OpenClawConfig): ConfigVal
       continue;
     }
     for (const error of result.errors) {
+      // Skip top-level additionalProperty errors: plugins legitimately extend the
+      // root channel config object with their own fields (e.g. replyMode, footer in
+      // openclaw-lark). The bundled schema uses additionalProperties:false for
+      // type-safety on known fields, but cannot enumerate plugin-registered fields.
+      // Nested additionalProperties errors (non-root path) are still surfaced.
+      if (error.additionalProperty && error.path === "<root>") {
+        continue;
+      }
       const message = error.additionalProperty
         ? `${error.message}: "${error.additionalProperty}"`
         : error.message;


### PR DESCRIPTION
## Problem

Closes #77887.

When a user has both the feishu channel enabled and the `openclaw-lark` plugin installed, running `openclaw config patch` fails with:

```
invalid config: must NOT have additional properties: "replyMode"
invalid config: must NOT have additional properties: "footer"
```

The bundled feishu schema uses `additionalProperties: false` for type-safety on known fields, but `openclaw-lark` legitimately extends the root channel config object with its own fields (`replyMode`, `footer`). The `collectRawBundledChannelConfigIssues` function validates against the static bundled schema and cannot know about plugin-registered extensions.

## Fix

In `collectRawBundledChannelConfigIssues` (`src/config/validation.ts`), skip AJV errors where:
- `error.additionalProperty` is set (it's an `additionalProperties` violation), AND
- `error.path === "<root>"` (the violation is at the channel config root, not nested)

Nested `additionalProperties` errors at deeper paths (e.g. inside sub-objects like `tts` or `connection`) are still surfaced. This preserves type-safety for known sub-schemas while allowing plugin-owned root-level extensions.

## Tests

Added two tests to `validation.channel-metadata.test.ts`:
1. Feishu config with required fields + plugin extension fields (`replyMode`, `footer`) → `ok: true`
2. Feishu config with genuinely invalid type (`enabled: "not-a-boolean"`) → `ok: false` with path `channels.feishu`

## Scope

- `src/config/validation.ts` — 8 lines added (guard + comment)
- `src/config/validation.channel-metadata.test.ts` — 2 new tests in new describe block

🤖 Generated with [Claude Code](https://claude.com/claude-code)