### PR TITLE
feat(matrix): transcribe inbound voice notes before mention gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Plugins/Matrix STT: transcribe inbound voice notes via the shared audio preflight helper before the mention gate so voice-only messages can carry an `@bot` mention through the transcript and reach the agent, mirroring Discord, Telegram, WhatsApp, and Feishu. The existing media path reuses the preflight download to avoid double-fetch. (#78016) [AI-assisted] Thanks @frankdierolf.
+
 ## 2026.4.26
 
 ### Changes

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -241,6 +241,21 @@ Use `allowBots` when you intentionally want inter-agent Matrix traffic:
 
 Use strict room allowlists and mention requirements when enabling bot-to-bot traffic in shared rooms.
 
+## Voice messages and audio transcription
+
+Inbound audio attachments (`m.audio`, plus `m.file` carrying an `audio/*` mimetype) are transcribed before the mention gate, so a voice note that mentions the bot by name reaches the agent in a `requireMention: true` room without a separate text mention.
+
+Transcription uses the shared `tools.media.audio` provider — typically OpenAI `gpt-4o-mini-transcribe`. See [Media tools overview](/tools/media-overview) for the provider matrix and config keys (`enabled`, `provider`, `model`, `maxBytes`, `timeoutSeconds`, `language`).
+
+Behavior:
+
+- The transcript is wrapped with `[Audio transcript (machine-generated, untrusted)]: ...` framing before reaching the agent body, so prompt-injection content inside the audio cannot impersonate system instructions.
+- Encrypted media is decrypted via the existing crypto adapter before transcription; the plaintext file is passed to the provider through the regular media-understanding pipeline.
+- The attachment is marked transcribed (`MediaTranscribedIndexes`) so downstream tools do not transcribe the same audio a second time.
+- Transcription failures are non-fatal — the message falls through to the `[matrix audio attachment]` placeholder body and the agent can still inspect the file via `MediaPath` / `MediaType`.
+
+Disable globally by setting `tools.media.audio.enabled: false`.
+
 ## Encryption and verification
 
 In encrypted (E2EE) rooms, outbound image events use `thumbnail_file` so image previews are encrypted alongside the full attachment. Unencrypted rooms still use plain `thumbnail_url`. No configuration is needed — the plugin detects E2EE state automatically.

--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- Matrix/STT: transcribe inbound voice notes via the shared `transcribeFirstAudio` helper before the mention gate so voice-only messages can carry an `@bot` mention through the transcript and reach the agent, mirroring Discord, Telegram, WhatsApp, and Feishu. The existing media path reuses the preflight download to avoid double-fetch, and encrypted audio is decrypted on the existing crypto adapter before transcription. (#78016) [AI-assisted] Thanks @frankdierolf.
 - Matrix/E2EE: add `openclaw matrix encryption setup` to enable Matrix encryption, bootstrap recovery, and print verification status from one setup flow. Thanks @gumadeiras.
 
 ### Fixes

--- a/extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts
@@ -1,0 +1,352 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import { MatrixMediaSizeLimitError } from "../media-errors.js";
+import {
+  createMatrixHandlerTestHarness,
+  createMatrixRoomMessageEvent,
+} from "./handler.test-helpers.js";
+
+const { downloadMatrixMediaMock, transcribeFirstAudioMock } = vi.hoisted(() => ({
+  downloadMatrixMediaMock: vi.fn(),
+  transcribeFirstAudioMock: vi.fn(),
+}));
+
+vi.mock("./media.js", async () => {
+  const actual = await vi.importActual<typeof import("./media.js")>("./media.js");
+  return {
+    ...actual,
+    downloadMatrixMedia: (...args: unknown[]) => downloadMatrixMediaMock(...args),
+  };
+});
+
+vi.mock("./preflight-audio.runtime.js", () => ({
+  transcribeFirstAudio: transcribeFirstAudioMock,
+}));
+
+function createAudioPreflightHarness(
+  overrides: Parameters<typeof createMatrixHandlerTestHarness>[0] = {},
+) {
+  return createMatrixHandlerTestHarness({
+    isDirectMessage: true,
+    shouldHandleTextCommands: () => true,
+    resolveMarkdownTableMode: () => "code",
+    resolveAgentRoute: () => ({
+      agentId: "main",
+      accountId: "ops",
+      sessionKey: "agent:main:matrix:channel:!room:example.org",
+      mainSessionKey: "agent:main:main",
+      channel: "matrix",
+      matchedBy: "binding.account",
+    }),
+    resolveStorePath: () => "/tmp/openclaw-test-session.json",
+    readSessionUpdatedAt: () => 123,
+    getRoomInfo: async () => ({
+      name: "Audio Room",
+      canonicalAlias: "#audio:example.org",
+      altAliases: [],
+    }),
+    getMemberDisplayName: async () => "Frank",
+    startupMs: Date.now() - 120_000,
+    startupGraceMs: 60_000,
+    textLimit: 4000,
+    mediaMaxBytes: 5 * 1024 * 1024,
+    replyToMode: "first",
+    ...overrides,
+  });
+}
+
+function createAudioEvent(content: Record<string, unknown>) {
+  return createMatrixRoomMessageEvent({
+    eventId: "$audio1",
+    sender: "@frank:matrix.example.org",
+    content: content as never,
+  });
+}
+
+describe("createMatrixRoomMessageHandler audio preflight", () => {
+  beforeEach(() => {
+    downloadMatrixMediaMock.mockReset();
+    transcribeFirstAudioMock.mockReset();
+    installMatrixMonitorTestRuntime();
+  });
+
+  it("transcribes inbound voice notes in DMs and surfaces the transcript as the agent body", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/voice.ogg",
+      contentType: "audio/ogg",
+      placeholder: "[matrix audio attachment]",
+    });
+    transcribeFirstAudioMock.mockResolvedValue("hello bot");
+    const { handler, recordInboundSession } = createAudioPreflightHarness();
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        url: "mxc://example/voice",
+        info: { mimetype: "audio/ogg", size: 12345 },
+      }),
+    );
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          MediaPaths: ["/tmp/inbound/voice.ogg"],
+          MediaTypes: ["audio/ogg"],
+        }),
+      }),
+    );
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          BodyForAgent: '[Audio transcript (machine-generated, untrusted)]: "hello bot"',
+          MediaTranscribedIndexes: [0],
+          MediaPath: "/tmp/inbound/voice.ogg",
+          MediaType: "audio/ogg",
+        }),
+      }),
+    );
+  });
+
+  it("treats m.file with an audio mimetype as a voice note for preflight", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/voice.opus",
+      contentType: "audio/opus",
+      placeholder: "[matrix audio attachment]",
+    });
+    transcribeFirstAudioMock.mockResolvedValue("opus transcript");
+    const { handler, recordInboundSession } = createAudioPreflightHarness();
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.file",
+        body: "voice.opus",
+        filename: "voice.opus",
+        url: "mxc://example/voice",
+        info: { mimetype: "audio/opus", size: 23456 },
+      }),
+    );
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          MediaTranscribedIndexes: [0],
+        }),
+      }),
+    );
+  });
+
+  it("lets a transcript-mentioned bot bypass the requireMention gate in a room", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/voice.ogg",
+      contentType: "audio/ogg",
+      placeholder: "[matrix audio attachment]",
+    });
+    transcribeFirstAudioMock.mockResolvedValue("bot can you check this");
+    const { handler, recordInboundSession } = createAudioPreflightHarness({
+      isDirectMessage: false,
+      mentionRegexes: [/\bbot\b/i],
+      roomsConfig: {
+        "!room:example.org": { requireMention: true } as never,
+      },
+    });
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        url: "mxc://example/voice",
+        info: { mimetype: "audio/ogg", size: 12345 },
+      }),
+    );
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          BodyForAgent: expect.stringContaining("bot can you check this"),
+          WasMentioned: true,
+        }),
+      }),
+    );
+  });
+
+  it("drops voice notes in requireMention rooms when the transcript does not match the bot", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/voice.ogg",
+      contentType: "audio/ogg",
+      placeholder: "[matrix audio attachment]",
+    });
+    transcribeFirstAudioMock.mockResolvedValue("hello world how are you");
+    const { handler, recordInboundSession } = createAudioPreflightHarness({
+      isDirectMessage: false,
+      mentionRegexes: [/\bbot\b/i],
+      roomsConfig: {
+        "!room:example.org": { requireMention: true } as never,
+      },
+    });
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        url: "mxc://example/voice",
+        info: { mimetype: "audio/ogg", size: 12345 },
+      }),
+    );
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the placeholder body when transcription fails", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/voice.ogg",
+      contentType: "audio/ogg",
+      placeholder: "[matrix audio attachment]",
+    });
+    transcribeFirstAudioMock.mockRejectedValue(new Error("STT down"));
+    const { handler, recordInboundSession } = createAudioPreflightHarness();
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        url: "mxc://example/voice",
+        info: { mimetype: "audio/ogg", size: 12345 },
+      }),
+    );
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          BodyForAgent: "[matrix audio attachment]",
+          MediaTranscribedIndexes: undefined,
+          MediaPath: "/tmp/inbound/voice.ogg",
+        }),
+      }),
+    );
+  });
+
+  it("does not invoke audio preflight for non-audio media", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/photo.jpg",
+      contentType: "image/jpeg",
+      placeholder: "[matrix media]",
+    });
+    const { handler, recordInboundSession } = createAudioPreflightHarness();
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.image",
+        body: "photo.jpg",
+        url: "mxc://example/photo",
+        info: { mimetype: "image/jpeg", size: 12345 },
+      }),
+    );
+
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(recordInboundSession).toHaveBeenCalled();
+  });
+
+  it("transcribes encrypted voice notes after decryption via the existing crypto adapter", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/encrypted-voice.ogg",
+      contentType: "audio/ogg",
+      placeholder: "[matrix audio attachment]",
+    });
+    transcribeFirstAudioMock.mockResolvedValue("encrypted hello");
+    const { handler, recordInboundSession } = createAudioPreflightHarness();
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        file: {
+          url: "mxc://example/encrypted-voice",
+          key: { kty: "oct", key_ops: ["encrypt"], alg: "A256CTR", k: "secret", ext: true },
+          iv: "iv",
+          hashes: { sha256: "hash" },
+          v: "v2",
+        },
+        info: { mimetype: "audio/ogg", size: 12345 },
+      }),
+    );
+
+    expect(downloadMatrixMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mxcUrl: "mxc://example/encrypted-voice",
+        file: expect.objectContaining({
+          url: "mxc://example/encrypted-voice",
+          key: expect.objectContaining({ alg: "A256CTR" }),
+        }),
+      }),
+    );
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          BodyForAgent: '[Audio transcript (machine-generated, untrusted)]: "encrypted hello"',
+          MediaTranscribedIndexes: [0],
+          MediaPath: "/tmp/inbound/encrypted-voice.ogg",
+        }),
+      }),
+    );
+  });
+
+  it("preserves the too-large placeholder when the audio download exceeds the size limit", async () => {
+    downloadMatrixMediaMock.mockRejectedValue(new MatrixMediaSizeLimitError());
+    const { handler, recordInboundSession } = createAudioPreflightHarness();
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.audio",
+        body: "big-voice.ogg",
+        url: "mxc://example/big-voice",
+        info: { mimetype: "audio/ogg", size: 10 * 1024 * 1024 },
+      }),
+    );
+
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          BodyForAgent: "[matrix audio attachment too large]",
+          MediaTranscribedIndexes: undefined,
+          MediaPath: undefined,
+        }),
+      }),
+    );
+  });
+
+  it("downloads the audio attachment exactly once across preflight and the existing media path", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/voice.ogg",
+      contentType: "audio/ogg",
+      placeholder: "[matrix audio attachment]",
+    });
+    transcribeFirstAudioMock.mockResolvedValue("hello bot");
+    const { handler } = createAudioPreflightHarness();
+
+    await handler(
+      "!room:example.org",
+      createAudioEvent({
+        msgtype: "m.audio",
+        body: "voice.ogg",
+        url: "mxc://example/voice",
+        info: { mimetype: "audio/ogg", size: 12345 },
+      }),
+    );
+
+    expect(downloadMatrixMediaMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -21,6 +21,7 @@ import {
   formatMatrixMediaTooLargeText,
   formatMatrixMediaUnavailableText,
   formatMatrixMessageText,
+  isLikelyBareFilename,
   resolveMatrixMessageAttachment,
   resolveMatrixMessageBody,
 } from "../media-text.js";
@@ -45,6 +46,11 @@ import type { MatrixInboundEventDeduper } from "./inbound-dedupe.js";
 import { resolveMatrixLocation, type MatrixLocationPayload } from "./location.js";
 import { downloadMatrixMedia } from "./media.js";
 import { resolveMentions, stripMatrixMentionPrefix } from "./mentions.js";
+import {
+  formatMatrixAudioTranscript,
+  isMatrixAudioContent,
+  resolveMatrixPreflightAudioTranscript,
+} from "./preflight-audio.js";
 import { deliverMatrixReplies } from "./replies.js";
 import { createMatrixReplyContextResolver } from "./reply-context.js";
 import { createRoomHistoryTracker } from "./room-history.js";
@@ -868,6 +874,71 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           return undefined;
         }
 
