### PR TITLE
fix(webhooks): scope child task sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Webhooks plugin: reject `run_task.childSessionKey` values outside the configured route session tree so webhook-owned TaskFlows cannot attach or cancel unrelated sessions. Fixes #79038.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Webhooks plugin: reject `run_task.childSessionKey` values outside the configured route session tree so webhook-owned TaskFlows cannot attach or cancel unrelated sessions. Fixes #79038.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.

--- a/docs/plugins/webhooks.md
+++ b/docs/plugins/webhooks.md
@@ -88,6 +88,9 @@ The plugin applies:
 - Fixed-window rate limiting
 - In-flight request limiting
 - Owner-bound TaskFlow access through `api.runtime.tasks.managedFlows.bindSession(...)`
+- Session-tree checks for `run_task.childSessionKey`, so a route can only attach
+  the bound session itself or child sessions already recorded as spawned or
+  parented by that bound session
 
 ## Request format
 
@@ -146,6 +149,11 @@ Allowed runtimes are:
 
 - `subagent`
 - `acp`
+
+`childSessionKey` is optional. When present, it must identify the route's bound
+session or an OpenClaw session already recorded as spawned or parented by that
+bound session. Use `runId` or `sourceId` for external system identifiers that
+are not OpenClaw session keys.
 
 Example:
 

