### PR TITLE
Agents/exec: show target node name in exec tool transparency messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,7 +380,6 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
 - Telegram/ACP: preserve explicit `:topic:` conversation suffixes when inbound ACP targets do not carry a separate thread id.
 - Browser/proxy: bypass the managed proxy for the exact local managed Chrome CDP readiness and DevTools WebSocket endpoints, so `openclaw browser start` works when the operator proxy blocks loopback egress. (#83255) Thanks @lightcap.
-- Agents/exec: surface the target node name in exec tool transparency messages when `host=node` is set, so users with paired nodes can tell where a command ran. (#77719)
 - Ollama: bypass the managed proxy for configured local embedding origins while keeping SSRF guardrails on unconfigured targets. Thanks @Kaspre.
 - OpenAI/images: route Codex API-key image generation through the native OpenAI Images API instead of the Codex OAuth streaming backend, avoiding 401s from valid API keys.
 - Agents/OpenAI completions: omit empty tool payload fields for proxy-like OpenAI-compatible endpoints so strict vLLM-style servers accept tool-free turns. (#85835) Thanks @rendrag-git.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,6 +380,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
 - Telegram/ACP: preserve explicit `:topic:` conversation suffixes when inbound ACP targets do not carry a separate thread id.
 - Browser/proxy: bypass the managed proxy for the exact local managed Chrome CDP readiness and DevTools WebSocket endpoints, so `openclaw browser start` works when the operator proxy blocks loopback egress. (#83255) Thanks @lightcap.
+- Agents/exec: surface the target node name in exec tool transparency messages when `host=node` is set, so users with paired nodes can tell where a command ran. (#77719)
 - Ollama: bypass the managed proxy for configured local embedding origins while keeping SSRF guardrails on unconfigured targets. Thanks @Kaspre.
 - OpenAI/images: route Codex API-key image generation through the native OpenAI Images API instead of the Codex OAuth streaming backend, avoiding 401s from valid API keys.
 - Agents/OpenAI completions: omit empty tool payload fields for proxy-like OpenAI-compatible endpoints so strict vLLM-style servers accept tool-free turns. (#85835) Thanks @rendrag-git.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -411,6 +411,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: enforce allowlist `argPattern` argument restrictions on Linux and macOS as well as Windows, so an entry like `{ pattern: "python3", argPattern: "^safe\.py$" }` no longer silently relaxes to a path-only match on non-Windows hosts. (#75143) Thanks @eleqtrizit.
 - Agents/compaction: disable Pi auto-compaction whenever OpenClaw effectively owns safeguard compaction, including provider-backed safeguard mode, so Pi and OpenClaw no longer fight over long-session compaction. Fixes #73003. (#73839) Thanks @bradhallett.
 - Telegram/streaming: finalize text replies by stopping the edited stream message instead of sending a second answer bubble, so Telegram turns cannot duplicate the streamed final response. (#77947) Thanks @obviyus.
+- Agents/exec: surface the target node name in exec tool transparency messages when `host=node` is set, so users with paired nodes (Raspberry Pi, remote servers) can tell at a glance where a command ran. (#77719)
 
 ## 2026.5.3-1
 

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -452,6 +452,9 @@ export function resolveExecDetail(
     return undefined;
   }
 
+  const nodeName =
+    typeof record.node === "string" && record.node.trim() ? record.node.trim() : undefined;
+
   const unwrapped = unwrapShellWrapper(raw);
   const result = summarizeExecCommand(unwrapped) ?? summarizeExecCommand(raw);
   const summary = result?.text || "run command";
@@ -466,8 +469,11 @@ export function resolveExecDetail(
 
   const compact = compactRawCommand(unwrapped);
   const cwdSuffix = cwd ? formatCwdSuffix(cwd) : undefined;
+  const nodeFragment = nodeName ? ` · node: ${nodeName}` : "";
+
   if (result?.allGeneric !== false && isGenericSummary(summary)) {
-    return cwdSuffix ? `${compact} ${cwdSuffix}` : compact;
+    const base = cwdSuffix ? `${compact} ${cwdSuffix}` : compact;
+    return `${base}${nodeFragment}`;
   }
 
   const displaySummary = cwdSuffix ? `${summary} ${cwdSuffix}` : summary;
@@ -477,8 +483,8 @@ export function resolveExecDetail(
     compact !== displaySummary &&
     compact !== summary
   ) {
-    return `${displaySummary} · \`${compact}\``;
+    return `${displaySummary}${nodeFragment} · \`${compact}\``;
   }
 
-  return displaySummary;
+  return `${displaySummary}${nodeFragment}`;
 }

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -453,7 +453,9 @@ export function resolveExecDetail(
   }
 
   const nodeName =
-    typeof record.node === "string" && record.node.trim() ? record.node.trim() : undefined;
+    record.host === "node" && typeof record.node === "string" && record.node.trim()
+      ? record.node.trim()
+      : undefined;
 
   const unwrapped = unwrapShellWrapper(raw);
   const result = summarizeExecCommand(unwrapped) ?? summarizeExecCommand(raw);

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -401,6 +401,9 @@ export function resolveExecDetail(
     return undefined;
   }
 
+  const nodeName =
+    typeof record.node === "string" && record.node.trim() ? record.node.trim() : undefined;
+
   const unwrapped = unwrapShellWrapper(raw);
   const result = summarizeExecCommand(unwrapped) ?? summarizeExecCommand(raw);
   const summary = result?.text || "run command";
@@ -414,8 +417,11 @@ export function resolveExecDetail(
   const cwd = cwdRaw?.trim() || result?.chdirPath || undefined;
 
   const compact = compactRawCommand(unwrapped);
+  const nodeFragment = nodeName ? ` · node: ${nodeName}` : "";
+
   if (result?.allGeneric !== false && isGenericSummary(summary)) {
-    return cwd ? `${compact} (in ${cwd})` : compact;
+    const base = cwd ? `${compact} (in ${cwd})` : compact;
+    return `${base}${nodeFragment}`;
   }
 
   const displaySummary = cwd ? `${summary} (in ${cwd})` : summary;
@@ -425,8 +431,8 @@ export function resolveExecDetail(
     compact !== displaySummary &&
     compact !== summary
   ) {
-    return `${displaySummary} · \`${compact}\``;
+    return `${displaySummary}${nodeFragment} · \`${compact}\``;
   }
 
-  return displaySummary;
+  return `${displaySummary}${nodeFragment}`;
 }

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -484,4 +484,17 @@ describe("tool display details", () => {
 
     expect(detail).not.toContain("node:");
   });
+
+  it("omits node label when host is not 'node' even if node is set", () => {
+    for (const host of ["gateway", "sandbox", "auto"]) {
+      const detail = formatToolDetail(
+        resolveToolDisplay({
+          name: "exec",
+          args: { command: "npm install", host, node: "raspberrypi" },
+        }),
+      );
+
+      expect(detail).not.toContain("node:");
+    }
+  });
 });

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -441,4 +441,47 @@ describe("tool display details", () => {
     expect(nodeCheckDetail).toContain("check js syntax for /tmp/test.js");
     expect(nodeShortCheckDetail).toContain("check js syntax for /tmp/test.js");
   });
+
+  it("appends node name to exec detail when node is set", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: "docker pull pihole/pihole:latest",
+          host: "node",
+          node: "raspberrypi",
+        },
+      }),
+    );
+
+    expect(detail).toContain("node: raspberrypi");
+  });
+
+  it("includes both cwd and node name in exec detail for known commands", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: "npm install",
+          workdir: "/app",
+          host: "node",
+          node: "raspberrypi",
+        },
+      }),
+    );
+
+    expect(detail).toContain("(in /app)");
+    expect(detail).toContain("node: raspberrypi");
+  });
+
+  it("omits node label when node param is absent or empty", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "npm install", host: "gateway" },
+      }),
+    );
+
+    expect(detail).not.toContain("node:");
+  });
 });

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -304,4 +304,47 @@ describe("tool display details", () => {
     expect(nodeCheckDetail).toContain("check js syntax for /tmp/test.js");
     expect(nodeShortCheckDetail).toContain("check js syntax for /tmp/test.js");
   });
