### PR TITLE
Signal: match allowlist on either uuid or e164 alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -643,6 +643,7 @@ Docs: https://docs.openclaw.ai
 - Browser/downloads: route explicit and managed browser download output directories through `fs-safe` validation before staging final files, so symlinked output roots are rejected before writes. (#78780) Thanks @jesse-merhi.
 - Agents/PI: skip the idle wait during aborted embedded-run cleanup, so stopped or timed-out runs clear pending tool state and release the session lock promptly. (#74919) Thanks @medns.
 - Agents/current-time: split UTC into a separate `Reference UTC:` prompt line so local `Current time:` stays anchored to the user's timezone. (#42654) Thanks @chencheng-li.
+- Channels/Signal: match `channels.signal.allowFrom` entries against either the inbound `sourceUuid` or `sourceNumber` when signal-cli reports both, so a sender approved as `uuid:<id>` while only the UUID was known no longer triggers the pairing flow once an outbound send teaches signal-cli the number → uuid mapping and inbound events begin carrying both forms. (#78022) Thanks @fransqaas.
 
 ## 2026.5.3-1
 

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -9,6 +9,7 @@ import { signalPlugin } from "./channel.js";
 import * as clientModule from "./client.js";
 import { classifySignalCliLogLine } from "./daemon.js";
 import {
+  isSignalSenderAllowed,
   looksLikeUuid,
   resolveSignalPeerId,
   resolveSignalRecipient,
@@ -44,7 +45,7 @@ describe("looksLikeUuid", () => {
 });
 
 describe("signal sender identity", () => {
-  it("prefers sourceNumber over sourceUuid", () => {
+  it("prefers sourceNumber over sourceUuid and keeps the uuid as an alias", () => {
     const sender = resolveSignalSender({
       sourceNumber: " +15550001111 ",
       sourceUuid: "123e4567-e89b-12d3-a456-426614174000",
@@ -53,6 +54,7 @@ describe("signal sender identity", () => {
       kind: "phone",
       raw: "+15550001111",
       e164: "+15550001111",
+      aliases: { uuid: "123e4567-e89b-12d3-a456-426614174000" },
     });
   });
 
@@ -70,6 +72,56 @@ describe("signal sender identity", () => {
     const sender = { kind: "uuid", raw: "123e4567-e89b-12d3-a456-426614174000" } as const;
     expect(resolveSignalRecipient(sender)).toBe("123e4567-e89b-12d3-a456-426614174000");
     expect(resolveSignalPeerId(sender)).toBe("uuid:123e4567-e89b-12d3-a456-426614174000");
+  });
+});
+
+describe("isSignalSenderAllowed", () => {
+  const uuid = "f4d0fe67-3b38-446d-828e-317c285ffa75";
+  const e164 = "+34688329273";
+
+  it("matches a phone-primary sender against a uuid allow entry via the alias", () => {
+    // Regression: a sender originally approved as `uuid:<id>` while signal-cli
+    // only knew their UUID kept getting re-paired once an outbound send taught
+    // signal-cli the number → uuid mapping and inbound events started carrying
+    // both forms (sourceNumber preferred). The allow check now treats the two
+    // forms as the same identity.
+    const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
+    expect(sender).not.toBeNull();
+    expect(isSignalSenderAllowed(sender!, [`uuid:${uuid}`])).toBe(true);
+  });
+
+  it("matches a phone-primary sender against a phone allow entry", () => {
+    const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
+    expect(isSignalSenderAllowed(sender!, [e164])).toBe(true);
+  });
+
+  it("does not match unrelated allow entries even when an alias is present", () => {
+    const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
+    expect(isSignalSenderAllowed(sender!, ["+15550009999"])).toBe(false);
+    expect(isSignalSenderAllowed(sender!, ["uuid:00000000-0000-0000-0000-000000000000"])).toBe(
+      false,
+    );
+  });
+
+  it("matches a uuid-only sender against a uuid allow entry", () => {
+    const sender = resolveSignalSender({ sourceUuid: uuid });
+    expect(isSignalSenderAllowed(sender!, [`uuid:${uuid}`])).toBe(true);
+  });
+
+  it("does not match a uuid-only sender against a phone allow entry", () => {
+    // No alias is known here, so the phone form cannot be inferred.
+    const sender = resolveSignalSender({ sourceUuid: uuid });
+    expect(isSignalSenderAllowed(sender!, [e164])).toBe(false);
+  });
+
+  it("honors wildcard allow entries", () => {
+    const sender = resolveSignalSender({ sourceNumber: e164 });
+    expect(isSignalSenderAllowed(sender!, ["*"])).toBe(true);
+  });
+
+  it("returns false for an empty allowlist", () => {
+    const sender = resolveSignalSender({ sourceNumber: e164 });
+    expect(isSignalSenderAllowed(sender!, [])).toBe(false);
   });
 });
 

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -19,6 +19,7 @@ import {
 import { signalPlugin } from "./channel.js";
 import * as clientModule from "./client-adapter.js";
 import {
+  isSignalSenderAllowed,
   looksLikeUuid,
   normalizeSignalAllowRecipient,
   resolveSignalPeerId,
@@ -59,7 +60,7 @@ describe("looksLikeUuid", () => {
 });
 
 describe("signal sender identity", () => {
-  it("prefers sourceNumber over sourceUuid", () => {
+  it("prefers sourceNumber over sourceUuid and keeps the uuid as an alias", () => {
     const sender = resolveSignalSender({
       sourceNumber: " +15550001111 ",
       sourceUuid: "123e4567-e89b-12d3-a456-426614174000",
@@ -68,6 +69,7 @@ describe("signal sender identity", () => {
       kind: "phone",
       raw: "+15550001111",
       e164: "+15550001111",
+      aliases: { uuid: "123e4567-e89b-12d3-a456-426614174000" },
     });
   });
 
@@ -101,6 +103,56 @@ describe("signal sender identity", () => {
     const sender = { kind: "uuid", raw: "123e4567-e89b-12d3-a456-426614174000" } as const;
     expect(resolveSignalRecipient(sender)).toBe("123e4567-e89b-12d3-a456-426614174000");
     expect(resolveSignalPeerId(sender)).toBe("uuid:123e4567-e89b-12d3-a456-426614174000");
+  });
+});
+
+describe("isSignalSenderAllowed", () => {
+  const uuid = "f4d0fe67-3b38-446d-828e-317c285ffa75";
+  const e164 = "+34688329273";
+
+  it("matches a phone-primary sender against a uuid allow entry via the alias", () => {
+    // Regression: a sender originally approved as `uuid:<id>` while signal-cli
+    // only knew their UUID kept getting re-paired once an outbound send taught
+    // signal-cli the number → uuid mapping and inbound events started carrying
+    // both forms (sourceNumber preferred). The allow check now treats the two
+    // forms as the same identity.
+    const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
+    expect(sender).not.toBeNull();
+    expect(isSignalSenderAllowed(sender!, [`uuid:${uuid}`])).toBe(true);
+  });
+
+  it("matches a phone-primary sender against a phone allow entry", () => {
+    const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
+    expect(isSignalSenderAllowed(sender!, [e164])).toBe(true);
+  });
+
+  it("does not match unrelated allow entries even when an alias is present", () => {
+    const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
+    expect(isSignalSenderAllowed(sender!, ["+15550009999"])).toBe(false);
+    expect(isSignalSenderAllowed(sender!, ["uuid:00000000-0000-0000-0000-000000000000"])).toBe(
+      false,
+    );
+  });
+
+  it("matches a uuid-only sender against a uuid allow entry", () => {
+    const sender = resolveSignalSender({ sourceUuid: uuid });
+    expect(isSignalSenderAllowed(sender!, [`uuid:${uuid}`])).toBe(true);
+  });
+
+  it("does not match a uuid-only sender against a phone allow entry", () => {
+    // No alias is known here, so the phone form cannot be inferred.
+    const sender = resolveSignalSender({ sourceUuid: uuid });
+    expect(isSignalSenderAllowed(sender!, [e164])).toBe(false);
+  });
+
+  it("honors wildcard allow entries", () => {
+    const sender = resolveSignalSender({ sourceNumber: e164 });
+    expect(isSignalSenderAllowed(sender!, ["*"])).toBe(true);
+  });
+
+  it("returns false for an empty allowlist", () => {
+    const sender = resolveSignalSender({ sourceNumber: e164 });
+    expect(isSignalSenderAllowed(sender!, [])).toBe(false);
   });
 });
 

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -111,48 +111,22 @@ describe("isSignalSenderAllowed", () => {
   const e164 = "+34688329273";
 
   it("matches a phone-primary sender against a uuid allow entry via the alias", () => {
-    // Regression: a sender originally approved as `uuid:<id>` while signal-cli
-    // only knew their UUID kept getting re-paired once an outbound send taught
-    // signal-cli the number → uuid mapping and inbound events started carrying
-    // both forms (sourceNumber preferred). The allow check now treats the two
-    // forms as the same identity.
     const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
-    expect(sender).not.toBeNull();
-    expect(isSignalSenderAllowed(sender!, [`uuid:${uuid}`])).toBe(true);
-  });
-
-  it("matches a phone-primary sender against a phone allow entry", () => {
-    const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
-    expect(isSignalSenderAllowed(sender!, [e164])).toBe(true);
+    if (!sender) {
+      throw new Error("expected Signal sender");
+    }
+    expect(isSignalSenderAllowed(sender, [`uuid:${uuid}`])).toBe(true);
   });
 
   it("does not match unrelated allow entries even when an alias is present", () => {
     const sender = resolveSignalSender({ sourceNumber: e164, sourceUuid: uuid });
-    expect(isSignalSenderAllowed(sender!, ["+15550009999"])).toBe(false);
-    expect(isSignalSenderAllowed(sender!, ["uuid:00000000-0000-0000-0000-000000000000"])).toBe(
+    if (!sender) {
+      throw new Error("expected Signal sender");
+    }
+    expect(isSignalSenderAllowed(sender, ["+15550009999"])).toBe(false);
+    expect(isSignalSenderAllowed(sender, ["uuid:00000000-0000-0000-0000-000000000000"])).toBe(
       false,
     );
-  });
-
-  it("matches a uuid-only sender against a uuid allow entry", () => {
-    const sender = resolveSignalSender({ sourceUuid: uuid });
-    expect(isSignalSenderAllowed(sender!, [`uuid:${uuid}`])).toBe(true);
-  });
-
-  it("does not match a uuid-only sender against a phone allow entry", () => {
-    // No alias is known here, so the phone form cannot be inferred.
-    const sender = resolveSignalSender({ sourceUuid: uuid });
-    expect(isSignalSenderAllowed(sender!, [e164])).toBe(false);
-  });
-
-  it("honors wildcard allow entries", () => {
-    const sender = resolveSignalSender({ sourceNumber: e164 });
-    expect(isSignalSenderAllowed(sender!, ["*"])).toBe(true);
-  });
-
-  it("returns false for an empty allowlist", () => {
-    const sender = resolveSignalSender({ sourceNumber: e164 });
-    expect(isSignalSenderAllowed(sender!, [])).toBe(false);
   });
 });
 

--- a/extensions/signal/src/identity.ts
+++ b/extensions/signal/src/identity.ts
@@ -2,9 +2,14 @@ import { evaluateSenderGroupAccessForPolicy } from "openclaw/plugin-sdk/group-ac
 import { normalizeE164, normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { looksLikeUuid } from "./uuid.js";
 
+export type SignalSenderAliases = {
+  e164?: string;
+  uuid?: string;
+};
+
 export type SignalSender =
-  | { kind: "phone"; raw: string; e164: string }
-  | { kind: "uuid"; raw: string };
+  | { kind: "phone"; raw: string; e164: string; aliases?: SignalSenderAliases }
+  | { kind: "uuid"; raw: string; aliases?: SignalSenderAliases };
 
 type SignalAllowEntry =
   | { kind: "any" }
@@ -22,14 +27,15 @@ export function resolveSignalSender(params: {
   sourceUuid?: string | null;
 }): SignalSender | null {
   const sourceNumber = params.sourceNumber?.trim();
+  const sourceUuid = params.sourceUuid?.trim();
   if (sourceNumber) {
     return {
       kind: "phone",
       raw: sourceNumber,
       e164: normalizeE164(sourceNumber),
+      ...(sourceUuid ? { aliases: { uuid: sourceUuid } } : {}),
     };
   }
-  const sourceUuid = params.sourceUuid?.trim();
   if (sourceUuid) {
     return { kind: "uuid", raw: sourceUuid };
   }
@@ -103,12 +109,18 @@ export function isSignalSenderAllowed(sender: SignalSender, allowFrom: string[])
   if (parsed.some((entry) => entry.kind === "any")) {
     return true;
   }
+  // A sender carries an alias when signal-cli has both forms cached locally
+  // (e.g. after the daemon resolved a number → uuid for an outbound send).
+  // Treat both forms as the same identity so an allowlist entry approved as
+  // one form keeps matching after the other becomes available.
+  const senderE164 = sender.kind === "phone" ? sender.e164 : sender.aliases?.e164;
+  const senderUuid = sender.kind === "uuid" ? sender.raw : sender.aliases?.uuid;
   return parsed.some((entry) => {
-    if (entry.kind === "phone" && sender.kind === "phone") {
-      return entry.e164 === sender.e164;
+    if (entry.kind === "phone") {
+      return senderE164 !== undefined && entry.e164 === senderE164;
     }
-    if (entry.kind === "uuid" && sender.kind === "uuid") {
-      return entry.raw === sender.raw;
+    if (entry.kind === "uuid") {
+      return senderUuid !== undefined && entry.raw === senderUuid;
     }
     return false;
   });

--- a/extensions/signal/src/identity.ts
+++ b/extensions/signal/src/identity.ts
@@ -3,7 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
 import { looksLikeUuid } from "./uuid.js";
 
-export type SignalSenderAliases = {
+type SignalSenderAliases = {
   e164?: string;
   uuid?: string;
 };

--- a/extensions/signal/src/identity.ts
+++ b/extensions/signal/src/identity.ts
@@ -3,9 +3,14 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
 import { looksLikeUuid } from "./uuid.js";
 
+export type SignalSenderAliases = {
+  e164?: string;
+  uuid?: string;
+};
+
 export type SignalSender =
-  | { kind: "phone"; raw: string; e164: string }
-  | { kind: "uuid"; raw: string };
+  | { kind: "phone"; raw: string; e164: string; aliases?: SignalSenderAliases }
+  | { kind: "uuid"; raw: string; aliases?: SignalSenderAliases };
 
 type SignalAllowEntry =
   | { kind: "any" }
@@ -23,13 +28,18 @@ export function resolveSignalSender(params: {
   sourceUuid?: string | null;
 }): SignalSender | null {
   const sourceNumber = params.sourceNumber?.trim();
+  const sourceUuid = params.sourceUuid?.trim();
   if (sourceNumber) {
     const e164 = normalizeE164(sourceNumber);
     if (e164) {
-      return { kind: "phone", raw: sourceNumber, e164 };
+      return {
+        kind: "phone",
+        raw: sourceNumber,
+        e164,
+        ...(sourceUuid ? { aliases: { uuid: sourceUuid } } : {}),
+      };
     }
   }
-  const sourceUuid = params.sourceUuid?.trim();
   if (sourceUuid) {
     return { kind: "uuid", raw: sourceUuid };
   }
@@ -104,12 +114,18 @@ export function isSignalSenderAllowed(sender: SignalSender, allowFrom: string[])
   if (parsed.some((entry) => entry.kind === "any")) {
     return true;
   }
+  // A sender carries an alias when signal-cli has both forms cached locally
+  // (e.g. after the daemon resolved a number → uuid for an outbound send).
+  // Treat both forms as the same identity so an allowlist entry approved as
+  // one form keeps matching after the other becomes available.
+  const senderE164 = sender.kind === "phone" ? sender.e164 : sender.aliases?.e164;
+  const senderUuid = sender.kind === "uuid" ? sender.raw : sender.aliases?.uuid;
   return parsed.some((entry) => {
-    if (entry.kind === "phone" && sender.kind === "phone") {
-      return entry.e164 === sender.e164;
+    if (entry.kind === "phone") {
+      return senderE164 !== undefined && entry.e164 === senderE164;
     }
-    if (entry.kind === "uuid" && sender.kind === "uuid") {
-      return entry.raw === sender.raw;
+    if (entry.kind === "uuid") {
+      return senderUuid !== undefined && entry.raw === senderUuid;
     }
     return false;
   });

--- a/extensions/signal/src/monitor/access-policy.test.ts
+++ b/extensions/signal/src/monitor/access-policy.test.ts
@@ -1,6 +1,7 @@
 // Signal tests cover access policy plugin behavior.
 import type { AccessGroupsConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it, vi } from "vitest";
+import { resolveSignalSender } from "../identity.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
 
 const SIGNAL_GROUP_ID = "signal-group-id";
@@ -10,6 +11,18 @@ const SIGNAL_SENDER = {
   e164: "+15551230000",
   raw: "+15551230000",
 };
+const SIGNAL_UUID = "f4d0fe67-3b38-446d-828e-317c285ffa75";
+
+function resolveAliasedSignalSender() {
+  const sender = resolveSignalSender({
+    sourceNumber: SIGNAL_SENDER.e164,
+    sourceUuid: SIGNAL_UUID,
+  });
+  if (!sender) {
+    throw new Error("expected Signal sender");
+  }
+  return sender;
+}
 
 async function resolveGroupAccess(params: {
   allowFrom?: string[];
@@ -181,6 +194,36 @@ describe("resolveSignalAccessState", () => {
     expect(senderAccess.effectiveAllowFrom).toEqual([SIGNAL_SENDER.e164]);
   });
 
+  it("keeps a UUID-paired sender allowed after signal-cli learns its phone alias", async () => {
+    const { senderAccess } = await resolveSignalAccessState({
+      accountId: "default",
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+      allowFrom: [],
+      groupAllowFrom: [],
+      sender: resolveAliasedSignalSender(),
+      isGroup: false,
+      readStoreAllowFrom: async () => [`uuid:${SIGNAL_UUID}`],
+    });
+
+    expect(senderAccess.decision).toBe("allow");
+    expect(senderAccess.effectiveAllowFrom).toContain(`uuid:${SIGNAL_UUID}`);
+  });
+
+  it("does not authorize an aliased sender through an unrelated UUID", async () => {
+    const { senderAccess } = await resolveSignalAccessState({
+      accountId: "default",
+      dmPolicy: "allowlist",
+      groupPolicy: "allowlist",
+      allowFrom: ["uuid:00000000-0000-0000-0000-000000000000"],
+      groupAllowFrom: [],
+      sender: resolveAliasedSignalSender(),
+      isGroup: false,
+    });
+
+    expect(senderAccess.decision).toBe("block");
+  });
+
   it("does not let pairing-store senders satisfy group access", async () => {
     const { groupDecision } = await resolveGroupAccess({
       groupAllowFrom: [],
@@ -232,6 +275,24 @@ describe("resolveSignalAccessState", () => {
       hasControlCommand: true,
     });
 
+    expect(access.commandAccess.authorized).toBe(true);
+    expect(access.commandAccess.shouldBlockControlCommand).toBe(false);
+  });
+
+  it("authorizes group control commands through a sender UUID alias", async () => {
+    const access = await resolveSignalAccessState({
+      accountId: "default",
+      dmPolicy: "allowlist",
+      groupPolicy: "allowlist",
+      allowFrom: [],
+      groupAllowFrom: [`uuid:${SIGNAL_UUID}`],
+      sender: resolveAliasedSignalSender(),
+      groupId: SIGNAL_GROUP_ID,
+      isGroup: true,
+      hasControlCommand: true,
+    });
+
+    expect(access.senderAccess.decision).toBe("allow");
     expect(access.commandAccess.authorized).toBe(true);
     expect(access.commandAccess.shouldBlockControlCommand).toBe(false);
   });

--- a/extensions/signal/src/monitor/access-policy.ts
+++ b/extensions/signal/src/monitor/access-policy.ts
@@ -97,11 +97,13 @@ const signalIngressIdentity = defineStableChannelIngressIdentity({
 });
 
 function signalSubjectInput(params: { sender: SignalSender; groupId?: string }) {
+  // signal-cli may learn a phone/UUID mapping after pairing. Keep both
+  // identifiers on the shared ingress subject or the existing entry stops matching.
   return {
     stableId: formatSignalSenderId(params.sender),
     aliases: {
-      phone: params.sender.kind === "phone" ? params.sender.e164 : undefined,
-      uuid: params.sender.kind === "uuid" ? params.sender.raw : undefined,
+      phone: params.sender.kind === "phone" ? params.sender.e164 : params.sender.aliases?.e164,
+      uuid: params.sender.kind === "uuid" ? params.sender.raw : params.sender.aliases?.uuid,
       group: params.groupId,
     },
   };


### PR DESCRIPTION
## Summary

- Preserve both phone and UUID identities when signal-cli supplies both on an inbound envelope.
- Project both identities into OpenClaw's existing shared channel-ingress alias model.
- Keep Signal's reaction and quoted-sender allowlist helper aligned with the same identity equivalence.

## What Problem This Solves

signal-cli can emit `sourceNumber` and `sourceUuid` together in a receive envelope, as shown in its [JSON-RPC contract examples](https://github.com/AsamK/signal-cli/blob/master/man/signal-cli-jsonrpc.5.adoc). OpenClaw preferred the phone number and discarded the UUID.

That breaks a real pairing transition: a sender first approved while only a UUID is known is stored as `uuid:<id>`. If signal-cli later learns the phone mapping, the same sender arrives phone-first and the UUID pairing-store entry stops matching, so pairing fires again.

## Implementation

- `resolveSignalSender` retains the secondary UUID as an internal alias when a valid phone number remains the primary identity.
- `signalSubjectInput` sends every known phone/UUID identity through the existing `ChannelIngressIdentitySubjectInput.aliases` seam. Direct-message, pairing-store, group, and command authorization therefore use one shared ingress decision path.
- `isSignalSenderAllowed` also checks retained aliases for the Signal-only reaction and quoted-sender callers.
- Invalid or unrelated aliases remain fail-closed. No config, session, memory, core policy, or public Plugin SDK surface was added.

## User impact

Signal users remain paired when signal-cli learns another identifier for the same sender. Phone-only and UUID-only senders keep existing routing and session identities, while unrelated allowlist entries still block.

## Evidence

- `node scripts/run-vitest.mjs extensions/signal/src/core.test.ts extensions/signal/src/monitor/access-policy.test.ts` — 2 files, 73 tests passed on the prepared tree.
- Regression coverage includes UUID-backed pairing-store admission after phone discovery, unrelated-UUID rejection, group control-command authorization through the UUID alias, sender resolution, and Signal helper consumers.
- `git diff --check` passed.
- Fresh branch-level autoreview against current `origin/main`: clean; no accepted/actionable findings.
- Exact-head hosted CI: pending on the refreshed PR head.

The contributor supplied a detailed live pre-fix reproduction from a paired Signal deployment. A new post-fix device roundtrip was not available in the isolated maintainer checkout; exact-head tests and hosted CI cover the rewritten current architecture.

AI-assisted maintainer rewrite after deep review. Contributor intent, authorship, and credit preserved.
