### PR TITLE
fix(feishu): handle interactive card sub-messages in merge_forward content

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -196,6 +196,8 @@ function formatSubMessageContent(content: string, contentType: string): string {
         return "[Sticker]";
       case "merge_forward":
         return "[Nested Merged Forward]";
+      case "interactive":
+        return "[Interactive Card]";
       default:
         return `[${contentType}]`;
     }

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1960,6 +1960,74 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("formats interactive card sub-messages as [Interactive Card] in merge_forward", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const mockGetMerged = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "container",
+            msg_type: "merge_forward",
+            body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+          },
+          {
+            message_id: "sub-interactive",
+            upper_message_id: "container",
+            msg_type: "interactive",
+            body: { content: JSON.stringify({ header: { title: { content: "Approval" } } }) },
+            create_time: "1000",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        message: {
+          get: mockGetMerged,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-interactive",
+        },
+      },
+      message: {
+        message_id: "msg-interactive-forward",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "merge_forward",
+        content: JSON.stringify({ text: "Merged and Forwarded Message" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining(
+          "[Merged and Forwarded Messages]\n- [Interactive Card]",
+        ),
+      }),
+    );
+  });
+
   it("falls back when merge_forward API returns no sub-messages", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockCreateFeishuClient.mockReturnValue({


### PR DESCRIPTION
## Problem

Closes #77909.

When a Feishu merge_forward bundle contains an interactive card (approval flow, form card), `formatSubMessageContent` falls through to the default `[${contentType}]` branch, producing `[interactive]` in the agent-visible content.

Log evidence from the issue:
```
feishu: merge_forward contains 1 sub-messages
feishu[default] DM from ou_xxx: [Merged and Forwarded Messages] - [interactive]
```

## Fix

Add an `interactive` case to `formatSubMessageContent` in `extensions/feishu/src/bot-content.ts`:

```ts
case "interactive":
  return "[Interactive Card]";
```

This follows the existing pattern for other non-text types (`image`, `audio`, `video`, `sticker`) and produces a descriptive placeholder instead of the raw msg_type wrapped in brackets.

## Tests

Added a test in `bot.test.ts`: a merge_forward API response where the sole sub-message has `msg_type: "interactive"` now produces `[Interactive Card]` in the agent body. All 61 existing feishu tests pass.

## Scope

- `extensions/feishu/src/bot-content.ts` — 2 lines added
- `extensions/feishu/src/bot.test.ts` — 1 new test (67 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)