### PR TITLE
fix(update-check): respect npm_config_registry env var for npm mirror support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- CLI/update-check: respect the `npm_config_registry` environment variable when fetching the latest package version so npm mirror users (Verdaccio, Nexus, Artifactory, etc.) are not silently re-routed to the public registry. (#79140)
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -141,6 +141,36 @@ describe("resolveNpmChannelTag", () => {
       error: "HTTP 404",
     });
   });
+
+  it("uses npm_config_registry env var as registry base when set", async () => {
+    const capturedUrls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        capturedUrls.push(url);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ version: "1.2.3", engines: { node: ">=22.16.0" } }),
+        } as Response;
+      }),
+    );
+    const originalRegistry = process.env["npm_config_registry"];
+    process.env["npm_config_registry"] = "https://my.mirror.example.com/npm/";
+    try {
+      await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 });
+    } finally {
+      if (originalRegistry === undefined) {
+        delete process.env["npm_config_registry"];
+      } else {
+        process.env["npm_config_registry"] = originalRegistry;
+      }
+    }
+    expect(capturedUrls).toHaveLength(1);
+    expect(capturedUrls[0]).toMatch(/^https:\/\/my\.mirror\.example\.com\/npm\/openclaw\//);
+  });
 });
 
 describe("formatGitInstallLabel", () => {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -326,7 +326,7 @@ export async function fetchNpmPackageTargetStatus(params: {
   const target = params.target;
   try {
     const res = await fetchWithTimeout(
-      `https://registry.npmjs.org/openclaw/${encodeURIComponent(target)}`,
+      `${(process.env["npm_config_registry"] ?? "https://registry.npmjs.org").replace(/\/$/, "")}/openclaw/${encodeURIComponent(target)}`,
       {},
       Math.max(250, timeoutMs),
     );


### PR DESCRIPTION
## Problem

`fetchNpmPackageTargetStatus` hardcodes `https://registry.npmjs.org` as the registry base, ignoring the standard `npm_config_registry` environment variable. Users behind corporate npm mirrors (Verdaccio, Nexus, Artifactory, CNPM) get update-check requests silently routed to the public registry, which either fails behind a firewall or leaks internal package names.

## Root cause

`src/infra/update-check.ts` line 329 (before this patch):
```typescript
`https://registry.npmjs.org/openclaw/${encodeURIComponent(target)}`
```

## Fix

Read `process.env["npm_config_registry"]` with the public registry as fallback, stripping any trailing slash so the URL is always well-formed:

```typescript
`${(process.env["npm_config_registry"] ?? "https://registry.npmjs.org").replace(/\/$/, "")}/openclaw/${encodeURIComponent(target)}`
```

`npm_config_registry` is the standard env variable npm itself writes when running scripts inside a project configured with a custom registry (`.npmrc` `registry=`). It is also the env var users set directly when calling npm from a mirror environment.

## Testing

- Regression test added: verifies that setting `npm_config_registry` to a custom mirror causes `fetchNpmPackageTargetStatus` to hit that mirror URL.
- All 14 existing `update-check` tests pass.

Fixes #79140