### PR TITLE
fix: preserve web tool metadata across config refresh

### DIFF
--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -6,8 +6,18 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { clearSecretsRuntimeSnapshot } from "./runtime.js";
 import { asConfig } from "./runtime.test-support.js";
 
+type ResolveRuntimeWebToolsTestParams = {
+  sourceConfig: {
+    tools?: {
+      web?: {
+        search?: { provider?: string };
+      };
+    };
+  };
+};
+
 const { resolveRuntimeWebToolsMock, runtimePrepareImportMock } = vi.hoisted(() => ({
-  resolveRuntimeWebToolsMock: vi.fn(async () => ({
+  resolveRuntimeWebToolsMock: vi.fn(async (_params?: ResolveRuntimeWebToolsTestParams) => ({
     search: { providerSource: "none", diagnostics: [] },
     fetch: { providerSource: "none", diagnostics: [] },
     diagnostics: [],
@@ -125,6 +135,58 @@ describe("secrets runtime fast path", () => {
     });
 
     expect(runtimePrepareImportMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves active web tool source surface when refresh source omits it", async () => {
+    resolveRuntimeWebToolsMock.mockImplementation(async (params) => {
+      const provider = params?.sourceConfig.tools?.web?.search?.provider;
+      return {
+        search: {
+          providerConfigured: provider,
+          providerSource: provider ? "configured" : "none",
+          selectedProvider: provider,
+          diagnostics: [],
+        },
+        fetch: { providerSource: "none", diagnostics: [] },
+        diagnostics: [],
+      };
+    });
+    const {
+      activateSecretsRuntimeSnapshot,
+      getActiveSecretsRuntimeSnapshot,
+      prepareSecretsRuntimeSnapshot,
+    } = await import("./runtime.js");
+    const { getRuntimeConfigSnapshotRefreshHandler } =
+      await import("../config/runtime-snapshot.js");
+
+    const initial = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: {
+          web: {
+            search: { provider: "brave" },
+          },
+        },
+      }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: emptyAuthStore,
+    });
+    activateSecretsRuntimeSnapshot(initial);
+    resolveRuntimeWebToolsMock.mockClear();
+
+    const refreshed = await getRuntimeConfigSnapshotRefreshHandler()?.refresh({
+      sourceConfig: asConfig({
+        gateway: {
+          auth: { mode: "token", token: "rewritten-token" },
+        },
+      }),
+    });
+
+    expect(refreshed).toBe(true);
+    expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
+    const refreshCall = resolveRuntimeWebToolsMock.mock.calls[0]?.[0];
+    expect(refreshCall?.sourceConfig.tools?.web?.search).toEqual({ provider: "brave" });
+    expect(getActiveSecretsRuntimeSnapshot()?.webTools.search.providerConfigured).toBe("brave");
   });
 
   it("uses the resolver path when an auth profile store contains a SecretRef", async () => {

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -322,6 +322,72 @@ function canUseSecretsRuntimeFastPath(params: {
   return !params.authStores.some((entry) => hasSecretRefCandidate(entry.store, defaults));
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwnKey(value: unknown, key: string): boolean {
+  return isPlainRecord(value) && Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function preserveOmittedRuntimeWebToolSurface(params: {
+  nextSourceConfig: OpenClawConfig;
+  previousSourceConfig: OpenClawConfig;
+}): OpenClawConfig {
+  if (!hasRuntimeWebToolConfigSurface(params.previousSourceConfig)) {
+    return params.nextSourceConfig;
+  }
+
+  let merged: OpenClawConfig | null = null;
+  const ensureMerged = (): OpenClawConfig => {
+    merged ??= structuredClone(params.nextSourceConfig);
+    return merged;
+  };
+
+  const previousWeb = params.previousSourceConfig.tools?.web;
+  if (isPlainRecord(previousWeb)) {
+    for (const key of ["search", "x_search", "fetch"] as const) {
+      if (!hasOwnKey(previousWeb, key) || hasOwnKey(params.nextSourceConfig.tools?.web, key)) {
+        continue;
+      }
+      const next = ensureMerged();
+      next.tools = isPlainRecord(next.tools) ? next.tools : {};
+      next.tools.web = isPlainRecord(next.tools.web) ? next.tools.web : {};
+      (next.tools.web as Record<string, unknown>)[key] = structuredClone(previousWeb[key]);
+    }
+  }
+
+  const previousEntries = params.previousSourceConfig.plugins?.entries;
+  if (isPlainRecord(previousEntries)) {
+    for (const [pluginId, previousEntry] of Object.entries(previousEntries)) {
+      if (!isPlainRecord(previousEntry) || !isPlainRecord(previousEntry.config)) {
+        continue;
+      }
+      for (const key of ["webSearch", "webFetch"] as const) {
+        if (!hasOwnKey(previousEntry.config, key)) {
+          continue;
+        }
+        const nextEntry = params.nextSourceConfig.plugins?.entries?.[pluginId];
+        const nextConfig = isPlainRecord(nextEntry) ? nextEntry.config : undefined;
+        if (hasOwnKey(nextConfig, key)) {
+          continue;
+        }
+        const next = ensureMerged();
+        next.plugins = isPlainRecord(next.plugins) ? next.plugins : {};
+        next.plugins.entries = isPlainRecord(next.plugins.entries) ? next.plugins.entries : {};
+        const mergedEntry = isPlainRecord(next.plugins.entries[pluginId])
+          ? next.plugins.entries[pluginId]
+          : structuredClone(previousEntry);
+        next.plugins.entries[pluginId] = mergedEntry;
+        mergedEntry.config = isPlainRecord(mergedEntry.config) ? mergedEntry.config : {};
+        mergedEntry.config[key] = structuredClone(previousEntry.config[key]);
+      }
+    }
+  }
+
+  return merged ?? params.nextSourceConfig;
+}
+
 export async function prepareSecretsRuntimeSnapshot(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -460,10 +526,14 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
       if (!activeSnapshot || !activeRefreshContext) {
         return false;
       }
+      const refreshSourceConfig = preserveOmittedRuntimeWebToolSurface({
+        nextSourceConfig: sourceConfig,
+        previousSourceConfig: activeSnapshot.sourceConfig,
+      });
       const refreshed = await prepareSecretsRuntimeSnapshot({
-        config: sourceConfig,
+        config: refreshSourceConfig,
         env: activeRefreshContext.env,
-        agentDirs: resolveRefreshAgentDirs(sourceConfig, activeRefreshContext),
+        agentDirs: resolveRefreshAgentDirs(refreshSourceConfig, activeRefreshContext),
         loadAuthStore: activeRefreshContext.loadAuthStore,
         loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
       });


### PR DESCRIPTION
## Summary

Prevents stripped config-write refreshes from dropping active runtime web tool metadata. When a refresh source config omits web tool surface paths that were present in the active source snapshot, the secrets runtime now preserves those previous web surface paths before preparing the refreshed snapshot, so the fast path cannot overwrite populated web metadata with an empty struct just because a writer had a partial source view.

## Changes

- Preserves omitted `tools.web.search`, `tools.web.x_search`, and `tools.web.fetch` paths from the active source snapshot during runtime refresh.
- Preserves omitted plugin `config.webSearch` / `config.webFetch` paths for plugin-provided web tools.
- Adds regression coverage for a stripped refresh source preserving an active Brave web search provider instead of taking the empty fast path.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm vitest run src/secrets/runtime.fast-path.test.ts` — passed, 6 tests.
- `git diff --check` — passed.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — all gates passed through the final pairing-account guard; process was SIGKILLed at final exit as observed on this host. Standalone `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-pairing-account-scope.mjs` passed.

Fixes #77826
