### PR TITLE
fix(feishu): default group source replies to automatic when not configured

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1156,6 +1156,57 @@ describe("handleFeishuMessage command authorization", () => {
       }),
     );
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    // #78204: when no visibleReplies preference is configured, Feishu
+    // group dispatch must default to automatic source replies. The
+    // cross-platform default of `message_tool_only` for groups would
+    // otherwise drop replies silently.
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultSourceReplyDeliveryMode: "automatic",
+      }),
+    );
+  });
+
+  it("does not force automatic Feishu group replies when visibleReplies is explicitly configured (#78204)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      messages: { groupChat: { visibleReplies: "message_tool" } },
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-allowed",
+        },
+      },
+      message: {
+        message_id: "msg-explicit-message-tool-#78204",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        defaultSourceReplyDeliveryMode: "automatic",
+      }),
+    );
   });
 
   it("blocks group sender when global groupSenderAllowFrom excludes sender", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1246,6 +1246,20 @@ export async function handleFeishuMessage(params: {
           (ctx.suppressReplyTarget ? undefined : ctx.messageId))
         : (ctx.replyTargetMessageId ?? (ctx.suppressReplyTarget ? undefined : ctx.messageId));
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+    // #78204: the cross-platform default for group/channel chats is
+    // `sourceReplyDeliveryMode: "message_tool_only"`, so when Feishu group
+    // mentions arrive and no explicit visibleReplies is configured, the
+    // typing indicator briefly shows and then the reply silently never
+    // lands (the model rarely uses the `message` tool in Feishu groups).
+    // For Feishu specifically we keep the historical behavior — automatic
+    // source replies for groups when the operator has not opted in to the
+    // message-tool flow. Explicit `visibleReplies` (including
+    // `message_tool`) is still honored.
+    const feishuVisibleRepliesConfigured =
+      cfg.messages?.groupChat?.visibleReplies !== undefined ||
+      cfg.messages?.visibleReplies !== undefined;
+    const defaultSourceReplyDeliveryMode =
+      isGroup && !feishuVisibleRepliesConfigured ? ("automatic" as const) : undefined;
 
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
@@ -1323,6 +1337,7 @@ export async function handleFeishuMessage(params: {
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             identity,
+            ...(defaultSourceReplyDeliveryMode ? { defaultSourceReplyDeliveryMode } : {}),
             messageCreateTimeMs,
           });
 
@@ -1488,6 +1503,7 @@ export async function handleFeishuMessage(params: {
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         identity,
+        ...(defaultSourceReplyDeliveryMode ? { defaultSourceReplyDeliveryMode } : {}),
         messageCreateTimeMs,
       });
 

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -297,6 +297,35 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(result.replyOptions).toHaveProperty("disableBlockStreaming", true);
   });
 
+  it("forces sourceReplyDeliveryMode=automatic when caller opts in (#78204)", async () => {
+    // Regression for #78204: Feishu group mentions silently dropped because
+    // the cross-platform default of `message_tool_only` for groups was
+    // never overridden when the user did not configure visibleReplies.
+    // The bot now passes `defaultSourceReplyDeliveryMode: "automatic"`
+    // for Feishu group dispatch and the dispatcher must propagate that to
+    // replyOptions.
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      defaultSourceReplyDeliveryMode: "automatic",
+    });
+
+    expect(result.replyOptions).toHaveProperty("sourceReplyDeliveryMode", "automatic");
+  });
+
+  it("does not force sourceReplyDeliveryMode when caller does not opt in", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions).not.toHaveProperty("sourceReplyDeliveryMode");
+  });
+
   it("enables core block streaming when Feishu blockStreaming is explicitly true", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -127,6 +127,16 @@ type CreateFeishuReplyDispatcherParams = {
   mentionTargets?: MentionTarget[];
   accountId?: string;
   identity?: OutboundIdentity;
+  /**
+   * Override the source-reply delivery mode the auto-reply pipeline
+   * resolves for this dispatch when the user has not configured an
+   * explicit `messages.{groupChat,}.visibleReplies`. Used by the bot
+   * dispatcher to keep Feishu group mentions automatic-reply by default
+   * (#78204): the cross-platform default for groups is
+   * `message_tool_only`, which silently drops replies in Feishu group
+   * chats because the agent rarely calls the message tool there.
+   */
+  defaultSourceReplyDeliveryMode?: "automatic";
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
@@ -667,6 +677,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     dispatcher,
     replyOptions: {
       ...replyOptions,
+      ...(params.defaultSourceReplyDeliveryMode
+        ? { sourceReplyDeliveryMode: params.defaultSourceReplyDeliveryMode }
+        : {}),
       onModelSelected: prefixContext.onModelSelected,
       disableBlockStreaming:
         typeof account.config?.blockStreaming === "boolean" ? !account.config.blockStreaming : true,


### PR DESCRIPTION
Fixes #78204.

## Root cause
Feishu group dispatch goes through the cross-platform reply pipeline,
which in `resolveSourceReplyDeliveryMode` defaults groups/channels to
`message_tool_only` whenever
`messages.groupChat.visibleReplies` / `messages.visibleReplies` are
unset. That mode only delivers the agent's reply if the model calls
the `message` tool. Models rarely call that tool in Feishu groups,
so the symptom in #78204 is exactly what the reporter sees: the bot
shows the typing indicator after a group mention, the indicator
disappears, and no reply ever lands. DMs are unaffected because their
default already resolves to `automatic`.

## What the fix does
- In `handleFeishuMessage`, compute
  `defaultSourceReplyDeliveryMode = \"automatic\"` for group dispatch
  whenever the user has not explicitly configured visibleReplies, and
  forward it to both `createFeishuReplyDispatcher` call sites
  (single-agent and broadcast).
- `createFeishuReplyDispatcher` accepts the new
  `defaultSourceReplyDeliveryMode` parameter and propagates it onto
  `replyOptions.sourceReplyDeliveryMode`. The auto-reply pipeline
  treats that as a `requested` mode and short-circuits the group
  default.
- Explicit `messages.groupChat.visibleReplies` (including
  `\"message_tool\"`) and explicit `messages.visibleReplies` continue
  to win — the override is only applied when the user has configured
  nothing.

## Tests
- `reply-dispatcher.test.ts`:
  - new positive case: dispatcher propagates
    `sourceReplyDeliveryMode: \"automatic\"` when caller opts in.
  - new negative case: dispatcher does not set
    `sourceReplyDeliveryMode` when caller does not opt in.
- `bot.test.ts`:
  - asserted that the existing group authorization test now sees
    `defaultSourceReplyDeliveryMode: \"automatic\"` on the dispatcher
    invocation.
  - new test: explicit `messages.groupChat.visibleReplies =
    \"message_tool\"` keeps the dispatcher call clean of the default
    override.

## Real behavior proof
Unit tests only. Local vitest blocked before tests by the
`@openclaw/fs-safe/config` import gap shared by the other PRs in
this repo. The change is targeted (default applied only when both
`isGroup` and visibleReplies-unset hold) and the new tests cover
both branches plus the explicit-config opt-out.