### PR TITLE
fix(update): keep npm staging on package prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.
+- Update: keep staged npm package swaps anchored to the resolved OpenClaw package root prefix when bare `npm root -g` reports a different global root, avoiding `/usr/local` staging on nvm-owned installs. Fixes #78775. Thanks @LDMB123.
 - Discord/voice: keep TTS playback running when another user starts speaking, ignore new capture during playback to avoid feedback loops, and downgrade expected receive-stream aborts to verbose diagnostics.
 - Telegram: treat successful same-chat `message` tool outbound sends during an inbound telegram turn as delivered when deciding whether to emit the rewritten silent reply fallback (#78685). Thanks @neeravmakwana.
 - Gateway/tasks: reconcile stale CLI run-context tasks whose live run context disappeared even when a child session row remains, and apply the default bounded reload deferral timeout to channel hot reloads so stale task records cannot block Discord/Slack/Telegram reloads forever.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.
-- Update: keep staged npm package swaps anchored to the resolved OpenClaw package root prefix when bare `npm root -g` reports a different global root, avoiding `/usr/local` staging on nvm-owned installs. Fixes #78775. Thanks @LDMB123.
+- Update: keep staged npm package swaps anchored to the resolved OpenClaw package root prefix when bare `npm root -g` reports a different global root, avoiding `/usr/local` staging on nvm-owned installs. Fixes #78775. Thanks @lovensky1992-wk and @hclsys.
 - Discord/voice: keep TTS playback running when another user starts speaking, ignore new capture during playback to avoid feedback loops, and downgrade expected receive-stream aborts to verbose diagnostics.
 - Telegram: treat successful same-chat `message` tool outbound sends during an inbound telegram turn as delivered when deciding whether to emit the rewritten silent reply fallback (#78685). Thanks @neeravmakwana.
 - Gateway/tasks: reconcile stale CLI run-context tasks whose live run context disappeared even when a child session row remains, and apply the default bounded reload deferral timeout to channel hot reloads so stale task records cannot block Discord/Slack/Telegram reloads forever.

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -356,6 +356,31 @@ describe("update global helpers", () => {
     }
   });
 
+  it("keeps npm update staging on the package root prefix when bare npm reports another root", async () => {
+    await withTempDir({ prefix: "openclaw-update-npm-target-prefix-" }, async (base) => {
+      const nvmRoot = path.join(base, "nvm", "versions", "node", "v22.17.0", "lib", "node_modules");
+      const pathNpmRoot = path.join(base, "usr", "local", "lib", "node_modules");
+      const pkgRoot = path.join(nvmRoot, "openclaw");
+      await fs.mkdir(pkgRoot, { recursive: true });
+
+      const runCommand = createNpmRootRunner({ defaultNpmRoot: pathNpmRoot });
+
+      await expect(
+        resolveGlobalInstallTarget({
+          manager: { manager: "npm", command: "npm" },
+          runCommand,
+          timeoutMs: 1000,
+          pkgRoot,
+        }),
+      ).resolves.toEqual({
+        manager: "npm",
+        command: "npm",
+        globalRoot: nvmRoot,
+        packageRoot: pkgRoot,
+      });
+    });
+  });
+
   it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {
     await withTempDir({ prefix: "openclaw-update-npm-missing-bin-" }, async (base) => {
       const brewRoot = path.join(base, "opt", "homebrew", "lib", "node_modules");

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -600,11 +600,17 @@ export async function resolveGlobalInstallTarget(params: {
     params.timeoutMs,
     params.pkgRoot,
   );
+  const inferredPkgRootGlobalRoot = inferGlobalRootFromPackageRoot(params.pkgRoot);
+  const npmPkgRootGlobalRoot =
+    command.manager === "npm" &&
+    resolveNpmGlobalPrefixLayoutFromGlobalRoot(inferredPkgRootGlobalRoot)
+      ? inferredPkgRootGlobalRoot
+      : null;
   const pkgRootGlobalRoot =
     command.manager === "pnpm" && (await isPnpmGlobalPackageRoot(params.pkgRoot))
       ? inferPnpmGlobalRootFromPackageRoot(params.pkgRoot)
       : null;
-  const targetGlobalRoot = pkgRootGlobalRoot ?? globalRoot;
+  const targetGlobalRoot = npmPkgRootGlobalRoot ?? pkgRootGlobalRoot ?? globalRoot;
   return {
     ...command,
     globalRoot: targetGlobalRoot,


### PR DESCRIPTION
## Summary

- Problem: `update.run` can stage an npm package swap under the global root reported by bare `npm root -g` even after OpenClaw has already resolved the running package root under a different npm prefix.
- What changed: npm global install target resolution now prefers the inferred global root from the resolved OpenClaw package root when that root has an npm global-prefix layout.
- Why it matters: nvm-owned installs should stage under the nvm prefix instead of trying to create `.openclaw-update-stage-*` under `/usr/local/lib/node_modules`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] CLI / update
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78775
- Related #60150
- [x] This PR fixes a bug or regression

## Real behavior proof

Behavior or issue addressed: npm package-update staging can target `/usr/local/lib/node_modules` even when the resolved OpenClaw package root is under an nvm npm prefix.

Real environment tested: local Ubuntu workspace, Node v22.22.0, pnpm v10.33.2, current `main` after `pnpm install --frozen-lockfile`.

Exact steps or command run after this patch: ran the update target resolver through `node --import tsx --input-type=module`, with a temp OpenClaw package root under `nvm/versions/node/v22.17.0/lib/node_modules/openclaw` and a command runner whose bare `npm root -g` returned a separate `usr/local/lib/node_modules` root; also ran `pnpm test src/infra/update-global.test.ts`, `pnpm format:check src/infra/update-global.ts src/infra/update-global.test.ts CHANGELOG.md`, and `pnpm exec oxlint src/infra/update-global.ts src/infra/update-global.test.ts --tsconfig config/tsconfig/oxlint.core.json`.

Evidence after fix: resolver terminal output ended with `"pathNpmRoot": "/tmp/openclaw-78775-proof-D4ajwj/usr/local/lib/node_modules"`, `"resolvedGlobalRoot": "/tmp/openclaw-78775-proof-D4ajwj/nvm/versions/node/v22.17.0/lib/node_modules"`, `"resolvedPackageRoot": "/tmp/openclaw-78775-proof-D4ajwj/nvm/versions/node/v22.17.0/lib/node_modules/openclaw"`, and `"stayedOnPackagePrefix": true`; targeted test shard passed with `Test Files 1 passed (1)` and `Tests 29 passed (29)`; direct oxlint reported `Found 0 warnings and 0 errors`; format check reported `All matched files use the correct format`.

Observed result after fix: when bare `npm` reports a different global root, `resolveGlobalInstallTarget` keeps `globalRoot` and `packageRoot` on the package root's nvm-style prefix, so the later staged install is prepared beside the resolved package instead of under `/usr/local`.

What was not tested: live macOS nvm `gateway update.run`; wrapper `pnpm lint:core -- ...` because it currently stops during unrelated plugin-sdk boundary dts preparation before linting these files (`ProviderNormalizeTransportContext.config` type errors in `src/agents/pi-embedded-runner/model.ts`).

## Regression Test Plan

- Added coverage in `src/infra/update-global.test.ts` for a package root under `nvm/versions/node/v22.17.0/lib/node_modules/openclaw` while bare npm reports `usr/local/lib/node_modules`.
- Verified the existing npm ownership test still keeps detection from relying on path shape alone when no caller has classified the install as npm.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: npm target resolution now trusts the already-resolved package root prefix once the install manager is npm.
  - Mitigation: the change only applies when the inferred package root global root has an npm global-prefix layout; manager detection still does not infer npm ownership from path shape alone.
