### PR TITLE
fix(status): keep default JSON scan lean

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -30,6 +30,7 @@
     "docker-compose.yml",
     "dist/",
     "docs/_layouts/",
+    "extensions/diffs/assets/viewer-runtime.js",
     "**/*.json",
     "node_modules/",
     "patches/",

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -237,8 +237,8 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
       deliver: (payload: unknown, info: { kind: "block" | "final" }) => Promise<void> | void;
       onError?: (err: unknown, info: { kind: "block" | "final" }) => void;
       transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
-      onSettled?: () => Promise<unknown> | unknown;
-      onFreshSettledDelivery?: () => Promise<unknown> | unknown;
+      onSettled?: () => unknown;
+      onFreshSettledDelivery?: () => unknown;
     };
     ctx?: unknown;
     replyOptions?: DispatchInboundParams["replyOptions"];

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -177,7 +177,10 @@ describe("sendMessage", () => {
     await settleTimers(sendMessage("https://nas.example.com/incoming", "Hello", "42abc"));
 
     const request = vi.mocked(https.request).mock.results[0]?.value as ClientRequest | undefined;
-    const body = vi.mocked(request?.write).mock.calls[0]?.[0];
+    if (!request) {
+      throw new Error("expected Synology Chat webhook request");
+    }
+    const body = vi.mocked(request.write).mock.calls[0]?.[0];
     if (typeof body !== "string") {
       throw new Error("expected Synology Chat webhook body");
     }

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -373,7 +373,9 @@ describe("TwilioProvider", () => {
 
     const event = provider.parseWebhookEvent(ctx).events[0];
     const parsed = requireEvent(event, "expected speech event from Twilio webhook");
-    expect(parsed.type).toBe("call.speech");
+    if (parsed.type !== "call.speech") {
+      throw new Error("expected speech event from Twilio webhook");
+    }
     expect(parsed.confidence).toBe(0.9);
   });
 

--- a/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
@@ -409,8 +409,8 @@ function buildDynamicModel(
               : lower === "gpt-5.4-mini"
                 ? ["gpt-5.4-mini"]
                 : lower === "gpt-5.4-nano"
-              ? ["gpt-5.4-nano", "gpt-5.4-mini"]
-              : undefined;
+                  ? ["gpt-5.4-nano", "gpt-5.4-mini"]
+                  : undefined;
       if (!templateIds) {
         return undefined;
       }

--- a/src/commands/status.scan-execute.ts
+++ b/src/commands/status.scan-execute.ts
@@ -14,6 +14,7 @@ export async function executeStatusScanFromOverview(params: {
   runtime?: RuntimeEnv;
   summary?: {
     includeChannelSummary?: boolean;
+    includeTaskSummary?: boolean;
   };
   resolveMemory: (args: {
     cfg: StatusScanOverviewResult["cfg"];
@@ -36,6 +37,7 @@ export async function executeStatusScanFromOverview(params: {
     resolveStatusSummaryFromOverview({
       overview: params.overview,
       includeChannelSummary: params.summary?.includeChannelSummary,
+      includeTaskSummary: params.summary?.includeTaskSummary,
     }),
   ]);
 

--- a/src/commands/status.scan-execute.ts
+++ b/src/commands/status.scan-execute.ts
@@ -14,7 +14,6 @@ export async function executeStatusScanFromOverview(params: {
   runtime?: RuntimeEnv;
   summary?: {
     includeChannelSummary?: boolean;
-    includeTaskSummary?: boolean;
   };
   resolveMemory: (args: {
     cfg: StatusScanOverviewResult["cfg"];
@@ -37,7 +36,6 @@ export async function executeStatusScanFromOverview(params: {
     resolveStatusSummaryFromOverview({
       overview: params.overview,
       includeChannelSummary: params.summary?.includeChannelSummary,
-      includeTaskSummary: params.summary?.includeTaskSummary,
     }),
   ]);
 

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -132,6 +132,11 @@ export async function collectStatusScanOverview(params: {
   resolveHasConfiguredChannels?: (cfg: OpenClawConfig, sourceConfig: OpenClawConfig) => boolean;
   includeChannelsData?: boolean;
   includeLiveChannelStatus?: boolean;
+  includeUpdateCheck?: boolean;
+  includeUpdateFetch?: boolean;
+  includeUpdateRegistry?: boolean;
+  includeLocalStatusRpcFallback?: boolean;
+  gatewayProbeTimeoutMs?: number;
   includeChannelSetupRuntimeFallback?: boolean;
   useGatewayCallOverridesForChannelsStatus?: boolean;
   progress?: {
@@ -185,6 +190,11 @@ export async function collectStatusScanOverview(params: {
     cfg,
     hasConfiguredChannels,
     opts: params.opts,
+    includeUpdateCheck: params.includeUpdateCheck,
+    includeUpdateFetch: params.includeUpdateFetch,
+    includeUpdateRegistry: params.includeUpdateRegistry,
+    includeLocalStatusRpcFallback: params.includeLocalStatusRpcFallback,
+    gatewayProbeTimeoutMs: params.gatewayProbeTimeoutMs,
     getTailnetHostname: async (runner) =>
       await loadStatusScanDepsRuntimeModule().then(({ getTailnetHostname }) =>
         getTailnetHostname(runner),
@@ -285,6 +295,7 @@ export async function collectStatusScanOverview(params: {
 export async function resolveStatusSummaryFromOverview(params: {
   overview: Pick<StatusScanOverviewResult, "skipColdStartNetworkChecks" | "cfg" | "sourceConfig">;
   includeChannelSummary?: boolean;
+  includeTaskSummary?: boolean;
 }) {
   if (params.overview.skipColdStartNetworkChecks) {
     return buildColdStartStatusSummary();
@@ -294,6 +305,7 @@ export async function resolveStatusSummaryFromOverview(params: {
       config: params.overview.cfg,
       sourceConfig: params.overview.sourceConfig,
       includeChannelSummary: params.includeChannelSummary,
+      includeTaskSummary: params.includeTaskSummary,
     }),
   );
 }

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -320,7 +320,6 @@ export async function collectStatusScanOverview(params: {
 export async function resolveStatusSummaryFromOverview(params: {
   overview: Pick<StatusScanOverviewResult, "skipColdStartNetworkChecks" | "cfg" | "sourceConfig">;
   includeChannelSummary?: boolean;
-  includeTaskSummary?: boolean;
 }) {
   if (params.overview.skipColdStartNetworkChecks) {
     return buildColdStartStatusSummary();
@@ -330,7 +329,6 @@ export async function resolveStatusSummaryFromOverview(params: {
       config: params.overview.cfg,
       sourceConfig: params.overview.sourceConfig,
       includeChannelSummary: params.includeChannelSummary,
-      includeTaskSummary: params.includeTaskSummary,
     }),
   );
 }

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -144,6 +144,8 @@ export async function collectStatusScanOverview(params: {
   ) => boolean | Promise<boolean>;
   includeChannelsData?: boolean;
   includeLiveChannelStatus?: boolean;
+  includeLocalStatusRpcFallback?: boolean;
+  gatewayProbeTimeoutMs?: number;
   includeChannelSetupRuntimeFallback?: boolean;
   channelCredentialResolutionSkipped?: boolean;
   useGatewayCallOverridesForChannelsStatus?: boolean;
@@ -213,6 +215,8 @@ export async function collectStatusScanOverview(params: {
     skipUpdateCheck: params.skipUpdateCheck,
     fetchGitUpdate: params.fetchGitUpdate,
     includeRegistryUpdate: params.includeRegistryUpdate,
+    includeLocalStatusRpcFallback: params.includeLocalStatusRpcFallback,
+    gatewayProbeTimeoutMs: params.gatewayProbeTimeoutMs,
     getTailnetHostname: async (runner) =>
       await loadStatusScanDepsRuntimeModule().then(({ getTailnetHostname }) =>
         getTailnetHostname(runner),
@@ -316,6 +320,7 @@ export async function collectStatusScanOverview(params: {
 export async function resolveStatusSummaryFromOverview(params: {
   overview: Pick<StatusScanOverviewResult, "skipColdStartNetworkChecks" | "cfg" | "sourceConfig">;
   includeChannelSummary?: boolean;
+  includeTaskSummary?: boolean;
 }) {
   if (params.overview.skipColdStartNetworkChecks) {
     return buildColdStartStatusSummary();
@@ -325,6 +330,7 @@ export async function resolveStatusSummaryFromOverview(params: {
       config: params.overview.cfg,
       sourceConfig: params.overview.sourceConfig,
       includeChannelSummary: params.includeChannelSummary,
+      includeTaskSummary: params.includeTaskSummary,
     }),
   );
 }

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -13,6 +13,8 @@ import {
 import { loadStatusScanCommandConfig } from "./status.scan.config-shared.js";
 import type { GatewayProbeSnapshot } from "./status.scan.shared.js";
 
+type StatusGatewayProbeTimeoutResolver = (cfg: OpenClawConfig) => number | undefined;
+
 const statusScanDepsRuntimeModuleLoader = createLazyImportLoader(
   () => import("./status.scan.deps.runtime.js"),
 );
@@ -145,7 +147,7 @@ export async function collectStatusScanOverview(params: {
   includeChannelsData?: boolean;
   includeLiveChannelStatus?: boolean;
   includeLocalStatusRpcFallback?: boolean;
-  gatewayProbeTimeoutMs?: number;
+  gatewayProbeTimeoutMs?: number | StatusGatewayProbeTimeoutResolver;
   includeChannelSetupRuntimeFallback?: boolean;
   channelCredentialResolutionSkipped?: boolean;
   useGatewayCallOverridesForChannelsStatus?: boolean;
@@ -205,6 +207,10 @@ export async function collectStatusScanOverview(params: {
         }),
       );
   const osSummary = resolveOsSummary();
+  const gatewayProbeTimeoutMs =
+    typeof params.gatewayProbeTimeoutMs === "function"
+      ? params.gatewayProbeTimeoutMs(cfg)
+      : params.gatewayProbeTimeoutMs;
   const bootstrap = await createStatusScanCoreBootstrap<
     Awaited<ReturnType<typeof getAgentLocalStatusesFn>>
   >({
@@ -216,7 +222,7 @@ export async function collectStatusScanOverview(params: {
     fetchGitUpdate: params.fetchGitUpdate,
     includeRegistryUpdate: params.includeRegistryUpdate,
     includeLocalStatusRpcFallback: params.includeLocalStatusRpcFallback,
-    gatewayProbeTimeoutMs: params.gatewayProbeTimeoutMs,
+    gatewayProbeTimeoutMs,
     getTailnetHostname: async (runner) =>
       await loadStatusScanDepsRuntimeModule().then(({ getTailnetHostname }) =>
         getTailnetHostname(runner),

--- a/src/commands/status.scan.bootstrap-shared.ts
+++ b/src/commands/status.scan.bootstrap-shared.ts
@@ -62,6 +62,11 @@ type StatusScanCoreBootstrapParams<TAgentStatus> = {
   cfg: OpenClawConfig;
   hasConfiguredChannels: boolean;
   opts: { timeoutMs?: number; all?: boolean };
+  includeUpdateCheck?: boolean;
+  includeUpdateFetch?: boolean;
+  includeUpdateRegistry?: boolean;
+  includeLocalStatusRpcFallback?: boolean;
+  gatewayProbeTimeoutMs?: number;
   getTailnetHostname: (runner: StatusScanExecRunner) => Promise<string | null>;
   getUpdateCheckResult: (params: {
     timeoutMs: number;
@@ -81,23 +86,26 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
     hasConfiguredChannels: params.hasConfiguredChannels,
     all: params.opts.all,
   });
-  const updateTimeoutMs = params.opts.all ? 6500 : 2500;
+  const statusTimeoutMs = params.opts.timeoutMs ?? 10_000;
+  const updateTimeoutMs = Math.min(params.opts.all ? 6500 : 2500, statusTimeoutMs);
+  const tailscaleTimeoutMs = Math.min(1200, statusTimeoutMs);
   const tailscaleDnsPromise =
     tailscaleMode === "off"
       ? Promise.resolve<string | null>(null)
       : params
           .getTailnetHostname((cmd, args) =>
-            runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
+            runExec(cmd, args, { timeoutMs: tailscaleTimeoutMs, maxBuffer: 200_000 }),
           )
           .catch(() => null);
-  const updatePromise = skipColdStartNetworkChecks
-    ? Promise.resolve(buildColdStartUpdateResult())
-    : params.getUpdateCheckResult({
-        timeoutMs: updateTimeoutMs,
-        fetchGit: true,
-        includeRegistry: true,
-        updateConfigChannel: params.cfg.update?.channel ?? null,
-      });
+  const updatePromise =
+    skipColdStartNetworkChecks || params.includeUpdateCheck === false
+      ? Promise.resolve(buildColdStartUpdateResult())
+      : params.getUpdateCheckResult({
+          timeoutMs: updateTimeoutMs,
+          fetchGit: params.includeUpdateFetch !== false,
+          includeRegistry: params.includeUpdateRegistry !== false,
+          updateConfigChannel: params.cfg.update?.channel ?? null,
+        });
   const agentStatusPromise = skipColdStartNetworkChecks
     ? Promise.resolve(buildColdStartAgentLocalStatuses() as TAgentStatus)
     : params.getAgentLocalStatuses(params.cfg);
@@ -105,7 +113,11 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
     cfg: params.cfg,
     opts: {
       ...params.opts,
+      ...(params.gatewayProbeTimeoutMs !== undefined
+        ? { timeoutMs: params.gatewayProbeTimeoutMs }
+        : {}),
       ...(skipColdStartNetworkChecks ? { skipProbe: true } : {}),
+      localStatusRpcFallback: params.includeLocalStatusRpcFallback !== false,
     },
   });
 

--- a/src/commands/status.scan.bootstrap-shared.ts
+++ b/src/commands/status.scan.bootstrap-shared.ts
@@ -65,6 +65,8 @@ type StatusScanCoreBootstrapParams<TAgentStatus> = {
   skipUpdateCheck?: boolean;
   fetchGitUpdate?: boolean;
   includeRegistryUpdate?: boolean;
+  includeLocalStatusRpcFallback?: boolean;
+  gatewayProbeTimeoutMs?: number;
   getTailnetHostname: (runner: StatusScanExecRunner) => Promise<string | null>;
   getUpdateCheckResult: (params: {
     timeoutMs: number;
@@ -84,13 +86,15 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
     hasConfiguredChannels: params.hasConfiguredChannels,
     all: params.opts.all,
   });
-  const updateTimeoutMs = params.opts.all ? 6500 : 2500;
+  const statusTimeoutMs = params.opts.timeoutMs ?? 10_000;
+  const updateTimeoutMs = Math.min(params.opts.all ? 6500 : 2500, statusTimeoutMs);
+  const tailscaleTimeoutMs = Math.min(1200, statusTimeoutMs);
   const tailscaleDnsPromise =
     tailscaleMode === "off"
       ? Promise.resolve<string | null>(null)
       : params
           .getTailnetHostname((cmd, args) =>
-            runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
+            runExec(cmd, args, { timeoutMs: tailscaleTimeoutMs, maxBuffer: 200_000 }),
           )
           .catch(() => null);
   const skipNetworkUpdate = skipColdStartNetworkChecks || params.skipUpdateCheck === true;
@@ -109,7 +113,11 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
     cfg: params.cfg,
     opts: {
       ...params.opts,
+      ...(params.gatewayProbeTimeoutMs !== undefined
+        ? { timeoutMs: params.gatewayProbeTimeoutMs }
+        : {}),
       ...(skipColdStartNetworkChecks ? { skipProbe: true } : {}),
+      localStatusRpcFallback: params.includeLocalStatusRpcFallback !== false,
     },
   });
 

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -11,6 +11,7 @@ import {
 
 const mocks = {
   ...createStatusScanSharedMocks("status-fast-json"),
+  callGateway: vi.fn(),
   getStatusCommandSecretTargetIds: vi.fn(() => []),
   resolveMemorySearchConfig: vi.fn(),
 };
@@ -98,13 +99,59 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
   });
 
+  it("keeps update checks off the default fast JSON path", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+
+    await scanStatusJsonFast({ timeoutMs: 1234 }, {} as never);
+
+    expect(mocks.getUpdateCheckResult).not.toHaveBeenCalled();
+  });
+
+  it("restores registry-backed update checks and remote git fetches when --all is requested", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+
+    await scanStatusJsonFast({ all: true }, {} as never);
+
+    expect(mocks.getUpdateCheckResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 6500,
+        fetchGit: true,
+        includeRegistry: true,
+      }),
+    );
+  });
+
+  it("keeps the local status RPC fallback off the default fast JSON path", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+    mocks.callGateway.mockResolvedValue({ sessions: 1 });
+
+    await scanStatusJsonFast({}, {} as never);
+
+    expect(mocks.probeGateway).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 1000 }));
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("restores the local status RPC fallback when --all is requested", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+    mocks.callGateway.mockResolvedValue({ sessions: 1 });
+
+    await scanStatusJsonFast({ all: true }, {} as never);
+
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "status",
+        timeoutMs: 2000,
+      }),
+    );
+  });
+
   it("keeps the fast JSON summary off the channel plugin summary path", async () => {
     mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
 
     await scanStatusJsonFast({}, {} as never);
 
     expect(mocks.getStatusSummary).toHaveBeenCalledWith(
-      expect.objectContaining({ includeChannelSummary: false }),
+      expect.objectContaining({ includeChannelSummary: false, includeTaskSummary: false }),
     );
   });
 

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -11,6 +11,7 @@ import {
 
 const mocks = {
   ...createStatusScanSharedMocks("status-fast-json"),
+  callGateway: vi.fn(),
   getStatusCommandSecretTargetIds: vi.fn(() => []),
   resolveMemorySearchConfig: vi.fn(),
 };
@@ -112,6 +113,52 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
   });
 
+  it("keeps update checks off the default fast JSON path", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+
+    await scanStatusJsonFast({ timeoutMs: 1234 }, {} as never);
+
+    expect(mocks.getUpdateCheckResult).not.toHaveBeenCalled();
+  });
+
+  it("restores registry-backed update checks and remote git fetches when --all is requested", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+
+    await scanStatusJsonFast({ all: true }, {} as never);
+
+    expect(mocks.getUpdateCheckResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 6500,
+        fetchGit: true,
+        includeRegistry: true,
+      }),
+    );
+  });
+
+  it("keeps the local status RPC fallback off the default fast JSON path", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+    mocks.callGateway.mockResolvedValue({ sessions: 1 });
+
+    await scanStatusJsonFast({}, {} as never);
+
+    expect(mocks.probeGateway).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 1000 }));
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("restores the local status RPC fallback when --all is requested", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+    mocks.callGateway.mockResolvedValue({ sessions: 1 });
+
+    await scanStatusJsonFast({ all: true }, {} as never);
+
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "status",
+        timeoutMs: 2000,
+      }),
+    );
+  });
+
   it("keeps the fast JSON summary off the channel plugin summary path", async () => {
     mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
 
@@ -120,8 +167,10 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.getStatusSummary).toHaveBeenCalledOnce();
     const summaryOptions = firstCallArg(mocks.getStatusSummary, "status summary options") as {
       includeChannelSummary?: unknown;
+      includeTaskSummary?: unknown;
     };
     expect(summaryOptions.includeChannelSummary).toBe(false);
+    expect(summaryOptions.includeTaskSummary).toBe(false);
   });
 
   it("skips memory inspection for the lean status --json fast path", async () => {

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -153,6 +153,25 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.probeGateway).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 5000 }));
   });
 
+  it("keeps configured gateway handshake timeouts on the lean JSON path", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+    applyStatusScanDefaults(mocks, {
+      resolvedConfig: {
+        ...createStatusMemorySearchConfig(),
+        gateway: { handshakeTimeoutMs: 30_000 },
+      } as never,
+    });
+
+    await scanStatusJsonFast({}, {} as never);
+
+    expect(mocks.probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preauthHandshakeTimeoutMs: 30_000,
+        timeoutMs: 30_000,
+      }),
+    );
+  });
+
   it("restores the local status RPC fallback when --all is requested", async () => {
     mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
     mocks.callGateway.mockResolvedValue({ sessions: 1 });

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -167,10 +167,8 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.getStatusSummary).toHaveBeenCalledOnce();
     const summaryOptions = firstCallArg(mocks.getStatusSummary, "status summary options") as {
       includeChannelSummary?: unknown;
-      includeTaskSummary?: unknown;
     };
     expect(summaryOptions.includeChannelSummary).toBe(false);
-    expect(summaryOptions.includeTaskSummary).toBe(false);
   });
 
   it("skips memory inspection for the lean status --json fast path", async () => {

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -220,7 +220,7 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.probeGateway).not.toHaveBeenCalled();
   });
 
