### PR TITLE
fix: resolve scp via PATH instead of hardcoded /usr/bin/scp (#78677)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Media/SCP: replace the hardcoded `/usr/bin/scp` spawn path with bare `scp` so remote inbound media staging resolves the binary through `PATH` on Windows (OpenSSH in `System32`) and non-FHS Linux layouts. Fixes #78677. Thanks @hclsys.
 - Docs/iMessage: deprecate BlueBubbles for new OpenClaw setups, document the upstream server-release rationale, and point new iMessage deployments toward the native `imsg` path while keeping BlueBubbles as a supported legacy fallback.
 - Discord/streaming: default Discord replies to progress draft previews so tool/work activity appears in one edited Discord message unless `channels.discord.streaming.mode` is set to `off`.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.

--- a/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
+++ b/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
@@ -117,4 +117,22 @@ describe("stageSandboxMedia scp remote paths", () => {
       }
     });
   });
+
+  it("invokes scp by bare command name so PATH resolves the binary on all platforms", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir, sessionKey } = createRemoteStageParams(home);
+      const remotePath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+      const { ctx, sessionCtx } = createRemoteContexts(remotePath);
+
+      let spawnCommand: string | undefined;
+      childProcessMocks.spawn.mockImplementation((cmd: string) => {
+        spawnCommand = cmd;
+        throw new Error("stop before scp");
+      });
+
+      await stageSandboxMedia({ ctx, sessionCtx, cfg, sessionKey, workspaceDir });
+
+      expect(spawnCommand).toBe("scp");
+    });
+  });
 });

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -319,7 +319,7 @@ async function scpFile(remoteHost: string, remotePath: string, localPath: string
   }
   return new Promise((resolve, reject) => {
     const child = spawn(
-      "/usr/bin/scp",
+      "scp",
       [
         "-o",
         "BatchMode=yes",


### PR DESCRIPTION
## Problem

`scpFile` in `src/auto-reply/reply/stage-sandbox-media.ts` hardcodes the scp binary path as `/usr/bin/scp`. This breaks remote inbound media staging on:

- **Windows**: OpenSSH ships scp at `%SystemRoot%\System32\OpenSSH\scp.exe`, not `/usr/bin/scp`
- **Non-FHS Linux layouts**: any distro or container where scp lives at `/bin/scp`, `/usr/local/bin/scp`, etc.

Fixes #78677.

## Fix

Replace `"/usr/bin/scp"` with `"scp"` in the `spawn()` call. Node's `child_process.spawn` with a bare command name uses the process `PATH` to resolve the binary — consistent with every other `spawn` call in the codebase that passes a bare command (e.g. `"ffmpeg"`, `"convert"`, `"npm"`).

## Audit A — existing helper check

No existing `detectBinary`/`resolveBinary` helper handles scp. `detect-binary.ts` only resolves optional tools to detect presence, not for spawning. Bare name is the established pattern here.

## Audit B — shared caller check

`scpFile` is private to `stage-sandbox-media.ts` (not exported, not imported elsewhere). One caller site only.

## Audit C — rival PR scan

No rival PR open for #78677 as of scout time.

## Real behavior proof

- Existing test suite (`reply.stage-sandbox-media.scp-remote-path.test.ts`) extended with a third case that captures the `spawn` command argument and asserts it equals `"scp"` (not `/usr/bin/scp`).
- All 3 tests pass: shell injection rejection, path-traversal-safe cache dir, and the new bare-command assertion.
- `pnpm -s tsgo:core` clean.

Co-authored-by: hclsys