### PR TITLE
perf(plugins): trim catalog and setup normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -575,6 +575,7 @@ Docs: https://docs.openclaw.ai
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Agents/commands: add `/steer <message>` for queue-independent steering of the active current-session run without starting a new turn when the session is idle. (#76934)
 - Core/performance: trim additional channel snapshot, turn-context, allowlist, bundled catalog, media probing, and model-catalog normalization hot paths by removing duplicate reads and intermediate array chains. Thanks @vincentkoc.
+- Core/performance: trim plugin registry, manifest/package entry, provider-owner, browser traversal, QA coverage/provider, schema, and command-preview helper normalization paths with direct loops. Thanks @vincentkoc.
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Doctor/config: `doctor --fix` now commits safe legacy migrations even when unrelated validation issues (e.g. a missing plugin) prevent full validation from passing, so `agents.defaults.llm` and other known-legacy keys are always cleaned up by `doctor --fix` regardless of other config problems. Fixes #76798. (#76800) Thanks @hclsys.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -574,6 +574,7 @@ Docs: https://docs.openclaw.ai
 
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Agents/commands: add `/steer <message>` for queue-independent steering of the active current-session run without starting a new turn when the session is idle. (#76934)
+- Core/performance: trim additional channel snapshot, turn-context, allowlist, bundled catalog, media probing, and model-catalog normalization hot paths by removing duplicate reads and intermediate array chains. Thanks @vincentkoc.
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Doctor/config: `doctor --fix` now commits safe legacy migrations even when unrelated validation issues (e.g. a missing plugin) prevent full validation from passing, so `agents.defaults.llm` and other known-legacy keys are always cleaned up by `doctor --fix` regardless of other config problems. Fixes #76798. (#76800) Thanks @hclsys.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -47,6 +47,7 @@ const bundledPluginIgnoredRuntimeDependencies = [
   "json5",
   "lit",
   "linkedom",
+  "lit",
   "openclaw",
   "pdfjs-dist",
 ] as const;

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -549,8 +549,12 @@ function buildRoleTree(nodes: RawAXNode[]): { tree: RoleTreeNode[]; roots: numbe
     }
   }
 
-  const roots = tree.map((_node, index) => index).filter((index) => !childIndexes.has(index));
-  const stack = roots.map((index) => ({ index, depth: 0 }));
+  const stack: Array<{ index: number; depth: number }> = [];
+  for (let index = 0; index < tree.length; index++) {
+    if (!childIndexes.has(index)) {
+      stack.push({ index, depth: 0 });
+    }
+  }
   while (stack.length) {
     const current = stack.pop();
     if (!current) {

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -549,9 +549,11 @@ function buildRoleTree(nodes: RawAXNode[]): { tree: RoleTreeNode[]; roots: numbe
     }
   }
 
+  const roots: number[] = [];
   const stack: Array<{ index: number; depth: number }> = [];
   for (let index = 0; index < tree.length; index++) {
     if (!childIndexes.has(index)) {
+      roots.push(index);
       stack.push({ index, depth: 0 });
     }
   }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -595,7 +595,10 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
 
 async function getAllPages(browser: Browser): Promise<Page[]> {
   const contexts = browser.contexts();
-  const pages = contexts.flatMap((c) => c.pages());
+  const pages: Page[] = [];
+  for (const context of contexts) {
+    pages.push(...context.pages());
+  }
   return pages;
 }
 

--- a/extensions/browser/src/browser/routes/utils.ts
+++ b/extensions/browser/src/browser/routes/utils.ts
@@ -83,6 +83,12 @@ export function toStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
-  const strings = value.map((v) => toStringOrEmpty(v)).filter(Boolean);
+  const strings: string[] = [];
+  for (const entry of value) {
+    const stringValue = toStringOrEmpty(entry);
+    if (stringValue) {
+      strings.push(stringValue);
+    }
+  }
   return strings.length ? strings : undefined;
 }

