### PR TITLE
fix(github-copilot): drop encrypted reasoning on replay for GPT/o-series

### DIFF
--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -185,6 +185,26 @@ inter-session user turns that only have provenance metadata.
   OpenAI-compatible Anthropic model payloads when reasoning is enabled, matching
   direct Anthropic and Cloudflare Anthropic replay behavior.
 
+**GitHub Copilot**
+
+- Routing split: Claude-family Copilot model IDs go through `anthropic-messages`;
+  every other Copilot model ID (GPT-family and `o*` reasoning models) goes through
+  `openai-responses`.
+- Claude-family Copilot models follow the standard Anthropic replay rules above
+  (thinking signature stripping, no historical reasoning drop).
+- Non-Claude Copilot models (GPT-family and `o*` reasoning models on the
+  `openai-responses` route) drop historical reasoning from the replay copy
+  (`dropReasoningFromHistory`). Copilot's enterprise endpoint rejects replayed
+  encrypted reasoning payloads with `Encrypted content item_id did not match`
+  even when the IDs are connection-bound, so we never replay prior-turn
+  `thinkingSignature` reasoning back to Copilot.
+- This is intentionally narrower than the native OpenAI Responses behavior:
+  native OpenAI Responses keeps replayable reasoning item payloads (including
+  encrypted empty-summary items) so manual/WebSocket replay can resume `rs_*`
+  state. Copilot does not honor that contract for non-Claude models, so we
+  diverge from native OpenAI Responses on this single point.
+- Image sanitization applies through the global rule.
+
 **Everything else**
 
 - Image sanitization only.

--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -182,6 +182,26 @@ inter-session user turns that only have provenance metadata.
   OpenAI-compatible Anthropic model payloads when reasoning is enabled, matching
   direct Anthropic and Cloudflare Anthropic replay behavior.
 
+**GitHub Copilot**
+
+- Routing split: Claude-family Copilot model IDs go through `anthropic-messages`;
+  every other Copilot model ID (GPT-family and `o*` reasoning models) goes through
+  `openai-responses`.
+- Claude-family Copilot models follow the standard Anthropic replay rules above
+  (thinking signature stripping, no historical reasoning drop).
+- Non-Claude Copilot models (GPT-family and `o*` reasoning models on the
+  `openai-responses` route) drop historical reasoning from the replay copy
+  (`dropReasoningFromHistory`). Copilot's enterprise endpoint rejects replayed
+  encrypted reasoning payloads with `Encrypted content item_id did not match`
+  even when the IDs are connection-bound, so we never replay prior-turn
+  `thinkingSignature` reasoning back to Copilot.
+- This is intentionally narrower than the native OpenAI Responses behavior:
+  native OpenAI Responses keeps replayable reasoning item payloads (including
+  encrypted empty-summary items) so manual/WebSocket replay can resume `rs_*`
+  state. Copilot does not honor that contract for non-Claude models, so we
+  diverge from native OpenAI Responses on this single point.
+- Image sanitization applies through the global rule.
+
 **Everything else**
 
 - Image sanitization only.

