### PR TITLE
fix(gateway): hide transcript-only history artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/history: omit transcript-only OpenClaw assistant artifacts from `chat.history` and `sessions.get`, and apply history limits after hidden delivery mirrors and Gateway-injected tails are removed. Refs #69208.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Providers: preserve non-OK `text/event-stream` response bodies so provider HTTP errors keep their JSON detail instead of collapsing to generic streaming failures. Fixes #78180.
 - Gateway/auth: make explicit `trusted-proxy` mode fail closed instead of accepting local password fallback credentials after trusted-proxy identity checks fail. Fixes #78684.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -431,8 +431,8 @@ enumeration of `src/gateway/server-methods/*.ts`.
     - `sessions.abort` aborts active work for a session. A caller may pass `key` plus optional `runId`, or pass `runId` alone for active runs the Gateway can resolve to a session.
     - `sessions.patch` updates session metadata/overrides and reports the resolved canonical model plus effective `agentRuntime`.
     - `sessions.reset`, `sessions.delete`, and `sessions.compact` perform session maintenance.
-    - `sessions.get` returns the full stored session row.
-    - Chat execution still uses `chat.history`, `chat.send`, `chat.abort`, and `chat.inject`. `chat.history` is display-normalized for UI clients: inline directive tags are stripped from visible text, plain-text tool-call XML payloads (including `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, `<function_calls>...</function_calls>`, and truncated tool-call blocks) and leaked ASCII/full-width model control tokens are stripped, pure silent-token assistant rows such as exact `NO_REPLY` / `no_reply` are omitted, and oversized rows can be replaced with placeholders.
+    - `sessions.get` returns recent stored session messages while omitting transcript-only OpenClaw assistant artifacts such as delivery mirrors and Gateway-injected assistant tails.
+    - Chat execution still uses `chat.history`, `chat.send`, `chat.abort`, and `chat.inject`. `chat.history` is display-normalized for UI clients: inline directive tags are stripped from visible text, plain-text tool-call XML payloads (including `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, `<function_calls>...</function_calls>`, and truncated tool-call blocks) and leaked ASCII/full-width model control tokens are stripped, transcript-only OpenClaw assistant artifacts such as delivery mirrors and Gateway-injected assistant tails are omitted, pure silent-token assistant rows such as exact `NO_REPLY` / `no_reply` are omitted, and oversized rows can be replaced with placeholders.
 
   </Accordion>
 

