### PR TITLE
fix(qqbot): preserve session on RECONNECT(7) to enable RESUME instead of IDENTIFY

### DIFF
--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -59,6 +59,8 @@ export class GatewayConnection {
   private isConnecting = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private shouldRefreshToken = false;
+  /** When true, the close event was triggered by a RECONNECT(7) and should not clear the session. */
+  private isReconnectInitiated = false;
 
   private readonly reconnect: ReconnectState;
   private readonly msgQueue;
@@ -263,6 +265,7 @@ export class GatewayConnection {
               break;
 
             case GatewayOp.RECONNECT:
+              this.isReconnectInitiated = true;
               this.cleanup();
               this.scheduleReconnect();
               break;
@@ -289,6 +292,13 @@ export class GatewayConnection {
       ws.on("close", (code, reason) => {
         log?.info(`WebSocket closed: ${code} ${reason.toString()}`);
         this.isConnecting = false;
+        // When RECONNECT(7) triggers cleanup(), the server responds with 4009.
+        // We must not clear the session so we can RESUME on the next connection.
+        if (this.isReconnectInitiated) {
+          this.isReconnectInitiated = false;
+          log?.debug?.(`Close from RECONNECT(7), preserving session for RESUME`);
+          return;
+        }
         this.handleClose(code);
       });
 


### PR DESCRIPTION
## Summary

Fixes #78890

When the QQ Bot server sends `RECONNECT` (opcode 7), the client calls `cleanup()` which closes the WebSocket. The server then responds with close code `4009` (session timed out), and `handleClose(4009)` clears `sessionId` and `lastSeq`, forcing `IDENTIFY` on the next connection instead of `RESUME`.

This happens every ~30 minutes (284 times in 3 days of logs), meaning the bot **never** successfully resumes a session and loses any in-flight messages during each reconnection window.

## Changes

- Add `isReconnectInitiated` flag to `GatewayConnection`
- Set the flag when `RECONNECT(7)` is received, before calling `cleanup()`
- In the WebSocket `close` handler, skip `handleClose()` when the flag is set, preserving the session for `RESUME`

## Testing

The RESUME flow works correctly when not disrupted by 4009 — early logs show successful `RESUMED` events. This change ensures the session persists across RECONNECT-initiated disconnects.

Before (every 30 min):
```
[qqbot:default] Server requested reconnect
[qqbot:default] WebSocket closed: 4009 Session timed out
[qqbot:default] Error 4009, will re-identify
[qqbot:default] Sending identify with intents: ...
```

Expected after fix:
```
[qqbot:default] Server requested reconnect
[qqbot:default] WebSocket closed: 4009 Session timed out
[qqbot:default] Close from RECONNECT(7), preserving session for RESUME
[qqbot:default] Sending RESUME with session_id=... seq=...
[qqbot:default] 📩 Dispatch event: t=RESUMED
```