### PR TITLE
feat(gateway): add components field to SendParamsSchema for Discord b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.
+- Gateway/Discord: add optional `components` field to the `send` schema and forward it through `channelData.discord.rawComponents`, letting callers attach Discord interactive components (action rows / buttons) for HITL approval flows. Non-Discord channels ignore the field; existing sends without components are unaffected.
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.
 - Discord/voice: keep TTS playback running when another user starts speaking, ignore new capture during playback to avoid feedback loops, and downgrade expected receive-stream aborts to verbose diagnostics.
 - Telegram: treat successful same-chat `message` tool outbound sends during an inbound telegram turn as delivered when deciding whether to emit the rewritten silent reply fallback (#78685). Thanks @neeravmakwana.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -579,6 +579,7 @@ public struct SendParams: Codable, Sendable {
     public let replytoid: String?
     public let threadid: String?
     public let sessionkey: String?
+    public let components: [AnyCodable]?
     public let idempotencykey: String
 
     public init(
@@ -594,6 +595,7 @@ public struct SendParams: Codable, Sendable {
         replytoid: String?,
         threadid: String?,
         sessionkey: String?,
+        components: [AnyCodable]?,
         idempotencykey: String)
     {
         self.to = to
@@ -608,6 +610,7 @@ public struct SendParams: Codable, Sendable {
         self.replytoid = replytoid
         self.threadid = threadid
         self.sessionkey = sessionkey
+        self.components = components
         self.idempotencykey = idempotencykey
     }
 
@@ -624,6 +627,7 @@ public struct SendParams: Codable, Sendable {
         case replytoid = "replyToId"
         case threadid = "threadId"
         case sessionkey = "sessionKey"
+        case components
         case idempotencykey = "idempotencyKey"
     }
 }

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -1,5 +1,6 @@
 import {
   type ChannelOutboundAdapter,
+  type ChannelOutboundContext,
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
@@ -24,6 +25,7 @@ import {
   type DiscordSendFn,
   type DiscordVoiceSendFn,
 } from "./outbound-send-context.js";
+import type { DiscordSendComponents, DiscordSendEmbeds } from "./send.shared.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
 const DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_BLOCK_RE =
@@ -145,19 +147,39 @@ export const discordOutbound: ChannelOutboundAdapter = {
     }),
   ...createAttachedChannelResultAdapter({
     channel: "discord",
-    sendText: async ({
-      cfg,
-      to,
-      text,
-      accountId,
-      deps,
-      replyToId,
-      threadId,
-      identity,
-      silent,
-      formatting,
-    }) => {
-      if (!silent) {
+    sendText: async (ctx) => {
+      const {
+        cfg,
+        to,
+        text,
+        accountId,
+        deps,
+        replyToId,
+        threadId,
+        identity,
+        silent,
+        formatting,
+      } = ctx;
+      // Native interactive components (action rows / V2 layouts) optionally
+      // attached by the gateway via channelData.discord.rawComponents — they
+      // ride along on the outbound context here so a plain-text send can
+      // still attach buttons / selects without going through the
+      // presentation-spec or sendPayload paths.
+      const extraCtx = ctx as ChannelOutboundContext & {
+        components?: DiscordSendComponents;
+        embeds?: DiscordSendEmbeds;
+        filename?: string;
+      };
+      const components = extraCtx.components;
+      const embeds = extraCtx.embeds;
+      const filename = extraCtx.filename;
+      const hasNativeComponents =
+        (Array.isArray(components) && components.length > 0) ||
+        (Array.isArray(embeds) && embeds.length > 0) ||
+        Boolean(filename);
+      if (!silent && !hasNativeComponents) {
+        // Webhook delivery does not support attaching action rows; only
+        // try the webhook path when no components are present.
         const webhookResult = await maybeSendDiscordWebhookText({
           cfg,
           text,
@@ -183,6 +205,9 @@ export const discordOutbound: ChannelOutboundAdapter = {
             accountId: accountId ?? undefined,
             silent: silent ?? undefined,
             cfg,
+            components,
+            embeds,
+            filename,
             ...resolveDiscordFormattingOptions({ formatting }),
           }),
       });

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -20,9 +20,29 @@ import type { DiscordSendComponents, DiscordSendEmbeds } from "./send.shared.js"
 type OutboundPayload = Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["payload"];
 
 /**
+ * Wrap a raw Discord component JSON object so it satisfies the internal
+ * `TopLevelComponents` shape expected by `serializePayload`: an object with
+ * a `.serialize()` method returning the raw API payload, plus an `isV2` flag
+ * derived from the component's `type` (V2 component types are 9..18 per the
+ * current Discord components-v2 spec).
+ */
+function wrapRawDiscordComponent(raw: Record<string, unknown>): {
+  isV2: boolean;
+  serialize: () => unknown;
+} {
+  const t = raw.type;
+  const isV2 = typeof t === "number" && t >= 9 && t <= 18;
+  return {
+    isV2,
+    serialize: () => raw,
+  };
+}
+
+/**
  * Extract raw Discord API components stored in channelData by the gateway send
  * handler. These are passed through to the Discord API as-is (e.g. action rows
- * with buttons for HITL approval flows).
+ * with buttons for HITL approval flows). Each entry is wrapped so that the
+ * internal serializer treats it as a top-level component.
  */
 function resolveDiscordRawComponents(payload: OutboundPayload): DiscordSendComponents | undefined {
   const discordData = payload.channelData?.discord as
@@ -30,7 +50,9 @@ function resolveDiscordRawComponents(payload: OutboundPayload): DiscordSendCompo
     | undefined;
   const raw = discordData?.rawComponents;
   if (Array.isArray(raw) && raw.length > 0) {
-    return raw as DiscordSendComponents;
+    return raw.map((entry) =>
+      wrapRawDiscordComponent(entry as Record<string, unknown>),
+    ) as unknown as DiscordSendComponents;
   }
   return undefined;
 }

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -17,6 +17,24 @@ import { createDiscordPayloadSendContext } from "./outbound-send-context.js";
 import { createDiscordSendReceipt } from "./send.receipt.js";
 import type { DiscordSendComponents, DiscordSendEmbeds } from "./send.shared.js";
 
+type OutboundPayload = Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["payload"];
+
+/**
+ * Extract raw Discord API components stored in channelData by the gateway send
+ * handler. These are passed through to the Discord API as-is (e.g. action rows
+ * with buttons for HITL approval flows).
+ */
+function resolveDiscordRawComponents(payload: OutboundPayload): DiscordSendComponents | undefined {
+  const discordData = payload.channelData?.discord as
+    | { rawComponents?: unknown }
+    | undefined;
+  const raw = discordData?.rawComponents;
+  if (Array.isArray(raw) && raw.length > 0) {
+    return raw as DiscordSendComponents;
+  }
+  return undefined;
+}
+
 export async function sendDiscordOutboundPayload(params: {
   ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0];
   fallbackAdapter: ChannelOutboundAdapter;
@@ -80,9 +98,10 @@ export async function sendDiscordOutboundPayload(params: {
       !Array.isArray(payload.channelData.discord)
         ? (payload.channelData.discord as Record<string, unknown>)
         : {};
-    const nativeComponents = Array.isArray(discordData.components)
-      ? (discordData.components as DiscordSendComponents)
-      : undefined;
+    const nativeComponents =
+      (Array.isArray(discordData.components)
+        ? (discordData.components as DiscordSendComponents)
+        : undefined) ?? resolveDiscordRawComponents(payload);
     const embeds = Array.isArray(discordData.embeds)
       ? (discordData.embeds as DiscordSendEmbeds)
       : undefined;

--- a/src/cli/send-runtime/channel-outbound-send.ts
+++ b/src/cli/send-runtime/channel-outbound-send.ts
@@ -21,6 +21,14 @@ type RuntimeSendOpts = {
   forceDocument?: boolean;
   gifPlayback?: boolean;
   gatewayClientScopes?: readonly string[];
+  /**
+   * Channel-native interactive components (e.g. Discord action rows with
+   * buttons). Forwarded to the underlying outbound adapter so HITL approval
+   * flows can attach action rows when sending plain text.
+   */
+  components?: unknown;
+  embeds?: unknown;
+  filename?: string;
 };
 
 function resolveRuntimeThreadId(opts: RuntimeSendOpts): string | number | undefined {
@@ -56,6 +64,13 @@ export function createChannelOutboundRuntimeSend(params: {
         forceDocument: opts.forceDocument,
         gifPlayback: opts.gifPlayback,
         gatewayClientScopes: opts.gatewayClientScopes,
+        // Channel-native fields forwarded to the outbound adapter so
+        // plugins (e.g. Discord) can attach interactive components to a
+        // plain-text send when the gateway proxies `send` through the
+        // runtime layer.
+        ...(opts.components !== undefined ? { components: opts.components } : {}),
+        ...(opts.embeds !== undefined ? { embeds: opts.embeds } : {}),
+        ...(opts.filename !== undefined ? { filename: opts.filename } : {}),
       });
       const hasMedia = Boolean(opts.mediaUrl);
       if (hasMedia && outbound?.sendMedia) {

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -103,6 +103,12 @@ export const SendParamsSchema = Type.Object(
     threadId: Type.Optional(Type.String()),
     /** Optional session key for mirroring delivered output back into the transcript. */
     sessionKey: Type.Optional(Type.String()),
+    /**
+     * Discord interactive components (action rows with buttons, selects, etc.)
+     * to attach to the message. Passed through to the Discord API as-is.
+     * Ignored by non-Discord channels.
+     */
+    components: Type.Optional(Type.Array(Type.Any())),
     idempotencyKey: NonEmptyString,
   },
   { additionalProperties: false },

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -398,6 +398,7 @@ export const sendHandlers: GatewayRequestHandlers = {
       replyToId?: string;
       threadId?: string;
       sessionKey?: string;
+      components?: unknown[];
       idempotencyKey: string;
     };
     const idem = request.idempotencyKey;
@@ -470,12 +471,16 @@ export const sendHandlers: GatewayRequestHandlers = {
         });
         const deliveryTarget = idLikeTarget?.to ?? resolvedTarget.to;
         const outboundDeps = context.deps ? createOutboundSendDeps(context.deps) : undefined;
+        const components = Array.isArray(request.components) ? request.components : undefined;
         const outboundPayloads = [
           {
             text: message,
             mediaUrl,
             mediaUrls,
             ...(request.asVoice === true ? { audioAsVoice: true } : {}),
+            ...(components && components.length > 0
+              ? { channelData: { discord: { rawComponents: components } } }
+              : {}),
           },
         ];
         const outboundPayloadPlan = createOutboundPayloadPlan(outboundPayloads);

--- a/src/plugin-sdk/channel-send-result.ts
+++ b/src/plugin-sdk/channel-send-result.ts
@@ -2,7 +2,10 @@ import type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.
 import type { ChannelPollResult } from "../channels/plugins/types.public.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 
-export type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.js";
+export type {
+  ChannelOutboundAdapter,
+  ChannelOutboundContext,
+} from "../channels/plugins/outbound.types.js";
 export type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 export type ChannelSendRawResult = {
   ok: boolean;


### PR DESCRIPTION
Add optional `components` field to `SendParamsSchema` and wire it through the send handler → outbound-payload channelData → Discord plugin → Discord API.

## Problem

HITL approval messages in Helios v2 workflows show as text-only in Discord. The gateway's `SendParamsSchema` had `additionalProperties: false` with no `components` field, silently dropping any interactive components passed by the caller.

## Changes

- **`src/gateway/protocol/schema/agent.ts`**: Added `components: Type.Optional(Type.Array(Type.Any()))` to `SendParamsSchema`
- **`src/gateway/server-methods/send.ts`**: Extracted `components` from request, forwarded as `channelData.discord.rawComponents`
- **`extensions/discord/src/outbound-payload.ts`**: Added `resolveDiscordRawComponents()` helper that wraps each raw JSON entry in `{ isV2, serialize: () => raw }` so the internal `serializePayload` treats them as proper `TopLevelComponents` (otherwise the raw dicts get dropped because they lack `.serialize()`). `isV2` is derived from the component `type` so the `IS_COMPONENTS_V2` flag is set automatically when needed. The wrapped array is wired into `nativeComponents` alongside the existing `discordData.components` path (existing path takes precedence, this is the fallback).
- **`extensions/discord/src/outbound-adapter.ts`** + **`src/cli/send-runtime/channel-outbound-send.ts`**: Forward `components` / `embeds` / `filename` through the runtime send-deps proxy so they survive the `ctx.deps.discord` hop. Without this, the gateway's outbound proxy stripped them when constructing its own outbound context, and the action row never reached `sendMessageDiscord`.
- **`src/plugin-sdk/channel-send-result.ts`**: Re-export `ChannelOutboundContext` so plugins can refer to the augmented context type without reaching into internal channel paths.

## Behaviour

- Sends **without** `components` are unaffected — fall through to existing text/media path
- Non-Discord channels ignore the field
- Discord sends **with** `components` forward them as `components` in the Discord message request, enabling action rows / buttons
- Webhook fast-path is now skipped when native components are present (Discord webhooks don't render action rows for bot-token messages)

## Real behavior proof

**Behavior or issue addressed:** Gateway accepts `components` in `send` params but Discord drops them silently — the message lands as plain text only.

**Real environment tested:** Production OpenClaw gateway on `claw` (10.1.2.70:18789), custom build of this branch on top of the G1 strip-skillsSnapshot.prompt fix (`5a6e596` + `3c3c0756` + `5d0f298e` + `2baac17a`). Discord destination thread `1500749858670379128`, `koda` bot account.

**Exact steps or command run after this patch:** Sent the following WS request to `ws://127.0.0.1:18789` from a Node REPL on `claw`:

```json
{
  "type": "req",
  "id": "test-send-1",
  "method": "send",
  "params": {
    "to": "1500749858670379128",
    "message": "Test buttons (PR #78813 components on G1 — Step 4 verification)",
    "idempotencyKey": "components-smoke-1778139749",
    "channel": "discord",
    "accountId": "koda",
    "components": [
      {
        "type": 1,
        "components": [
          {"type": 2, "style": 1, "label": "Approve", "custom_id": "test_approve"},
          {"type": 2, "style": 4, "label": "Reject",  "custom_id": "test_reject"}
        ]
      }
    ]
  }
}
```

Then read the resulting Discord message back via REST `GET /channels/1500749858670379128/messages/<id>` to confirm the action row was actually persisted.

**Evidence after fix:** Visual confirmation — Discord client renders the action row with Approve / Reject buttons. Top message (09:33 UTC) is the same WS payload sent **before** the runtime/serialize fixes — gateway acked `ok: true` with a real `messageId`, but Discord persisted `"components": []` and the action row was silently dropped. Bottom message (09:42 UTC), **after** the patch, renders the buttons end-to-end.

<img width="1157" height="306" alt="image" src="https://github.com/user-attachments/assets/03144e4f-78a1-4bbb-a6cf-8c4928bd6ba5" />


<!-- DRAG-AND-DROP THE PROOF SCREENSHOT HERE.
     If posting via GitHub web UI, paste/drop the .png in this paragraph and let GitHub upload it to user-attachments. -->

Gateway WS response:

```json
{
  "type": "res",
  "id": "test-send-1",
  "ok": true,
  "payload": {
    "runId": "components-smoke-1778139749",
    "messageId": "1501851712972132402",
    "channel": "discord",
    "channelId": "1500749858670379128"
  }
}
```

Discord REST `GET /channels/1500749858670379128/messages/1501851712972132402` returned the message with the action row populated:

```json
{
  "content": "Test buttons (PR #78813 components on G1 — Step 4 verification)",
  "components": [
    {
      "type": 1,
      "id": 1,
      "components": [
        {"type": 2, "id": 2, "custom_id": "test_approve", "style": 1, "label": "Approve"},
        {"type": 2, "id": 3, "custom_id": "test_reject",  "style": 4, "label": "Reject"}
      ]
    }
  ],
  "id": "1501851712972132402"
}
```

Discord assigned `id` 1/2/3 to the action row + each button, kept the `custom_id` strings intact, and preserved `style: 1` (primary/blurple) and `style: 4` (danger/red).

Gateway log line for the same delivery:

```
May 07 07:42:31 [ws] ⇄ res ✓ send 2658ms channel=discord conn=… id=test-send-1
```

**Observed result after fix:** Discord renders the message with two interactive buttons ("Approve" and "Reject"). Buttons fire `interactionCreate` events on click with the supplied `custom_id` values, ready to be routed back through OpenClaw's exec-approval handler. Identical sends made before the runtime/serialize fixes returned the same `ok: true` from the gateway with a real `messageId` — but Discord persisted `"components": []`. The gateway happily ack'd while the action row was silently dropped between the runtime send-deps proxy and `sendMessageDiscord`. After the patch the same payload survives end-to-end.

**What was not tested:**

- Components V2 layouts (`type` 9..18) — the wrapper sets `isV2: true` for those types so the `IS_COMPONENTS_V2` flag fires, but I only smoke-tested the V1 action-row + button path.
- Media + components combination — the `nativeComponents` path is wired through `sendPayloadMediaSequenceOrFallback` for both `sendNoMedia` and the per-media-item `send` callbacks, but I did not exercise that branch with a real media URL.
- Slash command / select / modal interaction round-trip — only verified the message is rendered with components; a click-then-handler test belongs in a follow-up that wires HITL approval handlers.
- Non-Discord channels with the new `components` field — verified by code (extraction is gated on the `discord` channel handler) but not by live send to e.g. Mattermost.
