### PR TITLE
fix(voice-call): auto-respond on the webhook event transcript path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 - Discord/voice: reuse or suppress late realtime consult tool calls without stealing newer speaker context or speaking forced fallback answers twice.
 - Discord/voice: skip likely incomplete realtime forced-consult transcript fragments and non-actionable closings so stale partial speech does not queue delayed answers over the next turn.
 - Discord/voice: synthesize realtime playback timestamps from emitted Discord PCM so OpenAI realtime barge-in truncation no longer sees `audioEndMs=0` and skips legitimate interruptions.
+- Voice Call: auto-respond to inbound user transcripts that arrive through the generic webhook event path (today: Telnyx and Plivo) by mirroring the Twilio media-stream `onTranscript` handoff, gated on `manager.processEvent` actually appending a user transcript entry so replays and turn-token mismatches stay idempotent. Fixes #79118. Thanks @dvy.
 - Plugin SDK: keep activated linked plugin runtime facades loadable when bundled plugin fallback is disabled. Thanks @shakkernerd.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -407,6 +407,16 @@ export class CallManager {
   }
 
   /**
+   * Returns true if there is an outstanding transcript waiter for this call
+   * (i.e., a programmatic flow is already lined up to consume the next user
+   * speech). Webhook-side code uses this to avoid double-firing
+   * auto-response when a turn-aware flow will already handle the transcript.
+   */
+  hasTranscriptWaiter(callId: CallId): boolean {
+    return this.transcriptWaiters.has(callId);
+  }
+
+  /**
    * Get an active call by provider call ID (e.g., Twilio CallSid).
    */
   getCallByProviderCallId(providerCallId: string): CallRecord | undefined {

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -115,10 +115,17 @@ const createCall = (startedAt: number): CallRecord => ({
 const createManager = (calls: CallRecord[]) => {
   const endCall = vi.fn(async () => ({ success: true }));
   const processEvent = vi.fn();
+  const callsByCallId = new Map(calls.map((c) => [c.callId, c]));
+  const callsByProviderCallId = new Map(
+    calls.filter((c) => c.providerCallId).map((c) => [c.providerCallId as string, c]),
+  );
   const manager = {
     getActiveCalls: () => calls,
     endCall,
     processEvent,
+    getCall: (callId: string) => callsByCallId.get(callId),
+    getCallByProviderCallId: (providerCallId: string) => callsByProviderCallId.get(providerCallId),
+    hasTranscriptWaiter: () => false,
   } as unknown as CallManager;
 
   return { manager, endCall, processEvent };
@@ -1542,6 +1549,201 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       expect(event.transcript).toBe("hello");
       expect(event.isFinal).toBe(true);
       expect(handleInboundResponse).toHaveBeenCalledWith("call-inbound", "hello");
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+// Regression coverage for https://github.com/openclaw/openclaw/issues/79118.
+// Providers whose final user transcripts arrive through the generic webhook
+// event path (today: Telnyx and Plivo) deliver them via webhook events
+// rather than a media-stream `onTranscript` callback, so the auto-response
+// handoff has to be triggered from `processParsedEvents` too.
+describe("VoiceCallWebhookServer webhook event path auto-response (#79118)", () => {
+  const createInboundCall = (): CallRecord => ({
+    callId: "call-inbound-79118",
+    providerCallId: "v3:provider-79118",
+    provider: "telnyx",
+    direction: "inbound",
+    state: "listening",
+    // Reserved US 555 test numbers — matching the createCall helper above.
+    from: "+15550009999",
+    to: "+15550000111",
+    startedAt: Date.now(),
+    transcript: [],
+    processedEventIds: [],
+  });
+
+  const buildSpeechEvent = (
+    call: CallRecord,
+  ): Extract<NormalizedEvent, { type: "call.speech" }> => ({
+    id: "evt-79118",
+    type: "call.speech",
+    // Telnyx inbound events fall back to providerCallId because the provider
+    // doesn't echo client_state on calls it originated; verify the lookup
+    // path tolerates that.
+    callId: call.providerCallId as string,
+    providerCallId: call.providerCallId,
+    timestamp: Date.now(),
+    transcript: "hallo wie geht es dir",
+    isFinal: true,
+  });
+
+  const buildTelnyxLikeProvider = (event: NormalizedEvent): VoiceCallProvider => ({
+    ...provider,
+    name: "telnyx",
+    verifyWebhook: () => ({ ok: true, verifiedRequestKey: "telnyx:req:79118" }),
+    parseWebhookEvent: () => ({ events: [event], statusCode: 200 }),
+  });
+
+  type ManagerOverrides = {
+    hasTranscriptWaiter?: () => boolean;
+    /**
+     * Controls whether the stub processEvent appends a user transcript entry
+     * to the call (mimicking the real manager path-2 behavior). Default
+     * appends; set to false to simulate dedupe / replay (manager skips
+     * the event because dedupeKey was already in processedEventIds).
+     */
+    appendTranscriptOnProcess?: boolean;
+  };
+
+  const buildManagerWith = (call: CallRecord, overrides: ManagerOverrides = {}) => {
+    const appendOnProcess = overrides.appendTranscriptOnProcess ?? true;
+    const processEvent = vi.fn((event: NormalizedEvent) => {
+      if (appendOnProcess && event.type === "call.speech" && event.isFinal) {
+        call.transcript.push({
+          timestamp: Date.now(),
+          speaker: "user",
+          text: event.transcript,
+          isFinal: true,
+        });
+      }
+    });
+    const manager = {
+      getActiveCalls: () => [call],
+      getCall: (id: string) => (id === call.callId ? call : undefined),
+      getCallByProviderCallId: (pid: string) => (pid === call.providerCallId ? call : undefined),
+      hasTranscriptWaiter: overrides.hasTranscriptWaiter ?? (() => false),
+      endCall: vi.fn(async () => ({ success: true })),
+      processEvent,
+    } as unknown as CallManager;
+    return { manager, processEvent };
+  };
+
+  const installHandleInboundResponseSpy = (server: VoiceCallWebhookServer) => {
+    const spy = vi.fn(async () => {});
+    (
+      server as unknown as {
+        handleInboundResponse: (callId: string, transcript: string) => Promise<void>;
+      }
+    ).handleInboundResponse = spy;
+    return spy;
+  };
+
+  it("fires handleInboundResponse once for a final inbound transcript when no waiter is pending", async () => {
+    const inboundCall = createInboundCall();
+    const event = buildSpeechEvent(inboundCall);
+    const { manager, processEvent } = buildManagerWith(inboundCall);
+    const config = createConfig({
+      skipSignatureVerification: true,
+      serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, buildTelnyxLikeProvider(event));
+    const handleInboundResponse = installHandleInboundResponseSpy(server);
+
+    try {
+      const baseUrl = await server.start();
+      const response = await postWebhookForm(server, baseUrl, "stub=1");
+      expect(response.status).toBe(200);
+      expect(processEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "call.speech",
+          transcript: "hallo wie geht es dir",
+          isFinal: true,
+        }),
+      );
+      expect(handleInboundResponse).toHaveBeenCalledTimes(1);
+      expect(handleInboundResponse).toHaveBeenCalledWith(
+        inboundCall.callId,
+        "hallo wie geht es dir",
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("does not fire handleInboundResponse when a transcript waiter is pending", async () => {
+    const inboundCall = createInboundCall();
+    const event = buildSpeechEvent(inboundCall);
+    const { manager } = buildManagerWith(inboundCall, { hasTranscriptWaiter: () => true });
+    const config = createConfig({
+      skipSignatureVerification: true,
+      serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, buildTelnyxLikeProvider(event));
+    const handleInboundResponse = installHandleInboundResponseSpy(server);
+
+    try {
+      const baseUrl = await server.start();
+      const response = await postWebhookForm(server, baseUrl, "stub=1");
+      expect(response.status).toBe(200);
+      expect(handleInboundResponse).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("does not fire handleInboundResponse for partial (non-final) transcripts", async () => {
+    const inboundCall = createInboundCall();
+    const event = { ...buildSpeechEvent(inboundCall), isFinal: false };
+    const { manager } = buildManagerWith(inboundCall);
+    const config = createConfig({
+      skipSignatureVerification: true,
+      serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, buildTelnyxLikeProvider(event));
+    const handleInboundResponse = installHandleInboundResponseSpy(server);
+
+    try {
+      const baseUrl = await server.start();
+      await postWebhookForm(server, baseUrl, "stub=1");
+      expect(handleInboundResponse).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  // Regression for the dedupe-bypass scenario raised in PR #79336 review:
+  // a redelivered webhook for an event already in `call.processedEventIds`
+  // makes `manager.processEvent` skip `addTranscriptEntry`, but a naive
+  // pre-computed pendingAutoResponse would still fire and produce a
+  // duplicate bot reply. Gating on `call.transcript.length` growth closes
+  // that window — this test is the regression.
+  it("does not fire handleInboundResponse when manager dedupes the event (replay)", async () => {
+    const inboundCall = createInboundCall();
+    const event = buildSpeechEvent(inboundCall);
+    // appendTranscriptOnProcess: false simulates the manager taking the
+    // dedupe early-return path (event was already in processedEventIds, so
+    // no transcript entry is appended even though processEvent was called).
+    const { manager, processEvent } = buildManagerWith(inboundCall, {
+      appendTranscriptOnProcess: false,
+    });
+    const config = createConfig({
+      skipSignatureVerification: true,
+      serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, buildTelnyxLikeProvider(event));
+    const handleInboundResponse = installHandleInboundResponseSpy(server);
+
+    try {
+      const baseUrl = await server.start();
+      const response = await postWebhookForm(server, baseUrl, "stub=1");
+      expect(response.status).toBe(200);
+      expect(processEvent).toHaveBeenCalledTimes(1);
+      // No transcript entry was appended → side effect must not fire.
+      expect(inboundCall.transcript).toHaveLength(0);
+      expect(handleInboundResponse).not.toHaveBeenCalled();
     } finally {
       await server.stop();
     }

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -854,7 +854,54 @@ export class VoiceCallWebhookServer {
   private processParsedEvents(events: NormalizedEvent[]): void {
     for (const event of events) {
       try {
+        // Providers whose final user transcripts arrive through the generic
+        // webhook event path (today: Telnyx and Plivo — neither has OpenClaw
+        // streaming integration yet) need the same auto-response handoff
+        // that Twilio Media Streams already gets in the `onTranscript`
+        // callback. Without it, the manager records the transcript and
+        // transitions to "listening" but the bot never replies. Peek at
+        // waiter state *before* `manager.processEvent` because that call
+        // clears the waiter, then gate firing on transcript-length growth
+        // so replays and turn-token mismatches stay idempotent.
+        // See https://github.com/openclaw/openclaw/issues/79118.
+        let pendingAutoResponse: { call: CallRecord; transcript: string } | null = null;
+        let transcriptLengthBeforeProcess = 0;
+        if (event.type === "call.speech" && event.isFinal) {
+          // event.callId is the manager UUID for outbound calls (carried via
+          // client_state) but falls back to providerCallId for inbound calls
+          // where the provider doesn't echo client_state (Telnyx case).
+          const call =
+            this.manager.getCall(event.callId) ??
+            this.manager.getCallByProviderCallId(event.callId);
+          if (call) {
+            const hadWaiter = this.manager.hasTranscriptWaiter(call.callId);
+            const callMode = call.metadata?.mode as string | undefined;
+            const shouldRespond = call.direction === "inbound" || callMode === "conversation";
+            if (!hadWaiter && shouldRespond) {
+              pendingAutoResponse = { call, transcript: event.transcript };
+              transcriptLengthBeforeProcess = call.transcript.length;
+            }
+          }
+        }
         this.manager.processEvent(event);
+        if (pendingAutoResponse) {
+          // Only auto-respond if `processEvent` actually appended a user
+          // transcript entry. This preserves the manager's dedupe + replay
+          // protection: a redelivered webhook for an already-processed event
+          // (or a turn-token mismatch path that breaks before
+          // addTranscriptEntry) leaves transcript.length unchanged, so we
+          // skip the side effect.
+          const userSpoke =
+            pendingAutoResponse.call.transcript.length > transcriptLengthBeforeProcess;
+          if (userSpoke) {
+            this.handleInboundResponse(
+              pendingAutoResponse.call.callId,
+              pendingAutoResponse.transcript,
+            ).catch((err) => {
+              console.warn(`[voice-call] Failed to auto-respond:`, err);
+            });
+          }
+        }
       } catch (err) {
         console.error(`[voice-call] Error processing event ${event.type}:`, err);
       }


### PR DESCRIPTION
Closes #79118.

## Summary

- Wire `processParsedEvents` (the generic webhook event path used by providers without OpenClaw streaming integration — Telnyx and Plivo today) to fire `handleInboundResponse` after a final `call.speech` event for inbound or conversation-mode calls, mirroring the path that already runs for Twilio Media Streams in the `onTranscript` callback. Gated on `manager.processEvent` actually appending a user transcript entry so replays and turn-token mismatches stay idempotent.
- Expose a small public `CallManager.hasTranscriptWaiter(callId)` so the webhook layer can avoid double-firing when a programmatic turn-aware flow (e.g. `continueCall`) is already lined up to consume the transcript.
- Lookup tolerates both `event.callId` shapes: the manager UUID (outbound calls carry it via `client_state`) and the providerCallId fallback (inbound Telnyx calls don't echo `client_state`, so the normalized event's `callId` is the call control ID).

## Why

Reported in #79118: on Telnyx (and any provider whose final user transcripts arrive through OpenClaw's generic webhook event path rather than a media-stream `onTranscript` callback), inbound calls answer, the greeting plays, the user transcript is captured to the call record, and then nothing — the bot never speaks again. The call sits in `listening` until the caller hangs up. Note that Telnyx and Plivo are streaming-capable carriers; OpenClaw's plugin just doesn't wire up streaming integration for them today (see #79324 for the in-flight Telnyx streaming work).

Root cause is a single missing call-site. `handleInboundResponse` had exactly one invocation, gated behind the Twilio Media Streams `onTranscript` callback (`webhook.ts:391`). The generic webhook `call.speech` handler in `manager/events.ts:238` records the transcript and transitions to `listening` but never invokes the auto-response. Provider webhook events flow through `processParsedEvents` → `manager.processEvent`, missing the auto-response handoff entirely.

The fix is the smallest viable change: a peek at waiter state before `manager.processEvent` (which clears the waiter), then fire `handleInboundResponse` afterward when no programmatic flow is waiting and the call is inbound or in conversation mode. Path-1 (Twilio Media Streams) is intentionally untouched — no behavior change for streaming providers.

## Real Behavior Proof

- Behavior or issue addressed: Telnyx inbound calls (and any provider whose final user transcripts arrive through OpenClaw's generic webhook event path rather than a media-stream `onTranscript` callback) answer and play the configured greeting, capture the user's final speech transcript to the call record, but the bot never replies — `processParsedEvents` only forwards the event to the manager and never invokes `handleInboundResponse`. This PR mirrors the Twilio media-stream auto-response handoff into the webhook event path, gated on actual transcript persistence to preserve manager replay/dedupe semantics. Telnyx and Plivo are streaming-capable carriers; OpenClaw's plugin just doesn't wire up streaming integration for them today (#79324 is the in-flight Telnyx streaming work).

- Real environment tested: Linux home server running OpenClaw `2026.5.7` gateway with `@openclaw/voice-call@2026.5.4` plugin, configured for provider Telnyx (Call Control v2). Regulated DE DID, BNetzA-cleared, Telnyx number status `active`. Inbound webhook served at `127.0.0.1:3334/voice/webhook` and exposed publicly via Cloudflare Tunnel with full Telnyx signature verification active (`TELNYX_PUBLIC_KEY`). Inbound policy `allowlist`, German `inboundGreeting`, per-number `responseSystemPrompt`, `streaming.enabled: false`, `realtime.enabled: false`. Because npm only ships the bundled plugin, the source-equivalent fix was applied as a small local patch to the `dist/runtime-entry-*.js` chunk file carrying the exact same `processParsedEvents` logic this PR adds.

- Exact steps or command run after this patch:
  1. Apply the source-equivalent patch to `~/.openclaw/npm/node_modules/@openclaw/voice-call/dist/runtime-entry-*.js` (idempotent shell tool, refuses to apply if upstream pattern shifts).
  2. `systemctl --user restart openclaw-gateway.service`.
  3. Dial the DID from the allowlisted mobile.
  4. Wait for the German greeting, then speak in English.
  5. Continue a multi-turn conversation; hang up.

- Evidence after fix: redacted runtime logs from `journalctl --user -u openclaw-gateway.service` after the test call. The `[voice-call] Auto-responding to inbound call …` line is the exact log statement that never appears on current main for the generic webhook event path; with the patch it appears once per final user transcript and the bot's reply is rendered through Telnyx-hosted TTS and audible to the caller.

  ```
  [voice-call] Inbound call accepted: +49***REDACTED*** is in allowlist
  [voice-call] Created inbound call record: c7be1d4a-…-… from +49***REDACTED***
  [voice-call] Speaking initial message for call c7be1d4a-…-… (mode: conversation)
  [voice-call] Auto-responding to inbound call c7be1d4a-…-…: "hi which Step are you using"
  [voice-call] Auto-responding to inbound call c7be1d4a-…-…: " and is this um 5 and 5 through the API or through a subscription"
  ```

  Persisted multi-turn call record copied live from `~/.openclaw/voice-calls/calls.jsonl` (redacted, four user turns each followed by a bot reply):

  ```json
  {
    "callId": "9df40ff1…",
    "provider": "telnyx",
    "direction": "inbound",
    "state": "completed",
    "from": "+49***REDACTED***",
    "to": "+49***REDACTED***",
    "endReason": "completed",
    "transcript": [
      { "speaker": "bot",  "text": "Hallo, was kann ich für dich tun?",                       "isFinal": true },
      { "speaker": "user", "text": "hello how are you",                                        "isFinal": true },
      { "speaker": "bot",  "text": "I'm good, thanks. How can I help you today?",             "isFinal": true },
      { "speaker": "user", "text": " right now",                                               "isFinal": true },
      { "speaker": "bot",  "text": "What would you like me to do right now?",                  "isFinal": true },
      { "speaker": "user", "text": " I want you to tell me which large language model are you","isFinal": true },
      { "speaker": "bot",  "text": "I'm running on OpenAI GPT 5.5 right now, inside OpenClaw.","isFinal": true },
      { "speaker": "user", "text": " okay thank you bye bye",                                  "isFinal": true },
      { "speaker": "bot",  "text": "You're welcome. Bye!",                                     "isFinal": true }
    ]
  }
  ```

  Before the fix, only the first two transcript entries existed (the bot greeting and one user turn) and `endReason` came from the caller hanging up after silence rather than from the bot saying goodbye.

- Observed result after fix: caller heard each bot reply audibly through the call. Multi-turn conversation worked end-to-end. Conversation ended naturally (caller said "okay thank you bye bye" → bot replied → caller hung up). No regressions observed in outbound calling or any other voice-call flow on the same gateway during the test session.

- What was not tested:
  - Plivo (the other provider currently using the generic webhook event path). The same `processParsedEvents` code path covers it and the fix is provider-agnostic, but I don't have a Plivo number to dial.
  - Twilio Media Streams (path-1) regression. The diff makes no behavioral change to that path, but I don't have a Twilio number to dial either. Unit coverage in `webhook.test.ts > VoiceCallWebhookServer media stream auto-response` continues to pass.
  - Live race between an active `transcriptWaiter` and a webhook transcript event. Covered by the unit test "does not fire handleInboundResponse when a transcript waiter is pending" but not exercised live.

## Verification

- `pnpm test extensions/voice-call/src/webhook.test.ts` — 38/38 pass (34 pre-existing + 4 new under the `webhook event path auto-response (#79118)` describe block)
- `pnpm test extensions/voice-call/src/manager/events.test.ts extensions/voice-call/src/manager.closed-loop.test.ts extensions/voice-call/src/providers/telnyx.test.ts` — all pass
- Whole voice-call extension test run (44 files, 377 tests) — all pass; no regressions
- `pnpm check:changed` — exit 0 (typecheck extensions, typecheck extension tests, lint extensions via oxlint, runtime sidecar loader guard, runtime import cycles, duplicate scan target coverage)

## Notes

- AI-assisted: PR drafted with Claude (Opus 4.7); fix logic, tests, and the live-call validation above are mine.
- I am the original reporter of #79118; the live call setup that produced the proof above is the same setup described in the issue body.
