### PR TITLE
fix(tui): avoid inserting spaces into long CJK text

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -321,6 +321,23 @@ describe("sanitizeRenderableText", () => {
     expectTokenWidthUnderLimit(input);
   });
 
+  it("preserves long CJK prose without inserting display spaces", () => {
+    const input =
+      "特蕾莎修女是一个极端投入极有宗教信念愿意亲身服务底层苦难者的人但她不是现代公共卫生意义上的慈善改革者";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+    expect(sanitized).not.toContain("苦难 者");
+  });
+
+  it("preserves mixed long CJK prose without inserting display spaces", () => {
+    const input =
+      "MotherTeresa更像是宗教慈悲的象征而不是现代慈善治理的典范她值得尊重的地方是真实走进极端苦难";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
   it("preserves long filesystem paths verbatim for copy safety", () => {
     const input =
       "/Users/jasonshawn/PerfectXiao/a_very_long_directory_name_designed_specifically_to_test_the_line_wrapping_issue/file.txt";

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -16,6 +16,7 @@ const EDGE_PUNCTUATION_RE = /^[`"'([{<]+|[`"')\]}>.,:;!?]+$/g;
 const ALPHANUMERIC_RE = /[A-Za-z0-9]/;
 const TOKENISH_MIN_LENGTH = 24;
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
+const CJK_SCRIPT_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
 const RTL_ISOLATE_START = "\u2067";
 const RTL_ISOLATE_END = "\u2069";
@@ -105,6 +106,12 @@ function isCopySensitiveToken(token: string): boolean {
 function normalizeLongTokenForDisplay(token: string): string {
   // Preserve copy-sensitive tokens exactly (paths/urls/file-like names).
   if (isCopySensitiveToken(token)) {
+    return token;
+  }
+  // CJK text naturally appears without spaces between words. Inserting spaces
+  // into long CJK runs makes assistant prose render with visible artifacts such
+  // as "苦难 者". Let the TUI renderer wrap these runs at grapheme boundaries.
+  if (CJK_SCRIPT_RE.test(token)) {
     return token;
   }
   // Pure symbol/punctuation runs (table borders made of `─`, `=`, `-`) carry


### PR DESCRIPTION
## Summary

Avoid inserting display spaces into long CJK text in TUI-rendered assistant output.

`sanitizeRenderableText()` currently protects narrow terminals by splitting long unbroken tokens into 32-character chunks joined with spaces. That works for long Latin tokens, but CJK prose is naturally written without spaces, so long Chinese/Japanese/Korean text can be rendered with visible artifacts such as `苦难 者`.

This change preserves long tokens containing CJK script characters verbatim and lets the TUI renderer wrap them at grapheme boundaries.

Made with [Cursor](https://cursor.com)

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/tui-formatters.test.ts`
- `pnpm format:check src/tui/tui-formatters.ts src/tui/tui-formatters.test.ts`
- `git diff --check`

Note: Full-repo `pnpm lint` was not relied on locally; invoking it pulled in unrelated workspace issues (e.g. missing `web-tree-sitter` under `src/infra/command-explainer`). Verification above is scoped to this change.

## Real behavior proof

- Behavior or issue addressed: Long uninterrupted CJK in TUI-rendered assistant text showed spurious display spaces between grapheme wraps (e.g. split mid-word visually).
- Real environment tested: Fedora Linux 44 (x86_64), Node 22.22.2, OpenClaw **from git checkout** at branch `fix-tui-cjk-long-token-spacing` (commit 7820ebe0f7), deps installed with `pnpm install`, command `pnpm openclaw tui` 
- Exact steps or command run after this patch: Rebuilt/synced deps; ran the
  CLI path that renders assistant text in the TUI (`pnpm openclaw tui`); triggered a reply with ≥33 uninterrupted CJK characters; compared rendering after the patch.
- Observed result after fix: Long CJK assistant lines wrap in the TUI without extra visible spaces between characters (matches grapheme wrapping only).
- What was not tested: None beyond this TUI path (e.g. other channels or Control UI).
- Evidence after fix: Terminal screenshot attached below 
<img width="1714" height="710" alt="image" src="https://github.com/user-attachments/assets/1715fb6e-a727-48cc-b6f1-81ae994317c4" />
