### PR TITLE
chore(test): add temp cleanup guard scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1436,6 +1436,7 @@
     "lint:tmp:no-random-messaging": "node scripts/check-no-random-messaging-tmp.mjs",
     "lint:tmp:no-raw-channel-fetch": "node scripts/check-no-raw-channel-fetch.mjs",
     "lint:tmp:no-raw-http2-imports": "node scripts/check-no-raw-http2-imports.mjs",
+    "lint:tmp:test-temp-cleanup": "node scripts/check-test-temp-cleanup.mjs",
     "lint:tmp:tsgo-core-boundary": "node scripts/check-tsgo-core-boundary.mjs",
     "lint:ui:no-raw-window-open": "node scripts/check-no-raw-window-open.mjs",
     "lint:web-fetch-provider-boundaries": "node scripts/check-web-fetch-provider-boundaries.mjs",

--- a/package.json
+++ b/package.json
@@ -1514,6 +1514,7 @@
     "lint:tmp:no-random-messaging": "node scripts/check-no-random-messaging-tmp.mjs",
     "lint:tmp:no-raw-channel-fetch": "node scripts/check-no-raw-channel-fetch.mjs",
     "lint:tmp:no-raw-http2-imports": "node scripts/check-no-raw-http2-imports.mjs",
+    "lint:tmp:test-temp-cleanup": "node scripts/check-test-temp-cleanup.mjs",
     "lint:tmp:tsgo-core-boundary": "node scripts/check-tsgo-core-boundary.mjs",
     "lint:ui:no-raw-window-open": "node scripts/check-no-raw-window-open.mjs",
     "lint:web-fetch-provider-boundaries": "node scripts/check-web-fetch-provider-boundaries.mjs",

