### PR TITLE
fix(message-tool): rename `type` schema property to avoid JSON Schema keyword collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Slack/plugins: route plugin-owned modal `view_submission` and `view_closed` events through Slack interactive handlers before compacting the agent-visible system event, so plugins can persist full submitted form state while the transcript stays compact. Fixes #82102. Thanks @shannon0430.
 - Providers/Xiaomi: promote legacy MiMo V2 reasoning-only final answers to visible text, including Xiaomi-compatible proxy routes, so `mimo-v2-pro` and `mimo-v2-omni` replies no longer appear blank when the answer arrives in `reasoning_content`. Fixes #60261. (#60304) Thanks @HiddenPuppy.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
+- Message tool: rename the Discord channel-create schema field exposed to models from `type` to `channelType`, avoiding NVIDIA NIM JSON Schema parser failures while still accepting legacy `type` tool calls. (#78920) Thanks @YashSaliya.
 
 ## 2026.5.14
 

--- a/extensions/discord/src/actions/runtime.shared.ts
+++ b/extensions/discord/src/actions/runtime.shared.ts
@@ -46,7 +46,10 @@ export function readDiscordChannelCreateParams(
   return {
     guildId: readStringParam(params, "guildId", { required: true }),
     name: readStringParam(params, "name", { required: true }),
-    type: readNumberParam(params, "type", { integer: true }) ?? undefined,
+    type:
+      readNumberParam(params, "channelType", { integer: true }) ??
+      readNumberParam(params, "type", { integer: true }) ??
+      undefined,
     parentId: parentId ?? undefined,
     topic: readStringParam(params, "topic") ?? undefined,
     position: readNumberParam(params, "position", { integer: true }) ?? undefined,

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -910,6 +910,27 @@ describe("handleDiscordGuildAction - channel management", () => {
     });
   });
 
+  it("prefers channelType when creating a channel", async () => {
+    await handleGuildAction(
+      "channelCreate",
+      {
+        guildId: "G1",
+        name: "forum-thread",
+        channelType: 11,
+        type: 0,
+      },
+      channelsEnabled,
+    );
+    expect(createChannelDiscord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "G1",
+        name: "forum-thread",
+        type: 11,
+      }),
+      { cfg: DISCORD_TEST_CFG },
+    );
+  });
+
   it("respects channel gating for channelCreate", async () => {
     await expect(
       handleGuildAction("channelCreate", { guildId: "G1", name: "test" }, channelsDisabled),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -467,7 +467,12 @@ function buildPresenceSchema() {
 function buildChannelManagementSchema() {
   return {
     name: Type.Optional(Type.String()),
-    type: Type.Optional(Type.Number()),
+    channelType: Type.Optional(
+      Type.Number({
+        description:
+          "Numeric channel type (e.g. Discord channel type). Renamed from `type` to avoid JSON Schema keyword collisions that break some OpenAI-compatible providers (notably NVIDIA NIM).",
+      }),
+    ),
     parentId: Type.Optional(Type.String()),
     topic: Type.Optional(Type.String()),
     position: Type.Optional(Type.Number()),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -444,7 +444,12 @@ function buildPresenceSchema() {
 function buildChannelManagementSchema() {
   return {
     name: Type.Optional(Type.String()),
-    type: Type.Optional(Type.Number()),
+    channelType: Type.Optional(
+      Type.Number({
+        description:
+          "Numeric channel type (e.g. Discord channel type). Renamed from `type` to avoid JSON Schema keyword collisions that break some OpenAI-compatible providers (notably NVIDIA NIM).",
+      }),
+    ),
     parentId: Type.Optional(Type.String()),
     topic: Type.Optional(Type.String()),
     position: Type.Optional(Type.Number()),


### PR DESCRIPTION
## Summary

The `message` tool's parameter schema (built in `src/agents/tools/message-tool.ts`'s `buildChannelManagementSchema`) defines a property literally named `type` (Discord's numeric channel type). Property names that collide with JSON-Schema keywords break some OpenAI-compatible providers — confirmed against NVIDIA NIM (`https://integrate.api.nvidia.com/v1/chat/completions`) with `moonshotai/kimi-k2.6`, which returns `HTTP 500 Internal server error: unhashable type: 'dict'` for any chat-completions request that includes the `message` tool. Renaming `type` to `channelType` resolves the collision.

## Change

- `src/agents/tools/message-tool.ts`: rename `type` → `channelType` in `buildChannelManagementSchema`, with a description noting why.
- `extensions/discord/src/actions/runtime.shared.ts`: `readDiscordChannelCreateParams` now reads `channelType` first, falling back to `type` for backward compatibility with any in-flight tool calls.

## Why this fix

NVIDIA NIM's parser is technically buggy — `{"type": {"type": "number"}}` is valid JSON Schema. But colliding property names with reserved JSON-Schema keywords is a fragile pattern that has now been observed to break a real, popular provider, and the rename costs nothing semantically (the LLM only sees the field name; Discord's actual channel-creation payload is constructed downstream).

## Real behavior proof

**Behavior or issue addressed:** Any OpenClaw chat-completions call to NVIDIA NIM (`integrate.api.nvidia.com`) with the `message` tool present fails with `HTTP 500 Internal server error: unhashable type: 'dict'`, surfaced through OpenClaw's failover layer as a permanent `model_not_found` failure. Bisecting the captured request body identifies the property literally named `type` inside the `message` tool's JSON-Schema as the sole trigger. After the fix, the same call succeeds with HTTP 200 and a real model completion.

**Real environment tested:** Live NVIDIA NIM endpoint `https://integrate.api.nvidia.com/v1/chat/completions` with a real `nvapi-…` API key (redacted) and real model `moonshotai/kimi-k2.6`. OpenClaw 2026.4.14 (323493f) installed via `npm i -g openclaw`, running locally on macOS 24.1.0 with Node 22. Provider config: `{ baseUrl: "https://integrate.api.nvidia.com/v1", api: "openai-completions", apiKey: "nvapi-…" }`. Captured the outbound bodies via a local HTTP capture proxy (`http://127.0.0.1:8765/v1`) configured as the NVIDIA NIM `baseUrl`, then replayed against the live NVIDIA endpoint to isolate the field.

**Exact steps or command run after this patch:**

1. Apply the rename to the installed dist files (`/usr/local/lib/node_modules/openclaw/dist/openclaw-tools-*.js` and `runtime-*.js`) — same change as in this PR's diff.
2. Restart the gateway: `openclaw gateway stop && openclaw gateway`.
3. Replay the captured OpenClaw payload directly against NVIDIA, with only `type` → `channelType` applied:
   ```
   curl -sS https://integrate.api.nvidia.com/v1/chat/completions \
     -H "Authorization: Bearer $NVAPI_KEY" \
     -H "Content-Type: application/json" \
     --data-binary @fixed.json -w "HTTP %{http_code}\n"
   ```
4. Run a one-shot turn through OpenClaw end-to-end:
   ```
   openclaw infer model run --local \
     --model "nvidia-nim/moonshotai/kimi-k2.6" --prompt "ok"
   ```

**Evidence after fix:**

Live terminal output from step 3 — replaying the previously-failing OpenClaw body, with only `type` renamed to `channelType`, against the production NVIDIA NIM endpoint:

```
$ curl -sS -o /tmp/r.out -w "HTTP %{http_code}\n" \
    https://integrate.api.nvidia.com/v1/chat/completions \
    -H "Authorization: Bearer $NVAPI_KEY" \
    -H "Content-Type: application/json" \
    --data-binary @fixed.json
HTTP 200

$ head -c 240 /tmp/r.out
{"id":"2ebc71e87084441b80c4ba7d137fd6bf","object":"chat.completion",
 "created":1778154280,"model":"moonshotai/kimi-k2.6",
 "choices":[{"index":0,"message":{"role":"assistant","content":"Hey there! 👋 W…
```

Live console output from step 4 — patched OpenClaw, real NVIDIA NIM call, real completion streamed back:

```
$ openclaw infer model run --local \
    --model "nvidia-nim/moonshotai/kimi-k2.6" --prompt "ok"
model.run via local
provider: nvidia-nim
model: moonshotai/kimi-k2.6
outputs: 1
The user said "ok", which is a very brief acknowledgment...
Hey. Just came online. Who am I? And who are you?
I'm fresh out the box here — no memories, no name, no idea who I'm talking to…
```

For comparison, the same `openclaw infer model run` against the unpatched bundle produced (verbatim):

```
[diagnostic] lane task error: lane=main durationMs=586 error="HTTP 500: Internal server error: unhashable type: 'dict'"
[model-fallback/decision] requested=nvidia-nim/moonshotai/kimi-k2.6 reason=model_not_found
HTTP 500: Internal server error: unhashable type: 'dict'
```

Field-level bisection of the captured OpenClaw body, replayed against live NVIDIA, isolated the offender:

```
[200] tools[0:6]                           ok
[500] tools[6:12]                          fail
[200] tools[7:8]    (cron)                 ok
[500] tools[8:9]    (message)              fail   ← single tool reproduces it

within tools[8].function.parameters.properties:
  without 'name'                : FAIL
  without 'type'                : ok       ← removing only `type` clears it
  without 'parentId'            : FAIL
  ... (all other properties)    : FAIL
```

**Observed result after fix:** Curl replay of the previously-failing captured OpenClaw payload (with only `type` → `channelType` applied) returns `HTTP 200` and a valid `chat.completion` JSON object — copied stdout above. `openclaw infer model run --local --model nvidia-nim/moonshotai/kimi-k2.6 --prompt "ok"` returns a streamed assistant reply through the patched OpenClaw bundle — copied stdout above. Pre-patch, the same command consistently terminates with `HTTP 500: Internal server error: unhashable type: 'dict'` after exhausting failover.

**What was not tested:** Other OpenAI-compatible providers were not regression-tested in this manual pass; the change only renames a property name and preserves backward-compatible reading via the legacy `type` fallback in `readDiscordChannelCreateParams`, so no behavior change is expected for OpenAI / Anthropic / Groq / Ollama / etc. Discord live channel-create against a real Discord guild was not exercised in this run — only the parameter reader was changed (with fallback to legacy `type`), so existing Discord flows continue to work.