### PR TITLE
fix(config): tolerate stale model catalog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,7 @@ Docs: https://docs.openclaw.ai
 - Image generation: include enabled generation providers such as fal in provider discovery even when another image provider is already active. Fixes #78141. Thanks @leoge007.
 - Slack: keep Socket Mode's native reconnect enabled so transient ping/pong misses can recover without forcing a full provider rebuild. Fixes #77933. Thanks @bmoran1022 and @brokemac79.
 - Cron: preserve cron timeout results when an isolated agent turn's `cron-nested` lane watchdog fires, preventing internal command-lane or model-fallback timeout text from being persisted. Fixes #77703. (#78168) Thanks @brokemac79 and @transxtech.
+- Config/validation: tolerate stale inactive `agents.defaults.models` catalog entries while still rejecting active aliases that resolve to suppressed models. Thanks @YannCedric.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.
 - ACPX/Codex: preserve trusted Codex project declarations when launching isolated Codex ACP sessions, avoiding interactive trust prompts in headless runs. Thanks @Stedyclaw.
 - ACPX/Codex: reap stale OpenClaw-owned ACPX/Codex ACP process trees on startup and after ACP session close, preventing orphaned harness processes from slowing the Gateway. Thanks @91wan.

--- a/src/config/config.model-ref-validation.test.ts
+++ b/src/config/config.model-ref-validation.test.ts
@@ -131,4 +131,132 @@ describe("config model reference validation", () => {
         "Unknown model: openai-codex/gpt-5.3-codex. gpt-5.3-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime.",
     });
   });
+
+  it("accepts statically suppressed provider/model pairs in the agent model catalog", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.4-mini",
+            },
+            models: {
+              "openai-codex/gpt-5.3-codex-spark": {
+                alias: "codex-sub-light",
+              },
+            },
+          },
+        },
+      },
+      {
+        pluginMetadataSnapshot: {
+          manifestRegistry: createModelSuppressionRegistry(),
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects active aliases that point at statically suppressed provider/model pairs", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "codex-sub-light",
+            },
+            models: {
+              "openai-codex/gpt-5.3-codex-spark": {
+                alias: "codex-sub-light",
+              },
+            },
+          },
+        },
+      },
+      {
+        pluginMetadataSnapshot: {
+          manifestRegistry: createModelSuppressionRegistry(),
+        },
+      },
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.issues).toContainEqual({
+      path: "agents.defaults.model.primary",
+      message:
+        "Unknown model: openai-codex/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+    });
+  });
+
+  it("rejects active profiled aliases that point at statically suppressed provider/model pairs", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "codex-sub-light@work",
+            },
+            models: {
+              "openai-codex/gpt-5.3-codex-spark": {
+                alias: "codex-sub-light",
+              },
+            },
+          },
+        },
+      },
+      {
+        pluginMetadataSnapshot: {
+          manifestRegistry: createModelSuppressionRegistry(),
+        },
+      },
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.issues).toContainEqual({
+      path: "agents.defaults.model.primary",
+      message:
+        "Unknown model: openai-codex/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+    });
+  });
+
+  it("rejects active slash-form aliases before provider/model parsing", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "codex/sub-light@work",
+            },
+            models: {
+              "openai-codex/gpt-5.3-codex-spark": {
+                alias: "codex/sub-light",
+              },
+            },
+          },
+        },
+      },
+      {
+        pluginMetadataSnapshot: {
+          manifestRegistry: createModelSuppressionRegistry(),
+        },
+      },
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.issues).toContainEqual({
+      path: "agents.defaults.model.primary",
+      message:
+        "Unknown model: openai-codex/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+    });
+  });
 });

