### PR TITLE
fix(cli): emit JSON for gateway transport failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Docs: https://docs.openclaw.ai
 - Agents: label `.openclaw/sandboxes` exec workdirs as sandbox runs in compact tool summaries instead of showing the full path.
 - OpenAI Codex: surface browser OAuth and device-code login failures instead of treating failed logins as empty successful auth results. Refs #80363.
 - CLI agents: carry runtime-only current-turn sender/reply context into CLI model prompts while keeping prompt-build hook input and transcript text clean.
+- CLI/gateway: emit structured JSON for gateway transport close and timeout failures when JSON output is requested. Fixes #79108.
 - Control UI: keep workspace file presence checks from treating `fs-safe` stat helper failures as missing files, restoring Agents file status for existing Windows workspace files. Fixes #79953. Thanks @lovelefeng-glitch.
 - Microsoft Foundry: report an explicit error when the Azure subscription prompt returns an id that is not present in the enabled subscription list, instead of continuing from an unsafe subscription assertion. (#62742) Thanks @oliviareid-svg.
 - fix(matrix): gate name-based allowlist resolution [AI]. (#79007) Thanks @pgondhi987.

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     urlSource: "local loopback",
     message: "",
   })),
+  formatGatewayTransportErrorJson: vi.fn(),
   listDevicePairing: vi.fn(),
   approveDevicePairing: vi.fn(),
   summarizeDeviceTokens: vi.fn(),
