### PR TITLE
fix(googlechat): fix googlechat grant_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Google Chat: use the `google-auth-library` bundled `Gaxios` and improve `Headers` compatibility for upstream interceptors, ensuring authorized requests correctly propagate authentication headers. Thanks @donbowman
 - Plugin SDK: keep activated linked plugin runtime facades loadable when bundled plugin fallback is disabled. Thanks @shakkernerd.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -8,8 +8,8 @@
   },
   "type": "module",
   "dependencies": {
-    "gaxios": "7.1.4",
-    "google-auth-library": "10.6.2"
+    "google-auth-library": "10.6.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -8,8 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "google-auth-library": "10.6.2",
-    "zod": "^4.4.3"
+    "google-auth-library": "10.6.2"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -8,34 +8,12 @@ const mocks = vi.hoisted(() => ({
     hostnameAllowlist: hosts,
   })),
   fetchWithSsrFGuard: vi.fn(),
-  gaxiosCtor: vi.fn(
-    function MockGaxios(
-      this: {
-        defaults: Record<string, unknown>;
-        interceptors: {
-          request: { add: ReturnType<typeof vi.fn> };
-          response: { add: ReturnType<typeof vi.fn> };
-        };
-      },
-      defaults,
-    ) {
-      this.defaults = defaults as Record<string, unknown>;
-      this.interceptors = {
-        request: { add: vi.fn() },
-        response: { add: vi.fn() },
-      };
-    },
-  ),
 }));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   buildHostnameAllowlistPolicyFromSuffixAllowlist:
     mocks.buildHostnameAllowlistPolicyFromSuffixAllowlist,
   fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
-}));
-
-vi.mock("gaxios", () => ({
-  Gaxios: mocks.gaxiosCtor,
 }));
 
 let __testing: typeof import("./google-auth.runtime.js").__testing;
@@ -56,7 +34,6 @@ beforeEach(() => {
   __testing.resetGoogleAuthRuntimeForTests();
   mocks.buildHostnameAllowlistPolicyFromSuffixAllowlist.mockClear();
   mocks.fetchWithSsrFGuard.mockReset();
-  mocks.gaxiosCtor.mockClear();
 });
 
 afterEach(() => {
@@ -111,6 +88,40 @@ describe("googlechat google auth runtime", () => {
       },
       url: "https://oauth2.googleapis.com/token",
     });
+    await expect(response.text()).resolves.toBe("ok");
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("preserves Request properties when gaxios passes a Request object", async () => {
+    const release = vi.fn();
+    const injectedFetch = vi.fn(globalThis.fetch);
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: new Response("ok", { status: 200 }),
+      release,
+    });
+
+    const guardedFetch = createGoogleAuthFetch(injectedFetch);
+    const request = new Request("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "grant_type=refresh_token",
+    });
+
+    const response = await guardedFetch(request);
+
+    expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://oauth2.googleapis.com/token",
+        init: expect.objectContaining({
+          method: "POST",
+          body: expect.anything(), // body is a ReadableStream in Request
+        }),
+      }),
+    );
+    // Native Headers in init should have the expected values
+    const callInit = mocks.fetchWithSsrFGuard.mock.calls[0]?.[0].init;
+    expect(callInit.headers.get("Content-Type")).toBe("application/x-www-form-urlencoded");
+
     await expect(response.text()).resolves.toBe("ok");
     expect(release).toHaveBeenCalledOnce();
   });
