### PR TITLE
fix: support dynamic plugin tool contracts

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -661,7 +661,9 @@ output before the model sees it.
 
 Runtime `api.registerTool(...)` registrations must match `contracts.tools`.
 Tool discovery uses this list to load only the plugin runtimes that can own the
-requested tools.
+requested tools. For dynamic catalogs, a tool contract may use one terminal
+wildcard, for example `acme_*`, to declare ownership of a bounded namespace. A
+contract entry of bare `*` is not treated as wildcard ownership.
 
 Provider plugins that implement `resolveExternalAuthProfiles` should declare
 `contracts.externalAuthProviders`. Plugins without the declaration still run

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2982,6 +2982,48 @@ module.exports = { id: "throws-after-import", register() {} };`,
     );
   });
 
+  it("allows plugin tool registrations covered by a terminal wildcard manifest contract", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "dynamic-tool-owner",
+      filename: "dynamic-tool-owner.cjs",
+      body: `module.exports = {
+        id: "dynamic-tool-owner",
+        register(api) {
+          api.registerTool({
+            name: "dynamic_runtime_tool",
+            description: "Runtime dynamic tool",
+            parameters: {},
+            execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+          });
+        },
+      };`,
+    });
+    updatePluginManifest(plugin, { contracts: { tools: ["dynamic_*"] } });
+
+    const registry = loadOpenClawPlugins({
+      activate: false,
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["dynamic-tool-owner"],
+        },
+      },
+    });
+
+    expect(registry.tools.flatMap((entry) => entry.names)).toEqual(["dynamic_runtime_tool"]);
+    expect(registry.diagnostics).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          pluginId: "dynamic-tool-owner",
+          message: expect.stringContaining("contracts.tools"),
+        }),
+      ]),
+    );
+  });
+
   it("rejects plugin tool names outside the manifest tool contract", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/tool-contracts.ts
+++ b/src/plugins/tool-contracts.ts
@@ -17,10 +17,44 @@ export function normalizePluginToolNames(names: readonly string[] | undefined): 
   return [...normalized];
 }
 
+export function isPluginToolContractPattern(name: string): boolean {
+  const trimmed = name.trim();
+  return trimmed.length > 1 && trimmed.endsWith("*") && trimmed.indexOf("*") === trimmed.length - 1;
+}
+
+export function pluginToolContractMatchesName(params: {
+  contractName: string;
+  toolName: string;
+}): boolean {
+  const contractName = params.contractName.trim();
+  const toolName = params.toolName.trim();
+  if (!contractName || !toolName) {
+    return false;
+  }
+  if (!isPluginToolContractPattern(contractName)) {
+    return contractName === toolName;
+  }
+  return toolName.startsWith(contractName.slice(0, -1));
+}
+
+export function pluginToolContractMatchesAnyName(params: {
+  contractName: string;
+  toolNames: readonly string[];
+}): boolean {
+  return normalizePluginToolNames(params.toolNames).some((toolName) =>
+    pluginToolContractMatchesName({ contractName: params.contractName, toolName }),
+  );
+}
+
 export function findUndeclaredPluginToolNames(params: {
   declaredNames: readonly string[];
   toolNames: readonly string[];
 }): string[] {
-  const declared = new Set(normalizePluginToolNames(params.declaredNames));
-  return normalizePluginToolNames(params.toolNames).filter((name) => !declared.has(name));
+  const declared = normalizePluginToolNames(params.declaredNames);
+  return normalizePluginToolNames(params.toolNames).filter(
+    (name) =>
+      !declared.some((contractName) =>
+        pluginToolContractMatchesName({ contractName, toolName: name }),
+      ),
+  );
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -895,6 +895,46 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("loads wildcard-owned dynamic plugin tools for an explicit runtime tool allowlist", () => {
+    const factory = vi.fn(() => [makeTool("dynamic_alpha"), makeTool("other_tool")]);
+    setRegistry([
+      {
+        pluginId: "dynamic-owner",
+        optional: false,
+        source: "/tmp/dynamic-owner.js",
+        names: ["dynamic_alpha"],
+        declaredNames: ["dynamic_*"],
+        factory,
+      },
+    ]);
+
+    const context = createContext();
+    context.config.plugins.allow.push("dynamic-owner");
+    installToolManifestSnapshots({
+      config: context.config,
+      plugins: [
+        {
+          id: "dynamic-owner",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["dynamic_*"] },
+        },
+      ],
+    });
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context,
+        toolAllowlist: ["dynamic_alpha"],
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["dynamic_alpha"]);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
   it("skips optional tools without explicit allowlist", () => {
     setOptionalDemoRegistry();
     const tools = resolveOptionalDemoTools();

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -18,7 +18,11 @@ import {
   resolvePluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "./runtime/standalone-runtime-registry-loader.js";
-import { findUndeclaredPluginToolNames } from "./tool-contracts.js";
+import {
+  findUndeclaredPluginToolNames,
+  pluginToolContractMatchesAnyName,
+  pluginToolContractMatchesName,
+} from "./tool-contracts.js";
 import {
   buildPluginToolDescriptorCacheKey,
   capturePluginToolDescriptor,
@@ -179,7 +183,15 @@ function isOptionalToolEntryPotentiallyAllowed(params: {
   if (params.names.length === 0) {
     return true;
   }
-  return params.names.some((name) => params.allowlist.has(normalizeToolName(name)));
+  return params.names.some((name) => {
+    const normalizedName = normalizeToolName(name);
+    if (params.allowlist.has(normalizedName)) {
+      return true;
+    }
+    return [...params.allowlist].some((allowlistedName) =>
+      pluginToolContractMatchesName({ contractName: name, toolName: allowlistedName }),
+    );
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -364,9 +376,15 @@ function listManifestToolNamesForAllowlist(params: {
   if (params.allowlist.has(pluginKey)) {
     return [...params.toolNames];
   }
-  const matchedToolNames = params.toolNames.filter((name) =>
-    params.allowlist.has(normalizeToolName(name)),
-  );
+  const matchedToolNames = params.toolNames.filter((name) => {
+    if (params.allowlist.has(normalizeToolName(name))) {
+      return true;
+    }
+    return pluginToolContractMatchesAnyName({
+      contractName: name,
+      toolNames: [...params.allowlist],
+    });
+  });
   if (!allowlistIncludesDefaultPluginTools(params.allowlist)) {
     return matchedToolNames;
   }
@@ -1076,6 +1094,9 @@ export function resolvePluginTools(params: {
       ? listRaw.filter((tool) => {
           const toolName = readPluginToolName(tool);
           const normalizedToolName = normalizeToolName(toolName);
+          const matchingManifestContractNames = availabilityNames.filter((name) =>
+            pluginToolContractMatchesName({ contractName: name, toolName }),
+          );
           if (
             isManifestToolOptional(manifestPlugin, toolName) &&
             !isOptionalToolAllowed({
@@ -1088,8 +1109,12 @@ export function resolvePluginTools(params: {
           }
           if (
             selectedManifestToolNames &&
-            manifestContractToolNames?.has(normalizedToolName) &&
-            !selectedManifestToolNames.has(normalizedToolName)
+            (manifestContractToolNames?.has(normalizedToolName) ||
+              matchingManifestContractNames.length > 0) &&
+            !selectedManifestToolNames.has(normalizedToolName) &&
+            !matchingManifestContractNames.some((name) =>
+              selectedManifestToolNames.has(normalizeToolName(name)),
+            )
           ) {
             return false;
           }


### PR DESCRIPTION
## Summary

Fixes dynamic plugin tool ownership without reverting the manifest-first plugin contract.

Plugins still must declare `contracts.tools`, but they can now declare a bounded terminal wildcard namespace such as `acme_*`. Runtime `api.registerTool()` names covered by that namespace are accepted, and explicit tool allowlists like `acme_search` can load the owning plugin instead of failing with no callable tools.

## Changes

- Add terminal wildcard matching for plugin tool contracts (`prefix_*`).
- Keep bare `*` from becoming catch-all ownership.
- Use wildcard ownership in registration validation, runtime plugin selection, and explicit allowlist matching.
- Filter factory-returned tools so a selected wildcard namespace does not expose unrelated siblings.
- Add loader and plugin tool resolution regression tests.
- Document dynamic namespace ownership in plugin manifest docs.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm vitest run src/plugins/loader.test.ts src/plugins/tools.optional.test.ts` — passed, 183 tests.
- `git diff --check` — passed.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — passed through pairing store guard, then SIGKILLed before/at final pairing-account guard on this host. Standalone `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-pairing-account-scope.mjs` passed.

Fixes #77800
