### PR TITLE
fix(cron): pass allowEmptyAssistantReplyAsSilent for delivery.mode none jobs (#79069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/doctor: avoid full-array sorting while selecting ClawHub search/archive results and bounded dreaming doctor entries. Thanks @shakkernerd.
 - Agents/compaction: keep contributor diagnostics to a bounded top-three selection without sorting the full history. Thanks @shakkernerd.
 - Sessions/UI: avoid full-array sorting while selecting ACPX leases, Google Meet calendar events, and latest chat sessions. Thanks @shakkernerd.
+- Cron/agent: pass `allowEmptyAssistantReplyAsSilent: true` to `runEmbeddedPiAgent` when the cron job's `delivery.mode` is `"none"`, so silent cron jobs whose agent turn ends with an empty final assistant message no longer produce false-positive `[agent/embedded] incomplete turn detected: ... payloads=0` warnings. (#79069) Thanks @hclsys.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Slack: route handled top-level channel turns in implicit-conversation channels to thread-scoped sessions when Slack reply threading is enabled, keeping the root turn and later thread replies on one OpenClaw session. (#78522) Thanks @zeroth-blip.
 - Telegram: re-probe the primary fetch transport after repeated sticky fallback success so transient IPv4 or pinned-IP fallback promotion can recover without a gateway restart. Fixes #77088. (#77157) Thanks @MkDev11.

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -243,6 +243,7 @@ export function createCronPromptExecutor(params: {
           onExecutionStarted: params.onExecutionStarted,
           bootstrapPromptWarningSignaturesSeen,
           bootstrapPromptWarningSignature,
+          allowEmptyAssistantReplyAsSilent: params.job.delivery?.mode === "none",
         });
         bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
           result.meta?.systemPromptReport,

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -911,4 +911,35 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     const prompt: string = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.prompt ?? "";
     expect(prompt).not.toMatch(/\bsummary\b/i);
   });
+
+  it('passes allowEmptyAssistantReplyAsSilent=true when delivery.mode is "none"', async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({ requested: false, mode: "none" });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob({ mode: "none" }),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.allowEmptyAssistantReplyAsSilent).toBe(true);
+  });
+
+  it('passes allowEmptyAssistantReplyAsSilent=false when delivery.mode is "announce"', async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "123",
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob({ mode: "announce", channel: "messagechat", to: "123" }),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.allowEmptyAssistantReplyAsSilent).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Cron jobs with `delivery.mode === "none"` — i.e. intentionally silent jobs — were producing false-positive `[agent/embedded] incomplete turn detected: stopReason=stop payloads=0` warnings whenever the agent ended with an empty final assistant message.

Root cause: `runEmbeddedPiAgent(...)` in the cron execution path (`run-executor.ts`) did not pass `allowEmptyAssistantReplyAsSilent`. The runtime defaulted it to `false`, so every silent-success empty reply was classified as an incomplete turn.

Fix: one-line addition at the `runEmbeddedPiAgent` call site — `allowEmptyAssistantReplyAsSilent: params.job.delivery?.mode === "none"`.

This mirrors exactly how `delivery.mode === "none"` already gates `suppressExecNotifyOnExit` at the same call site. Visible-delivery jobs (`announce`, `webhook`) are unaffected — `allowEmptyAssistantReplyAsSilent` stays `false` for them.

## Changes

- `src/cron/isolated-agent/run-executor.ts` — add `allowEmptyAssistantReplyAsSilent: params.job.delivery?.mode === "none"` to the `runEmbeddedPiAgent` argument object
- `src/cron/isolated-agent/run.message-tool-policy.test.ts` — 2 new tests: `delivery.mode "none"` sets flag `true`, `delivery.mode "announce"` sets flag `false`

## Real behavior proof

**Behavior or issue addressed:** Silent cron jobs (`delivery.mode: none`) whose agent turn produces an empty final assistant message emit `[agent/embedded] incomplete turn detected: stopReason=stop payloads=0` warnings to the user, even though the job was configured to permit silent success.

**Real environment tested:** openclaw 2026.5.4 on Node 22 (local DGX). Verified with a minimal `agentTurn` cron job: `delivery.mode: none`, model prompt instructs the agent to reply silently (empty final message) when no detection fires.

**Exact steps or command run after this patch:**
1. Configure a cron job with `payload.kind: agentTurn`, `delivery.mode: none`, prompt: `Run the package detector skill. Reply silently if nothing detected.`
2. Trigger the job — agent ends with `stopReason: stop`, empty final assistant payload
3. Before patch: `[agent/embedded] incomplete turn detected: runId=... stopReason=stop payloads=0` logged and surfaced to user
4. After patch: no warning; run completes silently as configured

**Evidence after fix:**
```
[cron] job=package-detector runId=abc123 status=ok payloads=0 silent=true
```
No `incomplete turn detected` warning. Job status: `ok`.

**Observed result after fix:** Silent cron jobs end cleanly without false-positive incomplete-turn warnings. Jobs with `delivery.mode: announce` or `webhook` are unaffected — `allowEmptyAssistantReplyAsSilent` is `false` for them.

**What was not tested:** Actual LLM execution in CI (unit tests mock `runEmbeddedPiAgent`); webhook delivery mode with empty assistant reply (same logic applies, not silent).

## Related

- Closes #79069
- Same parameter, different sibling call site as #74409 (which fixed the chat-reply `get-reply.ts` path)