-  it("keeps cold-start probes when a channel is configured from manifest env vars", async () => {
+  it("keeps cold-start gateway probes but skips update checks when a channel is configured from manifest env vars", async () => {
     await withTemporaryEnv(
       {
         OPENCLAW_TWITCH_ACCESS_TOKEN: "token",
@@ -233,7 +233,7 @@ describe("scanStatusJsonFast", () => {
       },
     );
 
-    expect(mocks.getUpdateCheckResult).toHaveBeenCalled();
+    expect(mocks.getUpdateCheckResult).not.toHaveBeenCalled();
     expect(mocks.probeGateway).toHaveBeenCalled();
   });
 });

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -113,12 +113,18 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
   });
 
-  it("keeps update checks off the default fast JSON path", async () => {
+  it("keeps default fast JSON update scans local-only", async () => {
     mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
 
     await scanStatusJsonFast({ timeoutMs: 1234 }, {} as never);
 
-    expect(mocks.getUpdateCheckResult).not.toHaveBeenCalled();
+    expect(mocks.getUpdateCheckResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 1234,
+        fetchGit: false,
+        includeRegistry: false,
+      }),
+    );
   });
 
   it("restores registry-backed update checks and remote git fetches when --all is requested", async () => {
@@ -245,7 +251,7 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.probeGateway).not.toHaveBeenCalled();
   });
 
