### PR TITLE
chore(catalog): split Weixin entry from channel fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,6 @@ Docs: https://docs.openclaw.ai
 - Docs: clarify that IRC uses raw TCP/TLS sockets outside operator-managed forward proxy routing, so direct IRC egress should be explicitly approved before enabling IRC. Thanks @jesse-merhi.
 - Dependencies: refresh runtime and provider packages including Pi 0.73.0, ACPX adapters, OpenAI, Anthropic, Slack, and TypeScript native preview, while keeping the Bedrock runtime installer override pinned below the Windows ARM Node 24 npm resolver failure.
 - Contributor PRs: require external pull requests to include after-fix real behavior proof from a real OpenClaw setup, with terminal screenshots, console output, redacted runtime logs, linked artifacts, and copied live output treated as valid evidence while unit tests, mocks, lint, typechecks, snapshots, and CI remain supplemental only.
-- Plugins/catalog: add an `@tencent-weixin/openclaw-weixin` external entry pinned to `2.4.1` so onboarding and `openclaw channels add` can install the Tencent Weixin (personal WeChat) channel by default. (#77269) Thanks @pumpkinxing1.
 - Developer tooling: add checked-in VS Code Gateway debugging configs and an opt-in `OUTPUT_SOURCE_MAPS=1` source-map build path for breakpoints in TypeScript source. (#45710) Thanks @SwissArmyBud.
 
 ### Fixes

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -83,45 +83,6 @@
       }
     },
     {
-      "name": "@tencent-weixin/openclaw-weixin",
-      "description": "OpenClaw Weixin channel plugin by the Tencent Weixin team.",
-      "source": "external",
-      "kind": "channel",
-      "openclaw": {
-        "plugin": {
-          "id": "openclaw-weixin",
-          "label": "Weixin"
-        },
-        "channel": {
-          "id": "openclaw-weixin",
-          "label": "Weixin",
-          "selectionLabel": "Weixin（微信）",
-          "detailLabel": "Weixin",
-          "docsPath": "/channels/wechat",
-          "docsLabel": "weixin",
-          "blurb": "Personal WeChat messaging via QR-code login.",
-          "aliases": ["weixin", "wechat", "微信"],
-          "order": 75
-        },
-        "channelConfigs": {
-          "openclaw-weixin": {
-            "label": "Weixin",
-            "description": "Personal WeChat conversation channel.",
-            "schema": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
-        },
-        "install": {
-          "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.1",
-          "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-FZnUVMQRpKGTKezeplr/DYal+5RSif2tXE51pljIFrO8rn7bVnnvpbj81/i9UMrYbuGiom1sl8OeSDzWRDKGhQ==",
-          "minHostVersion": ">=2026.3.22"
-        }
-      }
-    },
-    {
       "name": "@openclaw/bluebubbles",
       "description": "OpenClaw BlueBubbles channel plugin",
       "source": "official",

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -200,14 +200,14 @@ describe("doctor stale plugin config helpers", () => {
   it("removes stale third-party channel config and dependent channel refs", () => {
     const result = maybeRepairStalePluginConfig({
       plugins: {
-        allow: ["discord", "missing-chat-plugin"],
+        allow: ["discord", "openclaw-weixin"],
         entries: {
           discord: { enabled: true },
-          "missing-chat-plugin": { enabled: true },
+          "openclaw-weixin": { enabled: true },
         },
       },
       channels: {
-        "missing-chat-plugin": {
+        "openclaw-weixin": {
           enabled: true,
           token: "stale",
         },
@@ -216,7 +216,7 @@ describe("doctor stale plugin config helpers", () => {
         },
         modelByChannel: {
           openai: {
-            "missing-chat-plugin": "openai/gpt-5.4",
+            "openclaw-weixin": "openai/gpt-5.4",
             telegram: "openai/gpt-5.4",
           },
         },
@@ -224,7 +224,7 @@ describe("doctor stale plugin config helpers", () => {
       agents: {
         defaults: {
           heartbeat: {
-            target: "missing-chat-plugin",
+            target: "openclaw-weixin",
             every: "30m",
           },
         },
@@ -232,7 +232,7 @@ describe("doctor stale plugin config helpers", () => {
           {
             id: "pi",
             heartbeat: {
-              target: "missing-chat-plugin",
+              target: "openclaw-weixin",
             },
           },
           {
@@ -246,17 +246,17 @@ describe("doctor stale plugin config helpers", () => {
     } as OpenClawConfig);
 
     expect(result.changes).toEqual([
-      "- plugins.allow: removed 1 stale plugin id (missing-chat-plugin)",
-      "- plugins.entries: removed 1 stale plugin entry (missing-chat-plugin)",
-      "- channels: removed 1 stale channel config (missing-chat-plugin)",
-      "- agents heartbeat: removed 2 stale heartbeat targets (missing-chat-plugin)",
-      "- channels.modelByChannel: removed 1 stale channel model override (missing-chat-plugin)",
+      "- plugins.allow: removed 1 stale plugin id (openclaw-weixin)",
+      "- plugins.entries: removed 1 stale plugin entry (openclaw-weixin)",
+      "- channels: removed 1 stale channel config (openclaw-weixin)",
+      "- agents heartbeat: removed 2 stale heartbeat targets (openclaw-weixin)",
+      "- channels.modelByChannel: removed 1 stale channel model override (openclaw-weixin)",
     ]);
     expect(result.config.plugins?.allow).toEqual(["discord"]);
     expect(result.config.plugins?.entries).toEqual({
       discord: { enabled: true },
     });
-    expect(result.config.channels?.["missing-chat-plugin"]).toBeUndefined();
+    expect(result.config.channels?.["openclaw-weixin"]).toBeUndefined();
     expect(result.config.channels?.telegram).toEqual({ botToken: "keep" });
     expect(result.config.channels?.modelByChannel).toEqual({
       openai: {
@@ -304,25 +304,25 @@ describe("doctor stale plugin config helpers", () => {
 
   it("uses missing persisted install records as stale channel evidence", () => {
     installedPluginIndexMocks.loadInstalledPluginIndexInstallRecordsSync.mockReturnValue({
-      "missing-chat-plugin": {
+      "openclaw-weixin": {
         source: "npm",
-        resolvedName: "@example/missing-chat-plugin",
+        resolvedName: "@tencent-weixin/openclaw-weixin",
         installedAt: "2026-04-12T00:00:00.000Z",
       },
     });
 
     const result = maybeRepairStalePluginConfig({
       channels: {
-        "missing-chat-plugin": {
+        "openclaw-weixin": {
           enabled: true,
         },
       },
     } as OpenClawConfig);
 
     expect(result.changes).toEqual([
-      "- channels: removed 1 stale channel config (missing-chat-plugin)",
+      "- channels: removed 1 stale channel config (openclaw-weixin)",
     ]);
-    expect(result.config.channels?.["missing-chat-plugin"]).toBeUndefined();
+    expect(result.config.channels?.["openclaw-weixin"]).toBeUndefined();
   });
 
   it("does not auto-repair stale refs while plugin discovery has errors", () => {


### PR DESCRIPTION
## Summary

- Split the non-bug-fix Weixin official external catalog addition back out of #77269.
- Keep the channel-catalog install-records fix and its regression coverage intact on main.
- Restore stale-plugin doctor tests to use `openclaw-weixin` as missing third-party evidence now that it is no longer in the official catalog.

## Verification

- `pnpm test src/plugins/channel-catalog-registry.test.ts src/commands/doctor/shared/stale-plugin-config.test.ts test/official-channel-catalog.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md scripts/lib/official-external-channel-catalog.json src/commands/doctor/shared/stale-plugin-config.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
