### PR TITLE
fix(doctor): suppress openai-codex route warning/repair when bare Codex OAuth is active without the plugin

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -121,6 +121,60 @@ describe("collectCodexRouteWarnings", () => {
     expect(warnings).toEqual([]);
   });
 
+  it("does not warn when a usable Codex OAuth profile is present (openai-codex/* route is intentional)", () => {
+    const profileId = "openai-codex:default";
+    mocks.resolveAuthProfileOrder.mockReturnValue([profileId]);
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      profiles: {
+        [profileId]: { type: "oauth", accessToken: "tok", expiresAt: Date.now() + 3_600_000 },
+      },
+      usageStats: {},
+    });
+    mocks.evaluateStoredCredentialEligibility.mockReturnValue({ eligible: true, reasonCode: "ok" });
+    mocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(null);
+
+    const warnings = collectCodexRouteWarnings({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai-codex/gpt-5.5",
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("does not repair openai-codex/* refs when a usable Codex OAuth profile is present", () => {
+    const profileId = "openai-codex:default";
+    mocks.resolveAuthProfileOrder.mockReturnValue([profileId]);
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      profiles: {
+        [profileId]: { type: "oauth", accessToken: "tok", expiresAt: Date.now() + 3_600_000 },
+      },
+      usageStats: {},
+    });
+    mocks.evaluateStoredCredentialEligibility.mockReturnValue({ eligible: true, reasonCode: "ok" });
+    mocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(null);
+
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai-codex/gpt-5.5",
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    // Config must be left untouched — openai-codex/* route is valid with OAuth.
+    expect(result.cfg.agents?.defaults?.model).toBe("openai-codex/gpt-5.5");
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
   it("repairs configured Codex model refs to canonical OpenAI refs with the Codex runtime when ready", () => {
     const result = maybeRepairCodexRoutes({
       cfg: {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -609,10 +609,23 @@ function formatCodexRouteChange(hit: CodexRouteHit, runtime: CodexRepairRuntime)
   return `${hit.path}: ${hit.model} -> ${hit.canonicalModel}${suffix}.`;
 }
 
+function isCodexPluginPresent(cfg: OpenClawConfig, env?: NodeJS.ProcessEnv): boolean {
+  const index = loadInstalledPluginIndex({ config: cfg, env });
+  return getInstalledPluginRecord(index, "codex") !== undefined;
+}
+
+function isCodexOAuthWithoutPlugin(cfg: OpenClawConfig, env?: NodeJS.ProcessEnv): boolean {
+  return hasUsableCodexOAuthProfile(cfg) && !isCodexPluginPresent(cfg, env);
+}
+
 export function collectCodexRouteWarnings(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): string[] {
+  // Suppress: user relies on bare Codex OAuth (no plugin) — openai-codex/* routes are intentional.
+  if (isCodexOAuthWithoutPlugin(params.cfg, params.env)) {
+    return [];
+  }
   const hits = collectConfigModelRefs(params.cfg, params.env);
   if (hits.length === 0) {
     return [];
@@ -637,6 +650,10 @@ export function maybeRepairCodexRoutes(params: {
   shouldRepair: boolean;
   codexRuntimeReady?: boolean;
 }): { cfg: OpenClawConfig; warnings: string[]; changes: string[] } {
+  // When Codex OAuth is present without the plugin, openai-codex/* routes are valid — skip repair.
+  if (isCodexOAuthWithoutPlugin(params.cfg, params.env)) {
+    return { cfg: params.cfg, warnings: [], changes: [] };
+  }
   const hits = collectConfigModelRefs(params.cfg, params.env);
   if (hits.length === 0) {
     return { cfg: params.cfg, warnings: [], changes: [] };


### PR DESCRIPTION
## Root cause

`collectCodexRouteWarnings` and `maybeRepairCodexRoutes` unconditionally treat all `openai-codex/*` model refs as legacy and flag them for migration to `openai/*`. This is correct when the Codex plugin handles routing — but breaks setups where the user relies on bare Codex OAuth authentication (no Codex plugin installed) to reach GPT-5.x models directly via the `openai-codex` provider.

After `doctor --fix` rewrites `openai-codex/gpt-5.5 → openai/gpt-5.5`, the agent falls back to the PI runtime, which requires `OPENAI_API_KEY` — conflicting with the Codex OAuth flow that was working.

## Fix

Added `isCodexPluginPresent()` + `isCodexOAuthWithoutPlugin()` helpers. When the Codex plugin record is absent from the installed index but a usable Codex OAuth profile exists, the route is intentional — both the warning and the `--fix` repair are suppressed.

When the Codex plugin IS present (installed record found), existing behavior is unchanged: the migration proceeds and `agentRuntime.id` is set appropriately.

## Changed files

- `src/commands/doctor/shared/codex-route-warnings.ts` — `isCodexPluginPresent` + `isCodexOAuthWithoutPlugin` guards on both `collectCodexRouteWarnings` and `maybeRepairCodexRoutes`
- `src/commands/doctor/shared/codex-route-warnings.test.ts` — 2 new tests: no-warn and no-repair when bare Codex OAuth with no plugin

## Proof

```
pnpm test src/commands/doctor/shared/codex-route-warnings.test.ts
# Tests: 12 passed (12)

pnpm test src/commands/doctor/shared/
# Tests: 174 passed (174)

pnpm -s tsgo:core  # exit 0
pnpm -s build      # exit 0
```

Fixes #78509