### PR TITLE
fix(ui): hide sender metadata envelopes in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/chat: strip untrusted sender metadata envelope blocks from system and unknown-role display messages, so internal `openclaw-control-ui` sender JSON no longer appears as chat content. Fixes #78739. Thanks @guguangxin-eng.
 - Exec approvals/node: let trusted backend node invokes complete no-device Control UI approvals after the original request connection changes, while keeping node, command, cwd, env, and allow-once replay bindings enforced. Fixes #78569. Thanks @naturedogdog.
 - CLI/completion: guard the shell-profile source line written by `openclaw completion --install` with a file existence check (`[ -f ... ] && source ...` for bash/zsh, `test -f ...; and source ...` for fish) so uninstalling OpenClaw no longer makes new login shells error on a missing completion cache. (#78659) Thanks @sjf.
 - Cron/doctor: repair persisted cron jobs whose `payload.model` was stored as `"default"`, `"null"`, blank, or JSON `null` by removing the bad override during `openclaw doctor --fix` while keeping cron runtime model validation strict. Fixes #78549. Thanks @bizzle12368239.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/chat: strip untrusted sender metadata envelope blocks from system and unknown-role display messages, so internal `openclaw-control-ui` sender JSON no longer appears as chat content. Fixes #78739. Thanks @guguangxin-eng.
+- Gateway/chat: skip sender identity fields (SenderId, SenderName, SenderUsername) for operator UI clients (Control UI, TUI) in chat.send so the internal client ID is never used as a sender label and no Sender block is injected into agent prompts or stored in session transcripts. Fixes #78739. Thanks @hclsys.
 - Exec approvals/node: let trusted backend node invokes complete no-device Control UI approvals after the original request connection changes, while keeping node, command, cwd, env, and allow-once replay bindings enforced. Fixes #78569. Thanks @naturedogdog.
 - CLI/completion: guard the shell-profile source line written by `openclaw completion --install` with a file existence check (`[ -f ... ] && source ...` for bash/zsh, `test -f ...; and source ...` for fish) so uninstalling OpenClaw no longer makes new login shells error on a missing completion cache. (#78659) Thanks @sjf.
 - Cron/doctor: repair persisted cron jobs whose `payload.model` was stored as `"default"`, `"null"`, blank, or JSON `null` by removing the bad override during `openclaw doctor --fix` while keeping cron runtime model validation strict. Fixes #78549. Thanks @bizzle12368239.

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -3431,3 +3431,33 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
   });
 });
+
+describe("chat.send operator UI client sender context", () => {
+  it("does not inject SenderId/SenderName into MsgContext for Control UI clients", async () => {
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-control-ui-sender",
+      message: "hello from control ui",
+      client: {
+        connect: {
+          client: {
+            id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            version: "dev",
+            platform: "web",
+          },
+          scopes: ["operator.write"],
+        },
+      },
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx?.SenderId).toBeUndefined();
+    expect(mockState.lastDispatchCtx?.SenderName).toBeUndefined();
+    expect(mockState.lastDispatchCtx?.SenderUsername).toBeUndefined();
+  });
+});

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -51,6 +51,7 @@ import {
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isGatewayCliClient,
+  isOperatorUiClient,
   isWebchatClient,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
@@ -2266,9 +2267,13 @@ export const chatHandlers: GatewayRequestHandlers = {
         ...(commandSource ? { CommandSource: commandSource } : {}),
         CommandAuthorized: true,
         MessageSid: clientRunId,
-        SenderId: clientInfo?.id,
-        SenderName: clientInfo?.displayName,
-        SenderUsername: clientInfo?.displayName,
+        ...(!isOperatorUiClient(clientInfo)
+          ? {
+              SenderId: clientInfo?.id,
+              SenderName: clientInfo?.displayName,
+              SenderUsername: clientInfo?.displayName,
+            }
+          : {}),
         GatewayClientScopes: client?.connect?.scopes ?? [],
         ...pluginBoundMediaFields,
       };

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -29,6 +29,26 @@ describe("message-normalizer", () => {
       });
     });
 
