### PR TITLE
fix(feishu): serialize OpenClaw messages into Feishu v3 send payload

### DIFF
--- a/extensions/feishu/src/channel.runtime.ts
+++ b/extensions/feishu/src/channel.runtime.ts
@@ -24,6 +24,7 @@ import {
   getMessageFeishu as getMessageFeishuImpl,
   sendCardFeishu as sendCardFeishuImpl,
   sendMessageFeishu as sendMessageFeishuImpl,
+  sendOpenClawEnvelopeFeishu as sendOpenClawEnvelopeFeishuImpl,
 } from "./send.js";
 
 export const feishuChannelRuntime = {
@@ -44,4 +45,5 @@ export const feishuChannelRuntime = {
   getMessageFeishu: getMessageFeishuImpl,
   sendCardFeishu: sendCardFeishuImpl,
   sendMessageFeishu: sendMessageFeishuImpl,
+  sendOpenClawEnvelopeFeishu: sendOpenClawEnvelopeFeishuImpl,
 };

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -18,6 +18,7 @@ const removePinFeishuMock = vi.hoisted(() => vi.fn());
 const getChatInfoMock = vi.hoisted(() => vi.fn());
 const getChatMembersMock = vi.hoisted(() => vi.fn());
 const getFeishuMemberInfoMock = vi.hoisted(() => vi.fn());
+const sendOpenClawEnvelopeFeishuMock = vi.hoisted(() => vi.fn());
 const listFeishuDirectoryPeersLiveMock = vi.hoisted(() => vi.fn());
 const listFeishuDirectoryGroupsLiveMock = vi.hoisted(() => vi.fn());
 const feishuOutboundSendMediaMock = vi.hoisted(() => vi.fn());
@@ -48,6 +49,7 @@ vi.mock("./channel.runtime.js", () => ({
     removeReactionFeishu: removeReactionFeishuMock,
     sendCardFeishu: sendCardFeishuMock,
     sendMessageFeishu: sendMessageFeishuMock,
+    sendOpenClawEnvelopeFeishu: sendOpenClawEnvelopeFeishuMock,
     feishuOutbound: {
       sendText: vi.fn(),
       sendMedia: feishuOutboundSendMediaMock,
@@ -305,6 +307,39 @@ describe("feishuPlugin actions", () => {
       replyInThread: false,
     });
     expect(result?.details).toMatchObject({ ok: true, messageId: "om_sent", chatId: "oc_group_1" });
+  });
+
+  it("routes OpenClaw payload envelopes through the Feishu v3 envelope serializer", async () => {
+    sendOpenClawEnvelopeFeishuMock.mockResolvedValueOnce({
+      messageId: "om_env",
+      chatId: "oc_group_1",
+    });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "oc_group_1",
+        channel: "feishu",
+        payloads: [{ text: "hello", replyToTag: false, audioAsVoice: false }],
+      },
+      cfg,
+      accountId: "main",
+      toolContext: {},
+    } as never);
+
+    expect(sendOpenClawEnvelopeFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      envelope: {
+        to: "oc_group_1",
+        channel: "feishu",
+        payloads: [{ text: "hello", replyToTag: false, audioAsVoice: false }],
+      },
+      accountId: "main",
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({ ok: true, messageId: "om_env", chatId: "oc_group_1" });
   });
 
   it("renders presentation messages as cards", async () => {

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -342,6 +342,45 @@ describe("feishuPlugin actions", () => {
     expect(result?.details).toMatchObject({ ok: true, messageId: "om_env", chatId: "oc_group_1" });
   });
 
+  it("passes thread-reply payload envelopes with reply target and thread mode", async () => {
+    sendOpenClawEnvelopeFeishuMock.mockResolvedValueOnce({
+      messageId: "om_thread_env",
+      chatId: "oc_group_1",
+    });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "thread-reply",
+      params: {
+        to: "oc_group_1",
+        messageId: "om_parent",
+        channel: "feishu",
+        payloads: [{ text: "thread hello" }],
+      },
+      cfg,
+      accountId: "main",
+      toolContext: {},
+    } as never);
+
+    expect(sendOpenClawEnvelopeFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      envelope: {
+        to: "oc_group_1",
+        messageId: "om_parent",
+        channel: "feishu",
+        payloads: [{ text: "thread hello" }],
+      },
+      accountId: "main",
+      replyToMessageId: "om_parent",
+      replyInThread: true,
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({
+      ok: true,
+      messageId: "om_thread_env",
+      chatId: "oc_group_1",
+    });
+  });
+
   it("renders presentation messages as cards", async () => {
     sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -708,6 +708,22 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (ctx.action === "thread-reply" && !replyToMessageId) {
               throw new Error("Feishu thread-reply requires messageId.");
             }
+            if (Array.isArray(ctx.params.payloads)) {
+              const runtime = await loadFeishuChannelRuntime();
+              const result = await runtime.sendOpenClawEnvelopeFeishu({
+                cfg: ctx.cfg,
+                envelope: { ...ctx.params, to },
+                accountId: ctx.accountId ?? undefined,
+                replyToMessageId,
+                replyInThread: ctx.action === "thread-reply",
+              });
+              return jsonActionResult({
+                ok: true,
+                channel: "feishu",
+                action: ctx.action,
+                ...result,
+              });
+            }
             const presentation = normalizeMessagePresentation(ctx.params.presentation);
             const text = readFirstString(ctx.params, ["text", "message"]);
             const mediaUrl = readFeishuMediaParam(ctx.params);

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -167,6 +167,16 @@ describe("getMessageFeishu", () => {
     expect(JSON.parse(body.content)).toEqual({ text: "设置今日突破任务" });
   });
 
+  it("maps raw Feishu open IDs to open_id in OpenClaw envelopes", () => {
+    const body = buildFeishuV3MessageBodyFromOpenClawEnvelope({
+      payloads: [{ text: "hello" }],
+      to: "ou_user_1",
+    });
+
+    expect(body.receive_id).toBe("ou_user_1");
+    expect(body.receive_id_type).toBe("open_id");
+  });
+
   it("preserves explicit receive_id_type on OpenClaw envelopes", () => {
     const body = buildFeishuV3MessageBodyFromOpenClawEnvelope({
       payloads: [{ text: "hello" }],
@@ -195,6 +205,20 @@ describe("getMessageFeishu", () => {
       type: "template",
       data: { template_id: "tpl_1" },
     });
+  });
+
+  it("stringifies object-form interactive card envelope content once", () => {
+    const card = { type: "template", data: { template_id: "tpl_1" } };
+    const body = buildFeishuV3MessageBodyFromOpenClawEnvelope({
+      payloads: [{ msg_type: "interactive", content: card }],
+      to: "oc_group_1",
+    });
+
+    expect(body.msg_type).toBe("interactive");
+    expect(typeof body.content).toBe("string");
+    expect(body.content).toBe(JSON.stringify(card));
+    expect(body.content).not.toBe(JSON.stringify(JSON.stringify(card)));
+    expect(JSON.parse(body.content)).toEqual(card);
   });
 
   it("sends OpenClaw envelopes through the Feishu create API without internal-only fields", async () => {
@@ -227,6 +251,11 @@ describe("getMessageFeishu", () => {
         content: JSON.stringify({ text: "hello" }),
       },
     });
+    const createCall = create.mock.calls[0][0];
+    expect(createCall.data.receive_id).toBe("ou_user_1");
+    expect(createCall.params.receive_id_type).toBe("open_id");
+    expect(createCall.data.msg_type).toBe("text");
+    expect(createCall.data.content).toBe(JSON.stringify({ text: "hello" }));
     expect(JSON.stringify(create.mock.calls[0][0])).not.toContain("payloads");
     expect(JSON.stringify(create.mock.calls[0][0])).not.toContain("channel");
     expect(JSON.stringify(create.mock.calls[0][0])).not.toContain("replyToTag");

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -61,6 +61,8 @@ let editMessageFeishu: typeof import("./send.js").editMessageFeishu;
 let getMessageFeishu: typeof import("./send.js").getMessageFeishu;
 let listFeishuThreadMessages: typeof import("./send.js").listFeishuThreadMessages;
 let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTemplate;
+let buildFeishuV3MessageBodyFromOpenClawEnvelope: typeof import("./send.js").buildFeishuV3MessageBodyFromOpenClawEnvelope;
+let sendOpenClawEnvelopeFeishu: typeof import("./send.js").sendOpenClawEnvelopeFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
 
 describe("getMessageFeishu", () => {
@@ -71,6 +73,8 @@ describe("getMessageFeishu", () => {
       getMessageFeishu,
       listFeishuThreadMessages,
       resolveFeishuCardTemplate,
+      buildFeishuV3MessageBodyFromOpenClawEnvelope,
+      sendOpenClawEnvelopeFeishu,
       sendMessageFeishu,
     } = await import("./send.js"));
   });
@@ -129,6 +133,106 @@ describe("getMessageFeishu", () => {
     });
     expect(mockConvertMarkdownTables).toHaveBeenCalledWith("hello", "preserve");
     expect(result).toEqual({ messageId: "om_send", chatId: "oc_send" });
+  });
+
+  it("serializes OpenClaw text envelopes into Feishu v3 message bodies", async () => {
+    const body = buildFeishuV3MessageBodyFromOpenClawEnvelope({
+      payloads: [{ text: "hello", replyToTag: false, audioAsVoice: false }],
+      to: "oc_group_1",
+      channel: "feishu",
+    });
+
+    expect(body).toEqual({
+      receive_id: "oc_group_1",
+      receive_id_type: "chat_id",
+      msg_type: "text",
+      content: JSON.stringify({ text: "hello" }),
+    });
+    expect(body).not.toHaveProperty("payloads");
+    expect(body).not.toHaveProperty("channel");
+    expect(body).not.toHaveProperty("replyToTag");
+    expect(body).not.toHaveProperty("audioAsVoice");
+  });
+
+  it("preserves Chinese text and maps user-prefixed Feishu open IDs", async () => {
+    const body = buildFeishuV3MessageBodyFromOpenClawEnvelope({
+      payloads: [{ text: "设置今日突破任务" }],
+      to: "user:ou_user_1",
+      channel: "feishu",
+    });
+
+    expect(body.receive_id).toBe("ou_user_1");
+    expect(body.receive_id_type).toBe("open_id");
+    expect(body.msg_type).toBe("text");
+    expect(JSON.parse(body.content)).toEqual({ text: "设置今日突破任务" });
+  });
+
+  it("preserves explicit receive_id_type on OpenClaw envelopes", () => {
+    const body = buildFeishuV3MessageBodyFromOpenClawEnvelope({
+      payloads: [{ text: "hello" }],
+      to: "oc_group_1",
+      receive_id_type: "open_id",
+    });
+
+    expect(body.receive_id).toBe("oc_group_1");
+    expect(body.receive_id_type).toBe("open_id");
+  });
+
+  it("stringifies interactive card envelope content exactly once", () => {
+    const content = JSON.stringify({ type: "template", data: { template_id: "tpl_1" } });
+    const body = buildFeishuV3MessageBodyFromOpenClawEnvelope({
+      payloads: [{ msg_type: "interactive", content }],
+      to: "oc_group_1",
+    });
+
+    expect(body).toEqual({
+      receive_id: "oc_group_1",
+      receive_id_type: "chat_id",
+      msg_type: "interactive",
+      content,
+    });
+    expect(JSON.parse(body.content)).toEqual({
+      type: "template",
+      data: { template_id: "tpl_1" },
+    });
+  });
+
+  it("sends OpenClaw envelopes through the Feishu create API without internal-only fields", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_env" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+
+    const result = await sendOpenClawEnvelopeFeishu({
+      cfg: {} as ClawdbotConfig,
+      envelope: {
+        payloads: [{ text: "hello", replyToTag: false, audioAsVoice: false }],
+        to: "user:ou_user_1",
+        channel: "feishu",
+      },
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      params: { receive_id_type: "open_id" },
+      data: {
+        receive_id: "ou_user_1",
+        msg_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    });
+    expect(JSON.stringify(create.mock.calls[0][0])).not.toContain("payloads");
+    expect(JSON.stringify(create.mock.calls[0][0])).not.toContain("channel");
+    expect(JSON.stringify(create.mock.calls[0][0])).not.toContain("replyToTag");
+    expect(JSON.stringify(create.mock.calls[0][0])).not.toContain("audioAsVoice");
+    expect(typeof create.mock.calls[0][0].data.content).toBe("string");
+    expect(result).toEqual({ messageId: "om_env", chatId: "ou_user_1" });
   });
 
   it("extracts text content from interactive card elements", async () => {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -13,11 +13,13 @@ import { buildMentionedCardContent, buildMentionedMessage } from "./mention.js";
 import { parsePostContent } from "./post.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
+import { normalizeFeishuTarget, resolveReceiveIdType } from "./targets.js";
 import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./types.js";
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
 const INTERACTIVE_CARD_FALLBACK_TEXT = "[Interactive Card]";
 const POST_FALLBACK_TEXT = "[Rich text message]";
+const FEISHU_RECEIVE_ID_TYPES = new Set(["chat_id", "email", "open_id", "union_id", "user_id"]);
 const FEISHU_CARD_TEMPLATES = new Set([
   "blue",
   "green",
@@ -65,6 +67,105 @@ function isWithdrawnReplyError(err: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+type FeishuReceiveIdType = "chat_id" | "email" | "open_id" | "union_id" | "user_id";
+
+type FeishuV3MessageBody = {
+  receive_id: string;
+  receive_id_type: FeishuReceiveIdType;
+  msg_type: "interactive" | "text";
+  content: string;
+};
+
+function readStringField(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readExplicitReceiveIdType(
+  record: Record<string, unknown>,
+): FeishuReceiveIdType | undefined {
+  const raw = readStringField(record, ["receive_id_type", "receiveIdType"]);
+  return raw && FEISHU_RECEIVE_ID_TYPES.has(raw) ? (raw as FeishuReceiveIdType) : undefined;
+}
+
+function stringifyFeishuContentOnce(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function firstOpenClawEnvelopePayload(
+  envelope: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const payloads = envelope.payloads;
+  if (Array.isArray(payloads) && isRecord(payloads[0])) {
+    return payloads[0];
+  }
+  return isRecord(envelope.payload) ? envelope.payload : null;
+}
+
+function resolveFeishuEnvelopeMessage(
+  envelope: Record<string, unknown>,
+): Pick<FeishuV3MessageBody, "content" | "msg_type"> | null {
+  const payload = firstOpenClawEnvelopePayload(envelope);
+  for (const candidate of [payload, envelope]) {
+    if (!candidate) {
+      continue;
+    }
+    if (candidate.msg_type === "interactive" || candidate.msgType === "interactive") {
+      if ("content" in candidate) {
+        return {
+          msg_type: "interactive",
+          content: stringifyFeishuContentOnce(candidate.content),
+        };
+      }
+      if (isRecord(candidate.card)) {
+        return {
+          msg_type: "interactive",
+          content: JSON.stringify(candidate.card),
+        };
+      }
+    }
+    const text = readStringField(candidate, ["text", "message"]);
+    if (text !== undefined) {
+      return {
+        msg_type: "text",
+        content: JSON.stringify({ text }),
+      };
+    }
+  }
+  return null;
+}
+
+export function buildFeishuV3MessageBodyFromOpenClawEnvelope(
+  envelope: Record<string, unknown>,
+): FeishuV3MessageBody {
+  const rawTarget = readStringField(envelope, ["receive_id", "receiveId", "to", "target"]);
+  const receiveId = rawTarget ? normalizeFeishuTarget(rawTarget) : null;
+  if (!rawTarget || !receiveId) {
+    throw new Error("Feishu outbound envelope requires a receive_id or to target.");
+  }
+  const message = resolveFeishuEnvelopeMessage(envelope);
+  if (!message) {
+    throw new Error("Feishu outbound envelope requires text or an interactive card payload.");
+  }
+  const withoutProviderPrefix = rawTarget.replace(/^(feishu|lark):/i, "");
+  return {
+    receive_id: receiveId,
+    receive_id_type:
+      readExplicitReceiveIdType(envelope) ??
+      (resolveReceiveIdType(withoutProviderPrefix) as FeishuReceiveIdType),
+    msg_type: message.msg_type,
+    content: message.content,
+  };
 }
 
 type FeishuCreateMessageClient = {
@@ -601,6 +702,40 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     directParams,
     directErrorPrefix: "Feishu card send failed",
     replyErrorPrefix: "Feishu card reply failed",
+  });
+}
+
+export async function sendOpenClawEnvelopeFeishu(params: {
+  cfg: ClawdbotConfig;
+  envelope: Record<string, unknown>;
+  accountId?: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+}): Promise<FeishuSendResult> {
+  const body = buildFeishuV3MessageBodyFromOpenClawEnvelope(params.envelope);
+  const rawTarget = readStringField(params.envelope, ["receive_id", "receiveId", "to", "target"]);
+  if (!rawTarget) {
+    throw new Error("Feishu outbound envelope requires a receive_id or to target.");
+  }
+  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
+    cfg: params.cfg,
+    to: rawTarget,
+    accountId: params.accountId,
+  });
+  const directParams = {
+    receiveId,
+    receiveIdType: readExplicitReceiveIdType(params.envelope) ?? receiveIdType,
+    content: body.content,
+    msgType: body.msg_type,
+  };
+  return sendReplyOrFallbackDirect(client, {
+    replyToMessageId: params.replyToMessageId,
+    replyInThread: params.replyInThread,
+    content: body.content,
+    msgType: body.msg_type,
+    directParams,
+    directErrorPrefix: "Feishu send failed",
+    replyErrorPrefix: "Feishu reply failed",
   });
 }
 


### PR DESCRIPTION
## Summary
- Add a source-level Feishu serializer for OpenClaw outbound envelopes that contain `payloads`, `to`, and `channel`.
- Route Feishu `send` message actions with `payloads` through the serializer before calling the Feishu create-message API.
- Add mocked Feishu API regression coverage for target inference, Chinese text, internal-field stripping, content stringification, and interactive card content.

## Root cause
Some OpenClaw delivery paths can hand Feishu an internal outbound envelope shape instead of a Feishu API v3 create-message payload. That leaks internal-only fields like `payloads`, `channel`, `replyToTag`, and `audioAsVoice`, and omits required Feishu fields.

## Payload before/after
Before:
```json
{
  "payloads": [{ "text": "hello", "replyToTag": false, "audioAsVoice": false }],
  "to": "oc_xxx",
  "channel": "feishu"
}
```

After:
```json
{
  "receive_id": "oc_xxx",
  "receive_id_type": "chat_id",
  "msg_type": "text",
  "content": "{\"text\":\"hello\"}"
}
```

## Tests
- `timeout 120 pnpm exec vitest run extensions/feishu/src/send.test.ts extensions/feishu/src/channel.test.ts` timed out during transform startup before assertions.
- `timeout 300 pnpm exec vitest run extensions/feishu/src/send.test.ts` passed: 20 tests.
- `timeout 300 pnpm exec vitest run extensions/feishu/src/channel.test.ts` passed: 49 tests.
- `timeout 300 pnpm tsgo:extensions` passed.
- `git diff --check` passed.

## Runtime touched: No

## Deployment status: Not deployed

## Post-merge Claude Code deployment required
After merge, a source/runtime deployment is required by Claude Code only. This PR does not deploy, restart services, inspect VPS runtime, access DBs, or modify secrets.