### PR TITLE
fix(plugins): start selected context engine slot

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -251,6 +251,15 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         cliBackends: [],
       },
       {
+        id: "lossless-claw",
+        kind: "context-engine",
+        channels: [],
+        origin: "global",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
         id: "demo-global-sidecar",
         channels: [],
         activation: {
@@ -418,7 +427,13 @@ function createStartupConfig(params: {
   allowPluginIds?: string[];
   noConfiguredChannels?: boolean;
   memorySlot?: string;
+  contextEngineSlot?: string;
 }) {
+  const slots = {
+    ...(params.memorySlot ? { memory: params.memorySlot } : {}),
+    ...(params.contextEngineSlot ? { contextEngine: params.contextEngineSlot } : {}),
+  };
+  const hasSlots = Object.keys(slots).length > 0;
   return {
     ...(params.noConfiguredChannels
       ? {
@@ -435,7 +450,7 @@ function createStartupConfig(params: {
       ? {
           plugins: {
             ...(params.allowPluginIds?.length ? { allow: params.allowPluginIds } : {}),
-            ...(params.memorySlot ? { slots: { memory: params.memorySlot } } : {}),
+            ...(hasSlots ? { slots } : {}),
             entries: Object.fromEntries(
               params.enabledPluginIds.map((pluginId) => [pluginId, { enabled: true }]),
             ),
@@ -447,12 +462,10 @@ function createStartupConfig(params: {
               allow: params.allowPluginIds,
             },
           }
-        : params.memorySlot
+        : hasSlots
           ? {
               plugins: {
-                slots: {
-                  memory: params.memorySlot,
-                },
+                slots,
               },
             }
           : {}),
@@ -948,6 +961,107 @@ describe("resolveGatewayStartupPluginIds", () => {
         enabledPluginIds: ["memory-lancedb"],
       }),
       expected: ["demo-channel", "browser", "memory-core"],
+    });
+  });
+
+  it("includes the selected context engine plugin in startup scope", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        contextEngineSlot: "lossless-claw",
+      }),
+      expected: ["demo-channel", "browser", "memory-core", "lossless-claw"],
+    });
+  });
+
+  it("normalizes the raw context engine slot id before startup filtering", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        contextEngineSlot: "Lossless-Claw",
+      }),
+      expected: ["demo-channel", "browser", "memory-core", "lossless-claw"],
+    });
+  });
+
+  it("keeps the built-in legacy context engine out of startup scope", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        contextEngineSlot: "legacy",
+      }),
+      expected: ["demo-channel", "browser", "memory-core"],
+    });
+  });
+
+  it("lets a selected context engine plugin bypass restrictive allowlists", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        channels: {},
+        plugins: {
+          allow: ["browser", "memory-core"],
+          slots: { contextEngine: "lossless-claw" },
+        },
+      } as OpenClawConfig,
+      expected: ["browser", "memory-core", "lossless-claw"],
+    });
+  });
+
+  it("does not include a selected context engine plugin when plugins are disabled", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        plugins: {
+          enabled: false,
+          slots: { contextEngine: "lossless-claw" },
+        },
+      } as OpenClawConfig,
+      expected: [],
+    });
+  });
+
+  it("does not include a selected context engine plugin when it is denied", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        plugins: {
+          deny: ["lossless-claw"],
+          slots: { contextEngine: "lossless-claw" },
+        },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser", "memory-core"],
+    });
+  });
+
+  it("does not include a selected context engine plugin when it is explicitly disabled", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        plugins: {
+          slots: { contextEngine: "lossless-claw" },
+          entries: { "lossless-claw": { enabled: false } },
+        },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser", "memory-core"],
+    });
+  });
+
+  it("includes a selected workspace context engine plugin in startup scope", () => {
+    const fixture = createManifestRegistryFixture();
+    useManifestRegistryFixture({
+      ...fixture,
+      plugins: [
+        ...fixture.plugins,
+        withManifestLoadPaths({
+          id: "workspace-context-engine",
+          kind: "context-engine",
+          channels: [],
+          origin: "workspace",
+          enabledByDefault: undefined,
+          providers: [],
+          cliBackends: [],
+        }),
+      ],
+    });
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        contextEngineSlot: "workspace-context-engine",
+      }),
+      expected: ["demo-channel", "browser", "memory-core", "workspace-context-engine"],
     });
   });
 

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -146,14 +146,23 @@ export function normalizePluginsConfigWithResolver(
   normalizePluginId: NormalizePluginId = identityNormalizePluginId,
 ): NormalizedPluginsConfig {
   const memorySlot = normalizeSlotValue(config?.slots?.memory);
+  const contextEngineSlot = normalizeSlotValue(config?.slots?.contextEngine);
   return {
     enabled: config?.enabled !== false,
     allow: normalizeList(config?.allow, normalizePluginId),
     deny: normalizeList(config?.deny, normalizePluginId),
     loadPaths: normalizeList(config?.load?.paths, identityNormalizePluginId),
     slots: {
-      memory: memorySlot === undefined ? defaultSlotIdForKey("memory") : memorySlot,
-      contextEngine: normalizeSlotValue(config?.slots?.contextEngine),
+      memory:
+        memorySlot === undefined
+          ? defaultSlotIdForKey("memory")
+          : memorySlot === null
+            ? null
+            : normalizePluginId(memorySlot),
+      contextEngine:
+        contextEngineSlot === undefined || contextEngineSlot === null
+          ? contextEngineSlot
+          : normalizePluginId(contextEngineSlot),
     },
     entries: normalizePluginEntries(config?.entries, normalizePluginId),
   };

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -26,6 +26,7 @@ import {
   normalizePluginsConfigWithRegistry,
 } from "./plugin-registry-contributions.js";
 import type { PluginRegistrySnapshot } from "./plugin-registry-snapshot.js";
+import { defaultSlotIdForKey } from "./slots.js";
 
 export type GatewayStartupPluginPlan = {
   channelPluginIds: readonly string[];
@@ -95,13 +96,32 @@ function resolveMemorySlotStartupPluginId(params: {
   return normalizePluginId(configuredSlot);
 }
 
+function resolveContextEngineSlotStartupPluginId(params: {
+  activationSourcePlugins: ReturnType<typeof normalizePluginsConfigWithRegistry>;
+  normalizePluginId: (pluginId: string) => string;
+}): string | undefined {
+  const configuredSlot = params.activationSourcePlugins.slots.contextEngine;
+  if (typeof configuredSlot !== "string") {
+    return undefined;
+  }
+  const pluginId = params.normalizePluginId(configuredSlot);
+  if (pluginId === defaultSlotIdForKey("contextEngine")) {
+    return undefined;
+  }
+  return pluginId;
+}
+
 function shouldConsiderForGatewayStartup(params: {
   plugin: InstalledPluginIndexRecord;
   manifest: PluginManifestRecord | undefined;
   startupDreamingPluginIds: ReadonlySet<string>;
   memorySlotStartupPluginId?: string;
+  contextEngineSlotStartupPluginId?: string;
 }): boolean {
   if (params.manifest?.activation?.onStartup === true) {
+    return true;
+  }
+  if (params.contextEngineSlotStartupPluginId === params.plugin.pluginId) {
     return true;
   }
   if (!isGatewayStartupMemoryPlugin(params.plugin)) {
@@ -341,12 +361,17 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
   );
   const startupDreamingPluginIds = resolveGatewayStartupDreamingPluginIds(params.config);
   const manifestLookup = createManifestRegistryLookup(params.manifestRegistry);
+  const normalizePluginId = createPluginRegistryIdNormalizer(params.index, {
+    manifestRegistry: params.manifestRegistry,
+  });
   const memorySlotStartupPluginId = resolveMemorySlotStartupPluginId({
     activationSourceConfig,
     activationSourcePlugins,
-    normalizePluginId: createPluginRegistryIdNormalizer(params.index, {
-      manifestRegistry: params.manifestRegistry,
-    }),
+    normalizePluginId,
+  });
+  const contextEngineSlotStartupPluginId = resolveContextEngineSlotStartupPluginId({
+    activationSourcePlugins,
+    normalizePluginId,
   });
   const pluginIds = params.index.plugins
     .filter((plugin) => {
@@ -396,6 +421,7 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
           manifest,
           startupDreamingPluginIds,
           memorySlotStartupPluginId,
+          contextEngineSlotStartupPluginId,
         })
       ) {
         return false;


### PR DESCRIPTION
## Summary

- Problem: a configured `plugins.slots.contextEngine` plugin could be normalized but still excluded from the gateway startup plugin scope.
- Why it matters: custom context engine plugins need to be started when selected, otherwise the configured engine may never activate.
- What changed: normalize selected memory and context engine slot ids through the plugin id normalizer, include non-default selected context engine plugins in startup consideration, and add regression coverage for allowed, denied, disabled, legacy, and workspace plugin cases.
- What did NOT change (scope boundary): this does not change the built-in legacy context engine behavior or plugin denial and disabled-entry precedence.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: gateway startup only treated startup activation, dreaming plugins, and memory-slot plugins as startup candidates. The selected context engine slot was not included in that startup candidate path.
- Missing detection / guardrail: there was no regression test covering `plugins.slots.contextEngine` as an activation source for gateway startup.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/channel-plugin-ids.test.ts`
- Scenario the test should lock in: a configured non-default context engine plugin is included in startup scope after id normalization, while legacy, denied, disabled, and plugin-disabled cases remain excluded.
- Why this is the smallest reliable guardrail: startup plugin selection is resolved in this unit seam, so it directly validates the policy without requiring a full gateway boot.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Configured custom context engine plugins can now be started as part of gateway startup when selected through `plugins.slots.contextEngine`.

## Diagram (if applicable)

```text
Before:
plugins.slots.contextEngine -> normalized config -> not considered for gateway startup

After:
plugins.slots.contextEngine -> normalized plugin id -> startup candidate -> selected context engine starts
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.8.0-111-generic
- Runtime/container: Node.js v24.13.0, pnpm
- Model/provider: N/A
- Integration/channel (if any): Plugins, gateway startup
- Relevant config (redacted): `plugins.slots.contextEngine: "lossless-claw"`

### Steps

1. Configure a non-default context engine plugin through `plugins.slots.contextEngine`.
2. Resolve the gateway startup plugin plan.
3. Inspect the plugin ids selected for startup.

### Expected

- The configured context engine plugin is included in startup scope unless plugins are disabled, the plugin is denied, or the plugin entry is explicitly disabled.

### Actual

- Before this fix, the selected context engine plugin was not included in startup scope.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest run src/plugins/channel-plugin-ids.test.ts`

Result: 1 test file passed, 74 tests passed.

## Human Verification (required)

Verified the diff is scoped to startup plugin selection and regression tests. Also ran `git diff --check origin/main...HEAD` with no whitespace errors.