### PR TITLE
Add agent no-fallback diagnostic mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- CLI/agent: add `--no-fallback` and `OPENCLAW_AGENT_NO_FALLBACK=1` so diagnostics and CI probes can fail closed instead of silently running embedded fallback after Gateway dispatch failures.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -34,6 +34,7 @@ Related:
 - `--reply-channel <channel>`: delivery channel override
 - `--reply-account <id>`: delivery account override
 - `--local`: run the embedded agent directly (after plugin registry preload)
+- `--no-fallback`: fail when Gateway dispatch fails instead of running embedded fallback
 - `--deliver`: send the reply back to the selected channel/target
 - `--timeout <seconds>`: override agent timeout (default 600 or config value)
 - `--json`: output JSON
@@ -53,6 +54,7 @@ openclaw agent --agent ops --message "Run locally" --local
 ## Notes
 
 - Gateway mode falls back to the embedded agent when the Gateway request fails. Use `--local` to force embedded execution up front.
+- Use `--no-fallback` or `OPENCLAW_AGENT_NO_FALLBACK=1` for diagnostics and CI probes that must prove the Gateway path worked.
 - `--local` still preloads the plugin registry first, so plugin-provided providers, tools, and channels stay available during embedded runs.
 - `--local` and embedded fallback runs are treated as one-shot runs. Bundled MCP loopback resources and warm Claude stdio sessions opened for that local process are retired after the reply, so scripted invocations do not keep local child processes alive.
 - Gateway-backed runs leave Gateway-owned MCP loopback resources under the running Gateway process; older clients may still send the historical cleanup flag, but the Gateway accepts it as a compatibility no-op.

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -58,6 +58,7 @@ programmatic delivery.
 | `--agent \<id\>`              | Target a configured agent (uses its `main` session)         |
 | `--session-id \<id\>`         | Reuse an existing session by id                             |
 | `--local`                     | Force local embedded runtime (skip Gateway)                 |
+| `--no-fallback`               | Fail if Gateway dispatch fails instead of running embedded  |
 | `--deliver`                   | Send the reply to a chat channel                            |
 | `--channel \<name\>`          | Delivery channel (whatsapp, telegram, discord, slack, etc.) |
 | `--reply-to \<target\>`       | Delivery target override                                    |
@@ -73,6 +74,8 @@ programmatic delivery.
 - By default, the CLI goes **through the Gateway**. Add `--local` to force the
   embedded runtime on the current machine.
 - If the Gateway is unreachable, the CLI **falls back** to the local embedded run.
+- Add `--no-fallback` or set `OPENCLAW_AGENT_NO_FALLBACK=1` for diagnostic
+  probes that must fail when the Gateway path fails.
 - Session selection: `--to` derives the session key (group/channel targets
   preserve isolation; direct chats collapse to `main`).
 - Thinking and verbose flags persist into the session store.

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -46,6 +46,11 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
       "Run the embedded agent locally (requires model provider API keys in your shell)",
       false,
     )
