### PR TITLE
fix(update): honor npm_config_registry for update metadata fetches (#79140)

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -13,6 +13,7 @@ import {
   fetchNpmTagVersion,
   formatGitInstallLabel,
   resolveNpmChannelTag,
+  resolveNpmRegistryBaseUrl,
 } from "./update-check.js";
 
 describe("compareSemverStrings", () => {
@@ -41,16 +42,64 @@ describe("compareSemverStrings", () => {
   });
 });
 
+describe("resolveNpmRegistryBaseUrl", () => {
+  it("defaults to the public npm registry when no env override is set", () => {
+    expect(resolveNpmRegistryBaseUrl({})).toBe("https://registry.npmjs.org");
+  });
+
+  it("honors npm_config_registry and strips trailing slashes", () => {
+    expect(
+      resolveNpmRegistryBaseUrl({ npm_config_registry: "https://registry.npmmirror.com/" }),
+    ).toBe("https://registry.npmmirror.com");
+    expect(
+      resolveNpmRegistryBaseUrl({ npm_config_registry: "https://registry.npmmirror.com//" }),
+    ).toBe("https://registry.npmmirror.com");
+  });
+
+  it("honors uppercase NPM_CONFIG_REGISTRY when lowercase is unset", () => {
+    expect(resolveNpmRegistryBaseUrl({ NPM_CONFIG_REGISTRY: "https://registry.example.com" })).toBe(
+      "https://registry.example.com",
+    );
+  });
+
+  it("prefers lowercase npm_config_registry over uppercase when both are set", () => {
+    expect(
+      resolveNpmRegistryBaseUrl({
+        npm_config_registry: "https://lower.example.com",
+        NPM_CONFIG_REGISTRY: "https://upper.example.com",
+      }),
+    ).toBe("https://lower.example.com");
+  });
+
+  it("falls back to the default for empty, whitespace, or non-http values", () => {
+    expect(resolveNpmRegistryBaseUrl({ npm_config_registry: "" })).toBe(
+      "https://registry.npmjs.org",
+    );
+    expect(resolveNpmRegistryBaseUrl({ npm_config_registry: "   " })).toBe(
+      "https://registry.npmjs.org",
+    );
+    expect(resolveNpmRegistryBaseUrl({ npm_config_registry: "not-a-url" })).toBe(
+      "https://registry.npmjs.org",
+    );
+    expect(resolveNpmRegistryBaseUrl({ npm_config_registry: "file:///tmp/registry" })).toBe(
+      "https://registry.npmjs.org",
+    );
+  });
+});
+
 describe("resolveNpmChannelTag", () => {
   let versionByTag: Record<string, string | null>;
+  let lastFetchedUrl: string | null;
 
   beforeEach(() => {
     versionByTag = {};
+    lastFetchedUrl = null;
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
         const url =
           typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        lastFetchedUrl = url;
         const tag = decodeURIComponent(url.split("/").pop() ?? "");
         const version = versionByTag[tag] ?? null;
         return {
@@ -67,6 +116,8 @@ describe("resolveNpmChannelTag", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    delete process.env.npm_config_registry;
+    delete process.env.NPM_CONFIG_REGISTRY;
   });
 
   it("falls back to latest when beta is older", async () => {
@@ -140,6 +191,26 @@ describe("resolveNpmChannelTag", () => {
       version: null,
       error: "HTTP 404",
     });
+  });
+
+  it("queries the public npm registry by default", async () => {
+    versionByTag.latest = "1.0.6";
+    delete process.env.npm_config_registry;
+    delete process.env.NPM_CONFIG_REGISTRY;
+
+    await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 });
+
+    expect(lastFetchedUrl).toBe("https://registry.npmjs.org/openclaw/latest");
+  });
+
+  it("uses npm_config_registry when set so registry mirrors are honored", async () => {
+    versionByTag.latest = "1.0.7";
+    process.env.npm_config_registry = "https://registry.npmmirror.com/";
+
+    const status = await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 });
+
+    expect(lastFetchedUrl).toBe("https://registry.npmmirror.com/openclaw/latest");
+    expect(status.version).toBe("1.0.7");
   });
 });
 

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -318,6 +318,36 @@ export async function fetchNpmRegistryVersionForChannel(params: {
   };
 }
 
