### PR TITLE
fix(telegram): add OPENCLAW_TELEGRAM_FORCE_IPV4 opt-in env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/network: add opt-in `OPENCLAW_TELEGRAM_FORCE_IPV4` env override that pins every Telegram dispatcher to IPv4 from startup (`forceIpv4: true`, `autoSelectFamily: false`, `dnsResultOrder: ipv4first`) instead of waiting for the sticky-fallback path to engage after eligible failures. Useful on hosts where IPv6 is broken or partially routed and the dual-stack happy-eyeballs attempt sits long enough to wedge the long-poll dispatcher pool. Default behavior unchanged. (#78438) Thanks @glasswings-lang.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -967,6 +967,11 @@ channels:
       - `OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY=1`
       - `OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY=1`
       - `OPENCLAW_TELEGRAM_DNS_RESULT_ORDER=ipv4first`
+      - `OPENCLAW_TELEGRAM_FORCE_IPV4=1` — pins every Telegram dispatcher to
+        IPv4 from startup (`forceIpv4: true`, `autoSelectFamily: false`,
+        `dnsResultOrder: ipv4first`) instead of waiting for the sticky-fallback
+        path to engage after eligible failures. Only useful on hosts where
+        IPv6 is broken or partially routed.
     - Validate DNS answers:
 
 ```bash

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -192,6 +192,26 @@ function buildTelegramConnectOptions(params: {
   return Object.keys(connect).length > 0 ? connect : null;
 }
 
+/**
+ * Opt-in IPv4-only dispatcher policy for Telegram API.
+ *
+ * Some hosts (notably Windows 11 with broken or partial IPv6 connectivity)
+ * see chronic Telegram polling stalls because the dual-stack happy-eyeballs
+ * attempt sits in the IPv6 half-open state long enough to wedge the long-poll
+ * dispatcher pool. The existing sticky-fallback path eventually pins to IPv4,
+ * but only after burning a long timeout on every reconnect cycle.
+ *
+ * Setting OPENCLAW_TELEGRAM_FORCE_IPV4=1 (or true/yes/on) skips the dual-stack
+ * dance entirely and pins all Telegram API connections to IPv4 from startup,
+ * which on affected hosts eliminates the recurring polling stalls. Default
+ * remains IPv6-preferred to avoid changing behavior for users where IPv6 works.
+ */
+function isTelegramForceIpv4FromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.OPENCLAW_TELEGRAM_FORCE_IPV4?.trim().toLowerCase();
+  if (!raw) return false;
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
 function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
   const noProxyValue = env.no_proxy ?? env.NO_PROXY ?? "";
   if (!noProxyValue) {
@@ -609,11 +629,15 @@ export function resolveTelegramTransport(
   }
 
   const useEnvProxy = !resolvedExplicitProxyUrl && hasEnvProxy;
+  const forceIpv4FromEnv = isTelegramForceIpv4FromEnv();
+  if (forceIpv4FromEnv) {
+    log.info("OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup");
+  }
   const defaultDispatcherResolution = resolveTelegramDispatcherPolicy({
-    autoSelectFamily: autoSelectDecision.value,
-    dnsResultOrder,
+    autoSelectFamily: forceIpv4FromEnv ? false : autoSelectDecision.value,
+    dnsResultOrder: forceIpv4FromEnv ? "ipv4first" : dnsResultOrder,
     useEnvProxy,
-    forceIpv4: false,
+    forceIpv4: forceIpv4FromEnv,
     proxyUrl: resolvedExplicitProxyUrl,
   });
   const defaultDispatcher = createTelegramDispatcher(defaultDispatcherResolution.policy);


### PR DESCRIPTION
## Summary

Some hosts (notably Windows 11 with broken or partial IPv6 connectivity) see Telegram polling stalls because the dual-stack happy-eyeballs attempt sits in the IPv6 half-open state long enough to wedge the long-poll dispatcher pool. The existing sticky-fallback path eventually pins to IPv4, but only after burning a long timeout on every reconnect cycle.

## Changes

Adds opt-in env var `OPENCLAW_TELEGRAM_FORCE_IPV4`. When set to `1` / `true` / `yes` / `on`, all Telegram dispatchers are pinned to IPv4 from startup (`forceIpv4: true`, `autoSelectFamily: false`, `dnsResultOrder: ipv4first`). Default behavior unchanged for users where IPv6 works.

One log line on each transport resolution confirms the policy is active.

This branch has been **rebased onto current `main`** to drop a stagger commit that was inadvertently included on the original branch (that change lives in PR #78437 instead). The rebased branch is now a single focused commit. Also adds the user-facing CHANGELOG entry and documents the env var in `docs/channels/telegram.md`.

## Real behavior proof

**Behavior or issue addressed**: hosts with broken/partial IPv6 routing where the Telegram dispatcher's dual-stack happy-eyeballs attempt sits in IPv6 half-open long enough to wedge the long-poll pool, requiring an opt-in IPv4-from-startup pin instead of waiting for the existing sticky-fallback to engage after eligible failures. Subset of #73323 (the IPv6-routing slice of it).

**Real environment tested**: Windows 11 Home 26200, Node 24.14.0, glasswings-lang/openclaw fork at branch `local/all-fixes` (this PR's commit merged in). Five Telegram bot accounts on the same host. `OPENCLAW_TELEGRAM_FORCE_IPV4=1` set in Windows User scope and exported into the gateway shell.

**Exact steps or command run after this patch**: stopped the running gateway, removed the stale lock at `%TEMP%\openclaw\gateway.<hash>.lock`, restarted with the env var exported and stdout redirected:

```
cd "C:/git-src/openclaw"
export OPENROUTER_API_KEY=$(powershell -NoProfile -Command "[Environment]::GetEnvironmentVariable('OPENROUTER_API_KEY','User')")
export OPENCLAW_TELEGRAM_FORCE_IPV4=$(powershell -NoProfile -Command "[Environment]::GetEnvironmentVariable('OPENCLAW_TELEGRAM_FORCE_IPV4','User')")
node dist/index.js gateway --port 18789 > gateway-startup.log 2>&1
```

**After-fix evidence**: copied live output from the gateway log, ANSI stripped:

```
2026-05-06T12:32:13.510-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:14.484-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:16.420-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:17.082-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:19.420-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:20.069-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:22.422-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:23.106-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:25.423-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:26.086-08:00 [telegram] OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup
2026-05-06T12:32:28.443-08:00 [gateway] ready
```

**Observed result after fix**: the new branch in `extensions/telegram/src/fetch.ts` was reached on every transport rebuild and logged the confirmation line. All five Telegram dispatchers pinned to IPv4 from startup; no IPv6 dual-stack handshake delays observed during the boot window or during subsequent DM and group activity from the same gateway run.

**What was not tested**: live reproduction of the IPv6 dual-stack wedge from a host with that condition currently active — the test machine has the workaround running, so the pre-fix dual-stack failure path was not freshly reproduced for this PR. The chronic post-startup undici dispatcher degradation from #73323 also remains separately open and is unrelated to family-pinning.

## AI-assisted PR

Authored with Claude Code (Anthropic) in collaboration with the human contributor. The contributor verified the fix on their own Windows + multi-Telegram setup (proof above), reviewed the diff, and confirms understanding of the dispatcher pinning semantics.

## Test plan

- [x] Build passes locally (`pnpm build`)
- [x] Manual verification: env var set → "OPENCLAW_TELEGRAM_FORCE_IPV4 set; pinning Telegram dispatcher to IPv4 from startup" log line appears on transport resolution
- [x] Branch rebased onto current `main` (drops the stagger commit that belongs in #78437)
- [x] CHANGELOG entry added under `### Fixes`
- [x] `docs/channels/telegram.md` updated with the env var
- [ ] Polish suggestion: the log line currently fires per transport rebuild rather than once at startup — could be moved to module-level or guarded if log noise is a concern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
