### PR TITLE
Matrix: stream natively on Beeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Matrix: use Beeper-native AI stream events for thinking, text, tool progress, and approvals when the configured homeserver is Beeper, while keeping standard Matrix preview/edit streaming for other homeservers.
+- Matrix: use Beeper-native AI stream events for thinking, text, tool progress, and approvals when the configured homeserver is Beeper, including Beeper Desktop approval button reactions, while keeping standard Matrix preview/edit streaming for other homeservers.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Matrix: use Beeper-native AI stream events for thinking, text, tool progress, and approvals when the configured homeserver is Beeper, while keeping standard Matrix preview/edit streaming for other homeservers.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -181,6 +181,8 @@ A practical baseline with DM pairing, room allowlist, and E2EE:
 
 Matrix reply streaming is opt-in. `streaming` controls how OpenClaw delivers the in-flight assistant reply; `blockStreaming` controls whether each completed block is preserved as its own Matrix message.
 
+On Beeper homeservers (`beeper.com`, `beeper-staging.com`, `beeper-dev.com`, and subdomains), the Matrix plugin uses Beeper-native AI stream events when Matrix streaming is enabled. Beeper clients receive live structured parts for assistant text, thinking, tool progress, plans, command output, patches, and approval state, then OpenClaw finalizes the original Matrix message with `com.beeper.ai` content. Non-Beeper homeservers keep the standard Matrix preview/edit behavior described below.
+
 ```json5
 {
   channels: {

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -181,7 +181,7 @@ A practical baseline with DM pairing, room allowlist, and E2EE:
 
 Matrix reply streaming is opt-in. `streaming` controls how OpenClaw delivers the in-flight assistant reply; `blockStreaming` controls whether each completed block is preserved as its own Matrix message.
 
-On Beeper homeservers (`beeper.com`, `beeper-staging.com`, `beeper-dev.com`, and subdomains), the Matrix plugin uses Beeper-native AI stream events when Matrix streaming is enabled. Beeper clients receive live structured parts for assistant text, thinking, tool progress, plans, command output, patches, and approval state, then OpenClaw finalizes the original Matrix message with `com.beeper.ai` content. Non-Beeper homeservers keep the standard Matrix preview/edit behavior described below.
+On Beeper homeservers (`beeper.com`, `beeper-staging.com`, `beeper-dev.com`, and subdomains), the Matrix plugin uses Beeper-native AI stream events when Matrix streaming is enabled. Beeper clients receive live structured parts for assistant text, thinking, tool progress, plans, command output, patches, and approval state, Beeper Desktop approval buttons resolve the underlying OpenClaw approval through Matrix reactions, and OpenClaw finalizes the original Matrix message with `com.beeper.ai` content. Non-Beeper homeservers keep the standard Matrix preview/edit behavior described below.
 
 ```json5
 {
@@ -694,6 +694,8 @@ Both kinds share Matrix reaction shortcuts and message updates. Approvers see re
 - `♾️` allow always (when the effective exec policy allows it)
 
 Fallback slash commands: `/approve <id> allow-once`, `/approve <id> allow-always`, `/approve <id> deny`.
+
+On Beeper homeservers using Beeper-native AI streams, Beeper Desktop's approval buttons send the equivalent native reaction keys (`approval.allow_once`, `approval.allow_always`, and `approval.deny`) to the streamed AI message. OpenClaw resolves those reactions through the same Matrix approval authorization and persistence path as the emoji shortcuts.
 
 Only resolved approvers can approve or deny. Channel delivery for exec approvals includes the command text - only enable `channel` or `both` in trusted rooms.
 

--- a/extensions/matrix/src/approval-reactions.test.ts
+++ b/extensions/matrix/src/approval-reactions.test.ts
@@ -70,6 +70,37 @@ describe("matrix approval reactions", () => {
     });
   });
 
