### PR TITLE
fix: extend bundle MCP tool request timeout

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -420,12 +420,13 @@ Example config shape:
 
 Launches a local child process and communicates over stdin/stdout.
 
-| Field                      | Description                       |
-| -------------------------- | --------------------------------- |
-| `command`                  | Executable to spawn (required)    |
-| `args`                     | Array of command-line arguments   |
-| `env`                      | Extra environment variables       |
-| `cwd` / `workingDirectory` | Working directory for the process |
+| Field                      | Description                                                        |
+| -------------------------- | ------------------------------------------------------------------ |
+| `command`                  | Executable to spawn (required)                                     |
+| `args`                     | Array of command-line arguments                                    |
+| `env`                      | Extra environment variables                                        |
+| `cwd` / `workingDirectory` | Working directory for the process                                  |
+| `requestTimeoutMs`         | Per-tool-call request timeout in ms (optional; default 10 minutes) |
 
 <Warning>
 **Stdio env safety filter**
@@ -439,11 +440,12 @@ If your MCP server genuinely needs one of the blocked variables, set it on the g
 
 Connects to a remote MCP server over HTTP Server-Sent Events.
 
-| Field                 | Description                                                      |
-| --------------------- | ---------------------------------------------------------------- |
-| `url`                 | HTTP or HTTPS URL of the remote server (required)                |
-| `headers`             | Optional key-value map of HTTP headers (for example auth tokens) |
-| `connectionTimeoutMs` | Per-server connection timeout in ms (optional)                   |
+| Field                 | Description                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `url`                 | HTTP or HTTPS URL of the remote server (required)                  |
+| `headers`             | Optional key-value map of HTTP headers (for example auth tokens)   |
+| `connectionTimeoutMs` | Per-server connection timeout in ms (optional)                     |
+| `requestTimeoutMs`    | Per-tool-call request timeout in ms (optional; default 10 minutes) |
 
 Example:
 
@@ -474,6 +476,7 @@ Sensitive values in `url` (userinfo) and `headers` are redacted in logs and stat
 | `transport`           | Set to `"streamable-http"` to select this transport; when omitted, OpenClaw uses `sse` |
 | `headers`             | Optional key-value map of HTTP headers (for example auth tokens)                       |
 | `connectionTimeoutMs` | Per-server connection timeout in ms (optional)                                         |
+| `requestTimeoutMs`    | Per-tool-call request timeout in ms (optional; default 10 minutes)                     |
 
 OpenClaw config uses `transport: "streamable-http"` as the canonical spelling. CLI-native MCP `type: "http"` values are accepted when saved through `openclaw mcp set` and repaired by `openclaw doctor --fix` in existing config, but `transport` is what embedded Pi consumes directly.
 
@@ -487,6 +490,7 @@ Example:
         "url": "https://mcp.example.com/stream",
         "transport": "streamable-http",
         "connectionTimeoutMs": 10000,
+        "requestTimeoutMs": 600000,
         "headers": {
           "Authorization": "Bearer <token>"
         }

--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -141,7 +141,8 @@ MCP servers can use stdio or HTTP transport:
         "headers": {
           "Authorization": "Bearer ${MY_SECRET_TOKEN}"
         },
-        "connectionTimeoutMs": 30000
+        "connectionTimeoutMs": 30000,
+        "requestTimeoutMs": 600000
       }
     }
   }
@@ -157,6 +158,8 @@ MCP servers can use stdio or HTTP transport:
   descriptions and logs
 - `connectionTimeoutMs` overrides the default 30-second connection timeout for
   both stdio and HTTP transports
+- `requestTimeoutMs` overrides the default 10-minute per-tool-call timeout;
+  progress notifications reset this timeout while the tool is still active
 
 ##### Tool naming
 

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { logWarn } from "../logger.js";
-import { resolveMcpTransportConfig } from "./mcp-transport-config.js";
+import {
+  DEFAULT_BUNDLE_MCP_REQUEST_TIMEOUT_MS,
+  resolveMcpTransportConfig,
+} from "./mcp-transport-config.js";
 
 vi.mock("../logger.js", () => ({ logWarn: vi.fn() }));
 
@@ -9,11 +12,12 @@ describe("resolveMcpTransportConfig", () => {
     vi.mocked(logWarn).mockClear();
   });
 
