### PR TITLE
docs: align memorySearch embedding-cache default with runtime (#78953)

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -408,7 +408,7 @@ Supported formats: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`, `.heic`, `.heif` (i
 
 | Key                | Type      | Default | Description                      |
 | ------------------ | --------- | ------- | -------------------------------- |
-| `cache.enabled`    | `boolean` | `false` | Cache chunk embeddings in SQLite |
+| `cache.enabled`    | `boolean` | `true`  | Cache chunk embeddings in SQLite |
 | `cache.maxEntries` | `number`  | `50000` | Max cached embeddings            |
 
 Prevents re-embedding unchanged text during reindex or transcript updates.

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -115,6 +115,7 @@ const DEFAULT_MMR_ENABLED = false;
 const DEFAULT_MMR_LAMBDA = 0.7;
 const DEFAULT_TEMPORAL_DECAY_ENABLED = false;
 const DEFAULT_TEMPORAL_DECAY_HALF_LIFE_DAYS = 30;
+// Default true — see docs/reference/memory-config.md (Embedding cache).
 const DEFAULT_CACHE_ENABLED = true;
 const DEFAULT_SOURCES: Array<"memory" | "sessions"> = ["memory"];
 


### PR DESCRIPTION
Closes #78953

## Summary

`docs/reference/memory-config.md` listed `cache.enabled` default as `false`, but the runtime, schema help, and config type docs all resolve/state `true`. This updates the docs table to match the runtime and adds a one-line cross-reference comment at the runtime constant.

## Real behavior proof

- **Behavior addressed:** `memorySearch.cache.enabled` documented default in the reference table disagreed with the runtime, which resolves it to `true` when unset.
- **Real environment tested:** installed `openclaw` runtime, version `2026.5.22 (a374c3a)`, Node v25.9.0, macOS arm64.
- **Exact steps or command run after the patch:** loaded the published resolver `resolveMemorySearchConfig` from the installed package bundle (`dist/memory-search-*.js`) and resolved a config with the cache left unset, then again with an explicit override, via `node`.
- **Evidence after fix:** live console output below.

```
$ node ./memorysearch-cache-default-proof.mjs
bundle: memory-search-BEQRq9yG.js
empty config            -> cache.enabled = true
override cache.enabled=false -> cache.enabled = false
```

- **Observed result after fix:** with no cache configuration anywhere, the resolver returns `cache.enabled = true`; an explicit `cache.enabled: false` is honored. This matches the runtime constant `DEFAULT_CACHE_ENABLED = true` (`src/agents/memory-search.ts:119`) and its use in resolution (`src/agents/memory-search.ts:315`). The schema help and the `types.tools.ts` JSDoc already state `true`. The table value of `false` was the only stale source.
- **What was not tested:** none beyond the cache default-resolution path; the patch is docs plus one source comment and changes no runtime behavior.

## Note: superseded by main

The docs table row this PR targets has already been corrected to `true` on `main` by commit `884aa1b` ("docs: align memory search cache default", 2026-05-22). The documentation hunk here is therefore redundant; the only remaining delta over `main` is the one-line cross-reference comment beside `DEFAULT_CACHE_ENABLED`. This PR can be closed as superseded by `884aa1b` (duplicate #78966 covers the same row), or reduced to just the source comment if that line is worth keeping. Deferring to maintainers on consolidation.
