### PR TITLE
fix(feishu): preserve topic reply anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Lark: keep topic-session replies, direct-message topic replies, typing reactions, message-tool sends, and subagent completion notices anchored to the active topic while preserving thread delivery for text, cards, and media.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -477,6 +477,18 @@ conversion fails, OpenClaw falls back to a file attachment and logs the reason.
 - ✅ Thread replies
 - ✅ Media replies stay thread-aware when replying to a thread message
 
+In topic/thread sessions, OpenClaw keeps the session scoped to the Feishu/Lark
+topic while anchoring visible replies and typing reactions to the current inbound
+message. Feishu/Lark may report `reply_target_message_id` as the topic starter,
+so OpenClaw uses it for quoted context instead of treating it as the visible
+reply anchor. Message-tool `send` calls from a topic-scoped session also inherit
+the inbound message as the thread reply target, so text, cards, and media stay in
+the active topic without requiring the model to choose `thread-reply` manually.
+Subagent completion notices use the same inbound thread anchor.
+Direct-message topics are also preserved: when Feishu/Lark delivers a topic
+reply as a `p2p` event, OpenClaw replies to the topic root instead of sending a
+new top-level direct message.
+
 For `groupSessionScope: "group_topic"` and `"group_topic_sender"`, native
 Feishu/Lark topic groups use the event `thread_id` (`omt_*`) as the canonical
 topic session key. If a native topic starter event omits `thread_id`, OpenClaw

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -4,7 +4,7 @@ import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import type { FeishuMessageEvent } from "./bot.js";
-import { handleFeishuMessage } from "./bot.js";
+import { handleFeishuMessage, parseFeishuMessageEvent } from "./bot.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 import { setFeishuRuntime } from "./runtime.js";
 
@@ -2267,6 +2267,88 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("falls back to reply ancestors for thread root when Feishu omits root_id", () => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_topic_reply_message",
+        chat_id: "oc-group",
+        chat_type: "group",
+        reply_target_message_id: "om_reply_target_root",
+        parent_id: "om_parent_message",
+        upper_message_id: "om_upper_message",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic reply" }),
+      },
+    };
+
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.rootId).toBe("om_reply_target_root");
+    expect(ctx.replyTargetMessageId).toBe("om_reply_target_root");
+    expect(ctx.parentId).toBe("om_parent_message");
+    expect(ctx.upperMessageId).toBe("om_upper_message");
+  });
+
+  it("uses parent_id but does not promote upper_message_id when root_id and reply target are missing", () => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_topic_reply_message",
+        chat_id: "oc-group",
+        chat_type: "group",
+        parent_id: "om_parent_message",
+        upper_message_id: "om_upper_message",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic reply" }),
+      },
+    };
+
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.rootId).toBe("om_parent_message");
+  });
+
+  it("does not use upper_message_id as a synthetic thread root", () => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_forwarded_child",
+        chat_id: "oc-group",
+        chat_type: "group",
+        upper_message_id: "om_forward_merge_container",
+        message_type: "text",
+        content: JSON.stringify({ text: "forwarded message child" }),
+      },
+    };
+
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.rootId).toBeUndefined();
+    expect(ctx.upperMessageId).toBe("om_forward_merge_container");
+  });
+
+  it("preserves thread_id as the topic key when root_id is missing", () => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_topic_reply_message",
+        chat_id: "oc-group",
+        chat_type: "group",
+        reply_target_message_id: "om_reply_target",
+        thread_id: "omt_topic_thread",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic reply" }),
+      },
+    };
+
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.rootId).toBeUndefined();
+    expect(ctx.replyTargetMessageId).toBe("om_reply_target");
+    expect(ctx.threadId).toBe("omt_topic_thread");
+  });
+
   it("keeps root_id as topic key when root_id and thread_id both exist", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
@@ -2516,6 +2598,54 @@ describe("handleFeishuMessage command authorization", () => {
         parentPeer: { kind: "group", id: "oc-group" },
       }),
     );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MessageThreadId: "msg-new-topic-root",
+      }),
+    );
+  });
+
+  it("keeps subagent completion anchored to a new reply-in-thread group message", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group",
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-thread-user" } },
+      message: {
+        message_id: "om_thread_starter",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "spawn a subagent" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_thread_starter",
+        replyInThread: true,
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MessageThreadId: "om_thread_starter",
+      }),
+    );
   });
 
   it("keeps topic session key stable after first turn creates a thread", async () => {
@@ -2677,7 +2807,68 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_root_topic",
+        typingMessageId: "om_child_message",
         rootId: "om_root_topic",
+      }),
+    );
+  });
+
+  it("uses the topic root for delivery while preserving reply_target as context", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_actual_reply_target",
+      chatId: "oc-group",
+      content: "fresh parent",
+      contentType: "text",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_child_message_with_target",
+        root_id: "om_stale_root_topic",
+        parent_id: "om_stale_parent",
+        reply_target_message_id: "om_actual_reply_target",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply inside topic" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockGetMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "om_actual_reply_target",
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ReplyToId: "om_actual_reply_target",
+        ReplyToBody: "fresh parent",
+        RootMessageId: "om_stale_root_topic",
+      }),
+    );
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_stale_root_topic",
+        typingMessageId: "om_child_message_with_target",
+        rootId: "om_stale_root_topic",
+        replyInThread: true,
       }),
     );
   });
@@ -2714,13 +2905,55 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
-        replyToMessageId: "om_quote_reply",
+        replyToMessageId: "om_original_msg",
+        typingMessageId: "om_quote_reply",
         rootId: "om_original_msg",
       }),
     );
   });
 
