### PR TITLE
feat(workspace): add internal oc-path resolver

### DIFF
--- a/src/shared/oc-path.test.ts
+++ b/src/shared/oc-path.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { findOcPaths, getOcPathDocumentKind, parseOcPath, resolveOcPath } from "./oc-path.js";
+
+describe("workspace oc-path", () => {
+  it("parses supported workspace file paths and decoded segments", () => {
+    expect(parseOcPath("oc://policy.jsonc/tools/%5Bid=send-email%5D/sensitivity")).toEqual({
+      filePath: "policy.jsonc",
+      segments: ["tools", "[id=send-email]", "sensitivity"],
+    });
+    expect(parseOcPath("oc://notes/AGENTS.md/Tools")).toEqual({
+      filePath: "notes/AGENTS.md",
+      segments: ["Tools"],
+    });
+  });
+
+  it("rejects non oc paths and unsupported file kinds", () => {
+    expect(() => parseOcPath("policy.jsonc/tools")).toThrow("must start with oc://");
+    expect(() => parseOcPath("oc://policy.txt/tools")).toThrow(
+      "must include a supported workspace file",
+    );
+    expect(() => getOcPathDocumentKind("policy.txt")).toThrow("Unsupported OpenClaw path");
+  });
+
+  it("resolves JSONC object, array, negative-index, and predicate paths", () => {
+    const content = `{
+      // comments are accepted by the JSONC parser
+      tools: [
+        { id: "send-email", sensitivity: "restricted" },
+        { id: "calendar", sensitivity: "normal" },
+      ],
+    }`;
+
+    expect(
+      resolveOcPath({
+        ocPath: "oc://policy.jsonc/tools/0/id",
+        content,
+      }),
+    ).toMatchObject({ kind: "value", value: "send-email" });
+    expect(
+      resolveOcPath({
+        ocPath: "oc://policy.jsonc/tools/-1/id",
+        content,
+      }),
+    ).toMatchObject({ kind: "value", value: "calendar" });
+    expect(
+      resolveOcPath({
+        ocPath: "oc://policy.jsonc/tools/[id=send-email]/sensitivity",
+        content,
+      }),
+    ).toMatchObject({ kind: "value", value: "restricted" });
+    expect(
+      resolveOcPath({
+        ocPath: "oc://policy.jsonc/tools/[id=missing]/sensitivity",
+        content,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("finds JSONC wildcard matches", () => {
+    const matches = findOcPaths({
+      ocPath: "oc://policy.jsonc/tools/*/id",
+      content: `{ tools: [{ id: "send-email" }, { id: "calendar" }] }`,
+    });
+
+    expect(matches).toEqual([
+      { kind: "value", path: "oc://policy.jsonc/tools/0/id", value: "send-email" },
+      { kind: "value", path: "oc://policy.jsonc/tools/1/id", value: "calendar" },
+    ]);
+  });
+
+  it("resolves markdown heading paths without rewriting the document", () => {
+    const content = `# Agent
+
+Intro.
+
+## Tools
+
+### send-email
+
+R5, sensitivity: restricted
+
+### calendar
+
+R2, sensitivity: normal
+
+## Notes
+
+Other content.
+`;
+
+    expect(
+      resolveOcPath({
+        ocPath: "oc://AGENTS.md/Tools/send-email",
+        content,
+      }),
+    ).toMatchObject({
+      kind: "markdown-section",
+      heading: "send-email",
+      line: 7,
+      valueText: "R5, sensitivity: restricted",
+    });
+    expect(
+      resolveOcPath({
+        ocPath: "oc://AGENTS.md/Tools/missing",
+        content,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("finds markdown wildcard heading matches", () => {
+    const matches = findOcPaths({
+      ocPath: "oc://AGENTS.md/Tools/*",
+      content: `# Agent
+
+## Tools
+
+### send-email
+Email body.
+
+### calendar
+Calendar body.
+`,
+    });
+
+    expect(matches.map((match) => match.path)).toEqual([
+      "oc://AGENTS.md/Tools/send-email",
+      "oc://AGENTS.md/Tools/calendar",
+    ]);
+    expect(matches.map((match) => ("heading" in match ? match.heading : ""))).toEqual([
+      "send-email",
+      "calendar",
+    ]);
+  });
+});

--- a/src/shared/oc-path.ts
+++ b/src/shared/oc-path.ts
@@ -1,0 +1,369 @@
+import JSON5 from "json5";
+
+export type OcPathDocumentKind = "json" | "markdown";
+
+export type ParsedOcPath = {
+  filePath: string;
+  segments: string[];
+};
+
+export type OcPathResolvedNode =
+  | {
+      kind: "value";
+      path: string;
+      value: unknown;
+    }
+  | {
+      kind: "markdown-section";
+      path: string;
+      heading: string;
+      line: number;
+      valueText: string;
+    };
+
+type MarkdownSection = {
+  title: string;
+  depth: number;
+  line: number;
+  bodyStartOffset: number;
+  endOffset: number;
+  children: MarkdownSection[];
+};
+
+const JSON_EXTENSIONS = [".json", ".jsonc", ".json5"] as const;
+const MARKDOWN_EXTENSIONS = [".md", ".markdown"] as const;
+const SUPPORTED_EXTENSIONS = [...JSON_EXTENSIONS, ...MARKDOWN_EXTENSIONS] as const;
+
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function buildResolvedPath(filePath: string, segments: readonly string[]): string {
+  return `oc://${filePath}${segments.length > 0 ? `/${segments.join("/")}` : ""}`;
+}
+
+function findFilePathEnd(target: string): number {
+  let best = -1;
+  for (const extension of SUPPORTED_EXTENSIONS) {
+    let from = 0;
+    while (from < target.length) {
+      const index = target.indexOf(`${extension}/`, from);
+      if (index === -1) {
+        break;
+      }
+      best = Math.max(best, index + extension.length);
+      from = index + extension.length + 1;
+    }
+    if (target.endsWith(extension)) {
+      best = Math.max(best, target.length);
+    }
+  }
+  return best;
+}
+
+export function parseOcPath(input: string): ParsedOcPath {
+  if (!input.startsWith("oc://")) {
+    throw new Error("OpenClaw path must start with oc://");
+  }
+  const target = input.slice("oc://".length);
+  const filePathEnd = findFilePathEnd(target);
+  if (filePathEnd <= 0) {
+    throw new Error("OpenClaw path must include a supported workspace file");
+  }
+  const filePath = decodeSegment(target.slice(0, filePathEnd));
+  const rest = target.slice(filePathEnd);
+  const segments = rest.startsWith("/")
+    ? rest
+        .slice(1)
+        .split("/")
+        .filter((segment) => segment.length > 0)
+        .map(decodeSegment)
+    : [];
+  return { filePath, segments };
+}
+
+export function getOcPathDocumentKind(filePath: string): OcPathDocumentKind {
+  const lower = filePath.toLowerCase();
+  if (JSON_EXTENSIONS.some((extension) => lower.endsWith(extension))) {
+    return "json";
+  }
+  if (MARKDOWN_EXTENSIONS.some((extension) => lower.endsWith(extension))) {
+    return "markdown";
+  }
+  throw new Error(`Unsupported OpenClaw path file kind: ${filePath}`);
+}
+
+function parseJsonDocument(content: string): unknown {
+  return JSON5.parse(content);
+}
+
+function normalizeArrayIndex(segment: string, length: number): number | undefined {
+  if (!/^-?\d+$/.test(segment)) {
+    return undefined;
+  }
+  const parsed = Number(segment);
+  const index = parsed < 0 ? length + parsed : parsed;
+  return index >= 0 && index < length ? index : undefined;
+}
+
+function parsePredicate(segment: string): { key: string; value: string } | undefined {
+  const match = /^\[([^=\]]+)=([^\]]*)\]$/.exec(segment);
+  if (!match) {
+    return undefined;
+  }
+  return { key: match[1], value: match[2] };
+}
+
+function resolveJsonSegment(value: unknown, segment: string): unknown {
+  if (Array.isArray(value)) {
+    const index = normalizeArrayIndex(segment, value.length);
+    if (index !== undefined) {
+      return value[index];
+    }
+    const predicate = parsePredicate(segment);
+    if (predicate) {
+      return value.find((entry) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return false;
+        }
+        return String((entry as Record<string, unknown>)[predicate.key]) === predicate.value;
+      });
+    }
+    return undefined;
+  }
+  if (value && typeof value === "object") {
+    return (value as Record<string, unknown>)[segment];
+  }
+  return undefined;
+}
+
+function resolveJsonPath(params: {
+  filePath: string;
+  content: string;
+  segments: string[];
+}): OcPathResolvedNode | undefined {
+  let value = parseJsonDocument(params.content);
+  for (const segment of params.segments) {
+    value = resolveJsonSegment(value, segment);
+    if (value === undefined) {
+      return undefined;
+    }
+  }
+  return {
+    kind: "value",
+    path: buildResolvedPath(params.filePath, params.segments),
+    value,
+  };
+}
+
+function findJsonPathMatches(params: {
+  filePath: string;
+  content: string;
+  segments: string[];
+}): OcPathResolvedNode[] {
+  const root = parseJsonDocument(params.content);
+  const matches: Array<{ value: unknown; segments: string[] }> = [{ value: root, segments: [] }];
+  for (const segment of params.segments) {
+    const next: Array<{ value: unknown; segments: string[] }> = [];
+    for (const match of matches) {
+      if (segment === "*") {
+        if (Array.isArray(match.value)) {
+          match.value.forEach((value, index) =>
+            next.push({ value, segments: [...match.segments, String(index)] }),
+          );
+        } else if (match.value && typeof match.value === "object") {
+          for (const [key, value] of Object.entries(match.value)) {
+            next.push({ value, segments: [...match.segments, key] });
+          }
+        }
+        continue;
+      }
+      const value = resolveJsonSegment(match.value, segment);
+      if (value !== undefined) {
+        next.push({ value, segments: [...match.segments, segment] });
+      }
+    }
+    matches.splice(0, matches.length, ...next);
+  }
+  return matches.map((match) => ({
+    kind: "value",
+    path: buildResolvedPath(params.filePath, match.segments),
+    value: match.value,
+  }));
+}
+
+function parseMarkdownSections(content: string): MarkdownSection[] {
+  const root: MarkdownSection = {
+    title: "",
+    depth: 0,
+    line: 0,
+    bodyStartOffset: 0,
+    endOffset: content.length,
+    children: [],
+  };
+  const stack: MarkdownSection[] = [root];
+  const headingPattern = /^(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = headingPattern.exec(content))) {
+    const depth = match[1].length;
+    const line = content.slice(0, match.index).split("\n").length;
+    const section: MarkdownSection = {
+      title: match[2].trim(),
+      depth,
+      line,
+      bodyStartOffset: headingPattern.lastIndex,
+      endOffset: content.length,
+      children: [],
+    };
+    while (stack[stack.length - 1].depth >= depth) {
+      const closed = stack.pop();
+      if (closed) {
+        closed.endOffset = match.index;
+      }
+    }
+    stack[stack.length - 1].children.push(section);
+    stack.push(section);
+  }
+  return root.children;
+}
+
+function findMarkdownChild(
+  sections: readonly MarkdownSection[],
+  segment: string,
+): MarkdownSection | undefined {
+  return sections.find((section) => section.title === segment);
+}
+
+function findMarkdownDescendants(
+  sections: readonly MarkdownSection[],
+  segment: string,
+): MarkdownSection[] {
+  const matches: MarkdownSection[] = [];
+  for (const section of sections) {
+    if (section.title === segment) {
+      matches.push(section);
+    }
+    matches.push(...findMarkdownDescendants(section.children, segment));
+  }
+  return matches;
+}
+
+function toMarkdownResolvedNode(params: {
+  filePath: string;
+  content: string;
+  segments: string[];
+  section: MarkdownSection;
+}): OcPathResolvedNode {
+  return {
+    kind: "markdown-section",
+    path: buildResolvedPath(params.filePath, params.segments),
+    heading: params.section.title,
+    line: params.section.line,
+    valueText: params.content
+      .slice(params.section.bodyStartOffset, params.section.endOffset)
+      .trim(),
+  };
+}
+
+function resolveMarkdownPath(params: {
+  filePath: string;
+  content: string;
+  segments: string[];
+}): OcPathResolvedNode | undefined {
+  const roots = parseMarkdownSections(params.content);
+  let children = roots;
+  let section: MarkdownSection | undefined;
+  for (const [index, segment] of params.segments.entries()) {
+    section =
+      index === 0
+        ? (findMarkdownChild(children, segment) ?? findMarkdownDescendants(roots, segment)[0])
+        : findMarkdownChild(children, segment);
+    if (!section) {
+      return undefined;
+    }
+    children = section.children;
+  }
+  return section
+    ? toMarkdownResolvedNode({ ...params, section })
+    : {
+        kind: "markdown-section",
+        path: buildResolvedPath(params.filePath, []),
+        heading: "",
+        line: 1,
+        valueText: params.content.trim(),
+      };
+}
+
+function findMarkdownPathMatches(params: {
+  filePath: string;
+  content: string;
+  segments: string[];
+}): OcPathResolvedNode[] {
+  const roots = parseMarkdownSections(params.content);
+  let matches: Array<{ section: MarkdownSection; segments: string[] }> = roots.map((section) => ({
+    section,
+    segments: [section.title],
+  }));
+  if (params.segments.length === 0) {
+    return [
+      {
+        kind: "markdown-section",
+        path: buildResolvedPath(params.filePath, []),
+        heading: "",
+        line: 1,
+        valueText: params.content.trim(),
+      },
+    ];
+  }
+  for (const [index, segment] of params.segments.entries()) {
+    const source =
+      index === 0
+        ? (segment === "*" ? roots : findMarkdownDescendants(roots, segment)).map((section) => ({
+            section,
+            segments: [section.title],
+          }))
+        : matches.flatMap((match) =>
+            match.section.children.map((section) => ({
+              section,
+              segments: [...match.segments, section.title],
+            })),
+          );
+    matches =
+      index === 0 && segment !== "*"
+        ? source
+        : source.filter((match) => segment === "*" || match.section.title === segment);
+  }
+  return matches.map((match) =>
+    toMarkdownResolvedNode({
+      filePath: params.filePath,
+      content: params.content,
+      segments: match.segments,
+      section: match.section,
+    }),
+  );
+}
+
+export function resolveOcPath(params: {
+  ocPath: string;
+  content: string;
+}): OcPathResolvedNode | undefined {
+  const parsed = parseOcPath(params.ocPath);
+  const kind = getOcPathDocumentKind(parsed.filePath);
+  if (kind === "json") {
+    return resolveJsonPath({ ...parsed, content: params.content });
+  }
+  return resolveMarkdownPath({ ...parsed, content: params.content });
+}
+
+export function findOcPaths(params: { ocPath: string; content: string }): OcPathResolvedNode[] {
+  const parsed = parseOcPath(params.ocPath);
+  const kind = getOcPathDocumentKind(parsed.filePath);
+  if (kind === "json") {
+    return findJsonPathMatches({ ...parsed, content: params.content });
+  }
+  return findMarkdownPathMatches({ ...parsed, content: params.content });
+}


### PR DESCRIPTION
## Summary

- Problem: Workspace file handling proposals in #78051 need a small shared addressing foundation before larger lint, doctor, rollback, or policy work can be reviewed safely.
- Why it matters: Without a common resolver, future workspace tooling would keep reimplementing ad hoc JSONC and markdown traversal logic.
- What changed: Added an internal read-only `oc://` resolver for JSON/JSONC/JSON5 values and markdown heading sections, with focused unit coverage.
- What did NOT change (scope boundary): No CLI commands, public plugin SDK APIs, doctor integration, write/edit support, LKG rollback, or policy IR behavior were added.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78051 
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Internal workspace addressing can now resolve supported `oc://` paths over JSONC and markdown content without introducing broader runtime behavior.
- Real environment tested: Local OpenClaw checkout on Linux.
- Exact steps or command run after this patch:
  - `node --import tsx - <<'NODE' ... NODE`
- Evidence after fix: copied console output from the live local OpenClaw checkout:

  ```json
  {
    "jsoncPredicate": {
      "kind": "value",
      "path": "oc://policy.jsonc/tools/[id=send-email]/sensitivity",
      "value": "restricted"
    },
    "jsoncWildcard": [
      "send-email",
      "calendar"
    ],
    "markdownSection": {
      "kind": "markdown-section",
      "path": "oc://AGENTS.md/Tools/send-email",
      "heading": "send-email",
      "line": 5,
      "valueText": "Email body."
    }
  }
  ```

- Observed result after fix: The resolver returned the expected JSONC predicate value, wildcard JSONC values, and markdown section content from a real local module import.
- What was not tested: CLI usage, doctor integration, plugin registration, write/edit operations, and live runtime use, because this PR intentionally does not add those surfaces.
- Before evidence: Current main has no `parseOcPath`, `resolveOcPath`, `findOcPaths`, `registerLintRule`, `OcPathFixerSpec`, `PolicyIR`, or generalized LKG substrate.

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): #78051 is a design proposal, not a runtime regression.

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/shared/oc-path.test.ts`
- Scenario the test should lock in: `oc://` parsing and read-only resolution for JSONC values, array indexes, predicates, wildcards, and markdown heading sections.
- Why this is the smallest reliable guardrail: The new behavior is a pure internal resolver with no runtime side effects.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: New focused tests were added.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[workspace file content] -> [feature-specific parser]

After:
[workspace file content] -> [internal oc:// resolver] -> [matched JSONC value or markdown section]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/shared/oc-path.test.ts`.
2. Run `pnpm exec oxfmt --check --threads=1 src/shared/oc-path.ts src/shared/oc-path.test.ts`.
3. Run `git diff --cached --check`.
4. Run the local `node --import tsx` smoke shown in the real behavior proof section.

### Expected

- Focused unit tests pass.
- Targeted formatting check passes.
- Staged diff has no whitespace errors.
- Live resolver smoke prints the expected JSONC and markdown matches.

### Actual

- Focused unit tests passed.
- Targeted formatting check passed.
- Staged diff check passed.
- Live resolver smoke printed the expected JSONC and markdown matches.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Live local module smoke for JSONC predicate, JSONC wildcard, and markdown section resolution; focused tests for supported `oc://` parsing, invalid/unsupported paths, JSONC object/array/negative-index/predicate/wildcard paths, and markdown heading/wildcard paths.
- Edge cases checked: URL-decoded path segments, missing predicate match, missing markdown heading, markdown under an H1 wrapper.
- What you did **not** verify: CLI, doctor, plugin SDK, write/edit operations, LKG rollback, or policy IR behavior.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Reviewers may expect the broader #78051 substrate train rather than a narrow foundation.
  - Mitigation: PR scope explicitly limits this to an internal read-only resolver and leaves CLI, doctor, lint, LKG, and policy work for later maintainer-approved PRs.
