### PR TITLE
fix(agents): restore workspace-<id> sibling layout for non-default agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Docs: https://docs.openclaw.ai
 - Parallels/Windows update smoke: escape the stale post-swap import regex in the generated PowerShell script so expected `ERR_MODULE_NOT_FOUND` update handoffs continue to post-update health checks. (#75315)
 - Slack: allow draft preview streaming in top-level DMs when `replyToMode` is `off` while keeping Slack native streaming and assistant thread status gated on reply threads. Fixes #56480. (#56544) Thanks @HangGlidersRule.
 - Control UI/chat: remove the delete-confirm popover outside-click listener on every dismiss path, so Cancel, Delete, outside clicks, and same-button toggles no longer leave stale document listeners behind. Refs #75590 and #69982. Thanks @Ricardo-M-L.
-- Agents/workspace: restore `workspace-<id>` sibling layout as the default for non-default agents added via `agents add`; fixes TUI routing ambiguity introduced in #59789 (#78093)
+- Agents/workspace: restore `workspace-<id>` sibling layout as the default for non-default agents added via `agents add`; fixes TUI routing ambiguity introduced in #59789 (#78093) Thanks @jkf87
 
 ## 2026.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 - Parallels/Windows update smoke: escape the stale post-swap import regex in the generated PowerShell script so expected `ERR_MODULE_NOT_FOUND` update handoffs continue to post-update health checks. (#75315)
 - Slack: allow draft preview streaming in top-level DMs when `replyToMode` is `off` while keeping Slack native streaming and assistant thread status gated on reply threads. Fixes #56480. (#56544) Thanks @HangGlidersRule.
 - Control UI/chat: remove the delete-confirm popover outside-click listener on every dismiss path, so Cancel, Delete, outside clicks, and same-button toggles no longer leave stale document listeners behind. Refs #75590 and #69982. Thanks @Ricardo-M-L.
+- Agents/workspace: restore `workspace-<id>` sibling layout as the default for non-default agents added via `agents add`; fixes TUI routing ambiguity introduced in #59789 (#78093)
 
 ## 2026.5.2
 

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -162,16 +162,15 @@ export function resolveAgentWorkspaceDir(
     return stripNullBytes(resolveUserPath(configured, env));
   }
   const defaultAgentId = resolveDefaultAgentId(cfg);
-  const fallback = cfg.agents?.defaults?.workspace?.trim();
   if (id === defaultAgentId) {
+    const fallback = cfg.agents?.defaults?.workspace?.trim();
     if (fallback) {
       return stripNullBytes(resolveUserPath(fallback, env));
     }
     return stripNullBytes(resolveDefaultAgentWorkspaceDir(env));
   }
-  if (fallback) {
-    return stripNullBytes(path.join(resolveUserPath(fallback, env), id));
-  }
+  // Non-default agents always use the sibling workspace-<id> layout so that TUI
+  // routing cannot confuse them with the default agent's workspace subtree.
   const stateDir = resolveStateDir(env);
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));
 }

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -595,26 +595,26 @@ describe("resolveAgentConfig", () => {
     expect(agentDir).toBe(path.join(path.resolve(home), ".openclaw", "agents", "main", "agent"));
   });
 