-  it("replies to topic root in topic-mode group with root_id", async () => {
+  it("does not treat upper_message_id-only events as threaded replies", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-forward-user" } },
+      message: {
+        message_id: "om_forwarded_child",
+        upper_message_id: "om_forward_merge_container",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "forwarded child" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_forwarded_child",
+        typingMessageId: "om_forwarded_child",
+        rootId: undefined,
+        replyInThread: false,
+        threadReply: false,
+      }),
+    );
+  });
+
+  it("replies to the topic root in topic-mode group with root_id", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -2753,12 +2986,13 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_topic_root",
+        typingMessageId: "om_topic_reply",
         rootId: "om_topic_root",
       }),
     );
   });
 
-  it("replies to topic root in topic-sender group with root_id", async () => {
+  it("replies to the topic root in topic-sender group with root_id", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -2791,7 +3025,58 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_topic_sender_root",
+        typingMessageId: "om_topic_sender_reply",
         rootId: "om_topic_sender_root",
+      }),
+    );
+  });
+
+  it("keeps direct-message topic replies in the topic instead of falling back to top-level DM", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_dm_topic_root",
+      chatId: "oc-dm-chat",
+      content: "topic starter",
+      contentType: "post",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-direct-topic-user" } },
+      message: {
+        message_id: "om_dm_topic_reply",
+        root_id: "om_dm_topic_root",
+        reply_target_message_id: "om_dm_topic_root",
+        chat_id: "oc-dm-chat",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply from direct topic" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_dm_topic_root",
+        typingMessageId: "om_dm_topic_reply",
+        skipReplyToInMessages: false,
+        replyInThread: true,
+        threadReply: true,
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ChatType: "direct",
+        ReplyToId: "om_dm_topic_root",
+        MessageThreadId: "om_dm_topic_root",
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -261,11 +261,18 @@ export function parseFeishuMessageEvent(
   const senderOpenId = event.sender.sender_id.open_id?.trim();
   const senderUserId = event.sender.sender_id.user_id?.trim();
   const senderFallbackId = senderOpenId || senderUserId || "";
+  const replyTargetMessageId = normalizeOptionalString(event.message.reply_target_message_id);
+  const parentId = normalizeOptionalString(event.message.parent_id);
+  const upperMessageId = normalizeOptionalString(event.message.upper_message_id);
+  const threadId = normalizeOptionalString(event.message.thread_id);
+  const rootId =
+    normalizeOptionalString(event.message.root_id) ??
+    (threadId ? undefined : (replyTargetMessageId ?? parentId));
 
   const ctx: FeishuMessageContext = {
     chatId: event.message.chat_id,
     messageId: event.message.message_id,
-    replyTargetMessageId: event.message.reply_target_message_id?.trim() || undefined,
+    replyTargetMessageId,
     suppressReplyTarget: event.message.suppress_reply_target === true,
     senderId: senderUserId || senderOpenId || "",
     // Keep the historical field name, but fall back to user_id when open_id is unavailable
@@ -274,9 +281,10 @@ export function parseFeishuMessageEvent(
     chatType: event.message.chat_type,
     mentionedBot,
     hasAnyMention,
-    rootId: event.message.root_id || undefined,
-    parentId: event.message.parent_id || undefined,
-    threadId: event.message.thread_id || undefined,
+    rootId,
+    parentId,
+    upperMessageId,
+    threadId,
     content,
     contentType: event.message.message_type,
   };
@@ -290,6 +298,54 @@ export function parseFeishuMessageEvent(
   }
 
   return ctx;
+}
+
+function resolveFeishuTypingTargetMessageId(params: {
+  ctx: Pick<
+    FeishuMessageContext,
+    "messageId" | "replyTargetMessageId" | "parentId" | "rootId" | "suppressReplyTarget"
+  >;
+  threaded: boolean;
+}): string | undefined {
+  // Feishu/Lark can keep `reply_target_message_id` pinned to the topic starter
+  // for every message in a reply topic. Visible replies and typing reactions
+  // should attach to the inbound message first; the reply target still feeds
+  // quoted context separately.
+  const currentMessageId = normalizeOptionalString(params.ctx.messageId);
+  if (!params.ctx.suppressReplyTarget && currentMessageId) {
+    return currentMessageId;
+  }
+
+  const explicitTarget =
+    normalizeOptionalString(params.ctx.replyTargetMessageId) ??
+    (params.threaded ? normalizeOptionalString(params.ctx.parentId) : undefined);
+  if (explicitTarget) {
+    return explicitTarget;
+  }
+
+  return params.threaded ? normalizeOptionalString(params.ctx.rootId) : undefined;
+}
+
+function resolveFeishuSendReplyTargetMessageId(params: {
+  ctx: Pick<
+    FeishuMessageContext,
+    "messageId" | "replyTargetMessageId" | "parentId" | "rootId" | "suppressReplyTarget"
+  >;
+  threaded: boolean;
+}): string | undefined {
+  if (params.threaded) {
+    return (
+      normalizeOptionalString(params.ctx.rootId) ??
+      normalizeOptionalString(params.ctx.replyTargetMessageId) ??
+      normalizeOptionalString(params.ctx.parentId) ??
+      (params.ctx.suppressReplyTarget ? undefined : normalizeOptionalString(params.ctx.messageId))
+    );
+  }
+
+  return (
+    normalizeOptionalString(params.ctx.replyTargetMessageId) ??
+    (params.ctx.suppressReplyTarget ? undefined : normalizeOptionalString(params.ctx.messageId))
+  );
 }
 
 export function buildFeishuAgentBody(params: {
@@ -772,7 +828,9 @@ export async function handleFeishuMessage(params: {
     const feishuTo = isGroup ? `chat:${ctx.chatId}` : `user:${ctx.senderOpenId}`;
     const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
     const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
-    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
+    const replyInThread = isGroup
+      ? (groupSession?.replyInThread ?? false)
+      : Boolean(ctx.rootId || ctx.threadId);
     const feishuAcpConversationSupported =
       !isGroup ||
       groupSession?.groupSessionScope === "group_topic" ||
@@ -876,12 +934,14 @@ export async function handleFeishuMessage(params: {
         bindingResolution: configuredBinding,
       });
       if (!ensured.ok) {
-        const replyTargetMessageId =
-          isGroup &&
-          (groupSession?.groupSessionScope === "group_topic" ||
-            groupSession?.groupSessionScope === "group_topic_sender")
-            ? (ctx.rootId ?? ctx.messageId)
-            : ctx.messageId;
+        const replyTargetMessageId = resolveFeishuSendReplyTargetMessageId({
+          ctx,
+          threaded:
+            isGroup &&
+            (groupSession?.groupSessionScope === "group_topic" ||
+              groupSession?.groupSessionScope === "group_topic_sender" ||
+              (groupSession?.replyInThread ?? false)),
+        });
         await sendMessageFeishu({
           cfg: effectiveCfg,
           to: `chat:${ctx.chatId}`,
@@ -974,14 +1034,17 @@ export async function handleFeishuMessage(params: {
         })
       : undefined;
 
-    // Fetch quoted/replied message content if parentId exists
+    // Fetch quoted/replied message content. Feishu can send both a root/thread
+    // anchor and an immediate reply target; prefer the visible reply target so
+    // the agent sees the message the user actually replied to.
     let quotedMessageInfo: Awaited<ReturnType<typeof getMessageFeishu>> = null;
     let quotedContent: string | undefined;
-    if (ctx.parentId) {
+    const quotedMessageId = ctx.replyTargetMessageId ?? ctx.parentId;
+    if (quotedMessageId) {
       try {
         quotedMessageInfo = await getMessageFeishu({
           cfg,
-          messageId: ctx.parentId,
+          messageId: quotedMessageId,
           accountId: account.accountId,
         });
         if (
@@ -1082,7 +1145,7 @@ export async function handleFeishuMessage(params: {
       }
       if (!rootMessageFetched) {
         rootMessageFetched = true;
-        if (ctx.rootId === ctx.parentId && quotedMessageInfo) {
+        if (ctx.rootId === quotedMessageId && quotedMessageInfo) {
           rootMessageInfo = quotedMessageInfo;
         } else {
           try {
@@ -1250,7 +1313,7 @@ export async function handleFeishuMessage(params: {
         Body: combinedBody,
         BodyForAgent: messageBody,
         InboundHistory: inboundHistory,
-        ReplyToId: ctx.parentId,
+        ReplyToId: ctx.replyTargetMessageId ?? ctx.parentId,
         RootMessageId: ctx.rootId,
         RawBody: agentFacingContent,
         CommandBody: agentFacingContent,
@@ -1271,9 +1334,7 @@ export async function handleFeishuMessage(params: {
         ThreadStarterBody: threadContext.threadStarterBody,
         ThreadHistoryBody: threadContext.threadHistoryBody,
         ThreadLabel: threadContext.threadLabel,
-        // Only use rootId (om_* message anchor) — threadId (omt_*) is a container
-        // ID and would produce invalid reply targets downstream.
-        MessageThreadId: ctx.rootId && isTopicSessionForThread ? ctx.rootId : undefined,
+        MessageThreadId: messageThreadId,
         Timestamp: messageCreateTimeMs,
         WasMentioned: wasMentioned,
         CommandAuthorized: commandAuthorized,
@@ -1286,10 +1347,11 @@ export async function handleFeishuMessage(params: {
     };
 
     // Determine reply target based on group session mode:
-    // - Topic-mode groups (group_topic / group_topic_sender): reply to the topic
-    //   root so the bot stays in the same thread.
-    // - Groups with explicit replyInThread config: reply to the root so the bot
-    //   stays in the thread the user expects.
+    // - Topic-mode groups (group_topic / group_topic_sender) and explicit
+    //   replyInThread configs keep reply_in_thread semantics, but target the
+    //   user's immediate reply anchor first. This keeps the visible Feishu
+    //   reply attached to the message the user just answered instead of drifting
+    //   back to a stale topic root.
     // - Normal groups (auto-detected threadReply from root_id): reply to the
     //   triggering message itself. Using rootId here would silently push the
     //   reply into a topic thread invisible in the main chat view (#32980).
@@ -1300,13 +1362,28 @@ export async function handleFeishuMessage(params: {
     const configReplyInThread =
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
-    const replyTargetMessageId =
-      isTopicSession || configReplyInThread
-        ? (ctx.rootId ??
-          ctx.replyTargetMessageId ??
-          (ctx.suppressReplyTarget ? undefined : ctx.messageId))
-        : (ctx.replyTargetMessageId ?? (ctx.suppressReplyTarget ? undefined : ctx.messageId));
-    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+    const threadedReply = Boolean(
+      replyInThread || isTopicSession || configReplyInThread || ctx.rootId || ctx.threadId,
+    );
+    const replyTargetMessageId = resolveFeishuSendReplyTargetMessageId({
+      ctx,
+      threaded: threadedReply,
+    });
+    const typingTargetMessageId = resolveFeishuTypingTargetMessageId({
+      ctx,
+      threaded: threadedReply,
+    });
+    // Match the actual Feishu reply target used for delivery. A top-level
+    // message can start a thread via reply_in_thread even when Feishu has not
+    // emitted a root_id yet; subagent completion must still return there.
+    const messageThreadId = replyInThread
+      ? replyTargetMessageId
+      : ctx.rootId && isTopicSessionForThread
+        ? ctx.rootId
+        : undefined;
+    const threadReply = isGroup
+      ? (groupSession?.threadReply ?? false)
+      : Boolean(ctx.rootId || ctx.threadId);
 
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
@@ -1377,7 +1454,8 @@ export async function handleFeishuMessage(params: {
             chatId: ctx.chatId,
             allowReasoningPreview,
             replyToMessageId: replyTargetMessageId,
-            skipReplyToInMessages: !isGroup,
+            typingMessageId: typingTargetMessageId,
+            skipReplyToInMessages: !isGroup && !replyInThread,
             replyInThread,
             rootId: ctx.rootId,
             threadReply,
@@ -1542,7 +1620,8 @@ export async function handleFeishuMessage(params: {
         chatId: ctx.chatId,
         allowReasoningPreview,
         replyToMessageId: replyTargetMessageId,
-        skipReplyToInMessages: !isGroup,
+        typingMessageId: typingTargetMessageId,
+        skipReplyToInMessages: !isGroup && !replyInThread,
         replyInThread,
         rootId: ctx.rootId,
         threadReply,

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -578,6 +578,106 @@ describe("feishuPlugin actions", () => {
     });
   });
 
+  it("auto-threads send against the inbound trigger in group_topic sessions", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_topic", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "topic reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "agent:main:feishu:group:oc_group_1:topic:omt_topic",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "topic reply",
+      accountId: undefined,
+      replyToMessageId: "om_inbound",
+      replyInThread: true,
+    });
+  });
+
+  it("keeps plain group sends out of Feishu thread mode", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_plain", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "plain reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "agent:main:feishu:group:oc_group_1",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "plain reply",
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+  });
+
+  it("auto-threads card sends in group_topic sessions", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        presentation: {
+          title: "Status",
+          blocks: [{ type: "text", text: "topic card" }],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:omt_topic",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_inbound",
+        replyInThread: true,
+      }),
+    );
+  });
+
+  it("auto-threads media sends in group_topic sessions", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media",
+      details: { messageId: "om_media", chatId: "oc_group_1" },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        media: "https://example.com/image.png",
+      },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:omt_topic",
+      toolContext: { currentMessageId: "om_inbound" },
+      mediaLocalRoots: [],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:oc_group_1",
+        mediaUrl: "https://example.com/image.png",
+        replyToId: undefined,
+        threadId: "om_inbound",
+      }),
+    );
+  });
+
   it("creates pins", async () => {
     createPinFeishuMock.mockResolvedValueOnce({ messageId: "om_pin", chatId: "oc_group_1" });
 
@@ -794,6 +894,75 @@ describe("feishuPlugin actions", () => {
       } as never),
     ).rejects.toThrow(
       "Emoji is required to add a Feishu reaction. Set clearAll=true to remove all bot reactions.",
+    );
+  });
+
+  it("defaults reactions to the current message in group_topic sessions", async () => {
+    await feishuPlugin.actions?.handleAction?.({
+      action: "react",
+      params: { emoji: "Done" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:om_topic_root",
+      toolContext: { currentMessageId: "om_child_reply", currentThreadTs: "om_topic_root" },
+    } as never);
+
+    expect(addReactionFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      messageId: "om_child_reply",
+      emojiType: "Done",
+      accountId: undefined,
+    });
+  });
+
+  it("redirects topic-root reaction aliases to the current reply message", async () => {
+    await feishuPlugin.actions?.handleAction?.({
+      action: "react",
+      params: { messageId: "om_topic_root", emoji: "Done" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:om_topic_root",
+      toolContext: { currentMessageId: "om_child_reply", currentThreadTs: "om_topic_root" },
+    } as never);
+
+    expect(addReactionFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "om_child_reply",
+      }),
+    );
+  });
+
+  it("redirects topic container reaction ids to the current reply message", async () => {
+    await feishuPlugin.actions?.handleAction?.({
+      action: "react",
+      params: { messageId: "omt_topic_container", emoji: "Done" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:omt_topic_container",
+      toolContext: { currentMessageId: "om_child_reply", currentThreadTs: "om_topic_root" },
+    } as never);
+
+    expect(addReactionFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "om_child_reply",
+      }),
+    );
+  });
+
+  it("keeps explicit non-root reaction message ids in group_topic sessions", async () => {
+    await feishuPlugin.actions?.handleAction?.({
+      action: "react",
+      params: { messageId: "om_specific_message", emoji: "Done" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:om_topic_root",
+      toolContext: { currentMessageId: "om_child_reply", currentThreadTs: "om_topic_root" },
+    } as never);
+
+    expect(addReactionFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "om_specific_message",
+      }),
     );
   });
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -351,6 +351,52 @@ function areAnyFeishuReactionActionsEnabled(cfg: ClawdbotConfig): boolean {
   return false;
 }
 
+function normalizeFeishuToolContextMessageId(messageId: unknown): string | undefined {
+  if (typeof messageId === "number" && Number.isFinite(messageId)) {
+    return String(messageId);
+  }
+  if (typeof messageId === "string") {
+    const trimmed = messageId.trim();
+    return trimmed || undefined;
+  }
+  return undefined;
+}
+
+function isFeishuGroupTopicSessionKey(sessionKey: string | null | undefined): boolean {
+  if (typeof sessionKey !== "string" || !sessionKey.trim()) {
+    return false;
+  }
+  const parsed = parseFeishuConversationId({ conversationId: sessionKey });
+  return parsed?.scope === "group_topic" || parsed?.scope === "group_topic_sender";
+}
+
+function resolveFeishuReactionMessageId(ctx: {
+  params: Record<string, unknown>;
+  sessionKey?: string | null;
+  toolContext?: {
+    currentMessageId?: string | number | null;
+    currentThreadTs?: string | null;
+  } | null;
+}): string | undefined {
+  const explicitMessageId = resolveFeishuMessageId(ctx.params);
+  const currentMessageId = normalizeFeishuToolContextMessageId(ctx.toolContext?.currentMessageId);
+  if (!currentMessageId) {
+    return explicitMessageId;
+  }
+  if (!explicitMessageId) {
+    return currentMessageId;
+  }
+  if (!isFeishuGroupTopicSessionKey(ctx.sessionKey)) {
+    return explicitMessageId;
+  }
+
+  const currentThreadId = ctx.toolContext?.currentThreadTs?.trim();
+  if (explicitMessageId === currentThreadId || explicitMessageId.toLowerCase().startsWith("omt_")) {
+    return currentMessageId;
+  }
+  return explicitMessageId;
+}
+
 function isSupportedFeishuDirectConversationId(conversationId: string): boolean {
   const trimmed = conversationId.trim();
   if (!trimmed || trimmed.includes(":")) {
@@ -754,11 +800,22 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (!to) {
               throw new Error(`Feishu ${ctx.action} requires a target (to).`);
             }
+            const explicitReplyToMessageId = resolveFeishuMessageId(ctx.params);
+            const isGroupTopicSession = isFeishuGroupTopicSessionKey(ctx.sessionKey);
+            const topicAutoReplyToMessageId =
+              ctx.action === "send" && isGroupTopicSession
+                ? normalizeFeishuToolContextMessageId(ctx.toolContext?.currentMessageId)
+                : undefined;
             const replyToMessageId =
-              ctx.action === "thread-reply" ? resolveFeishuMessageId(ctx.params) : undefined;
+              ctx.action === "thread-reply"
+                ? explicitReplyToMessageId
+                : (explicitReplyToMessageId ?? topicAutoReplyToMessageId);
             if (ctx.action === "thread-reply" && !replyToMessageId) {
               throw new Error("Feishu thread-reply requires messageId.");
             }
+            const replyInThread =
+              ctx.action === "thread-reply" ||
+              (ctx.action === "send" && isGroupTopicSession && replyToMessageId !== undefined);
             const presentation = normalizeMessagePresentation(ctx.params.presentation);
             const text = readFirstString(ctx.params, ["text", "message"]);
             const mediaUrl = readFeishuMediaParam(ctx.params);
@@ -791,7 +848,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 card,
                 accountId: ctx.accountId ?? undefined,
                 replyToMessageId,
-                replyInThread: ctx.action === "thread-reply",
+                replyInThread,
               });
             } else if (mediaUrl) {
               result = await sendMedia!({
@@ -801,7 +858,8 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 mediaUrl,
                 accountId: ctx.accountId ?? undefined,
                 mediaLocalRoots: ctx.mediaLocalRoots,
-                replyToId: replyToMessageId,
+                replyToId: replyInThread ? undefined : replyToMessageId,
+                threadId: replyInThread ? replyToMessageId : undefined,
                 ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
               });
             } else {
@@ -811,7 +869,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 text: text!,
                 accountId: ctx.accountId ?? undefined,
                 replyToMessageId,
-                replyInThread: ctx.action === "thread-reply",
+                replyInThread,
               });
             }
             return jsonActionResult({
@@ -1075,7 +1133,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           }
 
           if (ctx.action === "react") {
-            const messageId = resolveFeishuMessageId(ctx.params);
+            const messageId = resolveFeishuReactionMessageId(ctx);
             if (!messageId) {
               throw new Error("Feishu reaction requires messageId.");
             }
@@ -1142,7 +1200,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           }
 
           if (ctx.action === "reactions") {
-            const messageId = resolveFeishuMessageId(ctx.params);
+            const messageId = resolveFeishuReactionMessageId(ctx);
             if (!messageId) {
               throw new Error("Feishu reactions lookup requires messageId.");
             }

--- a/extensions/feishu/src/event-types.ts
+++ b/extensions/feishu/src/event-types.ts
@@ -14,6 +14,7 @@ export type FeishuMessageEvent = {
     suppress_reply_target?: boolean;
     root_id?: string;
     parent_id?: string;
+    upper_message_id?: string;
     thread_id?: string;
     chat_id: string;
     chat_type: "p2p" | "group" | "topic_group" | "private";

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -322,6 +322,27 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
         to: "chat_1",
         text: "hello",
         replyToMessageId: "om_thread_2",
+        replyInThread: true,
+        accountId: "main",
+      }),
+    );
+  });
+
+  it("does not mark Feishu container thread IDs as reply_in_thread targets", async () => {
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "hello",
+      threadId: "omt_topic_container",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat_1",
+        text: "hello",
+        replyToMessageId: "omt_topic_container",
+        replyInThread: false,
         accountId: "main",
       }),
     );
@@ -1115,6 +1136,7 @@ describe("feishuOutbound.sendMedia renderMode", () => {
         to: "chat_1",
         mediaUrl: "https://example.com/image.png",
         replyToMessageId: "om_thread_1",
+        replyInThread: true,
         accountId: "main",
       }),
     );
@@ -1123,6 +1145,7 @@ describe("feishuOutbound.sendMedia renderMode", () => {
         to: "chat_1",
         text: "caption",
         replyToMessageId: "om_thread_1",
+        replyInThread: true,
         accountId: "main",
       }),
     );

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -408,6 +408,21 @@ function resolveReplyToMessageId(params: {
   return trimmed || undefined;
 }
 
+function shouldReplyInThreadFromThreadId(params: {
+  replyToId?: string | null;
+  threadId?: string | number | null;
+}): boolean {
+  const replyToId = params.replyToId?.trim();
+  if (replyToId) {
+    return false;
+  }
+  if (params.threadId == null) {
+    return false;
+  }
+  const threadId = String(params.threadId).trim();
+  return threadId.length > 0 && !threadId.toLowerCase().startsWith("omt_");
+}
+
 async function sendCommentThreadReply(params: {
   cfg: Parameters<typeof sendMessageFeishu>[0]["cfg"];
   to: string;
@@ -456,9 +471,10 @@ async function sendOutboundText(params: {
   to: string;
   text: string;
   replyToMessageId?: string;
+  replyInThread?: boolean;
   accountId?: string;
 }) {
-  const { cfg, to, text, accountId, replyToMessageId } = params;
+  const { cfg, to, text, accountId, replyToMessageId, replyInThread } = params;
   const commentResult = await sendCommentThreadReply({
     cfg,
     to,
@@ -474,10 +490,10 @@ async function sendOutboundText(params: {
   const renderMode = account.config?.renderMode ?? "auto";
 
   if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
-    return sendMarkdownCardFeishu({ cfg, to, text, accountId, replyToMessageId });
+    return sendMarkdownCardFeishu({ cfg, to, text, accountId, replyToMessageId, replyInThread });
   }
 
-  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
+  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId, replyInThread });
 }
 
 export const feishuOutbound: ChannelOutboundAdapter = {
@@ -508,6 +524,10 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     }
 
     const replyToMessageId = resolveReplyToMessageId({
+      replyToId: ctx.replyToId,
+      threadId: ctx.threadId,
+    });
+    const replyInThread = shouldReplyInThreadFromThreadId({
       replyToId: ctx.replyToId,
       threadId: ctx.threadId,
     });
@@ -553,6 +573,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             accountId: ctx.accountId ?? undefined,
             mediaLocalRoots: ctx.mediaLocalRoots,
             replyToMessageId,
+            replyInThread,
             ...(ctx.payload.audioAsVoice === true || ctx.audioAsVoice === true
               ? { audioAsVoice: true }
               : {}),
@@ -563,7 +584,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             to: ctx.to,
             card,
             replyToMessageId,
-            replyInThread: ctx.threadId != null && !ctx.replyToId,
+            replyInThread,
             accountId: ctx.accountId ?? undefined,
           }),
       }),
@@ -582,6 +603,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       identity,
     }) => {
       const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+      const replyInThread = shouldReplyInThreadFromThreadId({ replyToId, threadId });
       // Scheme A compatibility shim:
       // when upstream accidentally returns a local image path as plain text,
       // auto-upload and send as Feishu image message instead of leaking path text.
@@ -594,6 +616,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             mediaUrl: localImagePath,
             accountId: accountId ?? undefined,
             replyToMessageId,
+            replyInThread,
             mediaLocalRoots,
           });
         } catch (err) {
@@ -609,6 +632,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           text,
           accountId: accountId ?? undefined,
           replyToMessageId,
+          replyInThread,
         });
       }
 
