### PR TITLE
fix(agents): parse prompt_tokens/completion_tokens in CLI usage for llama.cpp compatibility (#77992)

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -383,6 +383,43 @@ describe("parseCliJsonl", () => {
     });
   });
 
+  it("parses llama.cpp OpenAI-compatible prompt_tokens/completion_tokens usage fields (#77992)", () => {
+    // llama.cpp and other OpenAI-compatible local providers return prompt_tokens
+    // and completion_tokens instead of input_tokens and output_tokens. Without
+    // the fallback, context display shows "?/131k" for all llama.cpp users.
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "init", session_id: "session-llamacpp" }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-llamacpp",
+          result: "Hello from llama.cpp",
+          usage: {
+            prompt_tokens: 11,
+            completion_tokens: 7,
+            total_tokens: 18,
+          },
+        }),
+      ].join("\n"),
+      {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      "claude-cli",
+    );
+
+    expect(result).toMatchObject({
+      text: "Hello from llama.cpp",
+      sessionId: "session-llamacpp",
+      usage: {
+        input: 11,
+        output: 7,
+        total: 18,
+      },
+    });
+  });
+
   it("parses multiple JSON objects embedded on the same line", () => {
     const result = parseCliJsonl(
       '{"type":"init","session_id":"session-999"} {"type":"result","session_id":"session-999","result":"done"}',

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -122,8 +122,15 @@ function toCliUsage(raw: Record<string, unknown>): CliUsage | undefined {
   };
   const pick = (key: string) =>
     typeof raw[key] === "number" && raw[key] > 0 ? raw[key] : undefined;
-  const totalInput = pick("input_tokens") ?? pick("inputTokens");
-  const output = pick("output_tokens") ?? pick("outputTokens");
+  // llama.cpp and other OpenAI-compatible providers use prompt_tokens /
+  // completion_tokens instead of input_tokens / output_tokens (#77992).
+  const totalInput =
+    pick("input_tokens") ?? pick("inputTokens") ?? pick("prompt_tokens") ?? pick("promptTokens");
+  const output =
+    pick("output_tokens") ??
+    pick("outputTokens") ??
+    pick("completion_tokens") ??
+    pick("completionTokens");
   const nestedCached =
     readNestedCached("input_tokens_details") ?? readNestedCached("prompt_tokens_details");
   const cacheRead =


### PR DESCRIPTION
## Summary
- `toCliUsage()` in `cli-output.ts` only recognized `input_tokens`/`output_tokens` (and camelCase aliases) from CLI runner output. llama.cpp and other OpenAI-compatible local providers return `prompt_tokens`/`completion_tokens` instead, which are the standard OpenAI field names.
- Without the fallback, usage was silently dropped and context display showed `?/131k` for all llama.cpp, Ollama, and similar OpenAI-compatible users.
- Fix: add `prompt_tokens` → fallback for `totalInput` and `completion_tokens` → fallback for `output` in `toCliUsage()`. Both `parseCliJson` and `parseCliJsonl` route through this function, so all CLI output parsing paths are covered.

Closes #77992

## Testing
- pnpm vitest run src/agents/cli-output.test.ts

## Real behavior proof
- Behavior: Context display shows `?/131k` with llama.cpp after upgrading to 2026.5.4 — field name mismatch causes usage to be silently dropped
- Tested via targeted unit test added in this PR that exercises the exact llama.cpp response shape (`prompt_tokens`, `completion_tokens`, `total_tokens`).
- What was not tested: live runtime — please apply maintainer `proof:` override or advise on evidence format.