### PR TITLE
fix(telegram): expand access group allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - QA/Mantis: add an opt-in Discord thread attachment before/after scenario that creates a real thread, calls `message.thread-reply` with `filePath`, and captures baseline/candidate screenshot evidence.
 - Discord: preserve `filePath` and `path` attachments when replying to a thread with the message tool.
 - Discord/message: parse provider-prefixed targets like `discord:channel:<id>` as channel sends instead of legacy Discord DM targets, so cross-channel agent `message(action="send")` calls no longer misroute channel IDs into misleading `Unknown Channel` failures. Fixes #78572. (#78625) Thanks @Patrick-Erichsen.
+- Telegram/access: expand `accessGroup:<name>` entries in group sender allowlists before enforcing group access, so message-sender access groups work in `channels.telegram.allowFrom` and group/topic overrides. Fixes #78660. Thanks @hclsys.
 - QA/Mantis: add visual desktop tasks with Crabbox MP4 recording, screenshot capture, and optional image-understanding assertions, and preserve video artifacts in Mantis before/after reports.
 - QA/WhatsApp: add `pnpm openclaw qa whatsapp` for live DM canary and pairing-gate coverage using two pre-linked WhatsApp Web sessions from the QA credential pool.
 - QA/Mantis: pass the runtime env through desktop-browser Crabbox and artifact-copy child commands, so embedded Mantis callers can provide Crabbox credentials without mutating the parent process. Thanks @vincentkoc.

--- a/extensions/telegram/src/bot-access.ts
+++ b/extensions/telegram/src/bot-access.ts
@@ -4,6 +4,7 @@ import {
   mergeDmAllowFromSources,
   type AllowlistMatch,
 } from "openclaw/plugin-sdk/allow-from";
