### PR TITLE
fix(agents): expose catalog headers to provider wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Provider plugins: expose sanitized provider catalog headers on the resolved runtime model passed to stream wrappers. Fixes #78843. Thanks @0xCAB0.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -394,6 +394,11 @@ API key auth, and dynamic model resolution.
       <Tab title="Custom headers">
         For providers that need custom request headers or body modifications:
 
+        `ctx.model.headers` contains sanitized static headers resolved from
+        provider and model catalog configuration. SecretRef-backed headers are
+        not exposed as raw values there. Stream wrappers should still merge
+        final per-call headers into `params.headers`.
+
         ```typescript
         // wrapStreamFn returns a StreamFn derived from ctx.streamFn
         wrapStreamFn: (ctx) => {

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -368,6 +368,11 @@ API key auth, and dynamic model resolution.
       <Tab title="Custom headers">
         For providers that need custom request headers or body modifications:
 
+        `ctx.model.headers` contains sanitized static headers resolved from
+        provider and model catalog configuration. SecretRef-backed headers are
+        not exposed as raw values there. Stream wrappers should still merge
+        final per-call headers into `params.headers`.
+
         ```typescript
         // wrapStreamFn returns a StreamFn derived from ctx.streamFn
         wrapStreamFn: (ctx) => {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../../test-utils/temp-dir.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   replaceRuntimeAuthProfileStoreSnapshots,
@@ -294,6 +295,31 @@ function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0): Record<stri
     throw new Error(`Expected mock call ${callIndex}`);
   }
   return call[0] as Record<string, unknown>;
+}
+
+async function resolveModelFromModelsJson(params: {
+  agentDir: string;
+  provider: string;
+  modelId: string;
+  modelsJson: unknown;
+}) {
+  fs.writeFileSync(
+    path.join(params.agentDir, "models.json"),
+    `${JSON.stringify(params.modelsJson, null, 2)}\n`,
+    "utf8",
+  );
+  const actualDiscovery = await vi.importActual<typeof import("../pi-model-discovery.js")>(
+    "../pi-model-discovery.js",
+  );
+  const authStorage = actualDiscovery.discoverAuthStorage(params.agentDir, {
+    skipCredentials: true,
+  });
+  const modelRegistry = actualDiscovery.discoverModels(authStorage, params.agentDir);
+  return resolveModel(params.provider, params.modelId, params.agentDir, {} as OpenClawConfig, {
+    authStorage,
+    modelRegistry,
+    runtimeHooks: createRuntimeHooks(),
+  });
 }
 
 describe("resolveModel", () => {
@@ -942,6 +968,64 @@ describe("resolveModel", () => {
 
     expect(model.headers).toEqual({
       "X-Static": "tenant-a",
+    });
+  });
+
+  it("includes provider catalog headers from generated models.json", async () => {
+    await withTempDir("openclaw-provider-catalog-headers-", async (agentDir) => {
+      const result = await resolveModelFromModelsJson({
+        agentDir,
+        provider: "cloudflare-unified-billing",
+        modelId: "openai/gpt-5.5",
+        modelsJson: {
+          providers: {
+            "cloudflare-unified-billing": {
+              baseUrl: "https://gateway.ai.cloudflare.com/v1/example/account/openai",
+              api: "openai-completions",
+              apiKey: "TEST_CF_TOKEN",
+              headers: {
+                "cf-aig-authorization": "Bearer TEST_CF_TOKEN",
+              },
+              models: [{ id: "openai/gpt-5.5", name: "openai/gpt-5.5" }],
+            },
+          },
+        },
+      });
+      const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
+
+      expect(model.headers).toEqual({
+        "cf-aig-authorization": "Bearer TEST_CF_TOKEN",
+      });
+    });
+  });
+
+  it("drops SecretRef marker provider catalog headers from generated models.json", async () => {
+    await withTempDir("openclaw-provider-catalog-headers-", async (agentDir) => {
+      const result = await resolveModelFromModelsJson({
+        agentDir,
+        provider: "custom",
+        modelId: "listed-model",
+        modelsJson: {
+          providers: {
+            custom: {
+              baseUrl: "http://localhost:9000",
+              api: "openai-completions",
+              apiKey: "TEST_TOKEN",
+              headers: {
+                Authorization: "secretref-env:OPENAI_HEADER_TOKEN",
+                "X-Managed": "secretref-managed",
+                "X-Static": "tenant-a",
+              },
+              models: [{ id: "listed-model", name: "listed-model" }],
+            },
+          },
+        },
+      });
+      const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
+
+      expect(model.headers).toEqual({
+        "X-Static": "tenant-a",
+      });
     });
   });
 

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1,4 +1,7 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../../test-utils/temp-dir.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
 
@@ -226,6 +229,31 @@ function resolveModelAsyncForTest(
     authStorage: { mocked: true } as never,
     modelRegistry: discoverModels({ mocked: true } as never, resolvedAgentDir),
     ...options,
+    runtimeHooks: createRuntimeHooks(),
+  });
+}
+
+async function resolveModelFromModelsJson(params: {
+  agentDir: string;
+  provider: string;
+  modelId: string;
+  modelsJson: unknown;
+}) {
+  await fs.writeFile(
+    path.join(params.agentDir, "models.json"),
+    `${JSON.stringify(params.modelsJson, null, 2)}\n`,
+    "utf8",
+  );
+  const actualDiscovery = await vi.importActual<typeof import("../pi-model-discovery.js")>(
+    "../pi-model-discovery.js",
+  );
+  const authStorage = actualDiscovery.discoverAuthStorage(params.agentDir, {
+    skipCredentials: true,
+  });
+  const modelRegistry = actualDiscovery.discoverModels(authStorage, params.agentDir);
+  return resolveModel(params.provider, params.modelId, params.agentDir, {} as OpenClawConfig, {
+    authStorage,
+    modelRegistry,
     runtimeHooks: createRuntimeHooks(),
   });
 }
