### PR TITLE
Talk: add additive sendVideoFrame/videoConfig seam for realtime voice plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/hooks: add a `before_agent_run` pass/block gate that can stop a user prompt before model submission while preserving a redacted transcript entry for the user, and clarify that raw conversation hooks require `hooks.allowConversationAccess=true`. (#75035) Thanks @jesse-merhi.
 - Config/Nix: keep startup-derived plugin enablement, gateway auth tokens, control UI origins, and owner-display secrets runtime-only instead of rewriting `openclaw.json`; in Nix mode, config writers, mutating `openclaw update`, plugin lifecycle mutators, and doctor repair/token-generation now refuse with agent-first nix-openclaw guidance. (#78047) Thanks @joshp123.
 - Agents/context engine: invalidate cached assembled context views when source history shrinks or assembly fails, preventing stale pre-reset history from being reused. Fixes #77968. (#78163) Thanks @brokemac79 and @ChrisBot2026.
+- Talk/voice: add an additive optional `sendVideoFrame` seam plus a `videoConfig` create-request hint and matching `RealtimeVoiceVideoFrameMimeType` / `RealtimeVoiceVideoFrameOptions` / `RealtimeVoiceVideoConfig` types on the public Plugin SDK so realtime voice provider plugins can stream periodic still frames alongside audio when the existing `supportsVideoFrames` capability flag is set, without requiring any change in providers that do not opt in.
 
 ### Fixes
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a2a671522a9855594b011c86425911f2297e756c666f4ceb1cc453f613983725  plugin-sdk-api-baseline.json
-b939b18ab3cbd21f338fe2a7cd8783b612c0956e79831d66dae4a49f9ba85014  plugin-sdk-api-baseline.jsonl
+e39cd211e5a7b393fa8de142b6de22863a69e699bd1f394568a9543cff1d90f7  plugin-sdk-api-baseline.json
+bc504c7d934775819a184e5cb6e902e6f1508415cf6316901b2baddf6f1a9320  plugin-sdk-api-baseline.jsonl

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -18,6 +18,9 @@ export type {
   RealtimeVoiceTool,
   RealtimeVoiceToolCallEvent,
   RealtimeVoiceToolResultOptions,
+  RealtimeVoiceVideoConfig,
+  RealtimeVoiceVideoFrameMimeType,
+  RealtimeVoiceVideoFrameOptions,
 } from "../talk/provider-types.js";
 export {
   REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -94,12 +94,25 @@ export type RealtimeVoiceProviderConfiguredContext = {
   providerConfig: RealtimeVoiceProviderConfig;
 };
 
+export type RealtimeVoiceVideoFrameMimeType = "image/jpeg" | "image/png" | "image/webp";
+
+export type RealtimeVoiceVideoFrameOptions = {
+  mimeType?: RealtimeVoiceVideoFrameMimeType;
+  captureTimestampMs?: number;
+};
+
+export type RealtimeVoiceVideoConfig = {
+  mimeType?: RealtimeVoiceVideoFrameMimeType;
+  fps?: number;
+};
+
 export type RealtimeVoiceBridgeCreateRequest = RealtimeVoiceBridgeCallbacks & {
   providerConfig: RealtimeVoiceProviderConfig;
   audioFormat?: RealtimeVoiceAudioFormat;
   instructions?: string;
   autoRespondToAudio?: boolean;
   tools?: RealtimeVoiceTool[];
+  videoConfig?: RealtimeVoiceVideoConfig;
 };
 
 export type RealtimeVoiceBrowserSessionCreateRequest = {
@@ -171,6 +184,7 @@ export type RealtimeVoiceBridge = {
   supportsToolResultContinuation?: boolean;
   connect(): Promise<void>;
   sendAudio(audio: Buffer): void;
+  sendVideoFrame?(frame: Buffer, options?: RealtimeVoiceVideoFrameOptions): void;
   setMediaTimestamp(ts: number): void;
   sendUserMessage?(text: string): void;
   triggerGreeting?(instructions?: string): void;


### PR DESCRIPTION
## Summary

Adds an additive, opt-in video-frame seam to the realtime voice provider contract on the public Plugin SDK so a realtime voice provider plugin can stream periodic still frames alongside audio when the existing `supportsVideoFrames` capability flag is set. Pure additive, fully backwards-compatible: providers that do not opt in see no behavior change.

This replaces the closed #78810 (which targeted the now-removed `src/realtime-voice/provider-types.ts`); the seam is now applied to the post-rename `src/talk/provider-types.ts` path.

## Changes

- `src/talk/provider-types.ts`:
  - Add `RealtimeVoiceVideoFrameMimeType = "image/jpeg" | "image/png" | "image/webp"`.
  - Add `RealtimeVoiceVideoFrameOptions { mimeType?, captureTimestampMs? }`.
  - Add `RealtimeVoiceVideoConfig { mimeType?, fps? }`.
  - Add optional `sendVideoFrame?(frame: Buffer, options?: RealtimeVoiceVideoFrameOptions): void` to `RealtimeVoiceBridge`.
  - Add optional `videoConfig?: RealtimeVoiceVideoConfig` to `RealtimeVoiceBridgeCreateRequest`.
- `src/plugin-sdk/realtime-voice.ts`:
  - Re-export the three new public types so plugin authors consume them through `openclaw/plugin-sdk/realtime-voice`.
- `docs/.generated/plugin-sdk-api-baseline.sha256`:
  - Regenerated via `pnpm plugin-sdk:api:gen`.
- `CHANGELOG.md`:
  - Unreleased / Changes entry under the existing block.

The capability flag `supportsVideoFrames?: boolean` on `RealtimeVoiceProviderCapabilities` already exists in main and is wired through gateway protocol/server-methods; this PR only adds the runtime seam that bridges register to actually deliver frames.

## Boundary notes

- Strictly additive on the public contract: no removed/renamed exports, no required-field changes.
- Both the bridge method and the create-request hint are optional, so existing audio-only providers compile unchanged.
- The new types are re-exported through the existing `src/plugin-sdk/realtime-voice.ts` facade — no new public subpath, no new SDK entrypoint.
- No core code currently calls `sendVideoFrame`; consumer wiring lands in a follow-up PR (callers gated on `capabilities.supportsVideoFrames === true`).

## Real behavior proof

The seam was validated end-to-end against a third-party `jina-live` realtime voice provider plugin (private repo) running on an installed gateway:

- Provider sets `capabilities.supportsVideoFrames = true` and implements `sendVideoFrame` (Gemini Live BidiGenerateContent inline image part, JPEG, 1 fps).
- Gateway logs after a live test:
  - `[jina-live] setupComplete model=models/gemini-2.5-flash-native-audio-latest`
  - `[onAudio frame #1 bytes=7680]` (assistant audio frames flowing back over the bridge as before)
  - Korean transcript: `"안녕하세요, 대현님! 지나예요 🌸"`
- Audio path (sendAudio + onAudio) and tool-call path are unchanged; only the new optional video path is exercised when the provider opts in.

## Verification

- `pnpm plugin-sdk:api:gen` then `pnpm plugin-sdk:api:check` → OK (baseline hash committed).
- `pnpm tsgo` produces no errors against the changed files (`src/talk/provider-types.ts`, `src/plugin-sdk/realtime-voice.ts`); other tsgo errors visible locally are pre-existing in unrelated areas (`src/media/**`, `src/plugins/**`, `src/secrets/**`, `src/plugin-sdk/{browser-trash,file-lock}.ts` workspace dep resolution).
- No build/lazy-loading topology change: only types added.

## Test plan

- [x] Plugin SDK API baseline regenerated and committed.
- [x] Existing realtime voice provider plugins continue to compile without implementing `sendVideoFrame`.
- [x] Third-party plugin can register a provider that sets `supportsVideoFrames: true` and implements `sendVideoFrame` and have audio + transcript continue to work (verified live).