### PR TITLE
Fix node host zombie gateway drops

### DIFF
--- a/src/node-host/runner.credentials.test.ts
+++ b/src/node-host/runner.credentials.test.ts
@@ -194,6 +194,24 @@ describe("createNodeHostGatewayDropWatchdog", () => {
     expect(exit).toHaveBeenCalledWith(1);
   });
 
+  it("counts a connect error followed by abnormal close as one failed attempt", () => {
+    const exit = vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    }) as (code: number) => never;
+    const watchdog = createNodeHostGatewayDropWatchdog({ writeLine: () => {}, exit });
+
+    watchdog.recordConnectError(new Error("Unexpected server response: 502"));
+    watchdog.recordClose(1006, "abnormal closure");
+    watchdog.recordConnectError(new Error("Unexpected server response: 502"));
+    watchdog.recordClose(1006, "abnormal closure");
+
+    expect(exit).not.toHaveBeenCalled();
+    expect(() =>
+      watchdog.recordConnectError(new Error("Unexpected server response: 502")),
+    ).toThrow("exit 1");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
   it("does not exit for isolated or stale abnormal gateway drops", () => {
     let currentTime = 1_000;
     const exit = vi.fn((code: number) => {

--- a/src/node-host/runner.credentials.test.ts
+++ b/src/node-host/runner.credentials.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { ConnectErrorDetailCodes } from "../gateway/protocol/connect-error-details.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
+  createNodeHostGatewayDropWatchdog,
   handleNodeHostReconnectPaused,
   resolveNodeHostGatewayCredentials,
   shouldExitNodeHostOnReconnectPaused,
@@ -150,6 +151,66 @@ describe("resolveNodeHostGatewayCredentials", () => {
         expect(credentials.password).toBeUndefined();
       },
     );
+  });
+});
+
+describe("createNodeHostGatewayDropWatchdog", () => {
+  it("exits after repeated abnormal websocket closes so systemd can restart zombies", () => {
+    let currentTime = 1_000;
+    const lines: string[] = [];
+    const exit = vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    }) as (code: number) => never;
+    const watchdog = createNodeHostGatewayDropWatchdog({
+      now: () => currentTime,
+      writeLine: (line) => lines.push(line),
+      exit,
+    });
+
+    watchdog.recordClose(1006, "");
+    currentTime += 1_000;
+    watchdog.recordClose(1006, "abnormal closure");
+    currentTime += 1_000;
+
+    expect(() => watchdog.recordClose(1006, "abnormal closure")).toThrow("exit 1");
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(lines).toEqual([
+      "node host gateway unhealthy after 3 transport failures in 60000ms (gateway closed (1006): abnormal closure); exiting for supervisor restart",
+    ]);
+  });
+
+  it("exits after repeated gateway proxy 502 connect failures", () => {
+    const exit = vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    }) as (code: number) => never;
+    const watchdog = createNodeHostGatewayDropWatchdog({ writeLine: () => {}, exit });
+
+    watchdog.recordConnectError(new Error("Unexpected server response: 502"));
+    watchdog.recordConnectError(new Error("Unexpected server response: 502"));
+
+    expect(() =>
+      watchdog.recordConnectError(new Error("Unexpected server response: 502")),
+    ).toThrow("exit 1");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not exit for isolated or stale abnormal gateway drops", () => {
+    let currentTime = 1_000;
+    const exit = vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    }) as (code: number) => never;
+    const watchdog = createNodeHostGatewayDropWatchdog({
+      now: () => currentTime,
+      writeLine: () => {},
+      exit,
+    });
+
+    watchdog.recordClose(1006, "abnormal closure");
+    currentTime += 61_000;
+    watchdog.recordConnectError(new Error("Unexpected server response: 502"));
+    watchdog.recordClose(1000, "normal closure");
+
+    expect(exit).not.toHaveBeenCalled();
   });
 });
 

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -53,6 +53,65 @@ type NodeHostReconnectPausedDeps = {
   exit?: (code: number) => never;
 };
 
