### PR TITLE
fix: persist cron run session under runSessionKey for correct deep-link (#78944)

### DIFF
--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -213,6 +213,37 @@ describe("createPersistCronSessionEntry", () => {
       systemSent: true,
     });
   });
+
+  it("persists under runSessionKey when provided", async () => {
+    const cronSession = makeCronSession(
+      makeSessionEntry({
+        sessionFile: await createTranscriptFile(),
+      }),
+    );
+    const storedKeys: string[] = [];
+    const updateSessionStore = vi.fn(
+      async (_storePath: string, update: (store: Record<string, SessionEntry>) => void) => {
+        const store: Record<string, SessionEntry> = {};
+        update(store);
+        storedKeys.push(...Object.keys(store));
+      },
+    );
+
+    const persist = createPersistCronSessionEntry({
+      isFastTestEnv: false,
+      cronSession,
+      agentSessionKey: "agent:main:cron:job1",
+      runSessionKey: "agent:main:cron:job1:run:abc123",
+      updateSessionStore,
+    });
+
+    await persist();
+
+    expect(cronSession.store["agent:main:cron:job1"]).toBe(cronSession.sessionEntry);
+    expect(cronSession.store["agent:main:cron:job1:run:abc123"]).toBe(cronSession.sessionEntry);
+    expect(storedKeys).toContain("agent:main:cron:job1");
+    expect(storedKeys).toContain("agent:main:cron:job1:run:abc123");
+  });
 });
 
 async function createTranscriptFile(): Promise<string> {

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -157,6 +157,33 @@ describe("createPersistCronSessionEntry", () => {
 
     expect(cronSession.store["agent:main:session"]).toBe(cronSession.sessionEntry);
   });
+
+  it("persists under runSessionKey when provided", async () => {
+    const cronSession = makeCronSession();
+    const storedKeys: string[] = [];
+    const updateSessionStore = vi.fn(
+      async (_storePath: string, update: (store: Record<string, SessionEntry>) => void) => {
+        const store: Record<string, SessionEntry> = {};
+        update(store);
+        storedKeys.push(...Object.keys(store));
+      },
+    );
+
+    const persist = createPersistCronSessionEntry({
+      isFastTestEnv: false,
+      cronSession,
+      agentSessionKey: "agent:main:cron:job1",
+      runSessionKey: "agent:main:cron:job1:run:abc123",
+      updateSessionStore,
+    });
+
+    await persist();
+
+    expect(cronSession.store["agent:main:cron:job1"]).toBe(cronSession.sessionEntry);
+    expect(cronSession.store["agent:main:cron:job1:run:abc123"]).toBe(cronSession.sessionEntry);
+    expect(storedKeys).toContain("agent:main:cron:job1");
+    expect(storedKeys).toContain("agent:main:cron:job1:run:abc123");
+  });
 });
 
 async function createTranscriptFile(): Promise<string> {

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -47,6 +47,7 @@ export function createPersistCronSessionEntry(params: {
   isFastTestEnv: boolean;
   cronSession: MutableCronSession;
   agentSessionKey: string;
+  runSessionKey?: string;
   updateSessionStore: UpdateSessionStore;
 }): PersistCronSessionEntry {
   return async () => {
@@ -60,8 +61,14 @@ export function createPersistCronSessionEntry(params: {
         ? toNonResumableCronSessionEntry(params.cronSession.sessionEntry)
         : params.cronSession.sessionEntry;
     params.cronSession.store[params.agentSessionKey] = persistedEntry;
+    if (params.runSessionKey && params.runSessionKey !== params.agentSessionKey) {
+      params.cronSession.store[params.runSessionKey] = persistedEntry;
+    }
     await params.updateSessionStore(params.cronSession.storePath, (store) => {
       store[params.agentSessionKey] = persistedEntry;
+      if (params.runSessionKey && params.runSessionKey !== params.agentSessionKey) {
+        store[params.runSessionKey] = persistedEntry;
+      }
     });
   };
 }

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -42,6 +42,7 @@ export function createPersistCronSessionEntry(params: {
   isFastTestEnv: boolean;
   cronSession: MutableCronSession;
   agentSessionKey: string;
+  runSessionKey?: string;
   updateSessionStore: UpdateSessionStore;
 }): PersistCronSessionEntry {
   return async () => {
@@ -55,8 +56,14 @@ export function createPersistCronSessionEntry(params: {
         ? toNonResumableCronSessionEntry(params.cronSession.sessionEntry)
         : params.cronSession.sessionEntry;
     params.cronSession.store[params.agentSessionKey] = persistedEntry;
+    if (params.runSessionKey && params.runSessionKey !== params.agentSessionKey) {
+      params.cronSession.store[params.runSessionKey] = persistedEntry;
+    }
     await params.updateSessionStore(params.cronSession.storePath, (store) => {
       store[params.agentSessionKey] = persistedEntry;
+      if (params.runSessionKey && params.runSessionKey !== params.agentSessionKey) {
+        store[params.runSessionKey] = persistedEntry;
+      }
     });
   };
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -564,6 +564,7 @@ async function prepareCronRunContext(params: {
     isFastTestEnv: params.isFastTestEnv,
     cronSession,
     agentSessionKey,
+    runSessionKey,
     updateSessionStore: async (storePath, update) => {
       const { updateSessionStore } = await loadSessionStoreRuntime();
       await updateSessionStore(storePath, update);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -543,6 +543,7 @@ async function prepareCronRunContext(params: {
     isFastTestEnv: params.isFastTestEnv,
     cronSession,
     agentSessionKey,
+    runSessionKey,
     updateSessionStore: async (storePath, update) => {
       const { updateSessionStore } = await loadSessionStoreRuntime();
       await updateSessionStore(storePath, update);


### PR DESCRIPTION
Fixes #78944

## Root Cause

`createPersistCronSessionEntry` only persisted the cron session entry under `agentSessionKey` (e.g. `agent:main:cron:jobid`), but the cron run log records a different key — `runSessionKey` (`agentSessionKey + ':run:' + runSessionId`).

When the UI's "Open Chat" button navigates to the session using the `runSessionKey` from the run log, the session store lookup fails because no entry exists under that key, resulting in an incorrect/empty session being displayed.

## Fix

Also persist the session entry under `runSessionKey` in both the in-memory store and the on-disk session store, so the UI can correctly resolve the cron run's session when deep-linking from the run history.