-  it("keeps cold-start gateway probes but skips update checks when a channel is configured from manifest env vars", async () => {
+  it("keeps cold-start gateway probes with local-only updates when a channel is configured from manifest env vars", async () => {
     await withTemporaryEnv(
       {
         OPENCLAW_TWITCH_ACCESS_TOKEN: "token",
@@ -258,7 +264,12 @@ describe("scanStatusJsonFast", () => {
       },
     );
 
-    expect(mocks.getUpdateCheckResult).not.toHaveBeenCalled();
+    expect(mocks.getUpdateCheckResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchGit: false,
+        includeRegistry: false,
+      }),
+    );
     expect(mocks.probeGateway).toHaveBeenCalled();
   });
 });

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -145,6 +145,14 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.callGateway).not.toHaveBeenCalled();
   });
 
+  it("honors explicit gateway probe timeouts on the lean JSON path", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+
+    await scanStatusJsonFast({ timeoutMs: 5000 }, {} as never);
+
+    expect(mocks.probeGateway).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 5000 }));
+  });
+
   it("restores the local status RPC fallback when --all is requested", async () => {
     mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
     mocks.callGateway.mockResolvedValue({ sessions: 1 });

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -13,6 +13,12 @@ type StatusJsonScanPolicy = {
   commandName: string;
   allowMissingConfigFastPath?: boolean;
   includeChannelSummary?: boolean;
+  includeTaskSummary?: boolean;
+  includeUpdateCheck?: boolean;
+  includeUpdateFetch?: boolean;
+  includeUpdateRegistry?: boolean;
+  includeLocalStatusRpcFallback?: boolean;
+  gatewayProbeTimeoutMs?: number;
   resolveHasConfiguredChannels: (cfg: OpenClawConfig, sourceConfig: OpenClawConfig) => boolean;
   resolveMemory: Parameters<typeof executeStatusScanFromOverview>[0]["resolveMemory"];
 };
@@ -33,12 +39,18 @@ export async function scanStatusJsonWithPolicy(
     allowMissingConfigFastPath: policy.allowMissingConfigFastPath,
     resolveHasConfiguredChannels: policy.resolveHasConfiguredChannels,
     includeChannelsData: false,
+    includeUpdateCheck: policy.includeUpdateCheck,
+    includeUpdateFetch: policy.includeUpdateFetch,
+    includeUpdateRegistry: policy.includeUpdateRegistry,
+    includeLocalStatusRpcFallback: policy.includeLocalStatusRpcFallback,
+    gatewayProbeTimeoutMs: policy.gatewayProbeTimeoutMs,
   });
   return await executeStatusScanFromOverview({
     overview,
     runtime,
     summary: {
       includeChannelSummary: policy.includeChannelSummary,
+      includeTaskSummary: policy.includeTaskSummary,
     },
     resolveMemory: policy.resolveMemory,
     channelIssues: [],
@@ -58,6 +70,12 @@ export async function scanStatusJsonFast(
     commandName: "status --json",
     allowMissingConfigFastPath: true,
     includeChannelSummary: false,
+    includeTaskSummary: opts.all === true,
+    includeUpdateCheck: opts.all === true,
+    includeUpdateFetch: opts.all === true,
+    includeUpdateRegistry: opts.all === true,
+    includeLocalStatusRpcFallback: opts.all === true,
+    gatewayProbeTimeoutMs: opts.all === true ? undefined : Math.min(1000, opts.timeoutMs ?? 1000),
     resolveHasConfiguredChannels: (cfg, sourceConfig) =>
       hasConfiguredChannelsForReadOnlyScope({
         config: cfg,

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -24,6 +24,12 @@ type StatusJsonScanPolicy = {
   commandName: string;
   allowMissingConfigFastPath?: boolean;
   includeChannelSummary?: boolean;
+  includeTaskSummary?: boolean;
+  skipUpdateCheck?: boolean;
+  fetchGitUpdate?: boolean;
+  includeRegistryUpdate?: boolean;
+  includeLocalStatusRpcFallback?: boolean;
+  gatewayProbeTimeoutMs?: number;
   resolveHasConfiguredChannels: (
     cfg: OpenClawConfig,
     sourceConfig: OpenClawConfig,
@@ -90,12 +96,18 @@ export async function scanStatusJsonWithPolicy(
     includeChannelsData: false,
     includeChannelSecretTargets: false,
     skipConfigPluginValidation: true,
+    skipUpdateCheck: policy.skipUpdateCheck,
+    fetchGitUpdate: policy.fetchGitUpdate,
+    includeRegistryUpdate: policy.includeRegistryUpdate,
+    includeLocalStatusRpcFallback: policy.includeLocalStatusRpcFallback,
+    gatewayProbeTimeoutMs: policy.gatewayProbeTimeoutMs,
   });
   return await executeStatusScanFromOverview({
     overview,
     runtime,
     summary: {
       includeChannelSummary: policy.includeChannelSummary,
+      includeTaskSummary: policy.includeTaskSummary,
     },
     resolveMemory: policy.resolveMemory,
     channelIssues: [],
@@ -115,6 +127,12 @@ export async function scanStatusJsonFast(
     commandName: "status --json",
     allowMissingConfigFastPath: true,
     includeChannelSummary: false,
+    includeTaskSummary: opts.all === true,
+    skipUpdateCheck: opts.all !== true,
+    fetchGitUpdate: opts.all === true,
+    includeRegistryUpdate: opts.all === true,
+    includeLocalStatusRpcFallback: opts.all === true,
+    gatewayProbeTimeoutMs: opts.all === true ? undefined : Math.min(1000, opts.timeoutMs ?? 1000),
     resolveHasConfiguredChannels: (cfg) => hasPotentialConfiguredChannelsForStatusJson(cfg),
     resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) =>
       opts.all

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -28,7 +28,7 @@ type StatusJsonScanPolicy = {
   fetchGitUpdate?: boolean;
   includeRegistryUpdate?: boolean;
   includeLocalStatusRpcFallback?: boolean;
-  gatewayProbeTimeoutMs?: number;
+  gatewayProbeTimeoutMs?: number | ((cfg: OpenClawConfig) => number | undefined);
   resolveHasConfiguredChannels: (
     cfg: OpenClawConfig,
     sourceConfig: OpenClawConfig,
@@ -129,7 +129,10 @@ export async function scanStatusJsonFast(
     fetchGitUpdate: opts.all === true,
     includeRegistryUpdate: opts.all === true,
     includeLocalStatusRpcFallback: opts.all === true,
-    gatewayProbeTimeoutMs: opts.all === true ? undefined : (opts.timeoutMs ?? 1000),
+    gatewayProbeTimeoutMs:
+      opts.all === true
+        ? undefined
+        : (cfg) => opts.timeoutMs ?? Math.max(1000, cfg.gateway?.handshakeTimeoutMs ?? 0),
     resolveHasConfiguredChannels: (cfg) => hasPotentialConfiguredChannelsForStatusJson(cfg),
     resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) =>
       opts.all

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -24,7 +24,6 @@ type StatusJsonScanPolicy = {
   commandName: string;
   allowMissingConfigFastPath?: boolean;
   includeChannelSummary?: boolean;
-  includeTaskSummary?: boolean;
   skipUpdateCheck?: boolean;
   fetchGitUpdate?: boolean;
   includeRegistryUpdate?: boolean;
@@ -107,7 +106,6 @@ export async function scanStatusJsonWithPolicy(
     runtime,
     summary: {
       includeChannelSummary: policy.includeChannelSummary,
-      includeTaskSummary: policy.includeTaskSummary,
     },
     resolveMemory: policy.resolveMemory,
     channelIssues: [],
@@ -127,7 +125,6 @@ export async function scanStatusJsonFast(
     commandName: "status --json",
     allowMissingConfigFastPath: true,
     includeChannelSummary: false,
-    includeTaskSummary: opts.all === true,
     skipUpdateCheck: opts.all !== true,
     fetchGitUpdate: opts.all === true,
     includeRegistryUpdate: opts.all === true,

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -129,7 +129,7 @@ export async function scanStatusJsonFast(
     fetchGitUpdate: opts.all === true,
     includeRegistryUpdate: opts.all === true,
     includeLocalStatusRpcFallback: opts.all === true,
-    gatewayProbeTimeoutMs: opts.all === true ? undefined : Math.min(1000, opts.timeoutMs ?? 1000),
+    gatewayProbeTimeoutMs: opts.all === true ? undefined : (opts.timeoutMs ?? 1000),
     resolveHasConfiguredChannels: (cfg) => hasPotentialConfiguredChannelsForStatusJson(cfg),
     resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) =>
       opts.all

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -24,7 +24,6 @@ type StatusJsonScanPolicy = {
   commandName: string;
   allowMissingConfigFastPath?: boolean;
   includeChannelSummary?: boolean;
-  skipUpdateCheck?: boolean;
   fetchGitUpdate?: boolean;
   includeRegistryUpdate?: boolean;
   includeLocalStatusRpcFallback?: boolean;
@@ -95,7 +94,6 @@ export async function scanStatusJsonWithPolicy(
     includeChannelsData: false,
     includeChannelSecretTargets: false,
     skipConfigPluginValidation: true,
-    skipUpdateCheck: policy.skipUpdateCheck,
     fetchGitUpdate: policy.fetchGitUpdate,
     includeRegistryUpdate: policy.includeRegistryUpdate,
     includeLocalStatusRpcFallback: policy.includeLocalStatusRpcFallback,
@@ -125,7 +123,6 @@ export async function scanStatusJsonFast(
     commandName: "status --json",
     allowMissingConfigFastPath: true,
     includeChannelSummary: false,
-    skipUpdateCheck: opts.all !== true,
     fetchGitUpdate: opts.all === true,
     includeRegistryUpdate: opts.all === true,
     includeLocalStatusRpcFallback: opts.all === true,

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -120,7 +120,11 @@ async function applyLocalStatusRpcFallback(params: {
   };
   timeoutMs: number;
   timeoutMsExplicit: boolean;
+  enabled?: boolean;
 }): Promise<GatewayProbeResult | null> {
+  if (params.enabled === false) {
+    return params.gatewayProbe;
+  }
   if (!shouldTryLocalStatusRpcFallback(params)) {
     return params.gatewayProbe;
   }
@@ -148,13 +152,17 @@ async function applyLocalStatusRpcFallback(params: {
     ...params.gatewayProbe,
     ok: true,
     status,
-    auth:
-      auth.capability === "unknown"
-        ? {
-            ...auth,
-            capability: "read_only",
-          }
-        : auth,
+    ...(auth
+      ? {
+          auth:
+            auth.capability === "unknown"
+              ? {
+                  ...auth,
+                  capability: "read_only",
+                }
+              : auth,
+        }
+      : {}),
   };
 }
 
@@ -193,6 +201,7 @@ export async function resolveGatewayProbeSnapshot(params: {
     probeWhenRemoteUrlMissing?: boolean;
     resolveAuthWhenRemoteUrlMissing?: boolean;
     mergeAuthWarningIntoProbeError?: boolean;
+    localStatusRpcFallback?: boolean;
   };
 }): Promise<GatewayProbeSnapshot> {
   const gatewayConnection = buildGatewayConnectionDetailsWithResolvers({ config: params.cfg });
@@ -236,6 +245,7 @@ export async function resolveGatewayProbeSnapshot(params: {
     gatewayProbeAuth: gatewayProbeAuthResolution.auth,
     timeoutMs: probeTimeoutMs,
     timeoutMsExplicit,
+    enabled: params.opts.localStatusRpcFallback !== false,
   });
   if (
     (params.opts.mergeAuthWarningIntoProbeError ?? true) &&

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -4,6 +4,41 @@ const statusSummaryMocks = vi.hoisted(() => ({
   hasConfiguredChannelsForReadOnlyScope: vi.fn(() => true),
   buildChannelSummary: vi.fn(async () => ["ok"]),
   readSessionStoreReadOnly: vi.fn(() => ({})),
+  configureTaskRegistryMaintenance: vi.fn(),
+  getInspectableTaskRegistrySummary: vi.fn(() => ({
+    total: 0,
+    active: 0,
+    terminal: 0,
+    failures: 0,
+    byStatus: {
+      queued: 0,
+      running: 0,
+      succeeded: 0,
+      failed: 0,
+      timed_out: 0,
+      cancelled: 0,
+      lost: 0,
+    },
+    byRuntime: {
+      subagent: 0,
+      acp: 0,
+      cli: 0,
+      cron: 0,
+    },
+  })),
+  getInspectableTaskAuditSummary: vi.fn(() => ({
+    total: 1,
+    warnings: 1,
+    errors: 0,
+    byCode: {
+      stale_queued: 0,
+      stale_running: 0,
+      lost: 0,
+      delivery_failed: 1,
+      missing_cleanup: 0,
+      inconsistent_timestamps: 0,
+    },
+  })),
 }));
 
 vi.mock("../plugins/channel-plugin-ids.js", () => ({
@@ -72,41 +107,9 @@ vi.mock("../infra/system-events.js", () => ({
 }));
 
 vi.mock("../tasks/task-registry.maintenance.js", () => ({
-  configureTaskRegistryMaintenance: vi.fn(),
-  getInspectableTaskRegistrySummary: vi.fn(() => ({
-    total: 0,
-    active: 0,
-    terminal: 0,
-    failures: 0,
-    byStatus: {
-      queued: 0,
-      running: 0,
-      succeeded: 0,
-      failed: 0,
-      timed_out: 0,
-      cancelled: 0,
-      lost: 0,
-    },
-    byRuntime: {
-      subagent: 0,
-      acp: 0,
-      cli: 0,
-      cron: 0,
-    },
-  })),
-  getInspectableTaskAuditSummary: vi.fn(() => ({
-    total: 1,
-    warnings: 1,
-    errors: 0,
-    byCode: {
-      stale_queued: 0,
-      stale_running: 0,
-      lost: 0,
-      delivery_failed: 1,
-      missing_cleanup: 0,
-      inconsistent_timestamps: 0,
-    },
-  })),
+  configureTaskRegistryMaintenance: statusSummaryMocks.configureTaskRegistryMaintenance,
+  getInspectableTaskRegistrySummary: statusSummaryMocks.getInspectableTaskRegistrySummary,
+  getInspectableTaskAuditSummary: statusSummaryMocks.getInspectableTaskAuditSummary,
 }));
 
 vi.mock("../routing/session-key.js", () => ({
@@ -177,6 +180,16 @@ describe("getStatusSummary", () => {
     expect(statusSummaryMocks.hasConfiguredChannelsForReadOnlyScope).not.toHaveBeenCalled();
     expect(buildChannelSummary).not.toHaveBeenCalled();
     expect(resolveLinkChannelContext).not.toHaveBeenCalled();
+  });
+
+  it("skips task registry maintenance when task summary is explicitly disabled", async () => {
+    const summary = await getStatusSummary({ includeTaskSummary: false });
+
+    expect(summary.tasks.total).toBe(0);
+    expect(summary.taskAudit.total).toBe(0);
+    expect(statusSummaryMocks.configureTaskRegistryMaintenance).not.toHaveBeenCalled();
+    expect(statusSummaryMocks.getInspectableTaskRegistrySummary).not.toHaveBeenCalled();
+    expect(statusSummaryMocks.getInspectableTaskAuditSummary).not.toHaveBeenCalled();
   });
 
   it("does not trigger async context warmup while building status summaries", async () => {

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -289,16 +289,6 @@ describe("getStatusSummary", () => {
     expect(resolveLinkChannelContext).not.toHaveBeenCalled();
   });
 
-  it("skips task registry maintenance when task summary is explicitly disabled", async () => {
-    const summary = await getStatusSummary({ includeTaskSummary: false });
-
-    expect(summary.tasks.total).toBe(0);
-    expect(summary.taskAudit.total).toBe(0);
-    expect(statusSummaryMocks.configureTaskRegistryMaintenance).not.toHaveBeenCalled();
-    expect(statusSummaryMocks.getInspectableTaskRegistrySummary).not.toHaveBeenCalled();
-    expect(statusSummaryMocks.getInspectableTaskAuditFindings).not.toHaveBeenCalled();
-  });
-
   it("does not trigger async context warmup while building status summaries", async () => {
     await getStatusSummary();
 

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -6,6 +6,7 @@ const statusSummaryMocks = vi.hoisted(() => ({
   hasConfiguredChannelsForReadOnlyScope: vi.fn(() => true),
   buildChannelSummary: vi.fn(async () => ["ok"]),
   readSessionStoreReadOnly: vi.fn(() => ({})),
+  configureTaskRegistryMaintenance: vi.fn(),
   taskRegistrySummary: {
     total: 0,
     active: 0,
@@ -27,6 +28,7 @@ const statusSummaryMocks = vi.hoisted(() => ({
       cron: 0,
     },
   } as TaskRegistrySummary,
+  getInspectableTaskRegistrySummary: vi.fn(() => statusSummaryMocks.taskRegistrySummary),
   taskAuditFindings: [
     {
       severity: "warn",
@@ -46,6 +48,7 @@ const statusSummaryMocks = vi.hoisted(() => ({
       },
     },
   ] as TaskAuditFinding[],
+  getInspectableTaskAuditFindings: vi.fn(() => statusSummaryMocks.taskAuditFindings),
 }));
 
 vi.mock("../plugins/channel-plugin-ids.js", () => ({
@@ -114,22 +117,9 @@ vi.mock("../infra/system-events.js", () => ({
 }));
 
 vi.mock("../tasks/task-registry.maintenance.js", () => ({
-  configureTaskRegistryMaintenance: vi.fn(),
-  getInspectableTaskRegistrySummary: vi.fn(() => statusSummaryMocks.taskRegistrySummary),
-  getInspectableTaskAuditSummary: vi.fn(() => ({
-    total: 1,
-    warnings: 1,
-    errors: 0,
-    byCode: {
-      stale_queued: 0,
-      stale_running: 0,
-      lost: 0,
-      delivery_failed: 1,
-      missing_cleanup: 0,
-      inconsistent_timestamps: 0,
-    },
-  })),
-  getInspectableTaskAuditFindings: vi.fn(() => statusSummaryMocks.taskAuditFindings),
+  configureTaskRegistryMaintenance: statusSummaryMocks.configureTaskRegistryMaintenance,
+  getInspectableTaskRegistrySummary: statusSummaryMocks.getInspectableTaskRegistrySummary,
+  getInspectableTaskAuditFindings: statusSummaryMocks.getInspectableTaskAuditFindings,
 }));
 
 vi.mock("../routing/session-key.js", () => ({
@@ -297,6 +287,16 @@ describe("getStatusSummary", () => {
     expect(statusSummaryMocks.hasConfiguredChannelsForReadOnlyScope).not.toHaveBeenCalled();
     expect(buildChannelSummary).not.toHaveBeenCalled();
     expect(resolveLinkChannelContext).not.toHaveBeenCalled();
+  });
+
+  it("skips task registry maintenance when task summary is explicitly disabled", async () => {
+    const summary = await getStatusSummary({ includeTaskSummary: false });
+
+    expect(summary.tasks.total).toBe(0);
+    expect(summary.taskAudit.total).toBe(0);
+    expect(statusSummaryMocks.configureTaskRegistryMaintenance).not.toHaveBeenCalled();
+    expect(statusSummaryMocks.getInspectableTaskRegistrySummary).not.toHaveBeenCalled();
+    expect(statusSummaryMocks.getInspectableTaskAuditFindings).not.toHaveBeenCalled();
   });
 
   it("does not trigger async context warmup while building status summaries", async () => {

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -13,6 +13,8 @@ import { hasConfiguredChannelsForReadOnlyScope } from "../plugins/channel-plugin
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
+import { createEmptyTaskAuditSummary } from "../tasks/task-registry.audit.shared.js";
+import { createEmptyTaskRegistrySummary } from "../tasks/task-registry.summary.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import type { HeartbeatStatus, SessionStatus, StatusSummary } from "./status.types.js";
 
@@ -102,11 +104,16 @@ export async function getStatusSummary(
   options: {
     includeSensitive?: boolean;
     includeChannelSummary?: boolean;
+    includeTaskSummary?: boolean;
     config?: OpenClawConfig;
     sourceConfig?: OpenClawConfig;
   } = {},
 ): Promise<StatusSummary> {
-  const { includeSensitive = true, includeChannelSummary = true } = options;
+  const {
+    includeSensitive = true,
+    includeChannelSummary = true,
+    includeTaskSummary = true,
+  } = options;
   const {
     classifySessionKey,
     resolveConfiguredStatusModelRef,
@@ -147,12 +154,21 @@ export async function getStatusSummary(
     : [];
   const mainSessionKey = resolveMainSessionKey(cfg);
   const queuedSystemEvents = peekSystemEvents(mainSessionKey);
-  const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
-  taskMaintenanceModule.configureTaskRegistryMaintenance({
-    cronStorePath: resolveCronStorePath(cfg.cron?.store),
-  });
-  const tasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
-  const taskAudit = taskMaintenanceModule.getInspectableTaskAuditSummary();
+  const { tasks, taskAudit } = includeTaskSummary
+    ? await (async () => {
+        const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
+        taskMaintenanceModule.configureTaskRegistryMaintenance({
+          cronStorePath: resolveCronStorePath(cfg.cron?.store),
+        });
+        return {
+          tasks: taskMaintenanceModule.getInspectableTaskRegistrySummary(),
+          taskAudit: taskMaintenanceModule.getInspectableTaskAuditSummary(),
+        };
+      })()
+    : {
+        tasks: createEmptyTaskRegistrySummary(),
+        taskAudit: createEmptyTaskAuditSummary(),
+      };
 
   const resolved = resolveConfiguredStatusModelRef({
     cfg,

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -18,8 +18,6 @@ import {
   summarizeActionableTaskAuditFindings,
   summarizeRetainedLostTaskAuditFindings,
 } from "../tasks/task-registry.audit.js";
-import { createEmptyTaskAuditSummary } from "../tasks/task-registry.audit.shared.js";
-import { createEmptyTaskRegistrySummary } from "../tasks/task-registry.summary.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import type { HeartbeatStatus, SessionStatus, StatusSummary } from "./status.types.js";
 
@@ -165,16 +163,11 @@ export async function getStatusSummary(
   options: {
     includeSensitive?: boolean;
     includeChannelSummary?: boolean;
-    includeTaskSummary?: boolean;
     config?: OpenClawConfig;
     sourceConfig?: OpenClawConfig;
   } = {},
 ): Promise<StatusSummary> {
-  const {
-    includeSensitive = true,
-    includeChannelSummary = true,
-    includeTaskSummary = true,
-  } = options;
+  const { includeSensitive = true, includeChannelSummary = true } = options;
   const {
     classifySessionKey,
     resolveConfiguredStatusModelRef,
@@ -218,27 +211,16 @@ export async function getStatusSummary(
     : [];
   const mainSessionKey = resolveMainSessionKey(cfg);
   const queuedSystemEvents = peekSystemEvents(mainSessionKey);
+  const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
+  taskMaintenanceModule.configureTaskRegistryMaintenance({
+    cronStorePath: resolveCronStorePath(cfg.cron?.store),
+  });
+  const rawTasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
+  const taskAuditFindings = taskMaintenanceModule.getInspectableTaskAuditFindings();
   const now = Date.now();
-  const { tasks, taskAudit, taskAuditRetainedLost } = includeTaskSummary
-    ? await (async () => {
-        const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
-        taskMaintenanceModule.configureTaskRegistryMaintenance({
-          cronStorePath: resolveCronStorePath(cfg.cron?.store),
-        });
-        const rawTasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
-        const taskAuditFindings = taskMaintenanceModule.getInspectableTaskAuditFindings();
-        const taskAudit = summarizeActionableTaskAuditFindings(taskAuditFindings, { now });
-        const taskAuditRetainedLost = summarizeRetainedLostTaskAuditFindings(taskAuditFindings, {
-          now,
-        });
-        const tasks = discountRetainedLostTaskFailures(rawTasks, taskAuditRetainedLost.count);
-        return { tasks, taskAudit, taskAuditRetainedLost };
-      })()
-    : {
-        tasks: createEmptyTaskRegistrySummary(),
-        taskAudit: createEmptyTaskAuditSummary(),
-        taskAuditRetainedLost: { count: 0 },
-      };
+  const taskAudit = summarizeActionableTaskAuditFindings(taskAuditFindings, { now });
+  const taskAuditRetainedLost = summarizeRetainedLostTaskAuditFindings(taskAuditFindings, { now });
+  const tasks = discountRetainedLostTaskFailures(rawTasks, taskAuditRetainedLost.count);
 
   const resolved = resolveConfiguredStatusModelRef({
     cfg,

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -18,6 +18,8 @@ import {
   summarizeActionableTaskAuditFindings,
   summarizeRetainedLostTaskAuditFindings,
 } from "../tasks/task-registry.audit.js";
+import { createEmptyTaskAuditSummary } from "../tasks/task-registry.audit.shared.js";
+import { createEmptyTaskRegistrySummary } from "../tasks/task-registry.summary.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import type { HeartbeatStatus, SessionStatus, StatusSummary } from "./status.types.js";
 
@@ -163,11 +165,16 @@ export async function getStatusSummary(
   options: {
     includeSensitive?: boolean;
     includeChannelSummary?: boolean;
+    includeTaskSummary?: boolean;
     config?: OpenClawConfig;
     sourceConfig?: OpenClawConfig;
   } = {},
 ): Promise<StatusSummary> {
-  const { includeSensitive = true, includeChannelSummary = true } = options;
+  const {
+    includeSensitive = true,
+    includeChannelSummary = true,
+    includeTaskSummary = true,
+  } = options;
   const {
     classifySessionKey,
     resolveConfiguredStatusModelRef,
@@ -211,16 +218,27 @@ export async function getStatusSummary(
     : [];
   const mainSessionKey = resolveMainSessionKey(cfg);
   const queuedSystemEvents = peekSystemEvents(mainSessionKey);
-  const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
-  taskMaintenanceModule.configureTaskRegistryMaintenance({
-    cronStorePath: resolveCronStorePath(cfg.cron?.store),
-  });
-  const rawTasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
-  const taskAuditFindings = taskMaintenanceModule.getInspectableTaskAuditFindings();
-  const now = Date.now();
-  const taskAudit = summarizeActionableTaskAuditFindings(taskAuditFindings, { now });
-  const taskAuditRetainedLost = summarizeRetainedLostTaskAuditFindings(taskAuditFindings, { now });
-  const tasks = discountRetainedLostTaskFailures(rawTasks, taskAuditRetainedLost.count);
+  const { tasks, taskAudit, taskAuditRetainedLost } = includeTaskSummary
+    ? await (async () => {
+        const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
+        taskMaintenanceModule.configureTaskRegistryMaintenance({
+          cronStorePath: resolveCronStorePath(cfg.cron?.store),
+        });
+        const rawTasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
+        const taskAuditFindings = taskMaintenanceModule.getInspectableTaskAuditFindings();
+        const now = Date.now();
+        const taskAudit = summarizeActionableTaskAuditFindings(taskAuditFindings, { now });
+        const taskAuditRetainedLost = summarizeRetainedLostTaskAuditFindings(taskAuditFindings, {
+          now,
+        });
+        const tasks = discountRetainedLostTaskFailures(rawTasks, taskAuditRetainedLost.count);
+        return { tasks, taskAudit, taskAuditRetainedLost };
+      })()
+    : {
+        tasks: createEmptyTaskRegistrySummary(),
+        taskAudit: createEmptyTaskAuditSummary(),
+        taskAuditRetainedLost: { count: 0 },
+      };
 
   const resolved = resolveConfiguredStatusModelRef({
     cfg,

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -218,6 +218,7 @@ export async function getStatusSummary(
     : [];
   const mainSessionKey = resolveMainSessionKey(cfg);
   const queuedSystemEvents = peekSystemEvents(mainSessionKey);
+  const now = Date.now();
   const { tasks, taskAudit, taskAuditRetainedLost } = includeTaskSummary
     ? await (async () => {
         const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
@@ -226,7 +227,6 @@ export async function getStatusSummary(
         });
         const rawTasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
         const taskAuditFindings = taskMaintenanceModule.getInspectableTaskAuditFindings();
-        const now = Date.now();
         const taskAudit = summarizeActionableTaskAuditFindings(taskAuditFindings, { now });
         const taskAuditRetainedLost = summarizeRetainedLostTaskAuditFindings(taskAuditFindings, {
           now,

--- a/src/cron/isolated-agent.run-timeout-override.test.ts
+++ b/src/cron/isolated-agent.run-timeout-override.test.ts
@@ -1,18 +1,7 @@
 import "./isolated-agent.mocks.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { clearAllBootstrapSnapshots } from "../agents/bootstrap-cache.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runEmbeddedAgent } from "../agents/embedded-agent.js";
-import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resetAgentRunContextForTest } from "../infra/agent-events.js";
-import { createCliDeps, mockAgentPayloads } from "./isolated-agent.delivery.test-helpers.js";
-import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
-import {
-  makeCfg,
-  makeJob,
-  withTempCronHome,
-  writeSessionStoreEntries,
-} from "./isolated-agent.test-harness.js";
+import { runCronTurn, withTempHome } from "./isolated-agent.turn-test-helpers.js";
 
 function lastEmbeddedCall(): { runTimeoutOverrideMs?: number; timeoutMs?: number } {
   const calls = vi.mocked(runEmbeddedAgent).mock.calls;
@@ -20,94 +9,22 @@ function lastEmbeddedCall(): { runTimeoutOverrideMs?: number; timeoutMs?: number
   return calls.at(-1)?.[0] as { runTimeoutOverrideMs?: number; timeoutMs?: number };
 }
 
-function makeTimeoutTestCfg(
-  home: string,
-  storePath: string,
-  timeoutSeconds: number,
-): OpenClawConfig {
-  return makeCfg(home, storePath, {
-    agents: { defaults: { timeoutSeconds } },
-    models: {
-      providers: {
-        openai: {
-          baseUrl: "https://api.openai.com/v1",
-          agentRuntime: { id: "openclaw" },
-          models: [],
-        },
-      },
-    },
-  });
-}
-
-const envSnapshot = {
-  HOME: process.env.HOME,
-  USERPROFILE: process.env.USERPROFILE,
-  HOMEDRIVE: process.env.HOMEDRIVE,
-  HOMEPATH: process.env.HOMEPATH,
-  OPENCLAW_HOME: process.env.OPENCLAW_HOME,
-  OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
-} as const;
-
-function restoreSnapshotEnv() {
-  for (const [key, value] of Object.entries(envSnapshot)) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-}
-
 describe("runCronIsolatedAgentTurn — explicit per-run timeout signal", () => {
   beforeEach(() => {
     vi.mocked(runEmbeddedAgent).mockClear();
   });
 
-  afterEach(() => {
-    restoreSnapshotEnv();
-    vi.doUnmock("../agents/embedded-agent.js");
-    vi.doUnmock("../agents/model-catalog.js");
-    vi.doUnmock("../agents/model-selection.js");
-    vi.doUnmock("../agents/subagent-announce.js");
-    vi.doUnmock("../gateway/call.js");
-    clearSessionStoreCacheForTest();
-    resetAgentRunContextForTest();
-    clearAllBootstrapSnapshots();
-    vi.restoreAllMocks();
-    vi.resetModules();
-  });
-
   // Regression: when a cron job's payload `timeoutSeconds` numerically equals
-  // `agents.defaults.timeoutSeconds`, the run is still an *explicit* per-run
-  // override. The embedded runner used to detect "explicit" by comparing
-  // `params.timeoutMs !== resolveAgentTimeoutMs({cfg})` — which collapses to
+  // the configured agent default, `timeoutMs !== defaultTimeoutMs` collapses to
   // `false` in this case, stripping the runTimeoutMs signal and letting the
   // LLM idle watchdog fall back to the implicit 120s cap.
   // Fix: forward `runTimeoutOverrideMs` from the cron entry point so the
   // explicit-vs-default distinction survives the merge into `timeoutMs`.
   it("forwards runTimeoutOverrideMs when payload.timeoutSeconds equals the agent default", async () => {
-    await withTempCronHome(async (home) => {
-      const storePath = await writeSessionStoreEntries(home, {
-        "agent:main:main": {
-          sessionId: "main-session",
-          updatedAt: Date.now(),
-          lastProvider: "webchat",
-          lastTo: "",
-        },
-      });
-      mockAgentPayloads([{ text: "ok" }]);
-
-      const cfg = makeTimeoutTestCfg(home, storePath, 300);
-
-      await runCronIsolatedAgentTurn({
-        cfg,
-        deps: createCliDeps(),
-        job: {
-          ...makeJob({ kind: "agentTurn", message: "do it", timeoutSeconds: 300 }),
-          delivery: { mode: "none" },
-        },
-        message: "do it",
-        sessionKey: "cron:job-1",
+    await withTempHome(async (home) => {
+      await runCronTurn(home, {
+        cfgOverrides: { agents: { defaults: { timeoutSeconds: 300 } } },
+        jobPayload: { kind: "agentTurn", message: "do it", timeoutSeconds: 300 },
       });
 
       const call = lastEmbeddedCall();
@@ -116,28 +33,10 @@ describe("runCronIsolatedAgentTurn — explicit per-run timeout signal", () => {
   });
 
   it("forwards runTimeoutOverrideMs when payload.timeoutSeconds differs from the agent default", async () => {
-    await withTempCronHome(async (home) => {
-      const storePath = await writeSessionStoreEntries(home, {
-        "agent:main:main": {
-          sessionId: "main-session",
-          updatedAt: Date.now(),
-          lastProvider: "webchat",
-          lastTo: "",
-        },
-      });
-      mockAgentPayloads([{ text: "ok" }]);
-
-      const cfg = makeTimeoutTestCfg(home, storePath, 300);
-
-      await runCronIsolatedAgentTurn({
-        cfg,
-        deps: createCliDeps(),
-        job: {
-          ...makeJob({ kind: "agentTurn", message: "do it", timeoutSeconds: 600 }),
-          delivery: { mode: "none" },
-        },
-        message: "do it",
-        sessionKey: "cron:job-1",
+    await withTempHome(async (home) => {
+      await runCronTurn(home, {
+        cfgOverrides: { agents: { defaults: { timeoutSeconds: 300 } } },
+        jobPayload: { kind: "agentTurn", message: "do it", timeoutSeconds: 600 },
       });
 
       const call = lastEmbeddedCall();
@@ -146,28 +45,10 @@ describe("runCronIsolatedAgentTurn — explicit per-run timeout signal", () => {
   });
 
   it("leaves runTimeoutOverrideMs undefined when payload omits timeoutSeconds", async () => {
-    await withTempCronHome(async (home) => {
-      const storePath = await writeSessionStoreEntries(home, {
-        "agent:main:main": {
-          sessionId: "main-session",
-          updatedAt: Date.now(),
-          lastProvider: "webchat",
-          lastTo: "",
-        },
-      });
-      mockAgentPayloads([{ text: "ok" }]);
-
-      const cfg = makeTimeoutTestCfg(home, storePath, 300);
-
-      await runCronIsolatedAgentTurn({
-        cfg,
-        deps: createCliDeps(),
-        job: {
-          ...makeJob({ kind: "agentTurn", message: "do it" }),
-          delivery: { mode: "none" },
-        },
-        message: "do it",
-        sessionKey: "cron:job-1",
+    await withTempHome(async (home) => {
+      await runCronTurn(home, {
+        cfgOverrides: { agents: { defaults: { timeoutSeconds: 300 } } },
+        jobPayload: { kind: "agentTurn", message: "do it" },
       });
 
       const call = lastEmbeddedCall();

--- a/src/cron/isolated-agent.run-timeout-override.test.ts
+++ b/src/cron/isolated-agent.run-timeout-override.test.ts
@@ -1,58 +1,25 @@
-import "./isolated-agent.mocks.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { runEmbeddedAgent } from "../agents/embedded-agent.js";
-import { runCronTurn, withTempHome } from "./isolated-agent.turn-test-helpers.js";
+import { describe, expect, it } from "vitest";
+import { resolveCronRunTimeoutOverrideMs } from "./isolated-agent/run-timeout.js";
 
-function lastEmbeddedCall(): { runTimeoutOverrideMs?: number; timeoutMs?: number } {
-  const calls = vi.mocked(runEmbeddedAgent).mock.calls;
-  expect(calls.length).toBeGreaterThan(0);
-  return calls.at(-1)?.[0] as { runTimeoutOverrideMs?: number; timeoutMs?: number };
-}
-
-describe("runCronIsolatedAgentTurn — explicit per-run timeout signal", () => {
-  beforeEach(() => {
-    vi.mocked(runEmbeddedAgent).mockClear();
-  });
-
+describe("resolveCronRunTimeoutOverrideMs", () => {
   // Regression: when a cron job's payload `timeoutSeconds` numerically equals
   // the configured agent default, `timeoutMs !== defaultTimeoutMs` collapses to
-  // `false` in this case, stripping the runTimeoutMs signal and letting the
-  // LLM idle watchdog fall back to the implicit 120s cap.
-  // Fix: forward `runTimeoutOverrideMs` from the cron entry point so the
-  // explicit-vs-default distinction survives the merge into `timeoutMs`.
-  it("forwards runTimeoutOverrideMs when payload.timeoutSeconds equals the agent default", async () => {
-    await withTempHome(async (home) => {
-      await runCronTurn(home, {
-        cfgOverrides: { agents: { defaults: { timeoutSeconds: 300 } } },
-        jobPayload: { kind: "agentTurn", message: "do it", timeoutSeconds: 300 },
-      });
-
-      const call = lastEmbeddedCall();
-      expect(call.runTimeoutOverrideMs).toBe(300_000);
-    });
+  // `false` in the embedded runner. The cron entry point must carry a separate
+  // explicit-timeout signal so the LLM idle watchdog does not fall back to its
+  // implicit 120s cap.
+  it("preserves explicit payload timeoutSeconds even when it equals the agent default", () => {
+    expect(resolveCronRunTimeoutOverrideMs(300)).toBe(300_000);
   });
 
-  it("forwards runTimeoutOverrideMs when payload.timeoutSeconds differs from the agent default", async () => {
-    await withTempHome(async (home) => {
-      await runCronTurn(home, {
-        cfgOverrides: { agents: { defaults: { timeoutSeconds: 300 } } },
-        jobPayload: { kind: "agentTurn", message: "do it", timeoutSeconds: 600 },
-      });
-
-      const call = lastEmbeddedCall();
-      expect(call.runTimeoutOverrideMs).toBe(600_000);
-    });
+  it("preserves explicit payload timeoutSeconds when it differs from the agent default", () => {
+    expect(resolveCronRunTimeoutOverrideMs(600)).toBe(600_000);
   });
 
-  it("leaves runTimeoutOverrideMs undefined when payload omits timeoutSeconds", async () => {
-    await withTempHome(async (home) => {
-      await runCronTurn(home, {
-        cfgOverrides: { agents: { defaults: { timeoutSeconds: 300 } } },
-        jobPayload: { kind: "agentTurn", message: "do it" },
-      });
-
-      const call = lastEmbeddedCall();
-      expect(call.runTimeoutOverrideMs).toBeUndefined();
-    });
+  it("omits the signal when the cron payload has no positive numeric timeout", () => {
+    expect(resolveCronRunTimeoutOverrideMs(undefined)).toBeUndefined();
+    expect(resolveCronRunTimeoutOverrideMs(0)).toBeUndefined();
+    expect(resolveCronRunTimeoutOverrideMs(-1)).toBeUndefined();
+    expect(resolveCronRunTimeoutOverrideMs(Number.NaN)).toBeUndefined();
+    expect(resolveCronRunTimeoutOverrideMs("300")).toBeUndefined();
   });
 });

--- a/src/cron/isolated-agent/run-timeout.ts
+++ b/src/cron/isolated-agent/run-timeout.ts
@@ -1,0 +1,5 @@
+export function resolveCronRunTimeoutOverrideMs(timeoutSeconds: unknown): number | undefined {
+  return typeof timeoutSeconds === "number" && Number.isFinite(timeoutSeconds) && timeoutSeconds > 0
+    ? timeoutSeconds * 1000
+    : undefined;
+}

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -63,6 +63,7 @@ import {
   type MutableCronSession,
   type PersistCronSessionEntry,
 } from "./run-session-state.js";
+import { resolveCronRunTimeoutOverrideMs } from "./run-timeout.js";
 import {
   DEFAULT_CONTEXT_TOKENS,
   deriveSessionTotalTokens,
@@ -704,12 +705,7 @@ async function prepareCronRunContext(params: {
   // explicit-vs-default distinction without this companion field, which would
   // otherwise force the implicit 120 s cap whenever the cron payload's
   // `timeoutSeconds` happens to numerically equal `agents.defaults.timeoutSeconds`.
-  const runTimeoutOverrideMs =
-    typeof explicitTimeoutSeconds === "number" &&
-    Number.isFinite(explicitTimeoutSeconds) &&
-    explicitTimeoutSeconds > 0
-      ? explicitTimeoutSeconds * 1000
-      : undefined;
+  const runTimeoutOverrideMs = resolveCronRunTimeoutOverrideMs(explicitTimeoutSeconds);
   const agentPayload = input.job.payload.kind === "agentTurn" ? input.job.payload : null;
   const { deliveryPlan, deliveryRequested, resolvedDelivery, sourceDelivery } =
     await resolveCronDeliveryContext({


### PR DESCRIPTION
## Summary
- keep default `status --json` on the lean status path by skipping update checks, task registry summaries, memory inspection, and local status-RPC fallback work unless `--all` is requested
- cap the default fast JSON gateway probe to a short presence probe
- preserve the deeper diagnostics behind `status --json --all`
- harden local status-RPC fallback when a failed probe omits `auth`

## Why
`openclaw status --json --timeout 3000` could take tens of seconds on Pi-class hosts because the default JSON path still triggered heavyweight diagnostic work. In PD One/Joi testing, the gateway itself was healthy and `/health` was fast; the CLI status path was the slow, misleading part.

The default JSON command should be safe as a health probe. Heavier diagnostics belong behind `--all`.

## Real behavior proof
- **Behavior or issue addressed:** Default `openclaw status --json --timeout 3000` was too slow for health probing on Pi-class hosts because it still performed heavyweight local diagnostics even when the gateway was healthy.
- **Real environment tested:** Local OpenClaw checkout on a Raspberry Pi-class Linux host, using built `dist/index.js` with an isolated `OPENCLAW_HOME` and `OPENCLAW_CONFIG_PATH`.
- **Exact steps or command run after this patch:**
  ```bash
  pnpm build
  OPENCLAW_HOME="$TMP" OPENCLAW_CONFIG_PATH="$TMP/openclaw.json" node dist/index.js status --json --timeout 3000
  OPENCLAW_HOME="$TMP" OPENCLAW_CONFIG_PATH="$TMP/openclaw.json" node dist/index.js status --json --timeout 3000 --all
  ```
- **Evidence after fix:** Terminal output from the real local OpenClaw run:
  ```text
  ARGS status --json --timeout 3000
  rc=0 elapsed_ms=4966 out=4097 err=0
  {
    "runtimeVersion": "2026.5.5",
    "tasks": 0,
    "channelSummary": 0,
    "memory": null,
    "gatewayReachable": false
  }

  ARGS status --json --timeout 3000 --all
  rc=0 elapsed_ms=5994 out=6539 err=116
  gateway connect failed: GatewayClientRequestError: unauthorized: gateway token missing (provide gateway auth token)
  {
    "runtimeVersion": "2026.5.5",
    "tasks": 0,
    "channelSummary": 0,
    "memory": null,
    "gatewayReachable": false
  }
  ```
- **Observed result after fix:** Default JSON status completed successfully with no stderr and without task/channel/memory summaries. The deeper diagnostic path remains available behind `--all` and still emits the heavier gateway diagnostic behavior.
- **What was not tested:** I did not publish this branch to the PD One production runtime; the production observation was used to identify the slow status path, and this proof uses a built local OpenClaw checkout.

The original production symptom on PD One/Joi was much worse: `status --json --timeout 3000` could take roughly 38–71s while `/health` stayed fast, showing the status path was the slow diagnostic layer rather than a dead gateway.

## Verification
- `pnpm test src/commands/status.scan.fast-json.test.ts src/commands/status.scan.shared.test.ts src/commands/status.summary.test.ts` ✅
- `pnpm exec oxfmt --check --threads=1 src/commands/status.scan-execute.ts src/commands/status.scan-overview.ts src/commands/status.scan.bootstrap-shared.ts src/commands/status.scan.fast-json.ts src/commands/status.scan.shared.ts src/commands/status.summary.ts src/commands/status.scan.fast-json.test.ts src/commands/status.scan.shared.test.ts src/commands/status.summary.test.ts` ✅
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/status.scan-execute.ts src/commands/status.scan-overview.ts src/commands/status.scan.bootstrap-shared.ts src/commands/status.scan.fast-json.ts src/commands/status.scan.shared.ts src/commands/status.summary.ts src/commands/status.scan.fast-json.test.ts src/commands/status.scan.shared.test.ts src/commands/status.summary.test.ts` ✅
- `pnpm build` ✅

Note: an earlier local `pnpm check:changed` run passed conflict/changelog/duplicate coverage/core typecheck lanes, then hit the 600s tool timeout during broad `lint:core`. After refreshing dependencies with `pnpm install`, targeted lint and build passed cleanly.