@@ -631,6 +659,64 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
       "X-Static": "tenant-a",
+    });
+  });
+
+  it("includes provider catalog headers from generated models.json", async () => {
+    await withTempDir("openclaw-provider-catalog-headers-", async (agentDir) => {
+      const result = await resolveModelFromModelsJson({
+        agentDir,
+        provider: "cloudflare-unified-billing",
+        modelId: "openai/gpt-5.2",
+        modelsJson: {
+          providers: {
+            "cloudflare-unified-billing": {
+              baseUrl: "https://gateway.ai.cloudflare.com/v1/example/account/openai",
+              api: "openai-completions",
+              apiKey: "TEST_CF_TOKEN",
+              headers: {
+                "cf-aig-authorization": "Bearer TEST_CF_TOKEN",
+              },
+              models: [{ id: "openai/gpt-5.2", name: "openai/gpt-5.2" }],
+            },
+          },
+        },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
+        "cf-aig-authorization": "Bearer TEST_CF_TOKEN",
+      });
+    });
+  });
+
+  it("drops SecretRef marker provider catalog headers from generated models.json", async () => {
+    await withTempDir("openclaw-provider-catalog-headers-", async (agentDir) => {
+      const result = await resolveModelFromModelsJson({
+        agentDir,
+        provider: "custom",
+        modelId: "listed-model",
+        modelsJson: {
+          providers: {
+            custom: {
+              baseUrl: "http://localhost:9000",
+              api: "openai-completions",
+              apiKey: "TEST_TOKEN",
+              headers: {
+                Authorization: "secretref-env:OPENAI_HEADER_TOKEN",
+                "X-Managed": "secretref-managed",
+                "X-Static": "tenant-a",
+              },
+              models: [{ id: "listed-model", name: "listed-model" }],
+            },
+          },
+        },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
+        "X-Static": "tenant-a",
+      });
     });
   });
 

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
@@ -12,6 +13,7 @@ import {
   normalizeProviderResolvedModelWithPlugin,
 } from "../plugins/provider-runtime.js";
 import { isRecord } from "../utils.js";
