### PR TITLE
fix(gateway): accept Paperclip agent metadata

### DIFF
--- a/src/gateway/protocol/agent.schema.test.ts
+++ b/src/gateway/protocol/agent.schema.test.ts
@@ -1,0 +1,40 @@
+import AjvPkg from "ajv";
+import { describe, expect, it } from "vitest";
+import { AgentParamsSchema } from "./schema/agent.js";
+
+const Ajv = AjvPkg as unknown as new (opts?: object) => import("ajv").default;
+
+describe("AgentParamsSchema", () => {
+  const validate = new Ajv({ allErrors: true, strict: false }).compile(AgentParamsSchema);
+
+  it("accepts opaque Paperclip adapter metadata on agent calls", () => {
+    expect(
+      validate({
+        message: "Paperclip wake event for a cloud adapter.",
+        sessionKey: "paperclip",
+        idempotencyKey: "run-123",
+        paperclip: {
+          runId: "run-123",
+          companyId: "company-123",
+          agentId: "agent-123",
+          wakeReason: "retry_failed_run",
+          issueIds: ["issue-123"],
+          workspace: {
+            cwd: "/paperclip/instances/default/workspaces/agent-123",
+            source: "agent_home",
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("continues rejecting unrelated top-level properties", () => {
+    expect(
+      validate({
+        message: "hello",
+        idempotencyKey: "run-123",
+        unexpected: { source: "integration" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -172,6 +172,11 @@ export const AgentParamsSchema = Type.Object(
     internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
     inputProvenance: Type.Optional(InputProvenanceSchema),
     voiceWakeTrigger: Type.Optional(Type.String()),
+    // Opaque metadata from Paperclip cloud adapters. The Gateway accepts this
+    // field for forward-compatible integrations but does not interpret it in
+    // the core agent handler; callers should continue to include any user-visible
+    // run context in `message`.
+    paperclip: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
   },


### PR DESCRIPTION
## Summary
- allow Gateway `agent` calls to include optional opaque `paperclip` metadata
- keep strict validation for unrelated top-level fields
- add schema coverage for Paperclip metadata acceptance and unknown-field rejection

## Context
Paperclip cloud adapters can attach structured run metadata alongside the agent message. Current Gateway validation rejects the request before the agent handler runs:

```
invalid agent params: at root: unexpected property 'paperclip'
```

This change makes the field forward-compatible while leaving interpretation to the external adapter/caller. User-visible run context should still be included in `message`; the Gateway only accepts this as opaque metadata.

## Validation
- `pnpm install --frozen-lockfile`
- `node --import tsx - <<'TS' ...` lightweight AJV compile/validation smoke
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-client.config.ts src/gateway/protocol/agent.schema.test.ts`
- `pnpm exec oxfmt --check src/gateway/protocol/schema/agent.ts src/gateway/protocol/agent.schema.test.ts`
- `pnpm exec oxlint src/gateway/protocol/schema/agent.ts src/gateway/protocol/agent.schema.test.ts`

Note: an initial direct `pnpm exec vitest run ...` attempt was SIGKILLed in this constrained environment after triggering a heavier transform path; the targeted gateway-client config passed cleanly.
