### PR TITLE
fix(memory-core): make dream narrative timeout configurable

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -115,10 +115,11 @@ The sweep includes the primary runtime workspace and any configured agent worksp
 
 Default cadence behavior:
 
-| Setting              | Default       |
-| -------------------- | ------------- |
-| `dreaming.frequency` | `0 3 * * *`   |
-| `dreaming.model`     | default model |
+| Setting                                 | Default       |
+| --------------------------------------- | ------------- |
+| `dreaming.frequency`                    | `0 3 * * *`   |
+| `dreaming.model`                        | default model |
+| `dreaming.execution.defaults.timeoutMs` | `60000` ms    |
 
 ## Quick start
 
@@ -216,6 +217,9 @@ All settings live under `plugins.entries.memory-core.config.dreaming`.
 </ParamField>
 <ParamField path="model" type="string">
   Optional Dream Diary subagent model override. Use a canonical `provider/model` value when also setting a subagent `allowedModels` allowlist.
+</ParamField>
+<ParamField path="execution.defaults.timeoutMs" type="integer" default="60000">
+  Optional Dream Diary narrative subagent wait timeout, in milliseconds. Phase-level `phases.<phase>.execution.timeoutMs` overrides this for `light`, `rem`, or `deep`.
 </ParamField>
 
 <Warning>

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -584,11 +584,13 @@ For conceptual behavior and slash commands, see [Dreaming](/concepts/dreaming).
 
 ### User settings
 
-| Key         | Type      | Default       | Description                                       |
-| ----------- | --------- | ------------- | ------------------------------------------------- |
-| `enabled`   | `boolean` | `false`       | Enable or disable dreaming entirely               |
-| `frequency` | `string`  | `0 3 * * *`   | Optional cron cadence for the full dreaming sweep |
-| `model`     | `string`  | default model | Optional Dream Diary subagent model override      |
+| Key                                  | Type      | Default       | Description                                                                   |
+| ------------------------------------ | --------- | ------------- | ----------------------------------------------------------------------------- |
+| `enabled`                            | `boolean` | `false`       | Enable or disable dreaming entirely                                           |
+| `frequency`                          | `string`  | `0 3 * * *`   | Optional cron cadence for the full dreaming sweep                             |
+| `model`                              | `string`  | default model | Optional Dream Diary subagent model override                                  |
+| `execution.defaults.timeoutMs`       | `integer` | `60000`       | Optional Dream Diary narrative subagent wait timeout in milliseconds          |
+| `phases.<phase>.execution.timeoutMs` | `integer` | inherited     | Optional per-phase Dream Diary timeout override for `light`, `rem`, or `deep` |
 
 ### Example
 
@@ -606,6 +608,11 @@ For conceptual behavior and slash commands, see [Dreaming](/concepts/dreaming).
             enabled: true,
             frequency: "0 3 * * *",
             model: "anthropic/claude-sonnet-4-6",
+            execution: {
+              defaults: {
+                timeoutMs: 120000,
+              },
+            },
           },
         },
       },
@@ -618,6 +625,7 @@ For conceptual behavior and slash commands, see [Dreaming](/concepts/dreaming).
 - Dreaming writes machine state to `memory/.dreams/`.
 - Dreaming writes human-readable narrative output to `DREAMS.md` (or existing `dreams.md`).
 - `dreaming.model` uses the existing plugin subagent trust gate; set `plugins.entries.memory-core.subagent.allowModelOverride: true` before enabling it.
+- Dream Diary waits up to 60 seconds by default; set `dreaming.execution.defaults.timeoutMs` or a phase-level `dreaming.phases.<phase>.execution.timeoutMs` to allow slower narrative model runs.
 - Dream Diary retries once with the session default model when the configured model is unavailable. Trust or allowlist failures are logged and are not silently retried.
 - The light/deep/REM phase policy and thresholds are internal behavior, not user-facing config.
 

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -25,6 +25,11 @@
       "label": "Dreaming Model",
       "placeholder": "anthropic/claude-sonnet-4-6",
       "help": "Optional provider/model override for Dream Diary narrative subagent runs. Requires plugins.entries.memory-core.subagent.allowModelOverride."
+    },
+    "dreaming.execution.defaults.timeoutMs": {
+      "label": "Dream Diary Timeout",
+      "placeholder": "120000",
+      "help": "Optional timeout in milliseconds for Dream Diary narrative subagent runs. Defaults to 60000."
     }
   },
   "configSchema": {
@@ -73,6 +78,10 @@
                 "properties": {
                   "model": {
                     "type": "string"
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1
                   }
                 }
               }
@@ -108,6 +117,10 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "timeoutMs": {
+                        "type": "integer",
+                        "minimum": 1
                       }
                     }
                   }
@@ -151,6 +164,10 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "timeoutMs": {
+                        "type": "integer",
+                        "minimum": 1
                       }
                     }
                   }
