### PR TITLE
fix(agents): use max_tokens for NVIDIA NIM OpenAI-compat endpoint

### DIFF
--- a/src/agents/openai-completions-compat.test.ts
+++ b/src/agents/openai-completions-compat.test.ts
@@ -60,6 +60,28 @@ describe("resolveOpenAICompletionsCompatDefaults", () => {
       }).supportsUsageInStreaming,
     ).toBe(false);
   });
+
+  it("uses max_tokens for NVIDIA NIM (integrate.api.nvidia.com) baseUrl", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "nvidia-nim",
+        baseUrl: "https://integrate.api.nvidia.com/v1",
+        endpointClass: "custom",
+        knownProviderFamily: "nvidia-nim",
+      }).maxTokensField,
+    ).toBe("max_tokens");
+  });
+
+  it("keeps max_completion_tokens for unrelated custom OpenAI-compatible endpoints", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "custom",
+        baseUrl: "https://api.example.com/v1",
+        endpointClass: "custom",
+        knownProviderFamily: "custom",
+      }).maxTokensField,
+    ).toBe("max_completion_tokens");
+  });
 });
 
 describe("detectOpenAICompletionsCompat", () => {
@@ -71,5 +93,15 @@ describe("detectOpenAICompletionsCompat", () => {
     });
 
     expect(detected.defaults.supportsUsageInStreaming).toBe(true);
+  });
+
+  it("emits max_tokens for NVIDIA NIM hosted models", () => {
+    const detected = detectOpenAICompletionsCompat({
+      provider: "nvidia-nim",
+      baseUrl: "https://integrate.api.nvidia.com/v1",
+      id: "qwen/qwen2.5-coder-32b-instruct",
+    });
+
+    expect(detected.defaults.maxTokensField).toBe("max_tokens");
   });
 });

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -4,12 +4,29 @@ import { resolveProviderRequestCapabilities } from "./provider-attribution.js";
 
 type OpenAICompletionsCompatDefaultsInput = {
   provider?: string;
+  baseUrl?: string;
   endpointClass: ProviderEndpointClass;
   knownProviderFamily: string;
   supportsNativeStreamingUsageCompat?: boolean;
   supportsOpenAICompletionsStreamingUsageCompat?: boolean;
   usesExplicitProxyLikeEndpoint?: boolean;
 };
+
+// NVIDIA NIM (build.nvidia.com) is OpenAI-compatible but its OpenAI-compat
+// endpoint rejects the newer `max_completion_tokens` field with HTTP 400.
+// It still expects the legacy `max_tokens`. Detect by hostname so users do
+// not need to set `compat.maxTokensField: "max_tokens"` on every NIM model.
+const NVIDIA_NIM_HOSTS = new Set(["integrate.api.nvidia.com"]);
+
+function isNvidiaNimBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return NVIDIA_NIM_HOSTS.has(host);
+  } catch {
+    return false;
+  }
+}
 
 type OpenAICompletionsCompatDefaults = {
   supportsStore: boolean;
@@ -71,7 +88,8 @@ export function resolveOpenAICompletionsCompatDefaults(
     endpointClass === "chutes-native" ||
     endpointClass === "mistral-public" ||
     knownProviderFamily === "mistral" ||
-    (isDefaultRoute && isDefaultRouteProvider(provider, "chutes"));
+    (isDefaultRoute && isDefaultRouteProvider(provider, "chutes")) ||
+    isNvidiaNimBaseUrl(input.baseUrl);
   return {
     supportsStore:
       !isNonStandard && knownProviderFamily !== "mistral" && !usesExplicitProxyLikeEndpoint,
@@ -107,6 +125,7 @@ function resolveOpenAICompletionsCompatDefaultsFromCapabilities(
     | "usesExplicitProxyLikeEndpoint"
   > & {
     provider?: string;
+    baseUrl?: string;
   },
 ): OpenAICompletionsCompatDefaults {
   return resolveOpenAICompletionsCompatDefaults(input);
@@ -133,6 +152,7 @@ export function detectOpenAICompletionsCompat(
     capabilities,
     defaults: resolveOpenAICompletionsCompatDefaultsFromCapabilities({
       provider: model.provider,
+      baseUrl: model.baseUrl,
       ...capabilities,
     }),
   };


### PR DESCRIPTION
## Summary

NVIDIA NIM (`integrate.api.nvidia.com/v1`) advertises OpenAI compatibility but its chat/completions endpoint rejects the newer `max_completion_tokens` field with HTTP 400 (`Extra inputs are not permitted`). It still expects the legacy `max_tokens`.

This makes any NIM model unusable from an OpenClaw agent unless the user manually sets `compat.maxTokensField: "max_tokens"` on every model entry. The fix detects NIM by hostname inside `resolveOpenAICompletionsCompatDefaults` so it works out of the box, matching the existing detection pattern used for `chutes-native`, `mistral-public`, etc.

## What changed

- `src/agents/openai-completions-compat.ts`
  - Added optional `baseUrl` to `OpenAICompletionsCompatDefaultsInput`.
  - New helper `isNvidiaNimBaseUrl()` matching `integrate.api.nvidia.com` hostname.
  - `usesMaxTokens` now also returns `true` for NIM-hosted models.
  - `detectOpenAICompletionsCompat` forwards `model.baseUrl` to the resolver.
- `src/agents/openai-completions-compat.test.ts`
  - Two new test cases covering: NIM baseUrl → `max_tokens`, unrelated custom OpenAI-compat endpoint stays on `max_completion_tokens`.

## Repro before the fix

```jsonc
// openclaw.json
"models": {
  "providers": {
    "nvidia-nim": {
      "baseUrl": "https://integrate.api.nvidia.com/v1",
      "apiKey": { "source": "env", "id": "NVIDIA_API_KEY" },
      "models": [
        { "id": "qwen/qwen2.5-coder-32b-instruct", "api": "openai-completions" }
      ]
    }
  }
}
```

```
openclaw agent --model qwen/qwen2.5-coder-32b-instruct --message "hi"
```

→ HTTP 400 from NIM with `max_completion_tokens` in the rejected fields.

After the fix the request goes through with `max_tokens` and the model responds normally. Verified locally against `qwen/qwen2.5-coder-32b-instruct` and `meta/llama-3.3-70b-instruct` on NIM.

## Notes

- Kept the change minimal — single hostname set, no new `endpointClass`. Happy to expand into a full manifest-backed `nvidia-nim` provider class in a follow-up if maintainers prefer that path.
- No behavior change for non-NIM endpoints (covered by the second new test).