### PR TITLE
docs: document Docker CLI DNS override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docs/Docker: document a local Compose override for Docker Desktop DNS failures in the shared-network `openclaw-cli` sidecar, keeping the default compose setup hardened while unblocking `openclaw plugins install` when users opt in. Fixes #79018. Thanks @Jason-Vaughan.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -335,6 +335,32 @@ See [ClawDock](/install/clawdock) for the full helper guide.
     `no-new-privileges` on both `openclaw-gateway` and `openclaw-cli`.
   </Accordion>
 
+  <Accordion title="Docker Desktop DNS failures in openclaw-cli">
+    Some Docker Desktop setups fail DNS lookups from the shared-network
+    `openclaw-cli` sidecar after `NET_RAW` is dropped, which shows up as
+    `EAI_AGAIN` during npm-backed commands such as `openclaw plugins install`.
+    Keep the default hardened compose file for normal gateway operation. The
+    local override below loosens the CLI container's security posture by
+    restoring Docker's default capabilities, so use it only for the one-off CLI
+    command that needs package registry access, not as your default Compose
+    invocation:
+
+    ```bash
+    printf '%s\n' \
+      'services:' \
+      '  openclaw-cli:' \
+      '    cap_drop: !reset []' \
+      > docker-compose.cli-no-dropped-caps.local.yml
+
+    docker compose -f docker-compose.yml -f docker-compose.cli-no-dropped-caps.local.yml run --rm openclaw-cli plugins install <package>
+    ```
+
+    If you already created a long-running `openclaw-cli` container, recreate it
+    with the same override. `docker compose exec` and `docker exec` cannot
+    change Linux capabilities on an already-created container.
+
+  </Accordion>
+
   <Accordion title="Permissions and EACCES">
     The image runs as `node` (uid 1000). If you see permission errors on
     `/home/node/.openclaw`, make sure your host bind mounts are owned by uid 1000:


### PR DESCRIPTION
Summary

- Document the Docker Desktop DNS failure mode where the shared-network openclaw-cli sidecar can hit EAI_AGAIN after NET_RAW/NET_ADMIN are dropped.
- Recent container hardening intentionally drops `NET_RAW` and `NET_ADMIN` on both openclaw-gateway and openclaw-cli, and that the default should remain hardened.
- Add a local Compose override recipe users can create for one-off plugin install commands that need package-registry DNS from openclaw-cli.

Fixes: #79018

Verification

- pnpm docs:check-mdx docs/install/docker.md
- git diff --check