### PR TITLE
feat(cli): openclaw sessions abort <key> admin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Sessions CLI/Gateway: add the admin-scoped `openclaw sessions abort <session-key> [--force]` command and `POST /api/sessions/:key/abort` endpoint so operators can fail and release orphaned cross-requester sessions without restarting the Gateway.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -53,6 +53,21 @@ This is the command path used by the `/export-trajectory` slash command after
 the owner approves the exec request. The output directory is always resolved
 inside `.openclaw/trajectory-exports/` under the selected workspace.
 
+Abort a session by key through the admin Gateway endpoint:
+
+```bash
+openclaw sessions abort "agent:main:subagent:worker"
+openclaw sessions abort "agent:main:subagent:worker" --force
+```
+
+`openclaw sessions abort` is admin-scoped and cross-requester: it can abort a
+session created from another chat thread or client. The command removes the
+in-memory diagnostic tracker entry when present, marks the persisted session
+record failed with `abortedBy=admin_cli`, and emits `session.aborted_by_admin`.
+`--force` also tries the registered subagent cancel hook when the active runtime
+exposes one; if no matching cancellable run is registered, the tracker/store
+abort still succeeds.
+
 `openclaw sessions --all-agents` reads configured agent stores. Gateway and ACP
 session discovery are broader: they also include disk-only stores found under
 the default `agents/` root or a templated `session.store` root. Those

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   statusCommand: vi.fn(),
   healthCommand: vi.fn(),
   sessionsCommand: vi.fn(),
+  sessionsAbortCommand: vi.fn(),
   sessionsCleanupCommand: vi.fn(),
   exportTrajectoryCommand: vi.fn(),
   commitmentsListCommand: vi.fn(),
