### PR TITLE
fix(plugins): make empty-allowlist actionable for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: add bundled-plugin session actions, `sendSessionAttachment`, and Cron-backed `scheduleSessionTurn`/tag cleanup under the grouped session namespace. Replaces #75578/#75581/#75588 and part of #73384/#74483. Thanks @100yenadmin.
 - Plugin SDK/media-understanding: add `extractStructuredWithModel(...)` plus the optional provider-side `extractStructured(...)` seam so trusted plugins can run bounded image-first structured extraction with optional supplemental text context through provider-owned runtimes such as Codex.
 - Exec approvals: add `tools.exec.commandHighlighting` so parser-derived command highlighting in approval prompts can be enabled globally or per agent. (#79348) Thanks @jesse-merhi.
+- Plugins/loader: include the discovered plugin ids, a ready-to-paste `plugins.allow` snippet (only when the discovered set fits inline, otherwise just the list/inspect pointers so a paste cannot silently disable omitted plugins), and pointers to `openclaw plugins list --enabled --verbose` / `openclaw plugins inspect <id>` (placeholder, not the literal manifest id, since manifest ids are not shell-safe) in the empty-allowlist and untracked-provenance startup warnings so first-time users have an actionable remediation path without losing the trust signal. (#68780) Thanks @pahuchi-joe.
 
 ### Fixes
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -305,6 +305,13 @@ does not import plugin runtime code, run a package manager, or repair missing
 dependencies.
 </Note>
 
+If startup logs `plugins.allow is empty; discovered non-bundled plugins may auto-load: ...`,
+use `openclaw plugins list --enabled --verbose` (or
+`openclaw plugins inspect <id>`) to confirm the plugin ids and copy them into
+`plugins.allow` in `openclaw.json`. The warning prints a ready-to-paste snippet
+that already includes the discovered ids; the same hint applies when a plugin loads
+`without install/load-path provenance`.
+
 `plugins search` is a remote ClawHub catalog lookup. It does not inspect local
 state, mutate config, install packages, or load plugin runtime code. Search
 results include the ClawHub package name, family, channel, version, summary, and

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -306,11 +306,14 @@ dependencies.
 </Note>
 
 If startup logs `plugins.allow is empty; discovered non-bundled plugins may auto-load: ...`,
-use `openclaw plugins list --enabled --verbose` (or
-`openclaw plugins inspect <id>`) to confirm the plugin ids and copy them into
-`plugins.allow` in `openclaw.json`. The warning prints a ready-to-paste snippet
-that already includes the discovered ids; the same hint applies when a plugin loads
-`without install/load-path provenance`.
+run `openclaw plugins list --enabled --verbose` or
+`openclaw plugins inspect --all` to confirm the plugin ids and copy trusted ids
+into `plugins.allow` in `openclaw.json`. When the warning can list every
+discovered plugin, it prints a ready-to-paste `plugins.allow` snippet that
+already includes those ids. If a plugin loads without install/load-path
+provenance, inspect the full plugin list, then either pin the trusted id in
+`plugins.allow` or reinstall the plugin from a trusted source so OpenClaw
+records install provenance.
 
 `plugins search` is a remote ClawHub catalog lookup. It does not inspect local
 state, mutate config, install packages, or load plugin runtime code. Search

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -307,13 +307,13 @@ dependencies.
 
 If startup logs `plugins.allow is empty; discovered non-bundled plugins may auto-load: ...`,
 run `openclaw plugins list --enabled --verbose` or
-`openclaw plugins inspect --all` to confirm the plugin ids and copy trusted ids
-into `plugins.allow` in `openclaw.json`. When the warning can list every
-discovered plugin, it prints a ready-to-paste `plugins.allow` snippet that
-already includes those ids. If a plugin loads without install/load-path
-provenance, inspect the full plugin list, then either pin the trusted id in
-`plugins.allow` or reinstall the plugin from a trusted source so OpenClaw
-records install provenance.
+`openclaw plugins inspect <id>` with a listed plugin id to confirm the plugin
+ids and copy trusted ids into `plugins.allow` in `openclaw.json`. When the
+warning can list every discovered plugin, it prints a ready-to-paste
+`plugins.allow` snippet that already includes those ids. If a plugin loads
+without install/load-path provenance, inspect that plugin id, then either pin
+the trusted id in `plugins.allow` or reinstall the plugin from a trusted source
+so OpenClaw records install provenance.
 
 `plugins search` is a remote ClawHub catalog lookup. It does not inspect local
 state, mutate config, install packages, or load plugin runtime code. Search

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -268,6 +268,13 @@ does not import plugin runtime code, run a package manager, or repair missing
 dependencies.
 </Note>
 
+If startup logs `plugins.allow is empty; discovered non-bundled plugins may auto-load: ...`,
+use `plugins list --enabled --verbose` (or `plugins inspect <id>`) to confirm
+the plugin ids and copy them into `plugins.allow` in `openclaw.json`. The
+warning prints a ready-to-paste snippet that already includes the discovered
+ids; the same hint applies when a plugin loads
+`without install/load-path provenance`.
+
 `plugins search` is a remote ClawHub catalog lookup. It does not inspect local
 state, mutate config, install packages, or load plugin runtime code. Search
 results include the ClawHub package name, family, channel, version, summary, and

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -213,10 +213,12 @@ the workspace or global plugin roots, startup logs
 The warning includes discovered plugin ids and, for short lists, a minimal
 `plugins.allow` snippet. Run
 [`openclaw plugins list --enabled --verbose`](/cli/plugins#list) or
-[`openclaw plugins inspect <id>`](/cli/plugins#inspect) to confirm the ids
+[`openclaw plugins inspect --all`](/cli/plugins#inspect) to confirm the ids
 before copying trusted plugins into `openclaw.json`. The same trust-pinning
 guidance applies when diagnostics say a plugin loaded
-`without install/load-path provenance`.
+`without install/load-path provenance`: inspect the full plugin list, then pin
+the trusted id in `plugins.allow` or reinstall from a trusted source so
+OpenClaw records install provenance.
 
 Run `openclaw doctor` or `openclaw doctor --fix` when config validation reports
 stale plugin ids, allowlist/tool mismatches, or legacy bundled plugin paths.

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -213,12 +213,12 @@ the workspace or global plugin roots, startup logs
 The warning includes discovered plugin ids and, for short lists, a minimal
 `plugins.allow` snippet. Run
 [`openclaw plugins list --enabled --verbose`](/cli/plugins#list) or
-[`openclaw plugins inspect --all`](/cli/plugins#inspect) to confirm the ids
-before copying trusted plugins into `openclaw.json`. The same trust-pinning
+[`openclaw plugins inspect <id>`](/cli/plugins#inspect) with the listed plugin
+id before copying trusted plugins into `openclaw.json`. The same trust-pinning
 guidance applies when diagnostics say a plugin loaded
-`without install/load-path provenance`: inspect the full plugin list, then pin
-the trusted id in `plugins.allow` or reinstall from a trusted source so
-OpenClaw records install provenance.
+`without install/load-path provenance`: inspect that plugin id, then pin the
+trusted id in `plugins.allow` or reinstall from a trusted source so OpenClaw
+records install provenance.
 
 Run `openclaw doctor` or `openclaw doctor --fix` when config validation reports
 stale plugin ids, allowlist/tool mismatches, or legacy bundled plugin paths.

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -207,6 +207,17 @@ Key policy rules:
   `codex` plugin owns Codex app-server runtime for canonical `openai/*` agent
   refs, explicit `agentRuntime.id: "codex"`, and legacy `codex/*` refs.
 
+When `plugins.allow` is unset and non-bundled plugins are auto-discovered from
+the workspace or global plugin roots, startup logs
+`plugins.allow is empty; discovered non-bundled plugins may auto-load: ...`.
+The warning includes discovered plugin ids and, for short lists, a minimal
+`plugins.allow` snippet. Run
+[`openclaw plugins list --enabled --verbose`](/cli/plugins#list) or
+[`openclaw plugins inspect <id>`](/cli/plugins#inspect) to confirm the ids
+before copying trusted plugins into `openclaw.json`. The same trust-pinning
+guidance applies when diagnostics say a plugin loaded
+`without install/load-path provenance`.
+
 Run `openclaw doctor` or `openclaw doctor --fix` when config validation reports
 stale plugin ids, allowlist/tool mismatches, or legacy bundled plugin paths.
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -320,6 +320,17 @@ restrictive allowlist configs with `"compat"` during migration so upgrades keep
 legacy bundled provider behavior until the operator opts into the stricter mode.
 An empty `plugins.allow` is still treated as unset/open.
 
+When `plugins.allow` is unset and a non-bundled plugin is auto-discovered from
+the workspace or `~/.openclaw/extensions/`, OpenClaw warns
+`plugins.allow is empty; discovered non-bundled plugins may auto-load: ...` and
+suggests a minimal `plugins.allow` snippet that already includes the discovered
+plugin ids. The same warning fires for plugins that load without install or
+load-path provenance. To resolve it, run [`openclaw plugins list --enabled --verbose`](/cli/plugins#list)
+or [`openclaw plugins inspect <id>`](/cli/plugins#inspect) to confirm the plugin
+ids, then copy them into `plugins.allow` in `openclaw.json`. Channel ids such as
+`feishu` are not plugin ids; the underlying plugin id (for example
+`openclaw-lark`) is what `plugins.allow` expects.
+
 Config changes made through `/plugins enable` or `/plugins disable` trigger an
 in-process Gateway plugin reload. New agent turns rebuild their tool list from
 the refreshed plugin registry. Source-changing operations such as install,

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -223,10 +223,19 @@ export function warnWhenAllowlistIsOpen(params: {
     .slice(0, 6)
     .map((entry) => `${entry.id} (${entry.source})`)
     .join(", ");
-  const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
+  const truncated = autoDiscoverable.length > 6;
+  const extra = truncated ? ` (+${autoDiscoverable.length - 6} more)` : "";
+  // Skip the snippet when truncated: a previewed-only allowlist would silently disable the rest
+  const remediation = truncated
+    ? "Run 'openclaw plugins list --enabled --verbose' to enumerate every discovered plugin id and add the ones you trust to plugins.allow in openclaw.json. Use 'openclaw plugins inspect <id>' for per-plugin details."
+    : `To trust them explicitly, set plugins.allow in openclaw.json (e.g. "plugins": { "allow": [${autoDiscoverable
+        .map((entry) => JSON.stringify(entry.id))
+        .join(
+          ", ",
+        )}] }). Run 'openclaw plugins list --enabled --verbose' or 'openclaw plugins inspect <id>' to confirm plugin ids.`;
   params.warningCache.recordOpenAllowlistWarning(params.warningCacheKey);
   params.logger.warn(
-    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. ${remediation}`,
   );
 }
 
@@ -256,8 +265,8 @@ export function warnAboutUntrackedLoadedPlugins(params: {
     ) {
       continue;
     }
-    const message =
-      "loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records";
+    // Inspect command keeps `<id>` placeholder; manifest ids are not shell-safe
+    const message = `loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }) or install records. Run 'openclaw plugins inspect <id>' to verify`;
     params.registry.diagnostics.push({
       level: "warn",
       pluginId: plugin.id,

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -1,5 +1,6 @@
 // Tracks plugin loader provenance for diagnostics and policy checks.
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
+import { quoteCliArg } from "../cli/quote-cli-arg.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { resolveUserPath } from "../utils.js";
 import { isBundledPluginInsideDevSourceRoot } from "./dev-source-root.js";
@@ -65,6 +66,10 @@ function matchesPathMatcher(matcher: PathMatcher, sourcePath: string): boolean {
     return true;
   }
   return matcher.dirs.some((dirPath) => isPathInside(dirPath, sourcePath));
+}
+
+function formatPluginInspectCommand(pluginId: string): string {
+  return `openclaw plugins inspect ${quoteCliArg(pluginId)}`;
 }
 
 /** Builds provenance matchers from configured load paths and install records. */
@@ -246,14 +251,17 @@ export function warnWhenAllowlistIsOpen(params: {
     .join(", ");
   const truncated = autoDiscoverable.length > 6;
   const extra = truncated ? ` (+${autoDiscoverable.length - 6} more)` : "";
+  const inspectCommands = autoDiscoverable
+    .map((entry) => `'${formatPluginInspectCommand(entry.id)}'`)
+    .join(", ");
   // Skip the snippet when truncated: a previewed-only allowlist would silently disable the rest
   const remediation = truncated
-    ? "Run 'openclaw plugins list --enabled --verbose' to enumerate every discovered plugin id and add the ones you trust to plugins.allow in openclaw.json. Run 'openclaw plugins inspect --all' for per-plugin details."
+    ? "Run 'openclaw plugins list --enabled --verbose' to enumerate every discovered plugin id, inspect trusted ids with 'openclaw plugins inspect <id>', and add the ones you trust to plugins.allow in openclaw.json."
     : `To trust them explicitly, set plugins.allow in openclaw.json (e.g. "plugins": { "allow": [${autoDiscoverable
         .map((entry) => JSON.stringify(entry.id))
         .join(
           ", ",
-        )}] }). Run 'openclaw plugins list --enabled --verbose' or 'openclaw plugins inspect --all' to confirm plugin ids.`;
+        )}] }). Run 'openclaw plugins list --enabled --verbose' or ${inspectCommands} to confirm plugin ids.`;
   params.warningCache.recordOpenAllowlistWarning(params.warningCacheKey);
   if (!hasConfiguredAllowlist) {
     params.logger.warn(
@@ -300,7 +308,7 @@ export function warnAboutUntrackedLoadedPlugins(params: {
     ) {
       continue;
     }
-    const message = `loaded without install/load-path provenance; treat as untracked local code. Verify source with 'openclaw plugins inspect --all', then pin trust via plugins.allow (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }) or reinstall from a trusted source so OpenClaw records install provenance.`;
+    const message = `loaded without install/load-path provenance; treat as untracked local code. Verify source with '${formatPluginInspectCommand(plugin.id)}', then pin trust via plugins.allow (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }) or reinstall from a trusted source so OpenClaw records install provenance.`;
     params.registry.diagnostics.push({
       level: "warn",
       pluginId: plugin.id,

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -244,11 +244,20 @@ export function warnWhenAllowlistIsOpen(params: {
     .slice(0, 6)
     .map((entry) => `${entry.id} (${entry.source})`)
     .join(", ");
-  const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
+  const truncated = autoDiscoverable.length > 6;
+  const extra = truncated ? ` (+${autoDiscoverable.length - 6} more)` : "";
+  // Skip the snippet when truncated: a previewed-only allowlist would silently disable the rest
+  const remediation = truncated
+    ? "Run 'openclaw plugins list --enabled --verbose' to enumerate every discovered plugin id and add the ones you trust to plugins.allow in openclaw.json. Use 'openclaw plugins inspect <id>' for per-plugin details."
+    : `To trust them explicitly, set plugins.allow in openclaw.json (e.g. "plugins": { "allow": [${autoDiscoverable
+        .map((entry) => JSON.stringify(entry.id))
+        .join(
+          ", ",
+        )}] }). Run 'openclaw plugins list --enabled --verbose' or 'openclaw plugins inspect <id>' to confirm plugin ids.`;
   params.warningCache.recordOpenAllowlistWarning(params.warningCacheKey);
   if (!hasConfiguredAllowlist) {
     params.logger.warn(
-      `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+      `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. ${remediation}`,
     );
     return;
   }
@@ -291,8 +300,8 @@ export function warnAboutUntrackedLoadedPlugins(params: {
     ) {
       continue;
     }
-    const message =
-      "loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records";
+    // Inspect command keeps `<id>` placeholder; manifest ids are not shell-safe
+    const message = `loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }) or install records. Run 'openclaw plugins inspect <id>' to verify`;
     params.registry.diagnostics.push({
       level: "warn",
       pluginId: plugin.id,

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -248,12 +248,12 @@ export function warnWhenAllowlistIsOpen(params: {
   const extra = truncated ? ` (+${autoDiscoverable.length - 6} more)` : "";
   // Skip the snippet when truncated: a previewed-only allowlist would silently disable the rest
   const remediation = truncated
-    ? "Run 'openclaw plugins list --enabled --verbose' to enumerate every discovered plugin id and add the ones you trust to plugins.allow in openclaw.json. Use 'openclaw plugins inspect <id>' for per-plugin details."
+    ? "Run 'openclaw plugins list --enabled --verbose' to enumerate every discovered plugin id and add the ones you trust to plugins.allow in openclaw.json. Run 'openclaw plugins inspect --all' for per-plugin details."
     : `To trust them explicitly, set plugins.allow in openclaw.json (e.g. "plugins": { "allow": [${autoDiscoverable
         .map((entry) => JSON.stringify(entry.id))
         .join(
           ", ",
-        )}] }). Run 'openclaw plugins list --enabled --verbose' or 'openclaw plugins inspect <id>' to confirm plugin ids.`;
+        )}] }). Run 'openclaw plugins list --enabled --verbose' or 'openclaw plugins inspect --all' to confirm plugin ids.`;
   params.warningCache.recordOpenAllowlistWarning(params.warningCacheKey);
   if (!hasConfiguredAllowlist) {
     params.logger.warn(
@@ -300,8 +300,7 @@ export function warnAboutUntrackedLoadedPlugins(params: {
     ) {
       continue;
     }
-    // Inspect command keeps `<id>` placeholder; manifest ids are not shell-safe
-    const message = `loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }) or install records. Run 'openclaw plugins inspect <id>' to verify`;
+    const message = `loaded without install/load-path provenance; treat as untracked local code. Verify source with 'openclaw plugins inspect --all', then pin trust via plugins.allow (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }) or reinstall from a trusted source so OpenClaw records install provenance.`;
     params.registry.diagnostics.push({
       level: "warn",
       pluginId: plugin.id,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -53,6 +53,7 @@ import {
   claimPluginInteractiveCallbackDedupe,
   commitPluginInteractiveCallbackDedupe,
 } from "./interactive-state.js";
+import { warnWhenAllowlistIsOpen } from "./loader-provenance.js";
 import {
   testing,
   clearPluginLoaderCache,
@@ -8722,6 +8723,111 @@ module.exports = {
       openAllowWarnings,
       "bundled-only allowlists should not trip the mismatch warning",
     ).toHaveLength(0);
+  });
+
+  it("includes actionable plugins.allow remediation hints in the open allowlist warning", () => {
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-open-allow-remediation",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+        },
+      },
+    });
+
+    const openAllowWarning = warnings.find((msg) => msg.includes("plugins.allow is empty"));
+    expect(openAllowWarning).toBeDefined();
+    expect(openAllowWarning).toContain('"warn-open-allow-remediation"');
+    expect(openAllowWarning).toContain('"plugins": { "allow": [');
+    expect(openAllowWarning).toContain("openclaw plugins list --enabled --verbose");
+    expect(openAllowWarning).toContain("openclaw plugins inspect");
+  });
+
+  it("includes actionable plugins.allow remediation hints in the untracked-provenance warning", () => {
+    useNoBundledPlugins();
+    const stateDir = makeTempDir();
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const globalDir = path.join(stateDir, "extensions", "warn-untracked-remediation");
+      mkdirSafe(globalDir);
+      writePlugin({
+        id: "warn-untracked-remediation",
+        body: simplePluginBody("warn-untracked-remediation"),
+        dir: globalDir,
+        filename: "index.cjs",
+      });
+
+      const warnings: string[] = [];
+      const registry = loadOpenClawPlugins({
+        cache: false,
+        logger: createWarningLogger(warnings),
+        config: {
+          plugins: {
+            enabled: true,
+          },
+        },
+      });
+
+      const untrackedWarning = warnings.find(
+        (msg) =>
+          msg.includes("warn-untracked-remediation") &&
+          msg.includes("loaded without install/load-path provenance"),
+      );
+      expect(untrackedWarning).toBeDefined();
+      expect(untrackedWarning).toContain('"warn-untracked-remediation"');
+      expect(untrackedWarning).toContain("openclaw plugins inspect <id>");
+      expect(untrackedWarning).not.toContain("openclaw plugins inspect warn-untracked-remediation");
+
+      const diagnostic = registry.diagnostics.find(
+        (entry) =>
+          entry.pluginId === "warn-untracked-remediation" &&
+          entry.message.includes("loaded without install/load-path provenance"),
+      );
+      expect(diagnostic?.message).toContain('"warn-untracked-remediation"');
+      expect(diagnostic?.message).toContain("openclaw plugins inspect <id>");
+      expect(diagnostic?.message).not.toContain(
+        "openclaw plugins inspect warn-untracked-remediation",
+      );
+    });
+  });
+
+  it("omits the truncated plugins.allow snippet when more than six plugins are discovered", () => {
+    const ids = Array.from({ length: 8 }, (_, index) => `discovered-plugin-${index + 1}`);
+    const warnings: string[] = [];
+    const cache = {
+      __seen: new Set<string>(),
+      hasOpenAllowlistWarning(key: string) {
+        return this.__seen.has(key);
+      },
+      recordOpenAllowlistWarning(key: string) {
+        this.__seen.add(key);
+      },
+    };
+    warnWhenAllowlistIsOpen({
+      emitWarning: true,
+      logger: createWarningLogger(warnings),
+      pluginsEnabled: true,
+      allow: [],
+      warningCacheKey: "truncated",
+      warningCache: cache,
+      discoverablePlugins: ids.map((id) => ({ id, source: `/tmp/${id}`, origin: "global" })),
+    });
+
+    expect(warnings).toHaveLength(1);
+    const message = warnings[0] ?? "";
+    expect(message).toContain("plugins.allow is empty");
+    expect(message).toContain("(+2 more)");
+    expect(message).not.toContain('"plugins": { "allow": [');
+    expect(message).toContain("openclaw plugins list --enabled --verbose");
+    expect(message).toContain("openclaw plugins inspect <id>");
   });
 
   it("handles workspace-discovered plugins according to trust and precedence", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -8800,13 +8800,13 @@ module.exports = {
   it("omits the truncated plugins.allow snippet when more than six plugins are discovered", () => {
     const ids = Array.from({ length: 8 }, (_, index) => `discovered-plugin-${index + 1}`);
     const warnings: string[] = [];
+    const seenWarningKeys = new Set<string>();
     const cache = {
-      __seen: new Set<string>(),
       hasOpenAllowlistWarning(key: string) {
-        return this.__seen.has(key);
+        return seenWarningKeys.has(key);
       },
       recordOpenAllowlistWarning(key: string) {
-        this.__seen.add(key);
+        seenWarningKeys.add(key);
       },
     };
     warnWhenAllowlistIsOpen({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -8749,7 +8749,7 @@ module.exports = {
     expect(openAllowWarning).toContain('"warn-open-allow-remediation"');
     expect(openAllowWarning).toContain('"plugins": { "allow": [');
     expect(openAllowWarning).toContain("openclaw plugins list --enabled --verbose");
-    expect(openAllowWarning).toContain("openclaw plugins inspect --all");
+    expect(openAllowWarning).toContain("openclaw plugins inspect warn-open-allow-remediation");
   });
 
   it("includes actionable plugins.allow remediation hints in the untracked-provenance warning", () => {
@@ -8783,9 +8783,8 @@ module.exports = {
       );
       expect(untrackedWarning).toBeDefined();
       expect(untrackedWarning).toContain('"warn-untracked-remediation"');
-      expect(untrackedWarning).toContain("openclaw plugins inspect --all");
+      expect(untrackedWarning).toContain("openclaw plugins inspect warn-untracked-remediation");
       expect(untrackedWarning).toContain("reinstall from a trusted source");
-      expect(untrackedWarning).not.toContain("openclaw plugins inspect <id>");
 
       const diagnostic = registry.diagnostics.find(
         (entry) =>
@@ -8793,9 +8792,8 @@ module.exports = {
           entry.message.includes("loaded without install/load-path provenance"),
       );
       expect(diagnostic?.message).toContain('"warn-untracked-remediation"');
-      expect(diagnostic?.message).toContain("openclaw plugins inspect --all");
+      expect(diagnostic?.message).toContain("openclaw plugins inspect warn-untracked-remediation");
       expect(diagnostic?.message).toContain("reinstall from a trusted source");
-      expect(diagnostic?.message).not.toContain("openclaw plugins inspect <id>");
     });
   });
 
@@ -8827,7 +8825,7 @@ module.exports = {
     expect(message).toContain("(+2 more)");
     expect(message).not.toContain('"plugins": { "allow": [');
     expect(message).toContain("openclaw plugins list --enabled --verbose");
-    expect(message).toContain("openclaw plugins inspect --all");
+    expect(message).toContain("openclaw plugins inspect <id>");
   });
 
   it("handles workspace-discovered plugins according to trust and precedence", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -8749,7 +8749,7 @@ module.exports = {
     expect(openAllowWarning).toContain('"warn-open-allow-remediation"');
     expect(openAllowWarning).toContain('"plugins": { "allow": [');
     expect(openAllowWarning).toContain("openclaw plugins list --enabled --verbose");
-    expect(openAllowWarning).toContain("openclaw plugins inspect");
+    expect(openAllowWarning).toContain("openclaw plugins inspect --all");
   });
 
   it("includes actionable plugins.allow remediation hints in the untracked-provenance warning", () => {
@@ -8783,8 +8783,9 @@ module.exports = {
       );
       expect(untrackedWarning).toBeDefined();
       expect(untrackedWarning).toContain('"warn-untracked-remediation"');
-      expect(untrackedWarning).toContain("openclaw plugins inspect <id>");
-      expect(untrackedWarning).not.toContain("openclaw plugins inspect warn-untracked-remediation");
+      expect(untrackedWarning).toContain("openclaw plugins inspect --all");
+      expect(untrackedWarning).toContain("reinstall from a trusted source");
+      expect(untrackedWarning).not.toContain("openclaw plugins inspect <id>");
 
       const diagnostic = registry.diagnostics.find(
         (entry) =>
@@ -8792,10 +8793,9 @@ module.exports = {
           entry.message.includes("loaded without install/load-path provenance"),
       );
       expect(diagnostic?.message).toContain('"warn-untracked-remediation"');
-      expect(diagnostic?.message).toContain("openclaw plugins inspect <id>");
-      expect(diagnostic?.message).not.toContain(
-        "openclaw plugins inspect warn-untracked-remediation",
-      );
+      expect(diagnostic?.message).toContain("openclaw plugins inspect --all");
+      expect(diagnostic?.message).toContain("reinstall from a trusted source");
+      expect(diagnostic?.message).not.toContain("openclaw plugins inspect <id>");
     });
   });
 
@@ -8827,7 +8827,7 @@ module.exports = {
     expect(message).toContain("(+2 more)");
     expect(message).not.toContain('"plugins": { "allow": [');
     expect(message).toContain("openclaw plugins list --enabled --verbose");
-    expect(message).toContain("openclaw plugins inspect <id>");
+    expect(message).toContain("openclaw plugins inspect --all");
   });
 
   it("handles workspace-discovered plugins according to trust and precedence", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -42,6 +42,7 @@ import {
   claimPluginInteractiveCallbackDedupe,
   commitPluginInteractiveCallbackDedupe,
 } from "./interactive-state.js";
+import { warnWhenAllowlistIsOpen } from "./loader-provenance.js";
 import {
   __testing,
   clearPluginLoaderCache,
@@ -6293,6 +6294,111 @@ module.exports = {
         label: scenario.label,
       });
     });
+  });
+
+  it("includes actionable plugins.allow remediation hints in the open allowlist warning", () => {
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-open-allow-remediation",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+        },
+      },
+    });
+
+    const openAllowWarning = warnings.find((msg) => msg.includes("plugins.allow is empty"));
+    expect(openAllowWarning).toBeDefined();
+    expect(openAllowWarning).toContain('"warn-open-allow-remediation"');
+    expect(openAllowWarning).toContain('"plugins": { "allow": [');
+    expect(openAllowWarning).toContain("openclaw plugins list --enabled --verbose");
+    expect(openAllowWarning).toContain("openclaw plugins inspect");
+  });
+
+  it("includes actionable plugins.allow remediation hints in the untracked-provenance warning", () => {
+    useNoBundledPlugins();
+    const stateDir = makeTempDir();
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const globalDir = path.join(stateDir, "extensions", "warn-untracked-remediation");
+      mkdirSafe(globalDir);
+      writePlugin({
+        id: "warn-untracked-remediation",
+        body: simplePluginBody("warn-untracked-remediation"),
+        dir: globalDir,
+        filename: "index.cjs",
+      });
+
+      const warnings: string[] = [];
+      const registry = loadOpenClawPlugins({
+        cache: false,
+        logger: createWarningLogger(warnings),
+        config: {
+          plugins: {
+            enabled: true,
+          },
+        },
+      });
+
+      const untrackedWarning = warnings.find(
+        (msg) =>
+          msg.includes("warn-untracked-remediation") &&
+          msg.includes("loaded without install/load-path provenance"),
+      );
+      expect(untrackedWarning).toBeDefined();
+      expect(untrackedWarning).toContain('"warn-untracked-remediation"');
+      expect(untrackedWarning).toContain("openclaw plugins inspect <id>");
+      expect(untrackedWarning).not.toContain("openclaw plugins inspect warn-untracked-remediation");
+
+      const diagnostic = registry.diagnostics.find(
+        (entry) =>
+          entry.pluginId === "warn-untracked-remediation" &&
+          entry.message.includes("loaded without install/load-path provenance"),
+      );
+      expect(diagnostic?.message).toContain('"warn-untracked-remediation"');
+      expect(diagnostic?.message).toContain("openclaw plugins inspect <id>");
+      expect(diagnostic?.message).not.toContain(
+        "openclaw plugins inspect warn-untracked-remediation",
+      );
+    });
+  });
+
+  it("omits the truncated plugins.allow snippet when more than six plugins are discovered", () => {
+    const ids = Array.from({ length: 8 }, (_, index) => `discovered-plugin-${index + 1}`);
+    const warnings: string[] = [];
+    const cache = {
+      __seen: new Set<string>(),
+      hasOpenAllowlistWarning(key: string) {
+        return this.__seen.has(key);
+      },
+      recordOpenAllowlistWarning(key: string) {
+        this.__seen.add(key);
+      },
+    };
+    warnWhenAllowlistIsOpen({
+      emitWarning: true,
+      logger: createWarningLogger(warnings),
+      pluginsEnabled: true,
+      allow: [],
+      warningCacheKey: "truncated",
+      warningCache: cache,
+      discoverablePlugins: ids.map((id) => ({ id, source: `/tmp/${id}`, origin: "global" })),
+    });
+
+    expect(warnings).toHaveLength(1);
+    const message = warnings[0] ?? "";
+    expect(message).toContain("plugins.allow is empty");
+    expect(message).toContain("(+2 more)");
+    expect(message).not.toContain('"plugins": { "allow": [');
+    expect(message).toContain("openclaw plugins list --enabled --verbose");
+    expect(message).toContain("openclaw plugins inspect <id>");
   });
 
   it("handles workspace-discovered plugins according to trust and precedence", () => {


### PR DESCRIPTION
## Summary

- Problem: On fresh installs, `plugins.allow is empty; discovered non-bundled plugins may auto-load: ...` and `loaded without install/load-path provenance` warnings list ids but give no remediation, and users routinely confuse channel ids (`feishu`) with plugin ids (`openclaw-lark`).
- Why it matters: First-run UX looks alarming and the warning is unactionable, even though the underlying trust signal is correct.
- What changed: Both warnings now embed a paste-ready `plugins.allow` snippet pre-filled with the discovered ids, plus pointers to `openclaw plugins list --enabled --verbose` and `openclaw plugins inspect <id>` for id discovery. Docs (`docs/tools/plugin.md`, `docs/cli/plugins.md`) tie the same remediation back to the warning copy.
- What did NOT change (scope boundary): No change to allowlist semantics, auto-load policy, channel-to-plugin id resolution, bundled-vs-third-party warn levels, or persisted registry behavior. Existing assertions on `plugins.allow is empty` and `loaded without install/load-path provenance` substrings stay valid.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68780 
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: empty `plugins.allow` warning + `loaded without install/load-path provenance` warning had no usable remediation on first boot.
- Real environment tested: local OpenClaw checkout on Linux/WSL2 (Node 22), `OPENCLAW_STATE_DIR` pointed at a temp dir simulating a fresh `~/.openclaw/extensions/` install.
- Exact steps or command run after this patch: `pnpm test src/plugins/loader.test.ts src/plugins/loader.cli-metadata.test.ts` (covers both warnings end-to-end via the loader, asserting the new copy is what an operator sees).
- Evidence after fix: targeted vitest output below shows the new regression tests passing with the new copy. Sample warning content asserted by the new tests:
  - `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: warn-open-allow-remediation (...). To trust them explicitly, set plugins.allow in openclaw.json (e.g. "plugins": { "allow": ["warn-open-allow-remediation"] }). Run 'openclaw plugins list --enabled --verbose' or 'openclaw plugins inspect <id>' to confirm plugin ids.`
  - `[plugins] warn-untracked-remediation: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow (e.g. "plugins": { "allow": ["warn-untracked-remediation"] }) or install records. Run 'openclaw plugins inspect warn-untracked-remediation' to verify (...)`
- Observed result after fix: warning still emitted at warn level (trust signal preserved), but now contains the exact ids, snippet, and discovery commands needed to act on it.
- What was not tested: no live multi-plugin gateway run on a freshly installed Windows/macOS host; the warning code path is exercised through the standard loader fixtures rather than a real fresh install.
- Before evidence (optional but encouraged): pre-patch warning is exactly the text quoted in #68780 (`plugins.allow is empty; discovered non-bundled plugins may auto-load: openclaw-lark, openclaw-weixin` and `openclaw-lark: loaded without install/load-path provenance`).

## Root Cause (if applicable)

- Root cause: `warnWhenAllowlistIsOpen` and `warnAboutUntrackedLoadedPlugins` in `src/plugins/loader-provenance.ts` only listed ids and a generic instruction to "set plugins.allow to explicit trusted ids" / "pin trust via plugins.allow or install records". Neither showed a concrete snippet nor pointed at the existing CLI commands that resolve plugin ids, so first-time users could not bridge from the warning to a config edit.
- Missing detection / guardrail: warning copy was treated as static; no test asserted the presence of remediation hints, only that the warning fired at all.
- Contributing context (if known): channel-id vs plugin-id naming (e.g. `feishu` vs `openclaw-lark`) makes the existing message especially confusing on first run.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/loader.test.ts`
- Scenario the test should lock in: empty-allowlist + workspace-discovered plugin and global untracked plugin both surface the new remediation hints (snippet with the actual id, plus `plugins list --enabled --verbose` / `plugins inspect` references) in both the logger warning and the persisted diagnostic.
- Why this is the smallest reliable guardrail: the warnings are user-facing strings; asserting their content at the loader boundary catches future regressions without needing a live install.
- Existing test that already covers this (if any): `warns about open allowlists only for auto-discovered plugins` and `suppresses trust warning logs for non-activating snapshot loads` cover the trigger conditions but not the copy.
- If no new test is added, why not: n/a, two new tests added.

## User-visible / Behavior Changes

- Startup logs and persisted diagnostics for the empty-allowlist and untracked-provenance warnings now include a `plugins.allow` snippet with the discovered ids and `openclaw plugins list --enabled --verbose` / `openclaw plugins inspect <id>` hints. Trigger conditions, log level (`warn`), and trust semantics are unchanged.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: n/a. Trust signal preserved (warn-level, same trigger), only the message text grew.

## Repro + Verification

### Environment

- OS: Linux (WSL2, Ubuntu)
- Runtime/container: Node 22, local OpenClaw checkout
- Model/provider: n/a (loader-only path)
- Integration/channel (if any): n/a
- Relevant config (redacted): no `plugins.allow` set

### Steps

1. Drop a non-bundled plugin into a workspace or `~/.openclaw/extensions/<id>` with no `plugins.allow` configured.
2. Start the gateway (or run the loader through the existing tests).
3. Observe the warning(s) on startup.

### Expected

- Warning includes the discovered plugin ids, a `plugins.allow` snippet pre-filled with those ids, and `openclaw plugins list --enabled --verbose` / `openclaw plugins inspect <id>` hints.

### Actual

- Matches Expected (asserted by `includes actionable plugins.allow remediation hints in the open allowlist warning` and `includes actionable plugins.allow remediation hints in the untracked-provenance warning` in `src/plugins/loader.test.ts`).

## Evidence

- [x] Test output after the fix:

```
$ pnpm test src/plugins/loader.test.ts src/plugins/loader.cli-metadata.test.ts
Test Files  1 passed (1)
     Tests  125 passed (125)
Test Files  1 passed (1)
     Tests  13 passed (13)
[test] passed 2 Vitest shards in 23.95s
```

```
$ pnpm check:changed
exit=0
```

## Human Verification (required)

- Verified scenarios: empty-allowlist warning copy on workspace-discovered plugin and on global untracked plugin (both via loader tests against real fixtures); doctor/lint/typecheck via `pnpm check:changed`; format via oxfmt.
- Edge cases checked: persisted diagnostic carries the same hint, not just the live log line; existing `plugins.allow is empty` substring still matches so legacy assertions stay green; CLI-metadata load path (`loadOpenClawPluginCliRegistry`) still suppresses the warning (`emitWarning: false`) and the cli-metadata test stays green.
- What I did **not** verify: no Windows/macOS live `openclaw gateway run` against a freshly installed host; no Mintlify preview render of the docs edits

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: n/a

## Risks and Mitigations

- Risk: longer warning line could wrap awkwardly in narrow terminals.
  - Mitigation: kept it single-line per repo convention; the snippet uses JSON-quoted ids so it stays paste-ready when copied out of any terminal width.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: empty plugins.allow + `loaded without install/load-path provenance` warnings on first boot were unactionable.
- Real environment tested: WSL2 (Ubuntu, Linux 6.6) on `i68780-plugin-allowlist` @ `80f2867cdc`, against the actual built loader (`dist/loader-*.js`) the CLI loads, with an isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_BUNDLED_PLUGINS_DIR` (no real `~/.openclaw` touched).
- Exact steps or command run after this patch:
  1. `mkdir -p $OPENCLAW_STATE_DIR/extensions/demo-third-party`
  2. write `openclaw.plugin.json` (id `demo-third-party`, empty `configSchema`) and `index.cjs` (`module.exports = { id: "demo-third-party", register() {} }`)
  3. drive the built loader with `loadOpenClawPlugins({ activate: true, config: { plugins: { enabled: true } } })` from `dist/plugins/loader.js`
  4. capture the logger.warn lines plus warn-level registry diagnostics
- Evidence after fix:
```
WARN [plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: demo-third-party (/tmp/openclaw-state-XXXXXX/extensions/demo-third-party/index.cjs). To trust them explicitly, set plugins.allow in openclaw.json (e.g. "plugins": { "allow": ["demo-third-party"] }). Run 'openclaw plugins list --enabled --verbose' or 'openclaw plugins inspect ' to confirm plugin ids.
WARN [plugins] demo-third-party: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow (e.g. "plugins": { "allow": ["demo-third-party"] }) or install records. Run 'openclaw plugins inspect demo-third-party' to verify (/tmp/openclaw-state-XXXXXX/extensions/demo-third-party/index.cjs)
DIAG.warn demo-third-party :: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow (e.g. "plugins": { "allow": ["demo-third-party"] }) or install records. Run 'openclaw plugins inspect demo-third-party' to verify
```

- Observed result after fix: warning still fires at warn level (trust signal preserved); now contains the discovered id, a paste-ready `plugins.allow` snippet pre-filled with the id, and the two CLI hints called out by the maintainer.
- What was not tested: full `openclaw gateway run` against a real channel (Telegram/Discord/etc.); only the loader/activation path that emits this warning was driven live.
- Before evidence: same fixture against `HEAD~1` of `src/plugins/loader-provenance.ts` (rebuilt dist):
```
WARN [plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: demo-third-party (/tmp/openclaw-state-XXXXXX/extensions/demo-third-party/index.cjs). Set plugins.allow to explicit trusted ids.
WARN [plugins] demo-third-party: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (/tmp/openclaw-state-XXXXXX/extensions/demo-third-party/index.cjs)
DIAG.warn demo-third-party :: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records
```

AI-assisted: implemented with Claude Opus 4.7