### PR TITLE
feat(skills): add triggers frontmatter field for keyword-based routing

### DIFF
--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -71,6 +71,17 @@ describe("formatSkillsCompact", () => {
     expect(out).toContain("hidden");
   });
 
+  it("includes triggers element when skill declares keyword triggers", () => {
+    const skill: Skill = { ...makeSkill("eyes", "Make eyes bigger"), triggers: ["大眼", "big-eye"] };
+    const out = formatSkillsForPrompt([skill]);
+    expect(out).toContain("<triggers>大眼, big-eye</triggers>");
+  });
+
+  it("omits triggers element when skill has no triggers", () => {
+    const out = formatSkillsForPrompt([makeSkill("weather", "Get weather data")]);
+    expect(out).not.toContain("<triggers>");
+  });
+
   it("returns empty string for no skills", () => {
     expect(formatSkillsCompact([])).toBe("");
   });

--- a/src/agents/skills/frontmatter.test.ts
+++ b/src/agents/skills/frontmatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "./frontmatter.js";
+import { resolveOpenClawMetadata, resolveSkillInvocationPolicy, resolveSkillTriggers } from "./frontmatter.js";
 
 describe("resolveSkillInvocationPolicy", () => {
   it("defaults to enabled behaviors", () => {
@@ -63,5 +63,27 @@ describe("resolveOpenClawMetadata install validation", () => {
       metadata: '{"openclaw":{"install":[{"kind":"download","url":"file:///tmp/payload.tgz"}]}}',
     });
     expect(install).toBeUndefined();
+  });
+});
+
+describe("resolveSkillTriggers", () => {
+  it("returns empty array when triggers frontmatter key is absent", () => {
+    expect(resolveSkillTriggers({})).toEqual([]);
+  });
+
+  it("parses a single trigger keyword", () => {
+    expect(resolveSkillTriggers({ triggers: "大眼" })).toEqual(["大眼"]);
+  });
+
+  it("parses comma-separated trigger keywords", () => {
+    expect(resolveSkillTriggers({ triggers: "大眼, big-eye, eyes" })).toEqual([
+      "大眼",
+      "big-eye",
+      "eyes",
+    ]);
+  });
+
+  it("trims whitespace from each trigger", () => {
+    expect(resolveSkillTriggers({ triggers: "  foo  ,  bar  " })).toEqual(["foo", "bar"]);
   });
 });

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -218,6 +218,10 @@ export function resolveSkillInvocationPolicy(
   };
 }
 
+export function resolveSkillTriggers(frontmatter: ParsedSkillFrontmatter): string[] {
+  return normalizeStringList(getFrontmatterString(frontmatter, "triggers"));
+}
+
 export function resolveSkillKey(skill: Skill, entry?: SkillEntry): string {
   return entry?.metadata?.skillKey ?? skill.name;
 }

--- a/src/agents/skills/local-loader.ts
+++ b/src/agents/skills/local-loader.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { openRootFileSync } from "../../infra/boundary-file-read.js";
-import { parseFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
+import { parseFrontmatter, resolveSkillInvocationPolicy, resolveSkillTriggers } from "./frontmatter.js";
 import { createSyntheticSourceInfo, type Skill } from "./skill-contract.js";
 import type { ParsedSkillFrontmatter } from "./types.js";
 
@@ -62,6 +62,7 @@ function loadSingleSkillDirectory(params: {
     return null;
   }
   const invocation = resolveSkillInvocationPolicy(frontmatter);
+  const triggers = resolveSkillTriggers(frontmatter);
   const filePath = path.resolve(skillFilePath);
   const baseDir = path.resolve(params.skillDir);
 
@@ -79,6 +80,7 @@ function loadSingleSkillDirectory(params: {
         origin: "top-level",
       }),
       disableModelInvocation: invocation.disableModelInvocation,
+      ...(triggers.length > 0 && { triggers }),
     },
     frontmatter,
   };

--- a/src/agents/skills/skill-contract.ts
+++ b/src/agents/skills/skill-contract.ts
@@ -6,6 +6,8 @@ export type SourceOrigin = "package" | "top-level";
 export type Skill = CanonicalSkill & {
   // Preserve legacy source reads while keeping the canonical upstream shape.
   source?: string;
+  // Keyword triggers declared in SKILL.md frontmatter for deterministic routing.
+  triggers?: string[];
 };
 
 export function createSyntheticSourceInfo(
@@ -56,6 +58,9 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
     lines.push("  <skill>");
     lines.push(`    <name>${escapeXml(skill.name)}</name>`);
     lines.push(`    <description>${escapeXml(skill.description)}</description>`);
+    if (skill.triggers && skill.triggers.length > 0) {
+      lines.push(`    <triggers>${escapeXml(skill.triggers.join(", "))}</triggers>`);
+    }
     lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
     lines.push("  </skill>");
   }

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -23,6 +23,7 @@ export type OpenClawSkillMetadata = {
   emoji?: string;
   homepage?: string;
   os?: string[];
+  triggers?: string[];
   requires?: {
     bins?: string[];
     anyBins?: string[];


### PR DESCRIPTION
## Problem

Closes #76782

Skills currently expose only `name` and `description` to the model for routing. Skill authors stuff all trigger phrases into `description` to increase match odds, producing verbose descriptions that degrade readability. The model still misses keyword matches because semantic similarity ≠ exact keyword matching.

## Solution

Add a `triggers` top-level frontmatter key to SKILL.md:

```yaml
---
name: eyes
description: Enhance and stylize photos
triggers: 大眼, big-eye, eyes, 放大眼睛
---
```

When declared, `<triggers>` is included in the `<available_skills>` prompt block alongside `<description>`, giving the model an explicit keyword list to match against:

```xml
<skill>
  <name>eyes</name>
  <description>Enhance and stylize photos</description>
  <triggers>大眼, big-eye, eyes, 放大眼睛</triggers>
  <location>/path/to/SKILL.md</location>
</skill>
```

Skills without `triggers` are unaffected — the element is omitted.

## Files changed

| File | Change |
|------|--------|
| `src/agents/skills/types.ts` | Add `triggers?: string[]` to `OpenClawSkillMetadata` |
| `src/agents/skills/skill-contract.ts` | Add `triggers?: string[]` to local `Skill` extension; emit `<triggers>` in `formatSkillsForPrompt` when set |
| `src/agents/skills/frontmatter.ts` | Export `resolveSkillTriggers` parsing `triggers` frontmatter key as CSV |
| `src/agents/skills/local-loader.ts` | Thread parsed triggers from frontmatter into the `Skill` object |
| `src/agents/skills/frontmatter.test.ts` | Tests for CSV parsing, single keyword, empty/absent |
| `src/agents/skills/compact-format.test.ts` | Tests for `<triggers>` inclusion/omission in prompt |

## Design notes

- `triggers` is a top-level frontmatter key (like `user-invocable`), not inside the `metadata:` JSON block — simpler authoring, consistent with other routing-relevant fields
- Parsing reuses `normalizeStringList`/`getFrontmatterString` from shared frontmatter utilities
- No breaking changes — `triggers` is optional; skills without it produce identical prompt output to today
- The `<triggers>` element position (after `<description>`, before `<location>`) keeps location last, consistent with how the model is instructed to read it