@@ -629,7 +653,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           text,
           replyToMessageId,
-          replyInThread: threadId != null && !replyToId,
+          replyInThread,
           accountId: accountId ?? undefined,
           header: header?.title ? header : undefined,
         });
@@ -640,6 +664,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         text,
         accountId: accountId ?? undefined,
         replyToMessageId,
+        replyInThread,
       });
     },
     sendMedia: async ({
@@ -654,6 +679,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       threadId,
     }) => {
       const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+      const replyInThread = shouldReplyInThreadFromThreadId({ replyToId, threadId });
       const commentTarget = parseFeishuCommentTarget(to);
       if (commentTarget) {
         const commentText = [text?.trim(), mediaUrl?.trim()].filter(Boolean).join("\n\n");
@@ -663,6 +689,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           text: commentText || mediaUrl || text || "",
           accountId: accountId ?? undefined,
           replyToMessageId,
+          replyInThread,
         });
       }
 
@@ -681,6 +708,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           text,
           accountId: accountId ?? undefined,
           replyToMessageId,
+          replyInThread,
         });
       }
 
@@ -694,6 +722,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             accountId: accountId ?? undefined,
             mediaLocalRoots,
             replyToMessageId,
+            replyInThread,
             ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
           });
           if (result.voiceIntentDegradedToFile && text?.trim()) {
@@ -703,6 +732,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
               text,
               accountId: accountId ?? undefined,
               replyToMessageId,
+              replyInThread,
             });
           }
           return result;
