### PR TITLE
fix(cache): honour explicit cacheRetention for OpenRouter→Anthropic models

### DIFF
--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -52,7 +52,7 @@ function isLongTtlEligibleEndpoint(baseUrl: string | undefined): boolean {
   );
 }
 
-function resolveAnthropicEphemeralCacheControl(
+export function resolveAnthropicEphemeralCacheControl(
   baseUrl: string | undefined,
   cacheRetention: AnthropicPayloadPolicyInput["cacheRetention"],
 ): AnthropicEphemeralCacheControl | undefined {
@@ -231,6 +231,8 @@ export function applyAnthropicPayloadPolicyToParams(
 /** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export function applyAnthropicEphemeralCacheControlMarkers(
   payloadObj: Record<string, unknown>,
+  cacheControl: AnthropicEphemeralCacheControl = { type: "ephemeral" },
+  skipMarkerInsertion: boolean = false,
 ): void {
   const messages = payloadObj.messages;
   if (!Array.isArray(messages)) {
@@ -239,18 +241,18 @@ export function applyAnthropicEphemeralCacheControlMarkers(
 
   for (const message of messages as Array<{ role?: string; content?: unknown }>) {
     if (message.role === "system" || message.role === "developer") {
-      if (typeof message.content === "string") {
-        message.content = [
-          { type: "text", text: message.content, cache_control: { type: "ephemeral" } },
-        ];
-        continue;
-      }
-      if (Array.isArray(message.content) && message.content.length > 0) {
-        const last = message.content[message.content.length - 1];
-        if (last && typeof last === "object") {
-          const record = last as Record<string, unknown>;
-          if (record.type !== "thinking" && record.type !== "redacted_thinking") {
-            record.cache_control = { type: "ephemeral" };
+      if (!skipMarkerInsertion) {
+        if (typeof message.content === "string") {
+          message.content = [{ type: "text", text: message.content, cache_control: cacheControl }];
+          continue;
+        }
+        if (Array.isArray(message.content) && message.content.length > 0) {
+          const last = message.content[message.content.length - 1];
+          if (last && typeof last === "object") {
+            const record = last as Record<string, unknown>;
+            if (record.type !== "thinking" && record.type !== "redacted_thinking") {
+              record.cache_control = cacheControl;
+            }
           }
         }
       }

--- a/src/agents/pi-embedded-runner/anthropic-cache-control-payload.test.ts
+++ b/src/agents/pi-embedded-runner/anthropic-cache-control-payload.test.ts
@@ -32,4 +32,29 @@ describe("applyAnthropicEphemeralCacheControlMarkers", () => {
       },
     ]);
   });
+
+  it("preserves ttl in custom cacheControl when provided", () => {
+    const payload = {
+      messages: [
+        {
+          role: "system",
+          content: "system prompt",
+        },
+      ],
+    } satisfies Record<string, unknown>;
+
+    applyAnthropicEphemeralCacheControlMarkers(payload, {
+      type: "ephemeral",
+      ttl: "1h",
+    });
+
+    expect(payload.messages).toEqual([
+      {
+        role: "system",
+        content: [
+          { type: "text", text: "system prompt", cache_control: { type: "ephemeral", ttl: "1h" } },
+        ],
+      },
+    ]);
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -686,7 +686,10 @@ function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
 function applyPostPluginStreamWrappers(
   ctx: ApplyExtraParamsContext & { providerWrapperHandled: boolean },
 ): void {
-  ctx.agent.streamFn = createOpenRouterSystemCacheWrapper(ctx.agent.streamFn);
+  ctx.agent.streamFn = createOpenRouterSystemCacheWrapper(
+    ctx.agent.streamFn,
+    ctx.effectiveExtraParams,
+  );
   ctx.agent.streamFn = createOpenAIStringContentWrapper(ctx.agent.streamFn);
   ctx.agent.streamFn = createOpenAICompletionsStrictMessageKeysWrapper(ctx.agent.streamFn);
   ctx.agent.streamFn = createOpenAICompletionsToolsCompatWrapper(ctx.agent.streamFn);

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -406,6 +406,7 @@ function createStreamFnWithExtraParams(
     provider,
     typeof model?.api === "string" ? model.api : undefined,
     typeof model?.id === "string" ? model.id : undefined,
+    typeof model?.baseUrl === "string" ? model.baseUrl : undefined,
   );
   if (Object.keys(streamParams).length > 0 || initialCacheRetention) {
     const debugParams = initialCacheRetention
@@ -421,6 +422,7 @@ function createStreamFnWithExtraParams(
       provider,
       typeof callModel.api === "string" ? callModel.api : undefined,
       typeof callModel.id === "string" ? callModel.id : undefined,
+      typeof callModel.baseUrl === "string" ? callModel.baseUrl : undefined,
     );
     if (Object.keys(streamParams).length === 0 && !cacheRetention) {
       return underlying(callModel, context, options);

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
@@ -29,6 +29,69 @@ describe("prompt cache retention", () => {
       resolveCacheRetention(undefined, "google", "google-generative-ai", "gemini-3.1-pro-preview"),
     ).toBeUndefined();
   });
+  it("honours explicit cacheRetention for OpenRouter Anthropic models", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "openrouter",
+        "openai-completions",
+        "anthropic/claude-haiku-4.5",
+      ),
+    ).toBe("long");
+  });
+
+  it('honours explicit cacheRetention "short" for proxy providers', () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "short" },
+        "openrouter",
+        "openai-completions",
+        "anthropic/claude-sonnet-4.6",
+      ),
+    ).toBe("short");
+  });
+
+  it('honours explicit cacheRetention "none" for proxy providers', () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "none" },
+        "openrouter",
+        "openai-completions",
+        "anthropic/claude-sonnet-4.6",
+      ),
+    ).toBe("none");
+  });
+
+  it("returns undefined for proxy providers without explicit config", () => {
+    expect(
+      resolveCacheRetention(
+        undefined,
+        "openrouter",
+        "openai-completions",
+        "anthropic/claude-sonnet-4.6",
+      ),
+    ).toBeUndefined();
+  });
+  it("ignores explicit cacheRetention for non-OpenRouter providers without cache family", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "amazon-bedrock",
+        "openai-completions",
+        "some/non-anthropic-model",
+      ),
+    ).toBeUndefined();
+  });
+  it("ignores explicit cacheRetention for OpenRouter non-Anthropic models", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "openrouter",
+        "openai-completions",
+        "deepseek/deepseek-r1",
+      ),
+    ).toBeUndefined();
+  });
 
   it("identifies supported direct Google cache families", () => {
     expect(

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
@@ -93,6 +93,42 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
+  it("skips explicit cacheRetention for OpenRouter provider on a non-OpenRouter baseUrl", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "openrouter",
+        "openai-completions",
+        "anthropic/claude-sonnet-4.6",
+        "https://my-custom-proxy.example.com/v1",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("honours explicit cacheRetention for OpenRouter provider on the default (unset) baseUrl", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "openrouter",
+        "openai-completions",
+        "anthropic/claude-sonnet-4.6",
+        undefined,
+      ),
+    ).toBe("long");
+  });
+
+  it("honours explicit cacheRetention for OpenRouter provider with openrouter.ai baseUrl", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "openrouter",
+        "openai-completions",
+        "anthropic/claude-sonnet-4.6",
+        "https://openrouter.ai/api/v1",
+      ),
+    ).toBe("long");
+  });
+
   it("identifies supported direct Google cache families", () => {
     expect(
       isGooglePromptCacheEligible({

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.ts
@@ -1,5 +1,8 @@
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
-import { resolveAnthropicCacheRetentionFamily } from "./anthropic-family-cache-semantics.js";
+import {
+  isAnthropicModelRef,
+  resolveAnthropicCacheRetentionFamily,
+} from "./anthropic-family-cache-semantics.js";
 
 type CacheRetention = "none" | "short" | "long";
 
@@ -22,6 +25,7 @@ export function resolveCacheRetention(
 ): CacheRetention | undefined {
   const hasExplicitCacheConfig =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
+
   const family = resolveAnthropicCacheRetentionFamily({
     provider,
     modelApi,
@@ -30,21 +34,31 @@ export function resolveCacheRetention(
   });
   const googleEligible = isGooglePromptCacheEligible({ modelApi, modelId });
 
+  // Determine if this is a verified OpenRouter→Anthropic route.
+  // OpenRouter uses the "openai-completions" API and the model ref
+  // starts with "anthropic/". This mirrors the endpoint-class +
+  // model-ref check in createOpenRouterSystemCacheWrapper.
+  const isOpenRouterAnthropicRoute =
+    provider === "openrouter" && modelId != null && isAnthropicModelRef(modelId);
+
+  const isEligible = !!family || googleEligible || isOpenRouterAnthropicRoute;
+
+  if (hasExplicitCacheConfig && isEligible) {
+    const newVal = extraParams?.cacheRetention;
+    if (newVal === "none" || newVal === "short" || newVal === "long") {
+      return newVal;
+    }
+    const legacy = extraParams?.cacheControlTtl;
+    if (legacy === "5m") {
+      return "short";
+    }
+    if (legacy === "1h") {
+      return "long";
+    }
+  }
+
   if (!family && !googleEligible) {
     return undefined;
-  }
-
-  const newVal = extraParams?.cacheRetention;
-  if (newVal === "none" || newVal === "short" || newVal === "long") {
-    return newVal;
-  }
-
-  const legacy = extraParams?.cacheControlTtl;
-  if (legacy === "5m") {
-    return "short";
-  }
-  if (legacy === "1h") {
-    return "long";
   }
 
   return family === "anthropic-direct" ? "short" : undefined;

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.ts
@@ -1,4 +1,5 @@
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
+import { resolveProviderRequestPolicy } from "../provider-attribution.js";
 import {
   isAnthropicModelRef,
   resolveAnthropicCacheRetentionFamily,
@@ -22,6 +23,7 @@ export function resolveCacheRetention(
   provider: string,
   modelApi?: string,
   modelId?: string,
+  baseUrl?: string,
 ): CacheRetention | undefined {
   const hasExplicitCacheConfig =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
@@ -34,12 +36,22 @@ export function resolveCacheRetention(
   });
   const googleEligible = isGooglePromptCacheEligible({ modelApi, modelId });
 
-  // Determine if this is a verified OpenRouter→Anthropic route.
-  // OpenRouter uses the "openai-completions" API and the model ref
-  // starts with "anthropic/". This mirrors the endpoint-class +
-  // model-ref check in createOpenRouterSystemCacheWrapper.
+  // Determine if this is a verified OpenRouter→Anthropic route using
+  // the same endpoint-class gate as createOpenRouterSystemCacheWrapper.
+  // This prevents cacheRetention from leaking to arbitrary OpenAI proxies
+  // when the OpenRouter provider is repointed at a custom baseUrl.
+  const endpointClass = resolveProviderRequestPolicy({
+    provider,
+    api: modelApi,
+    baseUrl,
+    capability: "llm",
+    transport: "stream",
+  }).endpointClass;
   const isOpenRouterAnthropicRoute =
-    provider === "openrouter" && modelId != null && isAnthropicModelRef(modelId);
+    (endpointClass === "openrouter" ||
+      (endpointClass === "default" && provider === "openrouter")) &&
+    modelId != null &&
+    isAnthropicModelRef(modelId);
 
   const isEligible = !!family || googleEligible || isOpenRouterAnthropicRoute;
 

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
@@ -7,7 +7,10 @@ import {
   createOpenRouterWrapper,
 } from "./proxy-stream-wrappers.js";
 
-function runSystemCacheWrapper(model: Partial<Model<"openai-completions">>) {
+function runSystemCacheWrapper(
+  model: Partial<Model<"openai-completions">>,
+  extraParams?: Record<string, unknown>,
+) {
   const payload = {
     messages: [{ role: "system", content: "system prompt" }],
   };
@@ -16,7 +19,7 @@ function runSystemCacheWrapper(model: Partial<Model<"openai-completions">>) {
     return createAssistantMessageEventStream();
   };
 
-  const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn);
+  const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn, extraParams);
   void wrapped(
     {
       api: "openai-completions",
@@ -200,6 +203,86 @@ describe("proxy stream wrappers", () => {
       baseUrl: "https://openrouter.ai/api/v1",
     });
 
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("includes ttl: 1h in cache_control when cacheRetention is long", () => {
+    const payload = runSystemCacheWrapper({}, { cacheRetention: "long" });
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral", ttl: "1h" } },
+    ]);
+  });
+
+  it("omits ttl in cache_control when cacheRetention is short", () => {
+    const payload = runSystemCacheWrapper({}, { cacheRetention: "short" });
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("omits ttl in cache_control when cacheRetention is not provided", () => {
+    const payload = runSystemCacheWrapper({});
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("skips cache_control markers when cacheRetention is none but still strips thinking cache_control", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "system prompt" },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", text: "draft", cache_control: { type: "ephemeral" } },
+            { type: "text", text: "answer" },
+          ],
+        },
+      ],
+    } satisfies Record<string, unknown>;
+    const baseStreamFn: StreamFn = (_resolvedModel, _context, options) => {
+      options?.onPayload?.(payload, {} as any);
+      return createAssistantMessageEventStream();
+    };
+    const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn, { cacheRetention: "none" });
+    wrapped(
+      {
+        id: "anthropic/claude-sonnet-4.6",
+        api: "openai-completions",
+        provider: "openrouter",
+      } as any,
+      {} as any,
+      { onPayload: () => {} } as any,
+    );
+    // System message: no cache_control added
+    expect(payload.messages[0]?.content).toBe("system prompt");
+    // Thinking block: cache_control stripped (sanitizer still active)
+    expect(payload.messages[1]?.content[0]).not.toHaveProperty("cache_control");
+  });
+
+  it("honours cacheRetention on custom provider pointing to openrouter.ai", () => {
+    const payload = runSystemCacheWrapper(
+      { provider: "custom-openrouter", baseUrl: "https://openrouter.ai/api/v1" } as Partial<
+        Model<"openai-completions">
+      >,
+      { cacheRetention: "long" },
+    );
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral", ttl: "1h" } },
+    ]);
+  });
+
+  it("honours legacy cacheControlTtl: 1h as cacheRetention long", () => {
+    const payload = runSystemCacheWrapper({}, { cacheControlTtl: "1h" });
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral", ttl: "1h" } },
+    ]);
+  });
+
+  it("honours legacy cacheControlTtl: 5m as cacheRetention short", () => {
+    const payload = runSystemCacheWrapper({}, { cacheControlTtl: "5m" });
     expect(payload.messages[0]?.content).toEqual([
       { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
     ]);

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -2,9 +2,13 @@ import type { StreamFn } from "@earendil-works/pi-agent-core";
 import { streamSimple } from "@earendil-works/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../../shared/string-coerce.js";
+import {
+  applyAnthropicEphemeralCacheControlMarkers,
+  resolveAnthropicEphemeralCacheControl,
+  type AnthropicEphemeralCacheControl,
+} from "../anthropic-payload-policy.js";
 import { resolveProviderRequestPolicy } from "../provider-attribution.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
-import { applyAnthropicEphemeralCacheControlMarkers } from "./anthropic-cache-control-payload.js";
 import { isAnthropicModelRef } from "./anthropic-family-cache-semantics.js";
 import { mapThinkingLevelToReasoningEffort } from "./reasoning-effort-utils.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
@@ -151,7 +155,10 @@ function normalizeProxyReasoningPayload(payload: unknown, thinkingLevel?: ThinkL
 }
 
 /** @deprecated OpenRouter provider-owned stream helper; do not use from third-party plugins. */
-export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+export function createOpenRouterSystemCacheWrapper(
+  baseStreamFn: StreamFn | undefined,
+  extraParams?: Record<string, unknown>,
+): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const provider = readStringValue(model.provider);
@@ -165,19 +172,42 @@ export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | unde
       capability: "llm",
       transport: "stream",
     }).endpointClass;
-    if (
-      !modelId ||
-      !isAnthropicModelRef(modelId) ||
-      !(
-        endpointClass === "openrouter" ||
-        (endpointClass === "default" && normalizeOptionalLowercaseString(provider) === "openrouter")
-      )
-    ) {
+    const isOpenRouterRoute =
+      endpointClass === "openrouter" ||
+      (endpointClass === "default" && normalizeOptionalLowercaseString(provider) === "openrouter");
+    if (!modelId || !isAnthropicModelRef(modelId) || !isOpenRouterRoute) {
       return underlying(model, context, options);
     }
-
+    // Resolve cacheRetention from extraParams only after confirming this
+    // is a verified OpenRouter→Anthropic route. This covers both built-in
+    // and custom-provider OpenRouter hosts (endpoint-class based), so
+    // explicit cacheRetention on any OpenRouter Anthropic route is honoured.
+    // Also support the legacy cacheControlTtl key ("5m" / "1h").
+    const explicitRetention = extraParams?.cacheRetention;
+    let cacheRetention: "short" | "long" | "none" | undefined =
+      explicitRetention === "none" || explicitRetention === "short" || explicitRetention === "long"
+        ? explicitRetention
+        : undefined;
+    if (cacheRetention === undefined) {
+      const legacy = extraParams?.cacheControlTtl;
+      if (legacy === "5m") {
+        cacheRetention = "short";
+      } else if (legacy === "1h") {
+        cacheRetention = "long";
+      }
+    }
+    // cacheRetention "none" means no new cache markers, but the sanitizer
+    // (thinking/redacted_thinking cleanup) must still run.
+    const cacheControl: AnthropicEphemeralCacheControl | undefined =
+      cacheRetention === "none"
+        ? undefined
+        : resolveAnthropicEphemeralCacheControl(undefined, cacheRetention);
     return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
-      applyAnthropicEphemeralCacheControlMarkers(payloadObj);
+      applyAnthropicEphemeralCacheControlMarkers(
+        payloadObj,
+        cacheControl ?? { type: "ephemeral" },
+        cacheRetention === "none",
+      );
     });
   };
 }


