### PR TITLE
fix(telegram): include quoted message context in finalPromptText (#77582)

### DIFF
--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -30,6 +30,8 @@ export type CurrentTurnPromptContext = {
     body: string;
     senderLabel?: string;
     isQuote?: boolean;
+    quoteText?: string;
+    quoteSourceText?: string;
   };
 };
 

--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
@@ -85,6 +85,36 @@ describe("runtime context prompt submission", () => {
     expect(buildCurrentTurnPromptContextSuffix({ reply: { body: "   " } })).toBe("");
   });
 
+  it("includes quote_text and quote_source_text when reply is a selected quote", () => {
+    const suffix = buildCurrentTurnPromptContextSuffix({
+      reply: {
+        senderLabel: "Alice",
+        isQuote: true,
+        body: "beta",
+        quoteText: "beta",
+        quoteSourceText: "alpha beta gamma",
+      },
+    });
+
+    expect(suffix).toContain('"is_quote": true');
+    expect(suffix).toContain('"quote_text": "beta"');
+    expect(suffix).toContain('"quote_source_text": "alpha beta gamma"');
+    expect(suffix).toContain('"body": "beta"');
+  });
+
+  it("omits quote fields when reply is not a quote", () => {
+    const suffix = buildCurrentTurnPromptContextSuffix({
+      reply: {
+        senderLabel: "Bob",
+        body: "hello world",
+      },
+    });
+
+    expect(suffix).not.toContain("quote_text");
+    expect(suffix).not.toContain("quote_source_text");
+    expect(suffix).toContain('"body": "hello world"');
+  });
+
   it("queues runtime context as a hidden next-turn custom message", async () => {
     const sentMessages: Array<{ content: string }> = [];
     const sendCustomMessage = vi.fn(async (message: { content: string }) => {

--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.ts
@@ -58,6 +58,12 @@ export function buildCurrentTurnPromptContextSuffix(
       ? sanitizeCurrentTurnContextString(reply.senderLabel)
       : undefined,
     is_quote: reply.isQuote === true ? true : undefined,
+    quote_text: reply.isQuote === true && reply.quoteText
+      ? sanitizeCurrentTurnContextString(reply.quoteText)
+      : undefined,
+    quote_source_text: reply.isQuote === true && reply.quoteSourceText
+      ? sanitizeCurrentTurnContextString(reply.quoteSourceText)
+      : undefined,
     body: sanitizeCurrentTurnContextString(replyBody),
   };
   return [

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -362,6 +362,12 @@ function resolveCurrentTurnPromptContext(
         ? { senderLabel: normalizeOptionalString(ctx.ReplyToSender) }
         : {}),
       ...(ctx.ReplyToIsQuote === true ? { isQuote: true } : {}),
+      ...(ctx.ReplyToIsQuote === true && normalizeOptionalString(ctx.ReplyToQuoteText)
+        ? { quoteText: normalizeOptionalString(ctx.ReplyToQuoteText) }
+        : {}),
+      ...(ctx.ReplyToIsQuote === true && normalizeOptionalString(ctx.ReplyToQuoteSourceText)
+        ? { quoteSourceText: normalizeOptionalString(ctx.ReplyToQuoteSourceText) }
+        : {}),
     },
   };
 }

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -479,6 +479,22 @@ describe("buildInboundUserContextPrefix", () => {
     expect(reply["body"]).toBe("quoted body");
   });
 
+  it("includes quote_text and quote_source_text for selected quote replies", () => {
+    const text = buildInboundUserContextPrefix({
+      ReplyToSender: "Alice",
+      ReplyToBody: "beta",
+      ReplyToIsQuote: true,
+      ReplyToQuoteText: "beta",
+      ReplyToQuoteSourceText: "alpha beta gamma",
+    } as TemplateContext);
+
+    const reply = parseReplyPayload(text);
+    expect(reply["is_quote"]).toBe(true);
+    expect(reply["quote_text"]).toBe("beta");
+    expect(reply["quote_source_text"]).toBe("alpha beta gamma");
+    expect(reply["body"]).toBe("beta");
+  });
+
   it("includes sender_id in conversation info", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "group",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -268,10 +268,14 @@ export function buildInboundUserContextPrefix(
 
   const replyToBody = sanitizePromptBody(ctx.ReplyToBody);
   if (replyToBody) {
+    const quoteSourceText =
+      ctx.ReplyToIsQuote === true ? sanitizePromptBody(ctx.ReplyToQuoteSourceText) : undefined;
     blocks.push(
       formatUntrustedJsonBlock("Reply target of current user message (untrusted, for context):", {
         sender_label: normalizePromptMetadataString(ctx.ReplyToSender),
         is_quote: ctx.ReplyToIsQuote === true ? true : undefined,
+        quote_text: ctx.ReplyToIsQuote === true ? sanitizePromptBody(ctx.ReplyToQuoteText) : undefined,
+        quote_source_text: quoteSourceText || undefined,
         body: replyToBody,
       }),
     );

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -97,6 +97,8 @@ export type MsgContext = {
   ReplyToBody?: string;
   ReplyToSender?: string;
   ReplyToIsQuote?: boolean;
+  ReplyToQuoteText?: string;
+  ReplyToQuoteSourceText?: string;
   /** Forward origin from the reply target (when reply_to_message is a forwarded message). */
   ReplyToForwardedFrom?: string;
   ReplyToForwardedFromType?: string;


### PR DESCRIPTION
## Summary

When a Telegram user selects a portion of a message to quote-reply, the selected quote text (`ReplyToQuoteText`) and the full source message (`ReplyToQuoteSourceText`) were captured in normalized context but never surfaced in the model-visible prompt. This caused short replies like "why?" or "explain" to lose the quote context they depend on.

## Changes

- **`src/auto-reply/templating.ts`**: Add `ReplyToQuoteText` and `ReplyToQuoteSourceText` to `MsgContext` type
- **`src/auto-reply/reply/inbound-meta.ts`**: Include `quote_text` and `quote_source_text` in the reply target prompt block when `is_quote` is true
- **`src/auto-reply/reply/get-reply-run.ts`**: Pass `quoteText` and `quoteSourceText` through `resolveCurrentTurnPromptContext`
- **`src/agents/pi-embedded-runner/run/params.ts`**: Extend `CurrentTurnPromptContext` type with quote fields
- **`src/agents/pi-embedded-runner/run/runtime-context-prompt.ts`**: Render quote fields in `buildCurrentTurnPromptContextSuffix`

## Tests

- Added test for `buildCurrentTurnPromptContextSuffix` with quote fields
- Added test for `buildInboundUserContextPrefix` with quote context
- Added negative test verifying quote fields are omitted for non-quote replies

Fixes #77582