### PR TITLE
fix: preserve empty quoted shell args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/commands: preserve empty quoted arguments when splitting shell command strings, so `""` and `''` survive command analysis and memory backend command parsing instead of being dropped.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.

--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
-import type { OpenClawConfig } from "./config-utils.js";
+import { splitShellArgs, type OpenClawConfig } from "./config-utils.js";
 
 type ResolvedMemoryBackendConfig = ReturnType<typeof resolveMemoryBackendConfig>;
 
@@ -401,6 +401,13 @@ describe("resolveMemoryBackendConfig", () => {
     const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
     expect(resolved.qmd?.searchMode).toBe("query");
     expect(resolved.qmd?.searchTool).toBe("hybrid_search");
+  });
+});
+
+describe("splitShellArgs", () => {
+  it("preserves empty quoted arguments", () => {
+    expect(splitShellArgs(`cmd "" '' tail`)).toEqual(["cmd", "", "", "tail"]);
+    expect(splitShellArgs(`cmd ""#literal`)).toEqual(["cmd", "#literal"]);
   });
 });
 

--- a/packages/memory-host-sdk/src/host/config-utils.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.ts
@@ -371,16 +371,19 @@ export function splitShellArgs(raw: string): string[] | null {
   let inSingle = false;
   let inDouble = false;
   let escaped = false;
+  let tokenStarted = false;
   const pushToken = () => {
-    if (buf.length > 0) {
+    if (tokenStarted) {
       tokens.push(buf);
       buf = "";
+      tokenStarted = false;
     }
   };
   for (let i = 0; i < raw.length; i += 1) {
     const ch = raw[i];
     if (escaped) {
       buf += ch;
+      tokenStarted = true;
       escaped = false;
       continue;
     }
@@ -393,6 +396,7 @@ export function splitShellArgs(raw: string): string[] | null {
         inSingle = false;
       } else {
         buf += ch;
+        tokenStarted = true;
       }
       continue;
     }
@@ -400,24 +404,29 @@ export function splitShellArgs(raw: string): string[] | null {
       const next = raw[i + 1];
       if (ch === "\\" && next && DOUBLE_QUOTE_ESCAPES.has(next)) {
         buf += next;
+        tokenStarted = true;
         i += 1;
       } else if (ch === '"') {
         inDouble = false;
       } else {
         buf += ch;
+        tokenStarted = true;
       }
       continue;
     }
     if (ch === "'") {
+      tokenStarted = true;
       inSingle = true;
     } else if (ch === '"') {
+      tokenStarted = true;
       inDouble = true;
-    } else if (ch === "#" && buf.length === 0) {
+    } else if (ch === "#" && !tokenStarted) {
       break;
     } else if (/\s/.test(ch)) {
       pushToken();
     } else {
       buf += ch;
+      tokenStarted = true;
     }
   }
   if (escaped || inSingle || inDouble) {

--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -10,11 +10,13 @@ export function splitShellArgs(raw: string): string[] | null {
   let inSingle = false;
   let inDouble = false;
   let escaped = false;
+  let tokenStarted = false;
 
   const pushToken = () => {
-    if (buf.length > 0) {
+    if (tokenStarted) {
       tokens.push(buf);
       buf = "";
+      tokenStarted = false;
     }
   };
 
@@ -22,6 +24,7 @@ export function splitShellArgs(raw: string): string[] | null {
     const ch = raw[i];
     if (escaped) {
       buf += ch;
+      tokenStarted = true;
       escaped = false;
       continue;
     }
@@ -34,6 +37,7 @@ export function splitShellArgs(raw: string): string[] | null {
         inSingle = false;
       } else {
         buf += ch;
+        tokenStarted = true;
       }
       continue;
     }
@@ -41,6 +45,7 @@ export function splitShellArgs(raw: string): string[] | null {
       const next = raw[i + 1];
       if (ch === "\\" && isDoubleQuoteEscape(next)) {
         buf += next;
+        tokenStarted = true;
         i += 1;
         continue;
       }
@@ -48,19 +53,22 @@ export function splitShellArgs(raw: string): string[] | null {
         inDouble = false;
       } else {
         buf += ch;
+        tokenStarted = true;
       }
       continue;
     }
     if (ch === "'") {
+      tokenStarted = true;
       inSingle = true;
       continue;
     }
     if (ch === '"') {
+      tokenStarted = true;
       inDouble = true;
       continue;
     }
     // In POSIX shells, "#" starts a comment only when it begins a word.
-    if (ch === "#" && buf.length === 0) {
+    if (ch === "#" && !tokenStarted) {
       break;
     }
     if (/\s/.test(ch)) {
@@ -68,6 +76,7 @@ export function splitShellArgs(raw: string): string[] | null {
       continue;
     }
     buf += ch;
+    tokenStarted = true;
   }
 
   if (escaped || inSingle || inDouble) {

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -52,6 +52,11 @@ describe("splitShellArgs", () => {
     expect(splitShellArgs(String.raw`echo "\$HOME"`)).toEqual(["echo", "$HOME"]);
   });
 
+  it("preserves empty quoted arguments", () => {
+    expect(splitShellArgs(`cmd "" '' tail`)).toEqual(["cmd", "", "", "tail"]);
+    expect(splitShellArgs(`cmd ""#literal`)).toEqual(["cmd", "#literal"]);
+  });
+
   it("returns null for unterminated quotes", () => {
     expect(splitShellArgs(`echo "oops`)).toBeNull();
     expect(splitShellArgs(`echo 'oops`)).toBeNull();


### PR DESCRIPTION
## Summary

- Problem: `splitShellArgs` dropped empty quoted words like `""` and `''` because it only emitted tokens with non-empty buffers.
- Why it matters: command analysis, system-run planning, and memory backend command parsing can receive shell command strings where an empty argument is meaningful.
- What changed: track whether a shell word has started separately from the token text, preserving empty quoted arguments and keeping `#` literal after an empty quoted word.
- What did NOT change (scope boundary): no shell expansion, environment interpolation, globbing, or command execution behavior changed.

AI-assisted: yes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: shell command splitting now preserves empty quoted argv entries.
- Real environment tested: macOS host, Node v25.9.0, pnpm 10.33.2 via `npx`.
- Exact steps or command run after this patch: `sh -c 'python3 -c "import sys; print(repr(sys.argv[1:]))" "" "" a'` and the targeted OpenClaw Vitest command listed below.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): shell proof printed `['', '', 'a']`; targeted tests passed with `32 passed (32)`.
- Observed result after fix: both OpenClaw shell arg parsers now return `["cmd", "", "", "tail"]` for `cmd "" '' tail` and `["cmd", "#literal"]` for `cmd ""#literal`.
- What was not tested: full local `pnpm test:changed` was stopped after it expanded into broad Vitest shards; Crabbox/Blacksmith binaries were not available in this shell for remote broad proof.
- Before evidence (optional but encouraged): `src/utils/utils-misc.test.ts` failed with `expected [ 'cmd', 'tail' ] to deeply equal [ 'cmd', '', '', 'tail' ]`; `packages/memory-host-sdk/src/host/backend-config.test.ts` failed with the same assertion.

## Root Cause (if applicable)

- Root cause: `splitShellArgs` used `buf.length > 0` to decide whether to emit a token, so quotes that began a shell word without adding characters were discarded.
- Missing detection / guardrail: no regression tests covered empty quoted shell words or comment parsing after an empty quoted word.
- Contributing context (if known): the memory host SDK carries a local copy of the parser, so it needed the same guardrail and fix.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/utils/utils-misc.test.ts`; `packages/memory-host-sdk/src/host/backend-config.test.ts`.
- Scenario the test should lock in: empty quoted arguments survive splitting, and `#` following an empty quoted word stays literal rather than starting a comment.
- Why this is the smallest reliable guardrail: this is pure parser behavior with no runtime process or gateway dependency.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Shell command strings parsed by OpenClaw command analysis and memory backend config now preserve empty quoted arguments.

## Diagram (if applicable)

```text
Before:
cmd "" '' tail -> ["cmd", "tail"]

After:
cmd "" '' tail -> ["cmd", "", "", "tail"]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v25.9.0, pnpm 10.33.2 via `npx`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `npx -y pnpm@10.33.2 test src/utils/utils-misc.test.ts -- --reporter=verbose` after adding the core regression test.
2. Run `npx -y pnpm@10.33.2 test packages/memory-host-sdk/src/host/backend-config.test.ts -- --reporter=verbose` after adding the SDK regression test.
3. Apply the parser fix.
4. Run `npx -y pnpm@10.33.2 test src/utils/utils-misc.test.ts packages/memory-host-sdk/src/host/backend-config.test.ts -- --reporter=verbose`.
5. Run `npx -y pnpm@10.33.2 check:changed`.

### Expected

- Empty quoted shell words are preserved as empty string argv entries.
- Targeted regression tests pass.

### Actual

- Before the fix, both new regression tests failed with `[ 'cmd', 'tail' ]` instead of `[ 'cmd', '', '', 'tail' ]`.
- After the fix, the targeted regression command passed: `32 passed (32)`.
- `check:changed` passed for `core`, `coreTests`, and `docs` lanes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: empty quoted args in the core parser and memory host SDK parser; `#` after an empty quoted word remains literal.
- Edge cases checked: `cmd "" '' tail`; `cmd ""#literal`; existing quote/comment tests in both touched suites.
- What you did **not** verify: full broad `pnpm test:changed`; live Gateway/system-run execution.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: callers that accidentally relied on dropped empty args will now see shell-compatible argv.
  - Mitigation: scoped parser regression tests cover existing quote/comment behavior plus the corrected empty-arg behavior.

## Verification

- `sh -c 'python3 -c "import sys; print(repr(sys.argv[1:]))" "" "" a'`
- `npx -y pnpm@10.33.2 test src/utils/utils-misc.test.ts -- --reporter=verbose` (red before fix)
- `npx -y pnpm@10.33.2 test packages/memory-host-sdk/src/host/backend-config.test.ts -- --reporter=verbose` (red before fix)
- `npx -y pnpm@10.33.2 test src/utils/utils-misc.test.ts packages/memory-host-sdk/src/host/backend-config.test.ts -- --reporter=verbose`
- `npx -y pnpm@10.33.2 exec oxfmt --check --threads=1 src/utils/shell-argv.ts src/utils/utils-misc.test.ts packages/memory-host-sdk/src/host/config-utils.ts packages/memory-host-sdk/src/host/backend-config.test.ts`
- `git diff --check`
- `npx -y pnpm@10.33.2 changed:lanes --json`
- `npx -y pnpm@10.33.2 check:changed`
