### PR TITLE
fix(active-memory): guard "/" in channel values to prevent dirName crash on Google Chat sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
+- Active-memory: extend the session-store channel guard to also reject slash-containing values (e.g. Google Chat `spaces/<id>`) before passing them as the embedded recall `messageChannel`, preventing the `Bundled plugin dirName must be a single directory` crash on Google Chat sessions. Fixes #78918. (#78924) Thanks @hclsys and @danieljimz.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.
 - Discord/voice: keep TTS playback running when another user starts speaking, ignore new capture during playback to avoid feedback loops, and downgrade expected receive-stream aborts to verbose diagnostics.

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3061,6 +3061,33 @@ describe("active-memory plugin", () => {
     });
   });
 
+  it("skips slash-containing session-store channels for embedded recall (Google Chat #78918)", async () => {
+    hoisted.sessionStore["agent:main:googlechat:default:direct:spaces/khfx4yaaaae"] = {
+      sessionId: "session-b",
+      updatedAt: 26,
+      channel: "spaces/khfx4yaaaae",
+      origin: {
+        provider: "googlechat",
+      },
+    };
+
+    await hooks.before_prompt_build(
+      { prompt: "what wings should i order? google chat stored channel", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:googlechat:default:direct:spaces/khfx4yaaaae",
+        messageProvider: "googlechat",
+        channelId: "googlechat",
+      },
+    );
+
+    expect(runEmbeddedPiAgent.mock.calls.at(-1)?.[0]).toMatchObject({
+      messageChannel: "googlechat",
+      messageProvider: "googlechat",
+    });
+  });
+
   it("preserves an explicit real channel hint over a stale stored wrapper channel", async () => {
     hoisted.sessionStore["agent:main:telegram:direct:12345"] = {
       sessionId: "session-a",

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -545,9 +545,11 @@ function resolveRecallRunChannelContext(params: {
   // A channelId that contains ":" is a scoped conversation id (e.g. Telegram
   // forum-topic "-100123:topic:77"), not a runnable channel name. Using it as
   // the embedded recall run's channel causes bundled-plugin dirName validation
-  // to throw because ":" is not allowed in directory names (#76704).
+  // to throw because ":" and "/" are not allowed in directory names (#76704, #78918).
   const runnableExplicitChannel =
-    explicitChannel && !explicitChannel.includes(":") ? explicitChannel : undefined;
+    explicitChannel && !explicitChannel.includes(":") && !explicitChannel.includes("/")
+      ? explicitChannel
+      : undefined;
   const trustedExplicitChannel =
     runnableExplicitChannel && runnableExplicitChannel !== explicitProvider
       ? runnableExplicitChannel
@@ -599,12 +601,14 @@ function resolveRecallRunChannelContext(params: {
     const rawStrongEntryChannel =
       normalizeOptionalString(sessionEntry?.lastChannel) ??
       normalizeOptionalString(sessionEntry?.channel);
-    // Channel IDs containing ":" are scoped conversation IDs (e.g. QQ c2c
-    // "c2c:10D4F7C2..."), not runnable channel names. The same guard that
-    // applies to explicit channelId (#76704) must also apply to channels
-    // read from the session store (#77396).
+    // Channel IDs containing ":" or "/" are scoped conversation IDs (e.g. QQ c2c
+    // "c2c:10D4F7C2...", Google Chat "spaces/khfx4yaaaae"), not runnable channel
+    // names. The same guard that applies to explicit channelId (#76704) must also
+    // apply to channels read from the session store (#77396, #78918).
     const strongEntryChannel =
-      rawStrongEntryChannel && !rawStrongEntryChannel.includes(":")
+      rawStrongEntryChannel &&
+      !rawStrongEntryChannel.includes(":") &&
+      !rawStrongEntryChannel.includes("/")
         ? rawStrongEntryChannel
         : undefined;
     const weakEntryChannel = normalizeOptionalString(sessionEntry?.origin?.provider);


### PR DESCRIPTION
## Problem

Active-memory recall fails with `Error: Bundled plugin dirName must be a single directory: spaces/khfx4yaaaae` for Google Chat sessions. The session key `agent:main:googlechat:default:direct:spaces/<spaceId>` causes the Google Chat space ID (`spaces/<spaceId>`) to be stored as the session's `lastChannel`, which then flows into `resolveRecallRunChannelContext` and eventually becomes a `dirName` argument — crashing on the `/` separator.

## Root cause

`resolveRecallRunChannelContext` already guards against `:` in channel values (fixes #76704, #77396), but not `/`. Google Chat space IDs contain `/` (e.g. `spaces/khfx4yaaaae`), which passes the `:` check, escapes into `runEmbeddedPiAgent` as `messageChannel`, and eventually hits `normalizeBundledPluginDirName`'s directory-separator validation.

## Fix

Extend both guards in `resolveRecallRunChannelContext` (`runnableExplicitChannel` and `strongEntryChannel`) to also reject values containing `/`, consistent with the existing `:` guard rationale.

**3 files changed: 1 file fix (4 lines) + regression test + CHANGELOG entry.**

## Audits

- Audit A: No existing `isRunnableChannelName` helper — inline guard extension is correct.
- Audit B: `resolveRecallRunChannelContext` is defined and called only within `active-memory/index.ts`. No shared contract mutations.
- Audit C: No rival PRs on #78918.

## Real behavior proof

- **Behavior or issue addressed**: Google Chat active-memory recall crash: `Error: Bundled plugin dirName must be a single directory: spaces/khfx4yaaaae` (#78918)
- **Real environment tested**: Live Google Chat session with OpenClaw active-memory enabled, tested by @danieljimz on their own self-hosted deployment
- **Exact steps or command run after this patch**: Run OpenClaw with Google Chat configured and active-memory enabled; send a message in a Google Chat space to trigger active-memory recall
- **Evidence after fix**: Before patch: `Bundled plugin dirName must be a single directory` error thrown for every Google Chat recall. After patch: recall completes without crash. Before screenshot: https://github.com/user-attachments/assets/21abdca4-2156-464d-ac44-c5ef58ec5b57 After screenshot: https://github.com/user-attachments/assets/a37e3b0e-c087-4e47-b294-2c7a0669807c
- **Observed result after fix**: Active-memory recall succeeds for Google Chat sessions with `spaces/<id>` space IDs; `messageChannel` falls back to the provider name `googlechat` instead of the slash-containing space ID
- **What was not tested**: Other slash-containing channel ID patterns beyond Google Chat `spaces/<id>` format; live test was performed by community contributor @danieljimz

Closes #78918