--- a/extensions/browser/src/node-host/invoke-browser.ts
+++ b/extensions/browser/src/node-host/invoke-browser.ts
@@ -40,7 +40,17 @@ const DEFAULT_BROWSER_PROXY_TIMEOUT_MS = 20_000;
 const BROWSER_PROXY_STATUS_TIMEOUT_MS = 750;
 
 function normalizeProfileAllowlist(raw?: string[]): string[] {
-  return Array.isArray(raw) ? raw.map((entry) => entry.trim()).filter(Boolean) : [];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const profiles: string[] = [];
+  for (const entry of raw) {
+    const trimmed = entry.trim();
+    if (trimmed) {
+      profiles.push(trimmed);
+    }
+  }
+  return profiles;
 }
 
 function resolveBrowserProxyConfig() {

--- a/extensions/discord/src/monitor/provider.deploy-errors.ts
+++ b/extensions/discord/src/monitor/provider.deploy-errors.ts
@@ -277,14 +277,18 @@ function formatDiscordRejectedDeployEntries(params: {
     return [];
   }
   const rawEntries = Object.entries(rejectedEntriesSource).filter(([key]) => /^\d+$/.test(key));
-  return rawEntries.slice(0, DISCORD_DEPLOY_REJECTED_ENTRY_LIMIT).flatMap(([key, value]) => {
+  const entries: string[] = [];
+  for (const [key, value] of rawEntries.slice(0, DISCORD_DEPLOY_REJECTED_ENTRY_LIMIT)) {
     const index = Number.parseInt(key, 10);
     if (!Number.isFinite(index) || index < 0 || index >= requestBody.length) {
-      return [];
+      continue;
     }
     const command = requestBody[index];
     if (!command || typeof command !== "object") {
-      return [`#${index} fields=${readDiscordDeployRejectedFields(value).join("|") || "unknown"}`];
+      entries.push(
+        `#${index} fields=${readDiscordDeployRejectedFields(value).join("|") || "unknown"}`,
+      );
+      continue;
     }
     const payload = command as {
       name?: unknown;
@@ -304,8 +308,9 @@ function formatDiscordRejectedDeployEntries(params: {
     if (Array.isArray(payload.options) && payload.options.length > 0) {
       parts.push(`options=${payload.options.length}`);
     }
-    return [parts.join(" ")];
-  });
+    entries.push(parts.join(" "));
+  }
+  return entries;
 }
 
 export function formatDiscordDeployErrorDetails(err: unknown): string {

--- a/extensions/discord/src/setup-core.ts
+++ b/extensions/discord/src/setup-core.ts
@@ -44,21 +44,23 @@ function mapDiscordSetupAllowlistEntries(resolved: unknown): DiscordGuildChannel
   if (!Array.isArray(resolved)) {
     return [];
   }
-  return resolved.flatMap((entry): DiscordGuildChannelAllowlistEntry[] => {
+  const entries: DiscordGuildChannelAllowlistEntry[] = [];
+  for (const entry of resolved) {
     if (!entry || typeof entry !== "object") {
-      return [];
+      continue;
     }
     const row = entry as DiscordSetupAllowlistResolution;
     if (row.resolved === false) {
-      return [];
+      continue;
     }
     const guildKey = normalizeOptionalString(row.guildId ?? row.guildKey);
     if (!guildKey) {
-      return [];
+      continue;
     }
     const channelKey = normalizeOptionalString(row.channelId ?? row.channelKey);
-    return channelKey ? [{ guildKey, channelKey }] : [{ guildKey }];
-  });
+    entries.push(channelKey ? { guildKey, channelKey } : { guildKey });
+  }
+  return entries;
 }
 
 function setDiscordGuildChannelAllowlist(
@@ -160,17 +162,24 @@ export function createDiscordSetupWizardBase(handlers: {
       currentPolicy: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
         resolveDiscordSetupAccountConfig({ cfg, accountId }).config.groupPolicy ?? "allowlist",
       currentEntries: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
-        Object.entries(
-          resolveDiscordSetupAccountConfig({ cfg, accountId }).config.guilds ?? {},
-        ).flatMap(([guildKey, value]) => {
-          const channels = value?.channels ?? {};
-          const channelKeys = Object.keys(channels);
-          if (channelKeys.length === 0) {
-            const input = /^\d+$/.test(guildKey) ? `guild:${guildKey}` : guildKey;
-            return [input];
+        (() => {
+          const entries: string[] = [];
+          for (const [guildKey, value] of Object.entries(
+            resolveDiscordSetupAccountConfig({ cfg, accountId }).config.guilds ?? {},
+          )) {
+            const channels = value?.channels ?? {};
+            const channelKeys = Object.keys(channels);
+            if (channelKeys.length === 0) {
+              const input = /^\d+$/.test(guildKey) ? `guild:${guildKey}` : guildKey;
+              entries.push(input);
+              continue;
+            }
+            for (const channelKey of channelKeys) {
+              entries.push(`${guildKey}/${channelKey}`);
+            }
           }
-          return channelKeys.map((channelKey) => `${guildKey}/${channelKey}`);
-        }),
+          return entries;
+        })(),
       updatePrompt: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
         Boolean(resolveDiscordSetupAccountConfig({ cfg, accountId }).config.guilds),
       resolveAllowlist: handlers.resolveGroupAllowlist,

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -229,6 +229,29 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
 
     const mediaUrl =
       typeof params.media === "string" ? params.media.trim() || undefined : undefined;
+    let buttons: Array<unknown> | undefined;
+    if (presentation) {
+      const interactive = presentationToInteractiveReply(presentation);
+      if (interactive) {
+        buttons = [];
+        for (const block of interactive.blocks) {
+          if (block.type !== "buttons") {
+            continue;
+          }
+          const row = [];
+          for (const button of block.buttons) {
+            if (button.value) {
+              row.push({
+                text: button.label,
+                callback_data: button.value,
+                style: button.style,
+              });
+            }
+          }
+          buttons.push(row);
+        }
+      }
+    }
 
     const result = await (
       await loadMattermostChannelRuntime()
@@ -236,23 +259,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       cfg,
       accountId: resolvedAccountId,
       replyToId,
-      buttons: presentation
-        ? presentationToInteractiveReply(presentation)
-            ?.blocks.filter((block) => block.type === "buttons")
-            .map((block) =>
-              block.buttons.flatMap((button) =>
-                button.value
-                  ? [
-                      {
-                        text: button.label,
-                        callback_data: button.value,
-                        style: button.style,
-                      },
-                    ]
-                  : [],
-              ),
-            )
-        : undefined,
+      buttons,
       attachmentText: typeof params.attachmentText === "string" ? params.attachmentText : undefined,
       mediaUrl,
     });

--- a/extensions/qa-lab/src/coverage-report.ts
+++ b/extensions/qa-lab/src/coverage-report.ts
@@ -112,7 +112,12 @@ export function buildQaCoverageInventory(
         scenarios: feature.scenarios.filter((scenario) => scenario.theme === theme),
       });
     }
-    const surfaces = new Set(feature.scenarios.flatMap((scenario) => scenario.surfaces));
+    const surfaces = new Set<string>();
+    for (const scenario of feature.scenarios) {
+      for (const surface of scenario.surfaces) {
+        surfaces.add(surface);
+      }
+    }
     for (const surface of surfaces) {
       bySurface[surface] ??= [];
       bySurface[surface].push({

--- a/extensions/qa-lab/src/providers/image-generation.ts
+++ b/extensions/qa-lab/src/providers/image-generation.ts
@@ -15,9 +15,14 @@ function splitModelProviderId(modelRef: string) {
 }
 
 function uniqueNonEmpty(values: readonly (string | null | undefined)[]) {
-  return [
-    ...new Set(values.map((value) => value?.trim()).filter((value): value is string => !!value)),
-  ];
+  const normalized = new Set<string>();
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      normalized.add(trimmed);
+    }
+  }
+  return [...normalized];
 }
 
 export function buildQaImageGenerationConfigPatch(input: QaImageGenerationPatchInput) {

--- a/extensions/qa-lab/src/providers/index.ts
+++ b/extensions/qa-lab/src/providers/index.ts
@@ -44,14 +44,18 @@ export function formatQaProviderModeHelp() {
 }
 
 export function listQaStandaloneProviderCommands() {
-  return PROVIDERS.flatMap((provider) =>
-    provider.standaloneCommand
-      ? [
-          {
-            providerMode: provider.mode,
-            ...provider.standaloneCommand,
-          },
-        ]
-      : [],
-  );
+  const commands: Array<
+    {
+      providerMode: QaProviderMode;
+    } & NonNullable<QaProviderDefinition["standaloneCommand"]>
+  > = [];
+  for (const provider of PROVIDERS) {
+    if (provider.standaloneCommand) {
+      commands.push({
+        providerMode: provider.mode,
+        ...provider.standaloneCommand,
+      });
+    }
+  }
+  return commands;
 }

--- a/extensions/slack/src/monitor/events/interactions.ts
+++ b/extensions/slack/src/monitor/events/interactions.ts
@@ -70,30 +70,29 @@ function buildCompactSlackInteractionPayload(
   payload: Record<string, unknown>,
 ): Record<string, unknown> {
   const rawInputs = Array.isArray(payload.inputs) ? payload.inputs : [];
-  const compactInputs = rawInputs
-    .slice(0, SLACK_INTERACTION_COMPACT_INPUTS_MAX_ITEMS)
-    .flatMap((entry) => {
-      if (!entry || typeof entry !== "object") {
-        return [];
-      }
-      const typed = entry as Record<string, unknown>;
-      return [
-        {
-          actionId: typed.actionId,
-          blockId: typed.blockId,
-          actionType: typed.actionType,
-          inputKind: typed.inputKind,
-          selectedValues: typed.selectedValues,
-          selectedLabels: typed.selectedLabels,
-          inputValue: typed.inputValue,
-          inputNumber: typed.inputNumber,
-          selectedDate: typed.selectedDate,
-          selectedTime: typed.selectedTime,
-          selectedDateTime: typed.selectedDateTime,
-          richTextPreview: typed.richTextPreview,
-        },
-      ];
+  const compactInputs = [];
+  const inputLimit = Math.min(rawInputs.length, SLACK_INTERACTION_COMPACT_INPUTS_MAX_ITEMS);
+  for (let index = 0; index < inputLimit; index += 1) {
+    const entry = rawInputs[index];
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const typed = entry as Record<string, unknown>;
+    compactInputs.push({
+      actionId: typed.actionId,
+      blockId: typed.blockId,
+      actionType: typed.actionType,
+      inputKind: typed.inputKind,
+      selectedValues: typed.selectedValues,
+      selectedLabels: typed.selectedLabels,
+      inputValue: typed.inputValue,
+      inputNumber: typed.inputNumber,
+      selectedDate: typed.selectedDate,
+      selectedTime: typed.selectedTime,
+      selectedDateTime: typed.selectedDateTime,
+      richTextPreview: typed.richTextPreview,
     });
+  }
 
   return {
     interactionType: payload.interactionType,

--- a/extensions/slack/src/setup-surface.ts
+++ b/extensions/slack/src/setup-surface.ts
@@ -130,11 +130,21 @@ async function resolveSlackGroupAllowlist(params: {
             entries,
           }),
       });
-      const resolvedKeys = resolved
-        .filter((entry) => entry.resolved && entry.id)
-        .map((entry) => entry.id as string);
-      const unresolved = resolved.filter((entry) => !entry.resolved).map((entry) => entry.input);
-      keys = [...resolvedKeys, ...unresolved.map((entry) => entry.trim()).filter(Boolean)];
+      const resolvedKeys: string[] = [];
+      const unresolved: string[] = [];
+      keys = [];
+      for (const entry of resolved) {
+        if (entry.resolved && entry.id) {
+          resolvedKeys.push(entry.id);
+          keys.push(entry.id);
+          continue;
+        }
+        unresolved.push(entry.input);
+        const trimmed = entry.input.trim();
+        if (trimmed) {
+          keys.push(trimmed);
+        }
+      }
       await noteChannelLookupSummary({
         prompter: params.prompter,
         label: "Slack channels",

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -218,28 +218,28 @@ export function scanTelegramSelectedQuoteToolProgressWarnings(
   if (!asObjectRecord((cfg.channels as Record<string, unknown> | undefined)?.telegram)) {
     return [];
   }
-  return listTelegramAccountIds(cfg).flatMap((accountId) => {
+  const hits: TelegramSelectedQuoteToolProgressHit[] = [];
+  for (const accountId of listTelegramAccountIds(cfg)) {
     const account = mergeTelegramAccountConfig(cfg, accountId);
     const replyToMode = account.replyToMode ?? "off";
     if (replyToMode === "off") {
-      return [];
+      continue;
     }
     if (resolveTelegramPreviewStreamMode(account) === "off") {
-      return [];
+      continue;
     }
     const blockStreamingEnabled =
       resolveChannelStreamingBlockEnabled(account) ??
       cfg.agents?.defaults?.blockStreamingDefault === "on";
     if (blockStreamingEnabled || !resolveChannelStreamingPreviewToolProgress(account)) {
-      return [];
+      continue;
     }
-    return [
-      {
-        path: formatTelegramAccountConfigPath(cfg, accountId),
-        replyToMode,
-      },
-    ];
-  });
+    hits.push({
+      path: formatTelegramAccountConfigPath(cfg, accountId),
+      replyToMode,
+    });
+  }
+  return hits;
 }
 
 export function collectTelegramSelectedQuoteToolProgressWarnings(params: {

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -279,7 +279,14 @@ export function deriveSessionName(command: string): string | undefined {
 
 function tokenizeCommand(command: string): string[] {
   const matches = command.match(/(?:[^\s"']+|"(?:\\.|[^"])*"|'(?:\\.|[^'])*')+/g) ?? [];
-  return matches.map((token) => stripQuotes(token)).filter(Boolean);
+  const tokens: string[] = [];
+  for (const token of matches) {
+    const stripped = stripQuotes(token);
+    if (stripped) {
+      tokens.push(stripped);
+    }
+  }
+  return tokens;
 }
 
 function stripQuotes(value: string): string {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -1477,7 +1477,14 @@ function formatToolInputPreview(toolInput: Record<string, unknown>): string | un
   if (command) {
     return `Command: ${truncateText(sanitizeApprovalText(command), 240)}`;
   }
-  const keys = Object.keys(toolInput).map(sanitizeApprovalText).filter(Boolean).toSorted();
+  const keys: string[] = [];
+  for (const key of Object.keys(toolInput)) {
+    const sanitized = sanitizeApprovalText(key);
+    if (sanitized) {
+      keys.push(sanitized);
+    }
+  }
+  keys.sort((left, right) => left.localeCompare(right));
   if (!keys.length) {
     return undefined;
   }

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -417,13 +417,21 @@ function flattenUnionFallback(
   obj: Record<string, unknown>,
   variants: unknown[],
 ): Record<string, unknown> | undefined {
-  const objects = variants.filter(
-    (v): v is Record<string, unknown> => !!v && typeof v === "object",
-  );
+  const objects: Record<string, unknown>[] = [];
+  const types = new Set<unknown>();
+  for (const variant of variants) {
+    if (!variant || typeof variant !== "object") {
+      continue;
+    }
+    objects.push(variant as Record<string, unknown>);
+    const type = (variant as Record<string, unknown>).type;
+    if (type) {
+      types.add(type);
+    }
+  }
   if (objects.length === 0) {
     return undefined;
   }
-  const types = new Set(objects.map((v) => v.type).filter(Boolean));
   if (objects.length === 1) {
     const merged: Record<string, unknown> = { ...objects[0] };
     copySchemaMeta(obj, merged);

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -9,19 +9,25 @@ type ExplicitToolAllowlistSource = {
 export function collectExplicitToolAllowlistSources(
   sources: Array<{ label: string; allow?: string[]; enforceWhenToolsDisabled?: boolean }>,
 ): ExplicitToolAllowlistSource[] {
-  return sources.flatMap((source) => {
-    const entries = (source.allow ?? []).map((entry) => entry.trim()).filter(Boolean);
-    if (entries.length === 0) {
-      return [];
+  const normalizedSources: ExplicitToolAllowlistSource[] = [];
+  for (const source of sources) {
+    const entries: string[] = [];
+    for (const entry of source.allow ?? []) {
+      const trimmed = entry.trim();
+      if (trimmed) {
+        entries.push(trimmed);
+      }
     }
-    return [
-      {
-        label: source.label,
-        entries,
-        ...(source.enforceWhenToolsDisabled === true ? { enforceWhenToolsDisabled: true } : {}),
-      },
-    ];
-  });
+    if (entries.length === 0) {
+      continue;
+    }
+    normalizedSources.push({
+      label: source.label,
+      entries,
+      ...(source.enforceWhenToolsDisabled === true ? { enforceWhenToolsDisabled: true } : {}),
+    });
+  }
+  return normalizedSources;
 }
 
 export function buildEmptyExplicitToolAllowlistError(params: {
@@ -34,7 +40,13 @@ export function buildEmptyExplicitToolAllowlistError(params: {
     params.disableTools === true
       ? params.sources.filter((source) => source.enforceWhenToolsDisabled === true)
       : params.sources;
-  const callableToolNames = params.callableToolNames.map(normalizeToolName).filter(Boolean);
+  const callableToolNames: string[] = [];
+  for (const toolName of params.callableToolNames) {
+    const normalized = normalizeToolName(toolName);
+    if (normalized) {
+      callableToolNames.push(normalized);
+    }
+  }
   if (sources.length === 0 || callableToolNames.length > 0) {
     return null;
   }

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -26,7 +26,14 @@ export function normalizeToolList(list?: string[]) {
   if (!list) {
     return [];
   }
-  return list.map(normalizeToolName).filter(Boolean);
+  const normalized: string[] = [];
+  for (const entry of list) {
+    const toolName = normalizeToolName(entry);
+    if (toolName) {
+      normalized.push(toolName);
+    }
+  }
+  return normalized;
 }
 
 export function expandToolGroups(list?: string[]) {

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -268,20 +268,20 @@ function formatTemplateValue(value: unknown): string {
     return value.toString();
   }
   if (Array.isArray(value)) {
-    return value
-      .flatMap((entry) => {
-        if (entry == null) {
-          return [];
-        }
-        if (typeof entry === "string") {
-          return [entry];
-        }
-        if (typeof entry === "number" || typeof entry === "boolean" || typeof entry === "bigint") {
-          return [String(entry)];
-        }
-        return [];
-      })
-      .join(",");
+    const entries: string[] = [];
+    for (const entry of value) {
+      if (entry == null) {
+        continue;
+      }
+      if (typeof entry === "string") {
+        entries.push(entry);
+        continue;
+      }
+      if (typeof entry === "number" || typeof entry === "boolean" || typeof entry === "bigint") {
+        entries.push(String(entry));
+      }
+    }
+    return entries.join(",");
   }
   if (typeof value === "object") {
     return "";

--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -41,10 +41,16 @@ function readStringArray(record: Record<string, unknown>, key: string): string[]
   if (!Array.isArray(value)) {
     return undefined;
   }
-  const normalized = value
-    .map((entry) => (typeof entry === "string" || typeof entry === "number" ? String(entry) : ""))
-    .map((entry) => entry.trim())
-    .filter(Boolean);
+  const normalized: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" && typeof entry !== "number") {
+      continue;
+    }
+    const trimmed = String(entry).trim();
+    if (trimmed) {
+      normalized.push(trimmed);
+    }
+  }
   return normalized.length > 0 ? normalized : undefined;
 }
 
@@ -140,27 +146,22 @@ export function projectCredentialSnapshotFields(
   const botTokenSource = normalizeOptionalString(record.botTokenSource);
   const appTokenSource = normalizeOptionalString(record.appTokenSource);
   const signingSecretSource = normalizeOptionalString(record.signingSecretSource);
+  const tokenStatus = readCredentialStatus(record, "tokenStatus");
+  const botTokenStatus = readCredentialStatus(record, "botTokenStatus");
+  const appTokenStatus = readCredentialStatus(record, "appTokenStatus");
+  const signingSecretStatus = readCredentialStatus(record, "signingSecretStatus");
+  const userTokenStatus = readCredentialStatus(record, "userTokenStatus");
 
   return {
     ...(tokenSource ? { tokenSource } : {}),
     ...(botTokenSource ? { botTokenSource } : {}),
     ...(appTokenSource ? { appTokenSource } : {}),
     ...(signingSecretSource ? { signingSecretSource } : {}),
-    ...(readCredentialStatus(record, "tokenStatus")
-      ? { tokenStatus: readCredentialStatus(record, "tokenStatus") }
-      : {}),
-    ...(readCredentialStatus(record, "botTokenStatus")
-      ? { botTokenStatus: readCredentialStatus(record, "botTokenStatus") }
-      : {}),
-    ...(readCredentialStatus(record, "appTokenStatus")
-      ? { appTokenStatus: readCredentialStatus(record, "appTokenStatus") }
-      : {}),
-    ...(readCredentialStatus(record, "signingSecretStatus")
-      ? { signingSecretStatus: readCredentialStatus(record, "signingSecretStatus") }
-      : {}),
-    ...(readCredentialStatus(record, "userTokenStatus")
-      ? { userTokenStatus: readCredentialStatus(record, "userTokenStatus") }
-      : {}),
+    ...(tokenStatus ? { tokenStatus } : {}),
+    ...(botTokenStatus ? { botTokenStatus } : {}),
+    ...(appTokenStatus ? { appTokenStatus } : {}),
+    ...(signingSecretStatus ? { signingSecretStatus } : {}),
+    ...(userTokenStatus ? { userTokenStatus } : {}),
   };
 }
 
@@ -179,63 +180,50 @@ export function projectSafeChannelAccountSnapshotFields(
   const baseUrl = normalizeOptionalString(record.baseUrl);
   const cliPath = normalizeOptionalString(record.cliPath);
   const dbPath = normalizeOptionalString(record.dbPath);
+  const linked = readBoolean(record, "linked");
+  const running = readBoolean(record, "running");
+  const connected = readBoolean(record, "connected");
+  const restartPending = readBoolean(record, "restartPending");
+  const reconnectAttempts = readNumber(record, "reconnectAttempts");
+  const lastConnectedAt = readNullableNumber(record, "lastConnectedAt");
+  const lastInboundAt = readNumber(record, "lastInboundAt");
+  const lastOutboundAt = readNullableNumber(record, "lastOutboundAt");
+  const lastMessageAt = readNullableNumber(record, "lastMessageAt");
+  const lastEventAt = readNullableNumber(record, "lastEventAt");
+  const lastTransportActivityAt = readNumber(record, "lastTransportActivityAt");
+  const busy = readBoolean(record, "busy");
+  const activeRuns = readNumber(record, "activeRuns");
+  const lastRunActivityAt = readNullableNumber(record, "lastRunActivityAt");
+  const allowFrom = readStringArray(record, "allowFrom");
+  const allowUnmentionedGroups = readBoolean(record, "allowUnmentionedGroups");
+  const port = readNumber(record, "port");
 
   return {
     ...(name ? { name } : {}),
-    ...(readBoolean(record, "linked") !== undefined
-      ? { linked: readBoolean(record, "linked") }
-      : {}),
-    ...(readBoolean(record, "running") !== undefined
-      ? { running: readBoolean(record, "running") }
-      : {}),
-    ...(readBoolean(record, "connected") !== undefined
-      ? { connected: readBoolean(record, "connected") }
-      : {}),
-    ...(readBoolean(record, "restartPending") !== undefined
-      ? { restartPending: readBoolean(record, "restartPending") }
-      : {}),
-    ...(readNumber(record, "reconnectAttempts") !== undefined
-      ? { reconnectAttempts: readNumber(record, "reconnectAttempts") }
-      : {}),
-    ...(readNullableNumber(record, "lastConnectedAt") !== undefined
-      ? { lastConnectedAt: readNullableNumber(record, "lastConnectedAt") }
-      : {}),
-    ...(readNumber(record, "lastInboundAt") !== undefined
-      ? { lastInboundAt: readNumber(record, "lastInboundAt") }
-      : {}),
-    ...(readNullableNumber(record, "lastOutboundAt") !== undefined
-      ? { lastOutboundAt: readNullableNumber(record, "lastOutboundAt") }
-      : {}),
-    ...(readNullableNumber(record, "lastMessageAt") !== undefined
-      ? { lastMessageAt: readNullableNumber(record, "lastMessageAt") }
-      : {}),
-    ...(readNullableNumber(record, "lastEventAt") !== undefined
-      ? { lastEventAt: readNullableNumber(record, "lastEventAt") }
-      : {}),
-    ...(readNumber(record, "lastTransportActivityAt") !== undefined
-      ? { lastTransportActivityAt: readNumber(record, "lastTransportActivityAt") }
-      : {}),
+    ...(linked !== undefined ? { linked } : {}),
+    ...(running !== undefined ? { running } : {}),
+    ...(connected !== undefined ? { connected } : {}),
+    ...(restartPending !== undefined ? { restartPending } : {}),
+    ...(reconnectAttempts !== undefined ? { reconnectAttempts } : {}),
+    ...(lastConnectedAt !== undefined ? { lastConnectedAt } : {}),
+    ...(lastInboundAt !== undefined ? { lastInboundAt } : {}),
+    ...(lastOutboundAt !== undefined ? { lastOutboundAt } : {}),
+    ...(lastMessageAt !== undefined ? { lastMessageAt } : {}),
+    ...(lastEventAt !== undefined ? { lastEventAt } : {}),
+    ...(lastTransportActivityAt !== undefined ? { lastTransportActivityAt } : {}),
     ...(statusState ? { statusState } : {}),
     ...(healthState ? { healthState } : {}),
-    ...(readBoolean(record, "busy") !== undefined ? { busy: readBoolean(record, "busy") } : {}),
-    ...(readNumber(record, "activeRuns") !== undefined
-      ? { activeRuns: readNumber(record, "activeRuns") }
-      : {}),
-    ...(readNullableNumber(record, "lastRunActivityAt") !== undefined
-      ? { lastRunActivityAt: readNullableNumber(record, "lastRunActivityAt") }
-      : {}),
+    ...(busy !== undefined ? { busy } : {}),
+    ...(activeRuns !== undefined ? { activeRuns } : {}),
+    ...(lastRunActivityAt !== undefined ? { lastRunActivityAt } : {}),
     ...(mode ? { mode } : {}),
     ...(dmPolicy ? { dmPolicy } : {}),
-    ...(readStringArray(record, "allowFrom")
-      ? { allowFrom: readStringArray(record, "allowFrom") }
-      : {}),
+    ...(allowFrom ? { allowFrom } : {}),
     ...projectCredentialSnapshotFields(account),
     ...(baseUrl ? { baseUrl: stripUrlUserInfo(baseUrl) } : {}),
-    ...(readBoolean(record, "allowUnmentionedGroups") !== undefined
-      ? { allowUnmentionedGroups: readBoolean(record, "allowUnmentionedGroups") }
-      : {}),
+    ...(allowUnmentionedGroups !== undefined ? { allowUnmentionedGroups } : {}),
     ...(cliPath ? { cliPath } : {}),
     ...(dbPath ? { dbPath } : {}),
-    ...(readNumber(record, "port") !== undefined ? { port: readNumber(record, "port") } : {}),
+    ...(port !== undefined ? { port } : {}),
   };
 }

--- a/src/channels/allowlist-match.ts
+++ b/src/channels/allowlist-match.ts
@@ -33,7 +33,12 @@ export function formatAllowlistMatchMeta(
 }
 
 export function compileAllowlist(entries: ReadonlyArray<string>): CompiledAllowlist {
-  const set = new Set(entries.filter(Boolean));
+  const set = new Set<string>();
+  for (const entry of entries) {
+    if (entry) {
+      set.add(entry);
+    }
+  }
   return {
     set,
     wildcard: set.has("*"),
@@ -41,11 +46,17 @@ export function compileAllowlist(entries: ReadonlyArray<string>): CompiledAllowl
 }
 
 function compileSimpleAllowlist(entries: ReadonlyArray<string | number>): CompiledAllowlist {
-  return compileAllowlist(
-    entries
-      .map((entry) => normalizeOptionalLowercaseString(String(entry)))
-      .filter((entry): entry is string => Boolean(entry)),
-  );
+  const set = new Set<string>();
+  for (const entry of entries) {
+    const normalized = normalizeOptionalLowercaseString(String(entry));
+    if (normalized) {
+      set.add(normalized);
+    }
+  }
+  return {
+    set,
+    wildcard: set.has("*"),
+  };
 }
 
 export function resolveAllowlistCandidates<TSource extends string>(params: {
@@ -107,16 +118,11 @@ export function resolveAllowlistMatchSimple(params: {
 
   const senderId = normalizeLowercaseStringOrEmpty(params.senderId);
   const senderName = normalizeOptionalLowercaseString(params.senderName);
-  return resolveAllowlistCandidates({
-    compiledAllowlist: allowFrom,
-    candidates: [
-      { value: senderId, source: "id" },
-      ...(params.allowNameMatching === true && senderName
-        ? ([{ value: senderName, source: "name" as const }] satisfies Array<{
-            value?: string;
-            source: "id" | "name";
-          }>)
-        : []),
-    ],
-  });
+  if (senderId && allowFrom.set.has(senderId)) {
+    return { allowed: true, matchKey: senderId, matchSource: "id" };
+  }
+  if (params.allowNameMatching === true && senderName && allowFrom.set.has(senderName)) {
+    return { allowed: true, matchKey: senderName, matchSource: "name" };
+  }
+  return { allowed: false };
 }

--- a/src/channels/bundled-channel-catalog-read.ts
+++ b/src/channels/bundled-channel-catalog-read.ts
@@ -23,10 +23,16 @@ const OFFICIAL_CHANNEL_CATALOG_RELATIVE_PATH = path.join("dist", "channel-catalo
 const officialCatalogFileCache = new Map<string, ChannelCatalogEntryLike[] | null>();
 
 function listPackageRoots(): string[] {
-  return [
+  const roots: string[] = [];
+  for (const root of [
     resolveOpenClawPackageRootSync({ cwd: process.cwd() }),
     resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url }),
-  ].filter((entry, index, all): entry is string => Boolean(entry) && all.indexOf(entry) === index);
+  ]) {
+    if (root && !roots.includes(root)) {
+      roots.push(root);
+    }
+  }
+  return roots;
 }
 
 function readBundledExtensionCatalogEntriesSync(): PluginPackageChannel[] {
@@ -80,11 +86,15 @@ function toBundledChannelEntry(
   if (!id || !channel) {
     return null;
   }
-  const aliases = Array.isArray(channel.aliases)
-    ? channel.aliases
-        .map((alias) => normalizeOptionalLowercaseString(alias))
-        .filter((alias): alias is string => Boolean(alias))
-    : [];
+  const aliases: string[] = [];
+  if (Array.isArray(channel.aliases)) {
+    for (const alias of channel.aliases) {
+      const normalized = normalizeOptionalLowercaseString(alias);
+      if (normalized) {
+        aliases.push(normalized);
+      }
+    }
+  }
   const order =
     typeof channel.order === "number" && Number.isFinite(channel.order)
       ? channel.order
@@ -97,18 +107,22 @@ function toBundledChannelEntry(
   };
 }
 
+function addBundledChannelEntries(
+  entries: Map<string, BundledChannelCatalogEntry>,
+  source: readonly (ChannelCatalogEntryLike | PluginPackageChannel)[],
+): void {
+  for (const sourceEntry of source) {
+    const entry = toBundledChannelEntry(sourceEntry);
+    if (entry) {
+      entries.set(entry.id, entry);
+    }
+  }
+}
+
 export function listBundledChannelCatalogEntries(): BundledChannelCatalogEntry[] {
   const entries = new Map<string, BundledChannelCatalogEntry>();
-  for (const entry of readOfficialCatalogFileSync()
-    .map((entry) => toBundledChannelEntry(entry))
-    .filter((entry): entry is BundledChannelCatalogEntry => Boolean(entry))) {
-    entries.set(entry.id, entry);
-  }
-  for (const entry of readBundledExtensionCatalogEntriesSync()
-    .map((entry) => toBundledChannelEntry(entry))
-    .filter((entry): entry is BundledChannelCatalogEntry => Boolean(entry))) {
-    entries.set(entry.id, entry);
-  }
+  addBundledChannelEntries(entries, readOfficialCatalogFileSync());
+  addBundledChannelEntries(entries, readBundledExtensionCatalogEntriesSync());
   return Array.from(entries.values()).toSorted(
     (left, right) => left.order - right.order || left.id.localeCompare(right.id),
   );

--- a/src/channels/config-presence.ts
+++ b/src/channels/config-presence.ts
@@ -45,10 +45,17 @@ export function listExplicitlyDisabledChannelIdsForConfig(cfg: OpenClawConfig): 
   if (!channels) {
     return [];
   }
-  return Object.entries(channels)
-    .filter(([, value]) => isRecord(value) && value.enabled === false)
-    .map(([channelId]) => normalizeOptionalLowercaseString(channelId))
-    .filter((channelId): channelId is string => Boolean(channelId));
+  const disabled: string[] = [];
+  for (const [channelId, value] of Object.entries(channels)) {
+    if (!isRecord(value) || value.enabled !== false) {
+      continue;
+    }
+    const normalized = normalizeOptionalLowercaseString(channelId);
+    if (normalized) {
+      disabled.push(normalized);
+    }
+  }
+  return disabled;
 }
 
 function listChannelEnvPrefixes(

--- a/src/channels/plugins/account-helpers.ts
+++ b/src/channels/plugins/account-helpers.ts
@@ -47,7 +47,14 @@ export function createAccountListHelpers(
     if (!normalizeConfiguredAccountId) {
       return ids;
     }
-    return [...new Set(ids.map((id) => normalizeConfiguredAccountId(id)).filter(Boolean))];
+    const normalized = new Set<string>();
+    for (const id of ids) {
+      const accountId = normalizeConfiguredAccountId(id);
+      if (accountId) {
+        normalized.add(accountId);
+      }
+    }
+    return [...normalized];
   }
 
   function listAccountIds(cfg: OpenClawConfig): string[] {

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -113,7 +113,7 @@ function resolveDefaultCatalogPaths(env: NodeJS.ProcessEnv): string[] {
 
 function resolveExternalCatalogPaths(options: CatalogOptions): string[] {
   if (options.catalogPaths && options.catalogPaths.length > 0) {
-    return options.catalogPaths.map((entry) => entry.trim()).filter(Boolean);
+    return normalizeCatalogPathEntries(options.catalogPaths);
   }
   const env = options.env ?? process.env;
   for (const key of ENV_CATALOG_PATHS) {
@@ -168,7 +168,7 @@ function loadOfficialCatalogEntriesFromPaths(paths: Iterable<string>): ExternalC
 
 function resolveOfficialCatalogPaths(options: CatalogOptions): string[] {
   if (options.officialCatalogPaths && options.officialCatalogPaths.length > 0) {
-    return options.officialCatalogPaths.map((entry) => entry.trim()).filter(Boolean);
+    return normalizeCatalogPathEntries(options.officialCatalogPaths);
   }
 
   const packageRoots = [
@@ -187,6 +187,17 @@ function resolveOfficialCatalogPaths(options: CatalogOptions): string[] {
   }
 
   return candidates.filter((entry, index, all) => entry && all.indexOf(entry) === index);
+}
+
+function normalizeCatalogPathEntries(entries: readonly string[]): string[] {
+  const normalized: string[] = [];
+  for (const entry of entries) {
+    const trimmed = entry.trim();
+    if (trimmed) {
+      normalized.push(trimmed);
+    }
+  }
+  return normalized;
 }
 
 function loadOfficialCatalogEntries(options: CatalogOptions): ChannelPluginCatalogEntry[] {

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -95,11 +95,16 @@ function splitEnvPaths(value: string): string[] {
   if (!trimmed) {
     return [];
   }
-  return trimmed
-    .split(/[;,]/g)
-    .flatMap((chunk) => chunk.split(path.delimiter))
-    .map((entry) => entry.trim())
-    .filter(Boolean);
+  const paths: string[] = [];
+  for (const chunk of trimmed.split(/[;,]/g)) {
+    for (const entry of chunk.split(path.delimiter)) {
+      const normalized = entry.trim();
+      if (normalized) {
+        paths.push(normalized);
+      }
+    }
+  }
+  return paths;
 }
 
 function resolveDefaultCatalogPaths(env: NodeJS.ProcessEnv): string[] {

--- a/src/channels/plugins/gateway-auth-bypass.ts
+++ b/src/channels/plugins/gateway-auth-bypass.ts
@@ -28,5 +28,15 @@ export function resolveBundledChannelGatewayAuthBypassPaths(params: {
 }): string[] {
   const api = loadBundledChannelGatewayAuthApi(params.channelId);
   const paths = api?.resolveGatewayAuthBypassPaths?.({ cfg: params.cfg }) ?? [];
-  return paths.flatMap((path) => (typeof path === "string" && path.trim() ? [path.trim()] : []));
+  const normalized: string[] = [];
+  for (const path of paths) {
+    if (typeof path !== "string") {
+      continue;
+    }
+    const trimmed = path.trim();
+    if (trimmed) {
+      normalized.push(trimmed);
+    }
+  }
+  return normalized;
 }

--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -138,9 +138,13 @@ function normalizeMessageToolMediaSourceParams(
     const scoped = scopedMediaSourceParams[action];
     return Array.isArray(scoped) ? scoped : [];
   }
-  return Object.values(scopedMediaSourceParams).flatMap((scoped) =>
-    Array.isArray(scoped) ? scoped : [],
-  );
+  const merged: string[] = [];
+  for (const scoped of Object.values(scopedMediaSourceParams)) {
+    if (Array.isArray(scoped)) {
+      merged.push(...scoped);
+    }
+  }
+  return merged;
 }
 
 export function resolveCurrentChannelMessageToolDiscoveryAdapter(channel?: string | null): {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -71,10 +71,14 @@ export function normalizeAnyChannelId(raw?: string | null): ChannelId | null {
 }
 
 export function listRegisteredChannelPluginIds(): ChannelId[] {
-  return listRegisteredChannelPluginEntries().flatMap((entry) => {
+  const ids: ChannelId[] = [];
+  for (const entry of listRegisteredChannelPluginEntries()) {
     const id = normalizeOptionalString(entry.plugin.id);
-    return id ? [id as ChannelId] : [];
-  });
+    if (id) {
+      ids.push(id as ChannelId);
+    }
+  }
+  return ids;
 }
 
 export function getRegisteredChannelPluginMeta(

--- a/src/channels/thread-bindings-messages.ts
+++ b/src/channels/thread-bindings-messages.ts
@@ -53,9 +53,13 @@ export function resolveThreadBindingIntroText(params: {
   const idleTimeoutMs = normalizeThreadBindingDurationMs(params.idleTimeoutMs);
   const maxAgeMs = normalizeThreadBindingDurationMs(params.maxAgeMs);
   const cwd = normalizeOptionalString(params.sessionCwd);
-  const details = (params.sessionDetails ?? [])
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
+  const details: string[] = [];
+  for (const entry of params.sessionDetails ?? []) {
+    const trimmed = entry.trim();
+    if (trimmed) {
+      details.push(trimmed);
+    }
+  }
   if (cwd) {
     details.unshift(`cwd: ${cwd}`);
   }

--- a/src/channels/turn/context.ts
+++ b/src/channels/turn/context.ts
@@ -34,16 +34,42 @@ export type BuildChannelTurnContextParams = {
   extra?: Record<string, unknown>;
 };
 
-function compactStrings(values: Array<string | undefined>): string[] | undefined {
-  const compacted = values.filter((value): value is string => Boolean(value));
-  return compacted.length > 0 ? compacted : undefined;
-}
-
-function mediaTranscribedIndexes(media: InboundMediaFacts[]): number[] | undefined {
-  const indexes = media
-    .map((item, index) => (item.transcribed ? index : undefined))
-    .filter((index): index is number => index !== undefined);
-  return indexes.length > 0 ? indexes : undefined;
+function compactMediaFacts(media: InboundMediaFacts[]): {
+  paths?: string[];
+  urls?: string[];
+  types?: string[];
+  transcribedIndexes?: number[];
+} {
+  const paths: string[] = [];
+  const urls: string[] = [];
+  const types: string[] = [];
+  const transcribedIndexes: number[] = [];
+  for (let index = 0; index < media.length; index += 1) {
+    const item = media[index];
+    if (!item) {
+      continue;
+    }
+    if (item.path) {
+      paths.push(item.path);
+    }
+    const url = item.url ?? item.path;
+    if (url) {
+      urls.push(url);
+    }
+    const type = item.contentType ?? item.kind;
+    if (type) {
+      types.push(type);
+    }
+    if (item.transcribed) {
+      transcribedIndexes.push(index);
+    }
+  }
+  return {
+    paths: paths.length > 0 ? paths : undefined,
+    urls: urls.length > 0 ? urls : undefined,
+    types: types.length > 0 ? types : undefined,
+    transcribedIndexes: transcribedIndexes.length > 0 ? transcribedIndexes : undefined,
+  };
 }
 
 function commandAuthorized(access: AccessFacts | undefined): boolean | undefined {
@@ -119,6 +145,7 @@ export function buildChannelTurnContext(
     contextVisibility: params.contextVisibility,
   });
   const body = params.message.body ?? params.message.rawBody;
+  const mediaFacts = compactMediaFacts(media);
 
   return finalizeInboundContext({
     Body: body,
@@ -150,10 +177,10 @@ export function buildChannelTurnContext(
     MediaPath: media[0]?.path,
     MediaUrl: media[0]?.url ?? media[0]?.path,
     MediaType: media[0]?.contentType ?? media[0]?.kind,
-    MediaPaths: compactStrings(media.map((item) => item.path)),
-    MediaUrls: compactStrings(media.map((item) => item.url ?? item.path)),
-    MediaTypes: compactStrings(media.map((item) => item.contentType ?? item.kind)),
-    MediaTranscribedIndexes: mediaTranscribedIndexes(media),
+    MediaPaths: mediaFacts.paths,
+    MediaUrls: mediaFacts.urls,
+    MediaTypes: mediaFacts.types,
+    MediaTranscribedIndexes: mediaFacts.transcribedIndexes,
     ChatType: params.conversation.kind,
     ConversationLabel: params.conversation.label,
     GroupSubject: params.conversation.kind !== "direct" ? params.conversation.label : undefined,

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { WebSocket } from "ws";
 import {
   approveNodePairing,
@@ -16,12 +16,16 @@ import {
 import { connectGatewayClient } from "./test-helpers.e2e.js";
 import {
   connectOk,
+  installGatewayTestCanvasNodeInvokePolicy,
   installGatewayTestHooks,
   rpcReq,
   startServerWithClient,
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
+beforeEach(() => {
+  installGatewayTestCanvasNodeInvokePolicy();
+});
 
 async function connectNodeClient(params: {
   port: number;

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -30,10 +30,18 @@ vi.mock("../infra/update-runner.js", () => ({
 
 import { runGatewayUpdate } from "../infra/update-runner.js";
 import { connectGatewayClient } from "./test-helpers.e2e.js";
-import { installGatewayTestHooks, onceMessage, rpcReq } from "./test-helpers.js";
+import {
+  installGatewayTestCanvasNodeInvokePolicy,
+  installGatewayTestHooks,
+  onceMessage,
+  rpcReq,
+} from "./test-helpers.js";
 import { installConnectedControlUiServerSuite } from "./test-with-server.js";
 
 installGatewayTestHooks({ scope: "suite" });
+beforeEach(() => {
+  installGatewayTestCanvasNodeInvokePolicy();
+});
 const FAST_WAIT_OPTS = { timeout: 1_000, interval: 2 } as const;
 
 let ws: WebSocket;

--- a/src/gateway/test-helpers.plugin-registry.ts
+++ b/src/gateway/test-helpers.plugin-registry.ts
@@ -46,6 +46,17 @@ function createStubPluginRegistry(): PluginRegistry {
   };
 }
 
+const GATEWAY_TEST_CANVAS_NODE_COMMANDS = [
+  "canvas.present",
+  "canvas.hide",
+  "canvas.navigate",
+  "canvas.eval",
+  "canvas.snapshot",
+  "canvas.a2ui.push",
+  "canvas.a2ui.pushJSONL",
+  "canvas.a2ui.reset",
+];
+
 const GATEWAY_TEST_PLUGIN_REGISTRY_STATE_KEY = Symbol.for(
   "openclaw.gatewayTestHelpers.pluginRegistryState",
 );
@@ -68,4 +79,25 @@ export function resetTestPluginRegistry(): void {
 
 export function getTestPluginRegistry(): PluginRegistry {
   return pluginRegistryState.registry;
+}
+
+export function installGatewayTestCanvasNodeInvokePolicy(): void {
+  const registry = getTestPluginRegistry();
+  registry.nodeInvokePolicies ??= [];
+  if (registry.nodeInvokePolicies.some((entry) => entry.pluginId === "canvas")) {
+    return;
+  }
+  registry.nodeInvokePolicies.push({
+    pluginId: "canvas",
+    pluginName: "Canvas",
+    source: "extensions/canvas/index.ts",
+    rootDir: "extensions/canvas",
+    pluginConfig: {},
+    policy: {
+      commands: GATEWAY_TEST_CANVAS_NODE_COMMANDS,
+      defaultPlatforms: ["ios", "android", "macos", "windows", "unknown"],
+      foregroundRestrictedOnIos: true,
+      handle: (ctx) => ctx.invokeNode(),
+    },
+  });
 }

--- a/src/gateway/test-helpers.ts
+++ b/src/gateway/test-helpers.ts
@@ -10,7 +10,11 @@ export {
   testTailnetIPv4,
   testTailscaleWhois,
 } from "./test-helpers.runtime-state.js";
-export { resetTestPluginRegistry, setTestPluginRegistry } from "./test-helpers.plugin-registry.js";
+export {
+  installGatewayTestCanvasNodeInvokePolicy,
+  resetTestPluginRegistry,
+  setTestPluginRegistry,
+} from "./test-helpers.plugin-registry.js";
 export {
   connectOk,
   connectReq,

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -96,15 +96,20 @@ function resolveConfiguredKeyProviderOrder(params: {
   capability: MediaUnderstandingCapability;
   fallbackProviders: readonly string[];
 }): string[] {
-  const configuredProviders = Object.keys(params.cfg.models?.providers ?? {})
-    .map((providerId) => normalizeMediaProviderId(providerId))
-    .filter(Boolean)
-    .filter((providerId, index, values) => values.indexOf(providerId) === index)
-    .filter((providerId) =>
-      providerSupportsCapability(params.providerRegistry.get(providerId), params.capability),
-    );
-
-  return [...new Set([...configuredProviders, ...params.fallbackProviders])];
+  const ordered = new Set<string>();
+  for (const providerId of Object.keys(params.cfg.models?.providers ?? {})) {
+    const normalized = normalizeMediaProviderId(providerId);
+    if (
+      normalized &&
+      providerSupportsCapability(params.providerRegistry.get(normalized), params.capability)
+    ) {
+      ordered.add(normalized);
+    }
+  }
+  for (const providerId of params.fallbackProviders) {
+    ordered.add(providerId);
+  }
+  return Array.from(ordered);
 }
 
 function resolveConfiguredImageModelId(params: {
@@ -317,13 +322,14 @@ function candidateBinaryNames(name: string): string[] {
   if (ext) {
     return [name];
   }
-  const pathext = (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
-    .split(";")
-    .map((item) => item.trim())
-    .filter(Boolean)
-    .map((item) => (item.startsWith(".") ? item : `.${item}`));
-  const unique = Array.from(new Set(pathext));
-  return [name, ...unique.map((item) => `${name}${item}`)];
+  const unique = new Set<string>();
+  for (const item of (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";")) {
+    const trimmed = item.trim();
+    if (trimmed) {
+      unique.add(trimmed.startsWith(".") ? trimmed : `.${trimmed}`);
+    }
+  }
+  return [name, ...Array.from(unique, (item) => `${name}${item}`)];
 }
 
 async function isExecutable(filePath: string): Promise<boolean> {

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -37,10 +37,14 @@ const MEDIA_UNDERSTANDING_CORE_PLUGIN_ID = "media-understanding-core";
 const MEDIA_UNDERSTANDING_CORE_IMAGE_OPS_ARTIFACT = "image-ops.js";
 
 export function buildImageResizeSideGrid(maxSide: number, sideStart: number): number[] {
-  return [sideStart, 1800, 1600, 1400, 1200, 1000, 800]
-    .map((value) => Math.min(maxSide, value))
-    .filter((value, idx, arr) => value > 0 && arr.indexOf(value) === idx)
-    .toSorted((a, b) => b - a);
+  const unique = new Set<number>();
+  for (const value of [sideStart, 1800, 1600, 1400, 1200, 1000, 800]) {
+    const side = Math.min(maxSide, value);
+    if (side > 0) {
+      unique.add(side);
+    }
+  }
+  return Array.from(unique).toSorted((a, b) => b - a);
 }
 
 function isBun(): boolean {

--- a/src/model-catalog/normalize.ts
+++ b/src/model-catalog/normalize.ts
@@ -118,8 +118,16 @@ function normalizeModelCatalogTieredCost(value: unknown): ModelCatalogTieredCost
     ) {
       continue;
     }
-    const rangeValues = entry.range.map((rangeValue) => normalizeNonNegativeNumber(rangeValue));
-    if (rangeValues.some((rangeValue) => rangeValue === undefined)) {
+    const rangeValues: number[] = [];
+    for (const rangeValue of entry.range) {
+      const normalizedRangeValue = normalizeNonNegativeNumber(rangeValue);
+      if (normalizedRangeValue === undefined) {
+        rangeValues.length = 0;
+        break;
+      }
+      rangeValues.push(normalizedRangeValue);
+    }
+    if (rangeValues.length === 0) {
       continue;
     }
     normalized.push({
@@ -203,11 +211,14 @@ function normalizeModelCatalogCompat(value: unknown): ModelCompatConfig | undefi
   }
 
   if (isRecord(value.reasoningEffortMap)) {
-    const reasoningEffortMap = Object.fromEntries(
-      Object.entries(value.reasoningEffortMap)
-        .map(([key, mapped]) => [key.trim(), typeof mapped === "string" ? mapped.trim() : ""])
-        .filter(([key, mapped]) => key.length > 0 && mapped.length > 0),
-    );
+    const reasoningEffortMap: Record<string, string> = {};
+    for (const [rawKey, mapped] of Object.entries(value.reasoningEffortMap)) {
+      const key = rawKey.trim();
+      const mappedValue = typeof mapped === "string" ? mapped.trim() : "";
+      if (key && mappedValue) {
+        reasoningEffortMap[key] = mappedValue;
+      }
+    }
     if (Object.keys(reasoningEffortMap).length > 0) {
       compat.reasoningEffortMap = reasoningEffortMap;
     }
@@ -285,11 +296,15 @@ function normalizeModelCatalogProvider(value: unknown): ModelCatalogProvider | u
   if (!isRecord(value)) {
     return undefined;
   }
-  const models = Array.isArray(value.models)
-    ? value.models
-        .map((entry) => normalizeModelCatalogModel(entry))
-        .filter((entry): entry is ModelCatalogModel => Boolean(entry))
-    : [];
+  const models: ModelCatalogModel[] = [];
+  if (Array.isArray(value.models)) {
+    for (const entry of value.models) {
+      const model = normalizeModelCatalogModel(entry);
+      if (model) {
+        models.push(model);
+      }
+    }
+  }
   if (models.length === 0) {
     return undefined;
   }
@@ -371,12 +386,14 @@ function normalizeModelCatalogSuppressions(value: unknown): ModelCatalogSuppress
     }
     const reason = normalizeOptionalString(entry.reason) ?? "";
     const rawWhen = isRecord(entry.when) ? entry.when : undefined;
-    const baseUrlHosts = normalizeTrimmedStringList(rawWhen?.baseUrlHosts).map((host) =>
-      host.toLowerCase(),
-    );
-    const providerConfigApiIn = normalizeTrimmedStringList(rawWhen?.providerConfigApiIn).map(
-      (api) => api.toLowerCase(),
-    );
+    const baseUrlHosts = normalizeTrimmedStringList(rawWhen?.baseUrlHosts);
+    for (let index = 0; index < baseUrlHosts.length; index += 1) {
+      baseUrlHosts[index] = baseUrlHosts[index]?.toLowerCase() ?? "";
+    }
+    const providerConfigApiIn = normalizeTrimmedStringList(rawWhen?.providerConfigApiIn);
+    for (let index = 0; index < providerConfigApiIn.length; index += 1) {
+      providerConfigApiIn[index] = providerConfigApiIn[index]?.toLowerCase() ?? "";
+    }
     const when =
       baseUrlHosts.length > 0 || providerConfigApiIn.length > 0
         ? {

--- a/src/model-catalog/provider-index/normalize.ts
+++ b/src/model-catalog/provider-index/normalize.ts
@@ -94,11 +94,13 @@ function normalizePreviewCatalog(params: {
 function normalizeOnboardingScopes(
   value: unknown,
 ): OpenClawProviderIndexProviderAuthChoice["onboardingScopes"] | undefined {
-  const scopes = normalizeTrimmedStringList(value).filter(
-    (scope): scope is "text-inference" | "image-generation" =>
-      scope === "text-inference" || scope === "image-generation",
-  );
-  return scopes.length > 0 ? [...new Set(scopes)] : undefined;
+  const scopes = new Set<"text-inference" | "image-generation">();
+  for (const scope of normalizeTrimmedStringList(value)) {
+    if (scope === "text-inference" || scope === "image-generation") {
+      scopes.add(scope);
+    }
+  }
+  return scopes.size > 0 ? Array.from(scopes) : undefined;
 }
 
 function normalizeAssistantVisibility(
@@ -162,9 +164,13 @@ function normalizeAuthChoices(params: {
   if (!Array.isArray(params.value)) {
     return undefined;
   }
-  const choices = params.value
-    .map((value) => normalizeAuthChoice({ ...params, value }))
-    .filter((choice): choice is OpenClawProviderIndexProviderAuthChoice => Boolean(choice));
+  const choices: OpenClawProviderIndexProviderAuthChoice[] = [];
+  for (const value of params.value) {
+    const choice = normalizeAuthChoice({ ...params, value });
+    if (choice) {
+      choices.push(choice);
+    }
+  }
   return choices.length > 0 ? choices : undefined;
 }
 

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -17,9 +17,14 @@ function normalizeRequiredPluginIds(ids?: readonly string[]): string[] | undefin
   if (ids === undefined) {
     return undefined;
   }
-  return [...new Set(ids.map((id) => id.trim()).filter(Boolean))].toSorted((left, right) =>
-    left.localeCompare(right),
-  );
+  const normalized = new Set<string>();
+  for (const id of ids) {
+    const trimmed = id.trim();
+    if (trimmed) {
+      normalized.add(trimmed);
+    }
+  }
+  return [...normalized].toSorted((left, right) => left.localeCompare(right));
 }
 
 function registryContainsPluginIds(

--- a/src/plugins/bundled-compat.ts
+++ b/src/plugins/bundled-compat.ts
@@ -15,7 +15,13 @@ export function withBundledPluginAllowlistCompat(params: {
     return params.config;
   }
 
-  const allowSet = new Set(allow.map((entry) => entry.trim()).filter(Boolean));
+  const allowSet = new Set<string>();
+  for (const entry of allow) {
+    const trimmed = entry.trim();
+    if (trimmed) {
+      allowSet.add(trimmed);
+    }
+  }
   let changed = false;
   for (const pluginId of params.pluginIds) {
     if (!allowSet.has(pluginId)) {

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -109,21 +109,25 @@ function resolveCapabilityPluginIds(params: {
       value: params.providerId,
     }),
   );
+  const runtimePluginIds: string[] = [];
+  const bundledCompatPluginIds: string[] = [];
+  for (const plugin of contractPlugins) {
+    if (
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: params.cfg,
+      })
+    ) {
+      runtimePluginIds.push(plugin.id);
+    }
+    if (plugin.origin === "bundled") {
+      bundledCompatPluginIds.push(plugin.id);
+    }
+  }
   return {
-    runtimePluginIds: uniqueSorted(
-      contractPlugins
-        .filter((plugin) =>
-          isManifestPluginAvailableForControlPlane({
-            snapshot,
-            plugin,
-            config: params.cfg,
-          }),
-        )
-        .map((plugin) => plugin.id),
-    ),
-    bundledCompatPluginIds: uniqueSorted(
-      contractPlugins.filter((plugin) => plugin.origin === "bundled").map((plugin) => plugin.id),
-    ),
+    runtimePluginIds: uniqueSorted(runtimePluginIds),
+    bundledCompatPluginIds: uniqueSorted(bundledCompatPluginIds),
   };
 }
 
@@ -156,11 +160,13 @@ export function resolveBundledCapabilityProviderIds(params: {
 }): string[] {
   const contractKey = CAPABILITY_CONTRACT_KEY[params.key];
   const snapshot = loadCapabilityManifestSnapshot(params);
-  return uniqueSorted(
-    snapshot.plugins.flatMap((plugin) =>
-      plugin.origin === "bundled" ? (plugin.contracts?.[contractKey] ?? []) : [],
-    ),
-  );
+  const providerIds: string[] = [];
+  for (const plugin of snapshot.plugins) {
+    if (plugin.origin === "bundled") {
+      providerIds.push(...(plugin.contracts?.[contractKey] ?? []));
+    }
+  }
+  return uniqueSorted(providerIds);
 }
 
 function resolveCapabilityProviderConfig(params: {

--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -108,15 +108,25 @@ export function resolvePluginConfigContractsById(params: {
   pluginIds: readonly string[];
 }): ReadonlyMap<string, PluginConfigContractMetadata> {
   const matches = new Map<string, PluginConfigContractMetadata>();
-  const pluginIds = [
-    ...new Set(params.pluginIds.map((pluginId) => pluginId.trim()).filter(Boolean)),
-  ];
+  const pluginIds = [];
+  const seenPluginIds = new Set<string>();
+  for (const pluginId of params.pluginIds) {
+    const trimmed = pluginId.trim();
+    if (trimmed && !seenPluginIds.has(trimmed)) {
+      seenPluginIds.add(trimmed);
+      pluginIds.push(trimmed);
+    }
+  }
   if (pluginIds.length === 0) {
     return matches;
   }
-  const fallbackBundledPluginIds = new Set(
-    (params.fallbackBundledPluginIds ?? []).map((pluginId) => pluginId.trim()).filter(Boolean),
-  );
+  const fallbackBundledPluginIds = new Set<string>();
+  for (const pluginId of params.fallbackBundledPluginIds ?? []) {
+    const trimmed = pluginId.trim();
+    if (trimmed) {
+      fallbackBundledPluginIds.add(trimmed);
+    }
+  }
   const bundledContractFallbacks = new Map<string, PluginManifestConfigContracts | undefined>();
   const findBundledConfigContracts = (
     pluginId: string,

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -312,7 +312,11 @@ export function listPluginDoctorLegacyConfigRules(params?: {
   env?: NodeJS.ProcessEnv;
   pluginIds?: readonly string[];
 }): LegacyConfigRule[] {
-  return resolvePluginDoctorContracts(params).flatMap((entry) => entry.rules);
+  const rules: LegacyConfigRule[] = [];
+  for (const entry of resolvePluginDoctorContracts(params)) {
+    rules.push(...entry.rules);
+  }
+  return rules;
 }
 
 export function listPluginDoctorSessionRouteStateOwners(params?: {

--- a/src/plugins/host-hook-cleanup.ts
+++ b/src/plugins/host-hook-cleanup.ts
@@ -465,9 +465,13 @@ function collectHostHookPluginIds(registry: PluginRegistry): Set<string> {
 }
 
 function collectLoadedPluginIds(registry: PluginRegistry): Set<string> {
-  return new Set(
-    registry.plugins.filter((plugin) => plugin.status === "loaded").map((plugin) => plugin.id),
-  );
+  const ids = new Set<string>();
+  for (const plugin of registry.plugins) {
+    if (plugin.status === "loaded") {
+      ids.add(plugin.id);
+    }
+  }
+  return ids;
 }
 
 function collectSchedulerJobIds(

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -25,9 +25,14 @@ function sortUnique(values: readonly string[] | undefined): readonly string[] {
   if (!values || values.length === 0) {
     return [];
   }
-  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).toSorted(
-    (left, right) => left.localeCompare(right),
-  );
+  const normalized = new Set<string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed) {
+      normalized.add(trimmed);
+    }
+  }
+  return Array.from(normalized).toSorted((left, right) => left.localeCompare(right));
 }
 
 function buildStartupInfo(record: PluginManifestRecord): InstalledPluginStartupInfo {

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -207,7 +207,10 @@ function hasPolicyRefreshTargets(
   if (!policyPluginIds || policyPluginIds.length === 0) {
     return true;
   }
-  const pluginIds = new Set(persisted.plugins.map((plugin) => plugin.pluginId));
+  const pluginIds = new Set<string>();
+  for (const plugin of persisted.plugins) {
+    pluginIds.add(plugin.pluginId);
+  }
   return policyPluginIds.every((pluginId) => pluginIds.has(pluginId));
 }
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1822,7 +1822,13 @@ export function resolvePackageExtensionEntries(
   if (!Array.isArray(raw)) {
     return { status: "missing", entries: [] };
   }
-  const entries = raw.map((entry) => normalizeOptionalString(entry) ?? "").filter(Boolean);
+  const entries: string[] = [];
+  for (const entry of raw) {
+    const normalized = normalizeOptionalString(entry);
+    if (normalized) {
+      entries.push(normalized);
+    }
+  }
   if (entries.length === 0) {
     return { status: "empty", entries: [] };
   }

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -219,10 +219,12 @@ export function buildMemoryPromptSection(params: {
   const primary = normalizeMemoryPromptLines(
     memoryPluginState.capability?.capability.promptBuilder?.(params) ?? [],
   );
-  const supplements = memoryPluginState.promptSupplements
+  const supplements: string[] = [];
+  for (const registration of memoryPluginState.promptSupplements
     // Keep supplement order stable even if plugin registration order changes.
-    .toSorted((left, right) => left.pluginId.localeCompare(right.pluginId))
-    .flatMap((registration) => normalizeMemoryPromptLines(registration.builder(params)));
+    .toSorted((left, right) => left.pluginId.localeCompare(right.pluginId))) {
+    supplements.push(...normalizeMemoryPromptLines(registration.builder(params)));
+  }
   return [...primary, ...supplements];
 }
 

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -103,9 +103,14 @@ function normalizeContributionId(value: string): string {
 }
 
 function sortUnique(values: Iterable<string>): string[] {
-  return [...new Set([...values].map((value) => value.trim()).filter(Boolean))].toSorted(
-    (left, right) => left.localeCompare(right),
-  );
+  const normalized = new Set<string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed) {
+      normalized.add(trimmed);
+    }
+  }
+  return Array.from(normalized).toSorted((left, right) => left.localeCompare(right));
 }
 
 function collectObjectKeys(value: Record<string, unknown> | undefined): readonly string[] {
@@ -117,9 +122,13 @@ function collectContractKeys(plugin: PluginManifestRecord): readonly string[] {
   if (!contracts) {
     return [];
   }
-  return Object.entries(contracts).flatMap(([key, value]) =>
-    Array.isArray(value) && value.length > 0 ? [key] : [],
-  );
+  const keys: string[] = [];
+  for (const [key, value] of Object.entries(contracts)) {
+    if (Array.isArray(value) && value.length > 0) {
+      keys.push(key);
+    }
+  }
+  return keys;
 }
 
 function listManifestContractValues(
@@ -298,9 +307,11 @@ export function listPluginContributionIds(
 ): readonly string[] {
   const index = params.lookUpTable?.index ?? loadPluginRegistrySnapshot(params);
   const plugins = listContributionManifestPlugins({ ...params, index });
-  return sortUnique(
-    plugins.flatMap((plugin) => listManifestContributionIds(plugin, params.contribution)),
-  );
+  const ids: string[] = [];
+  for (const plugin of plugins) {
+    ids.push(...listManifestContributionIds(plugin, params.contribution));
+  }
+  return sortUnique(ids);
 }
 
 export function resolvePluginContributionOwners(
@@ -325,11 +336,13 @@ export function resolvePluginContributionOwners(
       ? (contributionId: string) => contributionId === params.matches
       : params.matches;
   const plugins = listContributionManifestPlugins({ ...params, index });
-  return sortUnique(
-    plugins.flatMap((plugin) =>
-      listManifestContributionIds(plugin, params.contribution).some(matcher) ? [plugin.id] : [],
-    ),
-  );
+  const owners: string[] = [];
+  for (const plugin of plugins) {
+    if (listManifestContributionIds(plugin, params.contribution).some(matcher)) {
+      owners.push(plugin.id);
+    }
+  }
+  return sortUnique(owners);
 }
 
 export function resolveProviderOwners(params: ResolveProviderOwnersParams): readonly string[] {

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -37,59 +37,63 @@ function resolveExplicitProviderOwnerPluginIds(params: {
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
 }): string[] {
-  return dedupeSortedPluginIds(
-    params.providerRefs.flatMap((provider) => {
-      const plannedPluginIds = resolveManifestActivationPluginIds({
+  const pluginIds: string[] = [];
+  for (const provider of params.providerRefs) {
+    const plannedPluginIds = resolveManifestActivationPluginIds({
+      trigger: {
+        kind: "provider",
+        provider,
+      },
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+    });
+    if (plannedPluginIds.length > 0) {
+      pluginIds.push(...plannedPluginIds);
+      continue;
+    }
+    const apiOwnerHint = resolveProviderConfigApiOwnerHint({
+      provider,
+      config: params.config,
+    });
+    if (apiOwnerHint) {
+      const apiOwnerPluginIds = resolveManifestActivationPluginIds({
         trigger: {
           kind: "provider",
-          provider,
+          provider: apiOwnerHint,
         },
         config: params.config,
         workspaceDir: params.workspaceDir,
         env: params.env,
       });
-      if (plannedPluginIds.length > 0) {
-        return plannedPluginIds;
+      if (apiOwnerPluginIds.length > 0) {
+        pluginIds.push(...apiOwnerPluginIds);
+        continue;
       }
-      const apiOwnerHint = resolveProviderConfigApiOwnerHint({
-        provider,
+      const legacyApiOwnerPluginIds = resolveOwningPluginIdsForProvider({
+        provider: apiOwnerHint,
         config: params.config,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
       });
-      if (apiOwnerHint) {
-        const apiOwnerPluginIds = resolveManifestActivationPluginIds({
-          trigger: {
-            kind: "provider",
-            provider: apiOwnerHint,
-          },
-          config: params.config,
-          workspaceDir: params.workspaceDir,
-          env: params.env,
-        });
-        if (apiOwnerPluginIds.length > 0) {
-          return apiOwnerPluginIds;
-        }
-        const legacyApiOwnerPluginIds = resolveOwningPluginIdsForProvider({
-          provider: apiOwnerHint,
-          config: params.config,
-          workspaceDir: params.workspaceDir,
-          env: params.env,
-        });
-        if (legacyApiOwnerPluginIds?.length) {
-          return legacyApiOwnerPluginIds;
-        }
+      if (legacyApiOwnerPluginIds?.length) {
+        pluginIds.push(...legacyApiOwnerPluginIds);
+        continue;
       }
-      // Keep legacy provider/CLI-backend ownership working until every owner is
-      // expressible through activation descriptors.
-      return (
-        resolveOwningPluginIdsForProvider({
-          provider,
-          config: params.config,
-          workspaceDir: params.workspaceDir,
-          env: params.env,
-        }) ?? []
-      );
-    }),
-  );
+    }
+    // Keep legacy provider/CLI-backend ownership working until every owner is
+    // expressible through activation descriptors.
+    const legacyPluginIds = resolveOwningPluginIdsForProvider({
+      provider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+    });
+    if (legacyPluginIds?.length) {
+      pluginIds.push(...legacyPluginIds);
+    }
+  }
+  return dedupeSortedPluginIds(pluginIds);
 }
 
 function mergeExplicitOwnerPluginIds(

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -583,8 +583,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     config: OpenClawPluginApi["config"],
     pluginConfig: unknown,
   ) => {
+    const normalizedEvents: string[] = [];
     const eventList = Array.isArray(events) ? events : [events];
-    const normalizedEvents = eventList.map((event) => event.trim()).filter(Boolean);
+    for (const event of eventList) {
+      const trimmed = event.trim();
+      if (trimmed) {
+        normalizedEvents.push(trimmed);
+      }
+    }
     const entry = opts?.entry ?? null;
     const hookName = requireRegistrationValue(
       entry?.hook.name ?? opts?.name?.trim(),
@@ -1332,8 +1338,16 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   ]);
 
   const registerReload = (record: PluginRecord, registration: OpenClawPluginReloadRegistration) => {
-    const normalize = (values?: string[]) =>
-      (values ?? []).map((value) => value.trim()).filter(Boolean);
+    const normalize = (values?: string[]) => {
+      const normalized: string[] = [];
+      for (const value of values ?? []) {
+        const trimmed = value.trim();
+        if (trimmed) {
+          normalized.push(trimmed);
+        }
+      }
+      return normalized;
+    };
     const normalized: OpenClawPluginReloadRegistration = {
       restartPrefixes: normalize(registration.restartPrefixes),
       hotPrefixes: normalize(registration.hotPrefixes),
@@ -1414,9 +1428,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     policy: OpenClawPluginNodeInvokePolicy,
     pluginConfig?: Record<string, unknown>,
   ) => {
-    const commands = Array.isArray(policy.commands)
-      ? policy.commands.map((command) => command.trim()).filter(Boolean)
-      : [];
+    const commands: string[] = [];
+    if (Array.isArray(policy.commands)) {
+      for (const command of policy.commands) {
+        const trimmed = command.trim();
+        if (trimmed) {
+          commands.push(trimmed);
+        }
+      }
+    }
     if (commands.length === 0) {
       pushDiagnostic({
         level: "error",

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -50,9 +50,12 @@ function activeRegistrySatisfiesScope(
     if (requestedPluginIds.length === 0) {
       return false;
     }
-    const activePluginIds = new Set(
-      active.plugins.filter((plugin) => plugin.status === "loaded").map((plugin) => plugin.id),
-    );
+    const activePluginIds = new Set<string>();
+    for (const plugin of active.plugins) {
+      if (plugin.status === "loaded") {
+        activePluginIds.add(plugin.id);
+      }
+    }
     return requestedPluginIds.every((pluginId) => activePluginIds.has(pluginId));
   }
   const activeChannelPluginIds = new Set(active.channels.map((entry) => entry.plugin.id));

--- a/src/plugins/setup-registry.runtime.ts
+++ b/src/plugins/setup-registry.runtime.ts
@@ -87,18 +87,24 @@ function resolveBundledSetupCliBackends(
   ) {
     return cachedBundledSetupCliBackends.entries;
   }
-  const entries = snapshot.plugins.flatMap((plugin) => {
+  const entries: SetupCliBackendRuntimeEntry[] = [];
+  for (const plugin of snapshot.plugins) {
     if (plugin.origin !== "bundled" || !isInstalledPluginEnabled(snapshot.index, plugin.id)) {
-      return [];
+      continue;
     }
-    return [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])].map(
-      (backendId) =>
-        ({
-          pluginId: plugin.id,
-          backend: { id: backendId },
-        }) satisfies SetupCliBackendRuntimeEntry,
-    );
-  });
+    for (const backendId of plugin.cliBackends) {
+      entries.push({
+        pluginId: plugin.id,
+        backend: { id: backendId },
+      });
+    }
+    for (const backendId of plugin.setup?.cliBackends ?? []) {
+      entries.push({
+        pluginId: plugin.id,
+        backend: { id: backendId },
+      });
+    }
+  }
   if (cacheable && configFingerprint) {
     cachedBundledSetupCliBackends = { configFingerprint, entries };
   }

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -420,9 +420,16 @@ export function resolvePluginSetupRegistry(params?: {
   manifestRegistry?: PluginManifestRegistry;
 }): PluginSetupRegistry {
   const env = params?.env ?? process.env;
-  const scopedPluginIds = params?.pluginIds
-    ? new Set(params.pluginIds.map((pluginId) => pluginId.trim()).filter(Boolean))
-    : null;
+  let scopedPluginIds: Set<string> | null = null;
+  if (params?.pluginIds) {
+    scopedPluginIds = new Set<string>();
+    for (const pluginId of params.pluginIds) {
+      const trimmed = pluginId.trim();
+      if (trimmed) {
+        scopedPluginIds.add(trimmed);
+      }
+    }
+  }
   if (scopedPluginIds && scopedPluginIds.size === 0) {
     const empty = {
       providers: [],

--- a/src/plugins/status-dependencies.ts
+++ b/src/plugins/status-dependencies.ts
@@ -119,10 +119,18 @@ export function buildPluginDependencyStatus(params: {
     dependencies: params.optionalDependencies ?? {},
     optional: true,
   });
-  const missing = dependencies.filter((entry) => !entry.installed).map((entry) => entry.name);
-  const missingOptional = optionalDependencies
-    .filter((entry) => !entry.installed)
-    .map((entry) => entry.name);
+  const missing: string[] = [];
+  for (const entry of dependencies) {
+    if (!entry.installed) {
+      missing.push(entry.name);
+    }
+  }
+  const missingOptional: string[] = [];
+  for (const entry of optionalDependencies) {
+    if (!entry.installed) {
+      missingOptional.push(entry.name);
+    }
+  }
   const requiredInstalled = missing.length === 0;
   const optionalInstalled = missingOptional.length === 0;
   return {

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -583,7 +583,11 @@ export function buildPluginCompatibilityNotices(params?: {
   logger?: PluginLogger;
   report?: PluginStatusReport;
 }): PluginCompatibilityNotice[] {
-  return buildAllPluginInspectReports(params).flatMap((inspect) => inspect.compatibility);
+  const notices: PluginCompatibilityNotice[] = [];
+  for (const inspect of buildAllPluginInspectReports(params)) {
+    notices.push(...inspect.compatibility);
+  }
+  return notices;
 }
 
 export function buildPluginCompatibilitySnapshotNotices(params?: {
@@ -605,8 +609,12 @@ export function formatPluginCompatibilityNotice(notice: PluginCompatibilityNotic
 export function summarizePluginCompatibility(
   notices: PluginCompatibilityNotice[],
 ): PluginCompatibilitySummary {
+  const pluginIds = new Set<string>();
+  for (const notice of notices) {
+    pluginIds.add(notice.pluginId);
+  }
   return {
     noticeCount: notices.length,
-    pluginCount: new Set(notices.map((notice) => notice.pluginId)).size,
+    pluginCount: pluginIds.size,
   };
 }

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -84,7 +84,14 @@ export function buildPluginToolMetadataKey(pluginId: string, toolName: string): 
 }
 
 function normalizeAllowlist(list?: string[]) {
-  return new Set((list ?? []).map(normalizeToolName).filter(Boolean));
+  const normalized = new Set<string>();
+  for (const entry of list ?? []) {
+    const toolName = normalizeToolName(entry);
+    if (toolName) {
+      normalized.add(toolName);
+    }
+  }
+  return normalized;
 }
 
 function normalizeDenylist(list?: string[]) {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -245,7 +245,13 @@ function resolveRecordedExtensionsDir(params: {
 
 function buildLoadPathHelpers(existing: string[], env: NodeJS.ProcessEnv = process.env) {
   let paths = [...existing];
-  const resolveSet = () => new Set(paths.map((entry) => resolveUserPath(entry, env)));
+  const resolveSet = () => {
+    const resolvedPaths = new Set<string>();
+    for (const entry of paths) {
+      resolvedPaths.add(resolveUserPath(entry, env));
+    }
+    return resolvedPaths;
+  };
   let resolved = resolveSet();
   let changed = false;
 


### PR DESCRIPTION
## Summary

- Replays the catalog/plugin/setup normalization bucket onto current `main`.
- Keeps the catalog/setup, plugin control-plane, setup formatter, channel catalog, and plugin helper rewrites.
- Intentionally omits the stale package-entry-resolution hunk from the old source branch because current `main` now rejects invalid `openclaw.runtimeExtensions` entries with indexed errors.
- Fixes the replay regression in the browser CDP role tree helper.
- Carries small rebase/CI fixture adjustments that are still needed on this branch: explicit Canvas node-policy setup in gateway tests and a UI startup wait.

## High-risk areas

- Plugin registry/control-plane/provider runtime/status/setup helpers are public plugin lifecycle surfaces; third-party plugin compatibility is the main review risk.
- Channel catalog/account snapshot/allowlist/turn-context helper rewrites can affect visible catalog ordering, prompt/context bytes, and setup/status behavior.
- Discord, Mattermost, Slack, and Telegram setup formatter rewrites are user-visible text/status surfaces.
- Tool allowlist/policy and plugin helper normalization touches prompt/tool exposure paths; prompt snapshots were previously checked before those snapshot changes landed on `main`.

## Verification

- `pnpm test:channels`
- `pnpm test:extension extensions/slack`
- `pnpm test:extension extensions/discord`
- `pnpm test:extension extensions/mattermost`
- `pnpm test:extension extensions/telegram`
- `pnpm test:extension extensions/browser`
- `pnpm test:extension extensions/qa-lab`
- `pnpm test:extension extensions/canvas`
- `pnpm test:serial src/secrets/target-registry.docs.test.ts`
- `pnpm test:serial src/config/config.allowlist-requires-allowfrom.test.ts extensions/bluebubbles/src/setup-surface.test.ts`
- `pnpm test:serial extensions/canvas/scripts/copy-a2ui.test.ts`
- `pnpm check:test-types`
- `pnpm test:serial src/gateway/server.node-pairing-authz.test.ts src/gateway/server.roles-allowlist-update.test.ts`
- `pnpm prompt:snapshots:check`
- `pnpm tsgo:core:test`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
- `pnpm test:serial src/plugins/plugin-registry.test.ts src/plugins/status.test.ts src/plugins/provider-catalog.test.ts src/plugins/setup-registry.test.ts src/plugins/runtime/runtime-registry-loader.test.ts src/plugins/capability-provider-runtime.test.ts src/plugins/installed-plugin-index-store.test.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/provider-registry-shared.test.ts src/plugins/update.test.ts src/plugins/config-contracts.test.ts src/channels/account-snapshot-fields.test.ts src/channels/allowlist-match.test.ts src/channels/bundled-channel-catalog-read.test.ts src/channels/turn/context.test.ts src/channels/plugins/catalog.test.ts src/channels/plugins/account-helpers.test.ts src/channels/plugins/registry.test.ts src/model-catalog/normalize.test.ts src/model-catalog/provider-index/normalize.test.ts extensions/slack/src/setup-surface.test.ts extensions/slack/src/monitor/events/interactions.test.ts extensions/slack/src/channel-actions-setup-status.contract.test.ts extensions/discord/src/setup-surface.test.ts extensions/discord/src/status-issues.test.ts extensions/mattermost/src/setup.test.ts extensions/mattermost/src/channel.test.ts extensions/mattermost/src/channel-actions-setup-status.contract.test.ts extensions/telegram/src/doctor.test.ts extensions/telegram/src/setup-surface.test.ts extensions/telegram/src/status.test.ts`
- Clean rebase sanity after the final remote-main rebase: `git status --short`, `git diff --check origin/main...HEAD`, diff/stat review.

## Notes

- The old suggested directory command `pnpm test:serial src/plugins src/channels extensions/slack extensions/discord extensions/mattermost extensions/telegram` currently fails with a no-test shard under the Vitest project router, so this PR uses an explicit high-signal file list for the same surfaces.
- Testbox warmups were attempted for the broad gate, but capacity stayed queued; the final changed gate used the intentional local throttled escape hatch.
