### PR TITLE
feat(subagents): add durable per-spawn tool policies

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -249,6 +249,9 @@ Per-agent override: `agents.entries.*.subagents.delegationMode`.
 <ParamField path="worktreeBaseRef" type="string">
   Optional git base ref for the managed worktree. Requires `visible: true` and `worktree: true`.
 </ParamField>
+<ParamField path="tools" type='string | object'>
+  Native sub-agent runs only; unavailable with `visible: true`. Narrows the spawned child's model-facing tool set. Pass `"none"` to run the child with zero callable tools, or `{ "allow": ["read", "exec"] }` / `{ "deny": ["exec"] }` for selective narrowing (deny wins). Omit to use the normal child tool policy. The policy is **immutable** once set: for `thread: true` or `mode: "session"` native spawns, OpenClaw stores it on the child session and applies it to all subsequent turns — it cannot be widened or cleared later. Tool restrictions do not hide the child's skill catalog; denied tools remain unavailable even when skill instructions mention them. `runtime: "acp"` rejects this field. CLI-backed native runs accept allow-only and `"none"` policies but reject deny-based policies (the CLI harness cannot compute the complement).
+</ParamField>
 
 <Warning>
 `sessions_spawn` does **not** accept channel-delivery params (`target`,

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -1567,6 +1567,60 @@ describe("createOpenClawCodingTools", () => {
     ]);
   });
 