### PR DESCRIPTION
## Problem

When `cacheRetention: "long"` is explicitly configured for Anthropic models routed through OpenRouter, the resulting requests carry `cache_control: { type: "ephemeral" }` **without** `ttl: "1h"`. This means only 5-minute prompt cache lifetime instead of the expected 1 hour — a significant cost regression for heavy users. Additionally, `cacheRetention: "none"` was also silently ignored — the OpenRouter wrapper always injected ephemeral cache markers regardless.

The same `cacheRetention: "long"` config works correctly when using the direct Anthropic API.

## Root Cause

Three bugs in sequence:

### 1. `resolveCacheRetention()` — early return ignores explicit config

`src/agents/pi-embedded-runner/prompt-cache-retention.ts`

The function checked `resolveAnthropicCacheRetentionFamily()` first. For `provider: "openrouter"`, this returns `undefined` (not a recognized Anthropic/Google cache family). The subsequent early return:

```ts
if (!family && !googleEligible) {
  return undefined;
}
```

exited **before** ever checking `extraParams.cacheRetention`. Even with `cacheRetention: "long"` explicitly set in config, the function never reached that check.

**Fix:** Move explicit-config checks (`cacheRetention` / legacy `cacheControlTtl`) **before** the family-based early return, so operator-specified retention always wins.

