### PR TITLE
test(plugin-sdk): guard realtime voice exports

### DIFF
--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -51,6 +51,12 @@ const requiredSubpathExports = {
     "normalizeSecretInputString",
     "resolveSecretInputString",
   ],
+  "security-runtime": ["appendRegularFile", "privateFileStore", "privateFileStoreSync", "root"],
+  "realtime-voice": [
+    "createTalkSessionController",
+    "recordTalkObservabilityEvent",
+    "resolveRealtimeVoiceFastContextConsult",
+  ],
 };
 
 // The root plugin-sdk entry intentionally stays tiny. Keep this list aligned


### PR DESCRIPTION
## Summary\n- add plugin-sdk release guards for realtime voice runtime exports used by standalone voice-call plugins\n- add guards for security-runtime file-store helpers required by voice-call persistence/context loading\n\n## Why\nAIF-126 standalone voice-call validation showed that published package artifacts can miss these runtime exports even when local source builds work. This makes the build smoke fail before release if those exports disappear.\n\n## Test plan\n- pnpm build:strict-smoke\n- AIF-126 local linked validation: npm run build && npm test (44 files / 378 tests)