### PR TITLE
fix(cron): bootstrap channel plugins for delivery previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Docs: https://docs.openclaw.ai
 - Feishu: hydrate missing native topic starter thread IDs before session routing so first turns and follow-ups stay in the same topic session. Fixes #78262. Thanks @joeyzenghuan.
 - LINE: reject `dmPolicy: "open"` configs without wildcard `allowFrom` so webhook DMs fail validation instead of being acknowledged and silently blocked before inbound processing. Fixes #78316.
 - Telegram/Codex: keep message-tool-only progress drafts visible and render native Codex tool progress once per tool instead of duplicating item/tool draft lines. Fixes #75641. (#77949) Thanks @keshavbotagent.
+- Cron/Feishu: bootstrap configured channel plugins while resolving cron delivery previews, so valid Feishu announce jobs no longer show a misleading `Unsupported channel: feishu` detail in `cron list`/status output. Fixes #77712.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Matrix/approvals: retry approval delivery up to 3 times with a short backoff so transient Matrix send failures do not strand pending approval prompts. (#78179) Thanks @Patrick-Erichsen.

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -66,6 +66,26 @@ describe("resolveOutboundTarget defaultTo config fallback", () => {
     expect(res).toEqual({ ok: true, to: "room-one" });
   });
 
+  it("allows bootstrapping a configured channel plugin before reporting unsupported", () => {
+    const cfg: OpenClawConfig = {
+      channels: { alpha: { allowFrom: ["room-one"] } },
+    };
+
+    const res = resolveOutboundTarget({
+      channel: "alpha",
+      to: "room-one",
+      cfg,
+      mode: "explicit",
+    });
+
+    expect(res).toEqual({ ok: true, to: "room-one" });
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledWith({
+      channel: "alpha",
+      cfg,
+      allowBootstrap: true,
+    });
+  });
+
   it("uses a second plugin defaultTo when no explicit target is provided", () => {
     const cfg: OpenClawConfig = {
       channels: { beta: { defaultTo: "Beta:Default Room" } },

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -65,6 +65,7 @@ export function resolveOutboundTarget(params: {
       plugin: resolveOutboundChannelPlugin({
         channel: params.channel,
         cfg: params.cfg,
+        allowBootstrap: true,
       }),
       target: params,
       onMissingPlugin: () =>


### PR DESCRIPTION
## Summary

Fixes cron delivery previews for configured-but-not-yet-loaded channel plugins, matching the runtime delivery path so Feishu announce jobs no longer show a misleading `Unsupported channel: feishu` detail when `cron list` or status renders previews.

## Background

Issue #77712 reports valid Feishu cron announce jobs whose `lastDeliveryStatus` is delivered, while `deliveryPreviews` still claim the Feishu channel is unsupported. The preview path resolves outbound targets before the channel plugin has necessarily been loaded, so configured channels can look unavailable even though runtime delivery can send successfully.

## Changes

- Allow outbound target resolution to bootstrap configured channel plugins before returning the generic unsupported-channel error.
- Cover the bootstrap handoff in the outbound target resolver tests.
- Add a changelog entry for the cron/Feishu preview fix.

## Real behavior proof

- **Behavior or issue addressed:** `openclaw cron list --all --json` delivery preview for a Feishu announce cron job resolves the configured Feishu channel as an explicit delivery route instead of reporting `Unsupported channel: feishu`.
- **Real environment tested:** Live OpenClaw setup on macOS with Feishu configured and an announce cron job targeting a Feishu user. Recipient/user id redacted below.
- **Exact steps or command run after this patch:** Created a one-shot Feishu announce cron job, then inspected its delivery preview from the live cron store with `openclaw cron list --all --json | jq '.deliveryPreviews["e8170c03-a9be-402b-ad7b-bcdf70f6c0cf"]'`.
- **Evidence after fix:** copied live output from the configured OpenClaw cron store:

```console
$ openclaw cron list --all --json | jq '.deliveryPreviews["e8170c03-a9be-402b-ad7b-bcdf70f6c0cf"]'
{
  "label": "announce -> feishu:user:ou_REDACTED",
  "detail": "explicit"
}
```

- **Observed result after fix:** The Feishu preview detail is `explicit`; it does not contain `Unsupported channel: feishu`.
- **What was not tested:** I did not send a new Feishu message from this proof command; the issue is the preview/status output, and the live proof exercises that output path with a configured Feishu announce job.

## Verification

- `pnpm test src/infra/outbound/targets.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/outbound/targets.ts src/infra/outbound/targets.test.ts CHANGELOG.md`
- `git diff --check`
- `OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`

## Impact

This changes preview/target resolution to load configured channel plugins on demand before declaring a channel unsupported. It is intended to remove false-negative delivery preview details without changing explicit target parsing for already-loaded channels.

Fixes openclaw/openclaw#77712