### PR TITLE
fix(imessage): strip attributedBody prefix noise

### DIFF
--- a/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts
+++ b/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts
@@ -38,8 +38,26 @@ describe("stripImessageLengthPrefixedUtf8Text", () => {
     expect(stripImessageLengthPrefixedUtf8Text(inner)).toBe(inner);
   });
 
+  it("removes imsg attributedBody corruption markers from long decoded text", () => {
+    expect(stripImessageLengthPrefixedUtf8Text("��\u0000Direkt långtest från Bosse")).toBe(
+      "Direkt långtest från Bosse",
+    );
+    expect(stripImessageLengthPrefixedUtf8Text("�N\u0002Klart. Commit på N2-main")).toBe(
+      "Klart. Commit på N2-main",
+    );
+    expect(stripImessageLengthPrefixedUtf8Text("�\u000f\u0004Pass335 är klart")).toBe(
+      "Pass335 är klart",
+    );
+  });
+
   it("preserves plain text", () => {
     expect(stripImessageLengthPrefixedUtf8Text("Mrrrrow! 🐱")).toBe("Mrrrrow! 🐱");
+  });
+
+  it("preserves plain text that starts with a replacement character", () => {
+    expect(stripImessageLengthPrefixedUtf8Text("� unknown glyph at start")).toBe(
+      "� unknown glyph at start",
+    );
   });
 
   it("preserves text when the wrapped length does not consume the whole string", () => {

--- a/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.ts
+++ b/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.ts
@@ -5,6 +5,53 @@ type Varint = {
 
 const utf8Decoder = new TextDecoder();
 
+function isControlCodeUnit(value: number): boolean {
+  return value <= 0x1f || (value >= 0x7f && value <= 0x9f);
+}
+
+function isAsciiPrintableCodeUnit(value: number): boolean {
+  return value >= 0x20 && value <= 0x7e;
+}
+
+function attributedBodyCorruptionPrefixLength(text: string): number {
+  if (text.charCodeAt(0) !== 0xfffd) {
+    return 0;
+  }
+
+  const second = text.charCodeAt(1);
+  if (second === 0xfffd) {
+    const third = text.charCodeAt(2);
+    return Number.isNaN(third) || !isControlCodeUnit(third) ? 2 : 3;
+  }
+
+  if (isControlCodeUnit(second)) {
+    let offset = 1;
+    while (offset < 4 && isControlCodeUnit(text.charCodeAt(offset))) {
+      offset += 1;
+    }
+    return offset;
+  }
+
+  const third = text.charCodeAt(2);
+  if (isAsciiPrintableCodeUnit(second) && isControlCodeUnit(third)) {
+    return 3;
+  }
+
+  return 0;
+}
+
+function stripLeadingAttributedBodyCorruption(text: string): string {
+  const prefixLength = attributedBodyCorruptionPrefixLength(text);
+  if (prefixLength === 0) {
+    return text;
+  }
+  const next = text.slice(prefixLength);
+  if (!next || isControlCodeUnit(next.charCodeAt(0))) {
+    return text;
+  }
+  return next;
+}
+
 function readVarint(buf: Uint8Array, start: number): Varint | null {
   let offset = start;
   let value = 0;
@@ -48,6 +95,11 @@ export function tryStripImessageLengthPrefixedUtf8Buffer(buf: Uint8Array): Uint8
 export function stripImessageLengthPrefixedUtf8Text(text: string): string {
   if (!text) {
     return text;
+  }
+
+  const attributedBodyCleaned = stripLeadingAttributedBodyCorruption(text);
+  if (attributedBodyCleaned !== text) {
+    return attributedBodyCleaned;
   }
 
   const stripped = tryStripImessageLengthPrefixedUtf8Buffer(Buffer.from(text, "utf8"));


### PR DESCRIPTION
## Summary
- Strip leading attributedBody corruption markers from iMessage monitor text before routing.
- Keep the existing length-prefixed UTF-8 stripping path intact.
- Add regression coverage for observed corrupt prefixes and a replacement-character false-positive guard.

## Real behavior proof
- **Behavior or issue addressed:** iMessage monitor text from the local OpenClaw setup can include leading attributedBody corruption bytes such as replacement characters plus control bytes. Those bytes leaked into routed replies.
- **Real environment tested:** macOS Messages database via `imsg history` on the same local OpenClaw+iMessage setup where the corrupted outbound rows were observed.
- **Exact steps or command run after this patch:** Ran `node --import tsx` against the patched `stripImessageLengthPrefixedUtf8Text()` implementation and real `imsg history --chat-id 2 --limit 20 --json` output.
- **Evidence after fix:** Redacted terminal output from the real setup:

```text
row=20172 beforePrefix="��\u0003F" beforeLength=964 afterLength=961 stripped=true cleanStartsWithReplacement=false
row=20171 beforePrefix="�/\u0001P" beforeLength=301 afterLength=298 stripped=true cleanStartsWithReplacement=false
row=20170 beforePrefix="��\u0000P" beforeLength=176 afterLength=173 stripped=true cleanStartsWithReplacement=false
row=20167 beforePrefix="��\u0000D" beforeLength=190 afterLength=187 stripped=true cleanStartsWithReplacement=false
row=20164 beforePrefix="�\u000f\u0004P" beforeLength=1027 afterLength=1024 stripped=true cleanStartsWithReplacement=false
row=20162 beforePrefix="��\u0001J" beforeLength=367 afterLength=364 stripped=true cleanStartsWithReplacement=false
row=20160 beforePrefix="�9\u0001J" beforeLength=301 afterLength=298 stripped=true cleanStartsWithReplacement=false
row=20157 beforePrefix="��\u0000P" beforeLength=149 afterLength=146 stripped=true cleanStartsWithReplacement=false
row=20156 beforePrefix="��\u0003F" beforeLength=927 afterLength=924 stripped=true cleanStartsWithReplacement=false
checkedRealIMessageRows=9
```

- **Observed result after fix:** All 9 real corrupted iMessage rows had the leading prefix stripped, and none of the cleaned strings still started with a replacement character.
- **What was not tested:** I did not run a packaged OpenClaw release with this patch installed; the proof runs the patched parser from this branch against real iMessage history data.

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-imessage.config.ts extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts extensions/imessage/src/monitor/parse-notification.test.ts extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts`
- `pnpm lint:extensions -- extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.ts extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts`
- `git diff --check HEAD~1..HEAD`
- Changed-file secret scan
