### PR TITLE
fix(gateway/health): require delay co-evidence before flagging event_loop_utilization degraded (#79017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
 - Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/title/details, show web-search queries from provider-native argument shapes, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
+- Gateway/health: require observed delay co-evidence (`delayP99Ms` or `delayMaxMs` ≥ 25ms) before flagging `event_loop_utilization` degraded so idle gateways with frequent short async work (WebSocket keepalives, periodic timers) are no longer falsely reported as degraded when all delays are zero. Fixes #79017. (#79017) Thanks @hclsys.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/src/gateway/server/event-loop-health.test.ts
+++ b/src/gateway/server/event-loop-health.test.ts
@@ -83,12 +83,40 @@ describe("createGatewayEventLoopHealthMonitor", () => {
     harness.setNow(1_000);
     expect(harness.monitor.snapshot()).toMatchObject({
       degraded: true,
-      reasons: ["event_loop_utilization", "cpu"],
+      reasons: ["cpu"],
       intervalMs: 1_000,
       delayP99Ms: 0,
       delayMaxMs: 0,
       utilization: 1,
       cpuCoreRatio: 1,
+    });
+  });
+
+  it("does not flag event_loop_utilization when ELU is saturated but all delays are zero (#79017)", () => {
+    // WebSocket keepalives and periodic timers can saturate ELU to 1.0 even when the
+    // loop never blocks. delayP99Ms=0 and delayMaxMs=0 means the loop is genuinely idle.
+    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.01, utilization: 1 });
+    harness.setNow(1_000);
+
+    expect(harness.monitor.snapshot()).toMatchObject({
+      degraded: false,
+      reasons: [],
+      utilization: 1,
+      delayP99Ms: 0,
+      delayMaxMs: 0,
+    });
+  });
+
+  it("flags event_loop_utilization when ELU is saturated and delay co-evidence is present (#79017)", () => {
+    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.01, utilization: 1 });
+    harness.setDelay({ p99Ms: 30 });
+    harness.setNow(1_000);
+
+    expect(harness.monitor.snapshot()).toMatchObject({
+      degraded: true,
+      reasons: ["event_loop_utilization"],
+      utilization: 1,
+      delayP99Ms: 30,
     });
   });
 

--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -3,6 +3,10 @@ import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 const EVENT_LOOP_MONITOR_RESOLUTION_MS = 20;
 const EVENT_LOOP_DELAY_WARN_MS = 1_000;
 const EVENT_LOOP_UTILIZATION_WARN = 0.95;
+// ELU saturates at 1.0 when the loop wakes frequently for short async work (WebSocket
+// keepalives, periodic timers) even when each wake is sub-millisecond and the loop
+// never blocks. Require observed delay co-evidence before flagging utilization alone.
+const EVENT_LOOP_UTILIZATION_DELAY_COEVIDENCE_MS = 25;
 const CPU_CORE_RATIO_WARN = 0.9;
 const SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS = 1_000;
 
@@ -66,7 +70,12 @@ function resolveGatewayEventLoopHealthReasons(params: {
   ) {
     reasons.push("event_loop_delay");
   }
-  if (hasSustainedLoadWindow && params.utilization >= EVENT_LOOP_UTILIZATION_WARN) {
+  if (
+    hasSustainedLoadWindow &&
+    params.utilization >= EVENT_LOOP_UTILIZATION_WARN &&
+    (params.delayP99Ms >= EVENT_LOOP_UTILIZATION_DELAY_COEVIDENCE_MS ||
+      params.delayMaxMs >= EVENT_LOOP_UTILIZATION_DELAY_COEVIDENCE_MS)
+  ) {
     reasons.push("event_loop_utilization");
   }
   if (hasSustainedLoadWindow && params.cpuCoreRatio >= CPU_CORE_RATIO_WARN) {


### PR DESCRIPTION
Fixes #79017 — idle gateways with WebSocket keepalives or periodic timers are falsely flagged as `eventLoop.degraded: true` when all delays are zero.

## Root cause

Node's `perf_hooks.eventLoopUtilization()` saturates at 1.0 whenever the loop wakes frequently for short async work (WebSocket pings, keepalives, libuv timer callbacks) — even when each wake is sub-millisecond and the loop never blocks. The `event_loop_utilization` reason in `resolveGatewayEventLoopHealthReasons` (`src/gateway/server/event-loop-health.ts`) was gated only on `utilization >= 0.95` and a sustained sample window, with no requirement that actual blocking be observed.

`delayP99Ms` and `delayMaxMs` (from `monitorEventLoopDelay`) are the authoritative signal for actual blocking: they measure how long the loop was unable to schedule new work. If both are zero, the loop is healthy regardless of ELU.

## Fix

Added `EVENT_LOOP_UTILIZATION_DELAY_COEVIDENCE_MS = 25` constant. `event_loop_utilization` reason now requires `delayP99Ms >= 25 || delayMaxMs >= 25` in addition to `utilization >= 0.95` and the sustained window. The `event_loop_delay` (hard 1000ms threshold) and `cpu` reasons are unchanged.

## Real behavior proof

- **Behavior or issue addressed**: Idle gateway (ELU=1.0, delayP99=0, delayMax=0) reported `degraded: true, reasons: [event_loop_utilization]`; after fix it reports `degraded: false`
- **Real environment tested**: Node 22.16, openclaw@2026.5.6, Linux x86_64, branch `fix/event-loop-elu-false-positive-79017`
- **Exact steps or command run after this patch**: `node --import tsx` calling `createGatewayEventLoopHealthMonitor` (the real exported function from `src/gateway/server/event-loop-health.ts`) with injected deps matching the three key cases; `pnpm test src/gateway/server/event-loop-health.test.ts -- --run`
- **Evidence after fix**:
  ```
  Case 1 — Idle gateway (ELU=1.0, delayP99=0, delayMax=0, cpu=1%):
    Before fix: degraded=true, reasons=[event_loop_utilization]
    After fix:  {"degraded":false,"reasons":[],"intervalMs":1000,"delayP99Ms":0,"delayMaxMs":0,"utilization":1,"cpuCoreRatio":0.01}

  Case 2 — Genuinely blocked (ELU=1.0, delayP99=30ms):
    {"degraded":true,"reasons":["event_loop_utilization"],"intervalMs":1000,"delayP99Ms":30,"delayMaxMs":0,"utilization":1,"cpuCoreRatio":0.01}

  Case 3 — Hard delay block (delayMax=1500ms):
    {"degraded":true,"reasons":["event_loop_delay"],"intervalMs":1000,"delayP99Ms":0,"delayMaxMs":1500,"utilization":0.3,"cpuCoreRatio":0.01}

  Test Files  1 passed (1) — Tests  5 passed (5)
  ```
- **Observed result after fix**: `createGatewayEventLoopHealthMonitor().snapshot()` returns `degraded: false` for idle gateway with zero delays; genuinely blocked gateway (delays ≥ 25ms) still correctly returns `degraded: true`; 5/5 vitest tests pass including 2 new regression tests for the false-positive case
- **What was not tested**: Live Docker gateway measuring actual `perf_hooks.monitorEventLoopDelay` percentiles under real WebSocket keepalive load