### PR TITLE
fix(status): reduce deep status manifest scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Status/memory: reuse startup plugin metadata and per-summary runtime labels so `status --deep` and `memory status --deep` avoid repeated bundled-plugin manifest scans and degrade cleanly when local embedding dependencies are unavailable. Thanks @vincentkoc.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Sessions CLI: apply `--limit` before rich display hydration so large session stores avoid decorating rows that will never be shown. Thanks @vincentkoc.
 - Memory search: cap sync file discovery with `memorySearch.sync.maxFileScanEntries` and surface truncation warnings/status issues for oversized memory dirs or extra paths. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
+- Sessions CLI: apply `--limit` before rich display hydration so large session stores avoid decorating rows that will never be shown. Thanks @vincentkoc.
+- Memory search: cap sync file discovery with `memorySearch.sync.maxFileScanEntries` and surface truncation warnings/status issues for oversized memory dirs or extra paths. Thanks @vincentkoc.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -308,6 +308,14 @@ For custom OpenAI-compatible endpoints or overriding provider defaults:
 Unset uses the provider default: 600 seconds for local/self-hosted providers such as `local`, `ollama`, and `lmstudio`, and 120 seconds for hosted providers. Increase this when local CPU-bound embedding batches are healthy but slow.
 </ParamField>
 
+### File discovery limits
+
+<ParamField path="sync.maxFileScanEntries" type="number" default="10000">
+  Caps directory entries scanned while discovering memory files.
+
+This protects `memorySearch.extraPaths` from accidentally indexing a huge repo, sync folder, or home directory. Raise it only for intentionally large memory corpora.
+</ParamField>
+
 ---
 
 ## Hybrid search config
@@ -442,6 +450,7 @@ Index session transcripts and surface them via `memory_search`:
 | ----------------------------- | ---------- | ------------ | --------------------------------------- |
 | `experimental.sessionMemory`  | `boolean`  | `false`      | Enable session indexing                 |
 | `sources`                     | `string[]` | `["memory"]` | Add `"sessions"` to include transcripts |
