### PR TITLE
style(macos): hoist A2UI await expressions

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -471,7 +471,8 @@ actor MacNodeRuntime {
     }
 
     private func resolveA2UIHostUrl() async -> String? {
-        Self.resolveA2UIHostUrl(from: await self.canvasSurfaceUrl())
+        let canvasSurfaceUrl = await self.canvasSurfaceUrl()
+        return Self.resolveA2UIHostUrl(from: canvasSurfaceUrl)
     }
 
     private static func resolveA2UIHostUrl(from raw: String?) -> String? {
@@ -485,7 +486,8 @@ actor MacNodeRuntime {
         if !forceRefresh, let current = await self.resolveA2UIHostUrl() {
             return current
         }
-        return Self.resolveA2UIHostUrl(from: await self.refreshCanvasSurfaceUrl())
+        let canvasSurfaceUrl = await self.refreshCanvasSurfaceUrl()
+        return Self.resolveA2UIHostUrl(from: canvasSurfaceUrl)
     }
 
     private func isA2UIReady(poll: Bool = false) async -> Bool {


### PR DESCRIPTION
## Summary

- Problem: current macOS SwiftFormat lint fails on two inline `await` expressions in `MacNodeRuntime.swift` (`hoistAwait`).
- Why it matters: the failure is currently making unrelated PR CI red, including #78992.
- What changed: hoisted the two awaited A2UI URL calls into local values before passing them to the synchronous URL resolver.
- What did NOT change (scope boundary): no runtime behavior, public API, config, or tests changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #78992
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: SwiftFormat rejects current `MacNodeRuntime.swift` with `hoistAwait`.
- Real environment tested: local OpenClaw checkout on macOS.
- Exact steps or command run after this patch: `swiftc -parse apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift`; `git diff --check`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ swiftc -parse apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
$ git diff --check
```

- Observed result after fix: both commands exit 0.
- What was not tested: local `swiftformat --lint`; `swiftformat` is not installed in this environment.
- Before evidence (optional but encouraged): PR #78992 CI showed `MacNodeRuntime.swift:474:1` and `MacNodeRuntime.swift:488:1` failing `hoistAwait`.

## Root Cause (if applicable)

- Root cause: two async calls were embedded as inline awaited arguments to a synchronous helper call.
- Missing detection / guardrail: SwiftFormat catches this in macOS CI; the formatting issue landed on main before this PR.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: macOS SwiftFormat CI.
- Scenario the test should lock in: no inline awaited arguments that violate `hoistAwait`.
- Why this is the smallest reliable guardrail: this is a formatting rule, not runtime behavior.
- Existing test that already covers this (if any): `macos-swift` CI.
- If no new test is added, why not: formatting-only change.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): macOS app source
- Relevant config (redacted): N/A

### Steps

1. Inspect the failing SwiftFormat CI log from #78992.
2. Hoist both inline awaited expressions into locals.
3. Run `swiftc -parse apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift`.
4. Run `git diff --check`.

### Expected

- Swift source still parses and whitespace checks are clean.

### Actual

- Both local checks pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: exact changed Swift file parses; diff has no whitespace errors.
- Edge cases checked: no behavior path changed; only moved awaited values into locals.
- What you did **not** verify: full macOS SwiftFormat/build/test locally because `swiftformat` is not installed here.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
