### PR TITLE
feat(gateway): tracker reconciliation tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/diagnostics: add `gateway.sessionTracker.reconcileEverySeconds` to reconcile in-memory diagnostic session tracker entries against persisted terminal session/task state and emit `session.tracker.reconciled` when stale runtime entries are evicted.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -459,6 +459,7 @@ See [Inferred commitments](/concepts/commitments).
 - Relay-backed registrations are delegated to a specific gateway identity. The paired iOS app fetches `gateway.identity.get`, includes that identity in the relay registration, and forwards a registration-scoped send grant to the gateway. Another gateway cannot reuse that stored registration.
 - `OPENCLAW_APNS_RELAY_BASE_URL` / `OPENCLAW_APNS_RELAY_TIMEOUT_MS`: temporary env overrides for the relay config above.
 - `OPENCLAW_APNS_RELAY_ALLOW_HTTP=true`: development-only escape hatch for loopback HTTP relay URLs. Production relay URLs should stay on HTTPS.
+- `gateway.sessionTracker.reconcileEverySeconds`: interval in seconds for reconciling the in-memory diagnostic session tracker against persisted session/task state. Set `0` to disable. Default: `300`.
 - `gateway.handshakeTimeoutMs`: pre-auth Gateway WebSocket handshake timeout in milliseconds. Default: `15000`. `OPENCLAW_HANDSHAKE_TIMEOUT_MS` takes precedence when set. Increase this on loaded or low-powered hosts where local clients can connect while startup warmup is still settling.
 - `gateway.channelHealthCheckMinutes`: channel health-monitor interval in minutes. Set `0` to disable health-monitor restarts globally. Default: `5`.
 - `gateway.channelStaleEventThresholdMinutes`: stale-socket threshold in minutes. Keep this greater than or equal to `gateway.channelHealthCheckMinutes`. Default: `30`.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -267,6 +267,24 @@ candidate contains redacted secret placeholders such as `***`.
 
   </Accordion>
 
+  <Accordion title="Tune session tracker reconciliation">
+    Reconcile the gateway's in-memory diagnostic session tracker against persisted session and task state:
+
+    ```json5
+    {
+      gateway: {
+        sessionTracker: {
+          reconcileEverySeconds: 300,
+        },
+      },
+    }
+    ```
+
+    - Set `gateway.sessionTracker.reconcileEverySeconds: 0` to disable reconciliation.
+    - The default interval is `300` seconds.
+
+  </Accordion>
+
   <Accordion title="Tune gateway WebSocket handshake timeout">
     Give local clients more time to complete the pre-auth WebSocket handshake on
     loaded or low-powered hosts:

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -2338,6 +2338,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "session.long_running":
             case "session.stalled":
+            case "session.tracker.reconciled":
               return;
             case "session.stuck":
               recordSessionStuck(evt);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -95,6 +95,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Explicit gateway-level tool allowlist when you want a narrow set of tools available at runtime. Use this for locked-down environments where tool scope must be tightly controlled.",
   "gateway.tools.deny":
     "Explicit gateway-level tool denylist to block risky tools even if lower-level policies allow them. Use deny rules for emergency response and defense-in-depth hardening.",
+  "gateway.sessionTracker":
+    "In-memory session tracker reconciliation controls. Tune only when gateway diagnostics need a different stale-runtime cleanup cadence.",
+  "gateway.sessionTracker.reconcileEverySeconds":
+    "Seconds between checks that compare in-memory diagnostic session tracker entries with persisted session/task state. Set 0 to disable. Default: 300.",
   "gateway.handshakeTimeoutMs":
     "Pre-auth Gateway WebSocket handshake timeout in milliseconds. Use higher values on loaded or low-powered hosts where local clients can connect during startup warmup. OPENCLAW_HANDSHAKE_TIMEOUT_MS still takes precedence.",
   "gateway.channelHealthCheckMinutes":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -119,6 +119,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.tools": "Gateway Tool Exposure Policy",
   "gateway.tools.allow": "Gateway Tool Allowlist",
   "gateway.tools.deny": "Gateway Tool Denylist",
+  "gateway.sessionTracker": "Gateway Session Tracker",
+  "gateway.sessionTracker.reconcileEverySeconds": "Gateway Session Tracker Reconcile Interval (s)",
   "gateway.handshakeTimeoutMs": "Gateway Handshake Timeout",
   "gateway.channelHealthCheckMinutes": "Gateway Channel Health Check Interval (min)",
   "gateway.channelStaleEventThresholdMinutes": "Gateway Channel Stale Event Threshold (min)",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -430,6 +430,11 @@ export type GatewayWebchatConfig = {
   chatHistoryMaxChars?: number;
 };
 
