### PR TITLE
fix(imessage): honor groupAllowFrom before group registry drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
 - Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/title/details, show web-search queries from provider-native argument shapes, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
+- iMessage: let `groupAllowFrom` satisfy `groupPolicy: "allowlist"` when no `channels.imessage.groups` registry is configured, and warn at default log level when the group registry still drops a group message. Fixes #78749.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/extensions/imessage/src/monitor.gating.test.ts
+++ b/extensions/imessage/src/monitor.gating.test.ts
@@ -343,6 +343,39 @@ describe("imessage monitor gating + envelope builders", () => {
     expect(decision.kind).toBe("drop");
   });
 
+  it("allows groupPolicy allowlist groups when groupAllowFrom handles sender access", () => {
+    const cfg = baseCfg();
+    cfg.channels ??= {};
+    cfg.channels.imessage ??= {};
+    cfg.channels.imessage.groupPolicy = "allowlist";
+    delete cfg.channels.imessage.groups;
+
+    const groupHistories = new Map();
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 15,
+        chat_id: 123,
+        sender: "+15550001111",
+        is_from_me: false,
+        text: "@openclaw hello",
+        is_group: true,
+      },
+      opts: {},
+      messageText: "@openclaw hello",
+      bodyText: "@openclaw hello",
+      allowFrom: ["*"],
+      groupAllowFrom: ["+15550001111"],
+      groupPolicy: "allowlist",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories,
+    });
+    expect(decision.kind).toBe("dispatch");
+  });
+
   it("honors group allowlist and ignores pairing-store senders in groups", () => {
     const cfg = baseCfg();
     cfg.channels ??= {};

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -288,6 +288,36 @@ describe("resolveIMessageInboundDecision echo detection", () => {
       `imessage: dropping self-chat reflected duplicate: "${sanitizeTerminalText(bodyText)}"`,
     );
   });
+
+  it("warns when the group registry drops an otherwise authorized group", () => {
+    const logWarning = vi.fn();
+    const decision = resolveDecision({
+      cfg: {
+        channels: {
+          imessage: {
+            groupPolicy: "allowlist",
+            groups: { "999": { requireMention: false } },
+          },
+        },
+      } as OpenClawConfig,
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["+15555550123"],
+      logWarning,
+      message: {
+        id: 9901,
+        chat_id: 123,
+        text: "@openclaw hello",
+        is_group: true,
+      },
+      messageText: "@openclaw hello",
+      bodyText: "@openclaw hello",
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "group id not in allowlist" });
+    expect(logWarning).toHaveBeenCalledWith(
+      "imessage: skipping group message (123) not in allowlist",
+    );
+  });
 });
 
 describe("describeIMessageEchoDropLog", () => {

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -182,6 +182,7 @@ export function resolveIMessageInboundDecision(params: {
         channel: "imessage",
         accountId: params.accountId,
         groupId: groupIdCandidate,
+        hasGroupAllowFrom: params.groupAllowFrom.length > 0,
       })
     : {
         allowlistEnabled: false,

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -160,6 +160,7 @@ export function resolveIMessageInboundDecision(params: {
   };
   selfChatCache?: SelfChatCache;
   logVerbose?: (msg: string) => void;
+  logWarning?: (msg: string) => void;
 }): IMessageInboundDecision {
   const senderRaw = params.message.sender ?? "";
   const sender = senderRaw.trim();
@@ -174,6 +175,13 @@ export function resolveIMessageInboundDecision(params: {
   const createdAt = params.message.created_at ? Date.parse(params.message.created_at) : undefined;
   const messageText = params.messageText.trim();
   const bodyText = params.bodyText.trim();
+  const logWarningOrVerbose = (message: string) => {
+    if (params.logWarning) {
+      params.logWarning(message);
+      return;
+    }
+    params.logVerbose?.(message);
+  };
 
   const groupIdCandidate = chatId !== undefined ? String(chatId) : undefined;
   const groupListPolicy = groupIdCandidate
@@ -290,7 +298,7 @@ export function resolveIMessageInboundDecision(params: {
         return { kind: "drop", reason: "groupPolicy disabled" };
       }
       if (accessDecision.reasonCode === DM_GROUP_ACCESS_REASON.GROUP_POLICY_EMPTY_ALLOWLIST) {
-        params.logVerbose?.(
+        logWarningOrVerbose(
           "Blocked iMessage group message (groupPolicy: allowlist, no groupAllowFrom)",
         );
         return { kind: "drop", reason: "groupPolicy allowlist (empty groupAllowFrom)" };
@@ -313,7 +321,7 @@ export function resolveIMessageInboundDecision(params: {
   }
 
   if (isGroup && groupListPolicy.allowlistEnabled && !groupListPolicy.allowed) {
-    params.logVerbose?.(
+    logWarningOrVerbose(
       `imessage: skipping group message (${groupId ?? "unknown"}) not in allowlist`,
     );
     return { kind: "drop", reason: "group id not in allowlist" };

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -296,6 +296,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       echoCache: sentMessageCache,
       selfChatCache,
       logVerbose,
+      logWarning: (message) => runtime.log?.(warn(message)),
     });
 
     // Build conversation key for rate limiting (used by both drop and dispatch paths).


### PR DESCRIPTION
## Summary

Fixes #78749.

- Pass iMessage's configured `groupAllowFrom` state into the shared `resolveChannelGroupPolicy` helper so `groupPolicy: "allowlist"` with sender-level group access no longer falls through to the group registry drop when `channels.imessage.groups` is unset.
- Keep strict group registry behavior for configured `channels.imessage.groups` allowlists, but surface remaining registry drops at default warning level instead of debug-only verbose logging.
- Add focused iMessage regression coverage and a changelog entry.

## Audits

- Existing helper: reuses `resolveChannelGroupPolicy({ hasGroupAllowFrom })`; no new policy helper.
- Shared behavior: does not change the shared helper contract; aligns iMessage with the existing WhatsApp usage pattern.
- Duplicate search: `/usr/bin/gh pr list --repo openclaw/openclaw --state open --search '78749 in:body' --json number,title,author,headRefName,updatedAt` returned `[]` before opening this PR.

## Real behavior proof

Behavior addressed: iMessage inbound group gating with `groupPolicy: "allowlist"`, no `channels.imessage.groups` registry, and a sender allowed by `groupAllowFrom`. Before this patch the sender gate could allow the sender and the later group registry gate still returned `drop` with `reason: "group id not in allowlist"`. After this patch the same OpenClaw decision path dispatches, while strict configured registry misses still emit a default-level warning.

Real setup tested: local OpenClaw checkout on Linux, branch `fix/imessage-group-allowfrom-bypass-78749`, executing the bundled iMessage monitor decision code in `extensions/imessage/src/monitor/inbound-processing.ts` with `node --import tsx`. No mock replaces the production `resolveChannelGroupPolicy` helper.

Exact steps or command run after the patch:

```bash
node --import tsx - <<'NODE'
import { resolveIMessageInboundDecision } from './extensions/imessage/src/monitor/inbound-processing.ts';
const cfg = {
  channels: { imessage: { groupPolicy: 'allowlist' } },
  session: { mainKey: 'main' },
  messages: { groupChat: { mentionPatterns: ['@openclaw'] } },
};
const decision = resolveIMessageInboundDecision({
  cfg,
  accountId: 'default',
  message: { id: 9902, chat_id: 123, sender: '+15550001111', is_from_me: false, text: '@openclaw hello', is_group: true },
  opts: {},
  messageText: '@openclaw hello',
  bodyText: '@openclaw hello',
  allowFrom: ['*'],
  groupAllowFrom: ['+15550001111'],
  groupPolicy: 'allowlist',
  dmPolicy: 'open',
  storeAllowFrom: [],
  historyLimit: 0,
  groupHistories: new Map(),
});
console.log(JSON.stringify({ kind: decision.kind, isGroup: decision.kind === 'dispatch' ? decision.isGroup : undefined, sessionKey: decision.kind === 'dispatch' ? decision.route.sessionKey : undefined }, null, 2));
NODE
pnpm test extensions/imessage/src/monitor.gating.test.ts extensions/imessage/src/monitor/inbound-processing.test.ts
pnpm check:changed
```

Evidence after fix:

```text
$ node --import tsx <script above>
{
  "kind": "dispatch",
  "isGroup": true,
  "sessionKey": "agent:main:imessage:group:123"
}

$ pnpm test extensions/imessage/src/monitor.gating.test.ts extensions/imessage/src/monitor/inbound-processing.test.ts
[test] passed 1 Vitest shard in 6.28s
Test Files  2 passed (2)
Tests       24 passed (24)

$ pnpm check:changed
[check:changed] typecheck extensions: pass
[check:changed] typecheck extension tests: pass
[check:changed] lint extensions: 0 warnings, 0 errors
Import cycle check: 0 runtime value cycle(s)
```

Observed result after fix: the allowlisted iMessage group sender now dispatches to `agent:main:imessage:group:123` when `groups` is unset, proving the shared `hasGroupAllowFrom` bypass is wired into iMessage. The added inbound-processing regression observes `logWarning` for remaining group-registry drops, proving the drop is no longer verbose-only when the runtime supplies the default warning hook.

Not tested: no live macOS/iMessage Gateway run was performed in this Linux environment. The proof is source-level against the production iMessage decision path plus repository checks; a maintainer can apply proof override if live iMessage proof is required for this maintainer-labeled issue.