### PR TITLE
fix(imessage): keep pasted links, ignore Apple preview blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/iMessage: ignore Apple link-preview plugin payload attachments when users paste URLs, keeping the URL text while avoiding phantom media context. (#79374) Thanks @homer-byte.
 - fix(plugins): scan installed dependency runtime code [AI]. (#81066) Thanks @pgondhi987.
 - Inherit tool restrictions for delegated sessions [AI]. (#80979) Thanks @pgondhi987.
 - Telegram: discard legacy long-poll update offsets that cannot be tied to the current bot token, so token rotation no longer leaves bots silently skipping new messages. (#80671) Thanks @sxxtony.

--- a/extensions/imessage/src/monitor.plugin-payload.test.ts
+++ b/extensions/imessage/src/monitor.plugin-payload.test.ts
@@ -1,0 +1,102 @@
+import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { createIMessageRpcClient } from "./client.js";
+import { monitorIMessageProvider } from "./monitor.js";
+
+const waitForTransportReadyMock = vi.hoisted(() =>
+  vi.fn<typeof waitForTransportReady>(async () => {}),
+);
+const createIMessageRpcClientMock = vi.hoisted(() => vi.fn<typeof createIMessageRpcClient>());
+const shouldDebounceTextInboundMock = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("openclaw/plugin-sdk/transport-ready-runtime", () => ({
+  waitForTransportReady: waitForTransportReadyMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  return {
+    ...actual,
+    createChannelInboundDebouncer: vi.fn(
+      (opts: { shouldDebounce: (entry: unknown) => boolean }) => ({
+        debouncer: {
+          enqueue: async (entry: unknown) => {
+            opts.shouldDebounce(entry);
+          },
+        },
+      }),
+    ),
+    shouldDebounceTextInbound: shouldDebounceTextInboundMock,
+  };
+});
+
+vi.mock("./client.js", () => ({
+  createIMessageRpcClient: createIMessageRpcClientMock,
+}));
+
+vi.mock("./monitor/abort-handler.js", () => ({
+  attachIMessageMonitorAbortHandler: vi.fn(() => () => {}),
+}));
+
+describe("iMessage plugin payload attachments", () => {
+  beforeEach(() => {
+    waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);
+    createIMessageRpcClientMock.mockReset();
+    shouldDebounceTextInboundMock.mockReset().mockReturnValue(false);
+  });
+
+  it("does not count Apple rich-link plugin payloads as user media", async () => {
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async () => ({ subscription: 1 })),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 1,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "https://example.com/article",
+              attachments: [
+                {
+                  original_path:
+                    "/Users/openclaw/Library/Messages/Attachments/AA/BB/link.pluginPayloadAttachment",
+                  mime_type: null,
+                  missing: false,
+                  transfer_name: "link.pluginPayloadAttachment",
+                  uti: "com.apple.messages.pluginPayloadAttachment",
+                },
+              ],
+              is_group: false,
+            },
+          },
+        });
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: { imessage: { includeAttachments: true, dmPolicy: "open" } },
+        session: { mainKey: "main" },
+      } as never,
+    });
+
+    expect(shouldDebounceTextInboundMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "https://example.com/article",
+        hasMedia: false,
+      }),
+    );
+  });
+});

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -75,6 +75,21 @@ import { sanitizeIMessageWatchErrorPayload } from "./watch-error-log.js";
 const WATCH_SUBSCRIBE_MAX_ATTEMPTS = 3;
 const WATCH_SUBSCRIBE_RETRY_DELAY_MS = 1_000;
 
