### PR TITLE
[plugin sdk] Add structured extraction media runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: preserve scoped background exec/process session references across embedded compaction and after-turn runtime contexts without exposing sessions from unrelated scopes. Fixes #79284. (#79307) Thanks @TurboTheTurtle.
 - CLI/onboarding: improve setup, onboarding, configure, and channel command wayfinding so terminal flows explain the next useful command instead of relying on terse setup labels.
 - Agents/Codex: remove the configurable Codex dynamic-tools profile so Codex app-server always owns workspace, edit, patch, exec, process, and plan tools while OpenClaw integration tools remain available.
+- Plugin SDK/media-understanding: add `extractStructuredWithModel(...)` plus the optional provider-side `extractStructured(...)` seam so trusted plugins can run bounded image-first structured extraction with optional supplemental text context through provider-owned runtimes such as Codex.
 
 ### Fixes
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-32f0b7801c9e5e0b7ec8d7da11cec62713e968abf056560ad6372aac877fdf14  plugin-sdk-api-baseline.json
-e26cfb7da5e6e8addd0bd4669bd53a4188c53f8371cb20216d854f7dd0154b1b  plugin-sdk-api-baseline.jsonl
+70c2f91c978fc5ef8277858c547e7a0107bca718cbae846c83ea8f9bfbfa3878  plugin-sdk-api-baseline.json
+64e8df99e526a972ab5a361aea97a4b9f6e09076f47288dc3b71e9d8d978e370  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -499,6 +499,30 @@ const video = await api.runtime.mediaUnderstanding.describeVideoFile({
   filePath: "/tmp/inbound-video.mp4",
   cfg: api.config,
 });
+
+const extraction = await api.runtime.mediaUnderstanding.extractStructuredWithModel({
+  provider: "codex",
+  model: "gpt-5.5",
+  input: [
+    {
+      type: "image",
+      buffer: receiptImageBuffer,
+      fileName: "receipt.png",
+      mime: "image/png",
+    },
+    { type: "text", text: "Use the printed fields as the source of truth." },
+  ],
+  instructions: "Return entities and searchable tags.",
+  schemaName: "example.evidence",
+  jsonSchema: {
+    type: "object",
+    properties: {
+      entities: { type: "array", items: { type: "string" } },
+      tags: { type: "array", items: { type: "string" } },
+    },
+  },
+  cfg: api.config,
+});
 ```
 
 For audio transcription, plugins can use either the media-understanding runtime
@@ -517,6 +541,10 @@ Notes:
 
 - `api.runtime.mediaUnderstanding.*` is the preferred shared surface for
   image/audio/video understanding.
+- `extractStructuredWithModel(...)` is the plugin-facing seam for bounded
+  provider-owned image extraction with optional supplemental text context;
+  product plugins own their routes and schemas while OpenClaw owns the
+  provider/runtime boundary.
 - Uses core media-understanding audio configuration (`tools.media.audio`) and provider fallback order.
 - Returns `{ text: undefined }` when no transcription output is produced (for example skipped/unsupported input).
 - `api.runtime.stt.transcribeAudioFile(...)` remains as a compatibility alias.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -300,6 +300,33 @@ Provider and channel execution paths must use the active runtime config snapshot
       filePath: "/tmp/inbound-file.pdf",
       cfg: api.config,
     });
+
+    // Structured image extraction through a specific provider/model
+    const evidence = await api.runtime.mediaUnderstanding.extractStructuredWithModel({
+      provider: "codex",
+      model: "gpt-5.5",
+      input: [
+        {
+          type: "image",
+          buffer: receiptImageBuffer,
+          fileName: "receipt.png",
+          mime: "image/png",
+        },
+        { type: "text", text: "Prefer the printed total over handwritten notes." },
+      ],
+      instructions: "Extract vendor, total, and searchable tags.",
+      schemaName: "receipt.evidence",
+      jsonSchema: {
+        type: "object",
+        properties: {
+          vendor: { type: "string" },
+          total: { type: "number" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+        required: ["vendor", "total"],
+      },
+      cfg: api.config,
+    });
     ```
 
     Returns `{ text: undefined }` when no output is produced (e.g. skipped input).

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -271,7 +271,7 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
     | `plugin-sdk/media-mime` | Narrow MIME normalization, file-extension mapping, MIME detection, and media-kind helpers |
     | `plugin-sdk/media-store` | Narrow media store helpers such as `saveMediaBuffer` |
     | `plugin-sdk/media-generation-runtime` | Shared media-generation failover helpers, candidate selection, and missing-model messaging |
-    | `plugin-sdk/media-understanding` | Media understanding provider types plus provider-facing image/audio helper exports |
+    | `plugin-sdk/media-understanding` | Media understanding provider types plus provider-facing image/audio/structured-extraction helper exports |
     | `plugin-sdk/text-runtime` | Shared text/markdown/logging helpers such as assistant-visible-text stripping, markdown render/chunking/table helpers, redaction helpers, directive-tag helpers, and safe-text utilities |
     | `plugin-sdk/text-chunking` | Outbound text chunking helper |
     | `plugin-sdk/speech` | Speech provider types plus provider-facing directive, registry, validation, OpenAI-compatible TTS builder, and speech helper exports |

