### PR TITLE
Avoid native hook relay subprocesses without handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Agents/memory: explain that memory-triggered compaction exposes only `read` and append-only `write` when configured core tools are unavailable in `tools.allow` warnings. Fixes #82941. Thanks @galiniliev.
 - Agents/OpenAI: preserve deterministic tool payload ordering for prompt-cache reuse across OpenAI Responses and chat completions calls. (#82940) Thanks @galiniliev.
 - Agents/skills: apply the full effective tool policy pipeline to inline `command-dispatch: tool` skill dispatch before owner-only filtering, preserving configured allow, deny, sandbox, sender, group, and subagent restrictions. (#78525)
+- Codex: avoid spawning native hook relay subprocesses for post-tool/finalize events with no registered hook handlers while preserving pre-tool safety and approval relays. Fixes #76552. (#78004) Thanks @evgyur.
 - Channel accounts: keep top-level default channel accounts visible when named accounts are added alongside default credential material, so mixed legacy/new account configs keep resolving `default` instead of silently dropping it.
 - Codex/Telegram: synthesize native Codex tool progress from final turn snapshots so Telegram `/verbose` stays visible when command events arrive only at completion.
 - Mac app: make Channels settings open faster by deferring config-schema work, avoiding startup channel probes, caching decoded channel status rows, and showing only compact quick settings instead of the full generated channel schema.

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -146,6 +146,43 @@ describe("Codex native hook relay config", () => {
     });
   });
 
