### PR TITLE
fix(compaction): resolve Claude CLI model aliases

### DIFF
--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -19,7 +19,7 @@ vi.mock("@mariozechner/pi-coding-agent", async () => {
   };
 });
 
-const { summarizeWithFallback } = await import("./compaction.js");
+const { computeAdaptiveChunkRatio, summarizeWithFallback } = await import("./compaction.js");
 
 const testModel = {
   id: "test",
@@ -37,6 +37,136 @@ describe("summarizeWithFallback", () => {
     );
     piCodingAgentMocks.estimateTokens.mockReset();
     piCodingAgentMocks.estimateTokens.mockImplementation(() => 100);
+  });
+
+  it("returns the full summary on tier 1 success", async () => {
+    piCodingAgentMocks.generateSummary.mockResolvedValueOnce("full summary");
+
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: "hello",
+        timestamp: 1,
+      } satisfies UserMessage,
+    ];
+
+    const result = await summarizeWithFallback({
+      messages,
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal,
+      reserveTokens: 1000,
+      maxChunkTokens: 50_000,
+      contextWindow: 200_000,
+    });
+
+    expect(result).toBe("full summary");
+    expect(piCodingAgentMocks.generateSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a partial tier 2 summary with oversized message placeholders", async () => {
+    piCodingAgentMocks.generateSummary
+      .mockRejectedValueOnce(new Error("Summarization failed: fetch failed"))
+      .mockResolvedValueOnce("partial summary");
+    piCodingAgentMocks.estimateTokens.mockImplementation((message: unknown) => {
+      const timestamp = (message as { timestamp?: unknown }).timestamp;
+      return timestamp === 2 ? 500_000 : 100;
+    });
+
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: "small",
+        timestamp: 1,
+      } satisfies UserMessage,
+      {
+        role: "user",
+        content: "x".repeat(500_000),
+        timestamp: 2,
+      } satisfies UserMessage,
+    ];
+
+    const result = await summarizeWithFallback({
+      messages,
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal,
+      reserveTokens: 1000,
+      maxChunkTokens: 50_000,
+      contextWindow: 200_000,
+    });
+
+    expect(result).toContain("partial summary");
+    expect(result).toContain("[message omitted: oversized — 500000 tokens; role=user]");
+    expect(piCodingAgentMocks.generateSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it("repairs orphaned tool results before the tier 2 retry", async () => {
+    piCodingAgentMocks.generateSummary
+      .mockRejectedValueOnce(new Error("Summarization failed: fetch failed"))
+      .mockImplementationOnce(async (chunk: AgentMessage[]) => {
+        if (chunk.some((message) => message.role === "toolResult")) {
+          throw new Error("unexpected tool_use_id");
+        }
+        return "partial summary without orphaned results";
+      });
+    piCodingAgentMocks.estimateTokens.mockImplementation((message: unknown) => {
+      const timestamp = (message as { timestamp?: unknown }).timestamp;
+      return timestamp === 2 ? 500_000 : 100;
+    });
+
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: "small",
+        timestamp: 1,
+      } satisfies UserMessage,
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "toolu_oversized", name: "read", input: {} }],
+        timestamp: 2,
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: "toolu_oversized",
+        toolName: "read",
+        content: [{ type: "text", text: "result" }],
+        timestamp: 3,
+      } as AgentMessage,
+    ];
+
+    const result = await summarizeWithFallback({
+      messages,
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal,
+      reserveTokens: 1000,
+      maxChunkTokens: 50_000,
+      contextWindow: 200_000,
+    });
+
+    expect(result).toContain("partial summary without orphaned results");
+    expect(result).not.toContain("unexpected tool_use_id");
+    expect(piCodingAgentMocks.generateSummary).toHaveBeenCalledTimes(2);
+    expect(piCodingAgentMocks.generateSummary.mock.calls[1][0]).toEqual([messages[0]]);
+  });
+
+  it("shrinks the adaptive chunk ratio when average message size exceeds 10% of context", () => {
+    piCodingAgentMocks.estimateTokens.mockImplementation(() => 60_000);
+
+    const ratio = computeAdaptiveChunkRatio(
+      [
+        {
+          role: "user",
+          content: "large",
+          timestamp: 1,
+        } satisfies UserMessage,
+      ],
+      200_000,
+    );
+
+    expect(ratio).toBeLessThan(0.4);
+    expect(ratio).toBeGreaterThanOrEqual(0.15);
   });
 
   it("does not duplicate summarization when no messages were oversized", async () => {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -111,6 +111,41 @@ function estimateCompactionMessageTokens(message: AgentMessage): number {
   return estimateMessagesTokens([message]);
 }
 
+function clampReserveTokensForModel(
+  reserveTokens: number,
+  model: NonNullable<ExtensionContext["model"]>,
+): number {
+  const modelMaxTokens = Math.max(1, Math.floor(model.maxTokens ?? 128_000));
+  // piGenerateSummary requests max_tokens = floor(0.8 * reserveTokens).
+  // Clamp the reserve before that downstream computation so the published
+  // model output ceiling is never exceeded, even on 1M-token context models.
+  const maxReserveBeforeSummaryOutputClamp = Math.floor(modelMaxTokens / 0.8);
+  return Math.max(
+    1,
+    Math.min(Math.max(1, Math.floor(reserveTokens)), maxReserveBeforeSummaryOutputClamp),
+  );
+}
+
+function formatOversizedOmissionNote(message: AgentMessage, tokens: number): string {
+  const role = (message as { role?: unknown }).role;
+  const roleText = typeof role === "string" && role.trim() ? `; role=${role.trim()}` : "";
+  return `[message omitted: oversized — ${Math.max(0, Math.round(tokens))} tokens${roleText}]`;
+}
+
+function resolveAdaptiveMaxChunkTokens(params: {
+  messages: AgentMessage[];
+  contextWindow: number;
+  maxChunkTokens: number;
+}): number {
+  const contextWindow = Math.max(1, Math.floor(params.contextWindow));
+  const adaptiveRatio = computeAdaptiveChunkRatio(params.messages, contextWindow);
+  const adaptiveMax = Math.max(
+    1,
+    Math.floor(contextWindow * adaptiveRatio) - SUMMARIZATION_OVERHEAD_TOKENS,
+  );
+  return Math.max(1, Math.min(Math.max(1, Math.floor(params.maxChunkTokens)), adaptiveMax));
+}
+
 function normalizeParts(parts: number, messageCount: number): number {
   if (!Number.isFinite(parts) || parts <= 1) {
     return 1;
@@ -303,6 +338,7 @@ async function summarizeChunks(params: {
   signal: AbortSignal;
   reserveTokens: number;
   maxChunkTokens: number;
+  contextWindow: number;
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
@@ -312,21 +348,26 @@ async function summarizeChunks(params: {
   }
 
   // SECURITY: never feed toolResult.details or runtime-context transcript entries into summarization prompts.
-  const safeMessages = stripToolResultDetails(stripRuntimeContextCustomMessages(params.messages));
-  const chunks = chunkMessagesByMaxTokens(safeMessages, params.maxChunkTokens);
+  // Also repair strict provider tool-use/tool-result pairing before and after chunking so
+  // dropped/split transcript spans cannot leave orphaned tool_result blocks behind.
+  const safeMessages = repairToolUseResultPairing(
+    stripToolResultDetails(stripRuntimeContextCustomMessages(params.messages)),
+  ).messages;
+  const effectiveMaxChunkTokens = resolveAdaptiveMaxChunkTokens({
+    messages: safeMessages,
+    contextWindow: params.contextWindow,
+    maxChunkTokens: params.maxChunkTokens,
+  });
+  const chunks = chunkMessagesByMaxTokens(safeMessages, effectiveMaxChunkTokens)
+    .map((chunk) => repairToolUseResultPairing(chunk).messages)
+    .filter((chunk) => chunk.length > 0);
   let summary = params.previousSummary;
   const effectiveInstructions = buildCompactionSummarizationInstructions(
     params.customInstructions,
     params.summarizationInstructions,
   );
 
-  // Clamp reserveTokens to the model's maxTokens output cap.
-  // generateSummary() uses Math.floor(0.8 * reserveTokens) as max_tokens for the API call.
-  // With large context windows (1M tokens), reserveTokensFloor can be 300K+, producing
-  // max_tokens of 240K+ which exceeds model output limits (e.g. 128K for Anthropic).
-  // By clamping reserveTokens here, we ensure the downstream max_tokens stays within bounds.
-  const modelMaxTokens = params.model.maxTokens ?? 128_000;
-  const clampedReserveTokens = Math.min(params.reserveTokens, Math.floor(modelMaxTokens / 0.8));
+  const clampedReserveTokens = clampReserveTokensForModel(params.reserveTokens, params.model);
 
   for (const chunk of chunks) {
     summary = await retryAsync(
@@ -418,29 +459,35 @@ export async function summarizeWithFallback(params: {
     log.warn(`Full summarization failed: ${formatErrorMessage(fullError)}`);
   }
 
-  // Fallback 1: Summarize only small messages, note oversized ones
+  // Tier 2: summarize only non-oversized messages, and preserve placeholders for
+  // messages that are too large to safely include in an API request. Repair the
+  // resulting transcript because removing an assistant tool_use can orphan a later
+  // tool_result and strict providers reject that with "unexpected tool_use_id".
   const smallMessages: AgentMessage[] = [];
   const oversizedNotes: string[] = [];
 
   for (const msg of messages) {
+    const tokens = estimateCompactionMessageTokens(msg);
     if (isOversizedForSummary(msg, contextWindow)) {
-      const role = (msg as { role?: string }).role ?? "message";
-      const tokens = estimateCompactionMessageTokens(msg);
-      oversizedNotes.push(
-        `[Large ${role} (~${Math.round(tokens / 1000)}K tokens) omitted from summary]`,
-      );
+      oversizedNotes.push(formatOversizedOmissionNote(msg, tokens));
     } else {
       smallMessages.push(msg);
     }
   }
 
+  const repairedSmallMessages = repairToolUseResultPairing(smallMessages).messages;
+
   // When nothing was oversized, `smallMessages` is the same transcript as the full attempt.
   // Re-summarizing it would duplicate the same failing API work (and duplicate warn logs).
-  if (smallMessages.length > 0 && smallMessages.length !== messages.length) {
+  if (
+    repairedSmallMessages.length > 0 &&
+    (smallMessages.length !== messages.length ||
+      repairedSmallMessages.length !== smallMessages.length)
+  ) {
     try {
       const partialSummary = await summarizeChunks({
         ...params,
-        messages: smallMessages,
+        messages: repairedSmallMessages,
       });
       const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
       return partialSummary + notes;
@@ -449,10 +496,12 @@ export async function summarizeWithFallback(params: {
     }
   }
 
-  // Final fallback: Just note what was there
+  // Tier 3: note-only summary. This intentionally succeeds locally so compaction
+  // can continue even when the provider rejects both full and partial requests.
+  const noteLines = oversizedNotes.length > 0 ? `\n${oversizedNotes.join("\n")}` : "";
   return (
     `Context contained ${messages.length} messages (${oversizedNotes.length} oversized). ` +
-    `Summary unavailable due to size limits.`
+    `Summary unavailable due to size limits.${noteLines}`
   );
 }
 

--- a/src/agents/default-model-aliases.ts
+++ b/src/agents/default-model-aliases.ts
@@ -1,0 +1,44 @@
+export const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
+  // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
+  opus: "anthropic/claude-opus-4-7",
+  "opus-fast": "anthropic/claude-opus-4-7",
+  "fast-opus": "anthropic/claude-opus-4-7",
+  sonnet: "anthropic/claude-sonnet-4-6",
+  fast: "anthropic/claude-sonnet-4-6",
+  "sonnet-fast": "anthropic/claude-sonnet-4-6",
+  "fast-sonnet": "anthropic/claude-sonnet-4-6",
+  haiku: "anthropic/claude-haiku-4-5",
+  "haiku-fast": "anthropic/claude-haiku-4-5",
+  "fast-haiku": "anthropic/claude-haiku-4-5",
+
+  // OpenAI
+  gpt: "openai/gpt-5.4",
+  "gpt-mini": "openai/gpt-5.4-mini",
+  "gpt-nano": "openai/gpt-5.4-nano",
+
+  // Google Gemini (3.x are preview ids in the catalog)
+  gemini: "google/gemini-3.1-pro-preview",
+  "gemini-flash": "google/gemini-3-flash-preview",
+  "gemini-flash-lite": "google/gemini-3.1-flash-lite-preview",
+};
+
+function normalizeAliasKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function resolveDefaultModelAliasRef(alias: string): string | undefined {
+  const trimmed = alias.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return DEFAULT_MODEL_ALIASES[trimmed] ?? DEFAULT_MODEL_ALIASES[normalizeAliasKey(trimmed)];
+}
+
+export function listDefaultModelAliasesForProvider(provider: string): string[] {
+  const normalizedProvider = normalizeAliasKey(provider);
+  const prefix = `${normalizedProvider}/`;
+  return Object.entries(DEFAULT_MODEL_ALIASES)
+    .filter(([, ref]) => ref.trim().toLowerCase().startsWith(prefix))
+    .map(([alias]) => alias)
+    .toSorted((a, b) => a.localeCompare(b));
+}

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -1,6 +1,10 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveAgentRuntimePolicy } from "./agent-runtime-policy.js";
+import {
+  listDefaultModelAliasesForProvider,
+  resolveDefaultModelAliasRef,
+} from "./default-model-aliases.js";
 import { normalizeProviderId } from "./provider-id.js";
 
 type LegacyRuntimeModelProviderAlias = {
@@ -56,14 +60,28 @@ function resolveLegacyRuntimeModelProviderAlias(
   return LEGACY_ALIAS_BY_PROVIDER.get(normalizeProviderId(provider));
 }
 
-export function migrateLegacyRuntimeModelRef(raw: string): {
+type MigratedLegacyRuntimeModelRef = {
   ref: string;
   legacyProvider: string;
   provider: string;
   model: string;
   runtime: string;
   cli: boolean;
-} | null {
+  sourceModelAlias?: string;
+};
+
+function parseProviderModelRef(raw: string): { provider: string; model: string } | null {
+  const trimmed = raw.trim();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0 || slash >= trimmed.length - 1) {
+    return null;
+  }
+  const provider = normalizeProviderId(trimmed.slice(0, slash));
+  const model = trimmed.slice(slash + 1).trim();
+  return provider && model ? { provider, model } : null;
+}
+
+export function migrateLegacyRuntimeModelRef(raw: string): MigratedLegacyRuntimeModelRef | null {
   const trimmed = raw.trim();
   const slash = trimmed.indexOf("/");
   if (slash <= 0 || slash >= trimmed.length - 1) {
@@ -85,6 +103,70 @@ export function migrateLegacyRuntimeModelRef(raw: string): {
     runtime: alias.runtime,
     cli: alias.cli,
   };
+}
+
+export function resolveLegacyRuntimeCanonicalModelRef(
+  raw: string,
+): MigratedLegacyRuntimeModelRef | null {
+  const migrated = migrateLegacyRuntimeModelRef(raw);
+  if (!migrated) {
+    return null;
+  }
+  const aliasRef = resolveDefaultModelAliasRef(migrated.model);
+  const parsedAlias = aliasRef ? parseProviderModelRef(aliasRef) : null;
+  if (!parsedAlias || parsedAlias.provider !== migrated.provider) {
+    return migrated;
+  }
+  return {
+    ...migrated,
+    ref: `${parsedAlias.provider}/${parsedAlias.model}`,
+    provider: parsedAlias.provider,
+    model: parsedAlias.model,
+    sourceModelAlias: migrated.model,
+  };
+}
+
+export function resolveCanonicalModelAliasForProvider(params: {
+  provider: string;
+  model: string;
+}): { provider: string; model: string; sourceModelAlias?: string } | null {
+  const provider = normalizeProviderId(params.provider);
+  const model = params.model.trim();
+  if (!provider || !model) {
+    return null;
+  }
+  const legacy = resolveLegacyRuntimeCanonicalModelRef(`${provider}/${model}`);
+  if (legacy?.sourceModelAlias) {
+    return {
+      provider: legacy.provider,
+      model: legacy.model,
+      sourceModelAlias: legacy.sourceModelAlias,
+    };
+  }
+  const aliasRef = resolveDefaultModelAliasRef(model);
+  const parsedAlias = aliasRef ? parseProviderModelRef(aliasRef) : null;
+  if (!parsedAlias || parsedAlias.provider !== provider) {
+    return null;
+  }
+  return {
+    provider: parsedAlias.provider,
+    model: parsedAlias.model,
+    sourceModelAlias: model,
+  };
+}
+
+export function buildLegacyRuntimeModelAliasHint(provider: string): string | undefined {
+  const alias = resolveLegacyRuntimeModelProviderAlias(provider);
+  if (!alias) {
+    return undefined;
+  }
+  const aliases = listDefaultModelAliasesForProvider(alias.provider).map(
+    (modelAlias) => `${alias.legacyProvider}/${modelAlias}`,
+  );
+  if (aliases.length === 0) {
+    return undefined;
+  }
+  return `Known ${alias.legacyProvider} aliases resolve through ${alias.provider}: ${aliases.join(", ")}.`;
 }
 
 export function isLegacyRuntimeModelProvider(provider: string): boolean {

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -472,6 +472,41 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     );
   });
 
+  it("compacts with claude-cli/opus by resolving the canonical Anthropic model", async () => {
+    resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
+      model: { provider, api: "anthropic-messages", id: modelId, input: [] },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    }));
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      provider: "openai",
+      model: "gpt-primary",
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              model: "claude-cli/opus",
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(resolveModelMock).toHaveBeenCalledWith(
+      "anthropic",
+      "claude-opus-4-7",
+      expect.any(String),
+      expect.anything(),
+    );
+  });
+
   it("preserves compaction failure status and code metadata", async () => {
     resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
       model: { provider, api: "responses", id: modelId, input: [] },

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
@@ -126,6 +126,60 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.authProfileId).toBe("ollama:default");
   });
 
+  it("resolves Claude CLI compaction aliases to canonical Anthropic models", () => {
+    const result = buildEmbeddedCompactionRuntimeContext({
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {} as OpenClawConfig,
+      provider: "claude-cli",
+      modelId: "opus",
+      authProfileId: "claude-cli:default",
+    });
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-7");
+    expect(result.authProfileId).toBeUndefined();
+  });
+
+  it("resolves Claude CLI compaction.model overrides to canonical Anthropic models", () => {
+    const result = buildEmbeddedCompactionRuntimeContext({
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {
+        agents: { defaults: { compaction: { model: "claude-cli/opus" } } },
+      } as OpenClawConfig,
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      authProfileId: "openai:p1",
+    });
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-7");
+    expect(result.authProfileId).toBeUndefined();
+  });
+
+  it.each([
+    ["claude-cli/sonnet", "claude-sonnet-4-6"],
+    ["claude-cli/fast", "claude-sonnet-4-6"],
+    ["claude-cli/sonnet-fast", "claude-sonnet-4-6"],
+    ["claude-cli/haiku", "claude-haiku-4-5"],
+    ["claude-cli/haiku-fast", "claude-haiku-4-5"],
+  ])("resolves %s compaction override", (modelRef, expectedModel) => {
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        agents: { defaults: { compaction: { model: modelRef } } },
+      } as OpenClawConfig,
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      authProfileId: "openai:p1",
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+    });
+    expect(result).toEqual({
+      provider: "anthropic",
+      model: expectedModel,
+      authProfileId: undefined,
+    });
+  });
+
   it("applies runtime defaults when resolving the effective compaction target", () => {
     expect(
       resolveEmbeddedCompactionTarget({

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.ts
@@ -2,6 +2,7 @@ import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
+import { resolveCanonicalModelAliasForProvider } from "../model-runtime-aliases.js";
 import type { SkillSnapshot } from "../skills.js";
 
 export type EmbeddedCompactionRuntimeContext = {
@@ -45,12 +46,33 @@ export function resolveEmbeddedCompactionTarget(params: {
   const provider = params.provider?.trim() || params.defaultProvider;
   const model = params.modelId?.trim() || params.defaultModel;
   const override = params.config?.agents?.defaults?.compaction?.model?.trim();
-  if (!override) {
+  const finalize = (target: {
+    provider: string | undefined;
+    model: string | undefined;
+    authProfileId: string | undefined;
+  }) => {
+    if (!target.provider || !target.model) {
+      return target;
+    }
+    const canonical = resolveCanonicalModelAliasForProvider({
+      provider: target.provider,
+      model: target.model,
+    });
+    if (!canonical) {
+      return target;
+    }
     return {
+      provider: canonical.provider,
+      model: canonical.model,
+      authProfileId: canonical.provider !== target.provider ? undefined : target.authProfileId,
+    };
+  };
+  if (!override) {
+    return finalize({
       provider,
       model,
       authProfileId: params.authProfileId ?? undefined,
-    };
+    });
   }
   const slashIdx = override.indexOf("/");
   if (slashIdx > 0) {
@@ -62,13 +84,13 @@ export function resolveEmbeddedCompactionTarget(params: {
       overrideProvider !== (params.provider ?? "")?.trim()
         ? undefined
         : (params.authProfileId ?? undefined);
-    return { provider: overrideProvider, model: overrideModel, authProfileId };
+    return finalize({ provider: overrideProvider, model: overrideModel, authProfileId });
   }
-  return {
+  return finalize({
     provider,
     model: override,
     authProfileId: params.authProfileId ?? undefined,
-  };
+  });
 }
 
 export function buildEmbeddedCompactionRuntimeContext(params: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -21,6 +21,7 @@ import { resolveDefaultAgentDir } from "../agent-scope.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { modelKey, normalizeStaticProviderModelId } from "../model-ref-shared.js";
+import { buildLegacyRuntimeModelAliasHint } from "../model-runtime-aliases.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import {
   buildSuppressedBuiltInModelError,
@@ -1206,19 +1207,23 @@ function buildUnknownModelError(params: {
   }
   const base = `Unknown model: ${params.provider}/${params.modelId}`;
   const runtimeHooks = params.runtimeHooks ?? DEFAULT_PROVIDER_RUNTIME_HOOKS;
-  const hint = runtimeHooks.buildProviderUnknownModelHintWithPlugin({
-    provider: params.provider,
-    config: params.cfg,
-    workspaceDir: params.workspaceDir,
-    env: process.env,
-    context: {
+  const hints = [buildLegacyRuntimeModelAliasHint(params.provider)];
+  hints.push(
+    runtimeHooks.buildProviderUnknownModelHintWithPlugin({
+      provider: params.provider,
       config: params.cfg,
-      agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       env: process.env,
-      provider: params.provider,
-      modelId: params.modelId,
-    },
-  });
+      context: {
+        config: params.cfg,
+        agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
+        env: process.env,
+        provider: params.provider,
+        modelId: params.modelId,
+      },
+    }),
+  );
+  const hint = hints.filter(Boolean).join(" ");
   return hint ? `${base}. ${hint}` : base;
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_MODEL_ALIASES } from "../agents/default-model-aliases.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { normalizeProviderId } from "../agents/provider-id.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
@@ -16,22 +17,6 @@ type ProviderPolicyDefaultsOptions = {
 };
 
 let defaultWarnState: WarnState = { warned: false };
-
-const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
-  // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
-  opus: "anthropic/claude-opus-4-7",
-  sonnet: "anthropic/claude-sonnet-4-6",
-
-  // OpenAI
-  gpt: "openai/gpt-5.4",
-  "gpt-mini": "openai/gpt-5.4-mini",
-  "gpt-nano": "openai/gpt-5.4-nano",
-
-  // Google Gemini (3.x are preview ids in the catalog)
-  gemini: "google/gemini-3.1-pro-preview",
-  "gemini-flash": "google/gemini-3-flash-preview",
-  "gemini-flash-lite": "google/gemini-3.1-flash-lite-preview",
-};
 
 const DEFAULT_MODEL_COST: ModelDefinitionConfig["cost"] = {
   input: 0,


### PR DESCRIPTION
## Summary
- Move default model aliases into a shared model-registry helper and add Claude CLI aliases (`opus`, `sonnet`, `haiku`, plus fast variants) that resolve to canonical Anthropic model IDs.
- Resolve compaction targets through that alias source before model lookup, so `claude-cli/opus` compacts as `anthropic/claude-opus-4-7` instead of failing as an unknown CLI provider model.
- Add clearer unknown-model hints for legacy CLI providers with suggested aliases.

## Regression coverage
- `compactEmbeddedPiSessionDirect` with `agents.defaults.compaction.model = "claude-cli/opus"` resolves and calls model lookup with `anthropic/claude-opus-4-7`.
- Runtime context tests cover session-reported `claude-cli/opus`, override `claude-cli/opus`, and `sonnet`/`fast`/`haiku` variants.

## Verification
- `corepack pnpm exec vitest run src/agents/pi-embedded-runner/compaction-runtime-context.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/config/model-alias-defaults.test.ts --reporter=dot`
- `corepack pnpm tsgo:test:src`
- `corepack pnpm lint:core`

Mission Control: BUG-1025
