### PR TITLE
fix(active-memory): do not abort recall on advisory warnings in memory_search results (#77864)

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -2650,6 +2650,53 @@ describe("active-memory plugin", () => {
     expect(result?.prependContext).toContain("User usually orders ramen after late flights.");
   });
 
+  it("does not abort recall early when memory_search returns a warning without an error (#77864)", async () => {
+    // Regression test: Boolean(debug?.warning) was included in the `unavailable`
+    // condition, causing the terminal watch to short-circuit the sub-agent on any
+    // advisory warning (e.g. embedding provider slow, using fallback mode).
+    // Now only disabled===true or a hard error triggers the fast-fail path.
+    __testing.setMinimumTimeoutMsForTests(1);
+    __testing.setSetupGraceTimeoutMsForTests(0);
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: 500,
+      logging: true,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const sessionKey = "agent:main:warning-only";
+    hoisted.sessionStore[sessionKey] = { sessionId: "s-warning-only", updatedAt: 0 };
+    runEmbeddedPiAgent.mockImplementationOnce(async (params: { sessionFile: string }) => {
+      // Write a memory_search result with only a warning (no error, not disabled)
+      await writeTranscriptJsonl(params.sessionFile, [
+        {
+          message: {
+            role: "toolResult",
+            toolName: "memory_search",
+            details: {
+              results: [{ id: "m1", text: "User usually orders ramen." }],
+              warning: "Embedding provider is slow; using cached index.",
+            },
+          },
+        },
+      ]);
+      // Sub-agent completes normally with a useful summary
+      return { payloads: [{ text: "User usually orders ramen after late nights." }] };
+    });
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what food do i usually order? warning-only", messages: [] },
+      { agentId: "main", trigger: "user", sessionKey, messageProvider: "webchat" },
+    );
+
+    // The warning must NOT abort the sub-agent — useful memory should be returned
+    expect(result?.prependContext).toContain("User usually orders ramen after late nights.");
+
+    const infoLines = vi
+      .mocked(api.logger.info)
+      .mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(infoLines.some((line: string) => line.includes("done status=ok"))).toBe(true);
+  });
+
   it("returns undefined instead of throwing when an unexpected error escapes prompt building", async () => {
     const result = await hooks.before_prompt_build(
       { prompt: "what should i eat? escape test", messages: undefined as never },

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1651,8 +1651,12 @@ function extractTerminalMemorySearchResultFromSessionRecord(
   const debug = extractActiveMemorySearchDebugFromSessionRecord(value);
   const results = Array.isArray(details?.results) ? details.results : undefined;
   const disabled = details?.disabled === true;
-  const unavailable =
-    disabled || Boolean(debug?.warning) || Boolean(debug?.error) || Boolean(details?.error);
+  // A warning alone is not a hard failure: it indicates a degraded but
+  // operational state (e.g. embedding provider slow, fallback mode active).
+  // Including Boolean(debug?.warning) here caused every search with any
+  // advisory warning to abort the sub-agent immediately with status=empty
+  // (#77864). Only treat the search as unavailable for explicit hard failures.
+  const unavailable = disabled || Boolean(debug?.error) || Boolean(details?.error);
   const debugHits =
     typeof debug?.hits === "number" && Number.isFinite(debug.hits) ? debug.hits : undefined;
   const zeroHitSearch = results !== undefined ? results.length === 0 : debugHits === 0;


### PR DESCRIPTION
## Summary
- `extractTerminalMemorySearchResultFromSessionRecord` included `Boolean(debug?.warning)` in the `unavailable` condition. Any `memory_search` result carrying an advisory warning string (e.g. "embedding provider slow", "using fallback index") caused the terminal-search watcher to immediately resolve with `status=empty` and abort the sub-agent via `AbortController` before it could synthesize a response.
- This was the root cause of 100% `status=empty summaryChars=0` reported in #77864 — providers like Minimax, Gemma, Qwen, and GLM surface soft warnings on otherwise successful searches, which silently short-circuited recall for every query.
- Fix: narrow `unavailable` to `disabled === true` or a hard `error` field only. A warning without a hard error means a degraded-but-operational state; the sub-agent must be allowed to complete and synthesize a response.

Closes #77864

## Testing
- pnpm vitest run extensions/active-memory/index.test.ts

## Real behavior proof
- Behavior: Active Memory returns `status=empty elapsedMs=~45000 summaryChars=0` for 100% of queries across all models (minimax m2.7, Gemma4, Qwen3, GLM 4.6)
- Tested via targeted unit test added in this PR — see Testing section above. Test verifies that a `memory_search` result with only a `warning` (no `error`, not `disabled`) allows the sub-agent to complete normally and return a non-empty summary.
- What was not tested: live runtime — please apply maintainer `proof:` override or advise on evidence format.