+  it("applies a stored per-spawn tool policy after forced tools are assembled", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runtime-tool-policy-"));
+    try {
+      const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
+      const sessionKey = "agent:main:subagent:runtime-limited";
+      await writeSessionStore(storeTemplate, "main", {
+        [sessionKey]: {
+          sessionId: "runtime-limited-session",
+          updatedAt: Date.now(),
+          runtimeToolPolicy: { allow: ["read"] },
+        },
+      });
+
+      const names = toolNameList(
+        createOpenClawCodingTools({
+          sessionKey,
+          config: { session: { store: storeTemplate } },
+          forceMessageTool: true,
+        }),
+      );
+
+      expect(names).toContain("read");
+      expect(names).not.toContain("exec");
+      expect(names).not.toContain("message");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exposes zero callable tools for a stored none policy", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runtime-tools-none-"));
+    try {
+      const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
+      const sessionKey = "agent:main:subagent:runtime-none";
+      await writeSessionStore(storeTemplate, "main", {
+        [sessionKey]: {
+          sessionId: "runtime-none-session",
+          updatedAt: Date.now(),
+          runtimeToolPolicy: "none",
+        },
+      });
+
+      const tools = createOpenClawCodingTools({
+        sessionKey,
+        config: { session: { store: storeTemplate } },
+        forceMessageTool: true,
+      });
+
+      expect(tools).toEqual([]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("passes effective allow-list-restricted tool surface to spawned sessions", () => {
     const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
     createOpenClawToolsMock.mockClear();

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -24,11 +24,13 @@ import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { hasAgentRosterProperty } from "./agent-scope-config.js";
 import { listAgentEntries, resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveProviderToolPolicy } from "./provider-tool-policy.js";
+import { runtimeToolPolicyToSandboxPolicy } from "./runtime-tool-policy.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox.js";
 import { resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
 import {
   resolveSubagentCapabilityStore,
+  resolveStoredRuntimeToolPolicy,
   resolveStoredSubagentInheritedToolAllowlist,
   resolveStoredSubagentInheritedToolDenylist,
   resolveStoredSubagentCapabilities,
@@ -133,6 +135,26 @@ export function resolveInheritedToolPolicyForSession(
     ...(inheritedToolAllow.length > 0 ? { allow: inheritedToolAllow } : {}),
     ...(inheritedToolDeny.length > 0 ? { deny: inheritedToolDeny } : {}),
   };
+}
+
+/**
+ * Resolve the immutable per-spawn runtime tool policy from the session entry.
+ * Returns a `SandboxToolPolicy` for the tool pipeline, or `undefined` when no
+ * policy is set. Corrupted persisted data fail-closes to deny-all via
+ * `runtimeToolPolicyToSandboxPolicy`.
+ */
+export function resolveRuntimeToolPolicyForSession(
+  cfg: OpenClawConfig | undefined,
+  sessionKey: string | undefined | null,
+  opts?: {
+    store?: SessionCapabilityStore;
+  },
+): SandboxToolPolicy | undefined {
+  const policy = resolveStoredRuntimeToolPolicy(sessionKey, {
+    cfg,
+    store: opts?.store,
+  });
+  return runtimeToolPolicyToSandboxPolicy(policy);
 }
 
 /** Filter runtime tools by sandbox allow/deny policy. */

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -34,6 +34,7 @@ import { bindToolExecutionAttribution } from "./agent-tools.before-tool-call.att
 import type { ToolOutcomeObserver } from "./agent-tools.before-tool-call.js";
 import { finalizeAgentTools } from "./agent-tools.finalize.js";
 import { filterToolsByMessageProvider } from "./agent-tools.message-provider-policy.js";
+import { filterToolsByPolicy } from "./agent-tools.policy.js";
 import { wrapToolMemoryFlushAppendOnlyWrite } from "./agent-tools.read.js";
 import {
   getActiveAgentRingZeroTools,
@@ -927,6 +928,17 @@ export function createOpenClawCodingToolsInternal(
   ) {
     // Collector output is a run contract, not an operator-configurable capability.
     authorizedTools.push(swarmStructuredOutputTool);
+  }
+  // Final model-facing gate: the immutable per-spawn session runtime tool policy
+  // must be enforced AFTER all tool sources are merged (ring-zero, forced message,
+  // heartbeat, tool-search, bundle/plugin, structured output) but BEFORE the
+  // inherited/cron allowlist snapshots are taken, so that grandchild sessions
+  // inherit the restricted surface, not the pre-gate one.
+  const sessionRuntimeToolPolicy = capabilityProfile.policy.sessionRuntimeToolPolicy;
+  if (sessionRuntimeToolPolicy) {
+    const gatedTools = filterToolsByPolicy(authorizedTools, sessionRuntimeToolPolicy);
+    authorizedTools.length = 0;
+    authorizedTools.push(...gatedTools);
   }
   if (shouldInheritEffectiveToolAllowlist) {
     // Snapshot exporter only: this copies authorizedTools for descendants and

--- a/src/agents/cli-runner/tool-policy.test.ts
+++ b/src/agents/cli-runner/tool-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCliBackendToolAvailability,
   resolveCliRuntimeToolsAllow,
+  resolveCliSessionToolsAllow,
   stripOpenClawMcpToolPrefix,
 } from "./tool-policy.js";
 
@@ -31,5 +32,43 @@ describe("resolveCliRuntimeToolsAllow", () => {
     expect(resolveCliRuntimeToolsAllow(["memory_search"], true)).toEqual(["memory_search"]);
     expect(resolveCliRuntimeToolsAllow(["*"])).toBeUndefined();
     expect(resolveCliRuntimeToolsAllow(["memory_search"])).toEqual(["memory_search"]);
+  });
+});
+
+describe("resolveCliSessionToolsAllow", () => {
+  it("preserves the existing runtime cap when the session has no per-spawn policy", () => {
+    expect(
+      resolveCliSessionToolsAllow({
+        toolsAllow: ["message"],
+        toolsAllowIsDefault: true,
+        sessionPolicy: undefined,
+      }),
+    ).toEqual(["message"]);
+  });
+
+  it("uses an allow-only per-spawn policy when no other runtime cap is active", () => {
+    expect(
+      resolveCliSessionToolsAllow({
+        sessionPolicy: { allow: ["read"] },
+      }),
+    ).toEqual(["read"]);
+  });
+
+  it("keeps deny-all when either independent runtime cap is empty", () => {
+    expect(
+      resolveCliSessionToolsAllow({
+        toolsAllow: [],
+        sessionPolicy: { allow: ["read"] },
+      }),
+    ).toEqual([]);
+  });
+
+  it("fails closed instead of replacing an independent runtime cap", () => {
+    expect(() =>
+      resolveCliSessionToolsAllow({
+        toolsAllow: ["message"],
+        sessionPolicy: { allow: ["read"] },
+      }),
+    ).toThrow("cannot combine");
   });
 });

--- a/src/agents/cli-runner/tool-policy.ts
+++ b/src/agents/cli-runner/tool-policy.ts
@@ -1,3 +1,4 @@
+import type { RuntimeToolPolicy } from "../../config/sessions/runtime-tool-policy.types.js";
 import type { CliBackendToolAvailability } from "../../plugins/cli-backend.types.js";
 import { normalizeToolName } from "../tool-policy.js";
 
@@ -34,4 +35,65 @@ export function resolveCliRuntimeToolsAllow(
   return toolsAllow.some((toolName) => normalizeToolName(toolName) === "*")
     ? undefined
     : toolsAllow;
+}
+
+/**
+ * Convert a per-spawn `RuntimeToolPolicy` to the CLI harness's allow-only list.
+ *
+ * The CLI harness can only enforce an explicit allow list — it cannot compute
+ * the complement of a deny list against the full tool inventory. Therefore:
+ * - `undefined` → `undefined` (no restriction).
+ * - `"none"` → `[]` (zero tools).
+ * - `{ allow: [...] }` without deny → the allow list.
+ * - `{ deny: [...] }` without allow → **throw** (CLI can't compute the complement; fail closed).
+ * - `{ allow, deny }` → **throw** (CLI can't subtract deny from allow reliably with globs/groups; fail closed).
+ */
+function resolveCliRuntimeToolPolicyFromSession(
+  policy: RuntimeToolPolicy | undefined,
+): string[] | undefined {
+  if (policy === undefined) {
+    return undefined;
+  }
+  if (policy === "none") {
+    return [];
+  }
+  if (policy.deny && policy.deny.length > 0) {
+    throw new Error(
+      "CLI-backed native runs cannot enforce a deny-based runtime tool policy. " +
+        "Deny-only and allow+deny policies are rejected because the CLI harness " +
+        "cannot compute the tool complement. Use an allow-only policy or an embedded runtime.",
+    );
+  }
+  // allow-only (deny is absent or empty)
+  return policy.allow ?? [];
+}
+
+/**
+ * Preserve both the caller's runtime cap and the immutable per-spawn cap.
+ *
+ * CLI backends receive only one allow list. Two independent non-empty lists
+ * cannot be combined safely here because either list may contain groups or
+ * patterns whose intersection depends on the backend's concrete tool catalog.
+ */
+export function resolveCliSessionToolsAllow(params: {
+  toolsAllow?: string[];
+  toolsAllowIsDefault?: boolean;
+  sessionPolicy?: RuntimeToolPolicy;
+}): string[] | undefined {
+  const runtimeAllow = resolveCliRuntimeToolsAllow(params.toolsAllow, params.toolsAllowIsDefault);
+  const sessionAllow = resolveCliRuntimeToolPolicyFromSession(params.sessionPolicy);
+
+  if (runtimeAllow === undefined) {
+    return sessionAllow;
+  }
+  if (sessionAllow === undefined) {
+    return runtimeAllow;
+  }
+  if (runtimeAllow.length === 0 || sessionAllow.length === 0) {
+    return [];
+  }
+  throw new Error(
+    "CLI-backed native runs cannot combine an existing runtime tool cap with a per-spawn " +
+      "tool policy without risking broader access. Remove one cap or use an embedded runtime.",
+  );
 }

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -814,6 +814,7 @@ describe("CLI attempt execution", () => {
     runId: string;
     cwd?: string;
     onExecutionStarted?: () => void;
+    opts?: Partial<Parameters<typeof runAgentAttempt>[0]["opts"]>;
   }) {
     await runAgentAttempt({
       providerOverride: "claude-cli",
@@ -824,7 +825,11 @@ describe("CLI attempt execution", () => {
       cwd: params.cwd,
       body: params.body,
       runId: params.runId,
-      opts: { onExecutionStarted: params.onExecutionStarted },
+      opts: {
+        senderIsOwner: false,
+        onExecutionStarted: params.onExecutionStarted,
+        ...params.opts,
+      } as Parameters<typeof runAgentAttempt>[0]["opts"],
       agentDir,
       sessionStore: params.sessionStore,
       storePath,
@@ -911,6 +916,36 @@ describe("CLI attempt execution", () => {
       claudeCliSessionId: cliSessionId,
     };
   }
+
+  it.each([
+    { label: "deny-only", runtimeToolPolicy: { deny: ["exec"] } },
+    { label: "allow+deny", runtimeToolPolicy: { allow: ["read"], deny: ["exec"] } },
+  ])(
+    "rejects $label runtime tool policy for CLI-backed native runs",
+    async ({ runtimeToolPolicy }) => {
+      const sessionKey = "agent:main:subagent:cli-tools-allow";
+      const sessionEntry: SessionEntry = {
+        sessionId: "session-cli-tools-allow",
+        updatedAt: Date.now(),
+        runtimeToolPolicy,
+      };
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+      await expect(
+        runClaudeCliAttempt({
+          sessionKey,
+          sessionEntry,
+          sessionStore,
+          body: "use only read",
+          runId: "run-cli-tools-allow",
+        }),
+      ).rejects.toThrow("CLI-backed native runs cannot enforce a deny-based runtime tool policy");
+
+      expect(runCliAgentMock).not.toHaveBeenCalled();
+      expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("clears stale Claude CLI session IDs before a fresh retry after session expiration", async () => {
     const sessionKey = "agent:main:subagent:cli-expired";
@@ -2655,7 +2690,7 @@ describe("CLI attempt execution", () => {
     expect(firstRunCliAgentArg().authProfileId).toBeUndefined();
   });
 
-  it("forwards runtime toolsAllow into CLI attempts so the CLI harness can fail closed", async () => {
+  it("forwards the existing runtime toolsAllow into CLI attempts", async () => {
     const sessionKey = "agent:main:direct:claude-tools-allow";
     const sessionEntry = makeSessionEntry("openclaw-session-cli-tools-allow");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
@@ -2801,6 +2836,53 @@ describe("CLI attempt execution", () => {
       expect(runCliAgentMock).not.toHaveBeenCalled();
     },
   );
+
+  it("forwards a per-spawn runtime tool policy allow-list into CLI attempts", async () => {
+    const sessionKey = "agent:main:subagent:claude-session-tools-allow";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-cli-session-tools-allow",
+      updatedAt: Date.now(),
+      runtimeToolPolicy: { allow: ["read", "web_search"] },
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await writeSessionStoreSeed(sessionStore);
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("restricted cli"));
+
+    await runAgentAttempt({
+      providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
+      modelOverride: "opus",
+      cfg: {} as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "route this",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-cli-session-tools-allow",
+      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: "discord",
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "claude-cli",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expectMockArgFields(runCliAgentMock, {
+      provider: "claude-cli",
+      toolsAllow: ["read", "web_search"],
+    });
+  });
 
   it("keeps trusted CLI completion handoffs tool-free when inherited policy is restricted", async () => {
     const sessionKey = "agent:main:direct:claude-trusted-announce";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1198,7 +1198,8 @@ export function runAgentAttempt(params: {
     imageOrder: shouldForwardImagesToEmbedded ? params.opts.imageOrder : undefined,
     media: params.opts.media,
     clientTools: params.opts.clientTools,
-    toolsAllow: params.opts.toolsAllow,
+    // Announce handoffs may replace opts.toolsAllow with a tighter runtime cap.
+    toolsAllow: runtimeToolsAllow,
     provider: embeddedAgentProvider,
     model: params.modelOverride,
     modelFallbacksOverride: params.modelFallbacksOverride,
@@ -1226,7 +1227,6 @@ export function runAgentAttempt(params: {
     extraSystemPrompt: params.opts.extraSystemPrompt,
     bootstrapContextMode: params.opts.bootstrapContextMode,
     bootstrapContextRunKind: params.opts.bootstrapContextRunKind,
-    toolsAllow: runtimeToolsAllow,
     runtimePluginToolGrant: params.opts.runtimePluginToolGrant,
     trustedInternalHandoff: trustedSubagentAnnounceHandoff
       ? params.opts.trustedInternalHandoff

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -67,7 +67,7 @@ import {
 } from "../cli-execution-auth.js";
 import { runCliAgent } from "../cli-runner.js";
 import { hasClaudeLiveSessionForOwner } from "../cli-runner/claude-live-session.js";
-import { resolveCliRuntimeToolsAllow } from "../cli-runner/tool-policy.js";
+import { resolveCliSessionToolsAllow } from "../cli-runner/tool-policy.js";
 import {
   getCliSessionBinding,
   resolveCliSessionClearReason,
@@ -1049,10 +1049,11 @@ export function runAgentAttempt(params: {
             groupChannel: params.runContext.groupChannel,
             groupSpace: params.runContext.groupSpace,
             spawnedBy: params.spawnedBy,
-            toolsAllow: resolveCliRuntimeToolsAllow(
-              runtimeToolsAllow,
-              params.opts.toolsAllowIsDefault,
-            ),
+            toolsAllow: resolveCliSessionToolsAllow({
+              toolsAllow: runtimeToolsAllow,
+              toolsAllowIsDefault: params.opts.toolsAllowIsDefault,
+              sessionPolicy: params.sessionEntry?.runtimeToolPolicy,
+            }),
             scheduledToolPolicy: params.opts.scheduledToolPolicy,
             cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
             cleanupCliLiveSessionOnRunEnd: params.opts.cleanupCliLiveSessionOnRunEnd,
@@ -1197,6 +1198,7 @@ export function runAgentAttempt(params: {
     imageOrder: shouldForwardImagesToEmbedded ? params.opts.imageOrder : undefined,
     media: params.opts.media,
     clientTools: params.opts.clientTools,
+    toolsAllow: params.opts.toolsAllow,
     provider: embeddedAgentProvider,
     model: params.modelOverride,
     modelFallbacksOverride: params.modelFallbacksOverride,

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -175,6 +175,8 @@ export type ResolvedConversationCapabilityProfile = {
     sandboxPolicy?: SandboxToolPolicy;
     subagentPolicy?: SandboxToolPolicy;
     inheritedToolPolicy?: SandboxToolPolicy;
+    /** Immutable per-spawn runtime tool policy from the session entry. */
+    sessionRuntimeToolPolicy?: SandboxToolPolicy;
     delegated: boolean;
     requesterPolicySource: RequesterToolPolicySource;
     runtimeToolPolicyForInheritance?: ToolPolicyLike;
@@ -237,7 +239,13 @@ export function resolveConversationCapabilityProfile(
     groupPolicySessionKey: params.scheduledToolPolicy?.ownerSessionKey,
     requireConfiguredGroupAccount: params.scheduledToolPolicy?.mode === "account",
   });
-  const { groupPolicy, senderPolicy, subagentPolicy, inheritedToolPolicy } = requesterPolicies;
+  const {
+    groupPolicy,
+    senderPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+    sessionRuntimeToolPolicy,
+  } = requesterPolicies;
   const profilePolicy = resolveToolProfilePolicy(effective.profile);
   const providerProfilePolicy = resolveToolProfilePolicy(effective.providerProfile);
   const configuredOverridePolicies = [
@@ -370,6 +378,7 @@ export function resolveConversationCapabilityProfile(
       sandboxPolicy: params.sandboxToolPolicy,
       subagentPolicy,
       inheritedToolPolicy,
+      sessionRuntimeToolPolicy,
       delegated: requesterPolicies.delegated,
       requesterPolicySource: requesterPolicies.requesterPolicySource,
       runtimeToolPolicyForInheritance,

--- a/src/agents/conversation-tool-policy-pipeline.ts
+++ b/src/agents/conversation-tool-policy-pipeline.ts
@@ -19,6 +19,7 @@ type ResolvedConversationToolPolicies = {
   subagentPolicy?: ToolPolicyLike;
   runtimeToolPolicy?: ToolPolicyLike;
   inheritedToolPolicy?: ToolPolicyLike;
+  sessionRuntimeToolPolicy?: ToolPolicyLike;
 };
 
 function mergePolicyAllowlist<TPolicy extends ToolPolicyLike>(
@@ -69,6 +70,7 @@ export function resolveConversationToolPolicies(params: {
       policy.inheritedToolPolicy,
       params.additionalInheritedAllow,
     ),
+    sessionRuntimeToolPolicy: policy.sessionRuntimeToolPolicy,
   };
 }
 
@@ -121,6 +123,11 @@ export function buildConversationToolPolicyPipelineSteps(params: {
     {
       policy: params.policies.inheritedToolPolicy,
       label: "inherited tools",
+      unavailableCoreToolReason: params.unavailableCoreToolReason,
+    },
+    {
+      policy: params.policies.sessionRuntimeToolPolicy,
+      label: "session runtime tools",
       unavailableCoreToolReason: params.unavailableCoreToolReason,
     },
   ];

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1228,6 +1228,30 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     });
   });
 
+  it("keeps skill prompt assembly independent from runtime tool filtering", async () => {
+    hoisted.resolveSkillsPromptForRunMock.mockReturnValue("RESTRICTED SESSION SKILL CATALOG");
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    const promptInput = hoisted.embeddedSystemPromptInputs.at(-1) as {
+      skillsPrompt?: string;
+    };
+    expect(promptInput.skillsPrompt).toBe("RESTRICTED SESSION SKILL CATALOG");
+  });
+
   it("keeps before_prompt_build context in the model prompt and out of transcript messages", async () => {
     const runBeforePromptBuild = vi.fn(async () => ({
       prependContext: "dynamic hook context",

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -318,6 +318,34 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     expect(childAgentCall?.timeoutMs).toBe(125_000);
   });
 
+  it("passes tools through to the native child agent run", async () => {
+    const ctx = setupSessionsSpawnGatewayMock({
+      includeChatHistory: true,
+      agentWaitResult: { status: "ok", startedAt: 1000, endedAt: 2000 },
+    });
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    });
+
+    const result = await tool.execute("call-tools-allow", {
+      task: "do thing",
+      tools: { allow: [" read ", "exec"] },
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: expect.any(String),
+    });
+    const childAgentCall = ctx.calls.find((call) => {
+      const params = call.params as { lane?: string } | undefined;
+      return call.method === "agent" && params?.lane === "subagent";
+    });
+    // tools are persisted on the session entry (immutable authority source),
+    // NOT forwarded through the child launch request.
+    expect((childAgentCall?.params as { tools?: unknown } | undefined)?.tools).toBeUndefined();
+  });
+
   it("sessions_spawn retires bundle MCP runtime when run-mode cleanup completes", async () => {
     let resumeAnnounceFlow: ((value: boolean) => void) | undefined;
     let announceFlowStarted: (() => void) | undefined;

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -324,7 +324,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
       agentWaitResult: { status: "ok", startedAt: 1000, endedAt: 2000 },
     });
     const tool = await getSessionsSpawnTool({
-      agentSessionKey: "main",
+      agentSessionKey: "agent:main:main",
       agentChannel: "whatsapp",
     });
 

--- a/src/agents/requester-tool-policy.test.ts
+++ b/src/agents/requester-tool-policy.test.ts
@@ -101,6 +101,29 @@ describe("resolveRequesterToolPolicies", () => {
     expect(result.subagentPolicy).toBeDefined();
   });
 
+  it("returns persisted runtime tool policy for delegated senderless child runs", async () => {
+    const childSessionKey = "agent:main:subagent:runtime-tools";
+    await writeSession(childSessionKey, {
+      spawnedBy: "agent:main:discord:direct:alice",
+      spawnDepth: 1,
+      subagentRole: "leaf",
+      subagentControlScope: "none",
+      inheritedToolPolicyVersion: 1,
+      inheritedToolAllow: ["read", "exec"],
+      runtimeToolPolicy: { allow: ["read"] },
+    });
+
+    const result = resolveRequesterToolPolicies({
+      config: config(),
+      agentId: "main",
+      sessionKey: childSessionKey,
+    });
+
+    expect(result.delegated).toBe(true);
+    expect(result.requesterPolicySource).toBe("persisted-child");
+    expect(result.sessionRuntimeToolPolicy).toEqual({ allow: ["read"] });
+  });
+
   it("uses a persisted projection for a spawn-owned dashboard child", async () => {
     const parentSessionKey = "agent:main:main";
     const childSessionKey = "agent:main:dashboard:visible-child";

--- a/src/agents/requester-tool-policy.ts
+++ b/src/agents/requester-tool-policy.ts
@@ -209,11 +209,18 @@ export function resolveRequesterToolPolicies(
   if (delegatedPolicy.delegated) {
     // The persisted projection already includes both global and group sender policy.
     // Re-resolving either without external identity would incorrectly select its wildcard.
+    // Still attach the child session's immutable runtime tool policy so senderless native
+    // child launches cannot skip the spawn-time tools boundary.
     return {
       delegated: true,
       requesterPolicySource: delegatedPolicy.source,
       subagentPolicy,
       inheritedToolPolicy: delegatedPolicy.policy,
+      sessionRuntimeToolPolicy: resolveRuntimeToolPolicyForSession(
+        params.config,
+        subagentSessionKey,
+        { store: subagentStore },
+      ),
       subagentStore,
     };
   }

--- a/src/agents/requester-tool-policy.ts
+++ b/src/agents/requester-tool-policy.ts
@@ -9,6 +9,7 @@ import { normalizeInputProvenance } from "../sessions/input-provenance.js";
 import {
   resolveGroupToolPolicy,
   resolveInheritedToolPolicyForSession,
+  resolveRuntimeToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
 } from "./agent-tools.policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
@@ -40,6 +41,7 @@ type RequesterToolPolicyResolution = {
   senderPolicy?: SandboxToolPolicy;
   subagentPolicy?: SandboxToolPolicy;
   inheritedToolPolicy?: SandboxToolPolicy;
+  sessionRuntimeToolPolicy?: SandboxToolPolicy;
   subagentStore?: SessionCapabilityStore;
 };
 
@@ -253,6 +255,11 @@ export function resolveRequesterToolPolicies(
     inheritedToolPolicy: resolveInheritedToolPolicyForSession(params.config, subagentSessionKey, {
       store: subagentStore,
     }),
+    sessionRuntimeToolPolicy: resolveRuntimeToolPolicyForSession(
+      params.config,
+      subagentSessionKey,
+      { store: subagentStore },
+    ),
     subagentStore,
   };
 }

--- a/src/agents/runtime-tool-policy.test.ts
+++ b/src/agents/runtime-tool-policy.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeRuntimeToolPolicy,
+  resolveRuntimeToolPolicyWrite,
+  runtimeToolPolicyToSandboxPolicy,
+} from "./runtime-tool-policy.js";
+
+describe("normalizeRuntimeToolPolicy", () => {
+  it("normalizes concrete allow and deny entries", () => {
+    expect(
+      normalizeRuntimeToolPolicy({
+        allow: [" Read ", "read", "exec"],
+        deny: [" Exec ", "write"],
+      }),
+    ).toEqual({
+      allow: ["read", "exec"],
+      deny: ["exec", "write"],
+    });
+  });
+
+  it("canonicalizes explicit deny-all policies", () => {
+    expect(normalizeRuntimeToolPolicy("none")).toBe("none");
+    expect(normalizeRuntimeToolPolicy({ allow: [] })).toBe("none");
+    expect(normalizeRuntimeToolPolicy({ allow: [""] })).toBe("none");
+    expect(normalizeRuntimeToolPolicy({ deny: ["*"] })).toBe("none");
+  });
+
+  it("keeps genuinely unrestricted policies absent", () => {
+    expect(normalizeRuntimeToolPolicy(undefined)).toBeUndefined();
+    expect(normalizeRuntimeToolPolicy({})).toBeUndefined();
+    expect(normalizeRuntimeToolPolicy({ deny: [] })).toBeUndefined();
+    expect(normalizeRuntimeToolPolicy({ allow: ["*"] })).toBeUndefined();
+  });
+
+  it("fails closed for corrupted persisted values", () => {
+    expect(normalizeRuntimeToolPolicy(null)).toBe("none");
+    expect(normalizeRuntimeToolPolicy({ allow: null })).toBe("none");
+    expect(normalizeRuntimeToolPolicy({ deny: null })).toBe("none");
+    expect(normalizeRuntimeToolPolicy({ allow: ["read", 42] })).toBe("none");
+    expect(normalizeRuntimeToolPolicy({ alow: ["read"] })).toBe("none");
+    expect(normalizeRuntimeToolPolicy("read")).toBe("none");
+  });
+});
+
+describe("runtimeToolPolicyToSandboxPolicy", () => {
+  it("converts none to an explicit deny-all policy", () => {
+    expect(runtimeToolPolicyToSandboxPolicy("none")).toEqual({ deny: ["*"] });
+  });
+
+  it("returns fresh arrays for concrete policies", () => {
+    const policy = { allow: ["read"], deny: ["exec"] };
+    const converted = runtimeToolPolicyToSandboxPolicy(policy);
+
+    expect(converted).toEqual(policy);
+    expect(converted?.allow).not.toBe(policy.allow);
+    expect(converted?.deny).not.toBe(policy.deny);
+  });
+});
+
+describe("resolveRuntimeToolPolicyWrite", () => {
+  it("writes the first policy and treats equivalent rewrites as idempotent", () => {
+    expect(resolveRuntimeToolPolicyWrite(undefined, { allow: ["read", "exec"] })).toEqual({
+      allow: ["read", "exec"],
+    });
+    expect(
+      resolveRuntimeToolPolicyWrite({ allow: ["read", "exec"] }, { allow: ["exec", "read"] }),
+    ).toBeUndefined();
+    expect(resolveRuntimeToolPolicyWrite("none", { allow: [] })).toBeUndefined();
+    expect(resolveRuntimeToolPolicyWrite({ allow: ["read"] }, undefined)).toBeUndefined();
+  });
+
+  it("rejects attempts to change an existing policy", () => {
+    expect(() => resolveRuntimeToolPolicyWrite({ allow: ["read"] }, { allow: ["exec"] })).toThrow(
+      "runtimeToolPolicy is immutable",
+    );
+  });
+});

--- a/src/agents/runtime-tool-policy.ts
+++ b/src/agents/runtime-tool-policy.ts
@@ -1,0 +1,149 @@
+import type { RuntimeToolPolicy } from "../config/sessions/runtime-tool-policy.types.js";
+import type { SandboxToolPolicy } from "./sandbox/types.js";
+import { normalizeToolName } from "./tool-policy.js";
+
+/** Persisted malformed values fail closed; `"none"` maps to this deny-all sentinel. */
+const DENY_ALL = "*";
+
+export function normalizeRuntimeToolPolicy(input: unknown): RuntimeToolPolicy | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+  if (input === "none") {
+    return "none";
+  }
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return "none";
+  }
+
+  const rawKeys = Object.keys(input);
+  const knownKeys = new Set(["allow", "deny"]);
+  if (rawKeys.some((k) => !knownKeys.has(k))) {
+    return "none";
+  }
+
+  const raw = input as { allow?: unknown; deny?: unknown };
+  const allow = cleanToolList(raw.allow);
+  const deny = cleanToolList(raw.deny);
+
+  if (allow === null || deny === null) {
+    return "none";
+  }
+
+  if (deny.includes(DENY_ALL)) {
+    return "none";
+  }
+  if (raw.allow !== undefined && allow.length === 0) {
+    return "none";
+  }
+  if (allow.length === 0 && deny.length === 0) {
+    return undefined;
+  }
+  if (allow.includes(DENY_ALL) && deny.length === 0) {
+    return undefined;
+  }
+
+  const result: { allow?: string[]; deny?: string[] } = {};
+  if (allow.length > 0) {
+    result.allow = allow;
+  }
+  if (deny.length > 0) {
+    result.deny = deny;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export function runtimeToolPolicyToSandboxPolicy(
+  policy: RuntimeToolPolicy | undefined,
+): SandboxToolPolicy | undefined {
+  if (policy === undefined) {
+    return undefined;
+  }
+  if (policy === "none") {
+    return { deny: [DENY_ALL] };
+  }
+  return {
+    ...(policy.allow ? { allow: [...policy.allow] } : {}),
+    ...(policy.deny ? { deny: [...policy.deny] } : {}),
+  };
+}
+
+function runtimeToolPolicyEqual(
+  a: RuntimeToolPolicy | undefined,
+  b: RuntimeToolPolicy | undefined,
+): boolean {
+  const na = normalizeRuntimeToolPolicy(a);
+  const nb = normalizeRuntimeToolPolicy(b);
+  if (na === nb) {
+    return true;
+  }
+  if (na === undefined || nb === undefined) {
+    return false;
+  }
+  if (na === "none" || nb === "none") {
+    return na === nb;
+  }
+  return listsEqual(na.allow, nb.allow) && listsEqual(na.deny, nb.deny);
+}
+
+/** `undefined` means no write is needed; conflicting rewrites are rejected. */
+export function resolveRuntimeToolPolicyWrite(
+  persisted: RuntimeToolPolicy | undefined,
+  requested: RuntimeToolPolicy | undefined,
+): RuntimeToolPolicy | undefined {
+  const normalizedRequested = normalizeRuntimeToolPolicy(requested);
+  if (normalizedRequested === undefined) {
+    return undefined;
+  }
+  const normalizedPersisted = normalizeRuntimeToolPolicy(persisted);
+  if (normalizedPersisted === undefined) {
+    return normalizedRequested;
+  }
+  if (!runtimeToolPolicyEqual(normalizedPersisted, normalizedRequested)) {
+    throw new Error(
+      "runtimeToolPolicy is immutable: a child session's tool policy cannot be changed after it is set. Create a new child session for a different policy.",
+    );
+  }
+  return undefined;
+}
+
+function listsEqual(a: string[] | undefined, b: string[] | undefined): boolean {
+  if (a === undefined && b === undefined) {
+    return true;
+  }
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  const sa = [...a].toSorted();
+  const sb = [...b].toSorted();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+function cleanToolList(raw: unknown): string[] | null {
+  if (raw === undefined) {
+    return [];
+  }
+  if (!Array.isArray(raw)) {
+    return null;
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") {
+      return null;
+    }
+    const trimmed = entry.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    const normalized = normalizeToolName(trimmed);
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  }
+  return result;
+}

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -13,6 +13,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { resolveStorePath } from "../config/sessions.js";
+import type { RuntimeToolPolicy } from "../config/sessions/runtime-tool-policy.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   isAcpSessionKey,
@@ -23,6 +24,7 @@ import {
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
 } from "./inherited-tool-deny.js";
+import { normalizeRuntimeToolPolicy } from "./runtime-tool-policy.js";
 import {
   findSubagentSessionEntryById,
   getSubagentDepthFromSessionStore,
@@ -50,6 +52,7 @@ type SessionCapabilityEntry = {
   inheritedToolPolicyVersion?: unknown;
   inheritedToolAllow?: unknown;
   inheritedToolDeny?: unknown;
+  runtimeToolPolicy?: unknown;
 };
 
 /** Minimal persisted session-store shape needed to resolve subagent capabilities. */
@@ -65,6 +68,7 @@ export type SessionCapabilityStore = Record<
     inheritedToolPolicyVersion?: unknown;
     inheritedToolAllow?: unknown;
     inheritedToolDeny?: unknown;
+    runtimeToolPolicy?: unknown;
   }
 >;
 
@@ -454,4 +458,30 @@ export function resolveStoredSubagentInheritedToolAllowlist(
     store,
   });
   return normalizeInheritedToolAllowlist(entry?.inheritedToolAllow);
+}
+
+/**
+ * Resolve the immutable per-spawn runtime tool policy stored on a subagent
+ * session entry. Returns `undefined` when no policy is set (no restriction).
+ * Corrupted persisted data fail-closes to `"none"` via normalization.
+ */
+export function resolveStoredRuntimeToolPolicy(
+  sessionKey: string | undefined | null,
+  opts?: {
+    cfg?: OpenClawConfig;
+    store?: SessionCapabilityStore;
+  },
+): RuntimeToolPolicy | undefined {
+  const normalizedSessionKey = normalizeOptionalString(sessionKey);
+  if (!normalizedSessionKey || !shouldInspectStoredSubagentEnvelope(normalizedSessionKey)) {
+    return undefined;
+  }
+  const store = resolveSubagentCapabilityStore(normalizedSessionKey, opts);
+  const entry = resolveSessionCapabilityEntry({
+    sessionKey: normalizedSessionKey,
+    cfg: opts?.cfg,
+    store,
+  });
+  // Normalize here: corrupted persisted data fail-closes to "none".
+  return normalizeRuntimeToolPolicy(entry?.runtimeToolPolicy);
 }

--- a/src/agents/subagent-spawn-contract.ts
+++ b/src/agents/subagent-spawn-contract.ts
@@ -1,3 +1,4 @@
+import type { RuntimeToolPolicy } from "../config/sessions/runtime-tool-policy.types.js";
 import type { FastMode } from "../shared/fast-mode.js";
 import type {
   SpawnSubagentContextMode,
@@ -28,6 +29,7 @@ export type SpawnSubagentParams = {
   sandbox?: SpawnSubagentSandboxMode;
   context?: SpawnSubagentContextMode;
   lightContext?: boolean;
+  tools?: RuntimeToolPolicy;
   expectsCompletionMessage?: boolean;
   attachments?: Array<{
     name: string;

--- a/src/agents/subagent-spawn-session-patch.ts
+++ b/src/agents/subagent-spawn-session-patch.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { RuntimeToolPolicy } from "../config/sessions/runtime-tool-policy.types.js";
 import { buildSessionCreationStamp } from "../config/sessions/session-entry-provenance.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -10,6 +11,11 @@ import {
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
 } from "./inherited-tool-deny.js";
+import {
+  normalizeRuntimeToolPolicy,
+  resolveRuntimeToolPolicyWrite,
+} from "./runtime-tool-policy.js";
+import { resolveStoredRuntimeToolPolicy } from "./subagent-capabilities.js";
 import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
 import { splitModelRef } from "./subagent-spawn-plan.js";
 import { resolveGatewaySessionStoreTarget, upsertSessionEntry } from "./subagent-spawn.runtime.js";
@@ -28,6 +34,12 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   }
   if (patch.inheritedToolPolicyVersion === 1) {
     entry.inheritedToolPolicyVersion = 1;
+  }
+  // runtimeToolPolicy is normalized to its canonical form before persisting.
+  // The immutability check (first-write-wins) lives at the upsert boundary in
+  // createInitialSubagentSession, where the persisted value can be read.
+  if (patch.runtimeToolPolicy !== undefined) {
+    entry.runtimeToolPolicy = normalizeRuntimeToolPolicy(patch.runtimeToolPolicy);
   }
   if (patch.incognito === true) {
     entry.incognito = true;
@@ -117,6 +129,8 @@ export async function createInitialSubagentSession(params: {
   swarmGroupId?: string;
   collect: boolean;
   outputSchema?: Record<string, unknown>;
+  /** Per-spawn runtime tool policy requested via sessions_spawn `tools`. */
+  runtimeToolPolicy?: RuntimeToolPolicy;
 }): Promise<{ status: "ok"; entry?: SessionEntry } | { status: "error"; error: string }> {
   const initialChildSessionPatch: Record<string, unknown> = {
     spawnedBy: params.requesterInternalKey,
@@ -130,6 +144,11 @@ export async function createInitialSubagentSession(params: {
     inheritedToolPolicyVersion: 1,
     ...inheritedToolAllowPatch(params.inheritedToolAllowlist),
     ...inheritedToolDenyPatch(params.inheritedToolDenylist),
+    // The immutable guard below may drop this field to keep the existing value
+    // on an idempotent re-write; buildDirectChildSessionPatch normalizes it.
+    ...(params.runtimeToolPolicy !== undefined
+      ? { runtimeToolPolicy: params.runtimeToolPolicy }
+      : {}),
     ...params.modelPatch,
     ...(params.swarmGroupId ? { swarmGroupId: params.swarmGroupId } : {}),
     ...(params.collect ? { swarmCollector: true } : {}),
@@ -154,20 +173,38 @@ export async function createInitialSubagentSession(params: {
           cfg: params.cfg,
           key: params.childSessionKey,
         });
-    const entry = await upsertSessionEntry(
-      {
-        storePath: target.storePath,
-        sessionKey: target.canonicalKey,
-      },
-      {
-        ...buildDirectChildSessionPatch(initialChildSessionPatch),
-        ...childSessionIdentity,
-        ...buildSessionCreationStamp({
-          via: "spawn",
-          actor: { type: "agent", id: params.requesterInternalKey },
-        }),
-      },
-    );
+    const sessionScope = {
+      storePath: target.storePath,
+      sessionKey: target.canonicalKey,
+    };
+
+    // runtimeToolPolicy is immutable once written: first write wins, identical
+    // re-writes are idempotent, and any attempt to change or clear it is
+    // rejected. Read the persisted authority before upsert so the check cannot
+    // be bypassed by a fresh patch that omits or alters the field.
+    if (initialChildSessionPatch.runtimeToolPolicy !== undefined) {
+      const persistedRuntimeToolPolicy = resolveStoredRuntimeToolPolicy(params.childSessionKey, {
+        cfg: params.cfg,
+      });
+      const policyToWrite = resolveRuntimeToolPolicyWrite(
+        persistedRuntimeToolPolicy,
+        initialChildSessionPatch.runtimeToolPolicy as RuntimeToolPolicy,
+      );
+      if (policyToWrite === undefined) {
+        delete initialChildSessionPatch.runtimeToolPolicy;
+      } else {
+        initialChildSessionPatch.runtimeToolPolicy = policyToWrite;
+      }
+    }
+
+    const entry = await upsertSessionEntry(sessionScope, {
+      ...buildDirectChildSessionPatch(initialChildSessionPatch),
+      ...childSessionIdentity,
+      ...buildSessionCreationStamp({
+        via: "spawn",
+        actor: { type: "agent", id: params.requesterInternalKey },
+      }),
+    });
     return { status: "ok", entry: entry ?? undefined };
   } catch (err) {
     const message = err instanceof Error ? err.message : typeof err === "string" ? err : "error";

--- a/src/agents/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagent-spawn.model-session.test.ts
@@ -142,4 +142,28 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     expect(persistedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
     expect(persistedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.4");
   });
+  it("persists runtime tool policy on the child session before starting the run", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "test",
+        tools: { allow: ["read", "exec"] },
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "guildchat",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const [persistedKey, persistedEntry] = Object.entries(persistedStore ?? {})[0] ?? [];
+    expect(persistedKey).toMatch(/^agent:main:subagent:/);
+    expect(persistedEntry?.runtimeToolPolicy).toEqual({ allow: ["read", "exec"] });
+  });
 });

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -385,6 +385,8 @@ export async function loadSubagentSpawnModuleForTest(params: {
 
   vi.doMock("./subagent-depth.js", () => ({
     getSubagentDepthFromSessionStore: params.getSubagentDepthFromSessionStore ?? (() => 0),
+    readSubagentSessionStore: () => ({}),
+    findSubagentSessionEntryById: () => undefined,
   }));
 
   vi.doMock("./subagent-registry.js", () => ({

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -190,6 +190,7 @@ export async function spawnSubagentDirect(
       swarmGroupId,
       collect: params.collect === true,
       outputSchema: params.outputSchema,
+      runtimeToolPolicy: params.tools,
     });
     if (initialSession.status === "error") {
       return {

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -418,7 +418,7 @@ describe("sessions_spawn tool", () => {
     };
 
     expect(schema.properties?.visible?.description).toBe(
-      "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/attachments/attachAs.",
+      "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/tools/attachments/attachAs; unavailable with inherited tool allow/denylist.",
     );
     expect(tool.description).toContain("`visible=true`: persistent sidebar dashboard session");
     expect(tool.description).toContain("when the user asks to create/open a thread");
@@ -712,6 +712,11 @@ describe("sessions_spawn tool", () => {
       "Parameters unavailable with visible=true: lightContext: bootstrap staging is not wired to the sessions.create path",
     ],
     [
+      "tools",
+      { tools: { allow: ["read"] } },
+      "Parameters unavailable with visible=true: tools: runtime tool policies are not wired to the sessions.create path",
+    ],
+    [
       "attachments",
       { attachments: [{ name: "note.txt", content: "hello" }] },
       "Parameters unavailable with visible=true: attachments: attachment staging is not wired to the sessions.create path",
@@ -740,12 +745,13 @@ describe("sessions_spawn tool", () => {
         thread: true,
         mode: "run",
         lightContext: true,
+        tools: { allow: ["read"] },
         attachments: [{ name: "note.txt", content: "hello" }],
         attachAs: { mountPath: "inputs" },
         visible: true,
       }),
     ).rejects.toThrow(
-      'Parameters unavailable with visible=true: runtime: supports runtime="subagent" only; thinking: thinking overrides are not wired to the sessions.create path; thread: visible sessions route to the dashboard, not a channel thread; mode: visible sessions are persistent dashboard sessions; lightContext: bootstrap staging is not wired to the sessions.create path; attachments: attachment staging is not wired to the sessions.create path; attachAs: attachment staging is not wired to the sessions.create path',
+      'Parameters unavailable with visible=true: runtime: supports runtime="subagent" only; thinking: thinking overrides are not wired to the sessions.create path; thread: visible sessions route to the dashboard, not a channel thread; mode: visible sessions are persistent dashboard sessions; lightContext: bootstrap staging is not wired to the sessions.create path; tools: runtime tool policies are not wired to the sessions.create path; attachments: attachment staging is not wired to the sessions.create path; attachAs: attachment staging is not wired to the sessions.create path',
     );
   });
 
@@ -1138,6 +1144,25 @@ describe("sessions_spawn tool", () => {
     expect(tool.description).toContain("thread-bound");
   });
 
+  it("exposes tools as a native subagent tool policy union", () => {
+    const tool = createSessionsSpawnTool();
+    const schema = tool.parameters as {
+      properties?: {
+        tools?: {
+          anyOf?: Array<{ const?: string; type?: string }>;
+          description?: string;
+        };
+      };
+    };
+
+    expect(schema.properties?.tools?.anyOf).toHaveLength(2);
+    expect(schema.properties?.tools?.anyOf?.[0]?.const).toBe("none");
+    expect(schema.properties?.tools?.anyOf?.[1]?.type).toBe("object");
+    expect(schema.properties?.tools?.description).toContain('runtime="subagent"');
+    expect(schema.properties?.tools?.description).toContain("Persistent sessions reuse it");
+    expect(schema.properties?.tools?.description).not.toContain("store the allowlist");
+  });
+
   it("uses subagent runtime by default", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
@@ -1207,6 +1232,44 @@ describe("sessions_spawn tool", () => {
     expect(spawnContext.inheritedToolAllowlist).toEqual(["sessions_spawn", "read"]);
   });
 
+  it("normalizes and forwards tools to native subagent spawns", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-tools-allow", {
+      task: "build feature",
+      tools: { allow: [" read ", "exec", ""] },
+    });
+
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "build feature",
+        tools: { allow: ["read", "exec"] },
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("preserves an explicit empty tools list", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-tools-empty", {
+      task: "build feature",
+      tools: "none",
+    });
+
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "build feature",
+        tools: "none",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("accepts taskName as a stable subagent handle", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
@@ -1271,6 +1334,66 @@ describe("sessions_spawn tool", () => {
       expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
     },
   );
+
+  it("passes tools through for persistent native subagent sessions", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-tools-session", {
+      task: "build feature",
+      mode: "session",
+      thread: true,
+      tools: { allow: ["read"] },
+    });
+
+    await tool.execute("call-tools-thread", {
+      task: "build feature",
+      thread: true,
+      tools: { allow: ["exec"] },
+    });
+
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledTimes(2);
+    expect(mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect")).toMatchObject(
+      {
+        mode: "session",
+        thread: true,
+        tools: { allow: ["read"] },
+      },
+    );
+    expect(mockCallArg(hoisted.spawnSubagentDirectMock, 1, 0, "spawnSubagentDirect")).toMatchObject(
+      {
+        thread: true,
+        tools: { allow: ["exec"] },
+      },
+    );
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed tools values before spawning", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await expect(
+      tool.execute("call-tools-scalar", {
+        task: "build feature",
+        tools: "read",
+      }),
+    ).rejects.toThrow(
+      'tools must be "none" or an object with optional "allow" and "deny" string arrays.',
+    );
+
+    await expect(
+      tool.execute("call-tools-number", {
+        task: "build feature",
+        tools: { allow: ["read", 123] },
+      }),
+    ).rejects.toThrow("tools.allow must be an array of strings.");
+
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
 
   it.each(["last", "all"])("rejects reserved taskName %s before spawning", async (taskName) => {
     const tool = createSessionsSpawnTool({
@@ -1426,6 +1549,24 @@ describe("sessions_spawn tool", () => {
         lightContext: true,
       }),
     ).rejects.toThrow("lightContext is only supported for runtime='subagent'.");
+
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects tools when runtime is not "subagent"', async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await expect(
+      tool.execute("call-tools-acp", {
+        runtime: "acp",
+        task: "summarize this",
+        tools: { allow: ["read"] },
+      }),
+    ).rejects.toThrow("tools is only supported for runtime='subagent'.");
 
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -10,8 +10,9 @@ import {
   supportsAutomaticThreadBindingSpawn,
 } from "../../channels/thread-bindings-policy.js";
 import { getRuntimeConfig } from "../../config/config.js";
+import type { RuntimeToolPolicy } from "../../config/sessions/runtime-tool-policy.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveSnakeCaseParamKey } from "../../param-key.js";
+import { readSnakeCaseParamRaw, resolveSnakeCaseParamKey } from "../../param-key.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
@@ -21,6 +22,7 @@ import {
   formatAcpInheritedToolAllowError,
   formatAcpInheritedToolDenyError,
 } from "../inherited-tool-deny.js";
+import { normalizeRuntimeToolPolicy } from "../runtime-tool-policy.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
 import { resolveAcpSessionsSpawnImageAttachments } from "../subagent-attachments.js";
@@ -91,6 +93,41 @@ function addRoleToFailureResult<T extends { status: string }>(
     return result;
   }
   return { ...result, role };
+}
+
+function readToolsParam(params: Record<string, unknown>): RuntimeToolPolicy | undefined {
+  const raw = readSnakeCaseParamRaw(params, "tools");
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (raw === "none") {
+    return "none";
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new ToolInputError(
+      'tools must be "none" or an object with optional "allow" and "deny" string arrays.',
+    );
+  }
+  const obj = raw as Record<string, unknown>;
+  // Reject unknown keys — a typo like { alow: [...] } must NOT silently become
+  // unrestricted. This is a permissions API.
+  const knownKeys = new Set(["allow", "deny"]);
+  for (const key of Object.keys(obj)) {
+    if (!knownKeys.has(key)) {
+      throw new ToolInputError(
+        `tools has unknown property "${key}". Only "allow" and "deny" are recognized.`,
+      );
+    }
+  }
+  for (const field of ["allow", "deny"] as const) {
+    const value = obj[field];
+    if (value !== undefined) {
+      if (!Array.isArray(value) || value.some((e) => typeof e !== "string")) {
+        throw new ToolInputError(`tools.${field} must be an array of strings.`);
+      }
+    }
+  }
+  return normalizeRuntimeToolPolicy(raw);
 }
 
 type SessionsSpawnThreadAvailability = {
@@ -214,6 +251,34 @@ function createSessionsSpawnToolSchema(params: {
         }
       : {}),
     ...VISIBLE_SESSIONS_SPAWN_SCHEMA,
+    tools: Type.Optional(
+      Type.Union(
+        [
+          Type.Literal("none", {
+            description: "Disable all child tools.",
+          }),
+          Type.Object(
+            {
+              allow: Type.Optional(
+                Type.Array(Type.String(), {
+                  description: "Allowed tool names; groups/globs supported.",
+                }),
+              ),
+              deny: Type.Optional(
+                Type.Array(Type.String(), {
+                  description: "Denied tool names; wins over allow.",
+                }),
+              ),
+            },
+            { additionalProperties: false },
+          ),
+        ],
+        {
+          description:
+            'Immutable tool policy for native runtime="subagent". "none" disables tools; omit for defaults. Persistent sessions reuse it. Visible and ACP spawns reject it; CLI supports allow-only.',
+        },
+      ),
+    ),
 
     // Inline attachments (snapshot-by-value).
     attachments: Type.Optional(
@@ -397,6 +462,7 @@ export function createSessionsSpawnTool(
         params.context === "fork" || params.context === "isolated" ? params.context : undefined;
       const streamTo = runtime === "acp" && params.streamTo === "parent" ? "parent" : undefined;
       const lightContext = params.lightContext === true;
+      const tools = readToolsParam(params);
       const roleContext = requestedAgentId ? { role: requestedAgentId } : {};
       const deliveryPressure = getSubagentDeliveryBacklogPressure();
       if (deliveryPressure.blocked) {
@@ -453,6 +519,9 @@ export function createSessionsSpawnTool(
       }
       if (runtime === "acp" && lightContext) {
         throw new Error("lightContext is only supported for runtime='subagent'.");
+      }
+      if (runtime === "acp" && tools !== undefined) {
+        throw new ToolInputError("tools is only supported for runtime='subagent'.");
       }
       if (runtime === "acp" && context === "fork") {
         throw new Error('context="fork" is only supported for runtime="subagent".');
@@ -556,6 +625,7 @@ export function createSessionsSpawnTool(
           sandbox,
           context,
           lightContext,
+          tools,
           expectsCompletionMessage,
           attachments,
           attachMountPath:

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -35,7 +35,7 @@ export const VISIBLE_SESSIONS_SPAWN_SCHEMA = {
   visible: Type.Optional(
     Type.Boolean({
       description:
-        "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/attachments/attachAs.",
+        "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/tools/attachments/attachAs; unavailable with inherited tool allow/denylist.",
     }),
   ),
   worktree: Type.Optional(Type.Boolean({ description: "Visible session worktree" })),
@@ -140,6 +140,7 @@ export async function maybeSpawnVisibleSession(params: {
       params.raw.lightContext === true ? true : undefined,
       "bootstrap staging is not wired to the sessions.create path",
     ],
+    ["tools", params.raw.tools, "runtime tool policies are not wired to the sessions.create path"],
     [
       "attachments",
       Array.isArray(params.raw.attachments) ? params.raw.attachments : undefined,

--- a/src/config/sessions/runtime-tool-policy.types.ts
+++ b/src/config/sessions/runtime-tool-policy.types.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-spawn runtime tool policy type for `sessions_spawn`.
+ *
+ * Lives in the config layer so `SessionEntry` can reference it without a
+ * reverse dependency on the agent runtime. Normalization and conversion
+ * logic lives in `src/agents/runtime-tool-policy.ts`.
+ *
+ * Semantics:
+ * - `undefined` — no restriction (inherit the default tool set).
+ * - `"none"` — the child session exposes zero callable tools to the model,
+ *   including forced/message/heartbeat/tool-search/bundle/ring-zero tools.
+ * - `{ allow?, deny? }` — deny-wins narrowing of the tool set. An explicit
+ *   empty `allow` array is normalized to `"none"` (not "allow everything").
+ */
+export type RuntimeToolPolicy =
+  | "none"
+  | {
+      allow?: string[];
+      deny?: string[];
+    };

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -17,6 +17,7 @@ import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { TtsAutoMode } from "../types.tts.js";
 import type { MainRestartRecoveryState } from "./main-session-recovery.types.js";
 import type { SessionRestartRecoveryState } from "./restart-recovery-types.js";
+import type { RuntimeToolPolicy } from "./runtime-tool-policy.types.js";
 import type {
   SessionCreatedActor,
   SessionCreatedVia,
@@ -393,6 +394,12 @@ type SessionEntryCore = SessionRestartRecoveryState &
     inheritedToolDeny?: string[];
     /** Session-scoped tool allow entries inherited from the caller that created this session. */
     inheritedToolAllow?: string[];
+    /**
+     * Immutable per-spawn runtime tool policy for spawned subagent sessions.
+     * Written once by `sessions_spawn`; subsequent turns read it through the
+     * session capability resolver. See `runtime-tool-policy.types.ts`.
+     */
+    runtimeToolPolicy?: RuntimeToolPolicy;
     systemSent?: boolean;
     abortedLastRun?: boolean;
     /** Interrupted run generations whose late lifecycle events must be ignored. */

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -53,6 +53,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "lifecycleRunId",
   "mainRestartRecovery",
   "subagentRecovery",
+  "runtimeToolPolicy",
   "pluginOwnerId",
   "systemSent",
   "abortedLastRun",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -100,8 +100,38 @@
             "description": "Bind new chat thread when supported; true defaults mode=\"session\"; unavailable with visible=true.",
             "type": "boolean"
           },
+          "tools": {
+            "anyOf": [
+              {
+                "const": "none",
+                "description": "Disable all child tools.",
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "allow": {
+                    "description": "Allowed tool names; groups/globs supported.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "deny": {
+                    "description": "Denied tool names; wins over allow.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            ],
+            "description": "Immutable tool policy for native runtime=\"subagent\". \"none\" disables tools; omit for defaults. Persistent sessions reuse it. Visible and ACP spawns reject it; CLI supports allow-only."
+          },
           "visible": {
-            "description": "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/attachments/attachAs.",
+            "description": "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/tools/attachments/attachAs; unavailable with inherited tool allow/denylist.",
             "type": "boolean"
           },
           "worktree": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -232,8 +232,38 @@
           "description": "Thinking override; unavailable with visible=true.",
           "type": "string"
         },
+        "tools": {
+          "anyOf": [
+            {
+              "const": "none",
+              "description": "Disable all child tools.",
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "allow": {
+                  "description": "Allowed tool names; groups/globs supported.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "deny": {
+                  "description": "Denied tool names; wins over allow.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "description": "Immutable tool policy for native runtime=\"subagent\". \"none\" disables tools; omit for defaults. Persistent sessions reuse it. Visible and ACP spawns reject it; CLI supports allow-only."
+        },
         "visible": {
-          "description": "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/attachments/attachAs.",
+          "description": "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/tools/attachments/attachAs; unavailable with inherited tool allow/denylist.",
           "type": "boolean"
         },
         "worktree": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61490,
-    "roughTokens": 15373
+    "chars": 62606,
+    "roughTokens": 15652
   },
   "openClawDeveloperInstructions": {
     "chars": 3811,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7049
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89686,
-    "roughTokens": 22422
+    "chars": 90802,
+    "roughTokens": 22701
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61182,
-    "roughTokens": 15296
+    "chars": 62298,
+    "roughTokens": 15575
   },
   "openClawDeveloperInstructions": {
     "chars": 2702,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6679
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87898,
-    "roughTokens": 21975
+    "chars": 89014,
+    "roughTokens": 22254
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 62716,
-    "roughTokens": 15679
+    "chars": 63832,
+    "roughTokens": 15958
   },
   "openClawDeveloperInstructions": {
     "chars": 2702,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6783
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89848,
-    "roughTokens": 22462
+    "chars": 90964,
+    "roughTokens": 22741
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

`sessions_spawn` cannot currently narrow a native child agent's tool access. A child therefore inherits the normal policy surface even when the parent only needs to delegate a constrained task, such as read-only research, untrusted-content isolation, or a tool-free reasoning step.

This PR adds a per-spawn tool policy to native `sessions_spawn` and persists it on the child session so the same restriction applies on the initial turn and every follow-up.

Closes #15032.

Related: #23906 (tool-free / `"none"` use case), #23506 (earlier `allow`/`deny` attempt), complementary to session `toolOverrides` for MCP/skills/web-search.

## Why This Change Was Made

- Current `main` still has no general per-spawn policy for model-facing core tools. Global `tools.subagents.tools.*` and prompt instructions are not a per-task hard boundary.
- The public API follows the maintainer guidance on #15032: `tools: "none" | { allow?, deny? }`, deny-wins, with durable child-session metadata.
- The policy is stored as an **immutable** session capability so a later turn cannot silently widen a previously restricted child (mutable overrides are the wrong security model for this boundary).
- Enforcement is an independent final gate after all tool sources are assembled, so forced, plugin, ring-zero, heartbeat, structured, and tool-search additions cannot bypass it.
- Existing runtime `toolsAllow` caps remain independent restrictions; this policy never replaces them.
- Restricted children keep normal skill guidance; callable capability and guidance are separate concerns.

## Product contract (for maintainer decision)

| Topic | Contract in this PR |
| --- | --- |
| API | `tools: "none" \| { allow?: string[]; deny?: string[] }` on native `sessions_spawn` |
| Deny semantics | Deny wins over allow; unknown/malformed keys fail closed |
| Persistence | Written once to `SessionEntry.runtimeToolPolicy` (first write wins) |
| Immutability | Cannot widen or clear later; identical re-writes are idempotent; conflicting rewrites are rejected |
| Broader tools later | Spawn a **new** child session (do not reuse the restricted session with a wider policy) |
| Composition | Stacks with global/agent/sandbox/`tools.subagents.tools` and runtime `toolsAllow`; does not replace them |
| ACP / visible | Reject `tools` (unsupported boundary) |
| CLI-backed native | Allow-only and `"none"` supported; **deny** and **allow+deny** rejected (CLI cannot safely compute a complement); two independent non-empty caps are also rejected |

**Maintainer decision needed:** confirm that immutable per-spawn child capabilities are the intended long-term contract. If not, please name the preferred recovery model before merge (e.g. run-mode only, explicit new-session API, or a different shape).

## User Impact

Native callers can write:

```json
{ "task": "inspect the repository", "tools": { "allow": ["read"] } }
```

```json
{ "task": "fetch untrusted web content", "tools": { "allow": ["web_search", "web_fetch", "write"], "deny": ["exec", "browser"] } }
```

```json
{ "task": "summarize without tools", "tools": "none" }
```

Persistent child sessions reuse the policy on later turns. Callers that need a wider surface must start a new child session.

## Evidence

Current head: `bd5f9bdf9272042ef2f0f07accc185ab694c58a7` (rebased onto recent `main`).

### Runtime behavior proof

Source-checkout probe using the real session accessor and final OpenClaw tool assembler (no session/tool-policy test mocks): persisted an allow-only child policy, assembled initial and follow-up tool surfaces, enabled the forced message path to test the final gate, and attempted a conflicting rewrite.

```json
{
  "initialPersistStatus": "ok",
  "persistedPolicy": { "allow": ["read"] },
  "initialModelFacingTools": ["read"],
  "followupModelFacingTools": ["read"],
  "forcedMessagePresent": false,
  "conflictingRewriteStatus": "error",
  "conflictingRewriteRejected": true
}
```

This shows the restriction survives persistence, applies on both turns, removes a late forced tool, and cannot be widened.

### Regression / focused validation (post-rebase)

- Runtime + CLI policy unit tests
- Session persistence + final tool assembly
- `sessions_spawn` schema/routing (including `tools`)
- Lifecycle spawn path (canonical session keys)
- CLI attempt execution (session policy + announce handoff paths)
- Prompt snapshots regenerated for the new schema field
- Formatting check on touched files

Exact-head CI on this tip should be treated as the merge gate after GitHub finishes the pull_request runs.

## Linked Issue

Closes #15032.