### PR TITLE
fix(qwen): allow qwen3.6-plus on coding plan endpoints

### DIFF
--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -1,12 +1,7 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyQwenNativeStreamingUsageCompat } from "./api.js";
 import { buildQwenMediaUnderstandingProvider } from "./media-understanding-provider.js";
-import {
-  isQwenCodingPlanBaseUrl,
-  QWEN_36_PLUS_MODEL_ID,
-  QWEN_BASE_URL,
-  QWEN_DEFAULT_MODEL_REF,
-} from "./models.js";
+import { QWEN_BASE_URL, QWEN_DEFAULT_MODEL_REF } from "./models.js";
 import {
   applyQwenConfig,
   applyQwenConfigCn,

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -164,14 +164,9 @@ export default defineSingleProviderPluginEntry({
     applyNativeStreamingUsageCompat: ({ providerConfig }) =>
       applyQwenNativeStreamingUsageCompat(providerConfig),
     wrapStreamFn: wrapQwenProviderStream,
-    normalizeConfig: ({ providerConfig }) => {
-      if (!isQwenCodingPlanBaseUrl(providerConfig.baseUrl)) {
-        return undefined;
-      }
-      const models = providerConfig.models?.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
-      return models && models.length !== providerConfig.models?.length
-        ? { ...providerConfig, models }
-        : undefined;
+    normalizeConfig: () => {
+      // No longer filter qwen3.6-plus on coding plan endpoints
+      return undefined;
     },
   },
   register(api) {

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -124,7 +124,7 @@ export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
-export function isQwen36PlusSupportedBaseUrl(baseUrl: string | undefined): boolean {
+export function isQwen36PlusSupportedBaseUrl(_baseUrl: string | undefined): boolean {
   // Allow qwen3.6-plus on all baseUrls, including coding plan endpoints
   return true;
 }

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -125,7 +125,8 @@ export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
 }
 
 export function isQwen36PlusSupportedBaseUrl(baseUrl: string | undefined): boolean {
-  return !isQwenCodingPlanBaseUrl(baseUrl);
+  // Allow qwen3.6-plus on all baseUrls, including coding plan endpoints
+  return true;
 }
 
 export function buildQwenModelCatalogForBaseUrl(


### PR DESCRIPTION
## Summary

Allow `qwen3.6-plus` model to be used with Qwen Cloud Coding Plan endpoints (`coding.dashscope.aliyuncs.com` and `coding-intl.dashscope.aliyuncs.com`).

## Changes

### 1. `extensions/qwen/models.ts`
- `isQwen36PlusSupportedBaseUrl()` now returns `true` for all baseUrls
- Previously it excluded coding plan endpoints (`!isQwenCodingPlanBaseUrl(baseUrl)`)

### 2. `extensions/qwen/index.ts`
- `normalizeConfig` no longer filters `qwen3.6-plus` from the model list for coding plan endpoints

## Impact

Users with Qwen Cloud Coding Plan subscriptions can now use `qwen3.6-plus` without needing workarounds.

## Real behavior proof

**Issue addressed**: `qwen3.6-plus` was filtered out from the agent's runtime model list when using Qwen Cloud Coding Plan endpoints (`coding.dashscope.aliyuncs.com/v1`). The model was configured in `openclaw.json` but missing from the generated `~/.openclaw/agents/coder/agent/models.json`.

**Real setup tested**: Live OpenClaw instance on Linux (Ubuntu), running Gateway with `bailian` provider pointing to `https://coding.dashscope.aliyuncs.com/v1`, model `qwen3.6-plus`, `thinkingDefault: "high"`.

**Exact steps or command run after the patch**:
1. Apply the patch to `extensions/qwen/models.ts` and `extensions/qwen/index.ts`
2. Run `npm run build` (or `npx tsc --noEmit` for type check)
3. Restart OpenClaw Gateway to regenerate agent models.json
4. Check `~/.openclaw/agents/coder/agent/models.json` — `qwen3.6-plus` now appears in the bailian provider's model list

**Evidence after fix**:
```
After fix, coder agent models.json (baseUrl: https://coding.dashscope.aliyuncs.com/v1):
models: ["qwen3.6-plus", "qwen3.5-plus", "qwen3-max-2026-01-23", "qwen3-coder-next", "qwen3-coder-plus", "MiniMax-M2.5", "glm-5", "glm-4.7", "kimi-k2.5", "text-embedding-v3"]
```

**Observed result**: `qwen3.6-plus` is now present in the agent's runtime model list for the coding plan endpoint, whereas before it was silently filtered out.

**Not tested**: Cross-endpoint failover behavior with international coding URL (`coding-intl.dashscope.aliyuncs.com/v1`) — the fix applies the same logic but was only verified on the CN endpoint.