+export type GatewaySessionTrackerConfig = {
+  /** Interval in seconds to reconcile in-memory tracker against persisted session state. Default: 300. Set to 0 to disable. */
+  reconcileEverySeconds?: number;
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
@@ -474,6 +479,8 @@ export type GatewayConfig = {
   tools?: GatewayToolsConfig;
   /** WebChat display/history settings. */
   webchat?: GatewayWebchatConfig;
+  /** In-memory session tracker reconciliation settings. */
+  sessionTracker?: GatewaySessionTrackerConfig;
   /**
    * Pre-auth Gateway WebSocket handshake timeout in milliseconds.
    * Env var OPENCLAW_HANDSHAKE_TIMEOUT_MS takes precedence. Default: 15000.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -889,6 +889,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        sessionTracker: z
+          .object({
+            reconcileEverySeconds: z.number().int().min(0).optional(),
+          })
+          .strict()
+          .optional(),
         handshakeTimeoutMs: z.number().int().min(1).optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -92,6 +92,7 @@ import { loadGatewayTlsRuntime } from "./server/tls.js";
 import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
 import { maybeSeedControlUiAllowedOriginsAtStartup } from "./startup-control-ui-origins.js";
 
+// eslint-disable-next-line no-underscore-dangle -- Legacy test reset hook exported under this name.
 export async function __resetModelCatalogCacheForTest(): Promise<void> {
   const { __resetModelCatalogCacheForTest: resetModelCatalogCacheForTest } =
     await import("./server-model-catalog.js");

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -212,6 +212,11 @@ export type DiagnosticSessionRecoveryCompletedEvent = DiagnosticSessionRecoveryB
   stale?: boolean;
 };
 
+export type DiagnosticSessionTrackerReconciledEvent = DiagnosticBaseEvent & {
+  type: "session.tracker.reconciled";
+  evicted: number;
+};
+
 export type DiagnosticLaneEnqueueEvent = DiagnosticBaseEvent & {
   type: "queue.lane.enqueue";
   lane: string;
@@ -572,6 +577,7 @@ export type DiagnosticEventPayload =
   | DiagnosticSessionStuckEvent
   | DiagnosticSessionRecoveryRequestedEvent
   | DiagnosticSessionRecoveryCompletedEvent
+  | DiagnosticSessionTrackerReconciledEvent
   | DiagnosticLaneEnqueueEvent
   | DiagnosticLaneDequeueEvent
   | DiagnosticRunAttemptEvent

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -285,6 +285,8 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       }
       assignReasonCode(record, event.outcomeReason ?? event.reason);
       break;
+    case "session.tracker.reconciled":
+      break;
     case "queue.lane.enqueue":
       record.source = event.lane;
       record.queueSize = event.queueSize;

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionStore } from "../config/sessions/store-load.js";
 import {
   emitDiagnosticEvent,
   onDiagnosticEvent,
@@ -33,10 +35,27 @@ import {
   diagnosticLogger,
   markDiagnosticSessionProgress,
   resetDiagnosticStateForTest,
+  resolveTrackerReconcileIntervalMs,
   resolveStuckSessionAbortMs,
   resolveStuckSessionWarnMs,
   startDiagnosticHeartbeat,
 } from "./diagnostic.js";
+
+vi.mock("../config/sessions/store-load.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/store-load.js")>();
+  return {
+    ...actual,
+    loadSessionStore: vi.fn(() => ({})),
+  };
+});
+
+vi.mock("../config/sessions/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/paths.js")>();
+  return {
+    ...actual,
+    resolveStorePath: vi.fn(() => "/tmp/openclaw-test-sessions.json"),
+  };
+});
 
 function createEmitMemorySampleMock() {
   return vi.fn(() => ({
@@ -163,6 +182,99 @@ describe("diagnostic session activity aliases", () => {
     expect(getDiagnosticSessionActivitySnapshot({ sessionId: "s1" }).activeWorkKind).toBe(
       "embedded_run",
     );
+  });
+});
+
+describe("diagnostic session tracker reconciliation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetDiagnosticStateForTest();
+    resetDiagnosticEventsForTest();
+    vi.mocked(resolveStorePath).mockReturnValue("/tmp/openclaw-test-sessions.json");
+    vi.mocked(loadSessionStore).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    resetDiagnosticEventsForTest();
+    resetDiagnosticStateForTest();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("evicts terminal persisted sessions from the tracker on the heartbeat tick", () => {
+    const terminalKey = "agent:main:slack:channel:terminal";
+    const activeKey = "agent:main:slack:channel:active";
+    const events: DiagnosticEventPayload[] = [];
+    const infoSpy = vi.spyOn(diagnosticLogger, "info").mockImplementation(() => undefined);
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [terminalKey]: {
+        sessionId: "run-terminal",
+        updatedAt: 1,
+        endedAt: 12345,
+        status: "done",
+      },
+      [activeKey]: {
+        sessionId: "run-active",
+        updatedAt: 1,
+        status: "running",
+      },
+    });
+
+    try {
+      startDiagnosticHeartbeat(
+        {
+          gateway: { sessionTracker: { reconcileEverySeconds: 5 } },
+          diagnostics: { enabled: true },
+        },
+        { emitMemorySample: createEmitMemorySampleMock() },
+      );
+      logSessionStateChange({
+        sessionId: "run-terminal",
+        sessionKey: terminalKey,
+        state: "processing",
+      });
+      logSessionStateChange({
+        sessionId: "run-active",
+        sessionKey: activeKey,
+        state: "processing",
+      });
+      vi.advanceTimersByTime(30_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(diagnosticSessionStates.has(terminalKey)).toBe(false);
+    expect(diagnosticSessionStates.has(activeKey)).toBe(true);
+    expect(resolveStorePath).toHaveBeenCalledTimes(1);
+    expect(loadSessionStore).toHaveBeenCalledWith("/tmp/openclaw-test-sessions.json");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "session.tracker.reconciled",
+        evicted: 1,
+      }),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `tracker reconcile: evicting terminal session sessionKey=${terminalKey}`,
+      ),
+    );
+  });
+
+  it("resolves the configured tracker reconciliation interval", () => {
+    expect(resolveTrackerReconcileIntervalMs()).toBe(300_000);
+    expect(
+      resolveTrackerReconcileIntervalMs({
+        gateway: { sessionTracker: { reconcileEverySeconds: 5 } },
+      }),
+    ).toBe(5_000);
+    expect(
+      resolveTrackerReconcileIntervalMs({
+        gateway: { sessionTracker: { reconcileEverySeconds: 0 } },
+      }),
+    ).toBe(0);
   });
 });
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1,5 +1,8 @@
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { getRuntimeConfig } from "../config/config.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionStore } from "../config/sessions/store-load.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   areDiagnosticsEnabledForProcess,
@@ -8,6 +11,10 @@ import {
   type DiagnosticPhaseSnapshot,
   type DiagnosticLivenessWarningReason,
 } from "../infra/diagnostic-events.js";
+import {
+  findLatestTaskForRelatedSessionKey,
+  isTerminalTaskStatus,
+} from "../tasks/task-registry.js";
 import { emitDiagnosticMemorySample, resetDiagnosticMemoryForTest } from "./diagnostic-memory.js";
 import {
   getCurrentDiagnosticPhase,
@@ -925,6 +932,123 @@ export function logActiveRuns() {
 }
 
 let heartbeatInterval: NodeJS.Timeout | null = null;
+let lastTrackerReconcileAt = 0;
+
+const DEFAULT_TRACKER_RECONCILE_SECONDS = 300;
+
+export function resolveTrackerReconcileIntervalMs(config?: OpenClawConfig): number {
+  const raw = config?.gateway?.sessionTracker?.reconcileEverySeconds;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return DEFAULT_TRACKER_RECONCILE_SECONDS * 1000;
+  }
+  const seconds = Math.floor(raw);
+  if (seconds <= 0) {
+    return 0;
+  }
+  return seconds * 1000;
+}
+
+function findPersistedSessionEntry(
+  store: Record<string, SessionEntry>,
+  state: SessionRef,
+): SessionEntry | undefined {
+  for (const key of [state.sessionKey, state.sessionId]) {
+    if (!key) {
+      continue;
+    }
+    const entry = store[key];
+    if (entry) {
+      return entry;
+    }
+  }
+  if (!state.sessionId) {
+    return undefined;
+  }
+  return Object.values(store).find((entry) => entry.sessionId === state.sessionId);
+}
+
+function resolvePersistedSessionTerminalReason(
+  entry: SessionEntry | undefined,
+): string | undefined {
+  if (!entry) {
+    return undefined;
+  }
+  if (entry.endedAt != null) {
+    return "sessions_json_ended_at";
+  }
+  if (
+    entry.status === "failed" ||
+    entry.status === "done" ||
+    entry.status === "killed" ||
+    entry.status === "timeout"
+  ) {
+    return `sessions_json_status_${entry.status}`;
+  }
+  return undefined;
+}
+
+function resolveTaskRegistryTerminalReason(sessionKey: string | undefined): string | undefined {
+  if (!sessionKey) {
+    return undefined;
+  }
+  try {
+    const task = findLatestTaskForRelatedSessionKey(sessionKey);
+    if (task && isTerminalTaskStatus(task.status)) {
+      return `task_registry_status_${task.status}`;
+    }
+  } catch (err) {
+    diag.debug(
+      `tracker reconcile: task lookup failed sessionKey=${sessionKey} error=${String(err)}`,
+    );
+  }
+  return undefined;
+}
+
+export function reconcileDiagnosticSessionTracker(config?: OpenClawConfig): void {
+  if (!areDiagnosticsEnabledForProcess() || !isDiagnosticsEnabled(config)) {
+    return;
+  }
+  let store: Record<string, SessionEntry>;
+  try {
+    store = loadSessionStore(resolveStorePath());
+  } catch (err) {
+    diag.debug(`tracker reconcile: session store unavailable error=${String(err)}`);
+    return;
+  }
+
+  let checked = 0;
+  let evicted = 0;
+  for (const [key, state] of Array.from(diagnosticSessionStates.entries())) {
+    checked += 1;
+    const persistedReason = resolvePersistedSessionTerminalReason(
+      findPersistedSessionEntry(store, {
+        sessionId: state.sessionId,
+        sessionKey: state.sessionKey,
+      }),
+    );
+    const taskReason = resolveTaskRegistryTerminalReason(state.sessionKey);
+    const reason = persistedReason ?? taskReason;
+    if (!reason) {
+      continue;
+    }
+    diagnosticSessionStates.delete(key);
+    evicted += 1;
+    diag.info(
+      `tracker reconcile: evicting terminal session sessionKey=${
+        state.sessionKey ?? "unknown"
+      } sessionId=${state.sessionId ?? "unknown"} reason=${reason}`,
+    );
+  }
+  if (evicted > 0) {
+    emitDiagnosticEvent({
+      type: "session.tracker.reconciled",
+      evicted,
+    });
+    markActivity();
+    return;
+  }
+  diag.debug(`tracker reconcile: no stale entries (checked ${checked})`);
+}
 
 export function startDiagnosticHeartbeat(
   config?: OpenClawConfig,
@@ -1044,6 +1168,11 @@ export function startDiagnosticHeartbeat(
         }
       }
     }
+    const reconcileIntervalMs = resolveTrackerReconcileIntervalMs(heartbeatConfig);
+    if (reconcileIntervalMs > 0 && now - lastTrackerReconcileAt >= reconcileIntervalMs) {
+      lastTrackerReconcileAt = now;
+      reconcileDiagnosticSessionTracker(heartbeatConfig);
+    }
   }, 30_000);
   heartbeatInterval.unref?.();
 }
@@ -1071,6 +1200,7 @@ export function resetDiagnosticStateForTest(): void {
   webhookStats.processed = 0;
   webhookStats.errors = 0;
   webhookStats.lastReceived = 0;
+  lastTrackerReconcileAt = 0;
   stopDiagnosticHeartbeat();
   resetDiagnosticMemoryForTest();
   resetDiagnosticPhasesForTest();

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -19,6 +19,7 @@ import {
   shouldAutoDeliverTaskTerminalUpdate,
   shouldSuppressDuplicateTerminalDelivery,
 } from "./task-executor-policy.js";
+export { isTerminalTaskStatus } from "./task-executor-policy.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import {
   getTaskFlowById,


### PR DESCRIPTION
Defense-in-depth for the 0bae505d stalled-session incident.

## What

Adds a configurable tick inside the existing 30s diagnostic heartbeat that walks the in-memory session tracker, joins each entry against `sessions.json` and the task registry, and evicts entries whose persisted state is terminal.

## Config

```json
"gateway": {
  "sessionTracker": {
    "reconcileEverySeconds": 300
  }
}
```

Default: 300s. Set to 0 to disable.

## Behavior

- Session store loaded once per reconcile pass (defensive try/catch)
- Terminal detection: `endedAt != null` OR `status in {failed, done, killed, timeout}` from sessions.json, OR task registry shows terminal status
- Evictions logged at info level: `tracker reconcile: evicting terminal session sessionKey=... reason=...`
- `session.tracker.reconciled` event emitted with `evicted` count
- If store unavailable (file not found etc), logs at debug and skips pass

## Motivation

In the 0bae505d incident, a stalled subagent session kept its entry alive in the in-memory tracker long after the session had actually ended. This caused repeated stalled-session diagnostic alarms for ~8 hours. This reconciler evicts such zombie entries on the next tick.

Companion to PR #78582 (subagent watchdog auto-abort).