### 2. `applyAnthropicEphemeralCacheControlMarkers()` — hardcoded no-TTL markers

`src/agents/anthropic-payload-policy.ts`

Called by `createOpenRouterSystemCacheWrapper`, this function always wrote `{ type: "ephemeral" }` — even if the wrapper had resolved a `cacheControl` with `ttl: "1h"`, the TTL was discarded.

**Fix:** Accept an optional `cacheControl: AnthropicEphemeralCacheControl` parameter (defaults to `{ type: "ephemeral" }` for backward compat). Also export `resolveAnthropicEphemeralCacheControl()` so the wrapper can build the proper marker with TTL.

### 3. `cacheRetention: "none"` still injected markers

`src/agents/pi-embedded-runner/proxy-stream-wrappers.ts`

When `cacheRetention` is `"none"`, `resolveAnthropicEphemeralCacheControl` correctly returns `undefined`, but the wrapper's `cacheControl ?? { type: "ephemeral" }` fallback still injected a short-cache marker — contradicting the operator's explicit opt-out.

**Fix:** Skip marker insertion entirely when `cacheRetention === "none"`.

## Before / After

**Before** (OpenRouter→Anthropic, `cacheRetention: "long"`):
```json
"cache_control": { "type": "ephemeral" }
```

**After** (same config):
```json
"cache_control": { "type": "ephemeral", "ttl": "1h" }
```

