### PR TITLE
fix(agents): make loop breaker session-global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Slack: route handled top-level channel turns in implicit-conversation channels to thread-scoped sessions when Slack reply threading is enabled, keeping the root turn and later thread replies on one OpenClaw session. (#78522) Thanks @zeroth-blip.
 - Telegram: re-probe the primary fetch transport after repeated sticky fallback success so transient IPv4 or pinned-IP fallback promotion can recover without a gateway restart. Fixes #77088. (#77157) Thanks @MkDev11.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
+- Agents: make the global no-progress loop breaker session-wide across repeated tool patterns, so runaway cross-tool loops are blocked before they churn indefinitely. Fixes #79252. Thanks @TurboTheTurtle.
 - Discord/voice: make duplicate same-guild auto-join entries resolve to the last configured channel so moving an agent between voice channels does not keep joining the stale channel.
 - Discord/voice: add realtime `/vc` modes so Discord voice channels can run as STT/TTS, a realtime talk buffer with the OpenClaw agent brain, or a bidi realtime session with `openclaw_agent_consult`.
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -270,6 +270,28 @@ describe("before_tool_call loop detection behavior", () => {
     expectToolLoopBlockedResult(result, "global circuit breaker");
   });
 
+  it("blocks a different tool after the global breaker threshold is reached", async () => {
+    const { tool: readTool, params: readParams } = createGenericReadRepeatFixture();
+    const searchExecute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "search output" }],
+      details: { ok: true },
+    });
+    const searchTool = createWrappedTool("memory_search", searchExecute);
+
+    for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+      await expectUnblockedToolExecution(readTool, `read-${i}`, readParams);
+    }
+
+    const result = await searchTool.execute(
+      "search-after-global-breaker",
+      { query: "still looping" },
+      undefined,
+      undefined,
+    );
+    expectToolLoopBlockedResult(result, "global circuit breaker");
+    expect(searchExecute).not.toHaveBeenCalled();
+  });
+
   it("does not carry loop history across run ids", async () => {
     const execute = vi.fn().mockResolvedValue({
       content: [{ type: "text", text: "same output" }],

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -531,6 +531,99 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("blocks a different tool after the session-global no-progress threshold", () => {
+      const state = createState();
+      const fixture = createReadNoProgressFixture();
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: fixture.toolName,
+        toolParams: fixture.params,
+        result: fixture.result,
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+      });
+
+      const loopResult = detectToolCallLoop(
+        state,
+        "exec",
+        { command: "pwd" },
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.count).toBe(GLOBAL_CIRCUIT_BREAKER_THRESHOLD);
+        expect(loopResult.message).toContain("global circuit breaker");
+      }
+    });
+
+    it("counts stable no-progress repeats across multiple tool patterns", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 4,
+        globalCircuitBreakerThreshold: 5,
+      };
+
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: "read",
+        toolParams: { path: "/tmp/a.txt" },
+        result: { content: [{ type: "text", text: "same read" }], details: { ok: true } },
+        count: 3,
+      });
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: "exec",
+        toolParams: { command: "pwd" },
+        result: {
+          content: [{ type: "text", text: "/workspace" }],
+          details: { status: "completed", exitCode: 0, aggregated: "/workspace" },
+        },
+        count: 2,
+        startIndex: 3,
+      });
+
+      const loopResult = detectToolCallLoop(state, "memory_search", { query: "next" }, config);
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.count).toBe(5);
+      }
+    });
+
+    it("does not count unrelated one-off tools as global no-progress", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 4,
+        globalCircuitBreakerThreshold: 5,
+      };
+
+      for (const [index, toolName] of [
+        "read",
+        "list",
+        "exec",
+        "memory_search",
+        "fetch",
+      ].entries()) {
+        recordSuccessfulCall(
+          state,
+          toolName,
+          { id: index },
+          { content: [{ type: "text", text: "same output" }], details: { ok: true } },
+          index,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "write", { path: "/tmp/out" }, config);
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("blocks repeated completed exec calls despite volatile runtime details", () => {
       const state = createState();
       const params = { command: "grafana-api.sh datasources" };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -385,6 +385,45 @@ function getNoProgressStreak(
   return { count: streak, latestResultHash };
 }
 
+function getGlobalNoProgressStreak(history: Array<{ argsHash: string; resultHash?: string }>): {
+  count: number;
+  latestResultHash?: string;
+  patternCount: number;
+} {
+  const patterns = new Map<string, { resultHash: string; count: number }>();
+  let latestResultHash: string | undefined;
+
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (typeof record?.resultHash !== "string" || !record.resultHash) {
+      continue;
+    }
+    latestResultHash ??= record.resultHash;
+
+    const existing = patterns.get(record.argsHash);
+    if (!existing) {
+      patterns.set(record.argsHash, { resultHash: record.resultHash, count: 1 });
+      continue;
+    }
+    if (existing.resultHash !== record.resultHash) {
+      break;
+    }
+    existing.count += 1;
+  }
+
+  let count = 0;
+  let patternCount = 0;
+  for (const pattern of patterns.values()) {
+    if (pattern.count < 2) {
+      continue;
+    }
+    count += pattern.count;
+    patternCount += 1;
+  }
+
+  return { count, latestResultHash, patternCount };
+}
+
 function getPingPongStreak(
   history: Array<{ toolName: string; argsHash: string; resultHash?: string }>,
   currentSignature: string,
@@ -511,6 +550,8 @@ export function detectToolCallLoop(
   const unknownToolStreak = getUnknownToolRepeatStreak(history, toolName);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
+  const globalNoProgress = getGlobalNoProgressStreak(history);
+  const globalNoProgressStreak = globalNoProgress.count;
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
 
@@ -525,17 +566,17 @@ export function detectToolCallLoop(
     };
   }
 
-  if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
+  if (globalNoProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
     log.error(
-      `Global circuit breaker triggered: ${toolName} repeated ${noProgressStreak} times with no progress`,
+      `Global circuit breaker triggered: session repeated ${globalNoProgressStreak} no-progress outcomes across ${globalNoProgress.patternCount} tool pattern(s)`,
     );
     return {
       stuck: true,
       level: "critical",
       detector: "global_circuit_breaker",
-      count: noProgressStreak,
-      message: `CRITICAL: ${toolName} has repeated identical no-progress outcomes ${noProgressStreak} times. Session execution blocked by global circuit breaker to prevent runaway loops.`,
-      warningKey: `global:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+      count: globalNoProgressStreak,
+      message: `CRITICAL: Session tool calls have repeated identical no-progress outcomes ${globalNoProgressStreak} times across tools. Session execution blocked by global circuit breaker to prevent runaway loops.`,
+      warningKey: `global:session:${globalNoProgress.latestResultHash ?? "none"}`,
     };
   }
 


### PR DESCRIPTION
Closes #79252.

## Summary
- Make the global circuit breaker count stable no-progress outcomes across repeated tool-call patterns in the session, instead of only the current tool signature.
- Keep changing-output calls and unrelated one-off tools from contributing to the global breaker.
- Add detector-level and before-tool-call wrapper coverage proving a different tool is blocked once the session-global threshold is reached.
- Add an Unreleased changelog entry for the agent safety fix.

## Real behavior proof
- Behavior or issue addressed: a session that repeatedly produces stable no-progress tool outcomes should trip the global breaker and block a different next tool, instead of continuing the loop because the next tool has a different name/argument signature.
- Real environment tested: local macOS 26.4.1 (25E253) arm64 OpenClaw checkout, Node v25.8.2, pnpm 10.33.2, branch `codex/global-loop-breaker` at commit `9e76446e98d08d6ccb8963329bca5a09ce8db06e`.
- Exact steps or command run after this patch:
  - `pnpm install --frozen-lockfile --offline`
  - `pnpm exec vitest run src/agents/tool-loop-detection.test.ts --reporter=dot`
  - `pnpm test:e2e src/agents/pi-tools.before-tool-call.e2e.test.ts --reporter=dot`
  - `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts src/agents/pi-tools.before-tool-call.e2e.test.ts`
  - `git diff --check`
  - `pnpm check:changelog-attributions`
  - `pnpm tsgo:core`
  - `pnpm tsgo:core:test`
  - `pnpm exec tsx -e '<production before-tool-call smoke: run 30 stable read tool outcomes in one session, then invoke memory_search through the wrapped tool path>'`
- Evidence after fix: console output after fix from the production before-tool-call smoke:

```text
threshold=30
readExecutions=30
searchExecutions=0
blockedDeniedReason=tool-loop
blockedStatus=blocked
blockedContent=CRITICAL: Session tool calls have repeated identical no-progress outcomes 30 times across tools. Session execution blocked by global circuit breaker to prevent runaway loops.
```

Detector tests also passed with `Test Files 1 passed (1)` and `Tests 45 passed (45)`. Before-tool-call e2e tests passed with `Test Files 1 passed (1)` and `Tests 38 passed (38)`. Formatting, whitespace, changelog attribution, core typecheck, and core test typecheck all passed.
- Observed result after fix: after 30 stable no-progress read outcomes in the same session, the next `memory_search` call was blocked by `global_circuit_breaker` before its execute function ran (`searchExecutions=0`), matching the intended cross-tool session-global behavior.
- What was not tested: a live model-driven Gateway conversation with external services; the real-behavior smoke used production OpenClaw before-tool-call wrapping and diagnostic session state with local in-process tools.
