### PR TITLE
fix(acpx): bridge Codex OAuth into isolated ACP home

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -72,6 +72,33 @@ function expectWrapperToContainPathSuffix(wrapper: string, pathSuffix: string[])
   expect(wrapper.includes(escapedNativeSuffix) || wrapper.includes(posixSuffix)).toBe(true);
 }
 
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8")
+    .toString("base64url")
+    .replace(/=+$/u, "");
+}
+
+function fakeChatgptJwt(params: {
+  email: string;
+  accountId: string;
+  planType: string;
+  exp?: number;
+}): string {
+  return [
+    base64UrlJson({ alg: "none", typ: "JWT" }),
+    base64UrlJson({
+      exp: params.exp ?? 2_000_000_000,
+      "https://api.openai.com/profile": { email: params.email },
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: params.accountId,
+        chatgpt_plan_type: params.planType,
+        chatgpt_user_id: "user-id",
+      },
+    }),
+    "sig",
+  ].join(".");
+}
+
 afterEach(async () => {
   vi.restoreAllMocks();
   restoreEnv("CODEX_HOME");
@@ -258,6 +285,235 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.argv).toEqual([]);
     const expectedCodexHome = await fs.realpath(path.join(stateDir, "acpx", "codex-home"));
     expect(path.resolve(String(launched.codexHome))).toBe(expectedCodexHome);
+  });
+
+  it("syncs Docker OpenClaw openai-codex OAuth into isolated Codex ACP auth", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const generated = generatedCodexPaths(stateDir);
+    const accountId = "workspace-123";
+    const access = fakeChatgptJwt({
+      email: "user@example.com",
+      accountId,
+      planType: "team",
+    });
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            "openai-codex:user@example.com": {
+              type: "oauth",
+              provider: "openai-codex",
+              access,
+              refresh: "refresh-token",
+              email: "user@example.com",
+              accountId,
+              chatgptPlanType: "team",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await fs.writeFile(
+      path.join(agentDir, "auth-state.json"),
+      `${JSON.stringify(
+        { version: 1, lastGood: { "openai-codex": "openai-codex:user@example.com" } },
+        null,
+        2,
+      )}\n`,
+    );
+    const installedBinPath = path.join(root, "codex-acp-bin.js");
+    await fs.writeFile(
+      installedBinPath,
+      "console.log(JSON.stringify({ codexHome: process.env.CODEX_HOME }));\n",
+      "utf8",
+    );
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledCodexAcpBinPath: async () => installedBinPath,
+    });
+
+    await execFileAsync(process.execPath, [generated.wrapperPath], { cwd: root });
+    const auth = JSON.parse(
+      await fs.readFile(path.join(stateDir, "acpx", "codex-home", "auth.json"), "utf8"),
+    ) as {
+      auth_mode?: unknown;
+      OPENAI_API_KEY?: unknown;
+      tokens?: Record<string, unknown>;
+    };
+    expect(auth.auth_mode).toBe("chatgpt");
+    expect(auth.OPENAI_API_KEY).toBeUndefined();
+    expect(auth.tokens?.id_token).toBe(access);
+    expect(auth.tokens?.access_token).toBe(access);
+    expect(auth.tokens?.refresh_token).toBe("refresh-token");
+    expect(auth.tokens?.account_id).toBe(accountId);
+    await expect(
+      fs.access(path.join(stateDir, "acpx", "sync-codex-auth-from-openclaw.mjs")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores malformed Docker OpenClaw auth state while syncing Codex ACP auth", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const generated = generatedCodexPaths(stateDir);
+    const accountId = "workspace-first";
+    const access = fakeChatgptJwt({
+      email: "first@example.com",
+      accountId,
+      planType: "team",
+    });
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            "openai-codex:first@example.com": {
+              type: "oauth",
+              provider: "openai-codex",
+              access,
+              refresh: "first-refresh-token",
+              email: "first@example.com",
+              accountId,
+              chatgptPlanType: "team",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await fs.writeFile(path.join(agentDir, "auth-state.json"), "{not-json", "utf8");
+    const installedBinPath = path.join(root, "codex-acp-bin.js");
+    await fs.writeFile(installedBinPath, "console.log('launched');\n", "utf8");
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledCodexAcpBinPath: async () => installedBinPath,
+    });
+
+    const { stderr } = await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+    });
+    const auth = JSON.parse(
+      await fs.readFile(path.join(stateDir, "acpx", "codex-home", "auth.json"), "utf8"),
+    ) as { tokens?: Record<string, unknown> };
+    expect(auth.tokens?.account_id).toBe(accountId);
+    expect(auth.tokens?.refresh_token).toBe("first-refresh-token");
+    expect(stderr).toContain("ignored unreadable Docker OpenClaw auth state");
+  });
+
+  it("adopts rotated isolated Codex ACP OAuth back into the Docker OpenClaw profile", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const generated = generatedCodexPaths(stateDir);
+    const accountId = "workspace-rotated";
+    const oldAccess = fakeChatgptJwt({
+      email: "user@example.com",
+      accountId,
+      planType: "team",
+      exp: 2_000_000_000,
+    });
+    const rotatedAccess = fakeChatgptJwt({
+      email: "user@example.com",
+      accountId,
+      planType: "team",
+      exp: 2_000_000_900,
+    });
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            "openai-codex:user@example.com": {
+              type: "oauth",
+              provider: "openai-codex",
+              access: oldAccess,
+              refresh: "old-refresh-token",
+              expires: 2_000_000_000_000,
+              email: "user@example.com",
+              accountId,
+              chatgptPlanType: "team",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await fs.writeFile(
+      path.join(agentDir, "auth-state.json"),
+      `${JSON.stringify(
+        { version: 1, lastGood: { "openai-codex": "openai-codex:user@example.com" } },
+        null,
+        2,
+      )}\n`,
+    );
+    const installedBinPath = path.join(root, "codex-acp-bin.js");
+    await fs.writeFile(installedBinPath, "console.log('launched');\n", "utf8");
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledCodexAcpBinPath: async () => installedBinPath,
+    });
+    await fs.writeFile(
+      installedBinPath,
+      [
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        `const auth = ${JSON.stringify({
+          auth_mode: "chatgpt",
+          tokens: {
+            id_token: "rotated-id-token",
+            access_token: rotatedAccess,
+            refresh_token: "rotated-refresh-token",
+            account_id: accountId,
+          },
+          last_refresh: "2033-05-18T03:33:20.000Z",
+        })};`,
+        "fs.writeFileSync(path.join(process.env.CODEX_HOME, 'auth.json'), JSON.stringify(auth, null, 2) + '\\n');",
+        "console.log('rotated');",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await execFileAsync(process.execPath, [generated.wrapperPath], { cwd: root });
+    const store = JSON.parse(
+      await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as { profiles?: Record<string, Record<string, unknown>> };
+    const profile = store.profiles?.["openai-codex:user@example.com"];
+    expect(profile?.access).toBe(rotatedAccess);
+    expect(profile?.refresh).toBe("rotated-refresh-token");
+    expect(profile?.expires).toBe(2_000_000_900_000);
+    expect(profile?.idToken).toBe("rotated-id-token");
+    expect(profile?.accountId).toBe(accountId);
   });
 
   it("launches the locally installed Claude ACP bin without going through npm", async () => {

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -144,15 +144,18 @@ function buildAdapterWrapperScript(params: {
   binName: string;
   installedBinPath?: string;
   envSetup: string;
+  beforeLaunch?: string;
+  afterLaunch?: string;
 }): string {
   return `#!/usr/bin/env node
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 ${params.envSetup}
 const configuredArgs = process.argv.slice(2);
+${params.beforeLaunch ?? ""}
 
 function resolveNpmCliPath() {
   const candidate = path.resolve(
@@ -211,6 +214,7 @@ child.on("error", (error) => {
 });
 
 child.on("exit", (code, signal) => {
+${params.afterLaunch ?? ""}
   if (code !== null) {
     process.exit(code);
   }
@@ -230,7 +234,538 @@ const env = {
   ...process.env,
   CODEX_HOME: codexHome,
 };`,
+    beforeLaunch: `const authSyncScript = fileURLToPath(new URL("./sync-codex-auth-from-openclaw.mjs", import.meta.url));
+if (existsSync(authSyncScript)) {
+  const authSync = spawnSync(process.execPath, [authSyncScript], {
+    env,
+    stdio: "inherit",
+    windowsHide: true,
   });
+  if (authSync.error) {
+    console.error(\`[openclaw] failed to sync Docker Codex auth profile: \${authSync.error.message}\`);
+    process.exit(1);
+  }
+  if (authSync.status !== 0) {
+    process.exit(authSync.status ?? 1);
+  }
+}
+`,
+    afterLaunch: `if (existsSync(authSyncScript)) {
+  const authSync = spawnSync(process.execPath, [authSyncScript, "--adopt-codex-auth"], {
+    env,
+    stdio: "inherit",
+    windowsHide: true,
+  });
+  if (authSync.error) {
+    console.error(\`[openclaw] failed to adopt rotated Docker Codex auth profile: \${authSync.error.message}\`);
+  } else if (authSync.status !== 0) {
+    console.error("[openclaw] failed to adopt rotated Docker Codex auth profile after Codex ACP exited");
+  }
+}
+`,
+  });
+}
+
+function buildCodexAuthSyncScript(): string {
+  return `#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const baseDir = path.dirname(fileURLToPath(import.meta.url));
+const openclawStateDir = path.resolve(baseDir, "..");
+const authProfilesPath = path.join(
+  openclawStateDir,
+  "agents",
+  "main",
+  "agent",
+  "auth-profiles.json",
+);
+const authStatePath = path.join(
+  openclawStateDir,
+  "agents",
+  "main",
+  "agent",
+  "auth-state.json",
+);
+const codexHome = path.join(baseDir, "codex-home");
+const codexAuthPath = path.join(codexHome, "auth.json");
+const codexConfigPath = path.join(codexHome, "config.toml");
+const adoptCodexAuth = process.argv.includes("--adopt-codex-auth");
+const authStoreLockOptions = {
+  retries: { retries: 10, factor: 2, minTimeout: 100, maxTimeout: 10_000, randomize: true },
+  stale: 30_000,
+};
+const oauthRefreshLockOptions = {
+  retries: { retries: 20, factor: 2, minTimeout: 100, maxTimeout: 10_000, randomize: true },
+  stale: 180_000,
+};
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function decodeJwtPayload(token) {
+  if (typeof token !== "string") return undefined;
+  const parts = token.split(".");
+  if (parts.length < 3 || !parts[1]) return undefined;
+  try {
+    const padded = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function tokenExpirationSeconds(token) {
+  const payload = decodeJwtPayload(token);
+  return typeof payload?.exp === "number" ? payload.exp : 0;
+}
+
+function tokenExpirationMillis(token, fallback) {
+  const seconds = tokenExpirationSeconds(token);
+  return seconds > 0 ? seconds * 1000 : fallback;
+}
+
+function readExistingCodexAuth() {
+  if (!fs.existsSync(codexAuthPath)) return undefined;
+  try {
+    return readJson(codexAuthPath);
+  } catch {
+    return undefined;
+  }
+}
+
+function readOptionalJson(filePath, unreadableMessage) {
+  if (!fs.existsSync(filePath)) return undefined;
+  try {
+    return readJson(filePath);
+  } catch {
+    if (unreadableMessage) {
+      console.error("[openclaw] " + unreadableMessage);
+    }
+    return undefined;
+  }
+}
+
+function writeJsonAtomic(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = path.join(
+    path.dirname(filePath),
+    "." + path.basename(filePath) + "." + process.pid + "." + Date.now() + ".tmp",
+  );
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(value, null, 2) + "\\n", {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    fs.renameSync(tmpPath, filePath);
+  } finally {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function computeLockDelayMs(retries, attempt) {
+  const base = Math.min(
+    retries.maxTimeout,
+    Math.max(retries.minTimeout, retries.minTimeout * retries.factor ** attempt),
+  );
+  const jitter = retries.randomize ? 1 + Math.random() : 1;
+  return Math.min(retries.maxTimeout, Math.round(base * jitter));
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === "EPERM";
+  }
+}
+
+function readLockPayload(lockPath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+    if (typeof parsed?.pid !== "number" || typeof parsed?.createdAt !== "string") {
+      return undefined;
+    }
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function isStaleLock(lockPath, staleMs) {
+  const payload = readLockPayload(lockPath);
+  if (payload?.pid && !isPidAlive(payload.pid)) return true;
+  if (payload?.createdAt) {
+    const createdAt = Date.parse(payload.createdAt);
+    if (!Number.isFinite(createdAt) || Date.now() - createdAt > staleMs) return true;
+  }
+  try {
+    return Date.now() - fs.statSync(lockPath).mtimeMs > staleMs;
+  } catch {
+    return true;
+  }
+}
+
+function normalizeLockTargetPath(filePath) {
+  const resolved = path.resolve(filePath);
+  const dir = path.dirname(resolved);
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    return path.join(fs.realpathSync(dir), path.basename(resolved));
+  } catch {
+    return resolved;
+  }
+}
+
+function acquireFileLockSync(filePath, options) {
+  const normalizedFile = normalizeLockTargetPath(filePath);
+  const lockPath = normalizedFile + ".lock";
+  for (let attempt = 0; attempt <= options.retries.retries; attempt += 1) {
+    try {
+      const fd = fs.openSync(lockPath, "wx");
+      try {
+        fs.writeFileSync(
+          fd,
+          JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }, null, 2),
+          "utf8",
+        );
+      } catch (writeError) {
+        fs.closeSync(fd);
+        fs.rmSync(lockPath, { force: true });
+        throw writeError;
+      }
+      return {
+        release: () => {
+          try {
+            fs.closeSync(fd);
+          } catch {
+            // Best-effort cleanup only.
+          }
+          try {
+            fs.rmSync(lockPath, { force: true });
+          } catch {
+            // Best-effort cleanup only.
+          }
+        },
+      };
+    } catch (err) {
+      if (err?.code !== "EEXIST") throw err;
+      if (isStaleLock(lockPath, options.stale)) {
+        try {
+          fs.rmSync(lockPath, { force: true });
+        } catch {
+          // Another process may have removed it first.
+        }
+        continue;
+      }
+      if (attempt >= options.retries.retries) break;
+      sleepSync(computeLockDelayMs(options.retries, attempt));
+    }
+  }
+  throw new Error("file lock timeout for " + normalizedFile);
+}
+
+function withFileLockSync(filePath, options, run) {
+  const lock = acquireFileLockSync(filePath, options);
+  try {
+    return run();
+  } finally {
+    lock.release();
+  }
+}
+
+function resolveOAuthRefreshLockPath(provider, profileId) {
+  const hash = createHash("sha256");
+  hash.update(provider, "utf8");
+  hash.update("\\u0000", "utf8");
+  hash.update(profileId, "utf8");
+  return path.join(openclawStateDir, "locks", "oauth-refresh", "sha256-" + hash.digest("hex"));
+}
+
+function selectOpenAiCodexProfile(profilesJson, stateJson) {
+  const profiles = profilesJson?.profiles ?? {};
+  const preferredId = stateJson?.lastGood?.["openai-codex"];
+  if (
+    preferredId &&
+    profiles[preferredId]?.provider === "openai-codex" &&
+    profiles[preferredId]?.type === "oauth"
+  ) {
+    return [preferredId, profiles[preferredId]];
+  }
+  return Object.entries(profiles).find(
+    ([, profile]) => profile?.provider === "openai-codex" && profile?.type === "oauth",
+  );
+}
+
+function normalizeEmail(value) {
+  return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined;
+}
+
+function extractOpenAiCodexIdentity(accessToken) {
+  const claims = decodeJwtPayload(accessToken);
+  const authClaims = claims?.["https://api.openai.com/auth"];
+  const profileClaims = claims?.["https://api.openai.com/profile"];
+  const accountId =
+    typeof authClaims?.chatgpt_account_id === "string" ? authClaims.chatgpt_account_id : undefined;
+  if (!accountId) return undefined;
+  return {
+    accountId,
+    email: typeof profileClaims?.email === "string" ? profileClaims.email : undefined,
+    chatgptPlanType:
+      typeof authClaims?.chatgpt_plan_type === "string"
+        ? authClaims.chatgpt_plan_type
+        : undefined,
+  };
+}
+
+function codexAuthToCredential(codexAuth, existingProfile) {
+  const tokens = codexAuth?.tokens;
+  const access = tokens?.access_token;
+  const refresh = tokens?.refresh_token;
+  const tokenAccountId = tokens?.account_id;
+  if (
+    codexAuth?.auth_mode !== "chatgpt" ||
+    typeof access !== "string" ||
+    !access ||
+    typeof refresh !== "string" ||
+    !refresh ||
+    typeof tokenAccountId !== "string" ||
+    !tokenAccountId
+  ) {
+    return undefined;
+  }
+  const identity = extractOpenAiCodexIdentity(access);
+  if (!identity || identity.accountId !== tokenAccountId) return undefined;
+  const idToken = typeof tokens?.id_token === "string" && tokens.id_token ? tokens.id_token : undefined;
+  return {
+    ...existingProfile,
+    type: "oauth",
+    provider: "openai-codex",
+    access,
+    refresh,
+    expires: tokenExpirationMillis(access, Date.now() + 60 * 60 * 1000),
+    email: identity.email ?? existingProfile?.email,
+    accountId: identity.accountId,
+    chatgptPlanType: identity.chatgptPlanType ?? existingProfile?.chatgptPlanType,
+    ...(idToken ? { idToken } : {}),
+  };
+}
+
+function findProfileForCodexCredential(profilesJson, stateJson, credential) {
+  const preferred = selectOpenAiCodexProfile(profilesJson, stateJson);
+  if (preferred?.[1]?.accountId === credential.accountId) {
+    return preferred;
+  }
+  return Object.entries(profilesJson?.profiles ?? {}).find(
+    ([, profile]) =>
+      profile?.type === "oauth" &&
+      profile?.provider === "openai-codex" &&
+      profile?.accountId === credential.accountId,
+  );
+}
+
+function hasCompatibleProfileIdentity(profile, credential) {
+  if (profile?.provider !== "openai-codex" || profile?.type !== "oauth") return false;
+  if (profile.accountId && profile.accountId !== credential.accountId) return false;
+  const profileEmail = normalizeEmail(profile.email);
+  const credentialEmail = normalizeEmail(credential.email);
+  return !(profileEmail && credentialEmail && profileEmail !== credentialEmail);
+}
+
+function shouldAdoptCodexCredential(profile, credential, options = {}) {
+  if (!hasCompatibleProfileIdentity(profile, credential)) return false;
+  if (profile.access === credential.access && profile.refresh === credential.refresh) return false;
+  const profileExpires = tokenExpirationMillis(
+    profile.access,
+    Number.isFinite(profile.expires) ? profile.expires : 0,
+  );
+  if (credential.expires < profileExpires && !options.allowRefreshRotation) return false;
+  return true;
+}
+
+function adoptCodexAuthIntoOpenClaw(profilesJson, stateJson, options = {}) {
+  const codexAuth = readExistingCodexAuth();
+  const credential = codexAuthToCredential(codexAuth);
+  if (!credential) {
+    if (!options.quiet) {
+      keepExisting("no complete isolated Codex ACP web-login OAuth auth found to adopt");
+    }
+    return false;
+  }
+  const selected = findProfileForCodexCredential(profilesJson, stateJson, credential);
+  if (!selected) {
+    if (!options.quiet) {
+      keepExisting("no matching Docker OpenClaw openai-codex profile found for isolated Codex ACP auth");
+    }
+    return false;
+  }
+  const [profileId] = selected;
+  const refreshLockPath = resolveOAuthRefreshLockPath("openai-codex", profileId);
+  return withFileLockSync(refreshLockPath, oauthRefreshLockOptions, () =>
+    withFileLockSync(authProfilesPath, authStoreLockOptions, () => {
+      const lockedProfilesJson = readOptionalJson(
+        authProfilesPath,
+        "could not reread Docker OpenClaw auth profiles while adopting isolated Codex ACP auth",
+      );
+      const lockedStateJson = readOptionalJson(
+        authStatePath,
+        "ignored unreadable Docker OpenClaw auth state while adopting isolated Codex ACP auth",
+      );
+      const lockedSelected = findProfileForCodexCredential(
+        lockedProfilesJson,
+        lockedStateJson,
+        credential,
+      );
+      if (!lockedSelected || lockedSelected[0] !== profileId) return false;
+      const lockedProfile = lockedSelected[1];
+      const updatedCredential = codexAuthToCredential(codexAuth, lockedProfile);
+      if (
+        !updatedCredential ||
+        !shouldAdoptCodexCredential(lockedProfile, updatedCredential, {
+          allowRefreshRotation: options.allowRefreshRotation === true,
+        })
+      ) {
+        return false;
+      }
+      lockedProfilesJson.profiles[profileId] = updatedCredential;
+      writeJsonAtomic(authProfilesPath, lockedProfilesJson);
+      console.error(
+        "[openclaw] adopted rotated isolated Codex ACP auth into Docker OpenClaw profile " +
+          profileId,
+      );
+      return true;
+    }),
+  );
+}
+
+function ensureConfigUsesFileAuth() {
+  const existing = fs.existsSync(codexConfigPath)
+    ? fs.readFileSync(codexConfigPath, "utf8")
+    : "# Generated by OpenClaw for Codex ACP sessions.\\n";
+  if (/^\\s*cli_auth_credentials_store\\s*=\\s*"file"\\s*$/m.test(existing)) return;
+  const withoutOtherSetting = existing.replace(
+    /^\\s*cli_auth_credentials_store\\s*=.*(?:\\r?\\n)?/gm,
+    "",
+  );
+  fs.writeFileSync(
+    codexConfigPath,
+    withoutOtherSetting.trimEnd() + '\\ncli_auth_credentials_store = "file"\\n',
+    { encoding: "utf8", mode: 0o600 },
+  );
+}
+
+function keepExisting(message, profileId) {
+  ensureConfigUsesFileAuth();
+  const suffix = profileId ? " for Docker profile " + profileId : "";
+  console.error("[openclaw] " + message + suffix);
+  process.exit(0);
+}
+
+fs.mkdirSync(codexHome, { recursive: true });
+ensureConfigUsesFileAuth();
+
+if (!fs.existsSync(authProfilesPath)) {
+  keepExisting("no Docker OpenClaw openai-codex auth profile found; using existing Codex ACP auth if present");
+}
+
+let profilesJson;
+try {
+  profilesJson = readJson(authProfilesPath);
+} catch {
+  keepExisting("could not read Docker OpenClaw auth profiles; using existing Codex ACP auth if present");
+}
+let stateJson = readOptionalJson(
+  authStatePath,
+  "ignored unreadable Docker OpenClaw auth state; selecting first openai-codex profile",
+);
+
+if (adoptCodexAuth) {
+  adoptCodexAuthIntoOpenClaw(profilesJson, stateJson, { allowRefreshRotation: true });
+  process.exit(0);
+}
+
+try {
+  if (adoptCodexAuthIntoOpenClaw(profilesJson, stateJson, { quiet: true })) {
+    profilesJson = readJson(authProfilesPath);
+    stateJson = readOptionalJson(
+      authStatePath,
+      "ignored unreadable Docker OpenClaw auth state; selecting first openai-codex profile",
+    );
+  }
+} catch (err) {
+  console.error(
+    "[openclaw] could not adopt existing isolated Codex ACP auth before launch: " +
+      (err?.message ?? String(err)),
+  );
+}
+
+const selected = selectOpenAiCodexProfile(profilesJson, stateJson);
+
+if (!selected) {
+  keepExisting("no Docker OpenClaw openai-codex auth profile found; using existing Codex ACP auth if present");
+}
+
+const [profileId, profile] = selected;
+if (!profile.access || !profile.refresh || !profile.accountId) {
+  keepExisting("Docker OpenClaw openai-codex profile is incomplete; using existing Codex ACP auth if present", profileId);
+}
+
+const accessClaims = decodeJwtPayload(profile.access);
+if (!accessClaims?.["https://api.openai.com/auth"]?.chatgpt_account_id) {
+  keepExisting("Docker OpenClaw openai-codex access token is not a ChatGPT JWT; using existing Codex ACP auth if present", profileId);
+}
+
+const existingAuth = readExistingCodexAuth();
+const existingAccountId = existingAuth?.tokens?.account_id;
+const existingAccess = existingAuth?.tokens?.access_token;
+const existingRefresh = existingAuth?.tokens?.refresh_token;
+const existingAccessExp = tokenExpirationSeconds(existingAccess);
+const profileAccessExp = tokenExpirationSeconds(profile.access);
+
+if (
+  existingAuth?.auth_mode === "chatgpt" &&
+  existingAccountId === profile.accountId &&
+  typeof existingRefresh === "string" &&
+  existingRefresh &&
+  existingAccessExp >= profileAccessExp
+) {
+  keepExisting("kept existing isolated Codex ACP auth", profileId);
+}
+
+const authJson = {
+  auth_mode: "chatgpt",
+  tokens: {
+    id_token: profile.access,
+    access_token: profile.access,
+    refresh_token: profile.refresh,
+    account_id: profile.accountId,
+  },
+  last_refresh: new Date().toISOString(),
+};
+
+fs.writeFileSync(codexAuthPath, JSON.stringify(authJson, null, 2) + "\\n", {
+  encoding: "utf8",
+  mode: 0o600,
+});
+
+console.error(
+  "[openclaw] synced Docker OpenClaw auth profile " +
+    profileId +
+    " to isolated Codex ACP home",
+);
+`;
 }
 
 function buildClaudeAcpWrapperScript(installedBinPath?: string): string {
@@ -251,7 +786,7 @@ async function prepareIsolatedCodexHome(baseDir: string): Promise<string> {
   await fs.mkdir(codexHome, { recursive: true });
   await fs.writeFile(
     path.join(codexHome, "config.toml"),
-    "# Generated by OpenClaw for Codex ACP sessions.\n",
+    '# Generated by OpenClaw for Codex ACP sessions.\ncli_auth_credentials_store = "file"\n',
     "utf8",
   );
   return codexHome;
@@ -273,6 +808,14 @@ async function writeCodexAcpWrapper(baseDir: string, installedBinPath?: string):
   });
   await makeGeneratedWrapperExecutableIfPossible(wrapperPath);
   return wrapperPath;
+}
+
+async function writeCodexAuthSyncScript(baseDir: string): Promise<string> {
+  await fs.mkdir(baseDir, { recursive: true });
+  const syncPath = path.join(baseDir, "sync-codex-auth-from-openclaw.mjs");
+  await fs.writeFile(syncPath, buildCodexAuthSyncScript(), { encoding: "utf8" });
+  await makeGeneratedWrapperExecutableIfPossible(syncPath);
+  return syncPath;
 }
 
 async function writeClaudeAcpWrapper(baseDir: string, installedBinPath?: string): Promise<string> {
@@ -380,6 +923,7 @@ export async function prepareAcpxCodexAuthConfig(params: {
   void params.logger;
   const codexBaseDir = path.join(params.stateDir, "acpx");
   await prepareIsolatedCodexHome(codexBaseDir);
+  await writeCodexAuthSyncScript(codexBaseDir);
   const installedCodexBinPath = await (
     params.resolveInstalledCodexAcpBinPath ?? resolveInstalledCodexAcpBinPath
   )();


### PR DESCRIPTION
## Summary

This PR makes `@openclaw/acpx` bridge OpenClaw's existing `openai-codex` OAuth profile into the isolated `CODEX_HOME` used by Codex ACP.

`@openclaw/acpx` already creates an isolated Codex home for ACP sessions, which is the right behavior for Docker and isolated deployments. However, Codex ACP runs through Codex CLI, and Codex CLI reads authentication from its own `CODEX_HOME/auth.json`. Before this change, the isolated Codex ACP home was not provisioned from OpenClaw's existing Codex web-login OAuth profile, so Codex ACP could not use an already authorized Codex web-login account.

## Problem

OpenClaw stores Codex web-login OAuth credentials in:

```text
~/.openclaw/agents/main/agent/auth-profiles.json
```

Codex ACP uses Codex CLI, which reads auth from:

```text
$CODEX_HOME/auth.json
```

`@openclaw/acpx` sets an isolated `CODEX_HOME` for Codex ACP, but did not bridge the existing OpenClaw `openai-codex` OAuth profile into that Codex home.

As a result, Docker-isolated Codex ACP sessions could fail to authenticate even though OpenClaw already had a valid Codex web-login OAuth profile.

## Changes

- Generate `sync-codex-auth-from-openclaw.mjs` under the ACP state directory.
- Run that sync script before launching Codex ACP.
- Convert the selected OpenClaw `openai-codex` OAuth profile into Codex CLI native ChatGPT auth format.
- Preserve isolation by writing only into the ACP-owned Codex home:

```text
~/.openclaw/acpx/codex-home/auth.json
```

- Set `cli_auth_credentials_store = "file"` for the isolated Codex ACP home, so Codex CLI reads generated file auth in headless/container environments.
- Keep existing isolated Codex ACP auth when it is already present for the same account and is newer than the OpenClaw profile token.
- Do not copy or read host `~/.codex` / external `CODEX_HOME` auth.

## Real behavior proof

- Behavior or issue addressed: Docker-isolated Codex ACP should use OpenClaw's existing Codex web-login OAuth profile instead of relying on host `~/.codex` or an external `CODEX_HOME`.
- Real environment tested: Local Docker-isolated OpenClaw gateway container `openclaw_isolated_test-openclaw-gateway-1`, with `/home/node/.openclaw` mounted from the Docker state directory and Codex ACP launched through the generated OpenClaw ACP wrapper.
- Exact steps or command run after this patch: Ran Codex CLI login status inside the container with `CODEX_HOME=/home/node/.openclaw/acpx/codex-home`, then ran ACP through `acpx --agent "/usr/local/bin/node /home/node/.openclaw/acpx/codex-acp-wrapper.mjs" ... exec "Reply with exactly: ACP_OK"`.
- Evidence after fix:

```text
$ CODEX_HOME=/home/node/.openclaw/acpx/codex-home codex login status
Logged in using ChatGPT

$ acpx --agent "/usr/local/bin/node /home/node/.openclaw/acpx/codex-acp-wrapper.mjs" ... exec "Reply with exactly: ACP_OK"
codex_error_info: usage_limit_exceeded
message: usage limit exceeded / request admin / try again at May 7th, 2026 12:43 AM
```

- Observed result after fix: The isolated Codex ACP home was populated from the OpenClaw `openai-codex` OAuth profile, Codex CLI reported ChatGPT login from that isolated home, and ACP reached Codex. The final response was the expected account quota limit rather than an authentication failure.
- What was not tested: Full Vitest suite was not run locally because this checkout did not have the full workspace dependency install available; CI is expected to cover the repository-wide test matrix.

## Validation

- `git diff --check`
- `node --check extensions/acpx/src/codex-auth-bridge.ts`
- `node --check extensions/acpx/src/codex-auth-bridge.test.ts`
- Generated sync script template and verified it with `node --check` locally.
