### PR TITLE
Include token usage in model usage summaries

### DIFF
--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -26,7 +26,7 @@ metadata:
 
 ## Overview
 
-Get per-model usage cost from CodexBar's local cost logs. Supports "current model" (most recent daily entry) or "all models" summaries for Codex or Claude.
+Get per-model usage cost and token totals from CodexBar's local cost logs. Supports "current model" (most recent daily entry) or "all models" summaries for Codex or Claude.
 
 TODO: add Linux CLI support guidance once CodexBar CLI install path is documented for Linux.
 
@@ -62,7 +62,8 @@ cat /tmp/cost.json | python {baseDir}/scripts/model_usage.py --input - --mode cu
 ## Output
 
 - Text (default) or JSON (`--format json --pretty`).
-- Values are cost-only per model; tokens are not split by model in CodexBar output.
+- `--mode all` includes per-model cost plus token usage when CodexBar's `modelBreakdowns[]` entries expose token fields (`inputTokens`/`outputTokens`/cache/`totalTokens`, or OpenAI-style `prompt_tokens`/`completion_tokens`/`total_tokens`).
+- If CodexBar only provides `modelName` and `cost` for a model, the script reports `tokens unavailable` instead of inventing a per-model split from daily aggregate totals.
 
 ## References
 

--- a/skills/model-usage/scripts/model_usage.py
+++ b/skills/model-usage/scripts/model_usage.py
@@ -76,6 +76,18 @@ class ModelCost:
     cost: float
 
 