+import { parseAccessGroupAllowFromEntry } from "openclaw/plugin-sdk/command-auth";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 
@@ -48,7 +49,9 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter(
+    (value) => !/^\d+$/.test(value) && parseAccessGroupAllowFromEntry(value) == null,
+  );
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -36,11 +36,7 @@ import {
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveTelegramAccount, resolveTelegramMediaRuntimeOptions } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
-import {
-  isSenderAllowed,
-  normalizeDmAllowFromWithStore,
-  type NormalizedAllowFrom,
-} from "./bot-access.js";
+import { isSenderAllowed, type NormalizedAllowFrom } from "./bot-access.js";
 import {
   resolveAgentDir,
   resolveDefaultAgentId,
@@ -73,6 +69,7 @@ import {
   buildTelegramGroupFrom,
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
+  resolveTelegramEffectiveDmAllow,
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
@@ -710,17 +707,20 @@ export const registerTelegramHandlers = ({
     isGroup: boolean;
     isForum: boolean;
     messageThreadId?: number;
+    senderId?: string;
     groupAllowContext?: TelegramGroupAllowContext;
   }): Promise<TelegramEventAuthorizationContext> => {
     const groupAllowContext =
       params.groupAllowContext ??
       (await resolveTelegramGroupAllowFromContext({
         chatId: params.chatId,
+        cfg,
         accountId,
         isGroup: params.isGroup,
         isForum: params.isForum,
         messageThreadId: params.messageThreadId,
         groupAllowFrom,
+        senderId: params.senderId,
         readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
         resolveTelegramGroupConfig,
       }));
@@ -734,7 +734,7 @@ export const registerTelegramHandlers = ({
     return { dmPolicy: effectiveDmPolicy, ...groupAllowContext };
   };
 
-  const authorizeTelegramEventSender = (params: {
+  const authorizeTelegramEventSender = async (params: {
     chatId: number;
     chatTitle?: string;
     isGroup: boolean;
@@ -742,7 +742,7 @@ export const registerTelegramHandlers = ({
     senderUsername: string;
     mode: TelegramEventAuthorizationMode;
     context: TelegramEventAuthorizationContext;
-  }): TelegramEventAuthorizationResult => {
+  }): Promise<TelegramEventAuthorizationResult> => {
     const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context } = params;
     const {
       dmPolicy,
@@ -787,7 +787,10 @@ export const registerTelegramHandlers = ({
       }
       // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom.
       const dmAllowFrom = groupAllowOverride ?? allowFrom;
-      const effectiveDmAllow = normalizeDmAllowFromWithStore({
+      const effectiveDmAllow = await resolveTelegramEffectiveDmAllow({
+        cfg,
+        accountId,
+        senderId,
         allowFrom: dmAllowFrom,
         storeAllowFrom,
         dmPolicy,
@@ -810,14 +813,14 @@ export const registerTelegramHandlers = ({
     return { allowed: true };
   };
 
-  const isTelegramModelCallbackAuthorized = (params: {
+  const isTelegramModelCallbackAuthorized = async (params: {
     chatId: number;
     isGroup: boolean;
     senderId: string;
     senderUsername: string;
     context: TelegramEventAuthorizationContext;
     cfg: OpenClawConfig;
-  }): boolean => {
+  }): Promise<boolean> => {
     const { chatId, isGroup, senderId, senderUsername, context, cfg } = params;
     const useAccessGroups = cfg.commands?.useAccessGroups !== false;
     const dmAllowFrom = context.groupAllowOverride ?? allowFrom;
@@ -845,7 +848,10 @@ export const registerTelegramHandlers = ({
       }).isAuthorizedSender;
     }
 
-    const dmAllow = normalizeDmAllowFromWithStore({
+    const dmAllow = await resolveTelegramEffectiveDmAllow({
+      cfg,
+      accountId,
+      senderId,
       allowFrom: dmAllowFrom,
       storeAllowFrom: isGroup ? [] : context.storeAllowFrom,
       dmPolicy: context.dmPolicy,
@@ -917,8 +923,9 @@ export const registerTelegramHandlers = ({
         chatId,
         isGroup,
         isForum,
+        senderId,
       });
-      const senderAuthorization = authorizeTelegramEventSender({
+      const senderAuthorization = await authorizeTelegramEventSender({
         chatId,
         chatTitle: reaction.chat.title,
         isGroup,
@@ -1346,11 +1353,14 @@ export const registerTelegramHandlers = ({
         isForum: callbackMessage.chat.is_forum,
         getChat,
       });
+      const senderId = callback.from?.id ? String(callback.from.id) : "";
+      const senderUsername = callback.from?.username ?? "";
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({
         chatId,
         isGroup,
         isForum,
         messageThreadId,
+        senderId,
       });
       const { resolvedThreadId, dmThreadId, storeAllowFrom, groupConfig } = eventAuthContext;
       const requireTopic = (groupConfig as { requireTopic?: boolean } | undefined)?.requireTopic;
@@ -1360,13 +1370,11 @@ export const registerTelegramHandlers = ({
         );
         return;
       }
-      const senderId = callback.from?.id ? String(callback.from.id) : "";
-      const senderUsername = callback.from?.username ?? "";
       const authorizationMode: TelegramEventAuthorizationMode =
         !isGroup || (!execApprovalButtonsEnabled && inlineButtonsScope === "allowlist")
           ? "callback-allowlist"
           : "callback-scope";
-      const senderAuthorization = authorizeTelegramEventSender({
+      const senderAuthorization = await authorizeTelegramEventSender({
         chatId,
         chatTitle: callbackMessage.chat.title,
         isGroup,
@@ -1552,14 +1560,14 @@ export const registerTelegramHandlers = ({
       const modelCallback = parseModelCallbackData(data);
       if (modelCallback) {
         if (
-          !isTelegramModelCallbackAuthorized({
+          !(await isTelegramModelCallbackAuthorized({
             chatId,
             isGroup,
             senderId,
             senderUsername,
             context: eventAuthContext,
             cfg: runtimeCfg,
-          })
+          }))
         ) {
           logVerbose(
             `Blocked telegram model callback from ${senderId || "unknown"} (not authorized for /models)`,
@@ -1889,6 +1897,7 @@ export const registerTelegramHandlers = ({
         isGroup: event.isGroup,
         isForum: event.isForum,
         messageThreadId: event.messageThreadId,
+        senderId: event.senderId,
       });
       const {
         dmPolicy,
@@ -1903,7 +1912,10 @@ export const registerTelegramHandlers = ({
       } = eventAuthContext;
       // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom
       const dmAllowFrom = groupAllowOverride ?? allowFrom;
-      const effectiveDmAllow = normalizeDmAllowFromWithStore({
+      const effectiveDmAllow = await resolveTelegramEffectiveDmAllow({
+        cfg,
+        accountId,
+        senderId: event.senderId,
         allowFrom: dmAllowFrom,
         storeAllowFrom,
         dmPolicy,

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -10,7 +10,7 @@ import { normalizeAccountId, resolveThreadSessionKeys } from "openclaw/plugin-sd
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { mergeTelegramAccountConfig, resolveDefaultTelegramAccountId } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
-import { firstDefined, normalizeAllowFrom, normalizeDmAllowFromWithStore } from "./bot-access.js";
+import { firstDefined } from "./bot-access.js";
 import { resolveTelegramInboundBody } from "./bot-message-context.body.js";
 import {
   buildTelegramInboundContextPayload,
@@ -20,6 +20,8 @@ import type { BuildTelegramMessageContextParams } from "./bot-message-context.ty
 import {
   buildTypingThreadParams,
   extractTelegramForumFlag,
+  resolveTelegramEffectiveDmAllow,
+  resolveTelegramEffectiveGroupAllow,
   resolveTelegramForumFlag,
   resolveTelegramThreadSpec,
   shouldUseTelegramDmThreadSession,
@@ -258,13 +260,21 @@ export const buildTelegramMessageContext = async ({
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom
   const dmAllowFrom = groupAllowOverride ?? allowFrom;
-  const effectiveDmAllow = normalizeDmAllowFromWithStore({
+  const effectiveDmAllow = await resolveTelegramEffectiveDmAllow({
+    cfg: freshCfg,
+    accountId: account.accountId,
+    senderId,
     allowFrom: dmAllowFrom,
     storeAllowFrom,
     dmPolicy: effectiveDmPolicy,
   });
   // Group sender checks are explicit and must not inherit DM pairing-store entries.
-  const effectiveGroupAllow = normalizeAllowFrom(groupAllowOverride ?? groupAllowFrom);
+  const effectiveGroupAllow = await resolveTelegramEffectiveGroupAllow({
+    cfg: freshCfg,
+    accountId: account.accountId,
+    senderId,
+    allowFrom: groupAllowOverride ?? groupAllowFrom,
+  });
   const hasGroupAllowOverride = groupAllowOverride !== undefined;
   const senderUsername = msg.from?.username ?? "";
   const baseAccess = evaluateTelegramGroupBaseAccess({

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -53,7 +53,7 @@ import {
 } from "openclaw/plugin-sdk/text-runtime";
 import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
-import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
+import { isSenderAllowed } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramMessageContextOptions } from "./bot-message-context.types.js";
@@ -74,6 +74,7 @@ import {
   buildSenderName,
   buildTelegramGroupFrom,
   extractTelegramForumFlag,
+  resolveTelegramEffectiveDmAllow,
   resolveTelegramForumFlag,
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
@@ -489,13 +490,17 @@ async function resolveTelegramCommandAuth(params: {
   } = params;
   const { chatId, isGroup, isForum, messageThreadId, threadParams } =
     await resolveTelegramNativeCommandThreadContext({ msg, bot });
+  const senderId = msg.from?.id ? String(msg.from.id) : "";
+  const senderUsername = msg.from?.username ?? "";
   const groupAllowContext = await resolveTelegramGroupAllowFromContext({
     chatId,
+    cfg,
     accountId,
     isGroup,
     isForum,
     messageThreadId,
     groupAllowFrom,
+    senderId,
     readChannelAllowFromStore,
     resolveTelegramGroupConfig,
   });
@@ -522,8 +527,6 @@ async function resolveTelegramCommandAuth(params: {
   }
   // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom
   const dmAllowFrom = groupAllowOverride ?? allowFrom;
-  const senderId = msg.from?.id ? String(msg.from.id) : "";
-  const senderUsername = msg.from?.username ?? "";
   const commandsAllowFrom = cfg.commands?.allowFrom;
   const commandsAllowFromConfigured =
     commandsAllowFrom != null &&
@@ -626,7 +629,10 @@ async function resolveTelegramCommandAuth(params: {
     }
   }
 
-  const dmAllow = normalizeDmAllowFromWithStore({
+  const dmAllow = await resolveTelegramEffectiveDmAllow({
+    cfg,
+    accountId,
+    senderId,
     allowFrom: dmAllowFrom,
     storeAllowFrom: isGroup ? [] : storeAllowFrom,
     dmPolicy: effectiveDmPolicy,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1581,6 +1581,33 @@ describe("createTelegramBot", () => {
       expectedReplyCount: 1,
     },
     {
+      name: "allows group messages from sender accessGroup allowFrom entries",
+      config: {
+        accessGroups: {
+          admins: {
+            type: "message.senders",
+            members: {
+              telegram: ["123456789"],
+            },
+          },
+        },
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            allowFrom: ["accessGroup:admins"],
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      },
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 123456789, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+      },
+      expectedReplyCount: 1,
+    },
+    {
       name: "blocks group messages when allowFrom is configured with @username entries (numeric IDs required)",
       config: {
         channels: {
@@ -2621,6 +2648,32 @@ describe("createTelegramBot", () => {
         channels: {
           telegram: {
             allowFrom: ["  TG:123456789  "],
+          },
+        },
+      },
+      message: {
+        chat: { id: 123456789, type: "private" },
+        from: { id: 123456789, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+      },
+      expectedReplyCount: 1,
+    },
+    {
+      name: "allows direct messages from sender accessGroup allowFrom entries",
+      config: {
+        accessGroups: {
+          admins: {
+            type: "message.senders",
+            members: {
+              telegram: ["123456789"],
+            },
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "allowlist",
+            allowFrom: ["accessGroup:admins"],
           },
         },
       },

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -1,6 +1,8 @@
 import type { Chat, Message } from "@grammyjs/types";
 import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
+import { expandAllowFromWithAccessGroups } from "openclaw/plugin-sdk/command-auth";
 import type {
+  OpenClawConfig,
   TelegramAccountConfig,
   TelegramDirectConfig,
   TelegramGroupConfig,
@@ -10,7 +12,13 @@ import type {
 import { readChannelAllowFromStore } from "openclaw/plugin-sdk/conversation-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { firstDefined, normalizeAllowFrom, type NormalizedAllowFrom } from "../bot-access.js";
+import {
+  firstDefined,
+  isSenderAllowed,
+  normalizeDmAllowFromWithStore,
+  normalizeAllowFrom,
+  type NormalizedAllowFrom,
+} from "../bot-access.js";
 import { normalizeTelegramReplyToMessageId } from "../outbound-params.js";
 import { resolveTelegramPreviewStreamMode } from "../preview-streaming.js";
 import {
@@ -169,11 +177,13 @@ export function withResolvedTelegramForumFlag<T extends { chat: object }>(
 
 export async function resolveTelegramGroupAllowFromContext(params: {
   chatId: string | number;
+  cfg?: OpenClawConfig;
   accountId?: string;
   isGroup?: boolean;
   isForum?: boolean;
   messageThreadId?: number | null;
   groupAllowFrom?: Array<string | number>;
+  senderId?: string;
   readChannelAllowFromStore?: typeof readChannelAllowFromStore;
   resolveTelegramGroupConfig: (
     chatId: string | number,
@@ -214,7 +224,12 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   // Group sender access must remain explicit (groupAllowFrom/per-group allowFrom only).
   // DM pairing store entries are not a group authorization source.
-  const effectiveGroupAllow = normalizeAllowFrom(groupAllowOverride ?? params.groupAllowFrom);
+  const effectiveGroupAllow = await resolveTelegramEffectiveGroupAllow({
+    cfg: params.cfg,
+    accountId,
+    senderId: params.senderId,
+    allowFrom: groupAllowOverride ?? params.groupAllowFrom,
+  });
   const hasGroupAllowOverride = groupAllowOverride !== undefined;
   return {
     resolvedThreadId,
@@ -226,6 +241,54 @@ export async function resolveTelegramGroupAllowFromContext(params: {
     effectiveGroupAllow,
     hasGroupAllowOverride,
   };
+}
+
+export async function resolveTelegramEffectiveGroupAllow(params: {
+  cfg?: OpenClawConfig;
+  accountId?: string;
+  senderId?: string;
+  allowFrom?: Array<string | number>;
+}): Promise<NormalizedAllowFrom> {
+  return normalizeAllowFrom(await expandTelegramAllowFromForSender(params));
+}
+
+async function expandTelegramAllowFromForSender(params: {
+  cfg?: OpenClawConfig;
+  accountId?: string;
+  senderId?: string;
+  allowFrom?: Array<string | number>;
+}): Promise<Array<string | number> | undefined> {
+  const senderId = params.senderId ?? "";
+  return senderId
+    ? await expandAllowFromWithAccessGroups({
+        cfg: params.cfg,
+        allowFrom: params.allowFrom,
+        channel: "telegram",
+        accountId: normalizeAccountId(params.accountId),
+        senderId,
+        isSenderAllowed: (candidateSenderId, allowFrom) =>
+          isSenderAllowed({
+            allow: normalizeAllowFrom(allowFrom),
+            senderId: candidateSenderId,
+          }),
+      })
+    : params.allowFrom;
+}
+
+export async function resolveTelegramEffectiveDmAllow(params: {
+  cfg?: OpenClawConfig;
+  accountId?: string;
+  senderId?: string;
+  allowFrom?: Array<string | number>;
+  storeAllowFrom?: string[];
+  dmPolicy?: string;
+}): Promise<NormalizedAllowFrom> {
+  const allowFrom = await expandTelegramAllowFromForSender(params);
+  return normalizeDmAllowFromWithStore({
+    allowFrom,
+    storeAllowFrom: params.storeAllowFrom,
+    dmPolicy: params.dmPolicy,
+  });
 }
 
 /**

--- a/extensions/telegram/src/group-access.base-access.test.ts
+++ b/extensions/telegram/src/group-access.base-access.test.ts
@@ -28,6 +28,17 @@ describe("evaluateTelegramGroupBaseAccess", () => {
     });
   });
 
+  it("keeps access-group allowFrom entries configured without treating them as bad sender ids", () => {
+    const result = normalizeAllowFrom(["accessGroup:admins"]);
+
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
   it("fails closed when explicit group allowFrom override is empty", () => {
     const result = evaluateTelegramGroupBaseAccess({
       isGroup: true,


### PR DESCRIPTION
## Summary

- Reuse the existing access-group expansion helper for Telegram DM and group sender allowlists before numeric sender matching.
- Keep `accessGroup:<name>` entries configured without warning as invalid Telegram sender IDs, while unmatched/missing groups still fail closed.
- Add Telegram dispatch regressions for direct messages and group messages using `channels.telegram.allowFrom: [\"accessGroup:admins\"]`.

## Real behavior proof

Behavior or issue addressed: Fixes #78660, where documented Telegram `accessGroup:<name>` allowFrom entries were accepted by config/docs but normalized as invalid nonnumeric Telegram sender IDs before runtime authorization could match them.

Real environment tested: Local OpenClaw source runtime on Ubuntu/Linux, using `node --import tsx` to invoke the actual Telegram runtime allowlist helpers outside Vitest/CI.

Exact steps or command run after this patch:
- `node --import tsx - <<'EOF' ... import { normalizeAllowFrom } from './extensions/telegram/src/bot-access.ts'; import { resolveTelegramEffectiveDmAllow, resolveTelegramEffectiveGroupAllow } from './extensions/telegram/src/bot/helpers.ts'; ... EOF`
- `pnpm test extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/dm-access.test.ts extensions/telegram/src/group-access.base-access.test.ts src/plugin-sdk/command-auth.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot-access.ts extensions/telegram/src/bot/helpers.ts extensions/telegram/src/bot-message-context.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot-native-commands.ts extensions/telegram/src/group-access.base-access.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts CHANGELOG.md`
- `pnpm check:changed`
- `git diff --check`

Evidence after fix: Console output from `node --import tsx` against the OpenClaw Telegram source runtime:
```json
{
  "raw": { "entries": [], "hasEntries": true, "invalidEntries": [] },
  "dm": { "entries": ["123456789"], "hasEntries": true, "invalidEntries": [] },
  "group": { "entries": ["123456789"], "hasEntries": true, "invalidEntries": [] }
}
```

Observed result after fix: The literal Telegram allowlist alias remains configured without invalid-entry output, and the same sender is expanded into both direct-message and group effective allowlists before authorization.

What was not tested: Live Telegram Bot API delivery against a real Telegram account.

## Supplemental local checks

- `pnpm test extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/dm-access.test.ts extensions/telegram/src/group-access.base-access.test.ts src/plugin-sdk/command-auth.test.ts` passed 2 Vitest shards: unit-fast had 1 file / 5 tests passed; extension-telegram had 3 files / 93 tests passed.
- `pnpm exec oxfmt --check ...`, `pnpm check:changed`, and `git diff --check` exited 0.

## Pre-implement audit

- Existing-helper check: reused `expandAllowFromWithAccessGroups` / `parseAccessGroupAllowFromEntry`; no new access-group parser or membership model.
- Shared-caller check: `normalizeAllowFrom` remains numeric/wildcard based and only stops warning for `accessGroup:*`; Telegram DM/group call sites explicitly expand before authorization.
- Broader rival scan: live PR search for #78660 / Telegram accessGroup allowFrom returned no open competing PR.

Fixes #78660