### PR TITLE
fix(acp): forward sessions_spawn image attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - ACPX/Codex: preserve trusted Codex project declarations when launching isolated Codex ACP sessions, avoiding interactive trust prompts in headless runs. Thanks @Stedyclaw.
 - ACPX/Codex: reap stale OpenClaw-owned ACPX/Codex ACP process trees on startup and after ACP session close, preventing orphaned harness processes from slowing the Gateway. Thanks @91wan.
 - ACP sessions: allow parent agents to inspect and message their own spawned cross-agent ACP sessions without enabling broad agent-to-agent visibility. Thanks @barronlroth.
+- ACP sessions: forward base64 image attachments from `sessions_spawn(runtime="acp")` into the gateway turn so Codex ACP delegates can use native vision. Fixes #78919. Thanks @SonniaAI.
 - Talk/voice: unify realtime relay, transcription relay, managed-room handoff, Voice Call, Google Meet, VoiceClaw, and native clients around a shared Talk session controller and add the Gateway-managed `talk.session.*` RPC surface.
 - Diagnostics/Talk: export bounded Talk lifecycle/audio metrics and session recovery metrics through OpenTelemetry and Prometheus without exposing transcripts, audio payloads, room ids, turn ids, or session ids.
 - Logging/Talk: route shared Talk lifecycle events into bounded file and OTLP log records while keeping transcript text, audio payloads, turn ids, call ids, and provider item ids out of logs.

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -728,6 +728,37 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
   });
 
