### PR TITLE
fix(update): prefer owning npm prefix when PATH npm reports non-owning root (#78775)

### DIFF
--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -290,6 +290,59 @@ describe("update global helpers", () => {
     });
   });
 
+  it("prefers the owning npm prefix when PATH npm reports a non-owning global root (nvm scenario, #78775)", async () => {
+    // Reproduces the nvm-only setup where `gateway update.run` resolves a
+    // system `/usr/local` npm via PATH, but the running OpenClaw actually
+    // lives under `~/.nvm/versions/node/<v>/lib/node_modules/openclaw`. The
+    // resolved install target must point at the nvm prefix that owns the
+    // package, not the unwritable `/usr/local` global root.
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    try {
+      await withTempDir({ prefix: "openclaw-update-nvm-prefix-" }, async (base) => {
+        const nvmPrefix = path.join(base, "nvm", "versions", "node", "v22.17.0");
+        const nvmBin = path.join(nvmPrefix, "bin");
+        const nvmRoot = path.join(nvmPrefix, "lib", "node_modules");
+        const pkgRoot = path.join(nvmRoot, "openclaw");
+        const nvmNpm = path.join(nvmBin, "npm");
+        // The PATH-resolved npm reports an unrelated /usr/local global root.
+        const systemRoot = path.join(base, "usr", "local", "lib", "node_modules");
+        await fs.mkdir(pkgRoot, { recursive: true });
+        await fs.mkdir(systemRoot, { recursive: true });
+        await fs.mkdir(nvmBin, { recursive: true });
+        await fs.writeFile(nvmNpm, "", "utf8");
+
+        const runCommand = createNpmRootRunner({
+          defaultNpmRoot: systemRoot,
+          overrideCommand: nvmNpm,
+          overrideNpmRoot: nvmRoot,
+        });
+
+        // detectGlobalInstallManagerForRoot is happy because the owning npm
+        // (under the nvm prefix) reports the matching globalRoot.
+        await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe(
+          "npm",
+        );
+        // The resolved install target prefers the nvm globalRoot that owns the
+        // package, even though the PATH npm reports /usr/local.
+        await expect(
+          resolveGlobalInstallTarget({
+            manager: "npm",
+            runCommand,
+            timeoutMs: 1000,
+            pkgRoot,
+          }),
+        ).resolves.toEqual({
+          manager: "npm",
+          command: nvmNpm,
+          globalRoot: nvmRoot,
+          packageRoot: pkgRoot,
+        });
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it("prefers the owning npm prefix when PATH npm points at a different global root", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     try {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -545,6 +545,37 @@ export async function resolveGlobalPackageRoot(
   return path.join(root, PRIMARY_PACKAGE_NAME);
 }
 
+function deriveGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null {
+  const trimmed = pkgRoot?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const normalized = path.resolve(trimmed);
+  const nodeModulesDir = path.dirname(normalized);
+  if (path.basename(nodeModulesDir) !== "node_modules") {
+    return null;
+  }
+  return nodeModulesDir;
+}
+
+async function pkgRootIsInsideGlobalRoot(
+  pkgRoot: string | null | undefined,
+  globalRoot: string | null | undefined,
+): Promise<boolean> {
+  if (!pkgRoot || !globalRoot) {
+    return false;
+  }
+  const pkgReal = await tryRealpath(pkgRoot);
+  const globalReal = await tryRealpath(globalRoot);
+  const pkgResolved = path.resolve(pkgReal);
+  const globalResolved = path.resolve(globalReal);
+  if (pkgResolved === globalResolved) {
+    return true;
+  }
+  const rel = path.relative(globalResolved, pkgResolved);
+  return Boolean(rel) && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
 export async function resolveGlobalInstallTarget(params: {
   manager: GlobalInstallManager | ResolvedGlobalInstallCommand;
   runCommand: CommandRunner;
@@ -552,12 +583,25 @@ export async function resolveGlobalInstallTarget(params: {
   pkgRoot?: string | null;
 }): Promise<ResolvedGlobalInstallTarget> {
   const command = normalizeGlobalInstallCommand(params.manager, params.pkgRoot);
-  const globalRoot = await resolveGlobalRoot(
+  // Prefer the npm prefix that actually owns the running OpenClaw package,
+  // not whatever `npm root -g` returns from the gateway's PATH. On nvm-only
+  // setups, gateway processes can resolve a system `/usr/local` npm whose
+  // global root is unwritable, so the staged install fails with EACCES even
+  // though the live install lives under `~/.nvm/.../lib/node_modules`. See
+  // openclaw/openclaw#78775 (and the original Homebrew variant in #60150).
+  const inferredGlobalRoot = deriveGlobalRootFromPackageRoot(params.pkgRoot);
+  const inferredOwnsPackage = await pkgRootIsInsideGlobalRoot(params.pkgRoot, inferredGlobalRoot);
+  const reportedGlobalRoot = await resolveGlobalRoot(
     command,
     params.runCommand,
     params.timeoutMs,
     params.pkgRoot,
   );
+  const reportedOwnsPackage = await pkgRootIsInsideGlobalRoot(params.pkgRoot, reportedGlobalRoot);
+  const globalRoot =
+    inferredOwnsPackage && !reportedOwnsPackage
+      ? inferredGlobalRoot
+      : (reportedGlobalRoot ?? (inferredOwnsPackage ? inferredGlobalRoot : null));
   return {
     ...command,
     globalRoot,


### PR DESCRIPTION
## Summary

Fixes #78775 — `gateway update.run` (and `openclaw update`) fails with `global-install-failed` on nvm-only setups because the staged install path resolves to `/usr/local/lib/node_modules/...` instead of the nvm prefix that actually owns the running OpenClaw package.

## Root cause

`resolveGlobalInstallTarget` in `src/infra/update-global.ts` calls `resolveGlobalRoot(...)`, which runs `npm root -g`. When the gateway process resolves a system `npm` via `PATH` (common on nvm-only setups where the gateway was launched outside the user shell), that returns `/usr/local/lib/node_modules`, which is unwritable. The staged install then fails immediately with:

```
EACCES: permission denied, mkdtemp '/usr/local/lib/node_modules/.openclaw-update-stage-...'
```

## Fix

Derive the candidate global root from the running package root (`pkgRoot`), verify that the package is actually inside that path on disk via `tryRealpath`, and prefer the owning prefix when the PATH-resolved npm reports a different (non-owning) global root. Behavior for installs where the PATH npm matches the on-disk owner is unchanged. This mirrors the existing Homebrew-aware command preference already implemented in `resolvePreferredNpmCommand`.

## Changes

- `src/infra/update-global.ts`
  - Add `deriveGlobalRootFromPackageRoot(pkgRoot)` helper.
  - Add `pkgRootIsInsideGlobalRoot(pkgRoot, globalRoot)` helper using `tryRealpath`.
  - In `resolveGlobalInstallTarget`, prefer the inferred owning global root when the PATH npm reports a non-owning root; fall back to the reported root otherwise.
- `src/infra/update-global.test.ts`
  - Add nvm regression test: PATH npm reports `/usr/local`, owning npm under `~/.nvm/.../lib/node_modules` is preferred.

## Testing

`pnpm vitest run src/infra/update-global.test.ts` — all 26 tests pass, including the new nvm regression test alongside the existing Homebrew-shape and win32-shape preference tests.

## Related

- Fixes #78775
- Refs #60150 (locked Homebrew variant of the same root cause)