--- a/extensions/github-copilot/replay-policy.test.ts
+++ b/extensions/github-copilot/replay-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { buildGithubCopilotReplayPolicy } from "./replay-policy.js";
+
+describe("buildGithubCopilotReplayPolicy", () => {
+  describe("Claude family (anthropic-messages)", () => {
+    it("drops legacy thinking blocks for claude models", () => {
+      const policy = buildGithubCopilotReplayPolicy("claude-opus-4.5");
+      expect(policy).toMatchObject({ dropThinkingBlocks: true });
+      // Must NOT also flip the Responses-side flag — Anthropic transport doesn't
+      // need it and merging both could obscure regressions.
+      expect(policy).not.toHaveProperty("dropReasoningFromHistory");
+    });
+
+    it("matches claude regardless of casing", () => {
+      const policy = buildGithubCopilotReplayPolicy("Claude-Sonnet-4.5");
+      expect(policy).toMatchObject({ dropThinkingBlocks: true });
+    });
+  });
+
+  describe("GPT / o-series family (openai-responses) — issue #78867", () => {
+    // Regression: Copilot routes non-Claude models to openai-responses and
+    // rejects replayed `encrypted_content` from prior turns with
+    // `400 The encrypted content for item rs_<id> could not be verified`.
+    // The replay policy must drop reasoning from history without disabling
+    // reasoning entirely (which was the only bypass before this fix).
+
+    it("drops reasoning from history for gpt-5.5", () => {
+      const policy = buildGithubCopilotReplayPolicy("gpt-5.5");
+      expect(policy).toMatchObject({ dropReasoningFromHistory: true });
+      // dropThinkingBlocks would also wipe the *current* assistant turn's
+      // thinking, breaking o-series multi-step tool flows. Use the
+      // history-only variant.
+      expect(policy).not.toHaveProperty("dropThinkingBlocks");
+    });
+
+    it("drops reasoning from history for gpt-5.4 / 5.3-codex / gpt-5.2", () => {
+      for (const modelId of ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2", "gpt-5.4-mini"]) {
+        const policy = buildGithubCopilotReplayPolicy(modelId);
+        expect(policy, `model ${modelId}`).toMatchObject({ dropReasoningFromHistory: true });
+      }
+    });
+
+    it("drops reasoning from history for o-series and synthetic gpt model ids", () => {
+      // Catch-all for unknown models the user adds to agents.defaults.models.
+      // resolveCopilotForwardCompatModel() picks openai-responses for any
+      // non-claude id, so any non-claude model id should get the same policy.
+      for (const modelId of ["o3-mini", "o1", "raptor-mini", "goldeneye", "gemini-3.1-pro"]) {
+        const policy = buildGithubCopilotReplayPolicy(modelId);
+        expect(policy, `model ${modelId}`).toMatchObject({ dropReasoningFromHistory: true });
+      }
+    });
+
+    it("falls back to drop-from-history when modelId is missing", () => {
+      // Defensive: with no model id we can't tell, but the safer default is to
+      // protect against the encrypted_content replay regression rather than
+      // pass through unknown reasoning items.
+      const policy = buildGithubCopilotReplayPolicy(undefined);
+      expect(policy).toMatchObject({ dropReasoningFromHistory: true });
+    });
+  });
+});

