### PR TITLE
fix(cron): hint after disable about list filtering disabled jobs

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -371,8 +371,11 @@ For template files, keep the language instruction in the rendered prompt and ver
 ## Managing jobs
 
 ```bash
-# List all jobs
+# List enabled jobs
 openclaw cron list
+
+# Include disabled jobs
+openclaw cron list --all
 
 # Get one stored job as JSON
 openclaw cron get <jobId>

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -287,6 +287,7 @@ Manual run and inspection:
 
 ```bash
 openclaw cron list
+openclaw cron list --all
 openclaw cron list --agent ops
 openclaw cron get <job-id>
 openclaw cron show <job-id>
@@ -298,7 +299,7 @@ openclaw cron runs --id <job-id> --limit 50
 openclaw cron runs --id <job-id> --run-id <run-id>
 ```
 
-`openclaw cron list` shows all matching jobs by default. Pass `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.
+`openclaw cron list` shows enabled matching jobs by default. Pass `--all` to include disabled jobs. Pass `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.
 
 `openclaw cron get <job-id>` returns the stored job JSON directly. Use `cron show <job-id>` when you want the human-readable view with delivery-route preview.
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -287,7 +287,6 @@ Manual run and inspection:
 
 ```bash
 openclaw cron list
-openclaw cron list --all
 openclaw cron list --agent ops
 openclaw cron get <job-id>
 openclaw cron show <job-id>
@@ -299,7 +298,7 @@ openclaw cron runs --id <job-id> --limit 50
 openclaw cron runs --id <job-id> --run-id <run-id>
 ```
 
-`openclaw cron list` shows enabled matching jobs by default. Pass `--all` to include disabled jobs. Pass `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.
+`openclaw cron list` shows all matching jobs by default. Pass `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.
 
 `openclaw cron get <job-id>` returns the stored job JSON directly. Use `cron show <job-id>` when you want the human-readable view with delivery-route preview.
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -298,7 +298,7 @@ openclaw cron runs --id <job-id> --limit 50
 openclaw cron runs --id <job-id> --run-id <run-id>
 ```
 
-`openclaw cron list` shows all matching jobs by default. Pass `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.
+`openclaw cron list` shows enabled jobs by default. Pass `--all` to include disabled jobs, or `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.
 
 `openclaw cron get <job-id>` returns the stored job JSON directly. Use `cron show <job-id>` when you want the human-readable view with delivery-route preview.
 

--- a/src/cli/cron-cli/register.cron-simple.test.ts
+++ b/src/cli/cron-cli/register.cron-simple.test.ts
@@ -16,11 +16,34 @@ vi.mock("../gateway-rpc.js", async () => {
 });
 
 const { registerCronSimpleCommands } = await import("./register.cron-simple.js");
+const originalStderrIsTTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
 
 async function runCronShow(id: string): Promise<void> {
   const cron = new Command();
   registerCronSimpleCommands(cron);
   await cron.parseAsync(["show", id, "--json"], { from: "user" });
+}
+
+async function runCronToggle(command: "enable" | "disable"): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  registerCronSimpleCommands(program);
+  await program.parseAsync([command, "job-1"], { from: "user" });
+}
+
+function setStderrIsTTY(value: boolean): void {
+  Object.defineProperty(process.stderr, "isTTY", {
+    value,
+    configurable: true,
+  });
+}
+
+function restoreStderrIsTTY(): void {
+  if (originalStderrIsTTY) {
+    Object.defineProperty(process.stderr, "isTTY", originalStderrIsTTY);
+  } else {
+    Reflect.deleteProperty(process.stderr, "isTTY");
+  }
 }
 
 describe("cron show pagination guard (regression for #83856)", () => {
@@ -83,5 +106,44 @@ describe("cron show pagination guard (regression for #83856)", () => {
     expect(defaultRuntime.error).toHaveBeenCalledWith(
       expect.stringContaining("cron job not found: missing"),
     );
+  });
+});
+
+describe("cron disable hint", () => {
+  beforeEach(() => {
+    callGatewayFromCli.mockReset();
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.status") {
+        return { enabled: true };
+      }
+      return { ok: true };
+    });
+    vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    restoreStderrIsTTY();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { command: "disable" as const, tty: false, expectedHint: false },
+    { command: "disable" as const, tty: true, expectedHint: true },
+    { command: "enable" as const, tty: true, expectedHint: false },
+  ])("$command with stderr TTY=$tty emits hint=$expectedHint", async (params) => {
+    setStderrIsTTY(params.tty);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await runCronToggle(params.command);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { enabled: params.command === "enable" },
+    });
+    if (params.expectedHint) {
+      expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining("openclaw cron list --all"));
+    } else {
+      expect(stderrWrite).not.toHaveBeenCalled();
+    }
   });
 });

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -143,7 +143,7 @@ function registerCronToggleCommand(params: {
             patch: { enabled: params.enabled },
           });
           printCronJson(res);