-  it("non-default agent uses agents.defaults.workspace as base (#59789)", () => {
+  it("uses sibling workspace-<id> path for non-default agents regardless of agents.defaults.workspace", () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/state");
     const cfg: OpenClawConfig = {
       agents: {
-        defaults: { workspace: "/shared-ws" },
-        list: [{ id: "main" }, { id: "work", default: true, workspace: "/work-ws" }],
+        defaults: { workspace: "/state/workspace" },
+        list: [{ id: "main", default: true }, { id: "newbot" }],
       },
     };
-    const workspace = resolveAgentWorkspaceDir(cfg, "main");
-    expect(workspace).toBe(path.resolve("/shared-ws/main"));
+    expect(resolveAgentWorkspaceDir(cfg, "newbot")).toBe("/state/workspace-newbot");
   });
 
-  it("default agent without per-agent workspace uses agents.defaults.workspace directly", () => {
+  it("uses agents.defaults.workspace for the default agent", () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/state");
     const cfg: OpenClawConfig = {
       agents: {
-        defaults: { workspace: "/shared-ws" },
-        list: [{ id: "main" }, { id: "work", default: true }],
+        defaults: { workspace: "/custom/ws" },
+        list: [{ id: "main", default: true }],
       },
     };
-    const workspace = resolveAgentWorkspaceDir(cfg, "work");
-    expect(workspace).toBe(path.resolve("/shared-ws"));
+    expect(resolveAgentWorkspaceDir(cfg, "main")).toBe("/custom/ws");
   });
 
   it("non-default agent without defaults.workspace falls back to stateDir", () => {


### PR DESCRIPTION
## Summary

- **Problem:** PR #59789 changed `resolveAgentWorkspaceDir` so that non-default agents would use `agents.defaults.workspace` as a base, resulting in nested paths like `~/.openclaw/workspace/newbot/` instead of the expected sibling layout `~/.openclaw/workspace-newbot/`. This caused TUI routing ambiguity where both the default agent and non-default bots matched the same workspace prefix.
- **Why it matters:** Users who run `openclaw agents add` to create a new bot see workspace path changes and TUI routing breaks when `agents.defaults.workspace` is set.
- **What changed:** `resolveAgentWorkspaceDir` in `src/agents/agent-scope-config.ts` now only applies `agents.defaults.workspace` to the default agent. Non-default agents always fall back to `stateDir/workspace-<id>` (sibling layout), restoring pre-#59789 behavior.
- **What did NOT change:** Default agents still fully respect `agents.defaults.workspace`. Non-default agents with an explicit per-agent `workspace` config still use their configured path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #78093
- Related #59789

## User-visible / Behavior Changes

Non-default agents added via `agents add` now get `~/.openclaw/workspace-<id>/` (sibling) as the default workspace instead of `~/.openclaw/workspace/<id>/` (nested). Users with an explicit per-agent `workspace` config are unaffected. Default agents are unaffected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Tests updated in `src/agents/agent-scope.test.ts`:

1. `uses sibling workspace-<id> path for non-default agents regardless of agents.defaults.workspace` — verifies non-default agents get the `workspace-<id>` sibling path even when `agents.defaults.workspace` is set.
2. `uses agents.defaults.workspace for the default agent` — verifies default agents still use `agents.defaults.workspace` when set.
3. `non-default agent without defaults.workspace falls back to stateDir` — unchanged, verifies fallback behavior.

The pre-existing test `non-default agent uses agents.defaults.workspace as base (#59789)` is replaced by the corrected behavior tests above.

All 28 tests in `src/agents/agent-scope.test.ts` pass.

## Real behavior proof

- **Behavior or issue addressed:** Non-default agents created through `openclaw agents add` should default to the sibling `workspace-<id>` directory even when `agents.defaults.workspace` is configured for the default agent. This prevents the new agent from being nested under the default workspace and avoids TUI routing ambiguity.
- **Real environment tested:** Local macOS source checkout of `openclaw/openclaw` PR #78113 at commit `bca2506` (`fix/78093-workspace-sibling-layout-clean`), built with `pnpm build`, run with an isolated `OPENCLAW_STATE_DIR` and a real `openclaw.json` containing `agents.defaults.workspace`.
- **Exact steps or command run after this patch:** Created an isolated state dir with this config, then ran `HOME="$proof/home" OPENCLAW_STATE_DIR="$proof/state" node ./openclaw.mjs agents add newbot` from the built PR checkout and stopped at the interactive workspace prompt.
- **Evidence after fix:** Copied live terminal output from the real CLI run:

  ```text
  OpenClaw 2026.5.3 (bca2506)
  Add OpenClaw agent
  Workspace directory
  /var/folders/.../state/workspace-newbot
  ```

  Direct resolver output from the same checkout:

  ```text
  default=/tmp/oc-proof/state/workspace
  newbot=/tmp/oc-proof/state/workspace-newbot
  nested-exists=false
  ```
- **Observed result after fix:** The `agents add newbot` wizard proposed the sibling path `$OPENCLAW_STATE_DIR/workspace-newbot`; it did not propose `$OPENCLAW_STATE_DIR/workspace/newbot` or nest the new agent under `agents.defaults.workspace`.
- **What was not tested:** Full wizard completion was not tested because the workspace prompt already showed the changed default path; I aborted before writing extra isolated config changes.