@@ -345,26 +356,16 @@ describe("googlechat google auth runtime", () => {
     Reflect.deleteProperty(globalThis as object, "window");
     try {
       const transport = await getGoogleAuthTransport();
-      const transportDefaults = transport.defaults as { fetchImplementation?: unknown };
-      const requestInterceptorAdd = transport.interceptors.request.add as unknown as ReturnType<
-        typeof vi.fn
-      >;
-      const responseInterceptorAdd = transport.interceptors.response.add as unknown as ReturnType<
-        typeof vi.fn
-      >;
-      const requestInterceptor = requestInterceptorAdd.mock.calls[0]?.[0] as
-        | { resolved?: unknown }
-        | undefined;
-      const responseInterceptor = responseInterceptorAdd.mock.calls[0]?.[0] as
-        | { resolved?: unknown }
-        | undefined;
 
-      expect(mocks.gaxiosCtor).toHaveBeenCalledOnce();
-      expect(typeof transportDefaults.fetchImplementation).toBe("function");
-      expect(requestInterceptorAdd).toHaveBeenCalledOnce();
-      expect(typeof requestInterceptor?.resolved).toBe("function");
-      expect(responseInterceptorAdd).toHaveBeenCalledOnce();
-      expect(typeof responseInterceptor?.resolved).toBe("function");
+      expect(transport).toMatchObject({
+        defaults: {
+          fetchImplementation: expect.any(Function),
+        },
+      });
+      // We don't have access to the internals of the real Gaxios object easily,
+      // but we can check if it has interceptors
+      expect(transport.interceptors.request).toBeDefined();
+      expect(transport.interceptors.response).toBeDefined();
       expect("window" in globalThis).toBe(false);
     } finally {
       if (originalWindowDescriptor) {
@@ -378,11 +379,7 @@ describe("googlechat google auth runtime", () => {
     const second = await getGoogleAuthTransport();
 
     expect(first).not.toBe(second);
-    expect(mocks.gaxiosCtor).toHaveBeenCalledTimes(2);
-    expect(first.interceptors.request.add).toHaveBeenCalledOnce();
-    expect(first.interceptors.response.add).toHaveBeenCalledOnce();
-    expect(second.interceptors.request.add).toHaveBeenCalledOnce();
-    expect(second.interceptors.response.add).toHaveBeenCalledOnce();
+    expect(first.interceptors).not.toBe(second.interceptors);
   });
 
   it("normalizes Google auth request headers before upstream interceptors run", () => {
@@ -393,9 +390,12 @@ describe("googlechat google auth runtime", () => {
 
     const normalized = __testing.normalizeGoogleAuthPreparedRequestHeaders(config);
 
-    expect(normalized.headers).toBeInstanceOf(Headers);
-    expect(normalized.headers.has("x-test")).toBe(true);
-    expect(normalized.headers.get("x-test")).toBe("1");
+    expect(normalized.headers).not.toBeInstanceOf(Headers);
+    const h = normalized.headers as Record<string, unknown> & Partial<Headers>;
+    expect(typeof h.get).toBe("function");
+    expect(h.get?.("x-test")).toBe("1");
+    expect(h.get?.("X-TEST")).toBe("1");
+    expect(Object.keys(normalized.headers)).not.toContain("get");
   });
 
   it("normalizes Google auth response headers before upstream cache-control reads", () => {

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -13,13 +13,12 @@ type TlsCert = ConnectionOptions["cert"];
 type TlsKey = ConnectionOptions["key"];
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 type GoogleAuthModule = typeof import("google-auth-library");
-type GaxiosModule = typeof import("gaxios");
 type GoogleAuthRuntime = {
-  Gaxios: GaxiosModule["Gaxios"];
+  Gaxios: GoogleAuthModule["gaxios"]["Gaxios"];
   GoogleAuth: GoogleAuthModule["GoogleAuth"];
   OAuth2Client: GoogleAuthModule["OAuth2Client"];
 };
-type GoogleAuthTransport = InstanceType<GaxiosModule["Gaxios"]>;
+type GoogleAuthTransport = InstanceType<GoogleAuthModule["gaxios"]["Gaxios"]>;
 type GoogleAuthRequestWithUnknownHeaders = RequestInit & {
   headers?: unknown;
 };
@@ -30,6 +29,7 @@ type GuardedGoogleAuthRequestInit = RequestInit & {
   agent?: unknown;
   cert?: unknown;
   dispatcher?: unknown;
+  duplex?: "half" | "full";
   fetchImplementation?: unknown;
   key?: unknown;
   noProxy?: unknown;
@@ -74,11 +74,78 @@ let googleAuthRuntimePromise: Promise<GoogleAuthRuntime> | null = null;
 
 function normalizeGoogleAuthPreparedRequestHeaders<T extends GoogleAuthRequestWithUnknownHeaders>(
   config: T,
-): T & { headers: Headers } {
-  if (!(config.headers instanceof Headers)) {
-    config.headers = new Headers(config.headers as HeadersInit | undefined);
+): T {
+  if (config.headers && !(config.headers instanceof Headers)) {
+    const headers = config.headers as Record<string, unknown> & {
+      get?: unknown;
+      set?: unknown;
+      has?: unknown;
+      delete?: unknown;
+    };
+
+    const setHeader = (name: string, value: string): void => {
+      const lowerName = name.toLowerCase();
+      for (const key of Object.keys(headers)) {
+        if (key.toLowerCase() === lowerName) {
+          delete headers[key];
+        }
+      }
+      headers[name] = value;
+    };
+
+    const getHeader = (name: string): string | null => {
+      const lowerName = name.toLowerCase();
+      for (const key of Object.keys(headers)) {
+        if (key.toLowerCase() === lowerName) {
+          return String(headers[key]);
+        }
+      }
+      return null;
+    };
+
+    const hasHeader = (name: string): boolean => {
+      return getHeader(name) !== null;
+    };
+
+    const deleteHeader = (name: string): void => {
+      const lowerName = name.toLowerCase();
+      for (const key of Object.keys(headers)) {
+        if (key.toLowerCase() === lowerName) {
+          delete headers[key];
+        }
+      }
+    };
+
+    if (typeof headers.get !== "function") {
+      Object.defineProperty(headers, "get", {
+        value: getHeader,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+    if (typeof headers.set !== "function") {
+      Object.defineProperty(headers, "set", {
+        value: setHeader,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+    if (typeof headers.has !== "function") {
+      Object.defineProperty(headers, "has", {
+        value: hasHeader,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+    if (typeof headers.delete !== "function") {
+      Object.defineProperty(headers, "delete", {
+        value: deleteHeader,
+        enumerable: false,
+        configurable: true,
+      });
+    }
   }
-  return config as T & { headers: Headers };
+  return config;
 }
 
 function normalizeGoogleAuthResponseHeaders<T extends GoogleAuthResponseWithUnknownHeaders>(
@@ -436,8 +503,24 @@ function resolveGoogleAuthDispatcherPolicy(
 
 export function createGoogleAuthFetch(baseFetch?: FetchLike): FetchLike {
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const url = input instanceof Request ? input.url : String(input);
-    const guardedOptions = resolveGoogleAuthDispatcherPolicy(input, init);
+    let url: string;
+    let nextInit: GuardedGoogleAuthRequestInit;
+
+    if (input instanceof Request) {
+      url = input.url;
+      nextInit = {
+        method: input.method,
+        headers: new Headers(input.headers),
+        body: input.body,
+        ...(input.body && !("duplex" in (init ?? {})) ? { duplex: "half" } : {}),
+        ...init,
+      };
+    } else {
+      url = String(input);
+      nextInit = init ?? {};
+    }
+
+    const guardedOptions = resolveGoogleAuthDispatcherPolicy(url, nextInit);
     const { response, release } = await fetchWithSsrFGuard({
       auditContext: GOOGLE_AUTH_AUDIT_CONTEXT,
       dispatcherPolicy: guardedOptions.dispatcherPolicy,
@@ -516,12 +599,9 @@ export async function loadGoogleAuthRuntime(): Promise<GoogleAuthRuntime> {
   if (!googleAuthRuntimePromise) {
     googleAuthRuntimePromise = (async () => {
       try {
-        const [googleAuthModule, gaxiosModule] = await Promise.all([
-          import("google-auth-library"),
-          import("gaxios"),
-        ]);
+        const googleAuthModule = await import("google-auth-library");
         return {
-          Gaxios: gaxiosModule.Gaxios,
+          Gaxios: googleAuthModule.gaxios.Gaxios,
           GoogleAuth: googleAuthModule.GoogleAuth,
           OAuth2Client: googleAuthModule.OAuth2Client,
         };

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -34,22 +34,21 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => {
   };
 });
 
-vi.mock("gaxios", () => ({
-  Gaxios: class {
-    defaults: unknown;
-    interceptors = {
-      request: { add: vi.fn() },
-      response: { add: vi.fn() },
-    };
-
-    constructor(defaults?: unknown) {
-      this.defaults = defaults;
-      mocks.gaxiosCtor(defaults);
-    }
-  },
-}));
-
 vi.mock("google-auth-library", () => ({
+  gaxios: {
+    Gaxios: class {
+      defaults: unknown;
+      interceptors = {
+        request: { add: vi.fn() },
+        response: { add: vi.fn() },
+      };
+
+      constructor(defaults?: unknown) {
+        this.defaults = defaults;
+        mocks.gaxiosCtor(defaults);
+      }
+    },
+  },
   GoogleAuth: class {
     constructor(options?: unknown) {
       mocks.googleAuthCtor(options);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,12 +779,12 @@ importers:
 
   extensions/googlechat:
     dependencies:
-      gaxios:
-        specifier: 7.1.4
-        version: 7.1.4
       google-auth-library:
         specifier: 10.6.2
         version: 10.6.2
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,9 +782,6 @@ importers:
       google-auth-library:
         specifier: 10.6.2
         version: 10.6.2
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/src/plugins/contracts/package-manifest.contract.test.ts
+++ b/src/plugins/contracts/package-manifest.contract.test.ts
@@ -17,7 +17,7 @@ const packageManifestContractTests: PackageManifestContractParams[] = [
   { pluginId: "google-meet" },
   {
     pluginId: "googlechat",
-    pluginLocalRuntimeDeps: ["gaxios", "google-auth-library"],
+    pluginLocalRuntimeDeps: ["google-auth-library"],
     minHostVersionBaseline: "2026.3.22",
   },
   { pluginId: "irc", minHostVersionBaseline: "2026.3.22" },


### PR DESCRIPTION
## Summary

in recent refactor of gaxios, Google chat was broken. #77307 has more details.

- Resolves the `unsupported_grant_type` error by ensuring we instantiate the exact same version of `Gaxios` that `google-auth-library` uses internally.
- Previously, the dynamic `import('gaxios')` resolved to a hoisted version (6.7.1) in the workspace instead of the version (7.1.4) required by `google-auth-library@10.6.2`. The older version did not natively handle `URLSearchParams`, leading to the body being stringified as JSON (`"{}"`) and the token exchange failing due to missing grant type fields.
- Recent refactoring introduced a native `Headers` conversion that broke
    gaxios 7.x, as it uses direct property assignment (e.g. `headers['Content-Type']`)
    to prepare form-data bodies. Native `Headers` objects ignore these
    assignments, causing requests to be sent without the required
    `application/x-www-form-urlencoded` header.

    Changes:
    - Replace native `Headers` conversion in `normalizeGoogleAuthPreparedRequestHeaders`
      with a compatibility layer that adds `get`/`set`/`has`/`delete` to the
      plain headers object.
    - Update `createGoogleAuthFetch` to correctly extract `method`, `headers`,
      and `body` when called with a native `Request` object.
    - Add regression test for `Request` property preservation.

- Problem: resolves #77307 Google chat was broken in recent refactoring
- Why it matters:
- What changed: Google chat, headers,
- What did NOT change (scope boundary): no change in functionality or other modules

## Change Type (select all)

- [x ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #77307 
- Related #
- [x ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

Behavior or issue addressed: Corrects #77307 breakage of googlechat
Real environment tested: Ubuntu 26.04 with OpenClaw from pnpm and git
Exact steps or command run after this patch: enable googlechat, send a message to opencaw
Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): screenshot

Observed result after fix:

<img width="515" height="297" alt="image" src="https://github.com/user-attachments/assets/7d492f35-c191-4bbb-9003-e98ca81a256e" />

What was not tested: I ran the standard unit tests. I tested googlechat. I didn't test beyond that, the patch is self contained and small
Before evidence (optional but encouraged):



1. behaviour. See #77307, but, without this fix, Googlechat doesn't work at all, gives unknown grant_type log
2. environment. I tested this in Ubuntu 26.04
3. steps. 1. use it. 2. observe it doesn't work
4. evidence. see below screen shot of before and after
5. observed result: see below screenshot

after-fix evidence is below, its a screen shot of it working. this is a real OpenClaw setup.

its a bit hard to show the missing log for the error :)
Google chat now works for me, no longer exiting early with logs.

Ubuntu 26.04 was env tested. I tested manually with googlechat service account.

here is a screenshot
<img width="515" height="297" alt="image" src="https://github.com/user-attachments/assets/7d492f35-c191-4bbb-9003-e98ca81a256e" />




## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: refactor of gaxios broke this module which relied on it
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ x] Unit test -- we need googlechat unit tests
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.
none

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.
N/A


## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: ubuntu 26.04
- Runtime/container: pnpm
- Model/provider: N/A
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. install openclaw
2. add a Google service account
3. enable Google chat
4. try it. observed it doesn't work
7.
8.

### Expected

- Google chat works

### Actual

- gives unknown grant_type log

## Evidence

Attach at least one:

- [ x] Failing test/log before + passing after see #77307 
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)


<img width="515" height="297" alt="image" src="https://github.com/user-attachments/assets/7d492f35-c191-4bbb-9003-e98ca81a256e" />


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: used googlechat, said 'hi', it responded
- Edge cases checked:
- What you did **not** verify:
-
see screenshot
<img width="515" height="297" alt="image" src="https://github.com/user-attachments/assets/fcfd03a9-e3b6-4682-aa9f-50beef1fa5d5" />


## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
