### PR TITLE
fix(plugins): resolve loaded allowlisted tools

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2210,6 +2210,35 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("selects an already-loaded plugin by allowlisted registered tool name without a manifest snapshot match (#78907)", () => {
+    installToolManifestSnapshots({
+      config: createContext().config,
+      plugins: [],
+    });
+    const registry = createToolRegistry([
+      {
+        pluginId: "optional-demo",
+        names: ["second_nature_ops"],
+        declaredNames: ["second_nature_ops"],
+        optional: false,
+        source: "/tmp/second-nature.js",
+        factory: () => makeTool("second_nature_ops"),
+      },
+    ]);
+    setActivePluginRegistry(registry as never, "gateway-startup", "gateway-bindable", "/tmp");
+    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        toolAllowlist: ["second_nature_ops"],
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["second_nature_ops"]);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
   it("loads plugin tools when gateway-bindable tool loads have no active registry", () => {
     setOptionalDemoRegistry();
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -419,6 +419,67 @@ function filterManifestToolNamesForAvailability(params: {
   );
 }
 
+function listRegisteredToolNames(entry: PluginToolRegistration): string[] {
+  return entry.names.length > 0 ? entry.names : (entry.declaredNames ?? []);
+}
+
+function addLoadedRuntimePluginIdsForAllowlist(params: {
+  pluginIds: Set<string>;
+  allowlist: Set<string>;
+  denylist: ReturnType<typeof normalizeDenylist>;
+  normalizedPlugins: ReturnType<typeof normalizePluginsConfig>;
+  workspaceDir?: string;
+}) {
+  const registries = [
+    getLoadedRuntimePluginRegistry({
+      workspaceDir: params.workspaceDir,
+      surface: "channel",
+    }),
+    getLoadedRuntimePluginRegistry({
+      workspaceDir: params.workspaceDir,
+      surface: "active",
+    }),
+  ];
+  for (const registry of registries) {
+    if (!registry) {
+      continue;
+    }
+    for (const entry of registry.tools) {
+      if (params.pluginIds.has(entry.pluginId)) {
+        continue;
+      }
+      if (
+        params.normalizedPlugins.entries[entry.pluginId]?.enabled === false ||
+        params.normalizedPlugins.deny.includes(entry.pluginId)
+      ) {
+        continue;
+      }
+      if (
+        denylistBlocksPlugin({ pluginId: entry.pluginId, denylist: params.denylist }) ||
+        listRegisteredToolNames(entry).every((toolName) =>
+          denylistBlocksPluginTool({
+            pluginId: entry.pluginId,
+            toolName,
+            denylist: params.denylist,
+          }),
+        )
+      ) {
+        continue;
+      }
+      if (
+        pluginToolNamesMatchAllowlist({
+          names: listRegisteredToolNames(entry),
+          pluginId: entry.pluginId,
+          optional: entry.optional,
+          allowlist: params.allowlist,
+        })
+      ) {
+        params.pluginIds.add(entry.pluginId);
+      }
+    }
+  }
+}
+
 function resolvePluginToolRuntimePluginIds(params: {
   config: PluginLoadOptions["config"];
   availabilityConfig?: PluginLoadOptions["config"];
@@ -486,6 +547,13 @@ function resolvePluginToolRuntimePluginIds(params: {
       pluginIds.add(plugin.id);
     }
   }
+  addLoadedRuntimePluginIdsForAllowlist({
+    pluginIds,
+    allowlist,
+    denylist,
+    normalizedPlugins,
+    workspaceDir: params.workspaceDir,
+  });
   return [...pluginIds].toSorted((left, right) => left.localeCompare(right));
 }
 


### PR DESCRIPTION
Fixes #78907.

## Summary
- when an explicit plugin tool allowlist cannot be resolved from the manifest snapshot, also scan already-loaded channel/active plugin registries for matching registered tool names
- preserve existing plugin deny/disabled checks before selecting a loaded plugin id
- add a focused regression for `tools.allow: [second_nature_ops]` materializing an already-loaded plugin tool when the manifest snapshot cannot map that name

## Real behavior proof
- `pnpm test src/plugins/tools.optional.test.ts`
- `pnpm test src/agents/pi-tools.create-openclaw-coding-tools.test.ts src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.test.ts src/agents/tool-policy-pipeline.test.ts src/agents/tool-allowlist-guard.test.ts src/plugins/tools.optional.test.ts`
- `pnpm format:check src/plugins/tools.ts src/plugins/tools.optional.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Notes
- I did not run a live Feishu/direct-lane external plugin setup in this environment. The regression covers the failing source condition: a gateway-loaded plugin tool explicitly named by `tools.allow` must survive plugin id selection so the embedded fail-closed guard does not see an empty callable set.
