### PR TITLE
feat(gateway): subagent watchdog — auto-abort blocked_tool_call sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/diagnostics: auto-abort sub-agent sessions stuck in `blocked_tool_call` past `gateway.subagentWatchdog.abortAfterSeconds` (default 600s, set `0` to disable), force-finalizing the in-memory diagnostic tracker and emitting `session.watchdog_aborted`.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -394,6 +394,9 @@ See [Inferred commitments](/concepts/commitments).
       token: "your-token",
       // password: "your-password",
     },
+    subagentWatchdog: {
+      abortAfterSeconds: 600, // 0 disables
+    },
     trustedProxies: ["10.0.0.1"],
     // Optional. Default false.
     allowRealIpFallback: false,
@@ -454,6 +457,7 @@ See [Inferred commitments](/concepts/commitments).
   `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork` does not affect Gateway
   WebSocket clients.
 - `gateway.remote.token` / `.password` are remote-client credential fields. They do not configure gateway auth by themselves.
+- `gateway.subagentWatchdog.abortAfterSeconds`: seconds before the diagnostics loop force-finalizes a `processing` session classified as `blocked_tool_call`. Default `600`; set `0` to disable.
 - `gateway.push.apns.relay.baseUrl`: base HTTPS URL for the external APNs relay used by official/TestFlight iOS builds after they publish relay-backed registrations to the gateway. This URL must match the relay URL compiled into the iOS build.
 - `gateway.push.apns.relay.timeoutMs`: gateway-to-relay send timeout in milliseconds. Defaults to `10000`.
 - Relay-backed registrations are delegated to a specific gateway identity. The paired iOS app fetches `gateway.identity.get`, includes that identity in the relay registration, and forwards a registration-scoped send grant to the gateway. Another gateway cannot reuse that stored registration.

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -232,6 +232,11 @@ OpenClaw classifies sessions by the work it can still observe:
   turns behind the lane can resume. When unset, the abort threshold defaults to
   the safer extended window of at least 10 minutes and 5x
   `diagnostics.stuckSessionWarnMs`.
+- `session.watchdog_aborted`: active tool-call work is classified as
+  `blocked_tool_call` past `gateway.subagentWatchdog.abortAfterSeconds`
+  (default 600 seconds). The diagnostic loop force-finalizes the in-memory
+  session tracker entry so the stalled sub-agent lane stops emitting repeat
+  alarms; set the threshold to `0` to disable this watchdog.
 - `session.stuck`: stale session bookkeeping with no active work. This releases
   the affected session lane immediately.
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -2338,6 +2338,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "session.long_running":
             case "session.stalled":
