### PR TITLE
fix(gateway): return clear error for sessions.resolve key="current" alias

### DIFF
--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -227,6 +227,23 @@ describe("resolveSessionKeyFromResolveParams", () => {
     expect(hoisted.listSessionsFromStoreMock).not.toHaveBeenCalled();
   });
 
+  it('rejects key="current" with a clear alias-context error (not a misleading "No session found")', async () => {
+    const result = await resolveSessionKeyFromResolveParams({
+      cfg: {},
+      p: { key: "current" },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: ErrorCodes.INVALID_REQUEST,
+        message:
+          '"current" is a context alias resolved by the agent tool layer; pass the real session key instead',
+      },
+    });
+    expect(hoisted.resolveGatewaySessionStoreTargetMock).not.toHaveBeenCalled();
+  });
+
   it("rejects sessions belonging to a deleted agent (label-based lookup)", async () => {
     const deletedAgentKey = "agent:deleted-agent:main";
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -117,6 +117,15 @@ export async function resolveSessionKeyFromResolveParams(params: {
   }
 
   if (hasKey) {
+    if (key === "current") {
+      return {
+        ok: false,
+        error: errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          '"current" is a context alias resolved by the agent tool layer; pass the real session key instead',
+        ),
+      };
+    }
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const store = loadSessionStore(target.storePath);
     if (store[target.canonicalKey]) {


### PR DESCRIPTION
## Problem

When the system prompt instructs agents to use `sessionKey="current"` in tool calls, the underlying `sessions.resolve` WS method receives `key="current"` and probes the session store for a literal key named `"current"`. The store lookup fails and logs:

```
✗ sessions.resolve INVALID_REQUEST: No session found: current
```

The tool-layer wrapper immediately retries with the real session key and succeeds — so the user sees no failure — but every legitimate alias use generates one spurious `✗` log line per call.

This was reproducible on `2026.5.4` and `2026.5.5` (issue #78424).

## Fix

Guard against the literal `"current"` key at the top of `resolveSessionKeyFromResolveParams` (before probing the session store) and return a descriptive `INVALID_REQUEST` error:

> `"current"` is a context alias resolved by the agent tool layer; pass the real session key instead

This makes the error message self-documenting for any direct WS caller. The tool-layer wrapper fallback path is unaffected.

## Files changed

- `src/gateway/sessions-resolve.ts` — early return for `key === "current"` (9 lines)
- `src/gateway/sessions-resolve.test.ts` — 1 new test verifying the error and asserting `resolveGatewaySessionStoreTarget` is not called

## Test

```
node_modules/.bin/vitest run src/gateway/sessions-resolve.test.ts
# Test Files  3 passed (3)
#       Tests  24 passed (24)
```