### PR TITLE
fix: surface gateway version skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ Docs: https://docs.openclaw.ai
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.
 - Agents/Codex: auto-enable the Codex harness plugin for one-shot OpenAI model overrides so `openclaw agent --local --model openai/...` does not fail with an unregistered `codex` harness.
 - Gateway/live tests: avoid full model-registry enumeration for explicit provider-qualified live model filters, preventing `.profile` OpenAI gateway profile runs from hanging before provider dispatch.
+- Gateway/status: surface CLI and gateway runtime versions, warn about stale PATH/global wrappers when they differ, and add stale-wrapper checks to the newer-config warning. Refs #79091. Thanks @RamaAditya49 and @sallyom.
 - Providers: preserve non-OK `text/event-stream` response bodies so provider HTTP errors keep their JSON detail instead of collapsing to generic streaming failures. Fixes #78180.
 - Gateway/auth: make explicit `trusted-proxy` mode fail closed instead of accepting local password fallback credentials after trusted-proxy identity checks fail. Fixes #78684.
 - Active memory: treat Google Chat `spaces/...` conversation ids as scoped targets instead of runnable channel names so recall runs no longer fail bundled-plugin dirName validation. Fixes #78918.

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -84,6 +84,32 @@ describe("probeGatewayStatus", () => {
     });
   });
 
