### PR TITLE
fix(memory-wiki): resolve bridge-relative lint links

### DIFF
--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -50,6 +50,71 @@ describe("lintMemoryWikiVault", () => {
     expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toEqual([]);
   });
 
+  it("accepts bridge-relative source links and OpenClaw transcript directives", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-bridge-links-",
+      config: {
+        vault: { renderMode: "native" },
+      },
+    });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "bridge-index.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.bridge.index",
+          title: "Bridge Index",
+          sourceType: "memory-bridge",
+          sourcePath: "/workspace/memory/chatgpt/INDEX.md",
+          bridgeRelativePath: "memory/chatgpt/INDEX.md",
+          bridgeWorkspaceDir: "/workspace",
+        },
+        body:
+          "# Bridge Index\n\n" +
+          "[护肝产业创业者描述](./2025-06-04_护肝产业创业者描述_684054d0.md)\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "bridge-target.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.bridge.target",
+          title: "Bridge Target",
+          sourceType: "memory-bridge",
+          sourcePath: "/workspace/memory/chatgpt/2025-06-04_护肝产业创业者描述_684054d0.md",
+          bridgeRelativePath: "memory/chatgpt/2025-06-04_护肝产业创业者描述_684054d0.md",
+          bridgeWorkspaceDir: "/workspace",
+        },
+        body: "# Bridge Target\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "bridge-transcript.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.bridge.transcript",
+          title: "Bridge Transcript",
+          sourceType: "memory-bridge",
+          sourcePath: "/workspace/memory/transcript_20260502T180815Z_reset_keyigan-agent-workflow.md",
+          bridgeRelativePath: "memory/transcript_20260502T180815Z_reset_keyigan-agent-workflow.md",
+          bridgeWorkspaceDir: "/workspace",
+        },
+        body: "# Bridge Transcript\n\n[[reply_to_current]]\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toEqual([]);
+  });
+
   it("detects duplicate ids, provenance gaps, contradictions, and open questions", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -50,27 +50,69 @@ function toExpectedPageType(page: WikiPageSummary): string {
   return page.kind;
 }
 
+function isOpenClawTranscriptDirectiveLinkTarget(linkTarget: string): boolean {
+  return /^reply_to(?:_current|:.+)?$/.test(linkTarget);
+}
+
+function normalizeBridgeLinkTarget(params: {
+  page: WikiPageSummary;
+  linkTarget: string;
+}): string | null {
+  if (!params.page.bridgeRelativePath) return null;
+  if (
+    !params.linkTarget ||
+    params.linkTarget.startsWith("#") ||
+    /^[a-z][a-z0-9+.-]*:/i.test(params.linkTarget)
+  ) {
+    return null;
+  }
+  const cleanTarget = decodeURIComponent(
+    params.linkTarget.split("#")[0]?.split("?")[0] ?? "",
+  )
+    .replace(/\\/g, "/")
+    .trim();
+  if (!cleanTarget || isOpenClawTranscriptDirectiveLinkTarget(cleanTarget)) return null;
+  return path.posix.normalize(
+    path.posix.join(path.posix.dirname(params.page.bridgeRelativePath), cleanTarget),
+  );
+}
+
 function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
   const validTargets = new Set<string>();
+  const bridgeRelativeTargets = new Set<string>();
   for (const page of pages) {
     const withoutExtension = page.relativePath.replace(/\.md$/i, "");
     validTargets.add(page.relativePath);
     validTargets.add(withoutExtension);
     validTargets.add(path.basename(withoutExtension));
+    if (
+      (page.sourceType === "memory-bridge" || page.sourceType === "memory-bridge-events") &&
+      page.bridgeRelativePath
+    ) {
+      bridgeRelativeTargets.add(path.posix.normalize(page.bridgeRelativePath));
+    }
   }
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
     for (const linkTarget of page.linkTargets) {
-      if (!validTargets.has(linkTarget)) {
-        issues.push({
-          severity: "warning",
-          category: "links",
-          code: "broken-wikilink",
-          path: page.relativePath,
-          message: `Broken wikilink target \`${linkTarget}\`.`,
-        });
+      if (validTargets.has(linkTarget)) continue;
+      if (isOpenClawTranscriptDirectiveLinkTarget(linkTarget)) continue;
+      const bridgeLinkTarget = normalizeBridgeLinkTarget({ page, linkTarget });
+      if (
+        (page.sourceType === "memory-bridge" || page.sourceType === "memory-bridge-events") &&
+        bridgeLinkTarget &&
+        bridgeRelativeTargets.has(bridgeLinkTarget)
+      ) {
+        continue;
       }
+      issues.push({
+        severity: "warning",
+        category: "links",
+        code: "broken-wikilink",
+        path: page.relativePath,
+        message: `Broken wikilink target \`${linkTarget}\`.`,
+      });
     }
   }
   return issues;


### PR DESCRIPTION
## Summary

Fixes Memory Wiki `wiki lint` false-positive `broken-wikilink` warnings for bridge-imported memory sources.

Bridge-imported source pages preserve original relative Markdown links via `bridgeRelativePath`, while generated wiki source pages use sanitized/hashed filenames. The existing lint target set only considered generated wiki paths, so valid raw-memory relative links were reported as broken. OpenClaw transcript reply directives such as `[[reply_to_current]]` were also parsed as wikilinks and warned as broken.

## Changes

- Adds bridge-relative target resolution for `memory-bridge` and `memory-bridge-events` source pages.
- Keeps existing generated-wiki target validation unchanged.
- Ignores OpenClaw transcript reply directives (`reply_to_current`, `reply_to:<id>`) during broken-wikilink linting.
- Adds a regression test covering bridge-relative links and transcript directives.

## Local validation

- Local installed OpenClaw v2026.5.5 patched equivalent behavior: `openclaw wiki lint --json` returned `issueCount=0` on a bridge vault that previously reported 35 false-positive `broken-wikilink` warnings.
- `openclaw wiki compile --json` remained healthy with pageCounts source=129, synthesis=8, report=10.
- Source-repo test attempt: `pnpm test:extension memory-wiki lint.test.ts` was blocked locally by environment/dependency install issues (`@openclaw/fs-safe/config` missing when install scripts were ignored; full install later failed building `sharp`/native deps on Node 24). The included regression test is ready for CI.
