### PR TITLE
fix(providers): skip store:false for proxy-like Responses API endpoints

### DIFF
--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -176,4 +176,29 @@ describe("openai responses payload policy", () => {
       shouldStripStore: false,
     });
   });
+
+  it("skips store:false for proxy-like responses endpoints in disable mode", () => {
+    // LiteLLM and other OpenAI-compatible proxies (custom baseUrl) should not
+    // receive store:false — forwarding it to OpenAI prevents response persistence
+    // and breaks previous_response_id multi-turn continuations (#78897).
+    const proxyPolicy = resolveOpenAIResponsesPayloadPolicy(
+      {
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://litellm.example.com/v1",
+      },
+      { storeMode: "disable" },
+    );
+    expect(proxyPolicy.explicitStore).toBeUndefined();
+
+    const nativePolicy = resolveOpenAIResponsesPayloadPolicy(
+      {
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+      },
+      { storeMode: "disable" },
+    );
+    expect(nativePolicy.explicitStore).toBe(false);
+  });
 });

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -56,6 +56,7 @@ type OpenAIResponsesPayloadCapabilities = {
   allowsResponsesStore: boolean;
   shouldStripResponsesPromptCache: boolean;
   supportsResponsesStoreField: boolean;
+  usesExplicitProxyLikeEndpoint: boolean;
   usesKnownNativeOpenAIRoute: boolean;
 };
 
@@ -255,6 +256,7 @@ function resolveOpenAIResponsesPayloadCapabilities(
       usesKnownNativeOpenAIEndpoint,
     shouldStripResponsesPromptCache,
     supportsResponsesStoreField,
+    usesExplicitProxyLikeEndpoint,
     usesKnownNativeOpenAIRoute,
   };
 }
@@ -326,7 +328,7 @@ export function resolveOpenAIResponsesPayloadPolicy(
     storeMode === "preserve"
       ? undefined
       : storeMode === "disable"
-        ? capabilities.supportsResponsesStoreField
+        ? capabilities.supportsResponsesStoreField && !capabilities.usesExplicitProxyLikeEndpoint
           ? false
           : undefined
         : capabilities.allowsResponsesStore


### PR DESCRIPTION
## Problem

Fixes #78897.

When using an OpenAI-compatible proxy (e.g. LiteLLM) with the `openai-responses` API, multi-turn conversations fail because `store:false` is forwarded to OpenAI, which then discards items. A subsequent `previous_response_id` continuation returns a 400 error.

**Root cause:** `resolveOpenAIResponsesPayloadPolicy` with `storeMode: "disable"` sets `explicitStore = false` whenever `supportsResponsesStoreField` is true. That flag is `true` for **any** `openai-responses` API endpoint including LiteLLM proxies. The proxy transparently forwards `store:false` to OpenAI, breaking response persistence.

## Fix

Gate `storeMode === "disable"` on `!capabilities.usesExplicitProxyLikeEndpoint`, mirroring the existing `shouldStripResponsesPromptCache` pattern. `usesExplicitProxyLikeEndpoint` is already computed as `usesConfiguredBaseUrl && !usesKnownNativeOpenAIEndpoint`.

## Scope

2 files: `src/agents/openai-responses-payload-policy.ts` (+3/-1), `src/agents/openai-responses-payload-policy.test.ts` (+25). No new helpers.

## Behavior

| Endpoint | Before | After |
|---|---|---|
| api.openai.com (native) | store:false | store:false |
| LiteLLM proxy (custom baseUrl) | store:false (broken) | store:undefined (fixed) |
| Azure OpenAI | store:false | store:false |

## Change Type

- [x] Bug fix

## Real behavior proof

Behavior addressed: `storeMode:"disable"` was emitting `store:false` for proxy-like endpoints (custom baseUrl, not a known native OpenAI host), causing LiteLLM to forward it to OpenAI, which discards items and breaks `previous_response_id` multi-turn continuations.

Real environment tested: Ubuntu 24.04, Node v22.22.0, pnpm v10.33.2, working tree at `fix/openai-responses-proxy-store` on top of `955b025697`.

Exact steps run:
```
pnpm install --frozen-lockfile
pnpm test src/agents/openai-responses-payload-policy.test.ts
```

Evidence after fix:
```
 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  21:40:53
   Duration  121ms (transform 31ms, setup 0ms, import 40ms, tests 4ms, environment 0ms)
```

The new test `skips store:false for proxy-like responses endpoints in disable mode` verifies:
- `litellm.example.com/v1` (proxy) → `explicitStore: undefined` (no store field sent)
- `api.openai.com/v1` (native) → `explicitStore: false` (unchanged behavior)

All 7 existing tests continue to pass.

What was not tested: live LiteLLM proxy multi-turn conversation (requires running LiteLLM + OpenAI API key).

## Regression Test Plan

New unit test in `src/agents/openai-responses-payload-policy.test.ts`. All 8 tests pass.

## Compatibility / Migration

Backward compatible. Only affects proxy-like endpoints. Native OpenAI behavior unchanged.