**After** (`cacheRetention: "none"`): no `cache_control` markers at all.

## Review Fix: endpoint-class gate in resolveCacheRetention

Initial patch checked `provider === "openrouter"` in `resolveCacheRetention()`, but this did not account for `baseUrl`. If a user repoints the OpenRouter provider at a custom OpenAI-compatible proxy, the system wrapper correctly skips markers via the endpoint-class gate, but `resolveCacheRetention()` would still pass `cacheRetention` through to pi-ai — leaking `cache_control` with TTL to that proxy path.

**Fix:** `resolveCacheRetention()` now accepts an optional `baseUrl` parameter and uses `resolveProviderRequestPolicy` to determine `endpointClass`, mirroring the same gate as `createOpenRouterSystemCacheWrapper`. Both call sites in `extra-params.ts` pass `model.baseUrl` / `callModel.baseUrl`.

Regression tests added:
- OpenRouter provider + non-OpenRouter baseUrl → `undefined` (no leak)
- OpenRouter provider + default (unset) baseUrl → honoured
- OpenRouter provider + `openrouter.ai` baseUrl → honoured

## Real Behavior Proof

**Behavior or issue addressed:** `cacheRetention: "long"` config was silently ignored for OpenRouter→Anthropic models. Requests always got 5-minute ephemeral cache markers instead of 1-hour TTL. `cacheRetention: "none"` was also ignored — markers were always injected.

