### PR TITLE
fix(cli): emit json for gateway transport failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Gateway: emit structured JSON transport-error envelopes for gateway-backed `--json` commands such as `health`, `gateway health`, and `devices list` when the gateway connection closes or times out, preserving machine-readable failure output. Fixes #79108.
 - Providers: preserve non-OK `text/event-stream` response bodies so provider HTTP errors keep their JSON detail instead of collapsing to generic streaming failures. Fixes #78180.
 - Chat commands: make `/model default` reset the session model override instead of treating it as a literal model name. Fixes #78182.
 - Cron: make rejected `payload.model` errors show the configured `agents.defaults.models` allowlist instead of echoing the rejected model twice. Fixes #79058.

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -33,6 +33,22 @@ const {
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
   buildGatewayConnectionDetails: mocks.buildGatewayConnectionDetails,
+  isGatewayTransportError: (value: unknown) =>
+    value instanceof Error && value.name === "GatewayTransportError",
+  buildGatewayTransportErrorJson: (error: Error, context: Record<string, unknown>) => ({
+    ok: false,
+    error: {
+      type: "gateway_transport",
+      code: "gateway_closed",
+      message: error.message,
+      kind: "closed",
+      ...context,
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+      },
+    },
+  }),
 }));
 
 vi.mock("./progress.js", () => ({
@@ -633,6 +649,31 @@ describe("devices cli local fallback", () => {
       runDevicesCommand(["list", "--json", "--url", "ws://127.0.0.1:18789"]),
     ).rejects.toThrow("pairing required");
     expect(listDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("prints JSON for transport failures in list JSON mode", async () => {
+    callGateway.mockRejectedValueOnce(
+      Object.assign(new Error("gateway closed (1006): no close reason"), {
+        name: "GatewayTransportError",
+        kind: "closed",
+      }),
+    );
+
+    await runDevicesCommand(["list", "--json"]);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({
+          type: "gateway_transport",
+          code: "gateway_closed",
+          command: "devices list",
+          method: "device.pair.list",
+        }),
+      }),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 });
 

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -1,5 +1,10 @@
 import type { Command } from "commander";
-import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import {
+  buildGatewayConnectionDetails,
+  buildGatewayTransportErrorJson,
+  callGateway,
+  isGatewayTransportError,
+} from "../gateway/call.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
@@ -522,7 +527,22 @@ export function registerDevicesCli(program: Command) {
       .command("list")
       .description("List pending and paired devices")
       .action(async (opts: DevicesRpcOpts) => {
-        const list = await listPairingWithFallback(opts);
+        let list: DevicePairingList;
+        try {
+          list = await listPairingWithFallback(opts);
+        } catch (error) {
+          if (opts.json && isGatewayTransportError(error)) {
+            defaultRuntime.writeJson(
+              buildGatewayTransportErrorJson(error, {
+                command: "devices list",
+                method: "device.pair.list",
+              }),
+            );
+            defaultRuntime.exit(1);
+            return;
+          }
+          throw error;
+        }
         const pairedByDeviceId = indexPairedDevices(list.paired);
         if (opts.json) {
           defaultRuntime.writeJson(list);

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -44,6 +44,22 @@ vi.mock(
   new URL("../../gateway/call.ts", new URL("./gateway-cli/call.ts", import.meta.url)).href,
   () => ({
     callGateway: (opts: unknown) => callGateway(opts),
+    isGatewayTransportError: (value: unknown) =>
+      value instanceof Error && value.name === "GatewayTransportError",
+    buildGatewayTransportErrorJson: (error: Error, context: Record<string, unknown>) => ({
+      ok: false,
+      error: {
+        type: "gateway_transport",
+        code: "gateway_closed",
+        message: error.message,
+        kind: "closed",
+        ...context,
+        gateway: {
+          url: "ws://127.0.0.1:18789",
+          urlSource: "local loopback",
+        },
+      },
+    }),
     randomIdempotencyKey: () => "rk_test",
   }),
 );
@@ -151,6 +167,28 @@ describe("gateway-cli coverage", () => {
     await runGatewayCommand(["gateway", "probe", "--json"]);
 
     expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("prints JSON for gateway health transport failures in JSON mode", async () => {
+    callGateway.mockRejectedValueOnce(
+      Object.assign(new Error("gateway closed (1006): no close reason"), {
+        name: "GatewayTransportError",
+        kind: "closed",
+      }),
+    );
+
+    await expectGatewayExit(["gateway", "health", "--json"]);
+
+    expect(runtimeErrors).toEqual([]);
+    expect(JSON.parse(runtimeLogs.join("\n"))).toMatchObject({
+      ok: false,
+      error: {
+        type: "gateway_transport",
+        code: "gateway_closed",
+        command: "gateway health",
+        method: "health",
+      },
+    });
   });
 
   it("registers gateway stability and routes to diagnostics RPC", async () => {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import type { HealthSummary } from "../../commands/health.js";
+import { buildGatewayTransportErrorJson, isGatewayTransportError } from "../../gateway/call.js";
 import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
 import type {
   DiagnosticStabilityBundle,
@@ -97,8 +98,22 @@ function loadDaemonStatusGatherModule() {
   return daemonStatusGatherModuleLoader.load();
 }
 
-function runGatewayCommand(action: () => Promise<void>, label?: string) {
+function runGatewayCommand(
+  action: () => Promise<void>,
+  label?: string,
+  jsonFailure?: { json?: boolean; command?: string; method?: string },
+) {
   return runCommandWithRuntime(defaultRuntime, action, (err) => {
+    if (jsonFailure?.json && isGatewayTransportError(err)) {
+      defaultRuntime.writeJson(
+        buildGatewayTransportErrorJson(err, {
+          command: jsonFailure.command,
+          method: jsonFailure.method,
+        }),
+      );
+      defaultRuntime.exit(1);
+      return;
+    }
     const message = String(err);
     defaultRuntime.error(label ? `${label}: ${message}` : message);
     defaultRuntime.exit(1);
@@ -459,30 +474,34 @@ export function registerGatewayCli(program: Command) {
       .command("health")
       .description("Fetch Gateway health")
       .action(async (opts, command) => {
-        await runGatewayCommand(async () => {
-          const rpcOpts = resolveGatewayRpcOptions(opts, command);
-          const [{ formatHealthChannelLines }, { styleHealthChannelLine }] = await Promise.all([
-            loadGatewayHealthModule(),
-            loadHealthStyleModule(),
-          ]);
-          const result = await callGatewayCli("health", rpcOpts);
-          if (rpcOpts.json) {
-            defaultRuntime.writeJson(result);
-            return;
-          }
-          const rich = isRich();
-          const obj: Record<string, unknown> = result && typeof result === "object" ? result : {};
-          const durationMs = typeof obj.durationMs === "number" ? obj.durationMs : null;
-          defaultRuntime.log(colorize(rich, theme.heading, "Gateway Health"));
-          defaultRuntime.log(
-            `${colorize(rich, theme.success, "OK")}${durationMs != null ? ` (${durationMs}ms)` : ""}`,
-          );
-          if (obj.channels && typeof obj.channels === "object") {
-            for (const line of formatHealthChannelLines(obj as HealthSummary)) {
-              defaultRuntime.log(styleHealthChannelLine(line, rich));
+        const rpcOpts = resolveGatewayRpcOptions(opts, command);
+        await runGatewayCommand(
+          async () => {
+            const [{ formatHealthChannelLines }, { styleHealthChannelLine }] = await Promise.all([
+              loadGatewayHealthModule(),
+              loadHealthStyleModule(),
+            ]);
+            const result = await callGatewayCli("health", rpcOpts);
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson(result);
+              return;
             }
-          }
-        });
+            const rich = isRich();
+            const obj: Record<string, unknown> = result && typeof result === "object" ? result : {};
+            const durationMs = typeof obj.durationMs === "number" ? obj.durationMs : null;
+            defaultRuntime.log(colorize(rich, theme.heading, "Gateway Health"));
+            defaultRuntime.log(
+              `${colorize(rich, theme.success, "OK")}${durationMs != null ? ` (${durationMs}ms)` : ""}`,
+            );
+            if (obj.channels && typeof obj.channels === "object") {
+              for (const line of formatHealthChannelLines(obj as HealthSummary)) {
+                defaultRuntime.log(styleHealthChannelLine(line, rich));
+              }
+            }
+          },
+          undefined,
+          { json: Boolean(rpcOpts.json), command: "gateway health", method: "health" },
+        );
       }),
   );
 

--- a/src/commands/health.command.coverage.test.ts
+++ b/src/commands/health.command.coverage.test.ts
@@ -21,6 +21,22 @@ vi.mock("../gateway/call.js", () => ({
     Reflect.apply(callGatewayMock, undefined, args),
   buildGatewayConnectionDetails: (...args: [unknown, ...unknown[]]) =>
     Reflect.apply(buildGatewayConnectionDetailsMock, undefined, args),
+  isGatewayTransportError: (value: unknown) =>
+    value instanceof Error && value.name === "GatewayTransportError",
+  buildGatewayTransportErrorJson: (error: Error, context: Record<string, unknown>) => ({
+    ok: false,
+    error: {
+      type: "gateway_transport",
+      code: "gateway_closed",
+      message: error.message,
+      kind: "closed",
+      ...context,
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+      },
+    },
+  }),
 }));
 
 vi.mock("../config/config.js", () => ({

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -54,6 +54,22 @@ const createHealthSummary = (params: {
 const callGatewayMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
+  isGatewayTransportError: (value: unknown) =>
+    value instanceof Error && value.name === "GatewayTransportError",
+  buildGatewayTransportErrorJson: (error: Error, context: Record<string, unknown>) => ({
+    ok: false,
+    error: {
+      type: "gateway_transport",
+      code: "gateway_closed",
+      message: error.message,
+      kind: "closed",
+      ...context,
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+      },
+    },
+  }),
 }));
 
 describe("healthCommand", () => {
@@ -95,6 +111,29 @@ describe("healthCommand", () => {
     expect(parsed.channels.whatsapp?.linked).toBe(true);
     expect(parsed.channels.telegram?.configured).toBe(true);
     expect(parsed.sessions.count).toBe(1);
+  });
+
+  it("outputs JSON transport failures when JSON mode is requested", async () => {
+    const error = Object.assign(new Error("gateway closed (1006): no close reason"), {
+      name: "GatewayTransportError",
+      kind: "closed",
+    });
+    callGatewayMock.mockRejectedValueOnce(error);
+
+    await healthCommand({ json: true, timeoutMs: 5000, config: {} }, runtime as never);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    const logged = runtime.log.mock.calls[0]?.[0] as string;
+    expect(JSON.parse(logged)).toMatchObject({
+      ok: false,
+      error: {
+        type: "gateway_transport",
+        code: "gateway_closed",
+        command: "health",
+        method: "health",
+      },
+    });
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("passes explicit gateway credentials through to the gateway call", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -13,7 +13,12 @@ import { withProgress } from "../cli/progress.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import {
+  buildGatewayConnectionDetails,
+  buildGatewayTransportErrorJson,
+  callGateway,
+  isGatewayTransportError,
+} from "../gateway/call.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
@@ -543,22 +548,35 @@ export async function healthCommand(
 ) {
   const cfg = opts.config ?? (await readBestEffortHealthConfig());
   // Always query the running gateway; do not open a direct Baileys socket here.
-  const summary = await withProgress(
-    {
-      label: "Checking gateway health…",
-      indeterminate: true,
-      enabled: opts.json !== true,
-    },
-    async () =>
-      await callGateway<HealthSummary>({
-        method: "health",
-        params: opts.verbose ? { probe: true } : undefined,
-        timeoutMs: opts.timeoutMs,
-        config: cfg,
-        token: opts.token,
-        password: opts.password,
-      }),
-  );
+  let summary: HealthSummary;
+  try {
+    summary = await withProgress(
+      {
+        label: "Checking gateway health…",
+        indeterminate: true,
+        enabled: opts.json !== true,
+      },
+      async () =>
+        await callGateway<HealthSummary>({
+          method: "health",
+          params: opts.verbose ? { probe: true } : undefined,
+          timeoutMs: opts.timeoutMs,
+          config: cfg,
+          token: opts.token,
+          password: opts.password,
+        }),
+    );
+  } catch (error) {
+    if (opts.json && isGatewayTransportError(error)) {
+      writeRuntimeJson(
+        runtime,
+        buildGatewayTransportErrorJson(error, { command: "health", method: "health" }),
+      );
+      runtime.exit(1);
+      return;
+    }
+    throw error;
+  }
   // Gateway reachability defines success; channel issues are reported but not fatal here.
   const fatal = false;
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -134,6 +134,7 @@ vi.mock("./event-loop-ready.js", () => ({
 const {
   __testing,
   buildGatewayConnectionDetails,
+  buildGatewayTransportErrorJson,
   callGateway,
   callGatewayCli,
   callGatewayScoped,
@@ -873,6 +874,46 @@ describe("callGateway error details", () => {
     });
   });
 
+  it("builds a structured JSON payload for gateway close failures", async () => {
+    startMode = "close";
+    closeCode = 1006;
+    closeReason = "";
+    setLocalLoopbackGatewayConfig();
+
+    let err: unknown;
+    try {
+      await callGateway({ method: "health" });
+    } catch (caught) {
+      err = caught;
+    }
+
+    expect(isGatewayTransportError(err)).toBe(true);
+    if (!isGatewayTransportError(err)) {
+      throw new Error("expected GatewayTransportError");
+    }
+    expect(
+      buildGatewayTransportErrorJson(err, {
+        command: "health",
+        method: "health",
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: {
+        type: "gateway_transport",
+        code: "gateway_closed",
+        kind: "closed",
+        command: "health",
+        method: "health",
+        closeCode: 1006,
+        reason: "no close reason",
+        gateway: {
+          url: "ws://127.0.0.1:18789",
+          urlSource: "local loopback",
+        },
+      },
+    });
+  });
+
   it("keeps the request alive through internally retried startup-unavailable handshakes", async () => {
     startMode = "startup-retry-then-hello";
     setLocalLoopbackGatewayConfig();
@@ -919,6 +960,38 @@ describe("callGateway error details", () => {
       name: "GatewayTransportError",
       kind: "timeout",
       timeoutMs: 5,
+    });
+  });
+
+  it("builds a structured JSON payload for gateway timeout failures", async () => {
+    startMode = "silent";
+    setLocalLoopbackGatewayConfig();
+
+    vi.useFakeTimers();
+    let err: unknown;
+    const promise = callGateway({ method: "health", timeoutMs: 5 }).catch((caught) => {
+      err = caught;
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    await promise;
+
+    expect(isGatewayTransportError(err)).toBe(true);
+    if (!isGatewayTransportError(err)) {
+      throw new Error("expected GatewayTransportError");
+    }
+    expect(buildGatewayTransportErrorJson(err)).toMatchObject({
+      ok: false,
+      error: {
+        type: "gateway_transport",
+        code: "gateway_timeout",
+        kind: "timeout",
+        timeoutMs: 5,
+        gateway: {
+          url: "ws://127.0.0.1:18789",
+          urlSource: "local loopback",
+        },
+      },
     });
   });
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -131,6 +131,60 @@ export function isGatewayTransportError(value: unknown): value is GatewayTranspo
   );
 }
 
+export type GatewayTransportErrorJson = {
+  ok: false;
+  error: {
+    type: "gateway_transport";
+    code: "gateway_closed" | "gateway_timeout";
+    message: string;
+    kind: GatewayTransportErrorKind;
+    command?: string;
+    method?: string;
+    closeCode?: number;
+    reason?: string;
+    timeoutMs?: number;
+    gateway: {
+      url: string;
+      urlSource: string;
+      message?: string;
+    };
+  };
+};
+
+function gatewayTransportErrorCode(
+  error: GatewayTransportError,
+): GatewayTransportErrorJson["error"]["code"] {
+  return error.kind === "timeout" ? "gateway_timeout" : "gateway_closed";
+}
+
+export function buildGatewayTransportErrorJson(
+  error: GatewayTransportError,
+  context: {
+    command?: string;
+    method?: string;
+  } = {},
+): GatewayTransportErrorJson {
+  return {
+    ok: false,
+    error: {
+      type: "gateway_transport",
+      code: gatewayTransportErrorCode(error),
+      message: error.message,
+      kind: error.kind,
+      ...(context.command ? { command: context.command } : {}),
+      ...(context.method ? { method: context.method } : {}),
+      ...(typeof error.code === "number" ? { closeCode: error.code } : {}),
+      ...(typeof error.reason === "string" ? { reason: error.reason } : {}),
+      ...(typeof error.timeoutMs === "number" ? { timeoutMs: error.timeoutMs } : {}),
+      gateway: {
+        url: error.connectionDetails.url,
+        urlSource: error.connectionDetails.urlSource,
+        ...(error.connectionDetails.message ? { message: error.connectionDetails.message } : {}),
+      },
+    },
+  };
+}
+
 const defaultCreateGatewayClient = (opts: GatewayClientOptions) => new GatewayClient(opts);
 const defaultGatewayCallDeps = {
   createGatewayClient: defaultCreateGatewayClient,


### PR DESCRIPTION
## Summary

- add a shared JSON envelope for typed `GatewayTransportError` close/timeout failures
- emit that envelope for `health --json`, `gateway health --json`, and `devices list --json`
- preserve the existing human stderr/exit behavior for non-JSON command mode

Fixes #79108.

## Real behavior proof

Behavior or issue addressed: Gateway-backed JSON commands should print a structured JSON error envelope when the gateway connection closes or times out, instead of exiting with no JSON body.

Real environment tested: Patched OpenClaw source checkout at `/tmp/openclaw-79108`, built through `node scripts/run-node.mjs`, then run with Node against an isolated state/config path: `OPENCLAW_STATE_DIR=/tmp/openclaw-79108-proof-state OPENCLAW_CONFIG_PATH=/tmp/openclaw-79108-proof-state/openclaw.json`. The target `ws://127.0.0.1:9` had no gateway listening, so this exercises the live connection-failure path.

Exact steps or command run after this patch:

- `OPENCLAW_GATEWAY_URL=ws://127.0.0.1:9 OPENCLAW_GATEWAY_TOKEN=proof-token node openclaw.mjs health --json --timeout 200`
- `node openclaw.mjs gateway health --url ws://127.0.0.1:9 --token proof-token --timeout 200 --json`
- `node openclaw.mjs devices list --url ws://127.0.0.1:9 --token proof-token --timeout 200 --json`

Evidence after fix: Copied live stdout from the first command:

```json
{
  "ok": false,
  "error": {
    "type": "gateway_transport",
    "code": "gateway_closed",
    "kind": "closed",
    "command": "health",
    "method": "health",
    "closeCode": 1006,
    "reason": "no close reason",
    "gateway": {
      "url": "ws://127.0.0.1:9",
      "urlSource": "env OPENCLAW_GATEWAY_URL"
    }
  }
}
```

The `gateway health` run exited 1 and printed the same JSON envelope with `command: "gateway health"`, `method: "health"`, and `gateway.urlSource: "cli --url"`. The `devices list` run exited 1 and printed the same JSON envelope with `command: "devices list"`, `method: "device.pair.list"`, and `gateway.urlSource: "cli --url"`.

Observed result after fix: All three commands emitted JSON on stdout with `ok: false`, `error.type: "gateway_transport"`, a stable `gateway_closed` code, command/method context, and gateway URL/source details before exiting 1.

What was not tested: None.

## Validation

- `pnpm test src/gateway/call.test.ts src/cli/gateway-cli.coverage.test.ts src/commands/health.test.ts src/commands/health.command.coverage.test.ts src/cli/devices-cli.test.ts src/cli/program/register.status-health-sessions.test.ts --pool=forks --maxWorkers=1`
- `pnpm exec oxfmt --check --threads=1 src/gateway/call.ts src/gateway/call.test.ts src/cli/gateway-cli/register.ts src/cli/gateway-cli.coverage.test.ts src/cli/devices-cli.ts src/cli/devices-cli.test.ts src/commands/health.ts src/commands/health.test.ts src/commands/health.command.coverage.test.ts src/cli/program/register.status-health-sessions.test.ts`
- `git diff --check`
- `pnpm check:changed -- --base upstream/main --head HEAD`
