### PR TITLE
fix: guard against non-string entries in node caps/commands arrays (#78881)

### DIFF
--- a/src/gateway/node-catalog.test.ts
+++ b/src/gateway/node-catalog.test.ts
@@ -289,4 +289,30 @@ describe("gateway/node-catalog", () => {
       }),
     );
   });
+
+  it("handles non-string entries in caps/commands without crashing", () => {
+    const catalog = createKnownNodeCatalog({
+      pairedDevices: [],
+      pairedNodes: [],
+      connectedNodes: [
+        {
+          nodeId: "broken-node",
+          displayName: "Broken",
+          platform: "android",
+          caps: ["camera", undefined as unknown as string, null as unknown as string, ""],
+          commands: [undefined as unknown as string, "exec"],
+          connectedAtMs: 1,
+        },
+      ],
+    });
+
+    const node = getKnownNode(catalog, "broken-node");
+    expect(node).toEqual(
+      expect.objectContaining({
+        caps: ["camera"],
+        commands: ["exec"],
+        connected: true,
+      }),
+    );
+  });
 });

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -54,6 +54,9 @@ function uniqueSortedStrings(...items: Array<readonly string[] | undefined>): st
       continue;
     }
     for (const value of item) {
+      if (typeof value !== "string") {
+        continue;
+      }
       const trimmed = value.trim();
       if (trimmed) {
         values.add(trimmed);

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -45,9 +45,13 @@ export class NodeRegistry {
   register(client: GatewayWsClient, opts: { remoteIp?: string | undefined }) {
     const connect = client.connect;
     const nodeId = connect.device?.id ?? connect.client.id;
-    const caps = Array.isArray(connect.caps) ? connect.caps : [];
+    const caps = Array.isArray(connect.caps)
+      ? connect.caps.filter((c): c is string => typeof c === "string")
+      : [];
     const commands = Array.isArray((connect as { commands?: string[] }).commands)
-      ? ((connect as { commands?: string[] }).commands ?? [])
+      ? ((connect as { commands?: string[] }).commands ?? []).filter(
+          (c): c is string => typeof c === "string",
+        )
       : [];
     const permissions =
       typeof (connect as { permissions?: Record<string, boolean> }).permissions === "object"


### PR DESCRIPTION
When a connected node sends `caps` or `commands` arrays containing `null`/`undefined` values, the `uniqueSortedStrings` helper in `node-catalog.ts` crashes with:

```
TypeError: Cannot read properties of undefined (reading 'trim')
```

This causes the `node.list` RPC to fail continuously (~1/sec), which makes **all agent sessions hang** — messages are dispatched but never get a response.

## Root cause

`NodeRegistry.register()` accepts `connect.caps` / `connect.commands` via `Array.isArray()` without filtering non-string elements. If a node client sends a malformed array (e.g. `["camera", null]`), the values propagate to `uniqueSortedStrings()` which unconditionally calls `.trim()` on each element.

## Fix

1. **`node-catalog.ts`** — `uniqueSortedStrings()` now skips non-string entries  
2. **`node-registry.ts`** — filter caps/commands at registration time to only keep strings

Both layers defend independently so either is sufficient.

Fixes #78881