**Real environment tested:** Self-hosted OpenClaw v2026.5.7 on VMware VM (Linux Mint), OpenRouter provider, model `openrouter/anthropic/claude-haiku-4.5` with `params.cacheRetention: "long"`. Outbound request payloads captured via HTTPS logging proxy.

**Exact steps or command run after the patch:**
1. Built patched dist from fork branch cherry-picked onto `v2026.5.7` tag
2. Replaced `dist/` in production install and restarted gateway
3. Sent test message to Haiku model via Telegram
4. Captured outbound request payload through logging proxy

**Evidence after fix:**
```
=== Captured request payload (after patch, v2026.5.7) ===
model: anthropic/claude-haiku-4.5
system message: cache_control: { "type": "ephemeral", "ttl": "1h" }
last user message: cache_control: { "type": "ephemeral", "ttl": "1h" }
last tool definition: cache_control: { "type": "ephemeral", "ttl": "1h" }
```

**Observed result after the fix:** All 3 `cache_control` markers in the Anthropic-format payload now include `"ttl": "1h"`. Before the patch (same config, unpatched v2026.5.7), all 3 markers had only `{ "type": "ephemeral" }` without ttl. The fix restores the expected 1-hour prompt cache lifetime on the Anthropic backend, matching the direct Anthropic API behavior. When `cacheRetention: "none"` is set, no cache markers are injected.

