### PR TITLE
fix(macos): use tagged mlx audio release

### DIFF
--- a/apps/macos-mlx-tts/Package.resolved
+++ b/apps/macos-mlx-tts/Package.resolved
@@ -15,7 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift",
       "state" : {
-        "revision" : "fc4fe22dc41c053062e647a4e3db9142193670d2"
+        "revision" : "fcbd04daa1bfebe881932f630af2ba6ce9af3274",
+        "version" : "0.1.2"
       }
     },
     {

--- a/apps/macos-mlx-tts/Package.swift
+++ b/apps/macos-mlx-tts/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executable(name: "openclaw-mlx-tts", targets: ["OpenClawMLXTTSHelper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Blaizzy/mlx-audio-swift", revision: "fc4fe22dc41c053062e647a4e3db9142193670d2"),
+        .package(url: "https://github.com/Blaizzy/mlx-audio-swift", exact: "0.1.2"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Summary

- Problem: The isolated macOS MLX TTS helper still depended on `mlx-audio-swift` by raw revision.
- Why it matters: #63531 asked for the MLX Talk path to use a tagged `mlx-audio-swift` release rather than an untagged revision.
- What changed: The helper package now requires `mlx-audio-swift` exactly at `0.1.2`, and its package resolution records the corresponding tagged revision.
- What did NOT change (scope boundary): No Talk runtime behavior, model defaults, playback logic, or app package dependency surface changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63531
- Related #62534
- [ ] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: MLX helper dependency declaration now uses a tagged SwiftPM release.
- Real environment tested: Linux checkout for dependency/tag verification; macOS SwiftPM runtime unavailable here.
- Exact steps or command run after this patch: `git ls-remote --tags https://github.com/Blaizzy/mlx-audio-swift.git 'refs/tags/v0.1.2'`; inspected the package diff; ran `git diff --check`.
- Evidence after fix: Terminal capture below shows the `v0.1.2` tag exists and the PR diff switches the helper package to exact version `0.1.2`.
- Observed result after fix: `apps/macos-mlx-tts/Package.swift` uses `.package(..., exact: "0.1.2")`, and `apps/macos-mlx-tts/Package.resolved` records version `0.1.2` at the tagged revision.
- What was not tested: SwiftPM resolve/build and macOS Talk runtime, because `swift`, `pnpm`, and macOS are unavailable in this environment.

Copied terminal capture:

```text
$ git ls-remote --tags https://github.com/Blaizzy/mlx-audio-swift.git 'refs/tags/v0.1.2'
fcbd04daa1bfebe881932f630af2ba6ce9af3274	refs/tags/v0.1.2

$ git diff -- apps/macos-mlx-tts/Package.swift apps/macos-mlx-tts/Package.resolved
diff --git a/apps/macos-mlx-tts/Package.resolved b/apps/macos-mlx-tts/Package.resolved
index f27c66e3ac..6ab9e63fd 100644
--- a/apps/macos-mlx-tts/Package.resolved
+++ b/apps/macos-mlx-tts/Package.resolved
@@ -15,7 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift",
       "state" : {
-        "revision" : "fc4fe22dc41c053062e647a4e3db9142193670d2"
+        "revision" : "fcbd04daa1bfebe881932f630af2ba6ce9af3274",
+        "version" : "0.1.2"
       }
     },
     {
diff --git a/apps/macos-mlx-tts/Package.swift b/apps/macos-mlx-tts/Package.swift
index aa7703919d..96dffe3c40 100644
--- a/apps/macos-mlx-tts/Package.swift
+++ b/apps/macos-mlx-tts/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executable(name: "openclaw-mlx-tts", targets: ["OpenClawMLXTTSHelper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Blaizzy/mlx-audio-swift", revision: "fc4fe22dc41c053062e647a4e3db9142193670d2"),
+        .package(url: "https://github.com/Blaizzy/mlx-audio-swift", exact: "0.1.2"),
     ],
     targets: [
         .executableTarget(

$ git diff --check
# no output
```

## Root Cause (if applicable)

- Root cause: N/A.
- Missing detection / guardrail: N/A.
- Contributing context (if known): The MLX helper package was isolated from the main macOS app package, so this dependency pin remained revision-based after tagged upstream releases became available.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: N/A.
- Scenario the test should lock in: N/A.
- Why this is the smallest reliable guardrail: N/A.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: This is a SwiftPM dependency declaration update; validation is checking the tag and package diff rather than adding runtime tests.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux checkout
- Runtime/container: Local shell; `swift` unavailable; `pnpm` unavailable
- Model/provider: N/A
- Integration/channel (if any): macOS MLX TTS helper package
- Relevant config (redacted): N/A

### Steps

1. Verified upstream `mlx-audio-swift` tag `v0.1.2` exists.
2. Updated `apps/macos-mlx-tts/Package.swift` to use the exact tagged release.
3. Updated `apps/macos-mlx-tts/Package.resolved` to record version `0.1.2` and the tag revision.
4. Ran `git diff --check`.

### Expected

- The helper package depends on a tagged `mlx-audio-swift` release.

### Actual

- The helper package depends on exact version `0.1.2`, and whitespace validation passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Confirmed the `v0.1.2` tag exists remotely and that the package manifest now references it by exact version.
- Edge cases checked: Confirmed the change is limited to the isolated MLX helper package files.
- What you did **not** verify: SwiftPM resolve/build and macOS Talk runtime due unavailable `swift`/macOS environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: SwiftPM resolution was not regenerated by the local toolchain because `swift` is unavailable here.
  - Mitigation: The lockfile revision was updated to the verified `v0.1.2` tag revision; CI/macOS SwiftPM can provide final package resolution proof.
