### PR TITLE
fix(gateway): prevent shared-secret callers from gaining admin scopes on trusted-operator plugin routes

### DIFF
--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -383,7 +383,7 @@ describe("gateway plugin HTTP auth boundary", () => {
     expect(writeAllowedResults).toEqual([true]);
   });
 
-  test("allows trusted-operator plugin routes to resolve admin-capable runtime scopes for shared-secret bearer auth without scope headers", async () => {
+  test("does not escalate shared-secret bearer callers to admin scopes on trusted-operator surface", async () => {
     const observedRuntimeScopes: string[][] = [];
     const adminAllowedResults: boolean[] = [];
     const handlePluginRequest = createRuntimeScopeRecorderHandler({
@@ -415,15 +415,12 @@ describe("gateway plugin HTTP auth boundary", () => {
         );
 
         expect(response.res.statusCode).toBe(200);
-        expect(response.getBody()).toBe("ok");
       },
     });
 
     expect(observedRuntimeScopes).toHaveLength(1);
-    expect(observedRuntimeScopes[0]).toEqual(
-      expect.arrayContaining(["operator.admin", "operator.read", "operator.write"]),
-    );
-    expect(adminAllowedResults).toEqual([true]);
+    expect(observedRuntimeScopes[0]).not.toContain("operator.admin");
+    expect(adminAllowedResults).toEqual([false]);
   });
 
   test("allows unauthenticated Mattermost slash callback routes while keeping other channel routes protected", async () => {

--- a/src/gateway/server/plugin-route-runtime-scopes.test.ts
+++ b/src/gateway/server/plugin-route-runtime-scopes.test.ts
@@ -46,7 +46,7 @@ describe("resolvePluginRouteRuntimeOperatorScopes", () => {
     ).toEqual(["operator.write"]);
   });
 
-  it("restores trusted default operator scopes for shared-secret bearer routes opting into trusted-operator surface", () => {
+  it("does not restore admin scopes for shared-secret bearer routes opting into trusted-operator surface", () => {
     expect(
       resolvePluginRouteRuntimeOperatorScopes(
         createReq({
@@ -55,14 +55,7 @@ describe("resolvePluginRouteRuntimeOperatorScopes", () => {
         { authMethod: "token", trustDeclaredOperatorScopes: false },
         "trusted-operator",
       ),
-    ).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    ).toEqual([]);
   });
 
   it("restores trusted default operator scopes for trusted-proxy routes opting into trusted-operator when scopes header is absent", () => {

--- a/src/gateway/server/plugin-route-runtime-scopes.ts
+++ b/src/gateway/server/plugin-route-runtime-scopes.ts
@@ -4,7 +4,7 @@ import {
   resolveTrustedHttpOperatorScopes,
   type AuthorizedGatewayHttpRequest,
 } from "../http-auth-utils.js";
-import { CLI_DEFAULT_OPERATOR_SCOPES, WRITE_SCOPE } from "../method-scopes.js";
+import { WRITE_SCOPE } from "../method-scopes.js";
 
 export type PluginRouteRuntimeScopeSurface = "write-default" | "trusted-operator";
 
@@ -14,9 +14,6 @@ export function resolvePluginRouteRuntimeOperatorScopes(
   surface: PluginRouteRuntimeScopeSurface = "write-default",
 ): string[] {
   if (surface === "trusted-operator") {
-    if (!requestAuth.trustDeclaredOperatorScopes) {
-      return [...CLI_DEFAULT_OPERATOR_SCOPES];
-    }
     return resolveTrustedHttpOperatorScopes(req, requestAuth);
   }
   if (requestAuth.authMethod !== "trusted-proxy") {

--- a/src/gateway/server/plugins-http.runtime-scopes.test.ts
+++ b/src/gateway/server/plugins-http.runtime-scopes.test.ts
@@ -167,7 +167,45 @@ describe("plugin HTTP route runtime scopes", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("missing scope: operator.write"));
   });
 
-  it("restores trusted-operator defaults for routes opting into trusted surface", async () => {
+  it("does not escalate shared-secret callers to admin scopes on trusted-operator surface", async () => {
+    let observedScopes: string[] | undefined;
+    const log = createMockLogger();
+    const handler = createGatewayPluginRequestHandler({
+      registry: createTestRegistry({
+        httpRoutes: [
+          createRoute({
+            path: "/secure-admin-hook",
+            auth: "gateway",
+            gatewayRuntimeScopeSurface: "trusted-operator",
+            handler: async () => {
+              observedScopes =
+                getPluginRuntimeGatewayRequestScope()?.client?.connect?.scopes?.slice() ?? [];
+              return true;
+            },
+          }),
+        ],
+      }),
+      log,
+    });
+
+    const response = makeMockHttpResponse();
+    const handled = await handler(
+      { url: "/secure-admin-hook" } as IncomingMessage,
+      response.res,
+      undefined,
+      {
+        gatewayAuthSatisfied: true,
+        gatewayRequestAuth: { authMethod: "token", trustDeclaredOperatorScopes: false },
+        gatewayRequestOperatorScopes: ["operator.write"],
+      },
+    );
+
+    expect(handled).toBe(true);
+    expect(response.res.statusCode).toBe(200);
+    expect(observedScopes).not.toContain("operator.admin");
+  });
+
+  it("resolves trusted-operator defaults for trusted-proxy callers on trusted-operator surface", async () => {
     let observedScopes: string[] | undefined;
     const log = createMockLogger();
     const handler = createGatewayPluginRequestHandler({
@@ -191,12 +229,12 @@ describe("plugin HTTP route runtime scopes", () => {
 
     const response = makeMockHttpResponse();
     const handled = await handler(
-      { url: "/secure-admin-hook" } as IncomingMessage,
+      { url: "/secure-admin-hook", headers: {} } as IncomingMessage,
       response.res,
       undefined,
       {
         gatewayAuthSatisfied: true,
-        gatewayRequestAuth: { authMethod: "token", trustDeclaredOperatorScopes: false },
+        gatewayRequestAuth: { authMethod: "trusted-proxy", trustDeclaredOperatorScopes: true },
         gatewayRequestOperatorScopes: ["operator.write"],
       },
     );
@@ -250,12 +288,12 @@ describe("plugin HTTP route runtime scopes", () => {
 
     const response = makeMockHttpResponse();
     const handled = await handler(
-      { url: "/secure/admin-hook" } as IncomingMessage,
+      { url: "/secure/admin-hook", headers: {} } as IncomingMessage,
       response.res,
       undefined,
       {
         gatewayAuthSatisfied: true,
-        gatewayRequestAuth: { authMethod: "token", trustDeclaredOperatorScopes: false },
+        gatewayRequestAuth: { authMethod: "trusted-proxy", trustDeclaredOperatorScopes: true },
         gatewayRequestOperatorScopes: ["operator.write"],
       },
     );


### PR DESCRIPTION
## Summary

Fixes #78712 — beta blocker privilege escalation in plugin HTTP route scope resolution.

**Root cause:** `resolvePluginRouteRuntimeOperatorScopes` short-circuited to `CLI_DEFAULT_OPERATOR_SCOPES` (including `operator.admin`) whenever `surface === "trusted-operator"` and `!requestAuth.trustDeclaredOperatorScopes`. Shared-secret bearer auth always sets `trustDeclaredOperatorScopes: false`, so a token/password caller could gain admin-equivalent scopes even when they declared narrow or no scopes.

**Fix:** Remove the early-return that bypassed `resolveTrustedHttpOperatorScopes` for untrusted callers. The function now delegates to `resolveTrustedHttpOperatorScopes` unconditionally for the `trusted-operator` surface:

- Shared-secret callers (`trustDeclaredOperatorScopes: false`) → `[]` (no header) or their declared subset — never admin defaults
- `trusted-proxy` callers (`trustDeclaredOperatorScopes: true`) → full operator defaults when no scope header present (unchanged behavior)

**Files changed:**
- `src/gateway/server/plugin-route-runtime-scopes.ts` — 5-line fix, remove unused `CLI_DEFAULT_OPERATOR_SCOPES` import
- `src/gateway/server/plugin-route-runtime-scopes.test.ts` — update test that asserted buggy behavior
- `src/gateway/server/plugins-http.runtime-scopes.test.ts` — replace admin-escalation assertion with fail-closed assertion; add trusted-proxy positive case
- `src/gateway/server.plugin-http-auth.test.ts` — update integration test to assert no admin escalation for shared-secret callers

**Tests:** 3435/3435 gateway tests pass.

## Audit

- **Audit A (existing helper):** `resolveTrustedHttpOperatorScopes` already handles this correctly — reused, no new helper needed.
- **Audit B (shared caller check):** `resolvePluginRouteRuntimeOperatorScopes` is called from 2 sites (`server-http.ts:440`, `server/plugins-http.ts:120`). Both pass `requestAuth` as-is; no caller contract change.
- **Audit C (rival PR):** No rival PR touching `plugin-route-runtime-scopes.ts`. Related PRs (#57889, #51413) touch WebSocket connect-policy, not plugin route scopes.