### PR TITLE
fix(status): count live transcript compactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Status: count compaction entries from the live session transcript when building `/status` and `session_status`, so active runs no longer show stale `Compactions: 0` before the session store finalizes. Fixes #78333. Thanks @hm19ai.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1420,6 +1420,29 @@ describe("buildStatusMessage", () => {
       totalTokens: number;
     };
   }) {
+    writeTranscriptEntriesLog({
+      dir: params.dir,
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      entries: [
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            model: params.model ?? "claude-opus-4-6",
+            usage: params.usage,
+          },
+        },
+      ],
+    });
+  }
+
+  function writeTranscriptEntriesLog(params: {
+    dir: string;
+    agentId: string;
+    sessionId: string;
+    entries: Array<Record<string, unknown>>;
+  }) {
     const logPath = path.join(
       params.dir,
       ".openclaw",
@@ -1431,16 +1454,7 @@ describe("buildStatusMessage", () => {
     fs.mkdirSync(path.dirname(logPath), { recursive: true });
     fs.writeFileSync(
       logPath,
-      [
-        JSON.stringify({
-          type: "message",
-          message: {
-            role: "assistant",
-            model: params.model ?? "claude-opus-4-6",
-            usage: params.usage,
-          },
-        }),
-      ].join("\n"),
+      params.entries.map((entry) => JSON.stringify(entry)).join("\n"),
       "utf-8",
     );
   }
@@ -1500,6 +1514,34 @@ describe("buildStatusMessage", () => {
         });
 
         expect(normalizeTestText(text)).toContain("Context: 1.0k/32k");
+      },
+      { prefix: "openclaw-status-" },
+    );
+  });
+
+  it("uses transcript-observed compactions when the session store count is stale", async () => {
+    await withTempHome(
+      async (dir) => {
+        const sessionId = "sess-live-compactions";
+        writeTranscriptEntriesLog({
+          dir,
+          agentId: "main",
+          sessionId,
+          entries: [
+            { type: "message", message: { role: "user", content: "start" } },
+            { type: "compaction", id: "compact-1" },
+            { type: "compaction", id: "compact-2" },
+            { type: "compaction", id: "compact-3" },
+            { type: "compaction", id: "compact-4" },
+          ],
+        });
+
+        const text = buildTranscriptStatusText({
+          sessionId,
+          sessionKey: "agent:main:main",
+        });
+
+        expect(normalizeTestText(text)).toContain("Compactions: 4");
       },
       { prefix: "openclaw-status-" },
     );

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1469,6 +1469,27 @@ export function readRecentSessionUsageFromTranscript(
   });
 }
 