+  it("resolves Beeper native approval reaction keys", () => {
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:beeper.com",
+      eventId: "$beeper-stream",
+      approvalId: "req-beeper",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
+
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:beeper.com",
+        eventId: "$beeper-stream",
+        reactionKey: "approval.allow_once",
+      }),
+    ).toEqual({ approvalId: "req-beeper", decision: "allow-once" });
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:beeper.com",
+        eventId: "$beeper-stream",
+        reactionKey: "approval.allow_always",
+      }),
+    ).toEqual({ approvalId: "req-beeper", decision: "allow-always" });
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:beeper.com",
+        eventId: "$beeper-stream",
+        reactionKey: "approval.deny",
+      }),
+    ).toEqual({ approvalId: "req-beeper", decision: "deny" });
+  });
+
   it("ignores reactions that are not allowed on the registered approval anchor event", () => {
     registerMatrixApprovalReactionTarget({
       roomId: "!ops:example.org",

--- a/extensions/matrix/src/approval-reactions.ts
+++ b/extensions/matrix/src/approval-reactions.ts
@@ -4,17 +4,23 @@ import { getOptionalMatrixRuntime } from "./runtime.js";
 const MATRIX_APPROVAL_REACTION_META = {
   "allow-once": {
     emoji: "✅",
+    nativeKeys: ["approval.allow_once"],
     label: "Allow once",
   },
   "allow-always": {
     emoji: "♾️",
+    nativeKeys: ["approval.allow_always"],
     label: "Allow always",
   },
   deny: {
     emoji: "❌",
+    nativeKeys: ["approval.deny"],
     label: "Deny",
   },
-} satisfies Record<ExecApprovalReplyDecision, { emoji: string; label: string }>;
+} satisfies Record<
+  ExecApprovalReplyDecision,
+  { emoji: string; nativeKeys: readonly string[]; label: string }
+>;
 
 const MATRIX_APPROVAL_REACTION_ORDER = [
   "allow-once",
@@ -197,7 +203,8 @@ function resolveMatrixApprovalReactionDecision(
     if (!allowed.has(decision)) {
       continue;
     }
-    if (MATRIX_APPROVAL_REACTION_META[decision].emoji === normalizedReaction) {
+    const meta = MATRIX_APPROVAL_REACTION_META[decision];
+    if (meta.emoji === normalizedReaction || meta.nativeKeys.includes(normalizedReaction)) {
       return decision;
     }
   }

--- a/extensions/matrix/src/matrix/beeper-stream.test.ts
+++ b/extensions/matrix/src/matrix/beeper-stream.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMatrixBeeperStreamController, isBeeperHomeserver } from "./beeper-stream.js";
+
+const sendMocks = vi.hoisted(() => ({
+  editMessageMatrix: vi.fn(async () => "$edit"),
+  sendSingleTextMessageMatrix: vi.fn(async () => ({
+    messageId: "$target",
+    primaryMessageId: "$target",
+    receipt: { platformMessageIds: ["$target"] },
+    roomId: "!room:beeper.com",
+  })),
+}));
+
+vi.mock("./send.js", () => sendMocks);
+
+describe("Matrix Beeper stream controller", () => {
+  it("gates native streams to Beeper homeservers", () => {
+    expect(isBeeperHomeserver("https://matrix.beeper.com")).toBe(true);
+    expect(isBeeperHomeserver("https://chat.beeper-staging.com")).toBe(true);
+    expect(isBeeperHomeserver("https://matrix.example.org")).toBe(false);
+  });
+
+  it("sends Beeper AI stream content and finalizes the target event", async () => {
+    const listeners = new Map<string, (...args: unknown[]) => void>();
+    const sendToDevice = vi.fn(async () => {});
+    sendMocks.editMessageMatrix.mockClear();
+    sendMocks.sendSingleTextMessageMatrix.mockClear();
+    const client = {
+      getDeviceId: () => "DEVICE",
+      getEvent: vi.fn(async () => null),
+      getUserId: vi.fn(async () => "@bot:beeper.com"),
+      off: vi.fn((name: string) => listeners.delete(name)),
+      on: vi.fn((name: string, listener: (...args: unknown[]) => void) => {
+        listeners.set(name, listener);
+      }),
+      sendToDevice,
+    };
+
+    const controller = createMatrixBeeperStreamController({
+      roomId: "!room:beeper.com",
+      client: client as never,
+      cfg: { channels: { matrix: { streaming: "partial" } } },
+    });
+
+    await controller.onReasoningStream({ text: "checking" });
+    await controller.onReasoningEnd();
+    await controller.onPartialReply({ text: "hello" });
+    await controller.onApprovalEvent({
+      approvalId: "approval-1",
+      kind: "exec",
+      phase: "requested",
+      reason: "Needs shell access",
+      toolCallId: "tool-1",
+    });
+
+    listeners.get("to_device.event")?.({
+      content: {
+        device_id: "ALICEDEVICE",
+        event_id: "$target",
+        expiry_ms: 60_000,
+        room_id: "!room:beeper.com",
+      },
+      event_id: "$subscribe",
+      origin_server_ts: Date.now(),
+      sender: "@alice:beeper.com",
+      type: "com.beeper.stream.subscribe",
+    });
+
+    await controller.onPartialReply({ text: "hello world" });
+    await controller.finalize({ text: "hello world" });
+
+    const sendSingleCalls = sendMocks.sendSingleTextMessageMatrix.mock.calls as unknown[][];
+    expect(sendSingleCalls[0]?.[2]).toMatchObject({
+      extraContent: {
+        "com.beeper.ai": {
+          parts: [],
+          role: "assistant",
+        },
+        "com.beeper.stream": {
+          device_id: "DEVICE",
+          type: "com.beeper.llm",
+          user_id: "@bot:beeper.com",
+        },
+      },
+    });
+    expect(sendToDevice).toHaveBeenCalledWith(
+      "com.beeper.stream.update",
+      expect.objectContaining({
+        "@alice:beeper.com": expect.objectContaining({
+          ALICEDEVICE: expect.objectContaining({
+            "com.beeper.llm.deltas": expect.any(Array),
+          }),
+        }),
+      }),
+    );
+    const editCalls = sendMocks.editMessageMatrix.mock.calls as unknown[][];
+    const finalEdit = editCalls.at(-1);
+    expect(finalEdit?.slice(0, 3)).toEqual(["!room:beeper.com", "$target", "hello world"]);
+    expect(finalEdit?.[3]).toMatchObject({
+      extraContent: {
+        "com.beeper.ai": {
+          role: "assistant",
+        },
+        "com.beeper.stream": null,
+      },
+      topLevelExtraContent: {
+        "com.beeper.dont_render_edited": true,
+        "com.beeper.stream": null,
+      },
+    });
+    const parts = (finalEdit?.[3] as { extraContent?: { "com.beeper.ai"?: { parts?: unknown[] } } })
+      .extraContent?.["com.beeper.ai"]?.parts;
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        { state: "done", text: "checking", type: "reasoning" },
+        { state: "done", text: "hello world", type: "text" },
+        expect.objectContaining({
+          approval: expect.objectContaining({ id: "approval-1", reason: "Needs shell access" }),
+          state: "approval-requested",
+          toolCallId: "tool-1",
+          type: "tool-exec",
+        }),
+      ]),
+    );
+  });
+});

--- a/extensions/matrix/src/matrix/beeper-stream.test.ts
+++ b/extensions/matrix/src/matrix/beeper-stream.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearMatrixApprovalReactionTargetsForTest,
+  resolveMatrixApprovalReactionTarget,
+} from "../approval-reactions.js";
 import { createMatrixBeeperStreamController, isBeeperHomeserver } from "./beeper-stream.js";
 
 const sendMocks = vi.hoisted(() => ({
@@ -12,6 +16,10 @@ const sendMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./send.js", () => sendMocks);
+
+afterEach(() => {
+  clearMatrixApprovalReactionTargetsForTest();
+});
 
 describe("Matrix Beeper stream controller", () => {
   it("gates native streams to Beeper homeservers", () => {
@@ -52,6 +60,13 @@ describe("Matrix Beeper stream controller", () => {
       reason: "Needs shell access",
       toolCallId: "tool-1",
     });
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!room:beeper.com",
+        eventId: "$target",
+        reactionKey: "approval.allow_once",
+      }),
+    ).toEqual({ approvalId: "approval-1", decision: "allow-once" });
 
     listeners.get("to_device.event")?.({
       content: {

--- a/extensions/matrix/src/matrix/beeper-stream.ts
+++ b/extensions/matrix/src/matrix/beeper-stream.ts
@@ -1,4 +1,5 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { registerMatrixApprovalReactionTarget } from "../approval-reactions.js";
 import type { CoreConfig } from "../types.js";
 import type { MatrixClient, MatrixRawEvent } from "./sdk.js";
 import { editMessageMatrix, sendSingleTextMessageMatrix } from "./send.js";
@@ -347,6 +348,7 @@ export function createMatrixBeeperStreamController(params: {
       await publish({ data: payload, id: "plan", type: "data-openclaw-plan" });
     },
     onApprovalEvent: async (payload) => {
+      const active = await ensureState();
       const toolCallId =
         payload.toolCallId ??
         payload.itemId ??
@@ -355,6 +357,14 @@ export function createMatrixBeeperStreamController(params: {
         payload.phase === "resolved" || payload.status === "resolved"
           ? "tool-approval-response"
           : "tool-approval-request";
+      if (type === "tool-approval-request" && payload.approvalId?.trim()) {
+        registerMatrixApprovalReactionTarget({
+          roomId: active.roomId,
+          eventId: active.eventId,
+          approvalId: payload.approvalId,
+          allowedDecisions: ["allow-once", "allow-always", "deny"],
+        });
+      }
       await publish({
         approvalId: payload.approvalId,
         approved: payload.status === "approved",

--- a/extensions/matrix/src/matrix/beeper-stream.ts
+++ b/extensions/matrix/src/matrix/beeper-stream.ts
@@ -1,0 +1,683 @@
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import type { CoreConfig } from "../types.js";
+import type { MatrixClient, MatrixRawEvent } from "./sdk.js";
+import { editMessageMatrix, sendSingleTextMessageMatrix } from "./send.js";
+
+const BEEPER_STREAM_TYPE = "com.beeper.llm";
+const BEEPER_STREAM_DELTA_KEY = `${BEEPER_STREAM_TYPE}.deltas`;
+const BEEPER_STREAM_SUBSCRIBE_TYPE = "com.beeper.stream.subscribe";
+const BEEPER_STREAM_UPDATE_TYPE = "com.beeper.stream.update";
+const DEFAULT_DESCRIPTOR_EXPIRY_MS = 30 * 60 * 1000;
+
+const BEEPER_DOMAINS = new Set([
+  "beeper.com",
+  "beeper-staging.com",
+  "beeper-dev.com",
+  "beeper.localtest.me",
+]);
+
+type BeeperStreamDescriptor = {
+  user_id: string;
+  device_id?: string;
+  type: typeof BEEPER_STREAM_TYPE;
+  expiry_ms: number;
+};
+
+type BeeperSubscriber = {
+  userId: string;
+  deviceId: string;
+  expiresAt: number;
+};
+
+type BeeperAiMessage = {
+  id: string;
+  metadata: Record<string, unknown>;
+  parts: Record<string, unknown>[];
+  role: "assistant";
+};
+
+type BeeperStreamPart = Record<string, unknown> & { type: string };
+
+type BeeperStreamState = {
+  client: MatrixClient;
+  roomId: string;
+  eventId: string;
+  descriptor: BeeperStreamDescriptor;
+  turnId: string;
+  seq: number;
+  message: BeeperAiMessage;
+  subscribers: Map<string, BeeperSubscriber>;
+  pendingParts: BeeperStreamPart[];
+  textPartId: string | null;
+  reasoningPartId: string | null;
+  textPartIndexById: Map<string, number>;
+  reasoningPartIndexById: Map<string, number>;
+  toolPartIndexByCallId: Map<string, number>;
+  toolInputTextByCallId: Map<string, string>;
+  toolNameByCallId: Map<string, string>;
+};
+
+export function isBeeperHomeserver(homeserverUrl: string | undefined): boolean {
+  if (!homeserverUrl) {
+    return false;
+  }
+  try {
+    const hostname = new URL(homeserverUrl).hostname;
+    return (
+      BEEPER_DOMAINS.has(hostname) ||
+      [...BEEPER_DOMAINS].some((domain) => hostname.endsWith(`.${domain}`))
+    );
+  } catch {
+    return false;
+  }
+}
+
+export type MatrixBeeperStreamController = {
+  onPartialReply: (payload: ReplyPayload) => Promise<void>;
+  onReasoningStream: (payload: ReplyPayload) => Promise<void>;
+  onReasoningEnd: () => Promise<void>;
+  onAssistantMessageStart: () => Promise<void>;
+  onBlockReplyQueued: (payload: ReplyPayload) => Promise<void>;
+  onToolStart: (payload: {
+    name?: string;
+    phase?: string;
+    args?: Record<string, unknown>;
+  }) => Promise<void>;
+  onItemEvent: (payload: {
+    itemId?: string;
+    kind?: string;
+    title?: string;
+    name?: string;
+    phase?: string;
+    status?: string;
+    summary?: string;
+    progressText?: string;
+    meta?: string;
+    approvalId?: string;
+    approvalSlug?: string;
+  }) => Promise<void>;
+  onPlanUpdate: (payload: {
+    phase?: string;
+    title?: string;
+    explanation?: string;
+    steps?: string[];
+    source?: string;
+  }) => Promise<void>;
+  onApprovalEvent: (payload: {
+    phase?: string;
+    kind?: string;
+    status?: string;
+    title?: string;
+    itemId?: string;
+    toolCallId?: string;
+    approvalId?: string;
+    approvalSlug?: string;
+    command?: string;
+    host?: string;
+    reason?: string;
+    scope?: "turn" | "session";
+    message?: string;
+  }) => Promise<void>;
+  onCommandOutput: (payload: {
+    itemId?: string;
+    phase?: string;
+    title?: string;
+    toolCallId?: string;
+    name?: string;
+    output?: string;
+    status?: string;
+    exitCode?: number | null;
+    durationMs?: number;
+    cwd?: string;
+  }) => Promise<void>;
+  onPatchSummary: (payload: {
+    itemId?: string;
+    phase?: string;
+    title?: string;
+    toolCallId?: string;
+    name?: string;
+    added?: string[];
+    modified?: string[];
+    deleted?: string[];
+    summary?: string;
+  }) => Promise<void>;
+  finalize: (payload: ReplyPayload) => Promise<boolean>;
+  abort: (errorText?: string) => Promise<void>;
+  dispose: () => void;
+};
+
+export function createMatrixBeeperStreamController(params: {
+  roomId: string;
+  client: MatrixClient;
+  cfg: CoreConfig;
+  accountId?: string;
+  threadId?: string;
+  replyToId?: string;
+  log?: (message: string) => void;
+}): MatrixBeeperStreamController {
+  let state: BeeperStreamState | null = null;
+  let lastText = "";
+  let lastReasoning = "";
+  let closed = false;
+
+  const onToDevice = (event: MatrixRawEvent) => {
+    void handleToDeviceSubscribe(event).catch((error) => {
+      params.log?.(`beeper-stream: subscribe handling failed: ${String(error)}`);
+    });
+  };
+  params.client.on("to_device.event", onToDevice);
+
+  const ensureState = async (): Promise<BeeperStreamState> => {
+    if (closed) {
+      throw new Error("Beeper stream is closed");
+    }
+    if (state) {
+      return state;
+    }
+    const userId = await params.client.getUserId().catch(() => "");
+    const deviceId = params.client.getDeviceId() ?? undefined;
+    const turnId = `turn_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+    const descriptor: BeeperStreamDescriptor = {
+      user_id: userId,
+      ...(deviceId ? { device_id: deviceId } : {}),
+      type: BEEPER_STREAM_TYPE,
+      expiry_ms: DEFAULT_DESCRIPTOR_EXPIRY_MS,
+    };
+    const sent = await sendSingleTextMessageMatrix(params.roomId, "...", {
+      client: params.client,
+      cfg: params.cfg,
+      accountId: params.accountId,
+      threadId: params.threadId,
+      replyToId: params.replyToId,
+      extraContent: {
+        "com.beeper.ai": {
+          id: turnId,
+          metadata: { turn_id: turnId },
+          parts: [],
+          role: "assistant",
+        },
+        "com.beeper.stream": descriptor,
+      },
+    });
+    state = {
+      client: params.client,
+      roomId: params.roomId,
+      eventId: sent.messageId,
+      descriptor,
+      turnId,
+      seq: 1,
+      message: {
+        id: turnId,
+        metadata: { turn_id: turnId },
+        parts: [],
+        role: "assistant",
+      },
+      subscribers: new Map(),
+      pendingParts: [],
+      textPartId: null,
+      reasoningPartId: null,
+      textPartIndexById: new Map(),
+      reasoningPartIndexById: new Map(),
+      toolPartIndexByCallId: new Map(),
+      toolInputTextByCallId: new Map(),
+      toolNameByCallId: new Map(),
+    };
+    await publish({ messageId: turnId, messageMetadata: { turn_id: turnId }, type: "start" });
+    return state;
+  };
+
+  const publish = async (part: BeeperStreamPart): Promise<void> => {
+    const active = await ensureState();
+    applyPart(active, part);
+    active.pendingParts.push(part);
+    const subscribers = activeSubscribers(active);
+    if (subscribers.length === 0) {
+      return;
+    }
+    await publishPartToSubscribers(active, subscribers, part);
+  };
+
+  const handleToDeviceSubscribe = async (event: MatrixRawEvent) => {
+    if (!state || event.type !== BEEPER_STREAM_SUBSCRIBE_TYPE) {
+      return;
+    }
+    const content = event.content;
+    const roomId = typeof content.room_id === "string" ? content.room_id : "";
+    const eventId = typeof content.event_id === "string" ? content.event_id : "";
+    const deviceId = typeof content.device_id === "string" ? content.device_id : "";
+    if (roomId !== params.roomId || eventId !== state.eventId || !event.sender || !deviceId) {
+      return;
+    }
+    const expiryMs =
+      typeof content.expiry_ms === "number" && content.expiry_ms > 0
+        ? content.expiry_ms
+        : 5 * 60 * 1000;
+    const key = `${event.sender}:${deviceId}`;
+    const subscriber = { userId: event.sender, deviceId, expiresAt: Date.now() + expiryMs };
+    state.subscribers.set(key, subscriber);
+    for (const part of state.pendingParts) {
+      await publishPartToSubscribers(state, [subscriber], part);
+    }
+  };
+
+  const publishTextDelta = async (text: string) => {
+    const active = await ensureState();
+    const next = text ?? "";
+    if (!active.textPartId) {
+      active.textPartId = `text_${active.turnId}_${active.message.parts.length}`;
+      await publish({ id: active.textPartId, type: "text-start" });
+    }
+    const delta = next.startsWith(lastText) ? next.slice(lastText.length) : next;
+    lastText = next;
+    if (delta) {
+      await publish({ delta, id: active.textPartId, type: "text-delta" });
+    }
+  };
+
+  const endText = async () => {
+    if (!state?.textPartId) {
+      return;
+    }
+    const id = state.textPartId;
+    state.textPartId = null;
+    lastText = "";
+    await publish({ id, type: "text-end" });
+  };
+
+  const endReasoning = async () => {
+    if (!state?.reasoningPartId) {
+      return;
+    }
+    const id = state.reasoningPartId;
+    state.reasoningPartId = null;
+    lastReasoning = "";
+    await publish({ id, type: "reasoning-end" });
+  };
+
+  return {
+    onPartialReply: async (payload) => {
+      if (typeof payload.text === "string") {
+        await publishTextDelta(payload.text);
+      }
+    },
+    onReasoningStream: async (payload) => {
+      const active = await ensureState();
+      const next = payload.text ?? "";
+      if (!active.reasoningPartId) {
+        active.reasoningPartId = `reasoning_${active.turnId}_${active.message.parts.length}`;
+        await publish({ id: active.reasoningPartId, type: "reasoning-start" });
+      }
+      const delta = next.startsWith(lastReasoning) ? next.slice(lastReasoning.length) : next;
+      lastReasoning = next;
+      if (delta) {
+        await publish({ delta, id: active.reasoningPartId, type: "reasoning-delta" });
+      }
+    },
+    onReasoningEnd: endReasoning,
+    onAssistantMessageStart: async () => {
+      await endText();
+      await endReasoning();
+      await publish({ type: "start-step" });
+    },
+    onBlockReplyQueued: async (payload) => {
+      if (payload.text?.trim()) {
+        await publishTextDelta(payload.text);
+      }
+      await endText();
+      await publish({ type: "finish-step" });
+    },
+    onToolStart: async (payload) => {
+      const toolCallId = payload.name
+        ? `tool_${payload.name}_${Date.now().toString(36)}`
+        : `tool_${Date.now().toString(36)}`;
+      const toolName = payload.name ?? "tool";
+      await publish({ toolCallId, toolName, type: "tool-input-start" });
+      if (payload.args) {
+        await publish({ input: payload.args, toolCallId, toolName, type: "tool-input-available" });
+      }
+    },
+    onItemEvent: async (payload) => {
+      await publish({
+        data: payload,
+        id: payload.itemId ?? payload.title ?? payload.name,
+        type: "data-openclaw-item",
+      });
+    },
+    onPlanUpdate: async (payload) => {
+      await publish({ data: payload, id: "plan", type: "data-openclaw-plan" });
+    },
+    onApprovalEvent: async (payload) => {
+      const toolCallId =
+        payload.toolCallId ??
+        payload.itemId ??
+        `approval_${payload.approvalId ?? Date.now().toString(36)}`;
+      const type =
+        payload.phase === "resolved" || payload.status === "resolved"
+          ? "tool-approval-response"
+          : "tool-approval-request";
+      await publish({
+        approvalId: payload.approvalId,
+        approved: payload.status === "approved",
+        reason: payload.reason ?? payload.message,
+        toolCallId,
+        toolName: payload.kind ?? "approval",
+        type,
+      });
+    },
+    onCommandOutput: async (payload) => {
+      const toolCallId =
+        payload.toolCallId ??
+        payload.itemId ??
+        `command_${payload.name ?? Date.now().toString(36)}`;
+      await publish({
+        output: {
+          cwd: payload.cwd,
+          durationMs: payload.durationMs,
+          exitCode: payload.exitCode,
+          status: payload.status,
+          text: payload.output,
+          title: payload.title,
+        },
+        preliminary: payload.phase !== "end",
+        toolCallId,
+        toolName: payload.name ?? "exec",
+        type: payload.status === "error" ? "tool-output-error" : "tool-output-available",
+      });
+    },
+    onPatchSummary: async (payload) => {
+      await publish({
+        data: payload,
+        id: payload.itemId ?? payload.name ?? "patch",
+        type: "data-openclaw-patch",
+      });
+    },
+    finalize: async (payload) => {
+      if (!state) {
+        return false;
+      }
+      if (payload.text?.trim()) {
+        await publishTextDelta(payload.text);
+      }
+      await endText();
+      await endReasoning();
+      await publish({
+        finishReason: payload.isError ? "error" : "stop",
+        messageMetadata: {
+          finish_reason: payload.isError ? "error" : "stop",
+          turn_id: state.turnId,
+        },
+        type: "finish",
+      });
+      const finalText = getFinalMessageText(state.message) || payload.text?.trim() || "...";
+      await editMessageMatrix(params.roomId, state.eventId, finalText, {
+        client: params.client,
+        cfg: params.cfg,
+        accountId: params.accountId,
+        threadId: params.threadId,
+        extraContent: {
+          "com.beeper.ai": finalizeMessage(state),
+          "com.beeper.stream": null,
+        },
+        topLevelExtraContent: {
+          "com.beeper.dont_render_edited": true,
+          "com.beeper.stream": null,
+        },
+      });
+      return true;
+    },
+    abort: async (errorText) => {
+      if (!state) {
+        return;
+      }
+      await publish({ errorText, type: errorText ? "error" : "abort" });
+    },
+    dispose: () => {
+      closed = true;
+      params.client.off("to_device.event", onToDevice);
+    },
+  };
+}
+
+function activeSubscribers(state: BeeperStreamState): BeeperSubscriber[] {
+  const now = Date.now();
+  const active: BeeperSubscriber[] = [];
+  for (const [key, subscriber] of state.subscribers) {
+    if (subscriber.expiresAt <= now) {
+      state.subscribers.delete(key);
+    } else {
+      active.push(subscriber);
+    }
+  }
+  return active;
+}
+
+async function publishPartToSubscribers(
+  state: BeeperStreamState,
+  subscribers: BeeperSubscriber[],
+  part: BeeperStreamPart,
+): Promise<void> {
+  const delta = {
+    "m.relates_to": { event_id: state.eventId, rel_type: "m.reference" },
+    part,
+    seq: state.seq++,
+    target_event: state.eventId,
+    turn_id: state.turnId,
+  };
+  const content = {
+    [BEEPER_STREAM_DELTA_KEY]: [delta],
+    event_id: state.eventId,
+    room_id: state.roomId,
+  };
+  const messages: Record<string, Record<string, Record<string, unknown>>> = {};
+  for (const subscriber of subscribers) {
+    messages[subscriber.userId] ??= {};
+    messages[subscriber.userId][subscriber.deviceId] = content;
+  }
+  await state.client.sendToDevice(BEEPER_STREAM_UPDATE_TYPE, messages);
+}
+
+function applyPart(state: BeeperStreamState, part: BeeperStreamPart): void {
+  const type = part.type;
+  const id = typeof part.id === "string" ? part.id : undefined;
+  const toolCallId = typeof part.toolCallId === "string" ? part.toolCallId : undefined;
+
+  const ensureTextLikePart = (
+    kind: "text" | "reasoning",
+    indexById: Map<string, number>,
+    partId: string,
+  ) => {
+    const existing = indexById.get(partId);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const index = state.message.parts.length;
+    state.message.parts.push({ state: "streaming", text: "", type: kind });
+    indexById.set(partId, index);
+    return index;
+  };
+
+  const ensureToolPart = () => {
+    if (!toolCallId) {
+      return undefined;
+    }
+    if (typeof part.toolName === "string" && part.toolName.trim()) {
+      state.toolNameByCallId.set(toolCallId, part.toolName);
+    }
+    const existing = state.toolPartIndexByCallId.get(toolCallId);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const toolName = state.toolNameByCallId.get(toolCallId) ?? "tool";
+    const index = state.message.parts.length;
+    state.message.parts.push({
+      input: undefined,
+      state: "input-streaming",
+      toolCallId,
+      type: `tool-${toolName}`,
+    });
+    state.toolPartIndexByCallId.set(toolCallId, index);
+    return index;
+  };
+
+  switch (type) {
+    case "start":
+      if (typeof part.messageId === "string") {
+        state.message.id = part.messageId;
+      }
+      if (isRecord(part.messageMetadata)) {
+        state.message.metadata = { ...state.message.metadata, ...part.messageMetadata };
+      }
+      return;
+    case "text-start":
+      if (id) {
+        ensureTextLikePart("text", state.textPartIndexById, id);
+      }
+      return;
+    case "text-delta": {
+      if (!id || typeof part.delta !== "string") {
+        return;
+      }
+      const target = state.message.parts[ensureTextLikePart("text", state.textPartIndexById, id)];
+      target.text = `${typeof target.text === "string" ? target.text : ""}${part.delta}`;
+      target.state = "streaming";
+      return;
+    }
+    case "text-end": {
+      if (!id) {
+        return;
+      }
+      const target = state.message.parts[ensureTextLikePart("text", state.textPartIndexById, id)];
+      target.state = "done";
+      state.textPartIndexById.delete(id);
+      return;
+    }
+    case "reasoning-start":
+      if (id) {
+        ensureTextLikePart("reasoning", state.reasoningPartIndexById, id);
+      }
+      return;
+    case "reasoning-delta": {
+      if (!id || typeof part.delta !== "string") {
+        return;
+      }
+      const target =
+        state.message.parts[ensureTextLikePart("reasoning", state.reasoningPartIndexById, id)];
+      target.text = `${typeof target.text === "string" ? target.text : ""}${part.delta}`;
+      target.state = "streaming";
+      return;
+    }
+    case "reasoning-end": {
+      if (!id) {
+        return;
+      }
+      const target =
+        state.message.parts[ensureTextLikePart("reasoning", state.reasoningPartIndexById, id)];
+      target.state = "done";
+      state.reasoningPartIndexById.delete(id);
+      return;
+    }
+    case "tool-input-start":
+      ensureToolPart();
+      return;
+    case "tool-input-available":
+    case "tool-input-error": {
+      const index = ensureToolPart();
+      if (index === undefined) {
+        return;
+      }
+      const target = state.message.parts[index];
+      target.state = type === "tool-input-error" ? "output-error" : "input-available";
+      target.input = part.input;
+      return;
+    }
+    case "tool-approval-request":
+    case "tool-approval-response": {
+      const index = ensureToolPart();
+      if (index === undefined) {
+        return;
+      }
+      const target = state.message.parts[index];
+      target.state = type === "tool-approval-request" ? "approval-requested" : "approval-responded";
+      target.approval = {
+        approved: part.approved,
+        id: part.approvalId,
+        reason: part.reason,
+      };
+      return;
+    }
+    case "tool-output-available":
+    case "tool-output-error":
+    case "tool-output-denied": {
+      const index = ensureToolPart();
+      if (index === undefined) {
+        return;
+      }
+      const target = state.message.parts[index];
+      target.state =
+        type === "tool-output-available"
+          ? "output-available"
+          : type === "tool-output-error"
+            ? "output-error"
+            : "output-denied";
+      if (part.output !== undefined) {
+        target.output = part.output;
+      }
+      if (part.errorText !== undefined) {
+        target.errorText = part.errorText;
+      }
+      if (part.preliminary !== undefined) {
+        target.preliminary = part.preliminary;
+      }
+      return;
+    }
+    case "finish":
+      if (isRecord(part.messageMetadata)) {
+        state.message.metadata = { ...state.message.metadata, ...part.messageMetadata };
+      }
+      return;
+    case "error":
+    case "abort":
+      state.message.metadata = {
+        ...state.message.metadata,
+        beeper_terminal_state: type === "error" ? { errorText: part.errorText, type } : { type },
+      };
+      return;
+    default:
+      if (type === "start-step") {
+        state.message.parts.push({ type: "step-start" });
+      } else if (type.startsWith("data-")) {
+        state.message.parts.push({ data: part.data, id: part.id, type });
+      } else if (type === "source-url" || type === "source-document" || type === "file") {
+        state.message.parts.push({ ...part });
+      }
+  }
+}
+
+function finalizeMessage(state: BeeperStreamState): BeeperAiMessage {
+  for (const index of state.textPartIndexById.values()) {
+    const part = state.message.parts[index];
+    if (part) {
+      part.state = "done";
+    }
+  }
+  for (const index of state.reasoningPartIndexById.values()) {
+    const part = state.message.parts[index];
+    if (part) {
+      part.state = "done";
+    }
+  }
+  state.textPartIndexById.clear();
+  state.reasoningPartIndexById.clear();
+  return state.message;
+}
+
+function getFinalMessageText(message: BeeperAiMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => String(part.text))
+    .join("");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -33,6 +33,7 @@ import type {
   ReplyToMode,
 } from "../../types.js";
 import { resolveMatrixAccountAllowlistConfig } from "../account-config.js";
+import { createMatrixBeeperStreamController } from "../beeper-stream.js";
 import { formatMatrixErrorMessage } from "../errors.js";
 import { isMatrixMediaSizeLimitError } from "../media-errors.js";
 import {
@@ -191,6 +192,7 @@ export type MatrixMonitorHandlerParams = {
   /** DM session grouping behavior. */
   dmSessionScope?: "per-user" | "per-room";
   streaming: MatrixStreamingMode;
+  beeperNativeStreaming?: boolean;
   previewToolProgressEnabled: boolean;
   blockStreamingEnabled: boolean;
   dmEnabled: boolean;
@@ -1446,10 +1448,22 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           });
         },
       });
-      const draftStreamingEnabled = streaming !== "off";
+      const beeperNativeStreaming = params.beeperNativeStreaming === true;
+      const draftStreamingEnabled = streaming !== "off" && !beeperNativeStreaming;
       const quietDraftStreaming = streaming === "quiet" || streaming === "progress";
       const progressDraftStreaming = streaming === "progress";
       const draftReplyToId = replyToMode !== "off" && !threadTarget ? messageId : undefined;
+      const beeperStream = beeperNativeStreaming
+        ? createMatrixBeeperStreamController({
+            roomId,
+            client,
+            cfg,
+            threadId: threadTarget,
+            replyToId: draftReplyToId,
+            accountId: _route.accountId,
+            log: logVerboseMessage,
+          })
+        : undefined;
       const draftStream: MatrixDraftStreamHandle | undefined = draftStreamingEnabled
         ? await loadMatrixDraftStream().then(({ createMatrixDraftStream }) =>
             createMatrixDraftStream({
@@ -1742,6 +1756,57 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           ...prefixOptions,
           humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, _route.agentId),
           deliver: async (payload: ReplyPayload, info: { kind: string }) => {
+            const beeperPayloadHasMedia =
+              Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+            if (
+              beeperStream &&
+              info.kind !== "tool" &&
+              !payload.isCompactionNotice &&
+              !beeperPayloadHasMedia
+            ) {
+              try {
+                if (await beeperStream.finalize(payload)) {
+                  return;
+                }
+              } catch (err) {
+                logVerboseMessage(
+                  `matrix: Beeper native stream finalization failed: ${String(err)}`,
+                );
+                beeperStream.dispose();
+              }
+            }
+            if (
+              beeperStream &&
+              info.kind !== "tool" &&
+              !payload.isCompactionNotice &&
+              beeperPayloadHasMedia
+            ) {
+              try {
+                await beeperStream.finalize({
+                  ...payload,
+                  mediaUrl: undefined,
+                  mediaUrls: undefined,
+                });
+              } catch (err) {
+                logVerboseMessage(
+                  `matrix: Beeper native media stream finalization failed: ${String(err)}`,
+                );
+              }
+              await deliverMatrixReplies({
+                cfg,
+                replies: [{ ...payload, text: undefined }],
+                roomId,
+                client,
+                runtime,
+                textLimit,
+                replyToMode,
+                threadId: threadTarget,
+                accountId: _route.accountId,
+                mediaLocalRoots,
+                tableMode,
+              });
+              return;
+            }
             if (draftStream && info.kind !== "tool" && !payload.isCompactionNotice) {
               const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
 
@@ -2102,40 +2167,59 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                         // with draft previews on. The draft remains the live preview
                         // for the current assistant block, while block deliveries
                         // finalize completed blocks into their own preserved events.
-                        disableBlockStreaming: !blockStreamingEnabled,
-                        onPartialReply: draftStream
-                          ? (payload) => {
-                              if (progressDraftStreaming) {
-                                return;
+                        disableBlockStreaming: beeperStream ? true : !blockStreamingEnabled,
+                        ...(beeperStream ? { suppressDefaultToolProgressMessages: true } : {}),
+                        onPartialReply: beeperStream
+                          ? beeperStream.onPartialReply
+                          : draftStream
+                            ? (payload) => {
+                                if (progressDraftStreaming) {
+                                  return;
+                                }
+                                latestDraftFullText = payload.text ?? "";
+                                suppressPreviewToolProgressForAnswerText(latestDraftFullText);
+                                updateDraftFromLatestFullText();
                               }
-                              latestDraftFullText = payload.text ?? "";
-                              suppressPreviewToolProgressForAnswerText(latestDraftFullText);
-                              updateDraftFromLatestFullText();
-                            }
-                          : undefined,
-                        onBlockReplyQueued: draftStream
-                          ? (payload, context) => {
-                              if (payload.isCompactionNotice === true) {
-                                return;
+                            : undefined,
+                        onReasoningStream: beeperStream?.onReasoningStream,
+                        onReasoningEnd: beeperStream?.onReasoningEnd,
+                        onBlockReplyQueued: beeperStream
+                          ? beeperStream.onBlockReplyQueued
+                          : draftStream
+                            ? (payload, context) => {
+                                if (payload.isCompactionNotice === true) {
+                                  return;
+                                }
+                                queueDraftBlockBoundary(payload, context);
                               }
-                              queueDraftBlockBoundary(payload, context);
-                            }
-                          : undefined,
+                            : undefined,
                         // Reset draft boundary bookkeeping on assistant message
                         // boundaries so post-tool blocks stream from a fresh
                         // cumulative payload (payload.text resets upstream).
-                        onAssistantMessageStart: draftStream
-                          ? () => {
-                              resetDraftBlockOffsets();
-                              resetPreviewToolProgress();
+                        onAssistantMessageStart: beeperStream
+                          ? beeperStream.onAssistantMessageStart
+                          : draftStream
+                            ? () => {
+                                resetDraftBlockOffsets();
+                                resetPreviewToolProgress();
+                              }
+                            : undefined,
+                        ...(beeperStream
+                          ? {
+                              onToolStart: beeperStream.onToolStart,
+                              onItemEvent: beeperStream.onItemEvent,
+                              onPlanUpdate: beeperStream.onPlanUpdate,
+                              onApprovalEvent: beeperStream.onApprovalEvent,
+                              onCommandOutput: beeperStream.onCommandOutput,
+                              onPatchSummary: beeperStream.onPatchSummary,
                             }
-                          : undefined,
-                        ...buildPreviewToolProgressReplyOptions(),
+                          : buildPreviewToolProgressReplyOptions()),
                         onModelSelected,
                       },
                     });
                   } finally {
                     progressDraftGate.cancel();
+                    beeperStream?.dispose();
                     markRunComplete();
                   }
                 },

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -23,6 +23,7 @@ import type {
 import { resolveMatrixAccountConfig } from "../account-config.js";
 import { resolveConfiguredMatrixBotUserIds } from "../accounts.js";
 import { setActiveMatrixClient } from "../active-client.js";
+import { isBeeperHomeserver } from "../beeper-stream.js";
 import {
   backfillMatrixAuthDeviceIdAfterStartup,
   isBunRuntime,
@@ -301,6 +302,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const mediaMaxMb = opts.mediaMaxMb ?? accountConfig.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const streaming = resolveMatrixStreamingMode(accountConfig.streaming);
+  const beeperNativeStreaming = isBeeperHomeserver(auth.homeserver) && streaming !== "off";
   const previewToolProgressEnabled = resolveMatrixPreviewToolProgressEnabled(
     accountConfig.streaming,
   );
@@ -395,6 +397,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       dmThreadReplies,
       dmSessionScope,
       streaming,
+      beeperNativeStreaming,
       previewToolProgressEnabled,
       blockStreamingEnabled,
       dmEnabled,

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -924,6 +924,17 @@ export class MatrixClient {
     });
   }
 
+  getDeviceId(): string | null {
+    return this.client.getDeviceId() ?? null;
+  }
+
+  async sendToDevice(
+    eventType: string,
+    messages: Record<string, Record<string, Record<string, unknown>>>,
+  ): Promise<void> {
+    await this.client.sendToDevice(eventType as never, messages as never);
+  }
+
   // Keep outbound room events ordered when multiple plugin paths emit
   // messages/reactions/polls into the same Matrix room concurrently.
   private async runSerializedRoomSend<T>(roomId: string, task: () => Promise<T>): Promise<T> {
@@ -2062,6 +2073,10 @@ export class MatrixClient {
       if (isEncryptedEvent) {
         decryptBridge.attachEncryptedEvent(event, roomId);
       }
+    });
+
+    this.client.on(ClientEvent.ToDeviceEvent, (event: MatrixEvent) => {
+      this.emitter.emit("to_device.event", matrixEventToRaw(event, { contentMode: "original" }));
     });
 
     // Some SDK invite transitions are surfaced as room lifecycle events instead of raw timeline events.

--- a/extensions/matrix/src/matrix/sdk/types.ts
+++ b/extensions/matrix/src/matrix/sdk/types.ts
@@ -31,6 +31,7 @@ export type MatrixClientEventMap = {
   "room.encrypted_event": [roomId: string, event: MatrixRawEvent];
   "room.decrypted_event": [roomId: string, event: MatrixRawEvent];
   "room.failed_decryption": [roomId: string, event: MatrixRawEvent, error: Error];
+  "to_device.event": [event: MatrixRawEvent];
   "room.invite": [roomId: string, event: MatrixRawEvent];
   "room.join": [roomId: string, event: MatrixRawEvent];
   "sync.state": [state: MatrixSyncState, prevState: string | null, error?: unknown];

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -551,6 +551,7 @@ export async function editMessageMatrix(
     msgtype?: MatrixTextMsgType;
     includeMentions?: boolean;
     extraContent?: MatrixExtraContentFields;
+    topLevelExtraContent?: MatrixExtraContentFields;
     /** When true, marks the edit as a live/streaming update (MSC4357). */
     live?: boolean;
   },
@@ -615,6 +616,7 @@ export async function editMessageMatrix(
         ...(typeof newContent.formatted_body === "string"
           ? { formatted_body: `* ${newContent.formatted_body}` }
           : {}),
+        ...opts.topLevelExtraContent,
         "m.new_content": newContent,
         "m.relates_to": replaceRelation,
       };


### PR DESCRIPTION
## Summary

- Adds a Matrix-local Beeper native stream controller for `com.beeper.ai`, `com.beeper.stream`, and `com.beeper.llm.deltas`.
- Gates native streaming to Beeper homeservers while preserving existing Matrix preview/edit streaming elsewhere.
- Streams assistant text, thinking, tool/progress updates, command output, patches, and approval state into Beeper clients, then finalizes the target Matrix message.
- Registers streamed Beeper AI messages as Matrix approval reaction targets and accepts Beeper Desktop native approval reaction keys (`approval.allow_once`, `approval.allow_always`, `approval.deny`) through the existing authorization/resolution path.
- Documents the Beeper-specific behavior and adds a changelog entry.

## Verification

- `pnpm test extensions/matrix/src/approval-reactions.test.ts extensions/matrix/src/matrix/beeper-stream.test.ts extensions/matrix/src/matrix/monitor/reaction-events.test.ts extensions/matrix/src/matrix/monitor/handler.test.ts extensions/matrix/src/matrix/send.test.ts extensions/matrix/src/matrix/sdk.test.ts`
- `pnpm check:changed`
