### PR TITLE
perf(slack): reduce message hot-path overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Windows: bind the default loopback gateway listener only to `127.0.0.1` on Windows so libuv's dual-stack `::1` behavior cannot wedge localhost HTTP requests. (#69701, fixes #69674) Thanks @SARAMALI15792.
 - Slack/streaming: add `streaming.progress.render: "rich"` for Block Kit progress drafts backed by structured progress line data.
 - Slack/streaming: keep the newest rich progress lines when Block Kit limits trim long progress drafts. Thanks @vincentkoc.
+- Slack/performance: reduce message preparation, stream recipient lookup, and thread-context allocation overhead on Slack reply hot paths. Thanks @vincentkoc.
 - Channels/streaming: cap progress-draft tool lines by default so edited progress boxes avoid jumpy reflow from long wrapped lines.
 - Control UI/chat: add an agent-first filter to the chat session picker, keep chat controls/composer responsive across phone/tablet/desktop widths, keep desktop chat controls on one row, avoid duplicate avatar refreshes during initial chat load, and hide that row while scrolling down the transcript. Thanks @BunsDev.
 - Control UI/chat: collapse consecutive duplicate text messages into one bubble with a count so repeated text-only messages stay compact without hiding nearby context.

--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createSlackTurnDeliveryTracker,
   isSlackStreamingEnabled,
+  resetSlackStreamRecipientTeamCacheForTests,
   resolveSlackDisableBlockStreaming,
   resolveSlackStreamRecipientTeamId,
   resolveSlackStreamingThreadHint,
   shouldEnableSlackPreviewStreaming,
   shouldInitializeSlackDraftStream,
 } from "./dispatch.js";
