### PR TITLE
fix(gateway): fail hot reload when channel stop times out

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -324,7 +324,36 @@ describe("server-channels auto restart", () => {
     const snapshot = manager.getRuntimeSnapshot();
     const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
     expect(startAccount).toHaveBeenCalledTimes(1);
-    expect(account?.running).toBe(true);
+    expect(account?.running).toBe(false);
+    expect(account?.restartPending).toBe(false);
+    expect(account?.lastError).toContain("channel stop timed out");
+  });
+
+  it("can fail a stop call when the account task does not drain", async () => {
+    const startAccount = vi.fn(
+      async ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        await new Promise<void>(() => {
+          abortSignal.addEventListener("abort", () => {}, { once: true });
+        }),
+    );
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const stopExpectation = expect(
+      manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { failOnTimeout: true }),
+    ).rejects.toThrow("[discord:default] channel stop timed out after 5000ms");
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await stopExpectation;
+    const snapshot = manager.getRuntimeSnapshot();
+    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(account?.running).toBe(false);
     expect(account?.restartPending).toBe(false);
     expect(account?.lastError).toContain("channel stop timed out");
   });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -190,6 +190,7 @@ type StartChannelOptions = {
 
 type StopChannelOptions = {
   manual?: boolean;
+  failOnTimeout?: boolean;
 };
 
 export type ChannelManager = {
@@ -707,17 +708,21 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           CHANNEL_STOP_ABORT_TIMEOUT_MS,
         );
         if (!stoppedCleanly) {
+          const timeoutMessage = `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`;
           log.warn?.(
             `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
           );
           setRuntime(channelId, id, {
             accountId: id,
-            running: manual,
+            running: false,
             restartPending: !manual,
-            lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
+            lastError: timeoutMessage,
           });
           if (!manual) {
             recoveryStopTimedOut.add(rKey);
+          }
+          if (opts.failOnTimeout) {
+            throw new Error(`[${channelId}:${id}] ${timeoutMessage}`);
           }
           return;
         }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -243,7 +243,7 @@ describe("gateway plugin hot reload handlers", () => {
         changedPaths: ["plugins.enabled"],
       }),
     );
-    expect(stopChannel).toHaveBeenCalledWith("discord");
+    expect(stopChannel).toHaveBeenCalledWith("discord", { failOnTimeout: true });
     expect(startChannel).not.toHaveBeenCalled();
     expect(events).toEqual(["reload:start", "stop", "registry:replace"]);
     expect(setState).toHaveBeenCalledTimes(1);

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -97,7 +97,7 @@ type GatewayReloadHandlerParams = {
   getState: () => GatewayHotReloadState;
   setState: (state: GatewayHotReloadState) => void;
   startChannel: (name: ChannelKind) => Promise<void>;
-  stopChannel: (name: ChannelKind) => Promise<void>;
+  stopChannel: (name: ChannelKind, opts?: { failOnTimeout?: boolean }) => Promise<void>;
   reloadPlugins: (params: {
     nextConfig: OpenClawConfig;
     changedPaths: readonly string[];
@@ -294,7 +294,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
             continue;
           }
           params.logChannels.info(`stopping ${channel} channel before plugin reload`);
-          await params.stopChannel(channel);
+          await params.stopChannel(channel, { failOnTimeout: true });
           channelsStoppedBeforePluginReload.add(channel);
         }
       };
@@ -368,7 +368,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
           }
           params.logChannels.info(`restarting ${name} channel`);
           if (!channelsStoppedBeforePluginReload.has(name)) {
-            await params.stopChannel(name);
+            await params.stopChannel(name, { failOnTimeout: true });
           }
           await params.startChannel(name);
         };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1491,7 +1491,7 @@ export async function startGatewayServer(
         }
       },
       startChannel,
-      stopChannel,
+      stopChannel: (name, opts) => stopChannel(name, undefined, opts),
       reloadPlugins: reloadAttachedGatewayPlugins,
       logHooks,
       logChannels,


### PR DESCRIPTION
## Summary
- add a `failOnTimeout` stop option for channel shutdowns
- make gateway hot reload fail fast when a channel does not stop within the abort timeout
- leave timed-out channel runtime marked as not running instead of preserving a false running state
- cover both the channel manager timeout state and hot-reload stop calls in tests

## Why
During hot reload, a long-lived channel task can ignore abort and fail to drain before the stop timeout. Previously `stopChannel` logged the timeout but allowed hot reload to continue into `startChannel`. That can leave the old provider/task alive while the gateway reports a healthy/running replacement, which is especially risky for polling-based channels.

Failing the hot reload stop path prevents starting a replacement channel over a still-draining old one and avoids reporting a stale runtime as running.

## Test plan
- `pnpm test src/gateway/server-channels.test.ts src/gateway/server-reload-handlers.test.ts`
- `git diff --check`
