### PR TITLE
fix: preserve runtime alias with compat wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI/local runs: keep stable runtime plugin aliases present when legacy compatibility wrappers already exist in dist, so sending a message no longer fails with a missing `runtime-plugins.runtime.js` module.
 - Providers: preserve non-OK `text/event-stream` response bodies so provider HTTP errors keep their JSON detail instead of collapsing to generic streaming failures. Fixes #78180.
 - Chat commands: make `/model default` reset the session model override instead of treating it as a literal model name. Fixes #78182.
 - Cron: make rejected `payload.model` errors show the configured `agents.defaults.models` allowlist instead of echoing the rejected model twice. Fixes #79058.

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -155,8 +155,18 @@ export function writeStableRootRuntimeAliases(params = {}) {
   }
 
   const resolveAliasCandidate = (aliasFileName, candidates) => {
-    if (candidates.length === 1) {
-      return candidates[0];
+    const implementationCandidates = candidates.filter((candidate) => {
+      const filePath = path.join(distDir, candidate);
+      let source;
+      try {
+        source = fsImpl.readFileSync(filePath, "utf8");
+      } catch {
+        return false;
+      }
+      return !source.includes(`"./${aliasFileName}"`);
+    });
+    if (implementationCandidates.length === 1) {
+      return implementationCandidates[0];
     }
     if (aliasFileName === PLUGIN_INSTALL_RUNTIME_ALIAS.aliasFileName) {
       return resolveRootRuntimeCandidateByMarkers({
@@ -166,8 +176,8 @@ export function writeStableRootRuntimeAliases(params = {}) {
         sourceIncludes: PLUGIN_INSTALL_RUNTIME_ALIAS.sourceIncludes,
       });
     }
-    const candidateSet = new Set(candidates);
-    const wrappers = candidates.filter((candidate) => {
+    const candidateSet = new Set(implementationCandidates);
+    const wrappers = implementationCandidates.filter((candidate) => {
       const filePath = path.join(distDir, candidate);
       let source;
       try {
@@ -175,7 +185,7 @@ export function writeStableRootRuntimeAliases(params = {}) {
       } catch {
         return false;
       }
-      return candidates.some(
+      return implementationCandidates.some(
         (target) =>
           target !== candidate &&
           candidateSet.has(target) &&

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -385,6 +385,33 @@ describe("runtime postbuild static assets", () => {
     );
   });
 
+  it("writes stable aliases when legacy compatibility wrappers already exist", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const distDir = path.join(rootDir, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    await fs.writeFile(
+      path.join(distDir, "runtime-plugins.runtime-NewHash.js"),
+      "export const ready = true;\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(distDir, "runtime-plugins.runtime-CNAfmQRG.js"),
+      'export * from "./runtime-plugins.runtime.js";\n',
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(distDir, "runtime-plugins.runtime-fLHuT7Vs.js"),
+      'export * from "./runtime-plugins.runtime.js";\n',
+      "utf8",
+    );
+
+    writeStableRootRuntimeAliases({ rootDir });
+
+    expect(await fs.readFile(path.join(distDir, "runtime-plugins.runtime.js"), "utf8")).toBe(
+      'export * from "./runtime-plugins.runtime-NewHash.js";\n',
+    );
+  });
+
   it("writes compatibility aliases for previous release runtime chunk names", async () => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     const distDir = path.join(rootDir, "dist");


### PR DESCRIPTION
## Summary
- keep stable root runtime aliases writable when legacy compatibility wrappers already exist in `dist`
- add a regression test for `runtime-plugins.runtime.js` alias generation with old wrapper chunks present
- add a changelog entry for the TUI/local run failure mode

## Real behavior proof
- **Behavior or issue addressed:** Sending a message in the TUI/local dispatch path failed with `ERR_MODULE_NOT_FOUND` because `dist/dispatch-8E8vi2HV.js` imported `./runtime-plugins.runtime.js`, but the stable alias file was missing after `runtime-postbuild` saw old compatibility wrappers.
- **Real environment tested:** Local OpenClaw checkout on macOS in `/Users/kevinlin/code/openclaw`, using the existing generated `dist` tree that reproduced the missing `runtime-plugins.runtime.js` alias.
- **Exact steps or command run after this patch:** Ran `node scripts/runtime-postbuild.mjs`, then ran `node -e "import('./dist/runtime-plugins.runtime.js').then(m=>console.log(typeof m.ensureRuntimePluginsLoaded))"` and `node -e "import('./dist/dispatch-8E8vi2HV.js').then(()=>console.log('dispatch import ok'))"`.
- **Evidence after fix:** Terminal output from the local run showed `dist/runtime-plugins.runtime.js` existed with `export * from "./runtime-plugins.runtime-Ba2K5sm3.js";`, then the runtime alias import printed `function`, and the reported dispatch chunk import printed `dispatch import ok`.
- **Observed result after fix:** The missing stable alias was regenerated and both the exact runtime alias module and the previously failing dispatch chunk loaded successfully without `ERR_MODULE_NOT_FOUND`.
- **What was not tested:** I did not run an interactive TUI message send in this clean PR worktree; the local proof exercised the exact missing module import path from the reproduced failure.

## Verification
- `pnpm exec oxfmt --check --threads=1 scripts/runtime-postbuild.mjs test/scripts/runtime-postbuild.test.ts`
- `pnpm test test/scripts/runtime-postbuild.test.ts`
- `git diff --check origin/main...HEAD`
