### PR TITLE
fix(plugins): reuse workspace snapshot for model normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Docs: https://docs.openclaw.ai
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)
 - Agents/fallback: fail fast on session write-lock timeouts instead of trying fallback models for local file contention. Fixes #66646. Thanks @sallyom.
+- Plugins/models: reuse the Gateway-owned workspace-scoped metadata snapshot for unscoped model-id normalization callers so repeated model normalization requests avoid cold metadata rescans. Fixes #78461. (#78480) Thanks @hclsys.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -220,6 +220,20 @@ describe("manifest model id normalization", () => {
     expect(normalizeDemoModel()).toBe("bravo/demo-model");
   });
 
+  it("reuses workspace-scoped current metadata when no active runtime workspace is set", () => {
+    setCurrentPluginMetadataSnapshot(
+      createCurrentSnapshot({
+        manifestHash: "alpha",
+        prefix: "alpha",
+        workspaceDir: "/workspace/a",
+      }),
+      { config: {}, env: process.env },
+    );
+
+    expect(normalizeDemoModel()).toBe("alpha/demo-model");
+    expect(normalizeDemoModel("second-model")).toBe("alpha/second-model");
+  });
+
   it("reflects manifest edits and state-dir changes on the next lookup", () => {
     const stateDirA = makeTempDir();
     const pluginDirA = path.join(stateDirA, "extensions", "normalizer");

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -41,21 +41,23 @@ function resolveMetadataSnapshotForPolicies(
   snapshot: PluginMetadataSnapshot;
   cacheable: boolean;
 } {
+  const config = params.config ?? {};
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
   const current = getCurrentPluginMetadataSnapshot({
-    config: params.config,
+    config,
     env,
-    workspaceDir,
+    ...(workspaceDir !== undefined ? { workspaceDir } : {}),
+    ...(params.workspaceDir === undefined ? { allowWorkspaceScopedSnapshot: true } : {}),
   });
   if (current) {
     return { snapshot: current, cacheable: true };
   }
   return {
     snapshot: loadPluginMetadataSnapshot({
-      config: params.config ?? {},
+      config,
       env,
-      workspaceDir,
+      ...(workspaceDir !== undefined ? { workspaceDir } : {}),
     }),
     cacheable: false,
   };


### PR DESCRIPTION
## Problem

Manifest model-id normalization can miss the Gateway-owned plugin metadata snapshot when the caller does not pass an explicit workspace and the active runtime workspace has not been set yet. In that case `resolveMetadataSnapshotForPolicies()` calls `getCurrentPluginMetadataSnapshot()` without `allowWorkspaceScopedSnapshot`, so a valid workspace-scoped current snapshot is rejected and the path falls back to `loadPluginMetadataSnapshot()`.

That matches the source-level slow path reported in #78461: model normalization can rebuild plugin metadata / installed plugin indexes during embedded agent prep even though Gateway already prepared a compatible metadata snapshot.

Fixes #78461.

## Fix

- Normalize omitted config to `{}` before snapshot compatibility checks, matching adjacent manifest readers.
- Pass `allowWorkspaceScopedSnapshot: true` for unscoped callers, while still honoring an explicit `workspaceDir` or active runtime workspace when present.
- Avoid passing `workspaceDir: undefined` into the fallback loader.
- Add regression coverage for a workspace-scoped current snapshot with no active runtime workspace.

## Commit shape

This is intentionally split into two commits:

1. `fix(plugins): reuse workspace snapshot for model normalization`
2. `test(plugins): cover unscoped model normalization snapshot reuse`

## Scope boundary

What changed:
- `src/plugins/manifest-model-id-normalization.ts`
- `src/plugins/manifest-model-id-normalization.test.ts`

What did not change:
- provider selection semantics
- plugin install/index discovery policy
- current snapshot compatibility checks
- Gateway lifecycle / startup ordering
- provider runtime cache behavior from #77948

## Audits

- Existing-helper check: reused existing `getCurrentPluginMetadataSnapshot(... allowWorkspaceScopedSnapshot)` behavior already used by model catalog and manifest-contract readers.
- Shared-helper caller check: did not change `getCurrentPluginMetadataSnapshot` contract; only changed this caller.
- Rival scan: #77948 is adjacent provider-runtime snapshot reuse, but does not touch `src/plugins/manifest-model-id-normalization.ts`; #78474 is package-state probe resolution for #78462 and does not cover this path.

## Tests

```text
pnpm test src/plugins/manifest-model-id-normalization.test.ts src/plugins/current-plugin-metadata-snapshot.test.ts src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts
# passed 2 Vitest shards; 18 tests passed

pnpm -s tsgo:core
# exit 0

pnpm -s build
# exit 0

git diff --check origin/main..HEAD
# exit 0
```

## Real behavior proof

**Behavior or issue addressed:** Unscoped manifest model-id normalization now reuses the Gateway-owned workspace-scoped plugin metadata snapshot instead of falling back to a cold `loadPluginMetadataSnapshot()` path when the active runtime workspace is still unset. This addresses the #78461 model-normalization snapshot miss.

**Real environment tested:** Local OpenClaw source checkout `/home/chenglunhu/code/openclaw`, branch `fix/manifest-model-normalization-snapshot-78461`, built with `pnpm -s build`, OpenClaw `2026.5.6`, Node `v24.13.0`, Linux/WSL host. Runtime env for the smoke used an empty temporary `OPENCLAW_STATE_DIR` and `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` so the `alpha/demo-model` result can only come from the current metadata snapshot, not from a fallback manifest scan.

**Exact steps or command run after this patch:**

```bash
pnpm -s build
OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 OPENCLAW_STATE_DIR="$(mktemp -d)" node --input-type=module <<'EOF'
import { t as normalizeProviderModelIdWithManifest } from './dist/manifest-model-id-normalization-BsZfNFDu.js';
import { r as setCurrentPluginMetadataSnapshot, t as clearCurrentPluginMetadataSnapshot } from './dist/current-plugin-metadata-snapshot-vavLhBTt.js';
import { _ as resolveInstalledPluginIndexPolicyHash } from './dist/installed-plugin-index-store-BekK6vjO.js';

const policyHash = resolveInstalledPluginIndexPolicyHash({});
const workspaceDir = '/tmp/openclaw-real-workspace-78461';
const index = {
  version: 1,
  hostContractVersion: 'real-proof',
  compatRegistryVersion: 'real-proof',
  migrationVersion: 1,
  policyHash,
  generatedAtMs: Date.now(),
  installRecords: {},
  plugins: [],
  diagnostics: [],
};
const snapshot = {
  policyHash,
  workspaceDir,
  index,
  plugins: [
    {
      id: 'normalizer-real-proof',
      modelIdNormalization: {
        providers: {
          demo: {
            prefixWhenBare: 'alpha',
          },
        },
      },
    },
  ],
};

clearCurrentPluginMetadataSnapshot();
setCurrentPluginMetadataSnapshot(snapshot, { config: {}, env: process.env });
const normalized = normalizeProviderModelIdWithManifest({
  provider: 'demo',
  context: { provider: 'demo', modelId: 'demo-model' },
});
console.log(`openclawVersion=2026.5.6`);
console.log(`command=node --input-type=module dist manifest-normalization smoke`);
console.log(`activeRuntimeWorkspace=unset`);
console.log(`storedSnapshotWorkspace=${workspaceDir}`);
console.log(`normalized=${normalized}`);
console.log(`workspaceScopedSnapshotReused=${normalized === 'alpha/demo-model'}`);
EOF
```

**Evidence after fix:** copied terminal output from the built OpenClaw dist smoke:

```text
openclawVersion=2026.5.6
command=node --input-type=module dist manifest-normalization smoke
activeRuntimeWorkspace=unset
storedSnapshotWorkspace=/tmp/openclaw-real-workspace-78461
normalized=alpha/demo-model
workspaceScopedSnapshotReused=true
```

**Observed result after fix:** With no active runtime workspace and an empty plugin state dir, `normalizeProviderModelIdWithManifest()` returned `alpha/demo-model` from the stored workspace-scoped current snapshot. That verifies the unscoped caller reused the current snapshot path after this patch.

**What was not tested:** I did not run a live Gateway CPU profile in this PR. The live performance evidence is in #78461; this PR verifies the exact source-level snapshot miss with a built-dist smoke and regression test.
