### PR TITLE
fix(whatsapp): dedupe captioned MEDIA auto-replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,6 +488,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: have completed session-mode subagent registry rows honor `agents.defaults.subagents.archiveAfterMinutes` (default 60 minutes; same knob run-mode already uses for `archiveAtMs`) instead of a hardcoded 5-minute TTL, so `subagents list` and other registry-backed surfaces still show recently-completed runs and operators have one consistent retention knob across spawn modes. (#78263) Thanks @arniesaha.
 - Plugins/channel setup: fix `setChannelRuntime` being silently dropped from non-bundled external plugin setup entries — external channel plugins that export `{ plugin, setChannelRuntime }` from their setup entry now have the runtime setter invoked, so the runtime initializer the provider polls for is set before the channel starts, preventing a poll timeout and gateway crash loop when the plugin opts into deferred startup loading. Fixes #77779. (#77799) Thanks @openperf.
 - WhatsApp: route proactive phone-number sends through Baileys LID forward mappings when available, so LID-addressed contacts receive agent messages instead of creating sender-only ghost chats. Fixes #67378. (#74925) Thanks @edenfunf.
+- WhatsApp: send captioned `MEDIA:` directive auto-replies once instead of emitting an empty media message before the captioned media reply. (#78770) Thanks @ai-hpc.
 
 ## 2026.5.3-1
 

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -487,7 +487,7 @@ describe("whatsapp inbound dispatch", () => {
     expect(groupHistories.get("whatsapp:default:group:123@g.us") ?? []).toHaveLength(0);
   });
 
-  it("delivers block and final WhatsApp payloads; suppresses text-only tool payloads but delivers media", async () => {
+  it("replaces duplicate media-only interim payloads with the final captioned WhatsApp media", async () => {
     const deliverReply = vi.fn(async () => acceptedDeliveryResult());
     const rememberSentText = vi.fn();
 
@@ -509,16 +509,8 @@ describe("whatsapp inbound dispatch", () => {
         kind: "tool",
       },
     );
-    expect(deliverReply).toHaveBeenCalledTimes(1);
-    expect(rememberSentText).toHaveBeenCalledTimes(1);
-    expect(deliverReply).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        replyResult: expect.objectContaining({
-          mediaUrls: ["/tmp/generated.jpg"],
-          text: undefined,
-        }),
-      }),
-    );
+    expect(deliverReply).not.toHaveBeenCalled();
+    expect(rememberSentText).not.toHaveBeenCalled();
 
     await deliver?.(
       { text: "generated image", mediaUrls: ["/tmp/generated.jpg"] },
@@ -526,8 +518,8 @@ describe("whatsapp inbound dispatch", () => {
         kind: "block",
       },
     );
-    expect(deliverReply).toHaveBeenCalledTimes(2);
-    expect(rememberSentText).toHaveBeenCalledTimes(2);
+    expect(deliverReply).toHaveBeenCalledTimes(1);
+    expect(rememberSentText).toHaveBeenCalledTimes(1);
     expect(deliverReply).toHaveBeenLastCalledWith(
       expect.objectContaining({
         replyResult: expect.objectContaining({
@@ -539,8 +531,8 @@ describe("whatsapp inbound dispatch", () => {
 
     await deliver?.({ text: "block payload" }, { kind: "block" });
     await deliver?.({ text: "final payload" }, { kind: "final" });
-    expect(deliverReply).toHaveBeenCalledTimes(4);
-    expect(rememberSentText).toHaveBeenCalledTimes(4);
+    expect(deliverReply).toHaveBeenCalledTimes(3);
+    expect(rememberSentText).toHaveBeenCalledTimes(3);
   });
 
   it("queues final WhatsApp payloads through durable outbound delivery", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -60,9 +60,22 @@ type SenderContext = {
   e164?: string;
 };
 
+type ReplyDeliveryInfo = { kind: ReplyLifecycleKind };
+
+type PendingWhatsAppMediaOnlyPayload = {
+  info: ReplyDeliveryInfo;
+  mediaUrls: Set<string>;
+  payload: DeliverableWhatsAppOutboundPayload<ReplyPayload>;
+};
+
+type WhatsAppMediaOnlyFlushResult = {
+  delivered: number;
+  droppedDuplicateMedia: number;
+};
+
 function logWhatsAppReplyDeliveryError(params: {
   err: unknown;
-  info: { kind: ReplyLifecycleKind };
+  info: ReplyDeliveryInfo;
   connectionId: string;
   conversationId: string;
   msg: WebInboundMsg;
@@ -107,6 +120,85 @@ function resolveWhatsAppDeliverablePayload(
     return { ...payload, text: undefined };
   }
   return payload;
+}
+
+function getWhatsAppPayloadMediaUrls(payload: ReplyPayload): Set<string> {
+  return new Set(
+    [
+      ...(Array.isArray(payload.mediaUrls) ? payload.mediaUrls : []),
+      ...(typeof payload.mediaUrl === "string" ? [payload.mediaUrl] : []),
+    ]
+      .map((url) => url.trim())
+      .filter(Boolean),
+  );
+}
+
+function hasWhatsAppMediaUrlOverlap(left: Set<string>, right: Set<string>): boolean {
+  for (const url of left) {
+    if (right.has(url)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function shouldDeferWhatsAppMediaOnlyPayload(params: {
+  info: ReplyDeliveryInfo;
+  mediaUrls: Set<string>;
+  reply: ReturnType<typeof resolveSendableOutboundReplyParts>;
+}): boolean {
+  return (
+    params.info.kind !== "final" &&
+    params.reply.hasMedia &&
+    !params.reply.text.trim() &&
+    params.mediaUrls.size > 0
+  );
+}
+
+function createWhatsAppMediaOnlyReplyCoalescer(params: {
+  deliver: (pending: PendingWhatsAppMediaOnlyPayload) => Promise<void>;
+}) {
+  const pendingMediaOnlyPayloads: PendingWhatsAppMediaOnlyPayload[] = [];
+  const flushExceptDuplicateMedia = async (
+    mediaUrls?: Set<string>,
+  ): Promise<WhatsAppMediaOnlyFlushResult> => {
+    const flushResult: WhatsAppMediaOnlyFlushResult = {
+      delivered: 0,
+      droppedDuplicateMedia: 0,
+    };
+    const pending = pendingMediaOnlyPayloads.splice(0);
+    for (const candidate of pending) {
+      if (mediaUrls && hasWhatsAppMediaUrlOverlap(candidate.mediaUrls, mediaUrls)) {
+        flushResult.droppedDuplicateMedia += 1;
+        continue;
+      }
+      await params.deliver(candidate);
+      flushResult.delivered += 1;
+    }
+    return flushResult;
+  };
+
+  return {
+    defer(pending: PendingWhatsAppMediaOnlyPayload) {
+      pendingMediaOnlyPayloads.push(pending);
+    },
+    flushExceptDuplicateMedia,
+    flushAll: () => flushExceptDuplicateMedia(),
+  };
+}
+
+function logWhatsAppMediaOnlyFlushResult(result: WhatsAppMediaOnlyFlushResult) {
+  if (!shouldLogVerbose()) {
+    return;
+  }
+  if (result.droppedDuplicateMedia > 0) {
+    logVerbose(
+      `Dropped ${result.droppedDuplicateMedia} deferred media-only WhatsApp reply payload(s) superseded by captioned media`,
+    );
+  }
+  if (result.delivered > 0) {
+    logVerbose(`Flushed ${result.delivered} deferred media-only WhatsApp reply payload(s)`);
+  }
 }
 
 export function resolveWhatsAppResponsePrefix(params: {
@@ -335,6 +427,63 @@ export async function dispatchWhatsAppBufferedReply(params: {
   let didSendReply = false;
   let didLogHeartbeatStrip = false;
 
+  const deliverNormalizedPayload = async (
+    normalizedDeliveryPayload: DeliverableWhatsAppOutboundPayload<ReplyPayload>,
+    info: ReplyDeliveryInfo,
+  ) => {
+    const reply = resolveSendableOutboundReplyParts(normalizedDeliveryPayload);
+    if (!reply.hasMedia && !reply.text.trim()) {
+      return;
+    }
+    const delivery = await params.deliverReply({
+      replyResult: normalizedDeliveryPayload,
+      normalizedReplyResult: normalizedDeliveryPayload,
+      msg: params.msg,
+      mediaLocalRoots,
+      maxMediaBytes: params.maxMediaBytes,
+      textLimit,
+      chunkMode,
+      replyLogger: params.replyLogger,
+      connectionId: params.connectionId,
+      skipLog: false,
+      tableMode,
+    });
+    if (!delivery.providerAccepted) {
+      params.replyLogger.warn(
+        {
+          correlationId: params.msg.id ?? null,
+          connectionId: params.connectionId,
+          conversationId: params.conversationId,
+          chatId: params.msg.chatId,
+          to: params.msg.from,
+          from: params.msg.to,
+          replyKind: info.kind,
+        },
+        "auto-reply was not accepted by WhatsApp provider",
+      );
+      return;
+    }
+    didSendReply = true;
+    const shouldLog = normalizedDeliveryPayload.text ? true : undefined;
+    params.rememberSentText(normalizedDeliveryPayload.text, {
+      combinedBody: params.context.Body as string | undefined,
+      combinedBodySessionKey: params.route.sessionKey,
+      logVerboseMessage: shouldLog,
+    });
+    const fromDisplay =
+      params.msg.chatType === "group" ? params.conversationId : (params.msg.from ?? "unknown");
+    if (shouldLogVerbose()) {
+      const preview = normalizedDeliveryPayload.text != null ? reply.text : "<media>";
+      logVerbose(`Reply body: ${preview}${reply.hasMedia ? " (media)" : ""} -> ${fromDisplay}`);
+    }
+  };
+
+  const mediaOnlyCoalescer = createWhatsAppMediaOnlyReplyCoalescer({
+    deliver: async (pending) => {
+      await deliverNormalizedPayload(pending.payload, pending.info);
+    },
+  });
+
   const { queuedFinal, counts } = await dispatchReplyWithBufferedBlockDispatcher({
     ctx: params.context,
     cfg: params.cfg,
@@ -364,6 +513,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
           return;
         }
         if (!reply.hasMedia) {
+          logWhatsAppMediaOnlyFlushResult(await mediaOnlyCoalescer.flushAll());
           const durable = await deliverInboundReplyWithMessageSendContext({
             cfg: params.cfg,
             channel: "whatsapp",
@@ -395,48 +545,22 @@ export async function dispatchWhatsAppBufferedReply(params: {
           if (durable.status === "handled_no_send") {
             return;
           }
-        }
-        const delivery = await params.deliverReply({
-          replyResult: normalizedDeliveryPayload,
-          normalizedReplyResult: normalizedDeliveryPayload,
-          msg: params.msg,
-          mediaLocalRoots,
-          maxMediaBytes: params.maxMediaBytes,
-          textLimit,
-          chunkMode,
-          replyLogger: params.replyLogger,
-          connectionId: params.connectionId,
-          skipLog: false,
-          tableMode,
-        });
-        if (!delivery.providerAccepted) {
-          params.replyLogger.warn(
-            {
-              correlationId: params.msg.id ?? null,
-              connectionId: params.connectionId,
-              conversationId: params.conversationId,
-              chatId: params.msg.chatId,
-              to: params.msg.from,
-              from: params.msg.to,
-              replyKind: info.kind,
-            },
-            "auto-reply was not accepted by WhatsApp provider",
-          );
+          await deliverNormalizedPayload(normalizedDeliveryPayload, info);
           return;
         }
-        didSendReply = true;
-        const shouldLog = normalizedDeliveryPayload.text ? true : undefined;
-        params.rememberSentText(normalizedDeliveryPayload.text, {
-          combinedBody: params.context.Body as string | undefined,
-          combinedBodySessionKey: params.route.sessionKey,
-          logVerboseMessage: shouldLog,
-        });
-        const fromDisplay =
-          params.msg.chatType === "group" ? params.conversationId : (params.msg.from ?? "unknown");
-        if (shouldLogVerbose()) {
-          const preview = normalizedDeliveryPayload.text != null ? reply.text : "<media>";
-          logVerbose(`Reply body: ${preview}${reply.hasMedia ? " (media)" : ""} -> ${fromDisplay}`);
+        const mediaUrls = getWhatsAppPayloadMediaUrls(normalizedDeliveryPayload);
+        if (shouldDeferWhatsAppMediaOnlyPayload({ info, mediaUrls, reply })) {
+          mediaOnlyCoalescer.defer({
+            info,
+            mediaUrls,
+            payload: normalizedDeliveryPayload,
+          });
+          return;
         }
+        logWhatsAppMediaOnlyFlushResult(
+          await mediaOnlyCoalescer.flushExceptDuplicateMedia(mediaUrls),
+        );
+        await deliverNormalizedPayload(normalizedDeliveryPayload, info);
       },
       onReplyStart: params.msg.sendComposing,
       onError: (err, info) => {
@@ -456,6 +580,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
       onModelSelected: params.onModelSelected,
     },
   });
+  logWhatsAppMediaOnlyFlushResult(await mediaOnlyCoalescer.flushAll());
 
   const didQueueVisibleReply = hasVisibleInboundReplyDispatch({ queuedFinal, counts });
   if (!didQueueVisibleReply) {


### PR DESCRIPTION
## Summary

- Problem: WhatsApp inbound auto-reply can deliver a captioned `MEDIA:` directive twice: first as an empty media-only message, then again as the final captioned media reply.
- Why it matters: Users receive duplicate WhatsApp images even though the assistant emitted one final response with one `MEDIA:` directive.
- What changed: Buffer media-only interim WhatsApp auto-reply payloads and drop the buffered payload when a later block/final payload carries the same media URL with visible caption text.
- What did NOT change (scope boundary): Low-level WhatsApp media sending, CLI `message send --media`, and legitimate tool-only/media-only replies are preserved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78767
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: WhatsApp inbound auto-reply delivered media-only interim payloads immediately, then later delivered the final captioned payload with the same media URL.
- Missing detection / guardrail: The dispatcher did not coalesce same-media interim/final deliveries before handing them to WhatsApp delivery.
- Contributing context (if known): The assistant trajectory can contain one final visible response with `MEDIA:...`, while the dispatcher lifecycle can still surface an earlier media-only payload for the same media.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts`
- Scenario the test should lock in: a media-only interim payload with `/tmp/generated.jpg` is not sent when a later block payload contains the same media URL plus caption text.
- Why this is the smallest reliable guardrail: The duplicate is created in the WhatsApp inbound dispatch lifecycle before low-level delivery, so the dispatcher unit test catches it without live WhatsApp credentials.
- Existing test that already covers this (if any): existing delivery tests cover low-level media send behavior, but not lifecycle duplicate coalescing.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

WhatsApp auto-replies for captioned `MEDIA:` directives now send one captioned media message instead of an empty media message followed by the same captioned media message.

## Diagram (if applicable)

```text
Before:
media-only interim -> WhatsApp send
final caption + same media -> WhatsApp send again

After:
media-only interim -> buffer
final caption + same media -> replace buffered payload -> WhatsApp sends once
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu/Linux VPS
- Runtime/container: Node 22, local OpenClaw checkout
- Model/provider: existing configured agent
- Integration/channel (if any): WhatsApp `default`, linked and healthy
- Relevant config (redacted): loopback gateway, systemd user service

### Steps

1. Ensure a small local image exists, e.g. `media/whatsapp-tests/live-media-directive.png`.
2. From WhatsApp, send:
   ```text
   Reply with exactly these two lines, no markdown, no code fence, no extra text:
   WhatsApp inbound MEDIA directive live test
   MEDIA:media/whatsapp-tests/live-media-directive.png
   ```
3. Watch redacted logs for `Sent media reply` and `auto-reply sent (media)`.

### Expected

- One WhatsApp media reply with caption text.

### Actual

- Before this fix, WhatsApp sent the same image twice: first media-only, then captioned media.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Redacted failing live log shape:

```text
Sent media reply to +<redacted> (0.00MB)
auto-reply sent (media) {"text":"","mediaUrl":"<outbound-media>","mediaKind":"image"}
Sent media reply to +<redacted> (0.00MB)
auto-reply sent (media) {"text":"WhatsApp inbound MEDIA directive live test","mediaUrl":"<outbound-media>","mediaKind":"image"}
```

Validation:

```text
pnpm exec oxfmt --check --threads=1 extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts CHANGELOG.md
pnpm test extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts -- --reporter=verbose
pnpm check:changed
git diff --check
```

## Real behavior proof

- Behavior or issue addressed: WhatsApp inbound auto-reply for one captioned `MEDIA:` directive sent the same image twice, first as empty media and then as the captioned media reply.
- Real environment tested: Ubuntu 24.04 VPS, Node 22, local OpenClaw checkout, linked and healthy WhatsApp `default` channel, loopback Gateway, live WhatsApp direct chat.
- Exact steps or command run after this patch:
  1. Ran the local OpenClaw Gateway from this checkout.
  2. Sent this WhatsApp prompt to the linked OpenClaw number:
     ```text
     Reply with exactly these two lines, no markdown, no code fence, no extra text:
     WhatsApp inbound MEDIA directive live test
     MEDIA:media/whatsapp-tests/live-media-directive.png
     ```
  3. Tailed redacted OpenClaw runtime logs for `Inbound message`, `Sent media reply`, and `auto-reply sent (media)`.
- Evidence after fix: Redacted runtime log from the live WhatsApp run:
  ```text
  2026-05-07T03:01:32.497Z info gateway/channels/whatsapp/inbound Inbound message +<redacted> -> +<redacted> (direct, 294 chars)
  2026-05-07T03:01:48.688Z info gateway/channels/whatsapp/outbound Sent media reply to +<redacted> (0.00MB)
  2026-05-07T03:01:48.690Z info web-auto-reply {"text":"WhatsApp inbound MEDIA directive live test","mediaUrl":"<outbound-media>","mediaSizeBytes":91,"mediaKind":"image"} auto-reply sent (media)
  ```
- Observed result after fix: The live WhatsApp run produced one captioned media reply and no second `auto-reply sent (media)` line after waiting.
- What was not tested: No additional gaps beyond the redacted live WhatsApp setup above; automated regression tests cover the dispatcher replacement behavior and the tool-only media flush edge case.

## Human Verification (required)

- Verified scenarios: targeted WhatsApp dispatcher regression, low-level WhatsApp delivery tests, and previous live VPS reproduction with redacted logs.
- Edge cases checked: tool-only media still flushes and sends when no final replacement arrives; provider rejection still avoids `rememberSentText`.
- What you did **not** verify: additional handset/browser screenshots beyond the redacted live WhatsApp log proof above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: buffering media-only interim payloads could suppress legitimate media-only replies.
  - Mitigation: pending media-only payloads flush after the dispatcher completes when no same-media final replacement arrives, with unit coverage for tool-only media turns.