@@ -182,6 +199,10 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "timeoutMs": {
+                        "type": "integer",
+                        "minimum": 1
                       }
                     }
                   }

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -615,6 +615,7 @@ describe("generateAndAppendDreamNarrative", () => {
       model: "anthropic/claude-sonnet-4-6",
     });
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
+    expect(subagent.waitForRun.mock.calls[0][0]).toMatchObject({ timeoutMs: 60_000 });
     expect(subagent.deleteSession).toHaveBeenCalledOnce();
 
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
@@ -747,6 +748,25 @@ describe("generateAndAppendDreamNarrative", () => {
       .then(() => true)
       .catch(() => false);
     expect(exists).toBe(false);
+  });
+
+  it("uses a configured narrative timeout when provided", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("The longer wait let the diary finish.");
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "rem", snippets: ["some memory"] },
+      timeoutMs: 120_000,
+      logger,
+    });
+
+    expect(subagent.waitForRun).toHaveBeenCalledWith({
+      runId: "run-123",
+      timeoutMs: 120_000,
+    });
   });
 
   it("handles subagent timeout gracefully", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -96,7 +96,7 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // restart. 60 s gives realistic latency headroom while still capping the
 // worst case at one minute, well below the multi-minute stall the original
 // comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+export const DEFAULT_NARRATIVE_TIMEOUT_MS = 60_000;
 const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;
@@ -882,9 +882,16 @@ export async function generateAndAppendDreamNarrative(params: {
   nowMs?: number;
   timezone?: string;
   model?: string;
+  timeoutMs?: number;
   logger: Logger;
 }): Promise<void> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  const timeoutMs =
+    typeof params.timeoutMs === "number" &&
+    Number.isFinite(params.timeoutMs) &&
+    params.timeoutMs > 0
+      ? Math.floor(params.timeoutMs)
+      : DEFAULT_NARRATIVE_TIMEOUT_MS;
 
   if (params.data.snippets.length === 0 && !params.data.promotions?.length) {
     return;
@@ -925,7 +932,7 @@ export async function generateAndAppendDreamNarrative(params: {
 
         const result = await params.subagent.waitForRun({
           runId,
-          timeoutMs: NARRATIVE_TIMEOUT_MS,
+          timeoutMs,
         });
 
         if (result.status === "ok") {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -39,7 +39,7 @@ type DreamingHostConfig = unknown;
 type DreamingPhaseStorageConfig = {
   timezone?: string;
   storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
-  execution?: { model?: string };
+  execution?: { model?: string; timeoutMs?: number };
 };
 type LightDreamingConfig = DreamingPhaseStorageConfig & {
   enabled: boolean;
@@ -1633,6 +1633,7 @@ async function runLightDreaming(params: {
         nowMs,
         timezone: params.config.timezone,
         model: params.config.execution?.model,
+        timeoutMs: params.config.execution?.timeoutMs,
         logger: params.logger,
       });
     } else {
@@ -1643,6 +1644,7 @@ async function runLightDreaming(params: {
         nowMs,
         timezone: params.config.timezone,
         model: params.config.execution?.model,
+        timeoutMs: params.config.execution?.timeoutMs,
         logger: params.logger,
       });
     }
@@ -1732,6 +1734,7 @@ async function runRemDreaming(params: {
         nowMs,
         timezone: params.config.timezone,
         model: params.config.execution?.model,
+        timeoutMs: params.config.execution?.timeoutMs,
         logger: params.logger,
       });
     } else {
@@ -1742,6 +1745,7 @@ async function runRemDreaming(params: {
         nowMs,
         timezone: params.config.timezone,
         model: params.config.execution?.model,
+        timeoutMs: params.config.execution?.timeoutMs,
         logger: params.logger,
       });
     }

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -125,6 +125,7 @@ type ShortTermPromotionDreamingConfig = {
   };
   execution?: {
     model?: string;
+    timeoutMs?: number;
   };
 };
 
@@ -401,7 +402,16 @@ export function resolveShortTermPromotionDreamingConfig(params: {
     ...(typeof resolved.maxAgeDays === "number" ? { maxAgeDays: resolved.maxAgeDays } : {}),
     verboseLogging: resolved.verboseLogging,
     storage: resolved.storage,
-    ...(resolved.execution.model ? { execution: { model: resolved.execution.model } } : {}),
+    ...(resolved.execution.model || typeof resolved.execution.timeoutMs === "number"
+      ? {
+          execution: {
+            ...(resolved.execution.model ? { model: resolved.execution.model } : {}),
+            ...(typeof resolved.execution.timeoutMs === "number"
+              ? { timeoutMs: resolved.execution.timeoutMs }
+              : {}),
+          },
+        }
+      : {}),
   };
 }
 
@@ -647,6 +657,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
             nowMs: sweepNowMs,
             timezone: params.config.timezone,
             model: params.config.execution?.model,
+            timeoutMs: params.config.execution?.timeoutMs,
             logger: params.logger,
           });
         } else {
@@ -657,6 +668,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
             nowMs: sweepNowMs,
             timezone: params.config.timezone,
             model: params.config.execution?.model,
+            timeoutMs: params.config.execution?.timeoutMs,
             logger: params.logger,
           });
         }

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -58,7 +58,7 @@ describe("memory dreaming host helpers", () => {
     });
   });
 