+type NodeHostGatewayDropDeps = {
+  now?: () => number;
+  writeLine?: (message: string) => void;
+  exit?: (code: number) => never;
+};
+
+const NODE_HOST_UNHEALTHY_GATEWAY_DROP_LIMIT = 3;
+const NODE_HOST_UNHEALTHY_GATEWAY_DROP_WINDOW_MS = 60_000;
+
+function isNodeHostUnhealthyGatewayConnectError(message: string): boolean {
+  return /Unexpected server response:\s*502/i.test(message);
+}
+
+function isNodeHostUnhealthyGatewayClose(code: number): boolean {
+  return code === 1006;
+}
+
+export function createNodeHostGatewayDropWatchdog(deps: NodeHostGatewayDropDeps = {}): {
+  recordConnectError: (err: Error) => void;
+  recordClose: (code: number, reason: string) => void;
+} {
+  const now = deps.now ?? (() => Date.now());
+  const writeLine = deps.writeLine ?? writeStderrLine;
+  const exit = deps.exit ?? ((code: number): never => process.exit(code));
+  const unhealthyDrops: number[] = [];
+
+  function recordUnhealthyDrop(detail: string): void {
+    const current = now();
+    const cutoff = current - NODE_HOST_UNHEALTHY_GATEWAY_DROP_WINDOW_MS;
+    while (unhealthyDrops.length > 0 && unhealthyDrops[0] < cutoff) {
+      unhealthyDrops.shift();
+    }
+    unhealthyDrops.push(current);
+    if (unhealthyDrops.length < NODE_HOST_UNHEALTHY_GATEWAY_DROP_LIMIT) {
+      return;
+    }
+    writeLine(
+      `node host gateway unhealthy after ${unhealthyDrops.length} transport failures in ${NODE_HOST_UNHEALTHY_GATEWAY_DROP_WINDOW_MS}ms (${detail}); exiting for supervisor restart`,
+    );
+    exit(1);
+  }
+
+  return {
+    recordConnectError: (err: Error) => {
+      if (!isNodeHostUnhealthyGatewayConnectError(err.message)) {
+        return;
+      }
+      recordUnhealthyDrop(`connect failed: ${err.message}`);
+    },
+    recordClose: (code: number, reason: string) => {
+      if (!isNodeHostUnhealthyGatewayClose(code)) {
+        return;
+      }
+      const suffix = reason.trim() ? `: ${reason}` : "";
+      recordUnhealthyDrop(`gateway closed (${code})${suffix}`);
+    },
+  };
+}
+
 export function shouldExitNodeHostOnReconnectPaused(detailCode: string | null): boolean {
   return detailCode !== null && NODE_HOST_EXIT_ON_RECONNECT_PAUSE_CODES.has(detailCode);
 }
@@ -218,6 +277,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const scheme = gateway.tls ? "wss" : "ws";
   const url = `${scheme}://${host}:${port}`;
   const pathEnv = ensureNodePathEnv();
+  const gatewayDropWatchdog = createNodeHostGatewayDropWatchdog();
 
   const client = new GatewayClient({
     url,
@@ -253,14 +313,17 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       void handleInvoke(payload, client, skillBins);
     },
     onConnectError: (err) => {
-      // keep retrying (handled by GatewayClient)
+      // keep retrying (handled by GatewayClient) until repeated proxy/transport failures
+      // prove the node host is unhealthy enough for the service supervisor to restart it.
       writeStderrLine(`node host gateway connect failed: ${err.message}`);
+      gatewayDropWatchdog.recordConnectError(err);
     },
     onReconnectPaused: (info) => {
       handleNodeHostReconnectPaused(info);
     },
     onClose: (code, reason) => {
       writeStderrLine(`node host gateway closed (${code}): ${reason}`);
+      gatewayDropWatchdog.recordClose(code, reason);
     },
   });
 

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -78,6 +78,7 @@ export function createNodeHostGatewayDropWatchdog(deps: NodeHostGatewayDropDeps 
   const writeLine = deps.writeLine ?? writeStderrLine;
   const exit = deps.exit ?? ((code: number): never => process.exit(code));
   const unhealthyDrops: number[] = [];
+  let ignoreNextUnhealthyClose = false;
 
   function recordUnhealthyDrop(detail: string): void {
     const current = now();
@@ -100,10 +101,16 @@ export function createNodeHostGatewayDropWatchdog(deps: NodeHostGatewayDropDeps 
       if (!isNodeHostUnhealthyGatewayConnectError(err.message)) {
         return;
       }
+      ignoreNextUnhealthyClose = true;
       recordUnhealthyDrop(`connect failed: ${err.message}`);
     },
     recordClose: (code: number, reason: string) => {
       if (!isNodeHostUnhealthyGatewayClose(code)) {
+        ignoreNextUnhealthyClose = false;
+        return;
+      }
+      if (ignoreNextUnhealthyClose) {
+        ignoreNextUnhealthyClose = false;
         return;
       }
       const suffix = reason.trim() ? `: ${reason}` : "";


### PR DESCRIPTION
$## Summary\n- add a node-host gateway transport watchdog for repeated abnormal websocket/proxy failures\n- exit with code 1 after repeated 1006 closes or `Unexpected server response: 502` connect failures so systemd can restart the node host\n- cover the watchdog behavior in node-host runner tests\n\n## Why\nThe node host currently logs `node host gateway closed (1006)` / `node host gateway connect failed: Unexpected server response: 502` and keeps retrying inside the same process. If that process is wedged, systemd sees it as alive and never restarts it: a watchdog blindspot / zombie process. Exiting non-zero after repeated transport failures hands recovery back to the service supervisor.\n\n## Validation\n- `git diff --check`\n- Docker: `pnpm test:unit:fast -- src/node-host/runner.credentials.test.ts` could not complete because the git-hosted `@openclaw/fs-safe` dependency fails to prepare in a clean container (`TS7016` for `ms`, missing `JSX` namespace from `@types/mdx`).