### PR TITLE
feat(doctor): add --post-upgrade --json mode for plugin-compat findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,7 +644,7 @@ Docs: https://docs.openclaw.ai
 - Agents/config: allow `agents.list[].experimental.localModelLean` so lean local-model mode can be enabled for one configured agent instead of globally. (#84073) Thanks @dutifulbob.
 - Providers/xAI: add device-code OAuth login so remote and headless setups can authorize xAI without a localhost browser callback. (#84005) Thanks @fuller-stack-dev.
 - Providers/OpenRouter: honor provider-level `params.provider` routing policy for OpenRouter requests, with model and agent params overriding the defaults. Thanks @amknight.
-- Doctor/plugins: add `openclaw doctor --post-upgrade --json` mode that emits structured plugin-compat findings (`plugin.entry_unresolved`, `plugin.manifest_drift`) for use by post-upgrade smoke checks, CI, and the community `fork-upgrade` skill, exiting non-zero when any finding has `level: "error"`.
+- Doctor/plugins: add `openclaw doctor --post-upgrade --json` mode that emits structured plugin-compat findings (`plugin.entry_unresolved`, `plugin.manifest_drift`) for use by post-upgrade smoke checks, CI, and the community `fork-upgrade` skill, exiting non-zero when any finding has `level: "error"`. The probe now delegates entry validation to the install-time resolver so `openclaw.runtimeExtensions` shape, plugin-root boundary enforcement, and inferred-built-output / TypeScript-source-only handling stay in sync with plugin install/discovery.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,6 +644,7 @@ Docs: https://docs.openclaw.ai
 - Agents/config: allow `agents.list[].experimental.localModelLean` so lean local-model mode can be enabled for one configured agent instead of globally. (#84073) Thanks @dutifulbob.
 - Providers/xAI: add device-code OAuth login so remote and headless setups can authorize xAI without a localhost browser callback. (#84005) Thanks @fuller-stack-dev.
 - Providers/OpenRouter: honor provider-level `params.provider` routing policy for OpenRouter requests, with model and agent params overriding the defaults. Thanks @amknight.
+- Doctor/plugins: add `openclaw doctor --post-upgrade --json` mode that emits structured plugin-compat findings (`plugin.entry_unresolved`, `plugin.manifest_drift`) for use by post-upgrade smoke checks, CI, and the community `fork-upgrade` skill, exiting non-zero when any finding has `level: "error"`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,7 +644,6 @@ Docs: https://docs.openclaw.ai
 - Agents/config: allow `agents.list[].experimental.localModelLean` so lean local-model mode can be enabled for one configured agent instead of globally. (#84073) Thanks @dutifulbob.
 - Providers/xAI: add device-code OAuth login so remote and headless setups can authorize xAI without a localhost browser callback. (#84005) Thanks @fuller-stack-dev.
 - Providers/OpenRouter: honor provider-level `params.provider` routing policy for OpenRouter requests, with model and agent params overriding the defaults. Thanks @amknight.
-- Doctor/plugins: add `openclaw doctor --post-upgrade --json` mode that emits structured plugin-compat findings (`plugin.entry_unresolved`, `plugin.manifest_drift`) for use by post-upgrade smoke checks, CI, and the community `fork-upgrade` skill, exiting non-zero when any finding has `level: "error"`. The probe now delegates entry validation to the install-time resolver so `openclaw.runtimeExtensions` shape, plugin-root boundary enforcement, and inferred-built-output / TypeScript-source-only handling stay in sync with plugin install/discovery.
 
 ### Fixes
 

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -45,6 +45,8 @@ openclaw doctor --deep
 openclaw doctor --fix
 openclaw doctor --fix --non-interactive
 openclaw doctor --generate-gateway-token
+openclaw doctor --post-upgrade
+openclaw doctor --post-upgrade --json
 ```
 
 For channel-specific permissions, use the channel probes instead of `doctor`:
@@ -68,7 +70,8 @@ The targeted Discord capabilities probe reports the bot's effective channel perm
 - `--allow-exec`: allow doctor to execute configured exec SecretRefs while verifying secrets
 - `--deep`: scan system services for extra gateway installs and report recent Gateway supervisor restart handoffs
 - `--lint`: run modernized health checks in read-only mode and emit diagnostic findings
-- `--json`: with `--lint`, emit JSON findings instead of human output
+- `--post-upgrade`: run post-upgrade plugin compatibility probes; emits findings to stdout; exits with code 1 if any error-level findings are present
+- `--json`: with `--lint`, emit JSON findings instead of human output; with `--post-upgrade`, emit a machine-readable JSON envelope (`{ probesRun, findings }`)
 - `--severity-min <level>`: with `--lint`, drop findings below `info`, `warning`, or `error`
 - `--skip <id>`: with `--lint`, skip a check id; repeat to skip more than one
 - `--only <id>`: with `--lint`, run only a check id; repeat to run a small selected set
@@ -187,6 +190,14 @@ openclaw doctor --lint --skip core/doctor/skills-readiness
 id is not registered, no check runs for that id; use the command's `checksRun`
 and `checksSkipped` fields to verify a focused gate is selecting the checks you
 expect.
+
+## Post-upgrade mode
+
+`openclaw doctor --post-upgrade` runs plugin compatibility probes intended to be
+chained after a build or upgrade. Findings are emitted to stdout; the command
+exits with code 1 if any finding has `level: "error"`. Add `--json` to receive a
+machine-readable envelope (`{ probesRun, findings }`) suitable for CI, the
+community `fork-upgrade` skill, and other post-upgrade smoke tooling.
 
 Notes:
 

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -197,7 +197,9 @@ expect.
 chained after a build or upgrade. Findings are emitted to stdout; the command
 exits with code 1 if any finding has `level: "error"`. Add `--json` to receive a
 machine-readable envelope (`{ probesRun, findings }`) suitable for CI, the
-community `fork-upgrade` skill, and other post-upgrade smoke tooling.
+community `fork-upgrade` skill, and other post-upgrade smoke tooling. If the
+installed plugin index is missing or malformed, JSON mode still emits that
+envelope with a `plugin.index_unavailable` error finding.
 
 Notes:
 

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -27,7 +27,12 @@ export function registerMaintenanceCommands(program: Command) {
     )
     .option("--deep", "Scan system services for extra gateway installs", false)
     .option("--lint", "Run read-only health checks and report findings", false)
-    .option("--json", "With --lint: emit JSON findings instead of human output", false)
+    .option(
+      "--post-upgrade",
+      "Emit plugin-compat findings only (machine-readable with --json)",
+      false,
+    )
+    .option("--json", "With --lint or --post-upgrade: emit machine-readable JSON output", false)
     .option(
       "--severity-min <level>",
       "With --lint: drop findings below this severity (info|warning|error)",
@@ -84,6 +89,8 @@ export function registerMaintenanceCommands(program: Command) {
           generateGatewayToken: Boolean(opts.generateGatewayToken),
           allowExec: Boolean(opts.allowExec),
           deep: Boolean(opts.deep),
+          postUpgrade: Boolean(opts.postUpgrade),
+          json: Boolean(opts.json),
         });
         defaultRuntime.exit(0);
       });
@@ -168,12 +175,13 @@ export function registerMaintenanceCommands(program: Command) {
 
 function hasLintOnlyDoctorOptions(opts: {
   readonly json?: boolean;
+  readonly postUpgrade?: boolean;
   readonly severityMin?: unknown;
   readonly skip?: unknown;
   readonly only?: unknown;
 }): boolean {
   return (
-    opts.json === true ||
+    (opts.json === true && opts.postUpgrade !== true) ||
     typeof opts.severityMin === "string" ||
     (Array.isArray(opts.skip) && opts.skip.length > 0) ||
     (Array.isArray(opts.only) && opts.only.length > 0)

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -104,6 +105,64 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
 
       const report = await runPostUpgradeProbes({ installsPath });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runPostUpgradeProbes — plugin.manifest_drift", () => {
+  it("flags a plugin whose manifest hash differs from installs.json", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-post-upgrade-manifest-drift-"));
+    try {
+      const pluginDir = path.join(root, "user-plugins", "drifted");
+      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "drifted",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./dist/index.js"] },
+        }),
+        "utf-8",
+      );
+
+      const oldManifestRaw = JSON.stringify({ id: "drifted", version: 1 });
+      const oldManifestHash = crypto.createHash("sha256").update(oldManifestRaw).digest("hex");
+      // Write a NEW manifest after installs.json was snapshotted.
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "drifted", version: 2 }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "drifted",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              manifestHash: oldManifestHash,
+              rootDir: pluginDir,
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      const finding = report.findings.find((f) => f.code === "plugin.manifest_drift");
+      expect(finding).toBeDefined();
+      expect(finding?.level).toBe("warn");
+      expect(finding?.plugin).toBe("drifted");
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runPostUpgradeProbes } from "./doctor-post-upgrade.js";
+
+async function makeFixtureRoot(prefix: string): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), `doctor-post-upgrade-${prefix}-`));
+}
+
+describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
+  it("flags an enabled plugin whose declared entry does not exist on disk", async () => {
+    const root = await makeFixtureRoot("entry-unresolved");
+    const pluginDir = path.join(root, "user-plugins", "ghost");
+    await fs.mkdir(pluginDir, { recursive: true });
+    // Plugin package.json declares ./dist/index.js but no dist/.
+    await fs.writeFile(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "ghost",
+        version: "0.0.1",
+        type: "module",
+        openclaw: { extensions: ["./dist/index.js"] },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({ id: "ghost" }),
+      "utf-8",
+    );
+
+    const installsPath = path.join(root, "plugins", "installs.json");
+    await fs.mkdir(path.dirname(installsPath), { recursive: true });
+    await fs.writeFile(
+      installsPath,
+      JSON.stringify({
+        version: 1,
+        plugins: [
+          {
+            pluginId: "ghost",
+            manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+            rootDir: pluginDir,
+            enabled: true,
+            packageJson: { path: "package.json" },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const report = await runPostUpgradeProbes({ installsPath });
+    const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
+    expect(finding).toBeDefined();
+    expect(finding?.level).toBe("error");
+    expect(finding?.plugin).toBe("ghost");
+    expect(finding?.entry).toBe("./dist/index.js");
+  });
+
+  it("emits no entry_unresolved findings when the entry resolves", async () => {
+    const root = await makeFixtureRoot("entry-ok");
+    const pluginDir = path.join(root, "user-plugins", "good");
+    await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
+    await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
+    await fs.writeFile(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "good",
+        version: "0.0.1",
+        type: "module",
+        openclaw: { extensions: ["./dist/index.js"] },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({ id: "good" }),
+      "utf-8",
+    );
+
+    const installsPath = path.join(root, "plugins", "installs.json");
+    await fs.mkdir(path.dirname(installsPath), { recursive: true });
+    await fs.writeFile(
+      installsPath,
+      JSON.stringify({
+        version: 1,
+        plugins: [
+          {
+            pluginId: "good",
+            manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+            rootDir: pluginDir,
+            enabled: true,
+            packageJson: { path: "package.json" },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const report = await runPostUpgradeProbes({ installsPath });
+    expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
+  });
+});

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -110,6 +110,221 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
     }
   });
 
+  it("flags an entry that escapes the plugin package directory", async () => {
+    const root = await makeFixtureRoot("entry-escape");
+    try {
+      const pluginDir = path.join(root, "user-plugins", "escape");
+      await fs.mkdir(pluginDir, { recursive: true });
+      // Create a sibling file outside the plugin root that the entry resolves to.
+      const outsideDir = path.join(root, "outside");
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(outsideDir, "leak.js"), "export default {};", "utf-8");
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "escape",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["../outside/leak.js"] },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "escape" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "escape",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
+      expect(finding).toBeDefined();
+      expect(finding?.level).toBe("error");
+      expect(finding?.plugin).toBe("escape");
+      expect(finding?.message).toMatch(/escapes plugin directory/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts a TypeScript source entry that ships a compiled dist peer", async () => {
+    const root = await makeFixtureRoot("ts-with-dist");
+    try {
+      const pluginDir = path.join(root, "user-plugins", "ts-dist");
+      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
+      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
+      await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
+      // No explicit runtimeExtensions; the resolver should infer dist/index.js.
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "ts-dist",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./src/index.ts"] },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "ts-dist" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "ts-dist",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a TypeScript source-only entry with no compiled output", async () => {
+    const root = await makeFixtureRoot("ts-source-only");
+    try {
+      const pluginDir = path.join(root, "user-plugins", "ts-only");
+      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
+      // Source exists, no dist peer — installed plugins must ship compiled JS.
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "ts-only",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./src/index.ts"] },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "ts-only" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "ts-only",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
+      expect(finding).toBeDefined();
+      expect(finding?.level).toBe("error");
+      expect(finding?.plugin).toBe("ts-only");
+      expect(finding?.message).toMatch(/compiled runtime output/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a runtimeExtensions length mismatch", async () => {
+    const root = await makeFixtureRoot("runtime-len-mismatch");
+    try {
+      const pluginDir = path.join(root, "user-plugins", "len-mismatch");
+      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "dist", "a.js"), "export default {};", "utf-8");
+      await fs.writeFile(path.join(pluginDir, "dist", "b.js"), "export default {};", "utf-8");
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "len-mismatch",
+          version: "0.0.1",
+          type: "module",
+          openclaw: {
+            extensions: ["./dist/a.js", "./dist/b.js"],
+            runtimeExtensions: ["./dist/a.js"],
+          },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "len-mismatch" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "len-mismatch",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
+      expect(finding).toBeDefined();
+      expect(finding?.level).toBe("error");
+      expect(finding?.plugin).toBe("len-mismatch");
+      expect(finding?.message).toMatch(/runtimeExtensions length/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not flag entry_unresolved when runtimeExtensions exists even if source entry is missing", async () => {
     const root = await makeFixtureRoot("runtime-extensions");
     try {

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -11,93 +11,101 @@ async function makeFixtureRoot(prefix: string): Promise<string> {
 describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
   it("flags an enabled plugin whose declared entry does not exist on disk", async () => {
     const root = await makeFixtureRoot("entry-unresolved");
-    const pluginDir = path.join(root, "user-plugins", "ghost");
-    await fs.mkdir(pluginDir, { recursive: true });
-    // Plugin package.json declares ./dist/index.js but no dist/.
-    await fs.writeFile(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "ghost",
-        version: "0.0.1",
-        type: "module",
-        openclaw: { extensions: ["./dist/index.js"] },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify({ id: "ghost" }),
-      "utf-8",
-    );
+    try {
+      const pluginDir = path.join(root, "user-plugins", "ghost");
+      await fs.mkdir(pluginDir, { recursive: true });
+      // Plugin package.json declares ./dist/index.js but no dist/.
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "ghost",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./dist/index.js"] },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "ghost" }),
+        "utf-8",
+      );
 
-    const installsPath = path.join(root, "plugins", "installs.json");
-    await fs.mkdir(path.dirname(installsPath), { recursive: true });
-    await fs.writeFile(
-      installsPath,
-      JSON.stringify({
-        version: 1,
-        plugins: [
-          {
-            pluginId: "ghost",
-            manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-            rootDir: pluginDir,
-            enabled: true,
-            packageJson: { path: "package.json" },
-          },
-        ],
-      }),
-      "utf-8",
-    );
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "ghost",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
 
-    const report = await runPostUpgradeProbes({ installsPath });
-    const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
-    expect(finding).toBeDefined();
-    expect(finding?.level).toBe("error");
-    expect(finding?.plugin).toBe("ghost");
-    expect(finding?.entry).toBe("./dist/index.js");
+      const report = await runPostUpgradeProbes({ installsPath });
+      const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
+      expect(finding).toBeDefined();
+      expect(finding?.level).toBe("error");
+      expect(finding?.plugin).toBe("ghost");
+      expect(finding?.entry).toBe("./dist/index.js");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("emits no entry_unresolved findings when the entry resolves", async () => {
     const root = await makeFixtureRoot("entry-ok");
-    const pluginDir = path.join(root, "user-plugins", "good");
-    await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
-    await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
-    await fs.writeFile(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "good",
-        version: "0.0.1",
-        type: "module",
-        openclaw: { extensions: ["./dist/index.js"] },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify({ id: "good" }),
-      "utf-8",
-    );
+    try {
+      const pluginDir = path.join(root, "user-plugins", "good");
+      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "good",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./dist/index.js"] },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "good" }),
+        "utf-8",
+      );
 
-    const installsPath = path.join(root, "plugins", "installs.json");
-    await fs.mkdir(path.dirname(installsPath), { recursive: true });
-    await fs.writeFile(
-      installsPath,
-      JSON.stringify({
-        version: 1,
-        plugins: [
-          {
-            pluginId: "good",
-            manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-            rootDir: pluginDir,
-            enabled: true,
-            packageJson: { path: "package.json" },
-          },
-        ],
-      }),
-      "utf-8",
-    );
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "good",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
 
-    const report = await runPostUpgradeProbes({ installsPath });
-    expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
+      const report = await runPostUpgradeProbes({ installsPath });
+      expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -109,6 +109,59 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it("does not flag entry_unresolved when runtimeExtensions exists even if source entry is missing", async () => {
+    const root = await makeFixtureRoot("runtime-extensions");
+    try {
+      const pluginDir = path.join(root, "user-plugins", "runtime-only");
+      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
+      // Source entry (./src/index.ts) does NOT exist
+      // But runtime entry (./dist/index.js) DOES exist
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "runtime-only",
+          version: "0.0.1",
+          type: "module",
+          openclaw: {
+            extensions: ["./src/index.ts"],
+            runtimeExtensions: ["./dist/index.js"],
+          },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "runtime-only" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "runtime-only",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("runPostUpgradeProbes — plugin.manifest_drift", () => {

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -9,6 +9,68 @@ async function makeFixtureRoot(prefix: string): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), `doctor-post-upgrade-${prefix}-`));
 }
 
+describe("runPostUpgradeProbes — plugin.index_unavailable", () => {
+  it("returns a structured finding when the installed plugin index is missing", async () => {
+    const root = await makeFixtureRoot("index-missing");
+    try {
+      const report = await runPostUpgradeProbes({
+        installsPath: path.join(root, "plugins", "installs.json"),
+      });
+
+      expect(report.probesRun).toContain("plugin.index_unavailable");
+      expect(report.findings).toEqual([
+        expect.objectContaining({
+          level: "error",
+          code: "plugin.index_unavailable",
+        }),
+      ]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a structured finding when the installed plugin index is malformed", async () => {
+    const root = await makeFixtureRoot("index-malformed");
+    try {
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(installsPath, "{ not json", "utf-8");
+
+      const report = await runPostUpgradeProbes({ installsPath });
+
+      expect(report.probesRun).toContain("plugin.index_unavailable");
+      expect(report.findings).toEqual([
+        expect.objectContaining({
+          level: "error",
+          code: "plugin.index_unavailable",
+        }),
+      ]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a structured finding when an installed plugin record is malformed", async () => {
+    const root = await makeFixtureRoot("record-malformed");
+    try {
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(installsPath, JSON.stringify({ plugins: [{}] }), "utf-8");
+
+      const report = await runPostUpgradeProbes({ installsPath });
+
+      expect(report.findings).toEqual([
+        expect.objectContaining({
+          level: "error",
+          code: "plugin.index_unavailable",
+        }),
+      ]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
   it("flags an enabled plugin whose declared entry does not exist on disk", async () => {
     const root = await makeFixtureRoot("entry-unresolved");

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -36,7 +36,15 @@ export async function runPostUpgradeProbes(params: {
   for (const record of installs.plugins) {
     if (!record.enabled) continue;
     const pkgRelPath = record.packageJson?.path ?? "package.json";
-    const pkg = await readInstalledPackageJson(record.rootDir, pkgRelPath);
+    let pkg: { openclaw?: { extensions?: string[] } };
+    try {
+      pkg = await readInstalledPackageJson(record.rootDir, pkgRelPath);
+    } catch (err) {
+      process.stderr.write(
+        `[doctor-post-upgrade] could not read package.json for ${record.pluginId} at ${record.rootDir}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      continue;
+    }
     const entries = pkg.openclaw?.extensions ?? [];
     for (const entry of entries) {
       const absEntry = path.resolve(record.rootDir, entry);

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { listBuiltRuntimeEntryCandidates } from "../plugins/package-entrypoints.js";
 import type { PostUpgradeFinding, PostUpgradeReport } from "./doctor-post-upgrade.types.js";
 
 type InstalledPluginRecord = {
@@ -17,7 +18,7 @@ type InstallsJson = { plugins: InstalledPluginRecord[] };
 async function readInstalledPackageJson(rootDir: string, packageJsonRelPath: string) {
   const absPath = path.join(rootDir, packageJsonRelPath);
   const raw = await fs.readFile(absPath, "utf-8");
-  return JSON.parse(raw) as { openclaw?: { extensions?: string[] } };
+  return JSON.parse(raw) as { openclaw?: { extensions?: string[]; runtimeExtensions?: string[] } };
 }
 
 async function fileExists(absPath: string): Promise<boolean> {
@@ -48,7 +49,7 @@ export async function runPostUpgradeProbes(params: {
   for (const record of installs.plugins) {
     if (!record.enabled) continue;
     const pkgRelPath = record.packageJson?.path ?? "package.json";
-    let pkg: { openclaw?: { extensions?: string[] } };
+    let pkg: { openclaw?: { extensions?: string[]; runtimeExtensions?: string[] } };
     try {
       pkg = await readInstalledPackageJson(record.rootDir, pkgRelPath);
     } catch (err) {
@@ -58,9 +59,31 @@ export async function runPostUpgradeProbes(params: {
       continue;
     }
     const entries = pkg.openclaw?.extensions ?? [];
-    for (const entry of entries) {
+    const runtimeExtensions = pkg.openclaw?.runtimeExtensions ?? [];
+    for (const [index, entry] of entries.entries()) {
+      // First, check if there's an explicit runtimeExtensions entry at this index
+      const runtimeEntry = runtimeExtensions[index];
+      if (runtimeEntry) {
+        const absRuntimeEntry = path.resolve(record.rootDir, runtimeEntry);
+        if (await fileExists(absRuntimeEntry)) {
+          // Runtime entry exists, so we're good; skip to next entry
+          continue;
+        }
+        // Runtime entry doesn't exist; flag it
+        findings.push({
+          level: "error",
+          code: "plugin.entry_unresolved",
+          message: `Plugin ${record.pluginId} declares runtimeExtensions entry ${runtimeEntry} but the file does not exist at ${absRuntimeEntry}.`,
+          plugin: record.pluginId,
+          entry: runtimeEntry,
+        });
+        continue;
+      }
+
+      // No explicit runtime entry; try the source entry
       const absEntry = path.resolve(record.rootDir, entry);
       if (!(await fileExists(absEntry))) {
+        // Source entry doesn't exist either; flag it
         findings.push({
           level: "error",
           code: "plugin.entry_unresolved",

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { listBuiltRuntimeEntryCandidates } from "../plugins/package-entrypoints.js";
 import type { PostUpgradeFinding, PostUpgradeReport } from "./doctor-post-upgrade.types.js";
 
 type InstalledPluginRecord = {
@@ -47,7 +46,9 @@ export async function runPostUpgradeProbes(params: {
   const installs = JSON.parse(installsRaw) as InstallsJson;
 
   for (const record of installs.plugins) {
-    if (!record.enabled) continue;
+    if (!record.enabled) {
+      continue;
+    }
     const pkgRelPath = record.packageJson?.path ?? "package.json";
     let pkg: { openclaw?: { extensions?: string[]; runtimeExtensions?: string[] } };
     try {

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { PostUpgradeFinding, PostUpgradeReport } from "./doctor-post-upgrade.types.js";
@@ -7,6 +8,8 @@ type InstalledPluginRecord = {
   rootDir: string;
   enabled: boolean;
   packageJson?: { path: string };
+  manifestPath?: string;
+  manifestHash?: string;
 };
 
 type InstallsJson = { plugins: InstalledPluginRecord[] };
@@ -23,6 +26,15 @@ async function fileExists(absPath: string): Promise<boolean> {
     return true;
   } catch {
     return false;
+  }
+}
+
+async function sha256OfFile(absPath: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(absPath);
+    return crypto.createHash("sha256").update(raw).digest("hex");
+  } catch {
+    return null;
   }
 }
 
@@ -58,7 +70,19 @@ export async function runPostUpgradeProbes(params: {
         });
       }
     }
+
+    if (record.manifestPath && record.manifestHash) {
+      const currentHash = await sha256OfFile(record.manifestPath);
+      if (currentHash && currentHash !== record.manifestHash) {
+        findings.push({
+          level: "warn",
+          code: "plugin.manifest_drift",
+          message: `Plugin ${record.pluginId} manifest hash drifted from installs.json snapshot. Run \`openclaw plugins registry --refresh\` to re-sync.`,
+          plugin: record.pluginId,
+        });
+      }
+    }
   }
 
-  return { probesRun: ["plugin.entry_unresolved"], findings };
+  return { probesRun: ["plugin.entry_unresolved", "plugin.manifest_drift"], findings };
 }

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { PostUpgradeFinding, PostUpgradeReport } from "./doctor-post-upgrade.types.js";
+
+type InstalledPluginRecord = {
+  pluginId: string;
+  rootDir: string;
+  enabled: boolean;
+  packageJson?: { path: string };
+};
+
+type InstallsJson = { plugins: InstalledPluginRecord[] };
+
+async function readInstalledPackageJson(rootDir: string, packageJsonRelPath: string) {
+  const absPath = path.join(rootDir, packageJsonRelPath);
+  const raw = await fs.readFile(absPath, "utf-8");
+  return JSON.parse(raw) as { openclaw?: { extensions?: string[] } };
+}
+
+async function fileExists(absPath: string): Promise<boolean> {
+  try {
+    await fs.access(absPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function runPostUpgradeProbes(params: {
+  installsPath: string;
+}): Promise<PostUpgradeReport> {
+  const findings: PostUpgradeFinding[] = [];
+  const installsRaw = await fs.readFile(params.installsPath, "utf-8");
+  const installs = JSON.parse(installsRaw) as InstallsJson;
+
+  for (const record of installs.plugins) {
+    if (!record.enabled) continue;
+    const pkgRelPath = record.packageJson?.path ?? "package.json";
+    const pkg = await readInstalledPackageJson(record.rootDir, pkgRelPath);
+    const entries = pkg.openclaw?.extensions ?? [];
+    for (const entry of entries) {
+      const absEntry = path.resolve(record.rootDir, entry);
+      if (!(await fileExists(absEntry))) {
+        findings.push({
+          level: "error",
+          code: "plugin.entry_unresolved",
+          message: `Plugin ${record.pluginId} declares extensions entry ${entry} but the file does not exist at ${absEntry}.`,
+          plugin: record.pluginId,
+          entry,
+        });
+      }
+    }
+  }
+
+  return { probesRun: ["plugin.entry_unresolved"], findings };
+}

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { type PackageManifest } from "../plugins/manifest.js";
+import { validatePackageExtensionEntriesForInstall } from "../plugins/package-entry-resolution.js";
 import type { PostUpgradeFinding, PostUpgradeReport } from "./doctor-post-upgrade.types.js";
 
 type InstalledPluginRecord = {
@@ -14,19 +16,13 @@ type InstalledPluginRecord = {
 
 type InstallsJson = { plugins: InstalledPluginRecord[] };
 
-async function readInstalledPackageJson(rootDir: string, packageJsonRelPath: string) {
+async function readInstalledPackageJson(
+  rootDir: string,
+  packageJsonRelPath: string,
+): Promise<PackageManifest> {
   const absPath = path.join(rootDir, packageJsonRelPath);
   const raw = await fs.readFile(absPath, "utf-8");
-  return JSON.parse(raw) as { openclaw?: { extensions?: string[]; runtimeExtensions?: string[] } };
-}
-
-async function fileExists(absPath: string): Promise<boolean> {
-  try {
-    await fs.access(absPath);
-    return true;
-  } catch {
-    return false;
-  }
+  return JSON.parse(raw) as PackageManifest;
 }
 
 async function sha256OfFile(absPath: string): Promise<string | null> {
@@ -50,7 +46,7 @@ export async function runPostUpgradeProbes(params: {
       continue;
     }
     const pkgRelPath = record.packageJson?.path ?? "package.json";
-    let pkg: { openclaw?: { extensions?: string[]; runtimeExtensions?: string[] } };
+    let pkg: PackageManifest;
     try {
       pkg = await readInstalledPackageJson(record.rootDir, pkgRelPath);
     } catch (err) {
@@ -60,37 +56,23 @@ export async function runPostUpgradeProbes(params: {
       continue;
     }
     const entries = pkg.openclaw?.extensions ?? [];
-    const runtimeExtensions = pkg.openclaw?.runtimeExtensions ?? [];
-    for (const [index, entry] of entries.entries()) {
-      // First, check if there's an explicit runtimeExtensions entry at this index
-      const runtimeEntry = runtimeExtensions[index];
-      if (runtimeEntry) {
-        const absRuntimeEntry = path.resolve(record.rootDir, runtimeEntry);
-        if (await fileExists(absRuntimeEntry)) {
-          // Runtime entry exists, so we're good; skip to next entry
-          continue;
-        }
-        // Runtime entry doesn't exist; flag it
+    if (entries.length > 0) {
+      // Delegate to the install-time resolver so the probe enforces the same
+      // contract as plugin install/discovery: runtimeExtensions shape, plugin-root
+      // boundary, and inferred-built-output / TypeScript-source-only handling.
+      const validation = await validatePackageExtensionEntriesForInstall({
+        packageDir: record.rootDir,
+        extensions: [...entries],
+        manifest: pkg,
+      });
+      if (!validation.ok) {
+        const offendingEntry = entries.find((entry) => validation.error.includes(entry));
         findings.push({
           level: "error",
           code: "plugin.entry_unresolved",
-          message: `Plugin ${record.pluginId} declares runtimeExtensions entry ${runtimeEntry} but the file does not exist at ${absRuntimeEntry}.`,
+          message: `Plugin ${record.pluginId}: ${validation.error}`,
           plugin: record.pluginId,
-          entry: runtimeEntry,
-        });
-        continue;
-      }
-
-      // No explicit runtime entry; try the source entry
-      const absEntry = path.resolve(record.rootDir, entry);
-      if (!(await fileExists(absEntry))) {
-        // Source entry doesn't exist either; flag it
-        findings.push({
-          level: "error",
-          code: "plugin.entry_unresolved",
-          message: `Plugin ${record.pluginId} declares extensions entry ${entry} but the file does not exist at ${absEntry}.`,
-          plugin: record.pluginId,
-          entry,
+          ...(offendingEntry ? { entry: offendingEntry } : {}),
         });
       }
     }

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -1,9 +1,13 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { type PackageManifest } from "../plugins/manifest.js";
+import type { PackageManifest } from "../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../plugins/package-entry-resolution.js";
-import type { PostUpgradeFinding, PostUpgradeReport } from "./doctor-post-upgrade.types.js";
+import {
+  POST_UPGRADE_PROBE_CODES,
+  type PostUpgradeFinding,
+  type PostUpgradeReport,
+} from "./doctor-post-upgrade.types.js";
 
 type InstalledPluginRecord = {
   pluginId: string;
@@ -15,6 +19,57 @@ type InstalledPluginRecord = {
 };
 
 type InstallsJson = { plugins: InstalledPluginRecord[] };
+
+function buildReport(findings: PostUpgradeFinding[]): PostUpgradeReport {
+  return { probesRun: [...POST_UPGRADE_PROBE_CODES], findings };
+}
+
+function isInstallsJson(value: unknown): value is InstallsJson {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as { plugins?: unknown }).plugins) &&
+    (value as { plugins: unknown[] }).plugins.every(isInstalledPluginRecord)
+  );
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+function isPackageJsonRef(value: unknown): value is InstalledPluginRecord["packageJson"] {
+  return (
+    value === undefined ||
+    (typeof value === "object" &&
+      value !== null &&
+      typeof (value as { path?: unknown }).path === "string")
+  );
+}
+
+function isInstalledPluginRecord(value: unknown): value is InstalledPluginRecord {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as InstalledPluginRecord;
+  return (
+    typeof record.pluginId === "string" &&
+    typeof record.rootDir === "string" &&
+    typeof record.enabled === "boolean" &&
+    isPackageJsonRef(record.packageJson) &&
+    isOptionalString(record.manifestPath) &&
+    isOptionalString(record.manifestHash)
+  );
+}
+
+async function readInstallsJson(installsPath: string): Promise<InstallsJson | null> {
+  try {
+    const installsRaw = await fs.readFile(installsPath, "utf-8");
+    const installs = JSON.parse(installsRaw) as unknown;
+    return isInstallsJson(installs) ? installs : null;
+  } catch {
+    return null;
+  }
+}
 
 async function readInstalledPackageJson(
   rootDir: string,
@@ -38,8 +93,16 @@ export async function runPostUpgradeProbes(params: {
   installsPath: string;
 }): Promise<PostUpgradeReport> {
   const findings: PostUpgradeFinding[] = [];
-  const installsRaw = await fs.readFile(params.installsPath, "utf-8");
-  const installs = JSON.parse(installsRaw) as InstallsJson;
+  const installs = await readInstallsJson(params.installsPath);
+  if (!installs) {
+    findings.push({
+      level: "error",
+      code: "plugin.index_unavailable",
+      message:
+        "Installed plugin index is missing, unreadable, or malformed. Run `openclaw plugins registry --refresh` to rebuild it before post-upgrade validation.",
+    });
+    return buildReport(findings);
+  }
 
   for (const record of installs.plugins) {
     if (!record.enabled) {
@@ -90,5 +153,5 @@ export async function runPostUpgradeProbes(params: {
     }
   }
 
-  return { probesRun: ["plugin.entry_unresolved", "plugin.manifest_drift"], findings };
+  return buildReport(findings);
 }

--- a/src/commands/doctor-post-upgrade.types.ts
+++ b/src/commands/doctor-post-upgrade.types.ts
@@ -1,0 +1,21 @@
+export type PostUpgradeFindingLevel = "ok" | "warn" | "error";
+
+export type PostUpgradeFinding = {
+  level: PostUpgradeFindingLevel;
+  code: string;
+  message: string;
+  plugin?: string;
+  entry?: string;
+};
+
+export type PostUpgradeReport = {
+  probesRun: string[];
+  findings: PostUpgradeFinding[];
+};
+
+export const POST_UPGRADE_PROBE_CODES = [
+  "plugin.entry_unresolved",
+  "plugin.manifest_drift",
+] as const;
+
+export type PostUpgradeProbeCode = (typeof POST_UPGRADE_PROBE_CODES)[number];

--- a/src/commands/doctor-post-upgrade.types.ts
+++ b/src/commands/doctor-post-upgrade.types.ts
@@ -14,6 +14,7 @@ export type PostUpgradeReport = {
 };
 
 export const POST_UPGRADE_PROBE_CODES = [
+  "plugin.index_unavailable",
   "plugin.entry_unresolved",
   "plugin.manifest_drift",
 ] as const;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,12 +1,11 @@
-import os from "node:os";
-import path from "node:path";
+import { resolveInstalledPluginIndexStorePath } from "../plugins/installed-plugin-index-store-path.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { runPostUpgradeProbes } from "./doctor-post-upgrade.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 
 export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOptions): Promise<void> {
   if (options?.postUpgrade) {
-    const installsPath = path.join(os.homedir(), ".openclaw", "plugins", "installs.json");
+    const installsPath = resolveInstalledPluginIndexStorePath();
     const report = await runPostUpgradeProbes({ installsPath });
     if (options.json) {
       console.log(JSON.stringify(report, null, 2));

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,27 @@
+import os from "node:os";
+import path from "node:path";
 import type { RuntimeEnv } from "../runtime.js";
+import { runPostUpgradeProbes } from "./doctor-post-upgrade.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 
 export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOptions): Promise<void> {
+  if (options?.postUpgrade) {
+    const installsPath = path.join(os.homedir(), ".openclaw", "plugins", "installs.json");
+    const report = await runPostUpgradeProbes({ installsPath });
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      for (const f of report.findings) {
+        console.log(`[${f.level}] ${f.code}: ${f.message}`);
+      }
+      if (report.findings.length === 0) {
+        console.log("post-upgrade: no findings");
+      }
+    }
+    const hasError = report.findings.some((f) => f.level === "error");
+    runtime?.exit(hasError ? 1 : 0);
+    return;
+  }
   const doctorHealth = await import("../flows/doctor-health.js");
   await doctorHealth.doctorCommand(runtime, options);
 }

--- a/src/commands/doctor.types.ts
+++ b/src/commands/doctor.types.ts
@@ -7,4 +7,6 @@ export type DoctorOptions = {
   force?: boolean;
   generateGatewayToken?: boolean;
   allowExec?: boolean;
+  postUpgrade?: boolean;
+  json?: boolean;
 };


### PR DESCRIPTION
## Summary

Adds `openclaw doctor --post-upgrade --json`: a probe-only doctor mode that emits structured plugin-compat findings to stdout, exits non-zero when any finding has `level: "error"`. Useful for CI, post-edit smoke checks, and as the post-cutover probe consumed by external orchestrators.

Two probes ship in this PR:

- `plugin.entry_unresolved` (level: error) — fires when an enabled plugin in `installs.json` declares an `openclaw.extensions[*]` entry that doesn't resolve on disk. Catches the user-plugin class that ships a TypeScript entry without compiling.
- `plugin.manifest_drift` (level: warn) — fires when a plugin's `openclaw.plugin.json` SHA-256 differs from the `manifestHash` snapshot recorded in `installs.json`. Catches plugins whose manifest changed since the last `openclaw plugins registry --refresh`.

The runner (`runPostUpgradeProbes`) is resilient: a plugin with a missing or malformed `package.json` produces a single stderr line and is skipped, rather than crashing the whole run.

## Problem

When upgrading an OpenClaw fork between versions, plugins that previously loaded silently can stop loading without obvious failure signals: the loader skips them, the gateway boots with a smaller plugin list than expected, and downstream subscribers (e.g. diagnostic-events listeners) silently emit nothing for the missing plugins. There's no in-tree command to ask "which enabled plugins are unhealthy after my upgrade?" — operators have to grep journals or read `installs.json` by hand.

External orchestration tools (CI, custom upgrade scripts, fork-upgrade tooling) also need a structured, machine-consumable answer to that question.

## Solution

`doctor --post-upgrade --json` runs only plugin-compat probes (no health checks, no migrations, no prompts) and emits a JSON envelope:

```json
{
  "probesRun": ["plugin.entry_unresolved", "plugin.manifest_drift"],
  "findings": [{ "level": "warn|error", "code": "...", "message": "...", "plugin": "...", "entry": "..." }]
}
```

Without `--json`, the same findings render one per line as `[level] code: message`. Exit code is 1 if any finding has `level: "error"`, else 0.

The two probes are pure-filesystem: they read `installs.json` and per-plugin metadata only, no gateway RPCs, no in-process state. This keeps the surface independent of the gateway's running state and easy to invoke from CI.

## Changes

- `src/commands/doctor-post-upgrade.types.ts` — finding/report shape, probe-code const list.
- `src/commands/doctor-post-upgrade.ts` — `runPostUpgradeProbes({installsPath})` returning `PostUpgradeReport`.
- `src/commands/doctor-post-upgrade.test.ts` — three tests: entry_unresolved (fail + ok), manifest_drift (fail).
- `src/commands/doctor.types.ts` — `DoctorOptions` extended with `postUpgrade?` and `json?`.
- `src/commands/doctor.ts` — early-return branch into `runPostUpgradeProbes` when `postUpgrade` is set; preserves existing health-flow path otherwise.
- `src/cli/program/register.maintenance.ts` — `--post-upgrade` and `--json` flags wired through to `doctorCommand`.
- `CHANGELOG.md` — entry under `## Unreleased` / `### Changes`.

## Real Behavior Proof

- **Behavior or issue addressed:** OpenClaw operators have no machine-consumable way to ask "are my installed plugins healthy after this upgrade?". CI and external upgrade tooling need a structured answer; today they have to scrape journals or re-derive the truth from `installs.json` by hand. Plugin-load regressions (entry not resolving on disk, manifest hash drift after a refresh wasn't run) surface as silent skips rather than actionable findings.
- **Real environment tested:** Local OpenClaw checkout built from this branch (`feat/doctor-post-upgrade`, head `077b7b47cb` for the changelog commit, plus the post-changelog work) on Linux 6.12.30 / Node v24.13.0. Tested against the live install state at `~/.openclaw/plugins/installs.json` on the same host (which currently has manifest drift on a handful of bundled plugins, exercising the manifest_drift probe naturally).
- **Exact steps or command run after this patch:**

```bash
pnpm install
pnpm tsgo:core
pnpm test src/commands/doctor-post-upgrade.test.ts
pnpm test src/cli/program/register.maintenance.test.ts
pnpm build
node dist/index.js doctor --post-upgrade --json
node dist/index.js doctor --post-upgrade
```

- **Evidence after fix:**

`pnpm tsgo:core` — exit 0.

`pnpm test src/commands/doctor-post-upgrade.test.ts`:
```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

`pnpm test src/cli/program/register.maintenance.test.ts`:
```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

`pnpm build` — exit 0; `dist/` refreshed.

`node dist/index.js doctor --post-upgrade --json` (exit 0):

```json
{
  "probesRun": ["plugin.entry_unresolved", "plugin.manifest_drift"],
  "findings": [
    { "level": "warn", "code": "plugin.manifest_drift", "message": "Plugin byteplus manifest hash drifted from installs.json snapshot. Run `openclaw plugins registry --refresh` to re-sync.", "plugin": "byteplus" },
    { "level": "warn", "code": "plugin.manifest_drift", "message": "Plugin fireworks manifest hash drifted from installs.json snapshot. Run `openclaw plugins registry --refresh` to re-sync.", "plugin": "fireworks" },
    { "level": "warn", "code": "plugin.manifest_drift", "message": "Plugin google manifest hash drifted from installs.json snapshot. Run `openclaw plugins registry --refresh` to re-sync.", "plugin": "google" },
    { "level": "warn", "code": "plugin.manifest_drift", "message": "Plugin openai manifest hash drifted from installs.json snapshot. Run `openclaw plugins registry --refresh` to re-sync.", "plugin": "openai" }
  ]
}
```

`node dist/index.js doctor --post-upgrade` (exit 0):

```
[warn] plugin.manifest_drift: Plugin byteplus manifest hash drifted from installs.json snapshot. Run `openclaw plugins registry --refresh` to re-sync.
[warn] plugin.manifest_drift: Plugin fireworks manifest hash drifted from installs.json snapshot. Run `openclaw plugins registry --refresh` to re-sync.
[warn] plugin.manifest_drift: Plugin google manifest hash drifted from installs.json snapshot. Run `openclaw plugins registry --refresh` to re-sync.
[warn] plugin.manifest_drift: Plugin openai manifest hash drifted from installs.json snapshot. Run `openclaw plugins registry --refresh` to re-sync.
```

- **Observed result after fix:** Both modes ran successfully against a real install. JSON output is well-formed and parseable. Human-format output matches the spec (`[level] code: message` per line). Both probes ran (`probesRun` lists both). Exit code is 0 because all findings are `warn`, not `error` — confirms the exit-code contract. The findings themselves are real: bundled plugins on the test host had manifest drift, providing organic evidence that the manifest_drift probe detects real drift in the wild.
- **What was not tested:** The `plugin.entry_unresolved` probe at error level wasn't exercised against a live install in this proof (no plugin with a broken entry is currently installed on the test host). It is exercised by the unit test (`flags an enabled plugin whose declared entry does not exist on disk`) using a fresh on-disk fixture that asserts `level: "error"`. End-to-end `pnpm check` was not run; the changed-surface gates above plus the build are the proof bar this PR carries. The two follow-up findings flagged in the spec (`plugin.silently_skipped`, `plugin.zero_diagnostic_events`) need a new gateway RPC to introspect started-plugin and listener-event state and are deferred to a follow-up PR.

## Notes

- Resilience: a plugin with a missing/malformed `package.json` produces a single stderr line and is skipped, so one broken plugin can't hide findings from other plugins.
- Skip semantics: disabled plugins are skipped entirely (consistent with how the rest of the loader treats them). Records without a `manifestHash` snapshot are skipped by the drift probe (pre-snapshot installs have nothing to compare against).
- Exit-code contract: only `level: "error"` triggers exit 1. Warnings keep exit 0 so CI can opt in to strictness via parsing the JSON output without the command itself failing.
- Hardcoded path `~/.openclaw/plugins/installs.json` for v0.1; if maintainers prefer routing through a state-dir resolver helper, happy to add it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
