### PR TITLE
Drop stale conversation session bindings

### DIFF
--- a/src/channels/plugins/binding-routing.test.ts
+++ b/src/channels/plugins/binding-routing.test.ts
@@ -46,17 +46,22 @@ function createBinding(overrides?: Partial<SessionBindingRecord>): SessionBindin
 function registerAdapter(record: SessionBindingRecord | null): {
   resolveByConversation: ReturnType<typeof vi.fn>;
   touch: ReturnType<typeof vi.fn>;
+  unbind: ReturnType<typeof vi.fn>;
 } {
   const resolveByConversation = vi.fn<SessionBindingAdapter["resolveByConversation"]>(() => record);
   const touch = vi.fn<NonNullable<SessionBindingAdapter["touch"]>>();
+  const unbind = vi.fn<NonNullable<SessionBindingAdapter["unbind"]>>(async () =>
+    record ? [record] : [],
+  );
   registerSessionBindingAdapter({
     channel: "demo",
     accountId: "default",
     listBySession: () => [],
     resolveByConversation,
     touch,
+    unbind,
   });
-  return { resolveByConversation, touch };
+  return { resolveByConversation, touch, unbind };
 }
 
 describe("runtime conversation binding route", () => {
@@ -70,6 +75,7 @@ describe("runtime conversation binding route", () => {
 
     const result = resolveRuntimeConversationBindingRoute({
       route: createRoute(),
+      validateBindingTarget: () => true,
       conversation: {
         channel: "demo",
         accountId: "default",
@@ -90,6 +96,35 @@ describe("runtime conversation binding route", () => {
       sessionKey: "agent:review:acp:session-1",
       lastRoutePolicy: "session",
       matchedBy: "binding.channel",
+    });
+  });
+
+  it("drops stale runtime bindings before touching or rewriting the channel route", async () => {
+    const route = createRoute();
+    const binding = createBinding();
+    const { touch, unbind } = registerAdapter(binding);
+
+    const result = resolveRuntimeConversationBindingRoute({
+      route,
+      validateBindingTarget: () => false,
+      conversation: {
+        channel: "demo",
+        accountId: "default",
+        conversationId: "room-1",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(unbind).toHaveBeenCalledWith({
+        bindingId: "binding-1",
+        targetSessionKey: "agent:review:acp:session-1",
+        reason: "stale-session-target",
+      });
+    });
+    expect(touch).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      bindingRecord: null,
+      route,
     });
   });
 

--- a/src/channels/plugins/binding-routing.ts
+++ b/src/channels/plugins/binding-routing.ts
@@ -1,4 +1,12 @@
+import fs from "node:fs";
+import { getRuntimeConfig } from "../../config/config.js";
+import {
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+} from "../../config/sessions/paths.js";
+import { loadSessionStore } from "../../config/sessions/store.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveGatewaySessionStoreTarget } from "../../gateway/session-utils.js";
 import { logVerbose } from "../../globals.js";
 import {
   getSessionBindingService,
@@ -28,6 +36,11 @@ export type RuntimeConversationBindingRouteResult = {
   boundAgentId?: string;
 };
 
+type RuntimeBindingTargetValidator = (params: {
+  targetSessionKey: string;
+  bindingRecord: SessionBindingRecord;
+}) => boolean;
+
 type ConfiguredBindingRouteConversationInput =
   | {
       conversation: ConversationRef;
@@ -51,6 +64,58 @@ function resolveConfiguredBindingConversationRef(
     conversationId: params.conversationId,
     parentConversationId: params.parentConversationId,
   };
+}
+
+function isRuntimeBindingTargetPresent(params: {
+  targetSessionKey: string;
+  cfg?: OpenClawConfig;
+}): boolean {
+  try {
+    const cfg = params.cfg ?? getRuntimeConfig();
+    const target = resolveGatewaySessionStoreTarget({ cfg, key: params.targetSessionKey });
+    const store = loadSessionStore(target.storePath, { skipCache: true });
+    for (const storeKey of target.storeKeys) {
+      const entry = store[storeKey];
+      if (!entry?.sessionId) {
+        continue;
+      }
+      const transcriptPath = resolveSessionFilePath(
+        entry.sessionId,
+        entry,
+        resolveSessionFilePathOptions({ storePath: target.storePath }),
+      );
+      if (fs.existsSync(transcriptPath)) {
+        return true;
+      }
+    }
+  } catch (err) {
+    logVerbose(
+      `runtime conversation binding target validation failed for ${params.targetSessionKey}: ${String(
+        err,
+      )}`,
+    );
+  }
+  return false;
+}
+
+function unbindStaleRuntimeBinding(params: {
+  bindingRecord: SessionBindingRecord;
+  targetSessionKey: string;
+}): void {
+  const service = getSessionBindingService();
+  service
+    .unbind({
+      bindingId: params.bindingRecord.bindingId,
+      targetSessionKey: params.targetSessionKey,
+      reason: "stale-session-target",
+    })
+    .catch((err) =>
+      logVerbose(
+        `runtime conversation binding stale-target unbind failed for ${params.bindingRecord.bindingId}: ${String(
+          err,
+        )}`,
+      ),
+    );
 }
 
 function isPluginOwnedRuntimeBindingRecord(record: SessionBindingRecord | null): boolean {
@@ -112,9 +177,11 @@ export function resolveConfiguredBindingRoute(
 export function resolveRuntimeConversationBindingRoute(
   params: {
     route: ResolvedAgentRoute;
+    validateBindingTarget?: RuntimeBindingTargetValidator;
   } & ConfiguredBindingRouteConversationInput,
 ): RuntimeConversationBindingRouteResult {
-  const bindingRecord = getSessionBindingService().resolveByConversation(
+  const service = getSessionBindingService();
+  const bindingRecord = service.resolveByConversation(
     resolveConfiguredBindingConversationRef(params),
   );
   const boundSessionKey = bindingRecord?.targetSessionKey?.trim();
@@ -125,13 +192,30 @@ export function resolveRuntimeConversationBindingRoute(
     };
   }
 
-  getSessionBindingService().touch(bindingRecord.bindingId);
   if (isPluginOwnedRuntimeBindingRecord(bindingRecord)) {
+    service.touch(bindingRecord.bindingId);
     return {
       bindingRecord,
       route: params.route,
     };
   }
+
+  const isTargetPresent = (params.validateBindingTarget ?? isRuntimeBindingTargetPresent)({
+    targetSessionKey: boundSessionKey,
+    bindingRecord,
+  });
+  if (!isTargetPresent) {
+    logVerbose(
+      `runtime conversation binding target missing; unbinding ${bindingRecord.bindingId} -> ${boundSessionKey}`,
+    );
+    unbindStaleRuntimeBinding({ bindingRecord, targetSessionKey: boundSessionKey });
+    return {
+      bindingRecord: null,
+      route: params.route,
+    };
+  }
+
+  service.touch(bindingRecord.bindingId);
 
   const boundAgentId = resolveAgentIdFromSessionKey(boundSessionKey) || params.route.agentId;
   return {

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveStoredSessionOwnerAgentId } from "../../gateway/session-store-key.js";
+import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { getLogger } from "../../logging/logger.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
@@ -148,6 +149,24 @@ function pruneMissingTranscriptEntries(params: {
     }
   }
   return removed;
+}
+
+async function unbindRemovedSessionKeys(params: { keys: Iterable<string> }): Promise<void> {
+  const service = getSessionBindingService();
+  for (const key of params.keys) {
+    try {
+      await service.unbind({ targetSessionKey: key, reason: "session-cleanup" });
+    } catch (err) {
+      getLogger().debug("session cleanup binding unbind skipped", { key, err });
+    }
+  }
+}
+
+function resolveRemovedSessionKeys(params: {
+  beforeStore: Record<string, SessionEntry>;
+  afterStore: Record<string, SessionEntry>;
+}): string[] {
+  return Object.keys(params.beforeStore).filter((key) => !Object.hasOwn(params.afterStore, key));
 }
 
 function addEntryArtifactPathsToSet(params: {
@@ -337,6 +356,14 @@ export async function runSessionsCleanup(params: {
         },
       );
       const afterStore = loadSessionStore(target.storePath, { skipCache: true });
+      const beforeStore = previewResults.find(
+        (result) => result.summary.storePath === target.storePath,
+      )?.beforeStore;
+      if (beforeStore) {
+        await unbindRemovedSessionKeys({
+          keys: resolveRemovedSessionKeys({ beforeStore, afterStore }),
+        });
+      }
       const unreferencedArtifacts =
         mode === "warn"
           ? {

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -2,6 +2,10 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as sessionBindingTesting,
+  registerSessionBindingAdapter,
+} from "../../infra/outbound/session-binding-service.js";
 import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import {
   resolveTrajectoryFilePath,
@@ -104,6 +108,7 @@ describe("Integration: saveSessionStore with pruning", () => {
 
   afterEach(() => {
     mockLoadConfig.mockReset();
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
     clearSessionStoreCacheForTest();
     if (savedCacheTtl === undefined) {
       delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
@@ -305,6 +310,54 @@ describe("Integration: saveSessionStore with pruning", () => {
     await expect(fs.stat(referencedTranscript)).resolves.toBeDefined();
     await expect(fs.stat(referencedCheckpointPath)).resolves.toBeDefined();
     await expect(fs.stat(freshOrphanTranscript)).resolves.toBeDefined();
+  });
+
+  it("sessions cleanup unbinds bindings for removed session rows only when applied", async () => {
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "365d",
+          maxEntries: 500,
+        },
+      },
+    });
+
+    const store: Record<string, SessionEntry> = {
+      missing: { sessionId: "missing-session", updatedAt: Date.now() },
+      fresh: { sessionId: "fresh-session", updatedAt: Date.now() },
+    };
+    const freshTranscript = path.join(testDir, "fresh-session.jsonl");
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+    await fs.writeFile(freshTranscript, "fresh", "utf-8");
+
+    const unbind = vi.fn(async () => []);
+    registerSessionBindingAdapter({
+      channel: "demo",
+      accountId: "default",
+      listBySession: () => [],
+      resolveByConversation: () => null,
+      unbind,
+    });
+
+    await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, dryRun: true, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+    expect(unbind).not.toHaveBeenCalled();
+
+    await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(unbind).toHaveBeenCalledWith({
+      targetSessionKey: "missing",
+      reason: "session-cleanup",
+    });
+    expect(unbind).not.toHaveBeenCalledWith(expect.objectContaining({ targetSessionKey: "fresh" }));
   });
 
   it("sessions cleanup dry-run does not double-count artifacts already covered by disk budget", async () => {


### PR DESCRIPTION
Fixes #77871.

## Summary
- validate runtime conversation binding targets before touching or rewriting routes
- unbind stale runtime targets and fall back to the original route
- unbind conversation bindings for session keys removed by applied session cleanup
- keep dry-run cleanup read-only

## Verification
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs src/channels/plugins/binding-routing.test.ts src/config/sessions/store.pruning.integration.test.ts src/infra/outbound/session-binding-service.test.ts src/commands/sessions-cleanup.test.ts --maxWorkers=1`
- `git diff --check`

## Known unrelated blocker
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` currently fails in the extension typecheck lane on `extensions/codex/src/app-server/run-attempt.ts(19,3): Module "openclaw/plugin-sdk/agent-harness-runtime" has no exported member "resolveAgentDir"`. This branch does not touch Codex harness exports.