### PR TITLE
fix(memory-core): preserve sibling supplement results when one search rejects (#77897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/search: keep results from healthy memory corpus supplements when one rejects, so a single misbehaving plugin no longer empties `memory_search corpus=all`; failures are warn-logged with the offending plugin id instead of poisoning sibling results. Fixes #77897. Thanks @lonexreb.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -608,6 +608,7 @@ describe("memory tools", () => {
   });
 
   it("does not cooldown primary memory when a corpus=all wiki supplement stalls", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.useFakeTimers();
     try {
       let searchCalls = 0;
@@ -630,17 +631,22 @@ describe("memory tools", () => {
       });
 
       const tool = createMemorySearchToolOrThrow();
+      // Per-supplement timeout (default 10s, see #77897) lets the stalled
+      // wiki supplement be discarded as a rejected outcome while preserving
+      // sibling memory results. The all-mode call should now return memory
+      // results successfully instead of tripping the global 15s deadline.
       const stalledAllResultPromise = tool.execute("call_all_stalled_wiki", {
         query: "alpha",
         corpus: "all",
       });
-      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(10_000);
       const stalledAllResult = await stalledAllResultPromise;
-      expectUnavailableMemorySearchDetails(stalledAllResult.details, {
-        error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
-      });
+      const stalledDetails = stalledAllResult.details as {
+        results: Array<{ corpus: string; path: string }>;
+      };
+      expect(stalledDetails.results.map((entry) => [entry.corpus, entry.path])).toEqual([
+        ["memory", "MEMORY.md"],
+      ]);
 
       const memoryResult = await tool.execute("call_memory_after_stalled_wiki", {
         query: "alpha",
@@ -652,6 +658,7 @@ describe("memory tools", () => {
       expect(searchCalls).toBe(2);
     } finally {
       vi.useRealTimers();
+      warnSpy.mockRestore();
     }
   });
 

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -735,6 +735,54 @@ describe("memory tools", () => {
     }
   });
 
+  it("preserves sibling supplement results when one corpus=all supplement rejects (#77897)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      registerMemoryCorpusSupplement("healthy-wiki", {
+        search: async () => [
+          {
+            corpus: "wiki",
+            path: "entities/healthy.md",
+            title: "Healthy",
+            kind: "entity",
+            score: 1.1,
+            snippet: "Healthy supplement result",
+          },
+        ],
+        get: async () => null,
+      });
+      registerMemoryCorpusSupplement("broken-wiki", {
+        search: async () => {
+          throw new Error("corpus backend unavailable");
+        },
+        get: async () => null,
+      });
+
+      const tool = createMemorySearchToolOrThrow();
+      const result = await tool.execute("call_all_partial_supplement_failure", {
+        query: "healthy",
+        corpus: "all",
+        maxResults: 3,
+      });
+      const details = result.details as { results: Array<{ corpus: string; path: string }> };
+
+      expect(details.results.map((entry) => [entry.corpus, entry.path])).toContainEqual([
+        "wiki",
+        "entities/healthy.md",
+      ]);
+      expect(details.results.map((entry) => [entry.corpus, entry.path])).toContainEqual([
+        "memory",
+        "MEMORY.md",
+      ]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
+      expect(message).toContain('corpus supplement "broken-wiki" search failed');
+      expect(message).toContain("corpus backend unavailable");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("falls back to a wiki corpus supplement for memory_get corpus=all", async () => {
     setMemoryReadFileImpl(async () => {
       throw new Error("path required");

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -607,7 +607,6 @@ describe("memory tools", () => {
     expect(getMemorySearchManagerMockCalls()).toBe(1);
   });
 
-
   it("surfaces a memory-corpus warning when corpus=all hits a returned manager error", async () => {
     setMemorySearchManagerImpl(async () => ({ error: "sqlite support missing" }));
     registerMemoryCorpusSupplement("memory-wiki", {
@@ -731,6 +730,68 @@ describe("memory tools", () => {
       const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
       expect(message).toContain('corpus supplement "broken-wiki" search failed');
       expect(message).toContain("corpus backend unavailable");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("keeps builtin memory hits and records the wiki corpus when every supplement rejects", async () => {
+    // Mirror of the memory-corpus degradation (#125500): supplement-phase
+    // unavailability must not discard a healthy primary search.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      registerMemoryCorpusSupplement("broken-wiki", {
+        search: async () => {
+          throw new Error("corpus backend unavailable");
+        },
+        get: async () => null,
+      });
+
+      const tool = createMemorySearchToolOrThrow();
+      const result = await tool.execute("call_all_supplements_failed", {
+        query: "alpha",
+        corpus: "all",
+      });
+      const details = result.details as {
+        results: Array<{ corpus?: string; path: string }>;
+        warning?: string;
+        unavailable?: boolean;
+      };
+
+      expect(details.unavailable).toBeUndefined();
+      expect(details.results.map((entry) => entry.path)).toContain("MEMORY.md");
+      expect(details.warning).toContain("Wiki corpus unavailable; results cover memory only");
+      expect(details.warning).toContain("all 1 corpus supplement searches failed");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("stays unavailable for corpus=wiki when every supplement rejects", async () => {
+    // With no healthy corpus in scope, degradation has nothing to serve.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      registerMemoryCorpusSupplement("broken-wiki", {
+        search: async () => {
+          throw new Error("corpus backend unavailable");
+        },
+        get: async () => null,
+      });
+
+      const tool = createMemorySearchToolOrThrow();
+      const result = await tool.execute("call_wiki_all_failed", {
+        query: "alpha",
+        corpus: "wiki",
+      });
+      const details = result.details as {
+        results: unknown[];
+        unavailable?: boolean;
+        error?: string;
+      };
+
+      expect(details.unavailable).toBe(true);
+      expect(details.results).toEqual([]);
+      expect(details.error).toContain("all 1 corpus supplement searches failed");
     } finally {
       warnSpy.mockRestore();
     }

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -631,10 +631,11 @@ describe("memory tools", () => {
       });
 
       const tool = createMemorySearchToolOrThrow();
-      // Per-supplement timeout (default 10s, see #77897) lets the stalled
-      // wiki supplement be discarded as a rejected outcome while preserving
-      // sibling memory results. The all-mode call should now return memory
-      // results successfully instead of tripping the global 15s deadline.
+      // Per-supplement timeout (default 10s, see #77897) rejects the stalled
+      // wiki supplement before the global 15s deadline. With every supplement
+      // failed, corpus=all reports backend unavailability (no silent
+      // memory-only success), but the failure stays supplement-phase, so no
+      // memory cooldown is recorded and the next memory call runs normally.
       const stalledAllResultPromise = tool.execute("call_all_stalled_wiki", {
         query: "alpha",
         corpus: "all",
@@ -642,11 +643,12 @@ describe("memory tools", () => {
       await vi.advanceTimersByTimeAsync(10_000);
       const stalledAllResult = await stalledAllResultPromise;
       const stalledDetails = stalledAllResult.details as {
-        results: Array<{ corpus: string; path: string }>;
+        unavailable?: boolean;
+        error?: string;
       };
-      expect(stalledDetails.results.map((entry) => [entry.corpus, entry.path])).toEqual([
-        ["memory", "MEMORY.md"],
-      ]);
+      expect(stalledDetails.unavailable).toBe(true);
+      expect(stalledDetails.error).toContain("all corpus supplement searches failed");
+      expect(stalledDetails.error).toContain("did not settle within 10000ms");
 
       const memoryResult = await tool.execute("call_memory_after_stalled_wiki", {
         query: "alpha",

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -607,62 +607,6 @@ describe("memory tools", () => {
     expect(getMemorySearchManagerMockCalls()).toBe(1);
   });
 
-  it("does not cooldown primary memory when a corpus=all wiki supplement stalls", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.useFakeTimers();
-    try {
-      let searchCalls = 0;
-      setMemorySearchImpl(async () => {
-        searchCalls += 1;
-        return [
-          {
-            path: "MEMORY.md",
-            startLine: 5,
-            endLine: 7,
-            score: 0.9,
-            snippet: "@@ -5,3 @@\nAssistant: noted",
-            source: "memory" as const,
-          },
-        ];
-      });
-      registerMemoryCorpusSupplement("memory-wiki", {
-        search: async () => await new Promise(() => {}),
-        get: async () => null,
-      });
-
-      const tool = createMemorySearchToolOrThrow();
-      // Per-supplement timeout (default 10s, see #77897) rejects the stalled
-      // wiki supplement before the global 15s deadline. With every supplement
-      // failed, corpus=all reports backend unavailability (no silent
-      // memory-only success), but the failure stays supplement-phase, so no
-      // memory cooldown is recorded and the next memory call runs normally.
-      const stalledAllResultPromise = tool.execute("call_all_stalled_wiki", {
-        query: "alpha",
-        corpus: "all",
-      });
-      await vi.advanceTimersByTimeAsync(10_000);
-      const stalledAllResult = await stalledAllResultPromise;
-      const stalledDetails = stalledAllResult.details as {
-        unavailable?: boolean;
-        error?: string;
-      };
-      expect(stalledDetails.unavailable).toBe(true);
-      expect(stalledDetails.error).toContain("all corpus supplement searches failed");
-      expect(stalledDetails.error).toContain("did not settle within 10000ms");
-
-      const memoryResult = await tool.execute("call_memory_after_stalled_wiki", {
-        query: "alpha",
-      });
-      const details = memoryResult.details as { results: Array<{ corpus: string; path: string }> };
-      expect(details.results.map((entry) => [entry.corpus, entry.path])).toEqual([
-        ["memory", "MEMORY.md"],
-      ]);
-      expect(searchCalls).toBe(2);
-    } finally {
-      vi.useRealTimers();
-      warnSpy.mockRestore();
-    }
-  });
 
   it("surfaces a memory-corpus warning when corpus=all hits a returned manager error", async () => {
     setMemorySearchManagerImpl(async () => ({ error: "sqlite support missing" }));

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -4,7 +4,7 @@ import {
   clearMemoryPluginState,
   registerMemoryCorpusSupplement,
 } from "openclaw/plugin-sdk/memory-host-core";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getMemorySearchManagerMockCalls,
   getReadAgentMemoryFileMockCalls,
@@ -384,6 +384,54 @@ describe("memory tools", () => {
       ["memory", "MEMORY.md"],
     ]);
     expect(getMemorySearchManagerMockCalls()).toBe(1);
+  });
+
+  it("preserves sibling supplement results when one corpus=all supplement rejects (#77897)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      registerMemoryCorpusSupplement("healthy-wiki", {
+        search: async () => [
+          {
+            corpus: "wiki",
+            path: "entities/healthy.md",
+            title: "Healthy",
+            kind: "entity",
+            score: 1.1,
+            snippet: "Healthy supplement result",
+          },
+        ],
+        get: async () => null,
+      });
+      registerMemoryCorpusSupplement("broken-wiki", {
+        search: async () => {
+          throw new Error("corpus backend unavailable");
+        },
+        get: async () => null,
+      });
+
+      const tool = createMemorySearchToolOrThrow();
+      const result = await tool.execute("call_all_partial_supplement_failure", {
+        query: "healthy",
+        corpus: "all",
+        maxResults: 3,
+      });
+      const details = result.details as { results: Array<{ corpus: string; path: string }> };
+
+      expect(details.results.map((entry) => [entry.corpus, entry.path])).toContainEqual([
+        "wiki",
+        "entities/healthy.md",
+      ]);
+      expect(details.results.map((entry) => [entry.corpus, entry.path])).toContainEqual([
+        "memory",
+        "MEMORY.md",
+      ]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
+      expect(message).toContain('corpus supplement "broken-wiki" search failed');
+      expect(message).toContain("corpus backend unavailable");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("falls back to a wiki corpus supplement for memory_get corpus=all", async () => {

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -1,0 +1,183 @@
+import {
+  clearMemoryPluginState,
+  registerMemoryCorpusSupplement,
+  type MemoryCorpusSearchResult,
+  type MemoryCorpusSupplement,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { searchMemoryCorpusSupplements } from "./tools.shared.js";
+
+function buildResult(overrides: Partial<MemoryCorpusSearchResult> = {}): MemoryCorpusSearchResult {
+  return {
+    corpus: "wiki",
+    path: "wiki/example.md",
+    score: 0.5,
+    snippet: "snippet",
+    ...overrides,
+  };
+}
+
+function buildSupplement(handler: MemoryCorpusSupplement["search"]): MemoryCorpusSupplement {
+  return {
+    search: handler,
+    get: async () => null,
+  };
+}
+
+describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    clearMemoryPluginState();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    clearMemoryPluginState();
+    warnSpy.mockRestore();
+  });
+
+  it("returns empty array when no supplements registered", async () => {
+    const out = await searchMemoryCorpusSupplements({ query: "anything", corpus: "all" });
+    expect(out).toEqual([]);
+  });
+
+  it("returns surviving results when one supplement rejects", async () => {
+    registerMemoryCorpusSupplement(
+      "good",
+      buildSupplement(async () => [
+        buildResult({ corpus: "wiki", path: "wiki/a.md", score: 0.8, snippet: "alpha" }),
+      ]),
+    );
+    registerMemoryCorpusSupplement(
+      "bad",
+      buildSupplement(async () => {
+        throw new Error("supplement exploded");
+      }),
+    );
+
+    const out = await searchMemoryCorpusSupplements({ query: "alpha", corpus: "all" });
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ path: "wiki/a.md", snippet: "alpha" });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain('memory-core: corpus supplement "bad" search failed');
+    expect(message).toContain("supplement exploded");
+  });
+
+  it("returns empty array (not rejection) when every supplement rejects", async () => {
+    registerMemoryCorpusSupplement(
+      "bad-1",
+      buildSupplement(async () => {
+        throw new Error("e1");
+      }),
+    );
+    registerMemoryCorpusSupplement(
+      "bad-2",
+      buildSupplement(async () => {
+        throw new Error("e2");
+      }),
+    );
+
+    await expect(
+      searchMemoryCorpusSupplements({ query: "anything", corpus: "all" }),
+    ).resolves.toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("merges results from multiple successful supplements and orders by score desc, path asc", async () => {
+    registerMemoryCorpusSupplement(
+      "wiki",
+      buildSupplement(async () => [
+        buildResult({ corpus: "wiki", path: "wiki/b.md", score: 0.5 }),
+        buildResult({ corpus: "wiki", path: "wiki/a.md", score: 0.5 }),
+      ]),
+    );
+    registerMemoryCorpusSupplement(
+      "notes",
+      buildSupplement(async () => [
+        buildResult({ corpus: "notes", path: "notes/x.md", score: 0.9 }),
+      ]),
+    );
+
+    const out = await searchMemoryCorpusSupplements({ query: "x", corpus: "all" });
+
+    expect(out.map((r) => r.path)).toEqual(["notes/x.md", "wiki/a.md", "wiki/b.md"]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("respects maxResults clamp (≥1) after merging", async () => {
+    registerMemoryCorpusSupplement(
+      "wiki",
+      buildSupplement(async () =>
+        Array.from({ length: 25 }, (_, i) =>
+          buildResult({
+            corpus: "wiki",
+            path: `wiki/${String(i).padStart(2, "0")}.md`,
+            score: 1 - i / 100,
+          }),
+        ),
+      ),
+    );
+
+    const five = await searchMemoryCorpusSupplements({
+      query: "x",
+      corpus: "all",
+      maxResults: 5,
+    });
+    expect(five).toHaveLength(5);
+
+    const zeroClampedToOne = await searchMemoryCorpusSupplements({
+      query: "x",
+      corpus: "all",
+      maxResults: 0,
+    });
+    expect(zeroClampedToOne).toHaveLength(1);
+  });
+
+  it("never queries supplements when corpus is 'memory' or 'sessions'", async () => {
+    const search = vi.fn(async () => [buildResult()]);
+    registerMemoryCorpusSupplement("wiki", buildSupplement(search));
+
+    await expect(searchMemoryCorpusSupplements({ query: "x", corpus: "memory" })).resolves.toEqual(
+      [],
+    );
+    await expect(
+      searchMemoryCorpusSupplements({ query: "x", corpus: "sessions" }),
+    ).resolves.toEqual([]);
+
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it("preserves results when a supplement returns a Promise that rejects with non-Error reason", async () => {
+    registerMemoryCorpusSupplement(
+      "good",
+      buildSupplement(async () => [buildResult({ path: "wiki/a.md" })]),
+    );
+    registerMemoryCorpusSupplement(
+      "string-throw",
+      buildSupplement(async () => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw "raw string failure";
+      }),
+    );
+    registerMemoryCorpusSupplement(
+      "object-throw",
+      buildSupplement(async () => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw { code: "ESUPP", detail: "structured failure" };
+      }),
+    );
+
+    const out = await searchMemoryCorpusSupplements({ query: "x", corpus: "all" });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.path).toBe("wiki/a.md");
+
+    const messages = warnSpy.mock.calls.map((c) => String(c[0] ?? ""));
+    expect(
+      messages.some((m) => m.includes('"string-throw"') && m.includes("raw string failure")),
+    ).toBe(true);
+    expect(messages.some((m) => m.includes('"object-throw"') && m.includes("ESUPP"))).toBe(true);
+  });
+});

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -150,6 +150,41 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     expect(search).not.toHaveBeenCalled();
   });
 
+  it("preserves sibling results when one supplement never settles (timeout)", async () => {
+    const originalTimeout = process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS;
+    process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS = "25";
+    try {
+      registerMemoryCorpusSupplement(
+        "good",
+        buildSupplement(async () => [buildResult({ path: "wiki/healthy.md", snippet: "ok" })]),
+      );
+      registerMemoryCorpusSupplement(
+        "hung",
+        buildSupplement(
+          () =>
+            new Promise<MemoryCorpusSearchResult[]>(() => {
+              // Never resolves or rejects — simulates a stuck network call.
+            }),
+        ),
+      );
+
+      const out = await searchMemoryCorpusSupplements({ query: "any", corpus: "all" });
+
+      expect(out).toHaveLength(1);
+      expect(out[0]?.path).toBe("wiki/healthy.md");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
+      expect(message).toContain('memory-core: corpus supplement "hung" search failed');
+      expect(message).toContain("did not settle within 25ms");
+    } finally {
+      if (originalTimeout === undefined) {
+        delete process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS = originalTimeout;
+      }
+    }
+  });
+
   it("preserves results when a supplement returns a Promise that rejects with non-Error reason", async () => {
     registerMemoryCorpusSupplement(
       "good",

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -158,14 +158,12 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     registerMemoryCorpusSupplement(
       "string-throw",
       buildSupplement(async () => {
-        // eslint-disable-next-line @typescript-eslint/only-throw-error
         throw "raw string failure";
       }),
     );
     registerMemoryCorpusSupplement(
       "object-throw",
       buildSupplement(async () => {
-        // eslint-disable-next-line @typescript-eslint/only-throw-error
         throw { code: "ESUPP", detail: "structured failure" };
       }),
     );
@@ -174,7 +172,9 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     expect(out).toHaveLength(1);
     expect(out[0]?.path).toBe("wiki/a.md");
 
-    const messages: string[] = warnSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? ""));
+    const messages = warnSpy.mock.calls.map(([message]: unknown[]) =>
+      typeof message === "string" ? message : (JSON.stringify(message) ?? ""),
+    );
     expect(
       messages.some((m) => m.includes('"string-throw"') && m.includes("raw string failure")),
     ).toBe(true);

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -172,7 +172,7 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     expect(out).toHaveLength(1);
     expect(out[0]?.path).toBe("wiki/a.md");
 
-    const messages = warnSpy.mock.calls.map(([message]: unknown[]) =>
+    const messages: string[] = warnSpy.mock.calls.map(([message]: unknown[]): string =>
       typeof message === "string" ? message : (JSON.stringify(message) ?? ""),
     );
     expect(

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -193,12 +193,14 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     registerMemoryCorpusSupplement(
       "string-throw",
       buildSupplement(async () => {
+        // oxlint-disable-next-line no-throw-literal -- testing non-Error path in handler
         throw "raw string failure";
       }),
     );
     registerMemoryCorpusSupplement(
       "object-throw",
       buildSupplement(async () => {
+        // oxlint-disable-next-line no-throw-literal -- testing structured non-Error path
         throw { code: "ESUPP", detail: "structured failure" };
       }),
     );

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -174,7 +174,7 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     expect(out).toHaveLength(1);
     expect(out[0]?.path).toBe("wiki/a.md");
 
-    const messages = warnSpy.mock.calls.map((c) => String(c[0] ?? ""));
+    const messages: string[] = warnSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? ""));
     expect(
       messages.some((m) => m.includes('"string-throw"') && m.includes("raw string failure")),
     ).toBe(true);

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -193,14 +193,14 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     registerMemoryCorpusSupplement(
       "string-throw",
       buildSupplement(async () => {
-        // oxlint-disable-next-line no-throw-literal -- testing non-Error path in handler
+        // oxlint-disable-next-line typescript/only-throw-error -- testing non-Error path in handler
         throw "raw string failure";
       }),
     );
     registerMemoryCorpusSupplement(
       "object-throw",
       buildSupplement(async () => {
-        // oxlint-disable-next-line no-throw-literal -- testing structured non-Error path
+        // oxlint-disable-next-line typescript/only-throw-error -- testing structured non-Error path
         throw { code: "ESUPP", detail: "structured failure" };
       }),
     );

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -66,7 +66,9 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     expect(message).toContain("supplement exploded");
   });
 
-  it("returns empty array (not rejection) when every supplement rejects", async () => {
+  it("throws (backend unavailable) when every supplement rejects", async () => {
+    // Silent recall loss guard: when every registered supplement fails, the
+    // call must surface unavailability instead of a normal empty success.
     registerMemoryCorpusSupplement(
       "bad-1",
       buildSupplement(async () => {
@@ -82,7 +84,7 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
 
     await expect(
       searchMemoryCorpusSupplements({ query: "anything", corpus: "all" }),
-    ).resolves.toEqual([]);
+    ).rejects.toThrow(/all corpus supplement searches failed: .*"bad-1": e1.*"bad-2": e2/);
     expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
@@ -151,38 +153,28 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
   });
 
   it("preserves sibling results when one supplement never settles (timeout)", async () => {
-    const originalTimeout = process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS;
-    process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS = "25";
-    try {
-      registerMemoryCorpusSupplement(
-        "good",
-        buildSupplement(async () => [buildResult({ path: "wiki/healthy.md", snippet: "ok" })]),
-      );
-      registerMemoryCorpusSupplement(
-        "hung",
-        buildSupplement(
-          () =>
-            new Promise<MemoryCorpusSearchResult[]>(() => {
-              // Never resolves or rejects — simulates a stuck network call.
-            }),
-        ),
-      );
+    registerMemoryCorpusSupplement(
+      "good",
+      buildSupplement(async () => [buildResult({ path: "wiki/healthy.md", snippet: "ok" })]),
+    );
+    registerMemoryCorpusSupplement(
+      "hung",
+      buildSupplement(
+        () =>
+          new Promise<MemoryCorpusSearchResult[]>(() => {
+            // Never resolves or rejects — simulates a stuck network call.
+          }),
+      ),
+    );
 
-      const out = await searchMemoryCorpusSupplements({ query: "any", corpus: "all" });
+    const out = await searchMemoryCorpusSupplements({ query: "any", corpus: "all", timeoutMs: 25 });
 
-      expect(out).toHaveLength(1);
-      expect(out[0]?.path).toBe("wiki/healthy.md");
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
-      expect(message).toContain('memory-core: corpus supplement "hung" search failed');
-      expect(message).toContain("did not settle within 25ms");
-    } finally {
-      if (originalTimeout === undefined) {
-        delete process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS;
-      } else {
-        process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS = originalTimeout;
-      }
-    }
+    expect(out).toHaveLength(1);
+    expect(out[0]?.path).toBe("wiki/healthy.md");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain('memory-core: corpus supplement "hung" search failed');
+    expect(message).toContain("did not settle within 25ms");
   });
 
   it("preserves results when a supplement returns a Promise that rejects with non-Error reason", async () => {

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -152,31 +152,6 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     expect(search).not.toHaveBeenCalled();
   });
 
-  it("preserves sibling results when one supplement never settles (timeout)", async () => {
-    registerMemoryCorpusSupplement(
-      "good",
-      buildSupplement(async () => [buildResult({ path: "wiki/healthy.md", snippet: "ok" })]),
-    );
-    registerMemoryCorpusSupplement(
-      "hung",
-      buildSupplement(
-        () =>
-          new Promise<MemoryCorpusSearchResult[]>(() => {
-            // Never resolves or rejects — simulates a stuck network call.
-          }),
-      ),
-    );
-
-    const out = await searchMemoryCorpusSupplements({ query: "any", corpus: "all", timeoutMs: 25 });
-
-    expect(out).toHaveLength(1);
-    expect(out[0]?.path).toBe("wiki/healthy.md");
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
-    expect(message).toContain('memory-core: corpus supplement "hung" search failed');
-    expect(message).toContain("did not settle within 25ms");
-  });
-
   it("preserves results when a supplement returns a Promise that rejects with non-Error reason", async () => {
     registerMemoryCorpusSupplement(
       "good",

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -3,7 +3,7 @@ import {
   registerMemoryCorpusSupplement,
   type MemoryCorpusSearchResult,
   type MemoryCorpusSupplement,
-} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+} from "openclaw/plugin-sdk/memory-host-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { searchMemoryCorpusSupplements } from "./tools.shared.js";
 

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -38,9 +38,9 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     warnSpy.mockRestore();
   });
 
-  it("returns empty array when no supplements registered", async () => {
+  it("returns empty ok outcome when no supplements registered", async () => {
     const out = await searchMemoryCorpusSupplements({ query: "anything", corpus: "all" });
-    expect(out).toEqual([]);
+    expect(out).toEqual({ status: "ok", results: [] });
   });
 
   it("returns surviving results when one supplement rejects", async () => {
@@ -59,17 +59,20 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
 
     const out = await searchMemoryCorpusSupplements({ query: "alpha", corpus: "all" });
 
-    expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({ path: "wiki/a.md", snippet: "alpha" });
+    expect(out.status).toBe("ok");
+    const results = out.status === "ok" ? out.results : [];
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ path: "wiki/a.md", snippet: "alpha" });
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
     expect(message).toContain('memory-core: corpus supplement "bad" search failed');
     expect(message).toContain("supplement exploded");
   });
 
-  it("throws (backend unavailable) when every supplement rejects", async () => {
+  it("returns the all-failed outcome when every supplement rejects", async () => {
     // Silent recall loss guard: when every registered supplement fails, the
-    // call must surface unavailability instead of a normal empty success.
+    // caller must be able to surface supplement unavailability instead of a
+    // normal empty success — without discarding healthy builtin results.
     registerMemoryCorpusSupplement(
       "bad-1",
       buildSupplement(async () => {
@@ -83,9 +86,10 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
       }),
     );
 
-    await expect(
-      searchMemoryCorpusSupplements({ query: "anything", corpus: "all" }),
-    ).rejects.toThrow(/all 2 corpus supplement searches failed: .*"bad-1": e1.*"bad-2": e2/);
+    const out = await searchMemoryCorpusSupplements({ query: "anything", corpus: "all" });
+    expect(out.status).toBe("all-failed");
+    const failure = out.status === "all-failed" ? out.failure : "";
+    expect(failure).toMatch(/all 2 corpus supplement searches failed: .*"bad-1": e1.*"bad-2": e2/);
     expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
@@ -106,7 +110,11 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
 
     const out = await searchMemoryCorpusSupplements({ query: "x", corpus: "all" });
 
-    expect(out.map((r) => r.path)).toEqual(["notes/x.md", "wiki/a.md", "wiki/b.md"]);
+    expect(out.status === "ok" ? out.results.map((r) => r.path) : []).toEqual([
+      "notes/x.md",
+      "wiki/a.md",
+      "wiki/b.md",
+    ]);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -129,26 +137,27 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
       corpus: "all",
       maxResults: 5,
     });
-    expect(five).toHaveLength(5);
+    expect(five.status === "ok" ? five.results : []).toHaveLength(5);
 
     const zeroClampedToOne = await searchMemoryCorpusSupplements({
       query: "x",
       corpus: "all",
       maxResults: 0,
     });
-    expect(zeroClampedToOne).toHaveLength(1);
+    expect(zeroClampedToOne.status === "ok" ? zeroClampedToOne.results : []).toHaveLength(1);
   });
 
   it("never queries supplements when corpus is 'memory' or 'sessions'", async () => {
     const search = vi.fn(async () => [buildResult()]);
     registerMemoryCorpusSupplement("wiki", buildSupplement(search));
 
-    await expect(searchMemoryCorpusSupplements({ query: "x", corpus: "memory" })).resolves.toEqual(
-      [],
-    );
+    await expect(searchMemoryCorpusSupplements({ query: "x", corpus: "memory" })).resolves.toEqual({
+      status: "ok",
+      results: [],
+    });
     await expect(
       searchMemoryCorpusSupplements({ query: "x", corpus: "sessions" }),
-    ).resolves.toEqual([]);
+    ).resolves.toEqual({ status: "ok", results: [] });
 
     expect(search).not.toHaveBeenCalled();
   });
@@ -174,8 +183,9 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
     );
 
     const out = await searchMemoryCorpusSupplements({ query: "x", corpus: "all" });
-    expect(out).toHaveLength(1);
-    expect(out[0]?.path).toBe("wiki/a.md");
+    const results = out.status === "ok" ? out.results : [];
+    expect(results).toHaveLength(1);
+    expect(results[0]?.path).toBe("wiki/a.md");
 
     const messages: string[] = warnSpy.mock.calls.map(([message]: unknown[]): string =>
       typeof message === "string" ? message : (JSON.stringify(message) ?? ""),
@@ -206,8 +216,9 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
 
     const out = await searchMemoryCorpusSupplements({ query: "x", corpus: "all" });
 
-    expect(out).toHaveLength(1);
-    expect(out[0]?.path).toBe("wiki/a.md");
+    const results = out.status === "ok" ? out.results : [];
+    expect(results).toHaveLength(1);
+    expect(results[0]?.path).toBe("wiki/a.md");
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -221,16 +232,13 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
       );
     }
 
-    const error: unknown = await searchMemoryCorpusSupplements({
+    const out = await searchMemoryCorpusSupplements({
       query: "anything",
       corpus: "all",
-    }).then(
-      () => undefined,
-      (reason: unknown) => reason,
-    );
+    });
 
-    expect(error).toBeInstanceOf(Error);
-    const message = (error as Error).message;
+    expect(out.status).toBe("all-failed");
+    const message = out.status === "all-failed" ? out.failure : "";
     expect(message).toContain("all 6 corpus supplement searches failed");
     expect(message).toContain("+3 more");
     // 3 capped entries plus prefix; anything near the raw 60k concat is a leak.

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -1,9 +1,10 @@
+import type { MemoryCorpusSearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import {
   clearMemoryPluginState,
   registerMemoryCorpusSupplement,
-  type MemoryCorpusSearchResult,
-  type MemoryCorpusSupplement,
 } from "openclaw/plugin-sdk/memory-host-core";
+
+type MemoryCorpusSupplement = Parameters<typeof registerMemoryCorpusSupplement>[1];
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { searchMemoryCorpusSupplements } from "./tools.shared.js";
 
@@ -84,7 +85,7 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
 
     await expect(
       searchMemoryCorpusSupplements({ query: "anything", corpus: "all" }),
-    ).rejects.toThrow(/all corpus supplement searches failed: .*"bad-1": e1.*"bad-2": e2/);
+    ).rejects.toThrow(/all 2 corpus supplement searches failed: .*"bad-1": e1.*"bad-2": e2/);
     expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
@@ -183,5 +184,56 @@ describe("searchMemoryCorpusSupplements partial-failure tolerance (issue #77897)
       messages.some((m) => m.includes('"string-throw"') && m.includes("raw string failure")),
     ).toBe(true);
     expect(messages.some((m) => m.includes('"object-throw"') && m.includes("ESUPP"))).toBe(true);
+  });
+
+  it("preserves sibling results when a rejection is a cyclic null-prototype value", async () => {
+    // Hostile shape: JSON.stringify throws (cycle) and String() throws (no
+    // Object.prototype), so a naive formatter would abort the settle loop and
+    // discard the fulfilled sibling.
+    registerMemoryCorpusSupplement(
+      "good",
+      buildSupplement(async () => [buildResult({ path: "wiki/a.md" })]),
+    );
+    registerMemoryCorpusSupplement(
+      "hostile",
+      buildSupplement(async () => {
+        const hostile: Record<string, unknown> = Object.create(null);
+        hostile.self = hostile;
+        // oxlint-disable-next-line typescript/only-throw-error -- testing hostile non-Error rejection
+        throw hostile;
+      }),
+    );
+
+    const out = await searchMemoryCorpusSupplements({ query: "x", corpus: "all" });
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.path).toBe("wiki/a.md");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the all-failed diagnostic to a capped sample plus count", async () => {
+    for (let i = 0; i < 6; i += 1) {
+      registerMemoryCorpusSupplement(
+        `bad-${i}`,
+        buildSupplement(async () => {
+          throw new Error(`failure ${i}: ${"x".repeat(10_000)}`);
+        }),
+      );
+    }
+
+    const error: unknown = await searchMemoryCorpusSupplements({
+      query: "anything",
+      corpus: "all",
+    }).then(
+      () => undefined,
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain("all 6 corpus supplement searches failed");
+    expect(message).toContain("+3 more");
+    // 3 capped entries plus prefix; anything near the raw 60k concat is a leak.
+    expect(message.length).toBeLessThan(1_000);
   });
 });

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -162,11 +162,23 @@ export async function searchMemoryCorpusSupplements(params: {
   if (supplements.length === 0) {
     return [];
   }
-  const results = (
-    await Promise.all(
-      supplements.map(async (registration) => await registration.supplement.search(params)),
-    )
-  ).flat();
+  // Use allSettled so a single misbehaving supplement does not discard sibling
+  // results. Invariant: result ⊇ ⋃_{s succeeds} s.search(params).
+  const settled = await Promise.allSettled(
+    supplements.map(async (registration) => await registration.supplement.search(params)),
+  );
+  const results: MemoryCorpusSearchResult[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const outcome = settled[i];
+    if (outcome.status === "fulfilled") {
+      results.push(...outcome.value);
+    } else {
+      const pluginId = supplements[i]?.pluginId ?? "<unknown>";
+      console.warn(
+        `memory-core: corpus supplement "${pluginId}" search failed; sibling results preserved (${formatSupplementError(outcome.reason)}).`,
+      );
+    }
+  }
   return results
     .toSorted((left, right) => {
       if (left.score !== right.score) {
@@ -175,6 +187,20 @@ export async function searchMemoryCorpusSupplements(params: {
       return left.path.localeCompare(right.path);
     })
     .slice(0, Math.max(1, params.maxResults ?? 10));
+}
+
+function formatSupplementError(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.message || reason.name || "Error";
+  }
+  if (typeof reason === "string") {
+    return reason;
+  }
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
 }
 
 export async function getMemoryCorpusSupplementResult(params: {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -165,40 +165,6 @@ export function buildMemorySearchUnavailableResult(
   };
 }
 
-const DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS = 10_000;
-
-class SupplementSearchTimeoutError extends Error {
-  constructor(pluginId: string, timeoutMs: number) {
-    super(`supplement "${pluginId}" search did not settle within ${timeoutMs}ms`);
-    this.name = "SupplementSearchTimeoutError";
-  }
-}
-
-async function searchSupplementWithTimeout(
-  pluginId: string,
-  search: Promise<MemoryCorpusSearchResult[]>,
-  timeoutMs: number,
-): Promise<MemoryCorpusSearchResult[]> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race<MemoryCorpusSearchResult[]>([
-      search,
-      new Promise<MemoryCorpusSearchResult[]>((_, reject) => {
-        timer = setTimeout(() => {
-          reject(new SupplementSearchTimeoutError(pluginId, timeoutMs));
-        }, timeoutMs);
-        if (typeof timer?.unref === "function") {
-          timer.unref();
-        }
-      }),
-    ]);
-  } finally {
-    if (timer !== undefined) {
-      clearTimeout(timer);
-    }
-  }
-}
-
 export async function searchMemoryCorpusSupplements(params: {
   query: string;
   maxResults?: number;
@@ -206,8 +172,6 @@ export async function searchMemoryCorpusSupplements(params: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   corpus?: "memory" | "wiki" | "all" | "sessions";
-  /** Test seam only; production callers use the fixed default. */
-  timeoutMs?: number;
 }): Promise<MemoryCorpusSearchResult[]> {
   if (params.corpus === "memory" || params.corpus === "sessions") {
     return [];
@@ -216,17 +180,12 @@ export async function searchMemoryCorpusSupplements(params: {
   if (supplements.length === 0) {
     return [];
   }
-  // Use allSettled with a per-supplement timeout so a single misbehaving or
-  // hung supplement does not discard sibling results or block the whole call
-  // indefinitely. Invariant: result ⊇ ⋃_{s settles in time} s.search(params).
-  const timeoutMs = params.timeoutMs ?? DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS;
+  // allSettled so a single rejecting supplement does not discard sibling
+  // results. The caller's memory-search deadline owns time bounding; no local
+  // cutoff here, or a supplement settling inside that window loses its result.
   const settled = await Promise.allSettled(
     supplements.map((registration) =>
-      searchSupplementWithTimeout(
-        registration.pluginId,
-        Promise.resolve().then(() => registration.supplement.search(params)),
-        timeoutMs,
-      ),
+      Promise.resolve().then(() => registration.supplement.search(params)),
     ),
   );
   const results: MemoryCorpusSearchResult[] = [];

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -164,6 +164,52 @@ export function buildMemorySearchUnavailableResult(
   };
 }
 
+const DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS = 10_000;
+
+function resolveSupplementSearchTimeoutMs(): number {
+  const raw = process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS;
+  if (typeof raw !== "string" || raw.length === 0) {
+    return DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+export class SupplementSearchTimeoutError extends Error {
+  constructor(pluginId: string, timeoutMs: number) {
+    super(`supplement "${pluginId}" search did not settle within ${timeoutMs}ms`);
+    this.name = "SupplementSearchTimeoutError";
+  }
+}
+
+async function searchSupplementWithTimeout(
+  pluginId: string,
+  search: Promise<MemoryCorpusSearchResult[]>,
+  timeoutMs: number,
+): Promise<MemoryCorpusSearchResult[]> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race<MemoryCorpusSearchResult[]>([
+      search,
+      new Promise<MemoryCorpusSearchResult[]>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new SupplementSearchTimeoutError(pluginId, timeoutMs));
+        }, timeoutMs);
+        if (typeof timer?.unref === "function") {
+          timer.unref();
+        }
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 export async function searchMemoryCorpusSupplements(params: {
   query: string;
   maxResults?: number;
@@ -179,10 +225,18 @@ export async function searchMemoryCorpusSupplements(params: {
   if (supplements.length === 0) {
     return [];
   }
-  // Use allSettled so a single misbehaving supplement does not discard sibling
-  // results. Invariant: result ⊇ ⋃_{s succeeds} s.search(params).
+  // Use allSettled with a per-supplement timeout so a single misbehaving or
+  // hung supplement does not discard sibling results or block the whole call
+  // indefinitely. Invariant: result ⊇ ⋃_{s settles in time} s.search(params).
+  const timeoutMs = resolveSupplementSearchTimeoutMs();
   const settled = await Promise.allSettled(
-    supplements.map(async (registration) => await registration.supplement.search(params)),
+    supplements.map((registration) =>
+      searchSupplementWithTimeout(
+        registration.pluginId,
+        Promise.resolve().then(() => registration.supplement.search(params)),
+        timeoutMs,
+      ),
+    ),
   );
   const results: MemoryCorpusSearchResult[] = [];
   for (let i = 0; i < settled.length; i++) {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -2,6 +2,7 @@
 import { optionalFiniteNumberSchema, stringEnum } from "openclaw/plugin-sdk/channel-actions";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   listMemoryCorpusSupplements,
   resolveMemorySearchConfig,
@@ -10,6 +11,7 @@ import {
   type AnyAgentTool,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Type } from "typebox";
 import type { MemoryCoreAcquireLocalService } from "./memory/embedding-local-service.js";
@@ -171,6 +173,11 @@ export function buildMemorySearchUnavailableResult(
 const SUPPLEMENT_FAILURE_DETAIL_MAX_CHARS = 200;
 const SUPPLEMENT_FAILURES_REPORTED_MAX = 3;
 
+/** Every registered supplement rejected; the caller owns the degradation shape. */
+export type MemoryCorpusSupplementSearchOutcome =
+  | { status: "ok"; results: MemoryCorpusSearchResult[] }
+  | { status: "all-failed"; failure: string };
+
 export async function searchMemoryCorpusSupplements(params: {
   query: string;
   maxResults?: number;
@@ -178,13 +185,13 @@ export async function searchMemoryCorpusSupplements(params: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   corpus?: "memory" | "wiki" | "all" | "sessions";
-}): Promise<MemoryCorpusSearchResult[]> {
+}): Promise<MemoryCorpusSupplementSearchOutcome> {
   if (params.corpus === "memory" || params.corpus === "sessions") {
-    return [];
+    return { status: "ok", results: [] };
   }
   const supplements = listMemoryCorpusSupplements();
   if (supplements.length === 0) {
-    return [];
+    return { status: "ok", results: [] };
   }
   // allSettled so a single rejecting supplement does not discard sibling
   // results. The caller's memory-search deadline owns time bounding; no local
@@ -217,23 +224,30 @@ export async function searchMemoryCorpusSupplements(params: {
   }
   if (failures.length === supplements.length) {
     // Every supplement failed: that is backend unavailability, not an empty
-    // corpus. Throw so the memory tool surfaces its unavailable result
-    // (cooldown stays memory-phase-only) instead of a silent empty or
-    // memory-only success. The message reaches the agent-visible unavailable
-    // response, so report a bounded sample plus count, never every failure.
+    // corpus. Return the structured outcome so the caller can keep healthy
+    // builtin-memory hits and record the unavailable supplement corpus
+    // (cooldown stays memory-phase-only). The message reaches the
+    // agent-visible response, so report a bounded sample plus count, never
+    // every failure.
     const shown = failures.slice(0, SUPPLEMENT_FAILURES_REPORTED_MAX);
     const omitted = failures.length - shown.length;
     const detail = omitted > 0 ? `${shown.join("; ")}; +${omitted} more` : shown.join("; ");
-    throw new Error(`all ${supplements.length} corpus supplement searches failed: ${detail}`);
+    return {
+      status: "all-failed",
+      failure: `all ${supplements.length} corpus supplement searches failed: ${detail}`,
+    };
   }
-  return results
-    .toSorted((left, right) => {
-      if (left.score !== right.score) {
-        return right.score - left.score;
-      }
-      return left.path.localeCompare(right.path);
-    })
-    .slice(0, Math.max(1, params.maxResults ?? 10));
+  return {
+    status: "ok",
+    results: results
+      .toSorted((left, right) => {
+        if (left.score !== right.score) {
+          return right.score - left.score;
+        }
+        return left.path.localeCompare(right.path);
+      })
+      .slice(0, Math.max(1, params.maxResults ?? 10)),
+  };
 }
 
 export async function getMemoryCorpusSupplementResult(params: {
@@ -255,4 +269,73 @@ export async function getMemoryCorpusSupplementResult(params: {
     }
   }
   return null;
+}
+
+export type MemorySearchToolResult =
+  | (MemorySearchResult & { corpus: MemorySource })
+  | MemoryCorpusSearchResult;
+
+function mergeRankedMemorySearchToolStreams(
+  memoryResults: MemorySearchToolResult[],
+  supplementResults: MemorySearchToolResult[],
+): MemorySearchToolResult[] {
+  const merged: MemorySearchToolResult[] = [];
+  let memoryIndex = 0;
+  let supplementIndex = 0;
+  // Each backend owns its ranking. Memory scores intentionally omit some
+  // precedence facts, so compare only stream heads and never reorder a stream.
+  while (memoryIndex < memoryResults.length && supplementIndex < supplementResults.length) {
+    const memory = memoryResults[memoryIndex];
+    const supplement = supplementResults[supplementIndex];
+    if ((memory?.score ?? 0) >= (supplement?.score ?? 0)) {
+      if (memory) {
+        merged.push(memory);
+      }
+      memoryIndex += 1;
+    } else {
+      if (supplement) {
+        merged.push(supplement);
+      }
+      supplementIndex += 1;
+    }
+  }
+  merged.push(...memoryResults.slice(memoryIndex), ...supplementResults.slice(supplementIndex));
+  return merged;
+}
+
+export function mergeMemorySearchCorpusResults(params: {
+  memoryResults: MemorySearchToolResult[];
+  supplementResults: MemorySearchToolResult[];
+  maxResults: number;
+  balanceCorpora: boolean;
+}): MemorySearchToolResult[] {
+  const memoryResults = params.memoryResults;
+  const supplementResults = params.supplementResults;
+  if (!params.balanceCorpora || memoryResults.length === 0 || supplementResults.length === 0) {
+    return mergeRankedMemorySearchToolStreams(memoryResults, supplementResults).slice(
+      0,
+      params.maxResults,
+    );
+  }
+
+  const perCorpusCap = Math.ceil(params.maxResults / 2);
+  let memoryTake = Math.min(perCorpusCap, memoryResults.length);
+  let supplementTake = Math.min(perCorpusCap, supplementResults.length);
+  while (memoryTake + supplementTake < params.maxResults) {
+    const memory = memoryResults[memoryTake];
+    const supplement = supplementResults[supplementTake];
+    if (!memory && !supplement) {
+      break;
+    }
+    if (!supplement || (memory && memory.score >= supplement.score)) {
+      memoryTake += 1;
+    } else {
+      supplementTake += 1;
+    }
+  }
+
+  return mergeRankedMemorySearchToolStreams(
+    memoryResults.slice(0, memoryTake),
+    supplementResults.slice(0, supplementTake),
+  ).slice(0, params.maxResults);
 }

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -167,7 +167,7 @@ export function buildMemorySearchUnavailableResult(
 
 const DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS = 10_000;
 
-export class SupplementSearchTimeoutError extends Error {
+class SupplementSearchTimeoutError extends Error {
   constructor(pluginId: string, timeoutMs: number) {
     super(`supplement "${pluginId}" search did not settle within ${timeoutMs}ms`);
     this.name = "SupplementSearchTimeoutError";
@@ -231,8 +231,7 @@ export async function searchMemoryCorpusSupplements(params: {
   );
   const results: MemoryCorpusSearchResult[] = [];
   const failures: string[] = [];
-  for (let i = 0; i < settled.length; i++) {
-    const outcome = settled[i];
+  for (const [i, outcome] of settled.entries()) {
     if (outcome.status === "fulfilled") {
       results.push(...outcome.value);
     } else {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -1,6 +1,7 @@
 // Memory Core plugin module implements tools.shared behavior.
 import { optionalFiniteNumberSchema, stringEnum } from "openclaw/plugin-sdk/channel-actions";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import {
   listMemoryCorpusSupplements,
   resolveMemorySearchConfig,
@@ -166,18 +167,6 @@ export function buildMemorySearchUnavailableResult(
 
 const DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS = 10_000;
 
-function resolveSupplementSearchTimeoutMs(): number {
-  const raw = process.env.OPENCLAW_MEMORY_SUPPLEMENT_SEARCH_TIMEOUT_MS;
-  if (typeof raw !== "string" || raw.length === 0) {
-    return DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS;
-  }
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS;
-  }
-  return parsed;
-}
-
 export class SupplementSearchTimeoutError extends Error {
   constructor(pluginId: string, timeoutMs: number) {
     super(`supplement "${pluginId}" search did not settle within ${timeoutMs}ms`);
@@ -217,6 +206,8 @@ export async function searchMemoryCorpusSupplements(params: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   corpus?: "memory" | "wiki" | "all" | "sessions";
+  /** Test seam only; production callers use the fixed default. */
+  timeoutMs?: number;
 }): Promise<MemoryCorpusSearchResult[]> {
   if (params.corpus === "memory" || params.corpus === "sessions") {
     return [];
@@ -228,7 +219,7 @@ export async function searchMemoryCorpusSupplements(params: {
   // Use allSettled with a per-supplement timeout so a single misbehaving or
   // hung supplement does not discard sibling results or block the whole call
   // indefinitely. Invariant: result ⊇ ⋃_{s settles in time} s.search(params).
-  const timeoutMs = resolveSupplementSearchTimeoutMs();
+  const timeoutMs = params.timeoutMs ?? DEFAULT_SUPPLEMENT_SEARCH_TIMEOUT_MS;
   const settled = await Promise.allSettled(
     supplements.map((registration) =>
       searchSupplementWithTimeout(
@@ -239,16 +230,28 @@ export async function searchMemoryCorpusSupplements(params: {
     ),
   );
   const results: MemoryCorpusSearchResult[] = [];
+  const failures: string[] = [];
   for (let i = 0; i < settled.length; i++) {
     const outcome = settled[i];
     if (outcome.status === "fulfilled") {
       results.push(...outcome.value);
     } else {
       const pluginId = supplements[i]?.pluginId ?? "<unknown>";
+      // Supplement errors can carry tokens or private endpoints; route them
+      // through the shared redaction formatter before they reach any log.
+      const reason = redactSensitiveText(formatSupplementError(outcome.reason));
+      failures.push(`"${pluginId}": ${reason}`);
       console.warn(
-        `memory-core: corpus supplement "${pluginId}" search failed; sibling results preserved (${formatSupplementError(outcome.reason)}).`,
+        `memory-core: corpus supplement "${pluginId}" search failed; sibling results preserved (${reason}).`,
       );
     }
+  }
+  if (failures.length === supplements.length) {
+    // Every supplement failed: that is backend unavailability, not an empty
+    // corpus. Throw so the memory tool surfaces its unavailable result
+    // (cooldown stays memory-phase-only) instead of a silent empty or
+    // memory-only success.
+    throw new Error(`all corpus supplement searches failed: ${failures.join("; ")}`);
   }
   return results
     .toSorted((left, right) => {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -179,11 +179,23 @@ export async function searchMemoryCorpusSupplements(params: {
   if (supplements.length === 0) {
     return [];
   }
-  const results = (
-    await Promise.all(
-      supplements.map(async (registration) => await registration.supplement.search(params)),
-    )
-  ).flat();
+  // Use allSettled so a single misbehaving supplement does not discard sibling
+  // results. Invariant: result ⊇ ⋃_{s succeeds} s.search(params).
+  const settled = await Promise.allSettled(
+    supplements.map(async (registration) => await registration.supplement.search(params)),
+  );
+  const results: MemoryCorpusSearchResult[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const outcome = settled[i];
+    if (outcome.status === "fulfilled") {
+      results.push(...outcome.value);
+    } else {
+      const pluginId = supplements[i]?.pluginId ?? "<unknown>";
+      console.warn(
+        `memory-core: corpus supplement "${pluginId}" search failed; sibling results preserved (${formatSupplementError(outcome.reason)}).`,
+      );
+    }
+  }
   return results
     .toSorted((left, right) => {
       if (left.score !== right.score) {
@@ -192,6 +204,20 @@ export async function searchMemoryCorpusSupplements(params: {
       return left.path.localeCompare(right.path);
     })
     .slice(0, Math.max(1, params.maxResults ?? 10));
+}
+
+function formatSupplementError(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.message || reason.name || "Error";
+  }
+  if (typeof reason === "string") {
+    return reason;
+  }
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
 }
 
 export async function getMemoryCorpusSupplementResult(params: {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -1,7 +1,7 @@
 // Memory Core plugin module implements tools.shared behavior.
 import { optionalFiniteNumberSchema, stringEnum } from "openclaw/plugin-sdk/channel-actions";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import {
   listMemoryCorpusSupplements,
   resolveMemorySearchConfig,
@@ -165,6 +165,12 @@ export function buildMemorySearchUnavailableResult(
   };
 }
 
+// Failure text is plugin-supplied and lands in the agent-visible unavailable
+// response; without these caps one hostile or verbose supplement could consume
+// unbounded model context.
+const SUPPLEMENT_FAILURE_DETAIL_MAX_CHARS = 200;
+const SUPPLEMENT_FAILURES_REPORTED_MAX = 3;
+
 export async function searchMemoryCorpusSupplements(params: {
   query: string;
   maxResults?: number;
@@ -195,9 +201,14 @@ export async function searchMemoryCorpusSupplements(params: {
       results.push(...outcome.value);
     } else {
       const pluginId = supplements[i]?.pluginId ?? "<unknown>";
-      // Supplement errors can carry tokens or private endpoints; route them
-      // through the shared redaction formatter before they reach any log.
-      const reason = redactSensitiveText(formatSupplementError(outcome.reason));
+      // formatErrorMessage redacts secrets and never throws on hostile
+      // rejections (cyclic/null-prototype values); the cap keeps
+      // plugin-supplied text from flooding logs or the aggregate below.
+      const formatted = formatErrorMessage(outcome.reason);
+      const reason =
+        formatted.length > SUPPLEMENT_FAILURE_DETAIL_MAX_CHARS
+          ? `${formatted.slice(0, SUPPLEMENT_FAILURE_DETAIL_MAX_CHARS)}…`
+          : formatted;
       failures.push(`"${pluginId}": ${reason}`);
       console.warn(
         `memory-core: corpus supplement "${pluginId}" search failed; sibling results preserved (${reason}).`,
@@ -208,8 +219,12 @@ export async function searchMemoryCorpusSupplements(params: {
     // Every supplement failed: that is backend unavailability, not an empty
     // corpus. Throw so the memory tool surfaces its unavailable result
     // (cooldown stays memory-phase-only) instead of a silent empty or
-    // memory-only success.
-    throw new Error(`all corpus supplement searches failed: ${failures.join("; ")}`);
+    // memory-only success. The message reaches the agent-visible unavailable
+    // response, so report a bounded sample plus count, never every failure.
+    const shown = failures.slice(0, SUPPLEMENT_FAILURES_REPORTED_MAX);
+    const omitted = failures.length - shown.length;
+    const detail = omitted > 0 ? `${shown.join("; ")}; +${omitted} more` : shown.join("; ");
+    throw new Error(`all ${supplements.length} corpus supplement searches failed: ${detail}`);
   }
   return results
     .toSorted((left, right) => {
@@ -219,20 +234,6 @@ export async function searchMemoryCorpusSupplements(params: {
       return left.path.localeCompare(right.path);
     })
     .slice(0, Math.max(1, params.maxResults ?? 10));
-}
-
-function formatSupplementError(reason: unknown): string {
-  if (reason instanceof Error) {
-    return reason.message || reason.name || "Error";
-  }
-  if (typeof reason === "string") {
-    return reason;
-  }
-  try {
-    return JSON.stringify(reason);
-  } catch {
-    return String(reason);
-  }
 }
 
 export async function getMemoryCorpusSupplementResult(params: {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -14,7 +14,6 @@ import {
   readStringParam,
   resolveMemoryDreamingPluginConfig,
   resolveMemorySearchConfig,
-  type MemoryCorpusSearchResult,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
@@ -47,12 +46,10 @@ import {
   loadMemoryToolRuntime,
   MemoryGetSchema,
   MemorySearchSchema,
+  mergeMemorySearchCorpusResults,
   searchMemoryCorpusSupplements,
 } from "./tools.shared.js";
 
-type MemorySearchToolResult =
-  | (MemorySearchResult & { corpus: MemorySource })
-  | MemoryCorpusSearchResult;
 type MemoryManagerContext = Awaited<ReturnType<typeof getMemoryManagerContextWithPurpose>>;
 type ActiveMemoryManagerContext = Extract<MemoryManagerContext, { manager: unknown }>;
 type MemorySearchToolQueryDebug = NonNullable<
@@ -140,71 +137,6 @@ async function closeMemoryManagers(
   } catch {
     // Search results should not be hidden by best-effort transient cleanup.
   }
-}
-
-function mergeRankedMemorySearchToolStreams(
-  memoryResults: MemorySearchToolResult[],
-  supplementResults: MemorySearchToolResult[],
-): MemorySearchToolResult[] {
-  const merged: MemorySearchToolResult[] = [];
-  let memoryIndex = 0;
-  let supplementIndex = 0;
-  // Each backend owns its ranking. Memory scores intentionally omit some
-  // precedence facts, so compare only stream heads and never reorder a stream.
-  while (memoryIndex < memoryResults.length && supplementIndex < supplementResults.length) {
-    const memory = memoryResults[memoryIndex];
-    const supplement = supplementResults[supplementIndex];
-    if ((memory?.score ?? 0) >= (supplement?.score ?? 0)) {
-      if (memory) {
-        merged.push(memory);
-      }
-      memoryIndex += 1;
-    } else {
-      if (supplement) {
-        merged.push(supplement);
-      }
-      supplementIndex += 1;
-    }
-  }
-  merged.push(...memoryResults.slice(memoryIndex), ...supplementResults.slice(supplementIndex));
-  return merged;
-}
-
-function mergeMemorySearchCorpusResults(params: {
-  memoryResults: MemorySearchToolResult[];
-  supplementResults: MemorySearchToolResult[];
-  maxResults: number;
-  balanceCorpora: boolean;
-}): MemorySearchToolResult[] {
-  const memoryResults = params.memoryResults;
-  const supplementResults = params.supplementResults;
-  if (!params.balanceCorpora || memoryResults.length === 0 || supplementResults.length === 0) {
-    return mergeRankedMemorySearchToolStreams(memoryResults, supplementResults).slice(
-      0,
-      params.maxResults,
-    );
-  }
-
-  const perCorpusCap = Math.ceil(params.maxResults / 2);
-  let memoryTake = Math.min(perCorpusCap, memoryResults.length);
-  let supplementTake = Math.min(perCorpusCap, supplementResults.length);
-  while (memoryTake + supplementTake < params.maxResults) {
-    const memory = memoryResults[memoryTake];
-    const supplement = supplementResults[supplementTake];
-    if (!memory && !supplement) {
-      break;
-    }
-    if (!supplement || (memory && memory.score >= supplement.score)) {
-      memoryTake += 1;
-    } else {
-      supplementTake += 1;
-    }
-  }
-
-  return mergeRankedMemorySearchToolStreams(
-    memoryResults.slice(0, memoryTake),
-    supplementResults.slice(0, supplementTake),
-  ).slice(0, params.maxResults);
 }
 
 function buildRecallKey(
@@ -597,7 +529,7 @@ export function createMemorySearchTool(options: {
                 );
               }
             }
-            const supplementResults = shouldQuerySupplements
+            const supplementOutcome = shouldQuerySupplements
               ? await runUnavailablePhase(
                   "supplement",
                   async () =>
@@ -613,7 +545,25 @@ export function createMemorySearchTool(options: {
                         }),
                     ),
                 )
-              : [];
+              : { status: "ok" as const, results: [] };
+            const supplementCorpusUnavailable =
+              supplementOutcome.status === "all-failed" ? supplementOutcome.failure : undefined;
+            if (supplementCorpusUnavailable !== undefined) {
+              // Mirror the memory-corpus degradation: only when no healthy
+              // corpus remains does the whole search surface unavailability.
+              if (requestedCorpus === "wiki") {
+                return jsonResult(buildMemorySearchUnavailableResult(supplementCorpusUnavailable));
+              }
+              if (memoryCorpusUnavailable) {
+                return jsonResult(
+                  buildMemorySearchUnavailableResult(
+                    `${supplementCorpusUnavailable}; memory: ${memoryCorpusUnavailable}`,
+                  ),
+                );
+              }
+            }
+            const supplementResults =
+              supplementOutcome.status === "ok" ? supplementOutcome.results : [];
             // Wiki and memory scores use incomparable scales, so corpus=all first
             // balances candidate selection and then backfills any unused slots.
             const effectiveMax = Math.max(1, maxResults ?? 10);
@@ -642,7 +592,13 @@ export function createMemorySearchTool(options: {
                 ? {
                     warning: `Memory corpus unavailable; results cover wiki supplements only: ${memoryCorpusUnavailable}`,
                   }
-                : {}),
+                : supplementCorpusUnavailable
+                  ? {
+                      // Both-corpora-down returned unavailable above, so healthy
+                      // memory hits are always present here.
+                      warning: `Wiki corpus unavailable; results cover memory only: ${supplementCorpusUnavailable}`,
+                    }
+                  : {}),
               ...staleness,
               debug: searchDebug,
             });


### PR DESCRIPTION
## Summary

Fixes #77897. `searchMemoryCorpusSupplements` (extensions/memory-core/src/tools.shared.ts) used `Promise.all` to fan out to every registered corpus supplement (`memory-wiki`, third-party plugin supplements, etc.). `Promise.all` is fail-fast: a single rejection discards every sibling's already-resolved results.

This patch swaps `Promise.all` → `Promise.allSettled`, then re-flattens the fulfilled values. Rejections are logged once per offender with the registering plugin id so operators can correlate to the responsible supplement.

## Behavior contract (mathematical guarantee)

Let `S` be the set of registered corpus supplements at call time. Let `S_ok ⊆ S` be those whose `search(params)` fulfills, and `S_err = S \ S_ok` those that reject. The function now satisfies:

```
result = sort_score_desc_then_path(⋃_{s ∈ S_ok} s.search(params)).slice(0, max(1, maxResults ?? 10))
```

In particular:
- `|S_err| ≥ 1` does not collapse `result` to `[]`. Sibling results survive.
- `|S_err| = |S|` returns `[]` (graceful degradation, not throw).
- `|S_err| = 0` is byte-identical to the prior behavior — same merge, same sort, same `maxResults` clamp.

## Real behavior proof

- **Behavior or issue addressed:** A single misbehaving memory corpus supplement plugin causes `memory_search corpus=all` to return `[]` instead of preserving sibling supplement hits. The user-visible symptom is silent retrieval loss with no trace of the offending plugin in logs.
- **Real environment tested:** Local OpenClaw checkout at commit `0cc7b938ba6b7acfac935591bcd51ddddb46c5c1` on Node 22 / Darwin 25.2.0, exercising the production `memory_search` tool path through the live `openclaw/plugin-sdk/memory-core-host-runtime-core` SDK boundary. Two real corpus supplements (`healthy-wiki`, `broken-wiki`) registered through the public `registerMemoryCorpusSupplement(...)` SDK export — no mocks of the function under test, no mocks of the supplement registry, no stubs of `searchMemoryCorpusSupplements`.
- **Exact steps or command run after this patch:** `node scripts/test-projects.mjs extensions/memory-core/src/tools.citations.test.ts -- --reporter=verbose -t "preserves sibling"` from the repository root, which compiles the production source via tsgo and drives `createMemorySearchToolOrThrow().execute(...)` against the registered live supplements.
- **Evidence after fix:** Captured terminal output from the `node` invocation above; the fenced console output below shows the integration test exercising the production tool path with one resolving and one rejecting supplement, and capturing both the surviving wiki hit and the warn line that names the offender:

  ```
   RUN  v4.1.5 /Users/shubh-trips/Documents/personal-project/open-source/openclaw

   ✓ |extension-memory| extensions/memory-core/src/tools.citations.test.ts > memory tools > preserves sibling supplement results when one corpus=all supplement rejects (#77897) 6ms

   Test Files  1 passed (1)
        Tests  1 passed | 15 skipped (16)
     Start at  03:25:56
     Duration  1.05s

  [test] passed 1 Vitest shard in 2.97s
  ```

  The runtime assertions captured by this `node` run (full source: `extensions/memory-core/src/tools.citations.test.ts:386`) are:

  - `details.results` from the production `createMemorySearchToolOrThrow().execute(...)` envelope contains `["wiki", "entities/healthy.md"]` from the resolving `healthy-wiki` supplement
  - `details.results` simultaneously contains `["memory", "MEMORY.md"]` from the local memory backend
  - `console.warn` was invoked exactly once with a runtime log line of the shape `memory-core: corpus supplement "broken-wiki" search failed; sibling results preserved (corpus backend unavailable).`
- **Observed result after fix:** The surviving healthy supplement hit `wiki/entities/healthy.md` is delivered to the agent alongside the local `memory/MEMORY.md` result, and the runtime log emits the named-offender warn line `corpus supplement "broken-wiki" search failed; sibling results preserved (corpus backend unavailable).` exactly once — no `[]` collapse and no rethrow. Pre-fix on the same setup with current `Promise.all`-based main, the resolving supplement's `entities/healthy.md` hit is discarded and the user-facing `details.results` returns empty alongside an unhandled rejection bubbling through the supplement fanout.
- **What was not tested:** Cross-process supplement registration (the public SDK supplement registry is currently a single-process in-memory map; no IPC supplement adapter exists today, so cross-process degradation behavior is out of scope for this bug).

## Changelog

Entry added under `## Unreleased` → `### Fixes`:

> Memory/search: keep results from healthy memory corpus supplements when one rejects, so a single misbehaving plugin no longer empties `memory_search corpus=all`; failures are warn-logged with the offending plugin id instead of poisoning sibling results. Fixes #77897. Thanks @lonexreb.

## Why this matters

Memory search is on the agent's hot read path. Before this fix, a single misbehaving wiki/corpus plugin could cause all `memory_search(corpus="all")` calls to look empty — the agent silently loses retrieval signal, and the bad plugin is hard to identify because results just disappear. After this fix, the failing plugin is named in the runtime warn log and sibling retrieval continues to work, so a noisy supplement degrades gracefully instead of poisoning the whole memory subsystem.

## Risk

- **Surface**: one function in one bundled extension. Get-by-lookup is unchanged (it iterates synchronously and returns the first hit, so a single throw was already isolated).
- **Compat**: `Promise.allSettled` is supported in Node 22+ (the repo's stated runtime).
- **Logging**: one `console.warn` per failing supplement per call; matches existing `memory-core:` log prefix used in `dreaming-narrative.ts`.

Closes #77897

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Real behavior proof

- **Independent downstream evidence** ([comment](https://github.com/openclaw/openclaw/pull/78035#issuecomment-5170947059)): an official-main-derived patch set exercised the production `memory_search` path with one corpus supplement rejecting while a healthy supplement and builtin memory both returned hits — sibling results preserved; the all-rejected case surfaces backend unavailability instead of a silent empty success; caller cancellation (global abort) semantics preserved.
- Focused suites on the rebased head: `extensions/memory-core/src/tools.shared.test.ts` + `tools.citations.test.ts` — 36/36 green, including the deterministic partial-failure table (one supplement rejects → siblings kept; all reject → unavailable error).


**Review round (head `6410f0d1d54`):** the P1 deadline overlap is resolved by deletion — the 10-second per-supplement cutoff, its timeout error class, and the `timeoutMs` test seam are removed entirely; the caller's established 15-second memory-search deadline is the single time-bounding owner, so a supplement settling within that window can no longer lose its result. Tests for the removed cutoff are deleted with it (34/34 green). Remaining item is the real-runtime proof (exact-head Gateway/CLI output), which needs a live setup — the independent downstream evidence above covers the production path in the meantime.


**Review round (head `17b5852560a`, rebased on current main):** both failure-path findings are repaired at the owner boundary in `tools.shared.ts`:
- **[P0] bounded all-failed diagnostics** — per-plugin failure detail is capped at 200 chars and the thrown aggregate reports at most 3 entries plus a `+N more` count, so plugin-supplied text can no longer flood the agent-visible unavailable response. Regression: 6 supplements throwing 10k-char errors must produce a message under 1k chars.
- **[P2] canonical hostile-safe formatter** — the local `formatSupplementError` is deleted; rejections now go through the plugin SDK `formatErrorMessage` (canonical `normalization-core` formatter + `redactSensitiveText`), which never throws on unserializable values. Regression: a cyclic null-prototype rejection (both `JSON.stringify` and `String()` throw) preserves the fulfilled sibling's results.

Both regressions fail on pre-fix code for the intended reasons. 36/36 tests green (`tools.shared.test.ts` + `tools.citations.test.ts`), `tsgo` extensions + test lanes clean, oxlint clean, import cycles 0, `git diff --check` clean. Production LOC net +1 (+21/−20) — the deleted local formatter absorbs the bounding logic. Structured Codex review (gpt-5.6-sol, high): patch is correct (0.99), no actionable findings. Real-runtime Gateway/CLI proof remains the outstanding item.

### Real runtime proof (exact head `17b5852560a`, live Gateway, isolated `OPENCLAW_STATE_DIR`)

Setup — source checkout at the exact PR head, built dist, fresh isolated state dir. Real CLI end to end: `openclaw onboard --non-interactive --flow quickstart` (mock OpenAI responses-API provider on loopback, zero real credentials), then two external plugins installed through the real installer — `supplement-healthy` (registers a corpus supplement returning one wiki hit via `api.registerMemoryCorpusSupplement`) and `supplement-flaky` (its supplement always rejects). Builtin memory seeded and indexed via `openclaw memory index`. Live gateway: `node dist/index.js gateway --port 19317 --bind loopback`. The turn is driven by `openclaw agent --agent main --session-id proof-78035-gw --message "memory supplement qa check: …" --json`; the mock provider issues exactly one `memory_search {query: "saffron proof marker", corpus: "all"}` tool call and echoes the tool's JSON response verbatim in its final message.

**Scenario A — healthy supplement survives a rejected sibling.** Both plugins registered (`openclaw plugins list`: `supplement-healthy` loaded, `supplement-flaky` loaded). Tool response (from the captured agent turn JSON; memory rows elided):

```json
{
  "results": [
    { "path": "MEMORY.md", "corpus": "memory", "snippet": "- The saffron proof marker lives here (builtin memory hit)…", "score": 0.999 },
    { "corpus": "wiki", "path": "healthy-corpus/proof.md", "score": 0.91,
      "snippet": "HEALTHY_SUPPLEMENT_HIT for query: saffron proof marker" }
  ]
}
```

Gateway log, same turn — the rejection is contained and redacted-formatted at the owner boundary:

```
memory-core: corpus supplement "supplement-flaky" search failed; sibling results preserved (flaky supplement backend rejects by design (proof run)).
```

**Scenario B — every supplement fails ⇒ bounded agent-visible unavailability, not silent success.** `supplement-healthy` uninstalled via `openclaw plugins uninstall`, gateway restarted, same turn:

```json
{
  "results": [],
  "unavailable": true,
  "error": "all 1 corpus supplement searches failed: \"supplement-flaky\": flaky supplement backend rejects by design (proof run)",
  "warning": "Memory search is unavailable due to an embedding/provider error.",
  "action": "Check embedding provider configuration and retry memory_search."
}
```

The error string is the new bounded format (count + per-plugin detail capped at 200 chars, at most 3 entries + `+N more`). On pre-fix code the same all-failed path concatenated every plugin-supplied error unbounded.


**Review round (head `030b46649cf`):** the flagged live-revocation regression was stale-branch drift, not a code change in this PR — main landed the revocation guard (`9e7da04686a`, #125393) after this branch's last rebase, so the diff appeared to remove it. Rebased onto current main: the guard (`tools.shared.ts` live-getter revocation) and its regression test ("revokes retained memory tools when live config disables memory") are both intact on this head, alongside main's corpus=all omitted-memory warning (#125500). This PR's production diff remains supplement-scoped only (`searchMemoryCorpusSupplements` + bounded failure formatting). 38/38 tests green on the rebased head (`tools.shared.test.ts` + `tools.citations.test.ts`). The Gateway runtime proof above was captured on the pre-rebase head; the supplement code it exercises is byte-identical on this head.


**Review round (head `e95c9d418de`):** the all-failed loss path is repaired as one structured degradation, mirroring the memory-corpus mechanism from #125500. `searchMemoryCorpusSupplements` now returns a closed outcome (`{status:"ok", results}` | `{status:"all-failed", failure}`) instead of throwing; the tool keeps healthy builtin memory hits for corpus=all and records the supplement corpus in the response `warning` ("Wiki corpus unavailable; results cover memory only: …"), while corpus=wiki — and the both-corpora-down combination — still surface the full unavailable result. No cooldown is recorded for supplement-phase failure (unchanged invariant). Regressions: tool-level test proving memory hits + warning survive an all-supplement failure (fails on pre-fix code with the empty unavailable result), plus the corpus=wiki unavailable case; shared-suite tests updated to the outcome shape. The corpus-merge helpers moved to `tools.shared.ts` to keep `tools.ts` under the 700-line lint cap. 40/40 tests green, tsgo both lanes, oxlint, full build clean; structured Codex review: patch is correct (0.98), no findings.


### Real runtime proof v2 (exact head `e95c9d418de`, live Gateway, isolated `OPENCLAW_STATE_DIR`)

Same harness as v1 (dist built from this exact head; fresh isolated state dir; `openclaw onboard --non-interactive` with a loopback mock responses-API provider; two external plugins installed via the real installer — `supplement-healthy` returns one wiki hit, `supplement-flaky` always rejects; builtin memory seeded + `openclaw memory index`; live `node dist/index.js gateway`; one forced `memory_search {corpus:"all"}` turn via `openclaw agent --json`, tool response echoed verbatim).

**Scenario A — healthy supplement survives a rejected sibling** (both plugins installed). Tool response rows (trimmed) and no warning:

```json
[
 { "corpus": "memory", "path": "MEMORY.md", "snippet": "- The saffron proof marker lives here (builtin memory hit)…" },
 { "corpus": "wiki", "path": "healthy-corpus/proof.md", "snippet": "HEALTHY_SUPPLEMENT_HIT for query: saffron proof marker" }
]
```

Gateway log: `memory-core: corpus supplement "supplement-flaky" search failed; sibling results preserved (flaky supplement backend rejects by design (proof run)).`

**Scenario B — every supplement fails ⇒ the NEW degradation, not an unavailable loss** (`supplement-healthy` uninstalled, gateway restarted, same turn). The tool response has **no `unavailable` flag**, keeps the builtin memory hits, and records the supplement corpus:

```json
{
  "results": [ { "path": "MEMORY.md", "corpus": "memory", "…": "…" }, { "path": "USER.md", "…": "…" } ],
  "warning": "Wiki corpus unavailable; results cover memory only: all 1 corpus supplement searches failed: \"supplement-flaky\": flaky supplement backend rejects by design (proof run)"
}
```

This directly demonstrates the round's repair: the v1 trace's scenario B returned `results: []` + `unavailable: true` on the old head; the exact-head run now preserves the primary corpus and surfaces the supplement failure as a bounded warning.
