### PR TITLE
Update ACPX extension dependency

### DIFF
--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "0.32.0",
     "@zed-industries/codex-acp": "0.13.0",
-    "acpx": "0.6.1"
+    "acpx": "0.7.0"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,8 +304,8 @@ importers:
         specifier: 0.13.0
         version: 0.13.0
       acpx:
-        specifier: 0.6.1
-        version: 0.6.1
+        specifier: 0.7.0
+        version: 0.7.0
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1683,11 +1683,6 @@ packages:
   '@agentclientprotocol/claude-agent-acp@0.32.0':
     resolution: {integrity: sha512-3WIaD1bTmIciqHdeU97oeNajOG9H+ctloXnQ+R/T563C2CM8u1K7QsNqqgqR2F+Cn8NVBkXdHRvAMtUHglLzAw==}
     hasBin: true
-
-  '@agentclientprotocol/sdk@0.20.0':
-    resolution: {integrity: sha512-BxEHyE4MvwyOsdyVPub1vEtyrq8E0JSdjC+ckXWimY1VabFCTXdPyXv2y2Omz1j+iod7Z8oBJDXFCJptM0GBqQ==}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   '@agentclientprotocol/sdk@0.21.0':
     resolution: {integrity: sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==}
@@ -4603,8 +4598,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acpx@0.6.1:
-    resolution: {integrity: sha512-qxZPbm3SKq0UqQ0sOJ0M4iTLkF9AR7+I+JE/L/UeMUU1vW5N4nUVkZHytoHTBAu7nrej6THNzCPgrIZfv9T3AA==}
+  acpx@0.7.0:
+    resolution: {integrity: sha512-BratfuaUoZv1iSETJobqhiWM3E/Z3lJlGRxSImJX162LXSwqwnWiCEh6GjKzx2/56rJgZno8VV06aXev46mLmw==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -7885,10 +7880,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
-
-  '@agentclientprotocol/sdk@0.20.0(zod@4.4.3)':
-    dependencies:
-      zod: 4.4.3
 
   '@agentclientprotocol/sdk@0.21.0(zod@4.4.3)':
     dependencies:
@@ -11455,9 +11446,9 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  acpx@0.6.1:
+  acpx@0.7.0:
     dependencies:
-      '@agentclientprotocol/sdk': 0.20.0(zod@4.4.3)
+      '@agentclientprotocol/sdk': 0.21.0(zod@4.4.3)
       commander: 14.0.3
       skillflag: 0.1.4
       tsx: 4.21.0


### PR DESCRIPTION
Fixes #77694.

## Summary
- update the ACPX extension dependency from `acpx@0.6.1` to `acpx@0.7.0`
- refresh `pnpm-lock.yaml`

## Verification
- `git diff --check`
- `PATH="/tank/development/linus/openclaw/node_modules/.bin:$PATH" node scripts/test-projects.mjs extensions/acpx --maxWorkers=1` — passed, 9 files / 70 tests

## Notes
- Live `acpx flow run` against pi/opencode was not run because it requires live agent credentials/runtime side effects.
- Lockfile reproduction from worker evidence: `npx --yes pnpm@10.33.2 install --lockfile-only --filter ./extensions/acpx --config.minimumReleaseAge=0`.