**What was not tested:** Cache hit/miss ratio on the Anthropic backend side (only verified outbound `cache_control` markers). Did not test with `provider: "anthropic"` direct API (already working). Did not test `cacheRetention: "none"` end-to-end (unit test coverage only).

## Changes

| File | Change |
|------|--------|
| `prompt-cache-retention.ts` | Reorder: explicit config checks before family early-return; add `baseUrl` param; use `resolveProviderRequestPolicy` for endpoint-class gate |
| `anthropic-payload-policy.ts` | Export `resolveAnthropicEphemeralCacheControl`; add `cacheControl` param to marker function |
| `proxy-stream-wrappers.ts` | Accept `extraParams`; resolve + pass `cacheControl` with TTL; skip markers when `"none"` |
| `extra-params.ts` | Pass `effectiveExtraParams` to wrapper; pass `baseUrl` to `resolveCacheRetention` |

## Tests

| Test file | New cases |
|-----------|-----------|
| `prompt-cache-retention.test.ts` | explicit `long`/`short`/`none` for OpenRouter Anthropic; `undefined` without config; endpoint-class baseUrl gating (3 tests) |
| `anthropic-cache-control-payload.test.ts` | preserves `ttl` in custom `cacheControl` |
| `proxy-stream-wrappers.test.ts` | `ttl: "1h"` with `long`; no ttl with `short`/default; no markers with `"none"`; custom provider pointing to openrouter.ai |

## Related

- PR #42961 — addressed similar issue but targeted an older code architecture before the endpoint-class gating refactor
- PR #60761 — gates cache markers by endpoint class (orthogonal to this fix which is about TTL preservation)