### PR TITLE
fix(gateway): stagger Telegram channel startup to prevent polling stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/channels: serialize channel and account startup with a 3-second handoff stagger and defer primary model prewarm until after `startChannels()` completes, preventing simultaneous Telegram `getMe` calls and provider-runtime imports from starving the Node event loop. Multi-account hosts (especially Windows 11 + Node 24 with 5+ Telegram accounts) saw multi-minute polling stalls on startup. (#78437) Thanks @glasswings-lang.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.
 - Onboard/channels: recover externalized channel plugins from stale `channels.<id>` config by falling back to `ensureChannelSetupPluginInstalled` via the trusted catalog when the plugin is missing on disk, so leftover `appId`/token entries no longer dead-end onboard with "<channel> plugin not available." (#78328) Thanks @sliverp.
 - Codex/app-server: forward the OpenClaw workspace bootstrap block through Codex `developerInstructions` instead of `config.instructions`, so persona/style guidance reaches the behavior-shaping app-server lane. Fixes #77363. Thanks @lonexreb.

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -717,8 +717,8 @@ describe("server-channels auto restart", () => {
     );
   });
 
-  it("limits whole-channel account startup fanout to four", async () => {
-    const accountIds = ["one", "two", "three", "four", "five", "six"];
+  it("serializes whole-channel account startup with handoff stagger", async () => {
+    const accountIds = ["one", "two", "three"];
     const releases: Array<() => void> = [];
     let active = 0;
     let maxActive = 0;
@@ -749,28 +749,38 @@ describe("server-channels auto restart", () => {
     const start = manager.startChannel("discord");
     await flushMicrotasks();
 
-    expect(isConfigured).toHaveBeenCalledTimes(4);
-    expect(maxActive).toBe(4);
+    // Concurrency is now 1: only the first account's preflight runs.
+    expect(isConfigured).toHaveBeenCalledTimes(1);
+    expect(maxActive).toBe(1);
     expect(startAccount).not.toHaveBeenCalled();
 
-    releases.splice(0, 4).forEach((release) => release());
-    await waitForMicrotaskCondition(
-      () => isConfigured.mock.calls.length === 6,
-      "expected second account startup wave",
-    );
+    // Walk through all three accounts: release preflight, advance through
+    // the stagger sleep, and confirm only one is active at any time.
+    for (let i = 0; i < accountIds.length; i += 1) {
+      releases.shift()?.();
+      await flushMicrotasks();
+      // Stagger sleep happens after handoff inside the inner task; advance
+      // past it so the limiter picks up the next account.
+      await vi.advanceTimersByTimeAsync(3_000);
+      await flushMicrotasks();
+    }
 
-    expect(isConfigured).toHaveBeenCalledTimes(6);
-    expect(maxActive).toBe(4);
-
-    releases.splice(0).forEach((release) => release());
     await start;
-    expect(startAccount).toHaveBeenCalledTimes(6);
+    expect(isConfigured).toHaveBeenCalledTimes(3);
+    expect(startAccount).toHaveBeenCalledTimes(3);
+    expect(maxActive).toBe(1);
+    // sleepWithAbort(3_000, ...) is called once per account-handoff stagger.
+    expect(
+      hoisted.sleepWithAbort.mock.calls.filter(
+        ([ms]) => ms === 3_000,
+      ),
+    ).toHaveLength(3);
 
     await manager.stopChannel("discord");
   });
 
-  it("limits channel plugin startup fanout to four", async () => {
-    const channelIds = Array.from({ length: 6 }, (_, index) => `test-${index}` as ChannelId);
+  it("serializes channel plugin startup with handoff stagger", async () => {
+    const channelIds = Array.from({ length: 3 }, (_, index) => `test-${index}` as ChannelId);
     const releases: Array<() => void> = [];
     let active = 0;
     let maxActive = 0;
@@ -799,20 +809,24 @@ describe("server-channels auto restart", () => {
     const start = manager.startChannels();
     await flushMicrotasks();
 
-    expect(releases).toHaveLength(4);
-    expect(maxActive).toBe(4);
+    // Concurrency is 1: only the first plugin's preflight runs.
+    expect(releases).toHaveLength(1);
+    expect(maxActive).toBe(1);
 
-    releases.splice(0, 4).forEach((release) => release());
-    await waitForMicrotaskCondition(
-      () => releases.length === 2,
-      "expected second channel startup wave",
-    );
+    for (let i = 0; i < channelIds.length; i += 1) {
+      releases.shift()?.();
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(3_000);
+      await flushMicrotasks();
+    }
 
-    expect(releases).toHaveLength(2);
-    expect(maxActive).toBe(4);
-
-    releases.splice(0).forEach((release) => release());
     await start;
+    expect(maxActive).toBe(1);
+    expect(
+      hoisted.sleepWithAbort.mock.calls.filter(
+        ([ms]) => ms === 3_000,
+      ),
+    ).toHaveLength(3);
 
     await Promise.all(channelIds.map((id) => manager.stopChannel(id)));
   });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -37,7 +37,8 @@ const CHANNEL_RESTART_POLICY: BackoffPolicy = {
 };
 const MAX_RESTART_ATTEMPTS = 10;
 const CHANNEL_STOP_ABORT_TIMEOUT_MS = 5_000;
-const CHANNEL_STARTUP_CONCURRENCY = 4;
+const CHANNEL_STARTUP_CONCURRENCY = 1;
+const CHANNEL_STARTUP_STAGGER_MS = 3_000;
 
 type ChannelRuntimeStore = {
   aborts: Map<string, AbortController>;
@@ -618,6 +619,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             });
           handedOffTask = true;
           store.tasks.set(id, trackedPromise);
+          // Stagger handoff completion so the outer concurrency limiter spaces
+          // bot startups out, preventing the simultaneous getMe + model-prewarm
+          // contention that starves the event loop.
+          if (CHANNEL_STARTUP_STAGGER_MS > 0) {
+            await sleepWithAbort(CHANNEL_STARTUP_STAGGER_MS, abort.signal).catch(
+              () => undefined,
+            );
+          }
         } catch (error) {
           if (!handedOffTask) {
             setRuntime(channelId, id, {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -462,6 +462,9 @@ export async function startGatewaySidecars(params: {
   await measureStartup(params.startupTrace, "sidecars.channels", async () => {
     if (!skipChannels) {
       try {
+        await measureStartup(params.startupTrace, "sidecars.channel-start", () =>
+          params.startChannels(),
+        );
         schedulePrimaryModelPrewarm(
           {
             cfg: params.cfg,
@@ -470,9 +473,6 @@ export async function startGatewaySidecars(params: {
             startupTrace: params.startupTrace,
           },
           params.prewarmPrimaryModel,
-        );
-        await measureStartup(params.startupTrace, "sidecars.channel-start", () =>
-          params.startChannels(),
         );
       } catch (err) {
         params.logChannels.error(`channel startup failed: ${String(err)}`);


### PR DESCRIPTION
## Summary

Channel startup uses `runTasksWithConcurrency` with `limit: 4`, but each task's inner async function returns as soon as the provider promise is handed off (without awaiting it), so the concurrency limiter effectively serializes microsecond-scale handoffs while all providers boot in parallel. Combined with `schedulePrimaryModelPrewarm` firing concurrently with `startChannels()`, simultaneous `getMe` calls and provider-runtime imports starve the Node event loop.

On hosts with N>1 Telegram accounts, this manifests as: `getUpdates` polling stalls for several minutes before the watchdog forces restart cycles.

## Changes

- `CHANNEL_STARTUP_CONCURRENCY`: 4 → 1
- New `CHANNEL_STARTUP_STAGGER_MS = 3_000` with `await sleepWithAbort()` between task completions, so the limiter actually spaces account boots out
- Move `schedulePrimaryModelPrewarm()` to run AFTER `startChannels()` awaits, so prewarm's provider-runtime imports don't compete for CPU with channel handshakes
- Update `server-channels.test.ts` fanout assertions to match the new contract (concurrency 1, per-account stagger calls verified)
- Add user-facing CHANGELOG entry under `### Fixes`

## Real behavior proof

**Behavior or issue addressed**: multi-Telegram-account gateway startup wedge — polling stalls and `getMe` cascades during simultaneous bot startup, observed on Windows 11 + Node 24. Subset of the chronic #73323 pattern (the startup-cascade slice of it).

**Real environment tested**: Windows 11 Home 26200, Node 24.14.0, glasswings-lang/openclaw fork at branch `local/all-fixes` (this PR's commits merged in). Five Telegram bot accounts: `@EthelredBot`, `@MariaClone_bot`, `@runningkittenBot`, `@Rozaya1Bot`, `@HavenismBot`. Single-host setup with the user's normal `~/.openclaw/openclaw.json`.

**Exact steps or command run after this patch**: stopped the running gateway process and the registered Windows scheduled-task instance, removed the stale lock at `%TEMP%\openclaw\gateway.<hash>.lock`, then restarted with stdout redirected to a file:

```
cd "C:/git-src/openclaw"
export OPENCLAW_TELEGRAM_FORCE_IPV4=1
node dist/index.js gateway --port 18789 > gateway-startup.log 2>&1
```

**After-fix evidence**: copied live output from the gateway log on the affected host, ANSI stripped:

```
2026-05-06T12:32:12.314-08:00 [gateway] http server listening (2 plugins: memory-core, telegram; 9.4s)
2026-05-06T12:32:12.837-08:00 [gateway] starting channels and sidecars...
2026-05-06T12:32:14.280-08:00 [telegram] [aethelred] starting provider (@EthelredBot)
2026-05-06T12:32:17.078-08:00 [telegram] [maria]     starting provider (@MariaClone_bot)
2026-05-06T12:32:20.065-08:00 [telegram] [pet]       starting provider (@runningkittenBot)
2026-05-06T12:32:23.101-08:00 [telegram] [rozaya]    starting provider (@Rozaya1Bot)
2026-05-06T12:32:26.081-08:00 [telegram] [tensor]    starting provider (@HavenismBot)
2026-05-06T12:32:28.443-08:00 [gateway] ready
```

**Observed result after fix**: bot startups landed at 12:32:14, 12:32:17, 12:32:20, 12:32:23, 12:32:26 — inter-bot deltas of 2.798s, 2.987s, 3.036s, 2.980s, confirming the 3-second `CHANNEL_STARTUP_STAGGER_MS` spacing. All five accounts booted in serial under the new concurrency-1 contract; gateway reached `ready` 14 seconds after channel start kicked off; no polling stalls were observed during the boot window. Compare against the pre-fix #73323 reports where the same five-bot setup wedged for 4+ minutes during simultaneous startup. Bot tokens redacted; bot handles shown are public usernames.

**What was not tested**: the deeper chronic post-startup undici dispatcher state degradation from #73323 — that affects long-running gateway processes regardless of these mitigations and likely needs Node profiling to root-cause. This PR addresses the startup-cascade subset only.

## AI-assisted PR

Authored with Claude Code (Anthropic) in collaboration with the human contributor. The contributor verified the fix on their own multi-Telegram Windows setup (proof above), reviewed the diff, and confirms understanding of the concurrency/stagger semantics.

## Test plan

- [x] Build passes locally (`pnpm build`)
- [x] Updated `server-channels.test.ts` assertions reflect concurrency-1 + stagger contract
- [x] Manual: 5-bot Windows 11 + Node 24 reproduction shows clean staggered startup with no polling stalls during the boot window (log excerpt above)
- [ ] Maintainer review of stagger constant choice (3s default — happy to make it configurable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
