### PR TITLE
docs: document local avatar file size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/agents: document the 2 MB limit for local workspace-relative avatar image files in the CLI and gateway agent config references. Fixes #65312.
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.
 - Discord/voice: keep TTS playback running when another user starts speaking, ignore new capture during playback to avoid feedback loops, and downgrade expected receive-stream aborts to verbose diagnostics.
 - Telegram: treat successful same-chat `message` tool outbound sends during an inbound telegram turn as delivered when deciding whether to emit the rewritten silent reply fallback (#78685). Thanks @neeravmakwana.

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -195,7 +195,6 @@ Avatar paths resolve relative to the workspace root.
 - `theme`
 - `emoji`
 - `avatar` (workspace-relative path, http(s) URL, or data URI)
-- Local workspace-relative avatar image files are limited to 2 MB. HTTP(S) URLs and `data:` URIs are not checked with the local file-size limit.
 
 Options:
 
@@ -213,6 +212,7 @@ Notes:
 
 - `--agent` or `--workspace` can be used to select the target agent.
 - If you rely on `--workspace` and multiple agents share that workspace, the command fails and asks you to pass `--agent`.
+- Local workspace-relative avatar image files are limited to 2 MB. HTTP(S) URLs and `data:` URIs are not checked with the local file-size limit.
 - When no explicit identity fields are provided, the command reads identity data from `IDENTITY.md`.
 
 Load from `IDENTITY.md`:

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -195,6 +195,7 @@ Avatar paths resolve relative to the workspace root.
 - `theme`
 - `emoji`
 - `avatar` (workspace-relative path, http(s) URL, or data URI)
+- Local workspace-relative avatar image files are limited to 2 MB. HTTP(S) URLs and `data:` URIs are not checked with the local file-size limit.
 
 Options:
 

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -174,6 +174,7 @@ Avatar paths resolve relative to the workspace root.
 - `theme`
 - `emoji`
 - `avatar` (workspace-relative path, http(s) URL, or data URI)
+- Local workspace-relative avatar image files are limited to 2 MB. HTTP(S) URLs and `data:` URIs are not checked with the local file-size limit.
 
 Options:
 

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1103,6 +1103,7 @@ for provider examples and precedence.
 - `models`: optional per-agent model catalog/runtime overrides keyed by full `provider/model` ids. Use `models["provider/model"].agentRuntime` for per-agent runtime exceptions.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
+- Local workspace-relative `identity.avatar` image files are limited to 2 MB. `http(s)` URLs and `data:` URIs are not checked with the local file-size limit.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of configured agent ids for explicit `sessions_spawn.agentId` targets (`["*"]` = any configured target; default: same agent only). Include the requester id when self-targeted `agentId` calls should be allowed. Stale entries whose agent config was deleted are rejected by `sessions_spawn` and omitted from `agents_list`; run `openclaw doctor --fix` to clean them up, or add a minimal `agents.list[]` entry if that target should remain spawnable while inheriting defaults.
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1009,6 +1009,7 @@ for provider examples and precedence.
 - `agentRuntime`: optional per-agent low-level runtime policy override. Use `{ id: "codex" }` to make one agent Codex-only while other agents keep the default PI fallback in `auto` mode.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
+- Local workspace-relative `identity.avatar` image files are limited to 2 MB. `http(s)` URLs and `data:` URIs are not checked with the local file-size limit.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for explicit `sessions_spawn.agentId` targets (`["*"]` = any; default: same agent only). Include the requester id when self-targeted `agentId` calls should be allowed.
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.


### PR DESCRIPTION
## Summary

- document the 2 MB limit for local workspace-relative agent avatar files in the CLI agent identity docs
- add the same scope note to the gateway agent config reference
- clarify that HTTP(S) URLs and `data:` URI avatars are not checked with the local file-size limit
- add an Unreleased changelog entry

## Real behavior proof

- **Behavior or issue addressed**: Docs now state that local workspace-relative agent avatar image files are limited to 2 MB, while HTTP(S) URLs and `data:` URI avatars are outside that local file-size check.
- **Real environment tested**: GitHub PR branch `wangjieweb3-design:docs-avatar-local-size-limit` against `openclaw/openclaw` `main`; source-linked docs output was read from the live GitHub branch after the patch.
- **Exact steps or command run after this patch**:

```bash
gh api repos/wangjieweb3-design/openclaw/contents/docs/cli/agents.md?ref=docs-avatar-local-size-limit --jq .content | base64 --decode | sed -n 170,182p
gh api repos/wangjieweb3-design/openclaw/contents/docs/gateway/config-agents.md?ref=docs-avatar-local-size-limit --jq .content | base64 --decode | sed -n 1008,1016p
curl -fsSL https://raw.githubusercontent.com/wangjieweb3-design/openclaw/docs-avatar-local-size-limit/CHANGELOG.md | sed -n 1,14p
```

- **Evidence after fix**: Terminal output from the live branch shows the new CLI docs line:

```text
- `avatar` (workspace-relative path, http(s) URL, or data URI)
- Local workspace-relative avatar image files are limited to 2 MB. HTTP(S) URLs and `data:` URIs are not checked with the local file-size limit.
```

  Terminal output from the live branch shows the new gateway config line:

```text
- `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
- Local workspace-relative `identity.avatar` image files are limited to 2 MB. `http(s)` URLs and `data:` URIs are not checked with the local file-size limit.
```

  Terminal output from the live branch shows the changelog entry:

```text
- Docs/agents: document the 2 MB limit for local workspace-relative avatar image files in the CLI and gateway agent config references. Fixes #65312.
```

- **Observed result after fix**: The CLI docs, gateway config docs, and changelog all include the local-avatar 2 MB documentation. `check-docs` passed in GitHub Actions on this PR.
- **What was not tested**: I did not run a local OpenClaw gateway because this is a docs-only clarification of existing source behavior.

## Verification

- Checked generated patch shape against upstream `main`: 3 files, 3 added lines.
- Checked changed content for trailing whitespace during branch generation.
- GitHub Actions `check-docs`: passed.
- Not run locally: `pnpm exec oxfmt --check --threads=1 docs/cli/agents.md docs/gateway/config-agents.md CHANGELOG.md` because the local sparse checkout could not hydrate these blobs reliably.

Fixes #65312