### PR TITLE
fix: bound skills watcher traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ Docs: https://docs.openclaw.ai
 - Cron: make rejected `payload.model` errors show the configured `agents.defaults.models` allowlist instead of echoing the rejected model twice. Fixes #79058.
 - Agents/subagents: retry parent wake announces when the announce-summary model run fails with fallback cooldown exhaustion instead of dropping the wake on the first transient provider overload. Refs #78581.
 - Providers/network: honor IPv4 CIDR and octet-wildcard `NO_PROXY` entries such as `100.64.0.0/10` and `100.64.*` before enabling trusted env-proxy mode for model-provider requests. Fixes #79030.
+- Skills: cap skills watcher directory traversal at the same depth used by skill discovery so large non-skill trees under configured skill roots do not exhaust file descriptors on startup. Fixes #75501. Thanks @wzq-xzwj.
 - Docs/Docker: document a local Compose override for Docker Desktop DNS failures in the shared-network `openclaw-cli` sidecar, keeping the default compose setup hardened while unblocking `openclaw plugins install` when users opt in. Fixes #79018. Thanks @Jason-Vaughan.
 - Installer: when npm installs `openclaw` outside the parent shell PATH, print follow-up commands with the resolved binary path instead of telling users to run `openclaw` from a shell that will report `command not found`. Fixes #72382. Thanks @jbob762.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -60,12 +60,13 @@ describe("ensureSkillsWatcher", () => {
 
     expect(watchMock).toHaveBeenCalledTimes(1);
     const firstCall = (
-      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown }]>
+      watchMock.mock.calls as unknown as Array<[string[], { depth?: number; ignored?: unknown }]>
     )[0];
     const targets = firstCall?.[0] ?? [];
     const opts = firstCall?.[1] ?? {};
 
     expect(opts.ignored).toBe(refreshModule.shouldIgnoreSkillsWatchPath);
+    expect(opts.depth).toBe(2);
     const posix = (p: string) => p.replaceAll("\\", "/");
     expect(targets).toEqual(
       expect.arrayContaining([
@@ -98,6 +99,34 @@ describe("ensureSkillsWatcher", () => {
     expect(ignored("/tmp/workspace/skills/my-skill", { isDirectory: () => true })).toBe(false);
     expect(ignored("/tmp/workspace/skills/my-skill/README.md", {})).toBe(true);
     expect(ignored("/tmp/workspace/skills/my-skill/SKILL.md", {})).toBe(false);
+  });
+
+  it("keeps grouped skill folders within the watcher traversal depth", async () => {
+    vi.useFakeTimers();
+    const seen: SkillsChangeEvent[] = [];
+    refreshModule.registerSkillsChangeListener((change) => {
+      seen.push(change);
+    });
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/workspace",
+      config: { skills: { load: { watchDebounceMs: 10 } } },
+    });
+
+    const firstCall = (
+      watchMock.mock.calls as unknown as Array<[string[], { depth?: number; ignored?: unknown }]>
+    )[0];
+    expect(firstCall?.[1]?.depth).toBe(2);
+
+    createdWatchers[0]?.emit("change", "/tmp/workspace/skills/group/demo/SKILL.md");
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(seen).toEqual([
+      {
+        workspaceDir: "/tmp/workspace",
+        reason: "watch",
+        changedPath: "/tmp/workspace/skills/group/demo/SKILL.md",
+      },
+    ]);
   });
 
   it.each(["add", "change", "unlink", "unlinkDir"] as const)(

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -141,6 +141,8 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
 
   const watcher = chokidar.watch(watchTargets, {
     ignoreInitial: true,
+    // Skill discovery reads root skills, direct child skills, and one grouped skill level.
+    depth: 2,
     awaitWriteFinish: {
       stabilityThreshold: debounceMs,
       pollInterval: 100,


### PR DESCRIPTION
## Summary
- Cap skills watcher traversal to the root plus immediate child and one grouped skill directory depth that skill discovery supports.
- Keep existing SKILL.md filtering and ignored-directory hardening, while avoiding recursive watches of large non-skill trees under configured skill roots.
- Add regression coverage for grouped `skills/<group>/<skill>/SKILL.md` watcher refreshes and the watcher depth option.

## Real Behavior Proof

- Behavior or issue addressed: OpenClaw should not recursively watch deep non-skill trees such as venv/lib/python3.12/site-packages under configured skill roots, while still watching grouped skills such as skills/<group>/<skill>/SKILL.md that OpenClaw discovery supports.
- Real environment tested: macOS 15.4 host, Node 24.1.0, pnpm 10.33.2, OpenClaw branch fix-issue-75501 at commit 7f1befe515, isolated OPENCLAW_STATE_DIR and OPENCLAW_CONFIG_PATH under /var/folders, temp skill root configured through skills.load.extraDirs with demo-skill/SKILL.md, group/demo-skill/SKILL.md, and demo-skill/venv/lib/python3.12/site-packages/pkg/module.py.
- Exact steps or command run after this patch: Ran pnpm openclaw skills list --agent main --json against the isolated OpenClaw config to prove the configured skill root still loads, then ran the same Chokidar traversal fixture with and without depth: 2 to prove the after-fix watcher bound keeps grouped skill directories watched while avoiding the deep venv tree. I also attempted a native Chokidar recursive watch on this host and reproduced Error: EMFILE: too many open files, watch before ready.
- Evidence after fix: Terminal transcript:

  ```text
  $ OPENCLAW_STATE_DIR=/tmp/openclaw-rbp-75501/state OPENCLAW_CONFIG_PATH=/tmp/openclaw-rbp-75501/state/openclaw.json pnpm openclaw skills list --agent main --json
  exit=0
  demoLine=      "name": "demo-skill",
  stderr=<empty>

  $ node chokidar-depth-fixture.mjs
  recursive watched dirs=9; includes deep site-packages=true; includes grouped skill dir=true
  depth=2 watched dirs=6; includes deep site-packages=false; includes grouped skill dir=true
  depth=2 dirs=.,demo-skill,demo-skill/venv,demo-skill/venv/lib,group,group/demo-skill

  $ node native-recursive-watch-fixture.mjs
  Error: EMFILE: too many open files, watch
  ```
- Observed result after fix: The real OpenClaw CLI setup loaded the configured demo skill successfully with no stderr. The after-fix Chokidar depth setting kept the grouped skill directory watched, did not descend into demo-skill/venv/lib/python3.12/site-packages, and the unbounded native recursive watcher reproduced the reported EMFILE failure class on this host.
- What was not tested: No Docker, Podman, or long-running production gateway process was used for this proof; the focused changed-surface verification is local macOS OpenClaw CLI plus Chokidar traversal behavior.

## Verification
- pnpm test src/agents/skills/refresh.test.ts
- pnpm exec oxfmt --check --threads=1 src/agents/skills/refresh.ts src/agents/skills/refresh.test.ts
- git diff --check
- pnpm check:changed
- post-rebase sanity: git diff --check origin/main...HEAD

Fixes: #75501