### PR TITLE
feat(gateway): expose exec via /tools/invoke when explicitly allowlisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Memory/providers: move the local llama.cpp runtime into its provider plugin, batch embeddings across files, persist the agent model catalog cache, and keep QMD JSON search one-shot while filtering stale REM recall previews. (#91324, #89138, #90457, #91837, #91851) Thanks @osolmaz, @mushuiyu886, @ai-hpc, and @TurboTheTurtle.
 - Channels/mobile: add the QQBot group mention toggle, improve iPad and iPhone control surfaces, and expose the active connection host in the TUI footer. (#91423, #91557, #89909) Thanks @cxyhhhhh, @Solvely-Colin, and @baskduf.
 - Performance: prewarm TUI runtime plugins, deduplicate plugin auto-enable fanout, trim dense text-delta snapshots, and reuse prepared startup model metadata. (#90782, #89978, #91580, #91531) Thanks @RomneyDa and @ai-hpc.
+- Gateway/HTTP: register the bash `exec` tool on the `/tools/invoke` HTTP surface so `gateway.tools.allow: ["exec"]` actually exposes it; default-deny is preserved and the new entry is owner-only and reuses the configured `tools.exec` host/node/security/ask/safeBins/safeBinProfiles bindings via the shared exec-config resolver. (#79106) Thanks @outofcoffee.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
+- Gateway/HTTP: register the bash `exec` tool on the `/tools/invoke` HTTP surface so `gateway.tools.allow: ["exec"]` actually exposes it; default-deny is preserved and the new entry is owner-only and reuses the configured `tools.exec` host/node/security/ask/safeBins/safeBinProfiles bindings via the shared exec-config resolver. (#79106) Thanks @outofcoffee.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -141,6 +141,42 @@ to callers that do not have owner/admin identity (`operator.admin`) even when
 they are listed in `gateway.tools.allow`. Shared-secret bearer auth still follows
 the full trusted-operator rule above.
 
+### Unlocking `exec` for direct invokes
+
+The `exec` tool runs arbitrary shell commands on the gateway host, so it stays
+denied by default. Operators who need to script gateway-side commands can opt
+in with two settings:
+
+```json5
+{
+  gateway: {
+    tools: {
+      allow: ["exec"], // remove `exec` from the HTTP deny list
+    },
+  },
+  tools: {
+    exec: {
+      security: "full", // skip the agent approval flow
+      ask: "off", // /tools/invoke has no interactive approver
+    },
+  },
+}
+```
+
+Notes:
+
+- The HTTP-registered `exec` is owner-scoped. Shared-secret bearer auth always
+  resolves to owner; trusted-proxy callers must present `operator.admin`.
+- Stricter `tools.exec.security` settings (e.g. `allowlist`) still apply: a
+  command that requires approval will return `approval-unavailable` because
+  there is no interactive approver on the HTTP path.
+- Backgrounded execution is disabled on this surface; commands run synchronously
+  to completion or hit the configured `tools.exec.timeoutSec`.
+- The audit warning `gateway.tools_invoke_http.dangerous_allow` will fire
+  whenever `gateway.tools.allow` re-enables tools from the default deny list.
+  Treat the gateway token/password as full-admin and keep the bind on
+  loopback/tailnet.
+
 To help group policies resolve context, you can optionally set:
 
 - `x-openclaw-message-channel: <channel>` (example: `slack`, `telegram`)

--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -143,9 +143,12 @@ the full trusted-operator rule above.
 
 ### Unlocking `exec` for direct invokes
 
-The `exec` tool runs arbitrary shell commands on the gateway host, so it stays
-denied by default. Operators who need to script gateway-side commands can opt
-in with two settings:
+The `exec` tool runs arbitrary shell commands on the gateway host (or on a paired
+node when `tools.exec.host = "node"` is configured), so it stays denied by
+default. This is remote command execution against the same trust boundary the
+agent-side bash exec already uses — sandboxing/container/network policy is the
+isolation boundary, not the HTTP tool registry. Operators who need to script
+gateway-side commands can opt in with two settings:
 
 ```json5
 {
@@ -167,15 +170,21 @@ Notes:
 
 - The HTTP-registered `exec` is owner-scoped. Shared-secret bearer auth always
   resolves to owner; trusted-proxy callers must present `operator.admin`.
-- Stricter `tools.exec.security` settings (e.g. `allowlist`) still apply: a
-  command that requires approval will return `approval-unavailable` because
-  there is no interactive approver on the HTTP path.
+- The HTTP path reuses the full `tools.exec` defaults — `host`, `node`,
+  `security`, `ask`, `safeBins`, merged `safeBinProfiles`, `safeBinTrustedDirs`,
+  `strictInlineEval`, `pathPrepend`, `timeoutSec`, and exit-notification
+  settings — via the same resolver the agent path uses. Configured node
+  bindings and safe-bin hardening continue to apply over `/tools/invoke`.
+- Stricter `tools.exec.security` settings (e.g. `allowlist`) still apply and
+  fail closed: a command that requires approval returns `approval-unavailable`
+  because there is no interactive approver on the HTTP path.
 - Backgrounded execution is disabled on this surface; commands run synchronously
   to completion or hit the configured `tools.exec.timeoutSec`.
-- The audit warning `gateway.tools_invoke_http.dangerous_allow` will fire
-  whenever `gateway.tools.allow` re-enables tools from the default deny list.
-  Treat the gateway token/password as full-admin and keep the bind on
-  loopback/tailnet.
+- The audit warning `gateway.tools_invoke_http.dangerous_allow` fires whenever
+  `gateway.tools.allow` re-enables tools from the default deny list, and
+  escalates to critical when `gateway.bind` is non-loopback or Tailscale serve
+  is in funnel mode. Treat the gateway token/password as full-admin and keep
+  the bind on loopback/tailnet.
 
 To help group policies resolve context, you can optionally set:
 

--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -132,9 +132,12 @@ You can customize this deny list via `gateway.tools`:
 
 ### Unlocking `exec` for direct invokes
 
-The `exec` tool runs arbitrary shell commands on the gateway host, so it stays
-denied by default. Operators who need to script gateway-side commands can opt
-in with two settings:
+The `exec` tool runs arbitrary shell commands on the gateway host (or on a paired
+node when `tools.exec.host = "node"` is configured), so it stays denied by
+default. This is remote command execution against the same trust boundary the
+agent-side bash exec already uses — sandboxing/container/network policy is the
+isolation boundary, not the HTTP tool registry. Operators who need to script
+gateway-side commands can opt in with two settings:
 
 ```json5
 {
@@ -156,15 +159,21 @@ Notes:
 
 - The HTTP-registered `exec` is owner-scoped. Shared-secret bearer auth always
   resolves to owner; trusted-proxy callers must present `operator.admin`.
-- Stricter `tools.exec.security` settings (e.g. `allowlist`) still apply: a
-  command that requires approval will return `approval-unavailable` because
-  there is no interactive approver on the HTTP path.
+- The HTTP path reuses the full `tools.exec` defaults — `host`, `node`,
+  `security`, `ask`, `safeBins`, merged `safeBinProfiles`, `safeBinTrustedDirs`,
+  `strictInlineEval`, `pathPrepend`, `timeoutSec`, and exit-notification
+  settings — via the same resolver the agent path uses. Configured node
+  bindings and safe-bin hardening continue to apply over `/tools/invoke`.
+- Stricter `tools.exec.security` settings (e.g. `allowlist`) still apply and
+  fail closed: a command that requires approval returns `approval-unavailable`
+  because there is no interactive approver on the HTTP path.
 - Backgrounded execution is disabled on this surface; commands run synchronously
   to completion or hit the configured `tools.exec.timeoutSec`.
-- The audit warning `gateway.tools_invoke_http.dangerous_allow` will fire
-  whenever `gateway.tools.allow` re-enables tools from the default deny list.
-  Treat the gateway token/password as full-admin and keep the bind on
-  loopback/tailnet.
+- The audit warning `gateway.tools_invoke_http.dangerous_allow` fires whenever
+  `gateway.tools.allow` re-enables tools from the default deny list, and
+  escalates to critical when `gateway.bind` is non-loopback or Tailscale serve
+  is in funnel mode. Treat the gateway token/password as full-admin and keep
+  the bind on loopback/tailnet.
 
 To help group policies resolve context, you can optionally set:
 

--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -130,6 +130,42 @@ You can customize this deny list via `gateway.tools`:
 }
 ```
 
+### Unlocking `exec` for direct invokes
+
+The `exec` tool runs arbitrary shell commands on the gateway host, so it stays
+denied by default. Operators who need to script gateway-side commands can opt
+in with two settings:
+
+```json5
+{
+  gateway: {
+    tools: {
+      allow: ["exec"], // remove `exec` from the HTTP deny list
+    },
+  },
+  tools: {
+    exec: {
+      security: "full", // skip the agent approval flow
+      ask: "off", // /tools/invoke has no interactive approver
+    },
+  },
+}
+```
+
+Notes:
+
+- The HTTP-registered `exec` is owner-scoped. Shared-secret bearer auth always
+  resolves to owner; trusted-proxy callers must present `operator.admin`.
+- Stricter `tools.exec.security` settings (e.g. `allowlist`) still apply: a
+  command that requires approval will return `approval-unavailable` because
+  there is no interactive approver on the HTTP path.
+- Backgrounded execution is disabled on this surface; commands run synchronously
+  to completion or hit the configured `tools.exec.timeoutSec`.
+- The audit warning `gateway.tools_invoke_http.dangerous_allow` will fire
+  whenever `gateway.tools.allow` re-enables tools from the default deny list.
+  Treat the gateway token/password as full-admin and keep the bind on
+  loopback/tailnet.
+
 To help group policies resolve context, you can optionally set:
 
 - `x-openclaw-message-channel: <channel>` (example: `slack`, `telegram`)

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -11,24 +11,15 @@ import {
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import { HEARTBEAT_RESPONSE_TOOL_NAME } from "../auto-reply/heartbeat-tool-response.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
-import { resolveExecCommandHighlighting } from "../config/exec-command-highlighting.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 import { resolveEventSessionRoutingPolicy } from "../infra/event-session-routing.js";
-import {
-  type ExecAsk,
-  type ExecMode,
-  type ExecSecurity,
-  resolveExecPolicyForMode,
-} from "../infra/exec-approvals.js";
-import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../skills/types.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
-import { resolveAgentConfig } from "./agent-scope.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import {
   type ToolOutcomeObserver,
@@ -67,6 +58,7 @@ import type { ProcessToolDefaults } from "./bash-tools.process.js";
 import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
+import { applyExecPolicyLayer, resolveExecConfig } from "./exec-config-resolution.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import {
   filterLocalModelLeanTools,
@@ -323,72 +315,6 @@ function isApplyPatchAllowedForModel(params: {
     }
     return normalized === normalizedModelId || normalized === normalizedFull;
   });
-}
-
-type ExecPolicyLayer = {
-  mode?: ExecMode;
-  security?: ExecSecurity;
-  ask?: ExecAsk;
-};
-
-function hasLegacyExecPolicy(exec?: ExecPolicyLayer): boolean {
-  return exec?.security !== undefined || exec?.ask !== undefined;
-}
-
-function applyExecPolicyLayer(base: ExecPolicyLayer, layer?: ExecPolicyLayer): ExecPolicyLayer {
-  if (!layer) {
-    return base;
-  }
-  if (layer.mode) {
-    return {
-      mode: layer.mode,
-      ...resolveExecPolicyForMode(layer.mode),
-    };
-  }
-  if (hasLegacyExecPolicy(layer)) {
-    return {
-      security: layer.security ?? base.security,
-      ask: layer.ask ?? base.ask,
-    };
-  }
-  return base;
-}
-
-function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
-  const cfg = params.cfg;
-  const globalExec = cfg?.tools?.exec;
-  const agentExec =
-    cfg && params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools?.exec : undefined;
-  const layeredPolicy = applyExecPolicyLayer(applyExecPolicyLayer({}, globalExec), agentExec);
-  return {
-    host: agentExec?.host ?? globalExec?.host,
-    mode: layeredPolicy.mode,
-    security: layeredPolicy.security,
-    ask: layeredPolicy.ask,
-    node: agentExec?.node ?? globalExec?.node,
-    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
-    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
-    strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
-    commandHighlighting: resolveExecCommandHighlighting({
-      config: cfg,
-      agentId: params.agentId,
-    }),
-    safeBinTrustedDirs: agentExec?.safeBinTrustedDirs ?? globalExec?.safeBinTrustedDirs,
-    safeBinProfiles: resolveMergedSafeBinProfileFixtures({
-      global: globalExec,
-      local: agentExec,
-    }),
-    reviewer: agentExec?.reviewer ?? globalExec?.reviewer,
-    backgroundMs: agentExec?.backgroundMs ?? globalExec?.backgroundMs,
-    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
-    approvalRunningNoticeMs:
-      agentExec?.approvalRunningNoticeMs ?? globalExec?.approvalRunningNoticeMs,
-    cleanupMs: agentExec?.cleanupMs ?? globalExec?.cleanupMs,
-    notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
-    notifyOnExitEmptySuccess:
-      agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
-    applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
-  };
 }
 
 export { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -17,7 +17,6 @@ import type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.j
 import { resolveEventSessionRoutingPolicy } from "../infra/event-session-routing.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../skills/types.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
@@ -52,10 +51,11 @@ import { cleanToolSchemaForGemini, normalizeToolParameters } from "./agent-tools
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import { describeExecTool, describeProcessTool } from "./bash-tools.descriptions.js";
+import { describeProcessTool } from "./bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
+import { createLazyExecTool, loadBashToolsModule } from "./bash-tools.lazy.js";
 import type { ProcessToolDefaults } from "./bash-tools.process.js";
-import { execSchema, processSchema } from "./bash-tools.schemas.js";
+import { processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
 import { applyExecPolicyLayer, resolveExecConfig } from "./exec-config-resolution.js";
@@ -76,10 +76,7 @@ import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "./subagent-capabilities.js";
-import {
-  EXEC_TOOL_DISPLAY_SUMMARY,
-  PROCESS_TOOL_DISPLAY_SUMMARY,
-} from "./tool-description-presets.js";
+import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
 import {
@@ -160,46 +157,6 @@ function resolveSkillReadRoots(skillsSnapshot?: SkillSnapshot): string[] | undef
     return undefined;
   }
   return Array.from(roots);
-}
-
-type BashToolsModule = typeof import("./bash-tools.js");
-
-const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
-  () => import("./bash-tools.js"),
-);
-
-function loadBashToolsModule(): Promise<BashToolsModule> {
-  return bashToolsModuleLoader.load();
-}
-
-function createLazyExecTool(defaults?: ExecToolDefaults): AnyAgentTool {
-  let loadedTool: AnyAgentTool | undefined;
-  const loadTool = async () => {
-    if (!loadedTool) {
-      const { createExecTool } = await loadBashToolsModule();
-      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
-    }
-    return loadedTool;
-  };
-
-  return {
-    name: "exec",
-    label: "exec",
-    displaySummary: EXEC_TOOL_DISPLAY_SUMMARY,
-    get description() {
-      return describeExecTool({
-        agentId: defaults?.agentId,
-        hasCronTool: defaults?.hasCronTool === true,
-      });
-    },
-    parameters: execSchema,
-    prepareBeforeToolCallParams: async (...args) =>
-      (await loadTool()).prepareBeforeToolCallParams?.(...args) ?? args[0],
-    finalizeBeforeToolCallParams: (params, preparedParams) =>
-      loadedTool?.finalizeBeforeToolCallParams?.(params, preparedParams) ?? params,
-    execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
-      (await loadTool()).execute(...args),
-  } as AnyAgentTool;
 }
 
 function createLazyProcessTool(defaults?: ProcessToolDefaults): AnyAgentTool {
@@ -733,57 +690,60 @@ export function createOpenClawCodingTools(options?: {
   const effectiveExecPolicy = applyExecPolicyLayer(execConfig, options?.exec);
   const execTool = includeShellTools
     ? createLazyExecTool({
-        ...execDefaults,
-        host: options?.exec?.host ?? execConfig.host,
-        mode: effectiveExecPolicy.mode,
-        security: effectiveExecPolicy.security,
-        ask: effectiveExecPolicy.ask,
-        config: options?.exec?.config ?? options?.config,
-        reviewer: options?.exec?.reviewer ?? execConfig.reviewer,
-        trigger: options?.trigger,
-        node: options?.exec?.node ?? execConfig.node,
-        pathPrepend: options?.exec?.pathPrepend ?? execConfig.pathPrepend,
-        safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
-        strictInlineEval: options?.exec?.strictInlineEval ?? execConfig.strictInlineEval,
-        commandHighlighting: options?.exec?.commandHighlighting ?? execConfig.commandHighlighting,
-        safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
-        safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
-        agentId,
-        cwd: codingRoot,
-        allowBackground,
-        scopeKey,
-        sessionKey: options?.sessionKey,
-        sessionId: options?.sessionId,
-        sessionStore: options?.config?.session?.store,
-        mainKey: options?.config?.session?.mainKey,
-        sessionScope: options?.config?.session?.scope,
-        eventRouting: resolveEventSessionRoutingPolicy({
-          cfg: options?.config,
+        defaults: {
+          ...execDefaults,
+          host: options?.exec?.host ?? execConfig.host,
+          mode: effectiveExecPolicy.mode,
+          security: effectiveExecPolicy.security,
+          ask: effectiveExecPolicy.ask,
+          config: options?.exec?.config ?? options?.config,
+          reviewer: options?.exec?.reviewer ?? execConfig.reviewer,
+          trigger: options?.trigger,
+          node: options?.exec?.node ?? execConfig.node,
+          pathPrepend: options?.exec?.pathPrepend ?? execConfig.pathPrepend,
+          safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
+          strictInlineEval: options?.exec?.strictInlineEval ?? execConfig.strictInlineEval,
+          commandHighlighting:
+            options?.exec?.commandHighlighting ?? execConfig.commandHighlighting,
+          safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
+          safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
+          agentId,
+          cwd: codingRoot,
+          allowBackground,
+          scopeKey,
           sessionKey: options?.sessionKey,
-          channel: options?.messageProvider,
+          sessionId: options?.sessionId,
+          sessionStore: options?.config?.session?.store,
+          mainKey: options?.config?.session?.mainKey,
+          sessionScope: options?.config?.session?.scope,
+          eventRouting: resolveEventSessionRoutingPolicy({
+            cfg: options?.config,
+            sessionKey: options?.sessionKey,
+            channel: options?.messageProvider,
+            accountId: options?.agentAccountId,
+          }),
+          messageProvider: options?.messageProvider,
+          currentChannelId: options?.currentChannelId,
+          currentThreadTs: options?.currentThreadTs,
           accountId: options?.agentAccountId,
-        }),
-        messageProvider: options?.messageProvider,
-        currentChannelId: options?.currentChannelId,
-        currentThreadTs: options?.currentThreadTs,
-        accountId: options?.agentAccountId,
-        backgroundMs: options?.exec?.backgroundMs ?? execConfig.backgroundMs,
-        timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
-        approvalRunningNoticeMs:
-          options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
-        notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
-        notifyOnExitEmptySuccess:
-          options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
-        sandbox: sandbox
-          ? {
-              containerName: sandbox.containerName,
-              workspaceDir: sandbox.workspaceDir,
-              containerWorkdir: sandbox.containerWorkdir,
-              env: sandbox.backend?.env ?? sandbox.docker.env,
-              buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
-              finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
-            }
-          : undefined,
+          backgroundMs: options?.exec?.backgroundMs ?? execConfig.backgroundMs,
+          timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
+          approvalRunningNoticeMs:
+            options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
+          notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
+          notifyOnExitEmptySuccess:
+            options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+          sandbox: sandbox
+            ? {
+                containerName: sandbox.containerName,
+                workspaceDir: sandbox.workspaceDir,
+                containerWorkdir: sandbox.containerWorkdir,
+                env: sandbox.backend?.env ?? sandbox.docker.env,
+                buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
+                finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
+              }
+            : undefined,
+        },
       })
     : null;
   const processTool = includeShellTools

--- a/src/agents/bash-tools.lazy.ts
+++ b/src/agents/bash-tools.lazy.ts
@@ -1,0 +1,62 @@
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { describeExecTool } from "./bash-tools.descriptions.js";
+import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
+import { execSchema } from "./bash-tools.schemas.js";
+import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+type BashToolsModule = typeof import("./bash-tools.js");
+
+const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
+  () => import("./bash-tools.js"),
+);
+
+export function loadBashToolsModule(): Promise<BashToolsModule> {
+  return bashToolsModuleLoader.load();
+}
+
+/**
+ * Returns a lightweight `AnyAgentTool` stub for the bash `exec` tool that
+ * defers loading the heavyweight `bash-tools` runtime until `execute` is
+ * actually invoked. Both the agent path (`pi-tools`) and the Gateway HTTP
+ * `/tools/invoke` path (`tool-resolution`) use this so the static import
+ * graph for either surface stays small.
+ *
+ * Builds nothing config-shaped: callers pass `defaults` already resolved
+ * (the agent path threads them through `createOpenClawCodingTools`; the HTTP
+ * path layers HTTP-specific overrides on top of `resolveExecConfig`).
+ */
+export function createLazyExecTool(opts: {
+  defaults?: ExecToolDefaults;
+  ownerOnly?: boolean;
+}): AnyAgentTool {
+  const { defaults, ownerOnly } = opts;
+  let loadedTool: AnyAgentTool | undefined;
+  const loadTool = async () => {
+    if (!loadedTool) {
+      const { createExecTool } = await loadBashToolsModule();
+      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
+    }
+    return loadedTool;
+  };
+
+  const stub: AnyAgentTool = {
+    name: "exec",
+    label: "exec",
+    displaySummary: EXEC_TOOL_DISPLAY_SUMMARY,
+    get description() {
+      return describeExecTool({
+        agentId: defaults?.agentId,
+        hasCronTool: defaults?.hasCronTool === true,
+      });
+    },
+    parameters: execSchema,
+    execute: async (...args: Parameters<NonNullable<AnyAgentTool["execute"]>>) =>
+      (await loadTool()).execute(...args),
+  } as AnyAgentTool;
+
+  if (ownerOnly === true) {
+    stub.ownerOnly = true;
+  }
+  return stub;
+}

--- a/src/agents/bash-tools.lazy.ts
+++ b/src/agents/bash-tools.lazy.ts
@@ -1,0 +1,60 @@
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { describeExecTool } from "./bash-tools.descriptions.js";
+import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
+import { execSchema } from "./bash-tools.schemas.js";
+import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+type BashToolsModule = typeof import("./bash-tools.js");
+
+const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
+  () => import("./bash-tools.js"),
+);
+
+export function loadBashToolsModule(): Promise<BashToolsModule> {
+  return bashToolsModuleLoader.load();
+}
+
+/**
+ * Returns a lightweight `AnyAgentTool` stub for the bash `exec` tool that
+ * defers loading the heavyweight `bash-tools` runtime until `execute` is
+ * actually invoked. Both the agent path (`agent-tools`) and the Gateway HTTP
+ * `/tools/invoke` path (`tool-resolution`) use this so the static import
+ * graph for either surface stays small.
+ *
+ * Builds nothing config-shaped: callers pass `defaults` already resolved
+ * (the agent path threads them through `createOpenClawCodingTools`; the HTTP
+ * path layers HTTP-specific overrides on top of `resolveExecConfig`).
+ * Owner-only enforcement on the HTTP surface lives in
+ * `GATEWAY_OWNER_ONLY_CORE_TOOLS`; this factory does not encode it.
+ */
+export function createLazyExecTool(opts: { defaults?: ExecToolDefaults }): AnyAgentTool {
+  const { defaults } = opts;
+  let loadedTool: AnyAgentTool | undefined;
+  const loadTool = async () => {
+    if (!loadedTool) {
+      const { createExecTool } = await loadBashToolsModule();
+      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
+    }
+    return loadedTool;
+  };
+
+  return {
+    name: "exec",
+    label: "exec",
+    displaySummary: EXEC_TOOL_DISPLAY_SUMMARY,
+    get description() {
+      return describeExecTool({
+        agentId: defaults?.agentId,
+        hasCronTool: defaults?.hasCronTool === true,
+      });
+    },
+    parameters: execSchema,
+    prepareBeforeToolCallParams: async (...args) =>
+      (await loadTool()).prepareBeforeToolCallParams?.(...args) ?? args[0],
+    finalizeBeforeToolCallParams: (params, preparedParams) =>
+      loadedTool?.finalizeBeforeToolCallParams?.(params, preparedParams) ?? params,
+    execute: async (...args: Parameters<NonNullable<AnyAgentTool["execute"]>>) =>
+      (await loadTool()).execute(...args),
+  } as AnyAgentTool;
+}

--- a/src/agents/exec-config-resolution.test.ts
+++ b/src/agents/exec-config-resolution.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveExecConfig } from "./exec-config-resolution.js";
+
+describe("resolveExecConfig", () => {
+  it("returns all-undefined fields for an empty config", () => {
+    const result = resolveExecConfig({});
+    expect(result).toEqual({
+      host: undefined,
+      security: undefined,
+      ask: undefined,
+      node: undefined,
+      pathPrepend: undefined,
+      safeBins: undefined,
+      strictInlineEval: undefined,
+      safeBinTrustedDirs: undefined,
+      safeBinProfiles: undefined,
+      backgroundMs: undefined,
+      timeoutSec: undefined,
+      approvalRunningNoticeMs: undefined,
+      cleanupMs: undefined,
+      notifyOnExit: undefined,
+      notifyOnExitEmptySuccess: undefined,
+      applyPatch: undefined,
+    });
+  });
+
+  it("forwards global tools.exec values when no agent override is given", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "full",
+          ask: "off",
+          node: "node-a",
+          pathPrepend: ["/usr/local/bin"],
+          safeBins: ["/usr/bin/uptime"],
+          safeBinTrustedDirs: ["/usr/bin"],
+          strictInlineEval: true,
+          backgroundMs: 5_000,
+          timeoutSec: 60,
+          approvalRunningNoticeMs: 1_000,
+          cleanupMs: 30_000,
+          notifyOnExit: true,
+          notifyOnExitEmptySuccess: false,
+          applyPatch: { allowModels: ["openai/gpt-5.5"] },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg });
+
+    expect(result).toMatchObject({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      node: "node-a",
+      pathPrepend: ["/usr/local/bin"],
+      safeBins: ["/usr/bin/uptime"],
+      safeBinTrustedDirs: ["/usr/bin"],
+      strictInlineEval: true,
+      backgroundMs: 5_000,
+      timeoutSec: 60,
+      approvalRunningNoticeMs: 1_000,
+      cleanupMs: 30_000,
+      notifyOnExit: true,
+      notifyOnExitEmptySuccess: false,
+      applyPatch: { allowModels: ["openai/gpt-5.5"] },
+    });
+  });
+
+  it("lets agent-level tools.exec override matching global fields", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "allowlist",
+          node: "global-node",
+          timeoutSec: 60,
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            tools: {
+              exec: {
+                host: "node",
+                security: "full",
+                node: "agent-node",
+                timeoutSec: 120,
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg, agentId: "main" });
+
+    expect(result.host).toBe("node");
+    expect(result.security).toBe("full");
+    expect(result.node).toBe("agent-node");
+    expect(result.timeoutSec).toBe(120);
+  });
+
+  it("falls back to global fields the agent override does not specify", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "full",
+          node: "global-node",
+          timeoutSec: 60,
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            tools: {
+              exec: {
+                ask: "always",
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg, agentId: "main" });
+
+    expect(result.ask).toBe("always");
+    // unspecified at agent level — global wins
+    expect(result.host).toBe("gateway");
+    expect(result.security).toBe("full");
+    expect(result.node).toBe("global-node");
+    expect(result.timeoutSec).toBe(60);
+  });
+
+  it("ignores agent overrides when no agentId is supplied", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            tools: {
+              exec: {
+                host: "node",
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg });
+
+    expect(result.host).toBe("gateway");
+  });
+
+  it("merges global and agent safeBinProfiles with agent winning on key collision", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          safeBinProfiles: {
+            python3: { minPositional: 1, maxPositional: 4 },
+            node: { allowedValueFlags: ["--flag-from-global"] },
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            tools: {
+              exec: {
+                safeBinProfiles: {
+                  python3: { maxPositional: 8 },
+                  uptime: { minPositional: 0, maxPositional: 0 },
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg, agentId: "main" });
+
+    expect(result.safeBinProfiles).toBeDefined();
+    // agent override replaces the global key entirely (last-write merge)
+    expect(result.safeBinProfiles?.python3).toMatchObject({ maxPositional: 8 });
+    expect(result.safeBinProfiles?.python3?.minPositional).toBeUndefined();
+    // unique to global, preserved
+    expect(result.safeBinProfiles?.node).toMatchObject({
+      allowedValueFlags: ["--flag-from-global"],
+    });
+    // unique to agent, included
+    expect(result.safeBinProfiles?.uptime).toMatchObject({
+      minPositional: 0,
+      maxPositional: 0,
+    });
+  });
+
+  it("returns undefined safeBinProfiles when neither global nor agent set them", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg });
+
+    expect(result.safeBinProfiles).toBeUndefined();
+  });
+});

--- a/src/agents/exec-config-resolution.test.ts
+++ b/src/agents/exec-config-resolution.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveExecConfig } from "./exec-config-resolution.js";
+
+describe("resolveExecConfig", () => {
+  it("returns all-undefined fields for an empty config", () => {
+    const result = resolveExecConfig({});
+    expect(result).toMatchObject({
+      host: undefined,
+      security: undefined,
+      ask: undefined,
+      node: undefined,
+      pathPrepend: undefined,
+      safeBins: undefined,
+      strictInlineEval: undefined,
+      safeBinTrustedDirs: undefined,
+      safeBinProfiles: undefined,
+      backgroundMs: undefined,
+      timeoutSec: undefined,
+      approvalRunningNoticeMs: undefined,
+      cleanupMs: undefined,
+      notifyOnExit: undefined,
+      notifyOnExitEmptySuccess: undefined,
+      applyPatch: undefined,
+    });
+  });
+
+  it("forwards global tools.exec values when no agent override is given", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "full",
+          ask: "off",
+          node: "node-a",
+          pathPrepend: ["/usr/local/bin"],
+          safeBins: ["/usr/bin/uptime"],
+          safeBinTrustedDirs: ["/usr/bin"],
+          strictInlineEval: true,
+          backgroundMs: 5_000,
+          timeoutSec: 60,
+          approvalRunningNoticeMs: 1_000,
+          cleanupMs: 30_000,
+          notifyOnExit: true,
+          notifyOnExitEmptySuccess: false,
+          applyPatch: { allowModels: ["openai/gpt-5.5"] },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg });
+
+    expect(result).toMatchObject({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      node: "node-a",
+      pathPrepend: ["/usr/local/bin"],
+      safeBins: ["/usr/bin/uptime"],
+      safeBinTrustedDirs: ["/usr/bin"],
+      strictInlineEval: true,
+      backgroundMs: 5_000,
+      timeoutSec: 60,
+      approvalRunningNoticeMs: 1_000,
+      cleanupMs: 30_000,
+      notifyOnExit: true,
+      notifyOnExitEmptySuccess: false,
+      applyPatch: { allowModels: ["openai/gpt-5.5"] },
+    });
+  });
+
+  it("lets agent-level tools.exec override matching global fields", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "allowlist",
+          node: "global-node",
+          timeoutSec: 60,
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            tools: {
+              exec: {
+                host: "node",
+                security: "full",
+                node: "agent-node",
+                timeoutSec: 120,
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg, agentId: "main" });
+
+    expect(result.host).toBe("node");
+    expect(result.security).toBe("full");
+    expect(result.node).toBe("agent-node");
+    expect(result.timeoutSec).toBe(120);
+  });
+
+  it("falls back to global fields the agent override does not specify", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "full",
+          node: "global-node",
+          timeoutSec: 60,
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            tools: {
+              exec: {
+                ask: "always",
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg, agentId: "main" });
+
+    expect(result.ask).toBe("always");
+    // unspecified at agent level — global wins
+    expect(result.host).toBe("gateway");
+    expect(result.security).toBe("full");
+    expect(result.node).toBe("global-node");
+    expect(result.timeoutSec).toBe(60);
+  });
+
+  it("ignores agent overrides when no agentId is supplied", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            tools: {
+              exec: {
+                host: "node",
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg });
+
+    expect(result.host).toBe("gateway");
+  });
+
+  it("merges global and agent safeBinProfiles with agent winning on key collision", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          safeBinProfiles: {
+            python3: { minPositional: 1, maxPositional: 4 },
+            node: { allowedValueFlags: ["--flag-from-global"] },
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            tools: {
+              exec: {
+                safeBinProfiles: {
+                  python3: { maxPositional: 8 },
+                  uptime: { minPositional: 0, maxPositional: 0 },
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg, agentId: "main" });
+
+    expect(result.safeBinProfiles).toBeDefined();
+    // agent override replaces the global key entirely (last-write merge)
+    expect(result.safeBinProfiles?.python3).toMatchObject({ maxPositional: 8 });
+    expect(result.safeBinProfiles?.python3?.minPositional).toBeUndefined();
+    // unique to global, preserved
+    expect(result.safeBinProfiles?.node).toMatchObject({
+      allowedValueFlags: ["--flag-from-global"],
+    });
+    // unique to agent, included
+    expect(result.safeBinProfiles?.uptime).toMatchObject({
+      minPositional: 0,
+      maxPositional: 0,
+    });
+  });
+
+  it("returns undefined safeBinProfiles when neither global nor agent set them", () => {
+    const cfg = {
+      tools: {
+        exec: {
+          host: "gateway",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveExecConfig({ cfg });
+
+    expect(result.safeBinProfiles).toBeUndefined();
+  });
+});

--- a/src/agents/exec-config-resolution.ts
+++ b/src/agents/exec-config-resolution.ts
@@ -1,0 +1,79 @@
+import { resolveExecCommandHighlighting } from "../config/exec-command-highlighting.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  type ExecAsk,
+  type ExecMode,
+  type ExecSecurity,
+  resolveExecPolicyForMode,
+} from "../infra/exec-approvals.js";
+import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
+import { resolveAgentConfig } from "./agent-scope.js";
+
+export type ExecPolicyLayer = {
+  mode?: ExecMode;
+  security?: ExecSecurity;
+  ask?: ExecAsk;
+};
+
+export function hasLegacyExecPolicy(exec?: ExecPolicyLayer): boolean {
+  return exec?.security !== undefined || exec?.ask !== undefined;
+}
+
+export function applyExecPolicyLayer(
+  base: ExecPolicyLayer,
+  layer?: ExecPolicyLayer,
+): ExecPolicyLayer {
+  if (!layer) {
+    return base;
+  }
+  if (layer.mode) {
+    return {
+      mode: layer.mode,
+      ...resolveExecPolicyForMode(layer.mode),
+    };
+  }
+  if (hasLegacyExecPolicy(layer)) {
+    return {
+      security: layer.security ?? base.security,
+      ask: layer.ask ?? base.ask,
+    };
+  }
+  return base;
+}
+
+export function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
+  const cfg = params.cfg;
+  const globalExec = cfg?.tools?.exec;
+  const agentExec =
+    cfg && params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools?.exec : undefined;
+  const layeredPolicy = applyExecPolicyLayer(applyExecPolicyLayer({}, globalExec), agentExec);
+  return {
+    host: agentExec?.host ?? globalExec?.host,
+    mode: layeredPolicy.mode,
+    security: layeredPolicy.security,
+    ask: layeredPolicy.ask,
+    node: agentExec?.node ?? globalExec?.node,
+    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
+    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
+    commandHighlighting: resolveExecCommandHighlighting({
+      config: cfg,
+      agentId: params.agentId,
+    }),
+    safeBinTrustedDirs: agentExec?.safeBinTrustedDirs ?? globalExec?.safeBinTrustedDirs,
+    safeBinProfiles: resolveMergedSafeBinProfileFixtures({
+      global: globalExec,
+      local: agentExec,
+    }),
+    reviewer: agentExec?.reviewer ?? globalExec?.reviewer,
+    backgroundMs: agentExec?.backgroundMs ?? globalExec?.backgroundMs,
+    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    approvalRunningNoticeMs:
+      agentExec?.approvalRunningNoticeMs ?? globalExec?.approvalRunningNoticeMs,
+    cleanupMs: agentExec?.cleanupMs ?? globalExec?.cleanupMs,
+    notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
+    notifyOnExitEmptySuccess:
+      agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
+    applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
+  };
+}

--- a/src/agents/exec-config-resolution.ts
+++ b/src/agents/exec-config-resolution.ts
@@ -1,0 +1,33 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
+import { resolveAgentConfig } from "./agent-scope.js";
+
+export function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
+  const cfg = params.cfg;
+  const globalExec = cfg?.tools?.exec;
+  const agentExec =
+    cfg && params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools?.exec : undefined;
+  return {
+    host: agentExec?.host ?? globalExec?.host,
+    security: agentExec?.security ?? globalExec?.security,
+    ask: agentExec?.ask ?? globalExec?.ask,
+    node: agentExec?.node ?? globalExec?.node,
+    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
+    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
+    safeBinTrustedDirs: agentExec?.safeBinTrustedDirs ?? globalExec?.safeBinTrustedDirs,
+    safeBinProfiles: resolveMergedSafeBinProfileFixtures({
+      global: globalExec,
+      local: agentExec,
+    }),
+    backgroundMs: agentExec?.backgroundMs ?? globalExec?.backgroundMs,
+    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    approvalRunningNoticeMs:
+      agentExec?.approvalRunningNoticeMs ?? globalExec?.approvalRunningNoticeMs,
+    cleanupMs: agentExec?.cleanupMs ?? globalExec?.cleanupMs,
+    notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
+    notifyOnExitEmptySuccess:
+      agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
+    applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
+  };
+}

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -3,7 +3,6 @@ import { HEARTBEAT_RESPONSE_TOOL_NAME } from "../auto-reply/heartbeat-tool-respo
 import type { ModelCompatConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
-import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -12,7 +11,6 @@ import {
   normalizeOptionalLowercaseString,
 } from "../shared/string-coerce.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
-import { resolveAgentConfig } from "./agent-scope.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { describeExecTool, describeProcessTool } from "./bash-tools.descriptions.js";
@@ -21,6 +19,7 @@ import type { ProcessToolDefaults } from "./bash-tools.process.js";
 import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
+import { resolveExecConfig } from "./exec-config-resolution.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
@@ -201,36 +200,6 @@ function isApplyPatchAllowedForModel(params: {
     }
     return normalized === normalizedModelId || normalized === normalizedFull;
   });
-}
-
-function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
-  const cfg = params.cfg;
-  const globalExec = cfg?.tools?.exec;
-  const agentExec =
-    cfg && params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools?.exec : undefined;
-  return {
-    host: agentExec?.host ?? globalExec?.host,
-    security: agentExec?.security ?? globalExec?.security,
-    ask: agentExec?.ask ?? globalExec?.ask,
-    node: agentExec?.node ?? globalExec?.node,
-    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
-    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
-    strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
-    safeBinTrustedDirs: agentExec?.safeBinTrustedDirs ?? globalExec?.safeBinTrustedDirs,
-    safeBinProfiles: resolveMergedSafeBinProfileFixtures({
-      global: globalExec,
-      local: agentExec,
-    }),
-    backgroundMs: agentExec?.backgroundMs ?? globalExec?.backgroundMs,
-    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
-    approvalRunningNoticeMs:
-      agentExec?.approvalRunningNoticeMs ?? globalExec?.approvalRunningNoticeMs,
-    cleanupMs: agentExec?.cleanupMs ?? globalExec?.cleanupMs,
-    notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
-    notifyOnExitEmptySuccess:
-      agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
-    applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
-  };
 }
 
 export { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -5,7 +5,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -13,10 +12,11 @@ import {
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import { describeExecTool, describeProcessTool } from "./bash-tools.descriptions.js";
+import { describeProcessTool } from "./bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
+import { createLazyExecTool, loadBashToolsModule } from "./bash-tools.lazy.js";
 import type { ProcessToolDefaults } from "./bash-tools.process.js";
-import { execSchema, processSchema } from "./bash-tools.schemas.js";
+import { processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
 import { resolveExecConfig } from "./exec-config-resolution.js";
@@ -58,10 +58,7 @@ import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "./subagent-capabilities.js";
-import {
-  EXEC_TOOL_DISPLAY_SUMMARY,
-  PROCESS_TOOL_DISPLAY_SUMMARY,
-} from "./tool-description-presets.js";
+import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
 import {
@@ -84,42 +81,6 @@ function isOpenAIProvider(provider?: string) {
 }
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
-
-type BashToolsModule = typeof import("./bash-tools.js");
-
-const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
-  () => import("./bash-tools.js"),
-);
-
-function loadBashToolsModule(): Promise<BashToolsModule> {
-  return bashToolsModuleLoader.load();
-}
-
-function createLazyExecTool(defaults?: ExecToolDefaults): AnyAgentTool {
-  let loadedTool: AnyAgentTool | undefined;
-  const loadTool = async () => {
-    if (!loadedTool) {
-      const { createExecTool } = await loadBashToolsModule();
-      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
-    }
-    return loadedTool;
-  };
-
-  return {
-    name: "exec",
-    label: "exec",
-    displaySummary: EXEC_TOOL_DISPLAY_SUMMARY,
-    get description() {
-      return describeExecTool({
-        agentId: defaults?.agentId,
-        hasCronTool: defaults?.hasCronTool === true,
-      });
-    },
-    parameters: execSchema,
-    execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
-      (await loadTool()).execute(...args),
-  } as AnyAgentTool;
-}
 
 function createLazyProcessTool(defaults?: ProcessToolDefaults): AnyAgentTool {
   let loadedTool: AnyAgentTool | undefined;
@@ -531,43 +492,45 @@ export function createOpenClawCodingTools(options?: {
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
   const execTool = includeShellTools
     ? createLazyExecTool({
-        ...execDefaults,
-        host: options?.exec?.host ?? execConfig.host,
-        security: options?.exec?.security ?? execConfig.security,
-        ask: options?.exec?.ask ?? execConfig.ask,
-        trigger: options?.trigger,
-        node: options?.exec?.node ?? execConfig.node,
-        pathPrepend: options?.exec?.pathPrepend ?? execConfig.pathPrepend,
-        safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
-        strictInlineEval: options?.exec?.strictInlineEval ?? execConfig.strictInlineEval,
-        safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
-        safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
-        agentId,
-        cwd: workspaceRoot,
-        allowBackground,
-        scopeKey,
-        sessionKey: options?.sessionKey,
-        messageProvider: options?.messageProvider,
-        currentChannelId: options?.currentChannelId,
-        currentThreadTs: options?.currentThreadTs,
-        accountId: options?.agentAccountId,
-        backgroundMs: options?.exec?.backgroundMs ?? execConfig.backgroundMs,
-        timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
-        approvalRunningNoticeMs:
-          options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
-        notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
-        notifyOnExitEmptySuccess:
-          options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
-        sandbox: sandbox
-          ? {
-              containerName: sandbox.containerName,
-              workspaceDir: sandbox.workspaceDir,
-              containerWorkdir: sandbox.containerWorkdir,
-              env: sandbox.backend?.env ?? sandbox.docker.env,
-              buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
-              finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
-            }
-          : undefined,
+        defaults: {
+          ...execDefaults,
+          host: options?.exec?.host ?? execConfig.host,
+          security: options?.exec?.security ?? execConfig.security,
+          ask: options?.exec?.ask ?? execConfig.ask,
+          trigger: options?.trigger,
+          node: options?.exec?.node ?? execConfig.node,
+          pathPrepend: options?.exec?.pathPrepend ?? execConfig.pathPrepend,
+          safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
+          strictInlineEval: options?.exec?.strictInlineEval ?? execConfig.strictInlineEval,
+          safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
+          safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
+          agentId,
+          cwd: workspaceRoot,
+          allowBackground,
+          scopeKey,
+          sessionKey: options?.sessionKey,
+          messageProvider: options?.messageProvider,
+          currentChannelId: options?.currentChannelId,
+          currentThreadTs: options?.currentThreadTs,
+          accountId: options?.agentAccountId,
+          backgroundMs: options?.exec?.backgroundMs ?? execConfig.backgroundMs,
+          timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
+          approvalRunningNoticeMs:
+            options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
+          notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
+          notifyOnExitEmptySuccess:
+            options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+          sandbox: sandbox
+            ? {
+                containerName: sandbox.containerName,
+                workspaceDir: sandbox.workspaceDir,
+                containerWorkdir: sandbox.containerWorkdir,
+                env: sandbox.backend?.env ?? sandbox.docker.env,
+                buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
+                finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
+              }
+            : undefined,
+        },
       })
     : null;
   const processTool = includeShellTools

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -1,16 +1,24 @@
 // Gateway-scoped tool resolution for HTTP and loopback tool surfaces.
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import {
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
   resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
 } from "../agents/agent-tools.policy.js";
+import { describeExecTool } from "../agents/bash-tools.descriptions.js";
+import type { ExecToolDefaults } from "../agents/bash-tools.exec-types.js";
+import { execSchema } from "../agents/bash-tools.schemas.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "../agents/subagent-capabilities.js";
+import { EXEC_TOOL_DISPLAY_SUMMARY } from "../agents/tool-description-presets.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -35,6 +43,57 @@ import {
 } from "../security/dangerous-tools.js";
 
 type GatewayScopedToolSurface = "http" | "loopback";
+
+function createLazyHttpExecTool(opts: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  sessionKey: string;
+  workspaceDir?: string;
+}): AnyAgentTool {
+  const globalExec = opts.cfg.tools?.exec;
+  const agentExec = opts.agentId
+    ? resolveAgentConfig(opts.cfg, opts.agentId)?.tools?.exec
+    : undefined;
+  const defaults: ExecToolDefaults = {
+    host: agentExec?.host ?? globalExec?.host,
+    security: agentExec?.security ?? globalExec?.security,
+    ask: agentExec?.ask ?? globalExec?.ask,
+    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
+    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    safeBinTrustedDirs: agentExec?.safeBinTrustedDirs ?? globalExec?.safeBinTrustedDirs,
+    strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
+    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    agentId: opts.agentId,
+    sessionKey: opts.sessionKey,
+    cwd: opts.workspaceDir,
+    // HTTP /tools/invoke is synchronous request/response; backgrounding would
+    // orphan the process with no transcript to follow up on.
+    allowBackground: false,
+  };
+
+  let loadedTool: AnyAgentTool | undefined;
+  const loadTool = async () => {
+    if (!loadedTool) {
+      const { createExecTool } = await import("../agents/bash-tools.js");
+      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
+    }
+    return loadedTool;
+  };
+
+  return {
+    name: "exec",
+    label: "exec",
+    displaySummary: EXEC_TOOL_DISPLAY_SUMMARY,
+    description: describeExecTool({ agentId: opts.agentId, hasCronTool: false }),
+    parameters: execSchema,
+    // Mirrors the `nodes` exec_capable owner-only contract: trusted-proxy
+    // callers must have `operator.admin` to reach this. Shared-secret bearer
+    // auth always resolves to owner per the /tools/invoke security boundary.
+    ownerOnly: true,
+    execute: async (...args: Parameters<NonNullable<AnyAgentTool["execute"]>>) =>
+      (await loadTool()).execute(...args),
+  } as AnyAgentTool;
+}
 
 /** Resolve the tools visible to a gateway caller after agent, channel, and surface policy. */
 export function resolveGatewayScopedTools(params: {
@@ -192,8 +251,25 @@ export function resolveGatewayScopedTools(params: {
     inheritedToolDenylist,
   });
 
+  // Register the agent-side bash exec tool on the HTTP surface so operators
+  // can reach it via `POST /tools/invoke`. The standard HTTP deny list still
+  // blocks it by default; opting in via `gateway.tools.allow: ["exec"]` is
+  // what actually exposes it (mirrors the `nodes` registration contract).
+  const httpScopedTools: AnyAgentTool[] =
+    surface === "http"
+      ? [
+          ...allTools,
+          createLazyHttpExecTool({
+            cfg: params.cfg,
+            agentId,
+            sessionKey: params.sessionKey,
+            workspaceDir,
+          }),
+        ]
+      : allTools;
+
   const policyFiltered = applyToolPolicyPipeline({
-    tools: allTools,
+    tools: httpScopedTools,
     toolMeta: (tool: AnyAgentTool) => getPluginToolMeta(tool),
     warn: logWarn,
     steps: [

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -1,9 +1,5 @@
 // Gateway-scoped tool resolution for HTTP and loopback tool surfaces.
-import {
-  resolveAgentConfig,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-} from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
@@ -13,6 +9,7 @@ import {
 import { describeExecTool } from "../agents/bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "../agents/bash-tools.exec-types.js";
 import { execSchema } from "../agents/bash-tools.schemas.js";
+import { resolveExecConfig } from "../agents/exec-config-resolution.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   isSubagentEnvelopeSession,
@@ -50,19 +47,22 @@ function createLazyHttpExecTool(opts: {
   sessionKey: string;
   workspaceDir?: string;
 }): AnyAgentTool {
-  const globalExec = opts.cfg.tools?.exec;
-  const agentExec = opts.agentId
-    ? resolveAgentConfig(opts.cfg, opts.agentId)?.tools?.exec
-    : undefined;
+  const execConfig = resolveExecConfig({ cfg: opts.cfg, agentId: opts.agentId });
   const defaults: ExecToolDefaults = {
-    host: agentExec?.host ?? globalExec?.host,
-    security: agentExec?.security ?? globalExec?.security,
-    ask: agentExec?.ask ?? globalExec?.ask,
-    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
-    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
-    safeBinTrustedDirs: agentExec?.safeBinTrustedDirs ?? globalExec?.safeBinTrustedDirs,
-    strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
-    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    host: execConfig.host,
+    security: execConfig.security,
+    ask: execConfig.ask,
+    node: execConfig.node,
+    pathPrepend: execConfig.pathPrepend,
+    safeBins: execConfig.safeBins,
+    safeBinTrustedDirs: execConfig.safeBinTrustedDirs,
+    safeBinProfiles: execConfig.safeBinProfiles,
+    strictInlineEval: execConfig.strictInlineEval,
+    backgroundMs: execConfig.backgroundMs,
+    timeoutSec: execConfig.timeoutSec,
+    approvalRunningNoticeMs: execConfig.approvalRunningNoticeMs,
+    notifyOnExit: execConfig.notifyOnExit,
+    notifyOnExitEmptySuccess: execConfig.notifyOnExitEmptySuccess,
     agentId: opts.agentId,
     sessionKey: opts.sessionKey,
     cwd: opts.workspaceDir,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -1,4 +1,11 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
+import { describeExecTool } from "../agents/bash-tools.descriptions.js";
+import type { ExecToolDefaults } from "../agents/bash-tools.exec-types.js";
+import { execSchema } from "../agents/bash-tools.schemas.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   resolveEffectiveToolPolicy,
@@ -9,6 +16,7 @@ import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "../agents/subagent-capabilities.js";
+import { EXEC_TOOL_DISPLAY_SUMMARY } from "../agents/tool-description-presets.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -26,6 +34,57 @@ import { getPluginToolMeta } from "../plugins/tools.js";
 import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
 
 type GatewayScopedToolSurface = "http" | "loopback";
+
+function createLazyHttpExecTool(opts: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  sessionKey: string;
+  workspaceDir?: string;
+}): AnyAgentTool {
+  const globalExec = opts.cfg.tools?.exec;
+  const agentExec = opts.agentId
+    ? resolveAgentConfig(opts.cfg, opts.agentId)?.tools?.exec
+    : undefined;
+  const defaults: ExecToolDefaults = {
+    host: agentExec?.host ?? globalExec?.host,
+    security: agentExec?.security ?? globalExec?.security,
+    ask: agentExec?.ask ?? globalExec?.ask,
+    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
+    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    safeBinTrustedDirs: agentExec?.safeBinTrustedDirs ?? globalExec?.safeBinTrustedDirs,
+    strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
+    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    agentId: opts.agentId,
+    sessionKey: opts.sessionKey,
+    cwd: opts.workspaceDir,
+    // HTTP /tools/invoke is synchronous request/response; backgrounding would
+    // orphan the process with no transcript to follow up on.
+    allowBackground: false,
+  };
+
+  let loadedTool: AnyAgentTool | undefined;
+  const loadTool = async () => {
+    if (!loadedTool) {
+      const { createExecTool } = await import("../agents/bash-tools.js");
+      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
+    }
+    return loadedTool;
+  };
+
+  return {
+    name: "exec",
+    label: "exec",
+    displaySummary: EXEC_TOOL_DISPLAY_SUMMARY,
+    description: describeExecTool({ agentId: opts.agentId, hasCronTool: false }),
+    parameters: execSchema,
+    // Mirrors the `nodes` exec_capable owner-only contract: trusted-proxy
+    // callers must have `operator.admin` to reach this. Shared-secret bearer
+    // auth always resolves to owner per the /tools/invoke security boundary.
+    ownerOnly: true,
+    execute: async (...args: Parameters<NonNullable<AnyAgentTool["execute"]>>) =>
+      (await loadTool()).execute(...args),
+  } as AnyAgentTool;
+}
 
 export function resolveGatewayScopedTools(params: {
   cfg: OpenClawConfig;
@@ -122,8 +181,26 @@ export function resolveGatewayScopedTools(params: {
     ]),
   });
 
+  // Register the agent-side bash exec tool on the HTTP surface so operators
+  // can reach it via `POST /tools/invoke`. The standard HTTP deny list still
+  // blocks it by default; opting in via `gateway.tools.allow: ["exec"]` is
+  // what actually exposes it (mirrors the `nodes` registration contract).
+  const surface = params.surface ?? "http";
+  const httpScopedTools: AnyAgentTool[] =
+    surface === "http"
+      ? [
+          ...allTools,
+          createLazyHttpExecTool({
+            cfg: params.cfg,
+            agentId,
+            sessionKey: params.sessionKey,
+            workspaceDir,
+          }),
+        ]
+      : allTools;
+
   const policyFiltered = applyToolPolicyPipeline({
-    tools: allTools,
+    tools: httpScopedTools,
     toolMeta: (tool: AnyAgentTool) => getPluginToolMeta(tool),
     warn: logWarn,
     steps: [
@@ -145,7 +222,6 @@ export function resolveGatewayScopedTools(params: {
     ],
   });
 
-  const surface = params.surface ?? "http";
   const gatewayToolsCfg = params.cfg.gateway?.tools;
   const defaultGatewayDeny =
     surface === "http"

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -1,7 +1,6 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { describeExecTool } from "../agents/bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "../agents/bash-tools.exec-types.js";
-import { execSchema } from "../agents/bash-tools.schemas.js";
+import { createLazyExecTool } from "../agents/bash-tools.lazy.js";
 import { resolveExecConfig } from "../agents/exec-config-resolution.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
@@ -13,7 +12,6 @@ import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "../agents/subagent-capabilities.js";
-import { EXEC_TOOL_DISPLAY_SUMMARY } from "../agents/tool-description-presets.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -32,14 +30,18 @@ import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
 
 type GatewayScopedToolSurface = "http" | "loopback";
 
-function createLazyHttpExecTool(opts: {
+// Mirrors the `nodes` exec_capable owner-only contract: trusted-proxy callers
+// must have `operator.admin` to reach the HTTP-registered exec. Shared-secret
+// bearer auth always resolves to owner per the `/tools/invoke` security
+// boundary, so the gating is a no-op there.
+function buildHttpExecDefaults(opts: {
   cfg: OpenClawConfig;
   agentId?: string;
   sessionKey: string;
   workspaceDir?: string;
-}): AnyAgentTool {
+}): ExecToolDefaults {
   const execConfig = resolveExecConfig({ cfg: opts.cfg, agentId: opts.agentId });
-  const defaults: ExecToolDefaults = {
+  return {
     host: execConfig.host,
     security: execConfig.security,
     ask: execConfig.ask,
@@ -61,29 +63,6 @@ function createLazyHttpExecTool(opts: {
     // orphan the process with no transcript to follow up on.
     allowBackground: false,
   };
-
-  let loadedTool: AnyAgentTool | undefined;
-  const loadTool = async () => {
-    if (!loadedTool) {
-      const { createExecTool } = await import("../agents/bash-tools.js");
-      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
-    }
-    return loadedTool;
-  };
-
-  return {
-    name: "exec",
-    label: "exec",
-    displaySummary: EXEC_TOOL_DISPLAY_SUMMARY,
-    description: describeExecTool({ agentId: opts.agentId, hasCronTool: false }),
-    parameters: execSchema,
-    // Mirrors the `nodes` exec_capable owner-only contract: trusted-proxy
-    // callers must have `operator.admin` to reach this. Shared-secret bearer
-    // auth always resolves to owner per the /tools/invoke security boundary.
-    ownerOnly: true,
-    execute: async (...args: Parameters<NonNullable<AnyAgentTool["execute"]>>) =>
-      (await loadTool()).execute(...args),
-  } as AnyAgentTool;
 }
 
 export function resolveGatewayScopedTools(params: {
@@ -190,11 +169,14 @@ export function resolveGatewayScopedTools(params: {
     surface === "http"
       ? [
           ...allTools,
-          createLazyHttpExecTool({
-            cfg: params.cfg,
-            agentId,
-            sessionKey: params.sessionKey,
-            workspaceDir,
+          createLazyExecTool({
+            defaults: buildHttpExecDefaults({
+              cfg: params.cfg,
+              agentId,
+              sessionKey: params.sessionKey,
+              workspaceDir,
+            }),
+            ownerOnly: true,
           }),
         ]
       : allTools;

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -1,11 +1,8 @@
-import {
-  resolveAgentConfig,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-} from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { describeExecTool } from "../agents/bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "../agents/bash-tools.exec-types.js";
 import { execSchema } from "../agents/bash-tools.schemas.js";
+import { resolveExecConfig } from "../agents/exec-config-resolution.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   resolveEffectiveToolPolicy,
@@ -41,19 +38,22 @@ function createLazyHttpExecTool(opts: {
   sessionKey: string;
   workspaceDir?: string;
 }): AnyAgentTool {
-  const globalExec = opts.cfg.tools?.exec;
-  const agentExec = opts.agentId
-    ? resolveAgentConfig(opts.cfg, opts.agentId)?.tools?.exec
-    : undefined;
+  const execConfig = resolveExecConfig({ cfg: opts.cfg, agentId: opts.agentId });
   const defaults: ExecToolDefaults = {
-    host: agentExec?.host ?? globalExec?.host,
-    security: agentExec?.security ?? globalExec?.security,
-    ask: agentExec?.ask ?? globalExec?.ask,
-    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
-    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
-    safeBinTrustedDirs: agentExec?.safeBinTrustedDirs ?? globalExec?.safeBinTrustedDirs,
-    strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
-    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    host: execConfig.host,
+    security: execConfig.security,
+    ask: execConfig.ask,
+    node: execConfig.node,
+    pathPrepend: execConfig.pathPrepend,
+    safeBins: execConfig.safeBins,
+    safeBinTrustedDirs: execConfig.safeBinTrustedDirs,
+    safeBinProfiles: execConfig.safeBinProfiles,
+    strictInlineEval: execConfig.strictInlineEval,
+    backgroundMs: execConfig.backgroundMs,
+    timeoutSec: execConfig.timeoutSec,
+    approvalRunningNoticeMs: execConfig.approvalRunningNoticeMs,
+    notifyOnExit: execConfig.notifyOnExit,
+    notifyOnExitEmptySuccess: execConfig.notifyOnExitEmptySuccess,
     agentId: opts.agentId,
     sessionKey: opts.sessionKey,
     cwd: opts.workspaceDir,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -6,16 +6,14 @@ import {
   resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
 } from "../agents/agent-tools.policy.js";
-import { describeExecTool } from "../agents/bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "../agents/bash-tools.exec-types.js";
-import { execSchema } from "../agents/bash-tools.schemas.js";
+import { createLazyExecTool } from "../agents/bash-tools.lazy.js";
 import { resolveExecConfig } from "../agents/exec-config-resolution.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "../agents/subagent-capabilities.js";
-import { EXEC_TOOL_DISPLAY_SUMMARY } from "../agents/tool-description-presets.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -41,14 +39,18 @@ import {
 
 type GatewayScopedToolSurface = "http" | "loopback";
 
-function createLazyHttpExecTool(opts: {
+// Mirrors the `nodes` exec_capable owner-only contract: trusted-proxy callers
+// must have `operator.admin` to reach the HTTP-registered exec. Shared-secret
+// bearer auth always resolves to owner per the `/tools/invoke` security
+// boundary, so the gating is a no-op there.
+function buildHttpExecDefaults(opts: {
   cfg: OpenClawConfig;
   agentId?: string;
   sessionKey: string;
   workspaceDir?: string;
-}): AnyAgentTool {
+}): ExecToolDefaults {
   const execConfig = resolveExecConfig({ cfg: opts.cfg, agentId: opts.agentId });
-  const defaults: ExecToolDefaults = {
+  return {
     host: execConfig.host,
     security: execConfig.security,
     ask: execConfig.ask,
@@ -70,29 +72,6 @@ function createLazyHttpExecTool(opts: {
     // orphan the process with no transcript to follow up on.
     allowBackground: false,
   };
-
-  let loadedTool: AnyAgentTool | undefined;
-  const loadTool = async () => {
-    if (!loadedTool) {
-      const { createExecTool } = await import("../agents/bash-tools.js");
-      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
-    }
-    return loadedTool;
-  };
-
-  return {
-    name: "exec",
-    label: "exec",
-    displaySummary: EXEC_TOOL_DISPLAY_SUMMARY,
-    description: describeExecTool({ agentId: opts.agentId, hasCronTool: false }),
-    parameters: execSchema,
-    // Mirrors the `nodes` exec_capable owner-only contract: trusted-proxy
-    // callers must have `operator.admin` to reach this. Shared-secret bearer
-    // auth always resolves to owner per the /tools/invoke security boundary.
-    ownerOnly: true,
-    execute: async (...args: Parameters<NonNullable<AnyAgentTool["execute"]>>) =>
-      (await loadTool()).execute(...args),
-  } as AnyAgentTool;
 }
 
 /** Resolve the tools visible to a gateway caller after agent, channel, and surface policy. */
@@ -259,11 +238,13 @@ export function resolveGatewayScopedTools(params: {
     surface === "http"
       ? [
           ...allTools,
-          createLazyHttpExecTool({
-            cfg: params.cfg,
-            agentId,
-            sessionKey: params.sessionKey,
-            workspaceDir,
+          createLazyExecTool({
+            defaults: buildHttpExecDefaults({
+              cfg: params.cfg,
+              agentId,
+              sessionKey: params.sessionKey,
+              workspaceDir,
+            }),
           }),
         ]
       : allTools;

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -1026,6 +1026,21 @@ describe("POST /tools/invoke", () => {
     expect(nodesAdminRes.status).toBe(404);
   });
 
+  it("exposes exec when operators opt in via gateway.tools.allow=[exec]", async () => {
+    setMainAllowedTools({ allow: ["exec"], gatewayAllow: ["exec"] });
+
+    const execRes = await invokeTool({
+      port: sharedPort,
+      headers: gatewayAdminHeaders(),
+      tool: "exec",
+      args: { command: "echo ok" },
+      sessionKey: "main",
+    });
+
+    const body = await expectOkInvokeResponse(execRes);
+    expect(body.result).toEqual({ ok: true, result: "exec" });
+  });
+
   it("falls back to plugin-backed tools when a cataloged core tool has no core implementation", async () => {
     setMainAllowedTools({ allow: ["browser"] });
 

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -956,6 +956,21 @@ describe("POST /tools/invoke", () => {
     expect(nodesAdminRes.status).toBe(404);
   });
 
+  it("exposes exec when operators opt in via gateway.tools.allow=[exec]", async () => {
+    setMainAllowedTools({ allow: ["exec"], gatewayAllow: ["exec"] });
+
+    const execRes = await invokeTool({
+      port: sharedPort,
+      headers: gatewayAdminHeaders(),
+      tool: "exec",
+      args: { command: "echo ok" },
+      sessionKey: "main",
+    });
+
+    const body = await expectOkInvokeResponse(execRes);
+    expect(body.result).toEqual({ ok: true, result: "exec" });
+  });
+
   it("falls back to plugin-backed tools when a cataloged core tool has no core implementation", async () => {
     setMainAllowedTools({ allow: ["browser"] });
 

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -38,4 +38,4 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
  * `gateway.tools.allow` can remove the default HTTP deny only for owner/trusted-operator
  * callers; non-owner identity-bearing callers must not receive server-credential wrappers.
  */
-export const GATEWAY_OWNER_ONLY_CORE_TOOLS = ["cron", "gateway", "nodes"] as const;
+export const GATEWAY_OWNER_ONLY_CORE_TOOLS = ["cron", "exec", "gateway", "nodes"] as const;


### PR DESCRIPTION
## Summary

- Problem: `POST /tools/invoke` ignores `gateway.tools.allow: ["exec"]`. The bash exec tool is the gateway's only path for running shell commands, but `createOpenClawTools` never registers it for the HTTP surface, so the documented opt-in is a silent no-op (`404 not_found`).
- Why it matters: Operators who want to script gateway-side commands today have to either let an LLM call `exec` during an agent turn or proxy through a paired node. There is no operator-scope path to run a single command on the gateway, even with the deny-list opt-in flipped.
- What changed: `tool-resolution.ts` now appends a lazy `exec` entry to the HTTP-surface tool pool. `exec` is added to `GATEWAY_OWNER_ONLY_CORE_TOOLS` alongside `cron`/`gateway`/`nodes` so non-owner identity-bearing callers are denied even when the allowlist is flipped. The tool runs synchronously and reuses the operator's `tools.exec` config (host/security/ask/safeBins/safeBinProfiles) via the shared `resolveExecConfig`. The lazy factory itself is extracted to `src/agents/bash-tools.lazy.ts` so the HTTP surface and the agent path share one `createLazyExecTool`. The default deny list still hides it; the operator must set `gateway.tools.allow: ["exec"]` *and* loosen `tools.exec.security` to actually reach it.
- What did NOT change (scope boundary): `DEFAULT_GATEWAY_HTTP_TOOL_DENY` membership is untouched (default-deny preserved). The audit warning `gateway.tools_invoke_http.dangerous_allow` still fires on opt-in. The `gateway-tool-guard-coverage` test that blocks an *agent-driven* `config.patch` from sneaking `exec` into `gateway.tools.allow` still applies. Loopback (MCP) surface unchanged. No new RPC, no new endpoint.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: `POST /tools/invoke` ignores `gateway.tools.allow: ["exec"]` because the bash exec tool is never registered for the HTTP surface. After this fix, the documented opt-in actually exposes the tool, while the default deny stays intact.
- **Real environment tested**: Locally built gateway from this branch (`pnpm build` against `25d51fb`, run via `node openclaw.mjs gateway run`) on macOS 25.4.0, Node v22.16.0. Two parallel gateways with isolated `OPENCLAW_HOME` config dirs — one configured with `gateway.tools.allow: ["exec"]`, one without — to capture both the opt-in and the default-deny behavior on the same build. (Branch has since been rebased onto current main; head is now `15052313b`. Behavior unchanged; mechanism summary updated above to reflect the rebase.)
- **Exact steps or command run after this patch**:
  1. `pnpm install && pnpm build` against this branch.
  2. Wrote isolated configs:
     ```jsonc
     // /tmp/openclaw-pr-proof/.openclaw/openclaw.json — opt-in case
     {
       "gateway": {
         "mode": "local",
         "auth": { "mode": "token", "token": "lucinate-pr-test" },
         "tools": { "allow": ["exec"] },
         "bind": "loopback",
         "port": 18790
       },
       "tools": { "exec": { "security": "full", "ask": "off", "host": "gateway" } }
     }
     ```
     The default-deny config is identical except the `gateway.tools.allow` line is removed and the port is `18794`.
  3. Started two gateways from the branch build:
     ```
     OPENCLAW_HOME=/tmp/openclaw-pr-proof  node openclaw.mjs gateway run
     OPENCLAW_HOME=/tmp/openclaw-pr-proof2 node openclaw.mjs gateway run
     ```
  4. Issued the same `POST /tools/invoke` to each:
     ```
     curl -sS -X POST http://127.0.0.1:18790/tools/invoke \
       -H 'Authorization: Bearer lucinate-pr-test' -H 'Content-Type: application/json' \
       -d '{"tool":"exec","args":{"command":"uptime"}}'
     curl -sS -X POST http://127.0.0.1:18794/tools/invoke \
       -H 'Authorization: Bearer lucinate-pr-test2' -H 'Content-Type: application/json' \
       -d '{"tool":"exec","args":{"command":"uptime"}}'
     ```
- **Evidence after fix**: Live curl terminal captures from two real OpenClaw gateways built from this branch (commit `25d51fb`, run via `node openclaw.mjs gateway run` from the branch checkout on macOS 25.4.0, Node v22.16.0). Each gateway has its own isolated `OPENCLAW_HOME` so we are exercising real `gateway.tools.allow` resolution, real `tools.exec` config, real auth, and the real `runExecProcess` runtime — not mocks.

  Default deny path (no `gateway.tools.allow`) on the real gateway — same 404 as before, deny list still gating:
  ```
  $ curl -sS -X POST http://127.0.0.1:18794/tools/invoke \
      -H 'Authorization: Bearer lucinate-pr-test2' -H 'Content-Type: application/json' \
      -d '{"tool":"exec","args":{"command":"uptime"}}'
  {"ok":false,"error":{"type":"not_found","message":"Tool not available: exec"}}
  ```

  Opt-in path (`gateway.tools.allow: ["exec"]`) on the real gateway — runs `uptime` on the host and returns its actual stdout from `runExecProcess`:
  ```
  $ curl -sS -X POST http://127.0.0.1:18790/tools/invoke \
      -H 'Authorization: Bearer lucinate-pr-test' -H 'Content-Type: application/json' \
      -d '{"tool":"exec","args":{"command":"uptime"}}'
  {"ok":true,"result":{"content":[{"type":"text","text":"23:06  up 3 days,  5:03, 7 users, load averages: 4.02 5.09 6.59"}],"details":{"status":"completed","exitCode":0,"durationMs":9,"aggregated":"23:06  up 3 days,  5:03, 7 users, load averages: 4.02 5.09 6.59","cwd":"/Users/pete/projects/openclaw/gateway"}}}
  ```
- **Observed result after fix**: With opt-in, the gateway runs `uptime` on the host and returns `exitCode: 0` plus the actual stdout (`23:06  up 3 days, ...`). Without opt-in, the deny list still returns `404 not_found` — default-deny preserved.
- **What was not tested**: Trusted-proxy auth path (relies on `senderIsOwner=false` filtering via `GATEWAY_OWNER_ONLY_CORE_TOOLS`); gateway running on a non-loopback bind; behavior with `tools.exec.security: "allowlist"` against a non-allowlisted command (should surface `approval-unavailable`, derived from existing exec runtime tests rather than re-run live here).
- **Before evidence**: Same curl against a locally built `ghcr.io/openclaw/openclaw:latest` image with `gateway.tools.allow: ["exec"]` set in its config, captured before this branch landed:
  ```
  $ curl -sS -X POST http://127.0.0.1:18789/tools/invoke \
      -H 'Authorization: Bearer ...' -H 'Content-Type: application/json' \
      -d '{"tool":"exec","args":{"command":"uptime"}}'
  {"ok":false,"error":{"type":"not_found","message":"Tool not available: exec"}}
  ```

## Root Cause (if applicable)

N/A. This is a feature wiring gap, not a regression. The HTTP deny list at `src/security/dangerous-tools.ts` and the `gateway.tools.allow` opt-in were always documented as the gate, but `createOpenClawTools` only registered the gateway control-plane tools (sessions_*, message, web_*, etc.) for the HTTP surface. The bash `exec` tool is registered separately on the agent path via `src/agents/agent-tools.ts` (previously `pi-tools.ts`), and `/tools/invoke` resolved against the gateway pool only.

- Root cause: missing registration in the HTTP tool resolver.
- Missing detection / guardrail: no test asserted that an opt-in via `gateway.tools.allow` actually reached the affected tool. The deny-list test only checked the negative case.
- Contributing context: `nodes` is the precedent — registered, deny-listed by default, unlocked via `gateway.tools.allow: ["nodes"]`, and listed in `GATEWAY_OWNER_ONLY_CORE_TOOLS` so non-owner identity-bearing callers cannot reach it after the allowlist. `exec` had the deny-list entry but not the registration counterpart or the owner-only entry; this PR adds both.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/tools-invoke-http.test.ts`
- Scenario the test should lock in: with `gateway.tools.allow: ["exec"]` set, `POST /tools/invoke {tool: "exec"}` returns `200 ok`; without it, `404 not_found` (already covered by the existing `extends the HTTP deny list to high-risk execution and file tools` case).
- Why this is the smallest reliable guardrail: the routing/resolution path is the only thing this PR wires up; the underlying exec runtime has its own dedicated tests in `bash-tools.exec*.test.ts`, and the `resolveExecConfig` helper is covered directly by `src/agents/exec-config-resolution.test.ts`.
- Existing test that already covers this: the negative case (`extends the HTTP deny list ...`) covers default-deny. The new positive case `exposes exec when operators opt in via gateway.tools.allow=[exec]` covers the opt-in path.
- If no new test is added, why not: N/A — a new positive test is included.

## User-visible / Behavior Changes

- New: with `gateway.tools.allow: ["exec"]` and `tools.exec: { security: "full", ask: "off", host: "gateway" }`, `POST /tools/invoke {tool: "exec", args: {command: "..."}}` runs the command on the gateway host and returns its stdout/exit code.
- Unchanged: every config that does not include `exec` in `gateway.tools.allow` still returns `404 not_found` exactly as before.
- Unchanged: agent-side bash exec semantics are untouched. The shared `createLazyExecTool` factory now backs both surfaces, but the agent path passes the same defaults it always did.

## Diagram (if applicable)

```text
Before (this branch absent):
  POST /tools/invoke {tool:"exec"} -> resolveGatewayScopedTools (createOpenClawTools)
                                    -> exec NOT in pool -> 404 not_found
                                       (gateway.tools.allow: ["exec"] is a no-op)

After:
  POST /tools/invoke {tool:"exec"} -> resolveGatewayScopedTools
                                    -> createOpenClawTools  (no exec)
                                    -> + createLazyExecTool (HTTP surface only,
                                         defaults from resolveExecConfig)
                                    -> policy pipeline      (agents.tools.allow honored)
                                    -> deny set             (gateway.tools.allow gates;
                                         GATEWAY_OWNER_ONLY_CORE_TOOLS now includes
                                         "exec", so non-owner identity-bearing callers
                                         still receive 404)
                                    -> 404 (default)  OR  200 ok (opt-in) -> bash-tools.exec runtime
```

## Security Impact (required)

- New permissions/capabilities? Yes — operators can now invoke `exec` over `/tools/invoke` if they explicitly add it to `gateway.tools.allow`. Default-deny preserved; this PR finishes the wiring of an existing documented opt-in.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? Yes — see above.
- Data access scope changed? No.
- Risk + mitigation:
  - Risk: an operator turning on the allow flag exposes shell on their gateway host. Mitigation: `exec` is now in `GATEWAY_OWNER_ONLY_CORE_TOOLS` (alongside `cron`/`gateway`/`nodes`), so trusted-proxy callers without `operator.admin` are denied even when the allowlist is flipped. Shared-secret bearer auth always resolves to owner per the existing /tools/invoke contract — same authorization the operator already trusts for the rest of the operator-scope HTTP surface.
  - Risk: an LLM or sub-agent could try to flip `gateway.tools.allow` to unlock exec. Mitigation: unchanged — the existing `gateway-tool-guard-coverage` test that blocks `config.patch` from sneaking `exec`/`shell`/`spawn` into `gateway.tools.allow` still applies, so opt-in still requires an operator-level config edit (CLI, file, or doctor command), not an agent-driven mutation.
  - Risk: `tools.exec.security: "full"` lets HTTP run any command. Mitigation: docs explicitly call out the two-flag opt-in (`gateway.tools.allow: ["exec"]` + relaxed `tools.exec.security`); stricter `security: "allowlist"` configs still apply at runtime and a non-matching command surfaces `approval-unavailable` (no interactive approver on the HTTP path) instead of running.
  - Risk: backgrounded exec leaves orphaned processes. Mitigation: the HTTP-registered exec forces `allowBackground: false`.

## Repro + Verification

### Environment

- OS: macOS 25.4.0 (Darwin)
- Runtime/container: Node v22.16.0, gateway run via `node openclaw.mjs gateway run` from this branch (proof captured at commit `25d51fb`; branch is now at `15052313b` after rebase onto current main — behavior unchanged)
- Model/provider: not exercised — this PR's surface is operator HTTP, no LLM turn involved
- Integration/channel: none
- Relevant config (redacted): see "Real behavior proof" → opt-in / default-deny config blocks above

### Steps

1. Build the branch (`pnpm install && pnpm build`).
2. Run two gateways with the configs above (`OPENCLAW_HOME=...` to keep them isolated from any existing operator config).
3. Issue `POST /tools/invoke {tool:"exec",args:{command:"uptime"}}` to each.

### Expected

- Opt-in gateway: `200 ok` with `details.exitCode: 0` and the actual `uptime` output in `aggregated`.
- Default-deny gateway: `404 not_found {"type":"not_found","message":"Tool not available: exec"}`.

### Actual

- Opt-in gateway: matched expected — `exitCode: 0`, output `23:06  up 3 days,  5:03, 7 users, load averages: 4.02 5.09 6.59`.
- Default-deny gateway: matched expected — same `404 not_found` shape as the published-image baseline.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after — see Real behavior proof (live curl against published image vs branch build)
- [x] Trace/log snippets — `details.aggregated` from the opt-in run
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Default-deny path on a freshly built gateway from this branch returns `404 not_found` for `exec`.
  - Opt-in path (`gateway.tools.allow: ["exec"]` + `tools.exec.security: "full"`, `ask: "off"`) returns `200 ok` and runs the command on the host.
  - Pre-patch baseline: same opt-in config against the published image still returns `404 not_found` (proves the silent no-op).
- Edge cases checked:
  - Owner gating: `exec` is in `GATEWAY_OWNER_ONLY_CORE_TOOLS`, so trusted-proxy callers without `operator.admin` cannot reach it. Bearer auth resolves to owner (existing /tools/invoke contract), which is what the live test exercised.
  - Agent allow-list: the existing test `extends the HTTP deny list to high-risk execution and file tools` still passes — agent-side `tools.allow: ["exec"]` alone is not enough; `gateway.tools.allow` is still required.
- What I did **not** verify:
  - Trusted-proxy mode end-to-end (only the unit-level owner-only filter assertion).
  - Behavior under `tools.exec.security: "allowlist"` with a non-matching command. Existing exec runtime tests already cover the `approval-unavailable` path; I did not re-run that live.
  - Non-loopback bind behavior. The audit `gateway.tools_invoke_http.dangerous_allow` is expected to escalate to critical when bind is non-loopback or tailscale=funnel — that's existing audit behavior unchanged by this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — default behavior unchanged.
- Config/env changes? No new keys; `gateway.tools.allow` and `tools.exec.*` already exist and are documented.
- Migration needed? No.

## Risks and Mitigations

- Risk: operator opts in (`gateway.tools.allow: ["exec"]` + `tools.exec.security: "full"`, `ask: "off"`) without realizing the bearer secret is now equivalent to host-shell access.
  - Mitigation: docs (`docs/gateway/tools-invoke-http-api.md` → "Unlocking `exec` for direct invokes") spell out both flags and the audit warning; the existing `gateway.tools_invoke_http.dangerous_allow` audit fires on opt-in and escalates to critical when bind is not loopback or tailscale is funnel.
- Risk: stricter `tools.exec.security` blocks an HTTP exec call mid-flight in a way that surprises automation.
  - Mitigation: unchanged from the agent path — the result surfaces `approval-unavailable` (HTTP has no interactive approver), the response is structured, and the docs note this explicitly.

## AI-assisted

Built with Claude Code. I reviewed the diff line-by-line and confirm it preserves the existing default-deny security model: the new entry is lazy, owner-gated via `GATEWAY_OWNER_ONLY_CORE_TOOLS`, and only reachable when an operator both registers the allowlist *and* loosens `tools.exec.security` enough to skip approvals — the same combination that makes the agent-side bash exec actually run today.