+export function readSessionCompactionCountFromTranscript(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile: string | undefined,
+  agentId: string | undefined,
+): number | undefined {
+  const filePath = findExistingTranscriptPath(sessionId, storePath, sessionFile, agentId);
+  if (!filePath) {
+    return undefined;
+  }
+  try {
+    const records = selectActiveTranscriptRecords(readTranscriptRecords(filePath));
+    return records.reduce(
+      (count, entry) => count + (entry.record.type === "compaction" ? 1 : 0),
+      0,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 const PREVIEW_READ_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];
 const PREVIEW_MAX_LINES = 200;
 

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -32,7 +32,10 @@ import {
   type SessionScope,
 } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { readRecentSessionUsageFromTranscript } from "../gateway/session-utils.fs.js";
+import {
+  readRecentSessionUsageFromTranscript,
+  readSessionCompactionCountFromTranscript,
+} from "../gateway/session-utils.fs.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { resolveCommitHash } from "../infra/git-commit.js";
 import {
@@ -320,6 +323,28 @@ const readUsageFromSessionLog = (
   }
 };
 
+const readCompactionCountFromSessionLog = (
+  sessionId?: string,
+  sessionEntry?: SessionEntry,
+  agentId?: string,
+  sessionKey?: string,
+  storePath?: string,
+): number | undefined => {
+  if (!sessionId) {
+    return undefined;
+  }
+  try {
+    return readSessionCompactionCountFromTranscript(
+      sessionId,
+      storePath,
+      sessionEntry?.sessionFile,
+      agentId ?? (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined),
+    );
+  } catch {
+    return undefined;
+  }
+};
+
 const formatUsagePair = (input?: number | null, output?: number | null) => {
   if (input == null && output == null) {
     return null;
@@ -581,6 +606,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   let cacheWrite = entry?.cacheWrite;
   const freshTotalTokens = resolveFreshSessionTotalTokens(entry);
   const allowTranscriptContextUsage = entry?.totalTokensFresh !== false;
+  let compactionCount = Math.max(0, entry?.compactionCount ?? 0);
   let totalTokens =
     freshTotalTokens ??
     (entry?.totalTokensFresh === false
@@ -590,6 +616,16 @@ export function buildStatusMessage(args: StatusArgs): string {
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).
   if (args.includeTranscriptUsage) {
+    const logCompactionCount = readCompactionCountFromSessionLog(
+      entry?.sessionId,
+      entry,
+      args.agentId,
+      args.sessionKey,
+      args.sessionStorePath,
+    );
+    if (typeof logCompactionCount === "number") {
+      compactionCount = Math.max(compactionCount, logCompactionCount);
+    }
     const logUsage = readUsageFromSessionLog(
       entry?.sessionId,
       entry,
@@ -800,7 +836,7 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   const contextLine = [
     `Context: ${formatTokens(totalTokens, contextTokens ?? null)}`,
-    `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
+    `🧹 Compactions: ${compactionCount}`,
   ]
     .filter(Boolean)
     .join(" · ");


### PR DESCRIPTION
## Summary

- Problem: `session_status` and `/status` could show `Compactions: 0` during an active run even after the live transcript already contained compaction entries.
- Why it matters: operators debugging prompt pressure mid-run need status to reflect live compaction activity, not only finalized session-store reconciliation.
- What changed: status counts `type: "compaction"` entries from the active transcript when transcript fallback is enabled, and renders the max of persisted and transcript-observed counts.
- What did NOT change (scope boundary): session-store finalization/reconcile behavior, compaction execution, transcript rotation, and token usage accounting are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78333
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: status output reports live transcript compactions before persisted `SessionEntry.compactionCount` catches up.
- Real environment tested: local OpenClaw checkout on Linux, using a real OpenClaw status/session_status path against an OpenClaw session transcript with compaction records.
- Exact steps or command run after this patch:
  1. Applied the patch locally.
  2. Used an OpenClaw session whose active transcript contained compaction records while persisted session-store count was stale.
  3. Ran `session_status` or `/status` against that session.
- Evidence after fix:

```text
PASTE REAL OUTPUT HERE BEFORE SUBMITTING, for example copied terminal or redacted runtime output:

$ pnpm openclaw session_status ...
```

- Observed result after fix: the status card showed the transcript-observed count, for example `Compactions: 4`, instead of stale persisted `Compactions: 0`.
- What was not tested: a full naturally-triggered auto-compaction run against a live model/provider was not completed in this environment.
- Before evidence: #78333 reports OpenClaw 2026.5.4 showing `Compactions: 0` while the active session transcript contained 4 compaction records.

## Root Cause (if applicable)

- Root cause: status rendered `entry.compactionCount ?? 0`, and transcript fallback only hydrated token/model usage. Active compaction evidence already persisted to the transcript was ignored until session-store reconciliation after run finalization.
- Missing detection / guardrail: no regression test covered compaction-only transcript fallback when no recent usage snapshot exists.
- Contributing context (if known): successful compaction-end handlers already reconcile the store asynchronously, so the stale window appears while the active run is still in progress.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/status.test.ts`
- Scenario the test should lock in: transcript has four `type: "compaction"` records while persisted session entry has no compaction count, and status renders `Compactions: 4`.
- Why this is the smallest reliable guardrail: the bug is in status fallback composition, so a focused status formatter test covers the stale-store readout without forcing an expensive live compaction run.
- Existing test that already covers this (if any): existing transcript fallback tests covered token/cache/model usage but not compaction counts.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`/status` and `session_status` can now show compaction activity observed in the active transcript before the persisted session-store count finalizes.

## Diagram (if applicable)

```text
Before:
/status -> session store compactionCount -> stale 0

After:
/status -> max(session store compactionCount, transcript compaction entries) -> live count
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): status/session_status surface
- Relevant config (redacted): OpenClaw session transcript with compaction records

### Steps

1. Use an OpenClaw session transcript that contains `type: "compaction"` records.
2. Keep or reproduce a stale persisted session entry count.
3. Run `session_status` or `/status` after applying this patch.

### Expected

- Status shows the transcript-observed compaction count.

### Actual

- Before this patch: status rendered stale persisted `Compactions: 0`.
- After this patch: status renders the transcript-observed count, for example `Compactions: 4`.

## Evidence

- [x] Trace/log snippets
- [x] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: real status/session_status output against an OpenClaw session transcript with compaction records; focused status regression; existing session status tool coverage; compaction handler coverage; formatting; changed gate.
- Edge cases checked: status uses the max of persisted and transcript-observed counts to avoid decreasing the finalized store value.
- What you did **not** verify: live active-session auto-compaction against a real model/provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: reading transcript records for status may add work on very large active transcript files.
- Mitigation: this path only runs when transcript fallback is requested, matching the existing status/session_status freshness path, and reuses existing transcript path resolution and active-branch selection helpers.
