### PR TITLE
[AI-assisted] fix: enforce session ownership for all auth methods on outgoing media endpoint

### DIFF
--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -262,7 +262,7 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(result.statusCode).toBe(403);
   });
 
-  it("allows device-token access without requester session ownership", async () => {
+  it("rejects device-token access without requester session ownership", async () => {
     const { attachmentId, sessionKey } = await createFixture(stateDir);
 
     const { result } = await requestManagedImage({
@@ -271,8 +271,19 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       authResponse: { authMethod: "device-token" },
     });
 
-    expect(result.statusCode).toBe(200);
-    expect(result.body.toString("utf-8")).toBe("original-image");
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("rejects trusted-proxy access without requester session ownership", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+      authResponse: { trustDeclaredOperatorScopes: true },
+    });
+
+    expect(result.statusCode).toBe(403);
   });
 
   it("rejects non-GET methods", async () => {

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1009,9 +1009,6 @@ export async function handleManagedOutgoingImageHttpRequest(
     return true;
   }
 
-  const privilegedAccess =
-    requestAuth.trustDeclaredOperatorScopes || requestAuth.authMethod === "device-token";
-
   const requestedScopes = resolveOpenAiCompatibleHttpOperatorScopes(req, requestAuth);
   const scopeAuth = authorizeOperatorScopesForMethod("chat.history", requestedScopes);
   if (!scopeAuth.allowed) {
@@ -1046,32 +1043,30 @@ export async function handleManagedOutgoingImageHttpRequest(
     sendStatus(res, 404, "not found");
     return true;
   }
-  if (!privilegedAccess) {
-    const requesterSessionKey = resolveRequesterSessionKey(req);
-    if (!requesterSessionKey) {
-      sendJson(res, 403, {
-        ok: false,
-        error: {
-          type: "forbidden",
-          message: "requester session ownership required",
-        },
-      });
-      return true;
-    }
-    const ownsSession = await requesterOwnsManagedImageSession({
-      requesterSessionKey,
-      targetSessionKey: record.sessionKey,
+  const requesterSessionKey = resolveRequesterSessionKey(req);
+  if (!requesterSessionKey) {
+    sendJson(res, 403, {
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "requester session ownership required",
+      },
     });
-    if (!ownsSession) {
-      sendJson(res, 403, {
-        ok: false,
-        error: {
-          type: "forbidden",
-          message: "requester session does not own attachment session",
-        },
-      });
-      return true;
-    }
+    return true;
+  }
+  const ownsSession = await requesterOwnsManagedImageSession({
+    requesterSessionKey,
+    targetSessionKey: record.sessionKey,
+  });
+  if (!ownsSession) {
+    sendJson(res, 403, {
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "requester session does not own attachment session",
+      },
+    });
+    return true;
   }
   if (!(await recordMatchesTranscriptMessage(record))) {
     sendStatus(res, 404, "not found");


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: The outgoing media endpoint (`/api/chat/media/outgoing`) skips requester-session ownership checks when `requestAuth.trustDeclaredOperatorScopes` is true (trusted-proxy auth) or `requestAuth.authMethod === "device-token"` (device-token auth). This allows cross-session attachment retrieval (IDOR) for any caller with `chat.history` scope.
- Why it matters: Security vulnerability — any authenticated trusted-proxy or device-token caller can download attachments from sessions they do not own, leaking private conversation media across session boundaries.
- What changed: Removed the `privilegedAccess` variable and its conditional guard. Session ownership checks (`x-openclaw-requester-session-key` + `requesterOwnsManagedImageSession`) now run unconditionally for all auth methods.
- What did NOT change (scope boundary): No changes to scope resolution, auth method detection, session loading, record matching, or any other endpoint. Only the ownership bypass in the outgoing media handler was removed.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Gateway

## Linked Issue/PR
- Closes #78723
- Closes #78731
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: The `privilegedAccess` flag was designed to let "trusted" auth methods bypass per-session ownership, but this conflates trust-in-identity with trust-in-authorization. A caller being trusted (proxy or device-token) does not mean they should access all sessions — only the ones they own.
- Missing detection / guardrail: No test asserted that device-token or trusted-proxy callers without session ownership are rejected. The existing test explicitly asserted the wrong (vulnerable) behavior.
- Contributing context (if known): The privileged access pattern may have been added for operator/admin convenience but was overly broad.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/gateway/managed-image-attachments.test.ts`
- Scenario the test should lock in: Device-token and trusted-proxy callers without `x-openclaw-requester-session-key` or with non-owning session key receive 403 instead of 200.
- Why this is the smallest reliable guardrail: Unit test directly exercises the HTTP handler authorization path without needing a full gateway setup.
- Existing test that already covers this (if any): The existing device-token test was updated from expecting 200 to expecting 403. A new trusted-proxy test was added.
- If no new test is added, why not: N/A — tests were updated and added.

## User-visible / Behavior Changes
- Trusted-proxy and device-token authenticated callers must now provide `x-openclaw-requester-session-key` and prove session ownership to access outgoing media attachments. Previously they could access any session's attachments with only `chat.history` scope.

## Security Impact (required)
- New permissions/capabilities? No
- This fix closes an IDOR (Insecure Direct Object Reference) vulnerability where cross-session media access was possible for trusted-proxy and device-token auth methods. The fix enforces the same ownership checks that already applied to other auth methods.