### PR TITLE
fix(tts/xiaomi): support Token Plan TTS endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Xiaomi MiMo: send TTS requests with Bearer auth and reuse the Xiaomi model provider base URL for TTS when no speech-specific base URL is configured, supporting Token Plan regional endpoints. Fixes #77692. Thanks @kidding1412 and @ismael-81.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/docs/providers/xiaomi.md
+++ b/docs/providers/xiaomi.md
@@ -72,6 +72,13 @@ an `assistant` message and optional style guidance as a `user` message.
 | Default  | `mimo-v2.5-tts`, voice `mimo_default`    |
 | Output   | MP3 by default; WAV when configured      |
 
+Token Plan keys require the matching Xiaomi regional Token Plan endpoint, such
+as `https://token-plan-cn.xiaomimimo.com/v1` or
+`https://token-plan-ams.xiaomimimo.com/v1`. When
+`messages.tts.providers.xiaomi.baseUrl` is not set, Xiaomi TTS reuses
+`models.providers.xiaomi.baseUrl`; set the TTS base URL only when speech should
+use a different endpoint from chat completions.
+
 ```json5
 {
   messages: {
@@ -81,6 +88,8 @@ an `assistant` message and optional style guidance as a `user` message.
       providers: {
         xiaomi: {
           apiKey: "xiaomi_api_key",
+          // For Token Plan keys, set the matching regional endpoint here or in models.providers.xiaomi.baseUrl.
+          // baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
           model: "mimo-v2.5-tts",
           voice: "mimo_default",
           format: "mp3",

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -943,7 +943,7 @@ OpenAI and ElevenLabs output formats are fixed per channel as listed above.
 
   <Accordion title="Xiaomi MiMo">
     <ParamField path="apiKey" type="string">Env: `XIAOMI_API_KEY`.</ParamField>
-    <ParamField path="baseUrl" type="string">Default `https://api.xiaomimimo.com/v1`. Env: `XIAOMI_BASE_URL`.</ParamField>
+    <ParamField path="baseUrl" type="string">Default `https://api.xiaomimimo.com/v1`. Env: `XIAOMI_BASE_URL`. If omitted, TTS reuses `models.providers.xiaomi.baseUrl`, including Token Plan regional endpoints such as `https://token-plan-cn.xiaomimimo.com/v1` or `https://token-plan-ams.xiaomimimo.com/v1`.</ParamField>
     <ParamField path="model" type="string">Default `mimo-v2.5-tts`. Env: `XIAOMI_TTS_MODEL`. Also supports `mimo-v2-tts`.</ParamField>
     <ParamField path="voice" type="string">Default `mimo_default`. Env: `XIAOMI_TTS_VOICE`.</ParamField>
     <ParamField path="format" type='"mp3" | "wav"'>Default `mp3`. Env: `XIAOMI_TTS_FORMAT`.</ParamField>

