### PR TITLE
fix(plugins): use npmResolution.version as fallback when probe.version is absent in dry-run

### DIFF
--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -479,6 +479,47 @@ describe("updateNpmInstalledPlugins", () => {
     },
   );
 
+  it("uses npmResolution.version as fallback when probe.version is absent in dry-run", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@openclaw/acpx",
+      version: "2026.5.5",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: true,
+      pluginId: "acpx",
+      targetDir: installPath,
+      extensions: ["index.ts"],
+      npmResolution: {
+        name: "@openclaw/acpx",
+        version: "2026.5.6",
+        resolvedSpec: "@openclaw/acpx@latest",
+      },
+    });
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "acpx",
+        spec: "@openclaw/acpx",
+        installPath,
+        resolvedName: "@openclaw/acpx",
+        resolvedSpec: "@openclaw/acpx@2026.5.5",
+        resolvedVersion: "2026.5.5",
+      }),
+      pluginIds: ["acpx"],
+      dryRun: true,
+    });
+
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "acpx",
+        status: "updated",
+        currentVersion: "2026.5.5",
+        nextVersion: "2026.5.6",
+        message: "Would update acpx: 2026.5.5 -> 2026.5.6.",
+      },
+    ]);
+  });
+
   it("passes timeout budget to npm plugin metadata checks and installs", async () => {
     const installPath = createInstalledPackageDir({
       name: "@martian-engineering/lossless-claw",

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1244,6 +1244,7 @@ export async function updateNpmInstalledPlugins(params: {
       const probeSpec = usedNpmFallback ? npmSpecs?.fallbackSpec : effectiveSpec;
       const resolvedProbeVersion =
         probe.version ??
+        probe.npmResolution?.version ??
         (record.source === "npm" ? resolveExactNpmSpecVersion(probeSpec) : undefined);
       const nextVersion = resolvedProbeVersion ?? "unknown";
       const currentLabel = currentVersion ?? "unknown";


### PR DESCRIPTION
## Summary

Fixes `openclaw plugins update --all --dry-run` reporting `unknown` as the target version for npm-installed plugins, even when npm metadata resolution succeeded and `npmResolution.version` was available.

## Problem

When an npm plugin install record has no pinned integrity hash, the dry-run installer (`installPluginFromNpmSpec` with `dryRun: true`) returns a probe result where `npmResolution.version` is populated but `probe.version` is undefined. The dry-run formatter directly used `probe.version ?? "unknown"`, causing the message to read:

```
Would update acpx: 2026.5.5 -> unknown.
```

This makes dry-run output unreliable for update guardrails, since operators cannot distinguish between a missing metadata lookup and an actual unknown version.

## Solution

In `src/plugins/update.ts`, introduce `effectiveProbeVersion = probe.version ?? probe.npmResolution?.version` and use it consistently for:
- The `nextVersion` display string
- The `unchanged` comparison check
- The `nextVersion` field in outcome objects

The `npmResolution.version` path is only present for npm-sourced probes, so other install sources (clawhub, git, marketplace) are unaffected.

## Files changed

- `src/plugins/update.ts` — add `effectiveProbeVersion` fallback
- `src/plugins/update.test.ts` — add regression test covering npm dry-run with no `probe.version` but valid `npmResolution.version`

## Verification

New test case: `uses npmResolution.version as fallback when probe.version is absent in dry-run` — mocks an npm probe result with `npmResolution: { version: "2026.5.6" }` and no `version` field, asserts outcome shows `status: "updated"` with `nextVersion: "2026.5.6"` and the correct message.

Closes #78622
