### PR TITLE
Control UI/sessions: nest subagent sessions under parent with visual prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628.
+
 ### Changes
 
 - Models/OpenAI CLI auth: make `openclaw models auth login --provider openai` start the ChatGPT/Codex account login by default, while `--method api-key` remains the explicit OpenAI API-key setup path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628.
+- Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628. (#78623) Thanks @chinar-amrutkar.
 
 ### Changes
 

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -648,6 +648,36 @@ describe("resolveSessionOptionGroups", () => {
 
     expect(labels).toEqual(["Beta main"]);
   });
+
+  it("nests subagent sessions under their parent with visual prefix", () => {
+    const parentKey = "agent:main:main";
+    const subagentKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
+    const labels = labelsForSessionOptions({
+      sessionKey: parentKey,
+      sessions: [
+        row({ key: parentKey, label: "Spock" }),
+        row({ key: subagentKey, label: "PLC Coder", spawnedBy: parentKey }),
+      ],
+    });
+
+    expect(labels).toContain("Spock");
+    expect(labels).toContain("└─ PLC Coder");
+  });
+
+  it("uses raw key fallback for subagent without label when nested", () => {
+    const parentKey = "agent:main:main";
+    const subagentKey = "agent:main:subagent:f4ac7ef1-1234-5678-9abc-def012345678";
+    const labels = labelsForSessionOptions({
+      sessionKey: parentKey,
+      sessions: [
+        row({ key: parentKey, label: "Spock" }),
+        row({ key: subagentKey, spawnedBy: parentKey }),
+      ],
+    });
+
+    expect(labels).toContain("Spock");
+    expect(labels).toContain("└─ subagent:f4ac7ef1-1234-5678-9abc-def012345678");
+  });
 });
 
 describe("handleChatManualRefresh", () => {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -676,7 +676,23 @@ describe("resolveSessionOptionGroups", () => {
     });
 
     expect(labels).toContain("Spock");
-    expect(labels).toContain("└─ subagent:f4ac7ef1-1234-5678-9abc-def012345678");
+    expect(labels).toContain("└─ f4ac7ef1-1234-5678-9abc-def012345678");
+  });
+
+  it("preserves sibling row order when nesting subagent sessions", () => {
+    const parentKey = "agent:main:main";
+    const newerSubagentKey = "agent:main:subagent:newer";
+    const olderSubagentKey = "agent:main:subagent:older";
+    const labels = labelsForSessionOptions({
+      sessionKey: parentKey,
+      sessions: [
+        row({ key: newerSubagentKey, label: "Newer", spawnedBy: parentKey }),
+        row({ key: olderSubagentKey, label: "Older", spawnedBy: parentKey }),
+        row({ key: parentKey, label: "Spock" }),
+      ],
+    });
+
+    expect(labels).toEqual(["Spock", "└─ Newer", "└─ Older"]);
   });
 });
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -13,6 +13,7 @@ import { loadSessions } from "../controllers/sessions.ts";
 import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
 import {
   buildAgentMainSessionKey,
+  isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../session-key.ts";
@@ -564,6 +565,7 @@ type SessionOptionEntry = {
   label: string;
   scopeLabel: string;
   title: string;
+  parentKey?: string;
 };
 
 export type SessionOptionGroup = {
@@ -674,7 +676,7 @@ export function resolveSessionOptionGroups(
     return created;
   };
 
-  const addOption = (key: string) => {
+  const addOption = (key: string, parentKey?: string, isChild?: boolean) => {
     if (!key || seenKeys.has(key)) {
       return;
     }
@@ -688,12 +690,16 @@ export function resolveSessionOptionGroups(
         )
       : ensureGroup("other", "Other Sessions");
     const scopeLabel = normalizeOptionalString(parsed?.rest) ?? key;
-    const label = resolveSessionScopedOptionLabel(key, row, parsed?.rest);
+    let label = resolveSessionScopedOptionLabel(key, row, parsed?.rest);
+    if (isChild) {
+      label = `└─ ${label}`;
+    }
     group.options.push({
       key,
       label,
       scopeLabel,
       title: key,
+      ...(parentKey ? { parentKey } : {}),
     });
   };
 
@@ -710,7 +716,12 @@ export function resolveSessionOptionGroups(
     if (hideCron && row.key !== sessionKey && isCronSessionKey(row.key)) {
       continue;
     }
-    addOption(row.key);
+    const isSubagent = isSubagentSessionKey(row.key) || !!row.spawnedBy;
+    if (isSubagent && row.spawnedBy && byKey.has(row.spawnedBy)) {
+      addOption(row.key, row.spawnedBy, true);
+    } else {
+      addOption(row.key);
+    }
   }
   if (byKey.has(sessionKey)) {
     addOption(sessionKey);

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -731,15 +731,31 @@ export function resolveSessionOptionGroups(
 
   for (const group of groups.values()) {
     const options = group.options;
-    for (let i = options.length - 1; i >= 0; i--) {
-      const parentKey = options[i].parentKey;
-      if (parentKey) {
-        const parentIdx = options.findIndex((o) => o.key === parentKey);
-        if (parentIdx !== -1) {
-          const [child] = options.splice(i, 1);
-          options.splice(parentIdx + 1, 0, child);
+    const optionKeys = new Set(options.map((option) => option.key));
+    const childrenByParent = new Map<string, SessionOptionEntry[]>();
+    for (const option of options) {
+      if (option.parentKey && optionKeys.has(option.parentKey)) {
+        const siblings = childrenByParent.get(option.parentKey);
+        if (siblings) {
+          siblings.push(option);
+        } else {
+          childrenByParent.set(option.parentKey, [option]);
         }
       }
+    }
+    if (childrenByParent.size > 0) {
+      const reordered: SessionOptionEntry[] = [];
+      for (const option of options) {
+        if (option.parentKey && optionKeys.has(option.parentKey)) {
+          continue;
+        }
+        reordered.push(option);
+        const children = childrenByParent.get(option.key);
+        if (children) {
+          reordered.push(...children);
+        }
+      }
+      options.splice(0, options.length, ...reordered);
     }
   }
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -692,7 +692,7 @@ export function resolveSessionOptionGroups(
     const scopeLabel = normalizeOptionalString(parsed?.rest) ?? key;
     let label = resolveSessionScopedOptionLabel(key, row, parsed?.rest);
     if (isChild) {
-      label = `└─ ${label}`;
+      label = `└─ ${label.replace(/^Subagent:\s*/i, "")}`;
     }
     group.options.push({
       key,
@@ -727,6 +727,20 @@ export function resolveSessionOptionGroups(
     addOption(sessionKey);
   } else if (isAgentMainSessionKey(sessionKey)) {
     addOption(sessionKey);
+  }
+
+  for (const group of groups.values()) {
+    const options = group.options;
+    for (let i = options.length - 1; i >= 0; i--) {
+      const parentKey = options[i].parentKey;
+      if (parentKey) {
+        const parentIdx = options.findIndex((o) => o.key === parentKey);
+        if (parentIdx !== -1) {
+          const [child] = options.splice(i, 1);
+          options.splice(parentIdx + 1, 0, child);
+        }
+      }
+    }
   }
 
   for (const group of groups.values()) {


### PR DESCRIPTION
"## Summary\r\n\r\nWhen spawning suba"
