### PR TITLE
fix(gateway): guard buildGroupDisplayName behind group/channel chatType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/sessions: guard `buildGroupDisplayName` behind an explicit group/channel `chatType` (or parsed group/channel session key) at both `buildGatewaySessionRow` and `resolveSessionListSearchDisplayName` call sites so direct Telegram DMs fall through to `entry.label` / `origin.label` instead of being formatted as a group label, restoring the correct `openclaw-tui` label in the TUI footer and Control UI session dropdown. Fixes #55354. (#79040)
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -197,6 +197,36 @@ describe("gateway session utils", () => {
     expect(listed.hasMore).toBe(true);
   });
 
+  test("session list search includes direct-session origin display labels", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const store = {
+      "agent:main:telegram:direct:42": {
+        chatType: "direct",
+        channel: "telegram",
+        origin: { label: "openclaw-tui" },
+        updatedAt: 2,
+      } as SessionEntry,
+      "agent:main:telegram:direct:99": {
+        chatType: "direct",
+        channel: "telegram",
+        origin: { label: "other-direct" },
+        updatedAt: 1,
+      } as SessionEntry,
+    };
+
+    const listed = listSessionsFromStore({
+      cfg,
+      storePath: "",
+      store,
+      opts: { search: "openclaw-tui" },
+    });
+
+    expect(listed.sessions.map((session) => session.key)).toEqual([
+      "agent:main:telegram:direct:42",
+    ]);
+    expect(listed.sessions[0]?.displayName).toBe("openclaw-tui");
+  });
+
   test("session lists mark the final offset page without hasMore", () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     const store = Object.fromEntries(

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -703,6 +703,60 @@ describe("gateway session utils", () => {
     expect(classifySessionKey("main", entry)).toBe("group");
   });
 
+  test("buildGatewaySessionRow displayName falls through to origin label for direct sessions", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const entry = {
+      chatType: "direct",
+      channel: "telegram",
+      origin: { label: "openclaw-tui" },
+    } as SessionEntry;
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store: { "agent:main:telegram:direct:42": entry },
+      key: "agent:main:telegram:direct:42",
+      entry,
+    });
+    expect(row.displayName).toBe("openclaw-tui");
+  });
+
+  test("buildGatewaySessionRow displayName uses group display name for group sessions", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const entry = {
+      chatType: "group",
+      channel: "telegram",
+      subject: "Engineering",
+      origin: { label: "openclaw-tui" },
+    } as SessionEntry;
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store: { "agent:main:telegram:group:99": entry },
+      key: "agent:main:telegram:group:99",
+      entry,
+    });
+    expect(row.displayName).toMatch(/^telegram:/);
+    expect(row.displayName).not.toBe("openclaw-tui");
+  });
+
+  test("buildGatewaySessionRow prefers entry.label over origin.label for direct sessions", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const entry = {
+      chatType: "direct",
+      channel: "telegram",
+      label: "Alice",
+      origin: { label: "openclaw-tui" },
+    } as SessionEntry;
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store: { "agent:main:telegram:direct:42": entry },
+      key: "agent:main:telegram:direct:42",
+      entry,
+    });
+    expect(row.displayName).toBe("Alice");
+  });
+
   test("resolveSessionStoreKey maps main aliases to default agent main", () => {
     const cfg = {
       session: { mainKey: "work" },

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -488,6 +488,60 @@ describe("gateway session utils", () => {
     expect(classifySessionKey("main", entry)).toBe("group");
   });
 
+  test("buildGatewaySessionRow displayName falls through to origin label for direct sessions", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const entry = {
+      chatType: "direct",
+      channel: "telegram",
+      origin: { label: "openclaw-tui" },
+    } as SessionEntry;
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store: { "agent:main:telegram:direct:42": entry },
+      key: "agent:main:telegram:direct:42",
+      entry,
+    });
+    expect(row.displayName).toBe("openclaw-tui");
+  });
+
+  test("buildGatewaySessionRow displayName uses group display name for group sessions", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const entry = {
+      chatType: "group",
+      channel: "telegram",
+      subject: "Engineering",
+      origin: { label: "openclaw-tui" },
+    } as SessionEntry;
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store: { "agent:main:telegram:group:99": entry },
+      key: "agent:main:telegram:group:99",
+      entry,
+    });
+    expect(row.displayName).toMatch(/^telegram:/);
+    expect(row.displayName).not.toBe("openclaw-tui");
+  });
+
+  test("buildGatewaySessionRow prefers entry.label over origin.label for direct sessions", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const entry = {
+      chatType: "direct",
+      channel: "telegram",
+      label: "Alice",
+      origin: { label: "openclaw-tui" },
+    } as SessionEntry;
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store: { "agent:main:telegram:direct:42": entry },
+      key: "agent:main:telegram:direct:42",
+      entry,
+    });
+    expect(row.displayName).toBe("Alice");
+  });
+
   test("resolveSessionStoreKey maps main aliases to default agent main", () => {
     const cfg = {
       session: { mainKey: "work" },

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -2194,20 +2194,17 @@ function resolveSessionListSearchDisplayName(
   }
   const parsed = parseGroupKey(key);
   const channel = entry?.channel ?? parsed?.channel;
-  if (!channel) {
-    return undefined;
+  if (isGroupOrChannelDisplaySession(entry, parsed) && channel) {
+    return buildGroupDisplayName({
+      provider: channel,
+      subject: entry?.subject,
+      groupChannel: entry?.groupChannel,
+      space: entry?.space,
+      id: parsed?.id,
+      key,
+    });
   }
-  if (!isGroupOrChannelDisplaySession(entry, parsed)) {
-    return undefined;
-  }
-  return buildGroupDisplayName({
-    provider: channel,
-    subject: entry?.subject,
-    groupChannel: entry?.groupChannel,
-    space: entry?.space,
-    id: parsed?.id,
-    key,
-  });
+  return entry?.label ?? entry?.origin?.label;
 }
 
 function addSessionListSearchModelFields(

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1112,6 +1112,18 @@ export function parseGroupKey(
   return null;
 }
 
+function isGroupOrChannelDisplaySession(
+  entry: SessionEntry | undefined,
+  parsed: { kind?: "group" | "channel" } | null,
+): boolean {
+  return (
+    entry?.chatType === "group" ||
+    entry?.chatType === "channel" ||
+    parsed?.kind === "group" ||
+    parsed?.kind === "channel"
+  );
+}
+
 function isStorePathTemplate(store?: string): boolean {
   return typeof store === "string" && store.includes("{agentId}");
 }
@@ -1861,9 +1873,10 @@ export function buildGatewaySessionRow(params: {
   const id = parsed?.id;
   const origin = entry?.origin;
   const originLabel = origin?.label;
+  const isGroupSession = isGroupOrChannelDisplaySession(entry, parsed);
   const displayName =
     entry?.displayName ??
-    (channel
+    (isGroupSession && channel
       ? buildGroupDisplayName({
           provider: channel,
           subject,
@@ -2182,6 +2195,9 @@ function resolveSessionListSearchDisplayName(
   const parsed = parseGroupKey(key);
   const channel = entry?.channel ?? parsed?.channel;
   if (!channel) {
+    return undefined;
+  }
+  if (!isGroupOrChannelDisplaySession(entry, parsed)) {
     return undefined;
   }
   return buildGroupDisplayName({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -887,6 +887,18 @@ export function parseGroupKey(
   return null;
 }
 
+function isGroupOrChannelDisplaySession(
+  entry: SessionEntry | undefined,
+  parsed: { kind?: "group" | "channel" } | null,
+): boolean {
+  return (
+    entry?.chatType === "group" ||
+    entry?.chatType === "channel" ||
+    parsed?.kind === "group" ||
+    parsed?.kind === "channel"
+  );
+}
+
 function isStorePathTemplate(store?: string): boolean {
   return typeof store === "string" && store.includes("{agentId}");
 }
@@ -1569,9 +1581,10 @@ export function buildGatewaySessionRow(params: {
   const id = parsed?.id;
   const origin = entry?.origin;
   const originLabel = origin?.label;
+  const isGroupSession = isGroupOrChannelDisplaySession(entry, parsed);
   const displayName =
     entry?.displayName ??
-    (channel
+    (isGroupSession && channel
       ? buildGroupDisplayName({
           provider: channel,
           subject,
@@ -1849,6 +1862,9 @@ function resolveSessionListSearchDisplayName(
   const parsed = parseGroupKey(key);
   const channel = entry?.channel ?? parsed?.channel;
   if (!channel) {
+    return undefined;
+  }
+  if (!isGroupOrChannelDisplaySession(entry, parsed)) {
     return undefined;
   }
   return buildGroupDisplayName({


### PR DESCRIPTION
## Summary

Both `buildGatewaySessionRow()` and `resolveSessionListSearchDisplayName()` in `src/gateway/session-utils.ts` called `buildGroupDisplayName()` whenever `entry.channel` or the parsed channel was truthy, without first checking whether the session was actually a group/channel.

For a direct Telegram DM (`chatType: "direct"`, `channel: "telegram"`), the row `displayName` could become a group-style label such as `telegram:g-agent-main-telegram-direct-<chatId>`, preventing the expected `entry.label` / `origin.label` such as `openclaw-tui` from being used in the TUI footer and Control UI session dropdown.

This PR adds a private `isGroupOrChannelDisplaySession()` guard and uses it before `buildGroupDisplayName()` at both call sites. Direct sessions now fall through to `entry.label` / `origin.label`, while group/channel sessions keep the generated group display name. A maintainer follow-up also keeps session-list search aligned with the visible display-name fallback so direct sessions remain searchable by `origin.label`.

Closes #55354

## Test plan

- [x] `pnpm test src/gateway/session-utils.test.ts src/gateway/session-utils.telegram-recreate.test.ts` - 104 passed after maintainer rebase/fixup
- [x] `pnpm exec oxfmt --check --threads=1 src/gateway/session-utils.ts src/gateway/session-utils.test.ts` - clean
- [x] `pnpm tsgo:core` - clean
- [x] `git diff --check origin/main...HEAD` - clean
- [x] `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings

## Real behavior proof

**Behavior addressed:** Direct Telegram sessions with `chatType: "direct"` and sticky `channel: "telegram"` now display the direct label from `entry.label` / `origin.label` instead of a generated group-style `telegram:g-...` label in the TUI footer and Control UI session list.

**Real environment tested:** Patched OpenClaw build at `4de044a` running as the local gateway, with the patched TUI attached to a real direct-Telegram session inside a tmux pane.

**Exact steps or command run after this patch:** `pnpm build` -> stop npm-installed gateway -> start patched gateway on the same port with `--force` -> `openclaw tui --session telegram:direct:<TG_ID>` inside tmux -> DM the bot -> `tmux capture-pane -p` after settle -> revert to npm-installed gateway.

**Evidence after fix:** Terminal capture from the patched TUI footer, ANSI-stripped and PII redacted:

```text
agent main | session telegram:direct:<TG_ID> (<NAME> (@<HANDLE>) id:<TG_ID>) | claude-cli/claude-opus-4-7 | think high | tokens ?/1.0m
```

Patched gateway log confirming the real Telegram interaction during capture:

```text
[diagnostic] liveness warning: ... phase=channels.telegram.start-account ... work=[active=agent:main:telegram:direct:<TG_ID>(processing,q=1,age=17s) queued=agent:main:telegram:direct:<TG_ID>(processing,q=1,age=17s)]
```

**Observed result after fix:** The footer parenthetical is the direct-session `origin.label` (`<NAME> (@<HANDLE>) id:<TG_ID>`), not the previous group-style `telegram:g-agent-main-telegram-direct-<TG_ID>` fallback. The patched `buildGatewaySessionRow` falls through `entry.displayName ?? group-display-name-if-group ?? entry.label ?? origin.label` and lands on `origin.label` for this direct session.

**What was not tested:** No new live Telegram capture was taken after the maintainer search-index follow-up; that follow-up is covered by the focused `listSessionsFromStore` regression test for searching the visible `origin.label`.

## Notes

- The original PR branch included a `CHANGELOG.md` hunk; maintainers dropped it during rebase because changelog entries are release-owned.
- Earlier `pnpm check:changed` failures noted by the contributor were confirmed against unmodified `main` and unrelated to this change.
