### PR TITLE
fix(ollama): suppress unreachable warning when OLLAMA_API_KEY exists but Ollama is not configured

### DIFF
--- a/extensions/ollama/provider-discovery.test.ts
+++ b/extensions/ollama/provider-discovery.test.ts
@@ -225,6 +225,28 @@ describe("Ollama provider", () => {
     });
   });
 
+  it("does not warn when Ollama is unreachable and OLLAMA_API_KEY is set but Ollama is not in config (#77942)", async () => {
+    // Users with a stale OLLAMA_API_KEY env var from a past setup should not see
+    // "Ollama could not be reached" on every invocation when Ollama is not configured.
+    await withoutAmbientOllamaEnv(async () => {
+      enableDiscoveryEnv();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:11434"));
+      vi.stubGlobal("fetch", withFetchPreconnect(fetchMock));
+
+      await runOllamaCatalog({
+        env: { OLLAMA_API_KEY: "real-stale-key", VITEST: "", NODE_ENV: "development" },
+      });
+
+      expect(
+        warnSpy.mock.calls.filter(([message]) => String(message).includes("Ollama")),
+      ).toHaveLength(0);
+      warnSpy.mockRestore();
+    });
+  });
+
   it("does not warn when Ollama is unreachable and not explicitly configured", async () => {
     await withoutAmbientOllamaEnv(async () => {
       enableDiscoveryEnv();

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -268,7 +268,13 @@ export async function resolveOllamaDiscoveryResult(params: {
 
   const configuredBaseUrl = readProviderBaseUrl(explicit);
   const provider = await params.buildProvider(configuredBaseUrl, {
-    quiet: !hasRealOllamaKey && !hasMeaningfulExplicitConfig,
+    // Suppress the "Ollama could not be reached" warning during ambient discovery
+    // (no explicit Ollama provider config). A stale OLLAMA_API_KEY env var or
+    // auth-profile key from a past setup triggers discovery, but the user hasn't
+    // opted Ollama back in — noisy unreachable warnings corrupt programmatic
+    // stderr consumers (CI scripts, frontends). Only warn when the user has
+    // explicitly configured Ollama (models, baseUrl, apiKey, etc.).
+    quiet: !hasMeaningfulExplicitConfig,
   });
   if (provider.models?.length === 0 && !ollamaKey && !explicit?.apiKey) {
     return null;


### PR DESCRIPTION
Fixes #77942

## Root cause

`resolveOllamaDiscoveryResult` computes the `quiet` flag as:

```typescript
quiet: !hasRealOllamaKey && !hasMeaningfulExplicitConfig,
```

When a user has `OLLAMA_API_KEY` set in their environment from a previous Ollama setup — but has since removed Ollama from their config — `hasRealOllamaKey` is `true` (the key is a real key, not the synthetic `"ollama-local"` marker). This makes `quiet = false`, so when the ambient discovery probe finds Ollama unreachable, `buildOllamaProvider` emits:

```
Ollama could not be reached at http://127.0.0.1:11434.
```

on **every CLI invocation**, even for unrelated commands like `openclaw agents list --json`.

The `!hasRealOllamaKey` condition was intended to distinguish "user has a key, so they care about Ollama" from "this is just the local synthetic marker". But a real key from a past setup doesn't mean the user has opted Ollama back in — the absence of any explicit Ollama config in `openclaw.json` is the correct signal.

## Fix

Remove `!hasRealOllamaKey` from the `quiet` expression. Ambient discovery is always silent when there is no explicit Ollama config (`hasMeaningfulExplicitConfig = false`). The warn is only useful when the user has explicitly configured Ollama (models, custom baseUrl, apiKey, etc.) and it fails to connect.

```typescript
// Before
quiet: !hasRealOllamaKey && !hasMeaningfulExplicitConfig,

// After
quiet: !hasMeaningfulExplicitConfig,
```

## Test

Added a test case that reproduces the bug: `OLLAMA_API_KEY` set to a real (non-marker) value, no Ollama in config, Ollama unreachable → no `console.warn` fires.

All 15 existing Ollama provider-discovery tests pass.