+  it("passes image attachments to the ACP gateway dispatch", async () => {
+    const result = await spawnAcpDirect(
+      createSpawnRequest({
+        task: "Analyze attached diagram",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            content: "cG5nLWJ5dGVz",
+          },
+        ],
+      }),
+      createRequesterContext(),
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.runId).toBe("run-1");
+    const agentCall = findAgentGatewayCall();
+    expect(agentCall?.params).toMatchObject({
+      message: "Analyze attached diagram",
+      attachments: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          content: "cG5nLWJ5dGVz",
+        },
+      ],
+      acpTurnSource: "manual_spawn",
+    });
+  });
+
   it("allows ACP resume IDs recorded for the requester session", async () => {
     const resumeSessionId = "codex-inner-resume";
     hoisted.loadSessionStoreMock.mockReturnValue({

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -93,6 +93,11 @@ export const ACP_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 export type SpawnAcpSandboxMode = (typeof ACP_SPAWN_SANDBOX_MODES)[number];
 export const ACP_SPAWN_STREAM_TARGETS = ["parent"] as const;
 export type SpawnAcpStreamTarget = (typeof ACP_SPAWN_STREAM_TARGETS)[number];
+export type SpawnAcpAttachment = {
+  type: "image";
+  mimeType: string;
+  content: string;
+};
 
 export type SpawnAcpParams = {
   task: string;
@@ -107,6 +112,7 @@ export type SpawnAcpParams = {
   thread?: boolean;
   sandbox?: SpawnAcpSandboxMode;
   streamTo?: SpawnAcpStreamTarget;
+  attachments?: SpawnAcpAttachment[];
 };
 
 export type SpawnAcpContext = {
@@ -1395,6 +1401,7 @@ export async function spawnAcpDirect(
         deliver: deliveryPlan.useInlineDelivery,
         lane: AGENT_LANE_SUBAGENT,
         acpTurnSource: "manual_spawn",
+        attachments: params.attachments?.length ? params.attachments : undefined,
         ...(params.runTimeoutSeconds != null ? { timeout: params.runTimeoutSeconds } : {}),
         label: params.label || undefined,
       },

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => {
@@ -637,7 +638,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
-  it("rejects attachments for ACP runtime", async () => {
+  it("forwards base64 image attachments for ACP runtime", async () => {
     registerAcpBackendForTest();
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
@@ -649,15 +650,64 @@ describe("sessions_spawn tool", () => {
 
     const result = await tool.execute("call-3", {
       runtime: "acp",
+      task: "analyze image",
+      attachments: [
+        {
+          name: "diagram.png",
+          content: Buffer.from("png-bytes").toString("base64"),
+          encoding: "base64",
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "analyze image",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            content: Buffer.from("png-bytes").toString("base64"),
+          },
+        ],
+      }),
+      expect.any(Object),
+    );
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-image attachments for ACP runtime", async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "quietchat",
+      agentAccountId: "default",
+      agentTo: "channel:123",
+      agentThreadId: "456",
+    });
+
+    const result = await tool.execute("call-3a", {
+      runtime: "acp",
       task: "analyze file",
-      attachments: [{ name: "a.txt", content: "hello", encoding: "utf8" }],
+      attachments: [
+        {
+          name: "notes.txt",
+          content: Buffer.from("hello").toString("base64"),
+          encoding: "base64",
+          mimeType: "text/plain",
+        },
+      ],
     });
 
     expect(result.details).toMatchObject({
       status: "error",
     });
     const details = result.details as { error?: string };
-    expect(details.error).toContain("attachments are currently unsupported for runtime=acp");
+    expect(details.error).toContain("runtime=acp attachments only support image/*");
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -10,8 +10,10 @@ import { callGateway } from "../../gateway/call.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import type { SpawnAcpAttachment } from "../acp-spawn.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
+import { decodeStrictBase64 } from "../subagent-attachments.js";
 import { registerSubagentRun } from "../subagent-registry.js";
 import {
   SUBAGENT_SPAWN_CONTEXT_MODES,
@@ -33,6 +35,8 @@ import {
 
 const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp"] as const;
 const SESSIONS_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
+const ACP_IMAGE_ATTACHMENT_MAX_COUNT = 8;
+const ACP_IMAGE_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
 // Keep the schema local to avoid a circular import through acp-spawn/openclaw-tools.
 const SESSIONS_SPAWN_ACP_STREAM_TARGETS = ["parent"] as const;
 const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
@@ -47,6 +51,16 @@ const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
 ] as const;
 
 type AcpSpawnModule = typeof import("../acp-spawn.js");
+type SessionsSpawnAttachment = {
+  name: string;
+  content: string;
+  encoding?: "utf8" | "base64";
+  mimeType?: string;
+};
+
+type ResolveAcpImageAttachmentsResult =
+  | { status: "ok"; attachments?: SpawnAcpAttachment[] }
+  | { status: "error"; error: string };
 
 const acpSpawnModuleLoader = createLazyImportLoader<AcpSpawnModule>(
   () => import("../acp-spawn.js"),
@@ -84,6 +98,52 @@ function resolveTrackedSpawnMode(params: {
     return params.requestedMode;
   }
   return params.threadRequested ? "session" : "run";
+}
+
+function resolveAcpImageAttachments(
+  attachments: SessionsSpawnAttachment[] | undefined,
+): ResolveAcpImageAttachmentsResult {
+  if (!Array.isArray(attachments) || attachments.length === 0) {
+    return { status: "ok" };
+  }
+  if (attachments.length > ACP_IMAGE_ATTACHMENT_MAX_COUNT) {
+    return {
+      status: "error",
+      error: `runtime=acp image attachment count exceeded (max=${ACP_IMAGE_ATTACHMENT_MAX_COUNT})`,
+    };
+  }
+
+  const resolved: SpawnAcpAttachment[] = [];
+  for (const attachment of attachments) {
+    const mimeType =
+      typeof attachment.mimeType === "string" ? attachment.mimeType.trim().toLowerCase() : "";
+    if (!mimeType.startsWith("image/")) {
+      return {
+        status: "error",
+        error: "runtime=acp attachments only support image/* mimeType values",
+      };
+    }
+    if (attachment.encoding !== "base64") {
+      return {
+        status: "error",
+        error: "runtime=acp image attachments require encoding=base64",
+      };
+    }
+    const decoded = decodeStrictBase64(attachment.content, ACP_IMAGE_ATTACHMENT_MAX_BYTES);
+    if (decoded === null) {
+      return {
+        status: "error",
+        error: `runtime=acp image attachment is invalid base64 or exceeds ${ACP_IMAGE_ATTACHMENT_MAX_BYTES} bytes`,
+      };
+    }
+    resolved.push({
+      type: "image",
+      mimeType,
+      content: decoded.toString("base64"),
+    });
+  }
+
+  return { status: "ok", attachments: resolved };
 }
 
 async function cleanupUntrackedAcpSession(sessionKey: string): Promise<void> {
@@ -311,21 +371,16 @@ export function createSessionsSpawnTool(
           : undefined;
       const thread = params.thread === true;
       const attachments = Array.isArray(params.attachments)
-        ? (params.attachments as Array<{
-            name: string;
-            content: string;
-            encoding?: "utf8" | "base64";
-            mimeType?: string;
-          }>)
+        ? (params.attachments as SessionsSpawnAttachment[])
         : undefined;
 
       if (runtime === "acp") {
         const { isSpawnAcpAcceptedResult, spawnAcpDirect } = await loadAcpSpawnModule();
-        if (Array.isArray(attachments) && attachments.length > 0) {
+        const acpAttachments = resolveAcpImageAttachments(attachments);
+        if (acpAttachments.status === "error") {
           return jsonResult({
             status: "error",
-            error:
-              "attachments are currently unsupported for runtime=acp; use runtime=subagent or remove attachments",
+            error: acpAttachments.error,
             ...roleContext,
           });
         }
@@ -343,6 +398,7 @@ export function createSessionsSpawnTool(
             thread,
             sandbox,
             streamTo,
+            attachments: acpAttachments.attachments,
           },
           {
             agentSessionKey: opts?.agentSessionKey,


### PR DESCRIPTION
Fixes #78919.

## Summary
- allows sessions_spawn(runtime="acp") to accept base64 image/* attachments instead of rejecting all attachments
- validates ACP image attachments before dispatch and forwards them through the existing gateway attachment path
- adds regression coverage for the sessions_spawn tool bridge and ACP gateway dispatch params

## Tests
- pnpm test src/agents/tools/sessions-spawn-tool.test.ts src/agents/acp-spawn.test.ts
- git diff --check
- pnpm check:changed (fails in current upstream main: src/infra/kysely-node-sqlite.ts cannot resolve kysely; unrelated to this branch)

## Audit
- Existing-helper check: reused decodeStrictBase64 for bounded base64 validation; reused existing gateway attachment shape.
- Shared-helper caller check: did not change decodeStrictBase64 contract; spawnAcpDirect only gains optional attachments.
- Rival scan: no open PR directly covers sessions_spawn(runtime="acp") image attachments; related ACP/image PRs are broader channel/UI paths.