### PR TITLE
fix: keep origin-only approval delivery out of DMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/approvals: keep `channels.discord.execApprovals.target: "channel"` origin-only by avoiding approver-DM fallback when the originating channel or thread cannot be resolved. Thanks @jar-vision-ai.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1065,7 +1065,7 @@ Default slash command settings:
 
     For sensitive owner-only group commands such as `/diagnostics` and `/export-trajectory`, OpenClaw sends approval prompts and final results privately. It tries Discord DM first when the invoking owner has a Discord owner route; if that is not available, it falls back to the first available owner route from `commands.ownerAllowFrom`, such as Telegram.
 
-    When `target` is `channel` or `both`, the approval prompt is visible in the channel. Only resolved approvers can use the buttons; other users receive an ephemeral denial. Approval prompts include the command text, so only enable channel delivery in trusted channels. If the channel ID cannot be derived from the session key, OpenClaw falls back to DM delivery.
+    When `target` is `channel` or `both`, the approval prompt is visible in the channel. Only resolved approvers can use the buttons; other users receive an ephemeral denial. Approval prompts include the command text, so only enable channel delivery in trusted channels. When `target` is `channel`, OpenClaw treats channel delivery as origin-only: if the channel or thread target cannot be resolved, it does not fall back to approver DMs. Use `target: "both"` when you want channel delivery plus approver DM delivery.
 
     Discord also renders the shared approval buttons used by other chat channels. The native Discord adapter mainly adds approver DM routing and channel fanout.
     When those buttons are present, they are the primary approval UX; OpenClaw

--- a/src/infra/approval-native-delivery.test.ts
+++ b/src/infra/approval-native-delivery.test.ts
@@ -41,7 +41,7 @@ describe("resolveChannelNativeApprovalDeliveryPlan", () => {
     ]);
   });
 
-  it("falls back to approver DMs when origin delivery is unavailable", async () => {
+  it("does not fall back to approver DMs when origin-only delivery is unavailable", async () => {
     const adapter: ChannelApprovalNativeAdapter = {
       describeDeliveryCapabilities: () => ({
         enabled: true,
@@ -60,16 +60,37 @@ describe("resolveChannelNativeApprovalDeliveryPlan", () => {
       adapter,
     });
 
+    expect(plan.targets).toEqual([]);
+  });
+
+  it("falls back to approver DMs when origin is unsupported", async () => {
+    const adapter: ChannelApprovalNativeAdapter = {
+      describeDeliveryCapabilities: () => ({
+        enabled: true,
+        preferredSurface: "approver-dm",
+        supportsOriginSurface: false,
+        supportsApproverDmSurface: true,
+      }),
+      resolveApproverDmTargets: async () => [{ to: "approver-1" }, { to: "approver-2" }],
+    };
+
+    const plan = await resolveChannelNativeApprovalDeliveryPlan({
+      cfg: {} as never,
+      approvalKind: "exec",
+      request: execRequest,
+      adapter,
+    });
+
     expect(plan.targets).toEqual([
       {
         surface: "approver-dm",
         target: { to: "approver-1" },
-        reason: "fallback",
+        reason: "preferred",
       },
       {
         surface: "approver-dm",
         target: { to: "approver-2" },
-        reason: "fallback",
+        reason: "preferred",
       },
     ]);
   });

--- a/src/infra/approval-native-delivery.ts
+++ b/src/infra/approval-native-delivery.ts
@@ -110,7 +110,7 @@ export async function resolveChannelNativeApprovalDeliveryPlan(params: {
         reason: "preferred",
       });
     }
-  } else if (!originTarget) {
+  } else if (!originTarget && !preferOrigin) {
     for (const target of approverDmTargets) {
       plannedTargets.push({
         surface: "approver-dm",


### PR DESCRIPTION
## Summary

- keep native approval delivery in origin-only mode from falling back to approver DMs when the origin target cannot be resolved
- preserve approver-DM delivery for DM-preferred/native DM modes
- update approval delivery tests, Discord docs, and changelog for the channel-only routing contract

## Why

`channels.<channel>.execApprovals.target: "channel"` should behave as origin/channel-only routing. If origin resolution fails, silently pivoting to approver DMs makes channel mode feel nondeterministic and can send sensitive approval prompts somewhere the operator explicitly did not choose.

## Real behavior proof

**Behavior or issue addressed:** Discord native approval routing with `channels.discord.execApprovals.target: "channel"` must stay origin/thread-only and must not silently fall back to approver DMs when the originating channel or thread target cannot be resolved.

**Real environment tested:** Real local OpenClaw install on macOS with the compiled native approval runtime patched, Gateway restarted, and Discord configured with `channels.discord.execApprovals.target: "channel"`.

**Exact steps or command run after the patch:** Ran a live `node` command against the installed compiled runtime at `/usr/local/lib/node_modules/openclaw/dist/approval-native-runtime-CzBmDukU.js`, calling the native approval delivery planner with three real routing modes: origin-only with missing origin, origin-only with a resolved Discord thread origin, and DM-preferred with missing origin.

**Evidence after fix:** Copied live terminal output from the installed runtime check:

```json
{
  "runtimeFile": "/usr/local/lib/node_modules/openclaw/dist/approval-native-runtime-CzBmDukU.js",
  "originOnlyMissingOrigin": {
    "targets": [],
    "originTarget": null,
    "notifyOriginWhenDmOnly": false
  },
  "originOnlyResolvedThread": {
    "targets": [
      {
        "surface": "origin",
        "target": {
          "to": "1501641779890356307",
          "threadId": "1501641779890356307"
        },
        "reason": "preferred"
      }
    ],
    "originTarget": {
      "to": "1501641779890356307",
      "threadId": "1501641779890356307"
    },
    "notifyOriginWhenDmOnly": false
  },
  "dmPreferredMissingOrigin": {
    "targets": [
      {
        "surface": "approver-dm",
        "target": {
          "to": "approver-user"
        },
        "reason": "preferred"
      }
    ],
    "originTarget": null,
    "notifyOriginWhenDmOnly": false
  }
}
```

**Observed result after fix:** `target: "channel"` / origin-only with unresolved origin produced an empty `targets` array instead of an approver-DM target. A resolved Discord thread origin still produced the expected `origin` target. Explicit DM-preferred delivery still produced an approver-DM target.

**What was not tested:** No additional gaps.

## Test plan

- `git diff --check`
- `node scripts/test-projects.mjs src/infra/approval-native-delivery.test.ts extensions/discord/src/approval-native.test.ts`
- `/usr/local/opt/node@24/bin/node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/approval-native-delivery.ts src/infra/approval-native-delivery.test.ts`
- `node scripts/format-docs.mjs --check`

## Notes

A full root typecheck was attempted in the first worktree and currently fails on an unrelated existing error in `src/agents/pi-embedded-runner/run/attempt.test.ts` (`TS2352` conversion of `AgentMessage[]` to `Record<string, unknown>[]`).
