### PR TITLE
fix(discord): treat bare isConnecting=true as stale, not started gateway

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -65,8 +65,13 @@ function assignGatewayClient(
 }
 
 function hasGatewaySocketStarted(plugin: discordGateway.GatewayPlugin): boolean {
+  // Only an actual `ws` reference proves a transport has been started. A bare
+  // `isConnecting=true` flag without a socket is stale bookkeeping left over
+  // from a prior registration attempt that never reached `connect(false)`
+  // (#78104). Treating that as "started" makes us skip `super.registerClient`
+  // and the gateway hangs at "awaiting gateway readiness" forever.
   const state = plugin as unknown as DiscordGatewayRegistrationState;
-  return state.ws != null || state.isConnecting === true;
+  return state.ws != null;
 }
 
 type ResolveDiscordGatewayIntentsParams = {

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -730,10 +730,14 @@ describe("createDiscordGatewayPlugin", () => {
     globalFetchMock.mockReset();
     vi.useRealTimers();
 
+    // Regression for #78104: a bare `isConnecting=true` flag with no actual
+    // websocket is stale bookkeeping left over from a prior registration that
+    // never reached connect(false). We must still invoke super.registerClient
+    // or the gateway hangs at "awaiting gateway readiness".
     await runCase((plugin) => {
       (plugin as { isConnecting: boolean }).isConnecting = true;
     });
-    expect(baseRegisterClientSpy).not.toHaveBeenCalled();
+    expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes fallback gateway metadata on the next register attempt", async () => {


### PR DESCRIPTION
Fixes #78104.

## Root cause
`OpenClawGatewayPlugin.registerClient` short-circuits on
`hasGatewaySocketStarted` when an external connect races with the
gateway-info metadata fetch (#52372). That helper currently returns
true if the underlying plugin has either an actual `ws` reference
*or* its `isConnecting` flag set to true.

`isConnecting=true` without an attached socket is not a started
transport — it's stale bookkeeping left over from a previous
registration attempt that rejected before `connect(false)` ran and
never cleared the flag. Once that happens, every gateway boot from
that point on sees the stale flag, skips `super.registerClient`, and
the daemon logs `discord client initialized; awaiting gateway readiness`
forever. That's exactly the symptom in #78104: REST works, the gateway
WebSocket lifecycle never reaches `ready`, no error is surfaced, and
outbound replies are silently dropped after the first message.

The original #52372 case (a real concurrent connect during the
metadata fetch) is preserved because a real connect attaches `ws`
synchronously before the fetch resolves.

## What the fix does
Restrict `hasGatewaySocketStarted` to a non-null `ws`. A stale
`isConnecting` flag no longer suppresses normal gateway registration.

## Tests
- Updated `provider.proxy.test.ts`: the existing external-connect race
  regression now covers two branches. The `ws` branch still expects
  `super.registerClient` NOT to fire (#52372 behavior preserved). The
  `isConnecting` branch flips to expect `super.registerClient` to fire
  exactly once — that's the corrected behavior for #78104.

## Real behavior proof
Unit test only. Local vitest invocation for `extensions/discord/*`
fails before any test by an unrelated missing
`@openclaw/fs-safe/config` import in `src/infra/fs-safe-defaults.ts`
(known infra gap noted on several recent PRs in this area). The
behavior change is single-branch and exercised by the inverted
isConnecting case in the existing race test, which previously asserted
the current bug.