--- a/src/config/sessions/transcript-artifacts.ts
+++ b/src/config/sessions/transcript-artifacts.ts
@@ -1,0 +1,20 @@
+const TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS = new Set(["delivery-mirror", "gateway-injected"]);
+
+export function isTranscriptOnlyOpenClawAssistantMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  return (
+    entry.role === "assistant" &&
+    entry.provider === "openclaw" &&
+    typeof entry.model === "string" &&
+    TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS.has(entry.model)
+  );
+}
+
+export function filterTranscriptOnlyOpenClawAssistantMessages<T>(messages: T[]): T[] {
+  return messages.some(isTranscriptOnlyOpenClawAssistantMessage)
+    ? messages.filter((message) => !isTranscriptOnlyOpenClawAssistantMessage(message))
+    : messages;
+}

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -1,5 +1,6 @@
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../config/sessions/transcript-artifacts.js";
 import {
   parseAssistantTextSignature,
   resolveAssistantMessagePhase,
@@ -423,6 +424,9 @@ function hasAssistantMixedToolVisibleText(message: unknown): boolean {
 function shouldDropAssistantHistoryMessage(message: unknown): boolean {
   if (!message || typeof message !== "object") {
     return false;
+  }
+  if (isTranscriptOnlyOpenClawAssistantMessage(message)) {
+    return true;
   }
   const entry = message as { role?: unknown };
   if (entry.role !== "assistant") {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -216,6 +216,10 @@ const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
 ]);
 const CHANNEL_SCOPED_SESSION_SHAPES = new Set(["direct", "dm", "group", "channel"]);
 
+function resolveRawHistoryWindow(limit: number): number {
+  return limit * 20 + 20;
+}
+
 type ChatSendDeliveryEntry = {
   deliveryContext?: {
     channel?: string;
@@ -1747,7 +1751,8 @@ export const chatHandlers: GatewayRequestHandlers = {
     const localMessages =
       sessionId && storePath
         ? await readRecentSessionMessagesAsync(sessionId, storePath, entry?.sessionFile, {
-            maxMessages: max,
+            maxMessages: resolveRawHistoryWindow(max),
+            maxLines: resolveRawHistoryWindow(max),
             maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
           })
         : [];

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -551,6 +551,41 @@ describe("projectRecentChatDisplayMessages", () => {
 
     expect(result).toEqual([{ role: "assistant", content: "older answer", timestamp: 2 }]);
   });
+
+  it("applies history limits after dropping transcript-only OpenClaw assistant artifacts", () => {
+    const result = projectRecentChatDisplayMessages(
+      [
+        { role: "user", content: "older visible", timestamp: 1 },
+        {
+          role: "assistant",
+          provider: "openclaw",
+          model: "delivery-mirror",
+          content: "mirrored delivery",
+          timestamp: 2,
+        },
+        {
+          role: "assistant",
+          provider: "openclaw",
+          model: "gateway-injected",
+          content: "injected transcript tail",
+          timestamp: 3,
+        },
+        {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude",
+          content: "real",
+          timestamp: 4,
+        },
+      ],
+      { maxMessages: 2 },
+    );
+
+    expect(result).toEqual([
+      { role: "user", content: "older visible", timestamp: 1 },
+      { role: "assistant", provider: "anthropic", model: "claude", content: "real", timestamp: 4 },
+    ]);
+  });
 });
 
 describe("resolveEffectiveChatHistoryMaxChars", () => {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -26,6 +26,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { filterTranscriptOnlyOpenClawAssistantMessages } from "../../config/sessions/transcript-artifacts.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   createInternalHookEvent,
@@ -137,6 +138,10 @@ let sessionsRuntimeModulePromise: Promise<SessionsRuntimeModule> | undefined;
 let loggedSlowSessionsListCatalog = false;
 
 const SESSIONS_LIST_MODEL_CATALOG_TIMEOUT_MS = 750;
+
+function resolveRawSessionGetWindow(limit: number): number {
+  return limit * 20 + 20;
+}
 
 function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
   sessionsRuntimeModulePromise ??= import("./sessions.runtime.js");
@@ -1847,11 +1852,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       storePath,
       entry.sessionFile,
       {
-        maxMessages: limit,
-        maxLines: limit * 20 + 20,
+        maxMessages: resolveRawSessionGetWindow(limit),
+        maxLines: resolveRawSessionGetWindow(limit),
       },
     );
-    respond(true, { messages }, undefined);
+    respond(
+      true,
+      { messages: filterTranscriptOnlyOpenClawAssistantMessages(messages).slice(-limit) },
+      undefined,
+    );
   },
   "sessions.compact": async ({ req, params, respond, context, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsCompactParams, "sessions.compact", respond)) {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -681,6 +681,61 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history limits visible messages after hiding transcript-only OpenClaw artifacts", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "user",
+            content: "older visible",
+            timestamp: 1,
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "openclaw",
+            model: "delivery-mirror",
+            content: "mirrored delivery",
+            timestamp: 2,
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "openclaw",
+            model: "gateway-injected",
+            content: "injected transcript tail",
+            timestamp: 3,
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            content: "real answer",
+            timestamp: 4,
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { limit: 2 });
+      expect(messages).toEqual([
+        { role: "user", content: "older visible", timestamp: 1, __openclaw: { seq: 1 } },
+        {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          content: "real answer",
+          timestamp: 4,
+          __openclaw: { seq: 4 },
+        },
+      ]);
+    });
+  });
+
   test("chat.send does not force-disable block streaming", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const spy = getReplyFromConfig;

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -372,6 +372,73 @@ test("lists and patches session store via sessions.* RPC", async () => {
   expect(mainAfterModelPatch?.model).toBe("gpt-test-a");
   expect(mainAfterModelPatch?.agentRuntime).toEqual({ id: "pi", source: "implicit" });
 
+  await fs.writeFile(
+    path.join(dir, "sess-main.jsonl"),
+    [
+      JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
+      JSON.stringify({
+        message: {
+          role: "user",
+          content: "older visible",
+          timestamp: 1,
+        },
+      }),
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          provider: "openclaw",
+          model: "delivery-mirror",
+          content: "mirrored delivery",
+          timestamp: 2,
+        },
+      }),
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          provider: "openclaw",
+          model: "gateway-injected",
+          content: "injected transcript tail",
+          timestamp: 3,
+        },
+      }),
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          content: "real answer",
+          timestamp: 4,
+        },
+      }),
+    ].join("\n"),
+    "utf-8",
+  );
+  const messagesGet = await directSessionReq<{
+    messages: Array<{
+      role?: string;
+      content?: string;
+      provider?: string;
+      model?: string;
+      timestamp?: number;
+      __openclaw?: { seq?: number };
+    }>;
+  }>("sessions.get", {
+    key: "agent:main:main",
+    limit: 2,
+  });
+  expect(messagesGet.ok).toBe(true);
+  expect(messagesGet.payload?.messages).toEqual([
+    { role: "user", content: "older visible", timestamp: 1, __openclaw: { seq: 1 } },
+    {
+      role: "assistant",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      content: "real answer",
+      timestamp: 4,
+      __openclaw: { seq: 4 },
+    },
+  ]);
+
   const compacted = await directSessionReq<{ ok: true; compacted: boolean }>("sessions.compact", {
     key: "agent:main:main",
     maxLines: 3,

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -3,10 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, test } from "vitest";
-import {
-  appendAssistantMessageToSessionTranscript,
-  appendExactAssistantMessageToSessionTranscript,
-} from "../config/sessions/transcript.js";
+import { appendExactAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
   connectReq,
@@ -66,13 +63,15 @@ async function seedSession(params?: { text?: string }) {
 function makeTranscriptAssistantMessage(params: {
   text: string;
   content?: AssistantMessage["content"];
+  provider?: string;
+  model?: string;
 }): AssistantMessage {
   return {
     role: "assistant" as const,
     content: params.content ?? [{ type: "text", text: params.text }],
     api: "openai-responses",
-    provider: "openclaw",
-    model: "delivery-mirror",
+    provider: params.provider ?? "anthropic",
+    model: params.model ?? "claude-sonnet-4-6",
     usage: {
       input: 0,
       output: 0,
@@ -90,6 +89,18 @@ function makeTranscriptAssistantMessage(params: {
     stopReason: "stop" as const,
     timestamp: Date.now(),
   };
+}
+
+async function appendAssistantMessageToSessionTranscript(params: {
+  sessionKey: string;
+  text: string;
+  storePath?: string;
+}) {
+  return await appendExactAssistantMessageToSessionTranscript({
+    sessionKey: params.sessionKey,
+    storePath: params.storePath ?? testState.sessionStorePath,
+    message: makeTranscriptAssistantMessage({ text: params.text }),
+  });
 }
 
 async function appendTranscriptMessage(params: {


### PR DESCRIPTION
## Summary

- Problem: `chat.history` and `sessions.get` could surface transcript-only OpenClaw assistant rows (`delivery-mirror` / `gateway-injected`) as normal assistant messages.
- Why it matters: those artifacts are durable transcript/audit rows, but consumer history should not display or return them as model output, and hidden rows should not consume the visible history limit.
- What changed: added a shared transcript-artifact predicate, dropped those rows in chat display projection, over-read bounded history tails before visible limiting, and filtered `sessions.get` after the same over-read.
- What did NOT change (scope boundary): raw transcript writes, provider replay cleanup, channel routing, and broader #69208 idempotency/bootstrap tracks are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #69208
- Related #40716
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: transcript-only OpenClaw assistant artifacts should be hidden from `chat.history` and `sessions.get`, with limits applied after hidden rows are removed.
- Real environment tested: Ubuntu 24.04 workspace, Node via repo nvm/pnpm, real OpenClaw gateway test harness exercising WS `chat.history`, `sessions.get`, and HTTP/SSE session history paths against JSONL transcript files.
- Exact steps or command run after this patch: `pnpm test src/gateway/server-methods/server-methods.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server.sessions.store-rpc.test.ts src/gateway/sessions-history-http.test.ts`; `pnpm exec oxfmt --check --threads=1 src/config/sessions/transcript-artifacts.ts src/gateway/chat-display-projection.ts src/gateway/server-methods/chat.ts src/gateway/server-methods/sessions.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server.sessions.store-rpc.test.ts src/gateway/sessions-history-http.test.ts docs/gateway/protocol.md CHANGELOG.md`; `git diff --check`; `pnpm check:changed`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output: `Test Files 3 passed (3); Tests 104 passed (104)` and `Test Files 1 passed (1); Tests 12 passed (12)` from the targeted gateway run; copied terminal output: `All matched files use the correct format.`; copied terminal output: `pnpm check:changed ... node scripts/check-changed.mjs` exited `0`; copied terminal output: `git diff --check` exited `0`.
- Observed result after fix: regression tests prove `chat.history` and `sessions.get` return the older visible user row plus the real assistant row when the raw tail also contains hidden `delivery-mirror` and `gateway-injected` rows, preserving visible limit behavior and raw transcript sequence metadata.
- What was not tested: a full live provider/channel delivery run with real Telegram/Control UI credentials, and the full repository `pnpm check` / `pnpm test` sweeps.
- Before evidence (optional but encouraged): source proof on current `main` showed `chat.history` reading only the requested raw tail before projection and `sessions.get` returning raw recent messages without filtering transcript-only OpenClaw assistant artifacts.

## Root Cause (if applicable)

- Root cause: transcript-only OpenClaw assistant rows are persisted in the same JSONL message stream as real provider assistant output, but the history/API consumers did not consistently treat those rows as internal artifacts.
- Missing detection / guardrail: there was no gateway history regression that combined both artifact models with a small visible history limit.
- Contributing context (if known): provider replay already drops these artifacts, so this gap was limited to consumer history/API presentation paths on current `main`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/server-methods.test.ts`, `src/gateway/server.chat.gateway-server-chat-b.test.ts`, `src/gateway/server.sessions.store-rpc.test.ts`, `src/gateway/sessions-history-http.test.ts`.
- Scenario the test should lock in: raw transcript tails containing `provider:"openclaw"` with `model:"delivery-mirror"` or `model:"gateway-injected"` still produce the requested visible `chat.history` / `sessions.get` rows after filtering.
- Why this is the smallest reliable guardrail: it exercises the shared projection helper plus the two public consumer handlers without needing a real provider response.
- Existing test that already covers this (if any): replay history tests covered provider replay, but not these history/API consumers.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`chat.history` and `sessions.get` no longer return transcript-only OpenClaw assistant artifacts as visible assistant messages. Requested history limits now apply to visible rows after those artifacts are removed.

## Diagram (if applicable)

```text
Before:
[raw transcript tail] -> [delivery-mirror/gateway-injected rows included] -> [visible history limit may be consumed]

After:
[raw transcript tail] -> [drop transcript-only OpenClaw assistant artifacts] -> [limit visible rows] -> [consumer-safe history]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: repo Node/pnpm environment
- Model/provider: transcript fixtures using OpenClaw artifact rows plus Anthropic-shaped visible assistant rows
- Integration/channel (if any): Gateway WS/HTTP history surfaces
- Relevant config (redacted): default gateway test harness config

### Steps

1. Seed a session JSONL with a visible user row, `provider:"openclaw", model:"delivery-mirror"`, `provider:"openclaw", model:"gateway-injected"`, and a real assistant row.
2. Request `chat.history` or `sessions.get` with `limit: 2`.
3. Verify the two returned rows are the visible user row and the real assistant row, not either OpenClaw artifact.

### Expected

- Transcript-only OpenClaw assistant artifacts are omitted and do not consume the visible history limit.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused gateway tests for display projection, WS `chat.history`, RPC `sessions.get`, and HTTP/SSE session history behavior; formatting; whitespace; changed gate.
- Edge cases checked: both `delivery-mirror` and `gateway-injected` artifact models; visible limit applied after hidden rows; raw sequence metadata preserved across hidden rows.
- What you did **not** verify: full live channel cross-delivery with real external credentials, and full repository sweeps.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: callers that expected raw `sessions.get` artifacts may see fewer rows.
  - Mitigation: this matches the existing consumer-boundary intent, keeps raw JSONL unchanged for audit/debugging, and over-reads before filtering so visible history limits stay useful.