--- a/extensions/github-copilot/replay-policy.test.ts
+++ b/extensions/github-copilot/replay-policy.test.ts
@@ -41,10 +41,23 @@ describe("buildGithubCopilotReplayPolicy", () => {
     });
 
     it("drops reasoning from history for o-series and synthetic gpt model ids", () => {
-      // Catch-all for unknown models the user adds to agents.defaults.models.
-      // resolveCopilotForwardCompatModel() picks openai-responses for any
-      // non-claude id, so any non-claude model id should get the same policy.
-      for (const modelId of ["o3-mini", "o1", "raptor-mini", "goldeneye", "gemini-3.1-pro"]) {
+      // Catch-all for unknown non-Claude models the user adds to
+      // agents.defaults.models. resolveCopilotTransportApi picks
+      // openai-responses for any non-claude, non-gemini id, so any such model
+      // id should get the same policy. (Gemini routes to openai-completions
+      // where the policy is a no-op on the wire — covered separately below.)
+      for (const modelId of ["o3-mini", "o1", "raptor-mini", "goldeneye", "synthetic-future-gpt"]) {
+        const policy = buildGithubCopilotReplayPolicy(modelId);
+        expect(policy, `model ${modelId}`).toMatchObject({ dropReasoningFromHistory: true });
+      }
+    });
+
+    it("applies dropReasoningFromHistory for gemini ids even though they route to openai-completions", () => {
+      // resolveCopilotTransportApi routes gemini-* through openai-completions,
+      // which does not surface encrypted_content. We still emit the same
+      // policy for consistency with the catch-all and to keep behavior stable
+      // if Copilot ever moves Gemini onto Responses.
+      for (const modelId of ["gemini-3.1-pro", "gemini-2.5-flash"]) {
         const policy = buildGithubCopilotReplayPolicy(modelId);
         expect(policy, `model ${modelId}`).toMatchObject({ dropReasoningFromHistory: true });
       }

--- a/extensions/github-copilot/replay-policy.ts
+++ b/extensions/github-copilot/replay-policy.ts
@@ -1,9 +1,44 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+/**
+ * Build the replay policy for a Copilot-routed model.
+ *
+ * Copilot routes Claude models to `anthropic-messages` and everything else
+ * (GPT, o-series, Gemini, ...) to `openai-responses`. The policy returned here
+ * is consumed by `resolveTranscriptPolicy` and ultimately controls what the
+ * embedded runner strips from history before each replay.
+ *
+ * Rationale per family:
+ *
+ *  - Claude (anthropic-messages): drop legacy `thinking` blocks from history.
+ *    Older Claude versions (pre-4.5) don't preserve thinking blocks across
+ *    turns, so re-sending them is a noop at best and an error at worst.
+ *
+ *  - GPT / o-series / Gemini on Copilot (openai-responses): drop reasoning
+ *    items from history while preserving the current tool-turn reasoning.
+ *    Copilot's OpenAI-compatible `/responses` endpoint serializes prior
+ *    `thinking` blocks (via `thinkingSignature`) back into the input as
+ *    `reasoning` items carrying `encrypted_content` + `id`. Those tokens are
+ *    bound to the originating connection/turn and are rejected on replay with
+ *    `400 The encrypted content for item rs_<id> could not be verified`
+ *    (see https://github.com/openclaw/openclaw/issues/78867).
+ *
+ *    Native OpenAI Responses replay is unaffected: this hook only fires when
+ *    the github-copilot provider is selected. `dropReasoningFromHistory`
+ *    keeps reasoning attached to the current tool turn so multi-step
+ *    function-call flows on o-series models still continue correctly.
+ */
 export function buildGithubCopilotReplayPolicy(modelId?: string) {
-  return normalizeLowercaseStringOrEmpty(modelId).includes("claude")
-    ? {
-        dropThinkingBlocks: true,
-      }
-    : {};
+  const id = normalizeLowercaseStringOrEmpty(modelId);
+  if (id.includes("claude")) {
+    return {
+      dropThinkingBlocks: true,
+    };
+  }
+  // All non-Claude Copilot models route through openai-responses, where
+  // replayed `encrypted_content` from prior turns is rejected. Strip cross-turn
+  // reasoning while keeping current-turn tool-call reasoning intact.
+  return {
+    dropReasoningFromHistory: true,
+  };
 }

--- a/extensions/github-copilot/replay-policy.ts
+++ b/extensions/github-copilot/replay-policy.ts
@@ -3,10 +3,15 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 /**
  * Build the replay policy for a Copilot-routed model.
  *
- * Copilot routes Claude models to `anthropic-messages` and everything else
- * (GPT, o-series, Gemini, ...) to `openai-responses`. The policy returned here
- * is consumed by `resolveTranscriptPolicy` and ultimately controls what the
- * embedded runner strips from history before each replay.
+ * Copilot's transport routing (see `resolveCopilotTransportApi`):
+ *   - Claude-family model IDs → `anthropic-messages`
+ *   - Gemini-family model IDs → `openai-completions`
+ *   - everything else (GPT-family, `o*` reasoning models, future synthetic
+ *     IDs)            → `openai-responses`
+ *
+ * The policy returned here is consumed by `resolveTranscriptPolicy` and
+ * ultimately controls what the embedded runner strips from history before
+ * each replay.
  *
  * Rationale per family:
  *
@@ -14,12 +19,12 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
  *    Older Claude versions (pre-4.5) don't preserve thinking blocks across
  *    turns, so re-sending them is a noop at best and an error at worst.
  *
- *  - GPT / o-series / Gemini on Copilot (openai-responses): drop reasoning
- *    items from history while preserving the current tool-turn reasoning.
- *    Copilot's OpenAI-compatible `/responses` endpoint serializes prior
- *    `thinking` blocks (via `thinkingSignature`) back into the input as
- *    `reasoning` items carrying `encrypted_content` + `id`. Those tokens are
- *    bound to the originating connection/turn and are rejected on replay with
+ *  - GPT / o-series on Copilot (openai-responses): drop reasoning items from
+ *    history while preserving the current tool-turn reasoning. Copilot's
+ *    OpenAI-compatible `/responses` endpoint serializes prior `thinking`
+ *    blocks (via `thinkingSignature`) back into the input as `reasoning`
+ *    items carrying `encrypted_content` + `id`. Those tokens are bound to
+ *    the originating connection/turn and are rejected on replay with
  *    `400 The encrypted content for item rs_<id> could not be verified`
  *    (see https://github.com/openclaw/openclaw/issues/78867).
  *
@@ -27,6 +32,12 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
  *    the github-copilot provider is selected. `dropReasoningFromHistory`
  *    keeps reasoning attached to the current tool turn so multi-step
  *    function-call flows on o-series models still continue correctly.
+ *
+ *  - Gemini on Copilot (openai-completions): routed through Chat Completions,
+ *    which doesn't surface `encrypted_content` reasoning items, so the
+ *    history-drop is a no-op for the wire payload. We still apply it for
+ *    consistency with the catch-all branch below and to keep behavior stable
+ *    if a future Gemini model is ever moved onto Responses.
  */
 export function buildGithubCopilotReplayPolicy(modelId?: string) {
   const id = normalizeLowercaseStringOrEmpty(modelId);
@@ -35,9 +46,11 @@ export function buildGithubCopilotReplayPolicy(modelId?: string) {
       dropThinkingBlocks: true,
     };
   }
-  // All non-Claude Copilot models route through openai-responses, where
-  // replayed `encrypted_content` from prior turns is rejected. Strip cross-turn
-  // reasoning while keeping current-turn tool-call reasoning intact.
+  // Catch-all for non-Claude Copilot models. The GPT-family / `o*` branch
+  // (which routes to openai-responses) is the one that actually rejects
+  // replayed `encrypted_content` from prior turns; strip cross-turn reasoning
+  // while keeping current-turn tool-call reasoning intact. Gemini IDs (routed
+  // to openai-completions) fall through here as a no-op for the wire payload.
   return {
     dropReasoningFromHistory: true,
   };

--- a/extensions/github-copilot/replay-policy.ts
+++ b/extensions/github-copilot/replay-policy.ts
@@ -1,9 +1,44 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 
+/**
+ * Build the replay policy for a Copilot-routed model.
+ *
+ * Copilot routes Claude models to `anthropic-messages` and everything else
+ * (GPT, o-series, Gemini, ...) to `openai-responses`. The policy returned here
+ * is consumed by `resolveTranscriptPolicy` and ultimately controls what the
+ * embedded runner strips from history before each replay.
+ *
+ * Rationale per family:
+ *
+ *  - Claude (anthropic-messages): drop legacy `thinking` blocks from history.
+ *    Older Claude versions (pre-4.5) don't preserve thinking blocks across
+ *    turns, so re-sending them is a noop at best and an error at worst.
+ *
+ *  - GPT / o-series / Gemini on Copilot (openai-responses): drop reasoning
+ *    items from history while preserving the current tool-turn reasoning.
+ *    Copilot's OpenAI-compatible `/responses` endpoint serializes prior
+ *    `thinking` blocks (via `thinkingSignature`) back into the input as
+ *    `reasoning` items carrying `encrypted_content` + `id`. Those tokens are
+ *    bound to the originating connection/turn and are rejected on replay with
+ *    `400 The encrypted content for item rs_<id> could not be verified`
+ *    (see https://github.com/openclaw/openclaw/issues/78867).
+ *
+ *    Native OpenAI Responses replay is unaffected: this hook only fires when
+ *    the github-copilot provider is selected. `dropReasoningFromHistory`
+ *    keeps reasoning attached to the current tool turn so multi-step
+ *    function-call flows on o-series models still continue correctly.
+ */
 export function buildGithubCopilotReplayPolicy(modelId?: string) {
-  return normalizeLowercaseStringOrEmpty(modelId).includes("claude")
-    ? {
-        dropThinkingBlocks: true,
-      }
-    : {};
+  const id = normalizeLowercaseStringOrEmpty(modelId);
+  if (id.includes("claude")) {
+    return {
+      dropThinkingBlocks: true,
+    };
+  }
+  // All non-Claude Copilot models route through openai-responses, where
+  // replayed `encrypted_content` from prior turns is rejected. Strip cross-turn
+  // reasoning while keeping current-turn tool-call reasoning intact.
+  return {
+    dropReasoningFromHistory: true,
+  };
 }


### PR DESCRIPTION
## Summary

Fixes #78867.

`github-copilot/gpt-5.5` (and any non-Claude Copilot model routed to `openai-responses`) breaks across turns because reasoning `encrypted_content` from a prior turn is replayed into the next request and rejected upstream with:

```
400 The encrypted content for item rs_<...> could not be verified.
Reason: Encrypted content item_id did not match the target item id.
```

The only previous workaround was setting `reasoning: false` on the model entry, which kills single-turn reasoning too. This PR fixes the cross-turn replay without disabling reasoning.

## Approach (per [@clawsweeper-bot review on the issue](https://github.com/openclaw/openclaw/issues/78867))

> Add provider-owned Copilot replay handling for GPT/o-series Responses that avoids resending stale encrypted reasoning on full-history turns while leaving native OpenAI replay semantics intact.

`buildGithubCopilotReplayPolicy` already owned the Claude path (`dropThinkingBlocks: true` for legacy Claude versions). Extend it so non-Claude Copilot models (GPT / o-series / Gemini — all of which `resolveCopilotTransportApi` routes to `openai-responses`) get `dropReasoningFromHistory: true`.

The `dropReasoningFromHistory` helper already lives in `src/agents/pi-embedded-runner/thinking.ts` and is wired through `resolveTranscriptPolicy` → `replay-history.ts`. It strips reasoning from prior turns while preserving the **current** tool-turn reasoning (so o-series multi-step tool flows still work within a single turn), which is exactly what we want here.

## Why this is safe

- **Native OpenAI Responses is unaffected.** Native OpenAI uses `buildOpenAIReplayPolicy` (different hook). This change only fires when the `github-copilot` provider is selected.
- **Claude on Copilot is unaffected.** The Claude branch still returns `{ dropThinkingBlocks: true }` exactly as before.
- **Single-turn reasoning still works.** `dropReasoningFromHistory` preserves reasoning blocks attached to the active tool-call turn (assistant turn after the latest user message that's followed by a tool result). Only stale prior-turn reasoning gets stripped before the request is rebuilt.

## Files changed

- `extensions/github-copilot/replay-policy.ts` — extend the policy for the GPT/o-series/Gemini path; add explanatory JSDoc that links the issue
- `extensions/github-copilot/replay-policy.test.ts` — new file, 6 test cases covering Claude path, GPT-5.x ids, o-series + Gemini + synthetic catch-all ids, and missing-modelId fallback

## Tests

```
$ pnpm vitest run --config test/vitest/vitest.extension-providers.config.ts \
    extensions/github-copilot/connection-bound-ids.test.ts \
    extensions/github-copilot/replay-policy.test.ts \
    extensions/github-copilot/stream.test.ts

 ✓ extensions/github-copilot/stream.test.ts (6 tests)
 ✓ extensions/github-copilot/replay-policy.test.ts (6 tests)
 ✓ extensions/github-copilot/connection-bound-ids.test.ts (4 tests)

 Test Files  3 passed (3)
      Tests  16 passed (16)
```

Plus the suites clawsweeper called out as guards against regressions in the
shared replay path:

```
$ pnpm vitest run --config test/vitest/vitest.agents-core.config.ts \
    src/agents/pi-embedded-runner.sanitize-session-history.test.ts \
    src/agents/openai-transport-stream.test.ts

 ✓ src/agents/openai-transport-stream.test.ts (106 tests)
 ✓ src/agents/pi-embedded-runner.sanitize-session-history.test.ts (56 tests)

 Test Files  2 passed (2)
      Tests  162 passed (162)
```

Full `extensions/github-copilot/**` suite: **74/74 passing**.

## Caveats

- I do not have a Copilot enterprise token, so this PR ships **unit tests only** — no two-turn live probe against `https://api.enterprise.githubcopilot.com`. Mentioning this here per the acceptance-criteria note in the issue. The unit tests directly assert the policy shape that gets fed into `resolveTranscriptPolicy` → `dropReasoningFromHistory`, which is the exact path that produced the bad replay payload in the trajectory evidence on the issue.