### PR TITLE
fix(auto-reply): acknowledge group reset commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
+- Auto-reply/reset: return a clear unauthorized reset error and preserve bare `/reset` and `/new` acknowledgments, including group chat resets, without falling through into model execution. (#78968) Thanks @joeia26.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.
 - Discord/voice: keep TTS playback running when another user starts speaking, ignore new capture during playback to avoid feedback loops, and downgrade expected receive-stream aborts to verbose diagnostics.

--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -61,6 +61,7 @@ function buildResetParams(
   commandBody: string,
   cfg: OpenClawConfig,
   ctxOverrides?: Partial<MsgContext>,
+  paramOverrides?: Partial<HandleCommandsParams>,
 ): HandleCommandsParams {
   const ctx = {
     Body: commandBody,
@@ -102,6 +103,7 @@ function buildResetParams(
     model: "test-model",
     contextTokens: 0,
     isGroup: false,
+    ...paramOverrides,
   };
 }
 
@@ -356,7 +358,10 @@ describe("handleCommands reset hooks", () => {
 
     const result = await maybeHandleResetCommand(params);
 
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "⚠️ You are not authorized to reset this session." },
+    });
     expect(triggerInternalHookMock).not.toHaveBeenCalled();
     expect(params.command.softResetTriggered).not.toBe(true);
     expect(clearBootstrapSnapshotSpy).not.toHaveBeenCalled();
@@ -432,7 +437,59 @@ describe("handleCommands reset hooks", () => {
     expect(resetMocks.resetConfiguredBindingTargetInPlace).not.toHaveBeenCalled();
   });
 
-  it("acknowledges bare /reset without falling through to model execution", async () => {
+  it("acknowledges group bare /reset without falling through to model execution", async () => {
+    const params = buildResetParams(
+      "/reset",
+      {
+        commands: { text: true },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig,
+      {
+        ChatType: "group",
+      },
+      {
+        isGroup: true,
+      },
+    );
+
+    const result = await maybeHandleResetCommand(params);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "✅ Session reset." },
+    });
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "command", action: "reset" }),
+    );
+  });
+
+  it("acknowledges group bare /new without falling through to model execution", async () => {
+    const params = buildResetParams(
+      "/new",
+      {
+        commands: { text: true },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig,
+      {
+        ChatType: "group",
+      },
+      {
+        isGroup: true,
+      },
+    );
+
+    const result = await maybeHandleResetCommand(params);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "✅ New session started." },
+    });
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "command", action: "new" }),
+    );
+  });
+
+  it("keeps direct bare reset on the existing acknowledgment flow", async () => {
     const params = buildResetParams("/reset", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
@@ -449,7 +506,7 @@ describe("handleCommands reset hooks", () => {
     );
   });
 
-  it("acknowledges bare /new without falling through to model execution", async () => {
+  it("keeps direct bare new on the existing acknowledgment flow", async () => {
     const params = buildResetParams("/new", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
@@ -464,6 +521,48 @@ describe("handleCommands reset hooks", () => {
     expect(triggerInternalHookMock).toHaveBeenCalledWith(
       expect.objectContaining({ type: "command", action: "new" }),
     );
+  });
+
+  it("stops direct bare reset when a reset hook already routed a reply", async () => {
+    triggerInternalHookMock.mockImplementationOnce(async (event: { messages: string[] }) => {
+      event.messages.push("Reset hook says hi");
+    });
+    const params = buildResetParams("/reset", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+
+    const result = await maybeHandleResetCommand(params);
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "Reset hook says hi" },
+      }),
+    );
+    expect(result).toEqual({ shouldContinue: false });
+  });
+
+  it("returns a clear error for unauthorized bare reset attempts", async () => {
+    const params = buildResetParams(
+      "/reset",
+      {
+        commands: { text: true },
+        channels: { whatsapp: { allowFrom: ["owner"] } },
+      } as OpenClawConfig,
+      {
+        CommandAuthorized: false,
+      },
+    );
+    params.command.isAuthorizedSender = false;
+    params.command.senderIsOwner = false;
+
+    const result = await maybeHandleResetCommand(params);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "⚠️ You are not authorized to reset this session." },
+    });
+    expect(triggerInternalHookMock).not.toHaveBeenCalled();
   });
 
   it("keeps reset tails falling through so the model receives the user input", async () => {

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -38,7 +38,10 @@ export async function maybeHandleResetCommand(
       logVerbose(
         `Ignoring /reset soft from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
       );
-      return { shouldContinue: false };
+      return {
+        shouldContinue: false,
+        reply: { text: "⚠️ You are not authorized to reset this session." },
+      };
     }
 
     const boundAcpSessionKey = resolveBoundAcpThreadSessionKey(params);
@@ -114,7 +117,10 @@ export async function maybeHandleResetCommand(
     logVerbose(
       `Ignoring /reset from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
     );
-    return { shouldContinue: false };
+    return {
+      shouldContinue: false,
+      reply: { text: "⚠️ You are not authorized to reset this session." },
+    };
   }
 
   const commandAction: ResetCommandAction = resetMatch[1] === "reset" ? "reset" : "new";
@@ -167,15 +173,14 @@ export async function maybeHandleResetCommand(
     workspaceDir: params.workspaceDir,
   });
   if (!resetTail) {
+    if (hookResult.routedReply) {
+      return { shouldContinue: false };
+    }
     return {
       shouldContinue: false,
-      ...(hookResult.routedReply
-        ? {}
-        : {
-            reply: {
-              text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
-            },
-          }),
+      reply: {
+        text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
+      },
     };
   }
   return null;


### PR DESCRIPTION
# PR: Group reset feedback

## Summary

This PR tightens the reset flow for group chats and makes reset feedback visible to users.

It covers three related behaviors:

- group chat bare `/reset` and `/new` are explicitly covered by the existing clear success acknowledgment behavior
- unauthorized reset attempts now return a clear error message instead of failing silently
- direct bare `/reset` and `/new` keep the existing no-model acknowledgment behavior
- ACP-bound sessions are intentionally left on their existing path

## Problem

Before this change, reset behavior was inconsistent across chat types:

- group chat bare `/reset` and `/new` lacked explicit regression coverage for the success acknowledgment path
- unauthorized users could be rejected without a user-facing message

That made the reset flow hard to reason about in group chats, especially when users expected an immediate confirmation.

For reset commands, silent authorization failure is especially confusing: the user sees that the command was sent, but receives no indication that the session was not reset. In practice this can make users assume `/reset` is broken, retry the command, or continue the conversation under the wrong session-state assumption.

## What Changed

### 1. Unauthorized reset attempts now reply clearly

When the sender is not authorized, `/reset`, `/new`, and `/reset soft` now return:

- `⚠️ You are not authorized to reset this session.`

This is an intentional reset-specific policy exception to the previous fail-silent behavior. The message is deliberately generic: it does not disclose the configured operators, the authorization rule that failed, session identifiers, tenant information, or whether the sender is otherwise known to the bot.

### 2. Group chat bare reset commands explicitly acknowledge success

In group chats, when no reset hook has already routed a reply:

- bare `/reset` replies with `✅ Session reset.`
- bare `/new` replies with `✅ New session started.`

These commands still trigger the existing reset hooks. If a hook already routes a reply, the command stops there; otherwise the built-in acknowledgment is returned instead of falling through into model execution.

### 3. Direct chat acknowledgment behavior is preserved

In direct chats, bare `/reset` and `/new` still use the existing no-model acknowledgment behavior:

- bare `/reset` replies with `✅ Session reset.`
- bare `/new` replies with `✅ New session started.`

That is an explicit boundary of this PR: the patch does not change direct bare reset/new into a model-startup flow.

### 4. ACP-bound sessions are unchanged

ACP-bound sessions still use `resetConfiguredBindingTargetInPlace`.

This PR does not redirect ACP reset handling into the group-chat feedback path.

If an ACP reset includes a tail, it still uses `AcpDispatchTailAfterReset` to continue with the tail content.

## Security / Policy Rationale

ClawSweeper correctly points out that visible unauthorized reset denials are a behavior change from the existing fail-silent command-auth pattern. This PR keeps the visible denial intentionally for reset commands because reset is a user-facing state-control command: if authorization fails silently, the sender has no way to distinguish "the bot did not see my command" from "the bot saw it but refused to reset the session."

The intended tradeoff is:

- keep successful group reset acknowledgments visible, so users know the session was reset
- keep unauthorized reset denials visible, so users know the session was not reset
- keep the unauthorized denial generic, so it does not reveal authorization configuration or session details
- keep the change scoped to reset/new commands rather than changing the global command-auth policy

This PR is therefore requesting maintainer approval for a reset-specific exception to the previous fail-silent behavior.

## Behavior Matrix

| Command | Group chat | Direct chat | ACP-bound session |
|---|---|---|---|
| `/reset` | ACK success after reset | Existing ACK success after reset | ACP reset path |
| `/new` | ACK success after reset | Existing ACK success after reset | ACP reset path |
| `/reset soft` | Existing soft-reset behavior | Existing soft-reset behavior | Existing unsupported response |
| Unauthorized reset | Generic unauthorized error reply | Generic unauthorized error reply | Generic unauthorized error reply |

## Files Changed

- `src/auto-reply/reply/commands-reset.ts`
- `src/auto-reply/reply/commands-reset-hooks.test.ts`
- `CHANGELOG.md`

## Testing

Validated with:

- `node_modules/.bin/vitest run --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/reply/commands-reset-hooks.test.ts --reporter=verbose`

Result:

- `16 passed`

## Real behavior proof

Behavior or issue addressed: Group chat bare `/reset` should visibly acknowledge successful resets, and unauthorized group-chat `/reset` should visibly tell the sender that the session was not reset.

Real environment tested: Live OpenClaw gateway connected to Feishu group chats on 2026-05-07 at 18:21 and 23:05 Asia/Shanghai.

Exact steps or command run after this patch: In Feishu groups handled by `main-bot`, send exactly `/reset` once from an authorized sender and once from a sender that is not authorized to reset that session.

Evidence after fix: Successful group reset acknowledgment. Redacted runtime log excerpt from the live OpenClaw gateway. The message was classified as a Feishu group message, dispatched to the group session, and completed with one text reply.

```text
2026-05-07T18:21:36.796+08:00 [feishu] feishu[main-bot]: received message from <redacted-user> in <redacted-group> (group)
2026-05-07T18:21:36.800+08:00 [feishu] feishu[main-bot]: group session scope=group, peer=<redacted-group>
2026-05-07T18:21:36.803+08:00 [feishu] feishu[main-bot]: Feishu[main-bot] message in group <redacted-group>: /reset
2026-05-07T18:21:36.852+08:00 [feishu] feishu[main-bot]: dispatching to agent (session=agent:main:feishu:group:<redacted-group>)
2026-05-07T18:21:38.487+08:00 [feishu] feishu[main-bot] segment flush reason=final mode=text chars=16
2026-05-07T18:21:38.489+08:00 [feishu] feishu[main-bot]: dispatch complete (queuedFinal=true, replies=1)
```

Command hook log for the same turn:

```json
{"timestamp":"2026-05-07T10:21:37.954Z","action":"reset","sessionKey":"agent:main:feishu:group:<redacted-group>","senderId":"<redacted-user>","source":"feishu"}
```

Observed result after fix: The group reset completed with a single Feishu text reply. The final text flush length is 16 characters, matching the built-in group reset acknowledgment `✅ Session reset.`.

The live unauthorized-reset Feishu group run displayed the generic denial reply:

- `⚠️ You are not authorized to reset this session.`

Redacted runtime log excerpt from the same turn:

```text
2026-05-07T23:05:36.272+08:00 [feishu] feishu[main-bot]: received message from <redacted-user> in <redacted-group> (group)
2026-05-07T23:05:36.274+08:00 [feishu] feishu[main-bot]: group session scope=group, peer=<redacted-group>
2026-05-07T23:05:36.277+08:00 [feishu] feishu[main-bot]: Feishu[main-bot] message in group <redacted-group>: /reset
2026-05-07T23:05:36.335+08:00 [feishu] feishu[main-bot]: dispatching to agent (session=agent:main:feishu:group:<redacted-group>)
2026-05-07T23:05:37.455+08:00 [feishu] feishu[main-bot] segment flush reason=final mode=text chars=48
2026-05-07T23:05:37.457+08:00 [feishu] feishu[main-bot]: dispatch complete (queuedFinal=true, replies=1)
```

Observed result after fix: The unauthorized reset completed with one Feishu text reply and did not silently disappear. The final text flush length is 48 characters, matching the generic denial message `⚠️ You are not authorized to reset this session.`.

What was not tested: `/reset soft` unauthorized denial was not exercised in the live Feishu group run; that path is covered by the targeted unit test added in this PR.

## Notes

- During validation, one regression was caught and fixed: if reset hooks already route a reply, bare `/reset` and `/new` must stop instead of falling through into model execution.
- The final behavior keeps the patch focused on visible reset feedback while preserving direct no-model acknowledgments and ACP handling.
