### PR TITLE
fix(feishu): fix topic session splitting for both native topic_group and normal groups with topic message format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Feishu: fix topic session splitting for both native `topic_group` and normal groups using topic message format. Hydrate now queries the replied-to message (`rootId`) instead of the newly sent message, expands the hydrate condition to cover `chat_type="group"` groups with Feishu topic messaging, and suppresses stale `rootId` after successful hydration so the canonical `omt_*` topic ID is used consistently. Refs #78262. Thanks @joeyzenghuan.
+
 ### Changes
 
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -479,10 +479,16 @@ conversion fails, OpenClaw falls back to a file attachment and logs the reason.
 
 For `groupSessionScope: "group_topic"` and `"group_topic_sender"`, native
 Feishu/Lark topic groups use the event `thread_id` (`omt_*`) as the canonical
-topic session key. If a native topic starter event omits `thread_id`, OpenClaw
-hydrates it from Feishu before routing the turn. Normal group replies that
-OpenClaw turns into threads keep using the reply root message ID (`om_*`) so the
-first turn and follow-up turn stay in the same session.
+topic session key. This applies to both native topic groups (`chat_type:
+"topic_group"`) and normal groups using Feishu topic message format (`chat_type:
+"group"` with thread-based messaging enabled in group settings).
+
+If a topic event omits `thread_id` or carries a non-`omt_*` root ID from a
+quote-reply, OpenClaw hydrates the canonical topic thread ID from the replied-to
+message via the Feishu API before routing the turn. Normal group replies that
+OpenClaw turns into threads (without Feishu topic message format) keep using the
+reply root message ID (`om_*`) so the first turn and follow-up turn stay in the
+same session.
 
 ---
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2644,6 +2644,101 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("hydrates topic thread_id via rootId for normal groups with topic message format", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    // The replied-to message (rootId) is already in the topic; API returns its threadId
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_bot_reply_001",
+      chatId: "oc-group",
+      chatType: "group",
+      content: "bot reply",
+      contentType: "text",
+      threadId: "omt_hydrated_topic",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    // Normal group (chat_type="group") reply where threadId is missing but rootId is om_*
+    const replyEvent: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-user" } },
+      message: {
+        message_id: "om_user_reply_001",
+        chat_id: "oc-group",
+        chat_type: "group",
+        root_id: "om_bot_reply_001",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply without thread_id" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: replyEvent });
+
+    // Should hydrate via rootId
+    expect(mockGetMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "om_bot_reply_001",
+      }),
+    );
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:omt_hydrated_topic" },
+      }),
+    );
+  });
+
+  it("suppresses rootId when event carries omt_* threadId and om_* rootId in normal group", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    // Normal group reply where event already carries omt_* threadId + om_* rootId
+    const replyEvent: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-user" } },
+      message: {
+        message_id: "om_user_reply_002",
+        chat_id: "oc-group",
+        chat_type: "group",
+        root_id: "om_bot_reply_002",
+        thread_id: "omt_existing_topic",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply with omt threadId" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: replyEvent });
+
+    // Should use omt_* threadId, NOT om_* rootId
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:omt_existing_topic" },
+      }),
+    );
+  });
+
   it("replies to the topic root when handling a message inside an existing topic", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -533,30 +533,44 @@ export async function handleFeishuMessage(params: {
     ? resolveConfiguredFeishuGroupSessionScope({ groupConfig, feishuCfg })
     : null;
   let effectiveThreadId = ctx.threadId;
-  if (
-    isGroup &&
-    ctx.chatType === "topic_group" &&
-    !effectiveThreadId &&
-    isFeishuTopicSessionScope(groupSessionScope ?? "group")
-  ) {
-    try {
-      const messageInfo = await getMessageFeishu({
-        cfg,
-        accountId: account.accountId,
-        messageId: ctx.messageId,
-      });
-      const hydratedThreadId = messageInfo?.threadId?.trim();
-      if (hydratedThreadId) {
-        ctx = { ...ctx, threadId: hydratedThreadId };
-        effectiveThreadId = hydratedThreadId;
+  // Track whether we identified a native Feishu topic context so we can suppress
+  // rootId in session routing (rootId would otherwise take priority and split the session).
+  let hydratedToNativeTopic = false;
+  if (isGroup && isFeishuTopicSessionScope(groupSessionScope ?? "group")) {
+    const hasValidTopicThreadId = effectiveThreadId && effectiveThreadId.startsWith("omt_");
+    // Only attempt hydration when rootId looks like a real Feishu message ID (om_*)
+    // but is not already a native topic ID (omt_*). This avoids hydrating for
+    // OpenClaw-created threads where rootId is the initiating user message.
+    const hasFeishuRootIdToHydrate =
+      ctx.rootId && ctx.rootId.startsWith("om_") && !ctx.rootId.startsWith("omt_");
+    if (!hasValidTopicThreadId && (ctx.chatType === "topic_group" || hasFeishuRootIdToHydrate)) {
+      try {
+        // Prefer querying rootId (the replied-to message already in the topic)
+        // over messageId (the newly sent message which may not have threadId yet).
+        const hydrateMessageId = ctx.rootId || ctx.messageId;
+        const messageInfo = await getMessageFeishu({
+          cfg,
+          accountId: account.accountId,
+          messageId: hydrateMessageId,
+        });
+        const hydratedThreadId = messageInfo?.threadId?.trim();
+        if (hydratedThreadId && hydratedThreadId.startsWith("omt_")) {
+          ctx = { ...ctx, threadId: hydratedThreadId };
+          effectiveThreadId = hydratedThreadId;
+          hydratedToNativeTopic = true;
+          log(
+            `feishu[${account.accountId}]: hydrated topic thread_id=${hydratedThreadId} for message=${ctx.messageId} (via ${hydrateMessageId})`,
+          );
+        }
+      } catch (err) {
         log(
-          `feishu[${account.accountId}]: hydrated topic thread_id=${hydratedThreadId} for message=${ctx.messageId}`,
+          `feishu[${account.accountId}]: failed to hydrate topic thread_id for message=${ctx.messageId}: ${String(err)}`,
         );
       }
-    } catch (err) {
-      log(
-        `feishu[${account.accountId}]: failed to hydrate topic thread_id for message=${ctx.messageId}: ${String(err)}`,
-      );
+    } else if (hasValidTopicThreadId && hasFeishuRootIdToHydrate) {
+      // Event already carries omt_* threadId AND a Feishu rootId (om_*) — this means
+      // we are in a Feishu native topic with a quote-reply. Suppress rootId so threadId wins.
+      hydratedToNativeTopic = true;
     }
   }
   const effectiveGroupSenderAllowFrom = isGroup
@@ -569,7 +583,10 @@ export async function handleFeishuMessage(params: {
         chatId: ctx.chatId,
         senderOpenId: ctx.senderOpenId,
         messageId: ctx.messageId,
-        rootId: ctx.rootId,
+        // When we identified a native Feishu topic context (omt_*), suppress rootId
+        // so the topicScope fallback chain uses threadId instead of the stale om_* rootId.
+        // For OpenClaw-created threads (non-hydrated), rootId is preserved as-is.
+        rootId: hydratedToNativeTopic ? undefined : ctx.rootId,
         threadId: effectiveThreadId,
         chatType: ctx.chatType,
         groupConfig,


### PR DESCRIPTION
## Summary

- **Problem**: Feishu topic session splitting persists after #78310 — affects **both** native `topic_group` and normal groups with topic message format.
- **Why it matters**: With `groupSessionScope: "group_topic"`, the first turn routes by `rootId` (`om_*`) and follow-ups by `threadId` (`omt_*`), splitting one Feishu topic into multiple OpenClaw sessions.
- **What changed**: 
  1. Hydrate condition expanded to cover normal groups (`chat_type="group"`) with topic message format
  2. Hydrate now queries `rootId` (replied-to message) instead of `messageId` (newly sent message)
  3. When native Feishu topic context is detected (`omt_*` threadId + `om_*` rootId), `rootId` is suppressed in session routing so `threadId` wins
- **What did NOT change**: `resolveFeishuGroupSession` logic in `bot-content.ts` is untouched. OpenClaw-created thread behavior is preserved.

## Two types of Feishu "topic groups"

Feishu has two distinct mechanisms that produce topic-threaded conversations:

| Type | `chat_type` in event | How to create | PR #78310 coverage |
|------|---------------------|---------------|-------------------|
| **Native Topic Group** | `"topic_group"` | Create group → select "Topic" mode | Partially fixed |
| **Normal Group + Topic Message Format** | `"group"` | Group Settings → Message Format → Topic Messages | ❌ Not covered |

The second type is far more common among Feishu users. This PR fixes both.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (Feishu plugin)
- [x] Docs

## Linked Issue/PR

- Fixes remaining issues from #78262
- Extends #78310

## Root Cause

1. **Hydrate queries wrong message**: `ctx.messageId` (newly sent) may not have `threadId` yet in Feishu's API. The replied-to message (`ctx.rootId`) is already in the topic and reliably returns the `omt_*` thread ID.

2. **Hydrate condition too narrow**: `ctx.chatType === "topic_group"` excludes normal groups using topic message format (where `chat_type === "group"` but threads still use `omt_*` IDs).

3. **topicScope priority in `resolveFeishuGroupSession`**: When `chatType !== "topic_group"`, the fallback chain `?? normalizedRootId ?? normalizedThreadId` puts `rootId` (`om_*`) ahead of `threadId` (`omt_*`). Fixed by suppressing `rootId` at the call site when native topic context is detected.

## Real Behavior Proof

Tested on OpenClaw 2026.5.6, Azure VM (jzdm-d2-eastasia), Feishu WebSocket mode.

### Before fix (official 2026.5.6 code) — Session splitting on BOTH group types

**Normal group with topic message format** (`oc_6d8547`, `chat_type="group"`):
```
# User sends first message in topic
[08:29:24] peer=oc_6d8547...:topic:omt_1a99c5aab44c1b90  → session A

# User replies in SAME topic (quote-reply to bot's response)
[08:30:10] peer=oc_6d8547...:topic:om_x100b50f098f4a890  → session B ❌ SPLIT!
```

**Native topic group** (`oc_b70482`, `chat_type="topic_group"`):
```
# User sends first message in topic
[08:28:29] peer=oc_b70482...:topic:omt_1a99c5e5718d5be3  → session A

# User replies in SAME topic
[08:28:56] peer=oc_b70482...:topic:om_x100b50f09c08f484  → session B ❌ SPLIT!
```

### After fix — Stable sessions on BOTH group types

**Normal group with topic message format** (`oc_6d8547`):
```
# User sends "hello to normal group 2" in topic
[11:38:21] peer=oc_6d8547...:topic:omt_1a99f162d6ce9b84  → session A

# User replies "你现在在哪个session id里" in SAME topic  
[11:38:48] peer=oc_6d8547...:topic:omt_1a99f162d6ce9b84  → session A ✅ SAME!
```

**Native topic group** (`oc_b70482`):
```
# User sends "hello to real topic group 3" in topic
[11:40:38] peer=oc_b70482...:topic:omt_1a99f2fce996db84  → session A

# User replies "你现在在哪个session id里" in SAME topic
[11:41:07] peer=oc_b70482...:topic:omt_1a99f2fce996db84  → session A ✅ SAME!
```

### Verification methodology

1. Reverted to official 2026.5.6 code → confirmed session splitting on both group types
2. Applied this patch → confirmed all turns in same topic route to same `omt_*` session
3. Tested multiple rounds on both group types to ensure consistency
4. Verified OpenClaw-created threads (non-topic-message-format groups) still use `rootId`-based routing

## Regression Test Plan

Added 2 new test cases in `bot.test.ts`:
- `hydrates topic thread_id via rootId for normal groups with topic message format` — covers the hydration path when `threadId` is missing but `rootId` is `om_*`
- `suppresses rootId when event carries omt_* threadId and om_* rootId in normal group` — covers the `else if` branch where event already has valid data

Existing test `keeps topic session key stable after first turn creates a thread` verifies OpenClaw-created threads (non-`om_*` rootId) are unaffected.

## User-visible Changes

Feishu topic-mode sessions are stable for both native topic groups and normal groups using topic message format.

## Compatibility / Migration

- Backward compatible: Yes
- Config/env changes: No
- Migration needed: No

## Risks and Mitigations

- **Risk**: Extra Feishu message lookup on topic replies with missing/non-`omt_*` thread ID.
  **Mitigation**: Narrow condition (`rootId` must start with `om_`); failures are caught and logged; existing fallback behavior remains.

- **Risk**: OpenClaw-created thread routing could change.
  **Mitigation**: `hydratedToNativeTopic` is only set when hydration returns `omt_*` or when event carries both `omt_*` threadId + `om_*` rootId. Non-`om_*` rootIds (like those in OpenClaw-created threads) do not trigger any new behavior.
