### PR TITLE
Fix Telegram Pinching progress previews

### DIFF
--- a/extensions/telegram/src/approval-handler.runtime.test.ts
+++ b/extensions/telegram/src/approval-handler.runtime.test.ts
@@ -50,8 +50,7 @@ describe("telegramApprovalNativeRuntime", () => {
     expect(payload.buttons?.[0]?.map((button) => button.text)).toEqual(["Allow Once", "Deny"]);
   });
 
-  it("passes topic thread ids to typing and message delivery", async () => {
-    const sendTyping = vi.fn().mockResolvedValue({ ok: true });
+  it("passes topic thread ids to message delivery without pre-typing", async () => {
     const sendMessage = vi.fn().mockResolvedValue({
       chatId: "-1003841603622",
       messageId: "m1",
@@ -63,7 +62,6 @@ describe("telegramApprovalNativeRuntime", () => {
       context: {
         token: "tg-token",
         deps: {
-          sendTyping,
           sendMessage,
         },
       },
@@ -100,14 +98,6 @@ describe("telegramApprovalNativeRuntime", () => {
       },
     });
 
-    expect(sendTyping).toHaveBeenCalledWith(
-      "-1003841603622",
-      expect.objectContaining({
-        token: "tg-token",
-        accountId: "default",
-        messageThreadId: 928,
-      }),
-    );
     expect(sendMessage).toHaveBeenCalledWith(
       "-1003841603622",
       "pending",

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -21,7 +21,7 @@ import {
   isTelegramExecApprovalHandlerConfigured,
   shouldHandleTelegramExecApprovalRequest,
 } from "./exec-approvals.js";
-import { editMessageReplyMarkupTelegram, sendMessageTelegram, sendTypingTelegram } from "./send.js";
+import { editMessageReplyMarkupTelegram, sendMessageTelegram } from "./send.js";
 
 const log = createSubsystemLogger("telegram/approvals");
 
@@ -37,7 +37,7 @@ type TelegramPendingDelivery = {
 
 export type TelegramExecApprovalHandlerDeps = {
   nowMs?: () => number;
-  sendTyping?: typeof sendTypingTelegram;
+  sendTyping?: never;
   sendMessage?: typeof sendMessageTelegram;
   editReplyMarkup?: typeof editMessageReplyMarkupTelegram;
 };
@@ -147,16 +147,7 @@ export const telegramApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
       if (!resolved) {
         return null;
       }
-      const sendTyping = resolved.context.deps?.sendTyping ?? sendTypingTelegram;
       const sendMessage = resolved.context.deps?.sendMessage ?? sendMessageTelegram;
-      await sendTyping(preparedTarget.chatId, {
-        cfg,
-        token: resolved.context.token,
-        accountId: resolved.accountId,
-        ...(preparedTarget.messageThreadId != null
-          ? { messageThreadId: preparedTarget.messageThreadId }
-          : {}),
-      }).catch(() => {});
       const result = await sendMessage(preparedTarget.chatId, pendingPayload.text, {
         cfg,
         token: resolved.context.token,

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -7,6 +7,8 @@ import type {
   TelegramTopicConfig,
 } from "openclaw/plugin-sdk/config-types";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+import type { SourceReplyDeliveryMode } from "../../../src/auto-reply/get-reply-options.types.js";
+import type { TypingPolicy } from "../../../src/auto-reply/types.js";
 import type { StickerMetadata, TelegramContext } from "./bot/types.js";
 
 export type TelegramMediaRef = {
@@ -21,6 +23,14 @@ export type TelegramMessageContextOptions = {
   messageIdOverride?: string;
   receivedAtMs?: number;
   ingressBuffer?: "inbound-debounce" | "text-fragment";
+  typingPolicy?: TypingPolicy;
+  suppressTyping?: boolean;
+  isHeartbeat?: boolean;
+  systemEvent?: boolean;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  internal?: boolean;
+  runKind?: string;
+  kind?: string;
 };
 
 export type TelegramLogger = {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -7,7 +7,6 @@ import {
   createSequencedTestDraftStream,
   createTestDraftStream,
 } from "./draft-stream.test-helpers.js";
-import { renderTelegramHtmlText } from "./format.js";
 
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
@@ -781,7 +780,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("keeps non-command Telegram progress draft lines across post-tool assistant boundaries", async () => {
+  it("does not create Telegram progress-preview drafts for tool progress", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -802,21 +801,18 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.update).toHaveBeenCalledWith(
-      expect.stringMatching(/^Shelling\n`🔎 Web Search: docs lookup`\n• `tests passed`$/),
-    );
+    expect(draftStream.update).not.toHaveBeenCalled();
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
     expect(draftStream.materialize).not.toHaveBeenCalled();
-    expect(editMessageTelegram).toHaveBeenCalledWith(
-      123,
-      2001,
-      "Final after tool",
-      expect.any(Object),
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: "Final after tool" })],
+      }),
     );
-    expect(draftStream.clear).not.toHaveBeenCalled();
   });
 
-  it("cleans up tool-only Telegram previews archived at assistant boundaries", async () => {
+  it("does not archive tool-only Telegram progress previews at assistant boundaries", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
@@ -838,15 +834,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
       bot,
     });
 
-    expect(draftStream.update).toHaveBeenCalledWith(
-      expect.stringMatching(/`🛠️ Exec: exec git status`$/),
-    );
-    expect(draftStream.materialize).toHaveBeenCalled();
-    expect(draftStream.forceNewMessage).toHaveBeenCalled();
-    expect(bot.api.deleteMessage).toHaveBeenCalledWith(123, 2001);
+    expect(draftStream.update).not.toHaveBeenCalled();
+    expect(draftStream.materialize).not.toHaveBeenCalled();
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(bot.api.deleteMessage).not.toHaveBeenCalled();
   });
 
-  it("streams Telegram command progress text by default when preview streaming is active", async () => {
+  it("suppresses Telegram command progress text by default when preview streaming is active", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
@@ -861,9 +855,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext(), streamMode: "partial" });
 
-    expect(draftStream.update).toHaveBeenCalledWith(
-      expect.stringMatching(/\n`🛠️ Exec`\n`🛠️ Exec: exec ls ~\/Desktop`$/),
-    );
+    expect(draftStream.update).not.toHaveBeenCalled();
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyOptions: expect.objectContaining({
@@ -873,7 +865,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("can hide Telegram command progress text by config", async () => {
+  it("keeps Telegram command progress suppressed when command text config is present", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
@@ -892,8 +884,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "partial", preview: { commandText: "status" } } },
     });
 
-    expect(draftStream.update).toHaveBeenCalledWith(expect.stringMatching(/\n`🛠️ Exec`$/));
-    expect(draftStream.update.mock.calls.at(-1)?.[0]).not.toContain("exec ls");
+    expect(draftStream.update).not.toHaveBeenCalled();
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyOptions: expect.objectContaining({
@@ -947,7 +938,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("keeps non-command Telegram tool progress links inside code formatting", async () => {
+  it("does not expose non-command Telegram tool progress links in preview drafts", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
@@ -964,11 +955,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       streamMode: "partial",
     });
 
-    const lastPreviewText = draftStream.update.mock.calls.at(-1)?.[0];
-    expect(lastPreviewText).toMatch(
-      /\n`🛠️ Exec`\n`🔎 Web Search: read \[label\]\(tg:\/\/user\?id=123\)`$/,
-    );
-    expect(renderTelegramHtmlText(lastPreviewText ?? "")).not.toContain("<a ");
+    expect(draftStream.update).not.toHaveBeenCalled();
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyOptions: expect.objectContaining({
@@ -978,7 +965,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("bounds Telegram tool progress markdown preview formatting", async () => {
+  it("does not render long Telegram tool progress markdown into preview drafts", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);
     const longProgress = `${"`".repeat(1000)}${"x".repeat(1000)}[label](tg://user?id=123)`;
@@ -993,16 +980,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { preview: { toolProgress: true } } },
     });
 
-    const lastPreviewText = draftStream.update.mock.calls.at(-1)?.[0] ?? "";
-    const progressLine = lastPreviewText.split("\n").at(1) ?? "";
-
-    expect(lastPreviewText.length).toBeLessThan(340);
-    expect(progressLine).toMatch(/^• `.*…`$/);
-    expect(progressLine).toContain("…");
-    expect(renderTelegramHtmlText(lastPreviewText)).not.toContain("<a ");
+    expect(draftStream.update).not.toHaveBeenCalled();
   });
 
-  it("does not let Telegram tool progress backticks break out of code formatting", async () => {
+  it("does not let Telegram tool progress backticks reach preview drafts", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);
     const breakoutProgress = `${"`".repeat(10)} [label](tg://user?id=123)`;
@@ -1017,10 +998,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { preview: { toolProgress: true } } },
     });
 
-    const lastPreviewText = draftStream.update.mock.calls.at(-1)?.[0] ?? "";
-
-    expect(lastPreviewText).toContain(`• \`'''''''''' [label](tg://user?id=123)\``);
-    expect(renderTelegramHtmlText(lastPreviewText)).not.toContain("<a ");
+    expect(draftStream.update).not.toHaveBeenCalled();
   });
 
   it("keeps block streaming enabled when account config enables it", async () => {
@@ -2007,7 +1985,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("rotates after a visible tool payload lands between compaction and the next assistant message", async () => {
+  it("keeps the final visible after a tool payload lands between compaction and the next assistant message", async () => {
     const answerDraftStream = createSequencedDraftStream(1001);
     const reasoningDraftStream = createDraftStream();
     createTelegramDraftStream
@@ -2039,13 +2017,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
         replies: [expect.objectContaining({ mediaUrl: "file:///tmp/tool-result.png" })],
       }),
     );
-    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
-    expect(editMessageTelegram).toHaveBeenCalledWith(
-      123,
-      expect.any(Number),
-      "Message B final",
-      expect.any(Object),
+    const editedFinal = editMessageTelegram.mock.calls.some(
+      (call) => call[2] === "Message B final",
     );
+    const deliveredFinal = deliverReplies.mock.calls.some((call) =>
+      call[0]?.replies?.some((reply: { text?: string }) => reply.text === "Message B final"),
+    );
+    expect(editedFinal || deliveredFinal).toBe(true);
   });
 
   it("finalizes multi-message assistant stream to matching preview messages in order", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -6,16 +6,7 @@ import {
   removeAckReactionAfterReply,
 } from "openclaw/plugin-sdk/channel-feedback";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
-import {
-  createChannelProgressDraftGate,
-  formatChannelProgressDraftLine,
-  formatChannelProgressDraftLineForEntry,
-  formatChannelProgressDraftText,
-  isChannelProgressDraftWorkToolName,
-  resolveChannelProgressDraftMaxLines,
-  resolveChannelStreamingBlockEnabled,
-  resolveChannelStreamingPreviewToolProgress,
-} from "openclaw/plugin-sdk/channel-streaming";
+import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel-streaming";
 import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
 import type {
   OpenClawConfig,
@@ -231,24 +222,6 @@ function resolveTelegramReasoningLevel(params: {
   return "off";
 }
 
-const MAX_PROGRESS_MARKDOWN_TEXT_CHARS = 300;
-
-function clipProgressMarkdownText(text: string): string {
-  if (text.length <= MAX_PROGRESS_MARKDOWN_TEXT_CHARS) {
-    return text;
-  }
-  return `${text.slice(0, MAX_PROGRESS_MARKDOWN_TEXT_CHARS - 1).trimEnd()}…`;
-}
-
-function sanitizeProgressMarkdownText(text: string): string {
-  return text.replaceAll("`", "'");
-}
-
-function formatProgressAsMarkdownCode(text: string): string {
-  const clipped = clipProgressMarkdownText(text);
-  return `\`${sanitizeProgressMarkdownText(clipped)}\``;
-}
-
 export const dispatchTelegramMessage = async ({
   context,
   bot,
@@ -425,7 +398,6 @@ export const dispatchTelegramMessage = async ({
       ? (replyQuoteMessageId ?? msg.message_id)
       : undefined;
   const draftMinInitialChars = streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS;
-  const progressSeed = `${route.accountId}:${chatId}:${threadSpec.id ?? ""}`;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
@@ -480,78 +452,10 @@ export const dispatchTelegramMessage = async ({
   };
   const answerLane = lanes.answer;
   const reasoningLane = lanes.reasoning;
-  const previewToolProgressEnabled =
-    Boolean(answerLane.stream) && resolveChannelStreamingPreviewToolProgress(telegramCfg);
-  let previewToolProgressSuppressed = false;
-  let previewToolProgressLines: string[] = [];
   let answerLaneHasAssistantContent = false;
-  const renderProgressDraft = async (options?: { flush?: boolean }) => {
-    if (!answerLane.stream || streamMode !== "progress") {
-      return;
-    }
-    const previewText = formatChannelProgressDraftText({
-      entry: telegramCfg,
-      lines: previewToolProgressLines,
-      seed: progressSeed,
-      formatLine: formatProgressAsMarkdownCode,
-    });
-    if (!previewText || previewText === answerLane.lastPartialText) {
-      return;
-    }
-    answerLane.lastPartialText = previewText;
-    answerLane.hasStreamedMessage = true;
-    answerLane.stream.update(previewText);
-    if (options?.flush) {
-      await answerLane.stream.flush();
-    }
-  };
-  const progressDraftGate = createChannelProgressDraftGate({
-    onStart: () => renderProgressDraft({ flush: true }),
-  });
-  const pushPreviewToolProgress = async (line?: string, options?: { toolName?: string }) => {
-    if (!answerLane.stream) {
-      return;
-    }
-    if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
-      return;
-    }
-    const normalized = sanitizeProgressMarkdownText(line?.replace(/\s+/g, " ").trim() ?? "");
-    if (streamMode !== "progress") {
-      if (!previewToolProgressEnabled || previewToolProgressSuppressed || !normalized) {
-        return;
-      }
-      const previous = previewToolProgressLines.at(-1);
-      if (previous === normalized) {
-        return;
-      }
-      previewToolProgressLines = [...previewToolProgressLines, normalized].slice(
-        -resolveChannelProgressDraftMaxLines(telegramCfg),
-      );
-      const previewText = formatChannelProgressDraftText({
-        entry: telegramCfg,
-        lines: previewToolProgressLines,
-        seed: progressSeed,
-        formatLine: formatProgressAsMarkdownCode,
-      });
-      answerLane.lastPartialText = previewText;
-      answerLane.hasStreamedMessage = true;
-      answerLane.stream.update(previewText);
-      return;
-    }
-    if (previewToolProgressEnabled && !previewToolProgressSuppressed && normalized) {
-      const previous = previewToolProgressLines.at(-1);
-      if (previous !== normalized) {
-        previewToolProgressLines = [...previewToolProgressLines, normalized].slice(
-          -resolveChannelProgressDraftMaxLines(telegramCfg),
-        );
-      }
-    }
-    const alreadyStarted = progressDraftGate.hasStarted;
-    await progressDraftGate.noteWork();
-    if (alreadyStarted && progressDraftGate.hasStarted) {
-      await renderProgressDraft();
-    }
-  };
+  // Telegram progress-preview drafts are disabled. They leak internal tool/process
+  // activity into user-visible chat previews ("Pinching...", Process/Edit/Exec).
+  // Final replies and explicitly admitted typing actions remain handled elsewhere.
   let splitReasoningOnNextStream = false;
   let skipNextAnswerMessageStartRotation = false;
   let pendingCompactionReplayBoundary = false;
@@ -634,8 +538,6 @@ export const dispatchTelegramMessage = async ({
         return;
       }
       answerLaneHasAssistantContent = true;
-      previewToolProgressSuppressed = true;
-      previewToolProgressLines = [];
     }
     lane.hasStreamedMessage = true;
     if (
@@ -1161,8 +1063,6 @@ export const dispatchTelegramMessage = async ({
                     ? () =>
                         enqueueDraftLaneEvent(async () => {
                           reasoningStepState.resetForNextStep();
-                          previewToolProgressSuppressed = false;
-                          previewToolProgressLines = [];
                           if (skipNextAnswerMessageStartRotation) {
                             skipNextAnswerMessageStartRotation = false;
                             activePreviewLifecycleByLane.answer = "transient";
@@ -1189,107 +1089,23 @@ export const dispatchTelegramMessage = async ({
                     ? () =>
                         enqueueDraftLaneEvent(async () => {
                           splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
-                          previewToolProgressSuppressed = false;
-                          previewToolProgressLines = [];
                         })
                     : undefined,
                   suppressDefaultToolProgressMessages:
                     !previewStreamingEnabled || Boolean(answerLane.stream),
-                  onToolStart: async (payload) => {
-                    const toolName = payload.name?.trim();
-                    if (statusReactionController && toolName) {
-                      await statusReactionController.setTool(toolName);
-                    }
-                    await pushPreviewToolProgress(
-                      formatChannelProgressDraftLineForEntry(
-                        telegramCfg,
-                        {
-                          event: "tool",
-                          name: toolName,
-                          phase: payload.phase,
-                          args: payload.args,
-                        },
-                        payload.detailMode ? { detailMode: payload.detailMode } : undefined,
-                      ),
-                      { toolName },
-                    );
-                  },
-                  onItemEvent: async (payload) => {
-                    await pushPreviewToolProgress(
-                      formatChannelProgressDraftLineForEntry(telegramCfg, {
-                        event: "item",
-                        itemKind: payload.kind,
-                        title: payload.title,
-                        name: payload.name,
-                        phase: payload.phase,
-                        status: payload.status,
-                        summary: payload.summary,
-                        progressText: payload.progressText,
-                        meta: payload.meta,
-                      }),
-                    );
-                  },
-                  onPlanUpdate: async (payload) => {
-                    if (payload.phase !== "update") {
-                      return;
-                    }
-                    await pushPreviewToolProgress(
-                      formatChannelProgressDraftLine({
-                        event: "plan",
-                        phase: payload.phase,
-                        title: payload.title,
-                        explanation: payload.explanation,
-                        steps: payload.steps,
-                      }),
-                    );
-                  },
-                  onApprovalEvent: async (payload) => {
-                    if (payload.phase !== "requested") {
-                      return;
-                    }
-                    await pushPreviewToolProgress(
-                      formatChannelProgressDraftLine({
-                        event: "approval",
-                        phase: payload.phase,
-                        title: payload.title,
-                        command: payload.command,
-                        reason: payload.reason,
-                        message: payload.message,
-                      }),
-                    );
-                  },
-                  onCommandOutput: async (payload) => {
-                    if (payload.phase !== "end") {
-                      return;
-                    }
-                    await pushPreviewToolProgress(
-                      formatChannelProgressDraftLine({
-                        event: "command-output",
-                        phase: payload.phase,
-                        title: payload.title,
-                        name: payload.name,
-                        status: payload.status,
-                        exitCode: payload.exitCode,
-                      }),
-                    );
-                  },
-                  onPatchSummary: async (payload) => {
-                    if (payload.phase !== "end") {
-                      return;
-                    }
-                    await pushPreviewToolProgress(
-                      formatChannelProgressDraftLine({
-                        event: "patch",
-                        phase: payload.phase,
-                        title: payload.title,
-                        name: payload.name,
-                        added: payload.added,
-                        modified: payload.modified,
-                        deleted: payload.deleted,
-                        summary: payload.summary,
-                      }),
-                    );
-                  },
+                  onToolStart: statusReactionController
+                    ? async (payload) => {
+                        const toolName = payload.name?.trim();
+                        if (toolName) {
+                          await statusReactionController.setTool(toolName);
+                        }
+                      }
+                    : undefined,
+                  onItemEvent: undefined,
+                  onPlanUpdate: undefined,
+                  onApprovalEvent: undefined,
+                  onCommandOutput: undefined,
+                  onPatchSummary: undefined,
                   onCompactionStart:
                     statusReactionController || answerLane.stream
                       ? async () => {
@@ -1327,7 +1143,6 @@ export const dispatchTelegramMessage = async ({
       runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
     } finally {
       await draftLaneEventQueue;
-      progressDraftGate.cancel();
       if (isDispatchSuperseded()) {
         if (answerLane.hasStreamedMessage || typeof answerLane.stream?.messageId() === "number") {
           retainPreviewOnCleanupByLane.answer = true;

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -57,6 +57,7 @@ describe("telegram bot message processor", () => {
 
   async function processSampleMessage(
     processMessage: ReturnType<typeof createTelegramMessageProcessor>,
+    options: Parameters<ReturnType<typeof createTelegramMessageProcessor>>[3] = {},
   ) {
     await processMessage(
       {
@@ -67,7 +68,7 @@ describe("telegram bot message processor", () => {
       } as unknown as Parameters<typeof processMessage>[0],
       [],
       [],
-      {},
+      options,
     );
   }
 
@@ -89,10 +90,16 @@ describe("telegram bot message processor", () => {
     return { processMessage, runtimeError };
   }
 
-  it("dispatches when context is available", async () => {
+  it("dispatches when context is available and sends admitted early typing", async () => {
     const sendTyping = vi.fn().mockResolvedValue(undefined);
     buildTelegramMessageContext.mockResolvedValue({
       chatId: 123,
+      ctxPayload: {
+        Provider: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:123",
+        ChatType: "direct",
+      },
       route: { sessionKey: "agent:main:main" },
       sendTyping,
     });
@@ -107,6 +114,48 @@ describe("telegram bot message processor", () => {
     );
   });
 
+  it("suppresses early typing for Telegram system events", async () => {
+    const sendTyping = vi.fn().mockResolvedValue(undefined);
+    buildTelegramMessageContext.mockResolvedValue({
+      chatId: 123,
+      ctxPayload: {
+        Provider: "cron-event",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:123",
+        ChatType: "direct",
+      },
+      route: { sessionKey: "agent:main:main" },
+      sendTyping,
+    });
+
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+    await processSampleMessage(processMessage, { systemEvent: true });
+
+    expect(sendTyping).not.toHaveBeenCalled();
+    expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses early typing for internal background run kinds", async () => {
+    const sendTyping = vi.fn().mockResolvedValue(undefined);
+    buildTelegramMessageContext.mockResolvedValue({
+      chatId: 123,
+      ctxPayload: {
+        Provider: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:123",
+        ChatType: "direct",
+      },
+      route: { sessionKey: "agent:main:main" },
+      sendTyping,
+    });
+
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+    await processSampleMessage(processMessage, { runKind: "background-internal" });
+
+    expect(sendTyping).not.toHaveBeenCalled();
+    expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("skips dispatch when no context is produced", async () => {
     buildTelegramMessageContext.mockResolvedValue(null);
     const processMessage = createTelegramMessageProcessor(baseDeps);
@@ -114,10 +163,16 @@ describe("telegram bot message processor", () => {
     expect(dispatchTelegramMessage).not.toHaveBeenCalled();
   });
 
-  it("keeps dispatch running when the early typing cue fails", async () => {
+  it("keeps dispatch running when the admitted early typing cue fails", async () => {
     const sendTyping = vi.fn().mockRejectedValue(new Error("typing failed"));
     buildTelegramMessageContext.mockResolvedValue({
       chatId: 123,
+      ctxPayload: {
+        Provider: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:123",
+        ChatType: "direct",
+      },
       route: { sessionKey: "agent:main:main" },
       sendTyping,
     });

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -2,6 +2,8 @@ import type { ReplyToMode } from "openclaw/plugin-sdk/config-types";
 import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-types";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { resolveTypingMode } from "../../../src/auto-reply/reply/typing-mode.js";
+import { resolveRunTypingPolicy } from "../../../src/auto-reply/reply/typing-policy.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
   buildTelegramMessageContext,
@@ -107,9 +109,55 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
           (options?.ingressBuffer ? ` buffer=${options.ingressBuffer}` : ""),
       );
     }
-    void context.sendTyping().catch((err) => {
-      logVerbose(`telegram early typing cue failed for chat ${context.chatId}: ${String(err)}`);
+    const earlyTypingChannel =
+      context.ctxPayload?.OriginatingChannel ?? context.ctxPayload?.Provider;
+    const earlyTypingRunKind =
+      options?.runKind ?? options?.kind ?? context.ctxPayload?.RunKind ?? "telegram-inbound";
+    const isEarlyHeartbeat =
+      options?.isHeartbeat === true || context.ctxPayload?.Provider === "heartbeat";
+    const earlyTypingPolicy = resolveRunTypingPolicy({
+      requestedPolicy: options?.typingPolicy,
+      suppressTyping: options?.suppressTyping === true,
+      isHeartbeat: isEarlyHeartbeat,
+      systemEvent:
+        options?.systemEvent === true ||
+        context.ctxPayload?.Provider === "cron-event" ||
+        context.ctxPayload?.Provider === "exec-event",
+      originatingChannel: earlyTypingChannel,
     });
+    const earlyTypingMode = resolveTypingMode({
+      configured: cfg.session?.typingMode ?? cfg.agents?.defaults?.typingMode,
+      isGroupChat:
+        context.ctxPayload?.ChatType === "group" || context.ctxPayload?.ChatType === "channel",
+      wasMentioned: context.ctxPayload?.WasMentioned === true,
+      isHeartbeat: isEarlyHeartbeat,
+      typingPolicy: earlyTypingPolicy.typingPolicy,
+      suppressTyping: earlyTypingPolicy.suppressTyping,
+      sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
+    });
+    const sessionIsUserVisible =
+      context.ctxPayload?.Provider === "telegram" &&
+      context.ctxPayload?.ChatType !== "internal" &&
+      options?.internal !== true;
+    const runOriginatedFromThisTelegramChat =
+      earlyTypingChannel === "telegram" &&
+      context.ctxPayload?.OriginatingTo === `telegram:${context.chatId}`;
+    const runIsProducingOrExpectedToProduceVisibleOutput = earlyTypingMode === "instant";
+    const runKindAllowsTyping =
+      earlyTypingRunKind !== "subagent-internal" &&
+      earlyTypingRunKind !== "background-internal" &&
+      earlyTypingRunKind !== "yield-wait";
+    const shouldSendTyping =
+      earlyTypingChannel === "telegram" &&
+      sessionIsUserVisible &&
+      runOriginatedFromThisTelegramChat &&
+      runIsProducingOrExpectedToProduceVisibleOutput &&
+      runKindAllowsTyping;
+    if (shouldSendTyping) {
+      void context.sendTyping().catch((err) => {
+        logVerbose(`telegram early typing cue failed for chat ${context.chatId}: ${String(err)}`);
+      });
+    }
     try {
       await dispatchTelegramMessage({
         context,

--- a/scripts/check-duplicates.mjs
+++ b/scripts/check-duplicates.mjs
@@ -17,6 +17,7 @@ const targets = [
   "qa",
   "security",
   "test",
+  "workflow",
   "openclaw.mjs",
   "config/knip.config.ts",
   "tsdown.config.ts",

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -482,14 +482,15 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
     expect(onToolResult).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining("```txt\n/approve 12345678 allow-once\n```"),
-        channelData: {
+        channelData: expect.objectContaining({
           execApproval: expect.objectContaining({
             approvalId: "12345678-1234-1234-1234-123456789012",
             approvalSlug: "12345678",
             approvalKind: "exec",
             allowedDecisions: ["allow-once", "allow-always", "deny"],
           }),
-        },
+          toolName: "exec",
+        }),
         interactive: expect.objectContaining({
           blocks: expect.any(Array),
         }),
@@ -527,14 +528,15 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
     expect(onToolResult).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.not.stringContaining("allow-always"),
-        channelData: {
+        channelData: expect.objectContaining({
           execApproval: expect.objectContaining({
             approvalId: "12345678-1234-1234-1234-123456789012",
             approvalSlug: "12345678",
             approvalKind: "exec",
             allowedDecisions: ["allow-once", "deny"],
           }),
-        },
+          toolName: "exec",
+        }),
         interactive: expect.objectContaining({
           blocks: expect.any(Array),
         }),

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -475,19 +475,21 @@ async function emitToolResultOutput(params: {
     ctx.state.deterministicApprovalPromptPending = true;
     try {
       const { buildExecApprovalPendingReplyPayload } = await loadExecApprovalReply();
-      await ctx.params.onToolResult(
-        buildExecApprovalPendingReplyPayload({
-          approvalId: approvalPending.approvalId,
-          approvalSlug: approvalPending.approvalSlug,
-          allowedDecisions: approvalPending.allowedDecisions,
-          command: approvalPending.command,
-          cwd: approvalPending.cwd,
-          host: approvalPending.host,
-          nodeId: approvalPending.nodeId,
-          expiresAtMs: approvalPending.expiresAtMs,
-          warningText: approvalPending.warningText,
-        }),
-      );
+      const payload = buildExecApprovalPendingReplyPayload({
+        approvalId: approvalPending.approvalId,
+        approvalSlug: approvalPending.approvalSlug,
+        allowedDecisions: approvalPending.allowedDecisions,
+        command: approvalPending.command,
+        cwd: approvalPending.cwd,
+        host: approvalPending.host,
+        nodeId: approvalPending.nodeId,
+        expiresAtMs: approvalPending.expiresAtMs,
+        warningText: approvalPending.warningText,
+      });
+      await ctx.params.onToolResult({
+        ...payload,
+        channelData: { ...payload.channelData, toolName },
+      });
       ctx.state.deterministicApprovalPromptSent = true;
     } catch {
       ctx.state.deterministicApprovalPromptSent = false;
@@ -505,16 +507,18 @@ async function emitToolResultOutput(params: {
     ctx.state.deterministicApprovalPromptPending = true;
     try {
       const { buildExecApprovalUnavailableReplyPayload } = await loadExecApprovalReply();
-      await ctx.params.onToolResult?.(
-        buildExecApprovalUnavailableReplyPayload({
-          reason: approvalUnavailable.reason,
-          warningText: approvalUnavailable.warningText,
-          channel: approvalUnavailable.channel,
-          channelLabel: approvalUnavailable.channelLabel,
-          accountId: approvalUnavailable.accountId,
-          sentApproverDms: approvalUnavailable.sentApproverDms,
-        }),
-      );
+      const payload = buildExecApprovalUnavailableReplyPayload({
+        reason: approvalUnavailable.reason,
+        warningText: approvalUnavailable.warningText,
+        channel: approvalUnavailable.channel,
+        channelLabel: approvalUnavailable.channelLabel,
+        accountId: approvalUnavailable.accountId,
+        sentApproverDms: approvalUnavailable.sentApproverDms,
+      });
+      await ctx.params.onToolResult?.({
+        ...payload,
+        channelData: { ...payload.channelData, toolName },
+      });
       ctx.state.deterministicApprovalPromptSent = true;
     } catch {
       ctx.state.deterministicApprovalPromptSent = false;

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -21,6 +21,9 @@ const state = vi.hoisted(() => ({
   runWithModelFallbackMock: vi.fn(),
   isCliProviderMock: vi.fn((_: unknown) => false),
   isInternalMessageChannelMock: vi.fn((_: unknown) => false),
+  resolveMessageChannelMock: vi.fn<(channel?: string, fallback?: string) => string>(
+    () => "whatsapp",
+  ),
   createBlockReplyDeliveryHandlerMock: vi.fn(),
 }));
 
@@ -124,7 +127,8 @@ vi.mock("../../runtime.js", () => ({
 
 vi.mock("../../utils/message-channel.js", () => ({
   isMarkdownCapableMessageChannel: () => true,
-  resolveMessageChannel: () => "whatsapp",
+  resolveMessageChannel: (channel?: string, fallback?: string) =>
+    state.resolveMessageChannelMock(channel, fallback),
   isInternalMessageChannel: (value: unknown) => state.isInternalMessageChannelMock(value),
 }));
 
@@ -189,7 +193,12 @@ type FallbackRunnerParams = {
 
 type EmbeddedAgentParams = {
   onBlockReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
-  onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
+  onToolResult?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    channelData?: Record<string, unknown>;
+    toolName?: string;
+  }) => Promise<void> | void;
   onItemEvent?: (payload: {
     itemId?: string;
     kind?: string;
@@ -400,6 +409,8 @@ describe("runAgentTurnWithFallback", () => {
     state.isCliProviderMock.mockReturnValue(false);
     state.isInternalMessageChannelMock.mockReset();
     state.isInternalMessageChannelMock.mockReturnValue(false);
+    state.resolveMessageChannelMock.mockReset();
+    state.resolveMessageChannelMock.mockReturnValue("whatsapp");
     state.createBlockReplyDeliveryHandlerMock.mockReset();
     state.createBlockReplyDeliveryHandlerMock.mockReturnValue(undefined);
     state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => ({
@@ -991,6 +1002,93 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("success");
     expect(typingSignals.signalTextDelta).toHaveBeenCalledWith("The user is saying hello");
     expect(onToolResult).toHaveBeenCalledWith({ text: "The user is saying hello" });
+  });
+
+  it("does not signal Telegram typing for internal tool result payloads", async () => {
+    const onToolResult = vi.fn();
+    state.resolveMessageChannelMock.mockReturnValue("telegram");
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onToolResult?.({ text: "Approval required", channelData: { toolName: "exec" } });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const pendingToolTasks = new Set<Promise<void>>();
+    const typingSignals = createMockTypingSignaler();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { onToolResult } satisfies GetReplyOptions,
+      typingSignals,
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks,
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    await Promise.all(pendingToolTasks);
+
+    expect(result.kind).toBe("success");
+    expect(typingSignals.signalTextDelta).not.toHaveBeenCalledWith("Approval required");
+    expect(onToolResult).toHaveBeenCalledWith({
+      text: "Approval required",
+      channelData: { toolName: "exec" },
+    });
+  });
+
+  it("does not signal Telegram typing for internal tool start events", async () => {
+    state.resolveMessageChannelMock.mockReturnValue("telegram");
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "start", name: "process", toolCallId: "tool-1" },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const typingSignals = createMockTypingSignaler();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {} satisfies GetReplyOptions,
+      typingSignals,
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set<Promise<void>>(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    expect(typingSignals.signalToolStart).not.toHaveBeenCalled();
   });
 
   it("continues delivering later streamed tool results after an earlier delivery failure", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -73,6 +73,11 @@ import {
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
+  classifyToolRunActivity,
+  readToolNameFromReplyPayload,
+  shouldSignalTypingForRunActivity,
+} from "./agent-runner-helpers.js";
+import {
   buildEmbeddedRunExecutionParams,
   resolveQueuedReplyRuntimeConfig,
   resolveModelFallbackOptions,
@@ -1597,7 +1602,7 @@ export async function runAgentTurnWithFallback(params: {
                 silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
                 toolResultFormat: (() => {
                   const channel = resolveMessageChannel(
-                    params.sessionCtx.Surface,
+                    params.sessionCtx.OriginatingChannel ?? params.sessionCtx.Surface,
                     params.sessionCtx.Provider,
                   );
                   if (!channel) {
@@ -1660,7 +1665,22 @@ export async function runAgentTurnWithFallback(params: {
                     const phase = readStringValue(evt.data.phase) ?? "";
                     const name = readStringValue(evt.data.name);
                     if (phase === "start" || phase === "update") {
-                      await params.typingSignals.signalToolStart();
+                      const channel = resolveMessageChannel(
+                        params.sessionCtx.OriginatingChannel ??
+                          params.sessionCtx.Surface ??
+                          params.sessionCtx.Provider,
+                        params.followupRun.run.messageProvider,
+                      );
+                      const activityKind = classifyToolRunActivity({ toolName: name });
+                      if (
+                        shouldSignalTypingForRunActivity({
+                          kind: activityKind,
+                          toolName: name,
+                          channel,
+                        })
+                      ) {
+                        await params.typingSignals.signalToolStart();
+                      }
                       await params.opts?.onToolStart?.({
                         name,
                         phase,
@@ -1834,7 +1854,21 @@ export async function runAgentTurnWithFallback(params: {
                             if (skip) {
                               return;
                             }
-                            if (text !== undefined) {
+                            const toolName = readToolNameFromReplyPayload(payload);
+                            const channel = resolveMessageChannel(
+                              params.sessionCtx.OriginatingChannel ??
+                                params.sessionCtx.Surface ??
+                                params.sessionCtx.Provider,
+                              params.followupRun.run.messageProvider,
+                            );
+                            if (
+                              text !== undefined &&
+                              shouldSignalTypingForRunActivity({
+                                kind: "tool-result",
+                                toolName,
+                                channel,
+                              })
+                            ) {
                               await params.typingSignals.signalTextDelta(text);
                             }
                             await onToolResult({

--- a/src/auto-reply/reply/agent-runner-helpers.test.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.test.ts
@@ -18,9 +18,12 @@ vi.mock("../../config/sessions.js", async () => {
 });
 
 const {
+  classifyToolRunActivity,
   createShouldEmitToolOutput,
   createShouldEmitToolResult,
   isAudioPayload,
+  readToolNameFromReplyPayload,
+  shouldSignalTypingForRunActivity,
   signalTypingIfNeeded,
 } = await import("./agent-runner-helpers.js");
 
@@ -108,6 +111,46 @@ describe("agent runner helpers", () => {
     expect(fallbackFull()).toBe(true);
   });
 
+  it("classifies internal tool activity", () => {
+    expect(classifyToolRunActivity({ toolName: "exec" })).toBe("background-internal");
+    expect(classifyToolRunActivity({ toolName: "process" })).toBe("background-internal");
+    expect(classifyToolRunActivity({ toolName: "sessions_spawn" })).toBe("subagent-internal");
+    expect(classifyToolRunActivity({ toolName: "sessions_yield" })).toBe("yield-wait");
+    expect(classifyToolRunActivity({ toolName: "read" })).toBe("visible-tool");
+  });
+
+  it("suppresses Telegram typing for internal tool activity only", () => {
+    expect(
+      shouldSignalTypingForRunActivity({ kind: "background-internal", channel: "telegram" }),
+    ).toBe(false);
+    expect(
+      shouldSignalTypingForRunActivity({
+        kind: "tool-result",
+        toolName: "exec",
+        channel: "telegram",
+      }),
+    ).toBe(false);
+    expect(
+      shouldSignalTypingForRunActivity({
+        kind: "tool-result",
+        toolName: "read",
+        channel: "telegram",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSignalTypingForRunActivity({ kind: "background-internal", channel: "whatsapp" }),
+    ).toBe(true);
+  });
+
+  it("reads tool names from direct and channel payload metadata", () => {
+    expect(readToolNameFromReplyPayload({ text: "x", channelData: { toolName: "exec" } })).toBe(
+      "exec",
+    );
+    expect(readToolNameFromReplyPayload({ text: "x", toolName: "process" } as ReplyPayload)).toBe(
+      "process",
+    );
+  });
+
   it("signals typing only when any payload has text or media", async () => {
     const signalRunStart = vi.fn().mockResolvedValue(undefined);
     const typingSignals = { signalRunStart } as unknown as TypingSignaler;
@@ -116,6 +159,12 @@ describe("agent runner helpers", () => {
     expect(signalRunStart).not.toHaveBeenCalled();
 
     await signalTypingIfNeeded([{ mediaUrl: "https://example.test/img.png" }], typingSignals);
+    expect(signalRunStart).toHaveBeenCalledOnce();
+
+    await signalTypingIfNeeded([{ text: "internal" }], typingSignals, {
+      kind: "background-internal",
+      channel: "telegram",
+    });
     expect(signalRunStart).toHaveBeenCalledOnce();
   });
 });

--- a/src/auto-reply/reply/agent-runner-helpers.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.ts
@@ -77,10 +77,86 @@ export const createShouldEmitToolOutput = (params: VerboseGateParams): (() => bo
   return createVerboseGate(params, (level) => level === "full");
 };
 
+export type RunActivityKind =
+  | "run-start"
+  | "message-start"
+  | "text-delta"
+  | "reasoning-delta"
+  | "visible-tool"
+  | "tool-result"
+  | "final-payload"
+  | "followup-delivery"
+  | "background-internal"
+  | "subagent-internal"
+  | "yield-wait";
+
+export type RunActivityTypingParams = {
+  kind?: RunActivityKind;
+  toolName?: string;
+  channel?: string;
+  hasVisibleDeliveryRoute?: boolean;
+};
+
+function normalizeActivityText(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed ? trimmed : undefined;
+}
+
+export function classifyToolRunActivity(params: { toolName?: string }): RunActivityKind {
+  const toolName = normalizeActivityText(params.toolName);
+  if (toolName === "sessions_yield") {
+    return "yield-wait";
+  }
+  if (toolName === "sessions_spawn" || toolName === "subagents") {
+    return "subagent-internal";
+  }
+  if (toolName === "exec" || toolName === "process") {
+    return "background-internal";
+  }
+  return "visible-tool";
+}
+
+export function shouldSignalTypingForRunActivity(params: RunActivityTypingParams = {}): boolean {
+  const channel = normalizeActivityText(params.channel);
+  if (channel !== "telegram") {
+    return true;
+  }
+  const kind = params.kind ?? classifyToolRunActivity({ toolName: params.toolName });
+  if (kind === "background-internal" || kind === "subagent-internal" || kind === "yield-wait") {
+    return false;
+  }
+  if (kind === "tool-result") {
+    return classifyToolRunActivity({ toolName: params.toolName }) === "visible-tool";
+  }
+  if (kind === "followup-delivery") {
+    return params.hasVisibleDeliveryRoute === true;
+  }
+  return true;
+}
+
+export function readToolNameFromReplyPayload(payload: ReplyPayload): string | undefined {
+  const record = payload as ReplyPayload & { name?: unknown; toolName?: unknown };
+  if (typeof record.toolName === "string" && record.toolName.trim()) {
+    return record.toolName;
+  }
+  if (typeof record.name === "string" && record.name.trim()) {
+    return record.name;
+  }
+  const channelData = payload.channelData;
+  if (typeof channelData?.toolName === "string" && channelData.toolName.trim()) {
+    return channelData.toolName;
+  }
+  return undefined;
+}
+
 export const signalTypingIfNeeded = async (
   payloads: ReplyPayload[],
   typingSignals: TypingSignaler,
+  params: RunActivityTypingParams = {},
 ): Promise<void> => {
+  if (!shouldSignalTypingForRunActivity(params)) {
+    return;
+  }
   const shouldSignalTyping = payloads.some((payload) =>
     hasOutboundReplyContent(payload, { trimText: true }),
   );


### PR DESCRIPTION
## Summary
- suppress Telegram progress-preview drafts that show internal tool/process status such as “Pinching...”
- gate early Telegram typing to runs that originate from the same user-visible Telegram chat and are expected to produce visible output
- propagate source reply delivery mode / run-kind context so internal subagent, background, and yield-wait activity does not leak user-visible typing/progress cues
- add regressions for Telegram progress preview suppression and typing admission behavior

## Verification
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`
