### PR TITLE
fix(update): honor npm registry config in update checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Control UI: read the Quick Settings exec policy badge from `tools.exec.security` instead of the non-schema `agents.defaults.exec.security` path, so configured `full`/`deny` values render accurately. Fixes #78311. Thanks @FriedBack.
 - Control UI/usage: add transcript-backed historical lineage rollups for rotated logical sessions, with current-instance vs historical-lineage scope controls and long-range presets so usage history stays visible after restarts and updates. Fixes #50701. Thanks @dev-gideon-llc and @BunsDev.
+- Update check: respect npm registry mirror config when fetching OpenClaw package target metadata, falling back to the public registry only when no valid npm registry is configured. (#79140) Thanks @sixerLiu.
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
 - Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/title/details, show web-search queries from provider-native argument shapes, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.

--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   channelToNpmTag,
   formatUpdateChannelLabel,
@@ -7,7 +10,9 @@ import {
   normalizeUpdateChannel,
   resolveEffectiveUpdateChannel,
   resolveNpmPackageTargetRegistryUrl,
+  resolveNpmPackageTargetRegistryUrlAsync,
   resolveNpmRegistryBaseUrl,
+  resolveNpmRegistryBaseUrlAsync,
   resolveRegistryUpdateChannel,
   resolveUpdateChannelDisplay,
   type UpdateChannel,
@@ -78,19 +83,13 @@ describe("npm registry url resolution", () => {
     ).toBe("https://registry.npmmirror.com/openclaw/latest");
   });
 
-  it("falls back to uppercase and userconfig registry env vars", () => {
+  it("falls back to uppercase NPM_CONFIG_REGISTRY env var", () => {
     expect(
       resolveNpmPackageTargetRegistryUrl({
         target: "beta",
         env: { NPM_CONFIG_REGISTRY: "https://mirror.example/npm/" },
       }),
     ).toBe("https://mirror.example/npm/openclaw/beta");
-    expect(
-      resolveNpmPackageTargetRegistryUrl({
-        target: "dev",
-        env: { npm_config_userconfig_registry: "http://127.0.0.1:4873/" },
-      }),
-    ).toBe("http://127.0.0.1:4873/openclaw/dev");
   });
 
   it("ignores invalid registry values", () => {
@@ -100,6 +99,68 @@ describe("npm registry url resolution", () => {
         env: { npm_config_registry: "file:///tmp/registry" },
       }),
     ).toBe("https://registry.npmjs.org/openclaw/latest");
+  });
+});
+
+describe("npm registry url resolution — async npmrc", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-npmrc-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads registry from npm_config_userconfig npmrc file", async () => {
+    const npmrcPath = path.join(tmpDir, ".npmrc");
+    await fs.writeFile(npmrcPath, "registry=https://verdaccio.example.com/\n", "utf8");
+    const result = await resolveNpmRegistryBaseUrlAsync({
+      npm_config_userconfig: npmrcPath,
+    });
+    expect(result).toBe("https://verdaccio.example.com");
+  });
+
+  it("reads registry from NPM_CONFIG_USERCONFIG npmrc file", async () => {
+    const npmrcPath = path.join(tmpDir, ".npmrc");
+    await fs.writeFile(npmrcPath, "# comment\nregistry=http://nexus.corp/npm/\n", "utf8");
+    const result = await resolveNpmRegistryBaseUrlAsync({
+      NPM_CONFIG_USERCONFIG: npmrcPath,
+    });
+    expect(result).toBe("http://nexus.corp/npm");
+  });
+
+  it("env var registry takes precedence over npmrc file", async () => {
+    const npmrcPath = path.join(tmpDir, ".npmrc");
+    await fs.writeFile(npmrcPath, "registry=https://npmrc.example.com/\n", "utf8");
+    const result = await resolveNpmRegistryBaseUrlAsync({
+      npm_config_registry: "https://envvar.example.com/",
+      npm_config_userconfig: npmrcPath,
+    });
+    expect(result).toBe("https://envvar.example.com");
+  });
+
+  it("falls back to default when npmrc missing or has no registry key", async () => {
+    const result = await resolveNpmRegistryBaseUrlAsync({
+      npm_config_userconfig: path.join(tmpDir, "nonexistent.npmrc"),
+    });
+    expect(result).toBe("https://registry.npmjs.org");
+
+    const npmrcPath = path.join(tmpDir, ".npmrc");
+    await fs.writeFile(npmrcPath, "cache=/tmp/.npm\n", "utf8");
+    const result2 = await resolveNpmRegistryBaseUrlAsync({ npm_config_userconfig: npmrcPath });
+    expect(result2).toBe("https://registry.npmjs.org");
+  });
+
+  it("resolveNpmPackageTargetRegistryUrlAsync uses npmrc registry", async () => {
+    const npmrcPath = path.join(tmpDir, ".npmrc");
+    await fs.writeFile(npmrcPath, "registry=https://artifactory.corp/npm/\n", "utf8");
+    const url = await resolveNpmPackageTargetRegistryUrlAsync({
+      target: "latest",
+      env: { npm_config_userconfig: npmrcPath },
+    });
+    expect(url).toBe("https://artifactory.corp/npm/openclaw/latest");
   });
 });
 

