### PR TITLE
fix(feishu): honor proxy env vars in HTTP API calls

### DIFF
--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -102,6 +102,7 @@ async function fetchFeishuJson<T>(params: {
     init: params.init,
     policy: { allowedHostnames: [new URL(params.url).hostname] },
     auditContext: params.auditContext,
+    mode: "trusted_env_proxy",
   });
   try {
     // Registration poll returns 4xx for pending/error states with a JSON body.

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -85,6 +85,7 @@ async function getToken(creds: Credentials): Promise<string> {
     },
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
     auditContext: "feishu.streaming-card.token",
+    mode: "trusted_env_proxy",
   });
   if (!response.ok) {
     await release();
@@ -245,6 +246,7 @@ export class FeishuStreamingSession {
       },
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.create",
+      mode: "trusted_env_proxy",
     });
     if (!createRes.ok) {
       await releaseCreate();
@@ -334,6 +336,7 @@ export class FeishuStreamingSession {
       },
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.update",
+      mode: "trusted_env_proxy",
     })
       .then(async ({ release }) => {
         await release();
@@ -421,6 +424,7 @@ export class FeishuStreamingSession {
       },
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.note-update",
+      mode: "trusted_env_proxy",
     })
       .then(async ({ release }) => {
         await release();
@@ -472,6 +476,7 @@ export class FeishuStreamingSession {
       },
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.close",
+      mode: "trusted_env_proxy",
     })
       .then(async ({ release }) => {
         await release();


### PR DESCRIPTION
## Summary

- Problem: Feishu plugin HTTP API calls (token refresh, card create/update/close, app registration) use `fetchWithSsrFGuard` without specifying `mode`, which defaults to `strict` — bypassing any configured proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`).
- What changed: Added `mode: "trusted_env_proxy"` to all 6 `fetchWithSsrFGuard` call sites in `streaming-card.ts` (5 calls) and `fetchFeishuJson` in `app-registration.ts` (1 wrapper covering 3 callers).
- Why it matters: The Feishu WebSocket connection already respects proxy env vars via the agent parameter, but the HTTP API calls were silently bypassing the proxy, causing `httpx.ConnectError: All connection attempts failed` in proxy-only environments (containers, corporate networks, Clash TUN, etc.).

## Change Type

- [x] Bug fix

## Scope

- [x] Plugins / extensions (Feishu)

## Testing

Proxy-env coverage is exercised through the existing `streaming-card.test.ts` which mocks `fetchWithSsrFGuard` — mode propagation is validated by the fetch-guard unit tests in `src/infra/net`. No additional tests required for this one-param change.

Closes #78842