### PR TITLE
fix: preserve final media reply directives

### DIFF
--- a/src/agents/pi-embedded-subscribe.block-reply-rejections.test.ts
+++ b/src/agents/pi-embedded-subscribe.block-reply-rejections.test.ts
@@ -54,4 +54,23 @@ describe("subscribeEmbeddedPiSession block reply rejections", () => {
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     expect(unhandledRejections).toHaveLength(0);
   });
+
+  it("flushes trailing MEDIA directives held until final text_end", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    emitAssistantTextDelta({ emit, delta: "Here is the image.\nMEDIA:/tmp/final.png" });
+    emitAssistantTextEnd({ emit });
+    await waitForAsyncCallbacks();
+
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaUrls: ["/tmp/final.png"],
+      }),
+    );
+  });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -359,6 +359,43 @@ describe("handleMessageUpdate text signatures", () => {
       replyToCurrent: true,
     });
   });
+
+  it("extracts phase-aware final media when text_end only carries it in partial content", () => {
+    const accumulator = createStreamingDirectiveAccumulator();
+    const ctx = createMessageUpdateContext({
+      consumePartialReplyDirectives: vi.fn((text: string, options?: { final?: boolean }) =>
+        accumulator.consume(text, options),
+      ),
+      state: {
+        blockReplyBreak: "message_end",
+      },
+    });
+    const replyText = "Done.\nMEDIA:/tmp/final-only.png";
+
+    handleMessageUpdate(
+      ctx,
+      createTextUpdateEvent({
+        type: "text_end",
+        text: "",
+        partial: createOpenAiResponsesPartial({
+          text: replyText,
+          id: "item-final",
+          signaturePhase: "final_answer",
+          partialPhase: "final_answer",
+        }),
+      }),
+    );
+
+    expect(ctx.state.blockBuffer).toBe("Done.");
+    expect(
+      consumePendingAssistantReplyDirectivesIntoReply(ctx.state, {
+        text: "Done.",
+      }),
+    ).toEqual({
+      text: "Done.",
+      mediaUrls: ["/tmp/final-only.png"],
+    });
+  });
 });
 
 describe("consumePendingToolMediaIntoReply", () => {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -558,13 +558,27 @@ export function handleMessageUpdate(
     const finalParsedDelta =
       evtType === "text_end" ? ctx.consumePartialReplyDirectives("", { final: true }) : null;
     const parsedStreamDirectives = mergeReplyDirectiveResults(parsedDelta, finalParsedDelta);
+    // Some phase-aware providers surface the complete final_answer text only at
+    // text_end, without replaying it through visibleDelta. In that case the
+    // partial directive accumulator never sees trailing MEDIA: lines, so parse the
+    // complete visible text once at finalization and merge any reply metadata.
+    const phaseAwareFinalDirectives =
+      shouldUsePhaseAwareBlockReply && evtType === "text_end" && next
+        ? parseReplyDirectives(next)
+        : null;
+    const mergedStreamDirectives = mergeReplyDirectiveResults(
+      parsedStreamDirectives,
+      phaseAwareFinalDirectives,
+    );
     if (shouldUsePhaseAwareBlockReply) {
-      recordPendingAssistantReplyDirectives(ctx.state, parsedStreamDirectives);
+      recordPendingAssistantReplyDirectives(ctx.state, mergedStreamDirectives);
     }
     const parsedFull = parseReplyDirectives(splitTrailingDirective(next).text);
     const cleanedText = parsedFull.text;
-    const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
-    const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
+    const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(
+      mergedStreamDirectives ?? {},
+    );
+    const hasAudio = Boolean(mergedStreamDirectives?.audioAsVoice);
     const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
 
     let shouldEmit = false;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -448,11 +448,11 @@ describe("handleToolExecutionEnd media emission", () => {
     return ctx;
   }
 
-  it("does not queue structured media already emitted in plain verbose output", async () => {
+  it("keeps structured media queued after plain verbose output", async () => {
     const ctx = await handleVerboseGeneratedImage("plain");
 
     expect(ctx.emitToolOutput).toHaveBeenCalled();
-    expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+    expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/generated.png"]);
   });
 
   it("queues structured media once for markdown verbose output", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -49,7 +49,6 @@ import { normalizeToolName } from "./tool-policy.js";
 
 type ExecApprovalReplyModule = typeof import("../infra/exec-approval-reply.js");
 type HookRunnerGlobalModule = typeof import("../plugins/hook-runner-global.js");
-type MediaParseModule = typeof import("../media/parse.js");
 type BeforeToolCallModule = typeof import("./pi-tools.before-tool-call.js");
 
 const execApprovalReplyModuleLoader = createLazyImportLoader<ExecApprovalReplyModule>(
@@ -57,9 +56,6 @@ const execApprovalReplyModuleLoader = createLazyImportLoader<ExecApprovalReplyMo
 );
 const hookRunnerGlobalModuleLoader = createLazyImportLoader<HookRunnerGlobalModule>(
   () => import("../plugins/hook-runner-global.js"),
-);
-const mediaParseModuleLoader = createLazyImportLoader<MediaParseModule>(
-  () => import("../media/parse.js"),
 );
 const beforeToolCallModuleLoader = createLazyImportLoader<BeforeToolCallModule>(
   () => import("./pi-tools.before-tool-call.js"),
@@ -73,10 +69,6 @@ function loadExecApprovalReply(): Promise<ExecApprovalReplyModule> {
 
 function loadHookRunnerGlobal(): Promise<HookRunnerGlobalModule> {
   return hookRunnerGlobalModuleLoader.load();
-}
-
-function loadMediaParse(): Promise<MediaParseModule> {
-  return mediaParseModuleLoader.load();
 }
 
 function loadBeforeToolCall(): Promise<BeforeToolCallModule> {
@@ -410,19 +402,6 @@ function queuePendingToolMedia(
   }
 }
 
-async function collectEmittedToolOutputMediaUrls(
-  toolName: string,
-  outputText: string,
-  result: unknown,
-): Promise<string[]> {
-  const { splitMediaFromOutput } = await loadMediaParse();
-  const mediaUrls = splitMediaFromOutput(outputText).mediaUrls ?? [];
-  if (mediaUrls.length === 0) {
-    return [];
-  }
-  return filterToolResultMediaUrls(toolName, mediaUrls, result);
-}
-
 function readExecApprovalPendingDetails(result: unknown): {
   approvalId: string;
   approvalSlug: string;
@@ -529,7 +508,6 @@ async function emitToolResultOutput(params: {
     !Array.isArray((result as { details?: { media?: unknown } }).details?.media),
   );
   const approvalPending = readExecApprovalPendingDetails(result);
-  let emittedToolOutputMediaUrls: string[] = [];
   if (!isToolError && approvalPending) {
     if (!ctx.params.onToolResult) {
       return;
@@ -602,13 +580,6 @@ async function emitToolResultOutput(params: {
   if (shouldEmitOutput) {
     if (outputText) {
       ctx.emitToolOutput(rawToolName, meta, outputText, result);
-      if (ctx.params.toolResultFormat === "plain") {
-        emittedToolOutputMediaUrls = await collectEmittedToolOutputMediaUrls(
-          rawToolName,
-          outputText,
-          result,
-        );
-      }
     }
     if (!hasStructuredMedia) {
       return;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -622,10 +622,13 @@ async function emitToolResultOutput(params: {
   if (!mediaReply) {
     return;
   }
-  const pendingMediaUrls =
-    emittedToolOutputMediaUrls.length === 0
-      ? mediaUrls
-      : mediaUrls.filter((url) => !emittedToolOutputMediaUrls.includes(url));
+  // Keep structured tool media queued for the final outbound reply even when the
+  // tool text itself contained a MEDIA: directive. Plain external channels may
+  // strip tool-output MEDIA from the transcript without actually delivering the
+  // attachment, so treating emitted tool-output media as already sent can drop
+  // generated images before the channel adapter sees them. Downstream reply
+  // merging still de-duplicates identical media URLs.
+  const pendingMediaUrls = mediaUrls;
   if (pendingMediaUrls.length === 0) {
     return;
   }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -715,6 +715,43 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       stripBlockTags(text, state.blockState, { final: options?.final === true }),
     ).trimEnd();
     if (!chunk) {
+      // Final empty flushes are used to close the streaming directive accumulator.
+      // Do not return before consuming: a trailing MEDIA:/path line may have been
+      // held in pendingTail by a previous non-final chunk to avoid sending partial
+      // directives. Without this, final-line media is stripped from text but never
+      // delivered to channel adapters.
+      if (options?.final === true && params.onBlockReply) {
+        const splitResult = replyDirectiveAccumulator.consume("", { final: true });
+        if (
+          splitResult ||
+          state.pendingAssistantReplyDirectives ||
+          state.pendingToolMediaUrls.length > 0 ||
+          state.pendingToolAudioAsVoice
+        ) {
+          const {
+            text: cleanedText,
+            mediaUrls,
+            audioAsVoice,
+            replyToId,
+            replyToTag,
+            replyToCurrent,
+          } = splitResult ?? {};
+          emitBlockReply(
+            {
+              text: cleanedText,
+              mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
+              audioAsVoice,
+              replyToId,
+              replyToTag,
+              replyToCurrent,
+            },
+            {
+              assistantMessageIndex: options?.assistantMessageIndex ?? state.assistantMessageIndex,
+              consumePendingToolMedia: true,
+            },
+          );
+        }
+      }
       return;
     }
     if (chunk === state.lastBlockReplyText) {


### PR DESCRIPTION
## Summary

- Flush the streaming reply directive accumulator on final empty block chunks so trailing `MEDIA:/path` lines held in `pendingTail` are not dropped.
- Parse phase-aware final-answer text at `text_end` so providers that only surface final text in the partial can still deliver final media directives.
- Keep structured tool media queued for the final outbound reply instead of treating plain tool-output `MEDIA:` lines as already delivered.

## Real behavior proof

- **Behavior or issue addressed:** Final replies ending with `MEDIA:/path` could be stripped from text but fail to deliver media because the trailing directive stayed in `pendingTail` until the final empty flush, and tool media could also be treated as already emitted before the channel adapter sent it.
- **Real environment tested:** Real OpenClaw setup on `openclaw-01`, `openclaw 2026.5.5`, Node `22.22.2`, `openclaw-weixin` direct chat adapter.
- **Exact steps or command run after this patch:** Applied the runtime fix locally, restarted the Gateway, then sent an actual generated-image reply through the Weixin channel to verify the final outbound reply carried media to the channel adapter.
- **Evidence after fix:** Redacted runtime log excerpt from `/tmp/openclaw/openclaw-2026-05-08.log`:

```text
2026-05-08T15:30:51.192+08:00 gateway/channels/openclaw-weixin outbound: to=o9cq80zcMc6VxG_TAY_MhOnM9ZFM@im.wechat contextToken=AARzJW…(len=136) textLen=323 mediaUrl=present
2026-05-08T15:30:51.192+08:00 gateway/channels/openclaw-weixin [weixin] sendWeixinMediaFile: uploading image filePath=/home/openclaw-01/.openclaw/media/tool-image-generation/hofo_single_green_drink_lidded_menu_square---e80819f5-18cf-428f-a09f-2729abfdf358.jpg to=o9cq80zcMc6VxG_TAY_MhOnM9ZFM@im.wechat
2026-05-08T15:30:51.806+08:00 gateway/channels/openclaw-weixin [weixin] sendWeixinMediaFile: image upload done filekey=93152347eccb73431f937d375d97d01a size=100631
2026-05-08T15:30:51.806+08:00 gateway/channels/openclaw-weixin sendImageMessageWeixin: to=o9cq80zcMc6VxG_TAY_MhOnM9ZFM@im.wechat filekey=93152347eccb73431f937d375d97d01a fileSize=100631 aeskey=present
2026-05-08T15:30:52.208+08:00 gateway/channels/openclaw-weixin sendImageMessageWeixin: success to=o9cq80zcMc6VxG_TAY_MhOnM9ZFM@im.wechat clientId=openclaw-weixin:1778225452026-2ce8066f
2026-05-08T15:30:52.208+08:00 gateway/channels/openclaw-weixin outbound: media sent OK to=o9cq80zcMc6VxG_TAY_MhOnM9ZFM@im.wechat
```

- **Observed result after fix:** The outbound reply had `mediaUrl=present`, `sendWeixinMediaFile` uploaded the generated image, `sendImageMessageWeixin` succeeded, and the channel logged `media sent OK`.
- **What was not tested:** No known gaps.

## Validation

- `corepack pnpm exec vitest run --config test/vitest/vitest.unit.config.ts src/agents/pi-embedded-subscribe.block-reply-rejections.test.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts` ✅
- `git diff --check` ✅
- `corepack pnpm tsgo:test:src` currently fails in this checkout because install was run with `--ignore-scripts`, leaving generated/native dependency types unavailable (examples: `@openclaw/fs-safe/*`, `sharp`, `esbuild`).