@@ -30,6 +31,7 @@ const mocks = vi.hoisted(() => ({
 const statusCommand = mocks.statusCommand;
 const healthCommand = mocks.healthCommand;
 const sessionsCommand = mocks.sessionsCommand;
+const sessionsAbortCommand = mocks.sessionsAbortCommand;
 const sessionsCleanupCommand = mocks.sessionsCleanupCommand;
 const exportTrajectoryCommand = mocks.exportTrajectoryCommand;
 const commitmentsListCommand = mocks.commitmentsListCommand;
@@ -56,6 +58,10 @@ vi.mock("../../commands/health.js", () => ({
 
 vi.mock("../../commands/sessions.js", () => ({
   sessionsCommand: mocks.sessionsCommand,
+}));
+
+vi.mock("../../commands/sessions-abort.js", () => ({
+  sessionsAbortCommand: mocks.sessionsAbortCommand,
 }));
 
 vi.mock("../../commands/sessions-cleanup.js", () => ({
@@ -107,6 +113,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     statusCommand.mockResolvedValue(undefined);
     healthCommand.mockResolvedValue(undefined);
     sessionsCommand.mockResolvedValue(undefined);
+    sessionsAbortCommand.mockResolvedValue(undefined);
     sessionsCleanupCommand.mockResolvedValue(undefined);
     exportTrajectoryCommand.mockResolvedValue(undefined);
     commitmentsListCommand.mockResolvedValue(undefined);
@@ -253,6 +260,37 @@ describe("registerStatusHealthSessionsCommands", () => {
         enforce: true,
         fixMissing: true,
         activeKey: "agent:main:main",
+        json: true,
+      }),
+      runtime,
+    );
+  });
+
+  it("runs sessions abort subcommand with admin abort options", async () => {
+    await runCli([
+      "sessions",
+      "--json",
+      "abort",
+      "agent:main:subagent:worker",
+      "--force",
+      "--reason",
+      "incident cleanup",
+      "--url",
+      "ws://127.0.0.1:19001",
+      "--token",
+      "token-1",
+      "--timeout",
+      "5000",
+    ]);
+
+    expect(sessionsAbortCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:subagent:worker",
+        force: true,
+        reason: "incident cleanup",
+        url: "ws://127.0.0.1:19001",
+        token: "token-1",
+        timeout: "5000",
         json: true,
       }),
       runtime,

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -3,6 +3,7 @@ import { commitmentsDismissCommand, commitmentsListCommand } from "../../command
 import { exportTrajectoryCommand } from "../../commands/export-trajectory.js";
 import { flowsCancelCommand, flowsListCommand, flowsShowCommand } from "../../commands/flows.js";
 import { healthCommand } from "../../commands/health.js";
+import { sessionsAbortCommand } from "../../commands/sessions-abort.js";
 import { sessionsCleanupCommand } from "../../commands/sessions-cleanup.js";
 import { sessionsCommand } from "../../commands/sessions.js";
 import { statusCommand } from "../../commands/status.js";
@@ -168,6 +169,54 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       );
     });
   sessionsCmd.enablePositionalOptions();
+
+  sessionsCmd
+    .command("abort")
+    .description("Abort any session by key through the admin Gateway endpoint")
+    .argument("<session-key>", "Session key to abort")
+    .option(
+      "--force",
+      "Also try to cancel a matching active subagent run when the runtime exposes one",
+      false,
+    )
+    .option("--reason <text>", "Abort reason stored in the session record (default: manual)")
+    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--token <token>", "Gateway token (if required)")
+    .option("--timeout <ms>", "HTTP request timeout in milliseconds", "30000")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            "openclaw sessions abort agent:main:subagent:worker",
+            "Abort a cross-requester session.",
+          ],
+          [
+            "openclaw sessions abort agent:main:subagent:worker --force",
+            "Abort and try the registered subagent cancel hook.",
+          ],
+        ])}\n\n${theme.muted(
+          "Admin-scoped: this can abort sessions created by other requesters. --force only cancels child work when the active runtime exposes a matching subagent control hook; otherwise the session tracker and persisted record are still aborted.",
+        )}`,
+    )
+    .action(async (sessionKey, opts, command) => {
+      const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sessionsAbortCommand(
+          {
+            sessionKey: sessionKey as string,
+            force: Boolean(opts.force),
+            reason: opts.reason as string | undefined,
+            url: opts.url as string | undefined,
+            token: opts.token as string | undefined,
+            timeout: opts.timeout as string | undefined,
+            json: Boolean(opts.json || parentOpts?.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
 
   sessionsCmd
     .command("cleanup")

--- a/src/commands/sessions-abort.ts
+++ b/src/commands/sessions-abort.ts
@@ -1,0 +1,164 @@
+import { getRuntimeConfig } from "../config/config.js";
+import { resolveConfigPath } from "../config/paths.js";
+import {
+  buildGatewayConnectionDetails,
+  ensureExplicitGatewayAuth,
+  isGatewayTransportError,
+} from "../gateway/call.js";
+import { resolveGatewayCredentialsWithSecretInputs } from "../gateway/credentials-secret-inputs.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export type SessionsAbortCommandOptions = {
+  sessionKey: string;
+  force?: boolean;
+  reason?: string;
+  json?: boolean;
+  url?: string;
+  token?: string;
+  timeout?: string;
+};
+
+type SessionsAbortResponse = {
+  aborted?: boolean;
+  previousStatus?: string;
+  wasInMemory?: boolean;
+  forceKilled?: boolean;
+  ok?: boolean;
+  error?: {
+    type?: string;
+    message?: string;
+  };
+};
+
+function parseTimeoutMs(value: string | undefined): number {
+  if (value === undefined) {
+    return 30_000;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("--timeout must be a positive integer (milliseconds)");
+  }
+  return parsed;
+}
+
+function resolveHttpEndpointUrl(wsUrl: string, sessionKey: string): string {
+  const url = new URL(wsUrl);
+  if (url.protocol === "ws:") {
+    url.protocol = "http:";
+  } else if (url.protocol === "wss:") {
+    url.protocol = "https:";
+  } else if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`unsupported gateway URL protocol: ${url.protocol}`);
+  }
+  url.pathname = `/api/sessions/${encodeURIComponent(sessionKey)}/abort`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function resolveAbortErrorMessage(status: number, body: SessionsAbortResponse | undefined): string {
+  const message = normalizeOptionalString(body?.error?.message);
+  if (status === 404) {
+    return "session not found";
+  }
+  return message
+    ? `gateway abort failed (${status}): ${message}`
+    : `gateway abort failed (${status})`;
+}
+
+function resolveUrlOverride(opts: SessionsAbortCommandOptions): {
+  urlOverride?: string;
+  urlOverrideSource?: "cli" | "env";
+} {
+  const cliUrl = normalizeOptionalString(opts.url);
+  if (cliUrl) {
+    return { urlOverride: cliUrl, urlOverrideSource: "cli" };
+  }
+  const envUrl = normalizeOptionalString(process.env.OPENCLAW_GATEWAY_URL);
+  if (envUrl) {
+    return { urlOverride: envUrl, urlOverrideSource: "env" };
+  }
+  return {};
+}
+
+async function postAbortRequest(opts: SessionsAbortCommandOptions): Promise<SessionsAbortResponse> {
+  const cfg = getRuntimeConfig();
+  const connection = buildGatewayConnectionDetails({ config: cfg, url: opts.url });
+  const explicitAuth = { token: normalizeOptionalString(opts.token) };
+  const credentials = await resolveGatewayCredentialsWithSecretInputs({
+    config: cfg,
+    explicitAuth,
+    env: process.env,
+  });
+  const { urlOverride, urlOverrideSource } = resolveUrlOverride(opts);
+  ensureExplicitGatewayAuth({
+    urlOverride,
+    urlOverrideSource,
+    explicitAuth,
+    resolvedAuth: credentials,
+    errorHint: "Fix: pass --token or configure gateway auth.",
+    configPath: resolveConfigPath(process.env),
+  });
+
+  const endpoint = resolveHttpEndpointUrl(connection.url, opts.sessionKey);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), parseTimeoutMs(opts.timeout));
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json; charset=utf-8",
+    };
+    if (credentials.token) {
+      headers.Authorization = `Bearer ${credentials.token}`;
+    } else if (credentials.password) {
+      headers.Authorization = `Bearer ${credentials.password}`;
+    }
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        force: opts.force === true,
+        ...(normalizeOptionalString(opts.reason)
+          ? { reason: normalizeOptionalString(opts.reason) }
+          : {}),
+      }),
+      signal: controller.signal,
+    });
+    const parsed = (await response.json().catch(() => undefined)) as
+      | SessionsAbortResponse
+      | undefined;
+    if (!response.ok) {
+      throw new Error(resolveAbortErrorMessage(response.status, parsed));
+    }
+    return parsed ?? {};
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function sessionsAbortCommand(opts: SessionsAbortCommandOptions, runtime: RuntimeEnv) {
+  try {
+    const result = await postAbortRequest(opts);
+    if (opts.json) {
+      writeRuntimeJson(runtime, result);
+      return;
+    }
+    const previous = result.previousStatus ?? "unknown";
+    const memory = result.wasInMemory ? "yes" : "no";
+    const forced =
+      opts.force === true
+        ? ` Force kill: ${result.forceKilled ? "attempted and matched" : "no matching cancellable run"}.`
+        : "";
+    runtime.log(
+      `Aborted session ${opts.sessionKey} (previous status: ${previous}; in memory: ${memory}).${forced}`,
+    );
+  } catch (error) {
+    if (isGatewayTransportError(error)) {
+      runtime.error(`gateway unavailable: ${error.message}`);
+    } else {
+      runtime.error(formatErrorMessage(error));
+    }
+    runtime.exit(1);
+  }
+}

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -204,6 +204,10 @@ export type SessionEntry = {
   runtimeMs?: number;
   /** Final persisted subagent run status, used after in-memory run archival. */
   status?: "running" | "done" | "failed" | "killed" | "timeout";
+  /** Actor that forced this session into a terminal aborted state. */
+  abortedBy?: "admin_cli";
+  /** Human-readable reason captured for an admin abort. */
+  abortReason?: string;
   /**
    * Session-level stop cutoff captured when /stop is received.
    * Messages at/before this boundary are skipped to avoid replaying

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -68,6 +68,7 @@ let sessionHistoryHttpModulePromise:
   | Promise<typeof import("./sessions-history-http.js")>
   | undefined;
 let sessionKillHttpModulePromise: Promise<typeof import("./session-kill-http.js")> | undefined;
+let sessionAbortHttpModulePromise: Promise<typeof import("./sessions-abort-http.js")> | undefined;
 let toolsInvokeHttpModulePromise: Promise<typeof import("./tools-invoke-http.js")> | undefined;
 let canvasAuthModulePromise: Promise<typeof import("./server/http-auth.js")> | undefined;
 let httpAuthUtilsModulePromise: Promise<typeof import("./http-auth-utils.js")> | undefined;
@@ -118,6 +119,11 @@ function getSessionHistoryHttpModule() {
 function getSessionKillHttpModule() {
   sessionKillHttpModulePromise ??= import("./session-kill-http.js");
   return sessionKillHttpModulePromise;
+}
+
+function getSessionAbortHttpModule() {
+  sessionAbortHttpModulePromise ??= import("./sessions-abort-http.js");
+  return sessionAbortHttpModulePromise;
 }
 
 function getToolsInvokeHttpModule() {
@@ -211,6 +217,10 @@ function isManagedOutgoingImagePath(pathname: string): boolean {
 
 function isSessionKillPath(pathname: string): boolean {
   return /^\/sessions\/[^/]+\/kill$/.test(pathname);
+}
+
+function isSessionAbortPath(pathname: string): boolean {
+  return /^\/api\/sessions\/[^/]+\/abort$/.test(pathname);
 }
 
 function isSessionHistoryPath(pathname: string): boolean {
@@ -620,6 +630,18 @@ export function createGatewayHttpServer(opts: {
           name: "sessions-kill",
           run: async () =>
             (await getSessionKillHttpModule()).handleSessionKillHttpRequest(req, res, {
+              auth: resolvedAuth,
+              trustedProxies,
+              allowRealIpFallback,
+              rateLimiter,
+            }),
+        });
+      }
+      if (isSessionAbortPath(scopedRequestPath)) {
+        requestStages.push({
+          name: "sessions-abort",
+          run: async () =>
+            (await getSessionAbortHttpModule()).handleSessionAbortHttpRequest(req, res, {
               auth: resolvedAuth,
               trustedProxies,
               allowRealIpFallback,

--- a/src/gateway/sessions-abort-http.test.ts
+++ b/src/gateway/sessions-abort-http.test.ts
@@ -1,0 +1,247 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import {
+  diagnosticSessionStates,
+  resetDiagnosticSessionStateForTest,
+} from "../logging/diagnostic-session-state.js";
+import type { GatewayAuthResult } from "./auth.js";
+
+const TEST_GATEWAY_TOKEN = "test-gateway-token-1234567890";
+
+let cfg: Record<string, unknown> = {};
+const mocks = vi.hoisted(() => ({
+  authMock: vi.fn(async (): Promise<GatewayAuthResult> => ({ ok: true })),
+  isLocalDirectRequestMock: vi.fn(() => false),
+  loadSessionEntryMock: vi.fn(),
+  updateSessionStoreMock: vi.fn(),
+  killSubagentRunAdminMock: vi.fn(),
+}));
+const authMock = mocks.authMock;
+const isLocalDirectRequestMock = mocks.isLocalDirectRequestMock;
+const loadSessionEntryMock = mocks.loadSessionEntryMock;
+const updateSessionStoreMock = mocks.updateSessionStoreMock;
+const killSubagentRunAdminMock = mocks.killSubagentRunAdminMock;
+
+vi.mock("../config/io.js", () => ({
+  getRuntimeConfig: () => cfg,
+}));
+
+vi.mock("./auth.js", () => ({
+  authorizeHttpGatewayConnect: mocks.authMock,
+  isLocalDirectRequest: mocks.isLocalDirectRequestMock,
+}));
+
+vi.mock("./session-utils.js", () => ({
+  loadSessionEntry: mocks.loadSessionEntryMock,
+}));
+
+vi.mock("../config/sessions.js", async () => {
+  const original =
+    await vi.importActual<typeof import("../config/sessions.js")>("../config/sessions.js");
+  return {
+    ...original,
+    updateSessionStore: mocks.updateSessionStoreMock,
+  };
+});
+
+vi.mock("../agents/subagent-control.js", () => ({
+  killSubagentRunAdmin: mocks.killSubagentRunAdminMock,
+}));
+
+const { handleSessionAbortHttpRequest } = await import("./sessions-abort-http.js");
+
+beforeEach(() => {
+  cfg = {};
+  authMock.mockReset();
+  authMock.mockResolvedValue({ ok: true, method: "trusted-proxy" });
+  isLocalDirectRequestMock.mockReset();
+  isLocalDirectRequestMock.mockReturnValue(false);
+  loadSessionEntryMock.mockReset();
+  updateSessionStoreMock.mockReset();
+  killSubagentRunAdminMock.mockReset();
+  killSubagentRunAdminMock.mockResolvedValue({ found: false, killed: false });
+  resetDiagnosticEventsForTest();
+  resetDiagnosticSessionStateForTest();
+});
+
+function createJsonRequest(
+  pathname: string,
+  body: Record<string, unknown>,
+  extraHeaders?: Record<string, string>,
+) {
+  const rawBody = JSON.stringify(body);
+  const req = Readable.from([rawBody]) as unknown as IncomingMessage;
+  req.method = "POST";
+  req.url = pathname;
+  req.headers = {
+    authorization: `Bearer ${TEST_GATEWAY_TOKEN}`,
+    "content-type": "application/json; charset=utf-8",
+    "content-length": String(Buffer.byteLength(rawBody)),
+    "x-openclaw-scopes": "operator.admin",
+    ...extraHeaders,
+  };
+  return req;
+}
+
+function createJsonResponse() {
+  let body = "";
+  const res = {
+    statusCode: 200,
+    setHeader() {
+      return this;
+    },
+    end(value?: unknown) {
+      body =
+        typeof value === "string"
+          ? value
+          : Buffer.isBuffer(value)
+            ? value.toString("utf-8")
+            : value == null
+              ? ""
+              : JSON.stringify(value);
+      return this;
+    },
+  } as unknown as ServerResponse;
+  return {
+    res,
+    get statusCode() {
+      return res.statusCode;
+    },
+    json(): unknown {
+      return body ? JSON.parse(body) : undefined;
+    },
+  };
+}
+
+async function post(
+  pathname: string,
+  body: Record<string, unknown> = {},
+  extraHeaders?: Record<string, string>,
+) {
+  const req = createJsonRequest(pathname, body, extraHeaders);
+  const response = createJsonResponse();
+  const handled = await handleSessionAbortHttpRequest(req, response.res, {
+    auth: { mode: "token", token: TEST_GATEWAY_TOKEN, allowTailscale: false },
+  });
+  return { handled, response };
+}
+
+describe("POST /api/sessions/:sessionKey/abort", () => {
+  it("removes an in-memory session, emits an admin abort event, and marks the store failed", async () => {
+    const sessionKey = "agent:main:subagent:worker";
+    const entry: SessionEntry = {
+      sessionId: "sess-worker",
+      updatedAt: 100,
+      status: "running",
+    };
+    const store: Record<string, SessionEntry> = { [sessionKey]: entry };
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      entry,
+      canonicalKey: sessionKey,
+    });
+    updateSessionStoreMock.mockImplementation(
+      async (_storePath: string, mutator: (store: Record<string, SessionEntry>) => void) => {
+        mutator(store);
+      },
+    );
+    diagnosticSessionStates.set(sessionKey, {
+      sessionId: "sess-worker",
+      sessionKey,
+      lastActivity: 123,
+      state: "processing",
+      queueDepth: 1,
+    });
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+
+    const { handled, response } = await post(
+      `/api/sessions/${encodeURIComponent(sessionKey)}/abort`,
+      { reason: "incident cleanup" },
+    );
+    stop();
+
+    expect(handled).toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      aborted: true,
+      previousStatus: "running",
+      wasInMemory: true,
+    });
+    expect(diagnosticSessionStates.has(sessionKey)).toBe(false);
+    expect(store[sessionKey]).toMatchObject({
+      status: "failed",
+      abortedBy: "admin_cli",
+      abortReason: "incident cleanup",
+    });
+    expect(store[sessionKey]?.endedAt).toEqual(expect.any(Number));
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "session.aborted_by_admin",
+        sessionKey,
+        sessionId: "sess-worker",
+        previousStatus: "running",
+        wasInMemory: true,
+        reason: "incident cleanup",
+      }),
+    ]);
+  });
+
+  it("returns 404 for an unknown session key", async () => {
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      entry: undefined,
+      canonicalKey: "agent:main:missing",
+    });
+
+    const { handled, response } = await post("/api/sessions/agent%3Amain%3Amissing/abort");
+
+    expect(handled).toBe(true);
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({
+      ok: false,
+      error: { type: "not_found" },
+    });
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
+  });
+
+  it("allows loopback admin aborts even when bearer auth cannot assert scope headers", async () => {
+    isLocalDirectRequestMock.mockReturnValue(true);
+    authMock.mockResolvedValue({ ok: true, method: "token" });
+    const sessionKey = "agent:main:subagent:local";
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      entry: undefined,
+      canonicalKey: sessionKey,
+    });
+    diagnosticSessionStates.set(sessionKey, {
+      sessionId: "sess-local",
+      sessionKey,
+      lastActivity: 123,
+      state: "processing",
+      queueDepth: 1,
+    });
+
+    const { response } = await post(
+      `/api/sessions/${encodeURIComponent(sessionKey)}/abort`,
+      {},
+      { "x-openclaw-scopes": "" },
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      aborted: true,
+      previousStatus: "processing",
+      wasInMemory: true,
+    });
+  });
+});

--- a/src/gateway/sessions-abort-http.ts
+++ b/src/gateway/sessions-abort-http.ts
@@ -1,0 +1,217 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { killSubagentRunAdmin } from "../agents/subagent-control.js";
+import {
+  normalizeStoreSessionKey,
+  updateSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
+import { diagnosticSessionStates, type SessionState } from "../logging/diagnostic-session-state.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import { isLocalDirectRequest, type ResolvedGatewayAuth } from "./auth.js";
+import { readJsonBodyOrError, sendJson, sendMethodNotAllowed } from "./http-common.js";
+import {
+  authorizeGatewayHttpRequestOrReply,
+  resolveTrustedHttpOperatorScopes,
+} from "./http-utils.js";
+import { authorizeOperatorScopesForMethod, CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
+import { loadSessionEntry } from "./session-utils.js";
+
+const MAX_ABORT_BODY_BYTES = 16 * 1024;
+const DEFAULT_ABORT_REASON = "manual";
+
+function resolveSessionKeyFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/api\/sessions\/([^/]+)\/abort$/);
+  if (!match) {
+    return null;
+  }
+  try {
+    const decoded = decodeURIComponent(match[1] ?? "").trim();
+    return decoded || null;
+  } catch {
+    return null;
+  }
+}
+
+function asAbortBody(value: unknown): { force: boolean; reason: string } {
+  if (!value || typeof value !== "object") {
+    return { force: false, reason: DEFAULT_ABORT_REASON };
+  }
+  const record = value as { force?: unknown; reason?: unknown };
+  return {
+    force: record.force === true,
+    reason: normalizeOptionalString(record.reason) ?? DEFAULT_ABORT_REASON,
+  };
+}
+
+function findDiagnosticSessionEntry(
+  sessionKey: string,
+  sessionId?: string,
+): [string, SessionState] | null {
+  const direct = diagnosticSessionStates.get(sessionKey);
+  if (direct) {
+    return [sessionKey, direct];
+  }
+  if (!sessionId) {
+    return null;
+  }
+  for (const entry of diagnosticSessionStates.entries()) {
+    if (entry[1].sessionId === sessionId) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function resolvePreviousStatus(entry: SessionEntry | undefined, state: SessionState | undefined) {
+  return entry?.status ?? state?.state ?? "unknown";
+}
+
+async function markSessionAborted(params: {
+  storePath: string;
+  canonicalKey: string;
+  endedAt: number;
+  reason: string;
+}): Promise<void> {
+  await updateSessionStore(params.storePath, (store) => {
+    const normalized = normalizeStoreSessionKey(params.canonicalKey);
+    const storeKey =
+      store[params.canonicalKey] !== undefined
+        ? params.canonicalKey
+        : Object.keys(store).find((key) => normalizeStoreSessionKey(key) === normalized);
+    if (!storeKey) {
+      return;
+    }
+    const entry = store[storeKey];
+    if (!entry) {
+      return;
+    }
+    store[storeKey] = {
+      ...entry,
+      status: "failed",
+      endedAt: params.endedAt,
+      updatedAt: Math.max(entry.updatedAt ?? 0, params.endedAt),
+      abortedBy: "admin_cli",
+      abortReason: params.reason,
+    };
+  });
+}
+
+export async function handleSessionAbortHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: {
+    auth: ResolvedGatewayAuth;
+    trustedProxies?: string[];
+    allowRealIpFallback?: boolean;
+    rateLimiter?: AuthRateLimiter;
+  },
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const sessionKey = resolveSessionKeyFromPath(url.pathname);
+  if (!sessionKey) {
+    return false;
+  }
+
+  if (req.method !== "POST") {
+    sendMethodNotAllowed(res, "POST");
+    return true;
+  }
+
+  const requestAuth = await authorizeGatewayHttpRequestOrReply({
+    req,
+    res,
+    auth: opts.auth,
+    trustedProxies: opts.trustedProxies,
+    allowRealIpFallback: opts.allowRealIpFallback,
+    rateLimiter: opts.rateLimiter,
+  });
+  if (!requestAuth) {
+    return true;
+  }
+
+  const allowLocalAdminAbort = isLocalDirectRequest(
+    req,
+    opts.trustedProxies,
+    opts.allowRealIpFallback,
+  );
+  const requestedScopes = allowLocalAdminAbort
+    ? CLI_DEFAULT_OPERATOR_SCOPES
+    : resolveTrustedHttpOperatorScopes(req, requestAuth);
+  const scopeAuth = authorizeOperatorScopesForMethod("sessions.delete", requestedScopes);
+  if (!scopeAuth.allowed) {
+    sendJson(res, 403, {
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: `missing scope: ${scopeAuth.missingScope}`,
+      },
+    });
+    return true;
+  }
+
+  const body = await readJsonBodyOrError(req, res, MAX_ABORT_BODY_BYTES);
+  if (body === undefined) {
+    return true;
+  }
+  const abortBody = asAbortBody(body);
+
+  const loaded = loadSessionEntry(sessionKey);
+  const canonicalKey = loaded.canonicalKey ?? sessionKey;
+  const inMemoryEntry = findDiagnosticSessionEntry(canonicalKey, loaded.entry?.sessionId);
+  if (!loaded.entry && !inMemoryEntry) {
+    sendJson(res, 404, {
+      ok: false,
+      error: {
+        type: "not_found",
+        message: `session not found: ${sessionKey}`,
+      },
+    });
+    return true;
+  }
+
+  const previousStatus = resolvePreviousStatus(loaded.entry, inMemoryEntry?.[1]);
+  const wasInMemory = Boolean(inMemoryEntry);
+  if (inMemoryEntry) {
+    diagnosticSessionStates.delete(inMemoryEntry[0]);
+  }
+
+  const endedAt = Date.now();
+  if (loaded.entry && loaded.storePath) {
+    await markSessionAborted({
+      storePath: loaded.storePath,
+      canonicalKey,
+      endedAt,
+      reason: abortBody.reason,
+    });
+  }
+
+  let forceKilled = false;
+  if (abortBody.force) {
+    const result = await killSubagentRunAdmin({
+      cfg: loaded.cfg,
+      sessionKey: canonicalKey,
+    });
+    forceKilled = result.killed;
+  }
+
+  emitDiagnosticEvent({
+    type: "session.aborted_by_admin",
+    sessionKey: canonicalKey,
+    sessionId: loaded.entry?.sessionId ?? inMemoryEntry?.[1].sessionId,
+    previousStatus,
+    wasInMemory,
+    force: abortBody.force,
+    forceKilled,
+    reason: abortBody.reason,
+  });
+
+  sendJson(res, 200, {
+    aborted: true,
+    previousStatus,
+    wasInMemory,
+    ...(abortBody.force ? { forceKilled } : {}),
+  });
+  return true;
+}

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -212,6 +212,17 @@ export type DiagnosticSessionRecoveryCompletedEvent = DiagnosticSessionRecoveryB
   stale?: boolean;
 };
 
+export type DiagnosticSessionAbortedByAdminEvent = DiagnosticBaseEvent & {
+  type: "session.aborted_by_admin";
+  sessionKey: string;
+  sessionId?: string;
+  previousStatus?: string;
+  wasInMemory: boolean;
+  force?: boolean;
+  forceKilled?: boolean;
+  reason?: string;
+};
+
 export type DiagnosticLaneEnqueueEvent = DiagnosticBaseEvent & {
   type: "queue.lane.enqueue";
   lane: string;
@@ -572,6 +583,7 @@ export type DiagnosticEventPayload =
   | DiagnosticSessionStuckEvent
   | DiagnosticSessionRecoveryRequestedEvent
   | DiagnosticSessionRecoveryCompletedEvent
+  | DiagnosticSessionAbortedByAdminEvent
   | DiagnosticLaneEnqueueEvent
   | DiagnosticLaneDequeueEvent
   | DiagnosticRunAttemptEvent


### PR DESCRIPTION
## Context

`subagents kill` is requester-scoped — it only kills children spawned by the calling session. On 2026-05-06 an orphan subagent (`0bae505d-...`) spawned from a different DM thread held the gateway's diagnostic alarm hostage for 8 hours. The only workaround was a full gateway restart, which itself was blocked for 5 minutes by a separate zombie task.

## Change

Adds `openclaw sessions abort <session-key> [--force]` (CLI) plus `POST /api/sessions/:key/abort` (gateway HTTP), guarded by the existing admin auth used by other privileged endpoints. Removes the in-memory tracker entry, marks the persisted session `failed` with `abortedBy=admin_cli`, emits `session.aborted_by_admin`.

`--force` additionally attempts to kill the associated child process / cancel the active tool call (limitation: only works when the harness exposes a cancel hook — gracefully no-ops otherwise; documented in `--help`).

## Tests

Unit tests for the endpoint handler covering the happy path and the unknown-key 404 path.

## Companion work

Part of a 5-PR reliability series following the 0bae505d incident.