### PR TITLE
fix(agents): non-default agents use sibling workspace dirs, not nested (#78093)

### DIFF
--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -170,7 +170,9 @@ export function resolveAgentWorkspaceDir(
     return stripNullBytes(resolveDefaultAgentWorkspaceDir(env));
   }
   if (fallback) {
-    return stripNullBytes(path.join(resolveUserPath(fallback, env), id));
+    return stripNullBytes(
+      path.join(path.dirname(resolveUserPath(fallback, env)), `workspace-${id}`),
+    );
   }
   const stateDir = resolveStateDir(env);
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -610,7 +610,7 @@ describe("resolveAgentConfig", () => {
     expect(agentDir).toBe(path.join(stateDir, "agents", "ops", "agent"));
   });
 
-  it("non-default agent uses agents.defaults.workspace as base (#59789)", () => {
+  it("non-default agent with defaults.workspace uses sibling directory, not nested (#78093)", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { workspace: "/shared-ws" },
@@ -618,7 +618,20 @@ describe("resolveAgentConfig", () => {
       },
     };
     const workspace = resolveAgentWorkspaceDir(cfg, "main");
-    expect(workspace).toBe(path.resolve("/shared-ws/main"));
+    // Should be sibling of /shared-ws (i.e. /workspace-main), not nested inside it (/shared-ws/main)
+    expect(workspace).toBe(path.resolve("/workspace-main"));
+  });
+
+  it("non-default agent with nested defaults.workspace path generates sibling directory", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/home/user/.openclaw/workspace" },
+        list: [{ id: "newbot" }, { id: "main", default: true }],
+      },
+    };
+    const workspace = resolveAgentWorkspaceDir(cfg, "newbot");
+    // Sibling of ~/.openclaw/workspace, not nested inside it
+    expect(workspace).toBe(path.resolve("/home/user/.openclaw/workspace-newbot"));
   });
 
   it("default agent without per-agent workspace uses agents.defaults.workspace directly", () => {


### PR DESCRIPTION
## Problem

Closes #78093.

When `agents.defaults.workspace` was set (e.g. `~/.openclaw/workspace`) and a new agent was created without an explicit `--workspace`, the suggested workspace path was nested **inside** the default workspace: `~/.openclaw/workspace/newbot`.

This introduced routing ambiguity: `resolveAgentIdsByWorkspacePath` uses `isPathWithinRoot` (path prefix containment), so any path under `workspace/newbot/` also matched the default agent's `workspace/`. Both agents were returned; the longer path won via sort, but the boundary was fragile and confusing.

The regression was introduced by #59789, which changed the non-default agent fallback from `path.join(stateDir, 'workspace-${id}')` to `path.join(fallback, id)`. The `#59789` fix was correct for the default agent (honour `agents.defaults.workspace`), but it accidentally over-applied to all agents.

## Fix

For non-default agents without an explicit per-agent `workspace` config, when `agents.defaults.workspace` is set, generate the default workspace as a **sibling** of the fallback directory rather than a child:

```
Before: ~/.openclaw/workspace/newbot   ← nested, causes routing ambiguity
After:  ~/.openclaw/workspace-newbot   ← sibling, routing stays unambiguous
```

The `workspace-${id}` suffix convention matches the existing `stateDir`-based fallback path and is what the issue author describes as the pre-#59789 behavior.

## Files changed

| File | Change |
|------|--------|
| `src/agents/agent-scope-config.ts` | `resolveAgentWorkspaceDir`: use `path.dirname(fallback)/workspace-${id}` for non-default agents instead of `fallback/${id}` |
| `src/agents/agent-scope.test.ts` | Update existing regression test (#59789 behavior was wrong); add test for nested `defaults.workspace` path |

## Tests

```
Tests  60 passed (60)   # all pre-existing tests pass with corrected assertion
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)