### PR TITLE
feat(cron): add computed status field to --json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Telegram: treat successful same-chat `message` tool outbound sends during an inbound telegram turn as delivered when deciding whether to emit the rewritten silent reply fallback (#78685). Thanks @neeravmakwana.
 - Discord/voice: make `openclaw channels capabilities --channel discord --target channel:<id>` and `channels status --probe` audit voice-channel permissions, including auto-join targets, so missing Connect/Speak/Read Message History permissions show up before `/vc join`.
+- CLI/cron: add computed `status` field to `cron list --json` and `cron show <id> --json` output, mirroring the human-readable status column (disabled/running/ok/error/skipped/idle) so external tooling can determine job state without re-deriving it from raw state fields. (#78701) Thanks @aweiker.
 - Docs/iMessage: deprecate BlueBubbles for new OpenClaw setups, document the upstream server-release rationale, and point new iMessage deployments toward the native `imsg` path while keeping BlueBubbles as a supported legacy fallback.
 - Discord/streaming: default Discord replies to progress draft previews so tool/work activity appears in one edited Discord message unless `channels.discord.streaming.mode` is set to `off`.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -14,6 +14,7 @@ import { resolveCronCreateSchedule } from "./schedule-options.js";
 import {
   getCronChannelOptions,
   coerceCronDeliveryPreviews,
+  enrichCronJsonWithStatus,
   handleCronCliError,
   parseCronToolsAllow,
   printCronJson,
@@ -58,7 +59,7 @@ export function registerCronListCommand(cron: Command) {
           }
           const res = await callGatewayFromCli("cron.list", opts, listParams);
           if (opts.json) {
-            printCronJson(res);
+            printCronJson(enrichCronJsonWithStatus(res));
             return;
           }
           const jobs = (res as { jobs?: CronJob[] } | null)?.jobs ?? [];

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -6,6 +6,7 @@ import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import {
   coerceCronDeliveryPreviews,
+  enrichCronJsonWithStatus,
   handleCronCliError,
   printCronJson,
   printCronShow,
@@ -122,7 +123,7 @@ export function registerCronSimpleCommands(cron: Command) {
             throw new Error(`cron job not found: ${String(id)}`);
           }
           if (opts.json) {
-            printCronJson(job);
+            printCronJson(enrichCronJsonWithStatus(job));
             return;
           }
           printCronShow(job, defaultRuntime, { deliveryPreview });

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -29,6 +29,41 @@ export function printCronJson(value: unknown) {
   defaultRuntime.writeJson(value);
 }
 
+/**
+ * Enrich a CronJob (or list response) with a computed `status` field
+ * derived from enabled + state.runningAtMs + state.lastRunStatus.
+ * This mirrors the human-readable status shown by `cron list` / `cron show`.
+ */
+export function enrichCronJsonWithStatus(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  const obj = value as Record<string, unknown>;
+
+  // Single job object (has 'state' and 'enabled')
+  if ("state" in obj && "enabled" in obj) {
+    return { ...obj, status: computeStatus(obj as unknown as CronJob) };
+  }
+
+  // List response (has 'jobs' array)
+  if ("jobs" in obj && Array.isArray(obj.jobs)) {
+    return {
+      ...obj,
+      jobs: (obj.jobs as CronJob[]).map((job) => ({
+        ...job,
+        status: computeStatus(job),
+      })),
+    };
+  }
+
+  return value;
+}
+
+function computeStatus(job: CronJob): string {
+  if (!job.enabled) return "disabled";
+  const state = job.state ?? {};
+  if (state.runningAtMs) return "running";
+  return state.lastRunStatus ?? "idle";
+}
+
 export function handleCronCliError(err: unknown) {
   defaultRuntime.error(danger(String(err)));
   defaultRuntime.exit(1);

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -35,7 +35,9 @@ export function printCronJson(value: unknown) {
  * This mirrors the human-readable status shown by `cron list` / `cron show`.
  */
 export function enrichCronJsonWithStatus(value: unknown): unknown {
-  if (!value || typeof value !== "object") return value;
+  if (!value || typeof value !== "object") {
+    return value;
+  }
   const obj = value as Record<string, unknown>;
 
   // Single job object (has 'state' and 'enabled')
@@ -45,22 +47,24 @@ export function enrichCronJsonWithStatus(value: unknown): unknown {
 
   // List response (has 'jobs' array)
   if ("jobs" in obj && Array.isArray(obj.jobs)) {
-    return {
-      ...obj,
-      jobs: (obj.jobs as CronJob[]).map((job) => ({
-        ...job,
-        status: computeStatus(job),
-      })),
-    };
+    const enrichedJobs = (obj.jobs as CronJob[]).map((job) => {
+      const status = computeStatus(job);
+      return Object.assign({}, job, { status });
+    });
+    return { ...obj, jobs: enrichedJobs };
   }
 
   return value;
 }
 
 function computeStatus(job: CronJob): string {
-  if (!job.enabled) return "disabled";
+  if (!job.enabled) {
+    return "disabled";
+  }
   const state = job.state ?? {};
-  if (state.runningAtMs) return "running";
+  if (state.runningAtMs) {
+    return "running";
+  }
   return state.lastRunStatus ?? state.lastStatus ?? "idle";
 }
 

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -61,7 +61,7 @@ function computeStatus(job: CronJob): string {
   if (!job.enabled) return "disabled";
   const state = job.state ?? {};
   if (state.runningAtMs) return "running";
-  return state.lastRunStatus ?? "idle";
+  return state.lastRunStatus ?? state.lastStatus ?? "idle";
 }
 
 export function handleCronCliError(err: unknown) {


### PR DESCRIPTION
## Summary

`openclaw cron list --json` and `openclaw cron show <id> --json` now include a top-level `status` field on each job object.

## Problem

The human-readable `cron list` output shows a computed "Status" column (disabled/running/ok/error/idle), but `--json` output only includes the raw `state` object. External tooling (dashboards, ops gateways, scripts) must re-implement the status derivation logic:

```typescript
if (!job.enabled) return "disabled";
if (state.runningAtMs) return "running";
return state.lastRunStatus ?? state.lastStatus ?? "idle";
```

## Solution

Added `enrichCronJsonWithStatus()` in `shared.ts` that injects a computed `status` field into the JSON output for both `cron list --json` and `cron show <id> --json`.

**Values:** `"disabled"` | `"running"` | `"ok"` | `"error"` | `"skipped"` | `"idle"`

The status derivation preserves the deprecated `lastStatus` fallback for legacy jobs that may not have `lastRunStatus` set, matching the existing `formatStatus` behavior.

The raw `state` object is preserved unchanged for backward compatibility.

## Changes

- `src/cli/cron-cli/shared.ts` — new `enrichCronJsonWithStatus()` and `computeStatus()` helpers
- `src/cli/cron-cli/register.cron-add.ts` — wrap `cron list --json` output
- `src/cli/cron-cli/register.cron-simple.ts` — wrap `cron show --json` output
- `CHANGELOG.md` — added entry under Unreleased

## Real Behavior Proof

- **Behavior or issue addressed:** `cron list --json` and `cron show <id> --json` were missing the computed `status` field that the human-readable table output shows. External tools had to re-implement status derivation logic.
- **Real environment tested:** Local OpenClaw checkout at commit `17863c53` on branch `feat/cron-json-status`, built and run with `node openclaw.mjs` against a live gateway with active cron jobs.
- **Exact steps or command run after this patch:**

```bash
cd /tmp/openclaw-source
git checkout feat/cron-json-status
node openclaw.mjs cron list --json | jq '.jobs[:3] | map({name, status})'
node openclaw.mjs cron show watch-openclaw-pr-78701 --json | jq '{name, status}'
```

- **Evidence after fix:**

Terminal output from `node openclaw.mjs cron list --json`:

```json
[
  {
    "name": "watch-openclaw-pr-78701",
    "status": "running"
  },
  {
    "name": "slack-ask-rodin",
    "status": "ok"
  },
  {
    "name": "gargoyle-dev-loop",
    "status": "ok"
  }
]
```

Terminal output from `node openclaw.mjs cron show watch-openclaw-pr-78701 --json`:

```json
{
  "name": "watch-openclaw-pr-78701",
  "status": "running"
}
```

- **Observed result after fix:** The `status` field is present on all job objects in both list and show JSON outputs. Values match the human-readable Status column: `"running"` for active jobs (derived from `state.runningAtMs`), `"ok"` for completed jobs, `"disabled"` for disabled jobs.
- **What was not tested:** Edge case of a job with only the deprecated `lastStatus` field and no `lastRunStatus`. The fallback path is covered by code inspection but no legacy job was available in the test environment.
