### PR TITLE
fix: channels with only {enabled: true} config are skipped at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/startup: treat channels whose config contains only `enabled: true` as meaningfully configured, so explicitly enabled channels are no longer skipped at Gateway startup. Refs #77946.
 - Diagnostics: keep webhook/message OTEL attributes and Prometheus delivery labels low-cardinality and omit raw chat/message IDs from spans, so progress-draft and message-tool modes do not leak high-cardinality messaging identifiers.
 - Google Meet: stop advertising legacy `mode: "realtime"` to agents and config UIs, while keeping it as a hidden compatibility alias for `mode: "agent"`, so new joins use the STT -> OpenClaw agent -> TTS path instead of selecting the direct realtime voice fallback.
 - Google Meet: add `chrome.audioBufferBytes` for generated command-pair SoX audio commands and lower the default buffer from SoX's 8192 bytes to 4096 bytes to reduce Chrome talk-back latency.

--- a/src/channels/config-presence.test.ts
+++ b/src/channels/config-presence.test.ts
@@ -54,9 +54,9 @@ afterEach(() => {
 });
 
 describe("config presence", () => {
-  it("treats enabled-only channel sections as not meaningfully configured", () => {
+  it("treats channels as meaningfully configured when enabled or has non-enabled keys", () => {
     expect(hasMeaningfulChannelConfig({ enabled: false })).toBe(false);
-    expect(hasMeaningfulChannelConfig({ enabled: true })).toBe(false);
+    expect(hasMeaningfulChannelConfig({ enabled: true })).toBe(true);
     expect(hasMeaningfulChannelConfig({})).toBe(false);
     expect(hasMeaningfulChannelConfig({ homeserver: "https://matrix.example.org" })).toBe(true);
   });
@@ -70,6 +70,19 @@ describe("config presence", () => {
       env,
       expectedIds: [],
       expectedConfigured: false,
+      options: { includePersistedAuthState: false },
+    });
+  });
+
+  it("detects channel config with only {enabled: true} as meaningfully configured", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const cfg = { channels: { matrix: { enabled: true } } };
+
+    expectPotentialConfiguredChannelCase({
+      cfg,
+      env,
+      expectedIds: ["matrix"],
+      expectedConfigured: true,
       options: { includePersistedAuthState: false },
     });
   });

--- a/src/channels/config-presence.ts
+++ b/src/channels/config-presence.ts
@@ -37,6 +37,7 @@ export function hasMeaningfulChannelConfig(value: unknown): boolean {
   if (!isRecord(value)) {
     return false;
   }
+  if (value.enabled === true) return true;
   return Object.keys(value).some((key) => key !== "enabled");
 }
 

--- a/src/channels/config-presence.ts
+++ b/src/channels/config-presence.ts
@@ -37,7 +37,9 @@ export function hasMeaningfulChannelConfig(value: unknown): boolean {
   if (!isRecord(value)) {
     return false;
   }
-  if (value.enabled === true) return true;
+  if (value.enabled === true) {
+    return true;
+  }
   return Object.keys(value).some((key) => key !== "enabled");
 }
 


### PR DESCRIPTION
## Problem

`hasMeaningfulChannelConfig` in `src/channels/config-presence.ts` filters out channel configs that only contain `{"enabled": true}`. This causes channels to be excluded from `listPotentialConfiguredChannelIds`, and thus not loaded by the Gateway at startup.

`qqbot` channel works because it also has `appId` and `clientSecret` keys. But any channel that only sets `enabled: true` is silently skipped.

## Fix

Added early return `if (value.enabled === true) return true` — if a channel is explicitly enabled, it should always be considered meaningfully configured.

## Before/After

| Config | Before | After |
|--------|--------|-------|
| `{"enabled": true}` | ❌ skipped | ✅ loaded |
| `{"enabled": true, "appId": "x"}` | ✅ loaded | ✅ loaded |
| `{"enabled": false}` | ❌ skipped | ❌ skipped |
| `{}` | ❌ skipped | ❌ skipped |