### PR TITLE
fix: clarify group mentions target other people

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -349,6 +349,8 @@ Replying to a bot message counts as an implicit mention when the channel support
     - Per-agent override: `agents.list[].groupChat.mentionPatterns` (useful when multiple agents share a group).
     - Mention gating is only enforced when mention detection is possible (native mentions or `mentionPatterns` are configured).
     - Allowlisting a group or sender does not disable mention gating; set that group's `requireMention` to `false` when all messages should trigger.
+    - In group-chat prompt rules, agents should mostly lurk and should not answer every message. They should reply only when directly addressed, explicitly asked for help, or needed to prevent real confusion, security risk, or operational damage.
+    - An `@mention` of someone else means the message is addressed to that specific person, not to the agent, unless the message also clearly addresses the agent.
     - Group chat prompt context carries the resolved silent-reply instruction every turn; workspace files should not duplicate `NO_REPLY` mechanics.
     - Groups where silent replies are allowed treat clean empty or reasoning-only model turns as silent, equivalent to `NO_REPLY`. Direct chats do the same only when direct silent replies are explicitly allowed; otherwise empty replies remain failed agent turns.
     - Discord defaults live in `channels.discord.guilds."*"` (overridable per guild/channel).

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -43,6 +43,12 @@ describe("group runtime loading", () => {
     expect(toolOnlyContext).toContain("Normal final replies are private");
     expect(toolOnlyContext).toContain("message tool with action=send");
     expect(toolOnlyContext).toContain("Be a good group participant");
+    expect(toolOnlyContext).toContain("Do not answer every message");
+    expect(toolOnlyContext).toContain(
+      "prevents real confusion, security risk, or operational damage",
+    );
+    expect(toolOnlyContext).toContain("If a message @mentions someone else");
+    expect(toolOnlyContext).toContain("not to you");
     expect(toolOnlyContext).toContain("do not call message(action=send)");
     expect(toolOnlyContext).not.toContain('reply with exactly "NO_REPLY"');
     expect(
@@ -114,7 +120,7 @@ describe("group runtime loading", () => {
     expect(allowed).toContain('your final answer must still be exactly "NO_REPLY"');
     expect(allowed).toContain("Never say that you are staying quiet");
     expect(allowed).toContain(
-      "Be extremely selective: reply only when directly addressed or clearly helpful.",
+      "Be extremely selective: do not answer every message. Reply only when directly addressed, explicitly asked for help, or needed to prevent real confusion, security risk, or operational damage. An @mention of someone else is not a request for you to answer.",
     );
     expect(allowed).not.toContain("Otherwise stay silent.");
 

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -240,7 +240,7 @@ export function buildGroupChatContext(params: {
     );
   }
   lines.push(
-    "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.",
+    "Be a good group participant: mostly lurk. Do not answer every message. Reply only when directly addressed, when explicitly asked for help, or when a concise correction prevents real confusion, security risk, or operational damage. If a message @mentions someone else, treat it as addressed to that specific person, not to you, unless it also clearly addresses you. Prefer reactions over text for lightweight acknowledgment when available.",
   );
   lines.push(
     "Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.",
@@ -262,7 +262,9 @@ export function buildGroupChatContext(params: {
       lines.push(
         `If no response is needed, reply with exactly "${params.silentToken}" (and nothing else) so OpenClaw stays silent.`,
       );
-      lines.push("Be extremely selective: reply only when directly addressed or clearly helpful.");
+      lines.push(
+        "Be extremely selective: do not answer every message. Reply only when directly addressed, explicitly asked for help, or needed to prevent real confusion, security risk, or operational damage. An @mention of someone else is not a request for you to answer.",
+      );
     } else {
       lines.push(
         `If no response is needed, reply with exactly "${params.silentToken}" (and nothing else) so OpenClaw can send a short fallback reply.`,


### PR DESCRIPTION
## Summary
- tighten group-chat prompt rules so agents mostly lurk and do not answer every message
- clarify that @mentions of other people are addressed to that person, not the agent
- allow exceptions only for direct asks or concise corrections that prevent real confusion, security risk, or operational damage
- mirror the behavior in silent-reply guidance and group channel docs

## Verification
- pnpm test src/auto-reply/reply/groups.test.ts
- pnpm format:check docs/channels/groups.md src/auto-reply/reply/groups.ts src/auto-reply/reply/groups.test.ts