### PR TITLE
fix(commitments): stop hardcoding fastMode in extraction (#78451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.
+- Commitments/extraction: stop hardcoding `fastMode: true` in commitment extraction so MiniMax Coding Plan operators no longer hit `HTTP 500: your current token plan not support model, MiniMax-M2.7-highspeed (2061)` when their plan owns the base model but not the highspeed variant. Fixes #78451.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Harden macOS shell wrapper allowlist parsing [AI]. (#78518) Thanks @pgondhi987.

--- a/src/commitments/runtime.test.ts
+++ b/src/commitments/runtime.test.ts
@@ -202,6 +202,12 @@ describe("commitment extraction runtime", () => {
         disableTools: true,
       }),
     );
+    // Regression for #78451: commitment extraction must NOT hardcode fastMode,
+    // so MiniMax (and similar) stream wrappers do not flip the configured
+    // base model id to a -highspeed variant the operator's plan does not own.
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+    expect(callArgs).toBeDefined();
+    expect(callArgs).not.toHaveProperty("fastMode");
   });
 
   it("backs off hidden extraction after terminal model or auth failures", async () => {

--- a/src/commitments/runtime.test.ts
+++ b/src/commitments/runtime.test.ts
@@ -231,6 +231,11 @@ describe("commitment extraction runtime", () => {
     expect(request.provider).toBe("openai");
     expect(request.model).toBe("gpt-5.5");
     expect(request.disableTools).toBe(true);
+    // Regression for #78451: commitment extraction must NOT hardcode fastMode,
+    // so MiniMax (and similar) stream wrappers do not flip the configured
+    // base model id to a -highspeed variant the operator's plan does not own.
+    const rawRequest = runEmbeddedAgentMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(rawRequest).not.toHaveProperty("fastMode");
   });
 
   it("backs off hidden extraction after terminal model or auth failures", async () => {

--- a/src/commitments/runtime.ts
+++ b/src/commitments/runtime.ts
@@ -239,7 +239,11 @@ async function defaultExtractBatch(params: {
     thinkLevel: "off",
     verboseLevel: "off",
     reasoningLevel: "off",
-    fastMode: true,
+    // Do not hardcode fastMode here: leaving the field undefined lets the
+    // commitments extraction inherit the configured fast-mode state (which
+    // defaults to false). Hardcoding true caused MiniMax Coding Plans without
+    // highspeed access to fail with HTTP 500 because the MiniMax stream wrapper
+    // would rewrite MiniMax-M2.7 -> MiniMax-M2.7-highspeed (#78451).
     timeoutMs: resolved.extraction.timeoutSeconds * 1000,
     runId,
     bootstrapContextMode: "lightweight",

--- a/src/commitments/runtime.ts
+++ b/src/commitments/runtime.ts
@@ -271,7 +271,11 @@ async function defaultExtractBatch(params: {
     thinkLevel: "off",
     verboseLevel: "off",
     reasoningLevel: "off",
-    fastMode: true,
+    // Do not hardcode fastMode here: leaving the field undefined lets the
+    // commitments extraction inherit the configured fast-mode state (which
+    // defaults to false). Hardcoding true caused MiniMax Coding Plans without
+    // highspeed access to fail with HTTP 500 because the MiniMax stream wrapper
+    // would rewrite MiniMax-M2.7 -> MiniMax-M2.7-highspeed (#78451).
     timeoutMs: resolved.extraction.timeoutSeconds * 1000,
     runId,
     bootstrapContextMode: "lightweight",


### PR DESCRIPTION
## What Problem This Solves
MiniMax Coding Plan users whose token plan includes `MiniMax-M2.7` but not `MiniMax-M2.7-highspeed` could not run commitment extraction because the hidden extraction path hardcoded `fastMode: true`, silently rewriting the selected model to the unsupported highspeed variant.

## Evidence
The PR body documents the failing path: `src/commitments/runtime.ts` passed `fastMode: true` into `runEmbeddedPiAgent`, and `src/agents/pi-embedded-runner/minimax-stream-wrappers.ts` rewrote the model id to `-highspeed`. The fix removes the hardcoded fast mode for commitment extraction so the user's configured model stays unchanged.

---

## Summary

MiniMax Coding Plan operators whose plan owns `MiniMax-M2.7` but not the `-highspeed` variant hit `HTTP 500: your current token plan not support model, MiniMax-M2.7-highspeed (2061)` on every commitment extraction pass, because the commitments extraction path passed `fastMode: true` unconditionally to `runEmbeddedPiAgent`, which caused the MiniMax stream wrapper's `createMinimaxFastModeWrapper` to rewrite the base model id to `MiniMax-M2.7-highspeed`.

## Root Cause

- `src/commitments/runtime.ts:242` (pre-fix): the call to `runEmbeddedPiAgent` for hidden commitment extraction hardcoded `fastMode: true`.
- `src/agents/pi-embedded-runner/minimax-stream-wrappers.ts:24`: the MiniMax stream wrapper accepts a `fastMode` boolean and, when true, swaps the base model id to its `-highspeed` variant.
- Result: every commitments extraction request silently flipped `MiniMax-M2.7` → `MiniMax-M2.7-highspeed`, which Coding Plan operators do not own. MiniMax responds with HTTP 500 / error code 2061. Reporter verified the Coding Plan owns the base model but not highspeed.
- The reporter listed three valid fix shapes (drop the hardcode, add a config field, or inherit agent fastMode). This PR uses option 1: dropping the hardcode lets the existing `resolveFastModeState` helper continue to control fast-mode for the rest of the agent runtime, and commitments extraction inherits the same default-false behavior.

## Changes

- `src/commitments/runtime.ts`: remove `fastMode: true` from the `runEmbeddedPiAgent` payload built in the commitments extraction path. Add a comment explaining the reason so this does not regress.
- `src/commitments/runtime.test.ts`: extend the existing `runEmbeddedPiAgentMock` assertion to assert `fastMode` is **not** in the payload, locking in the regression fix.
- `CHANGELOG.md`: single-line entry under Unreleased / Fixes.

## Real behavior proof

- Behavior addressed: On every commitment extraction pass, MiniMax Coding Plan operators receive `HTTP 500: your current token plan not support model, MiniMax-M2.7-highspeed (2061)` from the MiniMax server because the agent runtime requested `MiniMax-M2.7-highspeed` even though their plan only owns `MiniMax-M2.7`. The reporter (`@advaitpaliwal`) verified `commitments.enabled: true, commitments.maxPerDay: 10` config, then ran a real Coding Plan session, observed extraction always selecting the highspeed variant, and traced the root cause to `dist/runtime-CXt7BFiH.js` line 386 (`fastMode: true` hardcoded). Issue: https://github.com/openclaw/openclaw/issues/78451
- Real environment tested: Local OpenClaw checkout at `../openclaw-78451` on Windows 11 + Node 22.14. The smoke script reads the **patched production file `src/commitments/runtime.ts` directly from the worktree**, locates the entire `defaultExtractBatch` function (the path that builds the `runEmbeddedPiAgent` payload), prints its SHA-256 + verbatim bytes, then runs structural assertions over the captured payload literal to prove `fastMode: true` is gone, the `#78451` explanatory comment is in place, and every sibling field is preserved. No mocks, no test runner — the patched source bytes drive the smoke. PR head: `a3189f329687fa8c2c9da783afbc0d644ea94573`.
- Exact steps or command run after this patch: `git checkout fix/commitments-no-fastmode-hardcode && node --experimental-strip-types ./smoke-pr78459.mts`, where `smoke-pr78459.mts` reads `src/commitments/runtime.ts`, slices the `async function defaultExtractBatch` body, hashes it, prints the verbatim payload object literal, and runs structural assertions against the live patched source.
- Evidence after fix: Terminal output captured locally on PR head `a3189f3296` (Windows 11 + Node 22.14, the patched `src/commitments/runtime.ts` `defaultExtractBatch` function read from the worktree, 1660 bytes, SHA-256 `ae3690fc3189a7bc3e6d33e8693a3a28aa24ee3c7a82822618c5f1c762bcb379`).

~~~text
$ node --experimental-strip-types ./smoke-pr78459.mts
=== Patched defaultExtractBatch function — bytes from src/commitments/runtime.ts ===
offset: 7245 -> 8905 ( 1660 bytes)
SHA-256: ae3690fc3189a7bc3e6d33e8693a3a28aa24ee3c7a82822618c5f1c762bcb379

function body still contains literal 'fastMode: true': false
explanatory '#78451' comment present                : true
  preserved field 'disableTools: true': true
  preserved field 'thinkLevel: "off"': true
  preserved field 'verboseLevel: "off"': true
  preserved field 'reasoningLevel: "off"': true

=== Payload object passed to runEmbeddedPiAgent (verbatim from patched code) ===
{ cfg, agentId: first.agentId });
  const result = await runEmbeddedPiAgent({
    sessionId: runId,
    sessionKey: `agent:${first.agentId}:commitments:${runId}`,
    agentId: first.agentId,
    trigger: "manual",
    sessionFile: resolveExtractionSessionFile(first.agentId, runId),
    workspaceDir: resolveAgentWorkspaceDir(cfg, first.agentId),
    config: cfg,
    provider: modelRef.provider,
    model: modelRef.model,
    prompt: buildCommitmentExtractionPrompt({ cfg, items: params.items }),
    disableTools: true,
    thinkLevel: "off",
    verboseLevel: "off",
    reasoningLevel: "off",
    // Do not hardcode fastMode here: leaving the field undefined lets the
    // commitments extraction inherit the configured fast-mode state (which
    // defaults to false). Hardcoding true caused MiniMax Coding Plans without
    // highspeed access to fail with HTTP 500 because the MiniMax stream wrapper
    // would rewrite MiniMax-M2.7 -> MiniMax-M2.7-highspeed (#78451).
    timeoutMs: resolved.extraction.timeoutSeconds * 1000,
    runId,
    bootstrapContextMode: "lightweight",
    skillsSnapshot: { prompt: "", skills: [] },
    suppressToolErrorWarnings: true,
  }

=== fastMode-related lines in the payload (BEFORE-vs-AFTER comparison) ===
  // Do not hardcode fastMode here: leaving the field undefined lets the
  // highspeed access to fail with HTTP 500 because the MiniMax stream wrapper
  // would rewrite MiniMax-M2.7 -> MiniMax-M2.7-highspeed (#78451).
~~~

- Observed result after fix: The patched `defaultExtractBatch` function — pinned by a 1660-byte / SHA-256 `ae3690fc3189a7bc3e6d33e8693a3a28aa24ee3c7a82822618c5f1c762bcb379` integrity check — has zero `fastMode: true` literals (`function body still contains literal 'fastMode: true': false`). The explanatory `#78451` comment is in place (`explanatory '#78451' comment present: true`), and every sibling field (`disableTools: true`, `thinkLevel: "off"`, `verboseLevel: "off"`, `reasoningLevel: "off"`) is preserved verbatim. The captured payload literal shown verbatim above confirms `runEmbeddedPiAgent` is now called without a `fastMode` key — so the MiniMax stream wrapper at `src/agents/pi-embedded-runner/minimax-stream-wrappers.ts:24` no longer flips `MiniMax-M2.7` → `MiniMax-M2.7-highspeed`, and the operator's configured base model id flows through unchanged.
- What was not tested: A live HTTP roundtrip against the real MiniMax server with a Coding Plan token is not available on the contributor machine, so this is source-level / structural proof against the patched payload-builder, not a live MiniMax 200 response. Maintainers may apply `proof: override` if a live MiniMax recording is required; the reporter's original issue already contains live HTTP 500 evidence from the real Coding Plan.

## Test

- `pnpm test src/commitments/runtime.test.ts` — 6 passed (including the new `expect(callArgs).not.toHaveProperty("fastMode")` regression assertion).

## Notes

- Scope: smallest complete fix. No new config surface and no provider/wrapper edits — the existing fast-mode resolution chain already covers the right behavior; the hardcode was the only thing forcing `true`.
- Compatibility: agents that need fast-mode for commitments can still set it via `agents.defaults.models.<id>.params.fastMode: true` (or per-agent `fastModeDefault: true`) — the `resolveFastModeState` chain is unchanged.

Closes #78451
