### PR TITLE
fix(plugin-sdk): bundle zod subpath artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
+- Plugin SDK: bundle the `openclaw/plugin-sdk/zod` runtime export into the published package so pnpm global installs do not need a package-local `zod` symlink before bundled channel plugins can register. Fixes #78398. Thanks @ggzeng.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.
 - PDF/Codex: include extraction-fallback instructions for `openai-codex/*` PDF tool requests so Codex Responses receives its required system prompt. Fixes #77872. Thanks @anyech.

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -119,6 +119,7 @@ export function collectInstalledPackageErrors(params: {
   }
 
   errors.push(...collectInstalledContextEngineRuntimeErrors(params.packageRoot));
+  errors.push(...collectInstalledPluginSdkZodArtifactErrors(params.packageRoot));
   errors.push(...collectInstalledRootDependencyManifestErrors(params.packageRoot));
 
   return errors;
@@ -202,6 +203,39 @@ export function collectInstalledContextEngineRuntimeErrors(packageRoot: string):
     }
   }
   return errors;
+}
+
+export function collectInstalledPluginSdkZodArtifactErrors(packageRoot: string): string[] {
+  const relativePath = "dist/plugin-sdk/zod.js";
+  const artifactPath = join(packageRoot, relativePath);
+  if (!existsSync(artifactPath)) {
+    return [`installed package is missing required plugin SDK artifact: ${relativePath}`];
+  }
+  const artifactStat = lstatSync(artifactPath);
+  if (!artifactStat.isFile() || artifactStat.size > MAX_INSTALLED_ROOT_DIST_JS_BYTES) {
+    return [
+      `installed package plugin SDK artifact '${relativePath}' is invalid or exceeds ${MAX_INSTALLED_ROOT_DIST_JS_BYTES} bytes.`,
+    ];
+  }
+
+  const source = readFileSync(artifactPath, "utf8");
+  const parsedSpecifiers = extractJavaScriptImportSpecifiers(source);
+  if (!parsedSpecifiers.ok) {
+    return [
+      `installed package plugin SDK artifact '${relativePath}' could not be parsed for runtime dependency verification: ${parsedSpecifiers.error}.`,
+    ];
+  }
+
+  const bareZodSpecifiers = [...parsedSpecifiers.specifiers]
+    .filter((specifier) => specifier === "zod" || specifier.startsWith("zod/"))
+    .toSorted((left, right) => left.localeCompare(right));
+  if (bareZodSpecifiers.length === 0) {
+    return [];
+  }
+
+  return [
+    `installed package plugin SDK artifact '${relativePath}' must be self-contained but imports ${bareZodSpecifiers.join(", ")}.`,
+  ];
 }
 
 function listInstalledRootDistJavaScriptFiles(packageRoot: string): string[] {

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -7,6 +7,7 @@ import {
   buildPublishedInstallScenarios,
   collectInstalledBundledRuntimeSidecarPaths,
   collectInstalledContextEngineRuntimeErrors,
+  collectInstalledPluginSdkZodArtifactErrors,
   collectInstalledRootDependencyManifestErrors,
   collectInstalledPackageErrors,
   normalizeInstalledBinaryVersion,
@@ -140,6 +141,48 @@ describe("collectInstalledContextEngineRuntimeErrors", () => {
       );
 
       expect(collectInstalledContextEngineRuntimeErrors(packageRoot)).toEqual([]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectInstalledPluginSdkZodArtifactErrors", () => {
+  function makeInstalledPackageRoot(): string {
+    return mkdtempSync(join(tmpdir(), "openclaw-postpublish-zod-sdk-"));
+  }
+
+  it("rejects plugin-sdk zod artifacts with a bare zod export", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      mkdirSync(join(packageRoot, "dist", "plugin-sdk"), { recursive: true });
+      writeFileSync(
+        join(packageRoot, "dist", "plugin-sdk", "zod.js"),
+        'import "../zod-D2c0iocA.js";\nexport * from "zod";\n',
+        "utf8",
+      );
+
+      expect(collectInstalledPluginSdkZodArtifactErrors(packageRoot)).toEqual([
+        "installed package plugin SDK artifact 'dist/plugin-sdk/zod.js' must be self-contained but imports zod.",
+      ]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts plugin-sdk zod artifacts that only import package-local chunks", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      mkdirSync(join(packageRoot, "dist", "plugin-sdk"), { recursive: true });
+      writeFileSync(
+        join(packageRoot, "dist", "plugin-sdk", "zod.js"),
+        'export { z } from "../zod-D2c0iocA.js";\n',
+        "utf8",
+      );
+
+      expect(collectInstalledPluginSdkZodArtifactErrors(packageRoot)).toEqual([]);
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });
     }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -175,7 +175,12 @@ function shouldNeverBundleDependency(id: string): boolean {
 }
 
 function shouldAlwaysBundleDependency(id: string): boolean {
-  return id === "@openclaw/fs-safe" || id.startsWith("@openclaw/fs-safe/");
+  return (
+    id === "@openclaw/fs-safe" ||
+    id.startsWith("@openclaw/fs-safe/") ||
+    id === "zod" ||
+    id.startsWith("zod/")
+  );
 }
 
 function listBundledPluginEntrySources(


### PR DESCRIPTION
## Summary

- Problem: `openclaw/plugin-sdk/zod` shipped as `dist/plugin-sdk/zod.js` with a bare runtime `export * from "zod"`, which can fail in pnpm global installs where `zod` is not resolvable from the OpenClaw package root.
- Why it matters: bundled and third-party channel plugins import this public SDK subpath during registration, so a missing bare `zod` dependency can prevent plugins such as Feishu and BlueBubbles from registering.
- What changed: force `zod` into the tsdown bundle graph so the published SDK subpath imports only package-local chunks.
- Guardrail: extend the npm postpublish verifier with a package-artifact check that rejects `dist/plugin-sdk/zod.js` when it imports or re-exports bare `zod`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #78398
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

`src/plugin-sdk/zod.ts` re-exported from bare `zod`, and the build did not force that dependency to stay bundled for the public SDK subpath. Published artifacts could therefore contain `export * from "zod"`, which relies on Node resolving `zod` from the installed OpenClaw package location. pnpm global installs can leave that dependency unavailable from that path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Package-artifact smoke
- Target test or file:
  - `test/openclaw-npm-postpublish-verify.test.ts`
  - `scripts/openclaw-npm-postpublish-verify.ts`
- Scenario the test locks in: installed `dist/plugin-sdk/zod.js` must be self-contained and must not import or re-export bare `zod`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux workspace
- Runtime/container: Node v24.15.0, pnpm 10.33.2/10.33.3 via Corepack
- Integration/channel: package artifact and plugin SDK zod subpath

### Steps

1. Build the package.
2. Inspect `dist/plugin-sdk/zod.js` for bare `zod` imports/exports.
3. Pack the candidate tarball.
4. Install it into an isolated pnpm global root.
5. Import `openclaw/plugin-sdk/zod` from the installed package.

### Expected

The zod SDK subpath imports successfully and the installed artifact verifier reports no bare `zod` import/export.

### Actual

After this patch, the installed pnpm global tarball import succeeded and the verifier returned `[]`.

## Evidence

```text
$ pnpm build
OK: All 4 required plugin-sdk exports verified.
[build-all] write-cli-compat

$ rg -n 'from "zod"|from "zod/|export \* from "zod|import\("zod' dist/plugin-sdk/zod.js dist -g '*.js' | head -100
# no output

$ pnpm pack --pack-destination /tmp/openclaw-zod-smoke
Tarball Details
/tmp/openclaw-zod-smoke/openclaw-2026.5.6.tgz

$ PNPM_HOME=/tmp/openclaw-zod-smoke/pnpm-home HOME=/tmp/openclaw-zod-smoke/home PATH=/tmp/openclaw-zod-smoke/pnpm-home:$PATH pnpm install -g /tmp/openclaw-zod-smoke/openclaw-2026.5.6.tgz --global-dir /tmp/openclaw-zod-smoke/global --store-dir /tmp/openclaw-zod-smoke/store --no-lockfile --dangerously-allow-all-builds
/tmp/openclaw-zod-smoke/global/5:
+ openclaw 2026.5.6

$ node --input-type=module --eval "const mod = await import('openclaw/plugin-sdk/zod'); console.log(typeof mod.z.object, typeof mod.object);"
function function

$ node --import tsx --input-type=module --eval "import { collectInstalledPluginSdkZodArtifactErrors } from './scripts/openclaw-npm-postpublish-verify.ts'; const errors = collectInstalledPluginSdkZodArtifactErrors('/tmp/openclaw-zod-smoke/global/5/node_modules/openclaw'); console.log(JSON.stringify(errors));"
[]
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: packaging more zod code into the OpenClaw runtime artifact could increase package size.
  - Mitigation: this only forces an existing root runtime dependency into the bundle graph for a public SDK subpath that must work from installed packages.