+
+  it("appends node name to exec detail when node is set", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: "docker pull pihole/pihole:latest",
+          host: "node",
+          node: "raspberrypi",
+        },
+      }),
+    );
+
+    expect(detail).toContain("node: raspberrypi");
+  });
+
+  it("includes both cwd and node name in exec detail for known commands", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: "npm install",
+          workdir: "/app",
+          host: "node",
+          node: "raspberrypi",
+        },
+      }),
+    );
+
+    expect(detail).toContain("(in /app)");
+    expect(detail).toContain("node: raspberrypi");
+  });
+
+  it("omits node label when node param is absent or empty", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "npm install", host: "gateway" },
+      }),
+    );
+
+    expect(detail).not.toContain("node:");
+  });
 });


### PR DESCRIPTION
## Summary

When the `exec` tool runs on a remote node (`host=node, node=<name>`), the tool-call transparency message currently shows only the command — there's no indication of which node the command ran on. This makes it hard to tell whether a command executed locally on the gateway or remotely on a paired device (e.g. a Raspberry Pi).

This PR surfaces the `node` parameter in the exec detail string:

**Before:**
> 🛠️ Exec: docker pull pihole/pihole:latest

**After:**
> 🛠️ Exec: docker pull pihole/pihole:latest, node: raspberrypi

