### PR TITLE
fix(cron): bootstrap outbound channel targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2326,6 +2326,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI-compatible providers: apply model-declared unsupported tool-schema keyword stripping to native OpenAI transport payloads and mark Fireworks Kimi K2.5 as rejecting `not` schemas. Fixes #75467.
 - OpenAI-compatible gateway: sanitize images supplied through request content even when the prompt text contains no image file references, preventing oversized attachment payloads from bypassing the resize/drop pipeline. Fixes #59913.
 - Auth profiles: normalize inline API keys and tokens loaded from `auth-profiles.json` so masked or rich-text credential artifacts fail as auth errors instead of crashing HTTP header construction. Fixes #77624.
+- Cron previews: bootstrap configured outbound channel plugins during target resolution so `openclaw cron list` no longer reports false `Unsupported channel` warnings for configured Feishu and other channel targets. Fixes #77712.
 - llm-task: resolve configured model aliases before embedded dispatch so `model="gemini-flash"` and other aliases route to the intended provider instead of the agent default. Fixes #54166.
 - Media generation: resolve slash-containing model-only overrides like `fal-ai/flux/dev` through registered provider model metadata so FAL image/video models do not get misparsed as provider `fal-ai`. Fixes #77444.
 - CLI backends: keep versioned OAuth identity matches reusable when auth profile ids rotate, so Claude CLI sessions do not reset and lose continuity during same-account OAuth refresh/profile alias changes. Fixes #78541.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI-compatible providers: apply model-declared unsupported tool-schema keyword stripping to native OpenAI transport payloads and mark Fireworks Kimi K2.5 as rejecting `not` schemas. Fixes #75467.
 - OpenAI-compatible gateway: sanitize images supplied through request content even when the prompt text contains no image file references, preventing oversized attachment payloads from bypassing the resize/drop pipeline. Fixes #59913.
 - Auth profiles: normalize inline API keys and tokens loaded from `auth-profiles.json` so masked or rich-text credential artifacts fail as auth errors instead of crashing HTTP header construction. Fixes #77624.
+- Cron previews: bootstrap configured outbound channel plugins during target resolution so `openclaw cron list` no longer reports false `Unsupported channel` warnings for configured Feishu and other channel targets. Fixes #77712.
 - llm-task: resolve configured model aliases before embedded dispatch so `model="gemini-flash"` and other aliases route to the intended provider instead of the agent default. Fixes #54166.
 - Media generation: resolve slash-containing model-only overrides like `fal-ai/flux/dev` through registered provider model metadata so FAL image/video models do not get misparsed as provider `fal-ai`. Fixes #77444.
 - Commands/BTW: show the `/btw` missing-question usage placeholder with brackets so outbound channel sanitization keeps it visible. Fixes #62877. Thanks @RajvardhanPatil07.

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -127,6 +127,25 @@ describe("resolveOutboundTarget defaultTo config fallback", () => {
     expect(res.ok).toBe(false);
   });
 
