### PR TITLE
fix(doctor): recommend automatic visibleReplies when message tool is unavailable (#78066)

### DIFF
--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -12,6 +12,7 @@ import {
 import { sanitizeForLog } from "../../../terminal/ansi.js";
 import { isRecord } from "./legacy-config-record-shared.js";
 import { isLegacyModelsAddCodexMetadataModel } from "./legacy-models-add-metadata.js";
+import { resolveMessageToolAvailability } from "./preview-warnings.js";
 export { normalizeLegacyTalkConfig } from "./legacy-talk-config-normalizer.js";
 
 function hasConfiguredChannels(cfg: OpenClawConfig): boolean {
@@ -35,13 +36,17 @@ export function normalizeMissingGroupVisibleRepliesDefault(
     return cfg;
   }
 
+  const messageToolAvailable = resolveMessageToolAvailability({ globalTools: cfg.tools });
+  const recommendedValue = messageToolAvailable ? "message_tool" : "automatic";
   const nextMessages = messages ? { ...messages } : {};
   nextMessages.groupChat = {
     ...messages?.groupChat,
-    visibleReplies: "message_tool",
+    visibleReplies: recommendedValue,
   };
   changes.push(
-    'Set messages.groupChat.visibleReplies to "message_tool" so group/channel replies use the message tool by default.',
+    messageToolAvailable
+      ? 'Set messages.groupChat.visibleReplies to "message_tool" so group/channel replies use the message tool by default.'
+      : 'Set messages.groupChat.visibleReplies to "automatic" (message tool unavailable for the active tool policy).',
   );
 
   return {

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.visibleReplies.test.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.visibleReplies.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMissingGroupVisibleRepliesDefault } from "./legacy-config-core-normalizers.js";
+
+describe("normalizeMissingGroupVisibleRepliesDefault", () => {
+  it("recommends message_tool when message tool is available (full profile)", () => {
+    const changes: string[] = [];
+    const result = normalizeMissingGroupVisibleRepliesDefault(
+      { channels: { myChannel: {} } },
+      changes,
+    );
+    expect(result.messages?.groupChat?.visibleReplies).toBe("message_tool");
+    expect(changes[0]).toContain("message_tool");
+  });
+
+  it("recommends automatic when message tool is unavailable (minimal profile)", () => {
+    const changes: string[] = [];
+    const result = normalizeMissingGroupVisibleRepliesDefault(
+      { channels: { myChannel: {} }, tools: { profile: "minimal" } },
+      changes,
+    );
+    expect(result.messages?.groupChat?.visibleReplies).toBe("automatic");
+    expect(changes[0]).toContain("automatic");
+    expect(changes[0]).toContain("message tool unavailable");
+  });
+
+  it("does not apply fix when visibleReplies is already set", () => {
+    const changes: string[] = [];
+    const result = normalizeMissingGroupVisibleRepliesDefault(
+      {
+        channels: { myChannel: {} },
+        tools: { profile: "minimal" },
+        messages: { groupChat: { visibleReplies: "message_tool" } },
+      },
+      changes,
+    );
+    expect(result.messages?.groupChat?.visibleReplies).toBe("message_tool");
+    expect(changes).toHaveLength(0);
+  });
+
+  it("does not apply fix when no channels are configured", () => {
+    const changes: string[] = [];
+    const result = normalizeMissingGroupVisibleRepliesDefault(
+      { tools: { profile: "minimal" } },
+      changes,
+    );
+    expect(result.messages?.groupChat?.visibleReplies).toBeUndefined();
+    expect(changes).toHaveLength(0);
+  });
+});

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -83,7 +83,7 @@ function hasConfiguredSafeBins(cfg: OpenClawConfig): boolean {
 
 type VisibleReplyPolicyProvenance = "default" | "global-explicit" | "group-explicit";
 
-function resolveMessageToolAvailability(params: {
+export function resolveMessageToolAvailability(params: {
   globalTools?: ToolsConfig;
   agentTools?: AgentToolsConfig;
 }): boolean {


### PR DESCRIPTION
## Root cause

`normalizeMissingGroupVisibleRepliesDefault` unconditionally set
`messages.groupChat.visibleReplies` to `"message_tool"` when applying
`doctor --fix`, without checking whether the message tool is actually
reachable under the active tool policy.

After running `--fix`, the next `doctor` invocation immediately emits:
> messages.groupChat.visibleReplies is set to "message_tool", but the message
> tool is unavailable — OpenClaw falls back to automatic visible replies.

This is a self-contradicting fix loop on every setup where the message tool
is not enabled (e.g. `tools.profile: minimal` or `full` with no message tool).

## Fix

Export `resolveMessageToolAvailability` from `preview-warnings.ts` — the same
helper the warning path already uses — and call it inside the normalizer.
When the message tool is unavailable for the global tool policy, recommend
`"automatic"` instead of `"message_tool"`.

## Files changed (3 files, clean branch off upstream main)

- `src/commands/doctor/shared/preview-warnings.ts` — `function` → `export function` for `resolveMessageToolAvailability`
- `src/commands/doctor/shared/legacy-config-core-normalizers.ts` — gate on tool availability; vary change-log message
- `src/commands/doctor/shared/legacy-config-core-normalizers.visibleReplies.test.ts` — 4 regression tests (new file)

## Tests

```
✓ recommends message_tool when message tool is available (full profile)
✓ recommends automatic when message tool is unavailable (minimal profile)
✓ does not apply fix when visibleReplies is already set
✓ does not apply fix when no channels are configured

Test Files  1 passed (1) · Tests  4 passed (4)
```

Closes #78066