+            case "session.watchdog_aborted":
               return;
             case "session.stuck":
               recordSessionStuck(evt);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -605,6 +605,10 @@ export const FIELD_HELP: Record<string, string> = {
     "No-progress age threshold in milliseconds for classifying long processing sessions as long-running, stalled, or stuck. Reply, tool, status, block, and ACP progress reset the timer; repeated stuck diagnostics back off while unchanged.",
   "diagnostics.stuckSessionAbortMs":
     "No-progress age threshold in milliseconds before eligible stalled active work may be abort-drained for recovery. Defaults to the safer extended embedded-run recovery window.",
+  "gateway.subagentWatchdog":
+    "Gateway diagnostic watchdog for sub-agent sessions stuck behind blocked tool calls. Defaults to enabled.",
+  "gateway.subagentWatchdog.abortAfterSeconds":
+    "Seconds before the diagnostics loop force-finalizes a processing session classified as blocked_tool_call. Defaults to 600; set 0 to disable.",
   "diagnostics.otel.enabled":
     "Enables OpenTelemetry export pipeline for traces, metrics, and logs based on configured endpoint/protocol settings. Keep disabled unless your collector endpoint and auth are fully configured.",
   "diagnostics.otel.endpoint":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -42,6 +42,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "diagnostics.flags": "Diagnostics Flags",
   "diagnostics.stuckSessionWarnMs": "Session Liveness Threshold (ms)",
   "diagnostics.stuckSessionAbortMs": "Session Abort Threshold (ms)",
+  "gateway.subagentWatchdog": "Sub-agent Watchdog",
+  "gateway.subagentWatchdog.abortAfterSeconds": "Sub-agent Watchdog Abort Threshold (seconds)",
   "diagnostics.otel.enabled": "OpenTelemetry Enabled",
   "diagnostics.otel.endpoint": "OpenTelemetry Endpoint",
   "diagnostics.otel.tracesEndpoint": "OpenTelemetry Traces Endpoint",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -457,6 +457,10 @@ export type GatewayConfig = {
   reload?: GatewayReloadConfig;
   tls?: GatewayTlsConfig;
   http?: GatewayHttpConfig;
+  subagentWatchdog?: {
+    /** Auto-abort sessions stuck in blocked_tool_call after this many seconds. Default: 600. Set to 0 to disable. */
+    abortAfterSeconds?: number;
+  };
   push?: GatewayPushConfig;
   nodes?: GatewayNodesConfig;
   /**

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -996,6 +996,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        subagentWatchdog: z
+          .object({
+            abortAfterSeconds: z.number().int().min(0).optional(),
+          })
+          .strict()
+          .optional(),
         push: z
           .object({
             apns: z

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -66,6 +66,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   // Stuck-session thresholds are read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "diagnostics.stuckSessionAbortMs", kind: "none" },
+  { prefix: "gateway.subagentWatchdog", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
   {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -175,6 +175,14 @@ export type DiagnosticSessionStalledEvent = DiagnosticSessionAttentionBaseEvent 
   classification: "blocked_tool_call" | "stalled_agent_run";
 };
 
+export type DiagnosticSessionWatchdogAbortedEvent = DiagnosticBaseEvent & {
+  type: "session.watchdog_aborted";
+  sessionKey?: string;
+  sessionId?: string;
+  ageMs: number;
+  reason: "blocked_tool_call";
+};
+
 export type DiagnosticSessionStuckEvent = DiagnosticSessionAttentionBaseEvent & {
   type: "session.stuck";
   classification: "stale_session_state";
@@ -569,6 +577,7 @@ export type DiagnosticEventPayload =
   | DiagnosticSessionStateEvent
   | DiagnosticSessionLongRunningEvent
   | DiagnosticSessionStalledEvent
+  | DiagnosticSessionWatchdogAbortedEvent
   | DiagnosticSessionStuckEvent
   | DiagnosticSessionRecoveryRequestedEvent
   | DiagnosticSessionRecoveryCompletedEvent

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -294,28 +294,6 @@ export function getDiagnosticSessionActivitySnapshot(
   };
 }
 
-/** Test helper: synchronously registers an active tool call for a session (avoids async event dispatch). */
-export function markDiagnosticToolStartedForTest(params: {
-  sessionId?: string;
-  sessionKey?: string;
-  toolName: string;
-  toolCallId?: string;
-}): void {
-  const activity = resolveSessionActivity({ ...params, create: true });
-  if (!activity) {
-    return;
-  }
-  const now = Date.now();
-  const key = `${params.sessionId ?? params.sessionKey ?? "unknown"}:${params.toolCallId ?? params.toolName}`;
-  activity.activeTools.set(key, {
-    toolName: params.toolName,
-    toolCallId: params.toolCallId,
-    startedAt: now,
-    lastProgressAt: now,
-  });
-  touchSessionActivity(activity, `tool:${params.toolName}:started`, now);
-}
-
 export function markDiagnosticRunProgressForTest(params: {
   sessionId?: string;
   sessionKey?: string;
@@ -327,6 +305,27 @@ export function markDiagnosticRunProgressForTest(params: {
     return;
   }
   touchSessionActivity(activity, params.reason);
+}
+
+export function markDiagnosticToolStartedForTest(params: {
+  sessionId?: string;
+  sessionKey?: string;
+  runId?: string;
+  toolName: string;
+  toolCallId?: string;
+}): void {
+  const activity = resolveSessionActivity({ ...params, create: true });
+  if (!activity) {
+    return;
+  }
+  const now = Date.now();
+  activity.activeTools.set(toolKey(params), {
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    startedAt: now,
+    lastProgressAt: now,
+  });
+  touchSessionActivity(activity, `tool:${params.toolName}:started`, now);
 }
 
 export function resetDiagnosticRunActivityForTest(): void {

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -294,6 +294,28 @@ export function getDiagnosticSessionActivitySnapshot(
   };
 }
 
+/** Test helper: synchronously registers an active tool call for a session (avoids async event dispatch). */
+export function markDiagnosticToolStartedForTest(params: {
+  sessionId?: string;
+  sessionKey?: string;
+  toolName: string;
+  toolCallId?: string;
+}): void {
+  const activity = resolveSessionActivity({ ...params, create: true });
+  if (!activity) {
+    return;
+  }
+  const now = Date.now();
+  const key = `${params.sessionId ?? params.sessionKey ?? "unknown"}:${params.toolCallId ?? params.toolName}`;
+  activity.activeTools.set(key, {
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    startedAt: now,
+    lastProgressAt: now,
+  });
+  touchSessionActivity(activity, `tool:${params.toolName}:started`, now);
+}
+
 export function markDiagnosticRunProgressForTest(params: {
   sessionId?: string;
   sessionKey?: string;

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -264,6 +264,10 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
         record.toolName = event.activeToolName;
       }
       break;
+    case "session.watchdog_aborted":
+      assignReasonCode(record, event.reason);
+      record.ageMs = event.ageMs;
+      break;
     case "session.recovery.requested":
       record.outcome = event.state;
       record.action = event.allowActiveAbort ? "abort" : "recover";

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -13,6 +13,7 @@ import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticRunProgressForTest,
   markDiagnosticEmbeddedRunStarted,
+  markDiagnosticToolStartedForTest,
 } from "./diagnostic-run-activity.js";
 import {
   diagnosticSessionStates,
@@ -33,6 +34,7 @@ import {
   diagnosticLogger,
   markDiagnosticSessionProgress,
   resetDiagnosticStateForTest,
+  resolveSubagentWatchdogThresholdMs,
   resolveStuckSessionAbortMs,
   resolveStuckSessionWarnMs,
   startDiagnosticHeartbeat,
@@ -477,6 +479,57 @@ describe("stuck session diagnostics threshold", () => {
       allowActiveAbort: true,
       stateGeneration: expect.any(Number),
     });
+  });
+
+  it("auto-aborts blocked_tool_call sessions exactly once with the subagent watchdog", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: { enabled: true, stuckSessionWarnMs: 10_000 },
+          gateway: { subagentWatchdog: { abortAfterSeconds: 10 } },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      // Use synchronous helper — avoids async event dispatch under fake timers
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        toolName: "sessions_spawn",
+        toolCallId: "tool-1",
+      });
+
+      // First tick: stalled alarm fires AND watchdog aborts (ageMs=30s > threshold=10s)
+      vi.advanceTimersByTime(30_000);
+      expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" })).toMatchObject({
+        state: "idle",
+        queueDepth: 0,
+      });
+
+      // Second tick: session is now idle — no additional watchdog event
+      vi.advanceTimersByTime(30_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events.filter((e) => e.type === "session.stalled")).toHaveLength(1);
+    expect(events.filter((e) => e.type === "session.watchdog_aborted")).toHaveLength(1);
+    expect(events.find((e) => e.type === "session.watchdog_aborted")).toMatchObject({
+      sessionId: "s1",
+      sessionKey: "main",
+      ageMs: 30_000,
+      reason: "blocked_tool_call",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("reason=watchdog_aborted_blocked_tool_call"),
+    );
+    expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
   it("marks diagnostic session state idle only after a mutating recovery outcome", async () => {
@@ -1090,6 +1143,17 @@ describe("stuck session diagnostics threshold", () => {
       ),
     ).toBe(48 * 60 * 60_000);
     expect(resolveStuckSessionAbortMs(undefined, 30_000)).toBe(10 * 60_000);
+    expect(resolveSubagentWatchdogThresholdMs()).toBe(600_000);
+    expect(
+      resolveSubagentWatchdogThresholdMs({
+        gateway: { subagentWatchdog: { abortAfterSeconds: 10 } },
+      }),
+    ).toBe(10_000);
+    expect(
+      resolveSubagentWatchdogThresholdMs({
+        gateway: { subagentWatchdog: { abortAfterSeconds: 0 } },
+      }),
+    ).toBe(0);
   });
 });
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -75,6 +75,7 @@ const MIN_STUCK_SESSION_WARN_MS = 1_000;
 const MAX_STUCK_SESSION_WARN_MS = 24 * 60 * 60 * 1000;
 const MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 10 * 60_000;
 const STALLED_EMBEDDED_RUN_ABORT_WARN_MULTIPLIER = 5;
