### PR TITLE
fix(agents): scope session-history guard to latest-user-answered

### DIFF
--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -40,6 +40,7 @@ async function jsonlFileHasAssistantMessage(filePath: string | undefined): Promi
     try {
       const rl = readline.createInterface({ input: fh.createReadStream({ encoding: "utf-8" }) });
       let recordCount = 0;
+      let hasAssistantAfterLatestUser = false;
       for await (const line of rl) {
         if (!line.trim()) {
           continue;
@@ -55,11 +56,22 @@ async function jsonlFileHasAssistantMessage(filePath: string | undefined): Promi
           continue;
         }
         const rec = obj as Record<string, unknown> | null;
-        if ((rec?.message as Record<string, unknown> | undefined)?.role === "assistant") {
-          return true;
+        const messageRole = (rec?.message as Record<string, unknown> | undefined)?.role;
+        const role =
+          rec?.type === "message"
+            ? messageRole
+            : rec?.type === "user" || rec?.type === "assistant"
+              ? rec.type
+              : undefined;
+        if (role === "user") {
+          hasAssistantAfterLatestUser = false;
+          continue;
+        }
+        if (role === "assistant") {
+          hasAssistantAfterLatestUser = true;
         }
       }
-      return false;
+      return hasAssistantAfterLatestUser;
     } finally {
       await fh.close();
     }

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -39,16 +39,19 @@ async function jsonlFileHasAssistantMessage(filePath: string | undefined): Promi
     const fh = await fs.open(filePath, "r");
     try {
       const rl = readline.createInterface({ input: fh.createReadStream({ encoding: "utf-8" }) });
-      let recordCount = 0;
-      let hasAssistantAfterLatestUser = false;
+      const recentLines: string[] = [];
       for await (const line of rl) {
         if (!line.trim()) {
           continue;
         }
-        recordCount++;
-        if (recordCount > SESSION_FILE_MAX_RECORDS) {
-          break;
+        recentLines.push(line);
+        if (recentLines.length > SESSION_FILE_MAX_RECORDS) {
+          recentLines.shift();
         }
+      }
+
+      let hasAssistantAfterLatestUser = false;
+      for (const line of recentLines) {
         let obj: unknown;
         try {
           obj = JSON.parse(line);

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -324,6 +324,20 @@ describe("sessionFileHasContent", () => {
     expect(await sessionFileHasContent(file)).toBe(true);
   });
 
+  it("returns false when a fresh user message appears after an earlier assistant response", async () => {
+    const file = path.join(tmpDir, "fresh-user-after-assistant.jsonl");
+    await fs.writeFile(
+      file,
+      [
+        '{"type":"message","message":{"role":"user","content":"old"}}',
+        '{"type":"message","message":{"role":"assistant","content":"answered"}}',
+        '{"type":"message","message":{"role":"user","content":"fresh unanswered"}}',
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    expect(await sessionFileHasContent(file)).toBe(false);
+  });
+
   it("returns true when session file has spaced JSON (role : assistant)", async () => {
     const file = path.join(tmpDir, "spaced.jsonl");
     await fs.writeFile(

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -348,6 +348,29 @@ describe("sessionFileHasContent", () => {
     expect(await sessionFileHasContent(file)).toBe(true);
   });
 
+  it("inspects the transcript tail when the newest user message is after the scan cap", async () => {
+    const file = path.join(tmpDir, "fresh-user-after-cap.jsonl");
+    const oldAnsweredTurn = [
+      { type: "message", message: { role: "user", content: "old" } },
+      { type: "message", message: { role: "assistant", content: "answered" } },
+    ];
+    const filler = Array.from({ length: 501 }, (_, index) => ({
+      type: "meta",
+      index,
+    }));
+    const freshUserTurn = [
+      { type: "message", message: { role: "user", content: "fresh unanswered" } },
+    ];
+    await fs.writeFile(
+      file,
+      [...oldAnsweredTurn, ...filler, ...freshUserTurn]
+        .map((line) => JSON.stringify(line))
+        .join("\n") + "\n",
+      "utf-8",
+    );
+    expect(await sessionFileHasContent(file)).toBe(false);
+  });
+
   it("returns true when assistant message appears after large user content", async () => {
     const file = path.join(tmpDir, "large-user.jsonl");
     // Create a user message whose JSON line exceeds 256KB to ensure the


### PR DESCRIPTION
Addresses part of #69086 (session-history guard only; retry-prompt hook/override remains separate).

## Summary
- scope the session-history guard to assistant messages that occur after the latest user message
- inspect the transcript tail rather than only the first 500 records so a fresh unanswered user turn after a long history is not misclassified as answered
- preserve Claude CLI transcript support for `type: assistant` / `type: user` JSONL records as well as OpenClaw `type: message` records
- add a regression fixture where an earlier assistant response is followed by a fresh unanswered user message

## Test
- `pnpm test src/agents/command/attempt-execution.test.ts` — 36/36 passed
- `pnpm exec oxfmt --check --threads=1 src/agents/command/attempt-execution.helpers.ts src/agents/command/attempt-execution.test.ts` — passed
- after rebasing onto current `origin/main`, reran the previously failing CI-adjacent files locally:
  - `pnpm test src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/sessions/extensions/loader.test.ts` — 8/8 passed

## Real behavior proof

**Behavior or issue addressed:** The attempt-execution session-history guard could treat an old assistant response as proof that the latest user message had already been answered. In a long JSONL transcript this suppresses the retry path for a fresh unanswered user turn.

**Real environment tested:** Real macOS OpenClaw development checkout on Dunny's Mac mini. Repository `openclaw/openclaw`; branch `fix/attempt-execution-session-guard-69086`; rebased onto current upstream `origin/main` at `3dfb76f13b` (`fix(synology-chat): centralize user id parsing`); head after rebase `0a63ea33f9`. No credentials, tokens, private chat content, or non-public endpoints are included here.

**Exact steps or command run after this patch:**
1. Rebased the PR branch onto current `openclaw/openclaw:main` after the dependency-guard notice.
2. Created a real temporary JSONL transcript on disk with old user→assistant history, 501 filler records, then a fresh unanswered user message at the tail.
3. Ran `pnpm exec tsx` against the production exported helper `sessionFileHasContent()` from `src/agents/command/attempt-execution.helpers.ts` and passed that real temp JSONL file path.
4. Reran targeted attempt-execution coverage, formatter checks, and the two CI-adjacent files that had previously failed from stale branch/base state.

**Evidence after fix:** Copied terminal output from the real local checkout after the rebase:

```text
$ pnpm exec tsx -e 'import { sessionFileHasContent } from "./src/agents/command/attempt-execution.helpers.ts"; (async()=>{ const file=process.argv[1]; console.log(JSON.stringify({fixture:file.split("/").pop(), result: await sessionFileHasContent(file)})); })();' "$FILE"
{"fixture":"session.jsonl","result":false}

$ pnpm test src/agents/command/attempt-execution.test.ts
✓ agents  src/agents/command/attempt-execution.test.ts (36 tests) 22ms
Test Files  1 passed (1)
Tests  36 passed (36)
[test] passed 1 Vitest shard in 3.49s

$ pnpm exec oxfmt --check --threads=1 src/agents/command/attempt-execution.helpers.ts src/agents/command/attempt-execution.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 14ms on 2 files using 1 threads.

$ pnpm test src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/sessions/extensions/loader.test.ts
✓ agents  src/agents/cli-runner/execute.supervisor-capture.test.ts (6 tests) 17ms
✓ agents  src/agents/sessions/extensions/loader.test.ts (2 tests) 6354ms
Test Files  2 passed (2)
Tests  8 passed (8)
[test] passed 1 Vitest shard in 47.38s
```

**Observed result after fix:** The real temp transcript with an old answered turn and a fresh unanswered final user turn returned `false` from `sessionFileHasContent()`. That means the guard no longer misclassifies the latest user message as already answered just because an older assistant record exists. Existing answered-history cases still return `true` in the targeted test suite.

**What was not tested:** I did not run a live Telegram/OpenClaw retry end-to-end in this PR because that would require exercising a real user-facing agent route. The proof above is from the real OpenClaw checkout and the production helper path with a transcript fixture matching the failure mode; CI remains the broader suite authority.
