### PR TITLE
docs: call out discord external plugin install

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -93,6 +93,21 @@ You will need to create a new application with a bot, add the bot to your server
 
   </Step>
 
+  <Step title="Install the Discord channel plugin">
+    Discord is distributed as an official external channel plugin. On Docker, npm,
+    and other package installs, a `channels.discord` config block alone is not
+    enough: install the plugin package before starting the gateway.
+
+```bash
+openclaw plugins install @openclaw/discord
+```
+
+    If Discord is configured but missing from `openclaw plugins list`, run
+    `openclaw doctor --fix` or install `@openclaw/discord` explicitly, then
+    restart the gateway.
+
+  </Step>
+
   <Step title="Set your bot token securely (do not send it in chat)">
     Your Discord bot token is a secret (like a password). Set it on the machine running OpenClaw before messaging your agent.
 


### PR DESCRIPTION
## Summary

Documents the Discord external plugin install step in the Discord quick setup.

The root package/Docker image no longer bundles the Discord runtime by default. A config-only `channels.discord` block can therefore leave Docker/npm users with Discord missing from `openclaw plugins list` and no loaded Discord channel. The existing install/doctor machinery is fine; the quick setup was the dishonest part because it implied config alone was enough.

## Changes

- Add a Discord setup step for `openclaw plugins install @openclaw/discord`.
- Explain that Docker/npm/package installs need the external plugin before gateway startup.
- Add recovery hint for configured-but-missing Discord: `openclaw doctor --fix` or explicit install, then restart.

## Testing

- `git diff --check` — passed.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — passed docs-only gates.

Fixes #77930
