### PR TITLE
fix(plugins): start explicit non-bundled hook plugins lacking onCapabilities

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -944,6 +944,35 @@ describe("resolveGatewayStartupPluginIds", () => {
     });
   });
 
+  // Regression coverage for #78196. Pre-v5.3 external extensions
+  // (e.g. claw-guard, approval-formatter) shipped without
+  // `activation.onCapabilities: ["hook"]` metadata and without explicit
+  // `hooks.*` policy keys; users enabled them via plugins.entries.<id>.enabled
+  // alone. v5.3+ silently skipped them. The fix treats an explicitly-enabled
+  // non-bundled plugin as having legacy hook startup intent.
+  it("loads explicitly enabled legacy external plugins lacking hook-capability metadata (#78196)", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        enabledPluginIds: ["external-hook-policy"],
+        allowPluginIds: ["external-hook-policy"],
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+      expected: ["external-hook-policy"],
+    });
+  });
+
+  it("does not ambient-load merely allowlisted legacy external plugins (#78196 negative case)", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        allowPluginIds: ["external-hook-policy"],
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+      expected: [],
+    });
+  });
+
   it("blocks hook-capability plugins when plugins are globally disabled", () => {
     expectStartupPluginIdsCase({
       config: {

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -427,9 +427,22 @@ function hasHookRuntimeStartupIntent(params: {
   if (params.manifest?.activation?.onCapabilities?.includes("hook")) {
     return true;
   }
-  return hasExplicitHookPolicyConfig(
-    params.activationSourcePlugins.entries[params.plugin.pluginId],
-  );
+  const entry = params.activationSourcePlugins.entries[params.plugin.pluginId];
+  // Pre-v5.3 external extensions were registered at startup as long as the
+  // user explicitly enabled them. They never declared
+  // `activation.onCapabilities: ["hook"]` (that metadata didn't exist) and
+  // they didn't always set explicit `hooks.*` policy keys. After the v5.3
+  // tightening they get silently skipped, which is #78196.
+  //
+  // Treat any non-bundled plugin that the user has explicitly enabled as
+  // having legacy hook startup intent. We deliberately don't extend this to
+  // bundled plugins (which already control startup via manifest activation)
+  // and we don't extend it to merely allowlisted plugins (the negative
+  // ambient-load case is still required behavior).
+  if (params.plugin.origin !== "bundled" && entry?.enabled === true) {
+    return true;
+  }
+  return hasExplicitHookPolicyConfig(entry);
 }
 
 function canStartExplicitHookPlugin(params: {


### PR DESCRIPTION
Fixes #78196.

## Root cause
v5.3 tightened `hasHookRuntimeStartupIntent` to require either a
manifest `activation.onCapabilities: [\"hook\"]` declaration or
explicit `hooks.*` policy keys. Pre-v5.3 external extensions
(`claw-guard`, `approval-formatter`, …) shipped before that metadata
existed and were activated solely via
`plugins.entries.<id>.enabled = true` plus `plugins.allow`. After
v5.3, those plugins quietly fall through `canStartExplicitHookPlugin`
because their startup intent is empty, so the gateway daemon skips
them with no error or warning.

The CLI-side path (`openclaw plugins inspect`) keeps reporting them
as `Status: loaded` because each CLI invocation re-imports the plugin
in its own short-lived Node process — that path is fine. The
long-lived gateway daemon, which is the process that needs the hook
wired to handle tool calls, is the one that silently skips them.

Net effect for the reporter: `before_tool_call` from `claw-guard`
never fires, `audit.jsonl` stops advancing, and tool calls run
unaudited.

## What the fix does
Treat any non-bundled plugin that the user has explicitly enabled
(`activationSourcePlugins.entries[pluginId]?.enabled === true`) as
having legacy hook startup intent. Bundled plugins keep their
manifest-driven activation. Merely allowlisted (but not explicitly
enabled) plugins remain ambient and are still skipped — the existing
allow-vs-load distinction is preserved.

## Tests
- Added two regression cases in `channel-plugin-ids.test.ts`
  reusing the existing `external-hook-policy` fixture (origin:
  global, no manifest hook capability, no explicit hook policy):
  - explicitly enabled + allowed => loads at startup
  - allowlisted only, no entry => still does NOT load (negative case)

## Real behavior proof
Unit tests only. Local vitest blocked before tests by the existing
`@openclaw/fs-safe/config` infra gap. The behavior change is a single
new short-circuit in `hasHookRuntimeStartupIntent` and is exercised by
the new positive/negative cases.