--- a/scripts/check-test-temp-cleanup.mjs
+++ b/scripts/check-test-temp-cleanup.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { runAsScript } from "./lib/ts-guard-utils.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const TEST_FILE_GLOBS = ["src", "test", "packages", "extensions", "scripts"];
+const TEST_FILE_GLOBS = ["src", "test", "packages", "extensions", "scripts", "ui"];
 const TEST_FILE_PATTERN =
   /(?:\.test(?:-[^./]+)?|\.test-helpers|\.test-harness|\.test-support)\.ts$/u;
 const MKDTEMP_PATTERN = /\bmkdtemp(?:Sync)?\s*\(/u;

--- a/scripts/check-test-temp-cleanup.mjs
+++ b/scripts/check-test-temp-cleanup.mjs
@@ -10,7 +10,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const TEST_FILE_GLOBS = ["src", "test", "packages", "extensions", "scripts"];
 const TEST_FILE_PATTERN =
   /(?:\.test(?:-[^./]+)?|\.test-helpers|\.test-harness|\.test-support)\.ts$/u;
-const MKDTEMP_PATTERN = /\bmkdtemp(?:Sync)?\s*\(/gu;
+const MKDTEMP_PATTERN = /\bmkdtemp(?:Sync)?\s*\(/u;
 const CLEANUP_CALL_PATTERN = /\brm(?:Sync)?\s*\(/u;
 const AFTER_EACH_PATTERN = /\bafterEach\s*\(/u;
 const AFTER_ALL_PATTERN = /\bafterAll\s*\(/u;
@@ -38,21 +38,22 @@ function collectCleanupSignals(source) {
 }
 
 function classifyCleanupRisk(source) {
-  const mkdtempMatches = source.match(MKDTEMP_PATTERN) ?? [];
-  if (mkdtempMatches.length === 0) {
+  if (!MKDTEMP_PATTERN.test(source)) {
     return null;
   }
   const cleanup = collectCleanupSignals(source);
-  if (cleanup.hasAfterEach || cleanup.hasAfterAll || cleanup.hasFinally) {
+  if (
+    cleanup.hasCleanupCall &&
+    (cleanup.hasAfterEach || cleanup.hasAfterAll || cleanup.hasFinally)
+  ) {
     return null;
   }
   return {
-    mkdtempCount: mkdtempMatches.length,
-    cleanup,
     severity: cleanup.hasCleanupCall ? "warning" : "error",
     reason: cleanup.hasCleanupCall
-      ? "uses mkdtemp without afterEach/afterAll/finally cleanup scope"
+      ? "uses mkdtemp without file-level afterEach/afterAll/finally cleanup scope"
       : "uses mkdtemp without any obvious cleanup",
+    cleanup,
   };
 }
 
@@ -97,9 +98,7 @@ export async function main(argv = process.argv.slice(2), io) {
     writeStderr("Test temp-dir cleanup findings:\n");
     for (const finding of findings) {
       const severity = finding.severity === "error" ? "error" : "warn";
-      writeStderr(
-        `- [${severity}] ${finding.file} mkdtemp=${finding.mkdtempCount}: ${finding.reason}\n`,
-      );
+      writeStderr(`- [${severity}] ${finding.file}: ${finding.reason}\n`);
     }
     writeStderr(
       "Use afterEach/afterAll or try/finally around mkdtemp-created directories so /tmp residue does not leak across runs.\n",

--- a/scripts/check-test-temp-cleanup.mjs
+++ b/scripts/check-test-temp-cleanup.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runAsScript } from "./lib/ts-guard-utils.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const TEST_FILE_GLOBS = ["src", "test", "packages", "extensions", "scripts"];
+const TEST_FILE_PATTERN =
+  /(?:\.test(?:-[^./]+)?|\.test-helpers|\.test-harness|\.test-support)\.ts$/u;
+const MKDTEMP_PATTERN = /\bmkdtemp(?:Sync)?\s*\(/gu;
+const CLEANUP_CALL_PATTERN = /\brm(?:Sync)?\s*\(/u;
+const AFTER_EACH_PATTERN = /\bafterEach\s*\(/u;
+const AFTER_ALL_PATTERN = /\bafterAll\s*\(/u;
+const FINALLY_PATTERN = /\bfinally\s*\{/u;
+
+function listTrackedTestFiles(root = repoRoot) {
+  const stdout = execFileSync("git", ["-C", root, "ls-files", "--", ...TEST_FILE_GLOBS], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  return stdout
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .filter((relativePath) => TEST_FILE_PATTERN.test(relativePath))
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+function collectCleanupSignals(source) {
+  return {
+    hasCleanupCall: CLEANUP_CALL_PATTERN.test(source),
+    hasAfterEach: AFTER_EACH_PATTERN.test(source),
+    hasAfterAll: AFTER_ALL_PATTERN.test(source),
+    hasFinally: FINALLY_PATTERN.test(source),
+  };
+}
+
+function classifyCleanupRisk(source) {
+  const mkdtempMatches = source.match(MKDTEMP_PATTERN) ?? [];
+  if (mkdtempMatches.length === 0) {
+    return null;
+  }
+  const cleanup = collectCleanupSignals(source);
+  if (cleanup.hasAfterEach || cleanup.hasAfterAll || cleanup.hasFinally) {
+    return null;
+  }
+  return {
+    mkdtempCount: mkdtempMatches.length,
+    cleanup,
+    severity: cleanup.hasCleanupCall ? "warning" : "error",
+    reason: cleanup.hasCleanupCall
+      ? "uses mkdtemp without afterEach/afterAll/finally cleanup scope"
+      : "uses mkdtemp without any obvious cleanup",
+  };
+}
+
+export async function collectTestTempCleanupFindings(root = repoRoot) {
+  const findings = [];
+  for (const relativePath of listTrackedTestFiles(root)) {
+    const absolutePath = path.join(root, relativePath);
+    const source = await fs.readFile(absolutePath, "utf8");
+    const risk = classifyCleanupRisk(source);
+    if (!risk) {
+      continue;
+    }
+    findings.push({
+      file: relativePath,
+      ...risk,
+    });
+  }
+  return findings;
+}
+
+export async function main(argv = process.argv.slice(2), io) {
+  const json = argv.includes("--json");
+  const findings = await collectTestTempCleanupFindings(repoRoot);
+  const writeStdout = (chunk) => {
+    if (io?.stdout?.write) {
+      io.stdout.write(chunk);
+      return;
+    }
+    process.stdout.write(chunk);
+  };
+  const writeStderr = (chunk) => {
+    if (io?.stderr?.write) {
+      io.stderr.write(chunk);
+      return;
+    }
+    process.stderr.write(chunk);
+  };
+
+  if (json) {
+    writeStdout(`${JSON.stringify(findings, null, 2)}\n`);
+  } else if (findings.length > 0) {
+    writeStderr("Test temp-dir cleanup findings:\n");
+    for (const finding of findings) {
+      const severity = finding.severity === "error" ? "error" : "warn";
+      writeStderr(
+        `- [${severity}] ${finding.file} mkdtemp=${finding.mkdtempCount}: ${finding.reason}\n`,
+      );
+    }
+    writeStderr(
+      "Use afterEach/afterAll or try/finally around mkdtemp-created directories so /tmp residue does not leak across runs.\n",
+    );
+  }
+
+  return findings.some((finding) => finding.severity === "error") ? 1 : 0;
+}
+
+runAsScript(import.meta.url, async (argv, io) => {
+  const exitCode = await main(argv, io);
+  if (!io && exitCode !== 0) {
+    process.exit(exitCode);
+  }
+  return exitCode;
+});

--- a/scripts/check-test-temp-cleanup.mjs
+++ b/scripts/check-test-temp-cleanup.mjs
@@ -82,25 +82,24 @@ export async function collectTestTempCleanupFindings(root = repoRoot) {
   return findings;
 }
 
-export async function main(argv = process.argv.slice(2), io) {
-  const json = argv.includes("--json");
-  const findings = await collectTestTempCleanupFindings(repoRoot);
+export async function renderTestTempCleanupReport(params) {
+  const findings = await collectTestTempCleanupFindings(params.root ?? repoRoot);
   const writeStdout = (chunk) => {
-    if (io?.stdout?.write) {
-      io.stdout.write(chunk);
+    if (params.io?.stdout?.write) {
+      params.io.stdout.write(chunk);
       return;
     }
     process.stdout.write(chunk);
   };
   const writeStderr = (chunk) => {
-    if (io?.stderr?.write) {
-      io.stderr.write(chunk);
+    if (params.io?.stderr?.write) {
+      params.io.stderr.write(chunk);
       return;
     }
     process.stderr.write(chunk);
   };
 
-  if (json) {
+  if (params.json) {
     writeStdout(`${JSON.stringify(findings, null, 2)}\n`);
   } else if (findings.length > 0) {
     writeStderr("Test temp-dir cleanup findings:\n");
@@ -113,7 +112,19 @@ export async function main(argv = process.argv.slice(2), io) {
     );
   }
 
-  return findings.some((finding) => finding.severity === "error") ? 1 : 0;
+  return {
+    findings,
+    exitCode: findings.some((finding) => finding.severity === "error") ? 1 : 0,
+  };
+}
+
+export async function main(argv = process.argv.slice(2), io) {
+  const result = await renderTestTempCleanupReport({
+    root: repoRoot,
+    json: argv.includes("--json"),
+    io,
+  });
+  return result.exitCode;
 }
 
 runAsScript(import.meta.url, async (argv, io) => {

--- a/scripts/check-test-temp-cleanup.mjs
+++ b/scripts/check-test-temp-cleanup.mjs
@@ -11,6 +11,8 @@ const TEST_FILE_GLOBS = ["src", "test", "packages", "extensions", "scripts"];
 const TEST_FILE_PATTERN =
   /(?:\.test(?:-[^./]+)?|\.test-helpers|\.test-harness|\.test-support)\.ts$/u;
 const MKDTEMP_PATTERN = /\bmkdtemp(?:Sync)?\s*\(/u;
+const MKDTEMP_BINDING_PATTERN =
+  /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:await\s+)?(?:[A-Za-z_$][\w$]*\s*\.\s*)*mkdtemp(?:Sync)?\s*\(/gu;
 const CLEANUP_CALL_PATTERN = /\brm(?:Sync)?\s*\(/u;
 const AFTER_EACH_PATTERN = /\bafterEach\s*\(/u;
 const AFTER_ALL_PATTERN = /\bafterAll\s*\(/u;
@@ -28,7 +30,7 @@ function listTrackedTestFiles(root = repoRoot) {
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-function collectCleanupSignals(source) {
+function collectFileCleanupSignals(source) {
   return {
     hasCleanupCall: CLEANUP_CALL_PATTERN.test(source),
     hasAfterEach: AFTER_EACH_PATTERN.test(source),
@@ -37,23 +39,71 @@ function collectCleanupSignals(source) {
   };
 }
 
+function collectMkdtempBindings(source) {
+  return Array.from(source.matchAll(MKDTEMP_BINDING_PATTERN), (match) => match[1]);
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function hasCleanupCallForBinding(source, variableName) {
+  const escapedVariableName = escapeRegExp(variableName);
+  const cleanupPattern = new RegExp(
+    String.raw`\brm(?:Sync)?\s*\([^\n;]*\b${escapedVariableName}\b`,
+    "u",
+  );
+  return cleanupPattern.test(source);
+}
+
 function classifyCleanupRisk(source) {
   if (!MKDTEMP_PATTERN.test(source)) {
     return null;
   }
-  const cleanup = collectCleanupSignals(source);
-  if (
-    cleanup.hasCleanupCall &&
-    (cleanup.hasAfterEach || cleanup.hasAfterAll || cleanup.hasFinally)
-  ) {
+
+  const cleanup = collectFileCleanupSignals(source);
+  const hasLifecycleScope = cleanup.hasAfterEach || cleanup.hasAfterAll || cleanup.hasFinally;
+  const bindings = collectMkdtempBindings(source).map((variableName) => ({
+    variableName,
+    hasCleanupCall: hasCleanupCallForBinding(source, variableName),
+  }));
+
+  if (bindings.length === 0) {
+    return {
+      severity: cleanup.hasCleanupCall ? "warning" : "error",
+      reason: cleanup.hasCleanupCall
+        ? "uses mkdtemp without cleanup tied to a temp-dir binding in afterEach/afterAll/finally scope"
+        : "uses mkdtemp without any obvious cleanup",
+      cleanup: {
+        ...cleanup,
+        bindings,
+      },
+    };
+  }
+
+  const unresolvedBindings = bindings.filter(
+    (binding) => !binding.hasCleanupCall || !hasLifecycleScope,
+  );
+  if (unresolvedBindings.length === 0) {
     return null;
   }
+
+  const bindingsMissingCleanup = unresolvedBindings
+    .filter((binding) => !binding.hasCleanupCall)
+    .map((binding) => binding.variableName);
+
   return {
-    severity: cleanup.hasCleanupCall ? "warning" : "error",
-    reason: cleanup.hasCleanupCall
-      ? "uses mkdtemp without file-level afterEach/afterAll/finally cleanup scope"
-      : "uses mkdtemp without any obvious cleanup",
-    cleanup,
+    severity: bindingsMissingCleanup.length > 0 ? "error" : "warning",
+    reason:
+      bindingsMissingCleanup.length > 0
+        ? `uses mkdtemp without cleanup for temp-dir binding(s): ${bindingsMissingCleanup.join(", ")}`
+        : `uses mkdtemp without file-level afterEach/afterAll/finally cleanup scope for temp-dir binding(s): ${unresolvedBindings
+            .map((binding) => binding.variableName)
+            .join(", ")}`,
+    cleanup: {
+      ...cleanup,
+      bindings,
+    },
   };
 }
 

--- a/scripts/check-test-temp-cleanup.mjs
+++ b/scripts/check-test-temp-cleanup.mjs
@@ -61,7 +61,15 @@ export async function collectTestTempCleanupFindings(root = repoRoot) {
   const findings = [];
   for (const relativePath of listTrackedTestFiles(root)) {
     const absolutePath = path.join(root, relativePath);
-    const source = await fs.readFile(absolutePath, "utf8");
+    let source;
+    try {
+      source = await fs.readFile(absolutePath, "utf8");
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
     const risk = classifyCleanupRisk(source);
     if (!risk) {
       continue;

--- a/scripts/check-test-temp-cleanup.mjs
+++ b/scripts/check-test-temp-cleanup.mjs
@@ -168,10 +168,11 @@ export async function renderTestTempCleanupReport(params) {
   };
 }
 
-export async function main(argv = process.argv.slice(2), io) {
+export async function main(argv, io) {
+  const effectiveArgv = argv ?? process.argv.slice(2);
   const result = await renderTestTempCleanupReport({
     root: repoRoot,
-    json: argv.includes("--json"),
+    json: effectiveArgv.includes("--json"),
     io,
   });
   return result.exitCode;

--- a/test/scripts/check-test-temp-cleanup.test.ts
+++ b/test/scripts/check-test-temp-cleanup.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { collectTestTempCleanupFindings, main } from "../../scripts/check-test-temp-cleanup.mjs";
+import {
+  collectTestTempCleanupFindings,
+  main,
+  renderTestTempCleanupReport,
+} from "../../scripts/check-test-temp-cleanup.mjs";
 
 const tempDirs: string[] = [];
 
@@ -85,19 +89,28 @@ describe("check-test-temp-cleanup", () => {
   });
 
   it("supports json output for tooling", async () => {
+    const root = await createFixtureRepo({
+      relativePath: "src/json.test.ts",
+      source: `import fs from "node:fs";\nimport os from "node:os";\nimport path from "node:path";\nconst dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-"));\nconsole.log(dir);\n`,
+    });
     let stdout = "";
-    const exitCode = await main(["--json"], {
-      stdout: { write: (chunk) => (stdout += chunk) },
-      stderr: { write: () => 0 },
+    const result = await renderTestTempCleanupReport({
+      root,
+      json: true,
+      io: {
+        stdout: { write: (chunk) => ((stdout += chunk), chunk.length) },
+        stderr: { write: () => 0 },
+      },
     });
 
-    expect(exitCode).toBe(1);
+    expect(result.exitCode).toBe(1);
     expect(() => JSON.parse(stdout)).not.toThrow();
     const parsed = JSON.parse(stdout) as Array<{ file?: unknown; severity?: unknown }>;
-    expect(parsed.length).toBeGreaterThan(0);
-    expect(parsed.some((entry) => typeof entry.file === "string")).toBe(true);
-    expect(parsed.some((entry) => entry.severity === "error" || entry.severity === "warning")).toBe(
-      true,
-    );
+    expect(parsed).toEqual([
+      expect.objectContaining({
+        file: "src/json.test.ts",
+        severity: "error",
+      }),
+    ]);
   });
 });

--- a/test/scripts/check-test-temp-cleanup.test.ts
+++ b/test/scripts/check-test-temp-cleanup.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { collectTestTempCleanupFindings, main } from "../../scripts/check-test-temp-cleanup.mjs";
+
+describe("check-test-temp-cleanup", () => {
+  it("reports current test files that use mkdtemp without scoped cleanup", async () => {
+    const findings = await collectTestTempCleanupFindings();
+
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: "test/scripts/blacksmith-testbox-runner.test.ts",
+          severity: "error",
+        }),
+        expect.objectContaining({
+          file: "src/gateway/hooks-mapping.test.ts",
+          severity: "error",
+        }),
+        expect.objectContaining({
+          file: "extensions/msteams/src/polls.test.ts",
+          severity: "error",
+        }),
+      ]),
+    );
+  });
+
+  it("supports json output for tooling", async () => {
+    let stdout = "";
+    const exitCode = await main(["--json"], {
+      stdout: { write: (chunk) => (stdout += chunk) },
+      stderr: { write: () => 0 },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(() => JSON.parse(stdout)).not.toThrow();
+    expect(JSON.parse(stdout)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: "test/scripts/blacksmith-testbox-runner.test.ts",
+        }),
+      ]),
+    );
+  });
+});

--- a/test/scripts/check-test-temp-cleanup.test.ts
+++ b/test/scripts/check-test-temp-cleanup.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { collectTestTempCleanupFindings, main } from "../../scripts/check-test-temp-cleanup.mjs";
 
 describe("check-test-temp-cleanup", () => {
-  it("reports current test files that use mkdtemp without scoped cleanup", async () => {
+  it("reports current test files that use mkdtemp without obvious cleanup", async () => {
     const findings = await collectTestTempCleanupFindings();
 
     expect(findings.length).toBeGreaterThan(0);
@@ -19,6 +19,24 @@ describe("check-test-temp-cleanup", () => {
         expect.objectContaining({
           file: "extensions/msteams/src/polls.test.ts",
           severity: "error",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps files with hooks but no cleanup call in the result set", async () => {
+    const findings = await collectTestTempCleanupFindings();
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: "src/gateway/hooks-mapping.test.ts",
+          severity: "error",
+          cleanup: expect.objectContaining({
+            hasAfterEach: false,
+            hasAfterAll: false,
+            hasFinally: false,
+            hasCleanupCall: false,
+          }),
         }),
       ]),
     );

--- a/test/scripts/check-test-temp-cleanup.test.ts
+++ b/test/scripts/check-test-temp-cleanup.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   collectTestTempCleanupFindings,
-  main,
   renderTestTempCleanupReport,
 } from "../../scripts/check-test-temp-cleanup.mjs";
 
@@ -44,6 +43,7 @@ describe("check-test-temp-cleanup", () => {
           hasAfterEach: false,
           hasAfterAll: false,
           hasFinally: false,
+          bindings: [expect.objectContaining({ variableName: "dir", hasCleanupCall: false })],
         }),
       }),
     ]);
@@ -64,6 +64,29 @@ describe("check-test-temp-cleanup", () => {
           hasAfterEach: true,
           hasAfterAll: false,
           hasFinally: false,
+          bindings: [expect.objectContaining({ variableName: "dir", hasCleanupCall: false })],
+        }),
+      }),
+    ]);
+  });
+
+  it("does not treat unrelated rm hooks as cleanup for another temp-dir binding", async () => {
+    const root = await createFixtureRepo({
+      relativePath: "src/unrelated-cleanup.test.ts",
+      source: `import fs from "node:fs";\nimport os from "node:os";\nimport path from "node:path";\nimport { afterEach } from "vitest";\nconst artifactDir = path.join(os.tmpdir(), "artifact-cache");\nafterEach(() => { fs.rmSync(artifactDir, { recursive: true, force: true }); });\nconst tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "leaky-"));\nconsole.log(tempDir);\n`,
+    });
+
+    await expect(collectTestTempCleanupFindings(root)).resolves.toEqual([
+      expect.objectContaining({
+        file: "src/unrelated-cleanup.test.ts",
+        severity: "error",
+        reason: expect.stringContaining("tempDir"),
+        cleanup: expect.objectContaining({
+          hasCleanupCall: true,
+          hasAfterEach: true,
+          hasAfterAll: false,
+          hasFinally: false,
+          bindings: [expect.objectContaining({ variableName: "tempDir", hasCleanupCall: false })],
         }),
       }),
     ]);

--- a/test/scripts/check-test-temp-cleanup.test.ts
+++ b/test/scripts/check-test-temp-cleanup.test.ts
@@ -49,6 +49,23 @@ describe("check-test-temp-cleanup", () => {
     ]);
   });
 
+  it("scans UI test files", async () => {
+    const root = await createFixtureRepo({
+      relativePath: "ui/leaky-ui.test.ts",
+      source: `import fs from "node:fs";\nimport os from "node:os";\nimport path from "node:path";\nconst dir = fs.mkdtempSync(path.join(os.tmpdir(), "leaky-ui-"));\nconsole.log(dir);\n`,
+    });
+
+    await expect(collectTestTempCleanupFindings(root)).resolves.toEqual([
+      expect.objectContaining({
+        file: "ui/leaky-ui.test.ts",
+        severity: "error",
+        cleanup: expect.objectContaining({
+          bindings: [expect.objectContaining({ variableName: "dir", hasCleanupCall: false })],
+        }),
+      }),
+    ]);
+  });
+
   it("keeps files with hooks but no cleanup call in the result set", async () => {
     const root = await createFixtureRepo({
       relativePath: "src/mixed-hooks.test.ts",

--- a/test/scripts/check-test-temp-cleanup.test.ts
+++ b/test/scripts/check-test-temp-cleanup.test.ts
@@ -1,45 +1,87 @@
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { collectTestTempCleanupFindings, main } from "../../scripts/check-test-temp-cleanup.mjs";
 
-describe("check-test-temp-cleanup", () => {
-  it("reports current test files that use mkdtemp without obvious cleanup", async () => {
-    const findings = await collectTestTempCleanupFindings();
+const tempDirs: string[] = [];
 
-    expect(findings.length).toBeGreaterThan(0);
-    expect(findings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          file: "test/scripts/blacksmith-testbox-runner.test.ts",
-          severity: "error",
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function createFixtureRepo(params: { relativePath: string; source: string }) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-temp-cleanup-"));
+  tempDirs.push(root);
+  await fs.mkdir(path.join(root, path.dirname(params.relativePath)), { recursive: true });
+  await fs.writeFile(path.join(root, params.relativePath), params.source, "utf8");
+  execFileSync("git", ["init"], { cwd: root, stdio: ["ignore", "ignore", "ignore"] });
+  execFileSync("git", ["add", params.relativePath], {
+    cwd: root,
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+  return root;
+}
+
+describe("check-test-temp-cleanup", () => {
+  it("reports fixture files that use mkdtemp without obvious cleanup", async () => {
+    const root = await createFixtureRepo({
+      relativePath: "src/leaky.test.ts",
+      source: `import fs from "node:fs";\nimport os from "node:os";\nimport path from "node:path";\nconst dir = fs.mkdtempSync(path.join(os.tmpdir(), "leaky-"));\nconsole.log(dir);\n`,
+    });
+
+    await expect(collectTestTempCleanupFindings(root)).resolves.toEqual([
+      expect.objectContaining({
+        file: "src/leaky.test.ts",
+        severity: "error",
+        cleanup: expect.objectContaining({
+          hasCleanupCall: false,
+          hasAfterEach: false,
+          hasAfterAll: false,
+          hasFinally: false,
         }),
-        expect.objectContaining({
-          file: "src/gateway/hooks-mapping.test.ts",
-          severity: "error",
-        }),
-        expect.objectContaining({
-          file: "extensions/msteams/src/polls.test.ts",
-          severity: "error",
-        }),
-      ]),
-    );
+      }),
+    ]);
   });
 
   it("keeps files with hooks but no cleanup call in the result set", async () => {
-    const findings = await collectTestTempCleanupFindings();
-    expect(findings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          file: "src/gateway/hooks-mapping.test.ts",
-          severity: "error",
-          cleanup: expect.objectContaining({
-            hasAfterEach: false,
-            hasAfterAll: false,
-            hasFinally: false,
-            hasCleanupCall: false,
-          }),
+    const root = await createFixtureRepo({
+      relativePath: "src/mixed-hooks.test.ts",
+      source: `import fs from "node:fs";\nimport os from "node:os";\nimport path from "node:path";\nimport { afterEach } from "vitest";\nafterEach(() => { resetMocks(); });\nconst dir = fs.mkdtempSync(path.join(os.tmpdir(), "leaky-"));\nconsole.log(dir);\n`,
+    });
+
+    await expect(collectTestTempCleanupFindings(root)).resolves.toEqual([
+      expect.objectContaining({
+        file: "src/mixed-hooks.test.ts",
+        severity: "error",
+        cleanup: expect.objectContaining({
+          hasCleanupCall: false,
+          hasAfterEach: true,
+          hasAfterAll: false,
+          hasFinally: false,
         }),
-      ]),
-    );
+      }),
+    ]);
+  });
+
+  it("suppresses files that combine cleanup calls with lifecycle cleanup scope", async () => {
+    const root = await createFixtureRepo({
+      relativePath: "src/clean.test.ts",
+      source: `import fs from "node:fs";\nimport os from "node:os";\nimport path from "node:path";\nimport { afterEach } from "vitest";\nconst dir = fs.mkdtempSync(path.join(os.tmpdir(), "clean-"));\nafterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });\n`,
+    });
+
+    await expect(collectTestTempCleanupFindings(root)).resolves.toEqual([]);
+  });
+
+  it("skips sparse-missing tracked files", async () => {
+    const root = await createFixtureRepo({
+      relativePath: "src/missing.test.ts",
+      source: `import fs from "node:fs";\nimport os from "node:os";\nimport path from "node:path";\nconst dir = fs.mkdtempSync(path.join(os.tmpdir(), "missing-"));\nconsole.log(dir);\n`,
+    });
+    await fs.rm(path.join(root, "src", "missing.test.ts"), { force: true });
+
+    await expect(collectTestTempCleanupFindings(root)).resolves.toEqual([]);
   });
 
   it("supports json output for tooling", async () => {
@@ -51,12 +93,11 @@ describe("check-test-temp-cleanup", () => {
 
     expect(exitCode).toBe(1);
     expect(() => JSON.parse(stdout)).not.toThrow();
-    expect(JSON.parse(stdout)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          file: "test/scripts/blacksmith-testbox-runner.test.ts",
-        }),
-      ]),
+    const parsed = JSON.parse(stdout) as Array<{ file?: unknown; severity?: unknown }>;
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(parsed.some((entry) => typeof entry.file === "string")).toBe(true);
+    expect(parsed.some((entry) => entry.severity === "error" || entry.severity === "warning")).toBe(
+      true,
     );
   });
 });


### PR DESCRIPTION
## Summary
- add `scripts/check-test-temp-cleanup.mjs` to scan tracked test files for `mkdtemp` usage without obvious scoped cleanup
- add `test/scripts/check-test-temp-cleanup.test.ts` coverage for the scanner and its JSON mode
- expose the scanner through `pnpm lint:tmp:test-temp-cleanup`

## Why this matters
- temp test directories under `/tmp` are easy to forget, but they accumulate across repeated local and CI runs
- leftover trees can trigger host security scanners, create noisy operational alerts, and make real residue harder to distinguish from harmless test artifacts
- even when the contents are benign, routine cleanup reduces false alarms and keeps test hygiene visible in code review

## Current scan snapshot
- 38 tracked test files currently match the heuristic
- 29 are `error` level (no obvious cleanup signal)
- 9 are `warning` level (`rm` present but no `afterEach` / `afterAll` / `finally` scope)

## Current limitations
- this is intentionally a lightweight heuristic, not a full AST or control-flow proof
- false negatives are still possible, especially when cleanup exists elsewhere in the file but is unrelated to a specific `mkdtemp` call
- false positives are also possible when cleanup happens through helpers or patterns this scan does not recognize yet
- this PR adds the scan first so we can review the signal/noise tradeoff before tightening the heuristic or wiring it into broader gates

## Validation
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test test/scripts/check-test-temp-cleanup.test.ts`
- `node scripts/check-test-temp-cleanup.mjs --json`

## Notes
This PR intentionally adds the guard as a standalone scan first. It does not fix the existing findings yet, so maintainers can review the heuristic and rollout strategy before wiring it into broader gates.
