### PR TITLE
fix(gateway): preserve text from oversized multimodal history

### DIFF
--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -1986,6 +1986,36 @@ describe("oversized transcript line guards", () => {
     expect(serialized).toContain("after oversized");
   });
 
+  test("readRecentSessionMessagesAsync preserves text blocks from oversized multimodal lines", async () => {
+    const sessionId = "test-oversized-multimodal-text";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const hugeImage = "A".repeat(300 * 1024);
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: sessionId }),
+      JSON.stringify({
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Please summarize this chart" },
+            { type: "image", mimeType: "image/png", data: hugeImage },
+          ],
+        },
+      }),
+    ];
+    fs.writeFileSync(transcriptPath, `${lines.join("\n")}\n`, "utf-8");
+
+    const out = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 10,
+    });
+
+    expect(out).toHaveLength(1);
+    const serialized = JSON.stringify(out);
+    expect(serialized).toContain("Please summarize this chart");
+    expect(serialized).toContain("[image omitted: too large]");
+    expect(serialized).not.toContain(hugeImage);
+    expect(serialized).not.toContain("[chat.history omitted: message too large]");
+  });
+
   test("readRecentSessionMessagesAsync keeps oversized active-tree leaves", async () => {
     const sessionId = "test-oversized-tree-tail";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -269,6 +269,8 @@ async function readRecentTranscriptTailLinesAsync(
 const MAX_TRANSCRIPT_PARSE_LINE_BYTES = 256 * 1024;
 const OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS = 64 * 1024;
 const TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER = "[chat.history omitted: message too large]";
+const TRANSCRIPT_OVERSIZED_IMAGE_PLACEHOLDER = "[image omitted: too large]";
+const TRANSCRIPT_OVERSIZED_TEXT_BLOCK_MAX_CHARS = 8 * 1024;
 
 function isOversizedTranscriptLine(line: string): boolean {
   return Buffer.byteLength(line, "utf8") > MAX_TRANSCRIPT_PARSE_LINE_BYTES;
@@ -297,20 +299,87 @@ function extractJsonNullableStringFieldPrefix(
   return extractJsonStringFieldPrefix(prefix, field);
 }
 
+function extractOversizedTranscriptTextBlocks(line: string): Array<Record<string, unknown>> {
+  const textBlocks: Array<Record<string, unknown>> = [];
+  const contentKey = '"content"';
+  const contentIndex = line.indexOf(contentKey);
+  if (contentIndex < 0) {
+    return textBlocks;
+  }
+  let searchIndex = contentIndex + contentKey.length;
+  while (true) {
+    const typeIndex = line.indexOf('"type":"text"', searchIndex);
+    if (typeIndex < 0) {
+      break;
+    }
+    const textKeyIndex = line.indexOf('"text":"', typeIndex);
+    if (textKeyIndex < 0) {
+      break;
+    }
+    const textStart = textKeyIndex + '"text":"'.length;
+    let i = textStart;
+    let escaped = false;
+    while (i < line.length) {
+      const ch = line[i];
+      if (escaped) {
+        escaped = false;
+        i += 1;
+        continue;
+      }
+      if (ch === "\\") {
+        escaped = true;
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        break;
+      }
+      i += 1;
+    }
+    if (i >= line.length) {
+      break;
+    }
+    const encoded = line.slice(textStart, i);
+    try {
+      const decoded = JSON.parse(`"${encoded}"`) as unknown;
+      const text = normalizeTailEntryString(decoded);
+      if (text) {
+        const clipped =
+          text.length > TRANSCRIPT_OVERSIZED_TEXT_BLOCK_MAX_CHARS
+            ? `${text.slice(0, TRANSCRIPT_OVERSIZED_TEXT_BLOCK_MAX_CHARS)}…`
+            : text;
+        textBlocks.push({ type: "text", text: clipped });
+      }
+    } catch {
+      // Ignore malformed blocks and keep scanning.
+    }
+    searchIndex = i + 1;
+  }
+  return textBlocks;
+}
+
 function buildOversizedTranscriptRecord(line: string): TailTranscriptRecord {
   const prefix = line.slice(0, OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS);
   const id = extractJsonStringFieldPrefix(prefix, "id");
   const parentId = extractJsonNullableStringFieldPrefix(prefix, "parentId");
   const type = extractJsonStringFieldPrefix(prefix, "type");
   const role = extractJsonStringFieldPrefix(prefix, "role") ?? "assistant";
+  const preservedTextBlocks = extractOversizedTranscriptTextBlocks(line);
+  const content = preservedTextBlocks.length
+    ? [...preservedTextBlocks, { type: "text", text: TRANSCRIPT_OVERSIZED_IMAGE_PLACEHOLDER }]
+    : [{ type: "text", text: TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER }];
   const record: Record<string, unknown> = {
     ...(type ? { type } : {}),
     ...(id ? { id } : {}),
     ...(parentId !== undefined ? { parentId } : {}),
     message: {
       role,
-      content: [{ type: "text", text: TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER }],
-      __openclaw: { truncated: true, reason: "oversized" },
+      content,
+      __openclaw: {
+        truncated: true,
+        reason: "oversized",
+        preservedText: preservedTextBlocks.length > 0,
+      },
     },
   };
   return {


### PR DESCRIPTION
## Summary
- preserve recoverable text blocks from oversized multimodal transcript lines
- replace omitted large image payloads with a lightweight placeholder instead of dropping the full message
- add a regression test covering text + oversized image history replay

Fixes #78729

## Root cause
When a transcript JSONL line exceeded the oversized-line guard, the tail reader fell back to a generic placeholder record and replaced the entire message with `[chat.history omitted: message too large]`. That meant a large inline image/base64 payload could cause nearby normal text in the same multimodal message to disappear from `chat.history`.

## Testing
- `pnpm test -- src/gateway/session-utils.fs.test.ts`