--- a/extensions/codex/media-understanding-provider.test.ts
+++ b/extensions/codex/media-understanding-provider.test.ts
@@ -76,6 +76,7 @@ function createFakeClient(options?: {
   completeWithItems?: boolean;
   notifyError?: string;
   approvalRequestMethod?: string;
+  responseText?: string;
 }) {
   const notifications = new Set<(notification: CodexServerNotification) => void>();
   const requestHandlers = new Set<(request: { method: string }) => JsonValue | undefined>();
@@ -125,7 +126,7 @@ function createFakeClient(options?: {
               threadId: "thread-1",
               turnId: "turn-1",
               itemId: "msg-1",
-              delta: "A red square.",
+              delta: options?.responseText ?? "A red square.",
             },
           });
           notify({
@@ -145,7 +146,7 @@ function createFakeClient(options?: {
               {
                 id: "msg-1",
                 type: "agentMessage",
-                text: "A blue circle.",
+                text: options?.responseText ?? "A blue circle.",
                 phase: null,
                 memoryCitation: null,
               },
@@ -297,5 +298,162 @@ describe("codex media understanding provider", () => {
         agentDir: "/tmp/openclaw-agent",
       }),
     ).rejects.toThrow("vision unavailable");
+  });
+
+  it("runs structured extraction through the same bounded Codex app-server path", async () => {
+    const { client, requests } = createFakeClient({
+      responseText: '{"summary":"red square","tags":["shape"]}',
+    });
+    const provider = buildCodexMediaUnderstandingProvider({
+      clientFactory: async () => client,
+    });
+
+    const result = await provider.extractStructured?.({
+      input: [
+        { type: "text", text: "Extract searchable evidence." },
+        {
+          type: "image",
+          buffer: Buffer.from("image-bytes"),
+          fileName: "image.png",
+          mime: "image/png",
+        },
+      ],
+      instructions: "Return a compact evidence object.",
+      schemaName: "example.media",
+      jsonSchema: {
+        type: "object",
+        properties: {
+          summary: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+        required: ["summary"],
+      },
+      provider: "codex",
+      model: "gpt-5.4",
+      timeoutMs: 30_000,
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+    });
+
+    expect(result).toEqual({
+      text: '{"summary":"red square","tags":["shape"]}',
+      parsed: { summary: "red square", tags: ["shape"] },
+      model: "gpt-5.4",
+      provider: "codex",
+      contentType: "json",
+    });
+    expect(requests.map((entry) => entry.method)).toEqual([
+      "model/list",
+      "thread/start",
+      "turn/start",
+    ]);
+    expect(requests[1]?.params).toMatchObject({
+      model: "gpt-5.4",
+      modelProvider: "openai",
+      approvalPolicy: "on-request",
+      sandbox: "read-only",
+      dynamicTools: [],
+      ephemeral: true,
+      persistExtendedHistory: false,
+    });
+    expect(requests[2]?.params).toMatchObject({
+      threadId: "thread-1",
+      approvalPolicy: "on-request",
+      model: "gpt-5.4",
+      input: [
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Return valid JSON only"),
+        }),
+        { type: "text", text: "Extract searchable evidence.", text_elements: [] },
+        { type: "image", url: "data:image/png;base64,aW1hZ2UtYnl0ZXM=" },
+      ],
+    });
+  });
+
+  it("rejects text-only structured extraction before starting a turn", async () => {
+    const { client, requests } = createFakeClient({
+      inputModalities: ["text"],
+      responseText: '{"summary":"only text"}',
+    });
+    const provider = buildCodexMediaUnderstandingProvider({
+      clientFactory: async () => client,
+    });
+
+    await expect(
+      provider.extractStructured?.({
+        input: [{ type: "text", text: "The answer is only text." }],
+        instructions: "Return summary JSON.",
+        provider: "codex",
+        model: "gpt-5.4",
+        timeoutMs: 30_000,
+        cfg: {},
+        agentDir: "/tmp/openclaw-agent",
+      }),
+    ).rejects.toThrow("Codex structured extraction requires at least one image input.");
+    expect(requests).toEqual([]);
+  });
+
+  it("returns a controlled error when structured JSON parsing fails", async () => {
+    const { client } = createFakeClient({ responseText: "not json" });
+    const provider = buildCodexMediaUnderstandingProvider({
+      clientFactory: async () => client,
+    });
+
+    await expect(
+      provider.extractStructured?.({
+        input: [
+          { type: "text", text: "Extract JSON." },
+          {
+            type: "image",
+            buffer: Buffer.from("image-bytes"),
+            fileName: "image.png",
+            mime: "image/png",
+          },
+        ],
+        instructions: "Return summary JSON.",
+        provider: "codex",
+        model: "gpt-5.4",
+        timeoutMs: 30_000,
+        cfg: {},
+        agentDir: "/tmp/openclaw-agent",
+      }),
+    ).rejects.toThrow("Codex structured extraction returned invalid JSON.");
+  });
+
+  it("validates structured extraction JSON against the requested schema", async () => {
+    const { client } = createFakeClient({
+      responseText: '{"summary":123,"tags":["shape"]}',
+    });
+    const provider = buildCodexMediaUnderstandingProvider({
+      clientFactory: async () => client,
+    });
+
+    await expect(
+      provider.extractStructured?.({
+        input: [
+          { type: "text", text: "Extract JSON." },
+          {
+            type: "image",
+            buffer: Buffer.from("image-bytes"),
+            fileName: "image.png",
+            mime: "image/png",
+          },
+        ],
+        instructions: "Return summary JSON.",
+        jsonSchema: {
+          type: "object",
+          properties: {
+            summary: { type: "string" },
+          },
+          required: ["summary"],
+        },
+        provider: "codex",
+        model: "gpt-5.4",
+        timeoutMs: 30_000,
+        cfg: {},
+        agentDir: "/tmp/openclaw-agent",
+      }),
+    ).rejects.toThrow("Codex structured extraction JSON did not match schema");
   });
 });

--- a/extensions/codex/media-understanding-provider.ts
+++ b/extensions/codex/media-understanding-provider.ts
@@ -5,6 +5,8 @@ import {
   type StructuredExtractionRequest,
   type StructuredExtractionResult,
 } from "openclaw/plugin-sdk/media-understanding";
+import { validateJsonSchemaValue } from "../../src/plugins/schema-validator.js";
+import type { JsonSchemaObject } from "../../src/shared/json-schema.types.js";
 import { CODEX_PROVIDER_ID, FALLBACK_CODEX_MODELS } from "./provider-catalog.js";
 import { type CodexAppServerClientFactory } from "./src/app-server/client-factory.js";
 import type { CodexAppServerClient } from "./src/app-server/client.js";
@@ -27,7 +29,6 @@ import {
   type JsonObject,
   type JsonValue,
 } from "./src/app-server/protocol.js";
-import { validateJsonSchemaValue } from "../../src/plugins/schema-validator.js";
 
 const DEFAULT_CODEX_IMAGE_MODEL =
   FALLBACK_CODEX_MODELS.find((model) => model.inputModalities.includes("image"))?.id ??
@@ -358,6 +359,10 @@ function buildStructuredExtractionPrompt(req: StructuredExtractionRequest): stri
     .join("\n\n");
 }
 
