### PR TITLE
fix(qqbot): normalize cron delivery targets

### DIFF
--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -22,6 +22,23 @@ const cfg = {
 } as OpenClawConfig;
 
 describe("qqbot message adapter", () => {
+  it("normalizes explicit delivery targets before outbound delivery", () => {
+    expect(qqbotPlugin.messaging?.parseExplicitTarget?.({ raw: "qqbot:c2c:USER_OPENID" })).toEqual({
+      to: "c2c:USER_OPENID",
+      chatType: "direct",
+    });
+    expect(qqbotPlugin.outbound?.resolveTarget?.({ to: "qqbot:c2c:USER_OPENID" })).toEqual({
+      ok: true,
+      to: "c2c:USER_OPENID",
+    });
+    expect(qqbotPlugin.outbound?.resolveTarget?.({ to: "qqbot:qqbot:c2c:USER_OPENID" })).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        message: expect.stringContaining("repeated qqbot: provider prefix"),
+      }),
+    });
+  });
+
   it("declares durable text, media, and reply target capabilities with receipt proofs", async () => {
     sendTextMock.mockResolvedValue({ messageId: "qq-text-1" });
     sendMediaMock.mockResolvedValue({ messageId: "qq-media-1" });

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -26,6 +26,7 @@ import { clearAccountCredentials } from "./engine/config/credentials.js";
 import {
   normalizeTarget as coreNormalizeTarget,
   looksLikeQQBotTarget,
+  parseTarget as coreParseTarget,
 } from "./engine/messaging/target-parser.js";
 import type { ResolvedQQBotAccount } from "./types.js";
 
@@ -191,6 +192,41 @@ function shouldSuppressLocalQQBotApprovalPrompt(params: {
   return EXEC_APPROVAL_COMMAND_RE.test(text);
 }
 
+function toQQBotChatType(type: "c2c" | "group" | "channel"): "direct" | "group" | "channel" {
+  if (type === "c2c") {
+    return "direct";
+  }
+  return type;
+}
+
+function parseQQBotExplicitTarget(raw: string) {
+  try {
+    const parsed = coreParseTarget(raw);
+    return {
+      to: `${parsed.type}:${parsed.id}`,
+      chatType: toQQBotChatType(parsed.type),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function resolveQQBotOutboundTarget(params: { to?: string }) {
+  const raw = params.to?.trim();
+  if (!raw) {
+    return { ok: false as const, error: new Error("QQ Bot target is required") };
+  }
+  try {
+    const parsed = coreParseTarget(raw);
+    return { ok: true as const, to: `${parsed.type}:${parsed.id}` };
+  } catch (err) {
+    return {
+      ok: false as const,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
 export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
   id: "qqbot",
   setupWizard: qqbotSetupWizard,
@@ -234,6 +270,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
     targetPrefixes: ["qqbot"],
     /** Normalize common QQ Bot target formats into the canonical qqbot:... form. */
     normalizeTarget: coreNormalizeTarget,
+    parseExplicitTarget: ({ raw }) => parseQQBotExplicitTarget(raw),
     targetResolver: {
       /** Return true when the id looks like a QQ Bot target. */
       looksLikeId: looksLikeQQBotTarget,
@@ -242,6 +279,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
   },
   outbound: {
     deliveryMode: "direct",
+    resolveTarget: ({ to }) => resolveQQBotOutboundTarget({ to }),
     chunker: (text, limit) => getQQBotRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 5000,

--- a/extensions/qqbot/src/engine/messaging/target-parser.test.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeQQBotTarget, normalizeTarget, parseTarget } from "./target-parser.js";
+
+describe("qqbot target parser", () => {
+  it("accepts provider-prefixed and channel-local target forms", () => {
+    expect(parseTarget("qqbot:c2c:USER_OPENID")).toEqual({
+      type: "c2c",
+      id: "USER_OPENID",
+    });
+    expect(parseTarget("group:GROUP_OPENID")).toEqual({
+      type: "group",
+      id: "GROUP_OPENID",
+    });
+    expect(parseTarget("A2B91CCEA0E039905B45C84DD96C92FD")).toEqual({
+      type: "c2c",
+      id: "A2B91CCEA0E039905B45C84DD96C92FD",
+    });
+  });
+
+  it("rejects repeated qqbot provider prefixes", () => {
+    expect(() => parseTarget("qqbot:qqbot:c2c:USER_OPENID")).toThrow(
+      /repeated qqbot: provider prefix/,
+    );
+    expect(normalizeTarget("qqbot:qqbot:c2c:USER_OPENID")).toBeUndefined();
+    expect(looksLikeQQBotTarget("qqbot:qqbot:c2c:USER_OPENID")).toBe(false);
+  });
+
+  it("normalizes accepted inputs to one provider prefix", () => {
+    expect(normalizeTarget("qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD")).toBe(
+      "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+    );
+    expect(normalizeTarget("c2c:A2B91CCEA0E039905B45C84DD96C92FD")).toBe(
+      "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+    );
+    expect(normalizeTarget("A2B91CCEA0E039905B45C84DD96C92FD")).toBe(
+      "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+    );
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/target-parser.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.ts
@@ -15,6 +15,26 @@ interface ParsedTarget {
   id: string;
 }
 
+function stripQQBotProviderPrefix(to: string): string {
+  const trimmed = to.trim();
+  const id = trimmed.replace(/^qqbot:/i, "");
+  if (/^qqbot:/i.test(id)) {
+    throw new Error(`Invalid target format: ${to} - repeated qqbot: provider prefix`);
+  }
+  return id;
+}
+
+function parseTypedTarget(id: string): { type: TargetType; value: string } | undefined {
+  const match = /^(c2c|group|channel):(.*)$/i.exec(id);
+  if (!match) {
+    return undefined;
+  }
+  return {
+    type: match[1].toLowerCase() as TargetType,
+    value: match[2],
+  };
+}
+
 /**
  * Parse a qqbot target string into a structured delivery target.
  *
@@ -32,30 +52,14 @@ interface ParsedTarget {
  * @throws {Error} When the target format is invalid.
  */
 export function parseTarget(to: string): ParsedTarget {
-  let id = to.replace(/^qqbot:/i, "");
+  const id = stripQQBotProviderPrefix(to);
 
-  if (id.startsWith("c2c:")) {
-    const userId = id.slice(4);
-    if (!userId) {
-      throw new Error(`Invalid c2c target format: ${to} - missing user ID`);
+  const typed = parseTypedTarget(id);
+  if (typed) {
+    if (!typed.value) {
+      throw new Error(`Invalid ${typed.type} target format: ${to} - missing target ID`);
     }
-    return { type: "c2c", id: userId };
-  }
-
-  if (id.startsWith("group:")) {
-    const groupId = id.slice(6);
-    if (!groupId) {
-      throw new Error(`Invalid group target format: ${to} - missing group ID`);
-    }
-    return { type: "group", id: groupId };
-  }
-
-  if (id.startsWith("channel:")) {
-    const channelId = id.slice(8);
-    if (!channelId) {
-      throw new Error(`Invalid channel target format: ${to} - missing channel ID`);
-    }
-    return { type: "channel", id: channelId };
+    return { type: typed.type, id: typed.value };
   }
 
   if (!id) {
@@ -72,17 +76,20 @@ export function parseTarget(to: string): ParsedTarget {
  * Returns `undefined` when the target does not look like a QQ Bot address.
  */
 export function normalizeTarget(target: string): string | undefined {
-  const id = target.replace(/^qqbot:/i, "");
-  if (id.startsWith("c2c:") || id.startsWith("group:") || id.startsWith("channel:")) {
-    return `qqbot:${id}`;
-  }
-  // 32-char hex openid
-  if (/^[0-9a-fA-F]{32}$/.test(id)) {
-    return `qqbot:c2c:${id}`;
-  }
-  // UUID-format openid
-  if (/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id)) {
-    return `qqbot:c2c:${id}`;
+  try {
+    const parsed = parseTarget(target);
+    if (
+      parsed.type !== "c2c" ||
+      /^[0-9a-fA-F]{32}$/.test(parsed.id) ||
+      /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+        parsed.id,
+      ) ||
+      /^(c2c|group|channel):/i.test(stripQQBotProviderPrefix(target))
+    ) {
+      return `qqbot:${parsed.type}:${parsed.id}`;
+    }
+  } catch {
+    return undefined;
   }
   return undefined;
 }
@@ -91,6 +98,9 @@ export function normalizeTarget(target: string): string | undefined {
  * Return true when the string looks like a QQ Bot target ID.
  */
 export function looksLikeQQBotTarget(id: string): boolean {
+  if (/^qqbot:qqbot:/i.test(id.trim())) {
+    return false;
+  }
   if (/^qqbot:(c2c|group|channel):/i.test(id)) {
     return true;
   }

--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -66,4 +66,27 @@ describe("resolveCronDeliveryPreview", () => {
     expect(preview).toEqual({ label: "not requested", detail: "not requested" });
     expect(mocks.resolveDeliveryTarget).not.toHaveBeenCalled();
   });
+
+  it("does not duplicate a resolved provider prefix in explicit delivery previews", async () => {
+    mocks.resolveDeliveryTarget.mockResolvedValue({
+      ok: true,
+      channel: "qqbot",
+      to: "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+      mode: "explicit",
+    });
+    const job = makeCronJob({
+      delivery: {
+        mode: "announce",
+        channel: "qqbot",
+        to: "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+      },
+    });
+
+    const preview = await resolveCronDeliveryPreview({
+      cfg: {} as never,
+      job,
+    });
+
+    expect(preview.label).toBe("announce -> qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD");
+  });
 });

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -10,7 +10,11 @@ function formatTarget(channel?: string, to?: string | null): string {
     return "last";
   }
   if (to) {
-    return `${channel}:${to}`;
+    const trimmedTo = to.trim();
+    if (trimmedTo.toLowerCase().startsWith(`${channel.toLowerCase()}:`)) {
+      return trimmedTo;
+    }
+    return `${channel}:${trimmedTo}`;
   }
   return channel;
 }


### PR DESCRIPTION
## Summary
- normalize QQBot explicit delivery targets to channel-local `type:id` form before cron/outbound delivery
- reject repeated `qqbot:` provider prefixes such as `qqbot:qqbot:c2c:...`
- avoid `cron list` preview labels that duplicate an already provider-prefixed resolved target

Fixes #78893

## Proof
- `pnpm test extensions/qqbot/src/engine/messaging/target-parser.test.ts extensions/qqbot/src/channel.message-adapter.test.ts src/cron/delivery-preview.test.ts src/cron/isolated-agent/delivery-target.test.ts src/gateway/server-methods/cron.validation.test.ts`
  - passed: gateway 14 tests, cron 37 tests, extension messaging 5 tests
- `pnpm exec oxfmt --check --threads=1 extensions/qqbot/src/engine/messaging/target-parser.ts extensions/qqbot/src/engine/messaging/target-parser.test.ts extensions/qqbot/src/channel.ts extensions/qqbot/src/channel.message-adapter.test.ts src/cron/delivery-preview.ts src/cron/delivery-preview.test.ts`
  - passed
- `pnpm check:changed`
  - local lanes passed through core/core-test/extension typechecks
  - failed in inherited current-main extension-test type drift: `extensions/codex/src/app-server/auth-bridge.test.ts(559,11): Type '"aws-sdk"' is not assignable to type '"api_key" | "oauth" | "token"'`

## Verification boundary
I did not run a live QQBot API delivery. The regression is covered at source level: parser/normalizer behavior, plugin explicit-target/outbound resolution, and cron preview formatting.
