### PR TITLE
fix(memory): reopen closed sqlite handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,7 @@ Docs: https://docs.openclaw.ai
 - Browser/SSRF: stop closing user-owned Chrome tabs when a read-only operation (snapshot/screenshot/interactions) is rejected by the SSRF guard — only OpenClaw-initiated navigations now close on policy denial. Thanks @scotthuang.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.
+- Memory: avoid reopening closed SQLite handles while sync owns an atomic reindex, then recover cached memory managers after the swap so `memory_search` and `openclaw memory search` no longer fail with `database is not open`. (#77999) Thanks @dmbyte.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @jacobtomlinson.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -471,6 +471,58 @@ describe("memory index", () => {
     );
   });
 
+  it("reopens a cached sqlite handle that was closed underneath the manager", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-reopen.sqlite"),
+      hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
+    });
+    const manager = await getPersistentManager(cfg);
+
+    await manager.sync({ reason: "test", force: true });
+    expect(manager.status().chunks).toBeGreaterThan(0);
+
+    (manager as unknown as { db: { close: () => void } }).db.close();
+
+    expect(manager.status().chunks).toBeGreaterThan(0);
+    const results = await manager.search("zebra");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.path).toContain("memory/2026-01-12.md");
+  });
+
+  it("does not reopen a closed sqlite handle while sync owns the index", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-reopen-during-sync.sqlite"),
+      hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
+    });
+    const manager = await getPersistentManager(cfg);
+    const managerInternals = manager as unknown as {
+      db: { close: () => void };
+      syncing: Promise<void> | null;
+      ensureDatabaseOpenForUse: () => boolean;
+    };
+
+    await manager.sync({ reason: "test", force: true });
+    expect(manager.status().chunks).toBeGreaterThan(0);
+
+    const originalDb = managerInternals.db;
+    let finishSync!: () => void;
+    const pendingSync = new Promise<void>((resolve) => {
+      finishSync = resolve;
+    }).finally(() => {
+      managerInternals.syncing = null;
+    });
+    managerInternals.syncing = pendingSync;
+    originalDb.close();
+
+    expect(managerInternals.ensureDatabaseOpenForUse()).toBe(false);
+    expect(managerInternals.db).toBe(originalDb);
+
+    finishSync();
+    await pendingSync;
+    expect(managerInternals.ensureDatabaseOpenForUse()).toBe(true);
+    expect(manager.status().chunks).toBeGreaterThan(0);
+  });
+
   it("streams embedding cache rows during safe reindex", async () => {
     vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
     type EmbeddingCacheRow = {

--- a/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
@@ -113,7 +113,9 @@ describe("memory manager atomic reindex", () => {
   });
 
   it("does not retry non-transient rename failures", async () => {
-    const rename = vi.fn().mockRejectedValue(Object.assign(new Error("invalid"), { code: "EINVAL" }));
+    const rename = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("invalid"), { code: "EINVAL" }));
     const wait = vi.fn().mockResolvedValue(undefined);
 
     await expect(

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -77,6 +77,11 @@ type EmbeddingProbeCacheEntry = {
 
 const EMBEDDING_PROBE_CACHE = new Map<string, EmbeddingProbeCacheEntry>();
 
+function isMemoryDatabaseNotOpenError(err: unknown): boolean {
+  const message = formatErrorMessage(err).toLowerCase();
+  return message.includes("database is not open") || message.includes("sqlite database is closed");
+}
+
 export async function closeAllMemoryIndexManagers(): Promise<void> {
   EMBEDDING_PROBE_CACHE.clear();
   await closeManagedCacheEntries({
@@ -181,6 +186,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       params.purpose === "status" || params.purpose === "cli" ? params.purpose : "default";
     const key = `${agentId}:${workspaceDir}:${JSON.stringify(settings)}:${purpose}`;
     const transient = purpose === "status" || purpose === "cli";
+    const cached = INDEX_CACHE.get(key);
+    if (cached?.closed) {
+      INDEX_CACHE.delete(key);
+    }
     return await getOrCreateManagedCacheEntry({
       cache: INDEX_CACHE,
       pending: INDEX_CACHE_PENDING,
@@ -250,6 +259,35 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.batch = this.resolveBatchConfig();
   }
 
+  private ensureDatabaseOpenForUse(): boolean {
+    if (this.closed) {
+      return false;
+    }
+    try {
+      this.db.prepare("SELECT 1").get();
+      return true;
+    } catch (err) {
+      if (!isMemoryDatabaseNotOpenError(err)) {
+        throw err;
+      }
+    }
+
+    if (this.syncing) {
+      log.warn("memory index sqlite handle is closed during sync; deferring reopen");
+      return false;
+    }
+
+    log.warn("memory index sqlite handle was closed; reopening");
+    this.db = this.openDatabase();
+    this.resetVectorState();
+    this.ensureSchema();
+    const meta = this.readMeta();
+    if (meta?.vectorDims) {
+      this.vector.dims = meta.vectorDims;
+    }
+    return true;
+  }
+
   private applyProviderResult(providerResult: EmbeddingProviderResult): void {
     const providerState = resolveMemoryProviderState(providerResult);
     this.provider = providerState.provider;
@@ -313,6 +351,22 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       sources?: MemorySource[];
     },
   ): Promise<MemorySearchResult[]> {
+    if (this.closed) {
+      return [];
+    }
+    if (!this.ensureDatabaseOpenForUse()) {
+      const pendingSync = this.syncing;
+      if (pendingSync) {
+        try {
+          await pendingSync;
+        } catch (err) {
+          log.warn(`memory sync failed before search recovery: ${String(err)}`);
+        }
+      }
+      if (!this.ensureDatabaseOpenForUse()) {
+        return [];
+      }
+    }
     opts?.onDebug?.({ backend: "builtin" });
     let hasIndexedContent = this.hasIndexedContent();
     if (!hasIndexedContent) {
@@ -506,6 +560,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private hasIndexedContent(): boolean {
+    if (!this.ensureDatabaseOpenForUse()) {
+      return false;
+    }
     const chunkRow = this.db.prepare(`SELECT 1 as found FROM chunks LIMIT 1`).get() as
       | {
           found?: number;
@@ -622,6 +679,15 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     progress?: (update: MemorySyncProgressUpdate) => void;
   }): Promise<void> {
     if (this.closed) {
+      return;
+    }
+    if (this.syncing) {
+      if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
+        return this.enqueueTargetedSessionSync(params.sessionFiles);
+      }
+      return this.syncing;
+    }
+    if (!this.ensureDatabaseOpenForUse()) {
       return;
     }
     await this.ensureProviderInitialized();
@@ -748,22 +814,29 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   status(): MemoryProviderStatus {
+    const dbAvailable = this.ensureDatabaseOpenForUse();
     const sourceFilter = this.buildSourceFilter();
-    const aggregateState = collectMemoryStatusAggregate({
-      db: {
-        prepare: (sql) => ({
-          all: (...args) =>
-            this.db.prepare(sql).all(...args) as Array<{
-              kind: "files" | "chunks";
-              source: MemorySource;
-              c: number;
-            }>,
-        }),
-      },
-      sources: this.sources,
-      sourceFilterSql: sourceFilter.sql,
-      sourceFilterParams: sourceFilter.params,
-    });
+    const aggregateState = dbAvailable
+      ? collectMemoryStatusAggregate({
+          db: {
+            prepare: (sql) => ({
+              all: (...args) =>
+                this.db.prepare(sql).all(...args) as Array<{
+                  kind: "files" | "chunks";
+                  source: MemorySource;
+                  c: number;
+                }>,
+            }),
+          },
+          sources: this.sources,
+          sourceFilterSql: sourceFilter.sql,
+          sourceFilterParams: sourceFilter.params,
+        })
+      : {
+          files: 0,
+          chunks: 0,
+          sourceCounts: Array.from(this.sources).map((source) => ({ source, files: 0, chunks: 0 })),
+        };
 
     const providerInfo = resolveStatusProviderInfo({
       provider: this.provider,
@@ -788,12 +861,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       cache: this.cache.enabled
         ? {
             enabled: true,
-            entries:
-              (
-                this.db.prepare(`SELECT COUNT(*) as c FROM ${EMBEDDING_CACHE_TABLE}`).get() as
-                  | { c: number }
-                  | undefined
-              )?.c ?? 0,
+            ...(dbAvailable
+              ? {
+                  entries:
+                    (
+                      this.db
+                        .prepare(`SELECT COUNT(*) as c FROM ${EMBEDDING_CACHE_TABLE}`)
+                        .get() as { c: number } | undefined
+                    )?.c ?? 0,
+                }
+              : {}),
             maxEntries: this.cache.maxEntries,
           }
         : { enabled: false, maxEntries: this.cache.maxEntries },


### PR DESCRIPTION
## Summary

- Detect when a cached memory index manager holds a closed sqlite handle and reopen it before search/status/sync.
- Drop closed cached managers before reuse.
- Add a regression test that closes the underlying DB handle and verifies status/search recover.

## Why

OpenClaw could return `memory_search` errors like `database is not open` after session compaction or concurrent memory-manager lifecycle activity, even though the underlying memory database was valid.

## AI assistance

This PR was prepared with Codex assistance. The human operator remains the contributor of record, reviewed the scope, and supplied and verified the live DGX Spark behavior proof before submission.

## Real behavior proof

- Behavior or issue addressed: `memory_search` could fail after compaction or memory-manager lifecycle reuse with `database is not open` when a cached sqlite-backed memory manager held a closed DB handle.
- Real environment tested: Live DGX Spark OpenClaw sandbox, OpenShell namespace `openshell`, pod `jarvis`, container `nemoclaw-web`, `HOME=/sandbox`, Ollama embeddings using `nomic-embed-text`, sqlite-vec arm64 extension loaded.
- Exact steps or command run after this patch:
  1. Applied the runtime-equivalent patch to the live OpenClaw install.
  2. Ran `HOME=/sandbox openclaw memory status --json --deep`.
  3. Ran `HOME=/sandbox openclaw memory search --query "MacBook Spark vLLM provider" --max-results 2 --json`.
- Evidence after fix (copied live output):

```text
$ HOME=/sandbox openclaw memory status --json --deep
provider: ollama
model: nomic-embed-text
embeddingProbe.ok: true
vector.semanticAvailable: true
vector.available: true
vector.dims: 768
custom.searchMode: hybrid
sourceCounts: memory=1 file / 1 chunk, sessions=16 files / 81 chunks

$ HOME=/sandbox openclaw memory search --query "MacBook Spark vLLM provider" --max-results 2 --json
results[0].path: sessions/main/439ebf9c-cfa9-4679-a157-0a638ea67657.jsonl
results[0].source: sessions
results[0].score: 0.6482941466349545
results[0].vectorScore: 0.5475357472896576
results[0].textScore: 0.8833970784406473
```

- Observed result after fix: Both live commands completed successfully. The status probe reported semantic vector memory available with embeddings ok, and search returned session-backed results. No `database is not open` error was returned.
- What was not tested: Full repository test suite execution in the fresh clone, because dependencies were not installed there. The source change was patch checked and the live memory status/search behavior was verified on the Spark instance.
- Before evidence (optional but encouraged):

```text
Assistant: MEMORY_ERROR database is not open
```

## Validation

- `git diff --check`
- `vitest run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.atomic-reindex.test.ts` (20 tests passed)
- Live DGX Spark OpenClaw memory status and search probes above
