### PR TITLE
fix: preserve plugin hook and tool closure state

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1613,6 +1613,70 @@ describe("resolvePluginTools optional tools", () => {
     expect(factory).toHaveBeenCalledTimes(2);
   });
 
+  it("bypasses cached descriptors when a live plugin registry has hooks and tools", async () => {
+    let currentSessionId = "warm-cache";
+    const warmFactory = vi.fn(() => makeTool("stateful_tool"));
+    setRegistry([
+      {
+        pluginId: "stateful-plugin",
+        optional: false,
+        source: "/tmp/stateful-plugin.js",
+        names: ["stateful_tool"],
+        factory: warmFactory,
+      },
+    ]);
+
+    expectResolvedToolNames(resolvePluginTools(createResolveToolsParams()), ["stateful_tool"]);
+    expect(warmFactory).toHaveBeenCalledTimes(1);
+
+    const liveFactory = vi.fn(() => ({
+      ...makeTool("stateful_tool"),
+      async execute() {
+        return { content: [{ type: "text", text: currentSessionId }] };
+      },
+    }));
+    const liveRegistry = {
+      plugins: [{ id: "stateful-plugin", status: "loaded" }],
+      tools: [
+        {
+          pluginId: "stateful-plugin",
+          optional: false,
+          source: "/tmp/stateful-plugin.js",
+          names: ["stateful_tool"],
+          declaredNames: ["stateful_tool"],
+          factory: liveFactory,
+        },
+      ],
+      hooks: [
+        {
+          pluginId: "stateful-plugin",
+          events: ["before_prompt_build"],
+          source: "/tmp/stateful-plugin.js",
+          entry: { name: "capture-session", handler: () => undefined },
+        },
+      ],
+      typedHooks: [],
+      diagnostics: [],
+    };
+    setActivePluginRegistry(
+      liveRegistry as never,
+      "test-tool-registry",
+      "gateway-bindable",
+      "/tmp",
+    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(liveRegistry);
+    currentSessionId = "shared-session";
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["stateful_tool"]);
+    expect(liveFactory).toHaveBeenCalledTimes(1);
+    await expect(tools[0]?.execute("call", {}, undefined)).resolves.toEqual({
+      content: [{ type: "text", text: "shared-session" }],
+    });
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
   it("reuses cached plugin tool descriptors across session identity changes", async () => {
     const factory = vi.fn((rawCtx: unknown) => {
       const ctx = rawCtx as { sessionId?: string };

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -13,6 +13,7 @@ import type { PluginManifestRecord } from "./manifest-registry.js";
 import { hasManifestToolAvailability } from "./manifest-tool-availability.js";
 import type { PluginMetadataManifestView } from "./plugin-metadata-snapshot.types.js";
 import type { PluginRegistry, PluginToolRegistration } from "./registry-types.js";
+import { getActivePluginChannelRegistry, getActivePluginRegistry } from "./runtime.js";
 import {
   buildPluginRuntimeLoadOptions,
   resolvePluginRuntimeLoadContext,
@@ -591,6 +592,26 @@ function createCachedDescriptorPluginTool(params: {
   return tool;
 }
 
+function registryHasPluginHooks(registry: PluginRegistry, pluginId: string): boolean {
+  return (
+    (registry.hooks ?? []).some((entry) => entry.pluginId === pluginId) ||
+    (registry.typedHooks ?? []).some((entry) => entry.pluginId === pluginId)
+  );
+}
+
+function liveRegistryAlreadyOwnsPluginToolsAndHooks(params: { pluginId: string }): boolean {
+  for (const registry of [getActivePluginChannelRegistry(), getActivePluginRegistry()]) {
+    if (
+      registry &&
+      registryHasScopedPluginTools(registry, [params.pluginId]) &&
+      registryHasPluginHooks(registry, params.pluginId)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function resolveCachedPluginTools(params: {
   snapshot: PluginMetadataManifestView;
   config: PluginLoadOptions["config"];
@@ -652,6 +673,13 @@ function resolveCachedPluginTools(params: {
       continue;
     }
     if (params.existingNormalized.has(normalizeToolName(plugin.id))) {
+      continue;
+    }
+    if (
+      liveRegistryAlreadyOwnsPluginToolsAndHooks({
+        pluginId: plugin.id,
+      })
+    ) {
       continue;
     }
     const cached = readCachedPluginToolDescriptors(


### PR DESCRIPTION
## Summary

Fixes plugin tool resolution so cached descriptor wrappers do not bypass an already-live plugin registry that owns both hooks and tools for the same plugin. That keeps hook handlers and tool factories on the same `register()` closure when a plugin uses closure state across `before_prompt_build` and a tool like `memory_add`.

## Changes

- Detect active/pinned-channel registries that already contain a plugin's tools and hooks.
- Skip cached descriptor wrappers for those stateful hook+tool plugins, forcing the normal live-registry materialization path.
- Preserve descriptor caching for plain tool-only plugins and cold/no-live-registry paths.
- Add regression coverage for a warmed descriptor cache being bypassed when a live hook+tool registry is available.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm vitest run src/plugins/tools.optional.test.ts` — passed, 59 tests.
- `git diff --check` — passed.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — all gates passed through final pairing-account guard; process was SIGKILLed at final exit on this host. Standalone `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-pairing-account-scope.mjs` passed.

Fixes #77822