-  it("resolves stdio config with connection timeout", () => {
+  it("resolves stdio config with connection and request timeouts", () => {
     const resolved = resolveMcpTransportConfig("probe", {
       command: "node",
       args: ["./server.mjs"],
       connectionTimeoutMs: 12_345,
+      requestTimeoutMs: 456_789,
     });
 
     expect(resolved).toMatchObject({
@@ -22,7 +26,19 @@ describe("resolveMcpTransportConfig", () => {
       command: "node",
       args: ["./server.mjs"],
       connectionTimeoutMs: 12_345,
+      requestTimeoutMs: 456_789,
     });
+  });
+
+  it("defaults bundled MCP tool request timeout above the SDK 60s default", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
+      command: "node",
+    });
+
+    expect(resolved).toMatchObject({
+      requestTimeoutMs: DEFAULT_BUNDLE_MCP_REQUEST_TIMEOUT_MS,
+    });
+    expect(DEFAULT_BUNDLE_MCP_REQUEST_TIMEOUT_MS).toBeGreaterThan(60_000);
   });
 
   it("drops dangerous env overrides from stdio config", () => {
@@ -55,6 +71,7 @@ describe("resolveMcpTransportConfig", () => {
       cwd: undefined,
       description: "node",
       connectionTimeoutMs: 30_000,
+      requestTimeoutMs: DEFAULT_BUNDLE_MCP_REQUEST_TIMEOUT_MS,
     });
     expect(logWarn).toHaveBeenCalledWith(
       'bundle-mcp: server "probe": env "NODE_OPTIONS" is blocked for stdio startup safety and was ignored.',
@@ -115,6 +132,7 @@ describe("resolveMcpTransportConfig", () => {
       },
       description: "https://mcp.example.com/sse",
       connectionTimeoutMs: 30_000,
+      requestTimeoutMs: DEFAULT_BUNDLE_MCP_REQUEST_TIMEOUT_MS,
     });
   });
 
@@ -135,6 +153,7 @@ describe("resolveMcpTransportConfig", () => {
       },
       description: "https://mcp.example.com/sse",
       connectionTimeoutMs: 30_000,
+      requestTimeoutMs: DEFAULT_BUNDLE_MCP_REQUEST_TIMEOUT_MS,
     });
   });
 

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -2,6 +2,7 @@ import { resolveOpenClawMcpTransportAlias } from "../config/mcp-config-normalize
 import { logWarn } from "../logger.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
+import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import {
   describeHttpMcpServerLaunchConfig,
   resolveHttpMcpServerLaunchConfig,
@@ -15,6 +16,7 @@ import {
 type ResolvedBaseMcpTransportConfig = {
   description: string;
   connectionTimeoutMs: number;
+  requestTimeoutMs: number;
 };
 
 type ResolvedStdioMcpTransportConfig = ResolvedBaseMcpTransportConfig & {
@@ -36,6 +38,7 @@ type ResolvedHttpMcpTransportConfig = ResolvedBaseMcpTransportConfig & {
 type ResolvedMcpTransportConfig = ResolvedStdioMcpTransportConfig | ResolvedHttpMcpTransportConfig;
 
 const DEFAULT_CONNECTION_TIMEOUT_MS = 30_000;
+export const DEFAULT_BUNDLE_MCP_REQUEST_TIMEOUT_MS = 10 * 60_000;
 
 function getConnectionTimeoutMs(rawServer: unknown): number {
   if (
@@ -47,6 +50,18 @@ function getConnectionTimeoutMs(rawServer: unknown): number {
     return (rawServer as { connectionTimeoutMs: number }).connectionTimeoutMs;
   }
   return DEFAULT_CONNECTION_TIMEOUT_MS;
+}
+
+function getRequestTimeoutMs(rawServer: unknown): number {
+  if (
+    rawServer &&
+    typeof rawServer === "object" &&
+    typeof (rawServer as { requestTimeoutMs?: unknown }).requestTimeoutMs === "number" &&
+    (rawServer as { requestTimeoutMs: number }).requestTimeoutMs > 0
+  ) {
+    return resolveSafeTimeoutDelayMs((rawServer as { requestTimeoutMs: number }).requestTimeoutMs);
+  }
+  return DEFAULT_BUNDLE_MCP_REQUEST_TIMEOUT_MS;
 }
 
 function getRequestedTransport(rawServer: unknown): string {
@@ -99,6 +114,7 @@ function resolveHttpTransportConfig(
     headers: launch.config.headers,
     description: describeHttpMcpServerLaunchConfig(launch.config),
     connectionTimeoutMs: getConnectionTimeoutMs(rawServer),
+    requestTimeoutMs: getRequestTimeoutMs(rawServer),
   };
 }
 
@@ -127,6 +143,7 @@ export function resolveMcpTransportConfig(
       cwd: stdioLaunch.config.cwd,
       description: describeStdioMcpServerLaunchConfig(stdioLaunch.config),
       connectionTimeoutMs: getConnectionTimeoutMs(rawServer),
+      requestTimeoutMs: getRequestTimeoutMs(rawServer),
     };
   }
 

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -15,6 +15,7 @@ type ResolvedMcpTransport = {
   description: string;
   transportType: "stdio" | "sse" | "streamable-http";
   connectionTimeoutMs: number;
+  requestTimeoutMs: number;
   detachStderr?: () => void;
 };
 
@@ -96,6 +97,7 @@ export function resolveMcpTransport(
       description: resolved.description,
       transportType: "stdio",
       connectionTimeoutMs: resolved.connectionTimeoutMs,
+      requestTimeoutMs: resolved.requestTimeoutMs,
       detachStderr: attachStderrLogging(serverName, transport),
     };
   }
@@ -107,6 +109,7 @@ export function resolveMcpTransport(
       description: resolved.description,
       transportType: "streamable-http",
       connectionTimeoutMs: resolved.connectionTimeoutMs,
+      requestTimeoutMs: resolved.requestTimeoutMs,
     };
   }
   const headers: Record<string, string> = {
@@ -122,5 +125,6 @@ export function resolveMcpTransport(
     description: resolved.description,
     transportType: "sse",
     connectionTimeoutMs: resolved.connectionTimeoutMs,
+    requestTimeoutMs: resolved.requestTimeoutMs,
   };
 }

--- a/src/agents/pi-bundle-mcp-runtime.call-tool-timeout.test.ts
+++ b/src/agents/pi-bundle-mcp-runtime.call-tool-timeout.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callToolMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(function Client() {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: "slow_probe",
+            description: "slow probe",
+            inputSchema: { type: "object" },
+          },
+        ],
+      }),
+      callTool: callToolMock,
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+}));
+
+vi.mock("./embedded-pi-mcp.js", () => ({
+  loadEmbeddedPiMcpConfig: (params: { cfg?: { mcp?: { servers?: Record<string, unknown> } } }) => ({
+    diagnostics: [],
+    mcpServers: params.cfg?.mcp?.servers ?? {},
+  }),
+}));
+
+vi.mock("./mcp-transport.js", () => ({
+  resolveMcpTransport: vi.fn().mockReturnValue({
+    transport: { close: vi.fn().mockResolvedValue(undefined) },
+    description: "mock transport",
+    transportType: "stdio",
+    connectionTimeoutMs: 30_000,
+    requestTimeoutMs: 456_789,
+  }),
+}));
+
+describe("createSessionMcpRuntime callTool request timeout", () => {
+  beforeEach(() => {
+    callToolMock.mockReset();
+    callToolMock.mockResolvedValue({ content: [], isError: false });
+  });
+
+  it("passes resolved MCP request timeout and progress reset options to SDK callTool", async () => {
+    const { createSessionMcpRuntime } = await import("./pi-bundle-mcp-runtime.js");
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-timeout",
+      workspaceDir: "/tmp",
+      cfg: {
+        mcp: {
+          servers: {
+            probe: { command: "node" },
+          },
+        },
+      },
+    });
+
+    await runtime.callTool("probe", "slow_probe", { ok: true });
+
+    expect(callToolMock).toHaveBeenCalledWith(
+      { name: "slow_probe", arguments: { ok: true } },
+      undefined,
+      { timeout: 456_789, resetTimeoutOnProgress: true },
+    );
+
+    await runtime.dispose();
+  });
+});

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -33,6 +33,7 @@ type BundleMcpSession = {
   client: Client;
   transport: Transport;
   transportType: "stdio" | "sse" | "streamable-http";
+  requestTimeoutMs: number;
   detachStderr?: () => void;
 };
 
