### PR TITLE
fix(skills): honor tool policy for inline dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/skills: apply the full effective tool policy pipeline to inline `command-dispatch: tool` skill dispatch before owner-only filtering, preserving configured allow, deny, sandbox, sender, group, and subagent restrictions. (#78525)
 - Providers/GitHub Copilot: request identity-encoded Copilot API responses across token exchange, catalog, model calls, usage, and embeddings so compressed Business-account error payloads no longer reach JSON parsers as gzip bytes. Fixes #82871. Thanks @tonyfe01.
 - Telegram: preserve replied-to bot messages, captions, and media metadata in group reply chains so follow-up replies understand what the user is reacting to. (#82863)
 - Agents/diagnostics: split slow embedded-run `attempt-dispatch` startup summaries into workspace, prompt, runtime-plan, and final dispatch subspans so traces identify the delayed setup phase. Fixes #82782. (#82783) Thanks @galiniliev.

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillCommandSpec } from "../../agents/skills.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -46,6 +49,16 @@ const createTypingController = (): TypingController => ({
   markDispatchIdle: () => {},
   cleanup: vi.fn(),
 });
+
+async function writeSessionStore(
+  storeTemplate: string,
+  agentId: string,
+  entries: Record<string, unknown>,
+) {
+  const storePath = storeTemplate.replaceAll("{agentId}", agentId);
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify(entries, null, 2), "utf-8");
+}
 
 const createHandleInlineActionsInput = (params: {
   ctx: ReturnType<typeof buildTestCtx>;
@@ -806,5 +819,145 @@ describe("handleInlineActions", () => {
     });
     expect(messageExecute).not.toHaveBeenCalled();
     expect(sessionsExecute).not.toHaveBeenCalled();
+  });
+
+  it("applies subagent policy to ACP envelope inline dispatch sessions", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inline-acp-policy-"));
+    try {
+      const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
+      await writeSessionStore(storeTemplate, "main", {
+        "agent:main:acp:leaf": {
+          sessionId: "session-acp-leaf",
+          updatedAt: Date.now(),
+          spawnedBy: "agent:main:subagent:parent",
+          spawnDepth: 2,
+          subagentRole: "leaf",
+          subagentControlScope: "none",
+        },
+      });
+
+      const typing = createTypingController();
+      const toolExecute = vi.fn(async () => ({ content: "spawned" }));
+      createOpenClawToolsMock.mockReturnValue([
+        {
+          name: "sessions_spawn",
+          execute: toolExecute,
+        },
+      ]);
+
+      const ctx = buildTestCtx({
+        Body: "/spawn_subagent investigate",
+        CommandBody: "/spawn_subagent investigate",
+      });
+      const skillCommands: SkillCommandSpec[] = [
+        {
+          name: "spawn_subagent",
+          skillName: "spawn-subagent",
+          description: "Spawn a subagent",
+          dispatch: {
+            kind: "tool",
+            toolName: "sessions_spawn",
+            argMode: "raw",
+          },
+          sourceFilePath: "/tmp/plugin/commands/spawn-subagent.md",
+        },
+      ];
+
+      const result = await handleInlineActions(
+        createHandleInlineActionsInput({
+          ctx,
+          typing,
+          cleanedBody: "/spawn_subagent investigate",
+          command: {
+            isAuthorizedSender: true,
+            senderId: "sender-1",
+            senderIsOwner: true,
+            abortKey: "sender-1",
+            rawBodyNormalized: "/spawn_subagent investigate",
+            commandBodyNormalized: "/spawn_subagent investigate",
+          },
+          overrides: {
+            cfg: {
+              commands: { text: true },
+              session: { store: storeTemplate },
+              agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
+            },
+            sessionKey: "agent:main:acp:leaf",
+            allowTextCommands: true,
+            skillCommands,
+          },
+        }),
+      );
+
+      expect(result).toEqual({
+        kind: "reply",
+        reply: { text: "❌ Tool not available: sessions_spawn" },
+      });
+      expect(toolExecute).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes sandboxed runtime state into inline tool construction", async () => {
+    const typing = createTypingController();
+    const toolExecute = vi.fn(async () => ({ content: "listed" }));
+    createOpenClawToolsMock.mockReturnValue([
+      {
+        name: "sessions_list",
+        execute: toolExecute,
+      },
+    ]);
+
+    const ctx = buildTestCtx({
+      Body: "/list_sessions now",
+      CommandBody: "/list_sessions now",
+    });
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "list_sessions",
+        skillName: "list-sessions",
+        description: "List sessions",
+        dispatch: {
+          kind: "tool",
+          toolName: "sessions_list",
+          argMode: "raw",
+        },
+        sourceFilePath: "/tmp/plugin/commands/list-sessions.md",
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/list_sessions now",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/list_sessions now",
+          commandBodyNormalized: "/list_sessions now",
+        },
+        overrides: {
+          cfg: {
+            commands: { text: true },
+            agents: { defaults: { sandbox: { mode: "all" } } },
+          },
+          sessionKey: "agent:main:thread",
+          allowTextCommands: true,
+          skillCommands,
+        },
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "✅ Done." } });
+    expect(createOpenClawToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandboxed: true,
+      }),
+    );
+    expect(toolExecute).toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -689,4 +689,122 @@ describe("handleInlineActions", () => {
     );
     expect(toolExecute).toHaveBeenCalled();
   });