+  it("clears requested hook events when the relay reports no local work", () => {
+    expect(
+      buildCodexNativeHookRelayConfig({
+        relay: createRelay({ inactiveEvents: ["post_tool_use", "before_agent_finalize"] }),
+        events: ["pre_tool_use", "post_tool_use", "before_agent_finalize"],
+      }),
+    ).toEqual({
+      "features.hooks": true,
+      "hooks.PreToolUse": [
+        {
+          hooks: [
+            {
+              type: "command",
+              command:
+                "openclaw hooks relay --provider codex --relay-id relay-1 --event pre_tool_use",
+              timeout: 5,
+              async: false,
+              statusMessage: "OpenClaw native hook relay",
+            },
+          ],
+        },
+      ],
+      "hooks.PostToolUse": [],
+      "hooks.Stop": [],
+      "hooks.state": {
+        "/<session-flags>/config.toml:pre_tool_use:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+        "<session-flags>/config.toml:pre_tool_use:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+      },
+    });
+  });
+
   it("omits matchers so Codex MCP tool names reach the relay with a stable trust hash", () => {
     const config = buildCodexNativeHookRelayConfig({
       relay: createRelay(),
@@ -171,7 +208,10 @@ describe("Codex native hook relay config", () => {
   });
 });
 
-function createRelay(): NativeHookRelayRegistrationHandle {
+function createRelay(options?: {
+  inactiveEvents?: readonly NativeHookRelayRegistrationHandle["allowedEvents"][number][];
+}): NativeHookRelayRegistrationHandle {
+  const inactiveEvents = new Set(options?.inactiveEvents ?? []);
   return {
     relayId: "relay-1",
     provider: "codex",
@@ -180,6 +220,7 @@ function createRelay(): NativeHookRelayRegistrationHandle {
     runId: "run-1",
     allowedEvents: ["pre_tool_use", "post_tool_use", "permission_request", "before_agent_finalize"],
     expiresAtMs: Date.now() + 1000,
+    shouldRelayEvent: (event) => !inactiveEvents.has(event),
     commandForEvent: (event) =>
       `openclaw hooks relay --provider codex --relay-id relay-1 --event ${event}`,
     renew: () => undefined,

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -45,6 +45,10 @@ export function buildCodexNativeHookRelayConfig(params: {
   const hookState: JsonObject = {};
   for (const event of events) {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];
+    if (!params.relay.shouldRelayEvent(event)) {
+      config[`hooks.${codexEvent}`] = [] satisfies JsonValue;
+      continue;
+    }
     const command = params.relay.commandForEvent(event);
     const timeout = normalizeHookTimeoutSec(params.hookTimeoutSec);
     config[`hooks.${codexEvent}`] = [

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3928,8 +3928,8 @@ describe("runCodexAppServerAttempt", () => {
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
     expect(Array.isArray(startConfig?.["hooks.PreToolUse"])).toBe(true);
-    expect(Array.isArray(startConfig?.["hooks.PostToolUse"])).toBe(true);
-    expect(Array.isArray(startConfig?.["hooks.Stop"])).toBe(true);
+    expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
+    expect(startConfig?.["hooks.Stop"]).toEqual([]);
     expect(startConfig).not.toHaveProperty("hooks.PermissionRequest");
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2062,7 +2062,8 @@ export async function runCodexAppServerAttempt(
   });
   projector = new CodexAppServerEventProjector(params, thread.threadId, activeTurnId, {
     nativePostToolUseRelayEnabled:
-      nativeHookRelay?.allowedEvents.includes("post_tool_use") === true,
+      nativeHookRelay?.allowedEvents.includes("post_tool_use") === true &&
+      nativeHookRelay.shouldRelayEvent("post_tool_use"),
     trajectoryRecorder,
   });
   if (

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -41,6 +41,9 @@ async function waitForNativeHookRelayBridgeRecord(
 
 describe("native hook relay registry", () => {
   it("registers a short-lived relay and builds hidden CLI commands", () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
     const relay = registerNativeHookRelay({
       provider: "codex",
       agentId: "agent-1",
@@ -66,6 +69,50 @@ describe("native hook relay registry", () => {
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
         `${relay.relayId} --event pre_tool_use --timeout 1234`,
     );
+  });
+
+  it("returns a cheap no-op command when a native event has no local hook work", () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.commandForEvent("pre_tool_use")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.commandForEvent("post_tool_use")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.commandForEvent("before_agent_finalize")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.commandForEvent("permission_request")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --event permission_request --timeout 1234`,
+    );
+  });
+
+  it("builds relay commands only for native events with matching local hooks", () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: vi.fn() }]),
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.commandForEvent("pre_tool_use")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.commandForEvent("post_tool_use")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --event post_tool_use --timeout 1234`,
+    );
+    expect(relay.commandForEvent("before_agent_finalize")).toBe("/usr/local/bin/node -e ''");
   });
 
   it("allows callers to replace a relay at a stable id", () => {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -81,6 +81,9 @@ async function waitForNativeHookRelayBridgeRecord(
 
 describe("native hook relay registry", () => {
   it("registers a short-lived relay and builds hidden CLI commands", () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
     const relay = registerNativeHookRelay({
       provider: "codex",
       agentId: "agent-1",
@@ -112,6 +115,50 @@ describe("native hook relay registry", () => {
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
         `${relay.relayId} --event pre_tool_use --timeout 1234`,
     );
+  });
+
+  it("returns a cheap no-op command when a native event has no local hook work", () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.commandForEvent("pre_tool_use")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.commandForEvent("post_tool_use")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.commandForEvent("before_agent_finalize")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.commandForEvent("permission_request")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --event permission_request --timeout 1234`,
+    );
+  });
+
+  it("builds relay commands only for native events with matching local hooks", () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: vi.fn() }]),
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.commandForEvent("pre_tool_use")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.commandForEvent("post_tool_use")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --event post_tool_use --timeout 1234`,
+    );
+    expect(relay.commandForEvent("before_agent_finalize")).toBe("/usr/local/bin/node -e ''");
   });
 
   it("allows callers to replace a relay at a stable id", () => {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -81,9 +81,6 @@ async function waitForNativeHookRelayBridgeRecord(
 
 describe("native hook relay registry", () => {
   it("registers a short-lived relay and builds hidden CLI commands", () => {
-    initializeGlobalHookRunner(
-      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
-    );
     const relay = registerNativeHookRelay({
       provider: "codex",
       agentId: "agent-1",
@@ -117,7 +114,7 @@ describe("native hook relay registry", () => {
     );
   });
 
-  it("returns a cheap no-op command when a native event has no local hook work", () => {
+  it("preserves safety relays while marking hook-only events without handlers inactive", () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
       sessionId: "session-1",
@@ -129,13 +126,10 @@ describe("native hook relay registry", () => {
       },
     });
 
-    expect(relay.commandForEvent("pre_tool_use")).toBe("/usr/local/bin/node -e ''");
-    expect(relay.commandForEvent("post_tool_use")).toBe("/usr/local/bin/node -e ''");
-    expect(relay.commandForEvent("before_agent_finalize")).toBe("/usr/local/bin/node -e ''");
-    expect(relay.commandForEvent("permission_request")).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --event permission_request --timeout 1234`,
-    );
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
+    expect(relay.shouldRelayEvent("post_tool_use")).toBe(false);
+    expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
+    expect(relay.shouldRelayEvent("permission_request")).toBe(true);
   });
 
   it("builds relay commands only for native events with matching local hooks", () => {
@@ -153,12 +147,35 @@ describe("native hook relay registry", () => {
       },
     });
 
-    expect(relay.commandForEvent("pre_tool_use")).toBe("/usr/local/bin/node -e ''");
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
+    expect(relay.shouldRelayEvent("post_tool_use")).toBe(true);
+    expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
     expect(relay.commandForEvent("post_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
         `${relay.relayId} --event post_tool_use --timeout 1234`,
     );
-    expect(relay.commandForEvent("before_agent_finalize")).toBe("/usr/local/bin/node -e ''");
+  });
+
+  it("builds relay commands for before-agent-finalize hooks", () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_agent_finalize", handler: vi.fn() }]),
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(true);
+    expect(relay.commandForEvent("before_agent_finalize")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --event before_agent_finalize --timeout 1234`,
+    );
   });
 
   it("allows callers to replace a relay at a stable id", () => {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -21,6 +21,7 @@ import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { hasGlobalHooks } from "../../plugins/hook-runner-global.js";
 import { PluginApprovalResolutions } from "../../plugins/types.js";
 import { runBeforeToolCallHook } from "../pi-tools.before-tool-call.js";
 import { normalizeToolName } from "../tool-policy.js";
@@ -351,6 +352,9 @@ export function buildNativeHookRelayCommand(params: {
   executable?: string;
   nodeExecutable?: string;
 }): string {
+  if (!nativeHookRelayEventHasLocalWork(params.event)) {
+    return buildNativeHookRelayNoopCommand(params);
+  }
   const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
   const executable = params.executable ?? resolveOpenClawCliExecutable();
   const argv =
@@ -370,6 +374,23 @@ export function buildNativeHookRelayCommand(params: {
     "--timeout",
     String(timeoutMs),
   ]);
+}
+
+function nativeHookRelayEventHasLocalWork(event: NativeHookRelayEvent): boolean {
+  if (event === "pre_tool_use") {
+    return hasGlobalHooks("before_tool_call");
+  }
+  if (event === "post_tool_use") {
+    return hasGlobalHooks("after_tool_call");
+  }
+  if (event === "before_agent_finalize") {
+    return hasGlobalHooks("before_agent_finalize");
+  }
+  return true;
+}
+
+function buildNativeHookRelayNoopCommand(params: { nodeExecutable?: string }): string {
+  return shellQuoteArgs([params.nodeExecutable ?? process.execPath, "-e", ""]);
 }
 
 export async function invokeNativeHookRelay(

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { privateFileStoreSync } from "../../infra/private-file-store.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { hasGlobalHooks } from "../../plugins/hook-runner-global.js";
 import { PluginApprovalResolutions } from "../../plugins/types.js";
 import { runBeforeToolCallHook } from "../pi-tools.before-tool-call.js";
 import { normalizeToolName } from "../tool-policy.js";
@@ -365,6 +366,9 @@ export function buildNativeHookRelayCommand(params: {
   executable?: string;
   nodeExecutable?: string;
 }): string {
+  if (!nativeHookRelayEventHasLocalWork(params.event)) {
+    return buildNativeHookRelayNoopCommand(params);
+  }
   const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
   const executable = params.executable ?? resolveOpenClawCliExecutable();
   const argv =
@@ -384,6 +388,23 @@ export function buildNativeHookRelayCommand(params: {
     "--timeout",
     String(timeoutMs),
   ]);
+}
+
+function nativeHookRelayEventHasLocalWork(event: NativeHookRelayEvent): boolean {
+  if (event === "pre_tool_use") {
+    return hasGlobalHooks("before_tool_call");
+  }
+  if (event === "post_tool_use") {
+    return hasGlobalHooks("after_tool_call");
+  }
+  if (event === "before_agent_finalize") {
+    return hasGlobalHooks("before_agent_finalize");
+  }
+  return true;
+}
+
+function buildNativeHookRelayNoopCommand(params: { nodeExecutable?: string }): string {
+  return shellQuoteArgs([params.nodeExecutable ?? process.execPath, "-e", ""]);
 }
 
 export async function invokeNativeHookRelay(

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -83,6 +83,7 @@ export type NativeHookRelayRegistration = {
 };
 
 export type NativeHookRelayRegistrationHandle = NativeHookRelayRegistration & {
+  shouldRelayEvent: (event: NativeHookRelayEvent) => boolean;
   commandForEvent: (event: NativeHookRelayEvent) => string;
   renew: (ttlMs?: number) => void;
   unregister: () => void;
@@ -313,6 +314,7 @@ export function registerNativeHookRelay(
   registerNativeHookRelayBridge(registration);
   const handle: NativeHookRelayRegistrationHandle = {
     ...registration,
+    shouldRelayEvent: nativeHookRelayEventHasLocalWork,
     commandForEvent: (event) =>
       buildNativeHookRelayCommand({
         provider: params.provider,
@@ -366,9 +368,6 @@ export function buildNativeHookRelayCommand(params: {
   executable?: string;
   nodeExecutable?: string;
 }): string {
-  if (!nativeHookRelayEventHasLocalWork(params.event)) {
-    return buildNativeHookRelayNoopCommand(params);
-  }
   const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
   const executable = params.executable ?? resolveOpenClawCliExecutable();
   const argv =
@@ -392,7 +391,7 @@ export function buildNativeHookRelayCommand(params: {
 
 function nativeHookRelayEventHasLocalWork(event: NativeHookRelayEvent): boolean {
   if (event === "pre_tool_use") {
-    return hasGlobalHooks("before_tool_call");
+    return true;
   }
   if (event === "post_tool_use") {
     return hasGlobalHooks("after_tool_call");
@@ -401,10 +400,6 @@ function nativeHookRelayEventHasLocalWork(event: NativeHookRelayEvent): boolean 
     return hasGlobalHooks("before_agent_finalize");
   }
   return true;
-}
-
-function buildNativeHookRelayNoopCommand(params: { nodeExecutable?: string }): string {
-  return shellQuoteArgs([params.nodeExecutable ?? process.execPath, "-e", ""]);
 }
 
 export async function invokeNativeHookRelay(


### PR DESCRIPTION
## Summary

- Suppress Codex native hook relay command installation for post-tool and finalize events when no matching OpenClaw hook handlers are registered.
- Keep `pre_tool_use` relayed through the full OpenClaw safety path and keep permission requests on the native approval path.
- Keep synthetic app-server observations enabled when native `PostToolUse` is not installed, so idle relay suppression does not hide tool progress.
- Add regression coverage for idle relay suppression and handler-present relay activation.

## Real behavior proof

Behavior addressed: High CPU/load from idle Codex native hook relay subprocess fan-out during runtime tasks, tracked in #76552.

Real environment tested: Self-hosted Linux OpenClaw gateway using the native Codex runtime with `openai/gpt-5.5` via Codex app-server, reached through a Telegram direct-message smoke path.

Exact steps or command run after this patch: A matching guard was hot-patched into the installed OpenClaw bundle on the Linux host, the gateway was restarted, a `chipdm` smoke probe was sent through the Codex runtime, and a 120s process watcher checked for new `openclaw-hooks` child processes.

Evidence after fix: Live output from the host showed the `chipdm` smoke probe returned `OK` after restart. The same watcher that previously caught relay process fan-out observed zero new `openclaw-hooks` processes during the 120s post-fix window.

Observed result after fix: The native approval/safety path still responded through Codex, while idle post-tool/finalize hook events no longer spawned relay subprocesses when no local OpenClaw hook handlers were registered.

What was not tested: A full production soak under sustained multi-run load was not run for this PR.

## Incident evidence

Before the fix, one Telegram direct message on the same self-hosted Linux gateway produced 29 `openclaw-hooks` subprocesses in about 70 seconds. Individual subprocesses reached roughly 140-156% CPU and about 270-320 MB RSS. The observed parent chain was:

```text
codex app-server -> openclaw -> openclaw-hooks
```

Gateway logs around the capture showed the active direct run was still in a Codex app-server notification path while hook relay processes continued to fan out.

## Verification

- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/native-hook-relay.ts extensions/codex/src/app-server/native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `node scripts/run-vitest.mjs src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/native-hook-relay.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "lets Codex app-server approval modes own native permission requests by default"`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01krt9knkmnmh8tymvdct9m0x4`
- Codex review: clean, no accepted/actionable findings

Closes #76552
