### PR TITLE
fix(status): clarify heartbeat cadence source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Cron CLI: add `openclaw cron list --agent <id>`, normalize the requested agent id, and include jobs without a stored agent id under the configured default agent while keeping `cron list` unfiltered when no agent is supplied. Fixes #77118. Thanks @zhanggttry.
 - Status: show compact Gateway process uptime and host system uptime in `/status`, making restart and host-lifetime checks visible from chat. Thanks @vincentkoc.
+- Status: label heartbeat cadence as config-derived and document observed-delivery checks so `openclaw status` does not look like scheduler receipt telemetry. (#78904) Thanks @Enashka.
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.
 - Gateway/Windows: bind the default loopback gateway listener only to `127.0.0.1` on Windows so libuv's dual-stack `::1` behavior cannot wedge localhost HTTP requests. (#69701, fixes #69674) Thanks @SARAMALI15792.
 - Slack/streaming: add `streaming.progress.render: "rich"` for Block Kit progress drafts backed by structured progress line data.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -67,6 +67,7 @@ Example config:
 - When heartbeats are disabled with `0m`, normal runs also omit `HEARTBEAT.md` from bootstrap context so the model does not see heartbeat-only instructions.
 - Active hours (`heartbeat.activeHours`) are checked in the configured timezone. Outside the window, heartbeats are skipped until the next tick inside the window.
 - Heartbeats automatically defer while cron work is active or queued. Set `heartbeat.skipWhenBusy: true` to defer on extra busy lanes (subagent or nested command work) as well; this is useful for local Ollama and other constrained single-runtime hosts.
+- `openclaw status` shows the configured/materialized cadence. Use `openclaw status --deep` or `openclaw system heartbeat last` to inspect the last observed heartbeat delivery.
 
 ## What the heartbeat prompt is for
 

--- a/src/commands/status-overview-rows.test.ts
+++ b/src/commands/status-overview-rows.test.ts
@@ -19,6 +19,7 @@ describe("status-overview-rows", () => {
             "1 files · 2 chunks · plugin memory · ok(vector ready) · warn(fts ready) · muted(cache warm)",
         },
         { Item: "Plugin compatibility", Value: "warn(1 notice · 1 plugin)" },
+        { Item: "Heartbeat config", Value: "1m (main)" },
         { Item: "Sessions", Value: "2 active · default gpt-5.5 (12k ctx) · store.json" },
       ]),
     );

--- a/src/commands/status-overview-rows.ts
+++ b/src/commands/status-overview-rows.ts
@@ -112,7 +112,7 @@ export function buildStatusCommandOverviewRows(
       { Item: "Probes", Value: probesValue },
       { Item: "Events", Value: eventsValue },
       { Item: "Tasks", Value: tasksValue },
-      { Item: "Heartbeat", Value: heartbeatValue },
+      { Item: "Heartbeat config", Value: heartbeatValue },
       ...(lastHeartbeatValue ? [{ Item: "Last heartbeat", Value: lastHeartbeatValue }] : []),
       {
         Item: "Sessions",


### PR DESCRIPTION
## Summary

  - Problem: `openclaw status` showed a row named `Heartbeat`, which made the displayed cadence look like observed
  scheduler/delivery telemetry.
  - Why it matters: issue #78904 showed this can mislead users when materialized config defaults differ from expected
  runtime delivery observations.
  - What changed: renamed the status overview row to `Heartbeat config`, documented observed-delivery inspection
  commands, and added focused status overview coverage.
  - What did NOT change (scope boundary): heartbeat scheduling, config resolution, materialized defaults, delivery
  behavior, and gateway runtime logic were not changed.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [x] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #78904
  - Related # N/A
  - [x] This PR fixes a bug or regression

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: `openclaw status` heartbeat cadence is now explicitly labeled as config-derived
  rather than observed heartbeat delivery telemetry.
  - Real environment tested: Local macOS checkout with Node 22 / pnpm.
  - Exact steps or command run after this patch:
    - `pnpm test src/commands/status-overview-rows.test.ts src/commands/status.command-sections.test.ts src/commands/
  status.summary.test.ts`
    - `pnpm test src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-runner.scheduler.test.ts
  src/config/config.pruning-defaults.test.ts extensions/anthropic/provider-policy-api.test.ts`
    - `pnpm build`
    - `pnpm docs:list`
    - `pnpm exec oxfmt --check --threads=1 src/commands/status-overview-rows.ts src/commands/status-overview-
  rows.test.ts`
    - `git diff --check`
    - `codex review --base origin/main`
  - Evidence after fix: Targeted status overview test asserts the row label is `Heartbeat config` with the existing
  cadence value.
  - Observed result after fix: The status overview presents heartbeat cadence as configuration, and docs point users
  to `openclaw status --deep` / `openclaw system heartbeat last` for observed delivery checks.
  - What was not tested: A live installed Gateway run of `openclaw status` was not captured.
  - Before evidence: The pre-change focused test failed because the row label was still `Heartbeat`.

  ## Root Cause (if applicable)

  - Root cause: The status overview label was too broad for the data it displayed; it showed resolved/materialized
  heartbeat configuration, not last observed delivery state.
  - Missing detection / guardrail: No focused assertion locked the human-facing status row label to clarify the source
  of the value.
  - Contributing context (if known): Heartbeat defaults can be materialized differently depending on config/provider
  setup, making a generic `Heartbeat` label ambiguous.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/commands/status-overview-rows.test.ts`
  - Scenario the test should lock in: Status overview renders the heartbeat cadence row as `Heartbeat config`.
  - Why this is the smallest reliable guardrail: The issue is the human-facing status overview label, so the row
  builder test directly covers the affected surface without changing scheduler behavior.
  - Existing test that already covers this (if any): Existing status summary and heartbeat scheduler tests cover
  config/scheduler behavior, not this label clarity.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  `openclaw status` now labels the heartbeat cadence row as `Heartbeat config`. Heartbeat behavior and defaults are
  unchanged.

  ## Diagram (if applicable)

  ```text
  Before:
  openclaw status -> Heartbeat -> 1h (main)

  After:
  openclaw status -> Heartbeat config -> 1h (main)
  openclaw status --deep / openclaw system heartbeat last -> observed delivery state
  ```

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node 22 / pnpm, local checkout
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): Heartbeat status overview fixture config in src/commands/status-overview-rows.test.ts

  ### Steps

  1. Run the focused status overview test.
  2. Run heartbeat scheduler/config regression tests.
  3. Run build, docs list, formatting check, diff whitespace check, and Codex review.

  ### Expected

  - Status overview heartbeat cadence is labeled as configuration.
  - Existing heartbeat scheduler/config behavior remains unchanged.
  - Build and focused tests pass.

  ### Actual

  - Heartbeat config row is asserted by the focused test.
  - Targeted heartbeat/status tests passed.
  - pnpm build, pnpm docs:list, git diff --check, formatter check, and Codex review completed successfully.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: focused status overview label, related status report tests, heartbeat scheduler/config tests,
    docs listing, build, formatting, whitespace, and Codex review.
  - Edge cases checked: disabled/enabled heartbeat cadence formatting remains unchanged; only the row label changed.
  - What you did not verify: live Gateway delivery behavior, because this PR intentionally does not change delivery or
    scheduler runtime behavior.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review
  conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk: Users or scripts scraping the human-readable openclaw status table by row label may need to adjust.
      - Mitigation: JSON/status contracts were not changed; this is limited to the human-facing status overview label.

### Built with Codex