+    .option(
+      "--no-fallback",
+      "Fail instead of running embedded fallback when Gateway dispatch fails",
+      false,
+    )
     .option("--deliver", "Send the agent's reply back to the selected channel", false)
     .option("--json", "Output result as JSON", false)
     .option(

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -123,15 +123,23 @@ vi.mock("../gateway/call.js", () => ({
 vi.mock("./agent.js", () => ({ agentCommand }));
 
 let originalForceConsoleToStderr = false;
+let originalNoFallbackEnv: string | undefined;
 
 beforeEach(() => {
   vi.clearAllMocks();
   originalForceConsoleToStderr = loggingState.forceConsoleToStderr;
   loggingState.forceConsoleToStderr = false;
+  originalNoFallbackEnv = process.env.OPENCLAW_AGENT_NO_FALLBACK;
+  delete process.env.OPENCLAW_AGENT_NO_FALLBACK;
 });
 
 afterEach(() => {
   loggingState.forceConsoleToStderr = originalForceConsoleToStderr;
+  if (originalNoFallbackEnv === undefined) {
+    delete process.env.OPENCLAW_AGENT_NO_FALLBACK;
+  } else {
+    process.env.OPENCLAW_AGENT_NO_FALLBACK = originalNoFallbackEnv;
+  }
 });
 
 describe("agentCliCommand", () => {
@@ -266,6 +274,35 @@ describe("agentCliCommand", () => {
 
       await expect(agentCliCommand({ message: "hi", to: "+1555" }, runtime)).rejects.toThrow(
         "missing scope: operator.admin",
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).not.toHaveBeenCalled();
+      expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("EMBEDDED FALLBACK"));
+    });
+  });
+
+  it("fails closed when --no-fallback is set and gateway dispatch fails", async () => {
+    await withTempStore(async () => {
+      callGateway.mockRejectedValue(createGatewayClosedError());
+
+      await expect(
+        agentCliCommand({ message: "hi", to: "+1555", noFallback: true }, runtime),
+      ).rejects.toThrow("embedded fallback is disabled");
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).not.toHaveBeenCalled();
+      expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("EMBEDDED FALLBACK"));
+    });
+  });
+
+  it("fails closed when OPENCLAW_AGENT_NO_FALLBACK is enabled and gateway times out", async () => {
+    await withTempStore(async () => {
+      process.env.OPENCLAW_AGENT_NO_FALLBACK = "1";
+      callGateway.mockRejectedValue(createGatewayTimeoutError());
+
+      await expect(agentCliCommand({ message: "hi", to: "+1555" }, runtime)).rejects.toThrow(
+        "embedded fallback is disabled",
       );
 
       expect(callGateway).toHaveBeenCalledTimes(1);

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -59,6 +59,7 @@ type AgentCliOpts = {
   runId?: string;
   extraSystemPrompt?: string;
   local?: boolean;
+  noFallback?: boolean;
 };
 
 function protectJsonStdout(opts: Pick<AgentCliOpts, "json">): void {
@@ -107,6 +108,23 @@ function isGatewayAgentTimeoutError(err: unknown): boolean {
 
 function isGatewayAgentEmbeddedFallbackError(err: unknown): boolean {
   return isGatewayTransportError(err);
+}
+
+function isNoFallbackEnvEnabled(): boolean {
+  const raw = process.env.OPENCLAW_AGENT_NO_FALLBACK;
+  if (raw === undefined) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function isEmbeddedFallbackDisabled(opts: Pick<AgentCliOpts, "noFallback">): boolean {
+  return opts.noFallback === true || isNoFallbackEnvEnabled();
+}
+
+function createGatewayFallbackDisabledError(err: unknown): Error {
+  return new Error(
+    `Gateway agent failed and embedded fallback is disabled. Re-run without --no-fallback or unset OPENCLAW_AGENT_NO_FALLBACK to allow local embedded fallback. Original error: ${String(err)}`,
+  );
 }
 
 function createGatewayTimeoutFallbackSessionId(): string {
@@ -237,7 +255,12 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
   try {
     return await agentViaGatewayCommand(opts, runtime);
   } catch (err) {
+    const fallbackDisabled = isEmbeddedFallbackDisabled(opts);
+
     if (isGatewayAgentTimeoutError(err)) {
+      if (fallbackDisabled) {
+        throw createGatewayFallbackDisabledError(err);
+      }
       const fallbackSession = createGatewayTimeoutFallbackSession(opts.agent);
       runtime.error?.(
         `EMBEDDED FALLBACK: Gateway agent timed out; running embedded agent with fresh session ${fallbackSession.sessionId}: ${String(err)}`,
@@ -262,6 +285,10 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
 
     if (!isGatewayAgentEmbeddedFallbackError(err)) {
       throw err;
+    }
+
+    if (fallbackDisabled) {
+      throw createGatewayFallbackDisabledError(err);
     }
 
     runtime.error?.(


### PR DESCRIPTION
## Summary
- add `openclaw agent --no-fallback` for gateway-only diagnostic probes
- add `OPENCLAW_AGENT_NO_FALLBACK=1` for CI/scripted hard-fail mode
- document the flag/env var and cover both closed-transport and timeout gateway failures

Refs #76492.

## Tests
- `pnpm exec oxfmt --check --threads=1 src/commands/agent-via-gateway.ts src/commands/agent-via-gateway.test.ts src/cli/program/register.agent.ts docs/cli/agent.md docs/tools/agent-send.md CHANGELOG.md`
- `pnpm test src/commands/agent-via-gateway.test.ts src/cli/program/register.agent.test.ts`