-          if (!params.enabled) {
+          if (!params.enabled && process.stderr.isTTY) {
             process.stderr.write(
               `Note: 'openclaw cron list' hides disabled jobs by default. Use 'openclaw cron list --all' to see this job, or 'openclaw cron enable <id>' to re-enable it.\n`,
             );

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -143,7 +143,7 @@ function registerCronToggleCommand(params: {
             patch: { enabled: params.enabled },
           });
           printCronJson(res);
-          if (params.enabled === false) {
+          if (!params.enabled) {
             process.stderr.write(
               `Note: 'openclaw cron list' hides disabled jobs by default. Use 'openclaw cron list --all' to see this job, or 'openclaw cron enable <id>' to re-enable it.\n`,
             );

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -143,6 +143,11 @@ function registerCronToggleCommand(params: {
             patch: { enabled: params.enabled },
           });
           printCronJson(res);
+          if (params.enabled === false) {
+            process.stderr.write(
+              `Note: 'openclaw cron list' hides disabled jobs by default. Use 'openclaw cron list --all' to see this job, or 'openclaw cron enable <id>' to re-enable it.\n`,
+            );
+          }
           await warnIfCronSchedulerDisabled(opts);
         } catch (err) {
           handleCronCliError(err);

--- a/src/cron/service/ops.update.disable-and-list.test.ts
+++ b/src/cron/service/ops.update.disable-and-list.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createIsolatedRegressionJob,
+  noopLogger,
+  setupCronRegressionFixtures,
+  writeCronJobs,
+} from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { list, update } from "./ops.js";
+import { createCronServiceState } from "./state.js";
+
+const fixtures = setupCronRegressionFixtures({
+  prefix: "cron-service-disable-and-list-",
+});
+
+describe("cron service ops: disable + list round-trip", () => {
+  it("hides disabled jobs from default list, surfaces them with includeDisabled, and restores them after enable", async () => {
+    const store = fixtures.makeStorePath();
+    const scheduledAt = Date.now() + 60_000;
+    const job = createIsolatedRegressionJob({
+      id: "disable-and-list",
+      name: "disable-and-list",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(),
+    });
+
+    await update(state, job.id, { enabled: false });
+
+    const defaultListAfterDisable = await list(state);
+    expect(defaultListAfterDisable.map((j) => j.id)).not.toContain(job.id);
+
+    const allListAfterDisable = await list(state, { includeDisabled: true });
+    const disabledFromAllList = allListAfterDisable.find((j) => j.id === job.id);
+    expect(disabledFromAllList).toBeDefined();
+    expect(disabledFromAllList?.enabled).toBe(false);
+    expect(disabledFromAllList?.name).toBe(job.name);
+    expect(disabledFromAllList?.schedule).toEqual(job.schedule);
+    expect(disabledFromAllList?.payload).toEqual(job.payload);
+
+    await update(state, job.id, { enabled: true });
+
+    const defaultListAfterEnable = await list(state);
+    const reenabled = defaultListAfterEnable.find((j) => j.id === job.id);
+    expect(reenabled).toBeDefined();
+    expect(reenabled?.enabled).toBe(true);
+  });
+});

--- a/src/cron/service/ops.update.disable-and-list.test.ts
+++ b/src/cron/service/ops.update.disable-and-list.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  createIsolatedRegressionJob,
   noopLogger,
   setupCronRegressionFixtures,
-  writeCronStoreSnapshot,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
-import { list, update } from "./ops.js";
+import { add, list, update } from "./ops.js";
 import { createCronServiceState } from "./state.js";
 
 const fixtures = setupCronRegressionFixtures({
@@ -16,16 +14,6 @@ describe("cron service ops: disable + list round-trip", () => {
   it("hides disabled jobs from default list, surfaces them with includeDisabled, and restores them after enable", async () => {
     const store = fixtures.makeStorePath();
     const scheduledAt = Date.now() + 60_000;
-    const job = createIsolatedRegressionJob({
-      id: "disable-and-list",
-      name: "disable-and-list",
-      scheduledAt,
-      schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
-      payload: { kind: "agentTurn", message: "ping" },
-      state: { nextRunAtMs: scheduledAt },
-    });
-    await writeCronStoreSnapshot(store.storePath, [job]);
-
     const state = createCronServiceState({
       cronEnabled: true,
       storePath: store.storePath,
@@ -35,7 +23,23 @@ describe("cron service ops: disable + list round-trip", () => {
       runIsolatedAgentJob: vi.fn(),
     });
 
+    const job = await add(state, {
+      name: "disable-and-list",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "ping" },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      delivery: { mode: "announce" },
+    });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+
     await update(state, job.id, { enabled: false });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
 
     const defaultListAfterDisable = await list(state);
     expect(defaultListAfterDisable.map((j) => j.id)).not.toContain(job.id);
@@ -49,6 +53,9 @@ describe("cron service ops: disable + list round-trip", () => {
     expect(disabledFromAllList?.payload).toEqual(job.payload);
 
     await update(state, job.id, { enabled: true });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
 
     const defaultListAfterEnable = await list(state);
     const reenabled = defaultListAfterEnable.find((j) => j.id === job.id);

--- a/src/cron/service/ops.update.disable-and-list.test.ts
+++ b/src/cron/service/ops.update.disable-and-list.test.ts
@@ -6,17 +6,14 @@ import {
 import { add, list, update } from "./ops.js";
 import { createCronServiceState } from "./state.js";
 
-const fixtures = setupCronRegressionFixtures({
-  prefix: "cron-service-disable-and-list-",
-});
+const fixtures = setupCronRegressionFixtures({ prefix: "cron-disable-list-" });
 
 describe("cron service ops: disable + list round-trip", () => {
-  it("hides disabled jobs from default list, surfaces them with includeDisabled, and restores them after enable", async () => {
-    const store = fixtures.makeStorePath();
-    const scheduledAt = Date.now() + 60_000;
+  it("keeps a disabled job available to --all and restores it after enable", async () => {
+    const { storePath } = fixtures.makeStorePath();
     const state = createCronServiceState({
       cronEnabled: true,
-      storePath: store.storePath,
+      storePath,
       log: noopLogger,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeat: vi.fn(),
@@ -26,40 +23,28 @@ describe("cron service ops: disable + list round-trip", () => {
     const job = await add(state, {
       name: "disable-and-list",
       enabled: true,
-      schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+      schedule: { kind: "every", everyMs: 60_000 },
       payload: { kind: "agentTurn", message: "ping" },
       sessionTarget: "isolated",
       wakeMode: "next-heartbeat",
       delivery: { mode: "announce" },
     });
-    if (state.timer) {
-      clearTimeout(state.timer);
+
+    try {
+      await update(state, job.id, { enabled: false });
+      expect((await list(state)).map(({ id }) => id)).not.toContain(job.id);
+      expect(await list(state, { includeDisabled: true })).toContainEqual(
+        expect.objectContaining({ id: job.id, enabled: false }),
+      );
+
+      await update(state, job.id, { enabled: true });
+      expect(await list(state)).toContainEqual(
+        expect.objectContaining({ id: job.id, enabled: true }),
+      );
+    } finally {
+      if (state.timer) {
+        clearTimeout(state.timer);
+      }
     }
-
-    await update(state, job.id, { enabled: false });
-    if (state.timer) {
-      clearTimeout(state.timer);
-    }
-
-    const defaultListAfterDisable = await list(state);
-    expect(defaultListAfterDisable.map((j) => j.id)).not.toContain(job.id);
-
-    const allListAfterDisable = await list(state, { includeDisabled: true });
-    const disabledFromAllList = allListAfterDisable.find((j) => j.id === job.id);
-    expect(disabledFromAllList).toBeDefined();
-    expect(disabledFromAllList?.enabled).toBe(false);
-    expect(disabledFromAllList?.name).toBe(job.name);
-    expect(disabledFromAllList?.schedule).toEqual(job.schedule);
-    expect(disabledFromAllList?.payload).toEqual(job.payload);
-
-    await update(state, job.id, { enabled: true });
-    if (state.timer) {
-      clearTimeout(state.timer);
-    }
-
-    const defaultListAfterEnable = await list(state);
-    const reenabled = defaultListAfterEnable.find((j) => j.id === job.id);
-    expect(reenabled).toBeDefined();
-    expect(reenabled?.enabled).toBe(true);
   });
 });

--- a/src/cron/service/ops.update.disable-and-list.test.ts
+++ b/src/cron/service/ops.update.disable-and-list.test.ts
@@ -3,7 +3,7 @@ import {
   createIsolatedRegressionJob,
   noopLogger,
   setupCronRegressionFixtures,
-  writeCronJobs,
+  writeCronStoreSnapshot,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { list, update } from "./ops.js";
 import { createCronServiceState } from "./state.js";
@@ -24,7 +24,7 @@ describe("cron service ops: disable + list round-trip", () => {
       payload: { kind: "agentTurn", message: "ping" },
       state: { nextRunAtMs: scheduledAt },
     });
-    await writeCronJobs(store.storePath, [job]);
+    await writeCronStoreSnapshot(store.storePath, [job]);
 
     const state = createCronServiceState({
       cronEnabled: true,


### PR DESCRIPTION
## What Problem This Solves

After `openclaw cron disable <id>` succeeds, plain `openclaw cron list` hides that job because the list defaults to enabled jobs. In an interactive terminal this can look like deletion and prompt users to recreate a job whose schedule, payload, model, and delivery settings are still intact.

## Why This Change Was Made

- Add one TTY-only stderr hint after a successful disable, pointing to `openclaw cron list --all` and `openclaw cron enable <id>`.
- Keep stdout JSON unchanged for scripts and pipelines.
- Emit nothing for non-interactive stderr or for `cron enable`.
- Preserve cron service, storage, scheduling, and enabled-only list behavior.
- Align the CLI and automation references with the enabled-only default.

## User Impact

Interactive operators get an immediate recovery path after disabling a cron job. Automated callers see no output change because the hint is gated on `process.stderr.isTTY` and stays off stdout.

Contributor: Kate Stahnke (@kate). Her rebased commits are preserved, and the maintainer documentation commit includes `Co-authored-by: Kate Stahnke <35552+kate@users.noreply.github.com>`.

## Evidence

Exact pushed head: `b3a982472e72eeb3ac9ba55fe828cfe98e3605ce`

- `node scripts/run-vitest.mjs src/cli/cron-cli/register.cron-simple.test.ts src/cron/service/ops.update.disable-and-list.test.ts` — 8 tests passed across 2 shards.
- Node 24 `node scripts/check-changed.mjs -- <five changed files>` — core/core-test typecheck, targeted lint, formatting, dependency/boundary/import-cycle, docs, and repository guards passed. Blacksmith Testbox stayed queued without allocation, so this used the documented trusted-source local fallback.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.
- Source-blind isolated Gateway/CLI proof exercised add → TTY disable → default list → list `--all` → enable → non-TTY disable → remove. The TTY path showed the hint, default list hid the job, `--all` returned it as disabled, and the non-TTY disable emitted no hint.

## Compatibility

No config, environment, storage, protocol, dependency, permission, or migration change. No changelog edit; release-note context and contributor credit are recorded here.
