### PR TITLE
Update NVIDIA hosted model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Providers/NVIDIA: update the bundled build.nvidia.com catalog and docs to use `moonshotai/kimi-k2.6` and `z-ai/glm-5.1` instead of the deprecated NVIDIA-hosted Kimi K2.5 and GLM 5 endpoints.
+- Providers/NVIDIA: update the bundled build.nvidia.com catalog and docs to use `moonshotai/kimi-k2.6`, `minimaxai/minimax-m2.7`, and `z-ai/glm-5.1` instead of the deprecated NVIDIA-hosted Kimi K2.5, MiniMax M2.5, and GLM 5 endpoints.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.
 - Sessions CLI: show the selected agent runtime in the `openclaw sessions` table so terminal output matches the runtime visibility already present in JSON/status surfaces. Thanks @vincentkoc.
 - Google Meet/Voice Call: make Twilio dial-in joins speak through the realtime Gemini voice bridge with paced audio streaming, backpressure-aware buffering, barge-in queue clearing, same-session agent consult routing, duplicate-consult coalescing, and no TwiML fallback during realtime speech, giving Meet participants a much snappier OpenClaw voice agent. (#77064) Thanks @scoootscooob.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Providers/NVIDIA: update the bundled build.nvidia.com catalog and docs to use `moonshotai/kimi-k2.6` and `z-ai/glm-5.1` instead of the deprecated NVIDIA-hosted Kimi K2.5 and GLM 5 endpoints.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.
 - Sessions CLI: show the selected agent runtime in the `openclaw sessions` table so terminal output matches the runtime visibility already present in JSON/status surfaces. Thanks @vincentkoc.
 - Google Meet/Voice Call: make Twilio dial-in joins speak through the realtime Gemini voice bridge with paced audio streaming, backpressure-aware buffering, barge-in queue clearing, same-session agent consult routing, duplicate-consult coalescing, and no TwiML fallback during realtime speech, giving Meet participants a much snappier OpenClaw voice agent. (#77064) Thanks @scoootscooob.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -331,7 +331,7 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
     API-key onboarding writes explicit text-only M2.7 chat model definitions; image understanding stays on the plugin-owned `MiniMax-VL-01` media provider.
   </Accordion>
   <Accordion title="NVIDIA">
-    Model ids use a `nvidia/<vendor>/<model>` namespace (for example `nvidia/nvidia/nemotron-...` alongside `nvidia/moonshotai/kimi-k2.5`); pickers preserve the literal `<provider>/<model-id>` composition while the canonical key sent to the API stays single-prefixed.
+    Model ids use a `nvidia/<vendor>/<model>` namespace (for example `nvidia/nvidia/nemotron-...` alongside `nvidia/moonshotai/kimi-k2.6`); pickers preserve the literal `<provider>/<model-id>` composition while the canonical key sent to the API stays single-prefixed.
   </Accordion>
   <Accordion title="xAI">
     Uses the xAI Responses path. `grok-4.3` is the bundled default chat model. `/fast` or `params.fastMode: true` rewrites `grok-3`, `grok-3-mini`, `grok-4`, and `grok-4-0709` to their `*-fast` variants. `tool_stream` defaults on; disable via `agents.defaults.models["xai/<model>"].params.tool_stream=false`.

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -68,7 +68,7 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
 | ------------------------------------------ | ---------------------------- | ------- | ---------- |
 | `nvidia/nvidia/nemotron-3-super-120b-a12b` | NVIDIA Nemotron 3 Super 120B | 262,144 | 8,192      |
 | `nvidia/moonshotai/kimi-k2.6`              | Kimi K2.6                    | 262,144 | 8,192      |
-| `nvidia/minimaxai/minimax-m2.5`            | Minimax M2.5                 | 196,608 | 8,192      |
+| `nvidia/minimaxai/minimax-m2.7`            | MiniMax M2.7                 | 196,608 | 8,192      |
 | `nvidia/z-ai/glm-5.1`                      | GLM 5.1                      | 202,752 | 8,192      |
 
 ## Advanced configuration

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -67,9 +67,9 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
 | Model ref                                  | Name                         | Context | Max output |
 | ------------------------------------------ | ---------------------------- | ------- | ---------- |
 | `nvidia/nvidia/nemotron-3-super-120b-a12b` | NVIDIA Nemotron 3 Super 120B | 262,144 | 8,192      |
-| `nvidia/moonshotai/kimi-k2.5`              | Kimi K2.5                    | 262,144 | 8,192      |
+| `nvidia/moonshotai/kimi-k2.6`              | Kimi K2.6                    | 262,144 | 8,192      |
 | `nvidia/minimaxai/minimax-m2.5`            | Minimax M2.5                 | 196,608 | 8,192      |
-| `nvidia/z-ai/glm5`                         | GLM 5                        | 202,752 | 8,192      |
+| `nvidia/z-ai/glm-5.1`                      | GLM 5.1                      | 202,752 | 8,192      |
 
 ## Advanced configuration
 

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -126,7 +126,7 @@ describe("nvidia provider hooks", () => {
     expect(entries?.map((entry) => entry.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.6",
-      "minimaxai/minimax-m2.5",
+      "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -125,9 +125,9 @@ describe("nvidia provider hooks", () => {
 
     expect(entries?.map((entry) => entry.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
+      "moonshotai/kimi-k2.6",
       "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "z-ai/glm-5.1",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
   });

--- a/extensions/nvidia/onboard.test.ts
+++ b/extensions/nvidia/onboard.test.ts
@@ -15,7 +15,7 @@ describe("nvidia onboard", () => {
     expect(cfg.models?.providers?.nvidia?.models.map((model) => model.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.6",
-      "minimaxai/minimax-m2.5",
+      "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
     ]);
     // Config stores the canonical form; the picker label shows the literal
@@ -40,7 +40,7 @@ describe("nvidia onboard", () => {
       "custom-model",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.6",
-      "minimaxai/minimax-m2.5",
+      "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
     ]);
   });

--- a/extensions/nvidia/onboard.test.ts
+++ b/extensions/nvidia/onboard.test.ts
@@ -14,9 +14,9 @@ describe("nvidia onboard", () => {
     });
     expect(cfg.models?.providers?.nvidia?.models.map((model) => model.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
+      "moonshotai/kimi-k2.6",
       "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "z-ai/glm-5.1",
     ]);
     // Config stores the canonical form; the picker label shows the literal
     // form via preserveLiteralProviderPrefix.
@@ -39,9 +39,9 @@ describe("nvidia onboard", () => {
     expect(provider?.models.map((model) => model.id)).toEqual([
       "custom-model",
       "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
+      "moonshotai/kimi-k2.6",
       "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "z-ai/glm-5.1",
     ]);
   });
 });

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -35,8 +35,8 @@
             }
           },
           {
-            "id": "moonshotai/kimi-k2.5",
-            "name": "Kimi K2.5",
+            "id": "moonshotai/kimi-k2.6",
+            "name": "Kimi K2.6",
             "input": ["text"],
             "contextWindow": 262144,
             "maxTokens": 8192,
@@ -67,8 +67,8 @@
             }
           },
           {
-            "id": "z-ai/glm5",
-            "name": "GLM-5",
+            "id": "z-ai/glm-5.1",
+            "name": "GLM 5.1",
             "input": ["text"],
             "contextWindow": 202752,
             "maxTokens": 8192,

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -51,8 +51,8 @@
             }
           },
           {
-            "id": "minimaxai/minimax-m2.5",
-            "name": "MiniMax M2.5",
+            "id": "minimaxai/minimax-m2.7",
+            "name": "MiniMax M2.7",
             "input": ["text"],
             "contextWindow": 196608,
             "maxTokens": 8192,

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -11,7 +11,7 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.map((model) => model.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.6",
-      "minimaxai/minimax-m2.5",
+      "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
     ]);
     expect(provider.models.every((model) => model.compat?.requiresStringContent === true)).toBe(

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -10,9 +10,9 @@ describe("nvidia provider catalog", () => {
     expect(provider.apiKey).toBe("NVIDIA_API_KEY");
     expect(provider.models.map((model) => model.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
+      "moonshotai/kimi-k2.6",
       "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "z-ai/glm-5.1",
     ]);
     expect(provider.models.every((model) => model.compat?.requiresStringContent === true)).toBe(
       true,

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -214,9 +214,9 @@ describe("model-selection", () => {
       },
       {
         name: "preserves nested model ids after the provider prefix",
-        variants: ["nvidia/moonshotai/kimi-k2.5"],
+        variants: ["nvidia/moonshotai/kimi-k2.6"],
         defaultProvider: "anthropic",
-        expected: { provider: "nvidia", model: "moonshotai/kimi-k2.5" },
+        expected: { provider: "nvidia", model: "moonshotai/kimi-k2.6" },
       },
       {
         name: "preserves nested MLX model ids after the provider prefix",
@@ -779,9 +779,9 @@ describe("model-selection", () => {
       const cfg: OpenClawConfig = {
         agents: {
           defaults: {
-            model: { primary: "nvidia/moonshotai/kimi-k2.5" },
+            model: { primary: "nvidia/moonshotai/kimi-k2.6" },
             models: {
-              "nvidia/moonshotai/kimi-k2.5": { alias: "Kimi K2.5 (NVIDIA)" },
+              "nvidia/moonshotai/kimi-k2.6": { alias: "Kimi K2.6 (NVIDIA)" },
             },
           },
         },
@@ -791,8 +791,8 @@ describe("model-selection", () => {
               baseUrl: "https://nvidia.example.com",
               models: [
                 {
-                  id: "moonshotai/kimi-k2.5",
-                  name: "Kimi K2.5 (Configured)",
+                  id: "moonshotai/kimi-k2.6",
+                  name: "Kimi K2.6 (Configured)",
                   contextWindow: 32_000,
                   reasoning: true,
                   compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
@@ -813,9 +813,9 @@ describe("model-selection", () => {
       expect(result.allowedCatalog).toEqual([
         {
           provider: "nvidia",
-          id: "moonshotai/kimi-k2.5",
-          name: "Kimi K2.5 (Configured)",
-          alias: "Kimi K2.5 (NVIDIA)",
+          id: "moonshotai/kimi-k2.6",
+          name: "Kimi K2.6 (Configured)",
+          alias: "Kimi K2.6 (NVIDIA)",
           contextWindow: 32_000,
           reasoning: true,
           compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
@@ -1129,7 +1129,7 @@ describe("model-selection", () => {
     it("strips profile suffix before alias resolution", () => {
       const index = {
         byAlias: new Map([
-          ["kimi", { alias: "kimi", ref: { provider: "nvidia", model: "moonshotai/kimi-k2.5" } }],
+          ["kimi", { alias: "kimi", ref: { provider: "nvidia", model: "moonshotai/kimi-k2.6" } }],
         ]),
         byKey: new Map(),
       };
@@ -1141,7 +1141,7 @@ describe("model-selection", () => {
       });
       expect(resolved?.ref).toEqual({
         provider: "nvidia",
-        model: "moonshotai/kimi-k2.5",
+        model: "moonshotai/kimi-k2.6",
       });
       expect(resolved?.alias).toBe("kimi");
     });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -793,12 +793,12 @@ describe("applyExtraParamsToAgent", () => {
   it("injects parallel_tool_calls for openai-completions payloads when configured", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "nvidia-nim",
-      applyModelId: "moonshotai/kimi-k2.5",
+      applyModelId: "moonshotai/kimi-k2.6",
       cfg: {
         agents: {
           defaults: {
             models: {
-              "nvidia-nim/moonshotai/kimi-k2.5": {
+              "nvidia-nim/moonshotai/kimi-k2.6": {
                 params: {
                   parallel_tool_calls: false,
                 },
@@ -810,7 +810,7 @@ describe("applyExtraParamsToAgent", () => {
       model: {
         api: "openai-completions",
         provider: "nvidia-nim",
-        id: "moonshotai/kimi-k2.5",
+        id: "moonshotai/kimi-k2.6",
       } as unknown as Model<"openai-completions">,
     });
 
@@ -1240,12 +1240,12 @@ describe("applyExtraParamsToAgent", () => {
   it("lets runtime override win across alias styles for parallel_tool_calls", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "nvidia-nim",
-      applyModelId: "moonshotai/kimi-k2.5",
+      applyModelId: "moonshotai/kimi-k2.6",
       cfg: {
         agents: {
           defaults: {
             models: {
-              "nvidia-nim/moonshotai/kimi-k2.5": {
+              "nvidia-nim/moonshotai/kimi-k2.6": {
                 params: {
                   parallel_tool_calls: true,
                 },
@@ -1260,7 +1260,7 @@ describe("applyExtraParamsToAgent", () => {
       model: {
         api: "openai-completions",
         provider: "nvidia-nim",
-        id: "moonshotai/kimi-k2.5",
+        id: "moonshotai/kimi-k2.6",
       } as Model<"openai-completions">,
     });
 
@@ -1270,12 +1270,12 @@ describe("applyExtraParamsToAgent", () => {
   it("lets null runtime override suppress inherited parallel_tool_calls injection", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "nvidia-nim",
-      applyModelId: "moonshotai/kimi-k2.5",
+      applyModelId: "moonshotai/kimi-k2.6",
       cfg: {
         agents: {
           defaults: {
             models: {
-              "nvidia-nim/moonshotai/kimi-k2.5": {
+              "nvidia-nim/moonshotai/kimi-k2.6": {
                 params: {
                   parallel_tool_calls: true,
                 },
@@ -1290,7 +1290,7 @@ describe("applyExtraParamsToAgent", () => {
       model: {
         api: "openai-completions",
         provider: "nvidia-nim",
-        id: "moonshotai/kimi-k2.5",
+        id: "moonshotai/kimi-k2.6",
       } as Model<"openai-completions">,
     });
 
@@ -1302,12 +1302,12 @@ describe("applyExtraParamsToAgent", () => {
     try {
       const payload = runParallelToolCallsPayloadMutationCase({
         applyProvider: "nvidia-nim",
-        applyModelId: "moonshotai/kimi-k2.5",
+        applyModelId: "moonshotai/kimi-k2.6",
         cfg: {
           agents: {
             defaults: {
               models: {
-                "nvidia-nim/moonshotai/kimi-k2.5": {
+                "nvidia-nim/moonshotai/kimi-k2.6": {
                   params: {
                     parallelToolCalls: "false",
                   },
@@ -1319,7 +1319,7 @@ describe("applyExtraParamsToAgent", () => {
         model: {
           api: "openai-completions",
           provider: "nvidia-nim",
-          id: "moonshotai/kimi-k2.5",
+          id: "moonshotai/kimi-k2.6",
         } as Model<"openai-completions">,
       });
 

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -677,9 +677,9 @@ describe("gateway server models + voicewake", () => {
       {
         agents: {
           defaults: {
-            model: { primary: "nvidia/moonshotai/kimi-k2.5" },
+            model: { primary: "nvidia/moonshotai/kimi-k2.6" },
             models: {
-              "nvidia/moonshotai/kimi-k2.5": { alias: "Kimi K2.5 (NVIDIA)" },
+              "nvidia/moonshotai/kimi-k2.6": { alias: "Kimi K2.6 (NVIDIA)" },
             },
           },
         },
@@ -689,8 +689,8 @@ describe("gateway server models + voicewake", () => {
               baseUrl: "https://nvidia.example.com",
               models: [
                 {
-                  id: "moonshotai/kimi-k2.5",
-                  name: "Kimi K2.5 (Configured)",
+                  id: "moonshotai/kimi-k2.6",
+                  name: "Kimi K2.6 (Configured)",
                   contextWindow: 32_000,
                 },
               ],
@@ -704,9 +704,9 @@ describe("gateway server models + voicewake", () => {
         expect(res.ok).toBe(true);
         expect(res.payload?.models).toEqual([
           expect.objectContaining({
-            id: "moonshotai/kimi-k2.5",
-            name: "Kimi K2.5 (Configured)",
-            alias: "Kimi K2.5 (NVIDIA)",
+            id: "moonshotai/kimi-k2.6",
+            name: "Kimi K2.6 (Configured)",
+            alias: "Kimi K2.6 (NVIDIA)",
             provider: "nvidia",
             contextWindow: 32_000,
           }),

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -299,7 +299,7 @@ test("sessions.patch preserves nested model ids under provider overrides", async
       try {
         piSdkMock.enabled = true;
         piSdkMock.models = [
-          { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5 (NVIDIA)", provider: "nvidia" },
+          { id: "moonshotai/kimi-k2.6", name: "Kimi K2.6 (NVIDIA)", provider: "nvidia" },
         ];
 
         const patched = await rpcReq<{
@@ -313,15 +313,15 @@ test("sessions.patch preserves nested model ids under provider overrides", async
           resolved?: { model?: string; modelProvider?: string };
         }>(ws, "sessions.patch", {
           key: "agent:main:main",
-          model: "nvidia/moonshotai/kimi-k2.5",
+          model: "nvidia/moonshotai/kimi-k2.6",
         });
         expect(patched.ok).toBe(true);
-        expect(patched.payload?.entry.modelOverride).toBe("moonshotai/kimi-k2.5");
+        expect(patched.payload?.entry.modelOverride).toBe("moonshotai/kimi-k2.6");
         expect(patched.payload?.entry.providerOverride).toBe("nvidia");
         expect(patched.payload?.entry.model).toBeUndefined();
         expect(patched.payload?.entry.modelProvider).toBeUndefined();
         expect(patched.payload?.resolved?.modelProvider).toBe("nvidia");
-        expect(patched.payload?.resolved?.model).toBe("moonshotai/kimi-k2.5");
+        expect(patched.payload?.resolved?.model).toBe("moonshotai/kimi-k2.6");
 
         const listed = await rpcReq<{
           sessions: Array<{ key: string; modelProvider?: string; model?: string }>;
@@ -331,7 +331,7 @@ test("sessions.patch preserves nested model ids under provider overrides", async
           (session) => session.key === "agent:main:main",
         );
         expect(mainSession?.modelProvider).toBe("nvidia");
-        expect(mainSession?.model).toBe("moonshotai/kimi-k2.5");
+        expect(mainSession?.model).toBe("moonshotai/kimi-k2.6");
       } finally {
         ws.close();
         await server.close();

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1161,10 +1161,10 @@ describe("resolveSessionModelRef", () => {
       sessionId: "s-nested",
       updatedAt: Date.now(),
       providerOverride: "nvidia",
-      modelOverride: "moonshotai/kimi-k2.5",
+      modelOverride: "moonshotai/kimi-k2.6",
     });
 
-    expect(resolved).toEqual({ provider: "nvidia", model: "moonshotai/kimi-k2.5" });
+    expect(resolved).toEqual({ provider: "nvidia", model: "moonshotai/kimi-k2.6" });
   });
 
   test("preserves explicit wrapper providers for vendor-prefixed override models", () => {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1233,7 +1233,7 @@ export type ProviderPlugin = {
    *
    * Set when the leading `<provider>/` segment in the native model id is
    * a meaningful vendor namespace (e.g. NVIDIA's `nvidia/nemotron-...`
-   * alongside `moonshotai/kimi-k2.5`).
+   * alongside `moonshotai/kimi-k2.6`).
    */
   preserveLiteralProviderPrefix?: boolean;
   /**

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -55,33 +55,33 @@ describe("chat-model-ref helpers", () => {
 
   it("prefers alias over name for picker labels", () => {
     const aliasedModel = {
-      id: "moonshotai/kimi-k2.5",
-      alias: "Kimi K2.5 (NVIDIA)",
-      name: "Kimi K2.5",
+      id: "moonshotai/kimi-k2.6",
+      alias: "Kimi K2.6 (NVIDIA)",
+      name: "Kimi K2.6",
       provider: "nvidia",
     };
 
     expect(buildChatModelOption(aliasedModel, [aliasedModel])).toEqual({
-      value: "nvidia/moonshotai/kimi-k2.5",
-      label: "Kimi K2.5 (NVIDIA)",
+      value: "nvidia/moonshotai/kimi-k2.6",
+      label: "Kimi K2.6 (NVIDIA)",
     });
-    expect(formatCatalogChatModelDisplay("nvidia/moonshotai/kimi-k2.5", [aliasedModel])).toBe(
-      "Kimi K2.5 (NVIDIA)",
+    expect(formatCatalogChatModelDisplay("nvidia/moonshotai/kimi-k2.6", [aliasedModel])).toBe(
+      "Kimi K2.6 (NVIDIA)",
     );
   });
 
   it("uses friendly catalog names for qualified nested model ids", () => {
     const nestedModel = {
-      id: "moonshotai/kimi-k2.5",
-      name: "Kimi K2.5 (NVIDIA)",
+      id: "moonshotai/kimi-k2.6",
+      name: "Kimi K2.6 (NVIDIA)",
       provider: "nvidia",
     };
     expect(buildChatModelOption(nestedModel, [nestedModel])).toEqual({
-      value: "nvidia/moonshotai/kimi-k2.5",
-      label: "Kimi K2.5 (NVIDIA)",
+      value: "nvidia/moonshotai/kimi-k2.6",
+      label: "Kimi K2.6 (NVIDIA)",
     });
-    expect(formatCatalogChatModelDisplay("nvidia/moonshotai/kimi-k2.5", [nestedModel])).toBe(
-      "Kimi K2.5 (NVIDIA)",
+    expect(formatCatalogChatModelDisplay("nvidia/moonshotai/kimi-k2.6", [nestedModel])).toBe(
+      "Kimi K2.6 (NVIDIA)",
     );
   });
 
@@ -188,31 +188,31 @@ describe("chat-model-ref helpers", () => {
 
   it("qualifies slash-containing server model ids with the recorded provider", () => {
     expect(
-      resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "nvidia", [
+      resolvePreferredServerChatModelValue("moonshotai/kimi-k2.6", "nvidia", [
         {
-          id: "moonshotai/kimi-k2.5",
-          name: "Kimi K2.5 (NVIDIA)",
+          id: "moonshotai/kimi-k2.6",
+          name: "Kimi K2.6 (NVIDIA)",
           provider: "nvidia",
         },
       ]),
-    ).toBe("nvidia/moonshotai/kimi-k2.5");
+    ).toBe("nvidia/moonshotai/kimi-k2.6");
   });
 
   it("uses the catalog-backed provider for slash-containing nested ids before stale provider fallback", () => {
     expect(
-      resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "zai", [
+      resolvePreferredServerChatModelValue("moonshotai/kimi-k2.6", "zai", [
         {
-          id: "moonshotai/kimi-k2.5",
-          name: "Kimi K2.5 (NVIDIA)",
+          id: "moonshotai/kimi-k2.6",
+          name: "Kimi K2.6 (NVIDIA)",
           provider: "nvidia",
         },
       ]),
-    ).toBe("nvidia/moonshotai/kimi-k2.5");
+    ).toBe("nvidia/moonshotai/kimi-k2.6");
   });
 
   it("falls back to the server-qualified value for slash-containing ids when the catalog is empty", () => {
-    expect(resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "nvidia", [])).toBe(
-      "moonshotai/kimi-k2.5",
+    expect(resolvePreferredServerChatModelValue("moonshotai/kimi-k2.6", "nvidia", [])).toBe(
+      "moonshotai/kimi-k2.6",
     );
   });
 

--- a/ui/src/ui/chat-model-select-state.test.ts
+++ b/ui/src/ui/chat-model-select-state.test.ts
@@ -118,25 +118,25 @@ describe("chat-model-select-state", () => {
   it("uses catalog names for the default label and matching picker options", () => {
     const state = createChatModelState({
       chatModelCatalog: createModelCatalog({
-        id: "moonshotai/kimi-k2.5",
-        alias: "Kimi K2.5 (NVIDIA)",
-        name: "Kimi K2.5 (NVIDIA)",
+        id: "moonshotai/kimi-k2.6",
+        alias: "Kimi K2.6 (NVIDIA)",
+        name: "Kimi K2.6 (NVIDIA)",
         provider: "nvidia",
       }),
       sessionsResult: createSessionsListResult({
-        model: "moonshotai/kimi-k2.5",
+        model: "moonshotai/kimi-k2.6",
         modelProvider: "nvidia",
-        defaultsModel: "moonshotai/kimi-k2.5",
+        defaultsModel: "moonshotai/kimi-k2.6",
         defaultsProvider: "nvidia",
       }),
     });
 
     const resolved = resolveChatModelSelectState(state);
-    expect(resolved.currentOverride).toBe("nvidia/moonshotai/kimi-k2.5");
-    expect(resolved.defaultLabel).toBe("Default (Kimi K2.5 (NVIDIA))");
+    expect(resolved.currentOverride).toBe("nvidia/moonshotai/kimi-k2.6");
+    expect(resolved.defaultLabel).toBe("Default (Kimi K2.6 (NVIDIA))");
     expect(resolved.options).toContainEqual({
-      value: "nvidia/moonshotai/kimi-k2.5",
-      label: "Kimi K2.5 (NVIDIA)",
+      value: "nvidia/moonshotai/kimi-k2.6",
+      label: "Kimi K2.6 (NVIDIA)",
     });
   });
 

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -418,7 +418,7 @@ describe("executeSlashCommand directives", () => {
   it("keeps provider-qualified nested ids when the patched catalog lookup fails", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.patch") {
-        return createResolvedModelPatch("moonshotai/kimi-k2.5", "nvidia");
+        return createResolvedModelPatch("moonshotai/kimi-k2.6", "nvidia");
       }
       if (method === "models.list") {
         throw new Error("models unavailable");
@@ -430,12 +430,12 @@ describe("executeSlashCommand directives", () => {
       { request } as unknown as GatewayBrowserClient,
       "main",
       "model",
-      "nvidia/moonshotai/kimi-k2.5",
+      "nvidia/moonshotai/kimi-k2.6",
     );
 
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "qualified",
-      value: "nvidia/moonshotai/kimi-k2.5",
+      value: "nvidia/moonshotai/kimi-k2.6",
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: NVIDIA's build.nvidia.com catalog still pointed at deprecated NVIDIA-hosted Kimi K2.5 and GLM 5 model ids.
- Why it matters: users selecting those NVIDIA catalog rows can no longer use the deprecated endpoints on `integrate.api.nvidia.com`.
- What changed: updates NVIDIA's bundled static catalog, NVIDIA provider docs, changelog, and NVIDIA nested-ref tests to use `moonshotai/kimi-k2.6`, `minimaxai/minimax-m2.7`, and `z-ai/glm-5.1`.
- What did NOT change (scope boundary): other providers' Kimi or GLM catalogs, including Moonshot, OpenRouter, DeepInfra, Together, Volcengine, BytePlus, and Z.AI, are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: NVIDIA static catalog no longer advertises deprecated `moonshotai/kimi-k2.5`, `minimaxai/minimax-m2.5`, or `z-ai/glm5` rows.
- Real environment tested: local macOS checkout.
- Exact steps or command run after this patch: `rg -n "(nvidia|NVIDIA|build\\.nvidia|integrate\\.api\\.nvidia|nvidia-nim).*kimi-k2\\.5|kimi-k2\\.5.*(nvidia|NVIDIA|build\\.nvidia|integrate\\.api\\.nvidia|nvidia-nim)" src extensions docs ui packages -g '!**/node_modules/**'`; `pnpm test extensions/nvidia/provider-catalog.test.ts extensions/nvidia/onboard.test.ts extensions/nvidia/index.test.ts src/agents/model-selection.test.ts src/gateway/server.models-voicewake-misc.test.ts src/gateway/server.sessions.compaction.test.ts src/gateway/session-utils.test.ts src/agents/pi-embedded-runner-extraparams.test.ts ui/src/ui/chat-model-ref.test.ts ui/src/ui/chat-model-select-state.test.ts ui/src/ui/chat/slash-command-executor.node.test.ts`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): focused NVIDIA/Kimi K2.5 search returned no matches; targeted test run passed 5 Vitest shards.
- Observed result after fix: NVIDIA catalog/docs/tests reference `moonshotai/kimi-k2.6`, `minimaxai/minimax-m2.7`, and `z-ai/glm-5.1`.
- What was not tested: live NVIDIA API inference against build.nvidia.com models.
- Before evidence (optional but encouraged): previous NVIDIA catalog rows were `moonshotai/kimi-k2.5`, `minimaxai/minimax-m2.5`, and `z-ai/glm5`.

## Root Cause (if applicable)

- Root cause: NVIDIA's static plugin catalog lagged behind build.nvidia.com endpoint deprecations.
- Missing detection / guardrail: no live availability check for the static NVIDIA catalog.
- Contributing context (if known): NVIDIA replaced the deprecated rows with Kimi K2.6 and GLM 5.1.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/nvidia/provider-catalog.test.ts`, `extensions/nvidia/onboard.test.ts`, `extensions/nvidia/index.test.ts`, plus nested model-ref UI/session tests.
- Scenario the test should lock in: NVIDIA catalog rows and nested provider/model ids preserve the replacement model ids through onboarding, model selection, sessions, and UI pickers.
- Why this is the smallest reliable guardrail: the change is a static catalog/docs update with existing model-ref parsing and display behavior.
- Existing test that already covers this (if any): the targeted tests listed above.
- If no new test is added, why not: existing assertions were updated to the replacement NVIDIA model ids.

## User-visible / Behavior Changes

NVIDIA provider users now see and select `nvidia/moonshotai/kimi-k2.6`, `nvidia/minimaxai/minimax-m2.7`, and `nvidia/z-ai/glm-5.1` instead of the deprecated NVIDIA-hosted Kimi K2.5 and GLM 5 entries.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: NVIDIA provider static catalog
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Inspect the NVIDIA bundled catalog and provider docs.
2. Search for NVIDIA/build/integrate references still paired with Kimi K2.5.
3. Run targeted NVIDIA catalog, onboarding, model selection, session, and UI picker tests.

### Expected

- NVIDIA catalog/docs use `moonshotai/kimi-k2.6`, `minimaxai/minimax-m2.7`, and `z-ai/glm-5.1`.
- No NVIDIA-scoped Kimi K2.5 references remain.
- Targeted tests pass.

### Actual

- NVIDIA catalog/docs use `moonshotai/kimi-k2.6`, `minimaxai/minimax-m2.7`, and `z-ai/glm-5.1`.
- Focused NVIDIA/Kimi K2.5 search returned no matches.
- Targeted tests passed.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: static NVIDIA catalog rows, NVIDIA docs table, nested NVIDIA model ref parsing/display/session behavior.
- Edge cases checked: provider-qualified nested ids such as `nvidia/moonshotai/kimi-k2.6` and legacy NVIDIA-NIM style keys in extra-param tests.
- What you did **not** verify: live NVIDIA API inference.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: manually configured deprecated NVIDIA model ids can still exist in user config.
  - Mitigation: this PR updates the bundled catalog/docs so new selection and onboarding paths use the available replacement ids.
