### PR TITLE
fix(control-ui): strip <think>/<final> tags from rendered assistant text

### DIFF
--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -633,6 +633,44 @@ describe("grouped chat rendering", () => {
     expect(streamingTime?.textContent?.trim()).toBe(display.label);
   });
 
+  it("strips <think> and <final> tags from streaming bubble text", () => {
+    const container = document.createElement("div");
+    const timestamp = Date.UTC(2026, 3, 24, 18, 30);
+
+    render(
+      renderStreamingGroup(
+        "<think>internal step 1</think><final>Visible answer</final>",
+        timestamp,
+      ),
+      container,
+    );
+
+    const text = container.querySelector<HTMLElement>(".chat-text")?.textContent ?? "";
+    expect(text).not.toContain("<think>");
+    expect(text).not.toContain("</think>");
+    expect(text).not.toContain("<final>");
+    expect(text).not.toContain("</final>");
+    expect(text).not.toContain("internal step 1");
+    expect(text).toContain("Visible answer");
+  });
+
+  it("strips <think> and <final> tags from non-streaming assistant bubble text", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: "<think>secret reasoning</think><final>Done.</final>",
+      timestamp: 1000,
+    });
+
+    const text = container.querySelector<HTMLElement>(".chat-text")?.textContent ?? "";
+    expect(text).not.toContain("<think>");
+    expect(text).not.toContain("</think>");
+    expect(text).not.toContain("<final>");
+    expect(text).not.toContain("</final>");
+    expect(text).not.toContain("secret reasoning");
+    expect(text).toContain("Done.");
+  });
+
   it("renders configured local user names", () => {
     const renderUser = (opts: Partial<RenderMessageGroupOptions>) => {
       const container = document.createElement("div");

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -17,6 +17,7 @@ import type {
 } from "../types/chat-types.ts";
 import { resolveLocalUserName } from "../user-identity.ts";
 export { resolveAssistantTextAvatar } from "../views/agents-utils.ts";
+import { stripThinkingTags } from "../strip-thinking-tags.ts";
 import { renderChatAvatar } from "./chat-avatar.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import { extractThinkingCached, formatReasoningMarkdown } from "./message-extract.ts";
@@ -1412,7 +1413,7 @@ function renderGroupedMessage(
   const hasImages = images.length > 0;
 
   const normalizedMessage = normalizeMessage(message);
-  const extractedText = normalizedMessage.content
+  const rawExtractedText = normalizedMessage.content
     .reduce<string[]>((lines, item) => {
       if (item.type === "text" && typeof item.text === "string") {
         lines.push(item.text);
@@ -1421,6 +1422,13 @@ function renderGroupedMessage(
     }, [])
     .join("\n")
     .trim();
+  // Strip <think>...</think> and <final>...</final> scaffolding from
+  // assistant-rendered text so they don't leak into the chat bubble. The
+  // non-streaming history path already strips these via extractText, but
+  // renderGroupedMessage reads message.content[].text directly, and the
+  // streaming path feeds raw model output here. See issue #77879.
+  const extractedText =
+    role === "assistant" ? stripThinkingTags(rawExtractedText) : rawExtractedText;
   const assistantAttachments = normalizedMessage.content.filter(
     (item): item is AttachmentItem => item.type === "attachment",
   );


### PR DESCRIPTION
## Summary
- `renderGroupedMessage` reads `message.content[].text` directly via `normalizeMessage`, so the streaming bubble and any non-streaming history message can render raw `<think>` / `<final>` scaffolding the model emitted as text.
- Run the assembled assistant text through `stripThinkingTags` (`internal-scaffolding` profile, already used elsewhere in the chat extractor) before it becomes `markdown`. User and tool roles are unchanged.
- Adds two regression tests covering both `renderStreamingGroup` and the non-streaming `renderMessageGroup` path.

Closes #77879

## Testing
- `pnpm vitest run ui/src/ui/chat/grouped-render.test.ts` (37/37, includes 2 new)
- `pnpm vitest run ui/src/ui/chat` (205/205)
- `pnpm vitest run ui/src/ui/views/chat.test.ts` (28/28)

## Real behavior proof
- Behavior or issue addressed: Issue #77879 reports literal `<think>` and `<final>` tags appearing in openclaw-control-ui chat bubbles even when `thinkingDefault` is \"off\". The two new tests fail on `origin/main` (text content includes the tag bodies) and pass after this patch.
- Real environment tested: Local OpenClaw checkout from this PR branch on macOS (Darwin 25.5.0) at HEAD f25a2824ec81a022727559a6ad1a8e8633ccd77e. Vitest runs from the branch worktree against the changed UI module.
- Exact steps or command run after this patch:
  ```
  pnpm vitest run ui/src/ui/chat/grouped-render.test.ts
  pnpm vitest run ui/src/ui/chat
  ```
- Evidence after fix:
  ```
   Test Files  1 passed (1)
        Tests  37 passed (37)
     Start at  15:06:14
     Duration  1.11s

   Test Files  17 passed (17)
        Tests  205 passed (205)
  ```
- Observed result after fix: Streaming and non-streaming assistant bubbles render \"Visible answer\" / \"Done.\" without the surrounding tags or the in-tag content; tool and user message rendering paths are untouched.
- What was not tested: A live multi-turn streaming session against `google/gemini-flash-3` was not run; this is a UI-side render fix, and the hosted control-ui smoke is covered by CI.