### PR TITLE
fix(providers): skip store:false on proxy-like Responses API endpoints

### DIFF
--- a/src/agents/openai-ws-request.ts
+++ b/src/agents/openai-ws-request.ts
@@ -185,19 +185,20 @@ export function buildOpenAIWebSocketResponseCreatePayload(params: {
     extraParams.text = { ...existingText, verbosity: textVerbosity };
   }
 
-  const supportsResponsesStoreField = resolveProviderRequestPolicyConfig({
-    provider: readStringValue(params.model.provider),
-    api: readStringValue(params.model.api),
-    baseUrl: readStringValue(params.model.baseUrl),
-    compat: (params.model as { compat?: { supportsStore?: boolean } }).compat,
-    capability: "llm",
-    transport: "websocket",
-  }).capabilities.supportsResponsesStoreField;
+  const { supportsResponsesStoreField, usesExplicitProxyLikeEndpoint } =
+    resolveProviderRequestPolicyConfig({
+      provider: readStringValue(params.model.provider),
+      api: readStringValue(params.model.api),
+      baseUrl: readStringValue(params.model.baseUrl),
+      compat: (params.model as { compat?: { supportsStore?: boolean } }).compat,
+      capability: "llm",
+      transport: "websocket",
+    }).capabilities;
 
   return {
     type: "response.create",
     model: params.model.id,
-    ...(supportsResponsesStoreField ? { store: false } : {}),
+    ...(supportsResponsesStoreField && !usesExplicitProxyLikeEndpoint ? { store: false } : {}),
     input: params.turnInput.inputItems,
     instructions: params.context.systemPrompt
       ? stripSystemPromptCacheBoundary(params.context.systemPrompt)


### PR DESCRIPTION
## Problem

When using `api = openai-responses` through a LiteLLM proxy, multi-turn conversations fail with a 400:

```
Item with id 'rs_...' not found
Items are not persisted when store is set to false
Try again with store set to true, or remove this item from your input
```

Closes #78897

## Root cause

`buildOpenAIWebSocketResponseCreatePayload` emits `store: false` whenever `supportsResponsesStoreField` is true — which includes LiteLLM and other OpenAI-compatible proxies. The proxy forwards `store: false` to OpenAI, preventing items from being persisted. On continuation turns where `previous_response_id` references an `rs_*` item, OpenAI rejects the request.

`supportsResponsesStoreField` means "the Responses API `store` field is syntactically supported", not "we want to request storage". `allowsResponsesStore` (already false for proxies) is the right gate for the latter.

## Fix

Mirror the `shouldStripResponsesPromptCache` pattern (`provider-attribution.ts:700-705`): gate `store: false` on `!usesExplicitProxyLikeEndpoint`. For proxy-like endpoints, omit `store` entirely — the proxy/provider controls persistence.

Native endpoints (openai-public, openai-codex, azure-openai) are unaffected.

## Change

`src/agents/openai-ws-request.ts` — destructure `usesExplicitProxyLikeEndpoint` from capabilities; add `&& !usesExplicitProxyLikeEndpoint` to the `store: false` spread.

1 file, 2-line behavioral change.

## Real behavior proof

Source-reproducible: LiteLLM with `api: openai-responses` and a configured `baseUrl` sets `usesExplicitProxyLikeEndpoint = true`. With this fix, `store: false` is omitted for that config, allowing Responses API items to be persisted and `previous_response_id` continuations to succeed.