### PR TITLE
fix(acp): preserve chunk whitespace in background-task progress summary [AI-Assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Docs: https://docs.openclaw.ai
 - Feishu: hydrate missing native topic starter thread IDs before session routing so first turns and follow-ups stay in the same topic session. Fixes #78262. Thanks @joeyzenghuan.
 - LINE: reject `dmPolicy: "open"` configs without wildcard `allowFrom` so webhook DMs fail validation instead of being acknowledged and silently blocked before inbound processing. Fixes #78316.
 - Telegram/Codex: keep message-tool-only progress drafts visible and render native Codex tool progress once per tool instead of duplicating item/tool draft lines. Fixes #75641. (#77949) Thanks @keshavbotagent.
+- ACP/background tasks: preserve chunk whitespace in background-task progress summaries so token-streamed CJK output no longer loses inter-character boundaries (e.g. `디렉토리` rendering as `디 렉 토 리`) when the parent channel announces the terminal result. Fixes #78312. Thanks @bykim0119.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Matrix/approvals: retry approval delivery up to 3 times with a short backoff so transient Matrix send failures do not strand pending approval prompts. (#78179) Thanks @Patrick-Erichsen.

--- a/src/acp/control-plane/manager.background-task-progress.test.ts
+++ b/src/acp/control-plane/manager.background-task-progress.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { appendBackgroundTaskProgressSummary } from "./manager.core.js";
+
+describe("appendBackgroundTaskProgressSummary", () => {
+  it("preserves CJK characters across one-char-per-chunk streaming", () => {
+    // Codex frequently emits one Hangul syllable per chunk; trimming each
+    // chunk and forcing a join space would produce "디 렉 토 리".
+    const chunks = ["디", "렉", "토", "리"];
+    let summary = "";
+    for (const chunk of chunks) {
+      summary = appendBackgroundTaskProgressSummary(summary, chunk);
+    }
+    expect(summary).toBe("디렉토리");
+  });
+
+  it("preserves a path streamed in mid-segment chunks", () => {
+    // Real-world Codex output: paths split between segments lose their
+    // separators and gain spurious spaces when each chunk is trimmed.
+    const chunks = ["/home/", "user/", "file.", "txt"];
+    let summary = "";
+    for (const chunk of chunks) {
+      summary = appendBackgroundTaskProgressSummary(summary, chunk);
+    }
+    expect(summary).toBe("/home/user/file.txt");
+  });
+
+  it("preserves a CamelCase identifier streamed mid-word", () => {
+    const chunks = ["unbeliev", "able"];
+    let summary = "";
+    for (const chunk of chunks) {
+      summary = appendBackgroundTaskProgressSummary(summary, chunk);
+    }
+    expect(summary).toBe("unbelievable");
+  });
+
+  it("preserves a leading-space chunk as the inter-word boundary", () => {
+    const chunks = ["hello", " world"];
+    let summary = "";
+    for (const chunk of chunks) {
+      summary = appendBackgroundTaskProgressSummary(summary, chunk);
+    }
+    expect(summary).toBe("hello world");
+  });
+
+  it("preserves a trailing-space chunk as the inter-word boundary", () => {
+    const chunks = ["hello ", "world"];
+    let summary = "";
+    for (const chunk of chunks) {
+      summary = appendBackgroundTaskProgressSummary(summary, chunk);
+    }
+    expect(summary).toBe("hello world");
+  });
+
+  it("collapses newlines and tabs to a single space within a chunk", () => {
+    expect(appendBackgroundTaskProgressSummary("", "line one\nline two")).toBe("line one line two");
+    expect(appendBackgroundTaskProgressSummary("", "col\tA\tcol\tB")).toBe("col A col B");
+  });
+
+  it("collapses runs of whitespace inside a chunk to a single space", () => {
+    expect(appendBackgroundTaskProgressSummary("", "foo    bar")).toBe("foo bar");
+  });
+
+  it("returns the current summary unchanged for empty or non-string chunks", () => {
+    expect(appendBackgroundTaskProgressSummary("foo", "")).toBe("foo");
+    expect(appendBackgroundTaskProgressSummary("foo", undefined as unknown as string)).toBe("foo");
+    expect(appendBackgroundTaskProgressSummary("foo", null as unknown as string)).toBe("foo");
+  });
+
+  it("truncates to the cap with an ellipsis when the combined length overflows", () => {
+    // Matches ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH in manager.core.ts.
+    const cap = 240;
+    const long = "a".repeat(cap + 50);
+    const result = appendBackgroundTaskProgressSummary("", long);
+    expect(result.length).toBe(cap);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("does not insert spaces between successive empty-yielding chunks", () => {
+    let summary = "";
+    summary = appendBackgroundTaskProgressSummary(summary, "abc");
+    summary = appendBackgroundTaskProgressSummary(summary, "");
+    summary = appendBackgroundTaskProgressSummary(summary, "def");
+    expect(summary).toBe("abcdef");
+  });
+});

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -97,12 +97,15 @@ function summarizeBackgroundTaskText(text: string): string {
   return `${normalized.slice(0, ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH - 1)}…`;
 }
 
-function appendBackgroundTaskProgressSummary(current: string, chunk: string): string {
-  const normalizedChunk = normalizeText(chunk)?.replace(/\s+/g, " ");
-  if (!normalizedChunk) {
+export function appendBackgroundTaskProgressSummary(current: string, chunk: string): string {
+  if (typeof chunk !== "string" || chunk.length === 0) {
     return current;
   }
-  const combined = current ? `${current} ${normalizedChunk}` : normalizedChunk;
+  // Token-streamed chunks (especially CJK) may split mid-word, so leading or
+  // trailing whitespace on a chunk carries the word-boundary signal. Collapse
+  // internal whitespace runs but do not trim chunk edges or force a join space.
+  const normalizedChunk = chunk.replace(/\s+/g, " ");
+  const combined = current + normalizedChunk;
   if (combined.length <= ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH) {
     return combined;
   }


### PR DESCRIPTION
## Summary

- Problem: `appendBackgroundTaskProgressSummary` in `src/acp/control-plane/manager.core.ts` trims every streamed chunk via `normalizeOptionalString` and joins with a forced single space, so token-streamed output whose chunk boundaries fall mid-word (CJK, paths, URLs, identifiers) loses inter-chunk word boundaries. Plain English prose escapes because BPE-style tokenizers prefix word tokens with a leading space, which incidentally aligns with the forced-space behavior.
- Why it matters: parent-channel terminal summaries become unreadable for any non-English ACP workload, and for English content that mixes paths or identifiers. Users on mobile Discord lose the primary signal of background-task output and have to drop into the child session to read the real result.
- What changed: drop the `normalizeText`/trim call on the chunk and the forced join space; concatenate the chunk verbatim after collapsing only its internal whitespace runs (newlines, tabs, multi-space) to a single space. Existing length cap and `…` truncation marker are preserved. The helper is exported for direct unit testing. New focused unit-test file covers CJK one-char-per-chunk, path mid-segment, CamelCase mid-word, leading-/trailing-space, whitespace-run collapse, length cap, empty-chunk no-op, and successive empty-yielding chunks.
- What did NOT change (scope boundary): no change to the cap value, the truncation marker, the `taskProgressSummary` / `terminalSummary` shape, or any downstream consumer. `resolveBackgroundTaskTerminalResult` and the success-path terminal-summary handling addressed by #74070 / PR #74103 are untouched — see "Scope vs #74070 / #74103" below.

Fixes #78312.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78312
- Related #74070, #74103
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: when Codex via ACP streams Korean output that includes a workspace path, the auto-announced terminal summary in the parent Discord channel renders inter-chunk word boundaries with spurious spaces (`현재 작업 디 렉 토 리 는 / home / by kim 0119 / . open claw / workspace 입니다`), losing both the CJK word grouping and the path separators. After the fix, the same announce renders the original text verbatim (`현재 작업 디렉토리는 /home/bykim0119/.openclaw/workspace 입니다`).
- **Real environment tested**: production OpenClaw 2026.4.21 install (`/usr/lib/node_modules/openclaw`) on Ubuntu 24.04, Discord channel bound to a Hermes orchestrator agent, ACP backend `acpx`, child agent `codex` (Codex CLI 0.121.0, `gpt-5.3-codex` via ChatGPT Plus auth, ACP runtime spawned by `sessions_spawn`). The same `appendBackgroundTaskProgressSummary` source on `main` at 2026.5.5 has the identical buggy code path, confirmed by `git show upstream/main:src/acp/control-plane/manager.core.ts | sed -n '99,109p'`.
- **Exact steps or command run after this patch**:
  1. Applied this patch's `src/acp/control-plane/manager.core.ts` change to the installed bundled file `/usr/lib/node_modules/openclaw/dist/manager-BPXdclo2.js` (the chunk-whitespace portion only — the cap and terminalSummary fields were left at their current upstream values).
  2. `sudo systemctl restart openclaw`.
  3. From the orchestrator agent in Discord: trigger a `sessions_spawn(runtime: "acp", agentId: "codex", task: "<Korean prompt asking Codex to print the absolute path of its current working directory>")`.
  4. Waited for the background-task `done` announce to land in the parent channel; captured the rendered text.
  5. Locally, ran the new unit-test file: `pnpm test src/acp/control-plane/manager.background-task-progress.test.ts`.
- **Evidence after fix**:

  Live Discord rendering of the announce after the patch (run `7495ffdb` → `fec2c09c` in OpenClaw's task-run log):

  ```
  현재 작업 디렉토리는 /home/bykim0119/.openclaw/workspace 입니다
  ```

  Same announce before the patch (same prompt, same agent, same model):

  ```
  현재 작업 디 렉 토 리 는 / home / by kim 0119 / . open claw / workspace 입니다
  ```

  Local unit-test output (10 deterministic cases including the live-mirroring CJK and path scenarios):

  ```
  RUN  v4.1.5 /home/bykim0119/autonormal/openclaw

   ✓ |unit-fast| src/acp/control-plane/manager.background-task-progress.test.ts (10 tests) 8ms

   Test Files  1 passed (1)
        Tests  10 passed (10)
     Duration  2.32s
  ```

  Existing manager test suite, run for regression coverage on the same change:

  ```
   ✓ |unit-fast| src/acp/control-plane/manager.test.ts (56 tests) 141ms

   Test Files  1 passed (1)
        Tests  56 passed (56)
     Duration  1.52s
  ```

- **Observed result after fix**: the live announce in Discord renders the Korean and the path verbatim, matching what Codex actually emitted; chunked unit-test inputs (CJK syllables, path segments, mid-word identifier, leading-/trailing-space chunks, whitespace-run chunks, empty chunks, oversized inputs) all produce the expected concatenation; existing AcpSessionManager test suite still passes unchanged.
- **What was not tested**: I did not exercise the non-Codex ACP runtimes (e.g. `claude-code`) end-to-end — the helper is generic and the unit tests cover the chunk surface, but live verification was only done against Codex via `acpx`. I did not run the full `pnpm test` / `pnpm test:extensions` suites locally; I ran `pnpm check:changed --base upstream/main --head HEAD` instead, which is the smart-gate equivalent for the changed paths and passed (typecheck core + core test, oxlint core, import-cycle, runtime-sidecar-loaders, webhook/auth guards, oxfmt).
- **Before evidence**: same Korean prompt against the unpatched 2026.4.21 install:

  ```
  현재 작업 디 렉 토 리 는 / home / by kim 0119 / . open claw / workspace 입니다
  ```

  Programmatic before-state from the buggy helper (deterministic, no ACP runtime needed):

  ```
  run(["디", "렉", "토", "리"])               // "디 렉 토 리"
  run(["/home/", "user/", "file.", "txt"]) // "/home/ user/ file. txt"
  run(["unbeliev", "able"])                // "unbeliev able"
  ```

## Root Cause (if applicable)

- Root cause: `normalizeText` is `normalizeOptionalString` from `src/shared/string-coerce.ts`, which unconditionally `.trim()`s its input. That is the right contract for whole strings but wrong for streaming chunks: trimming strips the leading/trailing whitespace that carries the inter-chunk word-boundary signal. The downstream `${current} ${normalizedChunk}` template then re-inserts a single space at every join, which produces visible gaps inside what was originally a single word for any tokenizer that splits chunks mid-word (CJK syllables, path segments, CamelCase identifiers).
- Missing detection / guardrail: no unit test directly exercised `appendBackgroundTaskProgressSummary` with chunked inputs; the only coverage was via end-to-end `AcpSessionManager` tests that use English-only single-chunk inputs, which incidentally hide this regression class because BPE leading-space tokens align with the forced-space behavior.
- Contributing context (if known): the helper was written against the assumption that the runtime emits whole-line progress strings; the assumption holds for some runtimes, but Codex's ACP runtime emits token-by-token progress, which exposes the chunk-boundary contract.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: new `src/acp/control-plane/manager.background-task-progress.test.ts`.
- Scenario the test should lock in: appending a sequence of mid-word chunks (CJK syllables, path segments, mid-word identifiers) must concatenate verbatim, while leading-/trailing-space chunks, whitespace-run chunks, empty/non-string chunks, and oversized inputs still behave correctly.
- Why this is the smallest reliable guardrail: the helper is pure, deterministic, and called per-chunk on the streaming path. A unit test directly on the helper deterministically catches any future regression of either the trimming or the forced-space behavior, at far lower cost than reviving the ACP+Codex live path.
- Existing test that already covers this (if any): none. `AcpSessionManager` tests in `manager.test.ts` cover the surrounding state machine but not the chunk-progress contract.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Parent-channel ACP background-task terminal summaries now render token-streamed text verbatim instead of with spurious inter-chunk spaces. No config or default changes. No change to summary length or truncation marker.

## Diagram (if applicable)

```text
Before:
chunks = ["디", "렉", "토", "리"]
  → trim each chunk          → ["디", "렉", "토", "리"]
  → join with forced space   → "디 렉 토 리"   ✗

After:
chunks = ["디", "렉", "토", "리"]
  → collapse internal \s runs only   → ["디", "렉", "토", "리"]
  → concatenate verbatim             → "디렉토리"     ✓
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

The change is a string-handling fix in a pure helper that processes already-received progress chunks. It cannot widen any trust boundary.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.4 LTS (x86_64)
- Runtime/container: Node 22.22.2, npm-global OpenClaw 2026.4.21 install (live env), upstream `main` at `cbaf999bd2` for the patch (2026.5.5)
- Model/provider: `gpt-5.3-codex` via Codex CLI 0.121.0, ChatGPT Plus auth
- Integration/channel (if any): Discord, parent agent (Hermes / `openai-codex/gpt-5.4`) → ACP `acpx` → Codex child
- Relevant config (redacted): `acp.backend: "acpx"`, `acp.defaultAgent: "codex"`, `acp.allowedAgents: ["codex"]`, `acp.dispatch.enabled: true`, `~/.codex/config.toml` with `model = "gpt-5.3-codex"`

### Steps

1. Trigger a `sessions_spawn(runtime: "acp", agentId: "codex", task: "<Korean prompt asking Codex to print the absolute path of its current working directory>")` from the orchestrator agent.
2. Wait for the background-task `done` announce in the parent channel.
3. Compare the rendered text against the actual Codex response in the child session log.

### Expected

- Announce text matches Codex's underlying response verbatim (Korean syllables joined, path separators preserved).

### Actual (with this patch applied)

- Announce text matches Codex's underlying response verbatim. Reproduced 1/1 immediately after applying the patch and restarting the gateway.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

The before/after announce text is included verbatim in the **Real behavior proof** section above. Unit-test output before the source change would fail at `expect(summary).toBe("디렉토리")` (actual `"디 렉 토 리"`); after the change all 10 cases pass.

## Human Verification (required)

- Verified scenarios:
  - Korean prompt to Codex via ACP, before and after patch, real Discord channel.
  - Mixed Korean + English path prompt to Codex, after patch — path separators preserved, Korean joined correctly.
  - Local unit tests on the patched helper for CJK one-char-per-chunk, path mid-segment, CamelCase mid-word, leading-/trailing-space chunks, whitespace-run chunks, empty/non-string chunks, length cap (240).
- Edge cases checked: empty chunk, `null`/`undefined` chunk (cast through `unknown`), pure-whitespace chunks, single-character chunks, oversized chunk that triggers the cap and `…` truncation.
- What you did **not** verify: non-Codex ACP runtimes (Claude Code etc.) end-to-end; native Windows or macOS gateway runs (the helper is platform-independent so this should not matter); full `pnpm test` / `pnpm test:extensions` suite (ran `pnpm check:changed` instead, which is the smart-gate equivalent for the changed paths).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

(No conversations yet at PR open time; will keep these in sync as bot reviews land.)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: a runtime that previously relied on the trim+force-space behavior to compress whitespace-only chunks into clean prose might now show extra leading whitespace if its first chunk is whitespace.
  - Mitigation: any leading whitespace from a stream's first chunk is still bounded by the existing length cap, and the downstream `resolveBackgroundTaskTerminalResult` already does its own `.trim()` on the final summary before producing user-visible text, so this surface is normalized at the edge. Internal multi-line chunks are still collapsed to a single space line within the helper.

## Scope vs #74070 / PR #74103

Independent. PR #74103 raises the cap and surfaces progress as `terminalSummary` on success — both useful — but keeps the same trim-and-force-space pattern in `appendBackgroundTaskProgressSummary`, so the rendered output would still show `디 렉 토 리` even after #74103 lands. This PR is orthogonal and safe to merge in either order; if both land, the resulting helper retains both improvements (visible inter-word boundaries from this PR, larger cap and success-path terminal summary from #74103).
