### PR TITLE
fix(qqbot): normalize cron delivery targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -528,6 +528,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: stop the `sessions_spawn` accepted note from recommending `sessions_yield` as the default wait path in push-based chat and CLI flows. Fixes #78913. Thanks @oiGaDio.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - Telegram: deduplicate media attachments in non-streaming mode so block-delivered images are not resent in the final reply, and clear legacy `mediaUrl` fallback when all media URLs are filtered. Fixes #78372.
+- QQBot/cron: strip redundant `qqbot:` prefixes from explicit cron delivery targets and avoid duplicate provider prefixes in `cron list` delivery previews. Fixes #78893. Thanks @jialudev.
 - Gateway/auth: allow `gateway.auth.mode: "none"` loopback backend RPC clients to skip device identity only for local non-browser backend connections, restoring subagent spawns and gateway tools without opening remote or browser-origin bypasses. Fixes #75780. Thanks @yozakura-ava.
 - Canvas plugin: keep legacy root `canvasHost` configs valid until `openclaw doctor --fix` migrates them into `plugins.entries.canvas.config.host`, move Canvas/A2UI clients to gateway protocol v4 plugin surfaces, and refresh the generated A2UI bundle hash so normal builds stay clean.
 - feishu: honor config write policy for dynamic agents [AI]. (#78520) Thanks @pgondhi987.

--- a/extensions/qqbot/src/channel.target-parser.test.ts
+++ b/extensions/qqbot/src/channel.target-parser.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { qqbotPlugin } from "./channel.js";
+
+vi.mock("./bridge/gateway.js", () => ({}));
+vi.mock("./engine/messaging/outbound.js", () => ({
+  sendText: vi.fn(),
+  sendMedia: vi.fn(),
+}));
+
+describe("qqbot messaging target parsing", () => {
+  it("registers a channel-local explicit target parser", () => {
+    expect(
+      qqbotPlugin.messaging?.parseExplicitTarget?.({
+        raw: "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+      }),
+    ).toEqual({
+      to: "c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+      chatType: "direct",
+    });
+  });
+
+  it("leaves foreign provider-prefixed targets for shared provider validation", () => {
+    expect(
+      qqbotPlugin.messaging?.parseExplicitTarget?.({
+        raw: "telegram:1234567890",
+      }),
+    ).toBeNull();
+  });
+});

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -26,6 +26,7 @@ import { clearAccountCredentials } from "./engine/config/credentials.js";
 import {
   normalizeTarget as coreNormalizeTarget,
   looksLikeQQBotTarget,
+  parseExplicitTarget as parseQQBotExplicitTarget,
 } from "./engine/messaging/target-parser.js";
 import type { ResolvedQQBotAccount } from "./types.js";
 
@@ -234,6 +235,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
     targetPrefixes: ["qqbot"],
     /** Normalize common QQ Bot target formats into the canonical qqbot:... form. */
     normalizeTarget: coreNormalizeTarget,
+    parseExplicitTarget: ({ raw }) => parseQQBotExplicitTarget(raw),
     targetResolver: {
       /** Return true when the id looks like a QQ Bot target. */
       looksLikeId: looksLikeQQBotTarget,

--- a/extensions/qqbot/src/engine/messaging/target-parser.test.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTarget, parseExplicitTarget, parseTarget } from "./target-parser.js";
+
+describe("QQ Bot target parser", () => {
+  it("parses documented provider-prefixed targets", () => {
+    expect(parseTarget("qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD")).toEqual({
+      type: "c2c",
+      id: "A2B91CCEA0E039905B45C84DD96C92FD",
+    });
+    expect(parseTarget("qqbot:group:group-openid")).toEqual({
+      type: "group",
+      id: "group-openid",
+    });
+    expect(parseTarget("qqbot:channel:channel-id")).toEqual({
+      type: "channel",
+      id: "channel-id",
+    });
+  });
+
+  it("rejects repeated provider prefixes instead of treating them as C2C ids", () => {
+    expect(() => parseTarget("qqbot:qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD")).toThrow(
+      /repeated qqbot: prefix/,
+    );
+    expect(normalizeTarget("qqbot:qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD")).toBeUndefined();
+  });
+
+  it("normalizes typed targets with one provider prefix", () => {
+    expect(normalizeTarget("qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD")).toBe(
+      "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+    );
+    expect(normalizeTarget("C2C:A2B91CCEA0E039905B45C84DD96C92FD")).toBe(
+      "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+    );
+  });
+
+  it("returns channel-local explicit targets for cron delivery routing", () => {
+    expect(parseExplicitTarget("qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD")).toEqual({
+      to: "c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+      chatType: "direct",
+    });
+    expect(parseExplicitTarget("qqbot:group:group-openid")).toEqual({
+      to: "group:group-openid",
+      chatType: "group",
+    });
+    expect(parseExplicitTarget("qqbot:channel:channel-id")).toEqual({
+      to: "channel:channel-id",
+      chatType: "channel",
+    });
+  });
+
+  it("declines foreign provider-prefixed explicit targets", () => {
+    expect(parseExplicitTarget("telegram:1234567890")).toBeNull();
+    expect(parseExplicitTarget("slack:C1234567890")).toBeNull();
+  });
+
+  it("does not parse repeated provider prefixes as explicit targets", () => {
+    expect(parseExplicitTarget("qqbot:qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD")).toBeNull();
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/target-parser.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.ts
@@ -15,6 +15,39 @@ interface ParsedTarget {
   id: string;
 }
 
+function stripProviderPrefix(raw: string): string {
+  const trimmed = raw.trim();
+  const id = trimmed.replace(/^qqbot:/i, "");
+  if (/^qqbot:/i.test(id)) {
+    throw new Error(`Invalid target format: ${raw} - repeated qqbot: prefix`);
+  }
+  return id;
+}
+
+function stripProviderPrefixOrUndefined(raw: string): string | undefined {
+  try {
+    return stripProviderPrefix(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function readTypedId(id: string, type: TargetType): string | undefined {
+  const prefix = `${type}:`;
+  return id.toLowerCase().startsWith(prefix) ? id.slice(prefix.length) : undefined;
+}
+
+function startsWithForeignProviderPrefix(raw: string): boolean {
+  const prefix = /^([a-z][a-z0-9_-]*):/i.exec(raw.trim())?.[1]?.toLowerCase();
+  return (
+    prefix != null &&
+    prefix !== "qqbot" &&
+    prefix !== "c2c" &&
+    prefix !== "group" &&
+    prefix !== "channel"
+  );
+}
+
 /**
  * Parse a qqbot target string into a structured delivery target.
  *
@@ -32,26 +65,27 @@ interface ParsedTarget {
  * @throws {Error} When the target format is invalid.
  */
 export function parseTarget(to: string): ParsedTarget {
-  let id = to.replace(/^qqbot:/i, "");
+  const id = stripProviderPrefix(to);
 
-  if (id.startsWith("c2c:")) {
-    const userId = id.slice(4);
+  const c2cId = readTypedId(id, "c2c");
+  if (c2cId != null) {
+    const userId = c2cId;
     if (!userId) {
       throw new Error(`Invalid c2c target format: ${to} - missing user ID`);
     }
     return { type: "c2c", id: userId };
   }
 
-  if (id.startsWith("group:")) {
-    const groupId = id.slice(6);
+  const groupId = readTypedId(id, "group");
+  if (groupId != null) {
     if (!groupId) {
       throw new Error(`Invalid group target format: ${to} - missing group ID`);
     }
     return { type: "group", id: groupId };
   }
 
-  if (id.startsWith("channel:")) {
-    const channelId = id.slice(8);
+  const channelId = readTypedId(id, "channel");
+  if (channelId != null) {
     if (!channelId) {
       throw new Error(`Invalid channel target format: ${to} - missing channel ID`);
     }
@@ -72,9 +106,15 @@ export function parseTarget(to: string): ParsedTarget {
  * Returns `undefined` when the target does not look like a QQ Bot address.
  */
 export function normalizeTarget(target: string): string | undefined {
-  const id = target.replace(/^qqbot:/i, "");
-  if (id.startsWith("c2c:") || id.startsWith("group:") || id.startsWith("channel:")) {
-    return `qqbot:${id}`;
+  const id = stripProviderPrefixOrUndefined(target);
+  if (!id) {
+    return undefined;
+  }
+  for (const type of ["c2c", "group", "channel"] as const) {
+    const typedId = readTypedId(id, type);
+    if (typedId != null) {
+      return typedId ? `qqbot:${type}:${typedId}` : undefined;
+    }
   }
   // 32-char hex openid
   if (/^[0-9a-fA-F]{32}$/.test(id)) {
@@ -85,6 +125,28 @@ export function normalizeTarget(target: string): string | undefined {
     return `qqbot:c2c:${id}`;
   }
   return undefined;
+}
+
+/**
+ * Parse a QQ Bot explicit route target for shared delivery/session routing.
+ *
+ * The returned `to` is channel-local because callers already know the channel.
+ */
+export function parseExplicitTarget(
+  raw: string,
+): { to: string; chatType: "direct" | "group" | "channel" } | null {
+  if (startsWithForeignProviderPrefix(raw)) {
+    return null;
+  }
+  try {
+    const target = parseTarget(raw);
+    return {
+      to: `${target.type}:${target.id}`,
+      chatType: target.type === "c2c" ? "direct" : target.type === "group" ? "group" : "channel",
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -66,4 +66,28 @@ describe("resolveCronDeliveryPreview", () => {
     expect(preview).toEqual({ label: "not requested", detail: "not requested" });
     expect(mocks.resolveDeliveryTarget).not.toHaveBeenCalled();
   });
+
+  it("does not duplicate provider prefixes in explicit delivery labels", async () => {
+    mocks.resolveDeliveryTarget.mockResolvedValue({
+      ok: true,
+      channel: "qqbot",
+      to: "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+      mode: "explicit",
+    });
+    const job = makeCronJob({
+      delivery: {
+        mode: "announce",
+        channel: "qqbot",
+        to: "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
+      },
+      sessionTarget: "isolated",
+    });
+
+    const preview = await resolveCronDeliveryPreview({
+      cfg: {} as never,
+      job,
+    });
+
+    expect(preview.label).toBe("announce -> qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD");
+  });
 });

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -10,6 +10,9 @@ function formatTarget(channel?: string, to?: string | null): string {
     return "last";
   }
   if (to) {
+    if (to.toLowerCase().startsWith(`${channel.toLowerCase()}:`)) {
+      return to;
+    }
     return `${channel}:${to}`;
   }
   return channel;


### PR DESCRIPTION
## Summary

- Normalize QQBot explicit cron delivery targets through the channel-owned parser so `qqbot:c2c:...` becomes channel-local `c2c:...` once the channel is already known.
- Reject repeated QQBot provider prefixes during QQBot target parsing instead of treating `qqbot:qqbot:c2c:...` as a malformed C2C id.
- Avoid duplicating provider prefixes in cron delivery preview labels.
- Preserve foreign provider prefixes during QQBot explicit target parsing so shared mismatch validation still rejects targets such as `telegram:...` when `delivery.channel=qqbot`.

Fixes #78893.

## Real behavior proof

Behavior or issue addressed: Cron delivery previews for explicit QQBot targets should not duplicate the provider prefix. A job configured with `delivery.channel=qqbot` and `delivery.to=qqbot:c2c:...` should preview as `announce -> qqbot:c2c:...`, not `announce -> qqbot:qqbot:c2c:...`.

Real environment tested: Local OpenClaw Gateway started from this branch, using an isolated `/tmp` OpenClaw home and loopback port 28791. The temporary Gateway was started with `--dev --reset --auth none --bind loopback --allow-unconfigured` so it did not touch the user's real `~/.openclaw` service or config.

Exact steps or command run after this patch:

```shell
OPENCLAW_HOME=/tmp/openclaw-proof-home OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-home/openclaw.json pnpm openclaw gateway run --dev --reset --auth none --bind loopback --port 28791 --allow-unconfigured --ws-log compact
OPENCLAW_HOME=/tmp/openclaw-proof-home OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-home/openclaw.json pnpm openclaw cron add --url ws://127.0.0.1:28791 --token proof-token --name qqbot-prefix-proof --every 24h --session isolated --message "proof only" --announce --channel qqbot --to qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD --disabled --json --timeout 10000
OPENCLAW_HOME=/tmp/openclaw-proof-home OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-home/openclaw.json pnpm openclaw cron list --url ws://127.0.0.1:28791 --token proof-token --all --json --timeout 10000
```

Evidence after fix: Copied live output from the temporary Gateway's `cron list --json` command:

```json
{
  "jobs": [
    {
      "id": "05bf6096-bb1b-4236-b2a2-eff42fe45be7",
      "name": "qqbot-prefix-proof",
      "delivery": {
        "mode": "announce",
        "channel": "qqbot",
        "to": "qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD"
      },
      "status": "disabled"
    }
  ],
  "deliveryPreviews": {
    "05bf6096-bb1b-4236-b2a2-eff42fe45be7": {
      "label": "announce -> qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD",
      "detail": "Unsupported channel: qqbot"
    }
  }
}
```

Observed result after fix: The live preview label has exactly one `qqbot:` prefix: `announce -> qqbot:c2c:A2B91CCEA0E039905B45C84DD96C92FD`. It does not contain the broken `qqbot:qqbot:c2c:...` or `qqbot:qqbot:qqbot:c2c:...` forms reported in #78893. The `Unsupported channel: qqbot` detail is expected in this temporary Gateway because QQBot is not configured there; the delivery preview formatting path is still exercised.

What was not tested: I did not send a live QQBot message to Tencent QQ. This proof covers the reported cron preview/normalization regression with a real Gateway and CLI run.

## Verification

- `pnpm test src/plugins/contracts/boundary-invariants.test.ts src/cron/isolated-agent/delivery-target.test.ts extensions/qqbot/src/engine/messaging/target-parser.test.ts extensions/qqbot/src/channel.target-parser.test.ts src/cron/delivery-preview.test.ts src/infra/outbound/targets.shared-test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cron/isolated-agent/delivery-target.test.ts extensions/qqbot/src/engine/messaging/target-parser.ts extensions/qqbot/src/engine/messaging/target-parser.test.ts extensions/qqbot/src/channel.ts extensions/qqbot/src/channel.target-parser.test.ts src/cron/delivery-preview.ts src/cron/delivery-preview.test.ts src/infra/outbound/targets.shared-test.ts CHANGELOG.md`
- `git diff --check upstream/main...HEAD`
- `pnpm check:changed`