+function isIMessagePluginPayloadAttachment(attachment: {
+  original_path?: string | null;
+  transfer_name?: string | null;
+  uti?: string | null;
+}): boolean {
+  const attachmentPath = attachment.original_path?.trim().toLowerCase() ?? "";
+  const transferName = attachment.transfer_name?.trim().toLowerCase() ?? "";
+  const uti = attachment.uti?.trim().toLowerCase() ?? "";
+  return (
+    attachmentPath.endsWith(".pluginpayloadattachment") ||
+    transferName.endsWith(".pluginpayloadattachment") ||
+    uti === "com.apple.messages.pluginpayloadattachment"
+  );
+}
+
 async function detectRemoteHostFromCliPath(cliPath: string): Promise<string | undefined> {
   try {
     const expanded = cliPath.startsWith("~")
@@ -296,7 +311,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       return shouldDebounceTextInbound({
         text: msg.text,
         cfg,
-        hasMedia: Boolean(msg.attachments && msg.attachments.length > 0),
+        hasMedia: Boolean(
+          msg.attachments?.some((attachment) => !isIMessagePluginPayloadAttachment(attachment)),
+        ),
       });
     },
     onFlush: async (entries) => {
@@ -337,6 +354,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const attachments = includeAttachments ? (message.attachments ?? []) : [];
     const effectiveAttachmentRoots = remoteHost ? remoteAttachmentRoots : attachmentRoots;
     const validAttachments = attachments.filter((entry) => {
+      if (isIMessagePluginPayloadAttachment(entry)) {
+        // Apple rich-link previews arrive as opaque .pluginPayloadAttachment
+        // files. The useful URL remains in message.text/attributedBody; treating
+        // the preview blob as media creates noisy phantom attachments and can
+        // keep split-send URL previews out of the text debounce path.
+        return false;
+      }
       const attachmentPath = entry?.original_path?.trim();
       if (!attachmentPath || entry?.missing) {
         return false;

--- a/extensions/imessage/src/monitor/parse-notification.test.ts
+++ b/extensions/imessage/src/monitor/parse-notification.test.ts
@@ -66,4 +66,37 @@ describe("parseIMessageNotification", () => {
     expect(parsed?.reaction_emoji).toBe("👍");
     expect(parsed?.reacted_to_guid).toBe("target-guid");
   });
+
+  it("accepts iMessage attachment transfer_name and uti metadata", () => {
+    const parsed = parseIMessageNotification({
+      message: {
+        id: 1,
+        guid: "link-preview-guid",
+        chat_id: 2,
+        sender: "+10000000000",
+        is_from_me: false,
+        text: "https://example.com/article",
+        attachments: [
+          {
+            original_path:
+              "/Users/openclaw/Library/Messages/Attachments/AA/BB/link.pluginPayloadAttachment",
+            mime_type: null,
+            missing: false,
+            transfer_name: "link.pluginPayloadAttachment",
+            uti: "com.apple.messages.pluginPayloadAttachment",
+          },
+        ],
+        chat_identifier: null,
+        chat_guid: null,
+        chat_name: null,
+        participants: null,
+        is_group: false,
+      },
+    });
+
+    expect(parsed?.attachments?.[0]).toMatchObject({
+      transfer_name: "link.pluginPayloadAttachment",
+      uti: "com.apple.messages.pluginPayloadAttachment",
+    });
+  });
 });

--- a/extensions/imessage/src/monitor/parse-notification.ts
+++ b/extensions/imessage/src/monitor/parse-notification.ts
@@ -42,7 +42,9 @@ function isOptionalAttachments(value: unknown): value is IMessagePayload["attach
     return (
       isOptionalString(attachment.original_path) &&
       isOptionalString(attachment.mime_type) &&
-      isOptionalBoolean(attachment.missing)
+      isOptionalBoolean(attachment.missing) &&
+      isOptionalString(attachment.transfer_name) &&
+      isOptionalString(attachment.uti)
     );
   });
 }

--- a/extensions/imessage/src/monitor/types.ts
+++ b/extensions/imessage/src/monitor/types.ts
@@ -5,6 +5,8 @@ type IMessageAttachment = {
   original_path?: string | null;
   mime_type?: string | null;
   missing?: boolean | null;
+  transfer_name?: string | null;
+  uti?: string | null;
 };
 
 export type IMessagePayload = {


### PR DESCRIPTION
## Summary
- ignore Apple `.pluginPayloadAttachment` rich-link preview blobs in the iMessage monitor
- keep pasted links flowing through the text/debounce path instead of treating private Apple preview wrappers as real user media
- preserve optional `transfer_name` / `uti` attachment metadata so preview blobs can be identified reliably

## User problem
When someone pastes a URL into Messages, Apple often turns it into a rich preview. In `chat.db`, that can show up as a normal URL in `message.text` plus an opaque `.pluginPayloadAttachment` attached to the same message.

To the user, they sent a link. To OpenClaw, that preview wrapper can make the message look like user-provided media. That is misleading: the preview file is Apple UI chrome, not content the agent should inspect.

## Fix
This PR treats `.pluginPayloadAttachment` files as link-preview wrappers, not inbound media:

- `monitor-provider` ignores preview blobs when deciding whether the inbound message has real media.
- media placeholder/path construction filters those blobs before dispatch.
- attachment parsing accepts optional `transfer_name` and `uti` fields so preview wrappers can be identified even when the original path is not the best signal.

This does not try to solve every split-send case where Apple stores text and URL previews as separate rows. That behavior is covered by the iMessage same-sender DM coalescing work in #78317. This PR is the narrower fix for the common case where the URL is already present in text and the preview blob should stay out of the agent's way.

## Real behavior proof
Behavior or issue addressed: A real inbound iMessage link preview from Messages.app produced a normal URL in `message.text` plus an Apple `.pluginPayloadAttachment` blob. The patch keeps the URL as text and prevents the preview wrapper from being treated as user media.

Real environment tested: macOS OpenClaw setup on an Apple silicon Mac mini, using a real inbound iMessage row from `/Users/openclaw/Library/Messages/chat.db` and the actual attachment file under `/Users/openclaw/Library/Messages/Attachments/...`.

Exact steps or command run after this patch: Queried the real `chat.db` row for Rich's pasted `https://x.com/pushmeet/status/2052507929153294387` message, confirmed the associated attachment was a `.pluginPayloadAttachment`, then exercised the patched monitor filtering/staging path against that real attachment metadata.

Evidence after fix: Terminal output from the real Mac/OpenClaw setup:

```text
Real iMessage row from chat.db:
{
  "message_id": 5602,
  "text": "https://x.com/pushmeet/status/2052507929153294387",
  "transfer_name": "BA909CB9-A19F-464A-AFA4-2DA8A7FFA591.pluginPayloadAttachment",
  "mime_type": null,
  "total_bytes": 13866
}

Patched filtering result for the real .pluginPayloadAttachment:
{
  "hasRealMedia": false,
  "stagedMedia": []
}
```

Observed result after fix: The real pasted URL remains visible in `message.text`, while the Apple preview blob is ignored as media.

What was not tested: A full live Gateway restart with this branch installed. The tested path is the patched filtering/staging behavior using a real inbound iMessage link-preview fixture from the live Mac.

## Related PR / base note
This PR is independent of #78580. Real iMessage attachments should still be handled as attachments; Apple link-preview wrappers should not be treated as user media. The branch has been cleaned down to a single link-preview wrapper commit; no #78580 changes are included.

For split-send cases where Apple stores the user's text and pasted URL as separate message rows, the related work is the iMessage same-sender DM coalescing support in #78317.

## Tests
- `pnpm exec oxfmt --check --threads=1 extensions/imessage/src/monitor.plugin-payload.test.ts extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor/parse-notification.ts extensions/imessage/src/monitor/types.ts extensions/imessage/src/monitor/parse-notification.test.ts`
- `node scripts/run-vitest.mjs run extensions/imessage/src/monitor.plugin-payload.test.ts extensions/imessage/src/monitor/parse-notification.test.ts`

Note: local `pnpm check:changed` still reaches the repo-wide extensions typecheck and fails on `extensions/oc-path` `jsonc-parser` resolution errors on current `main`, unrelated to this PR.

