### PR TITLE
fix(doctor): skip message_tool default when message tool is unavailable

### DIFF
--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -1,8 +1,12 @@
+import { pickSandboxToolPolicy } from "../../../agents/sandbox-tool-policy.js";
+import { isToolAllowedByPolicies } from "../../../agents/tool-policy-match.js";
+import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../../agents/tool-policy.js";
 import { migrateLegacyRuntimeModelRef } from "../../../agents/model-runtime-aliases.js";
 import { normalizeProviderId } from "../../../agents/provider-id.js";
 import { resolveSingleAccountKeysToMove } from "../../../channels/plugins/setup-promotion-helpers.js";
 import { resolveNormalizedProviderModelMaxTokens } from "../../../config/defaults.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { AgentToolsConfig, ToolsConfig } from "../../../config/types.tools.js";
 import { DEFAULT_GOOGLE_API_BASE_URL } from "../../../infra/google-api-base-url.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../routing/session-key.js";
 import {
@@ -13,6 +17,37 @@ import { sanitizeForLog } from "../../../terminal/ansi.js";
 import { isRecord } from "./legacy-config-record-shared.js";
 import { isLegacyModelsAddCodexMetadataModel } from "./legacy-models-add-metadata.js";
 export { normalizeLegacyTalkConfig } from "./legacy-talk-config-normalizer.js";
+
+function resolveMessageToolAvailable(params: {
+  globalTools?: ToolsConfig;
+  agentTools?: AgentToolsConfig;
+}): boolean {
+  const profile = params.agentTools?.profile ?? params.globalTools?.profile;
+  const profileAlsoAllow = Array.isArray(params.agentTools?.alsoAllow)
+    ? params.agentTools.alsoAllow
+    : Array.isArray(params.globalTools?.alsoAllow)
+      ? params.globalTools.alsoAllow
+      : undefined;
+  const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow);
+  return isToolAllowedByPolicies("message", [
+    profilePolicy,
+    pickSandboxToolPolicy(params.globalTools),
+    pickSandboxToolPolicy(params.agentTools),
+  ]);
+}
+
+function hasMessageToolAvailableForAgents(cfg: OpenClawConfig): boolean {
+  const agents = cfg.agents?.list ?? [];
+  if (agents.length === 0) {
+    return resolveMessageToolAvailable({ globalTools: cfg.tools });
+  }
+  return agents.every((agent) =>
+    resolveMessageToolAvailable({
+      globalTools: cfg.tools,
+      agentTools: agent.tools as AgentToolsConfig | undefined,
+    }),
+  );
+}
 
 function hasConfiguredChannels(cfg: OpenClawConfig): boolean {
   const channels = cfg.channels;
@@ -32,6 +67,10 @@ export function normalizeMissingGroupVisibleRepliesDefault(
     messages?.visibleReplies !== undefined ||
     messages?.groupChat?.visibleReplies !== undefined
   ) {
+    return cfg;
+  }
+
+  if (!hasMessageToolAvailableForAgents(cfg)) {
     return cfg;
   }
 


### PR DESCRIPTION
## Summary

`doctor --fix` was unconditionally setting `messages.groupChat.visibleReplies` to `"message_tool"` on installs without configured channels, even when the active tool policy has no message tool available. The next `doctor` run would then emit a warning that the set value is unavailable and falls back to automatic.

## Root cause

`normalizeMissingGroupVisibleRepliesDefault` in `src/commands/doctor/shared/legacy-config-core-normalizers.ts` had no check for message tool availability before assigning `"message_tool"`. The preview-warnings path already knew how to detect that `"message_tool"` is unavailable — the normalizer simply wasn't using the same check.

## Fix

`normalizeMissingGroupVisibleRepliesDefault` now checks whether the message tool is permitted by the resolved tool policy before setting `"message_tool"`. When the message tool is unavailable, the function returns early without modifying the config, leaving the effective default at `"automatic"` instead.

The check is implemented using the same tool-policy resolution helpers (`isToolAllowedByPolicies`, `resolveToolProfilePolicy`, `mergeAlsoAllowPolicy`, `pickSandboxToolPolicy`) that `preview-warnings.ts` uses, so both paths agree on what "message tool available" means.

## Reproduction (before fix)

```bash
openclaw doctor --fix --yes   # sets visibleReplies = "message_tool"
openclaw doctor                # warns: message tool is unavailable
```

## After fix

```bash
openclaw doctor --fix --yes   # no-op for visibleReplies when message tool unavailable
openclaw doctor                # no warning
```

## Verification

- Existing unit tests in `preview-warnings.test.ts` cover the warning path independently and remain unaffected.
- The logic change is guarded: the normalizer still applies `"message_tool"` on installs where the tool is actually available.

Closes #78066