--- a/extensions/xiaomi/speech-provider.test.ts
+++ b/extensions/xiaomi/speech-provider.test.ts
@@ -163,7 +163,10 @@ describe("buildXiaomiSpeechProvider", () => {
       expect(mockFetch).toHaveBeenCalledOnce();
       const [url, init] = mockFetch.mock.calls[0];
       expect(url).toBe("https://api.xiaomimimo.com/v1/chat/completions");
-      expect(init?.headers).toMatchObject({ "api-key": "sk-test" });
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer sk-test",
+        "Content-Type": "application/json",
+      });
       const body = JSON.parse(init!.body as string);
       expect(body.model).toBe("mimo-v2-tts");
       expect(body.messages).toEqual([
@@ -172,6 +175,72 @@ describe("buildXiaomiSpeechProvider", () => {
       ]);
       expect(body.audio).toEqual({ format: "mp3", voice: "default_en" });
       expect(transcodeAudioBufferToOpusMock).not.toHaveBeenCalled();
+    });
+
+    it("inherits the Xiaomi model provider baseUrl when TTS baseUrl is not configured", async () => {
+      const audio = Buffer.from("fake-mp3-audio").toString("base64");
+      const mockFetch = vi.mocked(globalThis.fetch);
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { audio: { data: audio } } }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await provider.synthesize({
+        text: "Hello from Token Plan.",
+        cfg: {
+          models: {
+            providers: {
+              xiaomi: {
+                baseUrl: "https://token-plan-ams.xiaomimimo.com/v1/",
+              },
+            },
+          },
+        } as never,
+        providerConfig: { apiKey: "tp-test" },
+        target: "audio-file",
+        timeoutMs: 30000,
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://token-plan-ams.xiaomimimo.com/v1/chat/completions");
+      expect(init?.headers).toMatchObject({ Authorization: "Bearer tp-test" });
+    });
+
+    it("prefers the TTS provider baseUrl over the Xiaomi model provider baseUrl", async () => {
+      const audio = Buffer.from("fake-mp3-audio").toString("base64");
+      const mockFetch = vi.mocked(globalThis.fetch);
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { audio: { data: audio } } }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await provider.synthesize({
+        text: "Hello from explicit TTS endpoint.",
+        cfg: {
+          models: {
+            providers: {
+              xiaomi: {
+                baseUrl: "https://token-plan-ams.xiaomimimo.com/v1",
+              },
+            },
+          },
+        } as never,
+        providerConfig: {
+          apiKey: "tp-test",
+          baseUrl: "https://token-plan-cn.xiaomimimo.com/v1/",
+        },
+        target: "audio-file",
+        timeoutMs: 30000,
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://token-plan-cn.xiaomimimo.com/v1/chat/completions");
     });
 
     it("transcodes Xiaomi output to Opus for voice-note targets", async () => {

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -36,7 +36,7 @@ type XiaomiTtsFormat = (typeof XIAOMI_TTS_FORMATS)[number];
 
 type XiaomiTtsProviderConfig = {
   apiKey?: string;
-  baseUrl: string;
+  baseUrl?: string;
   model: string;
   voice: string;
   format: XiaomiTtsFormat;
@@ -54,6 +54,11 @@ function normalizeXiaomiTtsBaseUrl(baseUrl?: string): string {
   return (baseUrl?.trim() || DEFAULT_XIAOMI_TTS_BASE_URL).replace(/\/+$/, "");
 }
 
+function normalizeOptionalXiaomiTtsBaseUrl(baseUrl: unknown): string | undefined {
+  const trimmed = trimToUndefined(baseUrl);
+  return trimmed ? normalizeXiaomiTtsBaseUrl(trimmed) : undefined;
+}
+
 function normalizeXiaomiTtsFormat(value: unknown): XiaomiTtsFormat | undefined {
   const normalized = trimToUndefined(value)?.toLowerCase();
   return XIAOMI_TTS_FORMATS.includes(normalized as XiaomiTtsFormat)
@@ -68,6 +73,13 @@ function resolveXiaomiTtsConfigRecord(
   return asObject(providers?.xiaomi) ?? asObject(providers?.mimo) ?? asObject(rawConfig.xiaomi);
 }
 
+function readXiaomiModelProviderConfig(cfg: unknown): Record<string, unknown> | undefined {
+  const root = asObject(cfg);
+  const models = asObject(root?.models);
+  const providers = asObject(models?.providers);
+  return asObject(providers?.xiaomi);
+}
+
 function normalizeXiaomiTtsProviderConfig(
   rawConfig: Record<string, unknown>,
 ): XiaomiTtsProviderConfig {
@@ -77,9 +89,9 @@ function normalizeXiaomiTtsProviderConfig(
       value: raw?.apiKey,
       path: "messages.tts.providers.xiaomi.apiKey",
     }),
-    baseUrl: normalizeXiaomiTtsBaseUrl(
-      trimToUndefined(raw?.baseUrl) ?? trimToUndefined(process.env.XIAOMI_BASE_URL),
-    ),
+    baseUrl:
+      normalizeOptionalXiaomiTtsBaseUrl(raw?.baseUrl) ??
+      normalizeOptionalXiaomiTtsBaseUrl(process.env.XIAOMI_BASE_URL),
     model:
       trimToUndefined(raw?.model) ??
       trimToUndefined(process.env.XIAOMI_TTS_MODEL) ??
@@ -105,12 +117,22 @@ function readXiaomiTtsProviderConfig(config: SpeechProviderConfig): XiaomiTtsPro
         value: config.apiKey,
         path: "messages.tts.providers.xiaomi.apiKey",
       }) ?? normalized.apiKey,
-    baseUrl: normalizeXiaomiTtsBaseUrl(trimToUndefined(config.baseUrl) ?? normalized.baseUrl),
+    baseUrl: normalizeOptionalXiaomiTtsBaseUrl(config.baseUrl) ?? normalized.baseUrl,
     model: trimToUndefined(config.model) ?? normalized.model,
     voice: trimToUndefined(config.voice) ?? trimToUndefined(config.voiceId) ?? normalized.voice,
     format: normalizeXiaomiTtsFormat(config.format) ?? normalized.format,
     style: trimToUndefined(config.style) ?? normalized.style,
   };
+}
+
+function resolveXiaomiTtsBaseUrl(params: {
+  cfg?: unknown;
+  providerConfig: XiaomiTtsProviderConfig;
+}): string {
+  return normalizeXiaomiTtsBaseUrl(
+    params.providerConfig.baseUrl ??
+      normalizeOptionalXiaomiTtsBaseUrl(readXiaomiModelProviderConfig(params.cfg)?.baseUrl),
+  );
 }
 
 function readXiaomiTtsOverrides(
@@ -214,7 +236,7 @@ async function xiaomiTTS(params: {
       init: {
         method: "POST",
         headers: {
-          "api-key": apiKey,
+          Authorization: `Bearer ${apiKey}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -263,7 +285,7 @@ export function buildXiaomiSpeechProvider(): SpeechProviderPlugin {
       const audioBuffer = await xiaomiTTS({
         text: req.text,
         apiKey,
-        baseUrl: config.baseUrl,
+        baseUrl: resolveXiaomiTtsBaseUrl({ cfg: req.cfg, providerConfig: config }),
         model: overrides.model ?? config.model,
         voice: overrides.voice ?? config.voice,
         format: outputFormat,


### PR DESCRIPTION
## Summary

Fix Xiaomi MiMo TTS for Token Plan users by:

- sending Xiaomi TTS requests with `Authorization: Bearer <key>` instead of the `api-key` header
- reusing `models.providers.xiaomi.baseUrl` for Xiaomi TTS when `messages.tts.providers.xiaomi.baseUrl` is not configured
- preserving explicit TTS `baseUrl` overrides for users who need speech to use a different endpoint
- documenting Token Plan regional endpoints such as `token-plan-cn` and `token-plan-ams`

This handles the Token Plan failure mode where `tp-...` keys must call the matching regional Token Plan endpoint instead of the default pay-as-you-go endpoint.

Closes #77692

## Real behavior proof

**Behavior or issue addressed:** Xiaomi MiMo TTS with a Token Plan key should call the regional Token Plan endpoint and synthesize audio successfully instead of returning `401 Invalid API Key` from the default pay-as-you-go endpoint.

**Real environment tested:** Local Mac mini OpenClaw checkout using a real Xiaomi MiMo Token Plan key against `https://token-plan-cn.xiaomimimo.com/v1`. The key was kept local and was not pasted into the PR, issue, logs, or code.

**Exact steps or command run after this patch:**

```bash
set +x
export XIAOMI_API_KEY="<redacted real Token Plan key>"
export XIAOMI_BASE_URL="https://token-plan-cn.xiaomimimo.com/v1"
export OPENCLAW_LIVE_TEST=1
npx pnpm@10.33.2 vitest run --config test/vitest/vitest.live.config.ts extensions/xiaomi/xiaomi.live.test.ts
unset XIAOMI_API_KEY XIAOMI_BASE_URL OPENCLAW_LIVE_TEST
```

**Evidence after fix:** Copied live terminal output from the local run, with secrets redacted:

```text
Result: PASS
baseUrl: token-plan-cn
Command: npx pnpm@10.33.2 vitest run --config test/vitest/vitest.live.config.ts extensions/xiaomi/xiaomi.live.test.ts
Tests: 2 passed
Endpoint: https://token-plan-cn.xiaomimimo.com/v1
Confirmed default endpoint was not used: https://api.xiaomimimo.com/v1

Passed live cases:
1. synthesizes MiMo TTS through the registered speech provider - 2.1s
2. synthesizes MiMo TTS as an Opus voice note - 13.1s
```

**Observed result after fix:** Both live Xiaomi TTS paths succeeded with the real Token Plan endpoint: MP3 audio-file synthesis and Opus voice-note synthesis. The run used `token-plan-cn` and did not hit the default pay-as-you-go endpoint.

**What was not tested:** `token-plan-ams` was not live-tested in this run. Unit coverage verifies `models.providers.xiaomi.baseUrl` inheritance and explicit TTS `baseUrl` precedence; the live run used `XIAOMI_BASE_URL` to target `token-plan-cn`.

## Verification

- `npx pnpm@10.33.2 test extensions/xiaomi/speech-provider.test.ts`
  - 14 passed
- `npx pnpm@10.33.2 exec oxfmt --check --threads=1 CHANGELOG.md docs/providers/xiaomi.md docs/tools/tts.md extensions/xiaomi/speech-provider.ts extensions/xiaomi/speech-provider.test.ts`
  - passed
- `git diff --check`
  - passed
- Live Token Plan CN verification from the local Mac mini environment:
  - `npx pnpm@10.33.2 vitest run --config test/vitest/vitest.live.config.ts extensions/xiaomi/xiaomi.live.test.ts`
  - 2 passed
  - endpoint: `https://token-plan-cn.xiaomimimo.com/v1`
  - confirmed the live run did not use `https://api.xiaomimimo.com/v1`

`npx pnpm@10.33.2 check:changed` passed the extension production typecheck but failed in the broader extension test typecheck on unrelated existing test files under `extensions/diffs`, `extensions/irc`, `extensions/line`, `extensions/nextcloud-talk`, and `extensions/qqbot`.
