### PR TITLE
fix(agents): strip reasoning items from context when switching to non-reasoning model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/context: strip reasoning items from prior-message context when the target model does not support reasoning, preventing 400 validation errors after model switches from reasoning-capable to non-reasoning models mid-session. Fixes #78545. (#78545) Thanks @hclsys.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1317,6 +1317,71 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("strips reasoning items from context when switching to a non-reasoning model", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 16384,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-responses",
+            provider: "venice",
+            model: "claude-sonnet-4-6",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "end",
+            timestamp: 1,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Let me reason about this.",
+                thinkingSignature: JSON.stringify({
+                  type: "reasoning",
+                  id: "rs_prior",
+                  encrypted_content: "ciphertext",
+                }),
+              },
+              {
+                type: "text",
+                text: "Here is my answer.",
+                textSignature: JSON.stringify({ v: 1, id: "msg_prior", phase: "commentary" }),
+              },
+            ],
+          },
+          { role: "user", content: "follow up question", timestamp: 2 },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      input?: Array<{ type?: string; role?: string }>;
+    };
+
+    const reasoningItem = params.input?.find((item) => item.type === "reasoning");
+    expect(reasoningItem).toBeUndefined();
+    const assistantMessage = params.input?.find(
+      (item) => item.type === "message" && item.role === "assistant",
+    );
+    expect(assistantMessage).toBeDefined();
+  });
+
   it("adds minimal user input for Codex responses when only the system prompt is present", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -994,7 +994,7 @@ export function buildOpenAIResponsesParams(
     {
       includeSystemPrompt: !isCodexResponses,
       supportsDeveloperRole,
-      replayReasoningItems: true,
+      replayReasoningItems: model.reasoning === true,
       replayResponsesItemIds: !isNativeCodexResponses,
     },
   );


### PR DESCRIPTION
## Root cause

`convertResponsesMessages` is called with `replayReasoningItems: true` unconditionally. When a session starts on a reasoning-capable model (e.g., `venice/claude-sonnet-4-6`, `reasoning: true`) and the user switches mid-session to a non-reasoning model (e.g., `openai/gpt-5.5`, `reasoning: false`), prior assistant messages with `thinkingSignature` fields get serialized as `{ type: "reasoning", encrypted_content: "..." }` items in the context payload. OpenAI rejects the request with a 400 validation error because the non-reasoning API does not accept reasoning item types.

## Fix

Gate `replayReasoningItems` on `model.reasoning === true`. When the target model does not explicitly support reasoning (`reasoning: false` or `reasoning: undefined`), reasoning items from prior messages are excluded from the payload. Text content from those assistant turns is preserved.

## Changed files

- `src/agents/openai-transport-stream.ts` — `replayReasoningItems: model.reasoning === true` (was `true`)
- `src/agents/openai-transport-stream.test.ts` — 1 new test: "strips reasoning items from context when switching to a non-reasoning model"
- `CHANGELOG.md` — Unreleased → Fixes entry

## Proof

```
pnpm test src/agents/openai-transport-stream.test.ts
# Tests: 104 passed (104)

pnpm -s tsgo:core  # exit 0
pnpm -s build      # exit 0
```

Fixes #78545