### PR TITLE
chore(ci): harden security ownership and workflow permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,13 +4,24 @@
 # WARNING: GitHub CODEOWNERS uses last-match-wins semantics.
 # If you add overlapping rules below the secops block, include @openclaw/openclaw-secops
 # on those entries too or you can silently remove required secops review.
-# Security-sensitive code, config, and docs require secops review.
+# Security-sensitive code, config, workflow automation, and docs require secops review.
 /SECURITY.md @openclaw/openclaw-secops
+/.github/actions/ @openclaw/openclaw-secops
+/.github/actionlint.yaml @openclaw/openclaw-secops
+/.github/codex/ @openclaw/openclaw-secops
 /.github/dependabot.yml @openclaw/openclaw-secops
 /.github/codeql/ @openclaw/openclaw-secops
-/.github/workflows/codeql.yml @openclaw/openclaw-secops
-/.github/workflows/codeql-android-critical-security.yml @openclaw/openclaw-secops
-/.github/workflows/codeql-critical-quality.yml @openclaw/openclaw-secops
+/.github/labeler.yml @openclaw/openclaw-secops
+/.github/workflows/ @openclaw/openclaw-secops
+/.github/zizmor.yml @openclaw/openclaw-secops
+/scripts/*publish* @openclaw/openclaw-secops
+/scripts/*release* @openclaw/openclaw-secops
+/scripts/*scan* @openclaw/openclaw-secops
+/scripts/*secret* @openclaw/openclaw-secops
+/scripts/lib/*publish* @openclaw/openclaw-secops
+/scripts/lib/*release* @openclaw/openclaw-secops
+/scripts/lib/*scan* @openclaw/openclaw-secops
+/scripts/lib/*secret* @openclaw/openclaw-secops
 /src/security/ @openclaw/openclaw-secops
 /src/secrets/ @openclaw/openclaw-secops
 /src/config/*secret*.ts @openclaw/openclaw-secops
@@ -49,8 +60,17 @@
 /docs/reference/secretref-user-supplied-credentials-matrix.json @openclaw/openclaw-secops
 
 # Release workflow and its supporting release-path checks.
-/.github/workflows/openclaw-npm-release.yml @openclaw/openclaw-release-managers
-/docs/reference/RELEASING.md @openclaw/openclaw-release-managers
-/scripts/openclaw-npm-publish.sh @openclaw/openclaw-release-managers
-/scripts/openclaw-npm-release-check.ts @openclaw/openclaw-release-managers
-/scripts/release-check.ts @openclaw/openclaw-release-managers
+/.github/workflows/docker-release.yml @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/.github/workflows/macos-release.yml @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/.github/workflows/openclaw-npm-release.yml @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/.github/workflows/openclaw-release-checks.yml @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/.github/workflows/openclaw-release-publish.yml @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/.github/workflows/plugin-clawhub-release.yml @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/.github/workflows/plugin-npm-release.yml @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/docs/reference/RELEASING.md @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/scripts/openclaw-npm-publish.sh @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/scripts/openclaw-npm-release-check.ts @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/scripts/plugin-npm-publish.sh @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/scripts/plugin-npm-release-check.ts @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/scripts/plugin-npm-release-plan.ts @openclaw/openclaw-secops @openclaw/openclaw-release-managers
+/scripts/release-check.ts @openclaw/openclaw-secops @openclaw/openclaw-release-managers

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,6 +21,8 @@ concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && format('docker-release-manual-{0}', inputs.tag) || format('docker-release-push-{0}', github.run_id) }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -22,6 +22,8 @@ concurrency:
   group: macos-release-${{ inputs.tag }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -30,6 +30,8 @@ concurrency:
   group: openclaw-npm-release-${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', inputs.tag, inputs.npm_dist_tag) || github.ref }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -78,6 +78,8 @@ concurrency:
   group: openclaw-release-checks-${{ inputs.expected_sha || inputs.ref }}-${{ inputs.rerun_group }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"

--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -25,6 +25,8 @@ concurrency:
   group: plugin-clawhub-release-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -37,6 +37,8 @@ concurrency:
   group: plugin-npm-release-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"


### PR DESCRIPTION
Summary
- broaden secops CODEOWNERS coverage for workflow, action, and release/security automation
- keep release-manager ownership while preserving required secops review on release paths
- default release and publish workflows to top-level permissions: {}

Verification
- git diff --check origin/main...HEAD
- pnpm check:workflows