--- a/src/config/model-refs.ts
+++ b/src/config/model-refs.ts
@@ -17,7 +17,10 @@ export const AGENT_MODEL_CONFIG_KEYS = [
 
 export function collectConfiguredModelRefs(
   config: unknown,
-  options: { includeChannelModelOverrides?: boolean } = {},
+  options: {
+    includeAgentModelCatalogEntries?: boolean;
+    includeChannelModelOverrides?: boolean;
+  } = {},
 ): ConfiguredModelRef[] {
   const refs: ConfiguredModelRef[] = [];
   const pushModelRef = (path: string, value: unknown) => {
@@ -62,7 +65,7 @@ export function collectConfiguredModelRefs(
         isRecord(agent.compaction.memoryFlush) ? agent.compaction.memoryFlush.model : undefined,
       );
     }
-    if (isRecord(agent.models)) {
+    if (options.includeAgentModelCatalogEntries !== false && isRecord(agent.models)) {
       for (const modelRef of Object.keys(agent.models)) {
         pushModelRef(`${path}.models.${modelRef}`, modelRef);
       }

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
+import { buildModelAliasIndex } from "../agents/model-selection-shared.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/ids.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
@@ -1139,7 +1142,9 @@ function validateConfigObjectWithPluginsBase(
   };
 
   const validateConfiguredModelRefs = () => {
-    const configuredRefs = collectConfiguredModelRefs(config);
+    const configuredRefs = collectConfiguredModelRefs(config, {
+      includeAgentModelCatalogEntries: false,
+    });
     if (configuredRefs.length === 0) {
       return;
     }
@@ -1164,9 +1169,21 @@ function validateConfigObjectWithPluginsBase(
     if (suppressedModels.size === 0) {
       return;
     }
+    const aliasIndex = buildModelAliasIndex({
+      cfg: config,
+      defaultProvider: DEFAULT_PROVIDER,
+    });
+    const resolveDefaultAgentModelAliasTarget = (value: string): string | null => {
+      const aliasKey = normalizeLowercaseStringOrEmpty(splitTrailingAuthProfile(value).model);
+      const aliasMatch = aliasKey ? aliasIndex.byAlias.get(aliasKey) : undefined;
+      return aliasMatch ? `${aliasMatch.ref.provider}/${aliasMatch.ref.model}` : null;
+    };
     const seen = new Set<string>();
     for (const ref of configuredRefs) {
-      const parsed = parseProviderModelRef(ref.value);
+      const configuredModel = splitTrailingAuthProfile(ref.value).model;
+      const resolvedModelRef =
+        resolveDefaultAgentModelAliasTarget(configuredModel) ?? configuredModel;
+      const parsed = resolvedModelRef ? parseProviderModelRef(resolvedModelRef) : null;
       if (!parsed) {
         continue;
       }


### PR DESCRIPTION
## Summary

- Problem: A stale suppressed model entry in `agents.defaults.models` could make config validation fail even when that entry was only an inactive catalog/allowlist option.
- Why it matters: Config validation failure can prevent the gateway from becoming ready, which makes commands such as `openclaw logs` and channel integrations such as Telegram unusable.
- What changed: Config validation now ignores inactive `agents.defaults.models` catalog entries, while still validating active model selections and aliases.
- What did NOT change (scope boundary): Active selections that resolve to suppressed models are still rejected, including aliases and auth-profile aliases such as `codex-sub-light@work`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A stale inactive `agents.defaults.models` entry no longer makes config validation fail.
- Real environment tested: VPS Linux OpenClaw checkout at `/home/openclaw/.openclaw/workspace/Github/openclaw`, using the built CLI and isolated `OPENCLAW_CONFIG_PATH` configs.
- Exact steps or command run after this patch:
  - `pnpm build`
  - `OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json node dist/cli/index.js doctor --json`
- Evidence after fix:

Terminal output from a config with valid active primary `openai-codex/gpt-5.4-mini` and inactive stale alias `codex-sub-light -> openai-codex/gpt-5.3-codex-spark`:

```json
{"valid":true,"path":"/tmp/.../openclaw.json"}
```

Terminal output from an active profiled alias pointing at the same suppressed model:

```json
{
  "valid": false,
  "path": "/tmp/.../openclaw.json",
  "issues": [
    {
      "path": "agents.defaults.model.primary",
      "message": "Unknown model: openai-codex/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5."
    }
  ]
}
```

- Observed result after fix: Inactive stale catalog entries do not reject config validation, while active selections resolving to suppressed models still fail.
- What was not tested: Live Telegram gateway restart with a production bot token after applying this patch.
- Before evidence: Before this fix, inactive `agents.defaults.models` entries were collected as configured model references and could fail validation with the suppressed-model error.

## Root Cause (if applicable)

- Root cause: `validateConfiguredModelRefs()` treated `agents.defaults.models` entries as active configured model references. That catalog is used for selectable aliases/options, so stale inactive entries were validated the same way as active defaults.
- Missing detection / guardrail: There was no regression test distinguishing inactive catalog entries from active selections.
- Contributing context (if known): A model that had previously existed in config, `openai-codex/gpt-5.3-codex-spark`, was later statically suppressed by the model catalog.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/config.model-ref-validation.test.ts`
- Scenario the test should lock in: Inactive suppressed `agents.defaults.models` entries are accepted when the active model is valid.
- Why this is the smallest reliable guardrail: The bug is in config reference collection/validation, so a focused config validation unit test covers the behavior without requiring gateway startup.
- Existing test that already covers this (if any): None before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Configs with stale inactive entries in `agents.defaults.models` no longer fail validation solely because of those inactive catalog entries. Active model selections that resolve to suppressed models still fail validation.

## Diagram (if applicable)

Before / After:

<img width="1280" height="720" alt="stale-model-validation-before-after" src="https://github.com/user-attachments/assets/6405439e-4477-47f3-a0bd-ae5cca954f3f" />

Still rejected:

<img width="1280" height="520" alt="active-suppressed-alias-still-rejected" src="https://github.com/user-attachments/assets/e8400c53-3a7c-4983-b74f-332021914d03" />

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Local Node/pnpm OpenClaw checkout
- Model/provider: `openai-codex/gpt-5.4-mini`, `openai-codex/gpt-5.3-codex-spark`
- Integration/channel (if any): Original user impact included Telegram; patch was verified through config validation/doctor.
- Relevant config (redacted): Isolated temporary `OPENCLAW_CONFIG_PATH` with valid active primary model and stale inactive `agents.defaults.models` alias.

### Steps

1. Build the CLI with `pnpm build`.
2. Run `doctor --json` against a temporary config where `agents.defaults.model.primary` is valid and `agents.defaults.models.codex-sub-light` points to `openai-codex/gpt-5.3-codex-spark`.
3. Run `doctor --json` against a temporary config where the active primary is `codex-sub-light@work` and that alias points to `openai-codex/gpt-5.3-codex-spark`.

### Expected

- Inactive stale catalog entry does not reject the config.
- Active alias or profiled alias resolving to a suppressed model still rejects the config.

### Actual

- Inactive stale catalog entry validates successfully.
- Active profiled alias resolving to `openai-codex/gpt-5.3-codex-spark` fails with the existing suppressed-model error.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```text
pnpm test src/config/config.model-ref-validation.test.ts
pnpm check:changed
pnpm build
codex review --base origin/main -c sandbox_mode='danger-full-access'
```

`codex review` found an active profiled-alias edge case during review. That finding was fixed and covered by a regression test. A second `codex review` found no discrete regression.

## Human Verification (required)

- Verified scenarios:
  - Inactive stale `agents.defaults.models` entry is accepted when the active primary model is valid.
  - Active alias pointing at a suppressed model is rejected.
  - Active auth-profile alias such as `codex-sub-light@work` pointing at a suppressed model is rejected.
- Edge cases checked:
  - Alias resolution for active defaults.
  - Auth-profile suffix handling for active aliases.
- What you did **not** verify:
  - Live Telegram gateway restart with a production bot token after applying this patch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A stale inactive alias remains visible as a selectable option in config.
  - Mitigation: This PR only changes validation for inactive catalog entries. If the alias is actively selected, validation still resolves the alias target and rejects suppressed models.
