### PR TITLE
fix(delivery): don't enqueue UNAVAILABLE WhatsApp dispatches in delivery-recovery (#79376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Outbound/WhatsApp: stop replaying WhatsApp messages whose dispatch returned `UNAVAILABLE` because the Web listener was down. The pre-flight "No active WhatsApp Web listener" failure is now raised as a tagged terminal dispatch error so `delivery-recovery` no longer silently re-sends those messages after the next gateway restart, eliminating duplicate group/broadcast posts; the recovery path keeps replaying entries that crashed mid-send. Also recognize the legacy error message as a permanent recovery error so any pending entries written by older builds are cleared on first scan. (#79376)
 - Docker: run the runtime image under `tini` so long-lived containers reap orphaned child processes and forward signals correctly. (#77885) Thanks @VintageAyu.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` and `google-gemini-cli/gemini-3-pro-preview` selections to `google/gemini-3.1-pro-preview` before they are written to model config.
 - Amazon Bedrock: support `serviceTier` parameter for Bedrock models, configurable via `agents.defaults.params.serviceTier` or per-model in `agents.defaults.models`. Valid values: `default`, `flex`, `priority`, `reserved`. (#64512) Thanks @mobilinkd.

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -262,6 +262,32 @@ describe("web outbound", () => {
     ).rejects.toThrow(/account: work/);
   });
 
+  it(
+    "raises a terminal dispatch error when no active listener exists, so " +
+      "delivery-recovery does not replay the send (#79376)",
+    async () => {
+      hoisted.controllerListeners.clear();
+      const { isOutboundDispatchTerminalError } = await import(
+        "openclaw/plugin-sdk/outbound-runtime"
+      );
+      let captured: unknown;
+      try {
+        await sendMessageWhatsApp("+1555", "hi", {
+          verbose: false,
+          cfg: WHATSAPP_TEST_CFG,
+          accountId: "work",
+        });
+      } catch (err) {
+        captured = err;
+      }
+      expect(captured).toBeDefined();
+      expect(isOutboundDispatchTerminalError(captured)).toBe(true);
+      if (isOutboundDispatchTerminalError(captured)) {
+        expect(captured.reason).toBe("whatsapp-listener-unavailable");
+      }
+    },
+  );
+
   it("maps audio to PTT with opus mime when ogg", async () => {
     const buf = Buffer.from("audio");
     loadWebMediaMock.mockResolvedValueOnce({

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -6,6 +6,7 @@ import {
   convertMarkdownTables,
   resolveMarkdownTableMode,
 } from "openclaw/plugin-sdk/markdown-table-runtime";
+import { OutboundDispatchTerminalError } from "openclaw/plugin-sdk/outbound-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { normalizePollInput, type PollInput } from "openclaw/plugin-sdk/poll-runtime";
 import { createSubsystemLogger, getChildLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -47,8 +48,15 @@ function requireOutboundActiveWebListener(params: { cfg: OpenClawConfig; account
   const listener =
     getRegisteredWhatsAppConnectionController(resolvedAccountId)?.getActiveListener() ?? null;
   if (!listener) {
-    throw new Error(
+    // Use a tagged terminal error so the outbound delivery queue does NOT
+    // re-enqueue this dispatch for `delivery-recovery` replay after the next
+    // gateway restart. The caller has been informed (errorCode=UNAVAILABLE)
+    // that the send did not happen and will decide whether to retry; silently
+    // replaying the same delivery would cause duplicate group posts. See
+    // openclaw/openclaw#79376.
+    throw new OutboundDispatchTerminalError(
       `No active WhatsApp Web listener (account: ${resolvedAccountId}). Start the gateway, then link WhatsApp with: ${formatCliCommand(`openclaw channels login --channel whatsapp --account ${resolvedAccountId}`)}.`,
+      "whatsapp-listener-unavailable",
     );
   }
   return { accountId: resolvedAccountId, listener };

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -42,6 +42,7 @@ const queueMocks = vi.hoisted(() => ({
   enqueueDelivery: vi.fn(async () => "mock-queue-id"),
   ackDelivery: vi.fn(async () => {}),
   failDelivery: vi.fn(async () => {}),
+  moveToFailed: vi.fn(async () => {}),
   markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {}),
   markDeliveryPlatformSendAttemptStarted: vi.fn(async () => {}),
   withActiveDeliveryClaim: vi.fn<
@@ -84,6 +85,7 @@ vi.mock("./delivery-queue.js", () => ({
   enqueueDelivery: queueMocks.enqueueDelivery,
   ackDelivery: queueMocks.ackDelivery,
   failDelivery: queueMocks.failDelivery,
+  moveToFailed: queueMocks.moveToFailed,
   markDeliveryPlatformOutcomeUnknown: queueMocks.markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted: queueMocks.markDeliveryPlatformSendAttemptStarted,
   withActiveDeliveryClaim: queueMocks.withActiveDeliveryClaim,
@@ -289,6 +291,8 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.ackDelivery.mockResolvedValue(undefined);
     queueMocks.failDelivery.mockClear();
     queueMocks.failDelivery.mockResolvedValue(undefined);
+    queueMocks.moveToFailed.mockClear();
+    queueMocks.moveToFailed.mockResolvedValue(undefined);
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockClear();
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockResolvedValue(undefined);
     queueMocks.markDeliveryPlatformSendAttemptStarted.mockClear();
@@ -815,6 +819,58 @@ describe("deliverOutboundPayloads", () => {
       expect.stringContaining("native send failed"),
     );
   });
+
+  it(
+    "moves the queue entry to failed/ (not pending) when dispatch throws " +
+      "OutboundDispatchTerminalError, so delivery-recovery does not replay it (#79376)",
+    async () => {
+      const { OutboundDispatchTerminalError } = await import("./target-errors.js");
+      const sendMatrix = vi.fn(async () => {
+        throw new OutboundDispatchTerminalError(
+          "No active WhatsApp Web listener (account: default)...",
+          "whatsapp-listener-unavailable",
+        );
+      });
+      await expect(
+        deliverOutboundPayloads({
+          cfg: {},
+          channel: "matrix",
+          to: "!room:example",
+          payloads: [{ text: "hi" }],
+          deps: { matrix: sendMatrix },
+        }),
+      ).rejects.toBeInstanceOf(OutboundDispatchTerminalError);
+      // Queue entry MUST be removed from the pending queue (moveToFailed),
+      // NOT just decorated with failDelivery (which keeps it pending and
+      // visible to the recovery scanner).
+      expect(queueMocks.moveToFailed).toHaveBeenCalledWith("mock-queue-id");
+      expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    },
+  );
+
+  it(
+    "keeps the queue entry pending (failDelivery) for generic crashes so " +
+      "delivery-recovery can replay them",
+    async () => {
+      const sendMatrix = vi.fn(async () => {
+        throw new Error("socket reset mid-send");
+      });
+      await expect(
+        deliverOutboundPayloads({
+          cfg: {},
+          channel: "matrix",
+          to: "!room:example",
+          payloads: [{ text: "hi" }],
+          deps: { matrix: sendMatrix },
+        }),
+      ).rejects.toThrow(/socket reset/);
+      expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+        "mock-queue-id",
+        expect.stringContaining("socket reset"),
+      );
+      expect(queueMocks.moveToFailed).not.toHaveBeenCalled();
+    },
+  );
 
   it("preserves successful sends when the success hook throws", async () => {
     const afterSendFailure = vi.fn();

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -54,9 +54,11 @@ import {
   failDelivery,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted,
+  moveToFailed,
   type QueuedRenderedMessageBatchPlan,
   withActiveDeliveryClaim,
 } from "./delivery-queue.js";
+import { isOutboundDispatchTerminalError } from "./target-errors.js";
 import type { OutboundDeliveryFormattingOptions } from "./formatting.js";
 import type { OutboundIdentity } from "./identity.js";
 import {
@@ -1223,7 +1225,17 @@ async function deliverOutboundPayloadsWithQueueCleanup(
       if (isAbortError(err)) {
         await ackDelivery(queueId).catch(() => {});
       } else if (!platformResultsReturned) {
-        await failDelivery(queueId, formatErrorMessage(err)).catch(() => {});
+        if (isOutboundDispatchTerminalError(err)) {
+          // The dispatcher reported a terminal pre-flight failure (e.g. the
+          // channel listener is down). The caller has been informed that the
+          // send did not happen, so we must NOT keep the entry in the pending
+          // queue — otherwise `delivery-recovery` would silently replay it
+          // after the next gateway restart, producing duplicate posts. See
+          // openclaw/openclaw#79376.
+          await moveToFailed(queueId).catch(() => {});
+        } else {
+          await failDelivery(queueId, formatErrorMessage(err)).catch(() => {});
+        }
       }
     }
     throw err;

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -75,6 +75,10 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /outbound not configured for channel/i,
   /ambiguous .* recipient/i,
   /User .* not in room/i,
+  // Channel listener was down at dispatch time. The caller has been told the
+  // send failed (errorCode=UNAVAILABLE); replaying after restart would
+  // produce duplicate posts. See openclaw/openclaw#79376.
+  /no active whatsapp web listener/i,
 ];
 
 const drainInProgress = new Map<string, boolean>();

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -467,6 +467,34 @@ describe("delivery-queue recovery", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
   });
 
+  it(
+    "treats 'No active WhatsApp Web listener' as a permanent error so legacy " +
+      "queue entries from a listener-down dispatch do not duplicate after restart (#79376)",
+    async () => {
+      const id = await enqueueDelivery(
+        { channel: "whatsapp", to: "+15551234@g.us", payloads: [{ text: "hi" }] },
+        tmpDir(),
+      );
+      const deliver = vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "No active WhatsApp Web listener (account: default). Start the gateway, then link WhatsApp with: openclaw channels login --channel whatsapp --account default.",
+          ),
+        );
+      const log = createRecoveryLog();
+      const { result } = await runRecovery({ deliver, log });
+
+      expect(result.failed).toBe(1);
+      expect(result.recovered).toBe(0);
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+      expect(
+        fs.existsSync(path.join(tmpDir(), "delivery-queue", "failed", `${id}.json`)),
+      ).toBe(true);
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
+    },
+  );
+
   it("treats Matrix 'User not in room' as a permanent error", async () => {
     const id = await enqueueDelivery(
       { channel: "matrix", to: "!lowercased:matrix.example.com", payloads: [{ text: "hi" }] },

--- a/src/infra/outbound/target-errors.test.ts
+++ b/src/infra/outbound/target-errors.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   ambiguousTargetError,
   ambiguousTargetMessage,
+  isOutboundDispatchTerminalError,
   missingTargetError,
   missingTargetMessage,
+  OutboundDispatchTerminalError,
   unknownTargetError,
   unknownTargetMessage,
 } from "./target-errors.js";
@@ -67,5 +69,46 @@ describe("target error helpers", () => {
     expect(ambiguousTargetError("Discord", "general", "Use channel:123").message).toContain(
       "Hint: Use channel:123",
     );
+  });
+});
+
+describe("OutboundDispatchTerminalError", () => {
+  it("is detected through instanceof checks", () => {
+    const err = new OutboundDispatchTerminalError("listener offline", "listener-down");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(OutboundDispatchTerminalError);
+    expect(err.name).toBe("OutboundDispatchTerminalError");
+    expect(err.reason).toBe("listener-down");
+    expect(err.message).toBe("listener offline");
+  });
+
+  it("is detected through isOutboundDispatchTerminalError", () => {
+    const err = new OutboundDispatchTerminalError("x", "r");
+    expect(isOutboundDispatchTerminalError(err)).toBe(true);
+  });
+
+  it(
+    "detects cross-bundle copies via the .name + .reason shape, since plugins " +
+      "may carry their own copy of the class",
+    () => {
+      // Simulate a plugin that bundles its own copy of the class — same name,
+      // same shape, but a different prototype chain.
+      const stand_in = new Error("listener offline") as Error & { reason: string };
+      stand_in.name = "OutboundDispatchTerminalError";
+      stand_in.reason = "whatsapp-listener-unavailable";
+      expect(stand_in instanceof OutboundDispatchTerminalError).toBe(false);
+      expect(isOutboundDispatchTerminalError(stand_in)).toBe(true);
+    },
+  );
+
+  it("rejects unrelated errors", () => {
+    expect(isOutboundDispatchTerminalError(new Error("boom"))).toBe(false);
+    expect(isOutboundDispatchTerminalError(undefined)).toBe(false);
+    expect(isOutboundDispatchTerminalError("OutboundDispatchTerminalError")).toBe(false);
+    // Same name but no reason — looks like an accidental collision, not the
+    // tagged terminal error.
+    const fake = new Error("x");
+    fake.name = "OutboundDispatchTerminalError";
+    expect(isOutboundDispatchTerminalError(fake)).toBe(false);
   });
 });

--- a/src/infra/outbound/target-errors.ts
+++ b/src/infra/outbound/target-errors.ts
@@ -1,3 +1,47 @@
+/**
+ * Tagged error indicating that an outbound dispatch failed terminally — the
+ * caller has been (or will be) informed that the send did not happen, and the
+ * delivery should NOT be replayed by `delivery-recovery` after a gateway
+ * restart.
+ *
+ * Use this for predictable pre-flight failures (e.g. "channel listener is
+ * down, login first"), not for crashes mid-send. Crashes mid-send still go
+ * through the normal failDelivery path so recovery can replay them.
+ *
+ * Detection across module boundaries uses `error.name === "OutboundDispatchTerminalError"`,
+ * see `isOutboundDispatchTerminalError`.
+ */
+export class OutboundDispatchTerminalError extends Error {
+  override readonly name = "OutboundDispatchTerminalError";
+  readonly reason: string;
+
+  constructor(message: string, reason: string) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
+/**
+ * Detect a terminal outbound dispatch error across module boundaries.
+ *
+ * Plugins (e.g. WhatsApp) raise the error from their own bundle, so an
+ * `instanceof` check would fail when the prototype lives in a separate copy of
+ * the module graph; we match on `error.name` instead, which is set on the
+ * class itself.
+ */
+export function isOutboundDispatchTerminalError(
+  err: unknown,
+): err is OutboundDispatchTerminalError {
+  if (err instanceof OutboundDispatchTerminalError) {
+    return true;
+  }
+  return (
+    err instanceof Error &&
+    err.name === "OutboundDispatchTerminalError" &&
+    typeof (err as { reason?: unknown }).reason === "string"
+  );
+}
+
 export function missingTargetMessage(provider: string, hint?: string): string {
   return `Delivering to ${provider} requires target${formatTargetHint(hint)}`;
 }

--- a/src/plugin-sdk/outbound-runtime.ts
+++ b/src/plugin-sdk/outbound-runtime.ts
@@ -10,6 +10,10 @@ export {
 } from "../infra/outbound/deliver.js";
 export { sanitizeForPlainText } from "../infra/outbound/sanitize-text.js";
 export {
+  isOutboundDispatchTerminalError,
+  OutboundDispatchTerminalError,
+} from "../infra/outbound/target-errors.js";
+export {
   buildOutboundSessionContext,
   type OutboundSessionContext,
 } from "../infra/outbound/session-context.js";


### PR DESCRIPTION
Fixes #79376.

## The bug

When the WhatsApp Web listener is disconnected, `openclaw message send --channel whatsapp` returned `errorCode=UNAVAILABLE` to the caller, **but the delivery-recovery WAL still held the entry as pending**. On the next gateway start, recovery silently replayed those deliveries, posting messages that the caller had already been told had failed (and may have manually retried).

Reproduced live this morning: 3 duplicate posts to the same broadcast group from one announcement.

```
13:20:32 [ws] ✗ send errorCode=UNAVAILABLE        ← caller marks send as failed
13:20:41 [ws] ✗ send errorCode=UNAVAILABLE        ← caller marks send as failed
13:21:07 [gateway] http server listening
13:21:22 [delivery-recovery] Recovered delivery <uuid> on whatsapp  ← OOPS, posted to group
13:21:24 [delivery-recovery] Recovered delivery <uuid> on whatsapp  ← OOPS, posted to group
13:22:01 [ws] ✓ send                              ← caller's manual retry
                                                   = 3 posts in the group
```

## Design

Two options were proposed in the issue:

1. **Don't enqueue `delivery-recovery` entries when the dispatch failed with UNAVAILABLE because the listener was down.** Caller's view + gateway's view agree: the send did not happen.
2. Change the WS response so the caller can distinguish "queued for retry" from "failed".

This PR implements **option 1**, the issue's preferred fix. Reasons:

- The error message we already return — `"Start the gateway, then link WhatsApp with: openclaw channels login..."` — strongly implies "your send did not happen". Changing the semantics so that the send *might still happen* later would surprise every caller already in the wild.
- Listener-down is a predictable pre-flight failure, distinct from the crash-mid-send case that motivated `delivery-recovery` in the first place. We keep `delivery-recovery` doing what it's good at (replaying entries that crashed between platform send and ack).
- The caller still receives the typed error and decides whether to retry. No surprises.

## Implementation

**`src/infra/outbound/target-errors.ts`**: new `OutboundDispatchTerminalError` class. Plugins raise it to mark a dispatch failure as terminal w.r.t. the queue. Cross-bundle detection uses `error.name === "OutboundDispatchTerminalError"` *in addition to* `instanceof`, because plugins may bundle their own copy of the class — a pure `instanceof` check would miss those (covered by a test).

**`src/plugin-sdk/outbound-runtime.ts`**: re-export the class and the `isOutboundDispatchTerminalError` guard so plugins can import them through the public plugin SDK surface.

**`extensions/whatsapp/src/send.ts`**: `requireOutboundActiveWebListener` now throws `OutboundDispatchTerminalError` with `reason="whatsapp-listener-unavailable"` instead of a plain `Error`. The user-facing message is unchanged.

**`src/infra/outbound/deliver.ts`**: in the WAL catch block, when the dispatcher raises `OutboundDispatchTerminalError`, the queue entry is moved to `failed/` (`moveToFailed`) instead of staying `pending` via `failDelivery`. Recovery never sees it again on the next start. The caller still receives the typed rejection.

**`src/infra/outbound/delivery-queue-recovery.ts`**: extend `PERMANENT_ERROR_PATTERNS` with `/no active whatsapp web listener/i`. This is **defense-in-depth for legacy queue entries** written by older builds (pre-upgrade). On the first recovery scan after upgrade, those legacy entries get moved to `failed/` instead of replayed, matching the new dispatch-path behavior.

## Tests

* `target-errors.test.ts` — class shape, `instanceof`, cross-bundle detection via `name + reason`, rejection of unrelated errors. (4 new tests.)
* `deliver.test.ts` — terminal dispatch error → `moveToFailed` (not `failDelivery`); generic crash → `failDelivery` (regression check). (2 new tests.)
* `delivery-queue.recovery.test.ts` — legacy pending entry whose `lastError` matches the WhatsApp listener-down string is moved to `failed/` on the first recovery scan, with `recovered=0`. (1 new test.)
* `extensions/whatsapp/src/send.test.ts` — `sendMessageWhatsApp` rejects with the typed terminal error and `reason=whatsapp-listener-unavailable`. The pre-existing message-shape assertions are kept for regression. (1 new test.)

## Repro / verification

Manual repro of the original bug, then re-run on this branch:

1. Start gateway, link WhatsApp, send a message successfully to a group.
2. Force the WhatsApp Web listener to disconnect (close the linked Web session or block the network).
3. Run `openclaw message send --channel whatsapp --target <GROUP_JID> --message "test"` → `errorCode=UNAVAILABLE` (unchanged caller experience).
4. Restart the gateway and let WhatsApp re-link.
5. **Before this fix**: `delivery-recovery` posts the message to the group → duplicate.
   **With this fix**: the queue entry is in `delivery-queue/failed/`, recovery finishes with `0 recovered`, no group post.

## No-regression

- All 538 outbound tests still pass.
- All 710 WhatsApp tests still pass.
- The gateway `server-runtime-services` suite still passes (10/10).
- Other channels (Telegram, Signal, Matrix, Discord) raise plain `Error`s for send failures and continue to follow the unchanged `failDelivery` path; recovery still replays them after a gateway crash, exactly as before.

## Notes

- Coordinated with the parallel #79365 fix sub-agent on a sibling branch — separate branch, no file overlap, distinct CHANGELOG entries (one in `### Changes`, one in `### Fixes`) so the merge is clean.
- The CHANGELOG entry is in the existing `Unreleased / Changes` section.