The `node` label is appended only when the `node` parameter is a non-empty string. It composes naturally with the existing `workdir`/`cwd` context suffix, raw-command appendix, and the `detailMode: "explain"` guard (raw command suppressed in explain mode, node label still shown).

Fixes #77719

## Changes

- `src/agents/tool-display-exec.ts`: Extract `node` from args in `resolveExecDetail()`; append ` · node: <name>` fragment (becomes `, node: <name>` after `formatToolDetailText` normalization). Preserves the `detailMode !== "explain"` guard for raw-command suppression.
- `src/agents/tool-display.test.ts`: Three new cases — node-only (unknown binary falls back to raw+node), node+cwd for a known command, and absent-node (no label).
- `CHANGELOG.md`: Entry appended to end of `### Fixes` in the `Unreleased` block.

## Test plan

- [x] `pnpm test src/agents/tool-display.test.ts` — 24/24 pass (3 new node cases)
- [x] `pnpm check` — conflict-markers, changelog, tool-display guards all green

## Real behavior proof

**Behavior or issue addressed**: When `exec` is called with `host=node, node=<name>`, the tool transparency detail omits the node name entirely. Users cannot tell from the progress display whether a command ran on the local gateway or a remote paired device.

**Real environment tested**: macOS 25.3.0, Node 25.2.1, tsx 4.21.0, source from rebased branch (`862c89a2cc`) at `src/agents/tool-display-exec.ts`.

**Exact steps or command run after this patch**:

```
npx tsx -e "
import { resolveExecDetail } from './src/agents/tool-display-exec.ts';
const cases = [
  [{ command: 'docker pull pihole/pihole:latest', host: 'node', node: 'raspberrypi' }, undefined],
  [{ command: 'npm install', workdir: '/app', host: 'node', node: 'raspberrypi' }, undefined],
  [{ command: 'npm install', workdir: '/app', host: 'node', node: 'raspberrypi' }, { detailMode: 'explain' }],
  [{ command: 'npm install', workdir: '/app' }, undefined],
];
for (const [args, options] of cases) { console.log(resolveExecDetail(args, options)); }
"
```

**Evidence after fix**: Actual console output from running the above node command against the patched source:

```
docker pull pihole/pihole:latest · node: raspberrypi
install dependencies (in /app) · node: raspberrypi · `npm install`
install dependencies (in /app) · node: raspberrypi
install dependencies (in /app) · `npm install`
```

Line 1: unknown binary — falls back to raw command + node label appended.
Line 2: known command (`npm install`) with cwd + node label + raw appendix (non-explain mode).
Line 3: same as line 2 but `detailMode: "explain"` — raw appendix suppressed, node label still present.
Line 4: `node` param absent — no label, output unchanged from before this patch.

The ` · ` separator becomes `, ` after `formatToolDetailText` normalization in the display layer.

**Observed result after fix**: The node name appears in all exec transparency detail strings when `node` is set. Existing output (no `node` param) is byte-identical to before.

**What was not tested**: Live end-to-end run through a real OpenClaw gateway with a physically paired node (Raspberry Pi, remote server). The function under test is pure formatting with no I/O — its behavior is fully captured by the code path exercised above. A maintainer with a paired-node setup can apply `proof: override` if the above is insufficient.