### PR TITLE
fix(telegram): emit sanitized runtime proof events

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -56,6 +56,7 @@ const loadSessionStore = vi.hoisted(() => vi.fn());
 const resolveStorePath = vi.hoisted(() => vi.fn(() => "/tmp/sessions.json"));
 const generateTopicLabel = vi.hoisted(() => vi.fn());
 const describeStickerImage = vi.hoisted(() => vi.fn(async () => null));
+const runtimeProofRaw = vi.hoisted(() => vi.fn());
 const loadModelCatalog = vi.hoisted(() => vi.fn(async () => ({})));
 const findModelInCatalog = vi.hoisted(() => vi.fn(() => null));
 const modelSupportsVision = vi.hoisted(() => vi.fn(() => false));
@@ -125,6 +126,17 @@ vi.mock("./bot-message-dispatch.agent.runtime.js", () => ({
   resolveAgentDir,
   resolveDefaultModelForAgent,
 }));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "telegram/runtime-proof" ? { ...logger, raw: runtimeProofRaw } : logger;
+    },
+  };
+});
 
 vi.mock("./sticker-cache.js", () => ({
   cacheSticker: vi.fn(),
@@ -204,6 +216,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     resolveMarkdownTableMode.mockClear();
     resolveSessionStoreEntry.mockClear();
     describeStickerImage.mockReset();
+    runtimeProofRaw.mockReset();
+    delete process.env.STOMME_E2E_RUN_ID;
     loadModelCatalog.mockReset();
     findModelInCatalog.mockReset();
     modelSupportsVision.mockReset();
@@ -1460,6 +1474,92 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
     expect(statusReactionController.setDone).not.toHaveBeenCalled();
     expect(reactionApi).not.toHaveBeenCalledWith(123, 456, []);
+  });
+
+  it("emits run-scoped Telegram runtime proof events for final visible replies", async () => {
+    process.env.STOMME_E2E_RUN_ID = "RUN-1234";
+    createTelegramDraftStream.mockReturnValue(createDraftStream());
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        replyOptions?.onModelSelected?.({
+          provider: "openai",
+          model: "gpt-test",
+          thinkLevel: undefined,
+        });
+        await dispatcherOptions.deliver({ text: "Assistant reply secret-free" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "telegram:raw-session-secret",
+          MessageSid: "telegram-message-456",
+          RawBody: "Manual Telegram E2E window for run_id=RUN-1234: raw prompt secret",
+          BodyForAgent: "raw prompt secret",
+        } as TelegramMessageContext["ctxPayload"],
+        route: {
+          agentId: "default",
+          accountId: "default",
+          sessionKey: "route-session-secret",
+        } as TelegramMessageContext["route"],
+      }),
+    });
+
+    const events = runtimeProofRaw.mock.calls.map((call) => {
+      const line = String(call[0]);
+      const payload = JSON.parse(line.replace("telegram_runtime_proof ", ""));
+      return { line, payload };
+    });
+
+    expect(events.map((event) => event.payload.kind)).toEqual([
+      "inbound_accepted",
+      "model_invocation_started",
+      "assistant_response_observed",
+      "telegram_delivery_observed",
+    ]);
+    for (const { line, payload } of events) {
+      expect(payload).toMatchObject({
+        event: payload.kind,
+        proofEvent: "telegram_runtime_proof",
+        status: "observed",
+        channel: "telegram",
+        runId: "RUN-1234",
+        accountId: "default",
+      });
+      expect(payload.type).toBe(payload.kind);
+      expect(payload.sessionKeyHash).toMatch(/^[a-f0-9]{12}$/u);
+      expect(payload.messageIdHash).toMatch(/^[a-f0-9]{12}$/u);
+      expect(line).not.toContain("raw prompt secret");
+      expect(line).not.toContain("Assistant reply secret-free");
+      expect(line).not.toContain("raw-session-secret");
+      expect(line).not.toContain("telegram-message-456");
+      expect(line).not.toContain("token");
+    }
+  });
+
+  it("does not emit delivery proof for error fallbacks", async () => {
+    process.env.STOMME_E2E_RUN_ID = "RUN-1234";
+    dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("dispatcher exploded"));
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "s1",
+          MessageSid: "m1",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+    });
+
+    const kinds = runtimeProofRaw.mock.calls.map((call) => {
+      const line = String(call[0]);
+      return JSON.parse(line.replace("telegram_runtime_proof ", "")).kind;
+    });
+    expect(kinds).toEqual(["inbound_accepted"]);
   });
 
   it("uses resolved DM config for auto-topic-label overrides", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -92,6 +92,13 @@ import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
 } from "./reasoning-lane-coordinator.js";