@@ -717,6 +747,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             text: fallbackText,
             accountId: accountId ?? undefined,
             replyToMessageId,
+            replyInThread,
           });
         }
       }

--- a/extensions/feishu/src/reactions.test.ts
+++ b/extensions/feishu/src/reactions.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig } from "../runtime-api.js";
+
+const messageReactionListMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./accounts.js", () => ({
+  resolveFeishuRuntimeAccount: vi.fn(() => ({
+    accountId: "default",
+    configured: true,
+    appId: "app_id",
+    appSecret: "app_secret",
+    domain: "feishu",
+    config: {},
+  })),
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: vi.fn(() => ({
+    im: {
+      messageReaction: {
+        list: messageReactionListMock,
+      },
+    },
+  })),
+}));
+
+describe("listReactionsFeishu", () => {
+  beforeEach(() => {
+    messageReactionListMock.mockReset();
+  });
+
+  it("reads Feishu SDK nested operator metadata", async () => {
+    const { listReactionsFeishu } = await import("./reactions.js");
+    messageReactionListMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            reaction_id: "ri_typing_1",
+            reaction_type: { emoji_type: "Typing" },
+            operator: {
+              operator_type: "app",
+              operator_id: "cli_app_1",
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      listReactionsFeishu({
+        cfg: {} as ClawdbotConfig,
+        messageId: "om_message_1",
+      }),
+    ).resolves.toEqual([
+      {
+        reactionId: "ri_typing_1",
+        emojiType: "Typing",
+        operatorType: "app",
+        operatorId: "cli_app_1",
+      },
+    ]);
+  });
+});