+
+  it("does not execute inline tool dispatch targets denied by tool policy", async () => {
+    const typing = createTypingController();
+    const toolExecute = vi.fn(async () => ({ content: "sent" }));
+    createOpenClawToolsMock.mockReturnValue([
+      {
+        name: "message",
+        execute: toolExecute,
+      },
+    ]);
+
+    const ctx = buildTestCtx({
+      Body: "/send_status hello",
+      CommandBody: "/send_status hello",
+    });
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "send_status",
+        skillName: "send-status",
+        description: "Send a status update",
+        dispatch: {
+          kind: "tool",
+          toolName: "message",
+          argMode: "raw",
+        },
+        sourceFilePath: "/tmp/plugin/commands/send-status.md",
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/send_status hello",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/send_status hello",
+          commandBodyNormalized: "/send_status hello",
+        },
+        overrides: {
+          cfg: { commands: { text: true }, tools: { deny: ["message"] } },
+          allowTextCommands: true,
+          skillCommands,
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "reply",
+      reply: { text: "❌ Tool not available: message" },
+    });
+    expect(toolExecute).not.toHaveBeenCalled();
+  });
+
+  it("does not execute inline tool dispatch targets outside tool allowlists", async () => {
+    const typing = createTypingController();
+    const messageExecute = vi.fn(async () => ({ content: "sent" }));
+    const sessionsExecute = vi.fn(async () => ({ content: "listed" }));
+    createOpenClawToolsMock.mockReturnValue([
+      {
+        name: "message",
+        execute: messageExecute,
+      },
+      {
+        name: "sessions_list",
+        execute: sessionsExecute,
+      },
+    ]);
+
+    const ctx = buildTestCtx({
+      Body: "/send_status hello",
+      CommandBody: "/send_status hello",
+    });
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "send_status",
+        skillName: "send-status",
+        description: "Send a status update",
+        dispatch: {
+          kind: "tool",
+          toolName: "message",
+          argMode: "raw",
+        },
+        sourceFilePath: "/tmp/plugin/commands/send-status.md",
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/send_status hello",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/send_status hello",
+          commandBodyNormalized: "/send_status hello",
+        },
+        overrides: {
+          cfg: { commands: { text: true }, tools: { allow: ["sessions_list"] } },
+          allowTextCommands: true,
+          skillCommands,
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "reply",
+      reply: { text: "❌ Tool not available: message" },
+    });
+    expect(messageExecute).not.toHaveBeenCalled();
+    expect(sessionsExecute).not.toHaveBeenCalled();
+  });
 });

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -921,6 +921,65 @@ describe("handleInlineActions", () => {
     expect(sessionsExecute).not.toHaveBeenCalled();
   });
 
+  it("applies sender-specific tool policy to inline tool dispatch", async () => {
+    const typing = createTypingController();
+    const toolExecute = vi.fn(async () => ({ content: "sent" }));
+    createOpenClawToolsMock.mockReturnValue([
+      {
+        name: "message",
+        execute: toolExecute,
+      },
+    ]);
+
+    const ctx = buildTestCtx({
+      Body: "/send_status hello",
+      CommandBody: "/send_status hello",
+    });
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "send_status",
+        skillName: "send-status",
+        description: "Send a status update",
+        dispatch: {
+          kind: "tool",
+          toolName: "message",
+          argMode: "raw",
+        },
+        sourceFilePath: "/tmp/plugin/commands/send-status.md",
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/send_status hello",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/send_status hello",
+          commandBodyNormalized: "/send_status hello",
+        },
+        overrides: {
+          cfg: {
+            commands: { text: true },
+            tools: { toolsBySender: { "id:sender-1": { deny: ["message"] } } },
+          },
+          allowTextCommands: true,
+          skillCommands,
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "reply",
+      reply: { text: "❌ Tool not available: message" },
+    });
+    expect(toolExecute).not.toHaveBeenCalled();
+  });
+
   it("applies subagent policy to ACP envelope inline dispatch sessions", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inline-acp-policy-"));
     try {
@@ -1052,7 +1111,7 @@ describe("handleInlineActions", () => {
       }),
     );
 
-    expect(result).toEqual({ kind: "reply", reply: { text: "✅ Done." } });
+    expect(result).toEqual({ kind: "reply", reply: { text: "listed" } });
     expect(createOpenClawToolsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sandboxed: true,

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillCommandSpec } from "../../agents/skills.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -46,6 +49,16 @@ const createTypingController = (): TypingController => ({
   markDispatchIdle: () => {},
   cleanup: vi.fn(),
 });
