### PR TITLE
[AI-assisted] fix: prevent shared-secret auth scope escalation on trusted-operator plugin routes

### DIFF
--- a/src/gateway/server/plugin-route-runtime-scopes.test.ts
+++ b/src/gateway/server/plugin-route-runtime-scopes.test.ts
@@ -46,7 +46,7 @@ describe("resolvePluginRouteRuntimeOperatorScopes", () => {
     ).toEqual(["operator.write"]);
   });
 
-  it("restores trusted default operator scopes for shared-secret bearer routes opting into trusted-operator surface", () => {
+  it("restricts shared-secret bearer routes to write scope on trusted-operator surface", () => {
     expect(
       resolvePluginRouteRuntimeOperatorScopes(
         createReq({
@@ -55,14 +55,7 @@ describe("resolvePluginRouteRuntimeOperatorScopes", () => {
         { authMethod: "token", trustDeclaredOperatorScopes: false },
         "trusted-operator",
       ),
-    ).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    ).toEqual(["operator.write"]);
   });
 
   it("restores trusted default operator scopes for trusted-proxy routes opting into trusted-operator when scopes header is absent", () => {

--- a/src/gateway/server/plugin-route-runtime-scopes.ts
+++ b/src/gateway/server/plugin-route-runtime-scopes.ts
@@ -4,7 +4,7 @@ import {
   resolveTrustedHttpOperatorScopes,
   type AuthorizedGatewayHttpRequest,
 } from "../http-auth-utils.js";
-import { CLI_DEFAULT_OPERATOR_SCOPES, WRITE_SCOPE } from "../method-scopes.js";
+import { WRITE_SCOPE } from "../method-scopes.js";
 
 export type PluginRouteRuntimeScopeSurface = "write-default" | "trusted-operator";
 
@@ -15,7 +15,7 @@ export function resolvePluginRouteRuntimeOperatorScopes(
 ): string[] {
   if (surface === "trusted-operator") {
     if (!requestAuth.trustDeclaredOperatorScopes) {
-      return [...CLI_DEFAULT_OPERATOR_SCOPES];
+      return [WRITE_SCOPE];
     }
     return resolveTrustedHttpOperatorScopes(req, requestAuth);
   }


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: Plugin HTTP routes with `gatewayRuntimeScopeSurface: "trusted-operator"` silently escalate shared-secret bearer auth callers to `operator.admin` and other privileged scopes, even when the caller declares narrow scopes or no scope header.
- Why it matters: Privilege escalation — shared-secret callers (token/password auth) can execute admin-only plugin logic without explicit admin authorization.
- What changed: `resolvePluginRouteRuntimeOperatorScopes` now returns `[WRITE_SCOPE]` instead of `[...CLI_DEFAULT_OPERATOR_SCOPES]` when `trustDeclaredOperatorScopes` is false on the `trusted-operator` surface. Removed the unused `CLI_DEFAULT_OPERATOR_SCOPES` import.
- What did NOT change (scope boundary): Trusted-proxy callers with explicit `x-openclaw-scopes` headers still have their declared scopes honored. The `write-default` surface behavior is unchanged. No changes to auth method detection or scope resolution utilities.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Gateway
- [x] Plugin SDK

## Linked Issue/PR
- Closes #78712
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: The `trusted-operator` surface was designed to give operator-level access to plugin routes, but it incorrectly treated all non-trusted callers as deserving full default operator scopes (including admin). The condition `!requestAuth.trustDeclaredOperatorScopes` (which is true for shared-secret auth) triggered a fallback to `CLI_DEFAULT_OPERATOR_SCOPES` instead of restricting to write-only.
- Missing detection / guardrail: The existing test explicitly asserted the escalation behavior as correct ("restores trusted default operator scopes for shared-secret bearer routes").
- Contributing context (if known): The `CLI_DEFAULT_OPERATOR_SCOPES` constant includes `operator.admin` because it represents the full local CLI operator scope set, which is appropriate for local CLI usage but not for remote shared-secret callers.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/gateway/server/plugin-route-runtime-scopes.test.ts`
- Scenario the test should lock in: Shared-secret bearer callers on `trusted-operator` surface receive only `operator.write`, not the full admin scope set.
- Why this is the smallest reliable guardrail: Pure function unit test that directly validates scope resolution output.
- Existing test that already covers this (if any): The existing test was updated from asserting admin escalation to asserting write-only restriction.
- If no new test is added, why not: N/A — existing test was corrected.

## User-visible / Behavior Changes
- Shared-secret bearer auth callers accessing plugin routes with `trusted-operator` surface will now only receive `operator.write` scope instead of full admin scopes. Plugin routes that relied on the previous escalation behavior for shared-secret callers will need to be reconfigured or use a trusted-proxy auth path with explicit scope headers.

## Security Impact (required)
- New permissions/capabilities? No
- This fix closes a privilege escalation vulnerability where shared-secret (token/password) authenticated callers were silently granted `operator.admin` scope on plugin routes using the `trusted-operator` runtime scope surface. The fix restricts these callers to `operator.write` only.