### PR TITLE
fix: resolve external channel plugins in isolated cron delivery (#78754)

### DIFF
--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -255,4 +255,39 @@ describe("outbound channel resolution", () => {
     ).toBe(plugin);
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
+
+  it("falls back to direct plugin lookup for channels not in the deliverable list", async () => {
+    // Simulate an external channel plugin (e.g. openclaw-weixin) that is not
+    // in the hardcoded deliverable list but is available via getChannelPlugin
+    // (bundled lazy load). This reproduces the isolated cron delivery bug #78754.
+    const plugin = { id: "openclaw-weixin" };
+    getChannelPluginMock.mockImplementation((id: string) =>
+      id === "openclaw-weixin" ? plugin : undefined,
+    );
+    const channelResolution = await importChannelResolution("fallback-external-channel");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "openclaw-weixin",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
+  });
+
+  it("falls back to active registry for channels not in the deliverable list", async () => {
+    const plugin = { id: "openclaw-weixin" };
+    getActivePluginRegistryMock.mockReturnValue({
+      channels: [{ plugin }],
+    });
+    getChannelPluginMock.mockReturnValue(undefined);
+    getLoadedChannelPluginMock.mockReturnValue(undefined);
+    const channelResolution = await importChannelResolution("fallback-registry-external");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "openclaw-weixin",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
+  });
 });

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -245,4 +245,39 @@ describe("outbound channel resolution", () => {
     ).toBe(plugin);
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
+
+  it("falls back to direct plugin lookup for channels not in the deliverable list", async () => {
+    // Simulate an external channel plugin (e.g. openclaw-weixin) that is not
+    // in the hardcoded deliverable list but is available via getChannelPlugin
+    // (bundled lazy load). This reproduces the isolated cron delivery bug #78754.
+    const plugin = { id: "openclaw-weixin" };
+    getChannelPluginMock.mockImplementation((id: string) =>
+      id === "openclaw-weixin" ? plugin : undefined,
+    );
+    const channelResolution = await importChannelResolution("fallback-external-channel");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "openclaw-weixin",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
+  });
+
+  it("falls back to active registry for channels not in the deliverable list", async () => {
+    const plugin = { id: "openclaw-weixin" };
+    getActivePluginRegistryMock.mockReturnValue({
+      channels: [{ plugin }],
+    });
+    getChannelPluginMock.mockReturnValue(undefined);
+    getLoadedChannelPluginMock.mockReturnValue(undefined);
+    const channelResolution = await importChannelResolution("fallback-registry-external");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "openclaw-weixin",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
+  });
 });

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -178,7 +178,19 @@ export function resolveOutboundChannelPlugin(params: {
 }): ChannelPlugin | undefined {
   const normalized = normalizeDeliverableOutboundChannel(params.channel);
   if (!normalized) {
-    return undefined;
+    // The channel may be a valid external plugin that is not yet in the
+    // deliverable list (e.g. isolated cron sessions where the plugin registry
+    // hasn't been fully populated). Fall back to direct plugin lookup.
+    const fallbackId = params.channel?.trim().toLowerCase();
+    if (!fallbackId) {
+      return undefined;
+    }
+    return (
+      getLoadedChannelPlugin(fallbackId as DeliverableMessageChannel) ??
+      resolveDirectFromActiveRegistry(fallbackId as DeliverableMessageChannel) ??
+      getChannelPlugin(fallbackId as DeliverableMessageChannel) ??
+      undefined
+    );
   }
 
   const resolveLoaded = () => getLoadedChannelPlugin(normalized);

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -57,7 +57,19 @@ export function resolveOutboundChannelPlugin(params: {
 }): ChannelPlugin | undefined {
   const normalized = normalizeDeliverableOutboundChannel(params.channel);
   if (!normalized) {
-    return undefined;
+    // The channel may be a valid external plugin that is not yet in the
+    // deliverable list (e.g. isolated cron sessions where the plugin registry
+    // hasn't been fully populated). Fall back to direct plugin lookup.
+    const fallbackId = params.channel?.trim().toLowerCase();
+    if (!fallbackId) {
+      return undefined;
+    }
+    return (
+      getLoadedChannelPlugin(fallbackId as DeliverableMessageChannel) ??
+      resolveDirectFromActiveRegistry(fallbackId as DeliverableMessageChannel) ??
+      getChannelPlugin(fallbackId as DeliverableMessageChannel) ??
+      undefined
+    );
   }
 
   const resolveLoaded = () => getLoadedChannelPlugin(normalized);


### PR DESCRIPTION
## Problem

Isolated session cron jobs with `delivery.mode: "announce"` targeting external channel plugins (e.g. `openclaw-weixin`) fail with:

```
cron-delivery: {"error":"Unsupported channel: openclaw-weixin"}
```

## Root Cause

In `resolveOutboundChannelPlugin` (src/infra/outbound/channel-resolution.ts), when a channel is not in the known deliverable list (`normalizeDeliverableOutboundChannel` returns `undefined`), the function immediately returns `undefined` without attempting any plugin lookup.

External channel plugins like `openclaw-weixin` are only added to the deliverable list when the active plugin registry is populated. In isolated cron sessions, the registry may not be fully initialized at delivery time, causing the early return.

## Fix

When `normalizeDeliverableOutboundChannel` returns `undefined`, fall back to direct plugin lookup using the raw channel string:
1. `getLoadedChannelPlugin` (already loaded in memory)
2. `resolveDirectFromActiveRegistry` (active plugin registry scan)
3. `getChannelPlugin` (bundled lazy load fallback)

This ensures external plugins that are loadable but not yet registered in the deliverable list can still be resolved for cron delivery.

## Test

Added unit tests verifying that channels not in the deliverable list are still resolved via the fallback paths.

Fixes #78754