### PR TITLE
fix(cli): reduce plugin hook fallback noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/plugins: suppress the misleading hook-pack fallback note when a plugin install fallback only proves the package is missing `openclaw.hooks`, while still showing real hook-pack validation failures. Thanks @vincentkoc.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.
 - PDF/Codex: include extraction-fallback instructions for `openai-codex/*` PDF tool requests so Codex Responses receives its required system prompt. Fixes #77872. Thanks @anyech.

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1158,6 +1158,29 @@ describe("plugins cli install", () => {
 
     expect(installPluginFromClawHub).not.toHaveBeenCalled();
     expect(runtimeErrors.at(-1)).toContain("npm install failed");
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
+  });
+
+  it("keeps actionable hook-pack fallback details for npm installs", async () => {
+    loadConfig.mockReturnValue({} as OpenClawConfig);
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error: "npm install failed",
+    });
+    installHooksFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error: "HOOK.md missing in /tmp/demo-hook",
+    });
+
+    await expect(runPluginsCommand(["plugins", "install", "npm:demo-hook"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain("npm install failed");
+    expect(runtimeErrors.at(-1)).toContain(
+      "Also not a valid hook pack: HOOK.md missing in /tmp/demo-hook",
+    );
   });
 
   it("adds a Git PATH hint when npm plugin dependency install cannot spawn git", async () => {
@@ -1185,7 +1208,7 @@ describe("plugins cli install", () => {
       "one of this plugin's npm dependencies is fetched from a git URL",
     );
     expect(runtimeErrors.at(-1)).toContain("winget install --id Git.Git -e");
-    expect(runtimeErrors.at(-1)).toContain("Also not a valid hook pack");
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
   it("does not resolve npm: prefixed bundled plugin ids through bundled installs", async () => {
@@ -1212,6 +1235,7 @@ describe("plugins cli install", () => {
     expect(installPluginFromClawHub).not.toHaveBeenCalled();
     expect(writeConfigFile).not.toHaveBeenCalled();
     expect(runtimeErrors.at(-1)).toContain("Package not found on npm: memory-lancedb.");
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
   it("rejects empty npm: prefix installs before resolver lookup", async () => {

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -187,6 +187,9 @@ export function formatPluginInstallWithHookFallbackError(
   ) {
     return formattedPluginError;
   }
+  if (isMissingHookPackManifestError(hookError)) {
+    return formattedPluginError;
+  }
   return `${formattedPluginError}\nAlso not a valid hook pack: ${formattedHookError}`;
 }
 
@@ -206,6 +209,10 @@ function formatPluginInstallAttemptError(error: string): string {
 function isMissingGitForNpmDependencyError(error: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(error);
   return /\bspawn\s+git\b/u.test(normalized) && /\benoent\b/u.test(normalized);
+}
+
+function isMissingHookPackManifestError(error: string): boolean {
+  return error.trim() === "package.json missing openclaw.hooks";
 }
 
 export function logHookPackRestartHint(runtime: RuntimeEnv = defaultRuntime) {


### PR DESCRIPTION
Summary
- suppress the misleading `Also not a valid hook pack: package.json missing openclaw.hooks` suffix when plugin install fallback only proves a package lacks a hook-pack manifest
- keep actionable hook-pack fallback details for real hook validation failures, such as missing `HOOK.md`
- add CLI install regressions and changelog entry

Verification
- `pnpm test:serial src/cli/plugins-cli.install.test.ts -- --reporter=dot` (81 tests)
- `pnpm exec oxfmt --check --threads=1 src/cli/plugins-command-helpers.ts src/cli/plugins-cli.install.test.ts CHANGELOG.md`
- `OPENCLAW_TESTBOX=1 pnpm testbox:run --id tbx_01kqy9341z4eje6p1evvbj55y3 -- "pnpm check:changed"` (GitHub Actions run: https://github.com/openclaw/openclaw/actions/runs/25426653255)