+  it("preserves gateway server version from the connect probe", async () => {
+    callGatewayMock.mockReset();
+    probeGatewayMock.mockReset();
+    probeGatewayMock.mockResolvedValueOnce({
+      ok: true,
+      auth: {
+        role: "operator",
+        scopes: ["operator.write"],
+        capability: "write_capable",
+      },
+      server: { version: "2026.5.6", connId: "conn-1" },
+    });
+
+    const result = await probeGatewayStatus({
+      url: "ws://127.0.0.1:19191",
+      token: "temp-token",
+      timeoutMs: 5_000,
+      json: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      server: { version: "2026.5.6", connId: "conn-1" },
+    });
+  });
+
   it("uses a real status RPC when requireRpc is enabled", async () => {
     callGatewayMock.mockReset();
     probeGatewayMock.mockReset();

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -1,9 +1,15 @@
 import type { OpenClawConfig } from "../../config/types.js";
+import type { GatewayProbeResult } from "../../gateway/probe.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { withProgress } from "../progress.js";
 
 type GatewayStatusProbeKind = "connect" | "read";
+type GatewayStatusRequireRpcProbeResult = {
+  ok: true;
+  authProbe: GatewayProbeResult | null;
+};
+type GatewayStatusProbeResult = GatewayProbeResult | GatewayStatusRequireRpcProbeResult;
 
 const probeGatewayModuleLoader = createLazyImportLoader(() => import("../../gateway/probe.js"));
 
@@ -24,6 +30,10 @@ function resolveProbeFailureMessage(result: {
   return result.error ?? closeHint ?? "gateway probe failed";
 }
 
+function resolveGatewayStatusProbeDetails(result: GatewayStatusProbeResult) {
+  return "authProbe" in result ? result.authProbe : result;
+}
+
 export async function probeGatewayStatus(opts: {
   url: string;
   token?: string;
@@ -38,7 +48,7 @@ export async function probeGatewayStatus(opts: {
 }) {
   const kind = (opts.requireRpc ? "read" : "connect") satisfies GatewayStatusProbeKind;
   try {
-    const result = await withProgress(
+    const result = await withProgress<GatewayStatusProbeResult>(
       {
         label: "Checking gateway status...",
         indeterminate: true,
@@ -77,7 +87,10 @@ export async function probeGatewayStatus(opts: {
         return await probeGateway(probeOpts);
       },
     );
-    const auth = "auth" in result ? result.auth : result.authProbe?.auth;
+    const probeDetails = resolveGatewayStatusProbeDetails(result);
+    const auth = probeDetails?.auth;
+    const server = probeDetails?.server;
+    const serverSummary = server ? { server } : {};
     if (result.ok) {
       return {
         ok: true,
@@ -89,6 +102,7 @@ export async function probeGatewayStatus(opts: {
               : "read_only"
             : auth?.capability,
         auth,
+        ...serverSummary,
       } as const;
     }
     return {
@@ -96,6 +110,7 @@ export async function probeGatewayStatus(opts: {
       kind,
       capability: auth?.capability,
       auth,
+      ...serverSummary,
       error: resolveProbeFailureMessage(result),
     } as const;
   } catch (err) {

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -5,15 +5,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockGatewayService } from "../../daemon/service.test-helpers.js";
 import type { GatewayRestartHandoff } from "../../infra/restart-handoff.js";
 import { captureEnv } from "../../test-utils/env.js";
+import { VERSION } from "../../version.js";
 import type { GatewayRestartSnapshot } from "./restart-health.js";
 import { gatherDaemonStatus } from "./status.gather.js";
 
 const callGatewayStatusProbe = vi.fn<
-  (opts?: unknown) => Promise<{ ok: boolean; url?: string; error?: string | null }>
+  (opts?: unknown) => Promise<{
+    ok: boolean;
+    url?: string;
+    error?: string | null;
+    server?: { version?: string | null; connId?: string | null };
+  }>
 >(async (_opts?: unknown) => ({
   ok: true,
   url: "ws://127.0.0.1:19001",
   error: null,
+  server: { version: "2026.5.6", connId: "conn-1" },
 }));
 const loadGatewayTlsRuntime = vi.fn(async (_cfg?: unknown) => ({
   enabled: true,
@@ -221,6 +228,11 @@ describe("gatherDaemonStatus", () => {
     expect(status.gateway?.tlsEnabled).toBe(true);
     expect(status.rpc?.url).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.ok).toBe(true);
+    expect(status.rpc?.server).toEqual({ version: "2026.5.6", connId: "conn-1" });
+    expect(status.cli?.version).toBe(VERSION);
+    if (process.argv[1]) {
+      expect(status.cli?.entrypoint).toBe(process.argv[1]);
+    }
     expect(inspectGatewayRestart).not.toHaveBeenCalled();
   });
 

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -35,6 +35,7 @@ import {
 } from "../../infra/restart-handoff.js";
 import { resolveConfiguredLogFilePath } from "../../logging/log-file-path.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { VERSION } from "../../version.js";
 import { normalizeListenerAddress, parsePortFromArgs, pickProbeHostForBind } from "./shared.js";
 import type { GatewayRpcOpts } from "./types.js";
 
@@ -84,6 +85,11 @@ type ResolvedGatewayStatus = {
   daemonPort: number;
   cliPort: number;
   probeUrlOverride: string | null;
+};
+
+type CliStatusSummary = {
+  version: string;
+  entrypoint?: string;
 };
 
 const gatewayProbeAuthModuleLoader = createLazyImportLoader(
@@ -237,6 +243,7 @@ function appendProbeNote(
   return [...new Set(values)].join(" ");
 }
 export type DaemonStatus = {
+  cli?: CliStatusSummary;
   logFile?: string;
   service: {
     label: string;
@@ -281,6 +288,10 @@ export type DaemonStatus = {
       scopes?: string[];
       capability?: string;
     };
+    server?: {
+      version?: string | null;
+      connId?: string | null;
+    };
     error?: string;
     url?: string;
     authWarning?: string;
@@ -300,6 +311,14 @@ function shouldReportPortUsage(status: PortUsageStatus | undefined, rpcOk?: bool
     return false;
   }
   return true;
+}
+
+function resolveCliStatusSummary(argv: string[] = process.argv): CliStatusSummary {
+  const entrypoint = argv[1]?.trim();
+  return {
+    version: VERSION,
+    ...(entrypoint ? { entrypoint } : {}),
+  };
 }
 
 async function loadDaemonConfigContext(
@@ -553,6 +572,7 @@ export async function gatherDaemonStatus(
   }
 
   return {
+    cli: resolveCliStatusSummary(),
     logFile: resolveConfiguredLogFilePath(cliCfg),
     service: {
       label: service.label,

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -157,6 +157,51 @@ describe("printDaemonStatus", () => {
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Capability: write-capable"));
   });
 
+  it("prints CLI and gateway versions with stale wrapper guidance when they differ", () => {
+    printDaemonStatus(
+      {
+        cli: {
+          version: "2026.4.23",
+          entrypoint: "/usr/local/bin/openclaw",
+        },
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18789,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18789",
+        },
+        rpc: {
+          ok: true,
+          kind: "connect",
+          capability: "write_capable",
+          url: "ws://127.0.0.1:18789",
+          server: { version: "2026.5.6", connId: "conn-1" },
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("CLI version: 2026.4.23 (/usr/local/bin/openclaw)"),
+    );
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Gateway version: 2026.5.6"));
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("CLI/runtime version skew detected"),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("stale PATH/global wrappers"),
+    );
+  });
+
   it("prints restart handoff diagnostics when deep status gathered one", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -62,6 +62,13 @@ function formatCapabilityLabel(capability?: string) {
   return capability.replaceAll("_", "-");
 }
 
+function formatCliVersionLine(cli: DaemonStatus["cli"]): string | null {
+  if (!cli) {
+    return null;
+  }
+  return cli.entrypoint ? `${cli.version} (${shortenHomePath(cli.entrypoint)})` : cli.version;
+}
+
 export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean }) {
   if (opts.json) {
     const sanitized = sanitizeDaemonStatusForJson(status);
@@ -172,6 +179,28 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
     }
     if (status.gateway.probeNote) {
       defaultRuntime.log(`${label("Probe note:")} ${infoText(status.gateway.probeNote)}`);
+    }
+    spacer();
+  }
+
+  const gatewayVersion = rpc?.server?.version?.trim();
+  const cliVersionLine = formatCliVersionLine(status.cli);
+  if (gatewayVersion) {
+    if (cliVersionLine) {
+      defaultRuntime.log(`${label("CLI version:")} ${infoText(cliVersionLine)}`);
+    }
+    defaultRuntime.log(`${label("Gateway version:")} ${infoText(gatewayVersion)}`);
+    if (status.cli?.version && status.cli.version !== gatewayVersion) {
+      defaultRuntime.error(
+        warnText(
+          `Warning: CLI/runtime version skew detected. CLI is ${status.cli.version}; gateway is ${gatewayVersion}.`,
+        ),
+      );
+      defaultRuntime.error(
+        warnText(
+          `Fix: check for stale PATH/global wrappers with \`command -v openclaw\`, \`readlink -f "$(command -v openclaw)"\`, and \`openclaw --version\`; reinstall the gateway service from the intended binary if needed.`,
+        ),
+      );
     }
     spacer();
   }

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -2,12 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
 const callGateway = vi.hoisted(() => vi.fn());
+const note = vi.hoisted(() => vi.fn());
 
 vi.mock("../gateway/call.js", () => ({
   buildGatewayConnectionDetails: vi.fn(() => ({
     message: "Gateway target: ws://127.0.0.1:18789",
   })),
   callGateway,
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note,
 }));
 
 vi.mock("./health.js", () => ({
@@ -21,6 +26,7 @@ describe("checkGatewayHealth", () => {
 
   beforeEach(() => {
     callGateway.mockReset();
+    note.mockReset();
   });
 
   it("uses a lightweight status RPC for the restart liveness gate", async () => {
@@ -43,6 +49,25 @@ describe("checkGatewayHealth", () => {
       timeoutMs: 6000,
     });
     expect(runtime.error).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalledWith(expect.any(String), "Gateway version skew");
+  });
+
+  it("notes CLI and gateway version skew when the gateway reports another runtime version", async () => {
+    callGateway.mockResolvedValueOnce({ runtimeVersion: "2026.4.23" }).mockResolvedValueOnce({});
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await expect(
+      checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 }),
+    ).resolves.toEqual({ healthOk: true, status: { runtimeVersion: "2026.4.23" } });
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway version: 2026.4.23"),
+      "Gateway version skew",
+    );
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("stale global wrapper"),
+      "Gateway version skew",
+    );
   });
 
   it("does not run follow-up channel probes when liveness fails", async () => {

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -5,6 +5,7 @@ import { collectChannelStatusIssues } from "../infra/channels-status-issues.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
+import { VERSION } from "../version.js";
 import { formatHealthCheckFailure } from "./health-format.js";
 import type { StatusSummary } from "./status.types.js";
 
@@ -25,6 +26,22 @@ function isGatewayCallTimeout(message: string): boolean {
   return /^gateway timeout after \d+ms(?:\n|$)/.test(message);
 }
 
+function noteCliGatewayVersionSkew(status: StatusSummary | undefined): void {
+  const gatewayVersion = status?.runtimeVersion?.trim();
+  if (!gatewayVersion || gatewayVersion === VERSION) {
+    return;
+  }
+  note(
+    [
+      `CLI version: ${VERSION}`,
+      `Gateway version: ${gatewayVersion}`,
+      "The CLI and running gateway are different versions. This can happen when PATH points at a stale global wrapper while the service runs a newer install.",
+      'Fix: run `openclaw gateway status --deep`; check `command -v openclaw`, `readlink -f "$(command -v openclaw)"`, and `openclaw --version`; reinstall the gateway service from the intended binary if needed.',
+    ].join("\n"),
+    "Gateway version skew",
+  );
+}
+
 export async function checkGatewayHealth(params: {
   runtime: RuntimeEnv;
   cfg: OpenClawConfig;
@@ -43,6 +60,7 @@ export async function checkGatewayHealth(params: {
       config: params.cfg,
     });
     healthOk = true;
+    noteCliGatewayVersionSkew(status);
   } catch (err) {
     const message = String(err);
     if (message.includes("gateway closed")) {

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -109,6 +109,45 @@ describe("config io paths", () => {
     });
   });
 
+  it("hints at stale wrappers when config was written by a newer OpenClaw", async () => {
+    await withTempHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            meta: { lastTouchedVersion: "9999.1.1" },
+            gateway: { mode: "local" },
+          },
+          null,
+          2,
+        ),
+      );
+      const logger = {
+        error: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      const io = createConfigIO({
+        configPath,
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger,
+      });
+      io.loadConfig();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("stale PATH or global wrappers"),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("command -v openclaw"));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("openclaw --version"));
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("openclaw gateway status --deep"),
+      );
+    });
+  });
+
   it("normalizes safe-bin config entries at config load time", async () => {
     const cfg = {
       tools: {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -908,7 +908,9 @@ function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console
     }
     warnedFutureTouchedVersions.add(touched);
     logger.warn(
-      `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}.`,
+      `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}. ` +
+        `If the gateway is healthy, check for CLI/runtime skew from stale PATH or global wrappers: ` +
+        `command -v openclaw; readlink -f "$(command -v openclaw)"; openclaw --version; openclaw gateway status --deep.`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- Problem: stale global/PATH wrappers can run an older CLI against a newer or older gateway runtime, but the diagnostics did not show the CLI wrapper version next to the running gateway version.
- Why it matters: issue #79091 reported a Linux install where `openclaw --version` and the gateway/config state disagreed, leaving the operator with a misleading newer-config warning and no direct stale-wrapper check.
- What changed: `openclaw gateway status --deep` now preserves and prints the gateway hello server version, warns on CLI/runtime version skew, and includes stale PATH/global wrapper checks. `openclaw doctor` now emits a matching gateway skew note from the gateway status RPC. The newer-config warning now points operators at the same stale-wrapper commands.
- What did NOT change: this does not migrate or rewrite user config, reinstall services, or change gateway startup/version semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79091
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: stale CLI/runtime skew is visible in real `gateway status --deep`, `doctor`, and newer-config warning output.
- Real environment tested: Blacksmith Linux Testbox via Crabbox, OpenClaw checkout at this branch, Node 22, gateway launched with `OPENCLAW_VERSION=2026.4.23` and CLI at `2026.5.6`.
- Exact steps or command run after this patch: started a real foreground gateway on loopback with token auth and `OPENCLAW_VERSION=2026.4.23`, then ran `node openclaw.mjs gateway status --url ws://127.0.0.1:18791 --token <redacted> --deep --require-rpc`, `node openclaw.mjs gateway call status --url ws://127.0.0.1:18791 --token <redacted> --json`, and `node openclaw.mjs doctor --non-interactive --deep`.
- Evidence after fix: Testbox `tbx_01kr2pm3z0q83dw26jsnjqngdz`, Actions run https://github.com/openclaw/openclaw/actions/runs/25533208594. Copied live output showed:

```text
CLI version: 2026.5.6 (~/_work/openclaw/openclaw/openclaw.mjs)
Gateway version: 2026.4.23
Warning: CLI/runtime version skew detected. CLI is 2026.5.6; gateway is 2026.4.23.
Fix: check for stale PATH/global wrappers with `command -v openclaw`, `readlink -f "$(command -v openclaw)"`, and `openclaw --version`; reinstall the gateway service from the intended binary if needed.
```

```text
◇  Gateway version skew
│  CLI version: 2026.5.6
│  Gateway version: 2026.4.23
│  when PATH points at a stale global wrapper while the service runs a
│  Fix: run `openclaw gateway status --deep`; check `command -v
```

The same run also showed the gateway `status` RPC returning:

```json
{
  "runtimeVersion": "2026.4.23"
}
```

A separate Testbox config-warning proof used a temp config stamped with `meta.lastTouchedVersion: "9999.1.1"` and ran `OPENCLAW_CONFIG_PATH=<temp>/openclaw.json pnpm openclaw config get gateway.mode`. It printed:

```text
Config was last written by a newer OpenClaw (9999.1.1); current version is 2026.5.6. If the gateway is healthy, check for CLI/runtime skew from stale PATH or global wrappers: command -v openclaw; readlink -f "$(command -v openclaw)"; openclaw --version; openclaw gateway status --deep.
local
```

- Observed result after fix: the CLI and gateway versions are surfaced together, version skew is called out directly, stale PATH/global wrapper commands are included, and doctor emits a visible `Gateway version skew` note.
- What was not tested: a real globally installed stale `/usr/local/bin/openclaw` wrapper was not installed on the Testbox; the live proof forced the same runtime-version skew through the gateway process environment while exercising real CLI/gateway RPC paths.
- Before evidence: issue #79091 includes the original Linux report where an older `/usr/local/bin/openclaw` wrapper produced confusing newer-config diagnostics without a direct CLI/runtime comparison.

## Root Cause (if applicable)

- Root cause: diagnostics had the gateway/runtime version available in separate places, but `gateway status --deep` did not carry the gateway hello `server.version` through to output and doctor did not compare the running gateway `status.runtimeVersion` with the CLI `VERSION`.
- Missing detection / guardrail: no focused tests asserted that status/doctor surface CLI/runtime skew or that newer-config warnings direct operators to stale wrapper checks.
- Contributing context (if known): stale globally installed wrappers can shadow the intended OpenClaw binary on Linux PATH.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/daemon-cli/probe.test.ts`, `src/cli/daemon-cli/status.gather.test.ts`, `src/cli/daemon-cli/status.print.test.ts`, `src/commands/doctor-gateway-health.test.ts`, `src/config/io.compat.test.ts`.
- Scenario the test should lock in: gateway probe server version is preserved, status prints and warns on CLI/runtime skew, doctor emits a skew note, and newer-config warnings mention stale PATH/global wrappers.
- Why this is the smallest reliable guardrail: the bug is in diagnostic plumbing and rendering, so focused unit/seam tests cover the affected surfaces without requiring service install churn.
- Existing test that already covers this (if any): none before this patch.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw gateway status --deep`, `openclaw doctor`, and newer-config warnings now include clearer CLI/runtime skew diagnostics and stale PATH/global wrapper checks.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: local macOS for focused edit-loop tests; Blacksmith Linux Testbox for remote real-behavior proof.
- Runtime/container: Node 22, pnpm.
- Model/provider: N/A.
- Integration/channel (if any): Gateway CLI/doctor diagnostics.
- Relevant config (redacted): Testbox gateway used loopback bind, token auth, and a forced gateway runtime version of `2026.4.23`.

### Steps

1. Run the focused unit/seam tests for status, doctor, probe, and config warning behavior.
2. Run the same focused tests on Blacksmith Testbox via Crabbox.
3. Start a real Testbox gateway with gateway runtime version `2026.4.23` and run current CLI status/doctor diagnostics against it.
4. Run the newer-config warning scenario against a temporary config with `lastTouchedVersion: "9999.1.1"`.

### Expected

- Status/doctor show both CLI and gateway versions and warn when they differ.
- Newer-config warning points to stale PATH/global wrapper checks.

### Actual

- Matches expected in focused tests and Blacksmith Testbox proof.

## Evidence

- [x] Trace/log snippets
- [x] Copied live terminal output
- [x] Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/25533208594
- [x] Focused Testbox tests: https://github.com/openclaw/openclaw/actions/runs/25531306391

## Human Verification (required)

- Verified scenarios: focused local tests, focused Blacksmith tests, real Testbox gateway status/doctor skew output, and real Testbox newer-config warning output.
- Edge cases checked: no gateway version means no status skew warning; matching versions do not warn; future-config warning remains a warning while adding stale-wrapper hints.
- What you did **not** verify: a real stale global wrapper installed under `/usr/local/bin`; the Testbox proof forced the equivalent gateway/runtime version skew without changing host package installation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: false-positive skew warnings if the gateway reports an invalid or unexpected runtime version.
  - Mitigation: warnings only render when a non-empty gateway version exists and differs from the CLI version; existing status/doctor behavior remains otherwise unchanged.
