### PR TITLE
Destroy bounded QMD read streams

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4037,6 +4037,40 @@ describe("QmdMemoryManager", () => {
     readFileSpy.mockRestore();
   });
 
+  it("destroys bounded qmd read streams before closing their file handles", async () => {
+    const text = Array.from({ length: 50 }, (_, index) => `line-${index + 1}`).join("\n");
+    const relPath = path.join("memory", "window-close.md");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, relPath), text, "utf-8");
+
+    const realOpen = fs.open;
+    const streamDestroySpies: Mock[] = [];
+    const createReadStreamOptions: unknown[] = [];
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      const realCreateReadStream = handle.createReadStream.bind(handle);
+      vi.spyOn(handle, "createReadStream").mockImplementation((options) => {
+        createReadStreamOptions.push(options);
+        const stream = realCreateReadStream(options);
+        streamDestroySpies.push(vi.spyOn(stream, "destroy"));
+        return stream;
+      });
+      return handle;
+    });
+
+    const { manager } = await createManager();
+    try {
+      await manager.readFile({ relPath, from: 10, lines: 3 });
+    } finally {
+      await manager.close();
+      openSpy.mockRestore();
+    }
+
+    expect(createReadStreamOptions).toContainEqual(expect.objectContaining({ autoClose: false }));
+    expect(streamDestroySpies).toHaveLength(1);
+    expect(streamDestroySpies[0]).toHaveBeenCalled();
+  });
+
   it("returns a bounded default excerpt for qmd memory reads without explicit lines", async () => {
     const relPath = path.join("memory", "default-window.md");
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2137,7 +2137,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       throw err;
     }
-    const stream = handle.createReadStream({ encoding: "utf-8" });
+    const stream = handle.createReadStream({ encoding: "utf-8", autoClose: false });
     const rl = readline.createInterface({
       input: stream,
       crlfDelay: Infinity,
@@ -2159,6 +2159,9 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
     } finally {
       rl.close();
+      if (!stream.destroyed) {
+        stream.destroy();
+      }
       await handle.close();
     }
     return {


### PR DESCRIPTION
Fixes #77327.

## Summary
- make bounded QMD file-read stream ownership explicit with `autoClose:false`
- destroy the read stream when the line-window reader exits early
- keep the FileHandle close as the single fd owner
- add a regression test for bounded QMD reads destroying the stream

## Verification
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs extensions/memory-core/src/memory/qmd-manager.test.ts --maxWorkers=1`
- `git diff --check`

## Known unrelated blocker
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` currently fails in the extension typecheck lane on `extensions/codex/src/app-server/run-attempt.ts(19,3): Module "openclaw/plugin-sdk/agent-harness-runtime" has no exported member "resolveAgentDir"`. This branch does not touch Codex or plugin-sdk harness exports.