### PR TITLE
fix(gateway): stop terminal WhatsApp restart loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **WhatsApp restart recovery:** stop automatic restart loops after logged-out or connection-replaced disconnects until the account reconnects. (#78511) Thanks @openperf.
 - **Control UI terminal tabs:** vertically center the new-session button in the terminal tab strip.
 - **Control UI composer scrollbar:** show the message-field scrollbar only when the draft actually overflows its autosized height.
 - **Control UI terminal cursor:** hide the browser-native contenteditable caret so the integrated terminal shows only its canvas-rendered cursor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **WhatsApp restart recovery:** stop automatic restart loops after logged-out or connection-replaced disconnects until the account reconnects. (#78511) Thanks @openperf.
 - **iMessage group warnings:** suppress the false drop-all startup warning when an effective group sender allowlist can admit groups, and point true empty-allowlist configurations at the correct remedy. (#100046)
 
 ## 2026.7.1
@@ -40,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **WhatsApp restart recovery:** stop automatic restart loops after logged-out or connection-replaced disconnects until the account reconnects. (#78511) Thanks @openperf.
 - **Control UI terminal tabs:** vertically center the new-session button in the terminal tab strip.
 - **Control UI composer scrollbar:** show the message-field scrollbar only when the draft actually overflows its autosized height.
 - **Control UI terminal cursor:** hide the browser-native contenteditable caret so the integrated terminal shows only its canvas-rendered cursor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ Docs: https://docs.openclaw.ai
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)
 - Agents/fallback: fail fast on session write-lock timeouts instead of trying fallback models for local file contention. Fixes #66646. Thanks @sallyom.
+- Gateway/WhatsApp: stop health-monitor restart loops for WhatsApp accounts stopped by terminal disconnects (loggedOut/connectionReplaced) by surfacing a `terminal-disconnect` health reason so the monitor skips the restart call without consuming hourly-restart budget, preventing unbounded Baileys WebSocket leaks and heap growth on multi-tenant gateways. Fixes #78419. (#78511) Thanks @openperf.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.

--- a/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
@@ -133,4 +133,77 @@ describe("createWebChannelStatusController", () => {
       loggedOut: false,
     });
   });
+
+  it("sets terminalDisconnect on markStopped after logged-out healthState", () => {
+    const patches: Record<string, unknown>[] = [];
+    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+
+    controller.noteConnected(1000);
+    controller.noteClose({
+      at: 2000,
+      statusCode: 401,
+      error: "logged out",
+      reconnectAttempts: 0,
+      healthState: "logged-out",
+    });
+    controller.markStopped(2100);
+
+    const last = patches.at(-1)!;
+    expect(last.terminalDisconnect).toBe(true);
+  });
+
+  it("sets terminalDisconnect on markStopped after conflict healthState", () => {
+    const patches: Record<string, unknown>[] = [];
+    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+
+    controller.noteConnected(1000);
+    controller.noteClose({
+      at: 2000,
+      statusCode: 440,
+      error: "connection replaced",
+      reconnectAttempts: 0,
+      healthState: "conflict",
+    });
+    controller.markStopped(2100);
+
+    const last = patches.at(-1)!;
+    expect(last.terminalDisconnect).toBe(true);
+  });
+
+  it("does not set terminalDisconnect on markStopped for non-terminal healthState", () => {
+    const patches: Record<string, unknown>[] = [];
+    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+
+    controller.noteConnected(1000);
+    controller.noteClose({
+      at: 2000,
+      statusCode: 408,
+      error: "timeout",
+      reconnectAttempts: 1,
+      healthState: "reconnecting",
+    });
+    controller.markStopped(2100);
+
+    const last = patches.at(-1)!;
+    expect(last.terminalDisconnect).toBeFalsy();
+  });
+
+  it("clears terminalDisconnect on noteConnected after a terminal stop", () => {
+    const patches: Record<string, unknown>[] = [];
+    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+
+    controller.noteConnected(1000);
+    controller.noteClose({
+      at: 2000,
+      statusCode: 401,
+      error: "logged out",
+      reconnectAttempts: 0,
+      healthState: "logged-out",
+    });
+    controller.markStopped(2100);
+    expect(patches.at(-1)!.terminalDisconnect).toBe(true);
+
+    controller.noteConnected(3000);
+    expect(patches.at(-1)!.terminalDisconnect).toBeUndefined();
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
@@ -134,59 +134,29 @@ describe("createWebChannelStatusController", () => {
     });
   });
 
-  it("sets terminalDisconnect on markStopped after logged-out healthState", () => {
-    const patches: Record<string, unknown>[] = [];
-    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+  it.each([
+    { healthState: "logged-out", statusCode: 401, terminalDisconnect: true },
+    { healthState: "conflict", statusCode: 440, terminalDisconnect: true },
+    { healthState: "reconnecting", statusCode: 408, terminalDisconnect: false },
+  ] as const)(
+    "sets terminalDisconnect=$terminalDisconnect after a $healthState stop",
+    ({ healthState, statusCode, terminalDisconnect }) => {
+      const patches: Record<string, unknown>[] = [];
+      const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
 
-    controller.noteConnected(1000);
-    controller.noteClose({
-      at: 2000,
-      statusCode: 401,
-      error: "logged out",
-      reconnectAttempts: 0,
-      healthState: "logged-out",
-    });
-    controller.markStopped(2100);
+      controller.noteConnected(1000);
+      controller.noteClose({
+        at: 2000,
+        statusCode,
+        error: healthState,
+        reconnectAttempts: healthState === "reconnecting" ? 1 : 0,
+        healthState,
+      });
+      controller.markStopped(2100);
 
-    const last = patches.at(-1)!;
-    expect(last.terminalDisconnect).toBe(true);
-  });
-
-  it("sets terminalDisconnect on markStopped after conflict healthState", () => {
-    const patches: Record<string, unknown>[] = [];
-    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
-
-    controller.noteConnected(1000);
-    controller.noteClose({
-      at: 2000,
-      statusCode: 440,
-      error: "connection replaced",
-      reconnectAttempts: 0,
-      healthState: "conflict",
-    });
-    controller.markStopped(2100);
-
-    const last = patches.at(-1)!;
-    expect(last.terminalDisconnect).toBe(true);
-  });
-
-  it("does not set terminalDisconnect on markStopped for non-terminal healthState", () => {
-    const patches: Record<string, unknown>[] = [];
-    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
-
-    controller.noteConnected(1000);
-    controller.noteClose({
-      at: 2000,
-      statusCode: 408,
-      error: "timeout",
-      reconnectAttempts: 1,
-      healthState: "reconnecting",
-    });
-    controller.markStopped(2100);
-
-    const last = patches.at(-1)!;
-    expect(last.terminalDisconnect).toBeFalsy();
-  });
+      expect(patches.at(-1)!.terminalDisconnect).toBe(terminalDisconnect);
+    },
+  );
 
   it("clears terminalDisconnect on noteConnected after a terminal stop", () => {
     const patches: Record<string, unknown>[] = [];

--- a/extensions/whatsapp/src/auto-reply/monitor-state.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.ts
@@ -41,6 +41,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       Object.assign(status, createTransportActivityStatusPatch(at));
       status.lastError = null;
       status.healthState = "healthy";
+      status.terminalDisconnect = undefined;
       emit();
     },
     noteInbound(at = Date.now()) {
@@ -97,6 +98,8 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       status.running = false;
       status.connected = false;
       status.lastEventAt = at;
+      status.terminalDisconnect =
+        status.healthState === "logged-out" || status.healthState === "conflict";
       if (!isTerminalHealthState(status.healthState)) {
         status.healthState = "stopped";
       }

--- a/extensions/whatsapp/src/auto-reply/monitor-state.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.ts
@@ -50,6 +50,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       }
       status.lastError = null;
       status.healthState = "healthy";
+      status.terminalDisconnect = undefined;
       emit();
     },
     noteInbound(at = Date.now()) {
@@ -119,6 +120,8 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       status.running = false;
       status.connected = false;
       status.lastEventAt = at;
+      status.terminalDisconnect =
+        status.healthState === "logged-out" || status.healthState === "conflict";
       if (!isTerminalHealthState(status.healthState)) {
         status.healthState = "stopped";
       }

--- a/extensions/whatsapp/src/auto-reply/types.ts
+++ b/extensions/whatsapp/src/auto-reply/types.ts
@@ -30,6 +30,7 @@ export type WebChannelStatus = {
   lastTransportActivityAt?: number | null;
   lastError?: string | null;
   healthState?: WebChannelHealthState;
+  terminalDisconnect?: boolean;
 };
 
 export type WebMonitorTuning = {

--- a/extensions/whatsapp/src/auto-reply/types.ts
+++ b/extensions/whatsapp/src/auto-reply/types.ts
@@ -35,6 +35,7 @@ export type WebChannelStatus = {
   lastRunActivityAt?: number | null;
   lastError?: string | null;
   healthState?: WebChannelHealthState;
+  terminalDisconnect?: boolean;
 };
 
 export type WebMonitorTuning = {

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -257,6 +257,9 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
             lastEventAt: snapshot.lastEventAt ?? null,
             lastError: snapshot.lastError ?? null,
             healthState: snapshot.healthState ?? undefined,
+            ...(snapshot.terminalDisconnect
+              ? { terminalDisconnect: snapshot.terminalDisconnect }
+              : {}),
           };
         },
         resolveAccountSnapshot: async ({ account, runtime }) => {

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -288,6 +288,9 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
             lastRunActivityAt: snapshot.lastRunActivityAt ?? null,
             lastError: snapshot.lastError ?? null,
             healthState: snapshot.healthState ?? undefined,
+            ...(snapshot.terminalDisconnect
+              ? { terminalDisconnect: snapshot.terminalDisconnect }
+              : {}),
           };
         },
         resolveAccountSnapshot: async ({ account, runtime }) => {
@@ -315,6 +318,9 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
               busy: runtime?.busy ?? false,
               lastRunActivityAt: runtime?.lastRunActivityAt ?? null,
               healthState: runtime?.healthState ?? undefined,
+              ...(runtime?.terminalDisconnect
+                ? { terminalDisconnect: runtime.terminalDisconnect }
+                : {}),
               dmPolicy: account.dmPolicy,
               allowFrom: account.allowFrom,
             },

--- a/src/channels/account-snapshot-fields.test.ts
+++ b/src/channels/account-snapshot-fields.test.ts
@@ -60,4 +60,15 @@ describe("projectSafeChannelAccountSnapshotFields", () => {
       lastTransportActivityAt: 456,
     });
   });
