### PR TITLE
fix(memory-wiki): skip empty source pages in refreshPageRelatedBlocks (#78121)

### DIFF
--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -482,4 +482,30 @@ describe("compileMemoryWikiVault", () => {
       fs.readFile(path.join(rootDir, "concepts", "gamma.md"), "utf8"),
     ).resolves.not.toContain("### Referenced By");
   });
+
+  it("does not overwrite empty source pages with a 107-byte managed-block stub (#78121)", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+
+    // Create a valid non-empty page and an empty page alongside it
+    await fs.writeFile(
+      path.join(rootDir, "sources", "valid.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.valid", title: "Valid" },
+        body: "# Valid\n",
+      }),
+      "utf8",
+    );
+    const emptyPagePath = path.join(rootDir, "sources", "empty.md");
+    await fs.writeFile(emptyPagePath, "", "utf8");
+
+    await compileMemoryWikiVault(config);
+
+    // Empty page must remain empty — not overwritten with the managed-block stub
+    const afterCompile = await fs.readFile(emptyPagePath, "utf8");
+    expect(afterCompile).toBe("");
+    expect(afterCompile).not.toContain("openclaw:wiki:related");
+  });
 });

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -774,6 +774,9 @@ async function refreshPageRelatedBlocks(params: {
       continue;
     }
     const original = await fs.readFile(page.absolutePath, "utf8");
+    if (original.trim().length === 0) {
+      continue;
+    }
     const updated = withTrailingNewline(
       replaceManagedMarkdownBlock({
         original,


### PR DESCRIPTION
## Problem

Closes #78121.

`refreshPageRelatedBlocks` reads each non-report wiki page from disk and pipes it through `replaceManagedMarkdownBlock` to update the `## Related` section. When a page is empty (zero bytes or whitespace-only), `replaceManagedMarkdownBlock`'s empty-input short-circuit at line 52 returns only the managed block (~107 bytes), **overwriting the empty file with a stub** containing no frontmatter, no title, and no content. `shouldSkipImportedSourceWrite` then preserves the stub indefinitely because the destination fingerprint stabilizes, leaving the page invisible to wiki_search, RAG, and Obsidian backlinks.

The affected code path (`compileMemoryWikiVault` → `refreshPageRelatedBlocks`) runs on every `wiki.search`, `wiki.compile`, and `openclaw wiki compile` invocation, so the stub persists until the user manually deletes the destination file.

## Fix

Add an early-`continue` guard in `refreshPageRelatedBlocks`: if the page content is empty after `trim()`, skip it without calling `replaceManagedMarkdownBlock`. Empty pages are left intact — no stub is written.

```ts
// Before
const original = await fs.readFile(page.absolutePath, "utf8");
const updated = withTrailingNewline(replaceManagedMarkdownBlock({ ... }));

// After
const original = await fs.readFile(page.absolutePath, "utf8");
if (original.trim().length === 0) {
  continue;
}
const updated = withTrailingNewline(replaceManagedMarkdownBlock({ ... }));
```

## Files changed

| File | Change |
|------|--------|
| `extensions/memory-wiki/src/compile.ts` | Add empty-content guard before `replaceManagedMarkdownBlock` in `refreshPageRelatedBlocks` |
| `extensions/memory-wiki/src/compile.test.ts` | Regression test: compile with an empty source page alongside a valid one; verify empty page remains `""` after compile |

## Tests

```
Tests  9 passed (9)   # 8 pre-existing + 1 new regression test
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)