### PR TITLE
test(agents): cover announce-idempotency helpers

### DIFF
--- a/src/agents/announce-idempotency.test.ts
+++ b/src/agents/announce-idempotency.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAnnounceIdempotencyKey,
+  buildAnnounceIdFromChildRun,
+  resolveQueueAnnounceId,
+} from "./announce-idempotency.js";
+
+describe("buildAnnounceIdFromChildRun", () => {
+  it("combines childSessionKey and childRunId under the v1 prefix", () => {
+    expect(buildAnnounceIdFromChildRun({ childSessionKey: "sess-abc", childRunId: "run-42" })).toBe(
+      "v1:sess-abc:run-42",
+    );
+  });
+
+  it("preserves colons inside session keys", () => {
+    expect(
+      buildAnnounceIdFromChildRun({
+        childSessionKey: "telegram:1234:thread:7",
+        childRunId: "run-1",
+      }),
+    ).toBe("v1:telegram:1234:thread:7:run-1");
+  });
+});
+
+describe("buildAnnounceIdempotencyKey", () => {
+  it("prefixes the announce id with announce:", () => {
+    expect(buildAnnounceIdempotencyKey("v1:sess-abc:run-42")).toBe("announce:v1:sess-abc:run-42");
+  });
+
+  it("prefixes legacy fallback announce ids without altering them", () => {
+    expect(buildAnnounceIdempotencyKey("legacy:sess-abc:1700000000000")).toBe(
+      "announce:legacy:sess-abc:1700000000000",
+    );
+  });
+});
+
+describe("resolveQueueAnnounceId", () => {
+  it("returns the supplied announce id verbatim when present and non-empty", () => {
+    expect(
+      resolveQueueAnnounceId({
+        announceId: "v1:sess-abc:run-42",
+        sessionKey: "sess-abc",
+        enqueuedAt: 1700000000000,
+      }),
+    ).toBe("v1:sess-abc:run-42");
+  });
+
+  it("trims surrounding whitespace from a non-empty announce id", () => {
+    expect(
+      resolveQueueAnnounceId({
+        announceId: "  v1:sess-abc:run-42  ",
+        sessionKey: "sess-abc",
+        enqueuedAt: 1700000000000,
+      }),
+    ).toBe("v1:sess-abc:run-42");
+  });
+
+  it("falls back to legacy fingerprint when announceId is whitespace-only", () => {
+    expect(
+      resolveQueueAnnounceId({
+        announceId: "   ",
+        sessionKey: "sess-abc",
+        enqueuedAt: 1700000000000,
+      }),
+    ).toBe("legacy:sess-abc:1700000000000");
+  });
+
+  it("falls back to legacy fingerprint when announceId is an empty string", () => {
+    expect(
+      resolveQueueAnnounceId({
+        announceId: "",
+        sessionKey: "sess-abc",
+        enqueuedAt: 1700000000000,
+      }),
+    ).toBe("legacy:sess-abc:1700000000000");
+  });
+
+  it("falls back to legacy fingerprint when announceId is undefined", () => {
+    expect(resolveQueueAnnounceId({ sessionKey: "sess-abc", enqueuedAt: 1700000000000 })).toBe(
+      "legacy:sess-abc:1700000000000",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a colocated test file for `src/agents/announce-idempotency.ts`, which previously had no direct unit coverage. The 3 exported helpers (`buildAnnounceIdFromChildRun`, `buildAnnounceIdempotencyKey`, `resolveQueueAnnounceId`) are pure functions used to derive subagent-announce idempotency keys; their behavior is exercised transitively in `subagent-announce.format.e2e.test.ts` but never directly.

`resolveQueueAnnounceId` in particular has 3 branches (announce id present + non-empty, whitespace-only fallback, undefined fallback) plus an implicit `.trim()` step. The legacy fallback fingerprint shape (`legacy:${sessionKey}:${enqueuedAt}`) is what production call sites depend on at `src/agents/subagent-announce-delivery.ts` for backward-compatibility with queue items predating `announceId`.

## Test plan

- [x] New file `src/agents/announce-idempotency.test.ts` covers all 3 helpers
- [x] All 5 branches of `resolveQueueAnnounceId` asserted (verbatim, trimmed, whitespace-only fallback, empty-string fallback, undefined fallback)
- [x] Legacy fingerprint format locked in tests
- [x] No production code changes — test-only PR

CI will run the new file as part of `checks-node-agentic-agents`.
