### PR TITLE
fix(channels): prefer built dist artifacts over source .ts in bundled package-state probes

### DIFF
--- a/src/channels/plugins/package-state-probes.test.ts
+++ b/src/channels/plugins/package-state-probes.test.ts
@@ -5,11 +5,28 @@ import {
   listBundledChannelIdsForPackageState,
 } from "./package-state-probes.js";
 
-const listChannelCatalogEntriesMock = vi.hoisted(() => vi.fn());
+const hoisted = vi.hoisted(() => ({
+  listChannelCatalogEntries: vi.fn(),
+  existsSync: vi.fn(() => false),
+  loadChannelPluginModule: vi.fn(),
+  resolveExistingPluginModulePath: vi.fn(),
+}));
 
 vi.mock("../../plugins/channel-catalog-registry.js", () => ({
-  listChannelCatalogEntries: listChannelCatalogEntriesMock,
+  listChannelCatalogEntries: hoisted.listChannelCatalogEntries,
 }));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return { ...actual, default: { ...actual, existsSync: hoisted.existsSync } };
+});
+
+vi.mock("./module-loader.js", () => ({
+  loadChannelPluginModule: hoisted.loadChannelPluginModule,
+  resolveExistingPluginModulePath: hoisted.resolveExistingPluginModulePath,
+}));
+
+const listChannelCatalogEntriesMock = hoisted.listChannelCatalogEntries;
 
 function makeBundledChannelCatalogEntry(params: {
   pluginId: string;
@@ -32,6 +49,10 @@ function makeBundledChannelCatalogEntry(params: {
 
 beforeEach(() => {
   listChannelCatalogEntriesMock.mockReset();
+  hoisted.existsSync.mockReset();
+  hoisted.existsSync.mockReturnValue(false);
+  hoisted.loadChannelPluginModule.mockReset();
+  hoisted.resolveExistingPluginModulePath.mockReset();
 });
 
 describe("channel package-state probes", () => {
@@ -60,5 +81,42 @@ describe("channel package-state probes", () => {
         env: { ALIAS_CHAT_TOKEN: "token" },
       }),
     ).toBe(false);
+  });
+
+  it("prefers built .js artifact over source .ts when dist path exists (dev-checkout source loading fix)", () => {
+    const sourceTs = "/home/ubuntu/openclaw/extensions/matrix/auth-presence.ts";
+    const builtJs = "/home/ubuntu/openclaw/dist/extensions/matrix/auth-presence.js";
+
+    const checkerEntry: PluginChannelCatalogEntry = {
+      pluginId: "matrix",
+      origin: "bundled",
+      rootDir: "/home/ubuntu/openclaw/extensions/matrix",
+      channel: {
+        id: "matrix",
+        persistedAuthState: { specifier: "./auth-presence", exportName: "hasAnyMatrixAuth" },
+      },
+    };
+    listChannelCatalogEntriesMock.mockReturnValue([checkerEntry]);
+
+    // Simulate dev checkout: resolveExistingPluginModulePath finds the source .ts first
+    hoisted.resolveExistingPluginModulePath.mockReturnValue(sourceTs);
+    // existsSync: dist .js exists, source .ts does not (in the dist check path)
+    hoisted.existsSync.mockImplementation((p: string) => p === builtJs);
+    hoisted.loadChannelPluginModule.mockReturnValue({ hasAnyMatrixAuth: () => true });
+
+    const result = hasBundledChannelPackageState({
+      metadataKey: "persistedAuthState",
+      channelId: "matrix",
+      cfg: {},
+    });
+
+    expect(result).toBe(true);
+    // The built .js path must have been passed to loadChannelPluginModule, not the source .ts
+    expect(hoisted.loadChannelPluginModule).toHaveBeenCalledWith(
+      expect.objectContaining({ modulePath: builtJs }),
+    );
+    expect(hoisted.loadChannelPluginModule).not.toHaveBeenCalledWith(
+      expect.objectContaining({ modulePath: sourceTs }),
+    );
   });
 });

--- a/src/channels/plugins/package-state-probes.ts
+++ b/src/channels/plugins/package-state-probes.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -31,8 +33,49 @@ export type ChannelPackageStateMetadataKey = "configuredState" | "persistedAuthS
 const log = createSubsystemLogger("channels");
 const sourcePackageStateLoaderCache: PluginModuleLoaderCache = new Map();
 
+const SOURCE_EXT_RE = /\.(c|m)?tsx?$/iu;
+const SOURCE_EXT_TO_BUILT: Readonly<Record<string, string>> = {
+  ".ts": ".js",
+  ".mts": ".mjs",
+  ".cts": ".cjs",
+  ".tsx": ".js",
+};
+
 function isSourceModulePath(modulePath: string): boolean {
-  return /\.(?:c|m)?tsx?$/iu.test(modulePath);
+  return SOURCE_EXT_RE.test(modulePath);
+}
+
+/**
+ * Given a resolved module path that points to a source TypeScript file under an
+ * `extensions/` directory, returns the equivalent built `.js` path under `dist/extensions/`
+ * if it exists on disk. Falls through to the original path if no built artifact is found.
+ *
+ * This prevents bundled-channel package-state probes from loading source `.ts` files that
+ * contain `openclaw/plugin-sdk/*` self-imports, which fail package resolution in a dev checkout
+ * because the source files require a built dist SDK, not the raw source tree.
+ */
+function resolveBuiltArtifactPath(modulePath: string): string {
+  const ext = path.extname(modulePath).toLowerCase();
+  const builtExt = SOURCE_EXT_TO_BUILT[ext];
+  if (!builtExt) {
+    return modulePath;
+  }
+  // Map: .../extensions/<chan>/auth-presence.ts → .../dist/extensions/<chan>/auth-presence.js
+  const sep = path.sep === "\\" ? /[\\/]extensions[\\/]/u : /\/extensions\//u;
+  const match = modulePath.match(sep);
+  if (!match || match.index === undefined) {
+    return modulePath;
+  }
+  const distPath =
+    modulePath.slice(0, match.index) +
+    path.sep +
+    "dist" +
+    path.sep +
+    "extensions" +
+    path.sep +
+    modulePath.slice(match.index + match[0].length, modulePath.length - ext.length) +
+    builtExt;
+  return fs.existsSync(distPath) ? distPath : modulePath;
 }
 
 function loadChannelPackageStateModule(params: { modulePath: string; rootDir: string }): unknown {
@@ -119,8 +162,11 @@ function resolveChannelPackageStateChecker(params: {
   }
 
   try {
+    const resolvedPath = resolveBuiltArtifactPath(
+      resolveExistingPluginModulePath(params.entry.rootDir, metadata.specifier!),
+    );
     const moduleExport = loadChannelPackageStateModule({
-      modulePath: resolveExistingPluginModulePath(params.entry.rootDir, metadata.specifier!),
+      modulePath: resolvedPath,
       rootDir: params.entry.rootDir,
     }) as Record<string, unknown>;
     const checker = moduleExport[metadata.exportName!] as ChannelPackageStateChecker | undefined;


### PR DESCRIPTION
## Problem

In a dev checkout, bundled channel `persistedAuthState`/`configuredState` probes load the wrong file. `resolveExistingPluginModulePath` finds `extensions/<chan>/auth-presence.ts` (source) before `dist/extensions/<chan>/auth-presence.js` (built artifact). The source `.ts` file imports `openclaw/plugin-sdk/*` subpaths that fail package self-resolution in the source tree, producing noisy gateway startup warnings:

```text
[channels] failed to load persistedAuthState checker for matrix: Cannot find module '/home/ubuntu/openclaw/dist/plugin-sdk/state-paths.js'
Require stack:
- /home/ubuntu/openclaw/extensions/matrix/auth-presence.ts
```

Reported in #78462.

## Fix

Added `resolveBuiltArtifactPath()` in `package-state-probes.ts`: when `resolveExistingPluginModulePath` returns a source `.ts`/`.mts`/`.cts` path under an `extensions/` directory, the function tries the corresponding `.js`/`.mjs`/`.cjs` path under `dist/extensions/` first. If the built artifact exists, it's used instead. Falls through to the source path otherwise.

**Files changed (2):**
- `src/channels/plugins/package-state-probes.ts` — `resolveBuiltArtifactPath` helper + call at the probe resolution site
- `src/channels/plugins/package-state-probes.test.ts` — test that asserts built `.js` is passed to `loadChannelPluginModule` when dist artifact exists

**Audits:**
- A (existing helper): `isSourceModulePath` already existed; reused regex pattern as `SOURCE_EXT_RE`. ✓
- B (shared caller check): `resolveExistingPluginModulePath` has 1 caller outside its file (this probe). ✓
- C (rival scan): No rival PR for #78462. ✓

**Tests:** 2/2 pass (`vitest run src/channels/plugins/package-state-probes.test.ts`)