@@ -252,6 +253,7 @@ export function createSessionMcpRuntime(params: {
             client,
             transport: resolved.transport,
             transportType: resolved.transportType,
+            requestTimeoutMs: resolved.requestTimeoutMs,
             detachStderr: resolved.detachStderr,
           };
           sessions.set(serverName, session);
@@ -355,10 +357,17 @@ export function createSessionMcpRuntime(params: {
       if (!session) {
         throw new Error(`bundle-mcp server "${serverName}" is not connected`);
       }
-      return (await session.client.callTool({
-        name: toolName,
-        arguments: isMcpConfigRecord(input) ? input : {},
-      })) as CallToolResult;
+      return (await session.client.callTool(
+        {
+          name: toolName,
+          arguments: isMcpConfigRecord(input) ? input : {},
+        },
+        undefined,
+        {
+          timeout: session.requestTimeoutMs,
+          resetTimeoutOnProgress: true,
+        },
+      )) as CallToolResult;
     },
     async dispose() {
       if (disposed) {

--- a/src/config/types.mcp.ts
+++ b/src/config/types.mcp.ts
@@ -17,6 +17,8 @@ export type McpServerConfig = {
   headers?: Record<string, string | number | boolean>;
   /** Optional connection timeout in milliseconds. */
   connectionTimeoutMs?: number;
+  /** Optional per-tool-call request timeout in milliseconds. */
+  requestTimeoutMs?: number;
   [key: string]: unknown;
 };
 


### PR DESCRIPTION
Fixes #78092.

## Summary
- add per-server bundled MCP `requestTimeoutMs` with a 10-minute default, separate from connection timeout
- pass SDK `callTool` request options with `resetTimeoutOnProgress: true`
- document the new setting and add regression coverage for config plumbing plus SDK call options

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/mcp-transport-config.test.ts src/agents/pi-bundle-mcp-runtime.call-tool-timeout.test.ts --reporter=verbose`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check src/agents/mcp-transport-config.ts src/agents/mcp-transport.ts src/agents/pi-bundle-mcp-runtime.ts src/agents/mcp-transport-config.test.ts src/agents/pi-bundle-mcp-runtime.call-tool-timeout.test.ts src/config/types.mcp.ts`
