### PR TITLE
fix(slack): keep bot starter context for direct threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/pairing: preserve deliberately narrowed role-token scopes when approving device scope upgrades instead of regranting the whole approved baseline.
 - Telegram/ACP: keep chat-bound ACP replies durable by delivering final-only ACP output as final text instead of transient Telegram preview blocks. Thanks @shakkernerd.
 - Telegram: hydrate replied-to messages as a persisted nearest-first reply chain so agents can see observed parent text, media refs, captions, senders, timestamps, and nested replies instead of guessing from a shallow reply id.
+- Slack: include the bot-authored root message as starter context for direct-message thread replies so follow-up replies to a bot answer keep the answer they are correcting. Fixes #79338.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -49,6 +49,7 @@ describe("resolveSlackThreadContextData", () => {
     threadStarter: { text: string; userId?: string; ts: string; botId?: string };
     allowFromLower: string[];
     allowNameMatching: boolean;
+    messageOverrides?: Partial<SlackMessageEvent>;
   }) {
     const { storePath } = storeFixture.makeTmpStorePath();
     const replies = vi.fn().mockResolvedValue({
@@ -65,7 +66,7 @@ describe("resolveSlackThreadContextData", () => {
     const result = await resolveSlackThreadContextData({
       ctx,
       account: createSlackTestAccount({ thread: { initialHistoryLimit: 20 } }),
-      message: createThreadMessage(),
+      message: createThreadMessage(params.messageOverrides),
       isThreadReply: true,
       threadTs: "100.000",
       threadStarter: params.threadStarter,
@@ -152,6 +153,30 @@ describe("resolveSlackThreadContextData", () => {
     expect(result.threadLabel).toBe("Slack thread #general");
     expect(result.threadHistoryBody).toContain("allowed follow-up");
     expect(result.threadHistoryBody).not.toContain("bot starter");
+    expect(result.threadHistoryBody).not.toContain("current message");
+  });
+
+  it("keeps self-authored starter text for direct message thread replies", async () => {
+    const { result } = await resolveAllowlistedThreadContext({
+      repliesMessages: [
+        { text: "bot decision summary", bot_id: "B1", ts: "100.000" },
+        { text: "actually choose Sunday", user: "U1", ts: "100.800" },
+        { text: "current message", user: "U1", ts: "101.000" },
+      ],
+      threadStarter: {
+        text: "bot decision summary",
+        botId: "B1",
+        ts: "100.000",
+      },
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+      messageOverrides: { channel_type: "im" },
+    });
+
+    expect(result.threadStarterBody).toBe("bot decision summary");
+    expect(result.threadLabel).toContain("bot decision summary");
+    expect(result.threadHistoryBody).toContain("actually choose Sunday");
+    expect(result.threadHistoryBody).not.toContain("bot decision summary");
     expect(result.threadHistoryBody).not.toContain("current message");
   });
 

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -137,8 +137,12 @@ export async function resolveSlackThreadContextData(params: {
       botId: starter.botId,
     }),
   );
+  const allowCurrentBotStarterContext =
+    starterIsCurrentBot &&
+    (params.message.channel_type === "im" || params.message.channel_type === "mpim");
   const starterAllowed =
     !starter ||
+    allowCurrentBotStarterContext ||
     (!starterIsCurrentBot &&
       isSlackThreadContextSenderAllowed({
         allowFromLower: params.allowFromLower,
@@ -149,6 +153,7 @@ export async function resolveSlackThreadContextData(params: {
       }));
   const includeStarterContext =
     !starter ||
+    allowCurrentBotStarterContext ||
     (!starterIsCurrentBot &&
       shouldIncludeSupplementalContext({
         mode: params.contextVisibilityMode,
@@ -175,7 +180,7 @@ export async function resolveSlackThreadContextData(params: {
   } else {
     threadLabel = `Slack thread ${params.roomLabel}`;
   }
-  if (starter?.text && starterIsCurrentBot) {
+  if (starter?.text && starterIsCurrentBot && !allowCurrentBotStarterContext) {
     logVerbose("slack: omitted current-bot thread starter from context");
   } else if (starter?.text && !includeStarterContext) {
     logVerbose(


### PR DESCRIPTION
Fixes #79338.

## Summary
- Include Slack thread starter text when the starter was authored by the current bot and the incoming thread reply is in a DM/MPIM.
- Preserve the existing channel behavior that omits current-bot starter/history context, so channel threads do not start echoing bot-authored messages.
- Add a regression guard for a direct-message thread reply to a bot-authored root message.

## Real behavior proof
Behavior addressed: Slack direct-message thread replies now receive the bot-authored root message as `ThreadStarterBody`, so a follow-up like "actually choose Sunday" can see the bot answer it is correcting.

Real environment tested: Local OpenClaw checkout on Linux using Node with the repo TypeScript runtime loader against the Slack resolver code on branch `fix/slack-dm-thread-bot-starter-context-79338`.

Exact steps or command run after this patch: I ran a direct Node probe with `node --import tsx --input-type=module`, importing `resolveSlackThreadContextData` and constructing a Slack DM thread event whose root message is authored by bot id `B1` and whose current reply is from user `U1`.

Evidence after fix:
```text
ThreadStarterBody=bot decision summary
ThreadLabel=Slack thread DM with Alice: bot decision summary
HistoryHasFollowup=true
HistoryDuplicatesBotRoot=false
```

Observed result after fix: The direct Node probe shows the bot root message is present in `ThreadStarterBody`, the user follow-up is still present in thread history, and the bot root is not duplicated in `ThreadHistoryBody`.

What was not tested: Live Slack workspace round trip was not run; the direct resolver probe uses the same Slack monitor resolver path with redacted local inputs.

## Verification
- `pnpm test -- extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts`
- `pnpm lint`
- `pnpm check:test-types`

## Audit
- Audit A (existing helper): reused the existing local current-bot author check.
- Audit B (shared callers): `resolveSlackThreadContextData` contract preserved; added a channel-type branch rather than changing Slack history filtering globally.
- Audit C (broader rival): no open PR found for #79338 before implementation.