### PR TITLE
fix(browser): guard current tab act routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser: enforce current-tab URL allowlist checks for `/act` evaluate/batch actions and `/highlight` routes while leaving tab-management actions unblocked. (#78523)
 - CI: require real-behavior-proof verdict markers to come from the ClawSweeper GitHub App before accepting exact-head proof. (#83692)
 - Agents/image generation: allow distinct `image_generate` prompts to start separate session-backed background tasks while same-prompt retries still return the active task status. (#83614) Thanks @Elarwei001.
 - Control UI: stop the chat reading indicator from sticking after an assistant response finishes. (#83515) Thanks @njuboy11.

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -71,6 +71,7 @@ describe("existing-session interaction navigation guard", () => {
       fn.mockClear();
     }
     chromeMcpMocks.evaluateChromeMcpScript.mockResolvedValue("https://example.com");
+    routeState.tab.url = "https://example.com";
     routeState.profileCtx.listTabs.mockReset();
     routeState.profileCtx.listTabs.mockResolvedValue([
       {
@@ -140,7 +141,7 @@ describe("existing-session interaction navigation guard", () => {
     expect(chromeMcpMocks.pressChromeMcpKey).toHaveBeenCalledWith(
       expect.objectContaining({ key: "Enter" }),
     );
-    expectNavigationProbeUrls(Array.from({ length: 6 }, () => "https://example.com"));
+    expectNavigationProbeUrls(Array.from({ length: 8 }, () => "https://example.com"));
   });
 
   it("rechecks the page url after delayed navigation-triggering interactions", async () => {
@@ -156,9 +157,29 @@ describe("existing-session interaction navigation guard", () => {
     expect(chromeMcpMocks.evaluateChromeMcpScript).toHaveBeenCalledTimes(4);
     expectNavigationProbeUrls([
       "https://example.com",
+      "https://example.com",
       "http://169.254.169.254/latest/meta-data/",
       "http://169.254.169.254/latest/meta-data/",
     ]);
+  });
+
+  it("blocks evaluate before execution when the current tab URL is disallowed", async () => {
+    routeState.tab.url = "http://169.254.169.254/latest/meta-data/";
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
+      async (opts?: { url: string }) => {
+        const url = opts?.url ?? "";
+        if (url.includes("169.254.169.254")) {
+          throw new Error("blocked current tab");
+        }
+      },
+    );
+
+    await expectActionToThrow(
+      { kind: "evaluate", fn: "() => document.body.innerText" },
+      "blocked current tab",
+    );
+    expect(chromeMcpMocks.evaluateChromeMcpScript).not.toHaveBeenCalled();
+    expectNavigationProbeUrls(["http://169.254.169.254/latest/meta-data/"]);
   });
 
   it("checks URLs for tabs opened during the interaction window", async () => {
@@ -185,6 +206,7 @@ describe("existing-session interaction navigation guard", () => {
     expect(response.statusCode).toBe(200);
     expect(chromeMcpMocks.clickChromeMcpElement).toHaveBeenCalledOnce();
     expectNavigationProbeUrls([
+      "https://example.com",
       "https://example.com",
       "https://example.com",
       "https://example.com",
@@ -231,7 +253,7 @@ describe("existing-session interaction navigation guard", () => {
       .mockResolvedValueOnce("   " as never);
 
     await expectActionToReject({ kind: "evaluate", fn: "() => 1" });
-    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
+    expectNavigationProbeUrls(["https://example.com"]);
   });
 
   it("fails closed when a later post-action probe becomes unreadable", async () => {
@@ -243,7 +265,7 @@ describe("existing-session interaction navigation guard", () => {
       .mockResolvedValueOnce(undefined as never); // follow-up probe - still unreadable
 
     await expectActionToReject({ kind: "evaluate", fn: "() => 1" });
-    expectNavigationProbeUrls(["https://example.com"]);
+    expectNavigationProbeUrls(["https://example.com", "https://example.com"]);
   });
 
   it("confirms stability via follow-up probe when URL changes on the last loop iteration", async () => {
@@ -266,6 +288,7 @@ describe("existing-session interaction navigation guard", () => {
     expect(chromeMcpMocks.evaluateChromeMcpScript).toHaveBeenCalledTimes(5);
     expectNavigationProbeUrls([
       "https://example.com",
+      "https://example.com",
       "https://safe-redirect.com",
       "https://safe-redirect.com",
     ]);
@@ -284,6 +307,7 @@ describe("existing-session interaction navigation guard", () => {
     expect(response.statusCode).toBe(200);
     expect(chromeMcpMocks.evaluateChromeMcpScript).toHaveBeenCalledTimes(5);
     expectNavigationProbeUrls([
+      "https://example.com",
       "https://example.com",
       "https://example.com",
       "https://safe-redirect.com",
@@ -313,7 +337,11 @@ describe("existing-session interaction navigation guard", () => {
       .mockRejectedValueOnce(new Error("context destroyed") as never); // follow-up → still errored
 
     await expectActionToReject({ kind: "evaluate", fn: "() => 1" });
-    expectNavigationProbeUrls(["https://example.com", "https://example.com"]);
+    expectNavigationProbeUrls([
+      "https://example.com",
+      "https://example.com",
+      "https://example.com",
+    ]);
   });
 
   it("skips the guard when no SSRF policy is configured", async () => {

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -70,7 +70,11 @@ describe("existing-session interaction navigation guard", () => {
     for (const fn of Object.values(navigationGuardMocks)) {
       fn.mockClear();
     }
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
+      async (_opts?: { url: string; ssrfPolicy?: unknown }) => {},
+    );
     chromeMcpMocks.evaluateChromeMcpScript.mockResolvedValue("https://example.com");
+    routeState.tab.url = "https://example.com";
     routeState.profileCtx.listTabs.mockReset();
     routeState.profileCtx.listTabs.mockResolvedValue([
       {
@@ -136,11 +140,10 @@ describe("existing-session interaction navigation guard", () => {
     expect(clickResponse.statusCode).toBe(200);
     expect(typeResponse.statusCode).toBe(200);
     expect(chromeMcpMocks.clickChromeMcpElement).toHaveBeenCalledOnce();
-    const keyPressCalls = chromeMcpMocks.pressChromeMcpKey.mock.calls as unknown as Array<
-      [{ key?: string }]
-    >;
-    expect(keyPressCalls[0]?.[0]?.key).toBe("Enter");
-    expectNavigationProbeUrls(Array.from({ length: 6 }, () => "https://example.com"));
+    expect(chromeMcpMocks.pressChromeMcpKey).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "Enter" }),
+    );
+    expectNavigationProbeUrls(Array.from({ length: 8 }, () => "https://example.com"));
   });
 
   it("rechecks the page url after delayed navigation-triggering interactions", async () => {
@@ -156,9 +159,29 @@ describe("existing-session interaction navigation guard", () => {
     expect(chromeMcpMocks.evaluateChromeMcpScript).toHaveBeenCalledTimes(4);
     expectNavigationProbeUrls([
       "https://example.com",
+      "https://example.com",
       "http://169.254.169.254/latest/meta-data/",
       "http://169.254.169.254/latest/meta-data/",
     ]);
+  });
+
+  it("blocks evaluate before execution when the current tab URL is disallowed", async () => {
+    routeState.tab.url = "http://169.254.169.254/latest/meta-data/";
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
+      async (opts?: { url: string }) => {
+        const url = opts?.url ?? "";
+        if (url.includes("169.254.169.254")) {
+          throw new Error("blocked current tab");
+        }
+      },
+    );
+
+    await expectActionToThrow(
+      { kind: "evaluate", fn: "() => document.body.innerText" },
+      "blocked current tab",
+    );
+    expect(chromeMcpMocks.evaluateChromeMcpScript).not.toHaveBeenCalled();
+    expectNavigationProbeUrls(["http://169.254.169.254/latest/meta-data/"]);
   });
 
   it("checks URLs for tabs opened during the interaction window", async () => {
@@ -185,6 +208,7 @@ describe("existing-session interaction navigation guard", () => {
     expect(response.statusCode).toBe(200);
     expect(chromeMcpMocks.clickChromeMcpElement).toHaveBeenCalledOnce();
     expectNavigationProbeUrls([
+      "https://example.com",
       "https://example.com",
       "https://example.com",
       "https://example.com",
@@ -231,7 +255,7 @@ describe("existing-session interaction navigation guard", () => {
       .mockResolvedValueOnce("   " as never);
 
     await expectActionToReject({ kind: "evaluate", fn: "() => 1" });
-    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
+    expectNavigationProbeUrls(["https://example.com"]);
   });
 
   it("fails closed when a later post-action probe becomes unreadable", async () => {
@@ -243,7 +267,7 @@ describe("existing-session interaction navigation guard", () => {
       .mockResolvedValueOnce(undefined as never); // follow-up probe - still unreadable
 
     await expectActionToReject({ kind: "evaluate", fn: "() => 1" });
-    expectNavigationProbeUrls(["https://example.com"]);
+    expectNavigationProbeUrls(["https://example.com", "https://example.com"]);
   });
 
   it("confirms stability via follow-up probe when URL changes on the last loop iteration", async () => {
@@ -266,6 +290,7 @@ describe("existing-session interaction navigation guard", () => {
     expect(chromeMcpMocks.evaluateChromeMcpScript).toHaveBeenCalledTimes(5);
     expectNavigationProbeUrls([
       "https://example.com",
+      "https://example.com",
       "https://safe-redirect.com",
       "https://safe-redirect.com",
     ]);
@@ -284,6 +309,7 @@ describe("existing-session interaction navigation guard", () => {
     expect(response.statusCode).toBe(200);
     expect(chromeMcpMocks.evaluateChromeMcpScript).toHaveBeenCalledTimes(5);
     expectNavigationProbeUrls([
+      "https://example.com",
       "https://example.com",
       "https://example.com",
       "https://safe-redirect.com",
@@ -313,7 +339,11 @@ describe("existing-session interaction navigation guard", () => {
       .mockRejectedValueOnce(new Error("context destroyed") as never); // follow-up → still errored
 
     await expectActionToReject({ kind: "evaluate", fn: "() => 1" });
-    expectNavigationProbeUrls(["https://example.com", "https://example.com"]);
+    expectNavigationProbeUrls([
+      "https://example.com",
+      "https://example.com",
+      "https://example.com",
+    ]);
   });
 
   it("skips the guard when no SSRF policy is configured", async () => {

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -276,6 +276,12 @@ const SELECTOR_ALLOWED_KINDS: ReadonlySet<string> = new Set([
   "type",
   "wait",
 ]);
+
+function shouldEnforceCurrentUrlForAct(action: BrowserActRequest): boolean {
+  // Batch stays guarded because nested actions can read or return page data.
+  return action.kind !== "resize" && action.kind !== "close";
+}
+
 function getExistingSessionUnsupportedMessage(action: BrowserActRequest): string | null {
   switch (action.kind) {
     case "click":
@@ -387,6 +393,7 @@ export function registerBrowserAgentActRoutes(
         res,
         ctx,
         targetId,
+        enforceCurrentUrlAllowed: shouldEnforceCurrentUrlForAct(action),
         run: async ({ profileCtx, cdpUrl, tab, resolveTabUrl }) => {
           const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
           const ssrfPolicy = ctx.state().resolved.ssrfPolicy;
@@ -738,6 +745,7 @@ export function registerBrowserAgentActRoutes(
         res,
         ctx,
         targetId,
+        enforceCurrentUrlAllowed: true,
         run: async ({ profileCtx, cdpUrl, tab, resolveTabUrl }) => {
           const jsonOk = async () => {
             const currentUrl = await resolveTabUrl(tab.url);

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -276,6 +276,12 @@ const SELECTOR_ALLOWED_KINDS: ReadonlySet<string> = new Set([
   "type",
   "wait",
 ]);
+
+function shouldEnforceCurrentUrlForAct(action: BrowserActRequest): boolean {
+  // Batch stays guarded because nested actions can read or return page data.
+  return action.kind !== "resize" && action.kind !== "close";
+}
+
 function getExistingSessionUnsupportedMessage(action: BrowserActRequest): string | null {
   switch (action.kind) {
     case "click":
@@ -387,6 +393,7 @@ export function registerBrowserAgentActRoutes(
         res,
         ctx,
         targetId,
+        enforceCurrentUrlAllowed: shouldEnforceCurrentUrlForAct(action),
         run: async ({ profileCtx, cdpUrl, tab, resolveTabUrl }) => {
           const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
           const ssrfPolicy = ctx.state().resolved.ssrfPolicy;
@@ -744,6 +751,7 @@ export function registerBrowserAgentActRoutes(
         res,
         ctx,
         targetId,
+        enforceCurrentUrlAllowed: true,
         run: async ({ profileCtx, cdpUrl, tab, resolveTabUrl }) => {
           const jsonOk = async () => {
             const currentUrl = await resolveTabUrl(tab.url);

--- a/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -26,6 +26,8 @@ type GuardedCurrentTabRouteCase = {
   body?: Record<string, unknown>;
   mockName:
     | "cookiesGetViaPlaywright"
+    | "executeActViaPlaywright"
+    | "highlightViaPlaywright"
     | "pdfViaPlaywright"
     | "getConsoleMessagesViaPlaywright"
     | "getPageErrorsViaPlaywright"
@@ -72,6 +74,28 @@ const guardedCurrentTabRouteCases: readonly GuardedCurrentTabRouteCase[] = [
     mockName: "responseBodyViaPlaywright",
   },
   {
+    method: "POST",
+    path: "/act",
+    body: { targetId: "abcd1234", kind: "evaluate", fn: "() => document.body.innerText" },
+    mockName: "executeActViaPlaywright",
+  },
+  {
+    method: "POST",
+    path: "/act",
+    body: {
+      targetId: "abcd1234",
+      kind: "batch",
+      actions: [{ kind: "evaluate", fn: "() => document.body.innerText" }],
+    },
+    mockName: "executeActViaPlaywright",
+  },
+  {
+    method: "POST",
+    path: "/highlight",
+    body: { targetId: "abcd1234", ref: "e1" },
+    mockName: "highlightViaPlaywright",
+  },
+  {
     method: "GET",
     path: "/cookies?targetId=abcd1234",
     mockName: "cookiesGetViaPlaywright",
@@ -92,6 +116,19 @@ const guardedCurrentTabRouteCases: readonly GuardedCurrentTabRouteCase[] = [
     path: "/trace/stop",
     body: { targetId: "abcd1234" },
     mockName: "traceStopViaPlaywright",
+  },
+] as const;
+
+const tabManagementActCases = [
+  {
+    kind: "resize",
+    body: { targetId: "abcd1234", kind: "resize", width: 1024, height: 768 },
+    mockName: "resizeViewportViaPlaywright",
+  },
+  {
+    kind: "close",
+    body: { targetId: "abcd1234", kind: "close" },
+    mockName: "closePageViaPlaywright",
   },
 ] as const;
 
@@ -532,6 +569,20 @@ describe("browser control server", () => {
       const body = (await res.json()) as { error?: unknown };
       expect(body.error).toEqual(expect.stringMatching(/(blocked|denied|not allowed|policy)/i));
       expect(pwMocks[routeCase.mockName]).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(tabManagementActCases)(
+    "allows tab-management act:$kind on disallowed current tab URLs",
+    async ({ body, mockName }) => {
+      setBrowserControlServerSsrFPolicy({ allowPrivateNetwork: false });
+      setBrowserControlServerTabUrl("http://127.0.0.1:8080/admin");
+      const base = await startServerAndBase();
+
+      const res = await postJson<{ ok?: boolean }>(`${base}/act`, body);
+
+      expect(res.ok).toBe(true);
+      expect(pwMocks[mockName]).toHaveBeenCalled();
     },
   );
 

--- a/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import "../test-support/browser-security.mock.js";
 import { BROWSER_NAVIGATION_BLOCKED_MESSAGE } from "./errors.js";
 import { DEFAULT_DOWNLOAD_DIR, DEFAULT_TRACE_DIR, DEFAULT_UPLOAD_DIR } from "./paths.js";
 import {
@@ -27,6 +28,8 @@ type GuardedCurrentTabRouteCase = {
   body?: Record<string, unknown>;
   mockName:
     | "cookiesGetViaPlaywright"
+    | "executeActViaPlaywright"
+    | "highlightViaPlaywright"
     | "pdfViaPlaywright"
     | "getConsoleMessagesViaPlaywright"
     | "getPageErrorsViaPlaywright"
@@ -73,6 +76,28 @@ const guardedCurrentTabRouteCases: readonly GuardedCurrentTabRouteCase[] = [
     mockName: "responseBodyViaPlaywright",
   },
   {
+    method: "POST",
+    path: "/act",
+    body: { targetId: "abcd1234", kind: "evaluate", fn: "() => document.body.innerText" },
+    mockName: "executeActViaPlaywright",
+  },
+  {
+    method: "POST",
+    path: "/act",
+    body: {
+      targetId: "abcd1234",
+      kind: "batch",
+      actions: [{ kind: "evaluate", fn: "() => document.body.innerText" }],
+    },
+    mockName: "executeActViaPlaywright",
+  },
+  {
+    method: "POST",
+    path: "/highlight",
+    body: { targetId: "abcd1234", ref: "e1" },
+    mockName: "highlightViaPlaywright",
+  },
+  {
     method: "GET",
     path: "/cookies?targetId=abcd1234",
     mockName: "cookiesGetViaPlaywright",
@@ -93,6 +118,19 @@ const guardedCurrentTabRouteCases: readonly GuardedCurrentTabRouteCase[] = [
     path: "/trace/stop",
     body: { targetId: "abcd1234" },
     mockName: "traceStopViaPlaywright",
+  },
+] as const;
+
+const tabManagementActCases = [
+  {
+    kind: "resize",
+    body: { targetId: "abcd1234", kind: "resize", width: 1024, height: 768 },
+    mockName: "resizeViewportViaPlaywright",
+  },
+  {
+    kind: "close",
+    body: { targetId: "abcd1234", kind: "close" },
+    mockName: "closePageViaPlaywright",
   },
 ] as const;
 
@@ -559,6 +597,20 @@ describe("browser control server", () => {
       const body = (await res.json()) as { error?: unknown };
       expect(body.error).toBe(BROWSER_NAVIGATION_BLOCKED_MESSAGE);
       expect(pwMocks[routeCase.mockName]).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(tabManagementActCases)(
+    "allows tab-management act:$kind on disallowed current tab URLs",
+    async ({ body, mockName }) => {
+      setBrowserControlServerSsrFPolicy({ allowPrivateNetwork: false });
+      setBrowserControlServerTabUrl("http://127.0.0.1:8080/admin");
+      const base = await startServerAndBase();
+
+      const res = await postJson<{ ok?: boolean }>(`${base}/act`, body);
+
+      expect(res.ok).toBe(true);
+      expect(pwMocks[mockName]).toHaveBeenCalled();
     },
   );
 

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -177,6 +177,7 @@ const pwMocks = vi.hoisted(() => ({
   getConsoleMessagesViaPlaywright: vi.fn(async () => []),
   getNetworkRequestsViaPlaywright: vi.fn(async () => ({ requests: [] })),
   getPageErrorsViaPlaywright: vi.fn(async () => ({ errors: [] })),
+  highlightViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
   hoverViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
   scrollIntoViewViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
   navigateViaPlaywright: vi.fn(async () => ({ url: "https://example.com" })),

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -180,6 +180,7 @@ const pwMocks = vi.hoisted(() => ({
     dialogs: { pending: [], recent: [] },
   })),
   getPageErrorsViaPlaywright: vi.fn(async () => ({ errors: [] })),
+  highlightViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
   hoverViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
   scrollIntoViewViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
   navigateViaPlaywright: vi.fn(async () => ({ url: "https://example.com" })),


### PR DESCRIPTION
## Summary
- Guards browser `/act` and `/highlight` against disallowed current-tab URLs before page-scoped operations run.
- Keeps pure tab-management `/act` operations available for blocked tabs.

## Changes
- Adds `shouldEnforceCurrentUrlForAct()` so `/act` enforces current-tab URL policy for every action except `resize` and `close`.
- Adds the same current-tab route guard to `/highlight`.
- Extends regression coverage for existing-session `evaluate`, `/act` evaluate/batch, `/highlight`, and resize/close exceptions.
- Installs the browser security DNS mock in the control-server contract test so guarded routes do not perform live hostname lookups.

## Validation
- `node scripts/run-vitest.mjs extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts`
- `node scripts/run-vitest.mjs extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts extensions/browser/src/browser/routes/agent.existing-session.test.ts extensions/browser/src/browser/routes/agent.shared.test.ts`
- `node scripts/run-vitest.mjs extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts`
- `corepack pnpm exec oxfmt --check extensions/browser/src/browser/routes/agent.act.ts extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts extensions/browser/src/browser/server.control-server.test-harness.ts`
- `git diff --cached --check`
- `git diff --check`

## Real Behavior Proof
- Behavior addressed: `/act` evaluate and batch requests plus `/highlight` now use the current-tab route gate before page-scoped dispatch; `resize` and `close` stay available as tab-management actions.
- Real environment tested: Local source checkout on branch `569` rebased onto `ee10fe17f0`.
- Exact steps or command run after this patch: the focused Vitest commands listed above, plus targeted formatting and whitespace checks.
- Evidence after fix: `agent.act.existing-session-navigation-guard.test.ts` passed 13 tests; `server.agent-contract-form-layout-act-commands.test.ts` passed 34 tests; combined route/contract proof passed 47 tests across 2 files; adjacent existing-session/shared route proof passed 32 tests across 3 files.
- Observed result after fix: Guarded `/act` evaluate, `/act` batch, and `/highlight` reject disallowed current-tab URLs before dispatch, while `/act` resize/close still dispatch on a disallowed current tab.
- What was not tested: Live browser control-server requests against a real running browser profile.

## Notes
- No `CHANGELOG.md` update per maintainer instruction.
- Codex review found one actionable test harness issue (missing DNS mock for guarded route tests); fixed before this refresh. The final uncommitted review before commit reported no discrete introduced bug. A post-commit review attempt timed out after trying unsupported Vitest `--runInBand`, so the focused commands above are the executable proof.