--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -6,6 +6,8 @@ import {
   isStableTag,
   normalizeUpdateChannel,
   resolveEffectiveUpdateChannel,
+  resolveNpmPackageTargetRegistryUrl,
+  resolveNpmRegistryBaseUrl,
   resolveRegistryUpdateChannel,
   resolveUpdateChannelDisplay,
   type UpdateChannel,
@@ -54,6 +56,51 @@ describe("channelToNpmTag", () => {
       expect(channelToNpmTag(channel)).toBe(expected);
     },
   );
+});
+
+describe("npm registry url resolution", () => {
+  it("defaults to the public npm registry", () => {
+    expect(resolveNpmRegistryBaseUrl({})).toBe("https://registry.npmjs.org");
+    expect(resolveNpmPackageTargetRegistryUrl({ target: "latest", env: {} })).toBe(
+      "https://registry.npmjs.org/openclaw/latest",
+    );
+  });
+
+  it("prefers npm_config_registry and trims trailing slashes", () => {
+    expect(
+      resolveNpmPackageTargetRegistryUrl({
+        target: "latest",
+        env: {
+          npm_config_registry: " https://registry.npmmirror.com// ",
+          NPM_CONFIG_REGISTRY: "https://registry.npmjs.org/",
+        },
+      }),
+    ).toBe("https://registry.npmmirror.com/openclaw/latest");
+  });
+
+  it("falls back to uppercase and userconfig registry env vars", () => {
+    expect(
+      resolveNpmPackageTargetRegistryUrl({
+        target: "beta",
+        env: { NPM_CONFIG_REGISTRY: "https://mirror.example/npm/" },
+      }),
+    ).toBe("https://mirror.example/npm/openclaw/beta");
+    expect(
+      resolveNpmPackageTargetRegistryUrl({
+        target: "dev",
+        env: { npm_config_userconfig_registry: "http://127.0.0.1:4873/" },
+      }),
+    ).toBe("http://127.0.0.1:4873/openclaw/dev");
+  });
+
+  it("ignores invalid registry values", () => {
+    expect(
+      resolveNpmPackageTargetRegistryUrl({
+        target: "latest",
+        env: { npm_config_registry: "file:///tmp/registry" },
+      }),
+    ).toBe("https://registry.npmjs.org/openclaw/latest");
+  });
 });
 
 describe("resolveEffectiveUpdateChannel", () => {

--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   channelToNpmTag,
   formatUpdateChannelLabel,

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -16,11 +19,7 @@ export const DEFAULT_GIT_CHANNEL: UpdateChannel = "dev";
 export const DEV_BRANCH = "main";
 export const DEFAULT_NPM_REGISTRY_URL = "https://registry.npmjs.org";
 
-const NPM_REGISTRY_ENV_KEYS = [
-  "npm_config_registry",
-  "NPM_CONFIG_REGISTRY",
-  "npm_config_userconfig_registry",
-] as const;
+const NPM_REGISTRY_ENV_KEYS = ["npm_config_registry", "NPM_CONFIG_REGISTRY"] as const;
 
 function normalizeNpmRegistryBaseUrl(value: string): string | null {
   try {
@@ -34,16 +33,58 @@ function normalizeNpmRegistryBaseUrl(value: string): string | null {
   }
 }
 
+function parseNpmrcRegistry(content: string): string | null {
+  for (const line of content.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#") || trimmed.startsWith(";")) {
+      continue;
+    }
+    const match = /^registry\s*=\s*(.+)$/u.exec(trimmed);
+    if (match) {
+      return normalizeNpmRegistryBaseUrl(match[1]?.trim() ?? "");
+    }
+  }
+  return null;
+}
+
+async function readNpmrcRegistryFromFile(filePath: string): Promise<string | null> {
+  try {
+    const content = await fs.readFile(filePath, "utf8");
+    return parseNpmrcRegistry(content);
+  } catch {
+    return null;
+  }
+}
+
 export function resolveNpmRegistryBaseUrl(
   env: Partial<Record<(typeof NPM_REGISTRY_ENV_KEYS)[number], string | undefined>> = process.env,
 ): string {
   const configured =
     normalizeOptionalString(env.npm_config_registry) ??
-    normalizeOptionalString(env.NPM_CONFIG_REGISTRY) ??
-    normalizeOptionalString(env.npm_config_userconfig_registry);
+    normalizeOptionalString(env.NPM_CONFIG_REGISTRY);
   return (
     normalizeNpmRegistryBaseUrl(configured ?? DEFAULT_NPM_REGISTRY_URL) ?? DEFAULT_NPM_REGISTRY_URL
   );
+}
+
+export async function resolveNpmRegistryBaseUrlAsync(
+  env: Partial<
+    Record<
+      (typeof NPM_REGISTRY_ENV_KEYS)[number] | "npm_config_userconfig" | "NPM_CONFIG_USERCONFIG",
+      string | undefined
+    >
+  > = process.env,
+): Promise<string> {
+  const fromEnv = resolveNpmRegistryBaseUrl(env);
+  if (fromEnv !== DEFAULT_NPM_REGISTRY_URL) {
+    return fromEnv;
+  }
+  const userconfig =
+    normalizeOptionalString(env.npm_config_userconfig) ??
+    normalizeOptionalString(env.NPM_CONFIG_USERCONFIG);
+  const npmrcPath = userconfig ?? path.join(os.homedir(), ".npmrc");
+  const fromFile = await readNpmrcRegistryFromFile(npmrcPath);
+  return fromFile ?? DEFAULT_NPM_REGISTRY_URL;
 }
 
 export function resolveNpmPackageTargetRegistryUrl(params: {
@@ -55,6 +96,19 @@ export function resolveNpmPackageTargetRegistryUrl(params: {
   const registryBaseUrl =
     (params.registryBaseUrl ? normalizeNpmRegistryBaseUrl(params.registryBaseUrl) : null) ??
     resolveNpmRegistryBaseUrl(params.env);
+  const packageName = params.packageName ?? "openclaw";
+  return `${registryBaseUrl}/${encodeURIComponent(packageName)}/${encodeURIComponent(params.target)}`;
+}
+
+export async function resolveNpmPackageTargetRegistryUrlAsync(params: {
+  packageName?: string;
+  target: string;
+  registryBaseUrl?: string;
+  env?: Parameters<typeof resolveNpmRegistryBaseUrlAsync>[0];
+}): Promise<string> {
+  const registryBaseUrl =
+    (params.registryBaseUrl ? normalizeNpmRegistryBaseUrl(params.registryBaseUrl) : null) ??
+    (await resolveNpmRegistryBaseUrlAsync(params.env));
   const packageName = params.packageName ?? "openclaw";
   return `${registryBaseUrl}/${encodeURIComponent(packageName)}/${encodeURIComponent(params.target)}`;
 }

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -1,4 +1,7 @@
-import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 
 export type UpdateChannel = "stable" | "beta" | "dev";
 export type UpdateChannelSource =
@@ -11,6 +14,50 @@ export type UpdateChannelSource =
 export const DEFAULT_PACKAGE_CHANNEL: UpdateChannel = "stable";
 export const DEFAULT_GIT_CHANNEL: UpdateChannel = "dev";
 export const DEV_BRANCH = "main";
+export const DEFAULT_NPM_REGISTRY_URL = "https://registry.npmjs.org";
+
+const NPM_REGISTRY_ENV_KEYS = [
+  "npm_config_registry",
+  "NPM_CONFIG_REGISTRY",
+  "npm_config_userconfig_registry",
+] as const;
+
+function normalizeNpmRegistryBaseUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    return url.toString().replace(/\/+$/u, "");
+  } catch {
+    return null;
+  }
+}
+
+export function resolveNpmRegistryBaseUrl(
+  env: Partial<Record<(typeof NPM_REGISTRY_ENV_KEYS)[number], string | undefined>> = process.env,
+): string {
+  const configured =
+    normalizeOptionalString(env.npm_config_registry) ??
+    normalizeOptionalString(env.NPM_CONFIG_REGISTRY) ??
+    normalizeOptionalString(env.npm_config_userconfig_registry);
+  return (
+    normalizeNpmRegistryBaseUrl(configured ?? DEFAULT_NPM_REGISTRY_URL) ?? DEFAULT_NPM_REGISTRY_URL
+  );
+}
+
+export function resolveNpmPackageTargetRegistryUrl(params: {
+  packageName?: string;
+  target: string;
+  registryBaseUrl?: string;
+  env?: Parameters<typeof resolveNpmRegistryBaseUrl>[0];
+}): string {
+  const registryBaseUrl =
+    (params.registryBaseUrl ? normalizeNpmRegistryBaseUrl(params.registryBaseUrl) : null) ??
+    resolveNpmRegistryBaseUrl(params.env);
+  const packageName = params.packageName ?? "openclaw";
+  return `${registryBaseUrl}/${encodeURIComponent(packageName)}/${encodeURIComponent(params.target)}`;
+}
 
 export function normalizeUpdateChannel(value?: string | null): UpdateChannel | null {
   const normalized = normalizeOptionalLowercaseString(value);

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -67,6 +67,7 @@ describe("resolveNpmChannelTag", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("falls back to latest when beta is older", async () => {
@@ -140,6 +141,22 @@ describe("resolveNpmChannelTag", () => {
       version: null,
       error: "HTTP 404",
     });
+  });
+
+  it("uses npm registry config when fetching package target metadata", async () => {
+    vi.stubEnv("npm_config_registry", "https://registry.npmmirror.com/");
+    versionByTag.latest = "1.0.6";
+
+    await expect(
+      fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 }),
+    ).resolves.toMatchObject({
+      target: "latest",
+      version: "1.0.6",
+    });
+
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe(
+      "https://registry.npmmirror.com/openclaw/latest",
+    );
   });
 });
 

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -7,7 +7,7 @@ import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 import {
   channelToNpmTag,
-  resolveNpmPackageTargetRegistryUrl,
+  resolveNpmPackageTargetRegistryUrlAsync,
   type UpdateChannel,
 } from "./update-channels.js";
 
@@ -329,11 +329,8 @@ export async function fetchNpmPackageTargetStatus(params: {
   const timeoutMs = params.timeoutMs ?? 3500;
   const target = params.target;
   try {
-    const res = await fetchWithTimeout(
-      resolveNpmPackageTargetRegistryUrl({ target }),
-      {},
-      Math.max(250, timeoutMs),
-    );
+    const registryUrl = await resolveNpmPackageTargetRegistryUrlAsync({ target });
+    const res = await fetchWithTimeout(registryUrl, {}, Math.max(250, timeoutMs));
     if (!res.ok) {
       return { target, version: null, nodeEngine: null, error: `HTTP ${res.status}` };
     }

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -5,7 +5,11 @@ import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { detectPackageManager as detectPackageManagerImpl } from "./detect-package-manager.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
-import { channelToNpmTag, type UpdateChannel } from "./update-channels.js";
+import {
+  channelToNpmTag,
+  resolveNpmPackageTargetRegistryUrl,
+  type UpdateChannel,
+} from "./update-channels.js";
 
 export type PackageManager = "pnpm" | "bun" | "npm" | "unknown";
 
@@ -326,7 +330,7 @@ export async function fetchNpmPackageTargetStatus(params: {
   const target = params.target;
   try {
     const res = await fetchWithTimeout(
-      `https://registry.npmjs.org/openclaw/${encodeURIComponent(target)}`,
+      resolveNpmPackageTargetRegistryUrl({ target }),
       {},
       Math.max(250, timeoutMs),
     );


### PR DESCRIPTION
## Summary
- Add a shared npm registry URL resolver for OpenClaw update metadata lookups.
- Use `npm_config_registry`, `NPM_CONFIG_REGISTRY`, or `npm_config_userconfig_registry` before falling back to `https://registry.npmjs.org`.
- Wire update package-target checks through the resolver so startup/status/update preflight paths inherit mirror config.

Fixes #79140.

## Validation

```bash
pnpm test src/infra/update-channels.test.ts src/infra/update-check.test.ts src/infra/update-startup.test.ts src/cli/update-cli.test.ts
pnpm check:changed
pnpm exec oxfmt --check --threads=1 src/infra/update-check.ts src/infra/update-check.test.ts src/infra/update-startup.ts src/infra/update-startup.test.ts src/cli/update-cli/status.ts src/cli/update-cli/shared.ts src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts src/infra/update-channels.ts src/infra/update-channels.test.ts CHANGELOG.md
```

## Real behavior proof

Behavior addressed: update metadata checks no longer hardcode `https://registry.npmjs.org/openclaw/<target>` when npm registry mirror config is present.

Real setup tested: local OpenClaw source checkout on the PR branch, invoking the actual registry URL resolver through Node with `tsx`.

Exact steps or command run after the patch: ran this command from the OpenClaw repo after applying the patch:

```bash
node --import tsx - <<'NODE'
import { resolveNpmPackageTargetRegistryUrl } from './src/infra/update-channels.ts';
console.log(resolveNpmPackageTargetRegistryUrl({ target: 'latest', env: { npm_config_registry: 'https://registry.npmmirror.com/' } }));
console.log(resolveNpmPackageTargetRegistryUrl({ target: 'latest', env: {} }));
NODE
```

Evidence after fix: copied terminal output from that command:

```text
https://registry.npmmirror.com/openclaw/latest
https://registry.npmjs.org/openclaw/latest
```

Observed result after fix: a configured npm mirror builds the update metadata URL against `registry.npmmirror.com`; an empty registry config still builds the default public npm metadata URL.

Not tested: a live gateway startup update check against a remote mirror, because the issue is proven at the central metadata URL construction path used by startup/status/update preflight.