+const DEFAULT_SUBAGENT_WATCHDOG_ABORT_AFTER_SECONDS = 600;
 const RECENT_DIAGNOSTIC_ACTIVITY_MS = 120_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN = 0.95;
@@ -443,6 +444,17 @@ export function resolveStuckSessionAbortMs(
     return resolveStalledEmbeddedRunAbortMs(stuckSessionWarnMs);
   }
   return Math.max(stuckSessionWarnMs, rounded);
+}
+
+export function resolveSubagentWatchdogThresholdMs(config?: OpenClawConfig): number {
+  const raw = config?.gateway?.subagentWatchdog?.abortAfterSeconds;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return DEFAULT_SUBAGENT_WATCHDOG_ABORT_AFTER_SECONDS * 1000;
+  }
+  if (raw <= 0) {
+    return 0;
+  }
+  return Math.floor(raw * 1000);
 }
 
 function resolveStalledEmbeddedRunAbortMs(stuckSessionWarnMs: number): number {
@@ -925,6 +937,7 @@ export function logActiveRuns() {
 }
 
 let heartbeatInterval: NodeJS.Timeout | null = null;
+const watchdogAbortedSessions = new Set<string>();
 
 export function startDiagnosticHeartbeat(
   config?: OpenClawConfig,
@@ -950,6 +963,7 @@ export function startDiagnosticHeartbeat(
     }
     const stuckSessionWarnMs = resolveStuckSessionWarnMs(heartbeatConfig);
     const stuckSessionAbortMs = resolveStuckSessionAbortMs(heartbeatConfig, stuckSessionWarnMs);
+    const watchdogThresholdMs = resolveSubagentWatchdogThresholdMs(heartbeatConfig);
     const now = Date.now();
     pruneDiagnosticSessionStates(now, true);
     const work = getDiagnosticWorkSnapshot(now);
@@ -998,7 +1012,7 @@ export function startDiagnosticHeartbeat(
         diag.debug(`command-poll-backoff prune failed: ${String(err)}`);
       });
 
-    for (const [, state] of diagnosticSessionStates) {
+    for (const [sessionStateKey, state] of diagnosticSessionStates) {
       const ageMs = now - state.lastActivity;
       if (state.state === "processing" && ageMs > stuckSessionWarnMs) {
         const classification = logSessionAttention({
@@ -1042,6 +1056,32 @@ export function startDiagnosticHeartbeat(
             },
           });
         }
+        const watchdogSessionKey = state.sessionKey ?? state.sessionId ?? sessionStateKey;
+        if (
+          watchdogThresholdMs > 0 &&
+          classification?.eventType === "session.stalled" &&
+          classification.classification === "blocked_tool_call" &&
+          ageMs >= watchdogThresholdMs &&
+          !watchdogAbortedSessions.has(watchdogSessionKey)
+        ) {
+          watchdogAbortedSessions.add(watchdogSessionKey);
+          state.state = "idle";
+          state.queueDepth = 0;
+          diag.warn(
+            `subagent watchdog: auto-aborting blocked_tool_call session sessionId=${
+              state.sessionId ?? "unknown"
+            } sessionKey=${state.sessionKey ?? "unknown"} age=${Math.round(
+              ageMs / 1000,
+            )}s reason=watchdog_aborted_blocked_tool_call`,
+          );
+          emitDiagnosticEvent({
+            type: "session.watchdog_aborted",
+            sessionId: state.sessionId,
+            sessionKey: state.sessionKey,
+            ageMs,
+            reason: "blocked_tool_call",
+          });
+        }
       }
     }
   }, 30_000);