+import {
+  buildTelegramRuntimeProofBase,
+  emitTelegramRuntimeProofEvent,
+  TELEGRAM_RUNTIME_PROOF_KINDS,
+  type TelegramRuntimeProofBase,
+  type TelegramRuntimeProofKind,
+} from "./runtime-proof.js";
 import { editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
@@ -99,6 +106,19 @@ export { pruneStickerMediaFromContext } from "./bot-message-dispatch.media.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
+const runtimeProofLogger = createSubsystemLogger("telegram/runtime-proof");
+
+function mergeTelegramRuntimeProofBase(
+  primary: TelegramRuntimeProofBase,
+  fallback: TelegramRuntimeProofBase,
+): TelegramRuntimeProofBase {
+  return {
+    runId: primary.runId ?? fallback.runId,
+    accountId: primary.accountId ?? fallback.accountId,
+    sessionKeyHash: primary.sessionKeyHash ?? fallback.sessionKeyHash,
+    messageIdHash: primary.messageIdHash ?? fallback.messageIdHash,
+  };
+}
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
@@ -726,6 +746,35 @@ export const dispatchTelegramMessage = async ({
   };
   const silentErrorReplies = telegramCfg.silentErrorReplies === true;
   const isDmTopic = !isGroup && threadSpec.scope === "dm" && threadSpec.id != null;
+  const runtimeProofBase = buildTelegramRuntimeProofBase({
+    accountId: route.accountId,
+    sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+    messageId: ctxPayload.MessageSid ?? msg.message_id,
+    cfg,
+    env: process.env,
+    textCandidates: [
+      ctxPayload.RawBody,
+      ctxPayload.BodyForAgent,
+      ctxPayload.Body,
+      ctxPayload.CommandBody,
+    ],
+  });
+  const emittedRuntimeProofKinds = new Set<TelegramRuntimeProofKind>();
+  const emitRuntimeProof = (kind: TelegramRuntimeProofKind, base = runtimeProofBase) => {
+    const eventBase = mergeTelegramRuntimeProofBase(base, runtimeProofBase);
+    if (emittedRuntimeProofKinds.has(kind)) {
+      return;
+    }
+    emitTelegramRuntimeProofEvent({
+      logger: runtimeProofLogger,
+      base: eventBase,
+      kind,
+      env: process.env,
+    });
+    if (eventBase.runId) {
+      emittedRuntimeProofKinds.add(kind);
+    }
+  };
   let queuedFinal = false;
   let suppressSilentReplyFallback = false;
   let hadErrorReplyFailureOrSkip = false;
@@ -862,6 +911,9 @@ export const dispatchTelegramMessage = async ({
         }
         if (durable.status === "handled_visible") {
           deliveryState.markDelivered();
+          if (payload.isError !== true && !silent) {
+            emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.telegramDeliveryObserved);
+          }
           return true;
         }
         if (durable.status === "handled_no_send") {
@@ -877,8 +929,36 @@ export const dispatchTelegramMessage = async ({
       });
       if (result.delivered) {
         deliveryState.markDelivered();
+        if (options?.durable && payload.isError !== true && !silent) {
+          emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.telegramDeliveryObserved);
+        }
       }
       return result.delivered;
+    };
+    const emitAssistantRuntimeProofIfFinal = (
+      payload: ReplyPayload,
+      info: { kind: "tool" | "block" | "final" },
+    ) => {
+      if (info.kind !== "final" || payload.isError === true || isDispatchSuperseded()) {
+        return;
+      }
+      const reply = resolveSendableOutboundReplyParts(payload);
+      if (reply.text.length === 0 && !reply.hasMedia) {
+        return;
+      }
+      emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.assistantResponseObserved);
+    };
+    const emitDeliveryRuntimeProofFromLaneResult = (result: LaneDeliveryResult) => {
+      if (isDispatchSuperseded()) {
+        return;
+      }
+      if (result.kind === "sent" || result.kind === "preview-retained") {
+        emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.telegramDeliveryObserved);
+        return;
+      }
+      if (result.kind === "preview-finalized" && typeof result.delivery.messageId === "number") {
+        emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.telegramDeliveryObserved);
+      }
     };
     const emitPreviewFinalizedHook = (result: LaneDeliveryResult) => {
       if (isDispatchSuperseded() || result.kind !== "preview-finalized") {
@@ -980,8 +1060,13 @@ export const dispatchTelegramMessage = async ({
         },
       },
     });
