### PR TITLE
fix(providers): skip store:false for proxy-like Responses API endpoints (#78897)

### DIFF
--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -159,6 +159,23 @@ describe("openai responses payload policy", () => {
     expect(payload).not.toHaveProperty("reasoning");
   });
 
+  it("does not emit store false for proxy-like endpoints in disable mode", () => {
+    const policy = resolveOpenAIResponsesPayloadPolicy(
+      {
+        api: "openai-responses",
+        provider: "litellm",
+        baseUrl: "http://litellm-host:4000/v1",
+      },
+      { storeMode: "disable" },
+    );
+
+    expect(policy.explicitStore).toBeUndefined();
+
+    const payload = {} satisfies Record<string, unknown>;
+    applyOpenAIResponsesPayloadPolicy(payload, policy);
+    expect(payload).not.toHaveProperty("store");
+  });
+
   it("emits store false for native OpenAI Codex responses disable mode", () => {
     const policy = resolveOpenAIResponsesPayloadPolicy(
       {

--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -160,6 +160,23 @@ describe("openai responses payload policy", () => {
     expect(payload).not.toHaveProperty("reasoning");
   });
 
+  it("does not emit store false for proxy-like endpoints in disable mode", () => {
+    const policy = resolveOpenAIResponsesPayloadPolicy(
+      {
+        api: "openai-responses",
+        provider: "litellm",
+        baseUrl: "http://litellm-host:4000/v1",
+      },
+      { storeMode: "disable" },
+    );
+
+    expect(policy.explicitStore).toBeUndefined();
+
+    const payload = {} satisfies Record<string, unknown>;
+    applyOpenAIResponsesPayloadPolicy(payload, policy);
+    expect(payload).not.toHaveProperty("store");
+  });
+
   it("emits store false for native OpenAI Codex responses disable mode", () => {
     expect(
       resolveOpenAIResponsesPayloadPolicy(

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -325,7 +325,7 @@ export function resolveOpenAIResponsesPayloadPolicy(
     storeMode === "preserve"
       ? undefined
       : storeMode === "disable"
-        ? capabilities.supportsResponsesStoreField
+        ? capabilities.supportsResponsesStoreField && capabilities.usesKnownNativeOpenAIRoute
           ? false
           : undefined
         : capabilities.allowsResponsesStore

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -326,7 +326,7 @@ export function resolveOpenAIResponsesPayloadPolicy(
     storeMode === "preserve"
       ? undefined
       : storeMode === "disable"
-        ? capabilities.supportsResponsesStoreField
+        ? capabilities.supportsResponsesStoreField && capabilities.usesKnownNativeOpenAIRoute
           ? false
           : undefined
         : capabilities.allowsResponsesStore


### PR DESCRIPTION
## Summary

For non-native OpenAI endpoints (e.g. LiteLLM proxies) using the Responses API, the transport stream unconditionally sends `store: false` in disable mode. This causes continuation failures when prior `rs_*` response items are replayed in subsequent turns — the backend rejects them because those items were never persisted.

## Root Cause

In `resolveOpenAIResponsesPayloadPolicy`, the `"disable"` store mode checked only `supportsResponsesStoreField` (true for any Responses API endpoint) without considering whether the endpoint is a known native OpenAI route. Proxy-like endpoints (custom baseUrl, non-OpenAI provider) received `store: false` even though they need persistence for multi-turn continuations.

## Fix

Only emit `store: false` in disable mode when `usesKnownNativeOpenAIRoute` is true. For proxy-like endpoints, `explicitStore` becomes `undefined` (omitted from payload), letting the backend use its default behavior (typically `store: true`).

## Test

Added a unit test verifying that a LiteLLM proxy endpoint with `storeMode: "disable"` does not emit `store: false`.

Fixes #78897