### PR TITLE
fix(compaction): ignore transcript metadata bytes for token pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/plugins: discover doctor contracts from load-path channel plugins during `openclaw doctor --fix`, so plugin-owned legacy config repair runs before validation. (#77477) Thanks @jalehman.
 - Dependencies: bump transitive `basic-ftp` to 5.3.1 so the runtime lockfile no longer includes the vulnerable 5.3.0 build flagged by the production dependency audit. (#78637) Thanks @sallyom.
 - Agents/compaction: clamp compaction summary reserve tokens to each model's output limit so high-context compaction no longer requests invalid `max_tokens` values. (#54392) Thanks @adzendo.
+- Agents/compaction: ignore pre-usage transcript metadata bytes when stale token snapshots estimate preflight compaction pressure, while still counting post-usage transcript tail pressure. Fixes #78604. (#78619) Thanks @hera8939.
 
 ## 2026.5.3-1
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -596,6 +596,65 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.currentTokenCount).toBeGreaterThan(100_000);
   });
 
+  it("combines latest usage with post-usage tail pressure for preflight compaction", async () => {
+    const sessionFile = path.join(rootDir, "combined-tail-pressure-session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: "small answer",
+            usage: { input: 86_000, output: 2_000 },
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "tool",
+            content: `moderate interrupted tool output ${"x".repeat(36_000)}`,
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    const compactCall = compactEmbeddedPiSessionMock.mock.calls[0]?.[0] as {
+      currentTokenCount?: number;
+    };
+    expect(compactCall.currentTokenCount).toBeGreaterThanOrEqual(96_000);
+  });
+
   it("does not treat raw transcript metadata bytes as token pressure", async () => {
     const sessionFile = path.join(rootDir, "metadata-heavy-session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -596,6 +596,75 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.currentTokenCount).toBeGreaterThan(100_000);
   });
 
+  it("does not treat raw transcript metadata bytes as token pressure", async () => {
+    const sessionFile = path.join(rootDir, "metadata-heavy-session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          id: "session",
+        }),
+        JSON.stringify({
+          type: "custom",
+          payload: "x".repeat(450_000),
+        }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: "small answer",
+            usage: { input: 40_000, output: 2_000 },
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {},
+              truncateAfterCompaction: true,
+              maxActiveTranscriptBytes: "10mb",
+            },
+          },
+        },
+      },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+  });
+
   it("triggers preflight compaction when the active transcript exceeds the configured byte threshold", async () => {
     const sessionFile = path.join(rootDir, "large-session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -161,6 +161,7 @@ function resolveMemoryFlushModelFallbackOptions(
 export type SessionTranscriptUsageSnapshot = {
   promptTokens?: number;
   outputTokens?: number;
+  trailingBytesTokens?: number;
 };
 
 // Keep a generous near-threshold window so large assistant outputs still trigger
@@ -223,8 +224,14 @@ function resolveSessionLogPath(
 }
 
 function deriveTranscriptUsageSnapshot(
-  usage: ReturnType<typeof normalizeUsage> | undefined,
+  snapshot:
+    | {
+        usage: ReturnType<typeof normalizeUsage> | undefined;
+        trailingBytes?: number;
+      }
+    | undefined,
 ): SessionTranscriptUsageSnapshot | undefined {
+  const usage = snapshot?.usage;
   if (!usage) {
     return undefined;
   }
@@ -240,6 +247,12 @@ function deriveTranscriptUsageSnapshot(
   return {
     promptTokens,
     outputTokens,
+    trailingBytesTokens:
+      typeof snapshot.trailingBytes === "number" &&
+      Number.isFinite(snapshot.trailingBytes) &&
+      snapshot.trailingBytes > 0
+        ? Math.ceil(snapshot.trailingBytes / FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN)
+        : undefined,
   };
 }
 
@@ -330,15 +343,28 @@ async function readLastNonzeroUsageFromSessionLog(logPath: string) {
       const combined = `${chunk}${leadingPartial}`;
       const lines = combined.split(/\n+/);
       leadingPartial = lines.shift() ?? "";
+      const suffixBytesBeforeChunk = stat.size - position;
       for (let i = lines.length - 1; i >= 0; i -= 1) {
         const usage = parseUsageFromTranscriptLine(lines[i] ?? "");
         if (usage) {
-          return usage;
+          const trailingLines = lines.slice(i + 1);
+          const trailingBytesInChunk =
+            Buffer.byteLength(trailingLines.join("\n"), "utf8") + trailingLines.length;
+          return {
+            usage,
+            trailingBytes: suffixBytesBeforeChunk + trailingBytesInChunk,
+          };
         }
       }
       position = start;
     }
-    return parseUsageFromTranscriptLine(leadingPartial);
+    const usage = parseUsageFromTranscriptLine(leadingPartial);
+    return usage
+      ? {
+          usage,
+          trailingBytes: Math.max(0, stat.size - Buffer.byteLength(leadingPartial, "utf8")),
+        }
+      : undefined;
   } finally {
     await handle.close();
   }
@@ -382,17 +408,7 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         ? Math.ceil(snapshot.byteSize / FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN)
         : undefined;
     const promptTokens = snapshot.usage?.promptTokens;
-    if (typeof promptTokens === "number" && Number.isFinite(promptTokens) && promptTokens > 0) {
-      const outputTokens = snapshot.usage?.outputTokens;
-      return {
-        promptTokens: Math.ceil(promptTokens),
-        outputTokens:
-          typeof outputTokens === "number" && Number.isFinite(outputTokens) && outputTokens > 0
-            ? Math.ceil(outputTokens)
-            : undefined,
-        transcriptBytesTokens,
-      };
-    }
+    const trailingBytesTokens = snapshot.usage?.trailingBytesTokens;
     const messages = (await readSessionMessagesAsync(
       sessionId,
       params.storePath,
@@ -403,11 +419,30 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         maxBytes: 1024 * 1024,
       },
     )) as AgentMessage[];
-    if (messages.length === 0) {
-      return undefined;
+    const estimatedMessageTokens = (() => {
+      if (messages.length === 0) {
+        return undefined;
+      }
+      const tokens = estimateMessagesTokens(messages);
+      return Number.isFinite(tokens) && tokens > 0 ? Math.ceil(tokens) : undefined;
+    })();
+    if (typeof promptTokens === "number" && Number.isFinite(promptTokens) && promptTokens > 0) {
+      const outputTokens = snapshot.usage?.outputTokens;
+      return {
+        promptTokens: Math.max(
+          Math.ceil(promptTokens),
+          estimatedMessageTokens ?? 0,
+          trailingBytesTokens ?? 0,
+        ),
+        outputTokens:
+          typeof outputTokens === "number" && Number.isFinite(outputTokens) && outputTokens > 0
+            ? Math.ceil(outputTokens)
+            : undefined,
+        transcriptBytesTokens,
+      };
     }
-    const estimatedTokens = estimateMessagesTokens(messages);
-    if (!Number.isFinite(estimatedTokens) || estimatedTokens <= 0) {
+    const estimatedTokens = estimatedMessageTokens ?? transcriptBytesTokens;
+    if (estimatedTokens === undefined) {
       return undefined;
     }
     return {
@@ -509,14 +544,6 @@ export async function runPreflightCompactionIfNeeded(params: {
     : undefined;
   const transcriptPromptTokens = transcriptUsageTokens?.promptTokens;
   const transcriptOutputTokens = transcriptUsageTokens?.outputTokens;
-  const transcriptBytesProjectedTokens =
-    typeof transcriptUsageTokens?.transcriptBytesTokens === "number"
-      ? resolveEffectivePromptTokens(
-          transcriptUsageTokens.transcriptBytesTokens,
-          undefined,
-          promptTokenEstimate,
-        )
-      : undefined;
   const usageProjectedTokenCount =
     typeof transcriptPromptTokens === "number"
       ? resolveEffectivePromptTokens(
@@ -527,7 +554,6 @@ export async function runPreflightCompactionIfNeeded(params: {
       : undefined;
   const projectedTokenCount = Math.max(
     usageProjectedTokenCount ?? 0,
-    transcriptBytesProjectedTokens ?? 0,
     stalePersistedPromptTokens ?? 0,
   );
   const tokenCountForCompaction =

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -428,12 +428,9 @@ async function estimatePromptTokensFromSessionTranscript(params: {
     })();
     if (typeof promptTokens === "number" && Number.isFinite(promptTokens) && promptTokens > 0) {
       const outputTokens = snapshot.usage?.outputTokens;
+      const usagePromptTokens = Math.ceil(promptTokens) + (trailingBytesTokens ?? 0);
       return {
-        promptTokens: Math.max(
-          Math.ceil(promptTokens),
-          estimatedMessageTokens ?? 0,
-          trailingBytesTokens ?? 0,
-        ),
+        promptTokens: Math.max(usagePromptTokens, estimatedMessageTokens ?? 0),
         outputTokens:
           typeof outputTokens === "number" && Number.isFinite(outputTokens) && outputTokens > 0
             ? Math.ceil(outputTokens)


### PR DESCRIPTION
## Summary

- Problem: stale preflight compaction checks could count whole transcript JSONL byte size as token pressure, including session headers, custom records, and plugin metadata that are not active model context.
- Why it matters: metadata-heavy sessions could compact every few minutes even when the active context was small and the transcript file was below `maxActiveTranscriptBytes`, disrupting conversations and wasting model calls.
- What changed: stale token estimation now prefers latest usage, active-message estimates, and only bytes appended after the latest usage entry; it no longer treats whole raw transcript size as token pressure.
- What did NOT change (scope boundary): explicit `maxActiveTranscriptBytes` byte-guard behavior, compaction execution, transcript rotation, memory plugin behavior, provider/model settings, and channel routing are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78604
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: metadata-heavy transcripts should not trigger token-based preflight compaction when active model context is below the threshold and the file is below `maxActiveTranscriptBytes`.
- Real environment tested: local OpenClaw checkout on Linux using the production `runPreflightCompactionIfNeeded` path against a temp OpenClaw session store and transcript.
- Exact steps or command run after this patch: ran a temp-session OpenClaw preflight script with `pnpm exec tsx`, using `truncateAfterCompaction: true`, `maxActiveTranscriptBytes: "10mb"`, stale `totalTokensFresh: false`, a 450KB custom transcript payload, and MiniMax model/session metadata.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
openclaw_preflight_compaction_real_setup=ok
session_file_bytes=450198
max_active_transcript_bytes=10485760
token_state_fresh=false
returned_same_entry=true
preflight_compaction_phase_seen=false
compaction_count=0
```

- Observed result after fix: OpenClaw returned the same active session entry, did not enter the `preflight_compacting` phase, and did not increment compaction count.
- What was not tested: live MiniMax + Feishu WebSocket + memory-lancedb-pro deployment.
- Before evidence (optional but encouraged): issue #78604 reports OpenClaw 2026.5.6 compacting five times between 03:11:18 and 03:33:28 UTC+8 while the transcript was about 666KB, below a 10MB byte guard.

## Root Cause (if applicable)

- Root cause: the stale preflight token fallback mixed two different signals: model-context token pressure and raw JSONL transcript file size. Whole-file `byteSize / 4` could overestimate token pressure because JSONL contains non-context records such as session headers, custom entries, and plugin metadata.
- Missing detection / guardrail: no regression covered stale token state with a metadata-heavy transcript whose active model context remained small.
- Contributing context (if known): `maxActiveTranscriptBytes` is the explicit transcript-size guard. The token path should not implicitly recreate that byte guard by using whole-file bytes as context tokens.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/agent-runner-memory.test.ts`
- Scenario the test should lock in: stale `totalTokensFresh: false`, 450KB custom metadata payload, small assistant usage, transcript rotation enabled, and `maxActiveTranscriptBytes: "10mb"` should not trigger preflight compaction.
- Why this is the smallest reliable guardrail: the bug is in preflight token estimation, so the focused runner-memory test proves the decision without requiring a live provider/channel/plugin setup.
- Existing test that already covers this (if any): existing tests covered stale usage and content appended after latest usage, but not non-context metadata bytes.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Metadata-heavy sessions should no longer compact every few minutes when active model context is not actually near the token threshold.

## Diagram (if applicable)

```text
Before:
stale token state -> whole transcript bytes / 4 -> false token pressure -> repeated compaction

After:
stale token state -> latest usage + active messages + trailing post-usage bytes -> real token pressure decision
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm checkout
- Model/provider: MiniMax metadata in local temp-session proof; no live model call required
- Integration/channel (if any): preflight compaction/session memory path
- Relevant config (redacted): `truncateAfterCompaction: true`, `maxActiveTranscriptBytes: "10mb"`

### Steps

1. Create a temp OpenClaw session transcript with a large custom metadata record and small assistant usage.
2. Mark the session entry token state stale with `totalTokensFresh: false`.
3. Run the production preflight compaction path with transcript rotation and 10MB byte guard enabled.

### Expected

- Preflight token compaction does not run because active model context is below threshold and the transcript is below the explicit byte guard.

### Actual

- Before this patch, whole raw transcript bytes could contribute to token pressure and trigger compaction.
- After this patch, copied live output shows `preflight_compaction_phase_seen=false` and `compaction_count=0`.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Supplemental checks run:

- `pnpm test src/auto-reply/reply/agent-runner-memory.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-memory.ts src/auto-reply/reply/agent-runner-memory.test.ts CHANGELOG.md`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
- `git diff --check`

## Human Verification (required)

- Verified scenarios: local production-path preflight run against a temp OpenClaw session store/transcript, focused metadata-heavy stale-token regression, existing conservative post-usage content behavior, formatting, changed-lane type/lint/guards.
- Edge cases checked: bytes appended after latest usage still count conservatively through trailing-byte accounting.
- What you did **not** verify: live MiniMax/Feishu/memory-lancedb-pro deployment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: underestimating token pressure when usage is stale and transcript content after the latest usage is large.
  - Mitigation: the estimator still includes active-message token estimates and trailing bytes after the latest usage entry.
```