### PR TITLE
test(auto-reply): cover dock native identity links

### DIFF
--- a/src/auto-reply/reply/commands-dock.test.ts
+++ b/src/auto-reply/reply/commands-dock.test.ts
@@ -102,6 +102,29 @@ describe("handleDockCommand", () => {
     expect(params.sessionEntry?.lastTo).toBe("UserCase123");
   });
 
+  it("matches source identityLinks from provider-native direct peer ids", async () => {
+    const params = buildDockParams("/dock-discord", {
+      NativeDirectUserId: "native-direct-42",
+      SenderId: "display-42",
+      From: "display-42",
+    });
+    params.cfg.session = {
+      ...params.cfg.session,
+      identityLinks: {
+        nativeAlice: ["telegram:native-direct-42", "discord:NativeTarget123"],
+      },
+    };
+
+    const result = await handleDockCommand(params, true);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "Docked replies to discord." },
+    });
+    expect(params.sessionEntry?.lastChannel).toBe("discord");
+    expect(params.sessionEntry?.lastTo).toBe("NativeTarget123");
+  });
+
   it("does not claim unrelated slash commands", async () => {
     const result = await handleDockCommand(buildDockParams("/status"), true);
 


### PR DESCRIPTION
## Summary

- Adds a focused dock-routing regression for provider-native direct peer IDs in `session.identityLinks`.
- Covers the cross-channel peer-link path where a displayed sender id differs from the native direct user id.

## Verification

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs src/auto-reply/reply/commands-dock.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`

## Real behavior proof

- **Behavior or issue addressed:** Dock routing must be able to match `session.identityLinks` through a provider-native direct peer id when the visible sender/from id is different, then persist the linked target channel peer.
- **Real environment tested:** Local OpenClaw checkout `/tank/development/linus/openclaw-worktrees/harness-dock-identitylinks`, Node v25.9.0, Linux 6.19.14-arch1-1.
- **Exact steps or command run after this patch:** `node scripts/test-projects.mjs src/auto-reply/reply/commands-dock.test.ts` and `node scripts/check-changed.mjs` with `PATH="/tmp/openclaw-pnpm-shim:$PATH"`.
- **Evidence after fix:** Terminal capture from the local OpenClaw setup:

```text
RUN v4.1.5 /tank/development/linus/openclaw-worktrees/harness-dock-identitylinks
✓ auto-reply src/auto-reply/reply/commands-dock.test.ts (8 tests) 96ms
Test Files 1 passed (1)
Tests 8 passed (8)
```

- **Observed result after fix:** The real `handleDockCommand` path used the active channel plugin registry, matched `telegram:native-direct-42`, and persisted the route to `discord` / `NativeTarget123`; the changed-file gate completed with 0 lint/typecheck errors.
- **What was not tested:** Live Telegram/Discord provider APIs were not contacted; this patch is scoped to the local auto-reply routing boundary.