+const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
+
+/**
+ * Resolves the npm registry base URL to use for OpenClaw update metadata
+ * lookups. Honors the standard npm/pnpm `npm_config_registry` (and uppercase
+ * `NPM_CONFIG_REGISTRY`) environment variable so that users behind a registry
+ * mirror (e.g. `registry.npmmirror.com`) are not forced to reach
+ * `registry.npmjs.org`. Falls back to the public registry when no override is
+ * configured.
+ *
+ * Trailing slashes are stripped so callers can safely append `/openclaw/<tag>`.
+ */
+export function resolveNpmRegistryBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const candidates = [env.npm_config_registry, env.NPM_CONFIG_REGISTRY];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const trimmed = candidate.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    if (!/^https?:\/\//i.test(trimmed)) {
+      continue;
+    }
+    return trimmed.replace(/\/+$/, "");
+  }
+  return DEFAULT_NPM_REGISTRY;
+}
+
 export async function fetchNpmPackageTargetStatus(params: {
   target: string;
   timeoutMs?: number;
@@ -325,8 +355,9 @@ export async function fetchNpmPackageTargetStatus(params: {
   const timeoutMs = params.timeoutMs ?? 3500;
   const target = params.target;
   try {
+    const registryBase = resolveNpmRegistryBaseUrl();
     const res = await fetchWithTimeout(
-      `https://registry.npmjs.org/openclaw/${encodeURIComponent(target)}`,
+      `${registryBase}/openclaw/${encodeURIComponent(target)}`,
       {},
       Math.max(250, timeoutMs),
     );


### PR DESCRIPTION
Fixes #79140.

## Problem

`fetchNpmPackageTargetStatus` in `src/infra/update-check.ts` had `https://registry.npmjs.org` hardcoded, so every update metadata lookup ignored npm/pnpm registry mirror configuration. Users behind a mirror (e.g. `registry.npmmirror.com`) saw `openclaw update` status and the gateway startup update check fail or return wrong versions even though their actual install path was honoring the mirror.

This helper backs:

- `fetchNpmTagVersion` / `fetchNpmLatestVersion`
- `fetchNpmRegistryVersionForChannel` and `resolveNpmChannelTag`
- The `openclaw update` preflight Node engine check (`src/cli/update-cli/update-command.ts`)
- The startup update check (`src/infra/update-startup.ts`)

…so fixing it once at the metadata fetch layer fixes the whole surface.

## Change

- New `resolveNpmRegistryBaseUrl(env = process.env)` exported from `update-check.ts`. Reads `npm_config_registry`, then `NPM_CONFIG_REGISTRY`, validates it's `http(s)://…`, strips trailing slashes, and falls back to `https://registry.npmjs.org` when unset/invalid.
- `fetchNpmPackageTargetStatus` uses it to build the package metadata URL.

No other behavior changes — same timeout, same error handling, same caller surface.

## Tests

- New `resolveNpmRegistryBaseUrl` describe block: defaults, lowercase env, uppercase env, lowercase precedence, and rejection of empty / non-http values.
- New cases in the existing fetch describe block that capture the requested URL and assert:
  - default queries `https://registry.npmjs.org/openclaw/latest`
  - with `npm_config_registry=https://registry.npmmirror.com/` set, queries `https://registry.npmmirror.com/openclaw/latest`

`update-check.test.ts` goes from 13 → 20 tests, all passing:

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/update-check.test.ts
✓ infra src/infra/update-check.test.ts (20 tests) 53ms
Test Files  1 passed (1)
     Tests  20 passed (20)
```

`src/infra/update-startup.test.ts` still passes (11/11). `src/cli/update-cli.test.ts` has 21 unrelated pre-existing failures on clean `main` (verified by stashing this change), so they are not introduced here.

`pnpm exec oxfmt --check --threads=1 src/infra/update-check.ts src/infra/update-check.test.ts` is clean.