+
+async function writeSessionStore(
+  storeTemplate: string,
+  agentId: string,
+  entries: Record<string, unknown>,
+) {
+  const storePath = storeTemplate.replaceAll("{agentId}", agentId);
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify(entries, null, 2), "utf-8");
+}
 
 const createHandleInlineActionsInput = (params: {
   ctx: ReturnType<typeof buildTestCtx>;
@@ -906,5 +919,145 @@ describe("handleInlineActions", () => {
     });
     expect(messageExecute).not.toHaveBeenCalled();
     expect(sessionsExecute).not.toHaveBeenCalled();
+  });
+
+  it("applies subagent policy to ACP envelope inline dispatch sessions", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inline-acp-policy-"));
+    try {
+      const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
+      await writeSessionStore(storeTemplate, "main", {
+        "agent:main:acp:leaf": {
+          sessionId: "session-acp-leaf",
+          updatedAt: Date.now(),
+          spawnedBy: "agent:main:subagent:parent",
+          spawnDepth: 2,
+          subagentRole: "leaf",
+          subagentControlScope: "none",
+        },
+      });
+
+      const typing = createTypingController();
+      const toolExecute = vi.fn(async () => ({ content: "spawned" }));
+      createOpenClawToolsMock.mockReturnValue([
+        {
+          name: "sessions_spawn",
+          execute: toolExecute,
+        },
+      ]);
+
+      const ctx = buildTestCtx({
+        Body: "/spawn_subagent investigate",
+        CommandBody: "/spawn_subagent investigate",
+      });
+      const skillCommands: SkillCommandSpec[] = [
+        {
+          name: "spawn_subagent",
+          skillName: "spawn-subagent",
+          description: "Spawn a subagent",
+          dispatch: {
+            kind: "tool",
+            toolName: "sessions_spawn",
+            argMode: "raw",
+          },
+          sourceFilePath: "/tmp/plugin/commands/spawn-subagent.md",
+        },
+      ];
+
+      const result = await handleInlineActions(
+        createHandleInlineActionsInput({
+          ctx,
+          typing,
+          cleanedBody: "/spawn_subagent investigate",
+          command: {
+            isAuthorizedSender: true,
+            senderId: "sender-1",
+            senderIsOwner: true,
+            abortKey: "sender-1",
+            rawBodyNormalized: "/spawn_subagent investigate",
+            commandBodyNormalized: "/spawn_subagent investigate",
+          },
+          overrides: {
+            cfg: {
+              commands: { text: true },
+              session: { store: storeTemplate },
+              agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
+            },
+            sessionKey: "agent:main:acp:leaf",
+            allowTextCommands: true,
+            skillCommands,
+          },
+        }),
+      );
+
+      expect(result).toEqual({
+        kind: "reply",
+        reply: { text: "❌ Tool not available: sessions_spawn" },
+      });
+      expect(toolExecute).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes sandboxed runtime state into inline tool construction", async () => {
+    const typing = createTypingController();
+    const toolExecute = vi.fn(async () => ({ content: "listed" }));
+    createOpenClawToolsMock.mockReturnValue([
+      {
+        name: "sessions_list",
+        execute: toolExecute,
+      },
+    ]);
+
+    const ctx = buildTestCtx({
+      Body: "/list_sessions now",
+      CommandBody: "/list_sessions now",
+    });
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "list_sessions",
+        skillName: "list-sessions",
+        description: "List sessions",
+        dispatch: {
+          kind: "tool",
+          toolName: "sessions_list",
+          argMode: "raw",
+        },
+        sourceFilePath: "/tmp/plugin/commands/list-sessions.md",
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/list_sessions now",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/list_sessions now",
+          commandBodyNormalized: "/list_sessions now",
+        },
+        overrides: {
+          cfg: {
+            commands: { text: true },
+            agents: { defaults: { sandbox: { mode: "all" } } },
+          },
+          sessionKey: "agent:main:thread",
+          allowTextCommands: true,
+          skillCommands,
+        },
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "✅ Done." } });
+    expect(createOpenClawToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandboxed: true,
+      }),
+    );
+    expect(toolExecute).toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -789,4 +789,122 @@ describe("handleInlineActions", () => {
     expect(blockedToolCall?.[2]).toBe(abortController.signal);
     expect(typing.cleanup).toHaveBeenCalledTimes(1);
   });
