### PR TITLE
fix(outbound): route media payloads through handler.sendPayload in agent --deliver

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1445,7 +1445,8 @@ async function deliverOutboundPayloadsCore(
             interactive: effectivePayload.interactive,
             channelData: effectivePayload.channelData,
           }) ||
-          effectivePayload.audioAsVoice === true)
+          effectivePayload.audioAsVoice === true ||
+          Boolean(effectivePayload.mediaUrl || effectivePayload.mediaUrls?.length))
       ) {
         const delivery = await handler.sendPayload(
           effectivePayload,


### PR DESCRIPTION
## Fix Summary

**Issue:** #77265 - `agent --deliver` returns `mediaUrl` payload but doesn't send Telegram media

**Root Cause:** In `src/infra/outbound/deliver.ts`, the condition for calling `handler.sendPayload` checks for `isError`, `presentation`, `interactive`, `channelData`, and `audioAsVoice`, but did not check for `mediaUrl` or `mediaUrls`. When a payload has only media (no presentation/interactive/channelData), the `handler.sendPayload` path was skipped.

**Fix:** Added media URL check to the `handler.sendPayload` condition so that payloads with media are correctly routed through `handler.sendPayload`, which the Telegram adapter uses to send media via `sendPayloadMediaSequenceOrFallback`.

## Files Changed
- `src/infra/outbound/deliver.ts` — 2 lines

## Test Plan
- [ ] Verify `openclaw agent --deliver` with media URL now sends Telegram media
- [ ] Verify existing text-only and multi-media deliveries still work

Closes #77265 