### PR TITLE
bootstrap-extra-files: opt-in bootstrapTrustExternal allows trusted external paths

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1308,6 +1308,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/runs-registry:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/runway:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -708,6 +708,7 @@ export async function loadExtraBootstrapFiles(
 export async function loadExtraBootstrapFilesWithDiagnostics(
   dir: string,
   extraPatterns: string[],
+  opts?: { trustExternal?: boolean },
 ): Promise<{
   files: WorkspaceBootstrapFile[];
   diagnostics: ExtraBootstrapLoadDiagnostic[];
@@ -749,6 +750,40 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
       });
       continue;
     }
+    // mod(bootstrap-extra-files): when opts.trustExternal is set (operator
+    // opt-in via `bootstrapTrustExternal: true` in openclaw.json), bypass
+    // workspace-boundary check so AOS Agents/ layered files under OneDrive
+    // can be ingested. Default behavior (no opt-in) is unchanged.
+    if (opts?.trustExternal === true) {
+      try {
+        const stat = await fs.stat(filePath);
+        if (stat.size > MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES) {
+          diagnostics.push({
+            path: filePath,
+            reason: "io",
+            detail: `bootstrap file exceeds ${MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES}-byte cap (${stat.size})`,
+          });
+          continue;
+        }
+        const content = await fs.readFile(filePath, "utf-8");
+        files.push({
+          name: baseName as WorkspaceBootstrapFileName,
+          path: filePath,
+          content,
+          missing: false,
+        });
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        const reason: ExtraBootstrapLoadDiagnosticCode = code === "ENOENT" ? "missing" : "io";
+        diagnostics.push({
+          path: filePath,
+          reason,
+          detail: err instanceof Error ? err.message : String(err),
+        });
+      }
+      continue;
+    }
+
     const loaded = await readWorkspaceFileWithGuards({
       filePath,
       workspaceDir: resolvedDir,

--- a/src/hooks/bundled/bootstrap-extra-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.ts
@@ -38,10 +38,13 @@ const bootstrapExtraFilesHook: HookHandler = async (event) => {
     return;
   }
 
+  const trustExternal = (hookConfig as Record<string, unknown>).bootstrapTrustExternal === true;
+
   try {
     const { files: extras, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(
       context.workspaceDir,
       patterns,
+      { trustExternal },
     );
     if (diagnostics.length > 0) {
       log.debug("skipped extra bootstrap candidates", {


### PR DESCRIPTION
**Files:** `src/agents/workspace.ts`, `src/hooks/bundled/bootstrap-extra-files/handler.ts`

**Change:** `loadExtraBootstrapFilesWithDiagnostics` gains an optional `opts: { trustExternal?: boolean }` parameter. When set, it bypasses `readWorkspaceFileWithGuards`'s workspace-boundary check and reads the file directly via `fs.readFile` (size cap retained at `MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES`). The hook reads `hookConfig.bootstrapTrustExternal === true` from `openclaw.json` and threads it through. Default (no opt-in) is byte-for-byte unchanged from upstream.

**Purpose:** Enables operator-authored config to ingest agent-config files from a non-workspace path. Upstream's boundary check (added in `242188b7b1 refactor: unify boundary-safe reads for bootstrap and includes`) intentionally rejects external paths to keep the standard bootstrap surface tight; this mod provides an explicit opt-in for the trusted-config use case without weakening the default.

**Verification:**
- `grep -c 'bootstrapTrustExternal' src/hooks/bundled/bootstrap-extra-files/handler.ts` → `1`
- `grep -c 'opts?.trustExternal' src/agents/workspace.ts` → `1`
- Gateway accepts `bootstrapTrustExternal: true` under `hooks.internal.entries.bootstrap-extra-files` without `Unrecognized key` error (verified via hot-reload journal entry).