### PR TITLE
Idle no-active-work stuck sessions

### DIFF
--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -73,7 +73,11 @@ export function recoveryOutcomeMutatesSessionState(
   if (!outcome) {
     return false;
   }
-  return outcome.status === "aborted" || outcome.status === "released";
+  return (
+    outcome.status === "aborted" ||
+    outcome.status === "released" ||
+    (outcome.status === "noop" && outcome.reason === "no_active_work")
+  );
 }
 
 export function recoveryOutcomeReleasedCount(outcome: StuckSessionRecoveryOutcome): number {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -522,6 +522,57 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("marks a stale processing ghost idle when recovery finds no active work", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockResolvedValue({
+      status: "noop",
+      action: "none",
+      reason: "no_active_work",
+      sessionId: "s1",
+      sessionKey: "main",
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+      vi.advanceTimersByTime(61_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    const state = getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" });
+    expect(state.state).toBe("idle");
+    expect(state.queueDepth).toBe(0);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "session.recovery.completed",
+        status: "noop",
+        action: "none",
+        outcomeReason: "no_active_work",
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "session.state",
+        state: "idle",
+        reason: "stuck_recovery:noop",
+      }),
+    );
+  });
+
   it("does not mark a newer processing generation idle after a late recovery outcome", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn().mockImplementation(async () => {


### PR DESCRIPTION
Fixes #77115.

## Summary
- treat `noop/no_active_work` stuck-session recovery as diagnostic-state mutating
- reuse the existing generation guard before marking the stale processing ghost idle
- add regression coverage for a processing ghost cleared after recovery proves no active work exists

## Verification
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts src/process/command-queue.test.ts --maxWorkers=1`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`

## Scope note
Restart persistence and stale `model_call` active-work recovery are separate. This PR only clears the source-backed no-active-work diagnostic ghost.