### PR TITLE
fix: tune diagnostic liveness and idle queue depth

### DIFF
--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -31,6 +31,7 @@ import {
   logSessionStateChange,
   logMessageQueued,
   diagnosticLogger,
+  hasDiagnosticEventLoopDelayWarningForTest,
   markDiagnosticSessionProgress,
   resetDiagnosticStateForTest,
   resolveStuckSessionAbortMs,
@@ -139,6 +140,21 @@ describe("diagnostic session state pruning", () => {
 
     expect(getDiagnosticSessionState({ sessionKey }).queueDepth).toBe(0);
     expect(getDiagnosticSessionStateCountForTest()).toBe(1);
+  });
+
+  it("clears queued work when a session becomes idle", () => {
+    logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+    logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+
+    expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(
+      2,
+    );
+
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+    expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(
+      0,
+    );
   });
 });
 
@@ -981,6 +997,24 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("ignores transient event-loop max spikes below the max-spike threshold", () => {
+    expect(
+      hasDiagnosticEventLoopDelayWarningForTest({
+        eventLoopDelayP99Ms: 21,
+        eventLoopDelayMaxMs: 1_500,
+      }),
+    ).toBe(false);
+  });
+
+  it("warns for transient event-loop max spikes above the max-spike threshold", () => {
+    expect(
+      hasDiagnosticEventLoopDelayWarningForTest({
+        eventLoopDelayP99Ms: 21,
+        eventLoopDelayMaxMs: 10_500,
+      }),
+    ).toBe(true);
+  });
+
   it("does not let idle liveness samples suppress later active-work warnings", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
@@ -1008,6 +1042,15 @@ describe("stuck session diagnostics threshold", () => {
     vi.advanceTimersByTime(30_000);
 
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("liveness warning:"));
+  });
+
+  it("warns for sustained P99 event-loop delay below the max-spike threshold", () => {
+    expect(
+      hasDiagnosticEventLoopDelayWarningForTest({
+        eventLoopDelayP99Ms: 1_500,
+        eventLoopDelayMaxMs: 1_500,
+      }),
+    ).toBe(true);
   });
 
   it("throttles repeated liveness warnings", () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -77,6 +77,7 @@ const MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 10 * 60_000;
 const STALLED_EMBEDDED_RUN_ABORT_WARN_MULTIPLIER = 5;
 const RECENT_DIAGNOSTIC_ACTIVITY_MS = 120_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
+const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_MAX_WARN_MS = 10_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN = 0.95;
 const DEFAULT_LIVENESS_CPU_CORE_RATIO_WARN = 0.9;
 const DEFAULT_LIVENESS_WARN_COOLDOWN_MS = 120_000;
@@ -233,6 +234,16 @@ function formatOptionalDiagnosticMetric(value: number | undefined): string {
   return value === undefined ? "unknown" : String(value);
 }
 
+function hasDiagnosticEventLoopDelayWarning(params: {
+  eventLoopDelayP99Ms: number;
+  eventLoopDelayMaxMs: number;
+}): boolean {
+  return (
+    params.eventLoopDelayP99Ms >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS ||
+    params.eventLoopDelayMaxMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_MAX_WARN_MS
+  );
+}
+
 function startDiagnosticLivenessSampler(): void {
   lastDiagnosticLivenessWallAt = Date.now();
   lastDiagnosticLivenessCpuUsage = process.cpuUsage();
@@ -297,10 +308,7 @@ function sampleDiagnosticLiveness(now: number): DiagnosticLivenessSample | null 
   const eventLoopUtilizationRatio = roundDiagnosticMetric(eventLoopUtilization, 3);
   const reasons: DiagnosticLivenessWarningReason[] = [];
 
-  if (
-    eventLoopDelayP99Ms >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS ||
-    eventLoopDelayMaxMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS
-  ) {
+  if (hasDiagnosticEventLoopDelayWarning({ eventLoopDelayP99Ms, eventLoopDelayMaxMs })) {
     reasons.push("event_loop_delay");
   }
   if (eventLoopUtilizationRatio >= DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN) {
@@ -642,7 +650,7 @@ export function logSessionStateChange(
   state.lastStuckWarnAgeMs = undefined;
   state.lastLongRunningWarnAgeMs = undefined;
   if (params.state === "idle") {
-    state.queueDepth = Math.max(0, state.queueDepth - 1);
+    state.queueDepth = 0;
   }
   if (!isProbeSession && diag.isEnabled("debug")) {
     diag.debug(
@@ -1060,6 +1068,13 @@ export function stopDiagnosticHeartbeat() {
 
 export function getDiagnosticSessionStateCountForTest(): number {
   return getDiagnosticSessionStateCountForTestImpl();
+}
+
+export function hasDiagnosticEventLoopDelayWarningForTest(params: {
+  eventLoopDelayP99Ms: number;
+  eventLoopDelayMaxMs: number;
+}): boolean {
+  return hasDiagnosticEventLoopDelayWarning(params);
 }
 
 export function resetDiagnosticStateForTest(): void {


### PR DESCRIPTION
## Summary
- add a separate 10s max event-loop delay threshold while keeping sustained P99 delay warnings at 1s
- clear diagnostic session `queueDepth` immediately when a session transitions to idle
- add focused regression coverage for both diagnostic behaviors

## Why
The diagnostic liveness sampler currently treats transient max event-loop spikes the same as sustained P99 delay. That makes short, isolated spikes noisy even when P99 remains healthy. The queue-depth tracker also decrements by one on idle, which can leave stale queued work visible after a session has completed.

## Real behavior proof
- **Behavior or issue addressed:** Diagnostic liveness warnings should not treat a transient max event-loop spike the same as sustained P99 delay, and completed/idle sessions should not retain stale queued work.
- **Real environment tested:** Local Windows OpenClaw Gateway install on `Zephyrus`, OpenClaw `2026.5.7 (eeef486)`, running as the active Telegram/Gateway setup.
- **Exact steps or command run after this patch:** Verified the active installed diagnostic bundle in the real local OpenClaw installation after applying the equivalent diagnostic change locally:
  - `openclaw --version`
  - `openclaw status --json`
  - `Select-String` against `C:\Users\kl_aj\AppData\Roaming\npm\node_modules\openclaw\dist\diagnostic-DbrcADVi.js` for `DEFAULT_LIVENESS_EVENT_LOOP_DELAY_MAX_WARN_MS`, the event-loop delay condition, and idle queue-depth handling.
- **Evidence after fix:** Copied live terminal output from the local OpenClaw setup:

```text
OpenClaw 2026.5.7 (eeef486)

openclaw status --json excerpt:
{
  "runtimeVersion": "2026.5.7",
  "tasks": {
    "total": 253,
    "active": 0,
    "terminal": 253,
    "failures": 0
  },
  "sessions": {
    "count": 27,
    "defaults": {
      "model": "gpt-5.5",
      "contextTokens": 200000
    }
  }
}

Select-String live output from active installed bundle:
file=C:\Users\kl_aj\AppData\Roaming\npm\node_modules\openclaw\dist\diagnostic-DbrcADVi.js
489:const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_MAX_WARN_MS = 10e3;
619:if (eventLoopDelayP99Ms >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS || eventLoopDelayMaxMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_MAX_WARN_MS) reasons.push("event_loop_delay");
788:if (params.state === "idle") state.queueDepth = 0;
```

- **Observed result after fix:** The active real OpenClaw install contains the separate 10s max-delay threshold and clears `queueDepth` to `0` immediately on idle. The gateway/status command still responds from the local runtime after the diagnostic change is present.
- **What was not tested:** I did not force a real production 10s event-loop stall; the threshold behavior is additionally covered by focused tests in this PR.

## Test plan
- `pnpm exec vitest run --config test/vitest/vitest.logging.config.ts src/logging/diagnostic.test.ts` — 38 passed
- `pnpm exec vitest run --config test/vitest/vitest.logging.config.ts src/logging/diagnostic.test.ts --testNamePattern "clears queued work|ignores transient event-loop max spikes|warns for transient event-loop max spikes above|warns for sustained P99"` — 4 passed
- `pnpm exec oxlint src/logging/diagnostic.ts src/logging/diagnostic.test.ts` — 0 warnings, 0 errors
- `$env:NODE_OPTIONS='--max-old-space-size=8192'; pnpm exec tsc --noEmit --pretty false -p tsconfig.core.json` — passed

Note: a full `pnpm exec tsc --noEmit --pretty false --skipLibCheck false -p tsconfig.json` run hit Node heap OOM locally before the narrower core typecheck passed with an 8GB heap.