+    const onRuntimeProofModelSelected: typeof onModelSelected = (modelContext) => {
+      onModelSelected?.(modelContext);
+      emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.modelInvocationStarted);
+    };
 
     try {
+      emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.inboundAccepted);
       const turnResult = await runInboundReplyTurn({
         channel: "telegram",
         accountId: route.accountId,
@@ -1017,6 +1102,7 @@ export const dispatchTelegramMessage = async ({
                     if (payload.isError === true) {
                       hadErrorReplyFailureOrSkip = true;
                     }
+                    emitAssistantRuntimeProofIfFinal(payload, info);
                     if (info.kind === "final") {
                       await enqueueDraftLaneEvent(async () => {});
                     }
@@ -1091,6 +1177,7 @@ export const dispatchTelegramMessage = async ({
                             });
                       if (info.kind === "final") {
                         emitPreviewFinalizedHook(result);
+                        emitDeliveryRuntimeProofFromLaneResult(result);
                       }
                       if (segment.lane === "reasoning") {
                         if (result.kind !== "skipped") {
@@ -1110,9 +1197,12 @@ export const dispatchTelegramMessage = async ({
                       if (reply.hasMedia) {
                         const payloadWithoutSuppressedReasoning =
                           typeof payload.text === "string" ? { ...payload, text: "" } : payload;
-                        await sendPayload(payloadWithoutSuppressedReasoning, {
+                        const delivered = await sendPayload(payloadWithoutSuppressedReasoning, {
                           durable: info.kind === "final",
                         });
+                        if (delivered && info.kind === "final") {
+                          emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.telegramDeliveryObserved);
+                        }
                       }
                       if (info.kind === "final") {
                         await flushBufferedFinalAnswer();
@@ -1132,7 +1222,12 @@ export const dispatchTelegramMessage = async ({
                       }
                       return;
                     }
-                    await sendPayload(payload, { durable: info.kind === "final" });
+                    const delivered = await sendPayload(payload, {
+                      durable: info.kind === "final",
+                    });
+                    if (delivered && info.kind === "final") {
+                      emitRuntimeProof(TELEGRAM_RUNTIME_PROOF_KINDS.telegramDeliveryObserved);
+                    }
                     if (info.kind === "final") {
                       await flushBufferedFinalAnswer();
                     }
@@ -1322,7 +1417,7 @@ export const dispatchTelegramMessage = async ({
                         await statusReactionController.setThinking();
                       }
                     : undefined,
-                  onModelSelected,
+                  onModelSelected: onRuntimeProofModelSelected,
                 },
               }),
           }),

--- a/extensions/telegram/src/runtime-proof.test.ts
+++ b/extensions/telegram/src/runtime-proof.test.ts
@@ -114,7 +114,7 @@ describe("telegram runtime proof helpers", () => {
       expect(proofPath).toBe(join(root, "logs", "telegram-runtime-proof.jsonl"));
       const lines = readFileSync(proofPath!, "utf8").trim().split("\n");
       expect(lines).toHaveLength(1);
-      expect(JSON.parse(lines[0]!)).toMatchObject({
+      expect(JSON.parse(lines[0])).toMatchObject({
         event: "inbound_accepted",
         kind: "inbound_accepted",
         proofEvent: TELEGRAM_RUNTIME_PROOF_EVENT,

--- a/extensions/telegram/src/runtime-proof.test.ts
+++ b/extensions/telegram/src/runtime-proof.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildTelegramRuntimeProofBase,
+  createTelegramRuntimeProofEvent,
+  emitTelegramRuntimeProofEvent,
+  extractTelegramRuntimeProofRunIdFromText,
+  hashTelegramRuntimeProofId,
+  resolveTelegramRuntimeProofJsonlPath,
+  resolveTelegramRuntimeProofRunId,
+  TELEGRAM_RUNTIME_PROOF_EVENT,
+  TELEGRAM_RUNTIME_PROOF_KINDS,
+} from "./runtime-proof.js";
+
+describe("telegram runtime proof helpers", () => {
+  it("extracts explicit run markers without accepting arbitrary text", () => {
+    expect(
+      extractTelegramRuntimeProofRunIdFromText(
+        "Manual Telegram E2E window for run_id=run_ABC-123: hello",
+      ),
+    ).toBe("run_ABC-123");
+    expect(
+      extractTelegramRuntimeProofRunIdFromText("please mention run but no marker"),
+    ).toBeUndefined();
+    expect(extractTelegramRuntimeProofRunIdFromText("run_id=abc")).toBeUndefined();
+    expect(extractTelegramRuntimeProofRunIdFromText("run_id=abc/123")).toBeUndefined();
+  });
+
+  it("prefers safe env run id, then prompt marker, then e2e config slug", () => {
+    expect(
+      resolveTelegramRuntimeProofRunId({
+        env: { STOMME_E2E_RUN_ID: "env_RUN-123" } as NodeJS.ProcessEnv,
+        textCandidates: ["run_id=text_RUN-123"],
+        cfg: { configSlug: "e2e-config-run" },
+      }),
+    ).toBe("env_RUN-123");
+    expect(
+      resolveTelegramRuntimeProofRunId({
+        env: { STOMME_E2E_RUN_ID: "bad value" } as NodeJS.ProcessEnv,
+        textCandidates: ["run_id=text_RUN-123"],
+        cfg: { configSlug: "e2e-config-run" },
+      }),
+    ).toBe("text_RUN-123");
+    expect(
+      resolveTelegramRuntimeProofRunId({
+        env: {} as NodeJS.ProcessEnv,
+        textCandidates: ["hello"],
+        cfg: { meta: { configSlug: "e2e-config-run" } },
+      }),
+    ).toBe("config-run");
+  });
+
+  it("hashes correlation identifiers and omits raw ids", () => {
+    const hash = hashTelegramRuntimeProofId("telegram:123456789");
+
+    expect(hash).toMatch(/^[a-f0-9]{12}$/u);
+    expect(hash).not.toContain("123456789");
+    expect(hashTelegramRuntimeProofId("telegram:123456789")).toBe(hash);
+  });
+
+  it("emits one parseable marked JSON line without prompt or secret fields", () => {
+    const raw = vi.fn();
+    const base = buildTelegramRuntimeProofBase({
+      accountId: "default",
+      sessionKey: "telegram:secret-chat-id",
+      messageId: 456,
+      env: { STOMME_E2E_RUN_ID: "RUN-1234" } as NodeJS.ProcessEnv,
+      textCandidates: ["run_id=RUN-1234 raw prompt should not leak"],
+    });
+
+    emitTelegramRuntimeProofEvent({
+      logger: { raw },
+      base,
+      kind: TELEGRAM_RUNTIME_PROOF_KINDS.assistantResponseObserved,
+    });
+
+    expect(raw).toHaveBeenCalledTimes(1);
+    const line = String(raw.mock.calls[0]?.[0]);
+    expect(line).toContain(`${TELEGRAM_RUNTIME_PROOF_EVENT} `);
+    expect(line).not.toContain("raw prompt should not leak");
+    expect(line).not.toContain("secret-chat-id");
+    expect(line).not.toContain("token");
+    const payload = JSON.parse(line.replace(`${TELEGRAM_RUNTIME_PROOF_EVENT} `, ""));
+    expect(payload).toMatchObject({
+      event: TELEGRAM_RUNTIME_PROOF_KINDS.assistantResponseObserved,
+      type: TELEGRAM_RUNTIME_PROOF_KINDS.assistantResponseObserved,
+      kind: TELEGRAM_RUNTIME_PROOF_KINDS.assistantResponseObserved,
+      proofEvent: TELEGRAM_RUNTIME_PROOF_EVENT,
+      status: "observed",
+      channel: "telegram",
+      runId: "RUN-1234",
+      accountId: "default",
+    });
+    expect(payload.sessionKeyHash).toMatch(/^[a-f0-9]{12}$/u);
+    expect(payload.messageIdHash).toMatch(/^[a-f0-9]{12}$/u);
+  });
+
+  it("also writes a dedicated config-scoped JSONL proof file", () => {
+    const root = mkdtempSync(join(tmpdir(), "telegram-runtime-proof-"));
+    try {
+      const raw = vi.fn();
+      emitTelegramRuntimeProofEvent({
+        logger: { raw },
+        base: { runId: "RUN-1234", accountId: "default" },
+        kind: TELEGRAM_RUNTIME_PROOF_KINDS.inboundAccepted,
+        env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+      });
+
+      const proofPath = resolveTelegramRuntimeProofJsonlPath({
+        OPENCLAW_STATE_DIR: root,
+      } as NodeJS.ProcessEnv);
+      expect(proofPath).toBe(join(root, "logs", "telegram-runtime-proof.jsonl"));
+      const lines = readFileSync(proofPath!, "utf8").trim().split("\n");
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0]!)).toMatchObject({
+        event: "inbound_accepted",
+        kind: "inbound_accepted",
+        proofEvent: TELEGRAM_RUNTIME_PROOF_EVENT,
+        runId: "RUN-1234",
+        accountId: "default",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not emit without a bound run id", () => {
+    const raw = vi.fn();
+    emitTelegramRuntimeProofEvent({
+      logger: { raw },
+      base: {},
+      kind: TELEGRAM_RUNTIME_PROOF_KINDS.inboundAccepted,
+    });
+    expect(raw).not.toHaveBeenCalled();
+  });
+
+  it("creates harness-compatible event and type aliases", () => {
+    const event = createTelegramRuntimeProofEvent(
+      TELEGRAM_RUNTIME_PROOF_KINDS.telegramDeliveryObserved,
+      {
+        runId: "RUN-1234",
+      },
+    );
+    expect(event.event).toBe("telegram_delivery_observed");
+    expect(event.kind).toBe("telegram_delivery_observed");
+    expect(event.type).toBe("telegram_delivery_observed");
+    expect(event.proofEvent).toBe(TELEGRAM_RUNTIME_PROOF_EVENT);
+  });
+});

--- a/extensions/telegram/src/runtime-proof.ts
+++ b/extensions/telegram/src/runtime-proof.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { SubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+
+export const TELEGRAM_RUNTIME_PROOF_EVENT = "telegram_runtime_proof";
+export const TELEGRAM_RUNTIME_PROOF_SCHEMA_VERSION = 1;
+
+export const TELEGRAM_RUNTIME_PROOF_KINDS = {
+  inboundAccepted: "inbound_accepted",
+  modelInvocationStarted: "model_invocation_started",
+  assistantResponseObserved: "assistant_response_observed",
+  telegramDeliveryObserved: "telegram_delivery_observed",
+} as const;
+
+export type TelegramRuntimeProofKind =
+  (typeof TELEGRAM_RUNTIME_PROOF_KINDS)[keyof typeof TELEGRAM_RUNTIME_PROOF_KINDS];
+
+const RUN_ID_RE = /^[A-Za-z0-9_-]{4,80}$/u;
+const RUN_ID_MARKER_RE = /(?:^|\b)(?:run_id|runId|run-id)\s*[:=]\s*([A-Za-z0-9_-]{4,80})(?:\b|$)/iu;
+const E2E_SLUG_PREFIX = "e2e-";
+const DEFAULT_PROOF_JSONL_FILENAME = "telegram-runtime-proof.jsonl";
+
+type RuntimeProofConfigLike = {
+  configSlug?: unknown;
+  meta?: { configSlug?: unknown } | undefined;
+};
+
+export type TelegramRuntimeProofBase = {
+  runId?: string;
+  accountId?: string;
+  sessionKeyHash?: string;
+  messageIdHash?: string;
+};
+
+export type TelegramRuntimeProofEvent = TelegramRuntimeProofBase & {
+  event: TelegramRuntimeProofKind;
+  kind: TelegramRuntimeProofKind;
+  type: TelegramRuntimeProofKind;
+  proofEvent: typeof TELEGRAM_RUNTIME_PROOF_EVENT;
+  schemaVersion: typeof TELEGRAM_RUNTIME_PROOF_SCHEMA_VERSION;
+  status: "observed";
+  channel: "telegram";
+  at: string;
+};
+
+export function normalizeTelegramRuntimeProofRunId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return RUN_ID_RE.test(trimmed) ? trimmed : undefined;
+}
+
+export function extractTelegramRuntimeProofRunIdFromText(text: unknown): string | undefined {
+  if (typeof text !== "string" || !text.includes("run")) {
+    return undefined;
+  }
+  const match = RUN_ID_MARKER_RE.exec(text.slice(0, 2_000));
+  return normalizeTelegramRuntimeProofRunId(match?.[1]);
+}
+
+function extractRunIdFromConfigSlug(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed.startsWith(E2E_SLUG_PREFIX)) {
+    return undefined;
+  }
+  return normalizeTelegramRuntimeProofRunId(trimmed.slice(E2E_SLUG_PREFIX.length));
+}
+
+function readConfigSlug(cfg: unknown): unknown {
+  const maybe = cfg as RuntimeProofConfigLike | undefined;
+  return maybe?.configSlug ?? maybe?.meta?.configSlug;
+}
+
+export function resolveTelegramRuntimeProofRunId(params: {
+  env?: NodeJS.ProcessEnv;
+  textCandidates?: unknown[];
+  cfg?: unknown;
+}): string | undefined {
+  const envRunId = normalizeTelegramRuntimeProofRunId(params.env?.STOMME_E2E_RUN_ID);
+  if (envRunId) {
+    return envRunId;
+  }
+  for (const candidate of params.textCandidates ?? []) {
+    const textRunId = extractTelegramRuntimeProofRunIdFromText(candidate);
+    if (textRunId) {
+      return textRunId;
+    }
+  }
+  return extractRunIdFromConfigSlug(readConfigSlug(params.cfg));
+}
+
+export function hashTelegramRuntimeProofId(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const raw = typeof value === "string" ? value : String(value);
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return createHash("sha256").update(trimmed, "utf8").digest("hex").slice(0, 12);
+}
+
+export function buildTelegramRuntimeProofBase(params: {
+  accountId?: unknown;
+  sessionKey?: unknown;
+  messageId?: unknown;
+  cfg?: unknown;
+  env?: NodeJS.ProcessEnv;
+  textCandidates?: unknown[];
+}): TelegramRuntimeProofBase {
+  return {
+    runId: resolveTelegramRuntimeProofRunId({
+      env: params.env,
+      textCandidates: params.textCandidates,
+      cfg: params.cfg,
+    }),
+    accountId: typeof params.accountId === "string" ? params.accountId : undefined,
+    sessionKeyHash: hashTelegramRuntimeProofId(params.sessionKey),
+    messageIdHash: hashTelegramRuntimeProofId(params.messageId),
+  };
+}
+
+export function createTelegramRuntimeProofEvent(
+  kind: TelegramRuntimeProofKind,
+  base: TelegramRuntimeProofBase,
+): TelegramRuntimeProofEvent {
+  return {
+    event: kind,
+    kind,
+    type: kind,
+    proofEvent: TELEGRAM_RUNTIME_PROOF_EVENT,
+    schemaVersion: TELEGRAM_RUNTIME_PROOF_SCHEMA_VERSION,
+    status: "observed",
+    channel: "telegram",
+    ...(base.runId ? { runId: base.runId } : {}),
+    ...(base.accountId ? { accountId: base.accountId } : {}),
+    ...(base.sessionKeyHash ? { sessionKeyHash: base.sessionKeyHash } : {}),
+    ...(base.messageIdHash ? { messageIdHash: base.messageIdHash } : {}),
+    at: new Date().toISOString(),
+  };
+}
+
+export function resolveTelegramRuntimeProofJsonlPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const stateDir = env.OPENCLAW_STATE_DIR?.trim();
+  if (stateDir) {
+    return join(stateDir, "logs", DEFAULT_PROOF_JSONL_FILENAME);
+  }
+  const configPath = env.OPENCLAW_CONFIG_PATH?.trim();
+  if (configPath) {
+    return join(dirname(configPath), "logs", DEFAULT_PROOF_JSONL_FILENAME);
+  }
+  return undefined;
+}
+
+function appendTelegramRuntimeProofJsonl(event: TelegramRuntimeProofEvent, env: NodeJS.ProcessEnv) {
+  const proofPath = resolveTelegramRuntimeProofJsonlPath(env);
+  if (!proofPath) {
+    return;
+  }
+  try {
+    mkdirSync(dirname(proofPath), { recursive: true, mode: 0o700 });
+    appendFileSync(proofPath, `${JSON.stringify(event)}\n`, { encoding: "utf8", mode: 0o600 });
+  } catch {
+    // Runtime proof is diagnostic-only and must never block Telegram delivery.
+  }
+}
+
+export function emitTelegramRuntimeProofEvent(params: {
+  logger: Pick<SubsystemLogger, "raw">;
+  base: TelegramRuntimeProofBase;
+  kind: TelegramRuntimeProofKind;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  if (!params.base.runId) {
+    return;
+  }
+  const event = createTelegramRuntimeProofEvent(params.kind, params.base);
+  const env = params.env ?? process.env;
+  // The Tauri E2E harness scans sanitized runtime log lines for this marker and
+  // parses the following JSON payload. Keep this as one line with no prompt,
+  // assistant text, chat id, sender id, token, or provider secret fields.
+  params.logger.raw(`${TELEGRAM_RUNTIME_PROOF_EVENT} ${JSON.stringify(event)}`);
+  appendTelegramRuntimeProofJsonl(event, env);
+}

--- a/extensions/telegram/src/runtime-proof.ts
+++ b/extensions/telegram/src/runtime-proof.ts
@@ -98,7 +98,14 @@ export function hashTelegramRuntimeProofId(value: unknown): string | undefined {
   if (value === null || value === undefined) {
     return undefined;
   }
-  const raw = typeof value === "string" ? value : String(value);
+  let raw: string;
+  if (typeof value === "string") {
+    raw = value;
+  } else if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean") {
+    raw = String(value);
+  } else {
+    return undefined;
+  }
   const trimmed = raw.trim();
   if (!trimmed) {
     return undefined;

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -264,6 +264,23 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(written).toContain("sk-raw…3456");
   });
 
+  it("keeps raw subsystem proof marker parseable in file logs", () => {
+    const logFile = logPathTracker.nextPath();
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file: logFile });
+    const log = createSubsystemLogger("telegram/runtime-proof");
+    const marker =
+      'telegram_runtime_proof {"event":"inbound_accepted","kind":"inbound_accepted","type":"inbound_accepted","proofEvent":"telegram_runtime_proof","status":"observed","runId":"RUN-1234"}';
+
+    log.raw(marker);
+
+    const written = fs.readFileSync(logFile, "utf8");
+    const record = JSON.parse(written.trim());
+    expect(record.message).toBe(marker);
+    const match = String(record.message).match(/telegram_runtime_proof\s+(\{.*\})/u);
+    expect(match?.[1]).toBeDefined();
+    expect(JSON.parse(match![1]).kind).toBe("inbound_accepted");
+  });
+
   it("keeps long-lived subsystem loggers on the current-day rolling file", () => {
     const logDir = path.dirname(logPathTracker.nextPath());
     const firstDay = path.join(logDir, "openclaw-2026-01-01.log");


### PR DESCRIPTION
## Summary
- add a Telegram runtime-proof helper that emits sanitized `telegram_runtime_proof` JSON lines and a config/state-scoped `telegram-runtime-proof.jsonl`
- instrument Telegram inbound dispatch, model selection, final assistant response, and successful delivery seams
- cover run-id binding, identifier hashing, raw prompt/reply redaction, parseable raw subsystem logs, and error fallback suppression

## Verification
- `corepack pnpm exec vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/runtime-proof.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `corepack pnpm exec vitest run --config test/vitest/vitest.logging.config.ts src/logging/subsystem.test.ts`
- `node --test /Users/jonathanlindsay/stomme-tauri/tests/windows-provisioned-e2e-harness.test.mjs`
- `git diff --check`

No credentialed Telegram/Windows E2E dispatch was run.
