### PR TITLE
fix: relink managed plugin openclaw peers on boot

### DIFF
--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -100,6 +100,20 @@ export async function prepareGatewayPluginBootstrap(params: {
           activationSourceConfig,
           metadataSnapshot: params.pluginMetadataSnapshot,
         });
+  if (pluginLookUpTable?.index) {
+    const { relinkOpenClawPeerDependenciesForInstalledPlugins } =
+      await import("../plugins/plugin-peer-link.js");
+    const result = await relinkOpenClawPeerDependenciesForInstalledPlugins({
+      index: pluginLookUpTable.index,
+      logger: params.log,
+    });
+    if (result.attempted > 0) {
+      params.log.debug(
+        `Checked openclaw peerDependency links for ${result.attempted} managed plugin(s).`,
+      );
+    }
+  }
+
   const deferredConfiguredChannelPluginIds = [
     ...(pluginLookUpTable?.startup.configuredDeferredChannelPluginIds ?? []),
   ];

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -14,6 +14,7 @@ import {
   PLUGIN_INSTALL_ERROR_CODE,
   resolvePluginInstallDir,
 } from "./install.js";
+import { relinkOpenClawPeerDependenciesForInstalledPlugins } from "./plugin-peer-link.js";
 import { createSuiteTempRootTracker } from "./test-helpers/fs-fixtures.js";
 
 vi.mock("../process/exec.js", () => ({
@@ -3049,6 +3050,58 @@ describe("linkOpenClawPeerDependencies (via installPluginFromDir)", () => {
     }
     const symlinkPath = path.join(second.targetDir, "node_modules", "openclaw");
     expect(fs.lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+  });
+
+  it("re-asserts peer links for managed installed plugins at boot", async () => {
+    const installedDir = suiteTempRootTracker.makeTempDir();
+    const fakeHostRoot = suiteTempRootTracker.makeTempDir();
+    resolveRootMock.mockReturnValue(fakeHostRoot);
+    fs.writeFileSync(
+      path.join(installedDir, "package.json"),
+      JSON.stringify({
+        name: "peer-dep-plugin",
+        version: "1.0.0",
+        peerDependencies: { openclaw: ">=2026.5.3" },
+      }),
+      "utf-8",
+    );
+
+    const result = await relinkOpenClawPeerDependenciesForInstalledPlugins({
+      index: {
+        version: 1,
+        hostContractVersion: "test",
+        compatRegistryVersion: "test",
+        migrationVersion: 1,
+        policyHash: "test",
+        generatedAtMs: 0,
+        installRecords: { "peer-dep-plugin": { source: "npm" } },
+        diagnostics: [],
+        plugins: [
+          {
+            pluginId: "peer-dep-plugin",
+            manifestPath: path.join(installedDir, "openclaw.plugin.json"),
+            manifestHash: "manifest",
+            packageJson: { path: "package.json", hash: "package" },
+            rootDir: installedDir,
+            origin: "global",
+            enabled: true,
+            startup: {
+              sidecar: false,
+              memory: false,
+              deferConfiguredChannelFullLoadUntilAfterListen: false,
+              agentHarnesses: [],
+            },
+            compat: [],
+          },
+        ],
+      },
+      logger: {},
+    });
+
+    expect(result).toEqual({ checked: 1, attempted: 1 });
+    const symlinkPath = path.join(installedDir, "node_modules", "openclaw");
+    expect(fs.lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(symlinkPath)).toBe(fs.realpathSync(fakeHostRoot));
   });
 
   it("warns and skips when resolveOpenClawPackageRootSync returns null", async () => {

--- a/src/plugins/plugin-peer-link.ts
+++ b/src/plugins/plugin-peer-link.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 
 type PluginPeerLinkLogger = {
   info?: (message: string) => void;
@@ -48,4 +49,82 @@ export async function linkOpenClawPeerDependencies(params: {
       params.logger.warn?.(`Failed to symlink peerDependency "${peerName}": ${String(err)}`);
     }
   }
+}
+
+function resolveManagedPackageJsonPath(params: {
+  rootDir: string;
+  packageJsonPath?: string;
+}): string | undefined {
+  if (!params.packageJsonPath) {
+    return undefined;
+  }
+  const packageJsonPath = path.resolve(params.rootDir, params.packageJsonPath);
+  const relative = path.relative(params.rootDir, packageJsonPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return undefined;
+  }
+  return packageJsonPath;
+}
+
+async function readPackagePeerDependencies(
+  packageJsonPath: string | undefined,
+): Promise<Record<string, string>> {
+  if (!packageJsonPath) {
+    return {};
+  }
+  try {
+    const raw = await fs.readFile(packageJsonPath, "utf8");
+    const parsed = JSON.parse(raw) as { peerDependencies?: unknown };
+    if (!parsed.peerDependencies || typeof parsed.peerDependencies !== "object") {
+      return {};
+    }
+    const peers: Record<string, string> = {};
+    for (const [name, version] of Object.entries(parsed.peerDependencies)) {
+      if (typeof version === "string") {
+        peers[name] = version;
+      }
+    }
+    return peers;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Re-assert host OpenClaw peer links for managed installed plugins before any
+ * gateway runtime import can resolve plugin code. This is intentionally a
+ * narrow boot-time repair for installs updated outside the plugin installer
+ * path (for example Homebrew replacing the host package under a managed npm
+ * plugin root).
+ */
+export async function relinkOpenClawPeerDependenciesForInstalledPlugins(params: {
+  index: InstalledPluginIndex;
+  logger: PluginPeerLinkLogger;
+}): Promise<{ checked: number; attempted: number }> {
+  let checked = 0;
+  let attempted = 0;
+  for (const record of params.index.plugins) {
+    if (!record.enabled) {
+      continue;
+    }
+    if (!record.installRecord && !params.index.installRecords[record.pluginId]) {
+      continue;
+    }
+    const packageJsonPath = resolveManagedPackageJsonPath({
+      rootDir: record.rootDir,
+      packageJsonPath: record.packageJson?.path,
+    });
+    const peerDependencies = await readPackagePeerDependencies(packageJsonPath);
+    if (!Object.hasOwn(peerDependencies, "openclaw")) {
+      continue;
+    }
+    checked += 1;
+    await linkOpenClawPeerDependencies({
+      installedDir: record.rootDir,
+      peerDependencies,
+      logger: params.logger,
+    });
+    attempted += 1;
+  }
+  return { checked, attempted };
 }


### PR DESCRIPTION
## Summary

Re-assert the host `openclaw` peerDependency link for enabled managed installed plugins during gateway startup, before runtime plugin imports. This gives installs updated outside the plugin install path (for example Homebrew replacing the host package) a cheap boot-time self-heal instead of crashing lanes with `ERR_MODULE_NOT_FOUND` for `openclaw/plugin-sdk/*`.

## Changes

- Add boot-time managed-plugin peer relink helper in `plugin-peer-link.ts`.
- Invoke the helper after plugin lookup/index resolution and before startup plugin runtime loading.
- Add regression coverage for re-linking a managed installed plugin declaring `peerDependencies.openclaw`.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs src/plugins/install.test.ts src/gateway/server-startup-plugins.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`
- `git diff --check`

Fixes openclaw/openclaw#77959

## Notes

Push note: Bryce's GitHub token lacks `workflow` scope, and the fork `main` is behind upstream by workflow-touching commits. The patch was developed and checked against current `origin/main` (`782963ae66`), then cherry-picked onto the fork's current `main` solely so the fork branch could be pushed without trying to create/update workflow files.