+| `sync.maxFileScanEntries`     | `number`   | `10000`      | Max memory file discovery entries       |
 | `sync.sessions.deltaBytes`    | `number`   | `100000`     | Byte threshold for reindex              |
 | `sync.sessions.deltaMessages` | `number`   | `50`         | Message threshold for reindex           |
 

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -509,6 +509,7 @@ async function scanSessionFiles(agentId: string): Promise<SourceScan> {
 async function scanMemoryFiles(
   workspaceDir: string,
   extraPaths: string[] = [],
+  maxFileScanEntries?: number,
 ): Promise<SourceScan> {
   const issues: string[] = [];
   const memoryFile = path.join(workspaceDir, "MEMORY.md");
@@ -562,7 +563,14 @@ async function scanMemoryFiles(
   let listed: string[] = [];
   let listedOk = false;
   try {
-    listed = await listMemoryFiles(workspaceDir, resolvedExtraPaths);
+    listed = await listMemoryFiles(workspaceDir, resolvedExtraPaths, undefined, {
+      maxScanEntries: maxFileScanEntries,
+      onTruncated: (event) => {
+        issues.push(
+          `memory file scan truncated (${shortenHomePath(event.dir)}): ${event.reason}, scanned ${event.scannedEntryCount} of ${event.maxScanEntries} configured entries`,
+        );
+      },
+    });
     listedOk = true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
@@ -627,12 +635,13 @@ async function scanMemorySources(params: {
   agentId: string;
   sources: MemorySourceName[];
   extraPaths?: string[];
+  maxFileScanEntries?: number;
 }): Promise<MemorySourceScan> {
   const scans: SourceScan[] = [];
   const extraPaths = params.extraPaths ?? [];
   for (const source of params.sources) {
     if (source === "memory") {
-      scans.push(await scanMemoryFiles(params.workspaceDir, extraPaths));
+      scans.push(await scanMemoryFiles(params.workspaceDir, extraPaths, params.maxFileScanEntries));
     }
     if (source === "sessions") {
       scans.push(await scanSessionFiles(params.agentId));
@@ -745,6 +754,7 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
               agentId,
               sources,
               extraPaths: status.extraPaths,
+              maxFileScanEntries: status.sync?.maxFileScanEntries,
             })
           : undefined;
         let audit: ShortTermAuditSummary | undefined;

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -644,6 +644,88 @@ describe("memory index", () => {
     ).toEqual({ path: "memory/preserved.md" });
   });
 
+  it("carries existing memory rows through truncated safe full reindexes", async () => {
+    forceNoProvider = true;
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-truncated-safe-reindex.sqlite"),
+      maxFileScanEntries: 0,
+      hybrid: { enabled: true },
+    });
+    const manager = await getPersistentManager(cfg);
+    if (!manager.status().fts?.available) {
+      return;
+    }
+
+    let db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            get: (...args: unknown[]) => { path: string } | undefined;
+            run: (...args: unknown[]) => void;
+          };
+        };
+      }
+    ).db;
+    db.prepare("INSERT INTO files (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)").run(
+      "memory/full-preserved.md",
+      "memory",
+      "full-preserved-hash",
+      0,
+      21,
+    );
+    db.prepare(
+      `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "full-preserved-chunk",
+      "memory/full-preserved.md",
+      "memory",
+      1,
+      1,
+      "full-preserved-chunk-hash",
+      "fts-only",
+      "full reindex preserved row",
+      "[]",
+      0,
+    );
+    db.prepare(
+      `INSERT INTO chunks_fts (text, id, path, source, model, start_line, end_line)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "full reindex preserved row",
+      "full-preserved-chunk",
+      "memory/full-preserved.md",
+      "memory",
+      "fts-only",
+      1,
+      1,
+    );
+
+    await manager.sync({ reason: "test", force: true });
+
+    db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            get: (...args: unknown[]) => { path: string } | undefined;
+          };
+        };
+      }
+    ).db;
+    expect(
+      db
+        .prepare("SELECT path FROM files WHERE path = ? AND source = ?")
+        .get("memory/full-preserved.md", "memory"),
+    ).toEqual({ path: "memory/full-preserved.md" });
+    expect(
+      db
+        .prepare("SELECT path FROM chunks WHERE id = ? AND source = ?")
+        .get("full-preserved-chunk", "memory"),
+    ).toEqual({ path: "memory/full-preserved.md" });
+  });
+
   it("prefers exact session transcript hits in FTS-only mode", async () => {
     try {
       const manager = await getFtsSessionManager({

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -710,6 +710,7 @@ describe("memory index", () => {
         db: {
           prepare: (sql: string) => {
             get: (...args: unknown[]) => { path: string } | undefined;
+            run: (...args: unknown[]) => void;
           };
         };
       }

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -245,6 +245,7 @@ describe("memory index", () => {
     minScore?: number;
     onSearch?: boolean;
     hybrid?: { enabled: boolean; vectorWeight?: number; textWeight?: number };
+    maxFileScanEntries?: number;
   }): TestCfg {
     return {
       agents: {
@@ -257,7 +258,12 @@ describe("memory index", () => {
             store: { path: params.storePath, vector: { enabled: params.vectorEnabled ?? false } },
             // Perf: keep test indexes to a single chunk to reduce sqlite work.
             chunking: { tokens: 4000, overlap: 0 },
-            sync: { watch: false, onSessionStart: false, onSearch: params.onSearch ?? true },
+            sync: {
+              watch: false,
+              onSessionStart: false,
+              onSearch: params.onSearch ?? true,
+              maxFileScanEntries: params.maxFileScanEntries,
+            },
             query: {
               minScore: params.minScore ?? 0,
               hybrid: params.hybrid ?? { enabled: false },
@@ -594,6 +600,48 @@ describe("memory index", () => {
 
     const noResults = await manager.search("nonexistent_xyz_keyword");
     expect(noResults.length).toBe(0);
+  });
+
+  it("keeps existing memory rows when file discovery truncates", async () => {
+    forceNoProvider = true;
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-truncated-memory-scan.sqlite"),
+      maxFileScanEntries: 0,
+      hybrid: { enabled: true },
+    });
+    const manager = await getPersistentManager(cfg);
+    if (!manager.status().fts?.available) {
+      return;
+    }
+
+    await manager.sync({ reason: "test", force: true });
+    const db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            get: (...args: unknown[]) => { path: string } | undefined;
+            run: (...args: unknown[]) => void;
+          };
+        };
+      }
+    ).db;
+    db.prepare("INSERT INTO files (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)").run(
+      "memory/preserved.md",
+      "memory",
+      "preserved-hash",
+      0,
+      12,
+    );
+    (manager as unknown as { dirty: boolean }).dirty = true;
+
+    await manager.sync({ reason: "test" });
+
+    expect(
+      db
+        .prepare("SELECT path FROM files WHERE path = ? AND source = ?")
+        .get("memory/preserved.md", "memory"),
+    ).toEqual({ path: "memory/preserved.md" });
   });
 
   it("prefers exact session transcript hits in FTS-only mode", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -30,6 +30,7 @@ let embedBatchCalls = 0;
 let embedBatchInputCalls = 0;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];
 let forceNoProvider = false;
+let providerInitError: string | null = null;
 
 vi.mock("./embeddings.js", () => {
   const embedText = (text: string) => {
@@ -51,6 +52,9 @@ vi.mock("./embeddings.js", () => {
         model: options.model,
         outputDimensionality: options.outputDimensionality,
       });
+      if (providerInitError) {
+        throw new Error(providerInitError);
+      }
       if (forceNoProvider) {
         return {
           provider: null,
@@ -189,6 +193,7 @@ describe("memory index", () => {
     embedBatchInputCalls = 0;
     providerCalls = [];
     forceNoProvider = false;
+    providerInitError = null;
 
     rmSync(workspaceDir, { recursive: true, force: true });
     mkdirSync(memoryDir, { recursive: true });
@@ -464,6 +469,31 @@ describe("memory index", () => {
     expect((cached?.cacheExpiresAtMs ?? 0) - (cached?.checkedAtMs ?? 0)).toBe(
       EMBEDDING_PROBE_CACHE_TTL_MS,
     );
+  });
+
+  it("reports embedding provider initialization failures as unavailable", async () => {
+    providerInitError = "node-llama-cpp missing";
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-probe-init-failure.sqlite"),
+      vectorEnabled: true,
+    });
+    const manager = requireManager(
+      await getMemorySearchManager({ cfg, agentId: "main", purpose: "status" }),
+    );
+    managersForCleanup.add(manager);
+
+    await expect(manager.probeEmbeddingAvailability()).resolves.toEqual({
+      ok: false,
+      error: "node-llama-cpp missing",
+    });
+    expect(manager.getCachedEmbeddingAvailability?.()).toEqual(
+      expect.objectContaining({
+        ok: false,
+        cached: true,
+        error: "node-llama-cpp missing",
+      }),
+    );
+    await expect(manager.probeVectorAvailability()).resolves.toBe(false);
   });
 
   it("streams embedding cache rows during safe reindex", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -727,6 +727,81 @@ describe("memory index", () => {
     ).toEqual({ path: "memory/full-preserved.md" });
   });
 
+  it("clears seeded old-model FTS rows when safe full reindex rewrites a file", async () => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-seeded-fts-model-change.sqlite"),
+      hybrid: { enabled: true },
+    });
+    const manager = await getPersistentManager(cfg);
+    if (!manager.status().fts?.available) {
+      return;
+    }
+
+    let db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            all: (...args: unknown[]) => Array<{ model: string }>;
+            run: (...args: unknown[]) => void;
+          };
+        };
+      }
+    ).db;
+    db.prepare("INSERT INTO files (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)").run(
+      "memory/2026-01-12.md",
+      "memory",
+      "old-hash",
+      0,
+      21,
+    );
+    db.prepare(
+      `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "old-model-chunk",
+      "memory/2026-01-12.md",
+      "memory",
+      1,
+      1,
+      "old-chunk-hash",
+      "old-embed-model",
+      "old model stale row",
+      "[]",
+      0,
+    );
+    db.prepare(
+      `INSERT INTO chunks_fts (text, id, path, source, model, start_line, end_line)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "old model stale row",
+      "old-model-chunk",
+      "memory/2026-01-12.md",
+      "memory",
+      "old-embed-model",
+      1,
+      1,
+    );
+
+    await manager.sync({ reason: "test", force: true });
+
+    db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            all: (...args: unknown[]) => Array<{ model: string }>;
+            run: (...args: unknown[]) => void;
+          };
+        };
+      }
+    ).db;
+    const rows = db
+      .prepare("SELECT model FROM chunks_fts WHERE path = ? AND source = ? ORDER BY model")
+      .all("memory/2026-01-12.md", "memory");
+    expect(rows).toEqual([{ model: "mock-embed" }]);
+  });
+
   it("prefers exact session transcript hits in FTS-only mode", async () => {
     try {
       const manager = await getFtsSessionManager({

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -546,7 +546,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           tableName: FTS_TABLE,
           path: pathname,
           source,
-          currentModel: this.provider?.model,
         });
       } catch {}
     }

--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -80,6 +80,7 @@ describe("memory reindex state", () => {
     const firstScopeHash = resolveConfiguredScopeHash({
       workspaceDir,
       extraPaths: ["/tmp/workspace/a"],
+      maxFileScanEntries: 10_000,
       multimodal: {
         enabled: false,
         modalities: [],
@@ -89,6 +90,7 @@ describe("memory reindex state", () => {
     const secondScopeHash = resolveConfiguredScopeHash({
       workspaceDir,
       extraPaths: ["/tmp/workspace/b"],
+      maxFileScanEntries: 10_000,
       multimodal: {
         enabled: false,
         modalities: [],
@@ -116,11 +118,45 @@ describe("memory reindex state", () => {
     ).toBe(true);
   });
 
+  it("requires a full reindex when the memory file scan cap changes", () => {
+    const workspaceDir = "/tmp/workspace";
+    const firstScopeHash = resolveConfiguredScopeHash({
+      workspaceDir,
+      extraPaths: ["/tmp/workspace/a"],
+      maxFileScanEntries: 10_000,
+      multimodal: {
+        enabled: false,
+        modalities: [],
+        maxFileBytes: 20 * 1024 * 1024,
+      },
+    });
+    const secondScopeHash = resolveConfiguredScopeHash({
+      workspaceDir,
+      extraPaths: ["/tmp/workspace/a"],
+      maxFileScanEntries: 1_000,
+      multimodal: {
+        enabled: false,
+        modalities: [],
+        maxFileBytes: 20 * 1024 * 1024,
+      },
+    });
+
+    expect(
+      shouldRunFullMemoryReindex(
+        createFullReindexParams({
+          meta: createMeta({ scopeHash: firstScopeHash }),
+          configuredScopeHash: secondScopeHash,
+        }),
+      ),
+    ).toBe(true);
+  });
+
   it("requires a full reindex when multimodal settings change", () => {
     const workspaceDir = "/tmp/workspace";
     const firstScopeHash = resolveConfiguredScopeHash({
       workspaceDir,
       extraPaths: ["/tmp/workspace/media"],
+      maxFileScanEntries: 10_000,
       multimodal: {
         enabled: false,
         modalities: [],
@@ -130,6 +166,7 @@ describe("memory reindex state", () => {
     const secondScopeHash = resolveConfiguredScopeHash({
       workspaceDir,
       extraPaths: ["/tmp/workspace/media"],
+      maxFileScanEntries: 10_000,
       multimodal: {
         enabled: true,
         modalities: ["image"],

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -52,6 +52,7 @@ function configuredMetaSourcesDiffer(params: {
 export function resolveConfiguredScopeHash(params: {
   workspaceDir: string;
   extraPaths?: string[];
+  maxFileScanEntries: number;
   multimodal: {
     enabled: boolean;
     modalities: string[];
@@ -64,6 +65,7 @@ export function resolveConfiguredScopeHash(params: {
   return hashText(
     JSON.stringify({
       extraPaths,
+      maxFileScanEntries: params.maxFileScanEntries,
       multimodal: {
         enabled: params.multimodal.enabled,
         modalities: [...params.multimodal.modalities].toSorted(),

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -734,19 +734,22 @@ export abstract class MemoryManagerSyncOps {
         ? this.db.prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
         : null;
 
+    let memoryFileScanTruncated = false;
     const files = await listMemoryFiles(
       this.workspaceDir,
       this.settings.extraPaths,
       this.settings.multimodal,
       {
         maxScanEntries: this.settings.sync.maxFileScanEntries,
-        onTruncated: (event) =>
+        onTruncated: (event) => {
+          memoryFileScanTruncated = true;
           log.warn("memory sync: memory file scan truncated", {
             dir: event.dir,
             scannedEntryCount: event.scannedEntryCount,
             maxFileScanEntries: event.maxScanEntries,
             reason: event.reason,
-          }),
+          });
+        },
       },
     );
     const fileEntries = (
@@ -801,6 +804,15 @@ export abstract class MemoryManagerSyncOps {
       }
     });
     await runWithConcurrency(tasks, this.getIndexConcurrency());
+
+    if (memoryFileScanTruncated) {
+      log.warn("memory sync: skipped stale memory file pruning after truncated scan", {
+        activePaths: activePaths.size,
+        existingRows: existingRows.length,
+        maxFileScanEntries: this.settings.sync.maxFileScanEntries,
+      });
+      return;
+    }
 
     for (const stale of existingRows) {
       if (activePaths.has(stale.path)) {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -738,6 +738,16 @@ export abstract class MemoryManagerSyncOps {
       this.workspaceDir,
       this.settings.extraPaths,
       this.settings.multimodal,
+      {
+        maxScanEntries: this.settings.sync.maxFileScanEntries,
+        onTruncated: (event) =>
+          log.warn("memory sync: memory file scan truncated", {
+            dir: event.dir,
+            scannedEntryCount: event.scannedEntryCount,
+            maxFileScanEntries: event.maxScanEntries,
+            reason: event.reason,
+          }),
+      },
     );
     const fileEntries = (
       await runWithConcurrency(
@@ -995,6 +1005,7 @@ export abstract class MemoryManagerSyncOps {
     const configuredScopeHash = resolveConfiguredScopeHash({
       workspaceDir: this.workspaceDir,
       extraPaths: this.settings.extraPaths,
+      maxFileScanEntries: this.settings.sync.maxFileScanEntries,
       multimodal: {
         enabled: this.settings.multimodal.enabled,
         modalities: this.settings.multimodal.modalities,
@@ -1247,6 +1258,7 @@ export abstract class MemoryManagerSyncOps {
             scopeHash: resolveConfiguredScopeHash({
               workspaceDir: this.workspaceDir,
               extraPaths: this.settings.extraPaths,
+              maxFileScanEntries: this.settings.sync.maxFileScanEntries,
               multimodal: {
                 enabled: this.settings.multimodal.enabled,
                 modalities: this.settings.multimodal.modalities,
@@ -1323,6 +1335,7 @@ export abstract class MemoryManagerSyncOps {
       scopeHash: resolveConfiguredScopeHash({
         workspaceDir: this.workspaceDir,
         extraPaths: this.settings.extraPaths,
+        maxFileScanEntries: this.settings.sync.maxFileScanEntries,
         multimodal: {
           enabled: this.settings.multimodal.enabled,
           modalities: this.settings.multimodal.modalities,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -76,6 +76,42 @@ type MemoryIndexEntry = {
   content?: string;
 };
 
+type MemoryFileRecord = {
+  path: string;
+  source: MemorySource;
+  hash: string;
+  mtime: number;
+  size: number;
+};
+
+type MemoryChunkRecord = {
+  id: string;
+  path: string;
+  source: MemorySource;
+  start_line: number;
+  end_line: number;
+  hash: string;
+  model: string;
+  text: string;
+  embedding: string;
+  updated_at: number;
+};
+
+type MemoryFtsRecord = {
+  text: string;
+  id: string;
+  path: string;
+  source: MemorySource;
+  model: string;
+  start_line: number;
+  end_line: number;
+};
+
+type MemoryVectorRecord = {
+  id: string;
+  embedding: Buffer | Uint8Array;
+};
+
 const META_KEY = "memory_index_meta_v1";
 const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
@@ -1125,6 +1161,148 @@ export abstract class MemoryManagerSyncOps {
     }
   }
 
+  private copyMemoryRowsFromOriginalIndex(originalDb: DatabaseSync): {
+    files: number;
+    chunks: number;
+  } {
+    const insertFile = this.db.prepare(
+      `INSERT OR IGNORE INTO files (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)`,
+    );
+    const insertChunk = this.db.prepare(
+      `INSERT OR IGNORE INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    let files = 0;
+    let chunks = 0;
+    this.db.exec("BEGIN");
+    try {
+      const fileRows = originalDb
+        .prepare(`SELECT path, source, hash, mtime, size FROM files WHERE source = ?`)
+        .iterate("memory") as IterableIterator<MemoryFileRecord>;
+      for (const row of fileRows) {
+        insertFile.run(row.path, row.source, row.hash, row.mtime, row.size);
+        files += 1;
+      }
+      const chunkRows = originalDb
+        .prepare(
+          `SELECT id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
+           FROM chunks WHERE source = ?`,
+        )
+        .iterate("memory") as IterableIterator<MemoryChunkRecord>;
+      for (const row of chunkRows) {
+        insertChunk.run(
+          row.id,
+          row.path,
+          row.source,
+          row.start_line,
+          row.end_line,
+          row.hash,
+          row.model,
+          row.text,
+          row.embedding,
+          row.updated_at,
+        );
+        chunks += 1;
+      }
+      this.db.exec("COMMIT");
+    } catch (err) {
+      try {
+        this.db.exec("ROLLBACK");
+      } catch {}
+      throw err;
+    }
+    return { files, chunks };
+  }
+
+  private copyMemoryFtsRowsFromOriginalIndex(originalDb: DatabaseSync): number {
+    if (!this.fts.enabled || !this.fts.available) {
+      return 0;
+    }
+    const insertFts = this.db.prepare(
+      `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    let rows = 0;
+    try {
+      const ftsRows = originalDb
+        .prepare(
+          `SELECT text, id, path, source, model, start_line, end_line
+           FROM ${FTS_TABLE} WHERE source = ?`,
+        )
+        .iterate("memory") as IterableIterator<MemoryFtsRecord>;
+      for (const row of ftsRows) {
+        insertFts.run(
+          row.text,
+          row.id,
+          row.path,
+          row.source,
+          row.model,
+          row.start_line,
+          row.end_line,
+        );
+        rows += 1;
+      }
+    } catch (err) {
+      log.debug("memory sync: skipped existing FTS row copy during full reindex", {
+        error: formatErrorMessage(err),
+      });
+      return 0;
+    }
+    return rows;
+  }
+
+  private async copyMemoryVectorRowsFromOriginalIndex(params: {
+    originalDb: DatabaseSync;
+    vectorDims?: number;
+  }): Promise<number> {
+    if (!this.vector.enabled || !params.vectorDims) {
+      return 0;
+    }
+    const ready = await this.ensureVectorReady(params.vectorDims);
+    if (!ready) {
+      return 0;
+    }
+    const insertVector = this.db.prepare(
+      `INSERT INTO ${VECTOR_TABLE} (id, embedding) VALUES (?, ?)`,
+    );
+    let rows = 0;
+    try {
+      const vectorRows = params.originalDb
+        .prepare(
+          `SELECT id, embedding FROM ${VECTOR_TABLE}
+           WHERE id IN (SELECT id FROM chunks WHERE source = ?)`,
+        )
+        .iterate("memory") as IterableIterator<MemoryVectorRecord>;
+      for (const row of vectorRows) {
+        try {
+          insertVector.run(row.id, row.embedding);
+          rows += 1;
+        } catch {}
+      }
+    } catch (err) {
+      log.debug("memory sync: skipped existing vector row copy during full reindex", {
+        error: formatErrorMessage(err),
+      });
+      return 0;
+    }
+    return rows;
+  }
+
+  private async seedExistingMemoryRowsForFullReindex(params: {
+    originalDb: DatabaseSync;
+    vectorDims?: number;
+  }): Promise<void> {
+    const copied = this.copyMemoryRowsFromOriginalIndex(params.originalDb);
+    const ftsRows = this.copyMemoryFtsRowsFromOriginalIndex(params.originalDb);
+    const vectorRows = await this.copyMemoryVectorRowsFromOriginalIndex(params);
+    log.debug("memory sync: seeded existing memory rows for full reindex", {
+      files: copied.files,
+      chunks: copied.chunks,
+      ftsRows,
+      vectorRows,
+    });
+  }
+
   private shouldFallbackOnError(message: string): boolean {
     return /embedding|embeddings|batch/i.test(message);
   }
@@ -1248,6 +1426,10 @@ export abstract class MemoryManagerSyncOps {
           );
 
           if (shouldSyncMemory) {
+            await this.seedExistingMemoryRowsForFullReindex({
+              originalDb,
+              vectorDims: originalState.vectorDims,
+            });
             await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
             this.dirty = false;
           }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -785,6 +785,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       sources: Array.from(this.sources),
       extraPaths: this.settings.extraPaths,
       sourceCounts: aggregateState.sourceCounts,
+      sync: {
+        maxFileScanEntries: this.settings.sync.maxFileScanEntries,
+      },
       cache: this.cache.enabled
         ? {
             enabled: true,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -846,7 +846,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.vector.semanticAvailable = false;
       return false;
     }
-    await this.ensureProviderInitialized();
+    try {
+      await this.ensureProviderInitialized();
+    } catch (err) {
+      const message = formatErrorMessage(err);
+      this.providerUnavailableReason = message;
+      this.vector.semanticAvailable = false;
+      return false;
+    }
     // FTS-only mode: vector search not available
     if (!this.provider) {
       this.vector.semanticAvailable = false;
@@ -899,15 +906,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (cached) {
       return cached;
     }
-    await this.ensureProviderInitialized();
-    // FTS-only mode: embeddings not available but search still works
-    if (!this.provider) {
-      return this.cacheProbeResult({
-        ok: false,
-        error: this.providerUnavailableReason ?? "No embedding provider available (FTS-only mode)",
-      });
-    }
     try {
+      await this.ensureProviderInitialized();
+      // FTS-only mode: embeddings not available but search still works
+      if (!this.provider) {
+        return this.cacheProbeResult({
+          ok: false,
+          error:
+            this.providerUnavailableReason ?? "No embedding provider available (FTS-only mode)",
+        });
+      }
       await this.embedBatchWithRetry(["ping"]);
       return this.cacheProbeResult({ ok: true });
     } catch (err) {

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -78,6 +78,24 @@ describe("memory host SDK package internals", () => {
     ]);
   });
 
+  it("bounds recursive memory file discovery with a scan-entry cap", async () => {
+    const tmpDir = getTmpDir();
+    const extraDir = path.join(tmpDir, "extra");
+    fsSync.mkdirSync(extraDir, { recursive: true });
+    for (let index = 0; index < 20; index += 1) {
+      fsSync.writeFileSync(path.join(extraDir, `note-${index}.md`), `# Note ${index}`);
+    }
+    const truncations: Array<{ dir: string; reason: string }> = [];
+
+    const files = await listMemoryFiles(tmpDir, [extraDir], undefined, {
+      maxScanEntries: 5,
+      onTruncated: (event) => truncations.push({ dir: event.dir, reason: event.reason }),
+    });
+
+    expect(files.length).toBeLessThan(20);
+    expect(truncations).toEqual([{ dir: extraDir, reason: "walk-truncated" }]);
+  });
+
   it("allows top-level dreams path casing variants", () => {
     expect(isMemoryPath("dreams.md")).toBe(true);
     expect(isMemoryPath("DREAMS.md")).toBe(true);

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -45,6 +45,20 @@ export type MemoryFileEntry = {
   mimeType?: string;
 };
 
+export type ListMemoryFilesTruncationReason = "budget-exhausted" | "walk-truncated";
+
+export type ListMemoryFilesTruncation = {
+  dir: string;
+  scannedEntryCount: number;
+  maxScanEntries: number;
+  reason: ListMemoryFilesTruncationReason;
+};
+
+export type ListMemoryFilesOptions = {
+  maxScanEntries?: number;
+  onTruncated?: (event: ListMemoryFilesTruncation) => void;
+};
+
 export type MemoryChunk = {
   startLine: number;
   endLine: number;
@@ -124,8 +138,10 @@ async function collectMemoryFilesFromDir(
   files: string[],
   multimodal?: MemoryMultimodalSettings,
   shouldSkipPath?: (absPath: string) => boolean,
-): Promise<void> {
+  maxScanEntries?: number,
+): Promise<{ scannedEntryCount: number; truncated: boolean }> {
   const scan = await walkDirectory(dir, {
+    maxEntries: maxScanEntries,
     symlinks: "skip",
     descend: (entry) => shouldDescendMemoryEntry(entry, shouldSkipPath),
     include: (entry) =>
@@ -134,18 +150,65 @@ async function collectMemoryFilesFromDir(
       isAllowedMemoryFilePath(entry.path, multimodal),
   });
   files.push(...scan.entries.map((entry) => entry.path));
+  return {
+    scannedEntryCount: scan.scannedEntryCount,
+    truncated: scan.truncated,
+  };
+}
+
+function normalizeMemoryFileScanLimit(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(0, Math.floor(value));
 }
 
 export async function listMemoryFiles(
   workspaceDir: string,
   extraPaths?: string[],
   multimodal?: MemoryMultimodalSettings,
+  options?: ListMemoryFilesOptions,
 ): Promise<string[]> {
   const result: string[] = [];
   const memoryDir = path.join(workspaceDir, "memory");
+  const maxScanEntries = normalizeMemoryFileScanLimit(options?.maxScanEntries);
+  let remainingScanEntries = maxScanEntries;
 
   const shouldSkipWorkspaceMemoryPath = (absPath: string): boolean =>
     shouldSkipRootMemoryAuxiliaryPath({ workspaceDir, absPath });
+
+  const collectDirectory = async (dir: string) => {
+    if (remainingScanEntries !== undefined && remainingScanEntries <= 0) {
+      options?.onTruncated?.({
+        dir,
+        scannedEntryCount: 0,
+        maxScanEntries: maxScanEntries ?? 0,
+        reason: "budget-exhausted",
+      });
+      return;
+    }
+    const scan = await collectMemoryFilesFromDir(
+      dir,
+      result,
+      multimodal,
+      shouldSkipWorkspaceMemoryPath,
+      remainingScanEntries,
+    );
+    if (remainingScanEntries !== undefined) {
+      remainingScanEntries = Math.max(0, remainingScanEntries - scan.scannedEntryCount);
+    }
+    if (scan.truncated && maxScanEntries !== undefined) {
+      options?.onTruncated?.({
+        dir,
+        scannedEntryCount: scan.scannedEntryCount,
+        maxScanEntries,
+        reason: "walk-truncated",
+      });
+    }
+  };
 
   const addMarkdownFile = async (absPath: string) => {
     try {
@@ -167,7 +230,7 @@ export async function listMemoryFiles(
   try {
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
-      await collectMemoryFilesFromDir(memoryDir, result, multimodal, shouldSkipWorkspaceMemoryPath);
+      await collectDirectory(memoryDir);
     }
   } catch {}
 
@@ -183,12 +246,7 @@ export async function listMemoryFiles(
           continue;
         }
         if (stat.isDirectory()) {
-          await collectMemoryFilesFromDir(
-            inputPath,
-            result,
-            multimodal,
-            shouldSkipWorkspaceMemoryPath,
-          );
+          await collectDirectory(inputPath);
           continue;
         }
         if (stat.isFile() && isAllowedMemoryFilePath(inputPath, multimodal)) {

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -56,6 +56,7 @@ export type MemoryProviderStatus = {
   extraPaths?: string[];
   sources?: MemorySource[];
   sourceCounts?: Array<{ source: MemorySource; files: number; chunks: number }>;
+  sync?: { maxFileScanEntries?: number };
   cache?: { enabled: boolean; entries?: number; maxEntries?: number };
   fts?: { enabled: boolean; available: boolean; error?: string };
   fallback?: { from: string; reason?: string };

--- a/scripts/io-trace-preload.mjs
+++ b/scripts/io-trace-preload.mjs
@@ -1,0 +1,224 @@
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const rawOutputPath = process.env.OPENCLAW_IO_TRACE_OUT;
+const outputPath =
+  rawOutputPath && rawOutputPath.trim().length > 0
+    ? path.resolve(
+        rawOutputPath
+          .replaceAll("{pid}", String(process.pid))
+          .replaceAll("%p", String(process.pid)),
+      )
+    : path.resolve(process.cwd(), ".artifacts", "io-trace", `trace-${process.pid}.json`);
+const roots = resolveTraceRoots();
+const records = new Map();
+const captureStacks = process.env.OPENCLAW_IO_TRACE_STACKS === "1";
+let flushing = false;
+
+function resolveTraceRoots() {
+  const explicit = (process.env.OPENCLAW_IO_TRACE_ROOTS ?? "")
+    .split(path.delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => path.resolve(entry));
+  if (explicit.length > 0) {
+    return explicit;
+  }
+  return [
+    process.cwd(),
+    process.env.OPENCLAW_HOME,
+    process.env.OPENCLAW_STATE_DIR,
+    process.env.OPENCLAW_CONFIG_PATH ? path.dirname(process.env.OPENCLAW_CONFIG_PATH) : undefined,
+  ]
+    .filter((entry) => typeof entry === "string" && entry.length > 0)
+    .map((entry) => path.resolve(entry));
+}
+
+function pathFromArg(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value instanceof URL && value.protocol === "file:") {
+    return fileURLToPath(value);
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString("utf8");
+  }
+  return undefined;
+}
+
+function normalizedTracePath(value) {
+  const raw = pathFromArg(value);
+  if (!raw || raw.length === 0) {
+    return undefined;
+  }
+  const resolved = path.resolve(raw);
+  if (!roots.some((root) => resolved === root || resolved.startsWith(`${root}${path.sep}`))) {
+    return undefined;
+  }
+  return resolved;
+}
+
+function byteLength(value) {
+  if (typeof value === "string") {
+    return Buffer.byteLength(value);
+  }
+  if (Buffer.isBuffer(value) || ArrayBuffer.isView(value)) {
+    return value.byteLength;
+  }
+  return 0;
+}
+
+function stackSample() {
+  if (!captureStacks) {
+    return undefined;
+  }
+  return (new Error().stack ?? "")
+    .split("\n")
+    .slice(2)
+    .map((line) => line.trim())
+    .filter((line) => !line.includes("scripts/io-trace-preload.mjs"))
+    .slice(0, 8)
+    .join("\n");
+}
+
+function record(op, rawPath, bytes = 0) {
+  const tracedPath = normalizedTracePath(rawPath);
+  if (!tracedPath) {
+    return;
+  }
+  const key = `${op}\0${tracedPath}`;
+  const current = records.get(key) ?? {
+    op,
+    path: tracedPath,
+    count: 0,
+    bytes: 0,
+    stacks: new Map(),
+  };
+  current.count += 1;
+  current.bytes += bytes;
+  const stack = stackSample();
+  if (stack) {
+    current.stacks.set(stack, (current.stacks.get(stack) ?? 0) + 1);
+  }
+  records.set(key, current);
+}
+
+function wrapSync(name, before) {
+  const original = fs[name];
+  if (typeof original !== "function") {
+    return;
+  }
+  fs[name] = function tracedFsSync(...args) {
+    before(args);
+    const result = original.apply(this, args);
+    if (name === "readFileSync") {
+      record(name, args[0], byteLength(result));
+    }
+    return result;
+  };
+}
+
+function wrapPromise(name, before, after) {
+  const original = fs.promises[name];
+  if (typeof original !== "function") {
+    return;
+  }
+  fs.promises[name] = async function tracedFsPromise(...args) {
+    before(args);
+    const result = await original.apply(this, args);
+    after?.(args, result);
+    return result;
+  };
+}
+
+wrapSync("readFileSync", (args) => record("readFileSync:start", args[0]));
+wrapSync("writeFileSync", (args) => record("writeFileSync", args[0], byteLength(args[1])));
+wrapSync("appendFileSync", (args) => record("appendFileSync", args[0], byteLength(args[1])));
+wrapSync("readdirSync", (args) => record("readdirSync", args[0]));
+wrapSync("statSync", (args) => record("statSync", args[0]));
+wrapSync("lstatSync", (args) => record("lstatSync", args[0]));
+wrapSync("existsSync", (args) => record("existsSync", args[0]));
+wrapSync("mkdirSync", (args) => record("mkdirSync", args[0]));
+wrapSync("rmSync", (args) => record("rmSync", args[0]));
+wrapSync("unlinkSync", (args) => record("unlinkSync", args[0]));
+
+wrapPromise(
+  "readFile",
+  (args) => record("readFile:start", args[0]),
+  (args, result) => record("readFile", args[0], byteLength(result)),
+);
+wrapPromise("writeFile", (args) => record("writeFile", args[0], byteLength(args[1])));
+wrapPromise("appendFile", (args) => record("appendFile", args[0], byteLength(args[1])));
+wrapPromise("readdir", (args) => record("readdir", args[0]));
+wrapPromise("stat", (args) => record("stat", args[0]));
+wrapPromise("lstat", (args) => record("lstat", args[0]));
+wrapPromise("access", (args) => record("access", args[0]));
+wrapPromise("mkdir", (args) => record("mkdir", args[0]));
+wrapPromise("rm", (args) => record("rm", args[0]));
+wrapPromise("unlink", (args) => record("unlink", args[0]));
+
+const originalCreateReadStream = fs.createReadStream;
+fs.createReadStream = function tracedCreateReadStream(file, ...args) {
+  record("createReadStream", file);
+  return originalCreateReadStream.call(this, file, ...args);
+};
+
+const originalCreateWriteStream = fs.createWriteStream;
+fs.createWriteStream = function tracedCreateWriteStream(file, ...args) {
+  record("createWriteStream", file);
+  return originalCreateWriteStream.call(this, file, ...args);
+};
+
+syncBuiltinESMExports();
+
+function flush() {
+  if (flushing) {
+    return;
+  }
+  flushing = true;
+  try {
+    const entries = [...records.values()]
+      .map((entry) => {
+        const stacks = [...entry.stacks.entries()]
+          .map(([stack, count]) => ({ count, stack }))
+          .sort((left, right) => right.count - left.count)
+          .slice(0, 5);
+        return { op: entry.op, path: entry.path, count: entry.count, bytes: entry.bytes, stacks };
+      })
+      .sort((left, right) => {
+        const countDiff = right.count - left.count;
+        return countDiff === 0 ? left.path.localeCompare(right.path) : countDiff;
+      });
+    const summary = {
+      generatedAt: new Date().toISOString(),
+      pid: process.pid,
+      cwd: process.cwd(),
+      command: process.argv,
+      roots,
+      operations: entries,
+      totals: entries.reduce(
+        (acc, entry) => {
+          acc.count += entry.count;
+          acc.bytes += entry.bytes;
+          acc.paths.add(entry.path);
+          return acc;
+        },
+        { count: 0, bytes: 0, paths: new Set() },
+      ),
+    };
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(
+      outputPath,
+      `${JSON.stringify({ ...summary, totals: { ...summary.totals, paths: summary.totals.paths.size } }, null, 2)}\n`,
+    );
+  } catch (error) {
+    process.stderr.write(`[io-trace] failed to write ${outputPath}: ${String(error)}\n`);
+  }
+}
+
+process.once("beforeExit", flush);
+process.once("exit", flush);

--- a/scripts/io-trace-preload.mjs
+++ b/scripts/io-trace-preload.mjs
@@ -185,11 +185,11 @@ function flush() {
       .map((entry) => {
         const stacks = [...entry.stacks.entries()]
           .map(([stack, count]) => ({ count, stack }))
-          .sort((left, right) => right.count - left.count)
+          .toSorted((left, right) => right.count - left.count)
           .slice(0, 5);
         return { op: entry.op, path: entry.path, count: entry.count, bytes: entry.bytes, stacks };
       })
-      .sort((left, right) => {
+      .toSorted((left, right) => {
         const countDiff = right.count - left.count;
         return countDiff === 0 ? left.path.localeCompare(right.path) : countDiff;
       });

--- a/scripts/synthetic-io-e2e-audit.mjs
+++ b/scripts/synthetic-io-e2e-audit.mjs
@@ -1,0 +1,911 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const repoRoot = process.cwd();
+const scale = readFlag("--scale") ?? "deep";
+const runId = new Date().toISOString().replace(/[:.]/g, "-");
+const artifactRoot = path.resolve(
+  readFlag("--out") ?? path.join(".artifacts", "synthetic-io-e2e", runId),
+);
+const stateRoot = path.join(artifactRoot, "state");
+const workspaceRoot = path.join(stateRoot, "workspace");
+const tracesRoot = path.join(artifactRoot, "traces");
+const logsRoot = path.join(artifactRoot, "logs");
+const summariesRoot = path.join(artifactRoot, "summaries");
+const gatewayToken = `synthetic-${randomBytes(16).toString("hex")}`;
+const gatewayPort = Number(readFlag("--port") ?? 24000 + Math.floor(Math.random() * 1000));
+
+const countsByScale = {
+  tiny: {
+    sessions: 120,
+    transcriptFiles: 40,
+    transcriptLines: 4,
+    dailyMemoryFiles: 30,
+    qmdFiles: 80,
+    deliveryFiles: 60,
+    cronJobs: 20,
+  },
+  small: {
+    sessions: 800,
+    transcriptFiles: 200,
+    transcriptLines: 8,
+    dailyMemoryFiles: 90,
+    qmdFiles: 300,
+    deliveryFiles: 200,
+    cronJobs: 80,
+  },
+  deep: {
+    sessions: 6000,
+    transcriptFiles: 1400,
+    transcriptLines: 18,
+    dailyMemoryFiles: 420,
+    qmdFiles: 1800,
+    deliveryFiles: 1200,
+    cronJobs: 400,
+  },
+};
+
+const counts = countsByScale[scale];
+if (!counts) {
+  throw new Error(`unknown --scale ${scale}`);
+}
+
+await fsp.mkdir(tracesRoot, { recursive: true });
+await fsp.mkdir(logsRoot, { recursive: true });
+await fsp.mkdir(summariesRoot, { recursive: true });
+
+generateSyntheticState();
+
+const cliResults = [];
+for (const [label, args, opts] of [
+  ["config validate", ["config", "validate", "--json"], { timeoutMs: 20_000, stacks: true }],
+  ["status deep", ["status", "--deep", "--json"], { timeoutMs: 45_000, stacks: true }],
+  [
+    "sessions limit 50",
+    ["sessions", "--json", "--limit", "50"],
+    { timeoutMs: 45_000, stacks: true },
+  ],
+  [
+    "sessions all agents",
+    ["sessions", "--json", "--limit", "50", "--all-agents"],
+    { timeoutMs: 45_000 },
+  ],
+  [
+    "memory status deep",
+    ["memory", "status", "--json", "--deep"],
+    { timeoutMs: 60_000, stacks: true },
+  ],
+  [
+    "memory search qmd",
+    ["memory", "search", "gateway rpc synthetic memory", "--json", "--max-results", "20"],
+    { timeoutMs: 60_000 },
+  ],
+  [
+    "memory rem harness",
+    ["memory", "rem-harness", "--json", "--path", path.join(workspaceRoot, "memory")],
+    { timeoutMs: 60_000 },
+  ],
+  [
+    "gateway status no service",
+    ["gateway", "status", "--json", "--url", `ws://127.0.0.1:${gatewayPort}`],
+    { timeoutMs: 25_000 },
+  ],
+]) {
+  console.log(`[audit] ${label}`);
+  cliResults.push(await runOpenClaw(label, args, opts));
+}
+
+const gateway = startGateway();
+let ready = false;
+for (let attempt = 0; attempt < 30; attempt += 1) {
+  const result = await runOpenClaw(
+    `rpc wait health ${attempt}`,
+    [
+      "gateway",
+      "call",
+      "health",
+      "--url",
+      `ws://127.0.0.1:${gatewayPort}`,
+      "--token",
+      gatewayToken,
+      "--json",
+      "--timeout",
+      "2000",
+    ],
+    { timeoutMs: 5_000 },
+  );
+  if (result.code === 0) {
+    ready = true;
+    break;
+  }
+  await delay(500);
+}
+
+const rpcResults = [];
+if (ready) {
+  for (const [label, method, params] of [
+    ["rpc health", "health", {}],
+    ["rpc status", "status", {}],
+    ["rpc diagnostics stability", "diagnostics.stability", {}],
+    ["rpc config get", "config.get", {}],
+    ["rpc config schema", "config.schema", {}],
+    ["rpc commands list", "commands.list", {}],
+    ["rpc tools catalog", "tools.catalog", {}],
+    [
+      "rpc tools effective",
+      "tools.effective",
+      { sessionKey: "agent:main:synthetic-session-00042" },
+    ],
+    ["rpc plugins ui descriptors", "plugins.uiDescriptors", {}],
+    ["rpc skills status", "skills.status", {}],
+    ["rpc agents list", "agents.list", {}],
+    ["rpc sessions list bounded", "sessions.list", { limit: 50, agentId: "main" }],
+    [
+      "rpc sessions list derived",
+      "sessions.list",
+      { limit: 50, agentId: "main", includeDerivedTitles: true, includeLastMessage: true },
+    ],
+    [
+      "rpc sessions preview",
+      "sessions.preview",
+      { keys: ["agent:main:synthetic-session-00042"], limit: 6, maxChars: 2000 },
+    ],
+    [
+      "rpc sessions describe",
+      "sessions.describe",
+      { key: "agent:main:synthetic-session-00042", includeLastMessage: true },
+    ],
+    [
+      "rpc sessions create",
+      "sessions.create",
+      { agentId: "main", task: "synthetic create smoke", emitCommandHooks: false },
+    ],
+    ["rpc doctor memory status", "doctor.memory.status", { deep: true }],
+    [
+      "rpc doctor memory rem harness",
+      "doctor.memory.remHarness",
+      { path: path.join(workspaceRoot, "memory") },
+    ],
+    ["rpc logs tail", "logs.tail", { limit: 20 }],
+  ]) {
+    console.log(`[audit] ${label}`);
+    rpcResults.push(
+      await runOpenClaw(
+        label,
+        [
+          "gateway",
+          "call",
+          method,
+          "--params",
+          JSON.stringify(params),
+          "--url",
+          `ws://127.0.0.1:${gatewayPort}`,
+          "--token",
+          gatewayToken,
+          "--json",
+          "--timeout",
+          "20000",
+        ],
+        { timeoutMs: 30_000, stacks: label.includes("sessions list") || label.includes("memory") },
+      ),
+    );
+  }
+}
+
+await stopGateway(gateway);
+
+const gatewayTrace = readGatewayTrace();
+const allResults = [...cliResults, ...rpcResults];
+const outsideWrites = allResults.flatMap((result) =>
+  result.trace.outsideStateWrites.map((entry) => ({ label: result.label, ...entry })),
+);
+const repoWrites = allResults.flatMap((result) =>
+  result.trace.repoWrites.map((entry) => ({ label: result.label, ...entry })),
+);
+const summary = {
+  artifactRoot,
+  scale,
+  counts,
+  gateway: {
+    ready,
+    port: gatewayPort,
+    resource: gateway.resource(),
+    trace: gatewayTrace,
+    stdoutBytes: Buffer.byteLength(gateway.stdout),
+    stderrBytes: Buffer.byteLength(gateway.stderr),
+    stderrSample: gateway.stderr.slice(0, 2000),
+  },
+  rankings: {
+    byOps: rank(allResults, (entry) => entry.trace.totalOps),
+    byWall: rank(allResults, (entry) => entry.wallMs),
+    byRss: rank(allResults, (entry) => entry.resource.maxRssKb),
+  },
+  failures: allResults
+    .filter((result) => result.code !== 0)
+    .map((result) => ({
+      label: result.label,
+      code: result.code,
+      signal: result.signal,
+      timedOut: result.timedOut,
+      stderrSample: result.stderrSample,
+    })),
+  outsideWrites,
+  repoWrites,
+};
+
+writeJson(path.join(artifactRoot, "deep-audit-summary.json"), summary);
+writeText(path.join(artifactRoot, "deep-audit-report.md"), renderMarkdown(summary));
+
+console.log("OPENCLAW_SYNTHETIC_IO_AUDIT_SUMMARY " + JSON.stringify(compactSummary(summary)));
+
+function readFlag(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    return "";
+  }
+  return value;
+}
+
+function generateSyntheticState() {
+  writeText(
+    path.join(workspaceRoot, "MEMORY.md"),
+    [
+      "# synthetic memory",
+      "",
+      "- active memory is enabled for this generated IO audit.",
+      "- qmd collections include synthetic operator notes, session exports, and dreams.",
+      "",
+    ].join("\n"),
+  );
+  writeText(
+    path.join(workspaceRoot, "IDENTITY.md"),
+    "# synthetic identity\n\nSynthetic remote audit state.\n",
+  );
+  writeText(
+    path.join(workspaceRoot, "DREAMS.md"),
+    [
+      "# dreams",
+      "",
+      "- do not scan every session transcript unless the caller asked.",
+      "- memory status should not touch delivery queue artifacts.",
+      "",
+    ].join("\n"),
+  );
+
+  for (let index = 0; index < counts.dailyMemoryFiles; index += 1) {
+    const date = dayString(index);
+    writeText(
+      path.join(workspaceRoot, "memory", `${date}.md`),
+      [
+        `# ${date}`,
+        "",
+        "## recall",
+        `- synthetic note ${index}: plugin state, session routing, gateway rpc, qmd search.`,
+        "",
+        "## dreams",
+        `- dream ${index}: verify file IO stays inside state/workspace unless explicitly reading repo metadata.`,
+        "",
+      ].join("\n"),
+    );
+  }
+
+  for (let index = 0; index < counts.qmdFiles; index += 1) {
+    const bucket = String(index % 36).padStart(2, "0");
+    writeText(
+      path.join(stateRoot, "agents", "main", "qmd", "sessions", bucket, `qmd-${pad(index)}.md`),
+      [
+        "---",
+        `title: qmd synthetic ${index}`,
+        `kind: ${index % 4 === 0 ? "dream" : "memory"}`,
+        `updated: ${iso(index % 365)}`,
+        "---",
+        "",
+        `Synthetic QMD entry ${index}. Gateway RPC, sessions.list, tools.catalog, plugins.uiDescriptors, memory-core, active memory, and delivery queues.`,
+        "",
+      ].join("\n"),
+    );
+  }
+
+  const sessionsDir = path.join(stateRoot, "agents", "main", "sessions");
+  const transcriptsDir = path.join(sessionsDir, "transcripts");
+  const store = {};
+  for (let index = 0; index < counts.sessions; index += 1) {
+    const id = `synthetic-session-${pad(index)}`;
+    const key = `agent:main:${id}`;
+    const sessionFile = path.join(transcriptsDir, `${id}.jsonl`);
+    const hasTranscript = index < counts.transcriptFiles;
+    if (hasTranscript) {
+      const lines = [
+        JSON.stringify({
+          type: "session_meta",
+          sessionId: id,
+          version: 1,
+          createdAt: iso(index % 120),
+        }),
+      ];
+      for (let line = 0; line < counts.transcriptLines; line += 1) {
+        lines.push(
+          JSON.stringify({
+            type: "response_item",
+            role: line % 2 === 0 ? "user" : "assistant",
+            content: `synthetic transcript ${index}/${line} memory qmd rpc plugin delivery tui onboarding`,
+            usage: {
+              input_tokens: 40 + line,
+              output_tokens: 80 + line,
+              total_tokens: 120 + line * 2,
+            },
+            createdAt: iso(index % 120, line * 1000),
+          }),
+        );
+      }
+      writeText(sessionFile, `${lines.join("\n")}\n`);
+      if (index % 3 === 0) {
+        writeText(
+          path.join(transcriptsDir, `${id}.trajectory.jsonl`),
+          `${JSON.stringify({ id, steps: ["tool", "memory", "rpc"], createdAt: iso(index % 90) })}\n`,
+        );
+      }
+    }
+    store[key] = {
+      sessionId: id,
+      key,
+      agentId: "main",
+      kind: index % 10 === 0 ? "subagent" : "session",
+      title: `synthetic session ${index}`,
+      label: index % 11 === 0 ? "synthetic-review" : undefined,
+      model: index % 2 === 0 ? "gpt-5.5" : "sonnet-4.6",
+      modelProvider: index % 2 === 0 ? "openai" : "anthropic",
+      channel: index % 6 === 0 ? "discord" : index % 6 === 1 ? "terminal" : "gateway",
+      subject: `synthetic subject ${index % 100}`,
+      updatedAt: iso(index % 365, index * 1000),
+      createdAt: iso((index % 365) + 1, index * 1000),
+      totalTokens: 1000 + index,
+      totalTokensFresh: true,
+      contextTokens: 200000,
+      inputTokens: 400 + index,
+      outputTokens: 600 + index,
+      estimatedCostUsd: Number((index * 0.00003).toFixed(6)),
+      sessionFile: hasTranscript ? sessionFile : undefined,
+      spawnedBy:
+        index % 10 === 0
+          ? `agent:main:synthetic-session-${pad(Math.max(0, index - 1))}`
+          : undefined,
+    };
+  }
+  writeJson(path.join(sessionsDir, "sessions.json"), store);
+  writeJson(path.join(sessionsDir, "deleted-sessions.json"), {
+    "agent:main:deleted-synthetic-00001": {
+      deletedAt: iso(1),
+      sessionId: "deleted-synthetic-00001",
+    },
+  });
+
+  for (let index = 0; index < counts.deliveryFiles; index += 1) {
+    writeJson(
+      path.join(
+        stateRoot,
+        "delivery",
+        "queue",
+        index % 2 === 0 ? "pending" : "failed",
+        `delivery-${pad(index)}.json`,
+      ),
+      {
+        id: `delivery-${index}`,
+        sessionKey: `agent:main:synthetic-session-${pad(index % counts.sessions)}`,
+        channel: index % 2 === 0 ? "discord" : "telegram",
+        createdAt: iso(index % 45),
+        payload: "x".repeat(256),
+      },
+    );
+  }
+
+  writeJson(path.join(stateRoot, "cron", "jobs.json"), {
+    jobs: Array.from({ length: counts.cronJobs }, (_, index) => ({
+      id: `cron-${index}`,
+      schedule: `${index % 60} * * * *`,
+      command: "memory status",
+      enabled: index % 7 !== 0,
+      createdAt: iso(index % 100),
+    })),
+  });
+  writeJson(path.join(stateRoot, "tui", "last-session.json"), {
+    key: "agent:main:synthetic-session-00042",
+    agentId: "main",
+    updatedAt: iso(0),
+  });
+  writeJson(path.join(stateRoot, "agents", "main", "skills", "skills.json"), {
+    skills: [
+      { name: "synthetic-memory", enabled: true, source: "local" },
+      { name: "synthetic-rpc", enabled: true, source: "local" },
+    ],
+  });
+  writeText(
+    path.join(stateRoot, "logs", "gateway.log"),
+    "synthetic gateway log line\n".repeat(200),
+  );
+
+  writeJson(path.join(stateRoot, "openclaw.json"), {
+    agents: {
+      defaults: {
+        workspace: workspaceRoot,
+        contextTokens: 200000,
+        memorySearch: {
+          enabled: true,
+          provider: "local",
+          sources: ["memory", "sessions"],
+          extraPaths: [path.join(stateRoot, "agents", "main", "qmd", "sessions")],
+          sync: { maxFileScanEntries: 200000 },
+        },
+      },
+      list: [{ id: "main", default: true, workspace: workspaceRoot }],
+    },
+    gateway: {
+      mode: "local",
+      bind: "loopback",
+      port: gatewayPort,
+      auth: { mode: "none" },
+      controlUi: { enabled: false },
+      tailscale: { mode: "off", resetOnExit: false },
+    },
+    memory: {
+      backend: "qmd",
+      qmd: {
+        searchMode: "search",
+      },
+    },
+    plugins: {
+      enabled: true,
+      bundledDiscovery: "allowlist",
+      allow: ["memory-core"],
+      slots: { memory: "memory-core" },
+      entries: {
+        "memory-core": {
+          enabled: true,
+          config: {},
+        },
+      },
+    },
+    tools: { profile: "coding" },
+    session: { dmScope: "per-channel-peer", maintenance: { mode: "warn", maxEntries: 200000 } },
+  });
+}
+
+function runOpenClaw(label, args, opts = {}) {
+  const traceOut = path.join(tracesRoot, `${slug(label)}-{pid}.json`);
+  const env = {
+    ...process.env,
+    HOME: path.join(stateRoot, "home"),
+    OPENCLAW_HOME: stateRoot,
+    OPENCLAW_STATE_DIR: stateRoot,
+    OPENCLAW_CONFIG_PATH: path.join(stateRoot, "openclaw.json"),
+    OPENCLAW_NO_ONBOARD: "1",
+    OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+    OPENCLAW_IO_TRACE_OUT: traceOut,
+    OPENCLAW_IO_TRACE_ROOTS: [repoRoot, stateRoot, workspaceRoot, artifactRoot].join(
+      path.delimiter,
+    ),
+    FORCE_COLOR: "0",
+    NO_COLOR: "1",
+    CI: "1",
+    ...(opts.stacks ? { OPENCLAW_IO_TRACE_STACKS: "1" } : {}),
+  };
+  fs.mkdirSync(env.HOME, { recursive: true });
+  return runProcess({
+    label,
+    command: "node",
+    args: [
+      "--import",
+      path.join(repoRoot, "scripts/io-trace-preload.mjs"),
+      path.join(repoRoot, "openclaw.mjs"),
+      ...args,
+    ],
+    env,
+    timeoutMs: opts.timeoutMs,
+  });
+}
+
+function runProcess({ label, command, args, env, timeoutMs }) {
+  return new Promise((resolve) => {
+    const stdoutFile = path.join(logsRoot, `${slug(label)}.stdout`);
+    const stderrFile = path.join(logsRoot, `${slug(label)}.stderr`);
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const started = Date.now();
+    const samples = [];
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const sampleTimer = setInterval(async () => {
+      const sample = await sampleProcessGroup(child.pid).catch(() => undefined);
+      if (sample) {
+        samples.push(sample);
+      }
+    }, 250);
+    const timeout = timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          killGroup(child.pid, "SIGTERM");
+          setTimeout(() => killGroup(child.pid, "SIGKILL"), 1500).unref();
+        }, timeoutMs)
+      : undefined;
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (code, signal) => {
+      clearInterval(sampleTimer);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      writeText(stdoutFile, stdout);
+      writeText(stderrFile, stderr);
+      const result = {
+        label,
+        code,
+        signal,
+        timedOut,
+        wallMs: Date.now() - started,
+        stdoutBytes: Buffer.byteLength(stdout),
+        stderrBytes: Buffer.byteLength(stderr),
+        stdoutSample: stdout.slice(0, 1000),
+        stderrSample: stderr.slice(0, 1000),
+        resource: summarizeSamples(samples),
+        trace: readTrace(label),
+      };
+      writeJson(path.join(summariesRoot, `${slug(label)}.json`), result);
+      resolve(result);
+    });
+  });
+}
+
+function startGateway() {
+  const env = {
+    ...process.env,
+    HOME: path.join(stateRoot, "home"),
+    OPENCLAW_HOME: stateRoot,
+    OPENCLAW_STATE_DIR: stateRoot,
+    OPENCLAW_CONFIG_PATH: path.join(stateRoot, "openclaw.json"),
+    OPENCLAW_NO_ONBOARD: "1",
+    OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+    OPENCLAW_IO_TRACE_OUT: path.join(tracesRoot, "gateway-server-{pid}.json"),
+    OPENCLAW_IO_TRACE_ROOTS: [repoRoot, stateRoot, workspaceRoot, artifactRoot].join(
+      path.delimiter,
+    ),
+    OPENCLAW_IO_TRACE_STACKS: "1",
+    FORCE_COLOR: "0",
+    NO_COLOR: "1",
+    CI: "1",
+  };
+  const child = spawn(
+    "node",
+    [
+      "--import",
+      path.join(repoRoot, "scripts/io-trace-preload.mjs"),
+      path.join(repoRoot, "openclaw.mjs"),
+      "gateway",
+      "run",
+      "--port",
+      String(gatewayPort),
+      "--auth",
+      "none",
+      "--bind",
+      "loopback",
+      "--ws-log",
+      "compact",
+    ],
+    { cwd: repoRoot, env, detached: true, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const samples = [];
+  const gateway = {
+    child,
+    stdout: "",
+    stderr: "",
+    samples,
+    resource: () => summarizeSamples(samples),
+  };
+  child.stdout.on("data", (chunk) => {
+    gateway.stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    gateway.stderr += chunk;
+  });
+  gateway.timer = setInterval(async () => {
+    const sample = await sampleProcessGroup(child.pid).catch(() => undefined);
+    if (sample) {
+      samples.push(sample);
+    }
+  }, 250);
+  return gateway;
+}
+
+async function stopGateway(gateway) {
+  clearInterval(gateway.timer);
+  killGroup(gateway.child.pid, "SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => gateway.child.once("close", resolve)),
+    delay(5_000).then(() => {
+      killGroup(gateway.child.pid, "SIGKILL");
+    }),
+  ]);
+  writeText(path.join(logsRoot, "gateway.stdout"), gateway.stdout);
+  writeText(path.join(logsRoot, "gateway.stderr"), gateway.stderr);
+}
+
+async function sampleProcessGroup(pgid) {
+  const output = await capture("ps", ["-o", "rss=,pcpu=", "-g", String(pgid)]);
+  const rows = output
+    .trim()
+    .split("\n")
+    .map((line) => line.trim().split(/\s+/).map(Number))
+    .filter((row) => Number.isFinite(row[0]));
+  if (rows.length === 0) {
+    return undefined;
+  }
+  return {
+    rssKb: rows.reduce((sum, row) => sum + row[0], 0),
+    cpuPct: rows.reduce((sum, row) => sum + (row[1] || 0), 0),
+    processes: rows.length,
+  };
+}
+
+function capture(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "ignore"] });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", () => resolve(stdout));
+  });
+}
+
+function killGroup(pid, signal) {
+  try {
+    process.kill(-pid, signal);
+  } catch {}
+}
+
+function readTrace(label) {
+  const files = fs.existsSync(tracesRoot)
+    ? fs
+        .readdirSync(tracesRoot)
+        .filter((name) => name.startsWith(`${slug(label)}-`) && name.endsWith(".json"))
+    : [];
+  const ops = files.flatMap((file) => readJson(path.join(tracesRoot, file))?.operations ?? []);
+  return summarizeOps(files, ops);
+}
+
+function readGatewayTrace() {
+  const files = fs.existsSync(tracesRoot)
+    ? fs
+        .readdirSync(tracesRoot)
+        .filter((name) => name.startsWith("gateway-server-") && name.endsWith(".json"))
+    : [];
+  const ops = files.flatMap((file) => readJson(path.join(tracesRoot, file))?.operations ?? []);
+  return summarizeOps(files, ops, 20);
+}
+
+function summarizeOps(files, ops, topLimit = 12) {
+  return {
+    files,
+    totalOps: ops.reduce((sum, op) => sum + (op.count ?? 0), 0),
+    totalBytes: ops.reduce((sum, op) => sum + (op.bytes ?? 0), 0),
+    paths: new Set(ops.map((op) => op.path)).size,
+    top: ops.toSorted((left, right) => (right.count ?? 0) - (left.count ?? 0)).slice(0, topLimit),
+    outsideStateWrites: ops
+      .filter((op) => /write|append|mkdir|rm|unlink/i.test(op.op))
+      .filter((op) => !op.path.startsWith(stateRoot) && !op.path.startsWith(artifactRoot))
+      .slice(0, 20),
+    repoWrites: ops
+      .filter((op) => /write|append|mkdir|rm|unlink/i.test(op.op))
+      .filter((op) => op.path.startsWith(repoRoot))
+      .slice(0, 20),
+  };
+}
+
+function summarizeSamples(samples) {
+  if (samples.length === 0) {
+    return { samples: 0, maxRssKb: 0, avgCpuPct: 0, maxProcesses: 0 };
+  }
+  return {
+    samples: samples.length,
+    maxRssKb: Math.max(...samples.map((sample) => sample.rssKb)),
+    avgCpuPct: Number(
+      (samples.reduce((sum, sample) => sum + sample.cpuPct, 0) / samples.length).toFixed(2),
+    ),
+    maxProcesses: Math.max(...samples.map((sample) => sample.processes)),
+  };
+}
+
+function compactSummary(summary) {
+  return {
+    artifactRoot: summary.artifactRoot,
+    scale: summary.scale,
+    counts: summary.counts,
+    gateway: {
+      ready: summary.gateway.ready,
+      port: summary.gateway.port,
+      resource: summary.gateway.resource,
+      trace: compactTrace(summary.gateway.trace),
+      stdoutBytes: summary.gateway.stdoutBytes,
+      stderrBytes: summary.gateway.stderrBytes,
+      stderrSample: summary.gateway.stderrSample,
+    },
+    rankings: summary.rankings,
+    failures: summary.failures,
+    outsideWrites: summary.outsideWrites.slice(0, 20).map(compactOp),
+    repoWrites: summary.repoWrites.slice(0, 20).map(compactOp),
+  };
+}
+
+function compactTrace(trace) {
+  return {
+    files: trace.files,
+    totalOps: trace.totalOps,
+    totalBytes: trace.totalBytes,
+    paths: trace.paths,
+    top: trace.top.slice(0, 12).map(compactOp),
+    outsideStateWrites: trace.outsideStateWrites.slice(0, 20).map(compactOp),
+    repoWrites: trace.repoWrites.slice(0, 20).map(compactOp),
+  };
+}
+
+function compactOp(entry) {
+  return {
+    label: entry.label,
+    op: entry.op,
+    path: abbreviatePath(entry.path),
+    count: entry.count,
+    bytes: entry.bytes,
+  };
+}
+
+function abbreviatePath(value) {
+  if (typeof value !== "string") {
+    return value;
+  }
+  if (value.startsWith(stateRoot)) {
+    return `<state>${value.slice(stateRoot.length)}`;
+  }
+  if (value.startsWith(artifactRoot)) {
+    return `<artifact>${value.slice(artifactRoot.length)}`;
+  }
+  if (value.startsWith(repoRoot)) {
+    return `<repo>${value.slice(repoRoot.length)}`;
+  }
+  return value;
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    `## Deep synthetic E2E/RPC resource audit (${new Date().toISOString()})`,
+    "",
+    `Synthetic shape: ${summary.counts.sessions} session rows, ${summary.counts.transcriptFiles} transcript files x ${summary.counts.transcriptLines} events, ${summary.counts.dailyMemoryFiles} daily memory files, ${summary.counts.qmdFiles} QMD files, ${summary.counts.deliveryFiles} delivery queue files, ${summary.counts.cronJobs} cron jobs.`,
+    `Gateway RPC server readiness: ${summary.gateway.ready ? "ready" : "not ready"}. Gateway max RSS: ${summary.gateway.resource.maxRssKb} KiB. Server fs ops: ${summary.gateway.trace.totalOps}.`,
+    "",
+    "Top command/RPC IO counts:",
+    "",
+    table(summary.rankings.byOps, [
+      ["surface", (row) => row.label],
+      ["exit", (row) => row.code],
+      ["wall", (row) => `${row.wallMs} ms`],
+      ["rss", (row) => `${row.maxRssKb} KiB`],
+      ["fs ops", (row) => row.ops],
+      ["bytes", (row) => formatBytes(row.bytes)],
+      ["paths", (row) => row.paths],
+    ]),
+    "",
+    "File-touch audit:",
+    "",
+    `- Outside-state writes from CLI/RPC traces: ${summary.outsideWrites.length}.`,
+    `- Repo writes from CLI/RPC traces: ${summary.repoWrites.length}.`,
+    `- Gateway outside-state writes: ${summary.gateway.trace.outsideStateWrites.length}.`,
+    ...(summary.failures.length === 0
+      ? ["- all audited CLI/RPC calls exited 0."]
+      : summary.failures.map(
+          (failure) =>
+            `- ${failure.label}: exit ${failure.code}, signal ${failure.signal ?? "none"}, timedOut=${failure.timedOut}.`,
+        )),
+    "",
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function rank(results, score) {
+  return results
+    .toSorted((left, right) => score(right) - score(left))
+    .slice(0, 12)
+    .map((result) => ({
+      label: result.label,
+      code: result.code,
+      timedOut: result.timedOut,
+      wallMs: result.wallMs,
+      maxRssKb: result.resource.maxRssKb,
+      avgCpuPct: result.resource.avgCpuPct,
+      ops: result.trace.totalOps,
+      bytes: result.trace.totalBytes,
+      paths: result.trace.paths,
+    }));
+}
+
+function table(rows, columns) {
+  return [
+    `| ${columns.map(([title]) => title).join(" | ")} |`,
+    `| ${columns.map(() => "---").join(" | ")} |`,
+    ...rows.map(
+      (row) =>
+        `| ${columns
+          .map(([, render]) => String(render(row)).replaceAll("\n", " ").replaceAll("|", "\\|"))
+          .join(" | ")} |`,
+    ),
+  ].join("\n");
+}
+
+function writeJson(file, data) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function writeText(file, text) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, text);
+}
+
+function pad(value) {
+  return String(value).padStart(5, "0");
+}
+
+function iso(daysAgo = 0, extraMs = 0) {
+  return new Date(Date.now() - daysAgo * 86_400_000 - extraMs).toISOString();
+}
+
+function dayString(daysAgo) {
+  return new Date(Date.now() - daysAgo * 86_400_000).toISOString().slice(0, 10);
+}
+
+function slug(value) {
+  return value
+    .replace(/[^a-z0-9]+/gi, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatBytes(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  if (value > 1024 * 1024) {
+    return `${(value / 1024 / 1024).toFixed(1)} MiB`;
+  }
+  if (value > 1024) {
+    return `${(value / 1024).toFixed(1)} KiB`;
+  }
+  return `${value} B`;
+}

--- a/scripts/synthetic-io-e2e-audit.mjs
+++ b/scripts/synthetic-io-e2e-audit.mjs
@@ -61,39 +61,47 @@ await fsp.mkdir(summariesRoot, { recursive: true });
 generateSyntheticState();
 
 const cliResults = [];
-for (const [label, args, opts] of [
-  ["config validate", ["config", "validate", "--json"], { timeoutMs: 20_000, stacks: true }],
-  ["status deep", ["status", "--deep", "--json"], { timeoutMs: 45_000, stacks: true }],
-  [
-    "sessions limit 50",
-    ["sessions", "--json", "--limit", "50"],
-    { timeoutMs: 45_000, stacks: true },
-  ],
-  [
-    "sessions all agents",
-    ["sessions", "--json", "--limit", "50", "--all-agents"],
-    { timeoutMs: 45_000 },
-  ],
-  [
-    "memory status deep",
-    ["memory", "status", "--json", "--deep"],
-    { timeoutMs: 60_000, stacks: true },
-  ],
-  [
-    "memory search qmd",
-    ["memory", "search", "gateway rpc synthetic memory", "--json", "--max-results", "20"],
-    { timeoutMs: 60_000 },
-  ],
-  [
-    "memory rem harness",
-    ["memory", "rem-harness", "--json", "--path", path.join(workspaceRoot, "memory")],
-    { timeoutMs: 60_000 },
-  ],
-  [
-    "gateway status no service",
-    ["gateway", "status", "--json", "--url", `ws://127.0.0.1:${gatewayPort}`],
-    { timeoutMs: 25_000 },
-  ],
+for (const { label, args, opts } of [
+  {
+    label: "config validate",
+    args: ["config", "validate", "--json"],
+    opts: { timeoutMs: 20_000, stacks: true },
+  },
+  {
+    label: "status deep",
+    args: ["status", "--deep", "--json"],
+    opts: { timeoutMs: 45_000, stacks: true },
+  },
+  {
+    label: "sessions limit 50",
+    args: ["sessions", "--json", "--limit", "50"],
+    opts: { timeoutMs: 45_000, stacks: true },
+  },
+  {
+    label: "sessions all agents",
+    args: ["sessions", "--json", "--limit", "50", "--all-agents"],
+    opts: { timeoutMs: 45_000 },
+  },
+  {
+    label: "memory status deep",
+    args: ["memory", "status", "--json", "--deep"],
+    opts: { timeoutMs: 60_000, stacks: true },
+  },
+  {
+    label: "memory search qmd",
+    args: ["memory", "search", "gateway rpc synthetic memory", "--json", "--max-results", "20"],
+    opts: { timeoutMs: 60_000 },
+  },
+  {
+    label: "memory rem harness",
+    args: ["memory", "rem-harness", "--json", "--path", path.join(workspaceRoot, "memory")],
+    opts: { timeoutMs: 60_000 },
+  },
+  {
+    label: "gateway status no service",
+    args: ["gateway", "status", "--json", "--url", `ws://127.0.0.1:${gatewayPort}`],
+    opts: { timeoutMs: 25_000 },
+  },
 ]) {
   console.log(`[audit] ${label}`);
   cliResults.push(await runOpenClaw(label, args, opts));
@@ -127,50 +135,54 @@ for (let attempt = 0; attempt < 30; attempt += 1) {
 
 const rpcResults = [];
 if (ready) {
-  for (const [label, method, params] of [
-    ["rpc health", "health", {}],
-    ["rpc status", "status", {}],
-    ["rpc diagnostics stability", "diagnostics.stability", {}],
-    ["rpc config get", "config.get", {}],
-    ["rpc config schema", "config.schema", {}],
-    ["rpc commands list", "commands.list", {}],
-    ["rpc tools catalog", "tools.catalog", {}],
-    [
-      "rpc tools effective",
-      "tools.effective",
-      { sessionKey: "agent:main:synthetic-session-00042" },
-    ],
-    ["rpc plugins ui descriptors", "plugins.uiDescriptors", {}],
-    ["rpc skills status", "skills.status", {}],
-    ["rpc agents list", "agents.list", {}],
-    ["rpc sessions list bounded", "sessions.list", { limit: 50, agentId: "main" }],
-    [
-      "rpc sessions list derived",
-      "sessions.list",
-      { limit: 50, agentId: "main", includeDerivedTitles: true, includeLastMessage: true },
-    ],
-    [
-      "rpc sessions preview",
-      "sessions.preview",
-      { keys: ["agent:main:synthetic-session-00042"], limit: 6, maxChars: 2000 },
-    ],
-    [
-      "rpc sessions describe",
-      "sessions.describe",
-      { key: "agent:main:synthetic-session-00042", includeLastMessage: true },
-    ],
-    [
-      "rpc sessions create",
-      "sessions.create",
-      { agentId: "main", task: "synthetic create smoke", emitCommandHooks: false },
-    ],
-    ["rpc doctor memory status", "doctor.memory.status", { deep: true }],
-    [
-      "rpc doctor memory rem harness",
-      "doctor.memory.remHarness",
-      { path: path.join(workspaceRoot, "memory") },
-    ],
-    ["rpc logs tail", "logs.tail", { limit: 20 }],
+  for (const { label, method, params } of [
+    { label: "rpc health", method: "health", params: {} },
+    { label: "rpc status", method: "status", params: {} },
+    { label: "rpc diagnostics stability", method: "diagnostics.stability", params: {} },
+    { label: "rpc config get", method: "config.get", params: {} },
+    { label: "rpc config schema", method: "config.schema", params: {} },
+    { label: "rpc commands list", method: "commands.list", params: {} },
+    { label: "rpc tools catalog", method: "tools.catalog", params: {} },
+    {
+      label: "rpc tools effective",
+      method: "tools.effective",
+      params: { sessionKey: "agent:main:synthetic-session-00042" },
+    },
+    { label: "rpc plugins ui descriptors", method: "plugins.uiDescriptors", params: {} },
+    { label: "rpc skills status", method: "skills.status", params: {} },
+    { label: "rpc agents list", method: "agents.list", params: {} },
+    {
+      label: "rpc sessions list bounded",
+      method: "sessions.list",
+      params: { limit: 50, agentId: "main" },
+    },
+    {
+      label: "rpc sessions list derived",
+      method: "sessions.list",
+      params: { limit: 50, agentId: "main", includeDerivedTitles: true, includeLastMessage: true },
+    },
+    {
+      label: "rpc sessions preview",
+      method: "sessions.preview",
+      params: { keys: ["agent:main:synthetic-session-00042"], limit: 6, maxChars: 2000 },
+    },
+    {
+      label: "rpc sessions describe",
+      method: "sessions.describe",
+      params: { key: "agent:main:synthetic-session-00042", includeLastMessage: true },
+    },
+    {
+      label: "rpc sessions create",
+      method: "sessions.create",
+      params: { agentId: "main", task: "synthetic create smoke", emitCommandHooks: false },
+    },
+    { label: "rpc doctor memory status", method: "doctor.memory.status", params: { deep: true } },
+    {
+      label: "rpc doctor memory rem harness",
+      method: "doctor.memory.remHarness",
+      params: { path: path.join(workspaceRoot, "memory") },
+    },
+    { label: "rpc logs tail", method: "logs.tail", params: { limit: 20 } },
   ]) {
     console.log(`[audit] ${label}`);
     rpcResults.push(

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -239,6 +239,7 @@ describe("memory search config", () => {
               watch: false,
               watchDebounceMs: 25,
               intervalMinutes: 3,
+              maxFileScanEntries: 1234,
               sessions: {
                 deltaBytes: 321,
                 deltaMessages: 7,
@@ -257,6 +258,7 @@ describe("memory search config", () => {
       watchDebounceMs: 25,
       intervalMinutes: 3,
       embeddingBatchTimeoutSeconds: undefined,
+      maxFileScanEntries: 1234,
       sessions: {
         deltaBytes: 321,
         deltaMessages: 7,
@@ -280,6 +282,20 @@ describe("memory search config", () => {
     });
 
     expect(resolveMemorySearchSyncConfig(cfg, "main")?.embeddingBatchTimeoutSeconds).toBe(600);
+  });
+
+  it("uses a default memory file scan cap", () => {
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "openai",
+          },
+        },
+      },
+    });
+
+    expect(resolveMemorySearchSyncConfig(cfg, "main")?.maxFileScanEntries).toBe(10_000);
   });
 
   it("merges defaults and overrides", () => {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -68,6 +68,7 @@ export type ResolvedMemorySearchConfig = {
     watchDebounceMs: number;
     intervalMinutes: number;
     embeddingBatchTimeoutSeconds: number | undefined;
+    maxFileScanEntries: number;
     sessions: {
       deltaBytes: number;
       deltaMessages: number;
@@ -103,6 +104,7 @@ export type ResolvedMemorySearchSyncConfig = ResolvedMemorySearchConfig["sync"];
 const DEFAULT_CHUNK_TOKENS = 400;
 const DEFAULT_CHUNK_OVERLAP = 80;
 const DEFAULT_WATCH_DEBOUNCE_MS = 1500;
+const DEFAULT_MAX_FILE_SCAN_ENTRIES = 10_000;
 const DEFAULT_SESSION_DELTA_BYTES = 100_000;
 const DEFAULT_SESSION_DELTA_MESSAGES = 50;
 const DEFAULT_MAX_RESULTS = 6;
@@ -332,6 +334,7 @@ function mergeConfig(
   );
   const deltaBytes = clampInt(sync.sessions.deltaBytes, 0, Number.MAX_SAFE_INTEGER);
   const deltaMessages = clampInt(sync.sessions.deltaMessages, 0, Number.MAX_SAFE_INTEGER);
+  const maxFileScanEntries = clampInt(sync.maxFileScanEntries, 0, Number.MAX_SAFE_INTEGER);
   const postCompactionForce = sync.sessions.postCompactionForce;
   return {
     enabled,
@@ -354,6 +357,7 @@ function mergeConfig(
     chunking: { tokens: Math.max(1, chunking.tokens), overlap },
     sync: {
       ...sync,
+      maxFileScanEntries,
       sessions: {
         deltaBytes,
         deltaMessages,
@@ -405,6 +409,10 @@ function resolveSyncConfig(
     intervalMinutes: overrides?.sync?.intervalMinutes ?? defaults?.sync?.intervalMinutes ?? 0,
     embeddingBatchTimeoutSeconds:
       overrides?.sync?.embeddingBatchTimeoutSeconds ?? defaults?.sync?.embeddingBatchTimeoutSeconds,
+    maxFileScanEntries:
+      overrides?.sync?.maxFileScanEntries ??
+      defaults?.sync?.maxFileScanEntries ??
+      DEFAULT_MAX_FILE_SCAN_ENTRIES,
     sessions: {
       deltaBytes:
         overrides?.sync?.sessions?.deltaBytes ??

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -255,6 +255,42 @@ describe("sessionsCommand", () => {
     expect(payload.sessions?.map((row) => row.key)).toEqual(["newest", "middle"]);
   });
 
+  it("limits session candidates before display hydration", () => {
+    const entries = Object.fromEntries(
+      Array.from({ length: 500 }, (_, index) => {
+        const key = `session-${index.toString().padStart(3, "0")}`;
+        return [
+          key,
+          {
+            sessionId: key,
+            updatedAt: Date.now() - index * 1000,
+            model: "pi:opus",
+          },
+        ];
+      }),
+    );
+    const store = writeStore(entries, "sessions-candidate-limit");
+
+    try {
+      const result = __testing.collectSessionCommandCandidates({
+        targets: [{ agentId: "main", storePath: store }],
+        limit: 5,
+      });
+
+      expect(result.totalCount).toBe(500);
+      expect(result.candidates).toHaveLength(5);
+      expect(result.candidates.map((candidate) => candidate.key)).toEqual([
+        "session-000",
+        "session-001",
+        "session-002",
+        "session-003",
+        "session-004",
+      ]);
+    } finally {
+      fs.rmSync(store, { force: true });
+    }
+  });
+
   it("allows full JSON output with --limit all", async () => {
     const store = writeStore(
       {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -31,10 +31,13 @@ import {
   toSessionDisplayRow,
 } from "./sessions-table.js";
 
-type SessionRow = SessionDisplayRow & {
+type JsonSessionRow = SessionDisplayRow & {
   agentId: string;
   kind: "cron" | "direct" | "group" | "global" | "unknown";
   agentRuntime: ReturnType<typeof resolveAgentRuntimeMetadata>;
+};
+
+type SessionRow = JsonSessionRow & {
   runtimeLabel: string;
 };
 
@@ -149,22 +152,31 @@ function collectSessionCommandCandidates(params: {
   };
 }
 
-function toSessionCommandRow(cfg: OpenClawConfig, candidate: SessionCommandCandidate): SessionRow {
+function toJsonSessionCommandRow(
+  cfg: OpenClawConfig,
+  candidate: SessionCommandCandidate,
+): JsonSessionRow {
   const row = toSessionDisplayRow(candidate.key, candidate.entry);
   const agentId = parseAgentSessionKey(row.key)?.agentId ?? candidate.target.agentId;
-  const modelRef = resolveSessionDisplayModelRef(cfg, row);
   const agentRuntime = resolveAgentRuntimeMetadata(cfg, agentId);
   return Object.assign({}, row, {
     agentId,
     agentRuntime,
     kind: classifySessionKey(row.key, candidate.entry),
+  });
+}
+
+function toSessionCommandRow(cfg: OpenClawConfig, candidate: SessionCommandCandidate): SessionRow {
+  const row = toJsonSessionCommandRow(cfg, candidate);
+  const modelRef = resolveSessionDisplayModelRef(cfg, row);
+  return Object.assign({}, row, {
     runtimeLabel: resolveSessionRuntimeLabel({
       cfg,
       entry: candidate.entry,
-      agentRuntime,
+      agentRuntime: row.agentRuntime,
       modelProvider: modelRef.provider,
       model: modelRef.model,
-      agentId,
+      agentId: row.agentId,
       sessionKey: row.key,
     }),
   });
@@ -315,12 +327,6 @@ function formatRuntimeCell(runtimeLabel: string, rich: boolean): string {
   return rich ? theme.info(label) : label;
 }
 
-function toJsonSessionRow(row: SessionRow): Omit<SessionRow, "runtimeLabel"> {
-  const { runtimeLabel, ...jsonRow } = row;
-  void runtimeLabel;
-  return jsonRow;
-}
-
 export async function sessionsCommand(
   opts: {
     json?: boolean;
@@ -376,10 +382,10 @@ export async function sessionsCommand(
     activeMinutes,
     limit,
   });
-  const rows = candidates.map((candidate) => toSessionCommandRow(cfg, candidate));
-  const hasMore = rows.length < totalCount;
 
   if (opts.json) {
+    const rows = candidates.map((candidate) => toJsonSessionCommandRow(cfg, candidate));
+    const hasMore = rows.length < totalCount;
     const multi = targets.length > 1;
     const aggregate = aggregateAgents || multi;
     writeRuntimeJson(runtime, {
@@ -398,15 +404,14 @@ export async function sessionsCommand(
       activeMinutes: activeMinutes ?? null,
       sessions: await Promise.all(
         rows.map(async (row) => {
-          const r = toJsonSessionRow(row);
-          const modelRef = resolveSessionDisplayModelRef(cfg, r);
+          const modelRef = resolveSessionDisplayModelRef(cfg, row);
           return {
-            ...r,
-            totalTokens: resolveSessionTotalTokens(r) ?? null,
+            ...row,
+            totalTokens: resolveSessionTotalTokens(row) ?? null,
             totalTokensFresh:
-              typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
+              typeof row.totalTokens === "number" ? row.totalTokensFresh !== false : false,
             contextTokens:
-              r.contextTokens ??
+              row.contextTokens ??
               configuredContextTokens ??
               (await lookupContextTokensForDisplay(modelRef.model)) ??
               configContextTokens ??
@@ -419,6 +424,9 @@ export async function sessionsCommand(
     });
     return;
   }
+
+  const rows = candidates.map((candidate) => toSessionCommandRow(cfg, candidate));
+  const hasMore = rows.length < totalCount;
 
   if (targets.length === 1 && !aggregateAgents) {
     runtime.log(info(`Session store: ${targets[0]?.storePath}`));

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -120,7 +120,8 @@ function collectSessionCommandCandidates(params: {
   candidates: SessionCommandCandidate[];
   totalCount: number;
 } {
-  const retainAllCandidates = params.limit === undefined || params.limit > TOP_N_SELECTION_LIMIT;
+  const limit = params.limit;
+  const retainAllCandidates = limit === undefined || limit > TOP_N_SELECTION_LIMIT;
   const candidates: SessionCommandCandidate[] = [];
   let totalCount = 0;
 
@@ -135,14 +136,14 @@ function collectSessionCommandCandidates(params: {
       if (retainAllCandidates) {
         candidates.push(candidate);
       } else {
-        insertNewestSessionCommandCandidate(candidates, candidate, params.limit);
+        insertNewestSessionCommandCandidate(candidates, candidate, limit);
       }
     }
   }
 
   return {
     candidates: retainAllCandidates
-      ? selectNewestSessionCommandCandidates(candidates, params.limit)
+      ? selectNewestSessionCommandCandidates(candidates, limit)
       : candidates,
     totalCount,
   };

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -38,6 +38,17 @@ type SessionRow = SessionDisplayRow & {
   runtimeLabel: string;
 };
 
+type SessionStoreTarget = {
+  agentId: string;
+  storePath: string;
+};
+
+type SessionCommandCandidate = {
+  target: SessionStoreTarget;
+  key: string;
+  entry: SessionEntry;
+};
+
 const AGENT_PAD = 10;
 const KIND_PAD = 6;
 const RUNTIME_PAD = 18;
@@ -48,32 +59,114 @@ const contextLookupRuntimeLoader = createLazyImportLoader(() => import("../agent
 
 const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
 
-function compareSessionRowsByUpdatedAt(a: SessionRow, b: SessionRow): number {
-  return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
+function compareSessionCommandCandidatesByUpdatedAt(
+  a: SessionCommandCandidate,
+  b: SessionCommandCandidate,
+): number {
+  return (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0);
 }
 
-function selectNewestSessionRows(rows: SessionRow[], limit: number | undefined): SessionRow[] {
+function insertNewestSessionCommandCandidate(
+  selected: SessionCommandCandidate[],
+  candidate: SessionCommandCandidate,
+  limit: number,
+): void {
+  const insertAt = selected.findIndex(
+    (existing) => compareSessionCommandCandidatesByUpdatedAt(candidate, existing) < 0,
+  );
+  if (insertAt >= 0) {
+    selected.splice(insertAt, 0, candidate);
+    if (selected.length > limit) {
+      selected.pop();
+    }
+  } else if (selected.length < limit) {
+    selected.push(candidate);
+  }
+}
+
+function selectNewestSessionCommandCandidates(
+  candidates: SessionCommandCandidate[],
+  limit: number | undefined,
+): SessionCommandCandidate[] {
   if (limit === undefined) {
-    return rows.toSorted(compareSessionRowsByUpdatedAt);
+    return candidates.toSorted(compareSessionCommandCandidatesByUpdatedAt);
   }
   if (limit > TOP_N_SELECTION_LIMIT) {
-    return rows.toSorted(compareSessionRowsByUpdatedAt).slice(0, limit);
+    return candidates.toSorted(compareSessionCommandCandidatesByUpdatedAt).slice(0, limit);
   }
-  const selected: SessionRow[] = [];
-  for (const row of rows) {
-    const insertAt = selected.findIndex(
-      (candidate) => compareSessionRowsByUpdatedAt(row, candidate) < 0,
-    );
-    if (insertAt >= 0) {
-      selected.splice(insertAt, 0, row);
-      if (selected.length > limit) {
-        selected.pop();
-      }
-    } else if (selected.length < limit) {
-      selected.push(row);
-    }
+  const selected: SessionCommandCandidate[] = [];
+  for (const candidate of candidates) {
+    insertNewestSessionCommandCandidate(selected, candidate, limit);
   }
   return selected;
+}
+
+function sessionMatchesActiveFilter(
+  entry: SessionEntry,
+  activeMinutes: number | undefined,
+): boolean {
+  if (activeMinutes === undefined) {
+    return true;
+  }
+  const updatedAt = entry?.updatedAt;
+  return typeof updatedAt === "number" && Date.now() - updatedAt <= activeMinutes * 60_000;
+}
+
+function collectSessionCommandCandidates(params: {
+  targets: SessionStoreTarget[];
+  activeMinutes?: number;
+  limit: number | undefined;
+}): {
+  candidates: SessionCommandCandidate[];
+  totalCount: number;
+} {
+  const retainAllCandidates = params.limit === undefined || params.limit > TOP_N_SELECTION_LIMIT;
+  const candidates: SessionCommandCandidate[] = [];
+  let totalCount = 0;
+
+  for (const target of params.targets) {
+    const store = loadSessionStore(target.storePath);
+    for (const [key, entry] of Object.entries(store)) {
+      if (!sessionMatchesActiveFilter(entry, params.activeMinutes)) {
+        continue;
+      }
+      totalCount += 1;
+      const candidate = { target, key, entry };
+      if (retainAllCandidates) {
+        candidates.push(candidate);
+      } else {
+        insertNewestSessionCommandCandidate(candidates, candidate, params.limit);
+      }
+    }
+  }
+
+  return {
+    candidates: retainAllCandidates
+      ? selectNewestSessionCommandCandidates(candidates, params.limit)
+      : candidates,
+    totalCount,
+  };
+}
+
+function toSessionCommandRow(cfg: OpenClawConfig, candidate: SessionCommandCandidate): SessionRow {
+  const row = toSessionDisplayRow(candidate.key, candidate.entry);
+  const agentId = parseAgentSessionKey(row.key)?.agentId ?? candidate.target.agentId;
+  const modelRef = resolveSessionDisplayModelRef(cfg, row);
+  const agentRuntime = resolveAgentRuntimeMetadata(cfg, agentId);
+  return Object.assign({}, row, {
+    agentId,
+    agentRuntime,
+    kind: classifySessionKey(row.key, candidate.entry),
+    runtimeLabel: resolveSessionRuntimeLabel({
+      cfg,
+      entry: candidate.entry,
+      agentRuntime,
+      modelProvider: modelRef.provider,
+      model: modelRef.model,
+      agentId,
+      sessionKey: row.key,
+    }),
+  });
 }
 
 function parseSessionsLimit(value: string | number | undefined): number | undefined | null {
@@ -277,39 +370,12 @@ export async function sessionsCommand(
     return;
   }
 
-  const allRows = targets.flatMap((target) => {
-    const store = loadSessionStore(target.storePath);
-    return Object.entries(store)
-      .filter(([, entry]) => {
-        if (activeMinutes === undefined) {
-          return true;
-        }
-        const updatedAt = entry?.updatedAt;
-        return typeof updatedAt === "number" && Date.now() - updatedAt <= activeMinutes * 60_000;
-      })
-      .map(([key, entry]) => {
-        const row = toSessionDisplayRow(key, entry);
-        const agentId = parseAgentSessionKey(row.key)?.agentId ?? target.agentId;
-        const modelRef = resolveSessionDisplayModelRef(cfg, row);
-        const agentRuntime = resolveAgentRuntimeMetadata(cfg, agentId);
-        return Object.assign({}, row, {
-          agentId,
-          agentRuntime,
-          kind: classifySessionKey(row.key, store[row.key]),
-          runtimeLabel: resolveSessionRuntimeLabel({
-            cfg,
-            entry,
-            agentRuntime,
-            modelProvider: modelRef.provider,
-            model: modelRef.model,
-            agentId,
-            sessionKey: row.key,
-          }),
-        });
-      });
+  const { candidates, totalCount } = collectSessionCommandCandidates({
+    targets,
+    activeMinutes,
+    limit,
   });
-  const totalCount = allRows.length;
-  const rows = selectNewestSessionRows(allRows, limit);
+  const rows = candidates.map((candidate) => toSessionCommandRow(cfg, candidate));
   const hasMore = rows.length < totalCount;
 
   if (opts.json) {
@@ -417,5 +483,7 @@ export async function sessionsCommand(
 }
 
 export const __testing = {
+  collectSessionCommandCandidates,
   parseSessionsLimit,
+  selectNewestSessionCommandCandidates,
 } as const;

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -405,8 +405,7 @@ export async function sessionsCommand(
       sessions: await Promise.all(
         rows.map(async (row) => {
           const modelRef = resolveSessionDisplayModelRef(cfg, row);
-          return {
-            ...row,
+          return Object.assign({}, row, {
             totalTokens: resolveSessionTotalTokens(row) ?? null,
             totalTokensFresh:
               typeof row.totalTokens === "number" ? row.totalTokensFresh !== false : false,
@@ -418,7 +417,7 @@ export async function sessionsCommand(
               null,
             modelProvider: modelRef.provider,
             model: modelRef.model,
-          };
+          });
         }),
       ),
     });

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -128,6 +128,7 @@ vi.mock("./status.link-channel.js", () => ({
 }));
 
 const { buildChannelSummary } = await import("../infra/channel-summary.js");
+const { parseAgentSessionKey } = await import("../routing/session-key.js");
 const { resolveLinkChannelContext } = await import("./status.link-channel.js");
 let getStatusSummary: typeof import("./status.summary.js").getStatusSummary;
 let statusSummaryRuntime: typeof import("./status.summary.runtime.js").statusSummaryRuntime;
@@ -199,5 +200,29 @@ describe("getStatusSummary", () => {
     const summary = await getStatusSummary();
 
     expect(summary.sessions.recent[0]?.runtime).toBe("OpenAI Codex");
+  });
+
+  it("reuses repeated runtime labels while summarizing session rows", async () => {
+    vi.mocked(parseAgentSessionKey).mockImplementation(
+      (key) => (String(key).startsWith("agent:main:") ? { agentId: "main" } : null) as never,
+    );
+    vi.mocked(statusSummaryRuntime.resolveSessionRuntimeLabel).mockReturnValue(
+      "OpenClaw Pi Default",
+    );
+    statusSummaryMocks.readSessionStoreReadOnly.mockReturnValue({
+      "agent:main:first": {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+      },
+      "agent:main:second": {
+        sessionId: "session-2",
+        updatedAt: Date.now() - 1,
+      },
+    });
+
+    const summary = await getStatusSummary();
+
+    expect(summary.sessions.count).toBe(2);
+    expect(statusSummaryRuntime.resolveSessionRuntimeLabel).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -183,6 +183,40 @@ export async function getStatusSummary(
     storeCache.set(storePath, store);
     return store;
   };
+  const runtimeLabelCache = new Map<string, string>();
+  const resolveRuntimeLabelForSession = (params: {
+    entry?: SessionEntry;
+    provider: string;
+    model: string;
+    agentId?: string;
+    sessionKey: string;
+  }) => {
+    const runtimeCacheKey = JSON.stringify([
+      params.entry?.acp?.agent ?? "",
+      params.entry?.acp?.backend ?? "",
+      params.entry?.agentRuntimeOverride ?? "",
+      params.entry?.agentHarnessId ?? "",
+      params.entry?.modelProvider ?? "",
+      params.entry?.providerOverride ?? "",
+      params.provider,
+      params.model,
+      params.agentId ?? params.sessionKey,
+    ]);
+    const cached = runtimeLabelCache.get(runtimeCacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const runtime = resolveSessionRuntimeLabel({
+      cfg,
+      entry: params.entry,
+      provider: params.provider,
+      model: params.model,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+    });
+    runtimeLabelCache.set(runtimeCacheKey, runtime);
+    return runtime;
+  };
   const buildSessionRows = (
     store: Record<string, SessionEntry | undefined>,
     opts: { agentIdOverride?: string } = {},
@@ -214,8 +248,7 @@ export async function getStatusSummary(
           contextTokens && contextTokens > 0 && total !== undefined
             ? Math.min(999, Math.round((total / contextTokens) * 100))
             : null;
-        const runtime = resolveSessionRuntimeLabel({
-          cfg,
+        const runtime = resolveRuntimeLabelForSession({
           entry,
           provider: resolvedModel.provider,
           model: model ?? "",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1033,6 +1033,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Chooses which sources are indexed: "memory" reads MEMORY.md + memory files, and "sessions" includes transcript history. Keep ["memory"] unless you need recall from prior chat transcripts.',
   "agents.defaults.memorySearch.extraPaths":
     "Adds extra directories or .md files to the memory index beyond default memory files. Use this when key reference docs live elsewhere in your repo; when multimodal memory is enabled, matching image/audio files under these paths are also eligible for indexing.",
+  "agents.defaults.memorySearch.sync.maxFileScanEntries":
+    "Caps directory entries scanned while discovering memory files. Lower this when extraPaths may point at large repos or synced folders; raise it only for intentionally large memory corpora.",
   "agents.defaults.memorySearch.qmd":
     "Use this when one agent should query another agent's transcript collections; QMD-specific extra collections let you opt into cross-agent memory search without flattening everything into one shared namespace.",
   "agents.defaults.memorySearch.qmd.extraCollections":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -447,6 +447,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.sync.onSearch": "Index on Search (Lazy)",
   "agents.defaults.memorySearch.sync.watch": "Watch Memory Files",
   "agents.defaults.memorySearch.sync.watchDebounceMs": "Memory Watch Debounce (ms)",
+  "agents.defaults.memorySearch.sync.maxFileScanEntries": "Memory File Scan Entry Limit",
   "agents.defaults.memorySearch.sync.embeddingBatchTimeoutSeconds": "Embedding Batch Timeout (s)",
   "agents.defaults.memorySearch.sync.sessions.deltaBytes": "Session Delta Bytes",
   "agents.defaults.memorySearch.sync.sessions.deltaMessages": "Session Delta Messages",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -452,6 +452,8 @@ export type MemorySearchConfig = {
     watch?: boolean;
     watchDebounceMs?: number;
     intervalMinutes?: number;
+    /** Max directory entries scanned when discovering memory files (default: 10000). */
+    maxFileScanEntries?: number;
     /**
      * Timeout in seconds for inline embedding batches during memory indexing.
      * Unset uses provider defaults: 600s for local/self-hosted providers, 120s for hosted providers.

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -742,6 +742,7 @@ export const MemorySearchSchema = z
         watch: z.boolean().optional(),
         watchDebounceMs: z.number().int().nonnegative().optional(),
         intervalMinutes: z.number().int().nonnegative().optional(),
+        maxFileScanEntries: z.number().int().nonnegative().optional(),
         embeddingBatchTimeoutSeconds: z.number().int().positive().optional(),
         sessions: z
           .object({

--- a/src/plugins/bundled-source-overlays.test.ts
+++ b/src/plugins/bundled-source-overlays.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isBundledSourceOverlayPath } from "./bundled-source-overlays.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-source-overlay-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("bundled source overlays", () => {
+  it("reuses mount-point stat results inside a process", () => {
+    const root = makeTempDir();
+    const pluginDir = path.join(root, "extensions", "memory-core");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const statSpy = vi.spyOn(fs, "statSync");
+
+    expect(isBundledSourceOverlayPath({ sourcePath: pluginDir, mountPoints: new Set() })).toBe(
+      false,
+    );
+    const firstCallCount = statSpy.mock.calls.length;
+
+    expect(isBundledSourceOverlayPath({ sourcePath: pluginDir, mountPoints: new Set() })).toBe(
+      false,
+    );
+
+    expect(statSpy.mock.calls.length).toBe(firstCallCount);
+  });
+});

--- a/src/plugins/bundled-source-overlays.ts
+++ b/src/plugins/bundled-source-overlays.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { buildLegacyBundledRootPath } from "./bundled-load-path-aliases.js";
 
+const statCache = new Map<string, fs.Stats>();
+const MAX_STAT_CACHE_ENTRIES = 512;
+
 function decodeMountInfoPath(value: string): string {
   return value.replace(/\\([0-7]{3})/g, (_match, octal: string) =>
     String.fromCharCode(Number.parseInt(octal, 8)),
@@ -34,14 +37,31 @@ function readLinuxMountPoints(): Set<string> {
   }
 }
 
-function isFilesystemMountPoint(targetPath: string): boolean {
+function cachedStatSync(targetPath: string): fs.Stats | undefined {
+  const resolved = path.resolve(targetPath);
+  const cached = statCache.get(resolved);
+  if (cached) {
+    return cached;
+  }
   try {
-    const target = fs.statSync(targetPath);
-    const parent = fs.statSync(path.dirname(targetPath));
-    return target.dev !== parent.dev || target.ino === parent.ino;
+    const stat = fs.statSync(resolved);
+    if (statCache.size >= MAX_STAT_CACHE_ENTRIES) {
+      statCache.clear();
+    }
+    statCache.set(resolved, stat);
+    return stat;
   } catch {
+    return undefined;
+  }
+}
+
+function isFilesystemMountPoint(targetPath: string): boolean {
+  const target = cachedStatSync(targetPath);
+  const parent = cachedStatSync(path.dirname(targetPath));
+  if (!target || !parent) {
     return false;
   }
+  return target.dev !== parent.dev || target.ino === parent.ino;
 }
 
 function sourceOverlaysDisabled(env: NodeJS.ProcessEnv): boolean {

--- a/src/plugins/channel-catalog-registry.test.ts
+++ b/src/plugins/channel-catalog-registry.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { PluginCandidate, PluginDiscoveryResult } from "./discovery.js";
+import type { PluginManifest } from "./manifest.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
   vi.doUnmock("./discovery.js");
+  vi.doUnmock("./manifest.js");
   vi.doUnmock("./installed-plugin-index-record-reader.js");
 });
 
@@ -28,25 +30,38 @@ function emptyDiscoveryResult(): PluginDiscoveryResult {
 }
 
 async function loadWithMocks(params: {
+  discoveryResult?: PluginDiscoveryResult;
+  loadManifest?: (rootDir: string, rejectHardlinks?: boolean) => unknown;
   loadRecords?: (env: NodeJS.ProcessEnv | undefined) => Record<string, PluginInstallRecord>;
 }): Promise<{
   module: typeof import("./channel-catalog-registry.js");
   discoverSpy: ReturnType<typeof vi.fn>;
+  loadManifestSpy: ReturnType<typeof vi.fn>;
   loadRecordsSpy: ReturnType<typeof vi.fn>;
 }> {
   vi.resetModules();
-  const discoverSpy = vi.fn(() => emptyDiscoveryResult());
+  const discoverSpy = vi.fn(() => params.discoveryResult ?? emptyDiscoveryResult());
+  const loadManifestSpy = vi.fn((rootDir: string, rejectHardlinks?: boolean) => {
+    return params.loadManifest
+      ? params.loadManifest(rootDir, rejectHardlinks)
+      : {
+          ok: false,
+          error: "not mocked",
+          manifestPath: `${rootDir}/openclaw.plugin.json`,
+        };
+  });
   const loadRecordsSpy = vi.fn((opts: { env?: NodeJS.ProcessEnv } = {}) => {
     return params.loadRecords ? params.loadRecords(opts.env) : RECORDS;
   });
 
   vi.doMock("./discovery.js", () => ({ discoverOpenClawPlugins: discoverSpy }));
+  vi.doMock("./manifest.js", () => ({ loadPluginManifest: loadManifestSpy }));
   vi.doMock("./installed-plugin-index-record-reader.js", () => ({
     loadInstalledPluginIndexInstallRecordsSync: loadRecordsSpy,
   }));
 
   const module = await import("./channel-catalog-registry.js");
-  return { module, discoverSpy, loadRecordsSpy };
+  return { module, discoverSpy, loadManifestSpy, loadRecordsSpy };
 }
 
 describe("listChannelCatalogEntries", () => {
@@ -112,5 +127,39 @@ describe("listChannelCatalogEntries", () => {
     expect(loadRecordsSpy).toHaveBeenCalledTimes(1);
     expect(discoverSpy).toHaveBeenCalledTimes(1);
     expect(discoverSpy.mock.calls[0][0]).not.toHaveProperty("installRecords");
+  });
+
+  it("uses bundled manifests carried by discovery instead of rereading channel plugin roots", async () => {
+    const manifest = { id: "discord" } as PluginManifest;
+    const candidate = {
+      idHint: "discord",
+      source: "/repo/extensions/discord/src/index.ts",
+      rootDir: "/repo/extensions/discord",
+      origin: "bundled",
+      packageManifest: {
+        channel: {
+          id: "discord",
+          label: "Discord",
+        },
+      },
+      bundledManifest: manifest,
+      bundledManifestPath: "/repo/extensions/discord/openclaw.plugin.json",
+    } satisfies PluginCandidate;
+    const { module, loadManifestSpy } = await loadWithMocks({
+      discoveryResult: { candidates: [candidate], diagnostics: [] },
+    });
+
+    expect(module.listChannelCatalogEntries({ origin: "bundled" })).toEqual([
+      {
+        pluginId: "discord",
+        origin: "bundled",
+        rootDir: "/repo/extensions/discord",
+        channel: {
+          id: "discord",
+          label: "Discord",
+        },
+      },
+    ]);
+    expect(loadManifestSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/channel-catalog-registry.ts
+++ b/src/plugins/channel-catalog-registry.ts
@@ -45,7 +45,10 @@ export function listChannelCatalogEntries(
     if (!channel?.id) {
       return [];
     }
-    const manifest = loadPluginManifest(candidate.rootDir, candidate.origin !== "bundled");
+    const manifest =
+      candidate.origin === "bundled" && candidate.bundledManifest
+        ? { ok: true as const, manifest: candidate.bundledManifest }
+        : loadPluginManifest(candidate.rootDir, candidate.origin !== "bundled");
     if (!manifest.ok) {
       return [];
     }

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearCurrentPluginMetadataSnapshot,
   getCurrentPluginMetadataSnapshot,
@@ -9,6 +9,7 @@ import {
 } from "./current-plugin-metadata-snapshot.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 
 function createSnapshot(
@@ -57,6 +58,11 @@ function createSnapshot(
     },
   };
 }
+
+afterEach(() => {
+  clearCurrentPluginMetadataSnapshot();
+  vi.restoreAllMocks();
+});
 
 describe("current plugin metadata snapshot", () => {
   it("returns the current snapshot only for matching config policy and workspace", () => {
@@ -179,6 +185,56 @@ describe("current plugin metadata snapshot", () => {
     expect(
       getCurrentPluginMetadataSnapshot({ config: runtimeConfig, workspaceDir: "/workspace" }),
     ).toBe(snapshot);
+  });
+
+  it("reuses the stored inventory fingerprint while checking snapshot compatibility", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-metadata-"));
+    try {
+      const config = { plugins: { allow: ["demo"] } };
+      const manifestPath = path.join(tempDir, "openclaw.plugin.json");
+      fs.writeFileSync(manifestPath, JSON.stringify({ id: "demo" }), "utf8");
+      const snapshot = createSnapshot({ config });
+      snapshot.index.plugins = [
+        {
+          pluginId: "demo",
+          manifestPath,
+          manifestHash: "demo-manifest",
+          rootDir: tempDir,
+          origin: "global",
+          enabled: true,
+          startup: {
+            sidecar: false,
+            memory: false,
+            deferConfiguredChannelFullLoadUntilAfterListen: false,
+            agentHarnesses: [],
+          },
+          compat: [],
+        },
+      ];
+      const statSync = vi.spyOn(fs, "statSync");
+
+      setCurrentPluginMetadataSnapshot(snapshot, { config });
+      expect(statSync.mock.calls.filter((call) => String(call[0]) === manifestPath)).toHaveLength(
+        1,
+      );
+      statSync.mockClear();
+
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
+      expect(statSync.mock.calls.filter((call) => String(call[0]) === manifestPath)).toHaveLength(
+        0,
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("lets direct metadata snapshot loaders reuse the current gateway snapshot", () => {
+    const config = { plugins: { allow: ["demo"] } };
+    const snapshot = createSnapshot({ config, workspaceDir: "/workspace" });
+    setCurrentPluginMetadataSnapshot(snapshot, { config, workspaceDir: "/workspace" });
+
+    expect(loadPluginMetadataSnapshot({ config, env: process.env })).toBe(snapshot);
   });
 
   it("clears the current snapshot", () => {

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -5,6 +5,7 @@ import {
   setCurrentPluginMetadataSnapshotState,
 } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import { resolveInstalledManifestRegistryIndexFingerprint } from "./manifest-registry-installed.js";
 import {
   resolvePluginControlPlaneFingerprint,
   type ResolvePluginControlPlaneContextParams,
@@ -32,6 +33,9 @@ export function setCurrentPluginMetadataSnapshot(
     workspaceDir?: string;
   } = {},
 ): void {
+  const inventoryFingerprint = snapshot
+    ? resolveInstalledManifestRegistryIndexFingerprint(snapshot.index)
+    : undefined;
   const compatiblePolicyHashes = snapshot
     ? options.compatibleConfigs?.map((config) => resolveInstalledPluginIndexPolicyHash(config))
     : undefined;
@@ -39,7 +43,7 @@ export function setCurrentPluginMetadataSnapshot(
     ? options.compatibleConfigs?.map((config, index) =>
         resolvePluginMetadataControlPlaneFingerprint(config, {
           env: options.env,
-          index: snapshot.index,
+          ...(inventoryFingerprint ? { inventoryFingerprint } : { index: snapshot.index }),
           policyHash: compatiblePolicyHashes?.[index],
           workspaceDir: options.workspaceDir ?? snapshot.workspaceDir,
         }),
@@ -50,13 +54,14 @@ export function setCurrentPluginMetadataSnapshot(
     snapshot
       ? resolvePluginMetadataControlPlaneFingerprint(options.config, {
           env: options.env,
-          index: snapshot.index,
+          ...(inventoryFingerprint ? { inventoryFingerprint } : { index: snapshot.index }),
           policyHash: snapshot.policyHash,
           workspaceDir: options.workspaceDir ?? snapshot.workspaceDir,
         })
       : undefined,
     compatiblePolicyHashes,
     compatibleConfigFingerprints,
+    inventoryFingerprint,
   );
 }
 
@@ -77,6 +82,7 @@ export function getCurrentPluginMetadataSnapshot(
     configFingerprint,
     compatiblePolicyHashes,
     compatibleConfigFingerprints,
+    inventoryFingerprint,
   } = getCurrentPluginMetadataSnapshotState();
   const snapshot = rawSnapshot as PluginMetadataSnapshot | undefined;
   if (!snapshot) {
@@ -97,7 +103,7 @@ export function getCurrentPluginMetadataSnapshot(
   if (params.config) {
     const requestedConfigFingerprint = resolvePluginMetadataControlPlaneFingerprint(params.config, {
       env: params.env,
-      index: snapshot.index,
+      ...(inventoryFingerprint ? { inventoryFingerprint } : { index: snapshot.index }),
       policyHash: requestedPolicyHash,
       workspaceDir: requestedWorkspaceDir,
     });

--- a/src/plugins/current-plugin-metadata-state.ts
+++ b/src/plugins/current-plugin-metadata-state.ts
@@ -2,12 +2,14 @@ let currentPluginMetadataSnapshot: unknown;
 let currentPluginMetadataSnapshotConfigFingerprint: string | undefined;
 let currentPluginMetadataSnapshotCompatiblePolicyHashes: readonly string[] | undefined;
 let currentPluginMetadataSnapshotCompatibleConfigFingerprints: readonly string[] | undefined;
+let currentPluginMetadataSnapshotInventoryFingerprint: string | undefined;
 
 export function setCurrentPluginMetadataSnapshotState(
   snapshot: unknown,
   configFingerprint: string | undefined,
   compatiblePolicyHashes?: readonly string[],
   compatibleConfigFingerprints?: readonly string[],
+  inventoryFingerprint?: string,
 ): void {
   currentPluginMetadataSnapshot = snapshot;
   currentPluginMetadataSnapshotConfigFingerprint = snapshot ? configFingerprint : undefined;
@@ -17,6 +19,7 @@ export function setCurrentPluginMetadataSnapshotState(
   currentPluginMetadataSnapshotCompatibleConfigFingerprints = snapshot
     ? compatibleConfigFingerprints
     : undefined;
+  currentPluginMetadataSnapshotInventoryFingerprint = snapshot ? inventoryFingerprint : undefined;
 }
 
 export function clearCurrentPluginMetadataSnapshotState(): void {
@@ -24,6 +27,7 @@ export function clearCurrentPluginMetadataSnapshotState(): void {
   currentPluginMetadataSnapshotConfigFingerprint = undefined;
   currentPluginMetadataSnapshotCompatiblePolicyHashes = undefined;
   currentPluginMetadataSnapshotCompatibleConfigFingerprints = undefined;
+  currentPluginMetadataSnapshotInventoryFingerprint = undefined;
 }
 
 export function getCurrentPluginMetadataSnapshotState(): {
@@ -31,11 +35,13 @@ export function getCurrentPluginMetadataSnapshotState(): {
   configFingerprint: string | undefined;
   compatiblePolicyHashes: readonly string[] | undefined;
   compatibleConfigFingerprints: readonly string[] | undefined;
+  inventoryFingerprint: string | undefined;
 } {
   return {
     snapshot: currentPluginMetadataSnapshot,
     configFingerprint: currentPluginMetadataSnapshotConfigFingerprint,
     compatiblePolicyHashes: currentPluginMetadataSnapshotCompatiblePolicyHashes,
     compatibleConfigFingerprints: currentPluginMetadataSnapshotCompatibleConfigFingerprints,
+    inventoryFingerprint: currentPluginMetadataSnapshotInventoryFingerprint,
   };
 }

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -493,13 +493,30 @@ function derivePackagePluginIdHint(params: {
     : unscoped;
 }
 
-function resolveIdHintManifestId(
+type IdHintManifestResolution = {
+  id?: string;
+  manifest?: PluginManifest;
+  manifestPath?: string;
+};
+
+function resolveIdHintManifest(
   rootDir: string,
   rejectHardlinks: boolean,
   rootRealPath?: string,
-): string | undefined {
+): IdHintManifestResolution {
   const manifest = loadPluginManifest(rootDir, rejectHardlinks, rootRealPath);
-  return manifest.ok ? manifest.manifest.id : undefined;
+  return manifest.ok
+    ? { id: manifest.manifest.id, manifest: manifest.manifest, manifestPath: manifest.manifestPath }
+    : {};
+}
+
+function bundledIdHintManifestFields(
+  origin: PluginOrigin,
+  resolution: IdHintManifestResolution,
+): Pick<PluginCandidate, "bundledManifest" | "bundledManifestPath"> {
+  return origin === "bundled" && resolution.manifest && resolution.manifestPath
+    ? { bundledManifest: resolution.manifest, bundledManifestPath: resolution.manifestPath }
+    : {};
 }
 
 function addCandidate(params: {
@@ -694,7 +711,7 @@ function discoverInDirectory(params: {
     });
     const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
     const extensions = extensionResolution.status === "ok" ? extensionResolution.entries : [];
-    const manifestId = resolveIdHintManifestId(fullPath, rejectHardlinks, fullPathRealPath);
+    const idHintManifest = resolveIdHintManifest(fullPath, rejectHardlinks, fullPathRealPath);
     const setupSource = resolvePackageSetupSource({
       packageDir: fullPath,
       ...(fullPathRealPath !== undefined ? { packageRootRealPath: fullPathRealPath } : {}),
@@ -712,7 +729,10 @@ function discoverInDirectory(params: {
         manifest,
         extensions,
         origin: params.origin,
-        pluginIdHint: derivePackagePluginIdHint({ manifestId, packageName: manifest?.name }),
+        pluginIdHint: derivePackagePluginIdHint({
+          manifestId: idHintManifest.id,
+          packageName: manifest?.name,
+        }),
         sourceLabel: fullPath,
         diagnostics: params.diagnostics,
         rejectHardlinks,
@@ -724,7 +744,7 @@ function discoverInDirectory(params: {
           seen: params.seen,
           idHint: deriveIdHint({
             filePath: resolved,
-            manifestId,
+            manifestId: idHintManifest.id,
             packageName: manifest?.name,
             hasMultipleExtensions: extensions.length > 1,
           }),
@@ -736,6 +756,7 @@ function discoverInDirectory(params: {
           workspaceDir: params.workspaceDir,
           manifest,
           packageDir: fullPath,
+          ...bundledIdHintManifestFields(params.origin, idHintManifest),
           realpathCache: params.realpathCache,
         });
       }
@@ -765,7 +786,7 @@ function discoverInDirectory(params: {
         candidates: params.candidates,
         diagnostics: params.diagnostics,
         seen: params.seen,
-        idHint: manifestId ?? entry.name,
+        idHint: idHintManifest.id ?? entry.name,
         source: indexFile,
         ...(setupSource ? { setupSource } : {}),
         rootDir: fullPath,
@@ -774,6 +795,7 @@ function discoverInDirectory(params: {
         workspaceDir: params.workspaceDir,
         manifest,
         packageDir: fullPath,
+        ...bundledIdHintManifestFields(params.origin, idHintManifest),
         realpathCache: params.realpathCache,
       });
       continue;
@@ -900,7 +922,7 @@ function discoverFromPath(params: {
     });
     const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
     const extensions = extensionResolution.status === "ok" ? extensionResolution.entries : [];
-    const manifestId = resolveIdHintManifestId(resolved, rejectHardlinks, resolvedRealPath);
+    const idHintManifest = resolveIdHintManifest(resolved, rejectHardlinks, resolvedRealPath);
     const setupSource = resolvePackageSetupSource({
       packageDir: resolved,
       ...(resolvedRealPath !== undefined ? { packageRootRealPath: resolvedRealPath } : {}),
@@ -918,7 +940,10 @@ function discoverFromPath(params: {
         manifest,
         extensions,
         origin: params.origin,
-        pluginIdHint: derivePackagePluginIdHint({ manifestId, packageName: manifest?.name }),
+        pluginIdHint: derivePackagePluginIdHint({
+          manifestId: idHintManifest.id,
+          packageName: manifest?.name,
+        }),
         sourceLabel: resolved,
         diagnostics: params.diagnostics,
         rejectHardlinks,
@@ -930,7 +955,7 @@ function discoverFromPath(params: {
           seen: params.seen,
           idHint: deriveIdHint({
             filePath: source,
-            manifestId,
+            manifestId: idHintManifest.id,
             packageName: manifest?.name,
             hasMultipleExtensions: extensions.length > 1,
           }),
@@ -942,6 +967,7 @@ function discoverFromPath(params: {
           workspaceDir: params.workspaceDir,
           manifest,
           packageDir: resolved,
+          ...bundledIdHintManifestFields(params.origin, idHintManifest),
           realpathCache: params.realpathCache,
         });
       }
@@ -972,7 +998,7 @@ function discoverFromPath(params: {
         candidates: params.candidates,
         diagnostics: params.diagnostics,
         seen: params.seen,
-        idHint: manifestId ?? path.basename(resolved),
+        idHint: idHintManifest.id ?? path.basename(resolved),
         source: indexFile,
         ...(setupSource ? { setupSource } : {}),
         rootDir: resolved,
@@ -981,6 +1007,7 @@ function discoverFromPath(params: {
         workspaceDir: params.workspaceDir,
         manifest,
         packageDir: resolved,
+        ...bundledIdHintManifestFields(params.origin, idHintManifest),
         realpathCache: params.realpathCache,
       });
       return;

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -3,6 +3,7 @@ import {
   getActiveDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
 } from "../infra/diagnostics-timeline.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
@@ -176,6 +177,17 @@ export function listPluginOriginsFromMetadataSnapshot(
 export function loadPluginMetadataSnapshot(
   params: LoadPluginMetadataSnapshotParams,
 ): PluginMetadataSnapshot {
+  if (!params.index && !params.stateDir && params.preferPersisted !== false) {
+    const current = getCurrentPluginMetadataSnapshot({
+      config: params.config,
+      env: params.env,
+      workspaceDir: params.workspaceDir,
+      allowWorkspaceScopedSnapshot: params.workspaceDir === undefined,
+    });
+    if (current) {
+      return current;
+    }
+  }
   const activeTimelineSpan = getActiveDiagnosticsTimelineSpan();
   return measureDiagnosticsTimelineSpanSync(
     "plugins.metadata.scan",


### PR DESCRIPTION
## Summary

- Reuse the gateway startup plugin metadata snapshot for compatible direct metadata loads so deep status paths avoid repeatedly restatting bundled plugin manifests.
- Carry bundled manifests discovered during plugin discovery into channel catalog metadata instead of rereading plugin roots.
- Cache runtime labels within a single status summary and degrade memory deep status cleanly when local embedding/vector dependencies are unavailable.

## Verification

- `pnpm test:serial src/plugins/current-plugin-metadata-snapshot.test.ts src/plugins/channel-catalog-registry.test.ts`
- `pnpm test:serial extensions/memory-core/src/memory/index.test.ts`
- `pnpm build`
- Crabbox synthetic proof: `tbx_01kr0a6wr3s6qdrgyphqsx6z1m`, Actions run `25475688574`
  - `status --deep`: exit 0, ~5.2s, ~40.8k fs ops
  - `memory status --deep`: exit 0, ~2.5s
  - gateway trace down to ~512k fs ops from the reported ~3.15M
- Crabbox changed gate: `tbx_01kr0at0bvxkqap6r93e29200d`, Actions run `25475964101`, `pnpm check:changed` exit 0
