### PR TITLE
fix(commands): preserve multiline args after slash command head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
 - Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/title/details, show web-search queries from provider-native argument shapes, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
+- Commands/skills: preserve multiline arguments after a slash command head so payloads like `/some-command\nline 1\nline 2` deliver all lines to the handler instead of only the first. (#79155)
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/src/auto-reply/commands-registry-normalize.ts
+++ b/src/auto-reply/commands-registry-normalize.ts
@@ -57,6 +57,7 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
 
   const newline = trimmed.indexOf("\n");
   const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
+  const multilineTail = newline === -1 ? "" : trimmed.slice(newline);
 
   const colonMatch = singleLine.match(/^\/([^\s:]+)\s*:(.*)$/);
   const normalized = colonMatch
@@ -80,24 +81,27 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
   const textAliasMap = getTextAliasMap();
   const exact = textAliasMap.get(lowered);
   if (exact) {
-    return exact.canonical;
+    return exact.canonical + multilineTail;
   }
 
   const tokenMatch = commandBody.match(/^\/([^\s]+)(?:\s+([\s\S]+))?$/);
   if (!tokenMatch) {
-    return commandBody;
+    return commandBody + multilineTail;
   }
   const [, token, rest] = tokenMatch;
   const tokenKey = `/${normalizeLowercaseStringOrEmpty(token)}`;
   const tokenSpec = textAliasMap.get(tokenKey);
   if (!tokenSpec) {
-    return commandBody;
+    return commandBody + multilineTail;
   }
   if (rest && !tokenSpec.acceptsArgs) {
-    return commandBody;
+    return commandBody + multilineTail;
   }
   const normalizedRest = rest?.trimStart();
-  return normalizedRest ? `${tokenSpec.canonical} ${normalizedRest}` : tokenSpec.canonical;
+  const resolvedHead = normalizedRest
+    ? `${tokenSpec.canonical} ${normalizedRest}`
+    : tokenSpec.canonical;
+  return resolvedHead + multilineTail;
 }
 
 export function getCommandDetection(_cfg?: OpenClawConfig): CommandDetection {

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -405,6 +405,18 @@ describe("commands registry", () => {
   it("keeps unregistered dock underscore aliases unchanged", () => {
     expect(normalizeCommandBody("/dock_telegram")).toBe("/dock_telegram");
   });
+
+  it("preserves multiline args after command head — regression for #79155", () => {
+    expect(normalizeCommandBody("/btw\nfirst line\nsecond line")).toBe(
+      "/btw\nfirst line\nsecond line",
+    );
+    expect(normalizeCommandBody("/help\nline 1\nline 2\nline 3")).toBe(
+      "/help\nline 1\nline 2\nline 3",
+    );
+    expect(
+      normalizeCommandBody("/help@openclaw\nmultiline args", { botUsername: "openclaw" }),
+    ).toBe("/help\nmultiline args");
+  });
 });
 
 describe("commands registry args", () => {


### PR DESCRIPTION
## Problem

\`normalizeCommandBody()\` truncated everything after the first newline when normalizing a slash command, so a message like:

\`\`\`text
/some-command
first line of payload
second line of payload
\`\`\`

only delivered \`first line of payload\` as args. The remaining lines were silently dropped before downstream command/skill handling.

## Root cause

\`src/auto-reply/commands-registry-normalize.ts\`:
\`\`\`typescript
const newline = trimmed.indexOf("\n");
const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
// multiline tail was never re-attached — lost at every return path
\`\`\`

## Fix

Capture \`multilineTail = trimmed.slice(newline)\` before normalization, then re-attach it to the final resolved output at every return path. The command head (first line) is still normalized for alias expansion and bot-mention stripping; the tail passes through verbatim.

## Real behavior proof

**Behavior or issue addressed:** \`normalizeCommandBody()\` drops multiline args after the slash command head — payload lines 2+ were silently discarded before command dispatch.

**Real environment tested:** local OpenClaw source checkout on PR branch (\`fix/normalize-command-body-multiline-args-79155\`), Node 24, running vitest against the changed normalization function.

**Exact steps or command run after this patch:**
\`\`\`bash
cd /tmp/openclaw_src
git checkout fix/normalize-command-body-multiline-args-79155
pnpm vitest run src/auto-reply/commands-registry.test.ts
\`\`\`

**Evidence after fix:** copied terminal output:
\`\`\`
 Test Files  1 passed (1)
      Tests  27 passed (27)
   Start at  09:09:14
   Duration  412ms
\`\`\`

The regression test added in this PR asserts:
\`\`\`typescript
expect(normalizeCommandBody("/btw\nfirst line\nsecond line")).toBe(
  "/btw\nfirst line\nsecond line",
);
\`\`\`
Before this patch, the output was \`"/btw"\` only (tail dropped). After, the full multiline payload is returned.

**Observed result after fix:** \`normalizeCommandBody("/btw\nfirst line\nsecond line")\` returns \`"/btw\nfirst line\nsecond line"\`. Bot-mention stripping also preserves the tail correctly.

**What was not tested:** live message delivery through a real channel adapter (Telegram, Discord, Slack) with actual multiline input. The fix is proven at the central normalization function used by all command dispatch paths.

Fixes #79155