### PR TITLE
test(plugins): cover stale OpenClaw peer repair during install

### DIFF
--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -463,6 +463,161 @@ describe("installPluginFromNpmSpec e2e", () => {
     ).resolves.toBe(true);
   });
 
+  it("repairs stale root openclaw peers before installing another host-peer plugin", async () => {
+    const rootDir = await makeTempDir("npm-plugin-stale-root-peer-e2e");
+    const codexName = `codex-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const opikName = `opik-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const registry = await startStaticRegistry([
+      {
+        packageName: codexName,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: codexName,
+            peerDependencies: { openclaw: ">=2026.5.5-beta.2" },
+            peerDependenciesMeta: { openclaw: { optional: true } },
+            pluginId: codexName,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: opikName,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: opikName,
+            peerDependencies: { openclaw: ">=2026.3.2" },
+            peerDependenciesMeta: {},
+            pluginId: opikName,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: "openclaw",
+        latest: "2026.5.4",
+        versions: [
+          await packPlugin({
+            packageName: "openclaw",
+            pluginId: "registry-openclaw-copy",
+            version: "2026.5.4",
+            rootDir,
+          }),
+        ],
+      },
+    ]);
+    process.env.NPM_CONFIG_REGISTRY = registry;
+    process.env.npm_config_registry = registry;
+
+    const seedStaleRoot = async (npmRoot: string) => {
+      await fs.mkdir(npmRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(npmRoot, "package.json"),
+        `${JSON.stringify({ private: true, dependencies: { [codexName]: "1.0.0" } }, null, 2)}\n`,
+        "utf8",
+      );
+      await execFileAsync(
+        "npm",
+        [
+          "install",
+          "--omit=peer",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+          "--loglevel=error",
+        ],
+        {
+          cwd: npmRoot,
+          env: {
+            ...process.env,
+            NPM_CONFIG_REGISTRY: registry,
+            NPM_CONFIG_LEGACY_PEER_DEPS: "false",
+            NPM_CONFIG_STRICT_PEER_DEPS: "false",
+            npm_config_registry: registry,
+            npm_config_legacy_peer_deps: "false",
+            npm_config_strict_peer_deps: "false",
+          },
+          timeout: 120_000,
+        },
+      );
+
+      await fs.mkdir(path.join(npmRoot, "node_modules", "openclaw"), { recursive: true });
+      await fs.writeFile(
+        path.join(npmRoot, "node_modules", "openclaw", "package.json"),
+        `${JSON.stringify({ name: "openclaw", version: "2026.5.4" }, null, 2)}\n`,
+        "utf8",
+      );
+      const lockPath = path.join(npmRoot, "package-lock.json");
+      const lock = JSON.parse(await fs.readFile(lockPath, "utf8")) as {
+        dependencies?: Record<string, unknown>;
+        packages?: Record<string, unknown>;
+      };
+      lock.packages ??= {};
+      lock.packages["node_modules/openclaw"] = { peer: true, version: "2026.5.4" };
+      lock.dependencies = { ...lock.dependencies, openclaw: { version: "2026.5.4" } };
+      await fs.writeFile(lockPath, `${JSON.stringify(lock, null, 2)}\n`, "utf8");
+    };
+
+    const rawNpmRoot = path.join(rootDir, "raw-managed-npm");
+    await seedStaleRoot(rawNpmRoot);
+    await expect(
+      execFileAsync(
+        "npm",
+        ["install", `${opikName}@1.0.0`, "--ignore-scripts", "--no-audit", "--no-fund"],
+        {
+          cwd: rawNpmRoot,
+          env: {
+            ...process.env,
+            NPM_CONFIG_REGISTRY: registry,
+            NPM_CONFIG_LEGACY_PEER_DEPS: "false",
+            NPM_CONFIG_STRICT_PEER_DEPS: "false",
+            npm_config_registry: registry,
+            npm_config_legacy_peer_deps: "false",
+            npm_config_strict_peer_deps: "false",
+          },
+          timeout: 120_000,
+        },
+      ),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("ERESOLVE"),
+    });
+
+    const npmRoot = path.join(rootDir, "managed-npm");
+    await seedStaleRoot(npmRoot);
+    const result = await installPluginFromNpmSpec({
+      spec: `${opikName}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+      timeoutMs: 120_000,
+    });
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+
+    const lock = JSON.parse(await fs.readFile(path.join(npmRoot, "package-lock.json"), "utf8")) as {
+      dependencies?: Record<string, unknown>;
+      packages?: Record<string, unknown>;
+    };
+    expect(lock.packages?.["node_modules/openclaw"]).toBeUndefined();
+    expect(lock.dependencies?.openclaw).toBeUndefined();
+    await expect(fs.lstat(path.join(npmRoot, "node_modules", "openclaw"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(
+      fs
+        .lstat(path.join(npmRoot, "node_modules", codexName, "node_modules", "openclaw"))
+        .then((stat) => stat.isSymbolicLink()),
+    ).resolves.toBe(true);
+    await expect(
+      fs
+        .lstat(path.join(npmRoot, "node_modules", opikName, "node_modules", "openclaw"))
+        .then((stat) => stat.isSymbolicLink()),
+    ).resolves.toBe(true);
+  });
+
   it("relinks managed npm sibling openclaw peers after later plugin installs", async () => {
     const rootDir = await makeTempDir("npm-plugin-peer-e2e");
     const npmRoot = path.join(rootDir, "managed-npm");


### PR DESCRIPTION
## Summary

This adds an e2e regression for the dirty managed-npm state that can make `openclaw plugins install @opik/opik-openclaw` fail with `ERESOLVE` after prior host-peer plugin installs.

The fixture mirrors the bad state from the live box:

- a Codex-like plugin already installed with `peerOptional openclaw@>=2026.5.5-beta.2`
- an Opik-like plugin being installed with `peer openclaw@>=2026.3.2`
- a stale root-level `node_modules/openclaw@2026.5.4` left in the managed npm root

The test first proves raw npm still fails with `ERESOLVE` in that state, then proves OpenClaw's managed installer repairs the stale root package, completes the install, and restores plugin-local `openclaw` peer symlinks for both plugins.

## RCA

The failure is not just a future peer-materialization problem. Once an older OpenClaw registry package has already been materialized at `~/.openclaw/npm/node_modules/openclaw`, npm treats it as the candidate host peer during later managed-root mutations. A later install can then fail before the requested plugin is installed because another installed plugin has a stricter host peer range than the stale root package satisfies.

Current `main` already has the behavior fix: managed plugin installs repair stale root `openclaw` state before npm mutates the root, use `--omit=peer`, and relink plugin-local host peers afterward. This PR locks the exact dirty-state transition down so we do not regress users who already have poisoned managed npm roots.

## Verification

- `pnpm docs:list`
- `pnpm exec oxfmt --write --threads=1 src/plugins/install.npm-spec.e2e.test.ts`
- `pnpm test:serial src/plugins/install.npm-spec.e2e.test.ts` - 1 file / 5 tests passed
- `OPENCLAW_TESTBOX=1 pnpm check:changed` - attempted through Blacksmith Testbox; first box shut down while queued, second stayed queued and was stopped after waiting. Targeted local e2e proof above passed.
