### PR TITLE
fix(mcp): honour per-server requestTimeoutMs for bundle-MCP callTool (#78092)

### DIFF
--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -163,4 +163,37 @@ describe("resolveMcpTransportConfig", () => {
       url: "https://mcp.example.com/http",
     });
   });
+
+  it("propagates requestTimeoutMs from stdio server config", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
+      command: "node",
+      args: ["./server.mjs"],
+      requestTimeoutMs: 120_000,
+    });
+
+    expect(resolved).toMatchObject({
+      kind: "stdio",
+      requestTimeoutMs: 120_000,
+    });
+  });
+
+  it("propagates requestTimeoutMs from HTTP server config", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
+      url: "https://mcp.example.com/sse",
+      requestTimeoutMs: 180_000,
+    });
+
+    expect(resolved).toMatchObject({
+      kind: "http",
+      requestTimeoutMs: 180_000,
+    });
+  });
+
+  it("leaves requestTimeoutMs undefined when not configured", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
+      command: "node",
+    });
+
+    expect(resolved?.requestTimeoutMs).toBeUndefined();
+  });
 });

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -15,6 +15,7 @@ import {
 type ResolvedBaseMcpTransportConfig = {
   description: string;
   connectionTimeoutMs: number;
+  requestTimeoutMs?: number;
 };
 
 type ResolvedStdioMcpTransportConfig = ResolvedBaseMcpTransportConfig & {
@@ -47,6 +48,18 @@ function getConnectionTimeoutMs(rawServer: unknown): number {
     return (rawServer as { connectionTimeoutMs: number }).connectionTimeoutMs;
   }
   return DEFAULT_CONNECTION_TIMEOUT_MS;
+}
+
+function getRequestTimeoutMs(rawServer: unknown): number | undefined {
+  if (
+    rawServer &&
+    typeof rawServer === "object" &&
+    typeof (rawServer as { requestTimeoutMs?: unknown }).requestTimeoutMs === "number" &&
+    (rawServer as { requestTimeoutMs: number }).requestTimeoutMs > 0
+  ) {
+    return (rawServer as { requestTimeoutMs: number }).requestTimeoutMs;
+  }
+  return undefined;
 }
 
 function getRequestedTransport(rawServer: unknown): string {
@@ -99,6 +112,7 @@ function resolveHttpTransportConfig(
     headers: launch.config.headers,
     description: describeHttpMcpServerLaunchConfig(launch.config),
     connectionTimeoutMs: getConnectionTimeoutMs(rawServer),
+    requestTimeoutMs: getRequestTimeoutMs(rawServer),
   };
 }
 
@@ -127,6 +141,7 @@ export function resolveMcpTransportConfig(
       cwd: stdioLaunch.config.cwd,
       description: describeStdioMcpServerLaunchConfig(stdioLaunch.config),
       connectionTimeoutMs: getConnectionTimeoutMs(rawServer),
+      requestTimeoutMs: getRequestTimeoutMs(rawServer),
     };
   }
 

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -15,6 +15,7 @@ type ResolvedMcpTransport = {
   description: string;
   transportType: "stdio" | "sse" | "streamable-http";
   connectionTimeoutMs: number;
+  requestTimeoutMs?: number;
   detachStderr?: () => void;
 };
 
@@ -96,6 +97,7 @@ export function resolveMcpTransport(
       description: resolved.description,
       transportType: "stdio",
       connectionTimeoutMs: resolved.connectionTimeoutMs,
+      requestTimeoutMs: resolved.requestTimeoutMs,
       detachStderr: attachStderrLogging(serverName, transport),
     };
   }
@@ -107,6 +109,7 @@ export function resolveMcpTransport(
       description: resolved.description,
       transportType: "streamable-http",
       connectionTimeoutMs: resolved.connectionTimeoutMs,
+      requestTimeoutMs: resolved.requestTimeoutMs,
     };
   }
   const headers: Record<string, string> = {
@@ -122,5 +125,6 @@ export function resolveMcpTransport(
     description: resolved.description,
     transportType: "sse",
     connectionTimeoutMs: resolved.connectionTimeoutMs,
+    requestTimeoutMs: resolved.requestTimeoutMs,
   };
 }

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -33,6 +33,7 @@ type BundleMcpSession = {
   client: Client;
   transport: Transport;
   transportType: "stdio" | "sse" | "streamable-http";
+  requestTimeoutMs?: number;
   detachStderr?: () => void;
 };
 
@@ -252,6 +253,7 @@ export function createSessionMcpRuntime(params: {
             client,
             transport: resolved.transport,
             transportType: resolved.transportType,
+            requestTimeoutMs: resolved.requestTimeoutMs,
             detachStderr: resolved.detachStderr,
           };
           sessions.set(serverName, session);
@@ -355,10 +357,11 @@ export function createSessionMcpRuntime(params: {
       if (!session) {
         throw new Error(`bundle-mcp server "${serverName}" is not connected`);
       }
-      return (await session.client.callTool({
-        name: toolName,
-        arguments: isMcpConfigRecord(input) ? input : {},
-      })) as CallToolResult;
+      return (await session.client.callTool(
+        { name: toolName, arguments: isMcpConfigRecord(input) ? input : {} },
+        undefined,
+        session.requestTimeoutMs !== undefined ? { timeout: session.requestTimeoutMs } : undefined,
+      )) as CallToolResult;
     },
     async dispose() {
       if (disposed) {


### PR DESCRIPTION
## Problem

Closes #78092.

`callTool()` in `pi-bundle-mcp-runtime.ts` was called without `RequestOptions`, so the MCP SDK's hardcoded `DEFAULT_REQUEST_TIMEOUT_MSEC = 60000` applied to every tool invocation regardless of server configuration. Long-running MCP tools (filesystem scans, slow external APIs, batch operations) reliably hit the 60 s ceiling and returned `-32001` errors with no way to raise the limit on a per-server basis.

## Fix

Add `requestTimeoutMs` to the bundle-MCP server config schema alongside the existing `connectionTimeoutMs`. Wire it through the resolution chain and use it when calling the SDK.

**Config shape** (YAML / JSON — same as `connectionTimeoutMs`):
\`\`\`yaml
mcpServers:
  my-slow-server:
    command: node
    args: [./server.mjs]
    connectionTimeoutMs: 30000   # existing — controls connect phase
    requestTimeoutMs: 300000     # new — controls each callTool invocation
\`\`\`

When `requestTimeoutMs` is absent the SDK default (60 s) continues to apply, so the change is fully backwards-compatible.

## Files changed

| File | Change |
|------|--------|
| `src/agents/mcp-transport-config.ts` | Add `requestTimeoutMs?: number` to `ResolvedBaseMcpTransportConfig`; add `getRequestTimeoutMs()` helper; populate field on both stdio and HTTP resolved configs |
| `src/agents/mcp-transport.ts` | Add `requestTimeoutMs?: number` to `ResolvedMcpTransport`; propagate from resolved config on all 3 transport branches |
| `src/agents/pi-bundle-mcp-runtime.ts` | Add `requestTimeoutMs?: number` to `BundleMcpSession`; pass `{ timeout: session.requestTimeoutMs }` as `RequestOptions` to `session.client.callTool()` |
| `src/agents/mcp-transport-config.test.ts` | 3 new regression tests: stdio propagation, HTTP propagation, absent → `undefined` |

## Tests

```
Tests  22 passed (22)   # 19 pre-existing + 3 new
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)