+function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function normalizeStructuredExtractionResult(params: {
   text: string;
   model: string;
@@ -376,7 +381,7 @@ function normalizeStructuredExtractionResult(params: {
     } catch {
       throw new Error("Codex structured extraction returned invalid JSON.");
     }
-    if (params.req.jsonSchema) {
+    if (isJsonSchemaObject(params.req.jsonSchema)) {
       const validation = validateJsonSchemaValue({
         schema: params.req.jsonSchema,
         cacheKey: "codex.media-understanding.extractStructured",

--- a/extensions/codex/media-understanding-provider.ts
+++ b/extensions/codex/media-understanding-provider.ts
@@ -2,6 +2,8 @@ import {
   type ImagesDescriptionRequest,
   type ImagesDescriptionResult,
   type MediaUnderstandingProvider,
+  type StructuredExtractionRequest,
+  type StructuredExtractionResult,
 } from "openclaw/plugin-sdk/media-understanding";
 import { CODEX_PROVIDER_ID, FALLBACK_CODEX_MODELS } from "./provider-catalog.js";
 import { type CodexAppServerClientFactory } from "./src/app-server/client-factory.js";
@@ -21,9 +23,11 @@ import {
   type CodexThreadStartParams,
   type CodexTurn,
   type CodexTurnStartParams,
+  type CodexUserInput,
   type JsonObject,
   type JsonValue,
 } from "./src/app-server/protocol.js";
+import { validateJsonSchemaValue } from "../../src/plugins/schema-validator.js";
 
 const DEFAULT_CODEX_IMAGE_MODEL =
   FALLBACK_CODEX_MODELS.find((model) => model.inputModalities.includes("image"))?.id ??
@@ -66,6 +70,7 @@ export function buildCodexMediaUnderstandingProvider(
         options,
       ),
     describeImages: async (req) => describeCodexImages(req, options),
+    extractStructured: async (req) => extractCodexStructured(req, options),
   };
 }
 
@@ -96,9 +101,10 @@ async function describeCodexImages(
   timeout.unref?.();
 
   try {
-    await assertCodexModelSupportsImage({
+    await assertCodexModelSupportsInput({
       client,
       model,
+      requiredModalities: ["text", "image"],
       timeoutMs,
       signal: abortController.signal,
     });
@@ -122,7 +128,7 @@ async function describeCodexImages(
         { timeoutMs, signal: abortController.signal },
       ),
     );
-    const collector = createCodexImageTurnCollector(thread.thread.id);
+    const collector = createCodexTurnCollector(thread.thread.id, "image understanding");
     const cleanup = client.addNotificationHandler(collector.handleNotification);
     const requestCleanup = client.addRequestHandler(denyCodexImageApprovalRequest);
     try {
@@ -163,6 +169,105 @@ async function describeCodexImages(
   }
 }
 
+async function extractCodexStructured(
+  req: StructuredExtractionRequest,
+  options: CodexMediaUnderstandingProviderOptions,
+): Promise<StructuredExtractionResult> {
+  const model = req.model.trim();
+  if (!model) {
+    throw new Error("Codex structured extraction requires model id.");
+  }
+  const instructions = req.instructions.trim();
+  if (!instructions) {
+    throw new Error("Codex structured extraction requires instructions.");
+  }
+  if (req.input.length === 0) {
+    throw new Error("Codex structured extraction requires at least one input.");
+  }
+  if (!req.input.some((entry) => entry.type === "image")) {
+    throw new Error("Codex structured extraction requires at least one image input.");
+  }
+
+  const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig: options.pluginConfig });
+  const timeoutMs = Math.max(100, req.timeoutMs);
+  const ownsClient = !options.clientFactory;
+  const client = options.clientFactory
+    ? await options.clientFactory(appServer.start, req.profile)
+    : await import("./src/app-server/shared-client.js").then(
+        ({ createIsolatedCodexAppServerClient }) =>
+          createIsolatedCodexAppServerClient({
+            startOptions: appServer.start,
+            timeoutMs,
+            authProfileId: req.profile,
+          }),
+      );
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort("timeout"), timeoutMs);
+  timeout.unref?.();
+
+  try {
+    await assertCodexModelSupportsInput({
+      client,
+      model,
+      requiredModalities: requiredStructuredModalities(),
+      timeoutMs,
+      signal: abortController.signal,
+    });
+    const thread = assertCodexThreadStartResponse(
+      await client.request<unknown>(
+        "thread/start",
+        {
+          model,
+          modelProvider: "openai",
+          cwd: req.agentDir || process.cwd(),
+          approvalPolicy: "on-request",
+          sandbox: "read-only",
+          serviceName: "OpenClaw",
+          developerInstructions:
+            "You are OpenClaw's bounded structured-extraction worker. Return only the requested extraction. Do not call tools, edit files, ask follow-up questions, or include secrets.",
+          dynamicTools: [],
+          experimentalRawEvents: true,
+          persistExtendedHistory: false,
+          ephemeral: true,
+        } satisfies CodexThreadStartParams,
+        { timeoutMs, signal: abortController.signal },
+      ),
+    );
+    const collector = createCodexTurnCollector(thread.thread.id, "structured extraction");
+    const cleanup = client.addNotificationHandler(collector.handleNotification);
+    const requestCleanup = client.addRequestHandler(denyCodexImageApprovalRequest);
+    try {
+      const turn = assertCodexTurnStartResponse(
+        await client.request<unknown>(
+          "turn/start",
+          {
+            threadId: thread.thread.id,
+            input: buildCodexStructuredInput(req),
+            cwd: req.agentDir || process.cwd(),
+            approvalPolicy: "on-request",
+            model,
+            effort: "low",
+          } satisfies CodexTurnStartParams,
+          { timeoutMs, signal: abortController.signal },
+        ),
+      );
+      const text = await collector.collect(turn.turn, {
+        timeoutMs,
+        signal: abortController.signal,
+      });
+      return normalizeStructuredExtractionResult({ text, model, provider: req.provider, req });
+    } finally {
+      requestCleanup();
+      cleanup();
+    }
+  } finally {
+    clearTimeout(timeout);
+    if (ownsClient) {
+      client.close();
+    }
+  }
+}
+
 function denyCodexImageApprovalRequest(request: { method: string }): JsonValue | undefined {
   if (
     request.method === "item/commandExecution/requestApproval" ||
@@ -188,9 +293,10 @@ function denyCodexImageApprovalRequest(request: { method: string }): JsonValue |
   return undefined;
 }
 
-async function assertCodexModelSupportsImage(params: {
+async function assertCodexModelSupportsInput(params: {
   client: CodexAppServerClient;
   model: string;
+  requiredModalities: string[];
   timeoutMs: number;
   signal: AbortSignal;
 }): Promise<void> {
@@ -204,8 +310,11 @@ async function assertCodexModelSupportsImage(params: {
   if (!match) {
     throw new Error(`Codex app-server model not found: ${params.model}`);
   }
-  if (!match.inputModalities.includes("image")) {
+  if (params.requiredModalities.includes("image") && !match.inputModalities.includes("image")) {
     throw new Error(`Codex app-server model does not support images: ${params.model}`);
+  }
+  if (params.requiredModalities.includes("text") && !match.inputModalities.includes("text")) {
+    throw new Error(`Codex app-server model does not support text: ${params.model}`);
   }
 }
 
@@ -217,7 +326,74 @@ function buildCodexImagePrompt(req: ImagesDescriptionRequest): string {
   return `${prompt}\n\nAnalyze all ${req.images.length} images together.`;
 }
 
-function createCodexImageTurnCollector(threadId: string) {
+function requiredStructuredModalities(): string[] {
+  return ["text", "image"];
+}
+
+function buildCodexStructuredInput(req: StructuredExtractionRequest): CodexUserInput[] {
+  return [
+    { type: "text", text: buildStructuredExtractionPrompt(req), text_elements: [] },
+    ...req.input.map((entry) => {
+      if (entry.type === "text") {
+        return { type: "text" as const, text: entry.text, text_elements: [] };
+      }
+      return {
+        type: "image" as const,
+        url: `data:${entry.mime ?? "image/png"};base64,${entry.buffer.toString("base64")}`,
+      };
+    }),
+  ];
+}
+
+function buildStructuredExtractionPrompt(req: StructuredExtractionRequest): string {
+  return [
+    req.instructions.trim(),
+    req.schemaName ? `Schema name: ${req.schemaName}` : undefined,
+    req.jsonSchema ? `JSON schema:\n${JSON.stringify(req.jsonSchema)}` : undefined,
+    req.jsonMode === false
+      ? "Return the extraction as concise text."
+      : "Return valid JSON only. Do not wrap the JSON in Markdown fences.",
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join("\n\n");
+}
+
+function normalizeStructuredExtractionResult(params: {
+  text: string;
+  model: string;
+  provider: string;
+  req: StructuredExtractionRequest;
+}): StructuredExtractionResult {
+  const result: StructuredExtractionResult = {
+    text: params.text,
+    model: params.model,
+    provider: params.provider,
+    contentType: params.req.jsonMode === false ? "text" : "json",
+  };
+  if (params.req.jsonMode !== false) {
+    try {
+      result.parsed = JSON.parse(params.text);
+    } catch {
+      throw new Error("Codex structured extraction returned invalid JSON.");
+    }
+    if (params.req.jsonSchema) {
+      const validation = validateJsonSchemaValue({
+        schema: params.req.jsonSchema,
+        cacheKey: "codex.media-understanding.extractStructured",
+        value: result.parsed,
+        cache: false,
+      });
+      if (!validation.ok) {
+        const message = validation.errors.map((error) => error.text).join("; ") || "invalid";
+        throw new Error(`Codex structured extraction JSON did not match schema: ${message}`);
+      }
+      result.parsed = validation.value as typeof result.parsed;
+    }
+  }
+  return result;
+}
+
+function createCodexTurnCollector(threadId: string, taskLabel: string) {
   let turnId: string | undefined;
   let completedTurn: CodexTurn | undefined;
   let promptError: string | undefined;
@@ -267,7 +443,7 @@ function createCodexImageTurnCollector(threadId: string) {
     if (notification.method === "error") {
       promptError =
         readCodexErrorNotification(notification.params)?.error.message ??
-        "codex app-server image turn failed";
+        `codex app-server ${taskLabel} turn failed`;
       resolveCompletion?.();
     }
   };
@@ -290,13 +466,16 @@ function createCodexImageTurnCollector(threadId: string) {
           completion,
           timeoutMs: options.timeoutMs,
           signal: options.signal,
+          taskLabel,
         });
       }
       if (promptError) {
         throw new Error(promptError);
       }
       if (completedTurn?.status === "failed") {
-        throw new Error(completedTurn.error?.message ?? "codex app-server image turn failed");
+        throw new Error(
+          completedTurn.error?.message ?? `codex app-server ${taskLabel} turn failed`,
+        );
       }
       const itemText = collectAssistantTextFromItems(completedTurn?.items);
       const deltaText = assistantItemOrder
@@ -306,7 +485,7 @@ function createCodexImageTurnCollector(threadId: string) {
         .trim();
       const text = (itemText || deltaText).trim();
       if (!text) {
-        throw new Error("Codex app-server image turn returned no text.");
+        throw new Error(`Codex app-server ${taskLabel} turn returned no text.`);
       }
       return text;
     },
@@ -317,6 +496,7 @@ async function waitForTurnCompletion(params: {
   completion: Promise<void>;
   timeoutMs: number;
   signal: AbortSignal;
+  taskLabel: string;
 }): Promise<void> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   let cleanupAbort: (() => void) | undefined;
@@ -325,11 +505,12 @@ async function waitForTurnCompletion(params: {
       params.completion,
       new Promise<never>((_, reject) => {
         timeout = setTimeout(
-          () => reject(new Error("codex app-server image turn timed out")),
+          () => reject(new Error(`codex app-server ${params.taskLabel} turn timed out`)),
           params.timeoutMs,
         );
         timeout.unref?.();
-        const abortListener = () => reject(new Error("codex app-server image turn aborted"));
+        const abortListener = () =>
+          reject(new Error(`codex app-server ${params.taskLabel} turn aborted`));
         params.signal.addEventListener("abort", abortListener, { once: true });
         cleanupAbort = () => params.signal.removeEventListener("abort", abortListener);
       }),

--- a/extensions/codex/media-understanding-provider.ts
+++ b/extensions/codex/media-understanding-provider.ts
@@ -1,12 +1,14 @@
 import {
+  type JsonSchemaObject,
+  validateJsonSchemaValue,
+} from "openclaw/plugin-sdk/json-schema-runtime";
+import {
   type ImagesDescriptionRequest,
   type ImagesDescriptionResult,
   type MediaUnderstandingProvider,
   type StructuredExtractionRequest,
   type StructuredExtractionResult,
 } from "openclaw/plugin-sdk/media-understanding";
-import { validateJsonSchemaValue } from "../../src/plugins/schema-validator.js";
-import type { JsonSchemaObject } from "../../src/shared/json-schema.types.js";
 import { CODEX_PROVIDER_ID, FALLBACK_CODEX_MODELS } from "./provider-catalog.js";
 import { type CodexAppServerClientFactory } from "./src/app-server/client-factory.js";
 import type { CodexAppServerClient } from "./src/app-server/client.js";
@@ -392,7 +394,7 @@ function normalizeStructuredExtractionResult(params: {
         const message = validation.errors.map((error) => error.text).join("; ") || "invalid";
         throw new Error(`Codex structured extraction JSON did not match schema: ${message}`);
       }
-      result.parsed = validation.value as typeof result.parsed;
+      result.parsed = validation.value;
     }
   }
   return result;

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -1,9 +1,11 @@
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { ActiveMediaModel } from "./active-model.types.js";
 import type {
   MediaUnderstandingDecision,
   MediaUnderstandingOutput,
   MediaUnderstandingProvider,
+  StructuredExtractionInput,
 } from "./types.js";
 
 export type RunMediaUnderstandingFileParams = {
@@ -51,6 +53,26 @@ type DescribeImageFileWithModelResult = Awaited<
   ReturnType<NonNullable<MediaUnderstandingProvider["describeImage"]>>
 >;
 
+export type ExtractStructuredWithModelParams = {
+  input: StructuredExtractionInput[];
+  instructions: string;
+  schemaName?: string;
+  jsonSchema?: unknown;
+  jsonMode?: boolean;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  provider: string;
+  model: string;
+  profile?: string;
+  preferredProfile?: string;
+  authStore?: AuthProfileStore;
+  timeoutMs?: number;
+};
+
+type ExtractStructuredWithModelResult = Awaited<
+  ReturnType<NonNullable<MediaUnderstandingProvider["extractStructured"]>>
+>;
+
 export type DescribeVideoFileParams = {
   filePath: string;
   cfg: OpenClawConfig;
@@ -77,6 +99,9 @@ export type MediaUnderstandingRuntime = {
   describeImageFileWithModel: (
     params: DescribeImageFileWithModelParams,
   ) => Promise<DescribeImageFileWithModelResult>;
+  extractStructuredWithModel: (
+    params: ExtractStructuredWithModelParams,
+  ) => Promise<ExtractStructuredWithModelResult>;
   describeVideoFile: (params: DescribeVideoFileParams) => Promise<RunMediaUnderstandingFileResult>;
   transcribeAudioFile: (
     params: TranscribeAudioFileParams,

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { MediaAttachment, MediaUnderstandingOutput } from "../media-understanding/types.js";
 import {
   describeImageFile,
   describeImageFileWithModel,
+  extractStructuredWithModel,
   runMediaUnderstandingFile,
 } from "./runtime.js";
 
@@ -14,6 +16,8 @@ const mocks = vi.hoisted(() => {
     createMediaAttachmentCache: vi.fn(() => ({ cleanup })),
     normalizeMediaAttachments: vi.fn<() => MediaAttachment[]>(() => []),
     normalizeMediaProviderId: vi.fn((provider: string) => provider.trim().toLowerCase()),
+    buildMediaUnderstandingRegistry: vi.fn(() => new Map()),
+    getMediaUnderstandingProvider: vi.fn(),
     readLocalFileSafely: vi.fn(async () => ({ buffer: Buffer.from("image") })),
     describeImageWithModel: vi.fn(async () => ({ text: "generic image ok", model: "vision" })),
     runCapability: vi.fn(),
@@ -30,6 +34,8 @@ vi.mock("./runner.js", () => ({
 
 vi.mock("./provider-registry.js", () => ({
   normalizeMediaProviderId: mocks.normalizeMediaProviderId,
+  buildMediaUnderstandingRegistry: mocks.buildMediaUnderstandingRegistry,
+  getMediaUnderstandingProvider: mocks.getMediaUnderstandingProvider,
 }));
 
 vi.mock("../infra/fs-safe.js", () => ({
@@ -46,6 +52,8 @@ describe("media-understanding runtime", () => {
     mocks.createMediaAttachmentCache.mockReset();
     mocks.normalizeMediaAttachments.mockReset();
     mocks.normalizeMediaProviderId.mockReset();
+    mocks.buildMediaUnderstandingRegistry.mockReset();
+    mocks.getMediaUnderstandingProvider.mockReset();
     mocks.readLocalFileSafely.mockReset();
     mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("image") });
     mocks.describeImageWithModel.mockReset();
@@ -251,6 +259,153 @@ describe("media-understanding runtime", () => {
       cfg: {},
       agentDir: "/tmp/agent",
     });
+  });
+
+  it("routes direct image description through a provider-specific image hook", async () => {
+    const describeImage = vi.fn(async () => ({
+      text: "image ok",
+      model: "vision-v1",
+    }));
+    mocks.buildProviderRegistry.mockReturnValue(
+      new Map([["gemini", { id: "gemini", capabilities: ["image"], describeImage }]]),
+    );
+    mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("image-bytes") });
+
+    await expect(
+      describeImageFileWithModel({
+        filePath: "/tmp/sample.jpg",
+        mime: "image/jpeg",
+        provider: "gemini",
+        model: "vision-v1",
+        prompt: "Describe the sample.",
+        cfg: {} as OpenClawConfig,
+        agentDir: "/tmp/agent",
+      }),
+    ).resolves.toEqual({
+      text: "image ok",
+      model: "vision-v1",
+    });
+
+    expect(mocks.normalizeMediaProviderId).toHaveBeenCalledWith("gemini");
+    expect(describeImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("image-bytes"),
+        fileName: "sample.jpg",
+        mime: "image/jpeg",
+        provider: "gemini",
+        model: "vision-v1",
+        prompt: "Describe the sample.",
+        agentDir: "/tmp/agent",
+      }),
+    );
+  });
+
+  it("routes structured extraction to a provider by id and model", async () => {
+    const providerRegistry = new Map();
+    const authStore = {} as AuthProfileStore;
+    const extractStructured = vi.fn(async () => ({
+      text: '{"ok":true}',
+      parsed: { ok: true },
+      model: "vision-json",
+      provider: "vision-plugin",
+      contentType: "json" as const,
+    }));
+    mocks.buildMediaUnderstandingRegistry.mockReturnValue(providerRegistry);
+    mocks.getMediaUnderstandingProvider.mockReturnValue({ id: "vision-plugin", extractStructured });
+
+    await expect(
+      extractStructuredWithModel({
+        input: [
+          { type: "text", text: "Extract the fact." },
+          {
+            type: "image",
+            buffer: Buffer.from("image-bytes"),
+            fileName: "fact.png",
+            mime: "image/png",
+          },
+        ],
+        instructions: "Return JSON.",
+        provider: "Vision-Plugin",
+        model: "vision-json",
+        profile: "work",
+        preferredProfile: "preferred-work",
+        authStore,
+        timeoutMs: 45_000,
+        cfg: {} as OpenClawConfig,
+        agentDir: "/tmp/agent",
+      }),
+    ).resolves.toEqual({
+      text: '{"ok":true}',
+      parsed: { ok: true },
+      model: "vision-json",
+      provider: "vision-plugin",
+      contentType: "json",
+    });
+
+    expect(mocks.buildMediaUnderstandingRegistry).toHaveBeenCalledWith(undefined, {});
+    expect(mocks.getMediaUnderstandingProvider).toHaveBeenCalledWith(
+      "Vision-Plugin",
+      providerRegistry,
+    );
+    expect(extractStructured).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          { type: "text", text: "Extract the fact." },
+          {
+            type: "image",
+            buffer: Buffer.from("image-bytes"),
+            fileName: "fact.png",
+            mime: "image/png",
+          },
+        ],
+        instructions: "Return JSON.",
+        provider: "Vision-Plugin",
+        model: "vision-json",
+        profile: "work",
+        preferredProfile: "preferred-work",
+        authStore,
+        timeoutMs: 45_000,
+        agentDir: "/tmp/agent",
+      }),
+    );
+  });
+
+  it("rejects text-only structured extraction before provider lookup", async () => {
+    await expect(
+      extractStructuredWithModel({
+        input: [{ type: "text", text: "Extract the fact." }],
+        instructions: "Return JSON.",
+        provider: "vision-plugin",
+        model: "vision-json",
+        cfg: {} as OpenClawConfig,
+      }),
+    ).rejects.toThrow("Structured extraction requires at least one image input.");
+
+    expect(mocks.buildMediaUnderstandingRegistry).not.toHaveBeenCalled();
+    expect(mocks.getMediaUnderstandingProvider).not.toHaveBeenCalled();
+  });
+
+  it("fails clearly when a provider lacks structured extraction", async () => {
+    const providerRegistry = new Map();
+    mocks.buildMediaUnderstandingRegistry.mockReturnValue(providerRegistry);
+    mocks.getMediaUnderstandingProvider.mockReturnValue({ id: "vision-plugin" });
+
+    await expect(
+      extractStructuredWithModel({
+        input: [
+          {
+            type: "image",
+            buffer: Buffer.from("image-bytes"),
+            fileName: "fact.png",
+            mime: "image/png",
+          },
+        ],
+        instructions: "Return JSON.",
+        provider: "vision-plugin",
+        model: "vision-json",
+        cfg: {} as OpenClawConfig,
+      }),
+    ).rejects.toThrow("Provider does not support structured extraction: vision-plugin");
   });
 
   it("surfaces the underlying provider failure when media understanding fails", async () => {

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { describeImageWithModel } from "./image-runtime.js";
-import { normalizeMediaProviderId } from "./provider-registry.js";
+import {
+  buildMediaUnderstandingRegistry,
+  getMediaUnderstandingProvider,
+  normalizeMediaProviderId,
+} from "./provider-registry.js";
 import { findDecisionReason, normalizeDecisionReason } from "./runner.entries.js";
 import {
   buildProviderRegistry,
@@ -13,6 +17,7 @@ import type {
   DescribeImageFileParams,
   DescribeImageFileWithModelParams,
   DescribeVideoFileParams,
+  ExtractStructuredWithModelParams,
   RunMediaUnderstandingFileParams,
   RunMediaUnderstandingFileResult,
   TranscribeAudioFileParams,
@@ -21,6 +26,7 @@ export type {
   DescribeImageFileParams,
   DescribeImageFileWithModelParams,
   DescribeVideoFileParams,
+  ExtractStructuredWithModelParams,
   RunMediaUnderstandingFileParams,
   RunMediaUnderstandingFileResult,
   TranscribeAudioFileParams,
@@ -46,6 +52,10 @@ function buildFileContext(params: { filePath: string; mime?: string }) {
     MediaPath: params.filePath,
     MediaType: params.mime,
   };
+}
+
+function hasStructuredImageInput(input: ExtractStructuredWithModelParams["input"]): boolean {
+  return input.some((entry) => entry.type === "image");
 }
 
 export async function runMediaUnderstandingFile(
@@ -164,6 +174,35 @@ export async function describeImageFileWithModel(params: DescribeImageFileWithMo
     model: params.model,
     prompt: params.prompt,
     maxTokens: params.maxTokens,
+    timeoutMs,
+    cfg: params.cfg,
+    agentDir: params.agentDir ?? "",
+  });
+}
+
+export async function extractStructuredWithModel(params: ExtractStructuredWithModelParams) {
+  const timeoutMs = params.timeoutMs ?? 30_000;
+  if (!hasStructuredImageInput(params.input)) {
+    throw new Error("Structured extraction requires at least one image input.");
+  }
+  const provider = getMediaUnderstandingProvider(
+    params.provider,
+    buildMediaUnderstandingRegistry(undefined, params.cfg),
+  );
+  if (!provider?.extractStructured) {
+    throw new Error(`Provider does not support structured extraction: ${params.provider}`);
+  }
+  return await provider.extractStructured({
+    input: params.input,
+    instructions: params.instructions,
+    schemaName: params.schemaName,
+    jsonSchema: params.jsonSchema,
+    jsonMode: params.jsonMode,
+    provider: params.provider,
+    model: params.model,
+    profile: params.profile,
+    preferredProfile: params.preferredProfile,
+    authStore: params.authStore,
     timeoutMs,
     cfg: params.cfg,
     agentDir: params.agentDir ?? "",

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -169,6 +169,46 @@ export type ImagesDescriptionResult = {
   model?: string;
 };
 
+export type StructuredExtractionTextInput = {
+  type: "text";
+  text: string;
+};
+
+export type StructuredExtractionImageInput = {
+  type: "image";
+  buffer: Buffer;
+  fileName: string;
+  mime?: string;
+};
+
+export type StructuredExtractionInput =
+  | StructuredExtractionTextInput
+  | StructuredExtractionImageInput;
+
+export type StructuredExtractionRequest = {
+  input: StructuredExtractionInput[];
+  instructions: string;
+  schemaName?: string;
+  jsonSchema?: unknown;
+  jsonMode?: boolean;
+  timeoutMs: number;
+  profile?: string;
+  preferredProfile?: string;
+  authStore?: AuthProfileStore;
+  agentDir: string;
+  cfg: OpenClawConfig;
+  model: string;
+  provider: string;
+};
+
+export type StructuredExtractionResult = {
+  text: string;
+  parsed?: unknown;
+  model?: string;
+  provider?: string;
+  contentType?: "json" | "text";
+};
+
 export type MediaUnderstandingProvider = {
   id: string;
   capabilities?: MediaUnderstandingCapability[];
@@ -179,4 +219,5 @@ export type MediaUnderstandingProvider = {
   describeVideo?: (req: VideoDescriptionRequest) => Promise<VideoDescriptionResult>;
   describeImage?: (req: ImageDescriptionRequest) => Promise<ImageDescriptionResult>;
   describeImages?: (req: ImagesDescriptionRequest) => Promise<ImagesDescriptionResult>;
+  extractStructured?: (req: StructuredExtractionRequest) => Promise<StructuredExtractionResult>;
 };

--- a/src/plugin-sdk/media-understanding-runtime.ts
+++ b/src/plugin-sdk/media-understanding-runtime.ts
@@ -2,8 +2,10 @@ export {
   describeImageFile,
   describeImageFileWithModel,
   describeVideoFile,
+  extractStructuredWithModel,
   runMediaUnderstandingFile,
   transcribeAudioFile,
+  type ExtractStructuredWithModelParams,
   type RunMediaUnderstandingFileParams,
   type RunMediaUnderstandingFileResult,
 } from "../media-understanding/runtime.js";

--- a/src/plugin-sdk/media-understanding.ts
+++ b/src/plugin-sdk/media-understanding.ts
@@ -9,6 +9,11 @@ export type {
   ImagesDescriptionRequest,
   ImagesDescriptionResult,
   MediaUnderstandingProvider,
+  StructuredExtractionImageInput,
+  StructuredExtractionInput,
+  StructuredExtractionRequest,
+  StructuredExtractionResult,
+  StructuredExtractionTextInput,
   VideoDescriptionRequest,
   VideoDescriptionResult,
 } from "../media-understanding/types.js";

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -404,6 +404,8 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["describeImageFile"],
       describeImageFileWithModel:
         vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["describeImageFileWithModel"],
+      extractStructuredWithModel:
+        vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["extractStructuredWithModel"],
       describeVideoFile:
         vi.fn() as unknown as PluginRuntime["mediaUnderstanding"]["describeVideoFile"],
       transcribeAudioFile:

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -245,6 +245,7 @@ describe("plugin runtime command execution", () => {
           "runFile",
           "describeImageFile",
           "describeImageFileWithModel",
+          "extractStructuredWithModel",
           "describeVideoFile",
         ]);
         expect(runtime.mediaUnderstanding.transcribeAudioFile).toBe(

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -69,6 +69,9 @@ function createRuntimeMediaUnderstandingFacade(): PluginRuntime["mediaUnderstand
     describeImageFileWithModel: bindMediaUnderstandingRuntime(
       (runtime) => runtime.describeImageFileWithModel,
     ),
+    extractStructuredWithModel: bindMediaUnderstandingRuntime(
+      (runtime) => runtime.extractStructuredWithModel,
+    ),
     describeVideoFile: bindMediaUnderstandingRuntime((runtime) => runtime.describeVideoFile),
     transcribeAudioFile: bindMediaUnderstandingRuntime((runtime) => runtime.transcribeAudioFile),
   };

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -246,6 +246,7 @@ export type PluginRuntimeCore = {
     runFile: MediaUnderstandingRuntime["runMediaUnderstandingFile"];
     describeImageFile: MediaUnderstandingRuntime["describeImageFile"];
     describeImageFileWithModel: MediaUnderstandingRuntime["describeImageFileWithModel"];
+    extractStructuredWithModel: MediaUnderstandingRuntime["extractStructuredWithModel"];
     describeVideoFile: MediaUnderstandingRuntime["describeVideoFile"];
     transcribeAudioFile: MediaUnderstandingRuntime["transcribeAudioFile"];
   };


### PR DESCRIPTION
## Why this matters

OpenClaw plugins increasingly need to turn unstructured user content into safe, typed data: receipts into expense records, screenshots into support evidence, invoices into accounting fields, customer messages into CRM notes, PDFs into knowledge-base snippets, and product photos into searchable inventory metadata.

Today each plugin has to choose between two bad options:

- implement its own model/auth/runtime bridge, usually requiring another user-managed API key; or
- add product-specific extraction routes to core, which does not scale as the plugin ecosystem grows.

This PR adds the missing middle layer: a generic structured extraction capability in the media-understanding SDK. Product plugins keep owning their routes, schemas, storage, and UX, while OpenClaw owns the provider/runtime boundary, auth source, safety posture, and typed SDK contract.

## What plugin authors can build with this

Examples this unlocks without adding plugin-specific logic to OpenClaw core:

- **Support plugins:** extract error messages, stack traces, product names, issue category, severity, and reproduction steps from screenshots.
- **Knowledge-base plugins:** convert documents or screenshots into normalized metadata and searchable evidence records.
- **CRM/sales plugins:** extract companies, people, dates, action items, sentiment, and deal updates from inbound media plus short text context.
- **Finance/admin plugins:** extract vendor, total, currency, tax, due date, and line-item hints from receipts or invoices.
- **Inventory/media plugins:** extract labels, visible text, tags, object categories, and image summaries from uploaded photos.
- **Migration/import plugins:** map arbitrary image inputs into a plugin-owned JSON schema before writing to the plugin's own database.

The important part: the plugin defines the schema and decides what to do with the result. OpenClaw only provides the generic, bounded extraction lane.

## New SDK shape

This PR adds:

- optional provider method: `MediaUnderstandingProvider.extractStructured(...)`
- runtime helper: `api.runtime.mediaUnderstanding.extractStructuredWithModel(...)`
- typed inputs for images plus optional supplemental text context
- optional `schemaName`, `jsonSchema`, `jsonMode`, and `timeoutMs`
- controlled result metadata: raw `text`, parsed JSON when JSON mode is enabled, model/provider, and content type

Example plugin call:

```ts
const result = await api.runtime.mediaUnderstanding.extractStructuredWithModel({
  provider: "codex",
  model: "gpt-5.5",
  input: [
    {
      type: "image",
      buffer: receiptImageBuffer,
      fileName: "receipt.png",
      mime: "image/png",
    },
    { type: "text", text: "Prefer the printed total over handwritten notes." },
  ],
  instructions: "Extract vendor, total, and searchable tags.",
  schemaName: "receipt.evidence",
  jsonSchema: {
    type: "object",
    properties: {
      vendor: { type: "string" },
      total: { type: "number" },
      tags: { type: "array", items: { type: "string" } },
    },
    required: ["vendor", "total"],
  },
  cfg: api.config,
});
```

## Runtime architecture

```mermaid
flowchart LR
  Plugin["Plugin route, skill, or importer"] --> Runtime["api.runtime.mediaUnderstanding.extractStructuredWithModel"]
  Runtime --> Provider["MediaUnderstandingProvider.extractStructured"]
  Provider --> HostRuntime["Provider-owned host runtime"]
  HostRuntime --> Result["JSON result or controlled error"]
  Result --> Plugin
  Plugin --> Storage["Plugin-owned storage, tools, or user workflow"]
```

For the bundled Codex provider, this uses the existing Codex app-server/OAuth path rather than requiring a user-supplied model API key.

```mermaid
flowchart LR
  Plugin["Any OpenClaw plugin"] --> SDK["Structured extraction SDK"]
  SDK --> CodexProvider["Codex media-understanding provider"]
  CodexProvider --> AppServer["Codex app-server / OAuth runtime"]
  AppServer --> BoundedTurn["Ephemeral no-tools turn"]
  BoundedTurn --> JSON["Parsed JSON or controlled error"]
```

## Safety and boundaries

The Codex implementation keeps the same bounded posture as image understanding:

- ephemeral thread
- read-only sandbox
- no dynamic tools
- approval policy set to `on-request`, with approval requests denied by the provider handler
- timeout enforcement
- model modality validation before turn start
- JSON parsing failure returned as a controlled error
- text-only extraction rejected at the runtime seam, keeping this image-first instead of turning it into a generic text completion lane
- no product-specific route names, storage models, or schemas in OpenClaw core

This is intentionally a platform seam, not a feature-specific integration.

## What changed

- Adds structured extraction request/result types to the media-understanding SDK.
- Adds `extractStructuredWithModel(...)` to the plugin runtime media-understanding facade.
- Implements `extractStructured(...)` in the bundled Codex provider.
- Preserves explicit config-provider image descriptions by keeping `describeImageFileWithModel(...)` on the full media-understanding registry instead of narrowing it to manifest-only plugin providers.
- Forwards structured extraction auth-profile selection through the runtime helper so provider-owned OAuth/app-server runtimes can honor plugin-selected credentials.
- Narrows the new seam to image-first extraction with optional supplemental text context instead of overlapping general text-only completion surfaces.
- Adds tests for bounded Codex structured extraction, invalid JSON/schema handling, runtime routing, auth-profile forwarding, image-required guardrails, direct image-model registry routing, provider lookup failure, and runtime API exposure.
- Documents the new runtime helper and the plugin/core ownership boundary.
- Adds the required changelog entry for the new plugin SDK/runtime capability.

## Relationship to existing LLM surfaces

OpenClaw already has `api.runtime.llm.complete` for trusted plugin text completions, and `llm-task` for workflow/tool-level JSON tasks. This PR is narrower and lower-level: a provider SDK/runtime media-understanding seam for schema-shaped extraction over image inputs with optional text context. That keeps extraction provider-owned and plugin-consumable without turning it into a general-purpose arbitrary Codex call API.

## Non-goals

- This does not add a product-specific extraction route to OpenClaw core.
- This does not choose any plugin's storage model or JSON schema.
- This does not replace existing image/audio/video media-understanding helpers.
- This does not require plugins to use Codex; other providers can implement the same optional method.
- This does not expand into generic text-only extraction; callers that want arbitrary text completions should keep using the existing LLM surfaces.

## Background

This closes openclaw/openclaw#79321.

The immediate downstream need came from a GBrain/OpenClaw integration, but the implementation here is deliberately generic. GBrain, support, CRM, finance, inventory, migration, and knowledge-base plugins can all consume the same SDK seam while keeping their own product-specific routes and schemas outside OpenClaw core.

## Real behavior proof

**Behavior or issue addressed:** The rebased branch exposes a typed plugin-runtime structured extraction seam that dispatches through a registered media-understanding provider, preserves the bounded Codex worker defaults, forwards the selected auth profile into the provider-owned runtime, and rejects text-only calls before provider dispatch.

**Real environment tested:** Local macOS OpenClaw checkout at `/Users/lume/openclaw-review-worktrees/pr-79334-rebase`, rebased head `78cfe4a76161fc7d3029beb4edcf7120a94a4d8b`, using a standalone `node --import tsx` proof command outside Vitest. The proof registers the real bundled Codex media-understanding provider in the active plugin runtime registry with a stubbed app-server client, then calls `createPluginRuntime().mediaUnderstanding.extractStructuredWithModel(...)` once with image-plus-text input and once with text-only input.

**Exact steps or command run after this patch:**

```text
cd /Users/lume/openclaw-review-worktrees/pr-79334-rebase
node --import tsx <<'EOF'
import { buildCodexMediaUnderstandingProvider } from './extensions/codex/media-understanding-provider.ts';
import { createPluginRuntime } from './src/plugins/runtime/index.ts';
import { createEmptyPluginRegistry } from './src/plugins/registry-empty.ts';
import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from './src/plugins/runtime.ts';

function codexModel(inputModalities = ['text', 'image']) {
  return {
    id: 'gpt-5.4',
    model: 'gpt-5.4',
    upgrade: null,
    upgradeInfo: null,
    availabilityNux: null,
    displayName: 'gpt-5.4',
    description: 'GPT-5.4',
    hidden: false,
    supportedReasoningEfforts: [{ reasoningEffort: 'low', description: 'fast' }],
    defaultReasoningEffort: 'low',
    inputModalities,
    supportsPersonality: false,
    additionalSpeedTiers: [],
    isDefault: true,
  };
}

function threadStartResult() {
  return {
    thread: {
      id: 'thread-1',
      sessionId: 'session-1',
      forkedFromId: null,
      preview: '',
      ephemeral: true,
      modelProvider: 'openai',
      createdAt: 1,
      updatedAt: 1,
      status: { type: 'idle' },
      path: null,
      cwd: process.cwd(),
      cliVersion: '0.125.0',
      source: 'unknown',
      agentNickname: null,
      agentRole: null,
      gitInfo: null,
      name: null,
      turns: [],
    },
    model: 'gpt-5.4',
    modelProvider: 'openai',
    serviceTier: null,
    cwd: process.cwd(),
    instructionSources: [],
    approvalPolicy: 'on-request',
    approvalsReviewer: 'user',
    sandbox: { type: 'dangerFullAccess' },
    permissionProfile: null,
    reasoningEffort: null,
  };
}

function turnStartResult(status = 'inProgress', items = []) {
  return {
    turn: {
      id: 'turn-1',
      status,
      items,
      error: null,
      startedAt: null,
      completedAt: null,
      durationMs: null,
    },
  };
}

function createFakeClient(responseText) {
  const notifications = new Set();
  const requestHandlers = new Set();
  const requests = [];
  const request = async (method, params) => {
    requests.push({ method, params });
    if (method === 'model/list') return { data: [codexModel()], nextCursor: null };
    if (method === 'thread/start') return threadStartResult();
    if (method === 'turn/start') {
      for (const notify of notifications) {
        notify({ method: 'item/agentMessage/delta', params: { threadId: 'thread-1', turnId: 'turn-1', itemId: 'msg-1', delta: responseText } });
        notify({ method: 'turn/completed', params: { threadId: 'thread-1', turnId: 'turn-1', turn: turnStartResult('completed').turn } });
      }
      for (const handler of requestHandlers) handler({ method: 'item/permissions/requestApproval' });
      return turnStartResult();
    }
    return {};
  };
  return {
    client: {
      request,
      addNotificationHandler(handler) { notifications.add(handler); return () => notifications.delete(handler); },
      addRequestHandler(handler) { requestHandlers.add(handler); return () => requestHandlers.delete(handler); },
      close() {},
    },
    requests,
  };
}

const authProfileIds = [];
const { client, requests } = createFakeClient('{"summary":"red square","tags":["shape"]}');
const provider = buildCodexMediaUnderstandingProvider({
  clientFactory: async (_startOptions, authProfileId) => {
    authProfileIds.push(authProfileId ?? null);
    return client;
  },
});

const registry = createEmptyPluginRegistry();
registry.mediaUnderstandingProviders.push({
  pluginId: 'codex',
  pluginName: 'Codex',
  source: 'proof-script',
  provider,
});
setActivePluginRegistry(registry, 'proof-script', 'default', process.cwd());

const runtime = createPluginRuntime();
const success = await runtime.mediaUnderstanding.extractStructuredWithModel({
  provider: 'codex',
  model: 'gpt-5.4',
  input: [
    {
      type: 'image',
      buffer: Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+kX3sAAAAASUVORK5CYII=', 'base64'),
      fileName: 'red-square.png',
      mime: 'image/png',
    },
    { type: 'text', text: 'Return searchable evidence for the uploaded image.' },
  ],
  instructions: 'Return JSON with summary and tags.',
  schemaName: 'proof.red-square',
  jsonSchema: {
    type: 'object',
    properties: {
      summary: { type: 'string' },
      tags: { type: 'array', items: { type: 'string' } },
    },
    required: ['summary'],
  },
  profile: 'openai-codex:work',
  cfg: {},
  agentDir: process.cwd(),
});

let guardError = null;
try {
  await runtime.mediaUnderstanding.extractStructuredWithModel({
    provider: 'codex',
    model: 'gpt-5.4',
    input: [{ type: 'text', text: 'No image present.' }],
    instructions: 'Return JSON.',
    cfg: {},
    agentDir: process.cwd(),
  });
} catch (error) {
  guardError = error instanceof Error ? error.message : String(error);
}

console.log(JSON.stringify({
  success,
  authProfileIds,
  requestMethods: requests.map((entry) => entry.method),
  threadStart: requests.find((entry) => entry.method === 'thread/start')?.params,
  turnInput: requests.find((entry) => entry.method === 'turn/start')?.params?.input,
  guardError,
}, null, 2));

resetPluginRuntimeStateForTest();
EOF
```

**Evidence after fix:**

```json
{
  "success": {
    "text": "{\"summary\":\"red square\",\"tags\":[\"shape\"]}",
    "model": "gpt-5.4",
    "provider": "codex",
    "contentType": "json",
    "parsed": {
      "summary": "red square",
      "tags": [
        "shape"
      ]
    }
  },
  "authProfileIds": [
    "openai-codex:work"
  ],
  "requestMethods": [
    "model/list",
    "thread/start",
    "turn/start"
  ],
  "threadStart": {
    "model": "gpt-5.4",
    "modelProvider": "openai",
    "cwd": "/Users/lume/openclaw-review-worktrees/pr-79334-rebase",
    "approvalPolicy": "on-request",
    "sandbox": "read-only",
    "serviceName": "OpenClaw",
    "developerInstructions": "You are OpenClaw's bounded structured-extraction worker. Return only the requested extraction. Do not call tools, edit files, ask follow-up questions, or include secrets.",
    "dynamicTools": [],
    "experimentalRawEvents": true,
    "persistExtendedHistory": false,
    "ephemeral": true
  },
  "turnInput": [
    {
      "type": "text",
      "text": "Return JSON with summary and tags.\n\nSchema name: proof.red-square\n\nJSON schema:\n{\"type\":\"object\",\"properties\":{\"summary\":{\"type\":\"string\"},\"tags\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"required\":[\"summary\"]}\n\nReturn valid JSON only. Do not wrap the JSON in Markdown fences.",
      "text_elements": []
    },
    {
      "type": "image",
      "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+kX3sAAAAASUVORK5CYII="
    },
    {
      "type": "text",
      "text": "Return searchable evidence for the uploaded image.",
      "text_elements": []
    }
  ],
  "guardError": "Structured extraction requires at least one image input."
}
```

**Observed result after fix:** The plugin runtime facade dispatched `extractStructuredWithModel(...)` through the registered Codex media-understanding provider, the provider returned parsed JSON on the bounded app-server path, the selected auth profile reached the provider-owned runtime, and the text-only call failed early with the intended image-required guard instead of widening this seam into general text extraction.

**What was not tested:** This proof intentionally uses a stubbed app-server client so it can exercise the real runtime/provider dispatch path deterministically in a local checkout without requiring a desktop-bound live OAuth session. The PR does not include a credentialed live Codex desktop turn artifact because that would require shipping private local auth/session material into public review evidence.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm plugin-sdk:api:gen`
- `pnpm plugin-sdk:api:check`
- `pnpm test src/media-understanding/runtime.test.ts src/media-understanding/provider-registry.test.ts extensions/codex/media-understanding-provider.test.ts src/plugins/runtime/index.test.ts`
- `pnpm check:changed`