--- a/extensions/webhooks/index.test.ts
+++ b/extensions/webhooks/index.test.ts
@@ -143,28 +143,27 @@ describe("webhooks plugin registration", () => {
   it("scopes run_task child session keys to the route session tree", async () => {
     const registerHttpRoute = vi.fn();
 
-    plugin.register(
-      createApi({
-        pluginConfig: {
-          routes: {
-            zapier: {
-              sessionKey: "agent:main:main",
-              secret: "shared-secret",
-            },
+    const api = createApi({
+      pluginConfig: {
+        routes: {
+          zapier: {
+            sessionKey: "agent:main:main",
+            secret: "shared-secret",
           },
         },
-        registerHttpRoute,
-        sessionStores: {
-          worker: {
-            "agent:worker:acp:child": {
-              sessionId: "child-session",
-              updatedAt: 1,
-              spawnedBy: "agent:main:main",
-            },
+      },
+      registerHttpRoute,
+      sessionStores: {
+        worker: {
+          "agent:worker:acp:child": {
+            sessionId: "child-session",
+            updatedAt: 1,
+            spawnedBy: "agent:main:main",
           },
         },
-      }),
-    );
+      },
+    });
+    plugin.register(api);
 
     const handler = registerHttpRoute.mock.calls[0]?.[0]?.handler as (
       req: IncomingMessage,
@@ -194,6 +193,9 @@ describe("webhooks plugin registration", () => {
       },
     });
     expect(denied.statusCode).toBe(403);
+    expect(api.runtime.agent.session.loadSessionStore).toHaveBeenCalledWith("victim", {
+      clone: false,
+    });
     expect(parseJsonBody(denied)).toMatchObject({
       ok: false,
       code: "child_session_forbidden",
@@ -212,6 +214,9 @@ describe("webhooks plugin registration", () => {
       },
     });
     expect(allowed.statusCode).toBe(200);
+    expect(api.runtime.agent.session.loadSessionStore).toHaveBeenCalledWith("worker", {
+      clone: false,
+    });
     expect(parseJsonBody(allowed)).toMatchObject({
       ok: true,
       result: {

--- a/extensions/webhooks/index.test.ts
+++ b/extensions/webhooks/index.test.ts
@@ -1,13 +1,81 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createRuntimeTaskFlow } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { createMockServerResponse } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "./api.js";
 import plugin from "./index.js";
+
+type MockIncomingMessage = IncomingMessage & {
+  destroyed?: boolean;
+  destroy: () => MockIncomingMessage;
+  socket: { remoteAddress: string };
+};
+
+function createJsonRequest(params: {
+  path: string;
+  secret?: string;
+  body: unknown;
+}): MockIncomingMessage {
+  const req = new EventEmitter() as MockIncomingMessage;
+  req.method = "POST";
+  req.url = params.path;
+  req.headers = {
+    "content-type": "application/json",
+    ...(params.secret ? { "x-openclaw-webhook-secret": params.secret } : {}),
+  };
+  req.socket = { remoteAddress: "127.0.0.1" } as MockIncomingMessage["socket"];
+  req.destroyed = false;
+  req.destroy = (() => {
+    req.destroyed = true;
+    return req;
+  }) as MockIncomingMessage["destroy"];
+
+  setImmediate(() => {
+    req.emit("data", Buffer.from(JSON.stringify(params.body), "utf8"));
+    req.emit("end");
+  });
+
+  return req;
+}
+
+async function dispatchJsonRequest(params: {
+  handler: (
+    req: IncomingMessage,
+    res: ReturnType<typeof createMockServerResponse>,
+  ) => Promise<unknown>;
+  path: string;
+  secret?: string;
+  body: unknown;
+}) {
+  const req = createJsonRequest({
+    path: params.path,
+    secret: params.secret,
+    body: params.body,
+  });
+  const res = createMockServerResponse();
+  await params.handler(req, res);
+  return res;
+}
+
+function parseJsonBody(res: { body?: string | Buffer | null }) {
+  return JSON.parse(String(res.body ?? ""));
+}
 
 function createApi(params?: {
   pluginConfig?: OpenClawPluginApi["pluginConfig"];
   registerHttpRoute?: OpenClawPluginApi["registerHttpRoute"];
   logger?: OpenClawPluginApi["logger"];
+  sessionStores?: Record<
+    string,
+    Record<
+      string,
+      { sessionId: string; updatedAt: number; spawnedBy?: string; parentSessionKey?: string }
+    >
+  >;
 }): OpenClawPluginApi {
+  const taskFlowRuntime = createRuntimeTaskFlow();
   return createTestPluginApi({
     id: "webhooks",
     name: "Webhooks",
@@ -15,8 +83,14 @@ function createApi(params?: {
     pluginConfig: params?.pluginConfig ?? {},
     runtime: {
       tasks: {
-        managedFlows: {
-          bindSession: vi.fn(({ sessionKey }: { sessionKey: string }) => ({ sessionKey })),
+        managedFlows: taskFlowRuntime,
+      },
+      agent: {
+        session: {
+          resolveStorePath: vi.fn(
+            (_store: unknown, context: { agentId: string }) => context.agentId,
+          ),
+          loadSessionStore: vi.fn((storePath: string) => params?.sessionStores?.[storePath] ?? {}),
         },
       },
     } as unknown as OpenClawPluginApi["runtime"],
@@ -64,5 +138,85 @@ describe("webhooks plugin registration", () => {
         replaceExisting: true,
       }),
     );
+  });
+
+  it("scopes run_task child session keys to the route session tree", async () => {
+    const registerHttpRoute = vi.fn();
+
+    plugin.register(
+      createApi({
+        pluginConfig: {
+          routes: {
+            zapier: {
+              sessionKey: "agent:main:main",
+              secret: "shared-secret",
+            },
+          },
+        },
+        registerHttpRoute,
+        sessionStores: {
+          worker: {
+            "agent:worker:acp:child": {
+              sessionId: "child-session",
+              updatedAt: 1,
+              spawnedBy: "agent:main:main",
+            },
+          },
+        },
+      }),
+    );
+
+    const handler = registerHttpRoute.mock.calls[0]?.[0]?.handler as (
+      req: IncomingMessage,
+      res: ReturnType<typeof createMockServerResponse>,
+    ) => Promise<boolean>;
+    const created = await dispatchJsonRequest({
+      handler,
+      path: "/plugins/webhooks/zapier",
+      secret: "shared-secret",
+      body: {
+        action: "create_flow",
+        goal: "Review inbound queue",
+      },
+    });
+    const flowId = parseJsonBody(created).result.flow.flowId;
+
+    const denied = await dispatchJsonRequest({
+      handler,
+      path: "/plugins/webhooks/zapier",
+      secret: "shared-secret",
+      body: {
+        action: "run_task",
+        flowId,
+        runtime: "acp",
+        childSessionKey: "agent:victim:acp:child",
+        task: "Inspect another session",
+      },
+    });
+    expect(denied.statusCode).toBe(403);
+    expect(parseJsonBody(denied)).toMatchObject({
+      ok: false,
+      code: "child_session_forbidden",
+    });
+
+    const allowed = await dispatchJsonRequest({
+      handler,
+      path: "/plugins/webhooks/zapier",
+      secret: "shared-secret",
+      body: {
+        action: "run_task",
+        flowId,
+        runtime: "acp",
+        childSessionKey: "agent:worker:acp:child",
+        task: "Inspect owned session",
+      },
+    });
+    expect(allowed.statusCode).toBe(200);
+    expect(parseJsonBody(allowed)).toMatchObject({
+      ok: true,
+      result: {
+        created: true,
+      },
+    });
   });
 });

--- a/extensions/webhooks/index.ts
+++ b/extensions/webhooks/index.ts
@@ -26,7 +26,9 @@ function createChildSessionKeyGuard(api: OpenClawPluginApi, requesterSessionKey:
     const storePath = api.runtime.agent.session.resolveStorePath(api.config.session?.store, {
       agentId,
     });
-    const entry = api.runtime.agent.session.loadSessionStore(storePath)[normalizedChildSessionKey];
+    const entry = api.runtime.agent.session.loadSessionStore(storePath, { clone: false })[
+      normalizedChildSessionKey
+    ];
     return checker.check({
       key: normalizedChildSessionKey,
       agentId,

--- a/extensions/webhooks/index.ts
+++ b/extensions/webhooks/index.ts
@@ -1,6 +1,40 @@
+import { resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/session-key-runtime";
+import {
+  createAgentToAgentPolicy,
+  createSessionVisibilityRowChecker,
+} from "openclaw/plugin-sdk/session-visibility";
 import { definePluginEntry, type OpenClawPluginApi } from "./api.js";
 import { resolveWebhooksPluginConfig } from "./src/config.js";
 import { createTaskFlowWebhookRequestHandler, type TaskFlowWebhookTarget } from "./src/http.js";
+
+function createChildSessionKeyGuard(api: OpenClawPluginApi, requesterSessionKey: string) {
+  const checker = createSessionVisibilityRowChecker({
+    action: "status",
+    requesterSessionKey,
+    visibility: "tree",
+    a2aPolicy: createAgentToAgentPolicy(api.config),
+  });
+  return (childSessionKey: string): boolean => {
+    const normalizedChildSessionKey = childSessionKey.trim();
+    if (!normalizedChildSessionKey) {
+      return false;
+    }
+    if (normalizedChildSessionKey === requesterSessionKey) {
+      return true;
+    }
+    const agentId = resolveAgentIdFromSessionKey(normalizedChildSessionKey);
+    const storePath = api.runtime.agent.session.resolveStorePath(api.config.session?.store, {
+      agentId,
+    });
+    const entry = api.runtime.agent.session.loadSessionStore(storePath)[normalizedChildSessionKey];
+    return checker.check({
+      key: normalizedChildSessionKey,
+      agentId,
+      ...(entry?.spawnedBy ? { spawnedBy: entry.spawnedBy } : {}),
+      ...(entry?.parentSessionKey ? { parentSessionKey: entry.parentSessionKey } : {}),
+    }).allowed;
+  };
+}
 
 function registerWebhookRoutes(api: OpenClawPluginApi): void {
   const routes = resolveWebhooksPluginConfig({
@@ -27,6 +61,7 @@ function registerWebhookRoutes(api: OpenClawPluginApi): void {
       secretConfigPath: `plugins.entries.webhooks.routes.${route.routeId}.secret`,
       defaultControllerId: route.controllerId,
       taskFlow,
+      canUseChildSessionKey: createChildSessionKeyGuard(api, route.sessionKey),
     };
     targetsByPath.set(target.path, [...(targetsByPath.get(target.path) ?? []), target]);
     api.registerHttpRoute({

--- a/extensions/webhooks/src/http.test.ts
+++ b/extensions/webhooks/src/http.test.ts
@@ -59,7 +59,9 @@ function createJsonRequest(params: {
   return req;
 }
 
-function createHandler(): {
+function createHandler(params?: {
+  canUseChildSessionKey?: TaskFlowWebhookTarget["canUseChildSessionKey"];
+}): {
   handler: ReturnType<typeof createTaskFlowWebhookRequestHandler>;
   target: TaskFlowWebhookTarget;
   secret: string;
@@ -76,6 +78,9 @@ function createHandler(): {
     taskFlow: runtime.bindSession({
       sessionKey: `agent:main:webhook-test-${String(nextSessionId)}`,
     }),
+    ...(params?.canUseChildSessionKey
+      ? { canUseChildSessionKey: params.canUseChildSessionKey }
+      : {}),
   };
   const targetsByPath = new Map<string, TaskFlowWebhookTarget[]>([[target.path, [target]]]);
   return {
@@ -221,7 +226,9 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("runs child tasks and scrubs task ownership fields from responses", async () => {
-    const { handler, target, secret } = createHandler();
+    const { handler, target, secret } = createHandler({
+      canUseChildSessionKey: (childSessionKey) => childSessionKey === "agent:main:subagent:child",
+    });
     const flow = target.taskFlow.createManaged({
       controllerId: "webhooks/zapier",
       goal: "Triage inbox",
@@ -253,6 +260,36 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     });
     expect(parsed.result.task.ownerKey).toBeUndefined();
     expect(parsed.result.task.requesterSessionKey).toBeUndefined();
+  });
+
+  it("rejects child task session keys outside the route session tree", async () => {
+    const { handler, target, secret } = createHandler({
+      canUseChildSessionKey: (childSessionKey) => childSessionKey === "agent:main:subagent:allowed",
+    });
+    const flow = target.taskFlow.createManaged({
+      controllerId: "webhooks/zapier",
+      goal: "Triage inbox",
+    });
+    const res = await dispatchJsonRequest({
+      handler,
+      path: target.path,
+      secret,
+      body: {
+        action: "run_task",
+        flowId: flow.flowId,
+        runtime: "acp",
+        childSessionKey: "agent:victim:acp:child",
+        task: "Inspect the next message batch",
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(parseJsonBody(res)).toMatchObject({
+      ok: false,
+      code: "child_session_forbidden",
+      error: "Child session key is outside this webhook route session tree.",
+    });
+    expect(target.taskFlow.getTaskSummary(flow.flowId)?.total ?? 0).toBe(0);
   });
 
   it("returns 404 for missing flow mutations", async () => {
@@ -360,7 +397,9 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("reuses the same task record when retried with the same runId", async () => {
-    const { handler, target, secret } = createHandler();
+    const { handler, target, secret } = createHandler({
+      canUseChildSessionKey: (childSessionKey) => childSessionKey === "agent:main:subagent:child",
+    });
     const flow = target.taskFlow.createManaged({
       controllerId: "webhooks/zapier",
       goal: "Triage inbox",

--- a/extensions/webhooks/src/http.ts
+++ b/extensions/webhooks/src/http.ts
@@ -22,6 +22,9 @@ type BoundTaskFlowRuntime = ReturnType<PluginRuntime["tasks"]["managedFlows"]["b
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 
+const CHILD_SESSION_FORBIDDEN_REASON =
+  "Child session key is outside this webhook route session tree.";
+
 const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   z.union([
     z.null(),
@@ -180,6 +183,7 @@ export type TaskFlowWebhookTarget = {
   secretConfigPath: string;
   defaultControllerId: string;
   taskFlow: BoundTaskFlowRuntime;
+  canUseChildSessionKey?: (childSessionKey: string) => boolean;
 };
 
 type FlowView = {
@@ -415,6 +419,13 @@ function mapRunTaskStatus(result: { created: boolean; found: boolean; reason?: s
   if (result.created) {
     return { statusCode: 200 };
   }
+  if (result.reason === CHILD_SESSION_FORBIDDEN_REASON) {
+    return {
+      statusCode: 403,
+      code: "child_session_forbidden",
+      error: result.reason,
+    };
+  }
   if (!result.found) {
     return {
       statusCode: 404,
@@ -531,6 +542,20 @@ function describeWebhookOutcome(params: { action: WebhookAction; result: unknown
   }
 }
 
+function canUseRunTaskChildSessionKey(params: {
+  action: Extract<WebhookAction, { action: "run_task" }>;
+  target: TaskFlowWebhookTarget;
+}): boolean {
+  const childSessionKey = params.action.childSessionKey?.trim();
+  if (!childSessionKey) {
+    return true;
+  }
+  if (childSessionKey === params.target.taskFlow.sessionKey) {
+    return true;
+  }
+  return params.target.canUseChildSessionKey?.(childSessionKey) === true;
+}
+
 async function executeWebhookAction(params: {
   action: WebhookAction;
   target: TaskFlowWebhookTarget;
@@ -627,6 +652,18 @@ async function executeWebhookAction(params: {
       };
     }
     case "run_task": {
+      if (
+        !canUseRunTaskChildSessionKey({
+          action,
+          target,
+        })
+      ) {
+        return {
+          found: true,
+          created: false,
+          reason: CHILD_SESSION_FORBIDDEN_REASON,
+        };
+      }
       const result = target.taskFlow.runTask({
         flowId: action.flowId,
         runtime: action.runtime,


### PR DESCRIPTION
## Summary

- Fixes #79038 by rejecting Webhooks plugin `run_task.childSessionKey` values unless they identify the route's bound session or a session already recorded as spawned or parented by that route session.
- Wires the registered plugin route to the existing session-tree visibility helper and keeps the HTTP handler default closed when no guard is provided.
- Uses the non-cloning session-store lookup while checking child sessions so webhook hot paths avoid full-store clone churn.
- Documents the `childSessionKey` contract.

## Real behavior proof

**Behavior or issue addressed:** Webhooks plugin `run_task.childSessionKey` requests must not attach managed child tasks to a session outside the route session tree, while valid on-disk child sessions spawned by the route session should still work.

**Real environment tested:** Local OpenClaw Gateway from this PR branch on Node 22, loopback port 19317, temporary config enabling the bundled `webhooks` plugin, and a temporary on-disk session store containing `agent:worker:acp:child` with `spawnedBy: agent:main:main`.

**Exact steps or command run after this patch:** Started `openclaw gateway run --port 19317 --auth none --bind loopback --verbose`, confirmed the bundled route registered, then used Node `fetch` to post real HTTP requests to `/plugins/webhooks/zapier`: `create_flow`, `run_task` with foreign child `agent:victim:acp:child`, `run_task` with owned child `agent:worker:acp:child`, and `get_task_summary`.

**Evidence after fix:** Copied live terminal output from the after-fix Gateway run and HTTP requests; the dummy route secret is omitted.

```text
[plugins] [webhooks] registered route zapier on /plugins/webhooks/zapier for session agent:main:main
[gateway] http server listening (1 plugin: webhooks; 3.3s)
[gateway] ready
real setup: local openclaw gateway run, bundled webhooks plugin route /plugins/webhooks/zapier
session store: agent:worker:acp:child spawnedBy agent:main:main
create_flow status=200 ok=true flowId=b4ac6a9d-4c84-464f-83c5-82cfd722a12d
foreign child status=403 ok=false code=child_session_forbidden
owned child status=200 ok=true created=true childSessionKey=agent:worker:acp:child
task_summary status=200 total=1 acp=1
```

**Observed result after fix:** The real route returned `403 child_session_forbidden` for `agent:victim:acp:child`, returned `200 created=true` for the on-disk `agent:worker:acp:child` spawned by `agent:main:main`, and the live TaskFlow summary showed exactly one ACP child task created.

**What was not tested:** External public webhook proxy delivery was not tested; the proof used a loopback Gateway with real plugin registration, on-disk session state, and real HTTP requests.

## Verification

- `pnpm docs:list`
- `pnpm test extensions/webhooks/src/http.test.ts extensions/webhooks/index.test.ts`
- `pnpm tsgo:extensions`
- `pnpm exec oxfmt --check --threads=1 extensions/webhooks/index.ts extensions/webhooks/index.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/webhooks/index.ts extensions/webhooks/index.test.ts extensions/webhooks/src/http.ts extensions/webhooks/src/http.test.ts`
- `pnpm format:docs:check docs/plugins/webhooks.md`
- `git diff --check origin/main..HEAD`

Note: `pnpm check:changed` passed the static checks and `tsgo:extensions`, then was stopped locally after `tsgo:extensions:test` produced no output for about 12 minutes. `blacksmith`/Testbox is not installed in this worktree, so the extension-test typecheck was not completed off-host.