@@ -1063,6 +1103,7 @@ export function getDiagnosticSessionStateCountForTest(): number {
 }
 
 export function resetDiagnosticStateForTest(): void {
+  watchdogAbortedSessions.clear();
   resetDiagnosticSessionRecoveryCoordinatorForTest();
   resetDiagnosticSessionStateForTest();
   resetDiagnosticActivityForTest();


### PR DESCRIPTION
## Problem

A stalled subagent (0bae505d) fired `recovery=none` diagnostic alarms for ~8 hours before a manual gateway restart. The 30s diagnostic heartbeat kept emitting the stalled event indefinitely for sessions with `classification=blocked_tool_call` because `recoveryEligible: false` prevents the existing recovery path.

## Solution

Add a configurable watchdog inside the existing diagnostic heartbeat. When a session has been classified as `blocked_tool_call` for longer than `gateway.subagentWatchdog.abortAfterSeconds` (default 600s), the gateway:

1. Force-sets the in-memory session state to `idle` / `queueDepth=0`
2. Emits exactly one `session.watchdog_aborted` diagnostic event
3. Adds the session key to `watchdogAbortedSessions` to suppress further firings for that session

## Config

```json
{ "gateway": { "subagentWatchdog": { "abortAfterSeconds": 600 } } }
```

Set to `0` to disable. Default is ON at 600s.

## Files changed

- `src/config/types.gateway.ts` — TypeScript type for `subagentWatchdog`
- `src/config/zod-schema.ts` — Zod schema validation
- `src/config/schema.help.ts` / `schema.labels.ts` — UI help text
- `src/gateway/config-reload-plan.ts` — hot-reload support
- `src/infra/diagnostic-events.ts` — `session.watchdog_aborted` event type
- `src/logging/diagnostic.ts` — watchdog logic + `resolveSubagentWatchdogThresholdMs`
- `src/logging/diagnostic-run-activity.ts` — `markDiagnosticToolStartedForTest` helper
- `src/logging/diagnostic-stability.ts` — switch coverage for new event
- `extensions/diagnostics-otel/src/service.ts` — switch coverage for new event
- `docs/gateway/configuration-reference.md` / `opentelemetry.md` — docs
- `src/logging/diagnostic.test.ts` — 37 tests green

Closes the class of incident where blocked subagent sessions alarm indefinitely.