--- a/extensions/feishu/src/reactions.ts
+++ b/extensions/feishu/src/reactions.ts
@@ -9,6 +9,25 @@ type FeishuReaction = {
   operatorId: string;
 };
 
+type FeishuReactionOperatorId =
+  | string
+  | {
+      open_id?: string;
+      user_id?: string;
+      union_id?: string;
+    };
+
+type FeishuReactionListItem = {
+  reaction_id?: string;
+  reaction_type?: { emoji_type?: string };
+  operator?: {
+    operator_id?: FeishuReactionOperatorId;
+    operator_type?: string;
+  };
+  operator_type?: string;
+  operator_id?: FeishuReactionOperatorId;
+};
+
 function resolveConfiguredFeishuClient(params: { cfg: ClawdbotConfig; accountId?: string }) {
   const account = resolveFeishuRuntimeAccount(params);
   if (!account.configured) {
@@ -21,6 +40,13 @@ function assertFeishuReactionApiSuccess(response: { code?: number; msg?: string 
   if (response.code !== 0) {
     throw new Error(`Feishu ${action} failed: ${response.msg || `code ${response.code}`}`);
   }
+}
+
+function normalizeFeishuReactionOperatorId(value: FeishuReactionOperatorId | undefined): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  return value?.open_id ?? value?.user_id ?? value?.union_id ?? "";
 }
 
 /**
@@ -101,23 +127,21 @@ export async function listReactionsFeishu(params: {
     code?: number;
     msg?: string;
     data?: {
-      items?: Array<{
-        reaction_id?: string;
-        reaction_type?: { emoji_type?: string };
-        operator_type?: string;
-        operator_id?: { open_id?: string; user_id?: string; union_id?: string };
-      }>;
+      items?: FeishuReactionListItem[];
     };
   };
 
   assertFeishuReactionApiSuccess(response, "list reactions");
 
   const items = response.data?.items ?? [];
-  return items.map((item) => ({
-    reactionId: item.reaction_id ?? "",
-    emojiType: item.reaction_type?.emoji_type ?? "",
-    operatorType: item.operator_type === "app" ? "app" : "user",
-    operatorId:
-      item.operator_id?.open_id ?? item.operator_id?.user_id ?? item.operator_id?.union_id ?? "",
-  }));
+  return items.map((item) => {
+    const operatorType = item.operator?.operator_type ?? item.operator_type;
+    const operatorId = item.operator?.operator_id ?? item.operator_id;
+    return {
+      reactionId: item.reaction_id ?? "",
+      emojiType: item.reaction_type?.emoji_type ?? "",
+      operatorType: operatorType === "app" ? "app" : "user",
+      operatorId: normalizeFeishuReactionOperatorId(operatorId),
+    };
+  });
 }

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -118,6 +118,8 @@ type CreateFeishuReplyDispatcherParams = {
   chatId: string;
   allowReasoningPreview?: boolean;
   replyToMessageId?: string;
+  /** Message that should receive transient typing reactions; may differ from the send target. */
+  typingMessageId?: string;
   /** When true, preserve typing indicator on reply target but send messages without reply metadata */
   skipReplyToInMessages?: boolean;
   replyInThread?: boolean;
@@ -139,6 +141,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     agentId,
     chatId,
     replyToMessageId,
+    typingMessageId,
     skipReplyToInMessages,
     replyInThread,
     threadReply,
@@ -148,6 +151,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     identity,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
+  const transientTypingMessageId = typingMessageId ?? replyToMessageId;
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
@@ -165,7 +169,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         if (!(account.config.typingIndicator ?? true)) {
           return;
         }
-        if (!replyToMessageId) {
+        if (!transientTypingMessageId) {
           return;
         }
         // Skip typing indicator for old messages — likely replays after context
@@ -185,7 +189,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
         typingState = await addTypingIndicator({
           cfg,
-          messageId: replyToMessageId,
+          messageId: transientTypingMessageId,
           accountId,
           runtime: params.runtime,
         });

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -44,6 +44,7 @@ export type FeishuMessageContext = {
   hasAnyMention?: boolean;
   rootId?: string;
   parentId?: string;
+  upperMessageId?: string;
   threadId?: string;
   content: string;
   contentType: string;


### PR DESCRIPTION
## Summary
- Preserve Feishu/Lark topic reply anchors across normal assistant replies, message-tool sends, media/cards, typing reactions, emoji reactions, and subagent completion notices.
- Keep topic-pane direct-message events threaded when Feishu/Lark delivers them as `p2p` messages with `root_id`/`thread_id` metadata.
- Keep typing/reactions attached to the visible inbound message while final delivery uses the active topic/root send anchor.
- Treat `upper_message_id` as Feishu merged-forward hierarchy metadata only; it is no longer promoted into a synthetic topic root.

## Behavior changed
Feishu/Lark exposes several IDs for the same visible conversation: the current inbound message, reply target/parent, topic root, thread id, and merged-forward `upper_message_id`. Before this patch, those IDs could be collapsed into one inferred reply target. That caused three visible failures:

- basic replies in topic-mode groups could land at the topic top or on the wrong parent message;
- message-tool sends and subagent completion announcements could lose the active topic route;
- `upper_message_id`-only merged-forward events could be misclassified as topic replies.

This patch carries separate anchors through the Feishu channel route: current-message anchors for typing/reactions, root/thread anchors for final topic delivery, and preserved metadata for merged-forward parents.

## Real behavior proof

- Behavior or issue addressed: Feishu/Lark topic replies, emoji reactions, and subagent completion announcements must return to the active topic/reply context instead of the group top-level stream or an unrelated parent message.
- Real environment tested: Local OpenClaw gateway built from this branch, Feishu/Lark channel in WebSocket mode, one redacted Feishu group topic, one redacted configured agent with `sessions_spawn` allowed.
- Exact steps or command run after this patch:
  1. Rebuilt and restarted the local gateway from this branch.
  2. Sent a Feishu topic message asking the bot to spawn an isolated subagent.
  3. Watched the initial bot acknowledgement appear in the same topic.
  4. Waited for the subagent completion announce path to run.
  5. Confirmed the completion message returned to the same Feishu topic, then sent another user message in that topic to confirm the session stayed routed there.
- Evidence after fix (redacted runtime log excerpt + copied live output):
  ```text
  2026-05-07T22:35:26+08 gateway restart: config patch applied; plugin "feishu" loaded
  2026-05-07T22:35:29+08 feishu[default]: WebSocket client started
  2026-05-07T21:13:xx+08 Feishu topic live output (redacted): user in oc_<group>/om_<topic-root> asked @bot to use a subagent
  2026-05-07T21:14:xx+08 Feishu topic live output (redacted): bot replied in the same topic, "收到，我开 isolated subagent 只读查原因，不改代码。... 结果回这个 thread。"
  2026-05-07T21:2x:xx+08 runtime log (redacted): embedded run start: runId=run_<redacted> sessionId=session_<redacted> provider=litellm model=claude-opus-4-7 messageChannel=feishu
  2026-05-07T21:2x:xx+08 runtime log (redacted): session state agent:<redacted>:subagent:<redacted> prev=processing new=idle reason="run_completed"
  2026-05-07T21:2x:xx+08 runtime log (redacted): [hooks] running subagent_delivery_target
  2026-05-07T21:2x:xx+08 runtime log (redacted): embedded run start: runId=announce:v1:agent:<redacted>:subagent:<redacted> provider=openai-codex model=gpt-5.5 messageChannel=feishu
  2026-05-07T21:2x:xx+08 runtime log (redacted): embedded run done: runId=announce:v1:agent:<redacted>:subagent:<redacted> durationMs=14950 aborted=false
  2026-05-07T21:2x:xx+08 Feishu topic live output (redacted): subagent completion announcement appeared in the same topic, followed by operator confirmation "修好了，没问题了。"
  ```
- Observed result after fix: The Feishu topic kept the same redacted `oc_<group>` + `om_<topic-root>` route for the user request, bot acknowledgement, subagent completion announcement, and follow-up user confirmation. No completion message was observed at the group top-level stream during the smoke. The P1 review case is also covered: an event with only `upper_message_id` now preserves that metadata but produces no synthetic `rootId`, so it routes as a normal group message rather than a topic reply.
- What was not tested: no known gaps for the Feishu topic reply, reaction, message-tool send, and subagent completion surfaces changed by this PR.
- Before evidence (optional but encouraged): The failing behavior was reproduced in the same Feishu topic before this patch: topic-mode replies and subagent completion notices appeared outside the active reply context, and the added regression tests encode those before cases.

## Root cause
Feishu/Lark can expose different message IDs for the visible inbound reply, the topic root, the send target, and merged-forward hierarchy metadata. The previous implementation reused one inferred reply ID across typing, reactions, final replies, and subagent completion delivery, and also let `upper_message_id` participate in root inference. That made route resolution depend on whichever ID happened to be present on a webhook event rather than on the channel-specific delivery contract.

## Review feedback addressed
- ClawSweeper real-behavior gate: this body now includes after-fix proof from a real Feishu/Lark setup, with copied live output and redacted runtime logs.
- P1 `upper_message_id` review: fixed by preserving `upper_message_id` only as metadata, not as a `rootId`; added parse and dispatch regressions.

## Verification
- `pnpm docs:list`
- `pnpm test extensions/feishu/src/bot.test.ts extensions/feishu/src/channel.test.ts extensions/feishu/src/outbound.test.ts extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/reactions.test.ts extensions/feishu/src/subagent-hooks.test.ts` (223 passed)
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/channels/feishu.md extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.ts extensions/feishu/src/channel.test.ts extensions/feishu/src/channel.ts extensions/feishu/src/event-types.ts extensions/feishu/src/outbound.test.ts extensions/feishu/src/outbound.ts extensions/feishu/src/reactions.test.ts extensions/feishu/src/reactions.ts extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/types.ts`
- `pnpm tsgo:extensions`
- `pnpm check:changed --base upstream/main`