@@ -25,6 +26,7 @@ const {
   runtime,
   callGateway,
   buildGatewayConnectionDetails,
+  formatGatewayTransportErrorJson,
   listDevicePairing,
   approveDevicePairing,
   summarizeDeviceTokens,
@@ -33,6 +35,7 @@ const {
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
   buildGatewayConnectionDetails: mocks.buildGatewayConnectionDetails,
+  formatGatewayTransportErrorJson: mocks.formatGatewayTransportErrorJson,
 }));
 
 vi.mock("./progress.js", () => ({
@@ -683,10 +686,36 @@ describe("devices cli list", () => {
     expect(output).toContain("spoof");
     expect(output).toContain("Paired");
   });
+
+  it("emits JSON when the gateway transport fails in JSON mode", async () => {
+    const err = Object.assign(new Error("gateway closed"), { name: "GatewayTransportError" });
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_transport_error",
+        kind: "timeout",
+        message: "gateway timeout after 1000ms",
+        timeoutMs: 1000,
+      },
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+      },
+    };
+    callGateway.mockRejectedValueOnce(err);
+    formatGatewayTransportErrorJson.mockReturnValueOnce(payload);
+
+    await runDevicesCommand(["list", "--json", "--url", "ws://127.0.0.1:18789"]);
+
+    expect(formatGatewayTransportErrorJson).toHaveBeenCalledWith(err);
+    expect(runtime.writeJson).toHaveBeenCalledWith(payload);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
+  formatGatewayTransportErrorJson.mockReturnValue(null);
   runtime.exit.mockImplementation(() => {});
 });
 

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import {
+  buildGatewayConnectionDetails,
+  callGateway,
+  formatGatewayTransportErrorJson,
+} from "../gateway/call.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
@@ -525,7 +529,20 @@ export function registerDevicesCli(program: Command) {
       .command("list")
       .description("List pending and paired devices")
       .action(async (opts: DevicesRpcOpts) => {
-        const list = await listPairingWithFallback(opts);
+        let list: DevicePairingList;
+        try {
+          list = await listPairingWithFallback(opts);
+        } catch (error) {
+          if (opts.json) {
+            const payload = formatGatewayTransportErrorJson(error);
+            if (payload) {
+              defaultRuntime.writeJson(payload);
+              defaultRuntime.exit(1);
+              return;
+            }
+          }
+          throw error;
+        }
         const pairedByDeviceId = indexPairedDevices(list.paired);
         if (opts.json) {
           defaultRuntime.writeJson(list);

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -12,6 +12,7 @@ type DiscoveredBeacon = Awaited<
 >[number];
 
 const callGateway = vi.fn<(opts: unknown) => Promise<{ ok: true }>>(async () => ({ ok: true }));
+const formatGatewayTransportErrorJson = vi.fn();
 const startGatewayServer = vi.fn<
   (port: number, opts?: unknown) => Promise<{ close: () => Promise<void> }>
 >(async () => ({
@@ -44,6 +45,7 @@ vi.mock(
   new URL("../../gateway/call.ts", new URL("./gateway-cli/call.ts", import.meta.url)).href,
   () => ({
     callGateway: (opts: unknown) => callGateway(opts),
+    formatGatewayTransportErrorJson: (error: unknown) => formatGatewayTransportErrorJson(error),
     randomIdempotencyKey: () => "rk_test",
   }),
 );
@@ -133,6 +135,8 @@ describe("gateway-cli coverage", () => {
     defaultRuntime.writeJson.mockClear();
     defaultRuntime.exit.mockClear();
     startGatewayServer.mockClear();
+    formatGatewayTransportErrorJson.mockReset();
+    formatGatewayTransportErrorJson.mockReturnValue(null);
     inspectPortUsage.mockClear();
     formatPortDiagnostics.mockClear();
   });
@@ -152,6 +156,32 @@ describe("gateway-cli coverage", () => {
     await runGatewayCommand(["gateway", "probe", "--json"]);
 
     expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes JSON for gateway health transport failures in JSON mode", async () => {
+    const err = Object.assign(new Error("gateway closed"), { name: "GatewayTransportError" });
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_transport_error",
+        kind: "closed",
+        message: "gateway closed (1006 abnormal closure (no close frame)): no close reason",
+        code: 1006,
+        reason: "no close reason",
+      },
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+      },
+    };
+    callGateway.mockRejectedValueOnce(err);
+    formatGatewayTransportErrorJson.mockReturnValueOnce(payload);
+
+    await expectGatewayExit(["gateway", "health", "--json"]);
+
+    expect(formatGatewayTransportErrorJson).toHaveBeenCalledWith(err);
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(payload);
+    expect(runtimeErrors.join("\n")).not.toContain("Gateway");
   });
 
   it("registers gateway stability and routes to diagnostics RPC", async () => {

--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { callGateway } from "../../gateway/call.js";
+import { callGateway, formatGatewayTransportErrorJson } from "../../gateway/call.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../gateway/protocol/client-info.js";
 import { withProgress } from "../progress.js";
 
@@ -13,6 +13,8 @@ export type GatewayRpcOpts = {
   expectFinal?: boolean;
   json?: boolean;
 };
+
+export { formatGatewayTransportErrorJson };
 
 export const gatewayCallOpts = (cmd: Command) =>
   cmd

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -21,7 +21,12 @@ import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { formatHelpExamples } from "../help-format.js";
 import { withProgress } from "../progress.js";
-import { callGatewayCli, gatewayCallOpts, type GatewayRpcOpts } from "./call.js";
+import {
+  callGatewayCli,
+  formatGatewayTransportErrorJson,
+  gatewayCallOpts,
+  type GatewayRpcOpts,
+} from "./call.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import {
   dedupeBeacons,
@@ -97,8 +102,16 @@ function loadDaemonStatusGatherModule() {
   return daemonStatusGatherModuleLoader.load();
 }
 
-function runGatewayCommand(action: () => Promise<void>, label?: string) {
+function runGatewayCommand(action: () => Promise<void>, label?: string, opts?: { json?: boolean }) {
   return runCommandWithRuntime(defaultRuntime, action, (err) => {
+    if (opts?.json) {
+      const payload = formatGatewayTransportErrorJson(err);
+      if (payload) {
+        defaultRuntime.writeJson(payload);
+        defaultRuntime.exit(1);
+        return;
+      }
+    }
     const message = String(err);
     defaultRuntime.error(label ? `${label}: ${message}` : message);
     defaultRuntime.exit(1);
@@ -414,20 +427,24 @@ export function registerGatewayCli(program: Command) {
       .argument("<method>", "Method name (health/status/system-presence/cron.*)")
       .option("--params <json>", "JSON object string for params", "{}")
       .action(async (method, opts, command) => {
-        await runGatewayCommand(async () => {
-          const rpcOpts = resolveGatewayRpcOptions(opts, command);
-          const params = JSON.parse(String(opts.params ?? "{}"));
-          const result = await callGatewayCli(method, rpcOpts, params);
-          if (rpcOpts.json) {
+        const rpcOpts = resolveGatewayRpcOptions(opts, command);
+        await runGatewayCommand(
+          async () => {
+            const params = JSON.parse(String(opts.params ?? "{}"));
+            const result = await callGatewayCli(method, rpcOpts, params);
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson(result);
+              return;
+            }
+            const rich = isRich();
+            defaultRuntime.log(
+              `${colorize(rich, theme.heading, "Gateway call")}: ${colorize(rich, theme.muted, String(method))}`,
+            );
             defaultRuntime.writeJson(result);
-            return;
-          }
-          const rich = isRich();
-          defaultRuntime.log(
-            `${colorize(rich, theme.heading, "Gateway call")}: ${colorize(rich, theme.muted, String(method))}`,
-          );
-          defaultRuntime.writeJson(result);
-        }, "Gateway call failed");
+          },
+          "Gateway call failed",
+          { json: Boolean(rpcOpts.json) },
+        );
       }),
   );
 
@@ -437,20 +454,24 @@ export function registerGatewayCli(program: Command) {
       .description("Fetch usage cost summary from session logs")
       .option("--days <days>", "Number of days to include", "30")
       .action(async (opts, command) => {
-        await runGatewayCommand(async () => {
-          const rpcOpts = resolveGatewayRpcOptions(opts, command);
-          const days = parseDaysOption(opts.days);
-          const result = await callGatewayCli("usage.cost", rpcOpts, { days });
-          if (rpcOpts.json) {
-            defaultRuntime.writeJson(result);
-            return;
-          }
-          const rich = isRich();
-          const summary = result as CostUsageSummary;
-          for (const line of await renderCostUsageSummaryAsync(summary, days, rich)) {
-            defaultRuntime.log(line);
-          }
-        }, "Gateway usage cost failed");
+        const rpcOpts = resolveGatewayRpcOptions(opts, command);
+        await runGatewayCommand(
+          async () => {
+            const days = parseDaysOption(opts.days);
+            const result = await callGatewayCli("usage.cost", rpcOpts, { days });
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson(result);
+              return;
+            }
+            const rich = isRich();
+            const summary = result as CostUsageSummary;
+            for (const line of await renderCostUsageSummaryAsync(summary, days, rich)) {
+              defaultRuntime.log(line);
+            }
+          },
+          "Gateway usage cost failed",
+          { json: Boolean(rpcOpts.json) },
+        );
       }),
   );
 
@@ -459,30 +480,34 @@ export function registerGatewayCli(program: Command) {
       .command("health")
       .description("Fetch Gateway health")
       .action(async (opts, command) => {
-        await runGatewayCommand(async () => {
-          const rpcOpts = resolveGatewayRpcOptions(opts, command);
-          const [{ formatHealthChannelLines }, { styleHealthChannelLine }] = await Promise.all([
-            loadGatewayHealthModule(),
-            loadHealthStyleModule(),
-          ]);
-          const result = await callGatewayCli("health", rpcOpts);
-          if (rpcOpts.json) {
-            defaultRuntime.writeJson(result);
-            return;
-          }
-          const rich = isRich();
-          const obj: Record<string, unknown> = result && typeof result === "object" ? result : {};
-          const durationMs = typeof obj.durationMs === "number" ? obj.durationMs : null;
-          defaultRuntime.log(colorize(rich, theme.heading, "Gateway Health"));
-          defaultRuntime.log(
-            `${colorize(rich, theme.success, "OK")}${durationMs != null ? ` (${durationMs}ms)` : ""}`,
-          );
-          if (obj.channels && typeof obj.channels === "object") {
-            for (const line of formatHealthChannelLines(obj as HealthSummary)) {
-              defaultRuntime.log(styleHealthChannelLine(line, rich));
+        const rpcOpts = resolveGatewayRpcOptions(opts, command);
+        await runGatewayCommand(
+          async () => {
+            const [{ formatHealthChannelLines }, { styleHealthChannelLine }] = await Promise.all([
+              loadGatewayHealthModule(),
+              loadHealthStyleModule(),
+            ]);
+            const result = await callGatewayCli("health", rpcOpts);
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson(result);
+              return;
             }
-          }
-        });
+            const rich = isRich();
+            const obj: Record<string, unknown> = result && typeof result === "object" ? result : {};
+            const durationMs = typeof obj.durationMs === "number" ? obj.durationMs : null;
+            defaultRuntime.log(colorize(rich, theme.heading, "Gateway Health"));
+            defaultRuntime.log(
+              `${colorize(rich, theme.success, "OK")}${durationMs != null ? ` (${durationMs}ms)` : ""}`,
+            );
+            if (obj.channels && typeof obj.channels === "object") {
+              for (const line of formatHealthChannelLines(obj as HealthSummary)) {
+                defaultRuntime.log(styleHealthChannelLine(line, rich));
+              }
+            }
+          },
+          undefined,
+          { json: Boolean(rpcOpts.json) },
+        );
       }),
   );
 
@@ -500,69 +525,76 @@ export function registerGatewayCli(program: Command) {
       .option("--export", "Write a shareable support diagnostics export", false)
       .option("--output <path>", "Diagnostics export output .zip path")
       .action(async (opts, command) => {
-        await runGatewayCommand(async () => {
-          const rpcOpts = resolveGatewayRpcOptions(opts, command);
-          const query = normalizeDiagnosticStabilityQuery(
-            {
-              limit: opts.limit,
-              sinceSeq: opts.sinceSeq,
-              type: opts.type,
-            },
-            { defaultLimit: 25 },
-          );
-          const bundleTarget = normalizeStabilityBundleTarget(opts.bundle);
-          if (opts.export) {
-            await writeSupportExportFromCli({
-              json: rpcOpts.json,
-              output: opts.output,
-              stabilityBundle: bundleTarget ?? "latest",
-              rpc: rpcOpts,
-            });
-            return;
-          }
-          if (bundleTarget) {
-            const result = await readStabilityBundleTarget(bundleTarget);
-            if (result.status !== "found") {
-              throw new Error(formatBundleError(result));
-            }
-            const snapshot = selectDiagnosticStabilitySnapshot(result.bundle.snapshot, query);
-            if (rpcOpts.json) {
-              defaultRuntime.writeJson({
-                path: result.path,
-                mtimeMs: result.mtimeMs,
-                bundle: {
-                  ...result.bundle,
-                  snapshot,
-                },
+        const rpcOpts = resolveGatewayRpcOptions(opts, command);
+        await runGatewayCommand(
+          async () => {
+            const query = normalizeDiagnosticStabilityQuery(
+              {
+                limit: opts.limit,
+                sinceSeq: opts.sinceSeq,
+                type: opts.type,
+              },
+              { defaultLimit: 25 },
+            );
+            const bundleTarget = normalizeStabilityBundleTarget(opts.bundle);
+            if (opts.export) {
+              await writeSupportExportFromCli({
+                json: rpcOpts.json,
+                output: opts.output,
+                stabilityBundle: bundleTarget ?? "latest",
+                rpc: rpcOpts,
               });
               return;
             }
+            if (bundleTarget) {
+              const result = await readStabilityBundleTarget(bundleTarget);
+              if (result.status !== "found") {
+                throw new Error(formatBundleError(result));
+              }
+              const snapshot = selectDiagnosticStabilitySnapshot(result.bundle.snapshot, query);
+              if (rpcOpts.json) {
+                defaultRuntime.writeJson({
+                  path: result.path,
+                  mtimeMs: result.mtimeMs,
+                  bundle: {
+                    ...result.bundle,
+                    snapshot,
+                  },
+                });
+                return;
+              }
+              const rich = isRich();
+              for (const line of renderStabilityBundleSummary({
+                bundle: result.bundle,
+                path: result.path,
+                rich,
+                snapshot,
+              })) {
+                defaultRuntime.log(line);
+              }
+              return;
+            }
+
+            const result = await callGatewayCli("diagnostics.stability", rpcOpts, {
+              limit: query.limit,
+              ...(query.type ? { type: query.type } : {}),
+              ...(query.sinceSeq !== undefined ? { sinceSeq: query.sinceSeq } : {}),
+            });
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson(result);
+              return;
+            }
             const rich = isRich();
-            for (const line of renderStabilityBundleSummary({
-              bundle: result.bundle,
-              path: result.path,
+            for (const line of renderStabilitySummary(
+              result as DiagnosticStabilitySnapshot,
               rich,
-              snapshot,
-            })) {
+            )) {
               defaultRuntime.log(line);
             }
-            return;
-          }
-
-          const result = await callGatewayCli("diagnostics.stability", rpcOpts, {
-            limit: query.limit,
-            ...(query.type ? { type: query.type } : {}),
-            ...(query.sinceSeq !== undefined ? { sinceSeq: query.sinceSeq } : {}),
-          });
-          if (rpcOpts.json) {
-            defaultRuntime.writeJson(result);
-            return;
-          }
-          const rich = isRich();
-          for (const line of renderStabilitySummary(result as DiagnosticStabilitySnapshot, rich)) {
-            defaultRuntime.log(line);
-          }
-        }, "Gateway stability failed");
+          },
+          "Gateway stability failed",
+          { json: Boolean(rpcOpts.json) },
+        );
       }),
   );
 
@@ -582,17 +614,21 @@ export function registerGatewayCli(program: Command) {
     .option("--no-stability-bundle", "Skip persisted stability bundle lookup")
     .option("--json", "Output JSON", false)
     .action(async (opts, command) => {
-      await runGatewayCommand(async () => {
-        const rpcOpts = resolveGatewayRpcOptions(opts, command);
-        await writeSupportExportFromCli({
-          json: opts.json,
-          output: opts.output,
-          logLines: opts.logLines,
-          logBytes: opts.logBytes,
-          stabilityBundle: opts.stabilityBundle === false ? false : "latest",
-          rpc: rpcOpts,
-        });
-      }, "Gateway diagnostics export failed");
+      const rpcOpts = resolveGatewayRpcOptions(opts, command);
+      await runGatewayCommand(
+        async () => {
+          await writeSupportExportFromCli({
+            json: opts.json,
+            output: opts.output,
+            logLines: opts.logLines,
+            logBytes: opts.logBytes,
+            stabilityBundle: opts.stabilityBundle === false ? false : "latest",
+            rpc: rpcOpts,
+          });
+        },
+        "Gateway diagnostics export failed",
+        { json: Boolean(opts.json) },
+      );
     });
 
   gateway

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -52,8 +52,10 @@ const createHealthSummary = (params: {
 };
 
 const callGatewayMock = vi.fn();
+const formatGatewayTransportErrorJsonMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
+  formatGatewayTransportErrorJson: (error: unknown) => formatGatewayTransportErrorJsonMock(error),
 }));
 
 function requireFirstRuntimeLog(): string {
@@ -83,6 +85,7 @@ function requireFirstGatewayRequest(): Record<string, unknown> {
 describe("healthCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    formatGatewayTransportErrorJsonMock.mockReturnValue(null);
   });
 
   it("outputs JSON from gateway", async () => {
@@ -173,6 +176,33 @@ describe("healthCommand", () => {
     expect(stripAnsi(runtime.log.mock.calls.flat().join("\n"))).toContain(
       "Model pricing: warning (optional pricing refresh degraded) (OpenRouter pricing fetch failed: TypeError: fetch failed)",
     );
+  });
+
+  it("emits JSON when gateway transport fails in JSON mode", async () => {
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_transport_error",
+        kind: "closed",
+        message: "gateway closed (1006 abnormal closure (no close frame)): no close reason",
+        code: 1006,
+        reason: "no close reason",
+      },
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+      },
+    };
+    const err = Object.assign(new Error("gateway closed"), { name: "GatewayTransportError" });
+    callGatewayMock.mockRejectedValueOnce(err);
+    formatGatewayTransportErrorJsonMock.mockReturnValueOnce(payload);
+
+    await healthCommand({ json: true, timeoutMs: 1000, config: {} }, runtime as never);
+
+    expect(formatGatewayTransportErrorJsonMock).toHaveBeenCalledWith(err);
+    const logged = runtime.log.mock.calls[0]?.[0] as string;
+    expect(JSON.parse(logged)).toEqual(payload);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("formats per-account probe timings", () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -13,7 +13,11 @@ import { withProgress } from "../cli/progress.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import {
+  buildGatewayConnectionDetails,
+  callGateway,
+  formatGatewayTransportErrorJson,
+} from "../gateway/call.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
@@ -603,22 +607,35 @@ export async function healthCommand(
 ) {
   const cfg = opts.config ?? (await readBestEffortHealthConfig());
   // Always query the running gateway; do not open a direct Baileys socket here.
-  const summary = await withProgress(
-    {
-      label: "Checking gateway health…",
-      indeterminate: true,
-      enabled: opts.json !== true,
-    },
-    async () =>
-      await callGateway<HealthSummary>({
-        method: "health",
-        params: opts.verbose ? { probe: true } : undefined,
-        timeoutMs: opts.timeoutMs,
-        config: cfg,
-        token: opts.token,
-        password: opts.password,
-      }),
-  );
+  let summary: HealthSummary;
+  try {
+    summary = await withProgress(
+      {
+        label: "Checking gateway health…",
+        indeterminate: true,
+        enabled: opts.json !== true,
+      },
+      async () =>
+        await callGateway<HealthSummary>({
+          method: "health",
+          params: opts.verbose ? { probe: true } : undefined,
+          timeoutMs: opts.timeoutMs,
+          config: cfg,
+          token: opts.token,
+          password: opts.password,
+        }),
+    );
+  } catch (error) {
+    if (opts.json) {
+      const payload = formatGatewayTransportErrorJson(error);
+      if (payload) {
+        writeRuntimeJson(runtime, payload);
+        runtime.exit(1);
+        return;
+      }
+    }
+    throw error;
+  }
   // Gateway reachability defines success; channel issues are reported but not fatal here.
   const fatal = false;
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -139,6 +139,7 @@ const {
   callGateway,
   callGatewayCli,
   callGatewayScoped,
+  formatGatewayTransportErrorJson,
   isGatewayTransportError,
 } = await import("./call.js");
 
@@ -904,6 +905,36 @@ describe("callGateway error details", () => {
     expect(transportError.kind).toBe("closed");
     expect(transportError.code).toBe(1006);
     expect(transportError.reason).toBe("no close reason");
+  });
+
+  it("serializes typed transport errors for CLI JSON output", async () => {
+    startMode = "close";
+    closeCode = 1006;
+    closeReason = "";
+    setLocalLoopbackGatewayConfig();
+
+    let err: unknown;
+    try {
+      await callGateway({ method: "health" });
+    } catch (caught) {
+      err = caught;
+    }
+
+    expect(formatGatewayTransportErrorJson(err)).toEqual({
+      ok: false,
+      error: {
+        type: "gateway_transport_error",
+        kind: "closed",
+        message: "gateway closed (1006 abnormal closure (no close frame)): no close reason",
+        code: 1006,
+        reason: "no close reason",
+      },
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+        bindDetail: "Bind: loopback",
+      },
+    });
   });
 
   it("keeps the request alive through internally retried startup-unavailable handshakes", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -116,6 +116,24 @@ export class GatewayTransportError extends Error {
   }
 }
 
+export type GatewayTransportErrorJson = {
+  ok: false;
+  error: {
+    type: "gateway_transport_error";
+    kind: GatewayTransportErrorKind;
+    message: string;
+    code?: number;
+    reason?: string;
+    timeoutMs?: number;
+  };
+  gateway: {
+    url: string;
+    urlSource: string;
+    bindDetail?: string;
+    remoteFallbackNote?: string;
+  };
+};
+
 export function isGatewayTransportError(value: unknown): value is GatewayTransportError {
   if (value instanceof GatewayTransportError) {
     return true;
@@ -129,6 +147,37 @@ export function isGatewayTransportError(value: unknown): value is GatewayTranspo
     typeof candidate.connectionDetails === "object" &&
     candidate.connectionDetails !== null
   );
+}
+
+function firstGatewayErrorLine(message: string): string {
+  return message.split("\n", 1)[0]?.trim() || message;
+}
+
+export function formatGatewayTransportErrorJson(value: unknown): GatewayTransportErrorJson | null {
+  if (!isGatewayTransportError(value)) {
+    return null;
+  }
+  return {
+    ok: false,
+    error: {
+      type: "gateway_transport_error",
+      kind: value.kind,
+      message: firstGatewayErrorLine(value.message),
+      ...(value.code !== undefined ? { code: value.code } : {}),
+      ...(value.reason !== undefined ? { reason: value.reason } : {}),
+      ...(value.timeoutMs !== undefined ? { timeoutMs: value.timeoutMs } : {}),
+    },
+    gateway: {
+      url: value.connectionDetails.url,
+      urlSource: value.connectionDetails.urlSource,
+      ...(value.connectionDetails.bindDetail
+        ? { bindDetail: value.connectionDetails.bindDetail }
+        : {}),
+      ...(value.connectionDetails.remoteFallbackNote
+        ? { remoteFallbackNote: value.connectionDetails.remoteFallbackNote }
+        : {}),
+    },
+  };
 }
 
 const defaultCreateGatewayClient = (opts: GatewayClientOptions) => new GatewayClient(opts);


### PR DESCRIPTION
## Summary

- Problem: gateway-backed CLI commands that advertise `--json` could exit on transport close/timeout without writing JSON to stdout.
- Why it matters: health-check and device automation scripts had to parse stderr even after opting into machine-readable output.
- What changed: added a shared `GatewayTransportError` JSON serializer and used it for JSON-mode `health`, `gateway health`, and `devices list` transport failures.
- What did NOT change (scope boundary): non-JSON command behavior, non-transport exceptions, gateway probe output, and local pairing fallback behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79108
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: JSON-mode gateway-backed commands now emit a structured `{ "ok": false, "error": ..., "gateway": ... }` payload when the gateway transport closes or times out before returning an RPC result.
- Real environment tested: macOS local source checkout, Node v25.8.2, pnpm v10.33.2.
- Real stopped/unavailable gateway target: `ws://127.0.0.1:9` with a redacted proof token.
- Exact steps or command run after this patch:
  - `OPENCLAW_GATEWAY_URL=ws://127.0.0.1:9 OPENCLAW_GATEWAY_TOKEN=proof-token pnpm openclaw health --json --timeout 500`
  - `pnpm openclaw gateway health --url ws://127.0.0.1:9 --token proof-token --json --timeout 500`
  - `pnpm openclaw devices list --url ws://127.0.0.1:9 --token proof-token --json --timeout 500`
- Evidence after fix: redacted stdout from the real unavailable-gateway commands. Each command also exited non-zero (`ELIFECYCLE Command failed with exit code 1`).

`health --json` redacted output:

```json
{
  "ok": false,
  "error": {
    "type": "gateway_transport_error",
    "kind": "closed",
    "message": "gateway closed (1006 abnormal closure (no close frame)): no close reason",
    "code": 1006,
    "reason": "no close reason"
  },
  "gateway": {
    "url": "ws://127.0.0.1:9",
    "urlSource": "env OPENCLAW_GATEWAY_URL"
  }
}
```

`gateway health --json` and `devices list --json` produced the same structured error shape with:

```json
{
  "gateway": {
    "url": "ws://127.0.0.1:9",
    "urlSource": "cli --url"
  }
}
```

- Observed result after fix: each command wrote structured JSON to stdout and exited non-zero instead of falling through to stderr-only handling.
- What was not tested: live Windows npm install repro from the issue.

## Root Cause (if applicable)

`callGateway` already produced typed `GatewayTransportError` instances, but affected JSON commands awaited the gateway RPC before reaching their success-only JSON output branch. The typed transport error escaped to the generic CLI error path, which wrote human-readable stderr and exited without stdout JSON.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/call.test.ts`
  - `src/commands/health.test.ts`
  - `src/cli/gateway-cli.coverage.test.ts`
  - `src/cli/devices-cli.test.ts`
- Scenario the test should lock in: JSON-mode command paths serialize typed gateway transport close/timeout failures instead of falling through to stderr-only handling.

## User-visible / Behavior Changes

When `--json` is requested, transport-level gateway close/timeout failures now produce stdout JSON before exiting with code 1.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel (if any): Gateway CLI transport failure handling
- Relevant config (redacted): loopback gateway URL and proof token only

### Steps

1. Run JSON-mode gateway-backed commands against an unavailable loopback gateway.
2. Inspect stdout JSON and exit behavior.

### Expected

- Commands write structured JSON with `ok: false`, transport `kind`, message/code/timeout details, and gateway target metadata.
- Commands still exit non-zero.

### Actual

- Real CLI proof above confirms the expected JSON payload and non-zero exit behavior for `health --json`, `gateway health --json`, and `devices list --json`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: shared transport-error serialization, `health --json`, `gateway health --json`, `devices list --json`, and status/health wrapper option forwarding.
- Edge cases checked: non-transport errors are not converted, non-JSON mode keeps the existing human error path, and explicit-url device listing still skips local fallback for plain pairing errors.
- What you did not verify: live Windows shell repro.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: scripts may have expected empty stdout on JSON transport failures.
  - Mitigation: this only changes commands when `--json` is explicitly requested, matching the documented machine-readable contract.

## Changelog

- Added an Unreleased changelog entry for JSON gateway transport failures.

## Additional Validation Note

- `pnpm exec vitest run src/gateway/call.test.ts src/commands/health.test.ts src/cli/gateway-cli.coverage.test.ts src/cli/devices-cli.test.ts --reporter=dot`: passed (`Test Files 6 passed`, `Tests 288 passed`).
- `pnpm exec vitest run src/cli/program/register.status-health-sessions.test.ts --reporter=dot`: passed (`Test Files 1 passed`, `Tests 21 passed`).
- `pnpm tsgo:core`: passed.
- `pnpm tsgo:core:test`: passed.
- `pnpm exec oxfmt --check --threads=1 src/gateway/call.ts src/gateway/call.test.ts src/commands/health.ts src/commands/health.test.ts src/cli/gateway-cli/call.ts src/cli/gateway-cli/register.ts src/cli/gateway-cli.coverage.test.ts src/cli/devices-cli.ts src/cli/devices-cli.test.ts CHANGELOG.md`: passed.
- `git diff --check`: passed.
