### PR TITLE
fix: reuse plugin metadata snapshot for provider runtime loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK/fs-safe: route browser, media, channel, and QA external output producers through staged fs-safe writes before final publication. (#78768)
 - Plugin SDK/fs-safe: rename the public temp workspace helpers to `tempWorkspace`, `withTempWorkspace`, `tempWorkspaceSync`, and `withTempWorkspaceSync`, matching the cleaner `@openclaw/fs-safe` API before the package is published.
 - Core/performance: trim reply payload routing, heartbeat filtering, tool display, core tool assembly, channel directory, task status, and Slack approval formatting helper chains with direct bounded scans. Thanks @vincentkoc.
+- Providers/performance: reuse the current workspace-compatible plugin metadata snapshot while planning provider runtime loads, catalog hooks, synthetic auth, and external auth profiles, reducing repeated plugin registry/index rebuilds on warm provider paths without changing provider selection and fixing snapshot misses from workspace path mismatches (#77926). Thanks @rolandrscheel.
 - Control UI/performance: keep chat, config, and channel refreshes responsive by decoupling slow history/schema/status work, reducing the client history window, and logging over-budget chat/config renders. Refs #77060, #45698, #47979, #44107. Thanks @BunsDev.
 - Gateway/diagnostics: add startup phase spans, active work labels, stale terminal bridge markers, and opt-in sync-I/O tracing in `pnpm gateway:watch` so slow Gateway turns are easier to attribute from logs and stability diagnostics.
 - QA/Mantis: add visual desktop tasks with Crabbox MP4 recording, screenshot capture, and optional image-understanding assertions, and preserve video artifacts in Mantis before/after reports.
@@ -524,7 +525,6 @@ Docs: https://docs.openclaw.ai
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.
 - Gateway/startup: keep model-catalog test helpers, run-session lookup code, QR pairing helpers, and TypeBox memory-tool schema construction out of hot startup import paths, reducing default gateway benchmark plugin-load and memory pressure.
-- Control UI/performance: record browser long animation frame or long task entries in the debug event log when supported, making slow dashboard renders easier to attribute from the UI.
 - Slack/streaming: add `streaming.progress.render: "rich"` for Block Kit progress drafts backed by structured progress line data.
 - Slack/streaming: keep the newest rich progress lines when Block Kit limits trim long progress drafts. Thanks @vincentkoc.
 - Channels/streaming: cap progress-draft tool lines by default so edited progress boxes avoid jumpy reflow from long wrapped lines.
@@ -555,10 +555,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenRouter: expand app-attribution categories so OpenClaw advertises coding, programming, writing, chat, and personal-agent usage on verified OpenRouter routes. Thanks @vincentkoc.
 - Plugins/update: make package upgrades swap pnpm/npm-prefix installs cleanly, keep legacy plugin install runtime chunks working, and on the beta channel fall back default-line npm plugins to default/latest when plugin beta releases are missing or fail install validation. Thanks @vincentkoc and @joshavant.
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.
-- Exec approvals: add a tree-sitter-backed shell command explainer for future approval and command-review surfaces. (#75004) Thanks @jesse-merhi.
-- Agents/sandbox: store sandbox container and browser registry entries as per-runtime shard files, reducing unrelated session lock contention while `openclaw doctor --fix` migrates legacy monolithic registry files. (#74831) Thanks @luckylhb90.
 - Plugins/ClawHub: annotate 429 errors from ClawHub with the reset window from `RateLimit-Reset`/`Retry-After` and append a `Sign in for higher rate limits.` hint when the request was unauthenticated, so users can see when downloads will recover and how to lift the cap. Thanks @romneyda.
-- Plugins/runtime state: add `registerIfAbsent` for atomic keyed-store dedupe claims that return whether a plugin successfully claimed a key without overwriting an existing live value. Thanks @amknight.
 - Plugin SDK: add plugin-owned `SessionEntry` slot projection and scoped trusted-policy session extension reads. (#75609; replaces part of #73384/#74483) Thanks @100yenadmin.
 - Sandbox/Windows: accept drive-absolute Docker bind sources while keeping sandbox blocked-path and allowed-root policy comparisons Windows-case-insensitive. (#42174) Thanks @6607changchun.
 
@@ -831,9 +828,7 @@ Docs: https://docs.openclaw.ai
 - Discord/status: let explicit reaction tool calls opt into tracking later tool progress with `trackToolCalls: true`, share tool display emoji mapping, and surface degraded Discord transport or gateway event-loop starvation in status output. (#76327) Thanks @joshavant.
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.
-- Agents/sandbox: store sandbox container and browser registry entries as per-runtime shard files, reducing unrelated session lock contention while `openclaw doctor --fix` migrates legacy monolithic registry files. (#74831) Thanks @luckylhb90.
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
-- Exec approvals: add a tree-sitter-backed shell command explainer for future approval and command-review surfaces. (#75004) Thanks @jesse-merhi.
 - QA/Mantis: add a `pnpm openclaw qa mantis discord-smoke` runner and manual GitHub workflow that verify the Mantis Discord bot can see the configured guild/channel, post a smoke message, add a reaction, and upload artifacts.
 
 ### Fixes

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveUserPath } from "../utils.js";
 import {
   clearCurrentPluginMetadataSnapshotState,
   getCurrentPluginMetadataSnapshotState,
@@ -10,6 +12,16 @@ import {
   type ResolvePluginControlPlaneContextParams,
 } from "./plugin-control-plane-context.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
+
+function normalizeWorkspaceDir(
+  dir: string | undefined,
+  env?: NodeJS.ProcessEnv,
+): string | undefined {
+  if (dir === undefined) {
+    return undefined;
+  }
+  return resolveUserPath(dir, env);
+}
 
 export function resolvePluginMetadataControlPlaneFingerprint(
   config?: OpenClawConfig,
@@ -92,9 +104,11 @@ export function getCurrentPluginMetadataSnapshot(
       return undefined;
     }
   }
-  const requestedWorkspaceDir =
+  const requestedWorkspaceDir = normalizeWorkspaceDir(
     params.workspaceDir ??
-    (params.allowWorkspaceScopedSnapshot === true ? snapshot.workspaceDir : undefined);
+      (params.allowWorkspaceScopedSnapshot === true ? snapshot.workspaceDir : undefined),
+    params.env,
+  );
   if (params.config) {
     const requestedConfigFingerprint = resolvePluginMetadataControlPlaneFingerprint(params.config, {
       env: params.env,
@@ -130,12 +144,13 @@ export function getCurrentPluginMetadataSnapshot(
       return undefined;
     }
   }
-  if (snapshot.workspaceDir !== undefined && requestedWorkspaceDir === undefined) {
+  const snapshotWorkspaceDir = normalizeWorkspaceDir(snapshot.workspaceDir, params.env);
+  if (snapshotWorkspaceDir !== undefined && requestedWorkspaceDir === undefined) {
     return undefined;
   }
   if (
     requestedWorkspaceDir !== undefined &&
-    (snapshot.workspaceDir ?? "") !== (requestedWorkspaceDir ?? "")
+    (snapshotWorkspaceDir ?? "") !== (requestedWorkspaceDir ?? "")
   ) {
     return undefined;
   }

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -7,7 +7,7 @@ import {
   loadPluginMetadataSnapshot,
   type PluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.js";
-import { getActivePluginRegistryWorkspaceDirFromState } from "./runtime-state.js";
+import { getActivePluginRegistryWorkspaceDirFromState } from "./runtime-state-key.js";
 
 type ManifestModelIdNormalizationLookupParams = {
   config?: OpenClawConfig;

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -3,6 +3,7 @@ import {
   getActiveDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
 } from "../infra/diagnostics-timeline.js";
+import { resolveUserPath } from "../utils.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
@@ -245,7 +246,9 @@ function loadPluginMetadataSnapshotImpl(
       policyHash: index.policyHash,
       workspaceDir: params.workspaceDir,
     }),
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    ...(params.workspaceDir
+      ? { workspaceDir: resolveUserPath(params.workspaceDir, params.env) }
+      : {}),
     index,
     registryDiagnostics: registryResult.diagnostics,
     manifestRegistry,

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
 import { resolvePluginDiscoveryProvidersRuntime } from "./provider-discovery.runtime.js";
 import {
@@ -159,10 +160,17 @@ function resolveProviderPluginsForCatalogHooks(params: {
 }): ProviderPlugin[] {
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
   const env = params.env ?? process.env;
+  const metadataSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    workspaceDir,
+    env,
+  });
   const onlyPluginIds = resolveCatalogHookProviderPluginIds({
     config: params.config,
     workspaceDir,
     env,
+    registry: metadataSnapshot?.index,
+    manifestRegistry: metadataSnapshot?.manifestRegistry,
   });
   if (onlyPluginIds.length === 0) {
     return [];
@@ -847,6 +855,13 @@ export function resolveProviderSyntheticAuthWithPlugin(params: {
   context: ProviderResolveSyntheticAuthContext;
 }) {
   const providerRefs = resolveProviderHookRefs(params.provider, params.context.providerConfig);
+  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
+  const env = params.env ?? process.env;
+  const metadataSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    workspaceDir,
+    env,
+  });
   const discoveryPluginIds = [
     ...new Set(
       providerRefs.flatMap(
@@ -854,8 +869,9 @@ export function resolveProviderSyntheticAuthWithPlugin(params: {
           resolveOwningPluginIdsForProvider({
             provider,
             config: params.config,
-            workspaceDir: params.workspaceDir,
-            env: params.env,
+            workspaceDir,
+            env,
+            manifestRegistry: metadataSnapshot?.manifestRegistry,
           }) ?? [],
       ),
     ),
@@ -864,10 +880,11 @@ export function resolveProviderSyntheticAuthWithPlugin(params: {
     discoveryPluginIds.length > 0
       ? resolvePluginDiscoveryProvidersRuntime({
           config: params.config,
-          workspaceDir: params.workspaceDir,
-          env: params.env,
+          workspaceDir,
+          env,
           onlyPluginIds: discoveryPluginIds,
           discoveryEntriesOnly: true,
+          pluginMetadataSnapshot: metadataSnapshot,
         })
       : []
   ).find((provider) => matchesAnyProviderPluginRef(provider, providerRefs));
@@ -901,8 +918,9 @@ export function resolveProviderSyntheticAuthWithPlugin(params: {
   if (providerRefs.length === 1) {
     return resolvePluginDiscoveryProvidersRuntime({
       config: params.config,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
+      workspaceDir,
+      env,
+      pluginMetadataSnapshot: metadataSnapshot,
     })
       .find((provider) => matchesAnyProviderPluginRef(provider, providerRefs))
       ?.resolveSyntheticAuth?.(params.context);
@@ -918,16 +936,25 @@ export function resolveExternalAuthProfilesWithPlugins(params: {
 }): ProviderExternalAuthProfile[] {
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
   const env = params.env ?? process.env;
+  const metadataSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    workspaceDir,
+    env,
+  });
   const externalAuthPluginIds = resolveExternalAuthProfileProviderPluginIds({
     config: params.config,
     workspaceDir,
     env,
+    registry: metadataSnapshot?.index,
+    manifestRegistry: metadataSnapshot?.manifestRegistry,
   });
   const declaredPluginIds = new Set(externalAuthPluginIds);
   const fallbackPluginIds = resolveExternalAuthProfileCompatFallbackPluginIds({
     config: params.config,
     workspaceDir,
     env,
+    registry: metadataSnapshot?.index,
+    manifestRegistry: metadataSnapshot?.manifestRegistry,
     declaredPluginIds,
   });
   const pluginIds = [...new Set([...externalAuthPluginIds, ...fallbackPluginIds])].toSorted(

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -2,6 +2,7 @@ import { withActivatedPluginIds } from "./activation-context.js";
 import { resolveBundledPluginCompatibleActivationInputs } from "./activation-context.js";
 import { resolveManifestActivationPluginIds } from "./activation-planner.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import {
   getRuntimePluginRegistryForLoadOptions,
   isPluginRegistryLoadInFlight,
@@ -36,6 +37,7 @@ function resolveExplicitProviderOwnerPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  manifestRegistry?: Parameters<typeof resolveOwningPluginIdsForProvider>[0]["manifestRegistry"];
 }): string[] {
   return dedupeSortedPluginIds(
     params.providerRefs.flatMap((provider) => {
@@ -47,6 +49,7 @@ function resolveExplicitProviderOwnerPluginIds(params: {
         config: params.config,
         workspaceDir: params.workspaceDir,
         env: params.env,
+        manifestRecords: params.manifestRegistry?.plugins,
       });
       if (plannedPluginIds.length > 0) {
         return plannedPluginIds;
@@ -64,6 +67,7 @@ function resolveExplicitProviderOwnerPluginIds(params: {
           config: params.config,
           workspaceDir: params.workspaceDir,
           env: params.env,
+          manifestRecords: params.manifestRegistry?.plugins,
         });
         if (apiOwnerPluginIds.length > 0) {
           return apiOwnerPluginIds;
@@ -73,6 +77,7 @@ function resolveExplicitProviderOwnerPluginIds(params: {
           config: params.config,
           workspaceDir: params.workspaceDir,
           env: params.env,
+          manifestRegistry: params.manifestRegistry,
         });
         if (legacyApiOwnerPluginIds?.length) {
           return legacyApiOwnerPluginIds;
@@ -86,6 +91,7 @@ function resolveExplicitProviderOwnerPluginIds(params: {
           config: params.config,
           workspaceDir: params.workspaceDir,
           env: params.env,
+          manifestRegistry: params.manifestRegistry,
         }) ?? []
       );
     }),
@@ -112,12 +118,18 @@ function resolvePluginProviderLoadBase(params: {
 }) {
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
+  const metadataSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    workspaceDir,
+    env,
+  });
   const providerOwnedPluginIds = params.providerRefs?.length
     ? resolveExplicitProviderOwnerPluginIds({
         providerRefs: params.providerRefs,
         config: params.config,
         workspaceDir,
         env,
+        manifestRegistry: metadataSnapshot?.manifestRegistry,
       })
     : [];
   const modelOwnedPluginIds = params.modelRefs?.length
@@ -126,6 +138,7 @@ function resolvePluginProviderLoadBase(params: {
         config: params.config,
         workspaceDir,
         env,
+        manifestRegistry: metadataSnapshot?.manifestRegistry,
       })
     : [];
   const requestedPluginIds =
@@ -152,6 +165,8 @@ function resolvePluginProviderLoadBase(params: {
     requestedPluginIds,
     explicitOwnerPluginIds,
     rawConfig: params.config,
+    registry: metadataSnapshot?.index,
+    manifestRegistry: metadataSnapshot?.manifestRegistry,
   };
 }
 
@@ -164,6 +179,8 @@ function resolveSetupProviderPluginLoadState(
     workspaceDir: base.workspaceDir,
     env: base.env,
     onlyPluginIds: base.requestedPluginIds,
+    registry: base.registry,
+    manifestRegistry: base.manifestRegistry,
     includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
   });
   const explicitOwnerPluginIds = resolveDiscoverableProviderOwnerPluginIds({
@@ -171,6 +188,8 @@ function resolveSetupProviderPluginLoadState(
     config: params.config,
     workspaceDir: base.workspaceDir,
     env: base.env,
+    registry: base.registry,
+    manifestRegistry: base.manifestRegistry,
     includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
   });
   const setupPluginIds = mergeExplicitOwnerPluginIds(providerPluginIds, explicitOwnerPluginIds);
@@ -195,6 +214,7 @@ function resolveSetupProviderPluginLoadState(
       pluginSdkResolution: params.pluginSdkResolution,
       cache: params.cache ?? false,
       activate: params.activate ?? false,
+      ...(base.manifestRegistry ? { manifestRegistry: base.manifestRegistry } : {}),
     },
   );
   return { loadOptions };
@@ -209,6 +229,8 @@ function resolveRuntimeProviderPluginLoadState(
     config: base.rawConfig,
     workspaceDir: base.workspaceDir,
     env: base.env,
+    registry: base.registry,
+    manifestRegistry: base.manifestRegistry,
     includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
   });
   const runtimeRequestedPluginIds =
@@ -230,7 +252,11 @@ function resolveRuntimeProviderPluginLoadState(
       enablement: "allowlist",
       vitest: params.bundledProviderVitestCompat,
     },
-    resolveCompatPluginIds: resolveBundledProviderCompatPluginIds,
+    resolveCompatPluginIds: (compatParams) =>
+      resolveBundledProviderCompatPluginIds({
+        ...compatParams,
+        manifestRegistry: base.manifestRegistry,
+      }),
   });
   const config = params.bundledProviderVitestCompat
     ? withBundledProviderVitestCompat({
@@ -245,6 +271,8 @@ function resolveRuntimeProviderPluginLoadState(
       workspaceDir: base.workspaceDir,
       env: base.env,
       onlyPluginIds: runtimeRequestedPluginIds,
+      registry: base.registry,
+      manifestRegistry: base.manifestRegistry,
     }),
     explicitOwnerPluginIds,
   );
@@ -262,6 +290,7 @@ function resolveRuntimeProviderPluginLoadState(
       pluginSdkResolution: params.pluginSdkResolution,
       cache: params.cache ?? true,
       activate: params.activate ?? false,
+      ...(base.manifestRegistry ? { manifestRegistry: base.manifestRegistry } : {}),
     },
   );
   return { loadOptions };

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { PluginAutoEnableResult } from "../config/plugin-auto-enable.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
+import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginRegistrySnapshot } from "./plugin-registry.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { ProviderPlugin } from "./types.js";
@@ -16,6 +17,12 @@ type LoadOpenClawPlugins = typeof import("./loader.js").loadOpenClawPlugins;
 type IsPluginRegistryLoadInFlight = typeof import("./loader.js").isPluginRegistryLoadInFlight;
 type LoadPluginManifestRegistry =
   typeof import("./manifest-registry.js").loadPluginManifestRegistry;
+type ClearCurrentPluginMetadataSnapshot =
+  typeof import("./current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
+type GetCurrentPluginMetadataSnapshot =
+  typeof import("./current-plugin-metadata-snapshot.js").getCurrentPluginMetadataSnapshot;
+type SetCurrentPluginMetadataSnapshot =
+  typeof import("./current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
 type ApplyPluginAutoEnable = typeof import("../config/plugin-auto-enable.js").applyPluginAutoEnable;
 type SetActivePluginRegistry = typeof import("./runtime.js").setActivePluginRegistry;
 
@@ -36,6 +43,9 @@ let resolveExternalAuthProfileProviderPluginIds: typeof import("./providers.js")
 let resolveDiscoveredProviderPluginIds: typeof import("./providers.js").resolveDiscoveredProviderPluginIds;
 let resolveDiscoverableProviderOwnerPluginIds: typeof import("./providers.js").resolveDiscoverableProviderOwnerPluginIds;
 let resolvePluginProviders: typeof import("./providers.runtime.js").resolvePluginProviders;
+let clearCurrentPluginMetadataSnapshot: ClearCurrentPluginMetadataSnapshot;
+let getCurrentPluginMetadataSnapshot: GetCurrentPluginMetadataSnapshot;
+let setCurrentPluginMetadataSnapshot: SetCurrentPluginMetadataSnapshot;
 let setActivePluginRegistry: SetActivePluginRegistry;
 
 function createManifestProviderPlugin(params: {
@@ -171,6 +181,43 @@ function createProviderRegistrySnapshotFixture(): PluginRegistrySnapshot {
     installRecords: {},
     plugins,
     diagnostics: [],
+  };
+}
+
+function createCurrentMetadataSnapshotFixture(params: {
+  index: PluginRegistrySnapshot;
+  plugins: PluginManifestRecord[];
+  workspaceDir?: string;
+}): PluginMetadataSnapshot {
+  const manifestRegistry = { plugins: params.plugins, diagnostics: [] };
+  return {
+    policyHash: params.index.policyHash,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    index: params.index,
+    registryDiagnostics: [],
+    manifestRegistry,
+    plugins: params.plugins,
+    diagnostics: [],
+    byPluginId: new Map(params.plugins.map((plugin) => [plugin.id, plugin])),
+    normalizePluginId: (pluginId) => pluginId,
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map(),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+    metrics: {
+      registrySnapshotMs: 0,
+      manifestRegistryMs: 0,
+      ownerMapsMs: 0,
+      totalMs: 0,
+      indexPluginCount: params.index.plugins.length,
+      manifestPluginCount: params.plugins.length,
+    },
   };
 }
 
@@ -428,6 +475,11 @@ describe("resolvePluginProviders", () => {
       resolveDiscoverableProviderOwnerPluginIds,
     } = await import("./providers.js"));
     ({ resolvePluginProviders } = await import("./providers.runtime.js"));
+    ({
+      clearCurrentPluginMetadataSnapshot,
+      getCurrentPluginMetadataSnapshot,
+      setCurrentPluginMetadataSnapshot,
+    } = await import("./current-plugin-metadata-snapshot.js"));
     ({ setActivePluginRegistry } = await import("./runtime.js"));
   });
 
@@ -457,7 +509,31 @@ describe("resolvePluginProviders", () => {
     expectOwningPluginIds("dynamic-provider", ["second-owner"]);
   });
 
+  it("reuses the current metadata snapshot while planning runtime provider loads", () => {
+    const workspaceDir = "/workspace/current-metadata";
+    const plugins = [
+      createManifestProviderPlugin({
+        id: "openai",
+        providerIds: ["openai", "openai-codex"],
+        enabledByDefault: true,
+      }),
+    ];
+    setManifestPlugins(plugins);
+    const index = createProviderRegistrySnapshotFixture();
+    const snapshot = createCurrentMetadataSnapshotFixture({ index, plugins, workspaceDir });
+    setCurrentPluginMetadataSnapshot(snapshot, { workspaceDir });
+    expect(getCurrentPluginMetadataSnapshot({ workspaceDir })).toBe(snapshot);
+    loadPluginManifestRegistryMock.mockClear();
+
+    resolvePluginProviders({ providerRefs: ["openai"], workspaceDir });
+
+    expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
+    expectLastRuntimeRegistryLoad({ onlyPluginIds: ["openai"] });
+    expect(getLastRuntimeRegistryCall().manifestRegistry).toBe(snapshot.manifestRegistry);
+  });
+
   beforeEach(() => {
+    clearCurrentPluginMetadataSnapshot();
     setActivePluginRegistry(createEmptyPluginRegistry());
     resolveRuntimePluginRegistryMock.mockReset();
     getRuntimePluginRegistryForLoadOptionsMock.mockReset();

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -90,7 +90,9 @@ function resolveProviderOwnerPluginIds(
   }
   const pluginIdSet = new Set(params.pluginIds);
   const registry = loadProviderRegistrySnapshot(params);
-  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry, {
+    manifestRegistry: params.manifestRegistry,
+  });
   return listRegistryPluginIds(
     registry,
     (plugin) => pluginIdSet.has(plugin.pluginId) && params.isEligible(plugin, normalizedConfig),
@@ -160,7 +162,9 @@ export function resolveBundledProviderCompatPluginIds(params: {
 export function resolveEnabledProviderPluginIds(params: ProviderRegistryLoadParams): string[] {
   const { registry, onlyPluginIdSet } = loadScopedProviderRegistry(params);
   const providerSurfacePluginIds = resolveProviderSurfacePluginIdSet({ ...params, registry });
-  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry, {
+    manifestRegistry: params.manifestRegistry,
+  });
   return listRegistryPluginIds(
     registry,
     (plugin) =>
@@ -178,6 +182,8 @@ export function resolveExternalAuthProfileProviderPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  registry?: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
 }): string[] {
   return resolveRegistryManifestContractPluginIds({
     ...params,
@@ -192,6 +198,8 @@ function resolveRegistryManifestContractPluginIds(params: {
   env?: PluginLoadOptions["env"];
   origin?: PluginRegistryRecord["origin"];
   onlyPluginIds?: readonly string[];
+  registry?: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
 }): string[] {
   const { registry, onlyPluginIdSet } = loadScopedProviderRegistry(params);
   return resolveManifestRegistry({
@@ -219,6 +227,8 @@ export function resolveExternalAuthProfileCompatFallbackPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  registry?: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
   declaredPluginIds?: ReadonlySet<string>;
 }): string[] {
   // Deprecated compatibility fallback for provider plugins that still implement
@@ -228,7 +238,9 @@ export function resolveExternalAuthProfileCompatFallbackPluginIds(params: {
     params.declaredPluginIds ?? new Set(resolveExternalAuthProfileProviderPluginIds(params));
   const registry = loadProviderRegistrySnapshot(params);
   const providerSurfacePluginIds = resolveProviderSurfacePluginIdSet({ ...params, registry });
-  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry, {
+    manifestRegistry: params.manifestRegistry,
+  });
   return listRegistryPluginIds(
     registry,
     (plugin) =>
@@ -256,7 +268,9 @@ export function resolveDiscoveredProviderPluginIds(params: {
   const providerSurfacePluginIds = resolveProviderSurfacePluginIdSet({ ...params, registry });
   const shouldFilterUntrustedWorkspacePlugins = params.includeUntrustedWorkspacePlugins === false;
   const shouldFilterBundledByAllowlist = params.config?.plugins?.bundledDiscovery !== "compat";
-  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry, {
+    manifestRegistry: params.manifestRegistry,
+  });
   return listRegistryPluginIds(registry, (plugin) => {
     if (
       !(
@@ -313,6 +327,8 @@ export function resolveDiscoverableProviderOwnerPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  registry?: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
   includeUntrustedWorkspacePlugins?: boolean;
 }): string[] {
   const shouldFilterUntrustedWorkspacePlugins = params.includeUntrustedWorkspacePlugins === false;
@@ -358,6 +374,8 @@ export function resolveActivatableProviderOwnerPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  registry?: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
   includeUntrustedWorkspacePlugins?: boolean;
 }): string[] {
   return resolveProviderOwnerPluginIds({
@@ -601,10 +619,14 @@ export function resolveNonBundledProviderPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  registry?: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
 }): string[] {
   const registry = loadProviderRegistrySnapshot(params);
   const providerSurfacePluginIds = resolveProviderSurfacePluginIdSet({ ...params, registry });
-  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry, {
+    manifestRegistry: params.manifestRegistry,
+  });
   return listRegistryPluginIds(
     registry,
     (plugin) =>
@@ -622,10 +644,14 @@ export function resolveCatalogHookProviderPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  registry?: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
 }): string[] {
   const registry = loadProviderRegistrySnapshot(params);
   const providerSurfacePluginIds = resolveProviderSurfacePluginIdSet({ ...params, registry });
-  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry, {
+    manifestRegistry: params.manifestRegistry,
+  });
   const enabledProviderPluginIds = listRegistryPluginIds(
     registry,
     (plugin) =>

--- a/src/plugins/runtime-state-key.ts
+++ b/src/plugins/runtime-state-key.ts
@@ -1,0 +1,13 @@
+export const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
+
+type GlobalRegistryWorkspaceState = typeof globalThis & {
+  [PLUGIN_REGISTRY_STATE]?: {
+    workspaceDir?: string | null;
+  };
+};
+
+export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
+  return (
+    (globalThis as GlobalRegistryWorkspaceState)[PLUGIN_REGISTRY_STATE]?.workspaceDir ?? undefined
+  );
+}

--- a/src/plugins/runtime-state.ts
+++ b/src/plugins/runtime-state.ts
@@ -1,6 +1,10 @@
 import type { PluginRegistry } from "./registry-types.js";
+import {
+  getActivePluginRegistryWorkspaceDirFromState as getWorkspaceDirFromState,
+  PLUGIN_REGISTRY_STATE,
+} from "./runtime-state-key.js";
 
-export const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
+export { PLUGIN_REGISTRY_STATE };
 
 export type RuntimeTrackedPluginRegistry = PluginRegistry;
 
@@ -35,6 +39,5 @@ export function getActivePluginChannelRegistryFromState(): RuntimeTrackedPluginR
 }
 
 export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
-  const state = getPluginRegistryState();
-  return state?.workspaceDir ?? undefined;
+  return getWorkspaceDirFromState();
 }


### PR DESCRIPTION
## Summary

- Problem: warm provider runtime/auth paths could rebuild plugin registry metadata and installed-plugin indexes even when the Gateway already had a compatible current plugin metadata snapshot.
- Why it matters: provider lookups run on model/auth/catalog paths, so repeated registry/index rebuilds showed up as multi-second CPU hot spots after the provider-resolution-scope cache work.
- What changed: provider runtime load planning, catalog hook lookup, synthetic auth, external auth profile discovery, and provider activation helpers now reuse the current workspace/config/env-compatible plugin metadata snapshot by passing its registry and manifest registry through existing helpers.
- What did NOT change (scope boundary): provider selection, auth semantics, plugin activation policy, and stale-cache compatibility checks remain unchanged; this only avoids redundant metadata/index work when the current snapshot is compatible.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #77848
- Related #77519
- Related #77532
- Related #78461
- Related #77926
- [x] This PR fixes a bug or regression
## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count.

- Behavior or issue addressed: repeated plugin registry / installed-plugin-index rebuilds on warm provider runtime and auth/profile paths after the provider-resolution-scope cache from #77848.
- Real environment tested: live OpenClaw Gateway on Linux 6.14.0-33-generic x86_64, OpenClaw 2026.5.4 installed runtime, Node v22.22.2, pnpm 10.33.2, real agent workspace/config/plugins. The before profile is the V2-only provider-resolution-scope hotpatch state; the after profile is V2+this snapshot-reuse patch on the same host.
- Exact steps or command run after this patch:
  1. Applied the installed-dist hotpatch generated from this source change on top of the V2 provider-resolution-scope patch.
  2. Restarted the Gateway.
  3. Captured a 120s live CPU profile while exercising chat/model-backed paths:
     ```bash
     cd /data/cpuprofile
     NODE_PATH="$(npm root -g)" node ./profile-node.js 120000 /tmp/openclaw_after_fix.cpuprofile
     ```
  4. Extracted inclusive totals:
     ```bash
     NODE_PATH="$(npm root -g)" node /data/cpuprofile/cpuprofile-total-times.js /tmp/openclaw_after_fix.cpuprofile 1 120
     ```
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  ```text
  # /tmp/openclaw_after_fix.cpuprofile, 120.095s root
  77.957s    77.957s  (idle)
  13.650s      3.2ms  loadPluginRegistrySnapshotWithMetadata  /usr/lib/node_modules/openclaw/dist/plugin-registry-PrQukci_.js:135:48
  12.469s      3.2ms  loadInstalledPluginIndex  /usr/lib/node_modules/openclaw/dist/installed-plugin-index-store-D3X0T5Yi.js:1306:34
  12.466s     20.4ms  buildInstalledPluginIndex  /usr/lib/node_modules/openclaw/dist/installed-plugin-index-store-D3X0T5Yi.js:1275:35
  11.303s      0.0ms  resolveProviderPluginsForHooks  /usr/lib/node_modules/openclaw/dist/provider-runtime-D2wRmWvE.js:86:40
   6.425s      2.1ms  resolveExternalAuthProfilesWithPlugins  /usr/lib/node_modules/openclaw/dist/provider-runtime-D2wRmWvE.js:571:48
   6.216s      7.5ms  resolveRuntimeProviderPluginLoadState  /usr/lib/node_modules/openclaw/dist/providers.runtime-DlSx4r2O.js:154:47
   4.732s      0.0ms  resolveCatalogProviderApiKey  /usr/lib/node_modules/openclaw/dist/models-config-BNy6yvyP.js:320:40
   4.693s      0.0ms  runProviderCatalogWithTimeout  /usr/lib/node_modules/openclaw/dist/models-config-BNy6yvyP.js:384:45
  ```
- Observed result after fix: non-idle CPU in the 120s window dropped from 76.921s to 42.138s, with the idle increase (+34.760s) matching the non-idle reduction (-34.783s). The target hot spots dropped materially: `loadPluginRegistrySnapshotWithMetadata` 33.183s -> 13.650s, `loadInstalledPluginIndex` 29.978s -> 12.469s, `buildInstalledPluginIndex` 29.971s -> 12.466s, `resolveProviderPluginsForHooks` 26.826s -> 11.303s, and `resolveRuntimeProviderPluginLoadState` 19.152s -> 6.216s.
- What was not tested: this was a live same-host profile comparison, not a perfectly isolated synthetic benchmark; workload/idle mix can vary between windows. I did not run the entire repository test suite.
- Before evidence (optional but encouraged):
  ```text
  # /tmp/openclaw_running.cpuprofile, V2-only provider-resolution-scope state, 120.118s root
  43.197s    43.197s  (idle)
  33.183s     11.8ms  loadPluginRegistrySnapshotWithMetadata  /usr/lib/node_modules/openclaw/dist/plugin-registry-PrQukci_.js:135:48
  29.978s      6.4ms  loadInstalledPluginIndex  /usr/lib/node_modules/openclaw/dist/installed-plugin-index-store-D3X0T5Yi.js:1306:34
  29.971s     36.2ms  buildInstalledPluginIndex  /usr/lib/node_modules/openclaw/dist/installed-plugin-index-store-D3X0T5Yi.js:1275:35
  26.826s      1.1ms  resolveProviderPluginsForHooks  /usr/lib/node_modules/openclaw/dist/provider-runtime-D2wRmWvE.js:83:40
  19.734s      2.2ms  resolveCatalogProviderApiKey  /usr/lib/node_modules/openclaw/dist/models-config-BNy6yvyP.js:320:40
  19.567s      0.0ms  runProviderCatalogWithTimeout  /usr/lib/node_modules/openclaw/dist/models-config-BNy6yvyP.js:384:45
  19.152s      2.2ms  resolveRuntimeProviderPluginLoadState  /usr/lib/node_modules/openclaw/dist/providers.runtime-DlSx4r2O.js:133:47
  17.313s      1.1ms  resolveProviderSyntheticAuthWithPlugin  /usr/lib/node_modules/openclaw/dist/provider-runtime-D2wRmWvE.js:486:48
   9.251s      1.1ms  resolveExternalAuthProfilesWithPlugins  /usr/lib/node_modules/openclaw/dist/provider-runtime-D2wRmWvE.js:551:48
  ```

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: provider runtime load planning and auth/profile lookup helpers accepted registry/manifest inputs but several warm call paths did not resolve and pass the current compatible plugin metadata snapshot, causing nested helpers to reload plugin registry metadata and installed-plugin indexes.
- Missing detection / guardrail: existing tests covered provider selection behavior but did not assert that runtime provider planning reuses the current metadata snapshot rather than rebuilding it.
- Contributing context (if known): #77848 reduced repeated provider-resolution work inside a catalog operation, which exposed the remaining registry/index rebuild cost on warm provider runtime paths.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/providers.test.ts`
- Scenario the test should lock in: `resolvePluginProviders` reuses the current metadata snapshot while planning runtime provider loads, including explicit provider owner and model-owner planning paths.
- Why this is the smallest reliable guardrail: it exercises the planning helper directly and verifies the snapshot-backed registry/manifest path without needing a live Gateway or plugin install scan.
- Existing test that already covers this (if any): related provider runtime, synthetic-auth discovery, and current-plugin-metadata-snapshot tests cover behavior compatibility around the changed helpers.
- If no new test is added, why not: N/A; a new regression test is added.

## User-visible / Behavior Changes

No intentional behavior/config changes. Users should only see lower CPU use and lower latency on affected warm provider runtime/auth/profile paths.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
provider runtime/auth lookup
  -> helper without snapshot
  -> load plugin registry metadata / installed-plugin index again
  -> select provider plugin

After:
provider runtime/auth lookup
  -> get current compatible metadata snapshot
  -> pass registry + manifest registry through helper stack
  -> select the same provider plugin without redundant registry/index rebuilds
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.14.0-33-generic x86_64
- Runtime/container: OpenClaw 2026.5.4 installed Gateway runtime, Node v22.22.2, pnpm 10.33.2
- Model/provider: live Gateway with configured provider plugins/auth profiles; profiling exercised model-backed chat/provider paths
- Integration/channel (if any): Webchat/direct Gateway session
- Relevant config (redacted): normal local `/data/.openclaw/openclaw.json`, secrets redacted/not included

### Steps

1. Apply the provider snapshot-reuse patch to the installed runtime and restart Gateway.
2. Capture 120s CPU profile with `/data/cpuprofile/profile-node.js` while exercising model-backed chat/provider paths.
3. Compare inclusive CPU totals with the V2-only 120s profile.
4. Run targeted plugin regression tests and type checks.

### Expected

- Provider behavior remains unchanged while warm provider runtime/auth/profile paths reuse compatible metadata snapshots.
- Repeated plugin registry/index rebuild totals drop in the live profile.

### Actual

- Provider/plugin tests and type checks passed.
- Live profile showed non-idle CPU dropping from 76.921s to 42.138s in a 120s window, and the target registry/index hot spots dropped materially.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added changelog entry under `CHANGELOG.md` Unreleased changes.
  - Ran `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/providers.test.ts src/plugins/provider-runtime.test.ts src/plugins/provider-runtime.synthetic-auth-discovery.test.ts src/plugins/current-plugin-metadata-snapshot.test.ts` -> 4 files / 111 tests passed.
  - Ran `pnpm -s tsgo:test --pretty false` -> exit 0.
  - Ran `pnpm -s check:test-types --pretty false` -> exit 0.
  - Ran `git diff --check` -> exit 0.
  - Captured and compared live 120s CPU profile totals from the installed OpenClaw Gateway runtime.
- Edge cases checked:
  - Snapshot reuse remains guarded by `getCurrentPluginMetadataSnapshot({ config, workspaceDir, env })` compatibility checks.
  - Existing explicit provider owner, model owner, synthetic auth discovery, external auth profiles, and catalog hook paths still resolve through the same provider-selection helpers.
- What you did **not** verify:
  - Full repository test suite.
  - A perfectly isolated synthetic benchmark with identical request mix; live same-host profiles were used for real behavior proof.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: reusing an incompatible stale snapshot could hide newly installed/disabled plugin metadata.
  - Mitigation: snapshot lookup goes through the existing config/workspace/env compatibility checks and falls back to normal loads when no compatible current snapshot exists.
- Risk: performance evidence is based on live profiles with different request/idle mix.
  - Mitigation: the comparison uses same-host 120s profiles and includes total idle/non-idle accounting plus specific hot-function totals; unit/type checks cover behavior compatibility.