+
+  it("does not execute inline tool dispatch targets denied by tool policy", async () => {
+    const typing = createTypingController();
+    const toolExecute = vi.fn(async () => ({ content: "sent" }));
+    createOpenClawToolsMock.mockReturnValue([
+      {
+        name: "message",
+        execute: toolExecute,
+      },
+    ]);
+
+    const ctx = buildTestCtx({
+      Body: "/send_status hello",
+      CommandBody: "/send_status hello",
+    });
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "send_status",
+        skillName: "send-status",
+        description: "Send a status update",
+        dispatch: {
+          kind: "tool",
+          toolName: "message",
+          argMode: "raw",
+        },
+        sourceFilePath: "/tmp/plugin/commands/send-status.md",
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/send_status hello",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/send_status hello",
+          commandBodyNormalized: "/send_status hello",
+        },
+        overrides: {
+          cfg: { commands: { text: true }, tools: { deny: ["message"] } },
+          allowTextCommands: true,
+          skillCommands,
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "reply",
+      reply: { text: "❌ Tool not available: message" },
+    });
+    expect(toolExecute).not.toHaveBeenCalled();
+  });
+
+  it("does not execute inline tool dispatch targets outside tool allowlists", async () => {
+    const typing = createTypingController();
+    const messageExecute = vi.fn(async () => ({ content: "sent" }));
+    const sessionsExecute = vi.fn(async () => ({ content: "listed" }));
+    createOpenClawToolsMock.mockReturnValue([
+      {
+        name: "message",
+        execute: messageExecute,
+      },
+      {
+        name: "sessions_list",
+        execute: sessionsExecute,
+      },
+    ]);
+
+    const ctx = buildTestCtx({
+      Body: "/send_status hello",
+      CommandBody: "/send_status hello",
+    });
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "send_status",
+        skillName: "send-status",
+        description: "Send a status update",
+        dispatch: {
+          kind: "tool",
+          toolName: "message",
+          argMode: "raw",
+        },
+        sourceFilePath: "/tmp/plugin/commands/send-status.md",
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/send_status hello",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/send_status hello",
+          commandBodyNormalized: "/send_status hello",
+        },
+        overrides: {
+          cfg: { commands: { text: true }, tools: { allow: ["sessions_list"] } },
+          allowTextCommands: true,
+          skillCommands,
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "reply",
+      reply: { text: "❌ Tool not available: message" },
+    });
+    expect(messageExecute).not.toHaveBeenCalled();
+    expect(sessionsExecute).not.toHaveBeenCalled();
+  });
 });

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -1,7 +1,6 @@
 import { collectTextContentBlocks } from "../../agents/content-blocks.js";
 import type { BlockReplyChunking } from "../../agents/pi-embedded-block-chunker.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