+
+afterEach(() => {
+  resetSlackStreamRecipientTeamCacheForTests();
+});
 
 describe("slack native streaming defaults", () => {
   it("is enabled for partial mode when native streaming is on", () => {
@@ -92,6 +97,26 @@ describe("slack native streaming recipient team", () => {
         fallbackTeamId: "T_LOCAL",
       }),
     ).toBe("T_LOCAL");
+  });
+
+  it("caches resolved user teams for repeated stream starts", async () => {
+    const usersInfo = vi.fn(async () => ({
+      user: { team_id: "T_LOOKUP" },
+    }));
+    const params = {
+      client: {
+        users: {
+          info: usersInfo,
+        },
+      } as never,
+      token: "xoxb-test",
+      userId: "U_REMOTE",
+      fallbackTeamId: "T_LOCAL",
+    };
+
+    await expect(resolveSlackStreamRecipientTeamId(params)).resolves.toBe("T_LOOKUP");
+    await expect(resolveSlackStreamRecipientTeamId(params)).resolves.toBe("T_LOOKUP");
+    expect(usersInfo).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -177,6 +177,9 @@ type SlackTurnDeliveryAttempt = {
   textOverride?: string;
 };
 
+const SLACK_STREAM_RECIPIENT_TEAM_CACHE_MAX = 2000;
+const slackStreamRecipientTeamCache = new Map<string, string>();
+
 function buildSlackTurnDeliveryKey(params: SlackTurnDeliveryAttempt): string | null {
   const reply = resolveSendableOutboundReplyParts(params.payload, {
     text: params.textOverride,
@@ -193,6 +196,48 @@ function buildSlackTurnDeliveryKey(params: SlackTurnDeliveryAttempt): string | n
     mediaUrls: reply.mediaUrls,
     blocks: slackBlocks ?? null,
   });
+}
+
+function readSlackStreamRecipientTeamCache(params: {
+  fallbackTeamId?: string;
+  userId?: string;
+}): string | undefined {
+  if (!params.fallbackTeamId || !params.userId) {
+    return undefined;
+  }
+  const cacheKey = `${params.fallbackTeamId}:${params.userId}`;
+  const cached = slackStreamRecipientTeamCache.get(cacheKey);
+  if (!cached) {
+    return undefined;
+  }
+  slackStreamRecipientTeamCache.delete(cacheKey);
+  slackStreamRecipientTeamCache.set(cacheKey, cached);
+  return cached;
+}
+
+function rememberSlackStreamRecipientTeam(params: {
+  fallbackTeamId?: string;
+  userId?: string;
+  teamId: string;
+}): void {
+  if (!params.fallbackTeamId || !params.userId) {
+    return;
+  }
+  const cacheKey = `${params.fallbackTeamId}:${params.userId}`;
+  if (slackStreamRecipientTeamCache.has(cacheKey)) {
+    slackStreamRecipientTeamCache.delete(cacheKey);
+  }
+  slackStreamRecipientTeamCache.set(cacheKey, params.teamId);
+  if (slackStreamRecipientTeamCache.size > SLACK_STREAM_RECIPIENT_TEAM_CACHE_MAX) {
+    const oldest = slackStreamRecipientTeamCache.keys().next().value;
+    if (oldest) {
+      slackStreamRecipientTeamCache.delete(oldest);
+    }
+  }
+}
+
+export function resetSlackStreamRecipientTeamCacheForTests(): void {
+  slackStreamRecipientTeamCache.clear();
 }
 
 export function createSlackTurnDeliveryTracker() {
@@ -231,6 +276,10 @@ export async function resolveSlackStreamRecipientTeamId(params: {
   userId?: PreparedSlackMessage["message"]["user"];
   fallbackTeamId?: string;
 }): Promise<string | undefined> {
+  const cachedTeamId = readSlackStreamRecipientTeamCache(params);
+  if (cachedTeamId) {
+    return cachedTeamId;
+  }
   if (params.userId) {
     try {
       const info = await params.client.users.info({
@@ -239,6 +288,7 @@ export async function resolveSlackStreamRecipientTeamId(params: {
       });
       const teamId = info.user?.team_id ?? info.user?.profile?.team;
       if (teamId) {
+        rememberSlackStreamRecipientTeam({ ...params, teamId });
         return teamId;
       }
     } catch (err) {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -109,7 +109,13 @@ const UNICODE_TO_SLACK: Record<string, string> = {
 };
 
 function toSlackEmojiName(emoji: string): string {
-  const trimmed = emoji.trim().replace(/^:+|:+$/g, "");
+  let trimmed = emoji.trim();
+  while (trimmed.startsWith(":")) {
+    trimmed = trimmed.slice(1);
+  }
+  while (trimmed.endsWith(":")) {
+    trimmed = trimmed.slice(0, -1);
+  }
   return UNICODE_TO_SLACK[trimmed] ?? trimmed;
 }
 

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -262,29 +262,29 @@ export async function resolveSlackMessageContent(params: {
     threadStarter: params.threadStarter,
   });
 
-  const media =
+  const mediaPromise =
     ownFiles && ownFiles.length > 0
-      ? await (async () => {
-          const { resolveSlackMedia } = await loadSlackMediaModule();
-          return resolveSlackMedia({
+      ? loadSlackMediaModule().then(({ resolveSlackMedia }) =>
+          resolveSlackMedia({
             files: ownFiles,
             token: params.botToken,
             maxBytes: params.mediaMaxBytes,
-          });
-        })()
-      : null;
+          }),
+        )
+      : Promise.resolve(null);
 
-  const attachmentContent =
+  const attachmentContentPromise =
     params.message.attachments && params.message.attachments.length > 0
-      ? await (async () => {
-          const { resolveSlackAttachmentContent } = await loadSlackMediaModule();
-          return resolveSlackAttachmentContent({
+      ? loadSlackMediaModule().then(({ resolveSlackAttachmentContent }) =>
+          resolveSlackAttachmentContent({
             attachments: params.message.attachments,
             token: params.botToken,
             maxBytes: params.mediaMaxBytes,
-          });
-        })()
-      : null;
+          }),
+        )
+      : Promise.resolve(null);
+
+  const [media, attachmentContent] = await Promise.all([mediaPromise, attachmentContentPromise]);
 
   const mergedMedia = [...(media ?? []), ...(attachmentContent?.media ?? [])];
   const effectiveDirectMedia = mergedMedia.length > 0 ? mergedMedia : null;

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -13,6 +13,7 @@ type SlackResolvedMessageContent = {
 
 const SLACK_MENTION_RESOLUTION_CONCURRENCY = 4;
 const SLACK_MENTION_RESOLUTION_MAX_LOOKUPS_PER_MESSAGE = 20;
+const SLACK_USER_MENTION_RE = /<@([A-Z0-9]+)(?:\|[^>]+)?>/gi;
 
 type SlackTextObject = {
   text?: unknown;
@@ -54,7 +55,8 @@ function collectUniqueSlackMentionIds(texts: Array<string | undefined>): string[
     if (!text) {
       continue;
     }
-    for (const match of text.matchAll(/<@([A-Z0-9]+)(?:\|[^>]+)?>/gi)) {
+    SLACK_USER_MENTION_RE.lastIndex = 0;
+    for (const match of text.matchAll(SLACK_USER_MENTION_RE)) {
       const userId = match[1];
       if (!userId || seen.has(userId)) {
         continue;
@@ -73,7 +75,8 @@ function renderSlackUserMentions(
   if (!text || renderedMentions.size === 0) {
     return text;
   }
-  return text.replace(/<@([A-Z0-9]+)(?:\|[^>]+)?>/gi, (full, userId: string) => {
+  SLACK_USER_MENTION_RE.lastIndex = 0;
+  return text.replace(SLACK_USER_MENTION_RE, (full, userId: string) => {
     const rendered = renderedMentions.get(userId);
     return rendered ?? full;
   });
@@ -139,16 +142,19 @@ function renderSlackRichTextElements(elements: unknown): string {
         break;
       }
       case "rich_text_list": {
-        const listText = Array.isArray(element.elements)
-          ? element.elements
-              .map((child) =>
-                child && typeof child === "object"
-                  ? renderSlackRichTextElements((child as SlackRichTextElement).elements)
-                  : "",
-              )
-              .filter(Boolean)
-              .join("\n")
-          : "";
+        const listParts: string[] = [];
+        if (Array.isArray(element.elements)) {
+          for (const child of element.elements) {
+            if (!child || typeof child !== "object") {
+              continue;
+            }
+            const rendered = renderSlackRichTextElements((child as SlackRichTextElement).elements);
+            if (rendered) {
+              listParts.push(rendered);
+            }
+          }
+        }
+        const listText = listParts.join("\n");
         parts.push(listText);
         break;
       }
@@ -174,7 +180,13 @@ function readSlackBlockText(block: unknown): string | undefined {
         return text;
       }
       if (Array.isArray(blockLike.fields)) {
-        const fields = blockLike.fields.map(readTextObject).filter(Boolean);
+        const fields: string[] = [];
+        for (const field of blockLike.fields) {
+          const fieldText = readTextObject(field);
+          if (fieldText) {
+            fields.push(fieldText);
+          }
+        }
         return fields.length > 0 ? fields.join("\n") : undefined;
       }
       return undefined;
@@ -185,7 +197,13 @@ function readSlackBlockText(block: unknown): string | undefined {
       if (!Array.isArray(blockLike.elements)) {
         return undefined;
       }
-      const parts = blockLike.elements.map(readTextObject).filter(Boolean);
+      const parts: string[] = [];
+      for (const element of blockLike.elements) {
+        const text = readTextObject(element);
+        if (text) {
+          parts.push(text);
+        }
+      }
       return parts.length > 0 ? parts.join(" ") : undefined;
     }
     case "image":
@@ -205,7 +223,13 @@ function resolveSlackBlocksText(blocks: unknown[] | undefined): string | undefin
   if (!blocks?.length) {
     return undefined;
   }
-  const parts = blocks.map(readSlackBlockText).filter(Boolean);
+  const parts: string[] = [];
+  for (const block of blocks) {
+    const text = readSlackBlockText(block);
+    if (text) {
+      parts.push(text);
+    }
+  }
   return parts.length > 0 ? parts.join("\n") : undefined;
 }
 
@@ -302,17 +326,19 @@ export async function resolveSlackMessageContent(params: {
       : undefined;
   const fileOnlyPlaceholder = fileOnlyFallback ? `[Slack file: ${fileOnlyFallback}]` : undefined;
 
-  const botAttachmentText =
-    params.isBotMessage && !attachmentContent?.text
-      ? (params.message.attachments ?? [])
-          .map(
-            (attachment) =>
-              normalizeOptionalString(attachment.text) ??
-              normalizeOptionalString(attachment.fallback),
-          )
-          .filter(Boolean)
-          .join("\n")
-      : undefined;
+  let botAttachmentText: string | undefined;
+  if (params.isBotMessage && !attachmentContent?.text) {
+    const botAttachmentTextParts: string[] = [];
+    for (const attachment of params.message.attachments ?? []) {
+      const text =
+        normalizeOptionalString(attachment.text) ?? normalizeOptionalString(attachment.fallback);
+      if (text) {
+        botAttachmentTextParts.push(text);
+      }
+    }
+    botAttachmentText =
+      botAttachmentTextParts.length > 0 ? botAttachmentTextParts.join("\n") : undefined;
+  }
 
   const blocksText = resolveSlackBlocksText(params.message.blocks);
   const primaryText = chooseSlackPrimaryText({

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -1,4 +1,5 @@
 import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
+import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import type { ContextVisibilityMode } from "openclaw/plugin-sdk/config-types";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -29,6 +30,8 @@ type SlackThreadContextData = {
   threadStarterMedia: SlackMediaResult[] | null;
 };
 
+const SLACK_THREAD_CONTEXT_USER_LOOKUP_CONCURRENCY = 4;
+
 function isSlackThreadContextSenderAllowed(params: {
   allowFromLower: string[];
   allowNameMatching: boolean;
@@ -48,6 +51,38 @@ function isSlackThreadContextSenderAllowed(params: {
     name: params.userName,
     allowNameMatching: params.allowNameMatching,
   }).allowed;
+}
+
+async function resolveSlackThreadUserMap(params: {
+  ctx: SlackMonitorContext;
+  messages: SlackThreadStarter[];
+}): Promise<Map<string, { name?: string }>> {
+  const uniqueUserIds: string[] = [];
+  const seen = new Set<string>();
+  for (const item of params.messages) {
+    if (!item.userId || seen.has(item.userId)) {
+      continue;
+    }
+    seen.add(item.userId);
+    uniqueUserIds.push(item.userId);
+  }
+  const userMap = new Map<string, { name?: string }>();
+  if (uniqueUserIds.length === 0) {
+    return userMap;
+  }
+  const { results } = await runTasksWithConcurrency({
+    tasks: uniqueUserIds.map((id) => async () => {
+      const user = await params.ctx.resolveUserName(id);
+      return user ? { id, user } : null;
+    }),
+    limit: SLACK_THREAD_CONTEXT_USER_LOOKUP_CONCURRENCY,
+  });
+  for (const result of results) {
+    if (result) {
+      userMap.set(result.id, result.user);
+    }
+  }
+  return userMap;
 }
 
 export async function resolveSlackThreadContextData(params: {
@@ -92,7 +127,7 @@ export async function resolveSlackThreadContextData(params: {
 
   const starter = params.threadStarter;
   const starterSenderName =
-    params.allowNameMatching && starter?.userId
+    params.allowNameMatching && params.allowFromLower.length > 0 && starter?.userId
       ? (await params.ctx.resolveUserName(starter.userId))?.name
       : undefined;
   const starterIsCurrentBot = Boolean(
@@ -174,39 +209,37 @@ export async function resolveSlackThreadContextData(params: {
       const omittedCurrentBotHistoryCount =
         threadHistory.length - threadHistoryWithoutCurrentBot.length;
 
-      const uniqueUserIds = [
-        ...new Set(
-          threadHistoryWithoutCurrentBot
-            .map((item) => item.userId)
-            .filter((id): id is string => Boolean(id)),
-        ),
-      ];
-      const userMap = new Map<string, { name?: string }>();
-      await Promise.all(
-        uniqueUserIds.map(async (id) => {
-          const user = await params.ctx.resolveUserName(id);
-          if (user) {
-            userMap.set(id, user);
-          }
-        }),
-      );
-
+      const userMapForFilter =
+        params.contextVisibilityMode !== "all" &&
+        params.allowNameMatching &&
+        params.allowFromLower.length > 0
+          ? await resolveSlackThreadUserMap({
+              ctx: params.ctx,
+              messages: threadHistoryWithoutCurrentBot,
+            })
+          : new Map<string, { name?: string }>();
       const { items: filteredThreadHistory, omitted: omittedHistoryCount } =
-        filterSupplementalContextItems({
-          items: threadHistoryWithoutCurrentBot,
-          mode: params.contextVisibilityMode,
-          kind: "thread",
-          isSenderAllowed: (historyMsg) => {
-            const msgUser = historyMsg.userId ? userMap.get(historyMsg.userId) : null;
-            return isSlackThreadContextSenderAllowed({
-              allowFromLower: params.allowFromLower,
-              allowNameMatching: params.allowNameMatching,
-              userId: historyMsg.userId,
-              userName: msgUser?.name,
-              botId: historyMsg.botId,
+        params.contextVisibilityMode === "all"
+          ? { items: threadHistoryWithoutCurrentBot, omitted: 0 }
+          : filterSupplementalContextItems({
+              items: threadHistoryWithoutCurrentBot,
+              mode: params.contextVisibilityMode,
+              kind: "thread",
+              isSenderAllowed: (historyMsg) => {
+                const msgUser = historyMsg.userId ? userMapForFilter.get(historyMsg.userId) : null;
+                return isSlackThreadContextSenderAllowed({
+                  allowFromLower: params.allowFromLower,
+                  allowNameMatching: params.allowNameMatching,
+                  userId: historyMsg.userId,
+                  userName: msgUser?.name,
+                  botId: historyMsg.botId,
+                });
+              },
             });
-          },
-        });
+      const userMap = await resolveSlackThreadUserMap({
+        ctx: params.ctx,
+        messages: filteredThreadHistory,
+      });
       if (omittedHistoryCount > 0 || omittedCurrentBotHistoryCount > 0) {
         logVerbose(
           `slack: omitted ${omittedHistoryCount + omittedCurrentBotHistoryCount} thread message(s) from context (mode=${params.contextVisibilityMode})`,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -67,6 +67,8 @@ import { isSlackSubteamMentionForBot } from "./subteam-mentions.js";
 import type { PreparedSlackMessage } from "./types.js";
 
 const mentionRegexCache = new WeakMap<SlackMonitorContext, Map<string, RegExp[]>>();
+const SLACK_ANY_MENTION_RE = /<@[^>]+>|<!subteam\^[^>]+>/;
+const SLACK_SUBTEAM_MENTION_MARKER = "<!subteam^";
 
 function resolveCachedMentionRegexes(
   ctx: SlackMonitorContext,
@@ -286,17 +288,20 @@ export async function prepareSlackMessage(params: {
     return null;
   }
   const { senderId, allowFromLower } = authorization;
-  const hasAnyMention = /<@[^>]+>|<!subteam\^[^>]+>/.test(message.text ?? "");
+  const messageText = message.text ?? "";
+  const hasAnyMention = SLACK_ANY_MENTION_RE.test(messageText);
+  const hasSubteamMention = messageText.includes(SLACK_SUBTEAM_MENTION_MARKER);
   const explicitlyMentioned = Boolean(
     ctx.botUserId &&
-    (message.text?.includes(`<@${ctx.botUserId}>`) ||
-      (await isSlackSubteamMentionForBot({
-        client: ctx.app.client,
-        text: message.text,
-        botUserId: ctx.botUserId,
-        teamId: ctx.teamId,
-        log: logVerbose,
-      }))),
+    (messageText.includes(`<@${ctx.botUserId}>`) ||
+      (hasSubteamMention &&
+        (await isSlackSubteamMentionForBot({
+          client: ctx.app.client,
+          text: messageText,
+          botUserId: ctx.botUserId,
+          teamId: ctx.teamId,
+          log: logVerbose,
+        })))),
   );
   const seedTopLevelRoomThreadBySource =
     opts.source === "app_mention" || opts.wasMentioned === true || explicitlyMentioned;
@@ -315,7 +320,7 @@ export async function prepareSlackMessage(params: {
     opts.wasMentioned ??
     (!isDirectMessage &&
       matchesMentionWithExplicit({
-        text: message.text ?? "",
+        text: messageText,
         mentionRegexes,
         explicit: {
           hasAnyMention,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -369,20 +369,30 @@ export async function prepareSlackMessage(params: {
       `slack: routed via bound conversation ${runtimeBinding.conversation.conversationId} -> ${runtimeBinding.targetSessionKey}`,
     );
   }
-  const implicitMentionKinds =
-    isDirectMessage || !ctx.botUserId || !message.thread_ts
-      ? []
-      : [
-          ...implicitMentionKindWhen("reply_to_bot", message.parent_user_id === ctx.botUserId),
-          ...implicitMentionKindWhen(
+  let implicitMentionKinds: ReturnType<typeof implicitMentionKindWhen> = [];
+  if (
+    !isDirectMessage &&
+    ctx.botUserId &&
+    message.thread_ts &&
+    !ctx.threadRequireExplicitMention &&
+    !wasMentioned
+  ) {
+    const replyToBotKinds = implicitMentionKindWhen(
+      "reply_to_bot",
+      message.parent_user_id === ctx.botUserId,
+    );
+    implicitMentionKinds =
+      replyToBotKinds.length > 0
+        ? replyToBotKinds
+        : implicitMentionKindWhen(
             "bot_thread_participant",
             await hasSlackThreadParticipationWithPersistence({
               accountId: account.accountId,
               channelId: message.channel,
               threadTs: message.thread_ts,
             }),
-          ),
-        ];
+          );
+  }
 
   let resolvedSenderName = normalizeOptionalString(message.username);
   const resolveSenderName = async (): Promise<string> => {

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -163,9 +163,9 @@ export async function resolveSlackThreadHistory(params: {
           continue;
         }
         retained.push(msg);
-        if (retained.length > maxMessages) {
-          retained.shift();
-        }
+      }
+      if (retained.length > maxMessages) {
+        retained.splice(0, retained.length - maxMessages);
       }
 
       const next = response.response_metadata?.next_cursor;


### PR DESCRIPTION
## Summary

- Cherry-picks the Slack message hot-path perf slice from `perf/telegram-slack-rtt-20260503`.
- Reduces Slack message preparation allocations, caches native stream recipient team lookups, reuses thread-participation state, and trims thread-context history retention work.
- Adds a changelog note for the Slack reply hot-path performance improvement.

Source commits:
- https://github.com/openclaw/openclaw/commit/9962328b7cf00e94e5d52abb725b1682a71c8d7c
- https://github.com/openclaw/openclaw/commit/8ce7cc8aae5b11d45993e82d2e0db0c7fbe52fa2
- https://github.com/openclaw/openclaw/commit/098a8b34b9aad6e1314330876e17d970faa19960
- https://github.com/openclaw/openclaw/commit/0caa419f76bdc3bd5eefc24edef1422da78a7d74

## Verification

- Crabbox `tbx_01kr06bg73x3mk2vfrrv3076jr`: `pnpm test extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts extensions/slack/src/monitor/message-handler.test.ts extensions/slack/src/monitor/replies.test.ts extensions/slack/src/monitor/monitor.thread-resolution.test.ts extensions/slack/src/monitor.threading.missing-thread-ts.test.ts extensions/slack/src/threading.test.ts` (10 files, 149 tests)
- Crabbox `tbx_01kr06dbjf7z4ajch55jjn3q47`: `pnpm check:changed` (extensions + extensionTests lanes)
- Crabbox `tbx_01kr06p31mkhvzpj70s162fcex`: `pnpm test extensions/slack` (91 files, 925 tests)
- Mantis Slack Desktop Smoke / Crabbox AWS: `slack-canary` passed against `d7a8201b0510c53d4477efe1104bc0dc92b33f68` in https://github.com/openclaw/openclaw/actions/runs/25474033044 (artifact https://github.com/openclaw/openclaw/actions/runs/25474033044/artifacts/6846354538)
- Mantis Slack Desktop Smoke / Crabbox Hetzner: `slack-thread-follow-up` passed against `d7a8201b0510c53d4477efe1104bc0dc92b33f68` in https://github.com/openclaw/openclaw/actions/runs/25475954203 (artifact https://github.com/openclaw/openclaw/actions/runs/25475954203/artifacts/6847037521)
- `git diff --check origin/main...HEAD`
- `pnpm check:changelog-attributions`

Note: an intermediate AWS retry for `slack-thread-follow-up` was canceled after Crabbox AWS bootstrap/quota fallback never reached Slack; the same scenario passed on Hetzner and is the counted thread-path proof.
