### PR TITLE
fix(agents): remove transient session repair backups

### DIFF
--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -45,15 +45,12 @@ describe("repairSessionFileIfNeeded", () => {
     const result = await repairSessionFileIfNeeded({ sessionFile: file });
     expect(result.repaired).toBe(true);
     expect(result.droppedLines).toBe(1);
-    expect(result.backupPath).toBeTruthy();
+    expect(result.backupPath).toBeUndefined();
 
     const repaired = await fs.readFile(file, "utf-8");
     expect(repaired.trim().split("\n")).toHaveLength(2);
-
-    if (result.backupPath) {
-      const backup = await fs.readFile(result.backupPath, "utf-8");
-      expect(backup).toBe(content);
-    }
+    const backups = (await fs.readdir(path.dirname(file))).filter((name) => name.includes(".bak-"));
+    expect(backups).toEqual([]);
   });
 
   it("does not drop CRLF-terminated JSONL lines", async () => {
@@ -134,7 +131,7 @@ describe("repairSessionFileIfNeeded", () => {
     expect(result.repaired).toBe(true);
     expect(result.droppedLines).toBe(0);
     expect(result.rewrittenAssistantMessages).toBe(1);
-    expect(result.backupPath).toBeTruthy();
+    expect(result.backupPath).toBeUndefined();
     expect(debug).toHaveBeenCalledTimes(1);
     const debugMessage = debug.mock.calls[0]?.[0] as string;
     expect(debugMessage).toContain("rewrote 1 assistant message(s)");
@@ -620,7 +617,7 @@ describe("repairSessionFileIfNeeded", () => {
 
     expect(result.repaired).toBe(true);
     expect(result.droppedLines).toBe(3);
-    expect(result.backupPath).toBeTruthy();
+    expect(result.backupPath).toBeUndefined();
 
     const after = await fs.readFile(file, "utf-8");
     const lines = after.trimEnd().split("\n");

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -279,6 +279,7 @@ export async function repairSessionFileIfNeeded(params: {
   const cleaned = `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
   const backupPath = `${sessionFile}.bak-${process.pid}-${Date.now()}`;
   const tmpPath = `${sessionFile}.repair-${process.pid}-${Date.now()}.tmp`;
+  let retainedBackupPath: string | undefined;
   try {
     const stat = await fs.stat(sessionFile).catch(() => null);
     await fs.writeFile(backupPath, content, "utf-8");
@@ -290,6 +291,14 @@ export async function repairSessionFileIfNeeded(params: {
       await fs.chmod(tmpPath, stat.mode);
     }
     await fs.rename(tmpPath, sessionFile);
+    await fs.unlink(backupPath).catch((cleanupErr: unknown) => {
+      retainedBackupPath = backupPath;
+      params.debug?.(
+        `session file repair backup cleanup failed: ${cleanupErr instanceof Error ? cleanupErr.message : "unknown error"} (${path.basename(
+          backupPath,
+        )})`,
+      );
+    });
   } catch (err) {
     try {
       await fs.unlink(tmpPath);
@@ -324,6 +333,6 @@ export async function repairSessionFileIfNeeded(params: {
     rewrittenAssistantMessages,
     droppedBlankUserMessages,
     rewrittenUserMessages,
-    backupPath,
+    ...(retainedBackupPath ? { backupPath: retainedBackupPath } : {}),
   };
 }


### PR DESCRIPTION
## Summary

- Delete transient `.bak-*` repair snapshots after a successful atomic session-file repair.
- Only report `backupPath` when cleanup fails and the backup is actually retained.
- Update repair tests to assert no `.bak-*` files remain after successful repair.

## Verification

- `node scripts/run-vitest.mjs run src/agents/session-file-repair.test.ts --config test/vitest/vitest.agents-core.config.ts`
- `corepack pnpm tsgo:core:test`
- `corepack pnpm exec oxlint src/agents/session-file-repair.ts src/agents/session-file-repair.test.ts`
- Internal-reference scan: PASS — no blocking issues found.

## AI review plan

First pass: @claude review + @codex review. Fallback/final signal only if needed: @copilot.