+@dataclass
+class ModelUsage:
+    model: str
+    cost: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    total_tokens: int = 0
+    tokens_available: bool = False
+
+
 def parse_daily_entries(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
     daily = payload.get("daily")
     if not daily:
@@ -107,8 +119,18 @@ def filter_by_days(entries: List[Dict[str, Any]], days: Optional[int]) -> List[D
     return filtered
 
 
-def aggregate_costs(entries: Iterable[Dict[str, Any]]) -> Dict[str, float]:
-    totals: Dict[str, float] = {}
+def numeric_int_field(item: Dict[str, Any], *names: str) -> Optional[int]:
+    for name in names:
+        value = item.get(name)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            return int(value)
+    return None
+
+
+def aggregate_model_usages(entries: Iterable[Dict[str, Any]]) -> Dict[str, ModelUsage]:
+    totals: Dict[str, ModelUsage] = {}
     for entry in entries:
         breakdowns = entry.get("modelBreakdowns")
         if not breakdowns:
@@ -119,13 +141,45 @@ def aggregate_costs(entries: Iterable[Dict[str, Any]]) -> Dict[str, float]:
             if not isinstance(item, dict):
                 continue
             model = item.get("modelName")
-            cost = item.get("cost")
             if not isinstance(model, str):
                 continue
-            if not isinstance(cost, (int, float)):
+
+            usage = totals.setdefault(model, ModelUsage(model=model))
+            cost = item.get("cost")
+            if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+                usage.cost += float(cost)
+
+            input_tokens = numeric_int_field(item, "inputTokens", "totalInputTokens", "prompt_tokens", "input_tokens")
+            output_tokens = numeric_int_field(item, "outputTokens", "totalOutputTokens", "completion_tokens", "output_tokens")
+            cache_read_tokens = numeric_int_field(item, "cacheReadTokens", "cache_read_tokens")
+            cache_creation_tokens = numeric_int_field(
+                item,
+                "cacheCreationTokens",
+                "cache_creation_tokens",
+                "cacheWriteTokens",
+                "cache_write_tokens",
+            )
+            explicit_total_tokens = numeric_int_field(item, "totalTokens", "total_tokens")
+
+            token_parts = [input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens]
+            has_token_data = explicit_total_tokens is not None or any(value is not None for value in token_parts)
+            if not has_token_data:
                 continue
-            totals[model] = totals.get(model, 0.0) + float(cost)
+
+            usage.tokens_available = True
+            usage.input_tokens += input_tokens or 0
+            usage.output_tokens += output_tokens or 0
+            usage.cache_read_tokens += cache_read_tokens or 0
+            usage.cache_creation_tokens += cache_creation_tokens or 0
+            if explicit_total_tokens is not None:
+                usage.total_tokens += explicit_total_tokens
+            else:
+                usage.total_tokens += sum(value or 0 for value in token_parts)
     return totals
+
+
+def aggregate_costs(entries: Iterable[Dict[str, Any]]) -> Dict[str, float]:
+    return {model: usage.cost for model, usage in aggregate_model_usages(entries).items()}
 
 
 def pick_current_model(entries: List[Dict[str, Any]]) -> Tuple[Optional[str], Optional[str]]:
@@ -203,10 +257,32 @@ def render_text_current(
     return "\n".join(lines)
 
 
-def render_text_all(provider: str, totals: Dict[str, float]) -> str:
+def format_int(value: int) -> str:
+    return f"{value:,}"
+
+
+def render_tokens(usage: ModelUsage) -> str:
+    if not usage.tokens_available:
+        return "tokens unavailable"
+    parts = [f"tokens {format_int(usage.total_tokens)}"]
+    details = []
+    if usage.input_tokens:
+        details.append(f"in {format_int(usage.input_tokens)}")
+    if usage.output_tokens:
+        details.append(f"out {format_int(usage.output_tokens)}")
+    if usage.cache_read_tokens:
+        details.append(f"cache read {format_int(usage.cache_read_tokens)}")
+    if usage.cache_creation_tokens:
+        details.append(f"cache create {format_int(usage.cache_creation_tokens)}")
+    if details:
+        parts.append(f"({', '.join(details)})")
+    return " ".join(parts)
+
+
+def render_text_all(provider: str, totals: Dict[str, ModelUsage]) -> str:
     lines = [f"Provider: {provider}", "Models:"]
-    for model, cost in sorted(totals.items(), key=lambda item: item[1], reverse=True):
-        lines.append(f"- {model}: {usd(cost)}")
+    for model, usage in sorted(totals.items(), key=lambda item: item[1].cost, reverse=True):
+        lines.append(f"- {model}: {usd(usage.cost)}, {render_tokens(usage)}")
     return "\n".join(lines)
 
 
@@ -231,13 +307,22 @@ def build_json_current(
     }
 
 
-def build_json_all(provider: str, totals: Dict[str, float]) -> Dict[str, Any]:
+def build_json_all(provider: str, totals: Dict[str, ModelUsage]) -> Dict[str, Any]:
     return {
         "provider": provider,
         "mode": "all",
         "models": [
-            {"model": model, "totalCostUSD": cost}
-            for model, cost in sorted(totals.items(), key=lambda item: item[1], reverse=True)
+            {
+                "model": model,
+                "totalCostUSD": usage.cost,
+                "tokensAvailable": usage.tokens_available,
+                "totalTokens": usage.total_tokens if usage.tokens_available else None,
+                "inputTokens": usage.input_tokens if usage.tokens_available else None,
+                "outputTokens": usage.output_tokens if usage.tokens_available else None,
+                "cacheReadTokens": usage.cache_read_tokens if usage.tokens_available else None,
+                "cacheCreationTokens": usage.cache_creation_tokens if usage.tokens_available else None,
+            }
+            for model, usage in sorted(totals.items(), key=lambda item: item[1].cost, reverse=True)
         ],
     }
 
@@ -301,7 +386,7 @@ def main() -> int:
             )
         return 0
 
-    totals = aggregate_costs(entries)
+    totals = aggregate_model_usages(entries)
     if not totals:
         eprint("No model breakdowns found in codexbar cost payload.")
         return 2

--- a/skills/model-usage/scripts/test_model_usage.py
+++ b/skills/model-usage/scripts/test_model_usage.py
@@ -7,7 +7,13 @@ import argparse
 from datetime import date, timedelta
 from unittest import TestCase, main
 
-from model_usage import filter_by_days, positive_int
+from model_usage import (
+    aggregate_model_usages,
+    build_json_all,
+    filter_by_days,
+    positive_int,
+    render_text_all,
+)
 
 
 class TestModelUsage(TestCase):
@@ -34,6 +40,74 @@ class TestModelUsage(TestCase):
         self.assertEqual(len(filtered), 2)
         self.assertEqual(filtered[0]["date"], (today - timedelta(days=1)).strftime("%Y-%m-%d"))
         self.assertEqual(filtered[1]["date"], today.strftime("%Y-%m-%d"))
+
+    def test_aggregate_model_usages_sums_cost_and_tokens_by_model(self):
+        entries = [
+            {
+                "date": "2026-05-04",
+                "modelBreakdowns": [
+                    {
+                        "modelName": "gpt-5.5",
+                        "cost": 1.25,
+                        "inputTokens": 100,
+                        "outputTokens": 25,
+                        "cacheReadTokens": 10,
+                        "cacheCreationTokens": 5,
+                        "totalTokens": 140,
+                    },
+                    {
+                        "modelName": "glm-5.1",
+                        "cost": 0.50,
+                        "inputTokens": 200,
+                        "outputTokens": 80,
+                    },
+                ],
+            },
+            {
+                "date": "2026-05-05",
+                "modelBreakdowns": [
+                    {
+                        "modelName": "gpt-5.5",
+                        "cost": 0.75,
+                        "prompt_tokens": 20,
+                        "completion_tokens": 10,
+                        "total_tokens": 30,
+                    }
+                ],
+            },
+        ]
+
+        totals = aggregate_model_usages(entries)
+
+        self.assertEqual(totals["gpt-5.5"].cost, 2.0)
+        self.assertEqual(totals["gpt-5.5"].input_tokens, 120)
+        self.assertEqual(totals["gpt-5.5"].output_tokens, 35)
+        self.assertEqual(totals["gpt-5.5"].cache_read_tokens, 10)
+        self.assertEqual(totals["gpt-5.5"].cache_creation_tokens, 5)
+        self.assertEqual(totals["gpt-5.5"].total_tokens, 170)
+        self.assertTrue(totals["gpt-5.5"].tokens_available)
+        self.assertEqual(totals["glm-5.1"].total_tokens, 280)
+
+    def test_all_outputs_include_token_usage_for_each_model(self):
+        entries = [
+            {
+                "modelBreakdowns": [
+                    {"modelName": "gpt-5.5", "cost": 2.0, "inputTokens": 100, "outputTokens": 50},
+                    {"modelName": "glm-5.1", "cost": 1.0},
+                ]
+            }
+        ]
+        totals = aggregate_model_usages(entries)
+
+        text = render_text_all("codex", totals)
+        payload = build_json_all("codex", totals)
+
+        self.assertIn("gpt-5.5: $2.00, tokens 150", text)
+        self.assertIn("glm-5.1: $1.00, tokens unavailable", text)
+        self.assertEqual(payload["models"][0]["totalTokens"], 150)
+        self.assertTrue(payload["models"][0]["tokensAvailable"])
+        self.assertIsNone(payload["models"][1]["totalTokens"])
+        self.assertFalse(payload["models"][1]["tokensAvailable"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include per-model token totals in `model-usage --mode all` text and JSON output when CodexBar model breakdowns expose token fields
- support CodexBar-style token fields and OpenAI-style `prompt_tokens` / `completion_tokens` / `total_tokens`
- report `tokens unavailable` when CodexBar only provides per-model cost, avoiding invented token splits from aggregate daily totals

## Real behavior proof

behavior: `skills/model-usage/scripts/model_usage.py --mode all` now prints and serializes per-model token usage for every model in the breakdown when token fields are present, while still listing cost-only models with an explicit unavailable token state.

environment: Local OpenClaw checkout on macOS using Python 3.14 for the direct script smoke check and a Python virtualenv for repo-style skills checks. The input was a local redacted sample CodexBar cost payload with no secrets.

steps:
1. Created `/tmp/model_usage_sample.json` with three model breakdown rows: CodexBar-style token fields, OpenAI-style token fields, and a cost-only row.
2. Ran `python3 skills/model-usage/scripts/model_usage.py --provider codex --mode all --input /tmp/model_usage_sample.json`.
3. Ran `python3 skills/model-usage/scripts/model_usage.py --provider codex --mode all --format json --input /tmp/model_usage_sample.json`.

evidence:
```text
Provider: codex
Models:
- gpt-5.5: $2.00, tokens 150 (in 100, out 50)
- glm-5.1: $1.00, tokens 275 (in 200, out 75)
- legacy: $0.25, tokens unavailable
{"provider": "codex", "mode": "all", "models": [{"model": "gpt-5.5", "totalCostUSD": 2.0, "tokensAvailable": true, "totalTokens": 150, "inputTokens": 100, "outputTokens": 50, "cacheReadTokens": 0, "cacheCreationTokens": 0}, {"model": "glm-5.1", "totalCostUSD": 1.0, "tokensAvailable": true, "totalTokens": 275, "inputTokens": 200, "outputTokens": 75, "cacheReadTokens": 0, "cacheCreationTokens": 0}, {"model": "legacy", "totalCostUSD": 0.25, "tokensAvailable": false, "totalTokens": null, "inputTokens": null, "outputTokens": null, "cacheReadTokens": null, "cacheCreationTokens": null}]}
```

observedResult: All three models appear in both text and JSON. The two models with token fields include computed token totals and input/output details. The cost-only model remains listed and reports `tokens unavailable` / `tokensAvailable: false`, so the command does not invent a per-model token split from aggregate daily totals.

notTested: I did not run against live CodexBar logs because this environment does not have the CodexBar CLI available on PATH; the verified smoke input mirrors the documented `modelBreakdowns[]` payload shape.

## Verification
- `python3 -m py_compile skills/model-usage/scripts/model_usage.py skills/model-usage/scripts/test_model_usage.py`
- `python3 skills/model-usage/scripts/test_model_usage.py`
- `/tmp/openclaw-skills-venv/bin/python -m ruff check --config skills/pyproject.toml skills/model-usage`
- `/tmp/openclaw-skills-venv/bin/python -m pytest -q -c skills/pyproject.toml skills/model-usage`

## Notes
- `bd sync` could not run in this checkout because no beads database exists.
