### PR TITLE
fix(agents): initialize context engines before CLI compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/CLI: initialize built-in context engines before CLI turn compaction resolves the default engine, preventing `Context engine "legacy" is not registered` crashes on CLI-mode compaction turns. Fixes #78943. (#78973) Thanks @hclsys.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -167,4 +167,59 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(updatedEntry?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(updatedEntry?.claudeCliSessionId).toBeUndefined();
   });
+
+  it("initializes built-in context engines before resolving CLI compaction engine", async () => {
+    const sessionKey = "agent:main:cli";
+    const sessionId = "session-cli";
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const initializeContextEngines = vi.fn();
+    const resolveContextEngine = vi.fn(async () => buildContextEngine({ compactCalls }));
+    setCliCompactionTestDeps({
+      ensureContextEnginesInitialized: initializeContextEngines,
+      resolveContextEngine,
+      createPreparedEmbeddedPiSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 100,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+    });
+
+    await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry: {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile,
+        contextTokens: 1_000,
+        totalTokens: 100,
+        totalTokensFresh: true,
+      },
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    expect(initializeContextEngines).toHaveBeenCalledTimes(1);
+    expect(resolveContextEngine).toHaveBeenCalledTimes(1);
+    expect(initializeContextEngines.mock.invocationCallOrder[0]).toBeLessThan(
+      resolveContextEngine.mock.invocationCallOrder[0],
+    );
+  });
 });

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { AgentCompactionMode } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { ensureContextEnginesInitialized as ensureContextEnginesInitializedImpl } from "../../context-engine/init.js";
 import { resolveContextEngine as resolveContextEngineImpl } from "../../context-engine/registry.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -32,6 +33,7 @@ type SettingsManagerLike = {
 };
 type CliCompactionDeps = {
   openSessionManager: (sessionFile: string) => SessionManagerLike;
+  ensureContextEnginesInitialized: () => void;
   resolveContextEngine: (cfg: OpenClawConfig) => Promise<ContextEngine>;
   createPreparedEmbeddedPiSettingsManager: (params: {
     cwd: string;
@@ -54,6 +56,7 @@ const log = createSubsystemLogger("agents/cli-compaction");
 
 const cliCompactionDeps: CliCompactionDeps = {
   openSessionManager: (sessionFile: string) => SessionManager.open(sessionFile),
+  ensureContextEnginesInitialized: ensureContextEnginesInitializedImpl,
   resolveContextEngine: resolveContextEngineImpl,
   createPreparedEmbeddedPiSettingsManager: createPreparedEmbeddedPiSettingsManagerImpl,
   applyPiAutoCompactionGuard: applyPiAutoCompactionGuardImpl,
@@ -70,6 +73,7 @@ export function setCliCompactionTestDeps(overrides: Partial<typeof cliCompaction
 export function resetCliCompactionTestDeps(): void {
   Object.assign(cliCompactionDeps, {
     openSessionManager: (sessionFile: string) => SessionManager.open(sessionFile),
+    ensureContextEnginesInitialized: ensureContextEnginesInitializedImpl,
     resolveContextEngine: resolveContextEngineImpl,
     createPreparedEmbeddedPiSettingsManager: createPreparedEmbeddedPiSettingsManagerImpl,
     applyPiAutoCompactionGuard: applyPiAutoCompactionGuardImpl,
@@ -201,6 +205,7 @@ export async function runCliTurnCompactionLifecycle(params: {
     return params.sessionEntry;
   }
 
+  cliCompactionDeps.ensureContextEnginesInitialized();
   const contextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
   const sessionManager = cliCompactionDeps.openSessionManager(sessionFile);
   const settingsManager = await cliCompactionDeps.createPreparedEmbeddedPiSettingsManager({


### PR DESCRIPTION
## Summary
- initialize built-in context engines before the CLI turn compaction lifecycle resolves the default context engine
- add regression coverage asserting initialization happens before context-engine resolution
- add CHANGELOG entry

Fixes #78943.

## Tests
- pnpm test src/agents/command/cli-compaction.test.ts src/agents/subagent-spawn.context.test.ts src/agents/subagent-registry.test.ts src/context-engine/context-engine.test.ts
- pnpm exec oxfmt --check src/agents/command/cli-compaction.ts src/agents/command/cli-compaction.test.ts

## Notes
- No changes to memory-core, dreaming, or REM narrative code. The fix is limited to CLI compaction bootstrap ordering.

## Real behavior proof

- **Behavior or issue addressed**: CLI turn compaction crashes with `Context engine "legacy" is not registered` on the `runCliTurnCompactionLifecycle` path when built-in engines are not yet registered (#78943). Root cause: `resolveContextEngine` is called before `ensureContextEnginesInitialized` in the CLI compaction path, leaving the registry empty.
- **Real environment tested**: Local OpenClaw source checkout on the patched branch, node 24.x, pnpm workspace
- **Exact steps or command run after this patch**: node --import tsx --input-type=module script that mirrors the patched runCliTurnCompactionLifecycle ordering — calls ensureContextEnginesInitialized first then resolveContextEngine
- **Evidence after fix**: node script output on patched branch: `[patched] ensureContextEnginesInitialized() ok` followed by `[patched] resolveContextEngine({}) engine: bound LegacyContextEngine` — the same sequence that runCliTurnCompactionLifecycle now executes. Without the patch, resolveContextEngine at line 205 throws `Context engine "legacy" is not registered` because ensureContextEnginesInitialized was never called in this path (only in embedded/subagent paths per clawsweeper review).
- **Observed result after fix**: The patched runCliTurnCompactionLifecycle calls ensureContextEnginesInitialized before resolveContextEngine, registering the built-in legacy engine so resolution succeeds without error
- **What was not tested**: End-to-end live session file compaction via a real CLI turn; the fix is a single-line ordering change mirroring the adjacent embedded/subagent path

Closes #78943
