### PR TITLE
fix: keep new agent workspaces as siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents: keep `agents add` defaults for new non-default agents as sibling `workspace-<id>` directories even when `agents.defaults.workspace` points at the main agent workspace, avoiding nested workspace routing ambiguity. Fixes #78093.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.
 - Google Meet/Voice Call: make Twilio dial-in joins speak through the realtime Gemini voice bridge with paced audio streaming, backpressure-aware buffering, barge-in queue clearing, same-session agent consult routing, duplicate-consult coalescing, and no TwiML fallback during realtime speech, giving Meet participants a much snappier OpenClaw voice agent. (#77064) Thanks @scoootscooob.
 - Voice Call/realtime: add opt-in OpenClaw agent voice context capsules and consult-cadence guidance so Gemini/OpenAI realtime calls can sound like the configured agent without consulting the full agent on every ordinary turn. Thanks @scoootscooob.

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -169,9 +169,6 @@ export function resolveAgentWorkspaceDir(
     }
     return stripNullBytes(resolveDefaultAgentWorkspaceDir(env));
   }
-  if (fallback) {
-    return stripNullBytes(path.join(resolveUserPath(fallback, env), id));
-  }
   const stateDir = resolveStateDir(env);
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));
 }

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -610,7 +610,9 @@ describe("resolveAgentConfig", () => {
     expect(agentDir).toBe(path.join(stateDir, "agents", "ops", "agent"));
   });
 
-  it("non-default agent uses agents.defaults.workspace as base (#59789)", () => {
+  it("non-default agent does not nest under agents.defaults.workspace", () => {
+    const stateDir = path.join(path.sep, "tmp", "test-state");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { workspace: "/shared-ws" },
@@ -618,7 +620,7 @@ describe("resolveAgentConfig", () => {
       },
     };
     const workspace = resolveAgentWorkspaceDir(cfg, "main");
-    expect(workspace).toBe(path.resolve("/shared-ws/main"));
+    expect(workspace).toBe(path.join(stateDir, "workspace-main"));
   });
 
   it("default agent without per-agent workspace uses agents.defaults.workspace directly", () => {

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -81,6 +81,47 @@ describe("agents add command", () => {
     expect(writeConfigFileMock).not.toHaveBeenCalled();
   });
 
+  it("suggests a sibling workspace for a non-default agent when defaults.workspace is configured", async () => {
+    const stateDir = path.join(os.tmpdir(), "openclaw-agents-add-state");
+    const textMock = vi.fn().mockRejectedValue(new WizardCancelledError());
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        ...baseConfigSnapshot.config,
+        agents: {
+          defaults: { workspace: "/tmp/openclaw-main-workspace" },
+          list: [{ id: "main", default: true }],
+        },
+      },
+      sourceConfig: {
+        ...baseConfigSnapshot.config,
+        agents: {
+          defaults: { workspace: "/tmp/openclaw-main-workspace" },
+          list: [{ id: "main", default: true }],
+        },
+      },
+    });
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn().mockResolvedValue(undefined),
+      text: textMock,
+      confirm: vi.fn(),
+      note: vi.fn(),
+      outro: vi.fn(),
+    });
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    await agentsAddCommand({ name: "New Bot" }, runtime);
+
+    expect(textMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Workspace directory",
+        initialValue: path.join(stateDir, "workspace-new-bot"),
+      }),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
   it("copies only portable auth profiles when seeding a new agent store", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agents-add-auth-copy-"));
     try {


### PR DESCRIPTION
## Summary

Keep new non-default agent workspaces as sibling `workspace-<id>` directories instead of nesting them under `agents.defaults.workspace`. The configured default agent still uses `agents.defaults.workspace` directly.

## Changes

- Remove the non-default `agents.defaults.workspace/<id>` fallback in `resolveAgentWorkspaceDir`
- Update resolver regression coverage for the sibling fallback
- Add `agents add` wizard coverage for the suggested default workspace
- Add changelog entry

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test src/agents/agent-scope.test.ts src/commands/agents.add.test.ts src/tui/tui.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check --threads=1 src/agents/agent-scope-config.ts src/agents/agent-scope.test.ts src/commands/agents.commands.add.ts src/commands/agents.add.test.ts src/tui/tui.test.ts CHANGELOG.md`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`

Fixes openclaw/openclaw#78093