-  it("lets execution defaults and phase execution override the top-level dreaming model", () => {
+  it("lets execution defaults and phase execution override Dream Diary runtime options", () => {
     const resolved = resolveMemoryDreamingConfig({
       pluginConfig: {
         dreaming: {
@@ -66,12 +66,14 @@ describe("memory dreaming host helpers", () => {
           execution: {
             defaults: {
               model: "openai/gpt-5.4",
+              timeoutMs: "120000",
             },
           },
           phases: {
             rem: {
               execution: {
                 model: "xai/grok-4.1-fast",
+                timeoutMs: 180000,
               },
             },
           },
@@ -80,9 +82,13 @@ describe("memory dreaming host helpers", () => {
     });
 
     expect(resolved.execution.defaults.model).toBe("openai/gpt-5.4");
+    expect(resolved.execution.defaults.timeoutMs).toBe(120_000);
     expect(resolved.phases.light.execution.model).toBe("openai/gpt-5.4");
+    expect(resolved.phases.light.execution.timeoutMs).toBe(120_000);
     expect(resolved.phases.deep.execution.model).toBe("openai/gpt-5.4");
+    expect(resolved.phases.deep.execution.timeoutMs).toBe(120_000);
     expect(resolved.phases.rem.execution.model).toBe("xai/grok-4.1-fast");
+    expect(resolved.phases.rem.execution.timeoutMs).toBe(180_000);
   });
 
   it("falls back to cfg timezone and deep defaults", () => {

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -299,13 +299,14 @@ function resolveExecutionConfig(
   fallback: MemoryDreamingExecutionConfig,
 ): MemoryDreamingExecutionConfig {
   const record = asNullableRecord(value);
-  const maxOutputTokens = normalizeOptionalPositiveInt(record?.maxOutputTokens);
-  const timeoutMs = normalizeOptionalPositiveInt(record?.timeoutMs);
+  const maxOutputTokens =
+    normalizeOptionalPositiveInt(record?.maxOutputTokens) ?? fallback.maxOutputTokens;
+  const timeoutMs = normalizeOptionalPositiveInt(record?.timeoutMs) ?? fallback.timeoutMs;
   const temperatureRaw = record?.temperature;
   const temperature =
     typeof temperatureRaw === "number" && Number.isFinite(temperatureRaw) && temperatureRaw >= 0
       ? Math.min(2, temperatureRaw)
-      : undefined;
+      : fallback.temperature;
   const model = normalizeTrimmedString(record?.model) ?? fallback.model;
 
   return {


### PR DESCRIPTION
## Summary
- Add `dreaming.execution.defaults.timeoutMs` and per-phase `phases.<phase>.execution.timeoutMs` schema support for memory-core Dream Diary narrative runs.
- Propagate the resolved timeout into detached and inline narrative subagent waits while preserving the 60s default.
- Document the new setting and cover normalization/default behavior in tests.

## Tests
- `corepack pnpm exec vitest run extensions/memory-core/src/dreaming-narrative.test.ts src/memory-host-sdk/dreaming.test.ts`
- `corepack pnpm run format:docs:check`

## Real behavior proof
- **Behavior or issue addressed:** `memory-core` Dream Diary narrative runs were hard-coded to wait 60s, so slower real narrative subagent runs could end with `status=timeout`; this patch exposes a configurable timeout and wires it into the narrative `waitForRun` call.
- **Real environment tested:** Local OpenClaw checkout on Linux (`/home/jee/code/openclaw`), Node v24.15.0, branch `fix/memory-dreaming-narrative-timeout-clean` after this patch.
- **Exact steps or command run after this patch:** Ran a live terminal command against the patched checkout to inspect the real bundled `memory-core` plugin manifest and the runtime narrative wait wiring:

  ```bash
  node - <<'NODE'
  const fs = require('node:fs');
  const manifest = JSON.parse(fs.readFileSync('extensions/memory-core/openclaw.plugin.json', 'utf8'));
  const dreaming = manifest.configSchema.properties.dreaming.properties;
  console.log(JSON.stringify({
    defaultTimeoutSchema: dreaming.execution.properties.defaults.properties.timeoutMs,
    remTimeoutSchema: dreaming.phases.properties.rem.properties.execution.properties.timeoutMs,
  }, null, 2));
  NODE
  printf '\nwaitForRun timeout wiring:\n'
  grep -n "timeoutMs," extensions/memory-core/src/dreaming-narrative.ts | head -3
  ```

- **Evidence after fix:** Terminal output from the patched checkout:

  ```console
  {
    "defaultTimeoutSchema": {
      "type": "integer",
      "minimum": 1
    },
    "remTimeoutSchema": {
      "type": "integer",
      "minimum": 1
    }
  }

  waitForRun timeout wiring:
  935:          timeoutMs,
  ```

- **Observed result after fix:** The real plugin manifest now exposes positive integer timeout schema entries for both default Dream Diary execution and REM phase execution, and the narrative runtime passes the resolved `timeoutMs` variable into `subagent.waitForRun` instead of the old fixed constant.
- **What was not tested:** I did not run a full live Dream Diary sweep against an external model in CI; targeted runtime/unit coverage and docs formatting were run separately.