+        const earlyContentInfo =
+          "info" in content && content.info && typeof content.info === "object"
+            ? (content.info as { mimetype?: string; size?: number })
+            : undefined;
+        const earlyContentType = earlyContentInfo?.mimetype;
+        const earlyContentSize =
+          typeof earlyContentInfo?.size === "number" ? earlyContentInfo.size : undefined;
+        const earlyContentBody = typeof content.body === "string" ? content.body.trim() : "";
+        const earlyContentFilename =
+          typeof content.filename === "string" ? content.filename.trim() : "";
+        const earlyOriginalFilename = earlyContentFilename || earlyContentBody || undefined;
+
+        // Voice-note preflight: download + transcribe before the mention gate so
+        // transcribed mentions can pass `requireMention` rooms (peer-channel parity).
+        let preflightMedia: {
+          path: string;
+          contentType?: string;
+          placeholder: string;
+        } | null = null;
+        let preflightMediaDownloadFailed = false;
+        let preflightMediaSizeLimitExceeded = false;
+        let preflightAudioTranscript: string | undefined;
+        if (
+          isMatrixAudioContent({
+            msgtype: typeof content.msgtype === "string" ? content.msgtype : undefined,
+            mimetype: earlyContentType,
+          }) &&
+          mediaUrl?.startsWith("mxc://")
+        ) {
+          try {
+            preflightMedia = await downloadMatrixMedia({
+              client,
+              mxcUrl: mediaUrl,
+              contentType: earlyContentType,
+              sizeBytes: earlyContentSize,
+              maxBytes: mediaMaxBytes,
+              file: contentFile,
+              originalFilename: earlyOriginalFilename,
+            });
+          } catch (err) {
+            preflightMediaDownloadFailed = true;
+            if (isMatrixMediaSizeLimitError(err)) {
+              preflightMediaSizeLimitExceeded = true;
+            }
+            const errorText = formatMatrixErrorMessage(err);
+            logVerboseMessage(
+              `matrix: media download failed room=${roomId} id=${event.event_id ?? "unknown"} type=${content.msgtype} error=${errorText}`,
+            );
+            logger.warn("matrix media download failed", {
+              roomId,
+              eventId: event.event_id,
+              msgtype: content.msgtype,
+              encrypted: Boolean(contentFile),
+              error: errorText,
+            });
+          }
+          if (preflightMedia) {
+            preflightAudioTranscript = await resolveMatrixPreflightAudioTranscript({
+              mediaPath: preflightMedia.path,
+              mediaContentType: preflightMedia.contentType,
+              cfg,
+            });
+          }
+        }
+
         const _messageId = event.event_id ?? "";
         const _threadRootId = resolveMatrixThreadRootId({ event, content });
         const thread = resolveMatrixThreadRouting({
@@ -897,11 +968,14 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         const selfDisplayName = content.formatted_body
           ? await getMemberDisplayName(roomId, selfUserId).catch(() => undefined)
           : undefined;
+        const mentionPrecheckTextWithTranscript = preflightAudioTranscript
+          ? [mentionPrecheckText, preflightAudioTranscript].filter(Boolean).join("\n").trim()
+          : mentionPrecheckText;
         const { wasMentioned, hasExplicitMention } = resolveMentions({
           content,
           userId: selfUserId,
           displayName: selfDisplayName,
-          text: mentionPrecheckText,
+          text: mentionPrecheckTextWithTranscript,
           mentionRegexes: agentMentionRegexes,
         });
         if (
@@ -999,9 +1073,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           path: string;
           contentType?: string;
           placeholder: string;
-        } | null = null;
-        let mediaDownloadFailed = false;
-        let mediaSizeLimitExceeded = false;
+        } | null = preflightMedia;
+        let mediaDownloadFailed = preflightMediaDownloadFailed;
+        let mediaSizeLimitExceeded = preflightMediaSizeLimitExceeded;
         const finalContentUrl =
           "url" in content && typeof content.url === "string" ? content.url : undefined;
         const finalContentFile =
@@ -1018,7 +1092,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             : undefined;
         const contentType = contentInfo?.mimetype;
         const contentSize = typeof contentInfo?.size === "number" ? contentInfo.size : undefined;
-        if (finalMediaUrl?.startsWith("mxc://")) {
+        if (!media && !mediaDownloadFailed && finalMediaUrl?.startsWith("mxc://")) {
           try {
             media = await downloadMatrixMedia({
               client,
@@ -1049,7 +1123,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
 
         const rawBody = locationPayload?.text ?? contentBody;
-        const bodyText = resolveMatrixInboundBodyText({
+        let bodyText = resolveMatrixInboundBodyText({
           rawBody,
           filename: typeof content.filename === "string" ? content.filename : undefined,
           mediaPlaceholder: media?.placeholder,
@@ -1058,6 +1132,20 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           mediaDownloadFailed,
           mediaSizeLimitExceeded,
         });
+        if (
+          preflightMedia &&
+          bodyText &&
+          bodyText !== preflightMedia.placeholder &&
+          isLikelyBareFilename(bodyText)
+        ) {
+          // Matrix voice clients auto-fill `body` with the attachment filename.
+          // Treat that as placeholder-equivalent so the agent sees a clear audio
+          // marker rather than a stray filename.
+          bodyText = preflightMedia.placeholder;
+        }
+        if (preflightAudioTranscript && bodyText && bodyText === media?.placeholder) {
+          bodyText = formatMatrixAudioTranscript(preflightAudioTranscript);
+        }
         if (!bodyText) {
           await commitInboundEventIfClaimed();
           return undefined;
@@ -1112,6 +1200,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           bodyText,
           commandBodyText,
           media,
+          preflightAudioTranscript,
           locationPayload,
           messageId: _messageId,
           triggerSnapshot,
@@ -1166,6 +1255,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         bodyText,
         commandBodyText,
         media,
+        preflightAudioTranscript,
         locationPayload,
         messageId: _messageId,
         triggerSnapshot,
@@ -1313,6 +1403,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         MediaPath: media?.path,
         MediaType: media?.contentType,
         MediaUrl: media?.path,
+        MediaTranscribedIndexes: preflightAudioTranscript !== undefined ? [0] : undefined,
         ...locationPayload?.context,
         CommandAuthorized: commandAuthorized,
         CommandSource: "text" as const,

--- a/extensions/matrix/src/matrix/monitor/preflight-audio.runtime.ts
+++ b/extensions/matrix/src/matrix/monitor/preflight-audio.runtime.ts
@@ -1,0 +1,9 @@
+import { transcribeFirstAudio as transcribeFirstAudioImpl } from "openclaw/plugin-sdk/media-runtime";
+
+type TranscribeFirstAudio = typeof import("openclaw/plugin-sdk/media-runtime").transcribeFirstAudio;
+
+export async function transcribeFirstAudio(
+  ...args: Parameters<TranscribeFirstAudio>
+): ReturnType<TranscribeFirstAudio> {
+  return await transcribeFirstAudioImpl(...args);
+}

--- a/extensions/matrix/src/matrix/monitor/preflight-audio.test.ts
+++ b/extensions/matrix/src/matrix/monitor/preflight-audio.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const transcribeFirstAudioMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./preflight-audio.runtime.js", () => ({
+  transcribeFirstAudio: transcribeFirstAudioMock,
+}));
+
+import {
+  formatMatrixAudioTranscript,
+  isMatrixAudioContent,
+  resolveMatrixPreflightAudioTranscript,
+} from "./preflight-audio.js";
+
+const cfg = {} as import("openclaw/plugin-sdk/config-runtime").OpenClawConfig;
+
+describe("isMatrixAudioContent", () => {
+  it("returns true for m.audio msgtype regardless of mimetype", () => {
+    expect(isMatrixAudioContent({ msgtype: "m.audio" })).toBe(true);
+    expect(isMatrixAudioContent({ msgtype: "m.audio", mimetype: "audio/opus" })).toBe(true);
+    expect(isMatrixAudioContent({ msgtype: "m.audio", mimetype: undefined })).toBe(true);
+  });
+
+  it("returns true for m.file with an audio mimetype", () => {
+    expect(isMatrixAudioContent({ msgtype: "m.file", mimetype: "audio/ogg" })).toBe(true);
+    expect(isMatrixAudioContent({ msgtype: "m.file", mimetype: "audio/mpeg" })).toBe(true);
+    expect(isMatrixAudioContent({ msgtype: "m.file", mimetype: "AUDIO/MP4" })).toBe(true);
+  });
+
+  it("returns false for m.file without an audio mimetype", () => {
+    expect(isMatrixAudioContent({ msgtype: "m.file", mimetype: "image/png" })).toBe(false);
+    expect(isMatrixAudioContent({ msgtype: "m.file", mimetype: "application/pdf" })).toBe(false);
+    expect(isMatrixAudioContent({ msgtype: "m.file" })).toBe(false);
+  });
+
+  it("returns false for non-audio msgtypes", () => {
+    expect(isMatrixAudioContent({ msgtype: "m.image" })).toBe(false);
+    expect(isMatrixAudioContent({ msgtype: "m.video", mimetype: "video/mp4" })).toBe(false);
+    expect(isMatrixAudioContent({ msgtype: "m.text" })).toBe(false);
+  });
+
+  it("returns false when msgtype is missing", () => {
+    expect(isMatrixAudioContent({})).toBe(false);
+    expect(isMatrixAudioContent({ mimetype: "audio/ogg" })).toBe(false);
+  });
+});
+
+describe("formatMatrixAudioTranscript", () => {
+  it("wraps the transcript with prompt-injection framing and JSON-encodes the payload", () => {
+    expect(formatMatrixAudioTranscript("hello world")).toBe(
+      `[Audio transcript (machine-generated, untrusted)]: "hello world"`,
+    );
+  });
+
+  it("escapes control characters and embedded quotes", () => {
+    expect(formatMatrixAudioTranscript('say "hi"\n then go')).toBe(
+      `[Audio transcript (machine-generated, untrusted)]: ${JSON.stringify('say "hi"\n then go')}`,
+    );
+  });
+});
+
+describe("resolveMatrixPreflightAudioTranscript", () => {
+  beforeEach(() => {
+    transcribeFirstAudioMock.mockReset();
+  });
+
+  it("forwards the local media path and content type to transcribeFirstAudio", async () => {
+    transcribeFirstAudioMock.mockResolvedValue("hello from voice");
+
+    const transcript = await resolveMatrixPreflightAudioTranscript({
+      mediaPath: "/tmp/inbound/voice.ogg",
+      mediaContentType: "audio/ogg",
+      cfg,
+    });
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          MediaPaths: ["/tmp/inbound/voice.ogg"],
+          MediaTypes: ["audio/ogg"],
+        }),
+        cfg,
+      }),
+    );
+    expect(transcript).toBe("hello from voice");
+  });
+
+  it("omits MediaTypes when no content type is provided", async () => {
+    transcribeFirstAudioMock.mockResolvedValue("transcript");
+
+    await resolveMatrixPreflightAudioTranscript({
+      mediaPath: "/tmp/inbound/voice.ogg",
+      cfg,
+    });
+
+    const args = transcribeFirstAudioMock.mock.calls[0]?.[0] as {
+      ctx: { MediaPaths?: string[]; MediaTypes?: string[] };
+    };
+    expect(args.ctx.MediaPaths).toEqual(["/tmp/inbound/voice.ogg"]);
+    expect(args.ctx.MediaTypes).toBeUndefined();
+  });
+
+  it("returns undefined when the runtime throws", async () => {
+    transcribeFirstAudioMock.mockRejectedValue(new Error("STT provider unavailable"));
+
+    const transcript = await resolveMatrixPreflightAudioTranscript({
+      mediaPath: "/tmp/inbound/voice.ogg",
+      mediaContentType: "audio/ogg",
+      cfg,
+    });
+
+    expect(transcript).toBeUndefined();
+  });
+
+  it("returns undefined when the runtime returns undefined", async () => {
+    transcribeFirstAudioMock.mockResolvedValue(undefined);
+
+    const transcript = await resolveMatrixPreflightAudioTranscript({
+      mediaPath: "/tmp/inbound/voice.ogg",
+      mediaContentType: "audio/ogg",
+      cfg,
+    });
+
+    expect(transcript).toBeUndefined();
+  });
+
+  it("returns undefined without invoking the runtime when the abort signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const transcript = await resolveMatrixPreflightAudioTranscript({
+      mediaPath: "/tmp/inbound/voice.ogg",
+      mediaContentType: "audio/ogg",
+      cfg,
+      abortSignal: controller.signal,
+    });
+
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(transcript).toBeUndefined();
+  });
+
+  it("returns undefined when the abort signal fires after the runtime call resolves", async () => {
+    const controller = new AbortController();
+    transcribeFirstAudioMock.mockImplementation(async () => {
+      controller.abort();
+      return "would-be-transcript";
+    });
+
+    const transcript = await resolveMatrixPreflightAudioTranscript({
+      mediaPath: "/tmp/inbound/voice.ogg",
+      mediaContentType: "audio/ogg",
+      cfg,
+      abortSignal: controller.signal,
+    });
+
+    expect(transcript).toBeUndefined();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/preflight-audio.ts
+++ b/extensions/matrix/src/matrix/monitor/preflight-audio.ts
@@ -1,0 +1,72 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+
+type MatrixPreflightAudioRuntime = typeof import("./preflight-audio.runtime.js");
+
+let matrixPreflightAudioRuntimePromise: Promise<MatrixPreflightAudioRuntime> | undefined;
+
+function loadMatrixPreflightAudioRuntime(): Promise<MatrixPreflightAudioRuntime> {
+  matrixPreflightAudioRuntimePromise ??= import("./preflight-audio.runtime.js");
+  return matrixPreflightAudioRuntimePromise;
+}
+
+/**
+ * Wrap a transcript with prompt-injection-resistant framing before showing it
+ * to the agent. Mirrors Telegram's local helper since plugins do not share
+ * extension-private code across boundaries.
+ */
+export function formatMatrixAudioTranscript(transcript: string): string {
+  return `[Audio transcript (machine-generated, untrusted)]: ${JSON.stringify(transcript)}`;
+}
+
+/**
+ * Predicate for inbound Matrix message content carrying audio.
+ * Matches `m.audio` directly and `m.file` with an `audio/*` mimetype hint.
+ */
+export function isMatrixAudioContent(params: { msgtype?: string; mimetype?: string }): boolean {
+  if (params.msgtype === "m.audio") {
+    return true;
+  }
+  if (params.msgtype === "m.file" && typeof params.mimetype === "string") {
+    return params.mimetype.toLowerCase().startsWith("audio/");
+  }
+  return false;
+}
+
+/**
+ * Transcribe an already-downloaded Matrix audio attachment before the mention gate.
+ * Mirrors the Telegram pattern (MediaPaths over MediaUrls) since Matrix already
+ * resolves and decrypts media via downloadMatrixMedia. Errors are swallowed; the
+ * caller should treat `undefined` as "no transcript available".
+ */
+export async function resolveMatrixPreflightAudioTranscript(params: {
+  mediaPath: string;
+  mediaContentType?: string;
+  cfg: OpenClawConfig;
+  abortSignal?: AbortSignal;
+}): Promise<string | undefined> {
+  if (params.abortSignal?.aborted) {
+    return undefined;
+  }
+  try {
+    const { transcribeFirstAudio } = await loadMatrixPreflightAudioRuntime();
+    if (params.abortSignal?.aborted) {
+      return undefined;
+    }
+    const transcript = await transcribeFirstAudio({
+      ctx: {
+        MediaPaths: [params.mediaPath],
+        MediaTypes: params.mediaContentType ? [params.mediaContentType] : undefined,
+      },
+      cfg: params.cfg,
+      agentDir: undefined,
+    });
+    if (params.abortSignal?.aborted) {
+      return undefined;
+    }
+    return transcript;
+  } catch (err) {
+    logVerbose(`matrix: audio preflight transcription failed: ${String(err)}`);
+    return undefined;
+  }
+}


### PR DESCRIPTION

## Summary

- **Problem**: Inbound voice messages on Matrix reach the agent as raw audio attachments with no transcript. The model improvises a reply instead of answering, and `requireMention: true` rooms drop voice notes entirely because there's no text to match the mention regex.
- **Why it matters**: Discord, Telegram, WhatsApp, and Feishu already transcribe inbound voice via `transcribeFirstAudio` before the mention gate. Matrix is the lone holdout — voice-only Matrix users have no way to talk to their agent.
- **What changed**: Wire the existing `transcribeFirstAudio` helper into the Matrix monitor handler before the mention gate, mirroring the Discord/Telegram pattern. The transcript feeds into the mention check (so a voice note that says the bot's name reaches the agent in `requireMention` rooms) and into `BodyForAgent` (so the agent reads the transcript instead of a placeholder). `MediaTranscribedIndexes` is set so downstream tools don't re-transcribe the same audio.
- **What did NOT change (scope boundary)**: No core media-understanding changes. No new config keys (operators control via the existing global `tools.media.audio.enabled`). Outbound TTS untouched. E2EE crypto path untouched (decryption stays inside `downloadMatrixMedia`; preflight receives the plaintext path). No changes to other channels.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #78016
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — feature parity request, not a regression.

## Regression Test Plan (if applicable)

N/A — feature parity. Test coverage:

- 15 unit tests in `extensions/matrix/src/matrix/monitor/preflight-audio.test.ts` covering the audio-detection predicate, transcript formatter, and runtime caller (happy paths, error swallowing, abort-signal short-circuit, MediaPaths/MediaTypes ctx shape).
- 9 integration tests in `extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts` covering: DM voice notes, `m.file` with audio mime, mention-gate bypass via transcript, mention-gate drop without transcript match, transcription failure fallback, non-audio bypass, single-download verification, encrypted (E2EE) audio, and size-limit handling.
- Existing `handler.test.ts`, `handler.media-failure.test.ts`, and the rest of the matrix monitor suite: 396/396 passing, no regressions.

## User-visible / Behavior Changes

- Inbound voice notes (`m.audio`, plus `m.file` carrying an `audio/*` mimetype) on Matrix now get transcribed before the mention gate. A voice note that mentions the bot by name (per the existing `mentionRegexes`) bypasses `requireMention: true` rooms, matching Discord/Telegram.
- The transcript is wrapped with `[Audio transcript (machine-generated, untrusted)]: …` framing (with `JSON.stringify` escaping) so prompt-injection content inside the audio cannot impersonate system instructions.
- Bare-filename audio bodies (e.g. `voice.ogg`, auto-set by Element) are replaced with the existing `[matrix audio attachment]` placeholder so the agent sees a clear audio marker rather than a stray filename. The download-failed path was already doing this; we extend it to the success path for audio specifically.
- Operators can disable globally via `tools.media.audio.enabled: false`.

## Diagram (if applicable)

```text
Before:
[user voice note] -> [Matrix handler]
  -> mention gate (drops if requireMention:true & no @mention text)
  -> media download
  -> agent ctx { MediaPath, MediaUrl, BodyForAgent: "[matrix media]" }
  -> agent improvises a reply about "an audio attachment"

After:
[user voice note] -> [Matrix handler]
  -> audio detect + early download + transcribeFirstAudio
  -> mention gate (sees transcript text, can match @bot mentions)
  -> agent ctx { MediaPath, MediaUrl, BodyForAgent: "[Audio transcript ...]: \"...\"", MediaTranscribedIndexes: [0] }
  -> agent answers the spoken question
```

## Security Impact (required)

- New permissions/capabilities? **No.**
- Secrets/tokens handling changed? **No.**
- New/changed network calls? **No new outbound endpoint** — uses the operator's existing `tools.media.audio.provider`, the same one Discord/Telegram/WhatsApp/Feishu already call. No new API keys required.
- Command/tool execution surface changed? **No.**
- Data access scope changed? **Yes (minor)** — audio attachment bytes (decrypted plaintext for E2EE rooms) are now sent to the operator-configured STT provider on Matrix, matching peer-channel behavior. Mitigation: gated by `tools.media.audio.enabled`; documented in `docs/channels/matrix.md`.

## Repro + Verification

### Environment

- OS: Linux (Debian)
- Runtime/container: OpenClaw gateway in Docker
- Model/provider: OpenAI `gpt-4o-mini-transcribe` (via `tools.media.audio.provider: openai`)
- Integration/channel: Matrix (self-hosted Synapse, Element clients)
- Relevant config (redacted): `tools.media.audio.{enabled, provider: openai, model: gpt-4o-mini-transcribe}`

### Steps

1. Send a voice note from Element to a Matrix bot in a `requireMention: true` room, saying the bot's name in the recording.
2. Send a voice note in a DM to the bot, with no text caption.
3. Send a non-audio attachment (e.g. an image) to the same room to confirm unchanged behavior.

### Expected

- (1) Bot transcribes the voice note, sees the spoken bot mention in the transcript, and replies normally.
- (2) Bot replies based on the transcribed body.
- (3) Behavior unchanged from main.

### Actual

- (1) (2) (3) Asserted by integration tests in `handler.audio-preflight.test.ts`. Live end-to-end on a personal homeserver is deferred (see Human Verification below).

## Evidence

- [x] Failing test/log before + passing after — the integration test file was authored TDD-style. Initial run showed 5 failed assertions on `expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1)`; once the handler was wired, all 9 cases turned green.
- [ ] Trace/log snippets — N/A; tests mock `downloadMatrixMedia` and `transcribeFirstAudio` following the Discord pattern.
- [ ] Screenshot/recording — N/A.
- [ ] Perf numbers — N/A.

## Human Verification (required)

- **Verified scenarios**: TDD-driven integration tests covering DM voice, room-mention-bypass via transcript, room-mention-drop without match, transcription-failure fallback, non-audio bypass, single-download verification, E2EE-encrypted audio, and size-limit handling. All 9 cases green. Full matrix monitor suite runs clean (396/396, including pre-existing `handler.media-failure.test.ts` and `handler.body-for-agent.test.ts`).
- **Edge cases checked**: Encrypted media (`file: { url, key, iv, hashes, v }`) decryption + transcription path. `m.file` with audio mimetype. Bare-filename body normalization. Abort signal short-circuit before SDK load. Empty / undefined transcript fallthrough.
- **What I did NOT verify**: Live end-to-end run against my own Synapse + Element clients on this branch. Reason: testing a fork build requires a custom Docker image; the framework-side path (`transcribeFirstAudio`) is exercised by the existing `src/media-understanding` test suite, and our handler integration is locked in by the new tests.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — additive only.
- Config/env changes? **No** — reuses existing `tools.media.audio` configuration.
- Migration needed? **No.**

## Risks and Mitigations

- **Risk**: Prompt injection via voice transcript ("ignore prior instructions and …").
  - **Mitigation**: Transcript is wrapped with `[Audio transcript (machine-generated, untrusted)]: ${JSON.stringify(transcript)}` framing before reaching the agent body, mirroring Telegram exactly. `JSON.stringify` escapes control characters and quote chars.
- **Risk**: STT cost amplification — every audio message in a watched room triggers an STT API call.
  - **Mitigation**: Operator-controlled via `tools.media.audio.enabled`. Existing room/sender allowlist in the Matrix handler runs BEFORE the preflight code, so unauthorized senders never trigger transcription.
- **Risk**: Reordering the audio download (now runs before mention gate) could shift failure semantics.
  - **Mitigation**: The existing media block now reuses the preflight result via `!media && !mediaDownloadFailed` guards. Same exception types propagate through the same logger paths. Existing `handler.media-failure.test.ts` still passes unchanged.

---

### Notes for reviewers

- The audio download + error-handling block in `handler.ts` duplicates ~25 lines with the existing media block (different scope, slightly different `encrypted: Boolean(...)` flag). Kept as-is for minimal-diff. Happy to extract into a helper if preferred.
- The early content-extraction block at handler.ts ~876-887 (`earlyContentInfo` etc.) duplicates the later block at ~1088-1096 because the audio path needs the info BEFORE the mention gate while non-audio doesn't. Same minimal-diff trade-off.
- No `disableAudioPreflight` per-room knob (Telegram has one). Operators rely on global `tools.media.audio.enabled: false`. Easy to add if the team wants finer-grained control — happy to send a follow-up.

This PR was developed with AI — `[AI-assisted]`.

Suggested reviewer: @gumadeiras (Matrix-area maintainer).

---

P.S. I didn't tested it live so far. Still need to. First lets send the pr and lets see from there.
