### PR TITLE
fix: /model default now resets to configured default model

### DIFF
--- a/src/auto-reply/reply/directive-handling.model-selection.ts
+++ b/src/auto-reply/reply/directive-handling.model-selection.ts
@@ -66,6 +66,19 @@ export function resolveModelSelectionFromDirective(params: {
   }
 
   const raw = params.directives.rawModelDirective.trim();
+
+  // /model default (or /model primary) resets the session to the configured default model.
+  const rawLower = raw.toLowerCase();
+  if ((rawLower === "default" || rawLower === "primary") && params.defaultProvider && params.defaultModel) {
+    return {
+      modelSelection: {
+        provider: params.defaultProvider,
+        model: params.defaultModel,
+        isDefault: true,
+      },
+    };
+  }
+
   const storedNumericProfile =
     params.directives.rawModelProfile === undefined
       ? resolveStoredNumericProfileModelDirective({

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -642,6 +642,36 @@ describe("/model chat UX", () => {
     });
   });
 
+  it("resets to default model when /model default is used", () => {
+    const resolved = resolveModelSelectionForCommand({
+      command: "/model default",
+      allowedModelKeys: new Set(["anthropic/claude-opus-4-6", "openai/gpt-4o"]),
+      allowedModelCatalog: [],
+    });
+
+    expect(resolved.errorText).toBeUndefined();
+    expect(resolved.modelSelection).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      isDefault: true,
+    });
+  });
+
+  it("resets to default model when /model primary is used", () => {
+    const resolved = resolveModelSelectionForCommand({
+      command: "/model primary",
+      allowedModelKeys: new Set(["anthropic/claude-opus-4-6"]),
+      allowedModelCatalog: [],
+    });
+
+    expect(resolved.errorText).toBeUndefined();
+    expect(resolved.modelSelection).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      isDefault: true,
+    });
+  });
+
   it("keeps openrouter provider/model split for exact selections", () => {
     const resolved = resolveModelSelectionForCommand({
       command: "/model openrouter/anthropic/claude-opus-4-6",


### PR DESCRIPTION
## Problem

Running `/model default` in chat passes the literal string `"default"` to the model resolver, which errors with `Unrecognized model "default"` or fuzzy-matches an unrelated model. Users have to type the full configured model name to reset.

## Fix

Added a special-case check in `resolveModelSelectionFromDirective` that early-returns a default model selection (`isDefault: true`) when the trimmed, lowercase raw token is `"default"` or `"primary"`. This composes correctly with the existing `applyModelOverrideToSessionEntry` logic, which deletes `providerOverride`/`modelOverride` when `selection.isDefault` is true, producing the existing "Model reset to default" ack.

## Testing

- 2 new tests: `/model default` and `/model primary` both return the configured default model with `isDefault: true`
- All 51 tests in `directive-handling.model.test.ts` pass

```
✓ src/auto-reply/reply/directive-handling.model.test.ts (51 tests)
```

Fixes #78182