### PR TITLE
fix(auto-reply): honor per-model thinking params

### DIFF
--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -75,6 +75,43 @@ describe("createModelSelectionState catalog loading", () => {
     expect(loadModelCatalog).not.toHaveBeenCalled();
   });
 
+  it("prefers per-model params.thinking over global thinkingDefault", async () => {
+    vi.mocked(loadModelCatalog).mockClear();
+    const cfg = {
+      agents: {
+        defaults: {
+          thinkingDefault: "low",
+          models: {
+            "openai-codex/gpt-5.4": {
+              params: { thinking: "high" },
+            },
+          },
+        },
+      },
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://api.openai.com/v1",
+            models: [makeConfiguredModel()],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      hasModelDirective: false,
+    });
+
+    await expect(state.resolveDefaultThinkingLevel()).resolves.toBe("high");
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+  });
+
   it("uses the implicit model default when no global thinking default is configured", async () => {
     vi.mocked(loadModelCatalog).mockClear();
     const cfg = {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -105,6 +105,43 @@ describe("createModelSelectionState catalog loading", () => {
     expect(loadModelCatalog).not.toHaveBeenCalled();
   });
 
+  it("prefers per-model params.thinking over global thinkingDefault", async () => {
+    vi.mocked(loadModelCatalog).mockClear();
+    const cfg = {
+      agents: {
+        defaults: {
+          thinkingDefault: "low",
+          models: {
+            "openai-codex/gpt-5.4": {
+              params: { thinking: "high" },
+            },
+          },
+        },
+      },
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://api.openai.com/v1",
+            models: [makeConfiguredModel()],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      hasModelDirective: false,
+    });
+
+    await expect(state.resolveDefaultThinkingLevel()).resolves.toBe("high");
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+  });
+
   it("uses the implicit model default when no global thinking default is configured", async () => {
     vi.mocked(loadModelCatalog).mockClear();
     const cfg = {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -277,10 +277,8 @@ export async function createModelSelectionState(params: {
       return defaultThinkingLevel;
     }
     const agentThinkingDefault = agentEntry?.thinkingDefault as ThinkLevel | undefined;
-    const configuredThinkingDefault = agentCfg?.thinkingDefault as ThinkLevel | undefined;
-    const explicitThinkingDefault = agentThinkingDefault ?? configuredThinkingDefault;
-    if (explicitThinkingDefault) {
-      defaultThinkingLevel = explicitThinkingDefault;
+    if (agentThinkingDefault) {
+      defaultThinkingLevel = agentThinkingDefault;
       return defaultThinkingLevel;
     }
     const catalogForThinking = await resolveThinkingCatalog();

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -7,6 +7,7 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { parseConfiguredModelVisibilityEntries } from "../../agents/model-selection-shared.js";
 import {
   buildConfiguredModelCatalog,
+  legacyModelKey,
   modelKey,
   normalizeModelRef,
   normalizeProviderId,
@@ -365,10 +366,32 @@ export async function createModelSelectionState(params: {
       return defaultThinkingLevel;
     }
     const agentThinkingDefault = agentEntry?.thinkingDefault as ThinkLevel | undefined;
+    if (agentThinkingDefault) {
+      defaultThinkingLevel = agentThinkingDefault;
+      return defaultThinkingLevel;
+    }
+    const configuredModels = cfg.agents?.defaults?.models;
+    const canonicalKey = modelKey(provider, model);
+    const legacyKey = legacyModelKey(provider, model);
+    const configuredModelThinkingDefault =
+      configuredModels?.[canonicalKey]?.params?.thinking ??
+      (legacyKey ? configuredModels?.[legacyKey]?.params?.thinking : undefined);
+    if (
+      configuredModelThinkingDefault === "off" ||
+      configuredModelThinkingDefault === "minimal" ||
+      configuredModelThinkingDefault === "low" ||
+      configuredModelThinkingDefault === "medium" ||
+      configuredModelThinkingDefault === "high" ||
+      configuredModelThinkingDefault === "xhigh" ||
+      configuredModelThinkingDefault === "adaptive" ||
+      configuredModelThinkingDefault === "max"
+    ) {
+      defaultThinkingLevel = configuredModelThinkingDefault;
+      return defaultThinkingLevel;
+    }
     const configuredThinkingDefault = agentCfg?.thinkingDefault as ThinkLevel | undefined;
-    const explicitThinkingDefault = agentThinkingDefault ?? configuredThinkingDefault;
-    if (explicitThinkingDefault) {
-      defaultThinkingLevel = explicitThinkingDefault;
+    if (configuredThinkingDefault) {
+      defaultThinkingLevel = configuredThinkingDefault;
       return defaultThinkingLevel;
     }
     const catalogForThinking = await resolveThinkingCatalog();


### PR DESCRIPTION
## Summary

- let auto-reply honor `agents.defaults.models[provider/model].params.thinking` before the global `agents.defaults.thinkingDefault`
- keep per-agent `thinkingDefault` as the highest-precedence override
- preserve the global-default fast path when no per-model override applies, so ordinary replies do not hydrate the runtime catalog unnecessarily
- add an auto-reply regression test covering the per-model-over-global precedence case

## Why

Current `openclaw/openclaw` main still short-circuits auto-reply thinking resolution at `agentCfg?.thinkingDefault` before it reaches the shared resolver that already gives per-model `params.thinking` higher precedence.

The earlier draft fix addressed that precedence bug, but Codex was right that it also removed the no-hydration fast path for the plain global-default case. This revision keeps the fix narrow: it checks configured per-model thinking first, then falls back to the global default, and only resolves the thinking catalog when neither override applies.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/model-selection.test.ts`
  - passed: `42 passed`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/model-selection.test.ts`
  - passed: `98 passed`
- focused regression proof:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/model-selection.test.ts -t "prefers per-model params.thinking over global thinkingDefault"`
  - passed
- current-main behavior check before this patch:
  - with `agents.defaults.thinkingDefault: low` and `agents.defaults.models["openai-codex/gpt-5.4"].params.thinking: high`, auto-reply resolved the global `low` because it returned before the shared resolver
- internal-reference scan: PASS — no blocking issues found

## Real behavior proof

- **Behavior or issue addressed**: Auto-reply was returning the global `agents.defaults.thinkingDefault` before it considered a model-specific `agents.defaults.models[provider/model].params.thinking` override.
- **Real environment tested**: Fresh current-source checkout of `openclaw/openclaw` on `origin/main` + this patch (`ee9984b60958`) in `/tmp/openclaw-pr-77953-20260514`, with repo dependencies installed via `corepack pnpm install --frozen-lockfile`, running under Node `v22.22.0`.
- **Exact steps or command run after this patch**:
  ```bash
  cd /tmp/openclaw-pr-77953-20260514
  node --import tsx scripts/proof/pr-77953-real-behavior-proof.ts
  ```
- **Evidence after fix**: terminal output from that live source-run command:
  ```json
  {
    "provider": "openai-codex",
    "model": "gpt-5.4",
    "thinking": "high",
    "reasoning": "on",
    "allowed": true
  }
  ```
- **Observed result after fix**: In the patched runtime path, auto-reply now resolves `thinking: "high"` for `openai-codex/gpt-5.4` even when the global default is `low`, while still selecting the configured model and normal reasoning defaults.
- **What was not tested**: No end-to-end channel send or live gateway session was exercised; this proof covers the real source runtime path for model-selection resolution only.

## AI review plan

First pass after this update: @claude review + @codex review. Fallback/final signal only if needed: @copilot.