+
+  it("projects terminalDisconnect when present and omits it when absent", () => {
+    const withFlag = projectSafeChannelAccountSnapshotFields({
+      connected: false,
+      terminalDisconnect: true,
+    });
+    expect(withFlag.terminalDisconnect).toBe(true);
+
+    const withoutFlag = projectSafeChannelAccountSnapshotFields({ connected: false });
+    expect(withoutFlag).not.toHaveProperty("terminalDisconnect");
+  });
 });

--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -237,6 +237,9 @@ export function projectSafeChannelAccountSnapshotFields(
       : {}),
     ...(statusState ? { statusState } : {}),
     ...(healthState ? { healthState } : {}),
+    ...(readBoolean(record, "terminalDisconnect") !== undefined
+      ? { terminalDisconnect: readBoolean(record, "terminalDisconnect") }
+      : {}),
     ...(readBoolean(record, "busy") !== undefined ? { busy: readBoolean(record, "busy") } : {}),
     ...(readNumber(record, "activeRuns") !== undefined
       ? { activeRuns: readNumber(record, "activeRuns") }

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -211,6 +211,7 @@ export type ChannelAccountSnapshot = {
   lastTransportActivityAt?: number | null;
   lastError?: string | null;
   healthState?: string;
+  terminalDisconnect?: boolean;
   lastStartAt?: number | null;
   lastStopAt?: number | null;
   lastInboundAt?: number | null;

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -213,6 +213,7 @@ export type ChannelAccountSnapshot = {
   lastTransportActivityAt?: number | null;
   lastError?: string | null;
   healthState?: string;
+  terminalDisconnect?: boolean;
   lastStartAt?: number | null;
   lastStopAt?: number | null;
   lastInboundAt?: number | null;

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -234,6 +234,36 @@ describe("channel-health-monitor", () => {
     await expectNoStart(manager);
   });
 
+  it("does not restart a channel with terminalDisconnect set", async () => {
+    const manager = createSnapshotManager({
+      whatsapp: {
+        default: {
+          running: false,
+          enabled: true,
+          configured: true,
+          terminalDisconnect: true,
+        },
+      },
+    });
+    await expectNoRestart(manager);
+  });
+
+  it("restarts a stopped channel without terminalDisconnect", async () => {
+    const manager = createSnapshotManager({
+      whatsapp: {
+        default: {
+          running: false,
+          enabled: true,
+          configured: true,
+          terminalDisconnect: false,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.startChannel).toHaveBeenCalledWith("whatsapp", "default");
+    monitor.stop();
+  });
+
   it("skips manually stopped channels", async () => {
     const manager = createSnapshotManager(
       {

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -274,6 +274,36 @@ describe("channel-health-monitor", () => {
     await expectNoStart(manager);
   });
 
+  it("does not restart a channel with terminalDisconnect set", async () => {
+    const manager = createSnapshotManager({
+      whatsapp: {
+        default: {
+          running: false,
+          enabled: true,
+          configured: true,
+          terminalDisconnect: true,
+        },
+      },
+    });
+    await expectNoRestart(manager);
+  });
+
+  it("restarts a stopped channel without terminalDisconnect", async () => {
+    const manager = createSnapshotManager({
+      whatsapp: {
+        default: {
+          running: false,
+          enabled: true,
+          configured: true,
+          terminalDisconnect: false,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.startChannel).toHaveBeenCalledWith("whatsapp", "default");
+    monitor.stop();
+  });
+
   it("skips manually stopped channels", async () => {
     const manager = createSnapshotManager(
       {

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -134,6 +134,12 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (health.healthy) {
             continue;
           }
+          if (health.reason === "terminal-disconnect") {
+            log.info?.(
+              `[${channelId}:${accountId}] health-monitor: skipping restart, terminal disconnect`,
+            );
+            continue;
+          }
 
           const key = rKey(channelId, accountId);
           const record = restartRecords.get(key) ?? {

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -138,6 +138,12 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (health.healthy) {
             continue;
           }
+          if (health.reason === "terminal-disconnect") {
+            log.info?.(
+              `[${channelId}:${accountId}] health-monitor: skipping restart, terminal disconnect`,
+            );
+            continue;
+          }
 
           const key = rKey(channelId, accountId);
           const record = restartRecords.get(key) ?? {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -294,6 +294,61 @@ describe("evaluateChannelHealth", () => {
     );
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
   });
+
+  it("treats terminal-disconnect channels as unhealthy but distinct from not-running", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: false,
+        enabled: true,
+        configured: true,
+        terminalDisconnect: true,
+      },
+      {
+        channelId: "whatsapp",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "terminal-disconnect" });
+  });
+
+  it("treats stopped channels without terminalDisconnect as not-running", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: false,
+        enabled: true,
+        configured: true,
+        terminalDisconnect: false,
+      },
+      {
+        channelId: "whatsapp",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "not-running" });
+  });
+
+  it("ignores terminalDisconnect when channel is still running", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        terminalDisconnect: true,
+      },
+      {
+        channelId: "whatsapp",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
 });
 
 describe("resolveChannelRestartReason", () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -184,6 +184,61 @@ describe("evaluateChannelHealth", () => {
     });
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
   });
+
+  it("treats terminal-disconnect channels as unhealthy but distinct from not-running", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: false,
+        enabled: true,
+        configured: true,
+        terminalDisconnect: true,
+      },
+      {
+        channelId: "whatsapp",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "terminal-disconnect" });
+  });
+
+  it("treats stopped channels without terminalDisconnect as not-running", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: false,
+        enabled: true,
+        configured: true,
+        terminalDisconnect: false,
+      },
+      {
+        channelId: "whatsapp",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "not-running" });
+  });
+
+  it("ignores terminalDisconnect when channel is still running", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        terminalDisconnect: true,
+      },
+      {
+        channelId: "whatsapp",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
 });
 
 describe("resolveChannelRestartReason", () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -185,59 +185,26 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
   });
 
-  it("treats terminal-disconnect channels as unhealthy but distinct from not-running", () => {
-    const evaluation = evaluateChannelHealth(
-      {
-        running: false,
-        enabled: true,
-        configured: true,
-        terminalDisconnect: true,
-      },
-      {
-        channelId: "whatsapp",
-        now: 100_000,
-        channelConnectGraceMs: 10_000,
-        staleEventThresholdMs: 30_000,
-      },
-    );
-    expect(evaluation).toEqual({ healthy: false, reason: "terminal-disconnect" });
-  });
-
-  it("treats stopped channels without terminalDisconnect as not-running", () => {
-    const evaluation = evaluateChannelHealth(
-      {
-        running: false,
-        enabled: true,
-        configured: true,
-        terminalDisconnect: false,
-      },
-      {
-        channelId: "whatsapp",
-        now: 100_000,
-        channelConnectGraceMs: 10_000,
-        staleEventThresholdMs: 30_000,
-      },
-    );
-    expect(evaluation).toEqual({ healthy: false, reason: "not-running" });
-  });
-
-  it("ignores terminalDisconnect when channel is still running", () => {
-    const evaluation = evaluateChannelHealth(
-      {
-        running: true,
-        connected: true,
-        enabled: true,
-        configured: true,
-        terminalDisconnect: true,
-      },
-      {
-        channelId: "whatsapp",
-        now: 100_000,
-        channelConnectGraceMs: 10_000,
-        staleEventThresholdMs: 30_000,
-      },
-    );
-    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  it.each([
+    {
+      name: "distinguishes a stopped terminal channel",
+      snapshot: { running: false, terminalDisconnect: true },
+      expected: { healthy: false, reason: "terminal-disconnect" },
+    },
+    {
+      name: "keeps ordinary stopped channels restartable",
+      snapshot: { running: false, terminalDisconnect: false },
+      expected: { healthy: false, reason: "not-running" },
+    },
+    {
+      name: "ignores stale terminal state while running",
+      snapshot: { running: true, connected: true, terminalDisconnect: true },
+      expected: { healthy: true, reason: "healthy" },
+    },
+  ] as const)("$name", ({ snapshot, expected }) => {
+    expect(
+      evaluateHealth({ enabled: true, configured: true, ...snapshot }, { channelId: "whatsapp" }),
+    ).toEqual(expected);
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -15,12 +15,14 @@ type ChannelHealthSnapshot = {
   lastStartAt?: number | null;
   reconnectAttempts?: number;
   mode?: string;
+  terminalDisconnect?: boolean;
 };
 
 type ChannelHealthEvaluationReason =
   | "healthy"
   | "unmanaged"
   | "not-running"
+  | "terminal-disconnect"
   | "busy"
   | "stuck"
   | "startup-connect-grace"
@@ -57,6 +59,9 @@ export function evaluateChannelHealth(
 ): ChannelHealthEvaluation {
   if (!isManagedAccount(snapshot)) {
     return { healthy: true, reason: "unmanaged" };
+  }
+  if (!snapshot.running && snapshot.terminalDisconnect) {
+    return { healthy: false, reason: "terminal-disconnect" };
   }
   if (!snapshot.running) {
     return { healthy: false, reason: "not-running" };

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -17,12 +17,14 @@ type ChannelHealthSnapshot = {
   lastStartAt?: number | null;
   reconnectAttempts?: number;
   mode?: string;
+  terminalDisconnect?: boolean;
 };
 
 type ChannelHealthEvaluationReason =
   | "healthy"
   | "unmanaged"
   | "not-running"
+  | "terminal-disconnect"
   | "busy"
   | "stuck"
   | "startup-connect-grace"
@@ -59,6 +61,9 @@ export function evaluateChannelHealth(
 ): ChannelHealthEvaluation {
   if (!isManagedAccount(snapshot)) {
     return { healthy: true, reason: "unmanaged" };
+  }
+  if (!snapshot.running && snapshot.terminalDisconnect) {
+    return { healthy: false, reason: "terminal-disconnect" };
   }
   if (!snapshot.running) {
     return { healthy: false, reason: "not-running" };

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -267,6 +267,29 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
 
+  it("does not auto-restart a channel task exit marked as terminal disconnect", async () => {
+    const startAccount = vi.fn(
+      async ({
+        setStatus,
+        accountId,
+      }: {
+        setStatus: ChannelGatewayContext["setStatus"];
+        accountId: string;
+      }) => {
+        setStatus({ accountId, terminalDisconnect: true });
+      },
+    );
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    const snapshot = manager.getRuntimeSnapshot();
+    expect(snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]?.terminalDisconnect).toBe(true);
+  });
+
   it("consumes rejected stop tasks during manual abort", async () => {
     const unhandledRejection = vi.fn();
     process.on("unhandledRejection", unhandledRejection);

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -365,6 +365,29 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
 
+  it("does not auto-restart a channel task exit marked as terminal disconnect", async () => {
+    const startAccount = vi.fn(
+      async ({
+        setStatus,
+        accountId,
+      }: {
+        setStatus: ChannelGatewayContext["setStatus"];
+        accountId: string;
+      }) => {
+        setStatus({ accountId, terminalDisconnect: true });
+      },
+    );
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    const snapshot = manager.getRuntimeSnapshot();
+    expect(snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]?.terminalDisconnect).toBe(true);
+  });
+
   it("consumes rejected stop tasks during manual abort", async () => {
     const unhandledRejection = vi.fn();
     process.on("unhandledRejection", unhandledRejection);

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -490,6 +490,38 @@ describe("server-channels auto restart", () => {
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
   });
 
+  it("does not restart when a timed-out recovery stop settles as terminal", async () => {
+    const releaseFirstTask = createDeferred();
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      ctx.abortSignal.addEventListener("abort", () => {}, { once: true });
+      await releaseFirstTask.promise;
+      ctx.setStatus({ accountId: DEFAULT_ACCOUNT_ID, terminalDisconnect: true });
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    releaseFirstTask.resolve();
+    await waitForMicrotaskCondition(
+      () =>
+        manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]
+          ?.restartPending === false,
+      "expected terminal recovery completion to clear restart state",
+    );
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(account?.terminalDisconnect).toBe(true);
+    expect(account?.restartPending).toBe(false);
+    expect(account?.reconnectAttempts).toBe(0);
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+  });
+
   it("keeps recovery timeout diagnostics when a stale task reports connected after abort", async () => {
     let emitLateStatus: (() => void) | undefined;
     const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -553,6 +553,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               if (manuallyStopped.has(rKey)) {
                 return;
               }
+              if (getRuntime(channelId, id).terminalDisconnect) {
+                log.info?.(`[${id}] auto-restart skipped, terminal disconnect`);
+                return;
+              }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;
               restartAttempts.set(rKey, attempt);
               if (attempt > MAX_RESTART_ATTEMPTS) {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -681,6 +681,20 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 recoveryStartRequested.delete(rKey);
                 return;
               }
+              if (getRuntime(channelId, id).terminalDisconnect) {
+                // Authentication/session termination wins over pending recovery.
+                // Leaving recovery state behind would restart a channel that needs user action.
+                recoveryStopTimedOut.delete(rKey);
+                recoveryStartRequested.delete(rKey);
+                restartAttempts.delete(rKey);
+                setRuntime(channelId, id, {
+                  accountId: id,
+                  restartPending: false,
+                  reconnectAttempts: 0,
+                });
+                log.info?.(`[${id}] auto-restart skipped, terminal disconnect`);
+                return;
+              }
               if (recoveryStopTimedOut.has(rKey)) {
                 recoveryStopTimedOut.delete(rKey);
                 if (!recoveryStartRequested.delete(rKey)) {
@@ -717,10 +731,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 } catch {
                   // abort or startup failure — runtime state was recorded by startChannelInternal
                 }
-                return;
-              }
-              if (getRuntime(channelId, id).terminalDisconnect) {
-                log.info?.(`[${id}] auto-restart skipped, terminal disconnect`);
                 return;
               }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -719,6 +719,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 }
                 return;
               }
+              if (getRuntime(channelId, id).terminalDisconnect) {
+                log.info?.(`[${id}] auto-restart skipped, terminal disconnect`);
+                return;
+              }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;
               restartAttempts.set(rKey, attempt);
               if (attempt > MAX_RESTART_ATTEMPTS) {

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -212,6 +212,36 @@ describe("channelsHandlers channels.status", () => {
     }
   });
 
+  it("annotates terminal-disconnect accounts with terminal-disconnect health state", async () => {
+    mocks.applyPluginAutoEnable.mockReturnValue({ config: { autoEnabled: true }, changes: [] });
+    mocks.buildChannelAccountSnapshot.mockResolvedValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      running: false,
+      terminalDisconnect: true,
+    });
+    const respond = vi.fn();
+
+    await channelsHandlers["channels.status"](
+      createOptions({ probe: false, timeoutMs: 2000 }, { respond }),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        channelAccounts: {
+          whatsapp: [
+            expect.objectContaining({
+              healthState: "terminal-disconnect",
+            }),
+          ],
+        },
+      }),
+      undefined,
+    );
+  });
+
   it("annotates unhealthy channel snapshots and includes event-loop health", async () => {
     const now = Date.now();
     mocks.applyPluginAutoEnable.mockReturnValue({ config: { autoEnabled: true }, changes: [] });

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -336,6 +336,36 @@ describe("channelsHandlers channels.status", () => {
     expect(account.configured).toBe(true);
   });
 
+  it("annotates terminal-disconnect accounts with terminal-disconnect health state", async () => {
+    mocks.applyPluginAutoEnable.mockReturnValue({ config: { autoEnabled: true }, changes: [] });
+    mocks.buildChannelAccountSnapshot.mockResolvedValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      running: false,
+      terminalDisconnect: true,
+    });
+    const respond = vi.fn();
+
+    await channelsHandlers["channels.status"](
+      createOptions({ probe: false, timeoutMs: 2000 }, { respond }),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        channelAccounts: {
+          whatsapp: [
+            expect.objectContaining({
+              healthState: "terminal-disconnect",
+            }),
+          ],
+        },
+      }),
+      undefined,
+    );
+  });
+
   it("annotates unhealthy channel snapshots and includes event-loop health", async () => {
     const now = Date.now();
     mocks.applyPluginAutoEnable.mockReturnValue({ config: { autoEnabled: true }, changes: [] });

--- a/src/plugin-sdk/status-helpers.test.ts
+++ b/src/plugin-sdk/status-helpers.test.ts
@@ -349,6 +349,24 @@ describe("buildRuntimeAccountStatusSnapshot", () => {
         probe: undefined,
       },
     },
+    {
+      name: "projects terminalDisconnect when set",
+      input: {
+        runtime: {
+          running: false,
+          healthState: "logged-out",
+          terminalDisconnect: true,
+        },
+      },
+      extra: undefined,
+      expected: {
+        ...defaultRuntimeState,
+        running: false,
+        healthState: "logged-out",
+        terminalDisconnect: true,
+        probe: undefined,
+      },
+    },
   ])("$name", ({ input, extra, expected }) => {
     expect(buildRuntimeAccountStatusSnapshot(input, extra)).toEqual(expected);
   });

--- a/src/plugin-sdk/status-helpers.ts
+++ b/src/plugin-sdk/status-helpers.ts
@@ -38,6 +38,7 @@ type RuntimeLifecycleSnapshot = {
   lastEventAt?: number | null;
   lastTransportActivityAt?: number | null;
   healthState?: string | null;
+  terminalDisconnect?: boolean | null;
   lastStartAt?: number | null;
   lastStopAt?: number | null;
   lastError?: string | null;
@@ -320,6 +321,7 @@ export function buildRuntimeAccountStatusSnapshot<TExtra extends StatusSnapshotE
       ? { lastTransportActivityAt: runtime.lastTransportActivityAt }
       : {}),
     ...(typeof runtime?.healthState === "string" ? { healthState: runtime.healthState } : {}),
+    ...(runtime?.terminalDisconnect ? { terminalDisconnect: runtime.terminalDisconnect } : {}),
     ...(extra ?? ({} as TExtra)),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Terminal WhatsApp disconnects such as logged-out and connection-replaced sessions could continue through recovery-stop timeout handling and schedule another automatic restart, creating a restart loop instead of waiting for operator reconnection.

Refs #78419.

## Why This Change Was Made

The repaired branch carries the WhatsApp-owned terminal-disconnect fact through the generic channel snapshot and makes gateway restart policy check it before recovery timeout handling. Terminal state clears pending restart bookkeeping and resets attempts; ordinary transient disconnect recovery is unchanged.

## User Impact

Logged-out or replaced WhatsApp sessions stop restarting automatically and remain stopped until the account is reconnected, avoiding noisy restart loops and repeated failed work.

## Evidence

- Final-rebase focused proof: 24 unit-fast, 332 gateway, and 12 WhatsApp tests passed.
- Remote Testbox build and changed gate passed: `tbx_01kws0677akakqfpk9p8s1a0f9`, Actions run `28739070734`.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Exact prepared head: `7c741fc2bbbc848ccf25374f34268ec002d36496`.
