### PR TITLE
test(gateway): cover reserved admin method scopes

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -153,6 +153,30 @@ describe("operator scope authorization", () => {
     });
   });
 
+  it.each([
+    "config.set",
+    "config.apply",
+    "config.schema",
+    "exec.approvals.get",
+    "exec.approvals.set",
+    "exec.approvals.node.get",
+    "exec.approvals.node.set",
+    "wizard.start",
+    "wizard.next",
+    "wizard.cancel",
+    "wizard.status",
+    "update.run",
+  ])("requires admin for reserved listed method %s", (method) => {
+    expect(resolveLeastPrivilegeOperatorScopesForMethod(method)).toEqual(["operator.admin"]);
+    expect(authorizeOperatorScopesForMethod(method, ["operator.write"])).toEqual({
+      allowed: false,
+      missingScope: "operator.admin",
+    });
+    expect(authorizeOperatorScopesForMethod(method, ["operator.admin"])).toEqual({
+      allowed: true,
+    });
+  });
+
   it("requires admin for reserved admin namespaces even if a plugin registered a narrower scope", () => {
     setPluginGatewayMethodScope(RESERVED_ADMIN_PLUGIN_METHOD, "operator.read");
 


### PR DESCRIPTION
## Summary

- Adds a focused gateway method-scope regression harness for listed reserved-admin methods.
- Verifies config, legacy exec approvals, wizard, and update methods resolve to `operator.admin` and reject `operator.write`.

## Verification

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/method-scopes.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`

## Real behavior proof

- **Behavior or issue addressed:** Gateway reserved-admin method dispatch must not silently downgrade config, legacy exec approvals, wizard, or update methods to write/read operator scope.
- **Real environment tested:** Local OpenClaw checkout `/tank/development/linus/openclaw-worktrees/harness-method-scope-coverage`, Node v25.9.0, Linux 6.19.14-arch1-1.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/method-scopes.test.ts` and `node scripts/check-changed.mjs` with `PATH="/tmp/openclaw-pnpm-shim:$PATH"`.
- **Evidence after fix:** Terminal capture from the local OpenClaw setup:

```text
RUN v4.1.5 /tank/development/linus/openclaw-worktrees/harness-method-scope-coverage
✓ gateway src/gateway/method-scopes.test.ts (56 tests) 50ms
Test Files 1 passed (1)
Tests 56 passed (56)
```

- **Observed result after fix:** The real `method-scopes.ts` resolver/authorizer required `operator.admin` for the listed reserved gateway methods, rejected `operator.write`, and the changed-file gate completed with 0 lint/typecheck errors.
- **What was not tested:** Live gateway WebSocket auth was not started; this patch is scoped to the method-scope boundary exercised directly in-process.
