### PR TITLE
Fix session runtime override reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/model: report and reuse `/model --runtime` as a session-scoped override so one forum topic can use the Codex runtime without making sibling topics appear to switch runtimes.
 - fix(auto-reply): gate inline skill tool dispatch [AI]. (#78517) Thanks @pgondhi987.
 - Canvas plugin: keep legacy root `canvasHost` configs valid until `openclaw doctor --fix` migrates them into `plugins.entries.canvas.config.host`, move Canvas/A2UI clients to gateway protocol v4 plugin surfaces, and refresh the generated A2UI bundle hash so normal builds stay clean.
 - feishu: honor config write policy for dynamic agents [AI]. (#78520) Thanks @pgondhi987.

--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -1,3 +1,4 @@
+import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -10,7 +11,7 @@ import {
 
 type AgentRuntimeMetadata = {
   id: string;
-  source: "env" | "agent" | "defaults" | "implicit";
+  source: "session" | "env" | "agent" | "defaults" | "implicit";
 };
 
 function normalizeRuntimeValue(value: unknown): EmbeddedAgentRuntime | undefined {
@@ -58,4 +59,20 @@ export function resolveAgentRuntimeMetadata(
     id: "pi",
     source: "implicit",
   };
+}
+
+export function resolveSessionAgentRuntimeMetadata(
+  cfg: OpenClawConfig,
+  agentId: string,
+  sessionEntry?: Pick<SessionEntry, "agentRuntimeOverride">,
+  env: NodeJS.ProcessEnv = process.env,
+): AgentRuntimeMetadata {
+  const sessionRuntime = normalizeRuntimeValue(sessionEntry?.agentRuntimeOverride);
+  if (sessionRuntime && sessionRuntime !== "auto") {
+    return {
+      id: sessionRuntime,
+      source: "session",
+    };
+  }
+  return resolveAgentRuntimeMetadata(cfg, agentId, env);
 }

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -21,7 +21,7 @@ type AgentListEntry = {
   model?: string;
   agentRuntime?: {
     id: string;
-    source: "env" | "agent" | "defaults" | "implicit";
+    source: "session" | "env" | "agent" | "defaults" | "implicit";
   };
 };
 

--- a/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
@@ -735,6 +735,55 @@ describe("trigger handling", () => {
     });
   });
 
+  it("keeps native runtime model changes isolated to one Telegram forum topic", async () => {
+    await withTempHome(async (home) => {
+      const cfg = makeCfg(home);
+      cfg.session = {
+        ...cfg.session,
+        store: join(home, "native-model-runtime-topic.sessions.json"),
+      };
+      const storePath = requireSessionStorePath(cfg);
+      const slashSessionKey = "agent:main:telegram:slash:7595562691";
+      const topicOneSessionKey = "agent:main:telegram:group:-100123:topic:11";
+      const topicTwoSessionKey = "agent:main:telegram:group:-100123:topic:22";
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [topicOneSessionKey]: {
+            sessionId: "session-topic-one",
+            updatedAt: Date.now(),
+          },
+          [topicTwoSessionKey]: {
+            sessionId: "session-topic-two",
+            updatedAt: Date.now(),
+          },
+        }),
+      );
+
+      const res = await getReplyFromConfig(
+        makeNativeTelegramCommandMessage({
+          body: "/model openai/gpt-5.5 --runtime codex",
+          slashSessionKey,
+          targetSessionKey: topicOneSessionKey,
+        }),
+        {},
+        cfg,
+      );
+
+      expect(maybeReplyText(res)).toContain("Model set to openai/gpt-5.5");
+
+      const store = loadSessionStore(storePath);
+      expect(store[topicOneSessionKey]?.providerOverride).toBe("openai");
+      expect(store[topicOneSessionKey]?.modelOverride).toBe("gpt-5.5");
+      expect(store[topicOneSessionKey]?.agentRuntimeOverride).toBe("codex");
+      expect(store[topicTwoSessionKey]?.providerOverride).toBeUndefined();
+      expect(store[topicTwoSessionKey]?.modelOverride).toBeUndefined();
+      expect(store[topicTwoSessionKey]?.agentRuntimeOverride).toBeUndefined();
+      expect(store[slashSessionKey]).toBeUndefined();
+    });
+  });
+
   it("applies native model auth profile overrides to the target session", async () => {
     await withTempHome(async (home) => {
       const cfg = makeCfg(home);

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -45,6 +45,7 @@ export const AgentSummarySchema = Type.Object(
           id: NonEmptyString,
           fallback: Type.Optional(Type.Union([Type.Literal("pi"), Type.Literal("none")])),
           source: Type.Union([
+            Type.Literal("session"),
             Type.Literal("env"),
             Type.Literal("agent"),
             Type.Literal("defaults"),

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
-import { resolveAgentRuntimeMetadata } from "../../agents/agent-runtime-metadata.js";
+import {
+  resolveAgentRuntimeMetadata,
+  resolveSessionAgentRuntimeMetadata,
+} from "../../agents/agent-runtime-metadata.js";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
@@ -1601,7 +1604,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       provider: resolved.provider,
       model: resolved.model,
     });
-    const agentRuntime = resolveAgentRuntimeMetadata(cfg, agentId);
+    const agentRuntime = resolveSessionAgentRuntimeMetadata(cfg, agentId, applied.entry);
     const result: SessionsPatchResult = {
       ok: true,
       path: storePath,
@@ -1944,7 +1947,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         config: cfg,
         provider: resolvedModel.provider,
         model: resolvedModel.model,
-        agentHarnessId: entry?.sessionId === sessionId ? entry.agentHarnessId : undefined,
+        agentHarnessId:
+          entry?.sessionId === sessionId
+            ? (entry.agentRuntimeOverride ?? entry.agentHarnessId)
+            : undefined,
         thinkLevel: normalizeThinkLevel(entry?.thinkingLevel),
         reasoningLevel: normalizeReasoningLevel(entry?.reasoningLevel),
         bashElevated: {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1438,6 +1438,44 @@ describe("listSessionsFromStore selected model display", () => {
     });
   });
 
+  test("keeps session runtime overrides isolated between Telegram topics", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "openai/gpt-5.5",
+      agentRuntime: { id: "pi" },
+    });
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:telegram:group:-100123:topic:11": {
+          sessionId: "topic-11",
+          updatedAt: Date.now(),
+          providerOverride: "openai",
+          modelOverride: "gpt-5.5",
+          agentRuntimeOverride: "codex",
+        } as SessionEntry,
+        "agent:main:telegram:group:-100123:topic:22": {
+          sessionId: "topic-22",
+          updatedAt: Date.now(),
+          providerOverride: "openai",
+          modelOverride: "gpt-5.5",
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    const byKey = new Map(result.sessions.map((session) => [session.key, session]));
+    expect(byKey.get("agent:main:telegram:group:-100123:topic:11")?.agentRuntime).toEqual({
+      id: "codex",
+      source: "session",
+    });
+    expect(byKey.get("agent:main:telegram:group:-100123:topic:22")?.agentRuntime).toEqual({
+      id: "pi",
+      source: "defaults",
+    });
+  });
+
   test("infers canonical provider for bare CLI models before default-provider fallback", () => {
     const cfg = createModelDefaultsConfig({
       primary: "openai/gpt-5.4",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
+import {
+  resolveAgentRuntimeMetadata,
+  resolveSessionAgentRuntimeMetadata,
+} from "../agents/agent-runtime-metadata.js";
 import {
   listAgentIds,
   resolveAgentConfig,
@@ -1711,7 +1714,7 @@ export function buildGatewaySessionRow(params: {
   const latestCompactionCheckpoint = buildCompactionCheckpointPreview(
     resolveLatestCompactionCheckpoint(entry),
   );
-  const agentRuntime = resolveAgentRuntimeMetadata(cfg, sessionAgentId);
+  const agentRuntime = resolveSessionAgentRuntimeMetadata(cfg, sessionAgentId, entry);
   const selectedOrRuntimeModelProvider = selectedModel?.provider ?? modelProvider;
   const selectedOrRuntimeModel = selectedModel?.model ?? model;
   const rowModelIdentity = lightweight

--- a/src/shared/session-types.ts
+++ b/src/shared/session-types.ts
@@ -14,7 +14,7 @@ export type GatewayAgentModel = {
 export type GatewayAgentRuntime = {
   id: string;
   fallback?: "pi" | "none";
-  source: "env" | "agent" | "defaults" | "implicit";
+  source: "session" | "env" | "agent" | "defaults" | "implicit";
 };
 
 export type GatewayAgentRow = {

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -143,7 +143,8 @@ async function resolveStatusHarnessId(params: {
       config: params.cfg,
       agentId: params.agentId,
       sessionKey: params.sessionKey,
-      agentHarnessId: params.sessionEntry?.agentHarnessId,
+      agentHarnessId:
+        params.sessionEntry?.agentRuntimeOverride ?? params.sessionEntry?.agentHarnessId,
     });
     const id = normalizeOptionalLowercaseString(selected.id);
     return id && id !== "pi" ? id : undefined;


### PR DESCRIPTION
Summary
- Report per-session runtime overrides in session/status surfaces.
- Prefer session-scoped `agentRuntimeOverride` when resolving status harness metadata.
- Add regression coverage for Telegram forum topics so `/model --runtime` stays topic-scoped.

Verification
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/agents/agent-runtime-metadata.ts src/gateway/protocol/schema/agents-models-skills.ts src/gateway/server-methods/sessions.ts src/gateway/session-utils.ts src/shared/session-types.ts src/status/status-text.ts src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts src/gateway/session-utils.test.ts`
- Not run locally: Vitest. GitHub workflows will validate.