-import { applyOwnerOnlyToolPolicy } from "../../agents/tool-policy.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -13,7 +12,6 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
-import { resolveGatewayMessageChannel } from "../../utils/message-channel.js";
 import {
   listReservedChatSlashCommandNames,
   resolveSkillCommandInvocation,
@@ -30,22 +28,21 @@ import { getAbortMemory, isAbortRequestText } from "./abort-primitives.js";
 import type { buildStatusReply, handleCommands } from "./commands.runtime.js";
 import { isDirectiveOnly } from "./directive-handling.directive-only.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
-import { extractExplicitGroupId } from "./group-id.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import { extractInlineSimpleCommand } from "./reply-inline.js";
 import type { TypingController } from "./typing.js";
 
 type SkillCommandsRuntime = typeof import("../skill-commands.runtime.js");
-type OpenClawToolsRuntime = typeof import("../../agents/openclaw-tools.runtime.js");
+type SkillToolDispatchRuntime = typeof import("./skill-tool-dispatch.runtime.js");
 type AbortCutoffRuntime = typeof import("./abort-cutoff.runtime.js");
 type CommandsRuntime = typeof import("./commands.runtime.js");
 
 const skillCommandsRuntimeLoader = createLazyImportLoader<SkillCommandsRuntime>(
   () => import("../skill-commands.runtime.js"),
 );
-const openClawToolsRuntimeLoader = createLazyImportLoader<OpenClawToolsRuntime>(
-  () => import("../../agents/openclaw-tools.runtime.js"),
+const skillToolDispatchRuntimeLoader = createLazyImportLoader<SkillToolDispatchRuntime>(
+  () => import("./skill-tool-dispatch.runtime.js"),
 );
 const abortCutoffRuntimeLoader = createLazyImportLoader<AbortCutoffRuntime>(
   () => import("./abort-cutoff.runtime.js"),
@@ -59,8 +56,8 @@ function loadSkillCommandsRuntime(): Promise<SkillCommandsRuntime> {
   return skillCommandsRuntimeLoader.load();
 }
 
-function loadOpenClawToolsRuntime(): Promise<OpenClawToolsRuntime> {
-  return openClawToolsRuntimeLoader.load();
+function loadSkillToolDispatchRuntime(): Promise<SkillToolDispatchRuntime> {
+  return skillToolDispatchRuntimeLoader.load();
 }
 
 function loadAbortCutoffRuntime(): Promise<AbortCutoffRuntime> {
@@ -266,27 +263,20 @@ export async function handleInlineActions(params: {
     const dispatch = skillInvocation.command.dispatch;
     if (dispatch?.kind === "tool") {
       const rawArgs = (skillInvocation.args ?? "").trim();
-      const channel =
-        resolveGatewayMessageChannel(ctx.Surface) ??
-        resolveGatewayMessageChannel(ctx.Provider) ??
-        undefined;
-
-      const { createOpenClawTools } = await loadOpenClawToolsRuntime();
-      const tools = createOpenClawTools({
-        agentSessionKey: sessionKey,
-        agentChannel: channel,
-        agentAccountId: (ctx as { AccountId?: string }).AccountId,
-        agentTo: ctx.OriginatingTo ?? ctx.To,
-        agentThreadId: ctx.MessageThreadId ?? undefined,
-        agentGroupId: extractExplicitGroupId(ctx.From),
-        requesterAgentIdOverride: agentId,
+      const { resolveSkillDispatchTools } = await loadSkillToolDispatchRuntime();
+      const authorizedTools = resolveSkillDispatchTools({
+        ctx,
+        cfg,
+        agentId,
         agentDir,
+        sessionEntry,
+        sessionKey,
         workspaceDir,
-        config: cfg,
-        allowGatewaySubagentBinding: true,
+        provider,
+        model,
+        senderId: command.senderId,
         senderIsOwner: command.senderIsOwner,
       });
-      const authorizedTools = applyOwnerOnlyToolPolicy(tools, command.senderIsOwner);
 
       const tool = authorizedTools.find((candidate) => candidate.name === dispatch.toolName);
       if (!tool) {

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -287,14 +287,13 @@ export async function handleInlineActions(params: {
         cfg,
         agentId,
         agentDir,
-        sessionEntry,
+        sessionEntry: targetSessionEntry,
         sessionKey,
         workspaceDir,
         provider,
         model,
         senderId: command.senderId,
         senderIsOwner: command.senderIsOwner,
-        sessionId: targetSessionEntry?.sessionId,
         currentChannelId: command.channelId,
       });
 

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -1,7 +1,6 @@
 import { collectTextContentBlocks } from "../../agents/content-blocks.js";
 import type { BlockReplyChunking } from "../../agents/pi-embedded-block-chunker.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
-import { applyOwnerOnlyToolPolicy } from "../../agents/tool-policy.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -13,7 +12,6 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
-import { resolveGatewayMessageChannel } from "../../utils/message-channel.js";
 import {
   listReservedChatSlashCommandNames,
   resolveSkillCommandInvocation,
@@ -30,22 +28,21 @@ import { getAbortMemory, isAbortRequestText } from "./abort-primitives.js";
 import type { buildStatusReply, handleCommands } from "./commands.runtime.js";
 import { isDirectiveOnly } from "./directive-handling.directive-only.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
-import { extractExplicitGroupId } from "./group-id.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import { extractInlineSimpleCommand } from "./reply-inline.js";
 import type { TypingController } from "./typing.js";
 
 type SkillCommandsRuntime = typeof import("../skill-commands.runtime.js");
-type OpenClawToolsRuntime = typeof import("../../agents/openclaw-tools.runtime.js");
+type SkillToolDispatchRuntime = typeof import("./skill-tool-dispatch.runtime.js");
 type AbortCutoffRuntime = typeof import("./abort-cutoff.runtime.js");
 type CommandsRuntime = typeof import("./commands.runtime.js");
 
 const skillCommandsRuntimeLoader = createLazyImportLoader<SkillCommandsRuntime>(
   () => import("../skill-commands.runtime.js"),
 );
-const openClawToolsRuntimeLoader = createLazyImportLoader<OpenClawToolsRuntime>(
-  () => import("../../agents/openclaw-tools.runtime.js"),
+const skillToolDispatchRuntimeLoader = createLazyImportLoader<SkillToolDispatchRuntime>(
+  () => import("./skill-tool-dispatch.runtime.js"),
 );
 const abortCutoffRuntimeLoader = createLazyImportLoader<AbortCutoffRuntime>(
   () => import("./abort-cutoff.runtime.js"),
@@ -59,8 +56,8 @@ function loadSkillCommandsRuntime(): Promise<SkillCommandsRuntime> {
   return skillCommandsRuntimeLoader.load();
 }
 
-function loadOpenClawToolsRuntime(): Promise<OpenClawToolsRuntime> {
-  return openClawToolsRuntimeLoader.load();
+function loadSkillToolDispatchRuntime(): Promise<SkillToolDispatchRuntime> {
+  return skillToolDispatchRuntimeLoader.load();
 }
 
 function loadAbortCutoffRuntime(): Promise<AbortCutoffRuntime> {
@@ -284,29 +281,22 @@ export async function handleInlineActions(params: {
     const dispatch = skillInvocation.command.dispatch;
     if (dispatch?.kind === "tool") {
       const rawArgs = (skillInvocation.args ?? "").trim();
-      const channel =
-        resolveGatewayMessageChannel(ctx.Surface) ??
-        resolveGatewayMessageChannel(ctx.Provider) ??
-        undefined;
-
-      const { createOpenClawTools } = await loadOpenClawToolsRuntime();
-      const tools = createOpenClawTools({
-        agentSessionKey: sessionKey,
-        agentChannel: channel,
-        agentAccountId: (ctx as { AccountId?: string }).AccountId,
-        agentTo: ctx.OriginatingTo ?? ctx.To,
-        agentThreadId: ctx.MessageThreadId ?? undefined,
-        agentGroupId: extractExplicitGroupId(ctx.From),
-        requesterAgentIdOverride: agentId,
+      const { resolveSkillDispatchTools } = await loadSkillToolDispatchRuntime();
+      const authorizedTools = resolveSkillDispatchTools({
+        ctx,
+        cfg,
+        agentId,
         agentDir,
+        sessionEntry,
+        sessionKey,
         workspaceDir,
-        config: cfg,
-        allowGatewaySubagentBinding: true,
+        provider,
+        model,
+        senderId: command.senderId,
         senderIsOwner: command.senderIsOwner,
         sessionId: targetSessionEntry?.sessionId,
         currentChannelId: command.channelId,
       });
-      const authorizedTools = applyOwnerOnlyToolPolicy(tools, command.senderIsOwner);
 
       const tool = authorizedTools.find((candidate) => candidate.name === dispatch.toolName);
       if (!tool) {

--- a/src/auto-reply/reply/skill-tool-dispatch.runtime.ts
+++ b/src/auto-reply/reply/skill-tool-dispatch.runtime.ts
@@ -7,6 +7,10 @@ import {
 import type { AnyAgentTool } from "../../agents/pi-tools.types.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status.js";
 import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "../../agents/subagent-capabilities.js";
+import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
 } from "../../agents/tool-policy-pipeline.js";
@@ -21,11 +25,15 @@ import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { getPluginToolMeta } from "../../plugins/tools.js";
-import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { resolveGatewayMessageChannel } from "../../utils/message-channel.js";
 import type { MsgContext } from "../templating.js";
 import { extractExplicitGroupId } from "./group-id.js";
 
+/**
+ * Policy-enforcement seam for skill `command-dispatch: tool` invocations.
+ * Keep this aligned with the normal tool surfaces so GHSA-mhm4-93fw-4qr2
+ * stays closed across allow/deny, group, sandbox, and subagent policy layers.
+ */
 export function resolveSkillDispatchTools(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
@@ -87,8 +95,16 @@ export function resolveSkillDispatchTools(params: {
     sessionKey: params.sessionKey,
   });
   const sandboxPolicy = sandboxRuntime.sandboxed ? sandboxRuntime.toolPolicy : undefined;
-  const subagentPolicy = isSubagentSessionKey(params.sessionKey)
-    ? resolveSubagentToolPolicyForSession(params.cfg, params.sessionKey)
+  const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, {
+    cfg: params.cfg,
+  });
+  const subagentPolicy = isSubagentEnvelopeSession(params.sessionKey, {
+    cfg: params.cfg,
+    store: subagentStore,
+  })
+    ? resolveSubagentToolPolicyForSession(params.cfg, params.sessionKey, {
+        store: subagentStore,
+      })
     : undefined;
   const tools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
@@ -104,6 +120,7 @@ export function resolveSkillDispatchTools(params: {
     workspaceDir: params.workspaceDir,
     config: params.cfg,
     allowGatewaySubagentBinding: true,
+    sandboxed: sandboxRuntime.sandboxed,
     requesterAgentIdOverride: params.agentId,
     requesterSenderId: params.senderId,
     senderIsOwner: params.senderIsOwner,

--- a/src/auto-reply/reply/skill-tool-dispatch.runtime.ts
+++ b/src/auto-reply/reply/skill-tool-dispatch.runtime.ts
@@ -1,0 +1,160 @@
+import { createOpenClawTools } from "../../agents/openclaw-tools.runtime.js";
+import {
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  resolveSubagentToolPolicyForSession,
+} from "../../agents/pi-tools.policy.js";
+import type { AnyAgentTool } from "../../agents/pi-tools.types.js";
+import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status.js";
+import {
+  applyToolPolicyPipeline,
+  buildDefaultToolPolicyPipelineSteps,
+} from "../../agents/tool-policy-pipeline.js";
+import {
+  applyOwnerOnlyToolPolicy,
+  collectExplicitDenylist,
+  collectExplicitAllowlist,
+  mergeAlsoAllowPolicy,
+  resolveToolProfilePolicy,
+} from "../../agents/tool-policy.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { logVerbose } from "../../globals.js";
+import { getPluginToolMeta } from "../../plugins/tools.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
+import { resolveGatewayMessageChannel } from "../../utils/message-channel.js";
+import type { MsgContext } from "../templating.js";
+import { extractExplicitGroupId } from "./group-id.js";
+
+export function resolveSkillDispatchTools(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+  agentDir?: string;
+  sessionEntry?: SessionEntry;
+  sessionKey: string;
+  workspaceDir: string;
+  provider: string;
+  model: string;
+  senderId?: string;
+  senderIsOwner: boolean;
+}): AnyAgentTool[] {
+  const channel =
+    resolveGatewayMessageChannel(params.ctx.Surface) ??
+    resolveGatewayMessageChannel(params.ctx.Provider) ??
+    undefined;
+  const {
+    agentId: resolvedAgentId,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    profile,
+    providerProfile,
+    profileAlsoAllow,
+    providerProfileAlsoAllow,
+  } = resolveEffectiveToolPolicy({
+    config: params.cfg,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    modelProvider: params.provider,
+    modelId: params.model,
+  });
+  const profilePolicy = resolveToolProfilePolicy(profile);
+  const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
+  const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(profilePolicy, profileAlsoAllow);
+  const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(
+    providerProfilePolicy,
+    providerProfileAlsoAllow,
+  );
+  const groupId = params.sessionEntry?.groupId ?? extractExplicitGroupId(params.ctx.From);
+  const groupPolicy = resolveGroupToolPolicy({
+    config: params.cfg,
+    sessionKey: params.sessionKey,
+    spawnedBy: params.sessionEntry?.spawnedBy,
+    messageProvider: channel,
+    groupId,
+    groupChannel: params.sessionEntry?.groupChannel,
+    groupSpace: params.sessionEntry?.space,
+    accountId: params.ctx.AccountId,
+    senderId: params.ctx.SenderId ?? params.senderId,
+    senderName: params.ctx.SenderName,
+    senderUsername: params.ctx.SenderUsername,
+    senderE164: params.ctx.SenderE164,
+  });
+  const sandboxRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+  });
+  const sandboxPolicy = sandboxRuntime.sandboxed ? sandboxRuntime.toolPolicy : undefined;
+  const subagentPolicy = isSubagentSessionKey(params.sessionKey)
+    ? resolveSubagentToolPolicyForSession(params.cfg, params.sessionKey)
+    : undefined;
+  const tools = createOpenClawTools({
+    agentSessionKey: params.sessionKey,
+    agentChannel: channel,
+    agentAccountId: params.ctx.AccountId,
+    agentTo: params.ctx.OriginatingTo ?? params.ctx.To,
+    agentThreadId: params.ctx.MessageThreadId ?? undefined,
+    agentGroupId: groupId,
+    agentGroupChannel: params.sessionEntry?.groupChannel,
+    agentGroupSpace: params.sessionEntry?.space,
+    agentMemberRoleIds: params.ctx.MemberRoleIds,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+    config: params.cfg,
+    allowGatewaySubagentBinding: true,
+    requesterAgentIdOverride: params.agentId,
+    requesterSenderId: params.senderId,
+    senderIsOwner: params.senderIsOwner,
+    sessionId: params.sessionEntry?.sessionId,
+    modelProvider: params.provider,
+    modelId: params.model,
+    pluginToolAllowlist: collectExplicitAllowlist([
+      profilePolicy,
+      providerProfilePolicy,
+      globalPolicy,
+      globalProviderPolicy,
+      agentPolicy,
+      agentProviderPolicy,
+      groupPolicy,
+      sandboxPolicy,
+      subagentPolicy,
+    ]),
+    pluginToolDenylist: collectExplicitDenylist([
+      profilePolicy,
+      providerProfilePolicy,
+      globalPolicy,
+      globalProviderPolicy,
+      agentPolicy,
+      agentProviderPolicy,
+      groupPolicy,
+      sandboxPolicy,
+      subagentPolicy,
+    ]),
+  }) as AnyAgentTool[];
+  const policyFiltered = applyToolPolicyPipeline({
+    tools,
+    toolMeta: (tool) => getPluginToolMeta(tool),
+    warn: logVerbose,
+    steps: [
+      ...buildDefaultToolPolicyPipelineSteps({
+        profilePolicy: profilePolicyWithAlsoAllow,
+        profile,
+        profileUnavailableCoreWarningAllowlist: profilePolicy?.allow,
+        providerProfilePolicy: providerProfilePolicyWithAlsoAllow,
+        providerProfile,
+        providerProfileUnavailableCoreWarningAllowlist: providerProfilePolicy?.allow,
+        globalPolicy,
+        globalProviderPolicy,
+        agentPolicy,
+        agentProviderPolicy,
+        groupPolicy,
+        agentId: resolvedAgentId,
+      }),
+      { policy: sandboxPolicy, label: "sandbox tools.allow" },
+      { policy: subagentPolicy, label: "subagent tools.allow" },
+    ],
+  });
+  return applyOwnerOnlyToolPolicy(policyFiltered, params.senderIsOwner) as AnyAgentTool[];
+}

--- a/src/auto-reply/reply/skill-tool-dispatch.runtime.ts
+++ b/src/auto-reply/reply/skill-tool-dispatch.runtime.ts
@@ -2,10 +2,12 @@ import { createOpenClawTools } from "../../agents/openclaw-tools.runtime.js";
 import {
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
+  resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
 } from "../../agents/pi-tools.policy.js";
 import type { AnyAgentTool } from "../../agents/pi-tools.types.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status.js";
+import { resolveSenderToolPolicy } from "../../agents/sender-tool-policy.js";
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
@@ -18,7 +20,9 @@ import {
   applyOwnerOnlyToolPolicy,
   collectExplicitDenylist,
   collectExplicitAllowlist,
+  hasRestrictiveAllowPolicy,
   mergeAlsoAllowPolicy,
+  replaceWithEffectiveToolAllowlist,
   resolveToolProfilePolicy,
 } from "../../agents/tool-policy.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -46,6 +50,7 @@ export function resolveSkillDispatchTools(params: {
   model: string;
   senderId?: string;
   senderIsOwner: boolean;
+  currentChannelId?: string;
 }): AnyAgentTool[] {
   const channel =
     resolveGatewayMessageChannel(params.ctx.Surface) ??
@@ -90,6 +95,15 @@ export function resolveSkillDispatchTools(params: {
     senderUsername: params.ctx.SenderUsername,
     senderE164: params.ctx.SenderE164,
   });
+  const senderPolicy = resolveSenderToolPolicy({
+    config: params.cfg,
+    agentId: resolvedAgentId,
+    messageProvider: channel,
+    senderId: params.ctx.SenderId ?? params.senderId,
+    senderName: params.ctx.SenderName,
+    senderUsername: params.ctx.SenderUsername,
+    senderE164: params.ctx.SenderE164,
+  });
   const sandboxRuntime = resolveSandboxRuntimeStatus({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
@@ -106,6 +120,23 @@ export function resolveSkillDispatchTools(params: {
         store: subagentStore,
       })
     : undefined;
+  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(params.cfg, params.sessionKey, {
+    store: subagentStore,
+  });
+  const explicitPolicyList = [
+    profilePolicy,
+    providerProfilePolicy,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    groupPolicy,
+    senderPolicy,
+    sandboxPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+  ];
+  const inheritedToolAllowlist: string[] = [];
   const tools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
     agentChannel: channel,
@@ -125,31 +156,14 @@ export function resolveSkillDispatchTools(params: {
     requesterSenderId: params.senderId,
     senderIsOwner: params.senderIsOwner,
     sessionId: params.sessionEntry?.sessionId,
+    currentChannelId: params.currentChannelId,
     modelProvider: params.provider,
     modelId: params.model,
-    pluginToolAllowlist: collectExplicitAllowlist([
-      profilePolicy,
-      providerProfilePolicy,
-      globalPolicy,
-      globalProviderPolicy,
-      agentPolicy,
-      agentProviderPolicy,
-      groupPolicy,
-      sandboxPolicy,
-      subagentPolicy,
-    ]),
-    pluginToolDenylist: collectExplicitDenylist([
-      profilePolicy,
-      providerProfilePolicy,
-      globalPolicy,
-      globalProviderPolicy,
-      agentPolicy,
-      agentProviderPolicy,
-      groupPolicy,
-      sandboxPolicy,
-      subagentPolicy,
-    ]),
-  }) as AnyAgentTool[];
+    pluginToolAllowlist: collectExplicitAllowlist(explicitPolicyList),
+    pluginToolDenylist: collectExplicitDenylist(explicitPolicyList),
+    inheritedToolAllowlist,
+    inheritedToolDenylist: collectExplicitDenylist(explicitPolicyList),
+  });
   const policyFiltered = applyToolPolicyPipeline({
     tools,
     toolMeta: (tool) => getPluginToolMeta(tool),
@@ -167,11 +181,17 @@ export function resolveSkillDispatchTools(params: {
         agentPolicy,
         agentProviderPolicy,
         groupPolicy,
+        senderPolicy,
         agentId: resolvedAgentId,
       }),
       { policy: sandboxPolicy, label: "sandbox tools.allow" },
       { policy: subagentPolicy, label: "subagent tools.allow" },
+      { policy: inheritedToolPolicy, label: "inherited tools" },
     ],
   });
-  return applyOwnerOnlyToolPolicy(policyFiltered, params.senderIsOwner) as AnyAgentTool[];
+  const authorizedTools = applyOwnerOnlyToolPolicy(policyFiltered, params.senderIsOwner);
+  if (explicitPolicyList.some(hasRestrictiveAllowPolicy)) {
+    replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, authorizedTools);
+  }
+  return authorizedTools;
 }


### PR DESCRIPTION
## Summary
- Keeps inline skill tool dispatch aligned with configured tool policy before selecting a dispatch target.
- Preserves the existing inline command behavior while passing the expected session, channel, sender, sandbox, and subagent context into tool construction.

## Changes
- Routes inline skill dispatch through a helper that applies effective profile, provider, global, agent, group, sender, sandbox, subagent, and inherited tool policy before owner-only gating.
- Preserves `sessionId` and `currentChannelId` for the inline dispatch tool runtime.
- Adds focused regressions for denied tools, allowlisted tools, sender-specific policy, ACP envelope policy, and sandboxed inline dispatch construction.

## Validation
- `node --import tsx -e '...'` runtime probe against `resolveSkillDispatchTools` with `tools.deny: ["message"]` and plugins disabled.
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts -- --reporter=verbose`
- `corepack pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/auto-reply/reply/get-reply-inline-actions.ts src/auto-reply/reply/skill-tool-dispatch.runtime.ts`
- `git diff --check`
- `node scripts/check-changed.mjs --dry-run`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src ui packages`
- Local agentic review was attempted with `claude -p "/review 78525"` and `codex review --uncommitted`; both were blocked by local harness/tooling errors before producing actionable findings.

## Real behavior proof
- **Behavior addressed:** Inline skill commands that dispatch directly to tools now remove dispatch targets excluded by the configured effective tool policy before execution.
- **Real environment tested:** Local OpenClaw source checkout on Linux with Node v22.22.2, using the real inline dispatch resolver and real OpenClaw core tool construction with plugins disabled.
- **Exact steps or command run after this patch:** Ran a `node --import tsx -e '...'` runtime probe that called `resolveSkillDispatchTools` with `cfg.tools.deny: ["message"]`, `plugins.enabled: false`, `senderIsOwner: true`, and a Telegram-like message context.
- **Evidence after fix:** Terminal output from the runtime command:

```json
{
  "deniedTool": "message",
  "messageAvailable": false,
  "sessionsListAvailable": true,
  "toolCount": 15
}
```

- **Observed result after fix:** The denied `message` dispatch target was absent from the resolved tool list while another core tool, `sessions_list`, remained available.
- **What was not tested:** Live channel delivery through Telegram, Slack, Discord, or WhatsApp was not exercised. Plugin tool dispatch was not part of the runtime probe because plugins were disabled to keep the proof isolated to the shipped core tool path. Testbox `pnpm check:changed` proof was blocked because the local Crabbox wrapper could not find a working `crabbox` binary.

## Notes
- No changelog entry included.
