### PR TITLE
fix(gateway): add 'unsafe-eval' to Control UI CSP script-src

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 import { buildControlUiCspHeader, computeInlineScriptHashes } from "./control-ui-csp.js";
 
 describe("buildControlUiCspHeader", () => {
-  it("blocks inline scripts while allowing inline styles", () => {
+  it("blocks inline scripts while allowing inline styles and eval for bundled code", () => {
     const csp = buildControlUiCspHeader();
     expect(csp).toContain("frame-ancestors 'none'");
-    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("script-src 'self' 'unsafe-eval'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
     expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
   });
@@ -39,7 +39,7 @@ describe("buildControlUiCspHeader", () => {
     const csp = buildControlUiCspHeader({
       inlineScriptHashes: ["sha256-abc123"],
     });
-    expect(csp).toContain("script-src 'self' 'sha256-abc123'");
+    expect(csp).toContain("script-src 'self' 'unsafe-eval' 'sha256-abc123'");
     expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
   });
 
@@ -47,12 +47,12 @@ describe("buildControlUiCspHeader", () => {
     const csp = buildControlUiCspHeader({
       inlineScriptHashes: ["sha256-aaa", "sha256-bbb"],
     });
-    expect(csp).toContain("script-src 'self' 'sha256-aaa' 'sha256-bbb'");
+    expect(csp).toContain("script-src 'self' 'unsafe-eval' 'sha256-aaa' 'sha256-bbb'");
   });
 
-  it("falls back to plain script-src self when hashes array is empty", () => {
+  it("falls back to plain script-src self with unsafe-eval when hashes array is empty", () => {
     const csp = buildControlUiCspHeader({ inlineScriptHashes: [] });
-    expect(csp).toMatch(/script-src 'self'(?:;|$)/);
+    expect(csp).toMatch(/script-src 'self' 'unsafe-eval'(?:;|$)/);
   });
 });
 

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -35,8 +35,8 @@ function hasScriptSrcAttribute(openTag: string): boolean {
 export function buildControlUiCspHeader(opts?: { inlineScriptHashes?: string[] }): string {
   const hashes = opts?.inlineScriptHashes;
   const scriptSrc = hashes?.length
-    ? `script-src 'self' ${hashes.map((h) => `'${h}'`).join(" ")}`
-    : "script-src 'self'";
+    ? `script-src 'self' 'unsafe-eval' ${hashes.map((h) => `'${h}'`).join(" ")}`
+    : "script-src 'self' 'unsafe-eval'";
   return [
     "default-src 'self'",
     "base-uri 'none'",


### PR DESCRIPTION
## Problem

Closes #78362

The Control UI gateway sets `script-src 'self'` without `'unsafe-eval'`. Zod v4's JIT compiler calls `new Function()` in the bundled JS, which browsers treat identically to `eval()`. This causes:

- CSP violations logged in DevTools for every page load
- Zod validators falling back to slower non-JIT evaluation paths

## Fix

Add `'unsafe-eval'` to `script-src` in `buildControlUiCspHeader`. This correctly reflects what the bundled JS requires and eliminates the CSP violation.

## Files changed

- `src/gateway/control-ui-csp.ts` — add `'unsafe-eval'` to both hash and no-hash `script-src` variants
- `src/gateway/control-ui-csp.test.ts` — update assertions to match new directive

## Test

All existing `buildControlUiCspHeader` tests updated. The `'unsafe-inline'` guard is preserved — only `eval`-equivalent dynamic code execution is permitted, not arbitrary inline scripts.