### PR TITLE
fix(gateway): remove password fallback from trusted-proxy auth mode (#78684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/auth: remove the local-direct password fallback from `trusted-proxy` mode so a failed proxy identity check always fails closed instead of succeeding through password auth. Fixes #78684. Thanks @hclsys.
+
 - Docs/iMessage: deprecate BlueBubbles for new OpenClaw setups, document the upstream server-release rationale, and point new iMessage deployments toward the native `imsg` path while keeping BlueBubbles as a supported legacy fallback.
 - Discord/streaming: default Discord replies to progress draft previews so tool/work activity appears in one edited Discord message unless `channels.discord.streaming.mode` is set to `off`.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -964,7 +964,7 @@ describe("trusted-proxy auth", () => {
       expect(res.reason).toBe("trusted_proxy_loopback_source");
     });
 
-    it("accepts local-direct password fallback when trusted-proxy auth fails", async () => {
+    it("rejects local-direct password when trusted-proxy auth fails (no fallback)", async () => {
       const limiter = createLimiterSpy();
       const res = await authorizeLocalDirect({
         password: "local-password", // pragma: allowlist secret
@@ -972,48 +972,9 @@ describe("trusted-proxy auth", () => {
         rateLimiter: limiter,
       });
 
-      expect(res).toEqual({ ok: true, method: "password" });
-      expect(limiter.check).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
-      expect(limiter.reset).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
-      expect(limiter.recordFailure).not.toHaveBeenCalled();
-    });
-
-    it("rejects wrong local-direct password fallback and records the failure", async () => {
-      const limiter = createLimiterSpy();
-      const res = await authorizeLocalDirect({
-        password: "local-password", // pragma: allowlist secret
-        connectPassword: "wrong-password", // pragma: allowlist secret
-        rateLimiter: limiter,
-      });
-
-      expect(res).toEqual({ ok: false, reason: "password_mismatch" });
-      expect(limiter.check).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
-      expect(limiter.recordFailure).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
-      expect(limiter.reset).not.toHaveBeenCalled();
-    });
-
-    it("enforces rate-limit lockout before local-direct password fallback", async () => {
-      const limiter = createLimiterSpy();
-      limiter.check.mockReturnValueOnce({
-        allowed: false,
-        remaining: 0,
-        retryAfterMs: 2500,
-      });
-
-      const res = await authorizeLocalDirect({
-        password: "local-password", // pragma: allowlist secret
-        connectPassword: "local-password", // pragma: allowlist secret
-        rateLimiter: limiter,
-      });
-
-      expect(res).toEqual({
-        ok: false,
-        reason: "rate_limited",
-        rateLimited: true,
-        retryAfterMs: 2500,
-      });
-      expect(limiter.recordFailure).not.toHaveBeenCalled();
-      expect(limiter.reset).not.toHaveBeenCalled();
+      expect(res.ok).toBe(false);
+      expect((res as { reason: string }).reason).toBe("trusted_proxy_loopback_source");
+      expect(limiter.check).not.toHaveBeenCalled();
     });
 
     it("keeps local-direct trusted-proxy on proxy failure when no password is supplied", async () => {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -466,26 +466,6 @@ async function authorizeGatewayConnectCore(
       }
       return { ok: true, method: "trusted-proxy", user: result.user };
     }
-    if (localDirect && auth.password && connectAuth?.password) {
-      if (limiter) {
-        const rlCheck: RateLimitCheckResult = limiter.check(ip, rateLimitScope);
-        if (!rlCheck.allowed) {
-          return {
-            ok: false,
-            reason: "rate_limited",
-            rateLimited: true,
-            retryAfterMs: rlCheck.retryAfterMs,
-          };
-        }
-      }
-      return authorizePasswordAuth({
-        authPassword: auth.password,
-        connectPassword: connectAuth.password,
-        limiter,
-        ip,
-        rateLimitScope,
-      });
-    }
     return { ok: false, reason: result.reason };
   }
 


### PR DESCRIPTION
## Problem

When `gateway.auth.mode` is `trusted-proxy`, a failed proxy identity check could still succeed via local-direct password auth if `OPENCLAW_GATEWAY_PASSWORD` (or `gateway.auth.password`) was configured. This creates a second undocumented auth path that violates the intent of trusted-proxy mode.

Source: `src/gateway/auth.ts:469-487` — after `authorizeTrustedProxy` returns a non-user result, the code falls through to `authorizePasswordAuth` when `localDirect && auth.password && connectAuth?.password`.

Fixes #78684.

## Fix

Remove the password fallback branch from the `auth.mode === "trusted-proxy"` block. A failed trusted-proxy check now always returns `{ ok: false, reason: result.reason }` regardless of whether a password is configured.

## Audit A — existing helper check

No new auth predicate needed. The `authorizeTrustedProxy` + `authorizePasswordAuth` functions already exist; this is a branch removal not a new abstraction.

## Audit B — shared caller check

`authorizeGatewayConnect` is called in 2 test-convenience helpers within `auth.test.ts` and in gateway connection flows. The function signature is unchanged; only the internal branching for `mode === "trusted-proxy"` is affected.

## Audit C — rival PR scan

No rival PR open for #78684 at scout time.

## Real behavior proof

Updated `src/gateway/auth.test.ts`:
- The existing "accepts local-direct password fallback when trusted-proxy auth fails" test now asserts `ok: false` with `reason: "trusted_proxy_loopback_source"` (the correct fail-closed behavior).
- The two tests for wrong-password fallback and rate-limit-before-fallback are removed — they tested the removed code path.
- All 207 tests in auth test suite pass.
- `pnpm -s tsgo:core` clean.

Co-authored-by: hclsys