### PR TITLE
fix(discord): preserve tool progress messages

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -198,7 +198,10 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
     onReplyStart?: () => Promise<void> | void;
   }) => ({
     dispatcher: {
-      sendToolResult: vi.fn(() => true),
+      sendToolResult: vi.fn((payload: unknown) => {
+        void opts.deliver(payload, { kind: "tool" });
+        return true;
+      }),
       sendBlockReply: vi.fn((payload: unknown) => {
         void opts.deliver(payload, { kind: "block" });
         return true;
@@ -981,6 +984,31 @@ describe("processDiscordMessage session routing", () => {
         senderRecipient: "222",
       },
     });
+  });
+
+  it("marks default tool progress deliveries so Discord safety scrubber preserves them", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      params?.dispatcher.sendToolResult({ text: "📖 Read: `lines 1-10 from file.txt`" });
+      return { queuedFinal: false, counts: { final: 0, tool: 1, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streaming: { mode: "off" } },
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(deliverDiscordReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [
+          expect.objectContaining({
+            text: "📖 Read: `lines 1-10 from file.txt`",
+            channelData: expect.objectContaining({ openclawDiscordToolProgress: true }),
+          }),
+        ],
+      }),
+    );
   });
 
   it("stores group lastRoute with channel target", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -542,9 +542,23 @@ export async function processDiscordMessage(
         if (isFinal) {
           notifyFinalReplyStart();
         }
+        const deliveryPayload: ReplyPayload =
+          info.kind === "tool"
+            ? {
+                ...payload,
+                channelData: {
+                  ...(payload.channelData &&
+                  typeof payload.channelData === "object" &&
+                  !Array.isArray(payload.channelData)
+                    ? payload.channelData
+                    : {}),
+                  openclawDiscordToolProgress: true,
+                },
+              }
+            : payload;
         await deliverDiscordReply({
           cfg,
-          replies: [payload],
+          replies: [deliveryPayload],
           target: deliverTarget,
           token,
           accountId,

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -150,6 +150,42 @@ describe("deliverDiscordReply", () => {
     );
   });
 
+  it("preserves marked Discord tool-progress labels at the front-channel boundary", async () => {
+    await deliverDiscordReply({
+      replies: [
+        {
+          text: "📖 Read: `lines 1-10 from file.txt`",
+          channelData: { openclawDiscordToolProgress: true },
+        },
+        {
+          text: "🛠️ Exec: `print text`",
+          channelData: { openclawDiscordToolProgress: true },
+        },
+      ],
+      target: "channel:101",
+      token: "token",
+      accountId: "default",
+      runtime,
+      cfg,
+      textLimit: 2000,
+    });
+
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [
+          {
+            text: "📖 Read: `lines 1-10 from file.txt`",
+            channelData: { openclawDiscordToolProgress: true },
+          },
+          {
+            text: "🛠️ Exec: `print text`",
+            channelData: { openclawDiscordToolProgress: true },
+          },
+        ],
+      }),
+    );
+  });
+
   it("drops pure internal trace text while preserving media-only delivery", async () => {
     await deliverDiscordReply({
       replies: [

--- a/extensions/discord/src/monitor/reply-safety.ts
+++ b/extensions/discord/src/monitor/reply-safety.ts
@@ -24,13 +24,34 @@ function hasInteractiveOrPresentationBlocks(value: unknown): boolean {
   return Array.isArray(record.blocks) && record.blocks.length > 0;
 }
 
+function getDiscordToolProgressChannelData(
+  payload: ReplyPayload,
+): Record<string, unknown> | undefined {
+  const channelData = payload.channelData;
+  if (!channelData || typeof channelData !== "object" || Array.isArray(channelData)) {
+    return undefined;
+  }
+  return channelData as Record<string, unknown>;
+}
+
+function hasNonMarkerChannelData(value: unknown): boolean {
+  if (!hasNonEmptyRecord(value)) {
+    return false;
+  }
+  return Object.keys(value).some((key) => key !== "openclawDiscordToolProgress");
+}
+
 function hasNonTextReplyPayloadContent(payload: ReplyPayload): boolean {
   return (
     payload.audioAsVoice === true ||
-    hasNonEmptyRecord(payload.channelData) ||
+    hasNonMarkerChannelData(payload.channelData) ||
     hasInteractiveOrPresentationBlocks(payload.interactive) ||
     hasInteractiveOrPresentationBlocks(payload.presentation)
   );
+}
+
+function shouldPreserveDiscordToolProgressText(payload: ReplyPayload): boolean {
+  return getDiscordToolProgressChannelData(payload)?.openclawDiscordToolProgress === true;
 }
 
 function stripDiscordInternalTraceLines(text: string): string {
@@ -73,7 +94,9 @@ export function sanitizeDiscordFrontChannelReplyPayloads(
   for (const payload of payloads) {
     const safeText =
       typeof payload.text === "string"
-        ? sanitizeDiscordFrontChannelText(payload.text)
+        ? shouldPreserveDiscordToolProgressText(payload)
+          ? sanitizeAssistantVisibleText(payload.text).trim()
+          : sanitizeDiscordFrontChannelText(payload.text)
         : payload.text;
     const nextPayload =
       safeText === payload.text


### PR DESCRIPTION
## Summary

Preserve Discord tool-progress messages (`📖 Read:`, `🛠️ Exec:`, etc.) when the Discord front-channel safety scrubber runs.

The Discord sanitizer intentionally strips internal trace/scaffolding lines from final channel output. However, normal tool-progress deliveries use the same visible labels, so the sanitizer also removed legitimate progress messages before they reached Discord. In practice, `📖 Read:` and `🛠️ Exec:` disappeared while `✍️ Write:` happened to survive because that emoji was not part of the internal-trace regex.

## Fix

- Mark default Discord tool-progress deliveries with `channelData.openclawDiscordToolProgress`.
- Let the Discord front-channel sanitizer preserve marked tool-progress text while still applying the generic assistant-visible text sanitizer.
- Do not treat the marker-only `channelData` as content by itself if text scrubs empty.
- Add regression coverage for both the process delivery path and final Discord send boundary.

## Validation

- Live Discord OpenClaw smoke after restart:
  - `✍️ Write` visible
  - `📖 Read` visible
  - `🛠️ Exec` visible
- `git diff --check`
- Focused Discord tests:

```bash
pnpm test:extensions -- extensions/discord/src/monitor/reply-delivery.test.ts extensions/discord/src/monitor/message-handler.process.test.ts
```

Result: the targeted Discord test pass completed successfully (`2 passed`, `66 passed`). The repository test runner then continued into broader extension suites; I stopped that broader run after Discord coverage had passed.