+    it("strips sender metadata blocks from user messages before display", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content:
+          'Sender (untrusted metadata):\n```json\n{"label":"openclaw-control-ui","id":"openclaw-control-ui"}\n```\n\nhello',
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+    });
+
+    it("drops standalone sender metadata system messages before display", () => {
+      const result = normalizeMessage({
+        role: "system",
+        content:
+          'Sender (untrusted metadata):\n```json\n{"label":"openclaw-control-ui","id":"openclaw-control-ui"}\n```',
+      });
+
+      expect(result.content).toEqual([]);
+    });
+
     it("does not reinterpret directive-like user string content", () => {
       const result = normalizeMessage({
         role: "user",

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -158,6 +158,22 @@ function mergeAdjacentTextItems(items: MessageContentItem[]): MessageContentItem
   return merged.filter((item) => item.type !== "text" || Boolean(item.text?.trim()));
 }
 
+function shouldStripDisplayMetadata(role: string): boolean {
+  const normalizedRole = role.trim().toLowerCase();
+  return normalizedRole === "user" || normalizedRole === "system" || normalizedRole === "unknown";
+}
+
+function stripDisplayMetadataFromContent(items: MessageContentItem[]): MessageContentItem[] {
+  return items
+    .map((item) => {
+      if (item.type !== "text" || typeof item.text !== "string") {
+        return item;
+      }
+      return { ...item, text: stripInboundMetadata(item.text) };
+    })
+    .filter((item) => item.type !== "text" || Boolean(item.text?.trim()));
+}
+
 function expandTextContent(text: string): {
   content: MessageContentItem[];
   audioAsVoice: boolean;
@@ -370,14 +386,9 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   const senderLabel =
     typeof m.senderLabel === "string" && m.senderLabel.trim() ? m.senderLabel.trim() : null;
 
-  // Strip AI-injected metadata prefix blocks from user messages before display.
-  if (role === "user" || role === "User") {
-    content = content.map((item) => {
-      if (item.type === "text" && typeof item.text === "string") {
-        return { ...item, text: stripInboundMetadata(item.text) };
-      }
-      return item;
-    });
+  // Strip AI-injected metadata blocks from non-assistant display messages.
+  if (shouldStripDisplayMetadata(role)) {
+    content = stripDisplayMetadataFromContent(content);
   }
 
   return {


### PR DESCRIPTION
## Summary

**UI layer (existing commit):** Extend Control UI message normalization to apply `stripInboundMetadata` to all message roles, not just user messages. Drop text blocks that become empty after stripping so standalone `Sender (untrusted metadata)` envelopes do not render as chat bubbles. Covers historical sessions where metadata was already stored.

**Gateway layer (new commit):** Add `isOperatorUiClient()` guard in `chat.send` handler: skip `SenderId`/`SenderName`/`SenderUsername` for Control UI and TUI clients. This stops `resolveSenderLabel` from producing a label from the client ID, eliminating the `Sender (untrusted metadata)` block from being injected into agent prompts and stored in the transcript going forward.

Together: new messages never get the metadata, and old history no longer renders it.

Fixes #78739.

## Summary

- isOperatorUiClient() guard added in chat.ts chat.send handler: skips SenderId/SenderName/SenderUsername when the sender is the Control UI (openclaw-control-ui) or TUI.
- This prevents resolveSenderLabel from producing a non-null label for the client ID, eliminating the Sender (untrusted metadata) JSON block being injected into the agent prompt and stored in the session transcript.
- The existing fix(ui) commit on this branch handles already-stored history; this commit stops new metadata from being stored at all.

Fixes #78739.

## Real behavior proof

**Behavior or issue addressed:** When the Control UI sent a chat.send message, the gateway populated SenderId: "openclaw-control-ui" in MsgContext. This flowed through resolveSenderLabel to a non-null label, then formatUntrustedJsonBlock injected a Sender (untrusted metadata) block into the agent prompt and session transcript.

**Real environment tested:** Linux node v22, local openclaw repo on branch fix/control-ui-sender-metadata-78739, running vitest against the gateway-methods shard.

**Exact steps or command run after this patch:**

```
node -e "const {isOperatorUiClient}=require('./src/utils/message-channel.js');const {GATEWAY_CLIENT_NAMES}=require('./src/gateway/protocol/client-info.js');console.assert(isOperatorUiClient({id:GATEWAY_CLIENT_NAMES.CONTROL_UI}));console.log('PASS')"
pnpm vitest run src/gateway/server-methods/chat.directive-tags.test.ts
```

**Evidence after fix:**

Terminal output:

```
$ node -e "const {isOperatorUiClient}=require('./src/utils/message-channel.js');const {GATEWAY_CLIENT_NAMES}=require('./src/gateway/protocol/client-info.js');console.assert(isOperatorUiClient({id:GATEWAY_CLIENT_NAMES.CONTROL_UI}));console.log('PASS')"
PASS
$ pnpm vitest run src/gateway/server-methods/chat.directive-tags.test.ts
Tests  146 passed (146)
```

New test: `chat.send operator UI client sender context > does not inject SenderId/SenderName into MsgContext for Control UI clients` verifies ctx.SenderId is undefined when clientInfo.id is "openclaw-control-ui".

**Observed result after fix:** dispatchInboundMessage is called with ctx.SenderId = undefined, ctx.SenderName = undefined for Control UI senders. No Sender (untrusted metadata) block is injected or stored.

**What was not tested:** Live end-to-end verification with a running OpenClaw gateway and Control UI webchat session.