+import { isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import type { PiCredentialMap } from "./pi-auth-credentials.js";
 import {
   resolvePiCredentialsForDiscovery,
@@ -38,6 +40,11 @@ type DiscoverModelsOptions = {
   normalizeModels?: boolean;
 };
 
+type ModelCatalogHeaderConfig = {
+  providerHeaders: Map<string, Record<string, string>>;
+  modelHeaders: Map<string, Record<string, string>>;
+};
+
 type InMemoryAuthStorageBackendLike = {
   withLock<T>(
     update: (current: string) => {
@@ -46,6 +53,126 @@ type InMemoryAuthStorageBackendLike = {
     },
   ): T;
 };
+
+const FORBIDDEN_MODEL_CATALOG_HEADER_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+function normalizeModelCatalogHeaderKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+function getModelCatalogHeaderKey(provider: string, modelId: string): string {
+  return `${provider}\0${modelId}`;
+}
+
+function mergeStaticModelCatalogHeaders(
+  ...headerSets: Array<Record<string, string> | undefined>
+): Record<string, string> | undefined {
+  let merged: Record<string, string> | undefined;
+  const headerNamesByLowerKey = new Map<string, string>();
+  for (const headers of headerSets) {
+    if (!headers) {
+      continue;
+    }
+    merged ??= {};
+    for (const [key, value] of Object.entries(headers)) {
+      const normalizedKey = normalizeModelCatalogHeaderKey(key);
+      if (!normalizedKey || FORBIDDEN_MODEL_CATALOG_HEADER_KEYS.has(normalizedKey)) {
+        continue;
+      }
+      const previousKey = headerNamesByLowerKey.get(normalizedKey);
+      if (previousKey && previousKey !== key) {
+        delete merged[previousKey];
+      }
+      merged[key] = value;
+      headerNamesByLowerKey.set(normalizedKey, key);
+    }
+  }
+  return merged && Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function readStaticModelCatalogHeaders(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  let headers: Record<string, string> | undefined;
+  const headerNamesByLowerKey = new Map<string, string>();
+  for (const [key, headerValue] of Object.entries(value)) {
+    if (typeof headerValue !== "string" || isSecretRefHeaderValueMarker(headerValue)) {
+      continue;
+    }
+    const normalizedKey = normalizeModelCatalogHeaderKey(key);
+    if (!normalizedKey || FORBIDDEN_MODEL_CATALOG_HEADER_KEYS.has(normalizedKey)) {
+      continue;
+    }
+    headers ??= {};
+    const previousKey = headerNamesByLowerKey.get(normalizedKey);
+    if (previousKey && previousKey !== key) {
+      delete headers[previousKey];
+    }
+    headers[key] = headerValue;
+    headerNamesByLowerKey.set(normalizedKey, key);
+  }
+  return headers && Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+function readModelCatalogHeaderConfig(
+  modelsJsonPath: string,
+): ModelCatalogHeaderConfig | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(modelsJsonPath, "utf8"));
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.providers)) {
+    return undefined;
+  }
+  const providerHeaders = new Map<string, Record<string, string>>();
+  const modelHeaders = new Map<string, Record<string, string>>();
+  for (const [provider, providerConfig] of Object.entries(parsed.providers)) {
+    if (!isRecord(providerConfig)) {
+      continue;
+    }
+    const staticProviderHeaders = readStaticModelCatalogHeaders(providerConfig.headers);
+    if (staticProviderHeaders) {
+      providerHeaders.set(provider, staticProviderHeaders);
+    }
+    const models = providerConfig.models;
+    if (!Array.isArray(models)) {
+      continue;
+    }
+    for (const model of models) {
+      if (!isRecord(model) || typeof model.id !== "string") {
+        continue;
+      }
+      const staticModelHeaders = readStaticModelCatalogHeaders(model.headers);
+      if (staticModelHeaders) {
+        modelHeaders.set(getModelCatalogHeaderKey(provider, model.id), staticModelHeaders);
+      }
+    }
+  }
+  return providerHeaders.size > 0 || modelHeaders.size > 0
+    ? { providerHeaders, modelHeaders }
+    : undefined;
+}
+
+function materializeModelCatalogHeaders<T>(
+  value: T,
+  config: ModelCatalogHeaderConfig | undefined,
+): T {
+  if (!config || !isRecord(value)) {
+    return value;
+  }
+  if (typeof value.provider !== "string" || typeof value.id !== "string") {
+    return value;
+  }
+  const headers = mergeStaticModelCatalogHeaders(
+    readStaticModelCatalogHeaders(value.headers),
+    config.providerHeaders.get(value.provider),
+    config.modelHeaders.get(getModelCatalogHeaderKey(value.provider, value.id)),
+  );
+  return headers ? ({ ...value, headers } as T) : value;
+}
 
 function createInMemoryAuthStorageBackend(
   initialData: PiCredentialMap,
@@ -148,25 +275,24 @@ function createOpenClawModelRegistry(
   const getAvailable = registry.getAvailable.bind(registry);
   const find = registry.find.bind(registry);
   const refresh = registry.refresh.bind(registry);
+  let catalogHeaderConfig = readModelCatalogHeaderConfig(modelsJsonPath);
   const providerFilter = options?.providerFilter ? normalizeProviderId(options.providerFilter) : "";
   const matchesProviderFilter = (entry: Model<Api>) =>
     !providerFilter || normalizeProviderId(entry.provider) === providerFilter;
   const shouldNormalize = options?.normalizeModels !== false;
   const findCache = new Map<string, Model<Api> | undefined>();
-  const normalizeEntry = (entry: Model<Api>) =>
-    shouldNormalize ? normalizeDiscoveredPiModel(entry, agentDir) : entry;
+  const prepareEntry = (entry: Model<Api>) => {
+    const materialized = materializeModelCatalogHeaders(entry, catalogHeaderConfig);
+    return shouldNormalize ? normalizeDiscoveredPiModel(materialized, agentDir) : materialized;
+  };
 
   registry.getAll = () => {
     const entries = getAll().filter((entry: Model<Api>) => matchesProviderFilter(entry));
-    return shouldNormalize
-      ? entries.map((entry: Model<Api>) => normalizeDiscoveredPiModel(entry, agentDir))
-      : entries;
+    return entries.map((entry: Model<Api>) => prepareEntry(entry));
   };
   registry.getAvailable = () => {
     const entries = getAvailable().filter((entry: Model<Api>) => matchesProviderFilter(entry));
-    return shouldNormalize
-      ? entries.map((entry: Model<Api>) => normalizeDiscoveredPiModel(entry, agentDir))
-      : entries;
+    return entries.map((entry: Model<Api>) => prepareEntry(entry));
   };
   registry.find = (provider: string, modelId: string) => {
     const normalizedProvider = normalizeProviderId(provider);
@@ -175,12 +301,13 @@ function createOpenClawModelRegistry(
       return findCache.get(key);
     }
     const fallbackEntry = find(provider, modelId);
-    const resolved = fallbackEntry ? normalizeEntry(fallbackEntry) : undefined;
+    const resolved = fallbackEntry ? prepareEntry(fallbackEntry) : undefined;
     findCache.set(key, resolved);
     return resolved;
   };
   registry.refresh = () => {
     findCache.clear();
+    catalogHeaderConfig = readModelCatalogHeaderConfig(modelsJsonPath);
     return refresh();
   };
 

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import * as PiCodingAgent from "@mariozechner/pi-coding-agent";
@@ -12,6 +13,7 @@ import {
   normalizeProviderResolvedModelWithPlugin,
 } from "../plugins/provider-runtime.js";
 import { isRecord } from "../utils.js";
+import { isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import type { PiCredentialMap } from "./pi-auth-credentials.js";
 import {
   resolvePiCredentialsForDiscovery,
@@ -38,6 +40,11 @@ type DiscoverModelsOptions = {
   normalizeModels?: boolean;
 };
 
+type ModelCatalogHeaderConfig = {
+  providerHeaders: Map<string, Record<string, string>>;
+  modelHeaders: Map<string, Record<string, string>>;
+};
+
 type InMemoryAuthStorageBackendLike = {
   withLock<T>(
     update: (current: string) => {
@@ -46,6 +53,126 @@ type InMemoryAuthStorageBackendLike = {
     },
   ): T;
 };
+
+const FORBIDDEN_MODEL_CATALOG_HEADER_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+function normalizeModelCatalogHeaderKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+function getModelCatalogHeaderKey(provider: string, modelId: string): string {
+  return `${provider}\0${modelId}`;
+}
+
+function mergeStaticModelCatalogHeaders(
+  ...headerSets: Array<Record<string, string> | undefined>
+): Record<string, string> | undefined {
+  let merged: Record<string, string> | undefined;
+  const headerNamesByLowerKey = new Map<string, string>();
+  for (const headers of headerSets) {
+    if (!headers) {
+      continue;
+    }
+    merged ??= {};
+    for (const [key, value] of Object.entries(headers)) {
+      const normalizedKey = normalizeModelCatalogHeaderKey(key);
+      if (!normalizedKey || FORBIDDEN_MODEL_CATALOG_HEADER_KEYS.has(normalizedKey)) {
+        continue;
+      }
+      const previousKey = headerNamesByLowerKey.get(normalizedKey);
+      if (previousKey && previousKey !== key) {
+        delete merged[previousKey];
+      }
+      merged[key] = value;
+      headerNamesByLowerKey.set(normalizedKey, key);
+    }
+  }
+  return merged && Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function readStaticModelCatalogHeaders(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  let headers: Record<string, string> | undefined;
+  const headerNamesByLowerKey = new Map<string, string>();
+  for (const [key, headerValue] of Object.entries(value)) {
+    if (typeof headerValue !== "string" || isSecretRefHeaderValueMarker(headerValue)) {
+      continue;
+    }
+    const normalizedKey = normalizeModelCatalogHeaderKey(key);
+    if (!normalizedKey || FORBIDDEN_MODEL_CATALOG_HEADER_KEYS.has(normalizedKey)) {
+      continue;
+    }
+    headers ??= {};
+    const previousKey = headerNamesByLowerKey.get(normalizedKey);
+    if (previousKey && previousKey !== key) {
+      delete headers[previousKey];
+    }
+    headers[key] = headerValue;
+    headerNamesByLowerKey.set(normalizedKey, key);
+  }
+  return headers && Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+function readModelCatalogHeaderConfig(
+  modelsJsonPath: string,
+): ModelCatalogHeaderConfig | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(modelsJsonPath, "utf8"));
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.providers)) {
+    return undefined;
+  }
+  const providerHeaders = new Map<string, Record<string, string>>();
+  const modelHeaders = new Map<string, Record<string, string>>();
+  for (const [provider, providerConfig] of Object.entries(parsed.providers)) {
+    if (!isRecord(providerConfig)) {
+      continue;
+    }
+    const staticProviderHeaders = readStaticModelCatalogHeaders(providerConfig.headers);
+    if (staticProviderHeaders) {
+      providerHeaders.set(provider, staticProviderHeaders);
+    }
+    const models = providerConfig.models;
+    if (!Array.isArray(models)) {
+      continue;
+    }
+    for (const model of models) {
+      if (!isRecord(model) || typeof model.id !== "string") {
+        continue;
+      }
+      const staticModelHeaders = readStaticModelCatalogHeaders(model.headers);
+      if (staticModelHeaders) {
+        modelHeaders.set(getModelCatalogHeaderKey(provider, model.id), staticModelHeaders);
+      }
+    }
+  }
+  return providerHeaders.size > 0 || modelHeaders.size > 0
+    ? { providerHeaders, modelHeaders }
+    : undefined;
+}
+
+function materializeModelCatalogHeaders<T>(
+  value: T,
+  config: ModelCatalogHeaderConfig | undefined,
+): T {
+  if (!config || !isRecord(value)) {
+    return value;
+  }
+  if (typeof value.provider !== "string" || typeof value.id !== "string") {
+    return value;
+  }
+  const headers = mergeStaticModelCatalogHeaders(
+    readStaticModelCatalogHeaders(value.headers),
+    config.providerHeaders.get(value.provider),
+    config.modelHeaders.get(getModelCatalogHeaderKey(value.provider, value.id)),
+  );
+  return headers ? ({ ...value, headers } as T) : value;
+}
 
 function createInMemoryAuthStorageBackend(
   initialData: PiCredentialMap,
@@ -147,27 +274,25 @@ function createOpenClawModelRegistry(
   const getAll = registry.getAll.bind(registry);
   const getAvailable = registry.getAvailable.bind(registry);
   const find = registry.find.bind(registry);
+  const catalogHeaderConfig = readModelCatalogHeaderConfig(modelsJsonPath);
   const providerFilter = options?.providerFilter ? normalizeProviderId(options.providerFilter) : "";
   const matchesProviderFilter = (entry: Model<Api>) =>
     !providerFilter || normalizeProviderId(entry.provider) === providerFilter;
   const shouldNormalize = options?.normalizeModels !== false;
+  const prepareEntry = <T>(entry: T): T => {
+    const materialized = materializeModelCatalogHeaders(entry, catalogHeaderConfig);
+    return shouldNormalize ? normalizeDiscoveredPiModel(materialized, agentDir) : materialized;
+  };
 
   registry.getAll = () => {
     const entries = getAll().filter((entry: Model<Api>) => matchesProviderFilter(entry));
-    return shouldNormalize
-      ? entries.map((entry: Model<Api>) => normalizeDiscoveredPiModel(entry, agentDir))
-      : entries;
+    return entries.map((entry: Model<Api>) => prepareEntry(entry));
   };
   registry.getAvailable = () => {
     const entries = getAvailable().filter((entry: Model<Api>) => matchesProviderFilter(entry));
-    return shouldNormalize
-      ? entries.map((entry: Model<Api>) => normalizeDiscoveredPiModel(entry, agentDir))
-      : entries;
+    return entries.map((entry: Model<Api>) => prepareEntry(entry));
   };
-  registry.find = (provider: string, modelId: string) =>
-    shouldNormalize
-      ? normalizeDiscoveredPiModel(find(provider, modelId), agentDir)
-      : find(provider, modelId);
+  registry.find = (provider: string, modelId: string) => prepareEntry(find(provider, modelId));
 
   return registry;
 }


### PR DESCRIPTION
## Summary

  - Problem: provider catalog/generated `models.json` headers were available to request auth, but not surfaced on
  `ctx.model.headers` passed to provider `wrapStreamFn`.
  - Why it matters: custom provider plugins, including Cloudflare AI Gateway-style wrappers, can fail to add required
  static headers from the resolved model context.
  - What changed: materialize sanitized provider/model catalog headers onto discovered runtime models, add regression
  coverage, clarify SDK docs, and add changelog entry.
  - What did NOT change (scope boundary): no Cloudflare-specific logic, no dependency patch, no provider auth transport
  behavior change, no secret resolution during discovery.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [x] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [x] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #78843
  - Related #39086
  - [x] This PR fixes a bug or regression

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: generated provider catalog headers now appear on the resolved model passed to provider
  stream wrappers.
  - Real environment tested: local macOS source checkout, Node/pnpm repo test environment, actual `pi-coding-agent` model
  registry reading a temporary generated `models.json`.
  - Exact steps or command run after this patch: see verification commands below.
  - Evidence after fix: targeted failing-before/passing-after test output for `provider catalog headers`, plus full
  adjacent model resolver test and build.
  - Observed result after fix: `ctx.model.headers` equivalent resolved model headers include static catalog headers, while
  SecretRef marker headers are stripped.
  - What was not tested: live provider request against Cloudflare AI Gateway; remote Testbox `pnpm check:changed` because
  `blacksmith`/`crabbox` were unavailable locally.
  - Before evidence: the new focused regression failed before implementation with `result.model.headers` received as
  `undefined`.

  ## Root Cause (if applicable)

  - Root cause: `@mariozechner/pi-coding-agent` stores provider/model headers for request auth, but materializes generated
  custom models with `model.headers` unset; OpenClaw passed that discovered model into provider wrappers.
  - Missing detection / guardrail: no regression covered generated catalog provider headers reaching the resolved runtime
  model context.
  - Contributing context (if known): configured provider headers were already handled in OpenClaw’s configured-provider
  path, so only generated catalog discovery had the gap.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [ ] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/agents/pi-embedded-runner/model.test.ts`
  - Scenario the test should lock in: generated `models.json` provider headers are exposed on the resolved model, and
  SecretRef marker headers are not exposed.
  - Why this is the smallest reliable guardrail: it exercises OpenClaw’s model resolution with the actual registry boundary
  without requiring a live provider call.
  - Existing test that already covers this (if any): configured provider fallback header coverage existed, but not
  generated catalog header materialization.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  Provider plugins can now read sanitized static provider/model catalog headers from `ctx.model.headers` in stream
  wrappers. SecretRef-backed headers are still not exposed as raw values.

  ## Diagram (if applicable)

  ```text
  Before:
  models.json provider headers -> pi request auth store -> ctx.model.headers missing

  After:
  models.json provider headers -> OpenClaw discovery bridge -> ctx.model.headers -> wrapStreamFn
  ```

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) Yes
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: static string headers are exposed to provider wrapper context, but SecretRef
    marker values are stripped and secrets are not resolved during discovery.

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: local Node/pnpm source checkout
  - Model/provider: generated custom OpenAI-compatible provider, Cloudflare AI Gateway-style header fixture
  - Integration/channel (if any): provider plugin model resolution
  - Relevant config (redacted): temporary models.json with dummy TEST_CF_TOKEN, no real credentials

  ### Steps

  1. Add generated models.json provider with static cf-aig-authorization header.
  2. Resolve cloudflare-unified-billing/openai/gpt-5.2.
  3. Inspect resolved model headers passed through OpenClaw model resolution.

  ### Expected

  - Resolved model includes sanitized static provider catalog headers.
  - SecretRef marker headers are omitted.

  ### Actual

  - Resolved model includes cf-aig-authorization.
  - SecretRef marker headers are omitted.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  Verification run:

  - pnpm test src/agents/pi-embedded-runner/model.test.ts -- -t "provider catalog headers"
  - pnpm test src/agents/pi-embedded-runner/model.test.ts -- -t "includes provider headers in provider fallback model"
  - pnpm test src/agents/pi-embedded-runner/model.test.ts
  - pnpm test src/agents/models-config.merge.test.ts
  - pnpm test src/agents/models-config.providers.implicit.discovery-scope.test.ts
  - pnpm exec oxfmt --check --threads=1 src/agents/pi-model-discovery.ts src/agents/pi-embedded-runner/model.test.ts docs/
    plugins/sdk-provider-plugins.md CHANGELOG.md
  - pnpm build
  - git diff --check

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: generated catalog headers materialize on resolved model; SecretRef marker headers are stripped;
    existing configured-provider header fallback still passes.
  - Edge cases checked: provider-level static headers, SecretRef env markers, managed SecretRef markers, existing
    configured provider behavior.
  - What you did not verify: live Cloudflare AI Gateway request; remote Testbox changed gate.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review
  conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk: static catalog headers become visible to provider wrapper code.
      - Mitigation: only sanitized string headers are materialized; SecretRef marker values are stripped; no secrets are
        resolved during discovery.
  - Risk: header precedence could diverge from configured provider resolution.
      - Mitigation: merge order mirrors existing OpenClaw semantics: discovered model headers, provider headers, then
        model-row headers.

### Built with Codex