### PR TITLE
test: verify Gemini replay drops runtime-context and errored turns

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -504,6 +504,81 @@ describe("google transport stream", () => {
     });
   });
 
+  it("drops poisoned Gemini replay turns and runtime-context entries from replay payloads", () => {
+    const params = buildGoogleGenerativeAiParams(buildGeminiModel(), {
+      messages: [
+        { role: "user", content: "Junk", timestamp: 0 },
+        {
+          role: "custom",
+          customType: "openclaw.runtime-context",
+          content: "hidden runtime context",
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-2.5-pro",
+          stopReason: "stop",
+          timestamp: 2,
+          content: [{ type: "text", text: "NO_REPLY" }],
+        },
+        { role: "user", content: "You alive and ready.", timestamp: 3 },
+        {
+          role: "custom",
+          customType: "openclaw.runtime-context",
+          content: "more hidden runtime context",
+          timestamp: 4,
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-2.5-flash",
+          stopReason: "error",
+          errorMessage: "Google Generative AI API error (400)",
+          timestamp: 5,
+          content: [{ type: "text", text: "[assistant turn failed before producing content]" }],
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-2.5-pro",
+          stopReason: "stop",
+          timestamp: 6,
+          content: [{ type: "text", text: "Yes." }],
+        },
+        { role: "user", content: "Good", timestamp: 7 },
+        {
+          role: "custom",
+          customType: "openclaw.runtime-context",
+          content: "latest hidden runtime context",
+          timestamp: 8,
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-2.5-pro",
+          stopReason: "error",
+          errorMessage: "Google Generative AI API error (400)",
+          timestamp: 9,
+          content: [],
+        },
+      ],
+    } as never);
+
+    expect(params.contents).toEqual([
+      { role: "user", parts: [{ text: "Junk" }] },
+      { role: "model", parts: [{ text: "NO_REPLY" }] },
+      { role: "user", parts: [{ text: "You alive and ready." }] },
+      { role: "model", parts: [{ text: "Yes." }] },
+      { role: "user", parts: [{ text: "Good" }] },
+    ]);
+  });
+
   it("builds direct Gemini payloads without negative fallback thinking budgets", () => {
     const model = {
       id: "custom-gemini-model",

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -539,7 +539,6 @@ describe("google transport stream", () => {
           errorMessage: "Google Generative AI API error (400)",
           timestamp: 5,
           content: [{ type: "text", text: "[assistant turn failed before producing content]" }],
-          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
         },
         {
           role: "assistant",

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -69,23 +69,27 @@ describe("installTestEnv", () => {
             custom: { baseUrl: "https://example.test/v1" },
           },
         },
-        channels: {
-          telegram: {
-            streaming: {
-              mode: "block",
-              chunkMode: "newline",
-              block: {
-                enabled: true,
-              },
-              preview: {
-                chunk: {
-                  minChars: 120,
-                },
+      channels: {
+        telegram: {
+          streaming: {
+            mode: "block",
+            chunkMode: "newline",
+            block: {
+              enabled: true,
+            },
+            preview: {
+              chunk: {
+                minChars: 120,
               },
             },
           },
         },
-      }`,
+      },
+      plugins: {
+        enabled: true,
+        bundledDiscovery: false,
+      },
+}`,
     );
     writeFile(path.join(realHome, ".openclaw", "credentials", "token.txt"), "secret\n");
     writeFile(
@@ -151,6 +155,9 @@ describe("installTestEnv", () => {
       block: { enabled: true },
       preview: { chunk: { minChars: 120 } },
     });
+    expect(
+      (copiedConfig as { plugins?: Record<string, unknown> }).plugins?.bundledDiscovery,
+    ).toBeUndefined();
 
     expect(
       fs.existsSync(path.join(testEnv.tempHome, ".openclaw", "credentials", "token.txt")),

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -328,6 +328,10 @@ function sanitizeLiveConfig(raw: string): string {
       });
     }
 
+    if (parsed.plugins && typeof parsed.plugins === "object") {
+      delete (parsed.plugins as Record<string, unknown>).bundledDiscovery;
+    }
+
     if (!isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST_NORMALIZE_CONFIG)) {
       return `${JSON.stringify(parsed, null, 2)}\n`;
     }


### PR DESCRIPTION
## Bug Description

Gemini replay payload construction could include stale/non-user-visible message artifacts in the replay history shape under some prior-turn conditions.

## Root Cause

Replay history needs to exclude:
- `openclaw.runtime-context` custom entries
- assistant turns that failed/errored and should not be replayed back into Gemini contents

## Fix

- add a regression test covering mixed replay history with:
  - runtime-context entries
  - valid assistant turns
  - errored assistant turns
- assert that only valid user/model turns remain in `params.contents`
- make the live-test harness drop legacy `plugins.bundledDiscovery` when copying a real local config into an isolated live-test home, so existing live verification can run end to end in legacy local environments
- add regression coverage for that harness sanitization

## Related Context

This PR adds regression coverage for Gemini replay-history sanitization and the minimal live-test harness compatibility needed to run upstream-facing proof in this environment.

It is adjacent to issue #78838 in the broader Google/Gemini bug cluster, but it does **not** claim to resolve that `rawText` / `assistant_message_end` long-response bug.

## How to Verify

1. Run `pnpm test extensions/google/google-shared.test.ts extensions/google/transport-stream.test.ts test/test-env.test.ts`
2. Confirm the focused suites pass
3. Run `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TOOL_REPLAY_REPAIR_MODELS=google/gemini-2.5-flash node scripts/test-live.mjs --no-quiet src/agents/tool-replay-repair.live.test.ts`
4. Confirm both live tests pass against Gemini

## Test Plan

- [x] Added regression test for replay-history sanitization
- [x] Added regression test for live-harness config sanitization
- [x] Existing focused tests still pass
- [x] Manual/live verification of the fix completed

## Risk Assessment

Low — the replay change remains test-only, and the additional harness change is isolated to test environment setup for live verification.
