### PR TITLE
docs(telegram): clarify access group allowlists

### DIFF
--- a/docs/channels/access-groups.md
+++ b/docs/channels/access-groups.md
@@ -125,7 +125,7 @@ Access groups are available in shared message-channel authorization paths, inclu
 - channel-specific per-room sender allowlists that use the same sender matching rules
 - command authorization paths that reuse message-channel sender allowlists
 
-Channel support depends on whether that channel is wired through the shared OpenClaw sender-authorization helpers. Current bundled support includes Discord, Google Chat, Nostr, WhatsApp, Zalo, and Zalo Personal. Static `message.senders` groups are designed to be channel-agnostic, so new message channels should support them by using the shared plugin SDK helpers instead of custom allowlist expansion.
+Channel support depends on whether that channel is wired through the shared OpenClaw sender-authorization helpers. Current bundled support includes Discord, Google Chat, Nostr, Telegram, WhatsApp, Zalo, and Zalo Personal. Static `message.senders` groups are designed to be channel-agnostic, so new message channels should support them by using the shared plugin SDK helpers instead of custom allowlist expansion.
 
 ## Discord channel audiences
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -113,7 +113,8 @@ Token resolution order is account-aware. In practice, config values win over env
 
     `dmPolicy: "open"` with `allowFrom: ["*"]` lets any Telegram account that finds or guesses the bot username command the bot. Use it only for intentionally public bots with tightly restricted tools; one-owner bots should use `allowlist` with numeric user IDs.
 
-    `channels.telegram.allowFrom` accepts numeric Telegram user IDs. `telegram:` / `tg:` prefixes are accepted and normalized.
+    `channels.telegram.allowFrom` accepts numeric Telegram user IDs, `*` for intentionally open DMs, and `accessGroup:<name>` aliases. `telegram:` / `tg:` prefixes are accepted and normalized for direct numeric sender entries.
+    When using `accessGroup:<name>`, keep the Telegram entries inside `accessGroups.<name>.members.telegram` as numeric sender user IDs. Missing access groups fail closed.
     In multi-account configs, a restrictive top-level `channels.telegram.allowFrom` is treated as a safety boundary: account-level `allowFrom: ["*"]` entries do not make that account public unless the effective account allowlist still contains an explicit wildcard after merging.
     `dmPolicy: "allowlist"` with empty `allowFrom` blocks all DMs and is rejected by config validation.
     Setup asks for numeric user IDs only.
@@ -160,9 +161,10 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
        - `disabled`
 
     `groupAllowFrom` is used for group sender filtering. If not set, Telegram falls back to `allowFrom`.
-    `groupAllowFrom` entries should be numeric Telegram user IDs (`telegram:` / `tg:` prefixes are normalized).
+    `groupAllowFrom` entries should be numeric Telegram user IDs or `accessGroup:<name>` aliases. `telegram:` / `tg:` prefixes are normalized for direct numeric sender entries.
+    When using `accessGroup:<name>`, keep the Telegram entries inside `accessGroups.<name>.members.telegram` as numeric sender user IDs. Missing access groups fail closed.
     Do not put Telegram group or supergroup chat IDs in `groupAllowFrom`. Negative chat IDs belong under `channels.telegram.groups`.
-    Non-numeric entries are ignored for sender authorization.
+    Other non-numeric entries are ignored for sender authorization.
     Security boundary (`2026.2.25+`): group sender auth does **not** inherit DM pairing-store approvals.
     Pairing stays DM-only. For groups, set `groupAllowFrom` or per-group/per-topic `allowFrom`.
     If `groupAllowFrom` is unset, Telegram falls back to config `allowFrom`, not the pairing store.


### PR DESCRIPTION
## Summary
- Document that Telegram allowFrom and groupAllowFrom accept accessGroup aliases.
- Add Telegram to the bundled access-groups channel support list in docs/channels/access-groups.md.
- Clarify that numeric Telegram sender IDs are required inside accessGroups members.telegram entries and that missing access groups fail closed.
- Update non-numeric-entry note to reflect that accessGroup is valid and only other non-numeric entries are ignored.

Refs #78660. Runtime support is already on current main via b6ae0b83a6; this PR fixes the remaining Telegram channel docs mismatch called out on #78665.

## Real behavior proof

**Behavior or issue addressed:** docs/channels/telegram.md and docs/channels/access-groups.md did not document that accessGroup aliases are valid for allowFrom and groupAllowFrom, and did not list Telegram as a supported bundled channel.

**Real environment tested:** Linux node v22, local openclaw repo clone on branch docs/telegram-access-group-allowlists-78660.

**Exact steps or command run after this patch:**

```
node -e "const fs=require('fs');const tg=fs.readFileSync('docs/channels/telegram.md','utf8');const ag=fs.readFileSync('docs/channels/access-groups.md','utf8');console.assert(tg.includes('accessGroup'));console.assert(tg.includes('fail closed'));console.assert(ag.includes('Telegram'));console.log('PASS')"
pnpm check:docs
```

**Evidence after fix:**

Terminal output after applying patch:

```
$ node -e "const fs=require('fs');const tg=fs.readFileSync('docs/channels/telegram.md','utf8');const ag=fs.readFileSync('docs/channels/access-groups.md','utf8');console.assert(tg.includes('accessGroup'));console.assert(tg.includes('fail closed'));console.assert(ag.includes('Telegram'));console.log('PASS')"
PASS
$ pnpm check:docs
checked_internal_links=4214 broken_links=0
```

**Observed result after fix:** node confirms all doc content assertions pass. pnpm check:docs shows 0 broken links. Telegram now listed in bundled channel support list in access-groups.md. Both allowFrom and groupAllowFrom sections in telegram.md now document accessGroup aliases and fail-closed behavior.

**What was not tested:** Runtime config parsing and live Telegram DM authorization (runtime support was already merged via b6ae0b83a6 -- this PR is docs-only).