### PR TITLE
fix(agents): clarify sessions_yield is optional in push-based spawn flows

### DIFF
--- a/src/agents/subagent-spawn-accepted-note.ts
+++ b/src/agents/subagent-spawn-accepted-note.ts
@@ -1,7 +1,7 @@
 import { isCronSessionKey } from "../routing/session-key.js";
 
 export const SUBAGENT_SPAWN_ACCEPTED_NOTE =
-  "Auto-announce is push-based. After spawning children, do NOT call sessions_list, sessions_history, exec sleep, or any polling tool. Track expected child session keys. If any required child completion has not arrived yet, call sessions_yield to end the turn and wait for completion events as user messages. Only send your final answer after ALL expected completions arrive. If a child completion event arrives AFTER your final answer, reply ONLY with NO_REPLY.";
+  "Auto-announce is push-based. After spawning children, do NOT call sessions_list, sessions_history, exec sleep, or any polling tool. Track expected child session keys. Wait for completion events to arrive as user messages. Only send your final answer after ALL expected completions arrive. If a child completion event arrives AFTER your final answer, reply ONLY with NO_REPLY. Only call sessions_yield if you must end the turn before completions arrive (e.g. to avoid a session timeout).";
 export const SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE =
   "thread-bound session stays active after this task; continue in-thread for follow-ups.";
 


### PR DESCRIPTION
## Problem

In push-based auto-announce flows, `sessions_spawn` returns a note that says:

> "If any required child completion has not arrived yet, call `sessions_yield` to end the turn and wait for completion events as user messages."

This is contradictory: the note already states completion is push-based (events arrive automatically), yet recommends `sessions_yield` as the default next step. Following this guidance creates extra visible handoff turns, wastes tokens, and nudges agents toward yield-based orchestration even in setups that intentionally avoid it.

Reported in #78913. Confirming the note string is in `src/agents/subagent-spawn-accepted-note.ts`.

## Fix

Reword `SUBAGENT_SPAWN_ACCEPTED_NOTE` so that:
- The default path is to wait for push-delivered completion events (correct for push-based flows)
- `sessions_yield` is surfaced as a conditional escape hatch (only needed if the agent must end its turn before completions arrive, e.g. to avoid a session timeout)

**Before:**
> Track expected child session keys. If any required child completion has not arrived yet, call sessions_yield to end the turn and wait for completion events as user messages.

**After:**
> Track expected child session keys. Wait for completion events to arrive as user messages. [...] Only call sessions_yield if you must end the turn before completions arrive (e.g. to avoid a session timeout).

## Proof

Static: the note string is in `src/agents/subagent-spawn-accepted-note.ts:4` and returns as-is to the model. Reporter confirmed the built dist path (`dist/subagent-spawn-BUD3ThOX.js:182`).

The test file uses `SUBAGENT_SPAWN_ACCEPTED_NOTE` as the expected value (not the literal string), so all existing test assertions remain valid without changes.

## Files changed

- `src/agents/subagent-spawn-accepted-note.ts` — note string only