+  it("bootstraps configured channel plugins before reporting an unsupported channel", () => {
+    const cfg: OpenClawConfig = {
+      channels: { alpha: { allowFrom: ["room-one"] } },
+    };
+
+    resolveOutboundTarget({
+      channel: "alpha",
+      to: "room-one",
+      cfg,
+      mode: "explicit",
+    });
+
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledWith({
+      channel: "alpha",
+      cfg,
+      allowBootstrap: true,
+    });
+  });
+
   it("falls back to the active registry when the cached channel map is stale", () => {
     const registry = createTargetsTestRegistry([]);
     setActivePluginRegistry(registry, "stale-registry-test");

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -102,6 +102,25 @@ describe("resolveOutboundTarget defaultTo config fallback", () => {
     expect(res.ok).toBe(false);
   });
 
+  it("bootstraps configured channel plugins before reporting an unsupported channel", () => {
+    const cfg: OpenClawConfig = {
+      channels: { alpha: { allowFrom: ["room-one"] } },
+    };
+
+    resolveOutboundTarget({
+      channel: "alpha",
+      to: "room-one",
+      cfg,
+      mode: "explicit",
+    });
+
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledWith({
+      channel: "alpha",
+      cfg,
+      allowBootstrap: true,
+    });
+  });
+
   it("falls back to the active registry when the cached channel map is stale", () => {
     const registry = createTargetsTestRegistry([]);
     setActivePluginRegistry(registry, "stale-registry-test");

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -65,6 +65,7 @@ export function resolveOutboundTarget(params: {
       plugin: resolveOutboundChannelPlugin({
         channel: params.channel,
         cfg: params.cfg,
+        allowBootstrap: true,
       }),
       target: params,
       onMissingPlugin: () =>

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -70,7 +70,7 @@ export function resolveOutboundTarget(params: {
       plugin: resolveOutboundChannelPlugin({
         channel: params.channel,
         cfg: params.cfg,
-        allowBootstrap: params.allowBootstrap,
+        allowBootstrap: params.allowBootstrap ?? true,
       }),
       target: params,
       onMissingPlugin: () =>


### PR DESCRIPTION
## Summary
- Fixes #77712 by allowing outbound target resolution to bootstrap configured channel plugins before returning unsupported-channel errors.
- Keeps cron delivery previews aligned with runtime delivery for configured bundled channels like Feishu.
- Adds regression coverage that target resolution requests plugin bootstrap.

## Background
Cron list delivery preview could show `Unsupported channel: feishu` even when Feishu was configured and recent deliveries succeeded. The preview path resolves outbound targets before the channel plugin has necessarily been loaded.

## Verification
- `pnpm test src/infra/outbound/targets.test.ts src/cron/isolated-agent/delivery-target.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/outbound/targets.ts src/infra/outbound/targets.test.ts`

## Real behavior proof
- Behavior or issue addressed: configured Feishu outbound target resolution bootstraps the channel plugin instead of reporting `Unsupported channel: feishu`.
- Real environment tested: macOS 25.3.0, Node v24.13.1, real local OpenClaw checkout `/tmp/openclaw-pr-77709`, active user OpenClaw config present, active plugin registry explicitly cleared before the call.
- Exact steps or command run after this patch: ran the same outbound target resolver used by cron delivery preview with a redacted configured `channels.feishu` block and a Feishu `ou_...` target.
- Evidence after fix:

```console
$ pnpm exec tsx -e "import { setActivePluginRegistry } from './src/plugins/runtime.ts'; import { resolveOutboundTarget } from './src/infra/outbound/targets.ts'; setActivePluginRegistry(undefined as any); const cfg={channels:{feishu:{enabled:true,appId:'cli_xxx',appSecret:'redacted'}}}; const res=resolveOutboundTarget({channel:'feishu',to:'ou_3e605fadb6dc02335602d16ec60bc8c3',cfg:cfg as any,mode:'explicit'}); console.log(JSON.stringify(res,null,2));"
{
  "ok": true,
  "to": "ou_3e605fadb6dc02335602d16ec60bc8c3"
}
[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: feishu-openclaw-plugin (.../.openclaw/extensions/feishu-openclaw-plugin/index.js). Set plugins.allow to explicit trusted ids.
[plugins] 1 plugin(s) failed to initialize (validation: feishu-openclaw-plugin). Run 'openclaw plugins list' for details.
```

- Observed result after fix: the configured bundled Feishu channel resolved successfully with `{ "ok": true }` instead of returning `Unsupported channel: feishu`, even before a channel plugin registry was preloaded.
- What was not tested: live Feishu message send; this change is limited to outbound target resolution/cron preview and does not alter message transport.

## Impact
Configured outbound channels can now be lazily loaded for preview/target resolution, reducing false unsupported-channel warnings without changing target normalization semantics.
