### PR TITLE
fix(comfy): bypass SSRF guard for DNS hostnames when allowPrivateNetwork is set in local mode

### DIFF
--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -193,6 +193,60 @@ describe("comfy image-generation provider", () => {
     });
   });
 
+  it("passes private-network SSRF policy when local mode uses a DNS hostname (#77922)", async () => {
+    _setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ prompt_id: "dns-prompt-1" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            "dns-prompt-1": {
+              outputs: {
+                "9": { images: [{ filename: "out.png", subfolder: "", type: "output" }] },
+              },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("png"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildComfyImageGenerationProvider();
+    await provider.generateImage({
+      provider: "comfy",
+      model: "workflow",
+      prompt: "a cat",
+      cfg: buildComfyConfig({
+        baseUrl: "http://comfy.local.example.com:8188",
+        mode: "local",
+        workflow: { "6": { inputs: { text: "" } }, "9": { inputs: {} } },
+        promptNodeId: "6",
+        outputNodeId: "9",
+      }),
+    });
+
+    // The fetch call must include a non-null policy that allows private networks.
+    // Without the fix, DNS hostnames that resolve to private IPs were excluded
+    // from the allowlist because isPrivateOrLoopbackHost returned false for them.
+    const firstCall = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(firstCall?.policy).toBeTruthy();
+  });
+
   it("uploads reference images for local edit workflows", async () => {
     _setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -18,7 +18,6 @@ import {
 import {
   buildHostnameAllowlistPolicyFromSuffixAllowlist,
   fetchWithSsrFGuard,
-  isPrivateOrLoopbackHost,
   mergeSsrFPolicies,
   ssrfPolicyFromDangerouslyAllowPrivateNetwork,
   type SsrFPolicy,
@@ -268,10 +267,14 @@ function resolveComfyNetworkPolicy(params: {
   }
 
   const hostname = normalizeOptionalLowercaseString(parsed.hostname) ?? "";
-  if (!hostname || !params.allowPrivateNetwork || !isPrivateOrLoopbackHost(hostname)) {
+  if (!hostname || !params.allowPrivateNetwork) {
     return {};
   }
-
+  // Always allowlist the configured hostname when allowPrivateNetwork is set.
+  // isPrivateOrLoopbackHost() only matches numeric private IPs and loopback —
+  // it returns false for DNS names like "comfy.local.example.com" that resolve
+  // to a private IP, causing the SSRF guard to block the request even though
+  // the user explicitly opted in to local mode.
   const hostnamePolicy = buildHostnameAllowlistPolicyFromSuffixAllowlist([hostname]);
   const privateNetworkPolicy = ssrfPolicyFromDangerouslyAllowPrivateNetwork(true);
   return {


### PR DESCRIPTION
## Problem

Closes #77922.

When using the Comfy plugin with `mode: "local"` (or `allowPrivateNetwork: true`) and a DNS hostname as `baseUrl` (e.g. `https://comfy.local.example.com`) that resolves to a private IP, the SSRF guard blocks the request:

```
Blocked: resolves to private/internal/special-use IP address
```

## Root cause

`resolveComfyNetworkPolicy` only applied the private-network SSRF bypass when `isPrivateOrLoopbackHost(hostname)` returned true. That check matches numeric private IPs and loopback addresses (`127.x`, `192.168.x`, `10.x`, `fc00::`) — but it returns **false** for DNS names, so the bypass was never applied for DNS-named local endpoints.

## Fix

Remove the `isPrivateOrLoopbackHost` gate in `resolveComfyNetworkPolicy`:

```ts
// Before
if (!hostname || !params.allowPrivateNetwork || !isPrivateOrLoopbackHost(hostname)) {
  return {};
}

// After
if (!hostname || !params.allowPrivateNetwork) {
  return {};
}
```

When `allowPrivateNetwork` is set, the configured hostname is always explicitly allowlisted (`buildHostnameAllowlistPolicyFromSuffixAllowlist`) and private-network IPs are allowed via `ssrfPolicyFromDangerouslyAllowPrivateNetwork(true)`. This is not a blanket bypass — the hostname must match the configured `baseUrl`.

Also removed the now-unused `isPrivateOrLoopbackHost` import.

## Tests

Added a test in `image-generation-provider.test.ts`: local mode with a DNS hostname passes a non-null `policy` to `fetchWithSsrFGuard`. All 21 comfy tests pass.

## Scope

- `extensions/comfy/workflow-runtime.ts` — 3 lines changed (removed gate condition + unused import)
- `extensions/comfy/image-generation-provider.test.ts` — 1 new test

🤖 Generated with [Claude Code](https://claude.com/claude-code)