### PR TITLE
refactor(plugins): expose loaded runtime metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: collapse consecutive duplicate text messages into one bubble with a count so repeated text-only messages stay compact without hiding nearby context.
 - Control UI/chat and Sessions: label inherited thinking defaults separately from explicit overrides while preserving provider-supplied option labels. Fixes #77581. Thanks @BunsDev and @Beandon13.
 - Agents/runtime: add prepared runtime foundation contracts for carrying provider, model, tool, TTS, and outbound runtime facts through later reply-path migrations. Thanks @mcaxtr.
+- Plugins/runtime: expose loaded startup runtime metadata for later prepared-runtime migrations so request paths can reuse provider, channel, and public plugin facts without rebuilding broad registries. Thanks @mcaxtr.
 - Control UI/WhatsApp: keep Show QR available for unlinked WhatsApp accounts while switching linked accounts to the explicit Relink action and showing Wait for scan only when a QR is active. Thanks @BunsDev.
 - Gateway/performance: reuse the compatible plugin metadata snapshot across dashboard and channel agent turns so auto-enabled runtime config does not repeatedly rescan plugin metadata before provider calls. Thanks @shakkernerd.
 - Gateway/performance: reuse current plugin metadata for provider activation, auth/env candidate lookup, and bundle settings during dashboard and channel agent turns while keeping the configless secret-target cache unscoped and refusing stale unscoped reuse when plugin discovery roots differ. Thanks @shakkernerd.

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
+  resolveGatewayStartupPluginIds: vi.fn(),
   ensureStandaloneRuntimePluginRegistryLoaded: vi.fn(),
   getActivePluginRuntimeSubagentMode: vi.fn<() => "default" | "explicit" | "gateway-bindable">(
     () => "default",
@@ -10,6 +11,10 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: hoisted.getCurrentPluginMetadataSnapshot,
+}));
+
+vi.mock("../plugins/gateway-startup-plugin-ids.js", () => ({
+  resolveGatewayStartupPluginIds: hoisted.resolveGatewayStartupPluginIds,
 }));
 
 vi.mock("../plugins/runtime/standalone-runtime-registry-loader.js", () => ({
@@ -26,6 +31,8 @@ describe("ensureRuntimePluginsLoaded", () => {
   beforeEach(async () => {
     hoisted.getCurrentPluginMetadataSnapshot.mockReset();
     hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue(undefined);
+    hoisted.resolveGatewayStartupPluginIds.mockReset();
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue([]);
     hoisted.ensureStandaloneRuntimePluginRegistryLoaded.mockReset();
     hoisted.ensureStandaloneRuntimePluginRegistryLoaded.mockReturnValue(undefined);
     hoisted.getActivePluginRuntimeSubagentMode.mockReset();
@@ -46,18 +53,27 @@ describe("ensureRuntimePluginsLoaded", () => {
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves runtime plugins through the shared runtime helper", () => {
+  it("falls back to the gateway startup plan when no prepared snapshot is pinned", () => {
+    const config = {} as never;
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue(["whatsapp", "openai"]);
+
     ensureRuntimePluginsLoaded({
-      config: {} as never,
+      config,
       workspaceDir: "/tmp/workspace",
       allowGatewaySubagentBinding: true,
     });
 
+    expect(hoisted.resolveGatewayStartupPluginIds).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
-      requiredPluginIds: undefined,
+      requiredPluginIds: ["whatsapp", "openai"],
       loadOptions: {
-        config: {} as never,
+        config,
         workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["whatsapp", "openai"],
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
@@ -160,16 +176,19 @@ describe("ensureRuntimePluginsLoaded", () => {
   });
 
   it("does not enable gateway subagent binding for normal runtime loads", () => {
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue(["telegram"]);
+
     ensureRuntimePluginsLoaded({
       config: {} as never,
       workspaceDir: "/tmp/workspace",
     });
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
-      requiredPluginIds: undefined,
+      requiredPluginIds: ["telegram"],
       loadOptions: {
         config: {} as never,
         workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["telegram"],
         runtimeOptions: undefined,
       },
     });
@@ -177,6 +196,7 @@ describe("ensureRuntimePluginsLoaded", () => {
 
   it("inherits gateway-bindable mode from an active gateway registry", () => {
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue(["telegram"]);
 
     ensureRuntimePluginsLoaded({
       config: {} as never,
@@ -184,10 +204,11 @@ describe("ensureRuntimePluginsLoaded", () => {
     });
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
-      requiredPluginIds: undefined,
+      requiredPluginIds: ["telegram"],
       loadOptions: {
         config: {} as never,
         workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["telegram"],
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { resolveGatewayStartupPluginIds } from "../plugins/gateway-startup-plugin-ids.js";
 import { getActivePluginRuntimeSubagentMode } from "../plugins/runtime.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "../plugins/runtime/standalone-runtime-registry-loader.js";
 import { resolveUserPath } from "../utils.js";
@@ -27,6 +28,24 @@ function resolveStartupPluginIdsFromCurrentSnapshot(params: {
   return pluginIds.filter((pluginId): pluginId is string => typeof pluginId === "string");
 }
 
+function resolveStartupPluginIds(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+}): string[] | undefined {
+  const snapshotPluginIds = resolveStartupPluginIdsFromCurrentSnapshot(params);
+  if (snapshotPluginIds !== undefined) {
+    return snapshotPluginIds;
+  }
+  if (!params.config) {
+    return undefined;
+  }
+  return resolveGatewayStartupPluginIds({
+    config: params.config,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    env: process.env,
+  });
+}
+
 export function ensureRuntimePluginsLoaded(params: {
   config?: OpenClawConfig;
   workspaceDir?: string | null;
@@ -36,7 +55,7 @@ export function ensureRuntimePluginsLoaded(params: {
     typeof params.workspaceDir === "string" && params.workspaceDir.trim()
       ? resolveUserPath(params.workspaceDir)
       : undefined;
-  const startupPluginIds = resolveStartupPluginIdsFromCurrentSnapshot({
+  const startupPluginIds = resolveStartupPluginIds({
     config: params.config,
     workspaceDir,
   });

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -3,7 +3,10 @@ import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginLookUpTable } from "../plugins/plugin-lookup-table.js";
 import type { PluginRegistry } from "../plugins/registry.js";
-import { pinActivePluginChannelRegistry } from "../plugins/runtime.js";
+import {
+  pinActivePluginChannelRegistry,
+  pinActivePluginGatewayRuntimeRegistry,
+} from "../plugins/runtime.js";
 import {
   setGatewayNodesRuntime,
   setGatewaySubagentRuntime,
@@ -73,6 +76,11 @@ function logGatewayPluginDiagnostics(params: {
   }
 }
 
+function pinGatewayStartupRegistries(pluginRegistry: PluginRegistry): void {
+  pinActivePluginChannelRegistry(pluginRegistry);
+  pinActivePluginGatewayRuntimeRegistry(pluginRegistry);
+}
+
 export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   const activationSourceConfig = params.activationSourceConfig ?? params.cfg;
   const autoEnabled = applyPluginAutoEnable({
@@ -125,7 +133,7 @@ export function loadGatewayStartupPlugins(
 ) {
   return prepareGatewayPluginLoad({
     ...params,
-    beforePrimeRegistry: pinActivePluginChannelRegistry,
+    beforePrimeRegistry: pinGatewayStartupRegistries,
   });
 }
 
@@ -137,6 +145,6 @@ export function reloadDeferredGatewayPlugins(
 ) {
   return prepareGatewayPluginLoad({
     ...params,
-    beforePrimeRegistry: pinActivePluginChannelRegistry,
+    beforePrimeRegistry: pinGatewayStartupRegistries,
   });
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -45,6 +45,7 @@ import {
 import type { PluginHookGatewayCronService } from "../plugins/hook-types.js";
 import {
   pinActivePluginChannelRegistry,
+  pinActivePluginGatewayRuntimeRegistry,
   pinActivePluginHttpRouteRegistry,
 } from "../plugins/runtime.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
@@ -1080,6 +1081,7 @@ export async function startGatewayServer(
       attachedPluginGatewayHandlerKeys = new Set(Object.keys(pluginRegistry.gatewayHandlers));
       pinActivePluginHttpRouteRegistry(pluginRegistry);
       pinActivePluginChannelRegistry(pluginRegistry);
+      pinActivePluginGatewayRuntimeRegistry(pluginRegistry);
     };
     const refreshAttachedGatewayDiscovery = async (nextPluginRegistry: typeof pluginRegistry) => {
       if (minimalTestGateway) {

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -1,13 +1,20 @@
 import { resolveCompatibleRuntimePluginRegistry, type PluginLoadOptions } from "./loader.js";
 import type { PluginRegistry } from "./registry-types.js";
 import {
+  getActivePluginChannelRegistryWorkspaceDir,
   getActivePluginChannelRegistry,
+  getActivePluginGatewayRuntimeRegistry,
+  getActivePluginGatewayRuntimeRegistryWorkspaceDir,
   getActivePluginHttpRouteRegistry,
   getActivePluginRegistry,
   getActivePluginRegistryWorkspaceDir,
 } from "./runtime.js";
 
-export type ActiveRuntimePluginRegistrySurface = "active" | "channel" | "http-route";
+export type ActiveRuntimePluginRegistrySurface =
+  | "active"
+  | "channel"
+  | "gateway-runtime"
+  | "http-route";
 
 export function getActiveRuntimePluginRegistry(): PluginRegistry | null {
   return getActivePluginRegistry();
@@ -62,10 +69,27 @@ function resolveSurfaceRegistry(
       return getActivePluginRegistry();
     case "channel":
       return getActivePluginChannelRegistry();
+    case "gateway-runtime":
+      return getActivePluginGatewayRuntimeRegistry();
     case "http-route":
       return getActivePluginHttpRouteRegistry();
   }
   return null;
+}
+
+function resolveSurfaceWorkspaceDir(
+  surface: ActiveRuntimePluginRegistrySurface,
+): string | undefined {
+  switch (surface) {
+    case "active":
+    case "http-route":
+      return getActivePluginRegistryWorkspaceDir();
+    case "channel":
+      return getActivePluginChannelRegistryWorkspaceDir();
+    case "gateway-runtime":
+      return getActivePluginGatewayRuntimeRegistryWorkspaceDir();
+  }
+  return undefined;
 }
 
 export function getLoadedRuntimePluginRegistry(
@@ -89,7 +113,7 @@ export function getLoadedRuntimePluginRegistry(
     return compatible;
   }
 
-  const activeWorkspaceDir = getActivePluginRegistryWorkspaceDir();
+  const activeWorkspaceDir = resolveSurfaceWorkspaceDir(surface);
   const requestedWorkspaceDir = params.workspaceDir ?? params.loadOptions?.workspaceDir;
   if (requestedWorkspaceDir !== undefined && activeWorkspaceDir !== requestedWorkspaceDir) {
     return undefined;

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -166,6 +166,7 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         cliBackends: ["codex-cli"],
         contracts: {
           imageGenerationProviders: ["openai"],
+          speechProviders: ["openai"],
           videoGenerationProviders: ["openai"],
         },
       },
@@ -623,7 +624,7 @@ describe("resolveGatewayStartupPluginIds", () => {
         enabledPluginIds: ["voice-call"],
         modelId: "demo-cli/demo-model",
       }),
-      ["demo-channel", "browser", "voice-call", "memory-core"],
+      ["demo-channel", "browser", "demo-provider-plugin", "voice-call", "memory-core"],
     ],
     [
       "keeps bundled startup sidecars with enabledByDefault at idle startup",
@@ -636,6 +637,19 @@ describe("resolveGatewayStartupPluginIds", () => {
         providerIds: ["demo-provider"],
       }),
       ["demo-channel", "browser", "memory-core"],
+    ],
+    [
+      "includes configured image and PDF model owner plugins at startup",
+      {
+        channels: {},
+        agents: {
+          defaults: {
+            imageModel: { primary: "demo-cli/image-model" },
+            pdfModel: { primary: "demo-cli/pdf-model" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      ["browser", "demo-provider-plugin", "memory-core"],
     ],
     [
       "includes configured bundled speech providers at startup",
@@ -1401,7 +1415,7 @@ describe("resolveGatewayStartupPluginIds", () => {
     });
   });
 
-  it("includes required agent harness owner plugins for model runtime policy", () => {
+  it("includes required agent harness and model owner plugins for model runtime policy", () => {
     expectStartupPluginIdsCase({
       config: {
         agents: {
@@ -1417,20 +1431,20 @@ describe("resolveGatewayStartupPluginIds", () => {
           },
         },
       } as OpenClawConfig,
-      expected: ["demo-channel", "browser", "codex", "memory-core"],
+      expected: ["demo-channel", "browser", "openai", "codex", "memory-core"],
     });
   });
 
-  it("includes Codex when an OpenAI agent model uses the implicit runtime default", () => {
+  it("includes Codex and the configured model owner when an OpenAI agent model uses the implicit runtime default", () => {
     expectStartupPluginIdsCase({
       config: createStartupConfig({
         modelId: "openai/gpt-5.5",
       }),
-      expected: ["demo-channel", "browser", "codex", "memory-core"],
+      expected: ["demo-channel", "browser", "openai", "codex", "memory-core"],
     });
   });
 
-  it("does not include Codex when an OpenAI model is manually pinned to PI", () => {
+  it("includes the configured model owner without Codex when an OpenAI model is pinned to PI", () => {
     expectStartupPluginIdsCase({
       config: {
         agents: {
@@ -1442,7 +1456,7 @@ describe("resolveGatewayStartupPluginIds", () => {
           },
         },
       } as OpenClawConfig,
-      expected: ["demo-channel", "browser", "memory-core"],
+      expected: ["demo-channel", "browser", "openai", "memory-core"],
     });
   });
 
@@ -1567,7 +1581,7 @@ describe("resolveGatewayStartupPluginIds", () => {
           },
         },
       } as OpenClawConfig,
-      expected: ["demo-channel", "browser", "memory-core"],
+      expected: ["demo-channel", "browser", "openai", "memory-core"],
     });
   });
 });

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -3,6 +3,7 @@ import {
   listExplicitlyDisabledChannelIdsForConfig,
   listPotentialConfiguredChannelIds,
 } from "../channels/config-presence.js";
+import { collectConfiguredModelRefValues } from "../config/model-refs.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   DEFAULT_MEMORY_DREAMING_PLUGIN_ID,
@@ -20,6 +21,10 @@ import {
   normalizeConfiguredSpeechProviderIdForStartup,
 } from "./gateway-startup-speech-providers.js";
 import type { InstalledPluginIndexRecord } from "./installed-plugin-index.js";
+import {
+  isActivatedManifestOwner,
+  passesManifestOwnerBasePolicy,
+} from "./manifest-owner-policy.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import {
   isPluginMetadataSnapshotCompatible,
@@ -31,6 +36,7 @@ import {
   normalizePluginsConfigWithRegistry,
 } from "./plugin-registry-contributions.js";
 import type { PluginRegistrySnapshot } from "./plugin-registry-snapshot.js";
+import { resolveOwningPluginIdsForModelRefs } from "./providers.js";
 
 export type GatewayStartupPluginPlan = {
   channelPluginIds: readonly string[];
@@ -57,6 +63,28 @@ function isConfigActivationValueEnabled(value: unknown): boolean {
     return false;
   }
   return true;
+}
+
+function isPluginBlockedByStartupConfig(params: {
+  pluginId: string;
+  pluginsConfig: NormalizedPluginsConfig;
+  activationSourcePlugins?: NormalizedPluginsConfig;
+  requireGlobalEnabled?: boolean;
+}): boolean {
+  const { pluginId, pluginsConfig, activationSourcePlugins } = params;
+  if (
+    params.requireGlobalEnabled === true &&
+    (!pluginsConfig.enabled || activationSourcePlugins?.enabled === false)
+  ) {
+    return true;
+  }
+  if (pluginsConfig.deny.includes(pluginId) || activationSourcePlugins?.deny.includes(pluginId)) {
+    return true;
+  }
+  return (
+    pluginsConfig.entries[pluginId]?.enabled === false ||
+    activationSourcePlugins?.entries[pluginId]?.enabled === false
+  );
 }
 
 function listPotentialEnabledChannelIds(config: OpenClawConfig, env: NodeJS.ProcessEnv): string[] {
@@ -129,6 +157,34 @@ function resolveContextEngineSlotStartupPluginId(params: {
     return undefined;
   }
   return normalized;
+}
+
+function canStartConfiguredModelOwnerPlugin(params: {
+  plugin: InstalledPluginIndexRecord;
+  pluginsConfig: ReturnType<typeof normalizePluginsConfigWithRegistry>;
+  rootConfig: OpenClawConfig;
+}): boolean {
+  const ownerPlugin = {
+    id: params.plugin.pluginId,
+    origin: params.plugin.origin,
+    enabledByDefault: params.plugin.enabledByDefault,
+  };
+  if (
+    !passesManifestOwnerBasePolicy({
+      plugin: ownerPlugin,
+      normalizedConfig: params.pluginsConfig,
+    })
+  ) {
+    return false;
+  }
+  if (params.plugin.origin !== "workspace") {
+    return true;
+  }
+  return isActivatedManifestOwner({
+    plugin: ownerPlugin,
+    normalizedConfig: params.pluginsConfig,
+    rootConfig: params.rootConfig,
+  });
 }
 
 function shouldConsiderForGatewayStartup(params: {
@@ -408,14 +464,11 @@ function canStartConfiguredSpeechProviderPlugin(params: {
     return false;
   }
   if (
-    params.pluginsConfig.deny.includes(params.plugin.pluginId) ||
-    params.activationSource.plugins.deny.includes(params.plugin.pluginId)
-  ) {
-    return false;
-  }
-  if (
-    params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false ||
-    params.activationSource.plugins.entries[params.plugin.pluginId]?.enabled === false
+    isPluginBlockedByStartupConfig({
+      pluginId: params.plugin.pluginId,
+      pluginsConfig: params.pluginsConfig,
+      activationSourcePlugins: params.activationSource.plugins,
+    })
   ) {
     return false;
   }
@@ -446,18 +499,13 @@ function canStartConfiguredRootPlugin(params: {
   if (!hasConfiguredActivationPath({ manifest: params.manifest, config: params.config })) {
     return false;
   }
-  if (!params.pluginsConfig.enabled || !params.activationSourcePlugins.enabled) {
-    return false;
-  }
   if (
-    params.pluginsConfig.deny.includes(params.plugin.pluginId) ||
-    params.activationSourcePlugins.deny.includes(params.plugin.pluginId)
-  ) {
-    return false;
-  }
-  if (
-    params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false ||
-    params.activationSourcePlugins.entries[params.plugin.pluginId]?.enabled === false
+    isPluginBlockedByStartupConfig({
+      pluginId: params.plugin.pluginId,
+      pluginsConfig: params.pluginsConfig,
+      activationSourcePlugins: params.activationSourcePlugins,
+      requireGlobalEnabled: true,
+    })
   ) {
     return false;
   }
@@ -512,18 +560,13 @@ function canStartExplicitHookPlugin(params: {
   ) {
     return false;
   }
-  if (!params.pluginsConfig.enabled || !params.activationSourcePlugins.enabled) {
-    return false;
-  }
   if (
-    params.pluginsConfig.deny.includes(params.plugin.pluginId) ||
-    params.activationSourcePlugins.deny.includes(params.plugin.pluginId)
-  ) {
-    return false;
-  }
-  if (
-    params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false ||
-    params.activationSourcePlugins.entries[params.plugin.pluginId]?.enabled === false
+    isPluginBlockedByStartupConfig({
+      pluginId: params.plugin.pluginId,
+      pluginsConfig: params.pluginsConfig,
+      activationSourcePlugins: params.activationSourcePlugins,
+      requireGlobalEnabled: true,
+    })
   ) {
     return false;
   }
@@ -549,13 +592,13 @@ function canStartConfiguredChannelPlugin(params: {
   manifestLookup: ManifestRegistryLookup;
   platform?: NodeJS.Platform;
 }): boolean {
-  if (!params.pluginsConfig.enabled) {
-    return false;
-  }
-  if (params.pluginsConfig.deny.includes(params.plugin.pluginId)) {
-    return false;
-  }
-  if (params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false) {
+  if (
+    isPluginBlockedByStartupConfig({
+      pluginId: params.plugin.pluginId,
+      pluginsConfig: params.pluginsConfig,
+      requireGlobalEnabled: true,
+    })
+  ) {
     return false;
   }
   const explicitBundledChannelConfig =
@@ -708,6 +751,14 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
     activationSourcePlugins,
     normalizePluginId,
   });
+  const configuredModelOwnerPluginIds = new Set(
+    resolveOwningPluginIdsForModelRefs({
+      models: collectConfiguredModelRefValues(activationSourceConfig),
+      config: activationSourceConfig,
+      env: params.env,
+      manifestRegistry: params.manifestRegistry,
+    }),
+  );
   const pluginIds = params.index.plugins
     .filter((plugin) => {
       const manifest = findManifestPlugin(manifestLookup, plugin.pluginId);
@@ -749,6 +800,13 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
         })
       ) {
         return true;
+      }
+      if (configuredModelOwnerPluginIds.has(plugin.pluginId)) {
+        return canStartConfiguredModelOwnerPlugin({
+          plugin,
+          pluginsConfig,
+          rootConfig: params.config,
+        });
       }
       if (
         canStartConfiguredSpeechProviderPlugin({

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -22,7 +22,7 @@ import type {
 } from "./types.js";
 
 const providerRuntimePluginCache: ConfigScopedRuntimeCache<ProviderPlugin | null> = new WeakMap();
-const PREPARED_PROVIDER_RUNTIME_SURFACES = ["channel"] as const;
+const PREPARED_PROVIDER_RUNTIME_SURFACES = ["channel", "gateway-runtime"] as const;
 
 export type ProviderRuntimePluginLookupParams = {
   provider: string;

--- a/src/plugins/runtime-state.ts
+++ b/src/plugins/runtime-state.ts
@@ -8,6 +8,9 @@ export type RegistrySurfaceState = {
   registry: RuntimeTrackedPluginRegistry | null;
   pinned: boolean;
   version: number;
+  key: string | null;
+  workspaceDir: string | null;
+  runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";
 };
 
 export type RegistryState = {
@@ -15,6 +18,7 @@ export type RegistryState = {
   activeVersion: number;
   httpRoute: RegistrySurfaceState;
   channel: RegistrySurfaceState;
+  gatewayRuntime: RegistrySurfaceState;
   key: string | null;
   workspaceDir: string | null;
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -1,23 +1,38 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { loadChannelOutboundAdapter } from "../channels/plugins/outbound/load.js";
 import { getChannelPlugin } from "../channels/plugins/registry.js";
+import { resolveProviderRuntimePluginHandle } from "./provider-hook-runtime.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import {
   getActivePluginChannelRegistryVersion,
+  getActivePluginGatewayRuntimeRegistry,
+  getActivePluginGatewayRuntimeRegistryVersion,
+  getActivePluginGatewayRuntimeRegistryWorkspaceDir,
+  getActivePluginGatewayRuntimeSubagentMode,
   getActivePluginRegistryVersion,
   getActivePluginChannelRegistry,
+  pinActivePluginGatewayRuntimeRegistry,
   pinActivePluginChannelRegistry,
+  releasePinnedPluginGatewayRuntimeRegistry,
   releasePinnedPluginChannelRegistry,
   requireActivePluginChannelRegistry,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "./runtime.js";
+import type { ProviderPlugin } from "./types.js";
 
 function createRegistryWithChannel(pluginId = "demo-channel") {
   const registry = createEmptyPluginRegistry();
   const plugin = { id: pluginId, meta: {} } as never;
   registry.channels = [{ plugin }] as never;
   return { registry, plugin };
+}
+
+function createRegistryWithProvider(pluginId = "demo-provider", providerId = "demo") {
+  const registry = createEmptyPluginRegistry();
+  const provider = { id: providerId, label: providerId } as ProviderPlugin;
+  registry.providers = [{ pluginId, provider, source: "test" }] as never;
+  return { registry, provider };
 }
 
 function createChannelRegistryPair(pluginId = "demo-channel") {
@@ -37,6 +52,12 @@ function createRegistrySet() {
 
 function expectActiveChannelRegistry(registry: ReturnType<typeof createEmptyPluginRegistry>) {
   expect(getActivePluginChannelRegistry()).toBe(registry);
+}
+
+function expectActiveGatewayRuntimeRegistry(
+  registry: ReturnType<typeof createEmptyPluginRegistry>,
+) {
+  expect(getActivePluginGatewayRuntimeRegistry()).toBe(registry);
 }
 
 function expectPinnedChannelRegistry(
@@ -194,5 +215,67 @@ describe("channel registry pinning", () => {
     // The outbound loader must still find the telegram adapter from the pinned registry.
     const adapter = await loadChannelOutboundAdapter("telegram");
     expect(adapter).toBe(outboundAdapter);
+  });
+});
+
+describe("gateway runtime registry pinning", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("preserves pinned gateway runtime registry across active registry churn", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup, "startup-key", "gateway-bindable", "/tmp/workspace");
+    pinActivePluginGatewayRuntimeRegistry(startup);
+
+    setActivePluginRegistry(replacement, "replacement-key", "default", "/tmp/other");
+
+    expectActiveGatewayRuntimeRegistry(startup);
+    expect(getActivePluginGatewayRuntimeRegistryWorkspaceDir()).toBe("/tmp/workspace");
+    expect(getActivePluginGatewayRuntimeSubagentMode()).toBe("gateway-bindable");
+  });
+
+  it("release restores live-tracking behavior", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup, "startup-key", "gateway-bindable", "/tmp/workspace");
+    pinActivePluginGatewayRuntimeRegistry(startup);
+    setActivePluginRegistry(replacement, "replacement-key", "default", "/tmp/other");
+
+    const gatewayVersionBeforeRelease = getActivePluginGatewayRuntimeRegistryVersion();
+    releasePinnedPluginGatewayRuntimeRegistry(startup);
+
+    expect(getActivePluginGatewayRuntimeRegistryVersion()).toBe(gatewayVersionBeforeRelease + 1);
+    expectActiveGatewayRuntimeRegistry(replacement);
+    expect(getActivePluginGatewayRuntimeRegistryWorkspaceDir()).toBe("/tmp/other");
+    expect(getActivePluginGatewayRuntimeSubagentMode()).toBe("default");
+  });
+
+  it("resetPluginRuntimeStateForTest clears gateway runtime pin", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup, "startup-key", "gateway-bindable", "/tmp/workspace");
+    pinActivePluginGatewayRuntimeRegistry(startup);
+
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(replacement);
+
+    expectActiveGatewayRuntimeRegistry(replacement);
+    expect(getActivePluginGatewayRuntimeRegistryWorkspaceDir()).toBeUndefined();
+    expect(getActivePluginGatewayRuntimeSubagentMode()).toBe("default");
+  });
+
+  it("provider runtime handles resolve from pinned gateway runtime registry", () => {
+    const { registry: startup, provider } = createRegistryWithProvider();
+    const replacement = createEmptyPluginRegistry();
+    setActivePluginRegistry(startup, "startup-key", "gateway-bindable", "/tmp/workspace");
+    pinActivePluginGatewayRuntimeRegistry(startup);
+
+    setActivePluginRegistry(replacement, "replacement-key", "default", "/tmp/workspace");
+
+    const handle = resolveProviderRuntimePluginHandle({
+      provider: "demo",
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(handle.plugin?.id).toBe(provider.id);
+    expect((handle.plugin as { pluginId?: string } | undefined)?.pluginId).toBe("demo-provider");
   });
 });

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -32,11 +32,25 @@ const state: RegistryState = (() => {
         registry: null,
         pinned: false,
         version: 0,
+        key: null,
+        workspaceDir: null,
+        runtimeSubagentMode: "default",
       },
       channel: {
         registry: null,
         pinned: false,
         version: 0,
+        key: null,
+        workspaceDir: null,
+        runtimeSubagentMode: "default",
+      },
+      gatewayRuntime: {
+        registry: null,
+        pinned: false,
+        version: 0,
+        key: null,
+        workspaceDir: null,
+        runtimeSubagentMode: "default",
       },
       key: null,
       workspaceDir: null,
@@ -104,30 +118,58 @@ function installSurfaceRegistry(
   surface: RegistrySurfaceState,
   registry: RegistryState["activeRegistry"],
   pinned: boolean,
+  metadata?: {
+    key?: string | null;
+    workspaceDir?: string | null;
+    runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
+  },
 ) {
   if (surface.registry === registry && surface.pinned === pinned) {
-    return;
+    if (!metadata) {
+      return;
+    }
+    const nextKey = metadata.key ?? surface.key;
+    const nextWorkspaceDir = metadata.workspaceDir ?? surface.workspaceDir;
+    const nextRuntimeSubagentMode = metadata.runtimeSubagentMode ?? surface.runtimeSubagentMode;
+    if (
+      surface.key === nextKey &&
+      surface.workspaceDir === nextWorkspaceDir &&
+      surface.runtimeSubagentMode === nextRuntimeSubagentMode
+    ) {
+      return;
+    }
   }
   surface.registry = registry;
   surface.pinned = pinned;
+  surface.key = metadata?.key ?? null;
+  surface.workspaceDir = metadata?.workspaceDir ?? null;
+  surface.runtimeSubagentMode = metadata?.runtimeSubagentMode ?? "default";
   surface.version += 1;
 }
 
 function syncTrackedSurface(
   surface: RegistrySurfaceState,
   registry: RegistryState["activeRegistry"],
+  metadata: {
+    key?: string | null;
+    workspaceDir?: string | null;
+    runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
+  } = {},
   refreshVersion = false,
 ) {
   if (surface.pinned) {
     return;
   }
   if (surface.registry === registry && !surface.pinned) {
+    surface.key = metadata.key ?? null;
+    surface.workspaceDir = metadata.workspaceDir ?? null;
+    surface.runtimeSubagentMode = metadata.runtimeSubagentMode ?? "default";
     if (refreshVersion) {
       surface.version += 1;
     }
     return;
   }
-  installSurfaceRegistry(surface, registry, false);
+  installSurfaceRegistry(surface, registry, false, metadata);
 }
 
 export function setActivePluginRegistry(
@@ -141,10 +183,16 @@ export function setActivePluginRegistry(
     markPluginRegistryRetired(previousRegistry);
   }
   markPluginRegistryActive(registry);
+  const metadata = {
+    key: cacheKey ?? null,
+    workspaceDir: workspaceDir ?? null,
+    runtimeSubagentMode,
+  };
   state.activeRegistry = registry;
   state.activeVersion += 1;
-  syncTrackedSurface(state.httpRoute, registry, true);
-  syncTrackedSurface(state.channel, registry, true);
+  syncTrackedSurface(state.httpRoute, registry, metadata, true);
+  syncTrackedSurface(state.channel, registry, metadata, true);
+  syncTrackedSurface(state.gatewayRuntime, registry, metadata, true);
   state.key = cacheKey ?? null;
   state.workspaceDir = workspaceDir ?? null;
   state.runtimeSubagentMode = runtimeSubagentMode;
@@ -182,14 +230,22 @@ export function requireActivePluginRegistry(): PluginRegistry {
 }
 
 export function pinActivePluginHttpRouteRegistry(registry: PluginRegistry) {
-  installSurfaceRegistry(state.httpRoute, registry, true);
+  installSurfaceRegistry(state.httpRoute, registry, true, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
 }
 
 export function releasePinnedPluginHttpRouteRegistry(registry?: PluginRegistry) {
   if (registry && state.httpRoute.registry !== registry) {
     return;
   }
-  installSurfaceRegistry(state.httpRoute, state.activeRegistry, false);
+  installSurfaceRegistry(state.httpRoute, state.activeRegistry, false, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
 }
 
 export function getActivePluginHttpRouteRegistry(): PluginRegistry | null {
@@ -231,14 +287,22 @@ export function resolveActivePluginHttpRouteRegistry(fallback: PluginRegistry): 
  *  gateway startup after the initial plugin load so that config-schema reads
  *  and other non-primary registry loads cannot evict channel plugins. */
 export function pinActivePluginChannelRegistry(registry: PluginRegistry) {
-  installSurfaceRegistry(state.channel, registry, true);
+  installSurfaceRegistry(state.channel, registry, true, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
 }
 
 export function releasePinnedPluginChannelRegistry(registry?: PluginRegistry) {
   if (registry && state.channel.registry !== registry) {
     return;
   }
-  installSurfaceRegistry(state.channel, state.activeRegistry, false);
+  installSurfaceRegistry(state.channel, state.activeRegistry, false, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
 }
 
 /** Return the registry that should be used for channel plugin resolution.
@@ -252,6 +316,10 @@ export function getActivePluginChannelRegistryVersion(): number {
   return state.channel.registry ? state.channel.version : state.activeVersion;
 }
 
+export function getActivePluginChannelRegistryWorkspaceDir(): string | undefined {
+  return state.channel.workspaceDir ?? undefined;
+}
+
 export function requireActivePluginChannelRegistry(): PluginRegistry {
   const existing = getActivePluginChannelRegistry();
   if (existing) {
@@ -260,6 +328,44 @@ export function requireActivePluginChannelRegistry(): PluginRegistry {
   const created = requireActivePluginRegistry();
   installSurfaceRegistry(state.channel, created, false);
   return created;
+}
+
+export function pinActivePluginGatewayRuntimeRegistry(registry: PluginRegistry) {
+  installSurfaceRegistry(state.gatewayRuntime, registry, true, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
+}
+
+export function releasePinnedPluginGatewayRuntimeRegistry(registry?: PluginRegistry) {
+  if (registry && state.gatewayRuntime.registry !== registry) {
+    return;
+  }
+  installSurfaceRegistry(state.gatewayRuntime, state.activeRegistry, false, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
+}
+
+export function getActivePluginGatewayRuntimeRegistry(): PluginRegistry | null {
+  return asPluginRegistry(state.gatewayRuntime.registry ?? state.activeRegistry);
+}
+
+export function getActivePluginGatewayRuntimeRegistryVersion(): number {
+  return state.gatewayRuntime.registry ? state.gatewayRuntime.version : state.activeVersion;
+}
+
+export function getActivePluginGatewayRuntimeRegistryWorkspaceDir(): string | undefined {
+  return state.gatewayRuntime.workspaceDir ?? undefined;
+}
+
+export function getActivePluginGatewayRuntimeSubagentMode():
+  | "default"
+  | "explicit"
+  | "gateway-bindable" {
+  return state.gatewayRuntime.runtimeSubagentMode;
 }
 
 export function getActivePluginRegistryKey(): string | null {
@@ -304,6 +410,7 @@ export function listImportedRuntimePluginIds(): string[] {
   collectLoadedPluginIds(asPluginRegistry(state.activeRegistry), imported);
   collectLoadedPluginIds(asPluginRegistry(state.channel.registry), imported);
   collectLoadedPluginIds(asPluginRegistry(state.httpRoute.registry), imported);
+  collectLoadedPluginIds(asPluginRegistry(state.gatewayRuntime.registry), imported);
   return [...imported].toSorted((left, right) => left.localeCompare(right));
 }
 
@@ -312,6 +419,7 @@ export function resetPluginRuntimeStateForTest(): void {
   state.activeVersion += 1;
   installSurfaceRegistry(state.httpRoute, null, false);
   installSurfaceRegistry(state.channel, null, false);
+  installSurfaceRegistry(state.gatewayRuntime, null, false);
   state.key = null;
   state.workspaceDir = null;
   state.runtimeSubagentMode = "default";

--- a/src/plugins/runtime/standalone-runtime-registry-loader.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.ts
@@ -10,6 +10,7 @@ import {
 import type { PluginRegistry } from "../registry-types.js";
 import {
   pinActivePluginChannelRegistry,
+  pinActivePluginGatewayRuntimeRegistry,
   pinActivePluginHttpRouteRegistry,
   setActivePluginRegistry,
 } from "../runtime.js";
@@ -41,6 +42,9 @@ function installStandaloneRegistry(
       break;
     case "channel":
       pinActivePluginChannelRegistry(registry);
+      break;
+    case "gateway-runtime":
+      pinActivePluginGatewayRuntimeRegistry(registry);
       break;
     case "http-route":
       pinActivePluginHttpRouteRegistry(registry);
@@ -80,6 +84,9 @@ export function ensureStandaloneRuntimePluginRegistryLoaded(params: {
         break;
       case "channel":
         pinActivePluginChannelRegistry(registry);
+        break;
+      case "gateway-runtime":
+        pinActivePluginGatewayRuntimeRegistry(registry);
         break;
       case "http-route":
         pinActivePluginHttpRouteRegistry(registry);


### PR DESCRIPTION
## Summary

- Problem: later prepared-runtime migrations need loaded provider, channel, public metadata, and outbound adapter facts from Gateway startup, but those facts were not exposed through one stable loaded-runtime surface.
- Why it matters: without this startup/public metadata layer, later reply, tool, outbound, TTS, and command PRs would either keep broad request-time rediscovery or add scattered cache layers around individual consumers.
- What changed: this PR makes Gateway startup and plugin runtime state expose loaded/public runtime metadata, pins the Gateway runtime registry beside the channel registry, expands startup plugin selection for configured model/media/speech facts, and lets selected-provider handle lookup reuse the `gateway-runtime` loaded registry surface.
- What did NOT change: this PR does not migrate reply/tool/outbound request-time consumers yet and does not remove compatibility fallback behavior needed by setup, startup, admin, standalone, or later migration surfaces.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #77700
- [ ] This PR fixes a bug or regression

## Details

This is PR 2 in the prepared runtime resolution migration.

It adds the loaded-runtime metadata layer that later migration PRs can consume without rebuilding plugin/provider/channel registries at request time:

- Active runtime registry lookup now has explicit surfaces for active, channel, Gateway runtime, and HTTP route registries.
- Gateway startup pins both channel and Gateway runtime registries so later config-schema or status registry churn cannot evict the runtime facts prepared during startup.
- `resolveProviderRuntimePluginHandle(...)` now checks the `gateway-runtime` loaded registry surface introduced here, completing the PR 1 follow-up called out in #77700.
- Runtime plugin metadata exposes loaded provider/channel/public facts needed by later prepared-runtime consumers.
- Startup plugin id selection includes configured model owner plugins, configured media model owners, configured speech providers, and bundled startup sidecars without broad request-time loading.
- Bundled channel metadata and outbound adapter loading can answer lightweight public-runtime questions without full channel plugin bootstrap.
- Web provider public/runtime artifacts reuse the loaded/public metadata path.
- Tool-result middleware loading checks prepared runtime registries before falling back to broader plugin loading.

The architectural line is the same as PR 1: this PR creates startup/runtime producer surfaces only. It does not redirect normal reply/tool/outbound consumers yet. Later PRs will migrate one surface at a time, prove that prepared facts are used, and remove old lookup branches only after the corresponding prepared path owns the call.

## Real behavior proof (required for external PRs)

N/A. Maintainer-authored internal refactor surface; no end-user reply path is migrated in this PR.

## Root Cause (if applicable)

- Root cause: startup already had useful plugin/provider/channel/runtime facts, but later code had no stable loaded-runtime metadata surface to read them from, so hot consumers kept pressure to rediscover those facts through broad loaders.
- Missing detection / guardrail: registry state was tracked mostly as active/channel/http-route compatibility state, not as an explicit Gateway runtime surface for prepared selected-provider lookup.
- Contributing context: broad compatibility fallback behavior is still necessary for setup, admin, standalone, and unmigrated callers, so this PR adds a canonical loaded-runtime surface before migrating consumers.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests or files:
  - `src/plugins/runtime.channel-pin.test.ts`
  - `src/plugins/channel-plugin-ids.test.ts`
  - `src/plugins/web-provider-runtime-shared.test.ts`
  - `src/plugins/agent-tool-result-middleware-loader.test.ts`
  - `src/gateway/server-startup-post-attach.test.ts`
  - `src/agents/runtime-plugins.test.ts`
- Scenario the tests should lock in: Gateway startup preserves loaded runtime registries, configured startup plugin ids include the owners later request paths need, provider handles can resolve from pinned Gateway runtime metadata, and middleware/public metadata lookup can use loaded runtime state before broad fallback.
- Why this is the smallest reliable guardrail: PR 2 is a startup/runtime metadata PR, so the useful boundary is the loaded registry/public metadata seam rather than a full live reply migration.
- Existing test that already covers this (if any): existing startup and runtime registry tests were extended to cover the new Gateway runtime surface.

## User-visible / Behavior Changes

None expected. This PR changes internal startup/runtime metadata plumbing and preserves compatibility fallback behavior for existing callers.

## Diagram (if applicable)

```text
Before:
[Gateway startup loads plugins] -> [later code cannot read exact loaded fact] -> [consumer broad-loads registry again]

After this PR:
[Gateway startup loads plugins] -> [loaded Gateway/runtime metadata surface] -> [later PRs can pass prepared fact forward]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm test src/plugins/runtime.channel-pin.test.ts src/plugins/channel-plugin-ids.test.ts src/plugins/bundle-mcp.test.ts src/plugins/web-provider-runtime-shared.test.ts src/plugins/agent-tool-result-middleware-loader.test.ts src/channels/plugins/bundled-root-caches.test.ts src/gateway/server-startup-post-attach.test.ts src/gateway/server-startup.test.ts src/agents/runtime-plugins.test.ts`
2. `pnpm build`
3. `git diff --check origin/main...HEAD`

### Expected

- Focused runtime/startup metadata tests pass.
- Build passes.
- Diff hygiene is clean.

### Actual

- Focused runtime/startup metadata tests passed: 4 Vitest shards in 49.57s.
- Build passed.
- `git diff --check origin/main...HEAD` passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence is the local targeted test/build proof above. During extraction, the standalone branch exposed two useful guardrails: startup model prewarm must remain metadata-only, and configured model owner plugins should be included in startup metadata alongside implicit runtime owner plugins.

## Human Verification (required)

- Verified scenarios: PR 2 is one commit on top of current `main`; file scope is startup/runtime metadata plus `CHANGELOG.md`; focused Gateway/plugins/channels/agents tests pass; build passes; diff hygiene is clean.
- Edge cases checked: provider handles resolve from the pinned Gateway runtime registry after active registry churn; Gateway startup model prewarm does not import PI runtime model resolution; generated Canvas bundle hash drift from build was kept out of the PR.
- What you did **not** verify: live Gateway reply benchmark, because this PR does not migrate the live reply path yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: loaded runtime metadata could be mistaken for a request-time consumer migration.
  - Mitigation: the scope is explicit: this PR exposes the loaded metadata surfaces only. Consumer migrations remain in later PRs tracked by #77700.
- Risk: startup might accidentally import heavier provider runtime work while exposing these facts.
  - Mitigation: Gateway startup tests preserve metadata-only primary model prewarm behavior, and build/lazy-loading proof is included.
- Risk: later PRs could still miss this surface and reintroduce broad lookups.
  - Mitigation: `resolveProviderRuntimePluginHandle(...)` now checks `gateway-runtime`, and #77700 continues to track each consumer migration surface.
