### PR TITLE
fix: preserve final replies without block streaming

### DIFF
--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-final-answer-with-preview.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-final-answer-with-preview.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createStubSessionHarness,
+  emitAssistantTextDelta,
+  emitAssistantTextEnd,
+} from "./pi-embedded-subscribe.e2e-harness.js";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+describe("subscribeEmbeddedPiSession", () => {
+  it("keeps the final assistant text when preview callbacks are enabled but block replies are disabled", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onPartialReply = vi.fn();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onPartialReply,
+      blockReplyChunking: { minChars: 50, maxChars: 200 },
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Draft " });
+    emitAssistantTextDelta({ emit, delta: "preview" });
+
+    expect(onPartialReply).toHaveBeenCalled();
+
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Final delivered answer" }],
+      },
+    });
+    emitAssistantTextEnd({ emit, content: "Draft preview" });
+
+    expect(subscription.assistantTexts).toEqual(["Final delivered answer"]);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -326,8 +326,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     const { text, addedDuringMessage, chunkerHasBuffered } = args;
 
     // If we're not streaming block replies, ensure the final payload includes
-    // the final text even when interim streaming was enabled.
-    if (state.includeReasoning && text && !params.onBlockReply) {
+    // the final text even when interim streaming/preview callbacks were enabled.
+    // Channel previews (for example Feishu cards) are not a delivery guarantee:
+    // the dispatch result still needs assistantTexts populated so the final
+    // reply can be sent by channels that did not actually open a streaming lane.
+    if (text && !params.onBlockReply) {
       if (assistantTexts.length > state.assistantTextBaseline) {
         assistantTexts.splice(
           state.assistantTextBaseline,


### PR DESCRIPTION
Fixes #78123.

## Summary
- always preserve the final assistant text when block replies are disabled, even if preview/partial callbacks were active
- keeps Feishu-style preview/card streaming from being treated as final delivery when no streaming lane/card was actually opened
- adds a regression test covering preview callbacks with block replies disabled

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-final-answer-with-preview.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-assistanttexts-final-answer-block-replies-are.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`
