### PR TITLE
feat: add worker trigger loop CLI contract

### DIFF
--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -125,6 +125,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         loadModule: () => import("./register.status-health-sessions.js"),
         exportName: "registerStatusHealthSessionsCommands",
       },
+      {
+        commandNames: ["worker"],
+        loadModule: () => import("./register.worker.js"),
+        exportName: "registerWorkerCommands",
+      },
     ]),
   ),
 ];

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -38,6 +38,13 @@ vi.mock("./register.status-health-sessions.js", () => ({
   },
 }));
 
+vi.mock("./register.worker.js", () => ({
+  registerWorkerCommands: (program: Command) => {
+    const worker = program.command("worker");
+    worker.command("trigger").command("loop");
+  },
+}));
+
 vi.mock("./register.crestodian.js", () => ({
   registerCrestodianCommand: (program: Command) => {
     program.command("crestodian");
@@ -78,6 +85,7 @@ describe("command-registry", () => {
     expect(names).toContain("mcp");
     expect(names).toContain("agent");
     expect(names).toContain("agents");
+    expect(names).toContain("worker");
   });
 
   it("returns only commands that support subcommands", () => {
@@ -89,6 +97,7 @@ describe("command-registry", () => {
     expect(names).toContain("sessions");
     expect(names).toContain("commitments");
     expect(names).toContain("tasks");
+    expect(names).toContain("worker");
     expect(names).not.toContain("agent");
     expect(names).not.toContain("crestodian");
     expect(names).not.toContain("status");
@@ -168,13 +177,14 @@ describe("command-registry", () => {
   it("can eagerly register the status/session command group repeatedly for completion", async () => {
     const program = createProgram();
 
-    for (const name of ["status", "health", "sessions", "commitments", "tasks"]) {
+    for (const name of ["status", "health", "sessions", "commitments", "tasks", "worker"]) {
       await expect(registerCoreCliByName(program, testProgramContext, name)).resolves.toBe(true);
     }
 
     const names = namesOf(program);
     expect(names.filter((name) => name === "commitments")).toHaveLength(1);
     expect(names.filter((name) => name === "tasks")).toHaveLength(1);
+    expect(names.filter((name) => name === "worker")).toHaveLength(1);
   });
 
   it("replaces placeholders when loading a grouped entry by secondary command name", async () => {

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -105,6 +105,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     description: "Inspect durable background task state",
     hasSubcommands: true,
   },
+  {
+    name: "worker",
+    description: "Run bounded local worker control-plane commands",
+    hasSubcommands: true,
+  },
 ] as const satisfies ReadonlyArray<CoreCliCommandDescriptor>);
 
 export const CORE_CLI_COMMAND_DESCRIPTORS = coreCliCommandCatalog.descriptors;

--- a/src/cli/program/register.worker.ts
+++ b/src/cli/program/register.worker.ts
@@ -1,0 +1,19 @@
+import type { Command } from "commander";
+import { workerTriggerLoopCommand } from "../../commands/worker-trigger.js";
+
+export function registerWorkerCommands(program: Command) {
+  const worker = program
+    .command("worker")
+    .description("Run bounded local worker control-plane commands");
+
+  const trigger = worker
+    .command("trigger")
+    .description("Validate or run bounded worker trigger contracts");
+
+  trigger
+    .command("loop")
+    .description("Run the local worker trigger loop contract without external dispatch")
+    .action(async () => {
+      await workerTriggerLoopCommand();
+    });
+}

--- a/src/commands/worker-trigger.test.ts
+++ b/src/commands/worker-trigger.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildWorkerTriggerLoopResult, workerTriggerLoopCommand } from "./worker-trigger.js";
+
+describe("worker trigger CLI contract", () => {
+  it("returns a bounded local contract without external dispatch", () => {
+    expect(buildWorkerTriggerLoopResult()).toEqual({
+      ok: true,
+      command: "worker trigger loop",
+      mode: "local-contract",
+      executed: false,
+      message: "Worker trigger loop accepted by the local contract; no external dispatch executed.",
+    });
+  });
+
+  it("prints machine-readable trigger-loop proof", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    let output = "";
+    try {
+      await workerTriggerLoopCommand();
+      output = String(write.mock.calls[0]?.[0] ?? "");
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(JSON.parse(output)).toMatchObject({
+      ok: true,
+      command: "worker trigger loop",
+      mode: "local-contract",
+      executed: false,
+    });
+  });
+});

--- a/src/commands/worker-trigger.ts
+++ b/src/commands/worker-trigger.ts
@@ -1,0 +1,21 @@
+export type WorkerTriggerLoopResult = {
+  ok: true;
+  command: "worker trigger loop";
+  mode: "local-contract";
+  executed: false;
+  message: string;
+};
+
+export function buildWorkerTriggerLoopResult(): WorkerTriggerLoopResult {
+  return {
+    ok: true,
+    command: "worker trigger loop",
+    mode: "local-contract",
+    executed: false,
+    message: "Worker trigger loop accepted by the local contract; no external dispatch executed.",
+  };
+}
+
+export async function workerTriggerLoopCommand(): Promise<void> {
+  process.stdout.write(`${JSON.stringify(buildWorkerTriggerLoopResult())}\n`);
+}


### PR DESCRIPTION
## Summary

- Adds the bounded `openclaw worker trigger loop` CLI contract.
- Registers the worker command in the CLI command registry and descriptors.
- Adds command and registry tests for the local contract path.

## Real behavior proof

- Behavior or issue addressed:
  Hermes/OpenClaw integration needs a safe, bounded local worker trigger command that can be allowlisted and validated without starting an uncontrolled autonomous dispatch loop.

- Real environment tested:
  Local OpenClaw checkout on WSL, branch `feat/worker-trigger-loop-local-contract-20260506`, rebased onto current `upstream/main` at `430814ebc1`.

- Exact steps or command run after this patch:

    pnpm openclaw worker trigger loop
    pnpm test src/commands/worker-trigger.test.ts src/cli/program/command-registry.test.ts

- Evidence after fix:
  Terminal output from the real local OpenClaw CLI command:

    > openclaw@2026.5.5 openclaw /home/sudol/openclaw
    > node scripts/run-node.mjs worker trigger loop

    {"ok":true,"command":"worker trigger loop","mode":"local-contract","executed":false,"message":"Worker trigger loop accepted by the local contract; no external dispatch executed."}

  Supplemental verification:

    > openclaw@2026.5.5 test /home/sudol/openclaw
    > node scripts/test-projects.mjs src/commands/worker-trigger.test.ts src/cli/program/command-registry.test.ts

    ??cli  src/cli/program/command-registry.test.ts (11 tests) 30ms
    ??commands  src/commands/worker-trigger.test.ts (2 tests) 24ms
    Test Files  2 passed via 2 Vitest shards

  Hermes bridge validation also accepted the exact allowlisted argv in dry-run mode:

    {"success":true,"accepted":true,"allowed":true,"dry_run":true,"execute":false,"argv":["worker","trigger","loop"],"message":"OpenClaw worker trigger request validated; no subprocess executed."}

- Observed result after fix:
  The CLI accepts `worker trigger loop`, returns machine-readable JSON, reports `executed:false`, and does not dispatch any external worker loop. Targeted command registry and worker trigger tests pass.

- What was not tested:
  A real external worker dispatch was intentionally left out of scope; this PR adds only the local safety contract and verifies that it does not execute external dispatch.

## Verification

- `git rebase upstream/main`: PASS, branch is `0 behind / 1 ahead` against `upstream/main`.
- `pnpm openclaw worker trigger loop`: PASS.
- `pnpm test src/commands/worker-trigger.test.ts src/cli/program/command-registry.test.ts`: PASS.
- Fork branch push verified: `origin/feat/worker-trigger-loop-local-contract-20260506` at `45b2af4e8f`.

## Security Impact

- The command is intentionally non-executing and returns `executed:false`.
- No broad shell execution, remote dispatch, credential handling, or background loop is introduced.
- This creates a narrow contract suitable for external approval-token gating by callers such as Hermes.

## Compatibility / Migration

- Additive CLI command only.
- Existing commands and protocol schemas are unchanged.
- No migration required.

## Risks

- Follow-up work must keep any real worker execution behind explicit approval and narrow allowlists.
- This PR intentionally avoids implementing the full dispatch loop to prevent unsafe execution semantics.
