### PR TITLE
Fix bundled capability contract propagation

### DIFF
--- a/src/plugins/bundled-capability-runtime.test.ts
+++ b/src/plugins/bundled-capability-runtime.test.ts
@@ -1,5 +1,79 @@
-import { describe, expect, it } from "vitest";
-import { buildVitestCapabilityShimAliasMap } from "./bundled-capability-runtime.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildVitestCapabilityShimAliasMap,
+  loadBundledCapabilityRuntimeRegistry,
+} from "./bundled-capability-runtime.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createBundledCapabilityToolPlugin(params: {
+  id: string;
+  toolName: string;
+  contractsTools?: string[];
+}): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-capability-plugin-"));
+  tempRoots.push(root);
+  const extensionsRoot = path.join(root, "extensions");
+  const pluginRoot = path.join(extensionsRoot, params.id);
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    `${JSON.stringify(
+      {
+        id: params.id,
+        configSchema: {
+          type: "object",
+          additionalProperties: true,
+        },
+        ...(params.contractsTools
+          ? {
+              contracts: {
+                tools: params.contractsTools,
+              },
+            }
+          : {}),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(pluginRoot, "index.js"),
+    `module.exports = {
+  register(api) {
+    api.registerTool({
+      name: ${JSON.stringify(params.toolName)},
+      description: "test capability tool",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ text: "ok" }),
+    });
+  },
+};
+`,
+  );
+  return extensionsRoot;
+}
+
+function loadFixtureCapabilityRegistry(params: { pluginId: string; extensionsRoot: string }) {
+  return loadBundledCapabilityRuntimeRegistry({
+    pluginIds: [params.pluginId],
+    env: {
+      ...process.env,
+      VITEST: "1",
+      OPENCLAW_BUNDLED_PLUGINS_DIR: params.extensionsRoot,
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+    },
+  });
+}
 
 describe("buildVitestCapabilityShimAliasMap", () => {
   it("keeps scoped and unscoped capability shim aliases aligned", () => {
@@ -16,6 +90,43 @@ describe("buildVitestCapabilityShimAliasMap", () => {
     );
     expect(aliasMap["openclaw/plugin-sdk/speech-core"]).toBe(
       aliasMap["@openclaw/plugin-sdk/speech-core"],
+    );
+  });
+});
+
+describe("loadBundledCapabilityRuntimeRegistry", () => {
+  it("propagates manifest tool contracts to bundled capability tool validation", () => {
+    const pluginId = "capability-tool-contract";
+    const toolName = "capability_tool";
+    const extensionsRoot = createBundledCapabilityToolPlugin({
+      id: pluginId,
+      toolName,
+      contractsTools: [toolName],
+    });
+
+    const registry = loadFixtureCapabilityRegistry({ pluginId, extensionsRoot });
+
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.contracts?.tools).toEqual([toolName]);
+    expect(registry.tools.flatMap((tool) => tool.names)).toContain(toolName);
+    expect(registry.diagnostics.map((entry) => entry.message)).not.toContain(
+      `plugin must declare contracts.tools for: ${toolName}`,
+    );
+  });
+
+  it("still rejects bundled capability tools missing manifest contracts", () => {
+    const pluginId = "capability-tool-missing-contract";
+    const toolName = "undeclared_capability_tool";
+    const extensionsRoot = createBundledCapabilityToolPlugin({
+      id: pluginId,
+      toolName,
+    });
+
+    const registry = loadFixtureCapabilityRegistry({ pluginId, extensionsRoot });
+
+    expect(registry.tools.flatMap((tool) => tool.names)).not.toContain(toolName);
+    expect(registry.diagnostics.map((entry) => entry.message)).toContain(
+      `plugin must declare contracts.tools for: ${toolName}`,
     );
   });
 });

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -11,6 +11,7 @@ import { createCapturedPluginRegistration } from "./captured-registration.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import type { PluginManifestContracts } from "./manifest.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
 import {
   createPluginModuleLoaderCache,
@@ -136,6 +137,7 @@ function createCapabilityPluginRecord(params: {
   source: string;
   rootDir?: string;
   workspaceDir?: string;
+  contracts?: PluginManifestContracts;
 }): PluginRecord {
   return {
     id: params.id,
@@ -146,6 +148,7 @@ function createCapabilityPluginRecord(params: {
     rootDir: params.rootDir,
     origin: "bundled",
     workspaceDir: params.workspaceDir,
+    contracts: params.contracts,
     enabled: true,
     status: "loaded",
     toolNames: [],
@@ -275,6 +278,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
           : candidate.source,
       rootDir: candidate.rootDir,
       workspaceDir: candidate.workspaceDir,
+      contracts: manifest.contracts,
     });
 
     const opened = openBoundaryFileSync({


### PR DESCRIPTION
## Summary
- propagate manifest-owned `contracts` into bundled capability plugin records
- keep tool contract validation manifest-owned; no module-export contract loading
- add regressions for declared bundled tools and undeclared tool rejection

Fixes #77982.

## Verification
- Local workflow batch verification passed before PR branch extraction.
- Targeted regression lives in `src/plugins/bundled-capability-runtime.test.ts`.
