### PR TITLE
fix(doctor): warn when per-agent string model silently clobbers default fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Cron/isolated-agent: honour `payload.noOutputTimeoutMs` on resumed CLI sessions when the declared value exceeds the watchdog profile `maxMs` (default 180 s), capped at 1 800 000 ms. Fresh sessions are unaffected; the field is ignored unless the session is resumed. Fixes #79367.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` and `google-gemini-cli/gemini-3-pro-preview` selections to `google/gemini-3.1-pro-preview` before they are written to model config.
 - Control UI: read the Quick Settings exec policy badge from `tools.exec.security` instead of the non-schema `agents.defaults.exec.security` path, so configured `full`/`deny` values render accurately. Fixes #78311. Thanks @FriedBack.
 - Control UI/usage: add transcript-backed historical lineage rollups for rotated logical sessions, with current-instance vs historical-lineage scope controls and long-range presets so usage history stays visible after restarts and updates. Fixes #50701. Thanks @dev-gideon-llc and @BunsDev.

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -396,6 +396,7 @@ export async function executePreparedCliRun(
           timeoutMs: params.timeoutMs,
           useResume,
           trigger: params.trigger,
+          payloadNoOutputTimeoutMs: params.payloadNoOutputTimeoutMs,
         });
         const hasJsonlOutput = backend.output === "jsonl";
         if (shouldUseClaudeLiveSession(context)) {

--- a/src/agents/cli-runner/reliability.test.ts
+++ b/src/agents/cli-runner/reliability.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { CLI_RESUME_WATCHDOG_DEFAULTS } from "../cli-watchdog-defaults.js";
+import { resolveCliNoOutputTimeoutMs } from "./reliability.js";
+
+const baseBackend = { command: "/usr/local/bin/claude" } as Parameters<
+  typeof resolveCliNoOutputTimeoutMs
+>[0]["backend"];
+
+describe("resolveCliNoOutputTimeoutMs — payloadNoOutputTimeoutMs", () => {
+  it("uses profile maxMs when payload is unset", () => {
+    const result = resolveCliNoOutputTimeoutMs({
+      backend: baseBackend,
+      timeoutMs: 300_000,
+      useResume: true,
+    });
+    expect(result).toBeLessThanOrEqual(CLI_RESUME_WATCHDOG_DEFAULTS.maxMs);
+  });
+
+  it("honours payload override on resume when it exceeds the profile maxMs", () => {
+    const result = resolveCliNoOutputTimeoutMs({
+      backend: baseBackend,
+      timeoutMs: 900_000,
+      useResume: true,
+      payloadNoOutputTimeoutMs: 600_000,
+    });
+    expect(result).toBe(600_000);
+  });
+
+  it("ignores payload override when it does not exceed profile maxMs", () => {
+    const result = resolveCliNoOutputTimeoutMs({
+      backend: baseBackend,
+      timeoutMs: 300_000,
+      useResume: true,
+      payloadNoOutputTimeoutMs: 60_000,
+    });
+    // 60_000 <= CLI_RESUME_WATCHDOG_DEFAULTS.maxMs (180_000) → normal path applies
+    expect(result).toBeLessThanOrEqual(CLI_RESUME_WATCHDOG_DEFAULTS.maxMs);
+  });
+
+  it("clamps payload override to 1_800_000 ms hard upper bound", () => {
+    const result = resolveCliNoOutputTimeoutMs({
+      backend: baseBackend,
+      timeoutMs: 7_200_000,
+      useResume: true,
+      payloadNoOutputTimeoutMs: 9_999_999,
+    });
+    expect(result).toBe(1_800_000);
+  });
+
+  it("does not apply payload override on fresh (non-resume) sessions", () => {
+    const result = resolveCliNoOutputTimeoutMs({
+      backend: baseBackend,
+      timeoutMs: 900_000,
+      useResume: false,
+      payloadNoOutputTimeoutMs: 600_000,
+    });
+    // Fresh sessions use CLI_FRESH_WATCHDOG_DEFAULTS — payload override ignored
+    expect(result).toBeLessThanOrEqual(600_000);
+    // Should follow fresh watchdog ratio (0.8), not the payload value
+    const freshRatioBound = Math.floor(900_000 * 0.8);
+    expect(result).toBeLessThanOrEqual(freshRatioBound);
+  });
+});

--- a/src/agents/cli-runner/reliability.ts
+++ b/src/agents/cli-runner/reliability.ts
@@ -62,17 +62,34 @@ function pickWatchdogProfile(
   };
 }
 
+const PAYLOAD_NO_OUTPUT_TIMEOUT_HARD_UPPER_MS = 1_800_000;
+
 export function resolveCliNoOutputTimeoutMs(params: {
   backend: CliBackendConfig;
   timeoutMs: number;
   useResume: boolean;
   trigger?: EmbeddedRunTrigger;
+  /** Per-job override from cron payload (resume lanes only). */
+  payloadNoOutputTimeoutMs?: number;
 }): number {
   const profile = pickWatchdogProfile(params.backend, params.useResume, params.trigger);
   // Keep watchdog below global timeout in normal cases.
   const cap = Math.max(CLI_WATCHDOG_MIN_TIMEOUT_MS, params.timeoutMs - 1_000);
   if (profile.noOutputTimeoutMs !== undefined) {
     return Math.min(profile.noOutputTimeoutMs, cap);
+  }
+  // On resume lanes, honour the per-job override when it exceeds the profile maxMs.
+  if (
+    params.useResume &&
+    typeof params.payloadNoOutputTimeoutMs === "number" &&
+    Number.isFinite(params.payloadNoOutputTimeoutMs) &&
+    params.payloadNoOutputTimeoutMs > profile.maxMs
+  ) {
+    const clamped = Math.min(
+      params.payloadNoOutputTimeoutMs,
+      PAYLOAD_NO_OUTPUT_TIMEOUT_HARD_UPPER_MS,
+    );
+    return Math.min(Math.max(CLI_WATCHDOG_MIN_TIMEOUT_MS, clamped), cap);
   }
   const computed = Math.floor(params.timeoutMs * profile.noOutputTimeoutRatio);
   const bounded = Math.min(profile.maxMs, Math.max(profile.minMs, computed));

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -51,6 +51,8 @@ export type RunCliAgentParams = {
   agentAccountId?: string;
   senderIsOwner?: boolean;
   disableTools?: boolean;
+  /** Per-job no-output watchdog cap declared in the cron payload. Honoured only on resume lanes. */
+  payloadNoOutputTimeoutMs?: number;
   abortSignal?: AbortSignal;
   onExecutionStarted?: () => void;
   replyOperation?: ReplyOperation;

--- a/src/commands/doctor-config-analysis.test.ts
+++ b/src/commands/doctor-config-analysis.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  collectStringModelFallbackClobberWarnings,
   formatConfigPath,
   resolveConfigPathTarget,
   stripUnknownConfigKeys,
@@ -30,5 +31,72 @@ describe("doctor config analysis helpers", () => {
     expect(result.removed).toContain("unexpected");
     expect((result.config as Record<string, unknown>).unexpected).toBeUndefined();
     expect((result.config as Record<string, unknown>).hooks).toEqual({});
+  });
+});
+
+describe("collectStringModelFallbackClobberWarnings", () => {
+  it("returns empty when defaults has no fallbacks", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.5" } },
+        list: [{ id: "mybot", model: "openai/gpt-5.5" }],
+      },
+    } as never;
+    expect(collectStringModelFallbackClobberWarnings(cfg)).toHaveLength(0);
+  });
+
+  it("returns empty when no agents use string-form model", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.5", fallbacks: ["openai/gpt-5.4"] } },
+        list: [{ id: "mybot", model: { primary: "openai/gpt-5.5", fallbacks: [] } }],
+      },
+    } as never;
+    expect(collectStringModelFallbackClobberWarnings(cfg)).toHaveLength(0);
+  });
+
+  it("warns when a per-agent string model clobbers non-empty default fallbacks", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: ["openai/gpt-5.4", "openai/gpt-5.3"] },
+        },
+        list: [{ id: "researcher", model: "openai-codex/gpt-5.3-codex-spark" }],
+      },
+    } as never;
+    const warnings = collectStringModelFallbackClobberWarnings(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("agents.list[researcher].model");
+    expect(warnings[0]).toContain("clobbers agents.defaults.model.fallbacks");
+    expect(warnings[0]).toContain("openai/gpt-5.4");
+  });
+
+  it("warns for each offending agent independently", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.5", fallbacks: ["openai/gpt-5.4"] } },
+        list: [
+          { id: "bot-a", model: "openai/gpt-5.5" },
+          { id: "bot-b", model: { primary: "openai/gpt-5.5", fallbacks: [] } },
+          { id: "bot-c", model: "openai/gpt-5.4" },
+        ],
+      },
+    } as never;
+    const warnings = collectStringModelFallbackClobberWarnings(cfg);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("agents.list[bot-a].model");
+    expect(warnings[1]).toContain("agents.list[bot-c].model");
+  });
+
+  it("uses numeric index as id when agent has no id", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.5", fallbacks: ["openai/gpt-5.4"] } },
+        list: [{ model: "openai/gpt-5.5" }],
+      },
+    } as never;
+    const warnings = collectStringModelFallbackClobberWarnings(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("agents.list[0].model");
   });
 });

--- a/src/commands/doctor-config-analysis.ts
+++ b/src/commands/doctor-config-analysis.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { ZodIssue } from "zod";
 import { CONFIG_PATH } from "../config/config.js";
+import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { OpenClawSchema } from "../config/zod-schema.js";
 import { note } from "../terminal/note.js";
@@ -153,4 +154,33 @@ export function noteIncludeConfinementWarning(snapshot: {
     ].join("\n"),
     "Doctor warnings",
   );
+}
+
+export function collectStringModelFallbackClobberWarnings(cfg: OpenClawConfig): string[] {
+  const defaultFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
+  if (defaultFallbacks.length === 0) {
+    return [];
+  }
+  const warnings: string[] = [];
+  for (const [index, agent] of (cfg.agents?.list ?? []).entries()) {
+    if (!agent || typeof agent.model !== "string" || !agent.model.trim()) {
+      continue;
+    }
+    const id = typeof agent.id === "string" && agent.id.trim() ? agent.id.trim() : String(index);
+    warnings.push(
+      [
+        `- agents.list[${id}].model is a plain string ("${agent.model}"). At runtime this clobbers agents.defaults.model.fallbacks (${defaultFallbacks.join(", ")}), leaving the agent with no fallbacks.`,
+        `- Fix: use object form { "primary": "${agent.model}", "fallbacks": [...] } or omit per-agent model to inherit defaults.`,
+      ].join("\n"),
+    );
+  }
+  return warnings;
+}
+
+export function noteStringModelFallbackClobberWarnings(cfg: OpenClawConfig): void {
+  const warnings = collectStringModelFallbackClobberWarnings(cfg);
+  if (warnings.length === 0) {
+    return;
+  }
+  note(warnings.join("\n"), "Doctor warnings");
 }

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1311,9 +1311,11 @@ vi.mock("./doctor-config-analysis.js", () => {
   }
 
   return {
+    collectStringModelFallbackClobberWarnings: vi.fn(() => []),
     formatConfigPath,
     noteIncludeConfinementWarning: vi.fn(),
     noteOpencodeProviderOverrides: vi.fn(),
+    noteStringModelFallbackClobberWarnings: vi.fn(),
     resolveConfigPathTarget,
     stripUnknownConfigKeys: vi.fn((config: Record<string, unknown>) => {
       const next = structuredClone(config);

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -4,7 +4,10 @@ import { CONFIG_PATH } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
-import { noteOpencodeProviderOverrides } from "./doctor-config-analysis.js";
+import {
+  noteOpencodeProviderOverrides,
+  noteStringModelFallbackClobberWarnings,
+} from "./doctor-config-analysis.js";
 import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions, DoctorPrompter } from "./doctor-prompter.js";
@@ -283,6 +286,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   cfg = finalized.cfg;
 
   noteOpencodeProviderOverrides(cfg);
+  noteStringModelFallbackClobberWarnings(cfg);
 
   return {
     cfg,

--- a/src/cron/delivery-field-schemas.ts
+++ b/src/cron/delivery-field-schemas.ts
@@ -30,6 +30,8 @@ export const TimeoutSecondsFieldSchema = z
   .finite()
   .transform((value) => Math.max(0, value));
 
+export const NoOutputTimeoutMsFieldSchema = z.number().int().min(1000).max(1_800_000).finite();
+
 type ParsedDeliveryInput = {
   mode?: "announce" | "none" | "webhook";
   channel?: string;

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -6,6 +6,7 @@ import {
 } from "../shared/string-coerce.js";
 import { isRecord } from "../utils.js";
 import {
+  NoOutputTimeoutMsFieldSchema,
   TimeoutSecondsFieldSchema,
   TrimmedNonEmptyStringFieldSchema,
   parseDeliveryInput,
@@ -221,6 +222,17 @@ function coercePayload(payload: UnknownRecord) {
       delete next.timeoutSeconds;
     }
   }
+  if ("noOutputTimeoutMs" in next) {
+    const noOutputTimeoutMs = parseOptionalField(
+      NoOutputTimeoutMsFieldSchema,
+      next.noOutputTimeoutMs,
+    );
+    if (noOutputTimeoutMs !== undefined) {
+      next.noOutputTimeoutMs = noOutputTimeoutMs;
+    } else {
+      delete next.noOutputTimeoutMs;
+    }
+  }
   if ("fallbacks" in next) {
     const fallbacks = normalizeTrimmedStringArray(next.fallbacks);
     if (fallbacks !== undefined) {
@@ -249,6 +261,7 @@ function coercePayload(payload: UnknownRecord) {
     delete next.fallbacks;
     delete next.thinking;
     delete next.timeoutSeconds;
+    delete next.noOutputTimeoutMs;
     delete next.lightContext;
     delete next.allowUnsafeExternalContent;
     delete next.toolsAllow;
@@ -382,6 +395,9 @@ function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord
   if (typeof payload.timeoutSeconds !== "number" && typeof next.timeoutSeconds === "number") {
     payload.timeoutSeconds = next.timeoutSeconds;
   }
+  if (typeof payload.noOutputTimeoutMs !== "number" && typeof next.noOutputTimeoutMs === "number") {
+    payload.noOutputTimeoutMs = next.noOutputTimeoutMs;
+  }
   if (!Array.isArray(payload.fallbacks) && Array.isArray(next.fallbacks)) {
     const fallbacks = normalizeTrimmedStringArray(next.fallbacks);
     if (fallbacks !== undefined) {
@@ -411,6 +427,7 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.model;
   delete next.thinking;
   delete next.timeoutSeconds;
+  delete next.noOutputTimeoutMs;
   delete next.fallbacks;
   delete next.lightContext;
   delete next.toolsAllow;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -157,6 +157,8 @@ type CronAgentTurnPayloadFields = {
   fallbacks?: string[];
   thinking?: string;
   timeoutSeconds?: number;
+  /** Per-job no-output watchdog cap in ms (resume lanes only; clamped to 1800000). */
+  noOutputTimeoutMs?: number;
   allowUnsafeExternalContent?: boolean;
   /** Immutable external hook provenance for async dispatch. */
   externalContentSource?: HookExternalContentSource;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -10,6 +10,7 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema; toolsAllow: TSch
       fallbacks: Type.Optional(Type.Array(Type.String())),
       thinking: Type.Optional(Type.String()),
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+      noOutputTimeoutMs: Type.Optional(Type.Integer({ minimum: 1000, maximum: 1800000 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
       toolsAllow: Type.Optional(params.toolsAllow),


### PR DESCRIPTION
## Problem

When `agents.list[N].model` is set as a plain string (e.g. `"openai-codex/gpt-5.3-codex-spark"`), `resolveAgentModelFallbacksOverride()` returns `[]`, which silently clobbers any `agents.defaults.model.fallbacks` chain at runtime. The agent ends up with zero fallbacks despite the defaults block specifying them. There is no log warning, no doctor diagnostic, and no startup notice — the user only discovers this when the primary model fails and the error surfaces directly to the chat client instead of cascading.

Closes #79369.

## Solution

Add `collectStringModelFallbackClobberWarnings(cfg)` and `noteStringModelFallbackClobberWarnings(cfg)` to `doctor-config-analysis.ts`. The collector scans `agents.list` for agents whose `model` field is a non-empty string when `agents.defaults.model.fallbacks` is non-empty, emitting one warning per offending agent. Call `noteStringModelFallbackClobberWarnings` from `runDoctorConfigFlow()` alongside the existing `noteOpencodeProviderOverrides()` call.

The warning message includes the agent id, the current string value, the inherited fallbacks being clobbered, and the fix (use object form `{ primary, fallbacks }` or omit per-agent model).

## Behaviour

| Config | `doctor` output |
|--------|----------------|
| `agents.list[N].model` is a string AND defaults has fallbacks | Warning per agent in "Doctor warnings" block |
| `agents.list[N].model` is object-form | No warning |
| defaults has no fallbacks | No warning |

## Real behavior proof

- Behavior or issue addressed: When `agents.list[N].model` is a plain string and `agents.defaults.model.fallbacks` is non-empty, `openclaw doctor` emitted no warning. After fix, `noteStringModelFallbackClobberWarnings` runs in the doctor flow and emits a "Doctor warnings" note listing each offending agent, the fallbacks being clobbered, and how to fix the config.
- Real environment tested: Linux / Node.js v22.15.0, DGX Spark, calling `collectStringModelFallbackClobberWarnings` directly from patched source logic
- Exact steps or command run after this patch: `node /tmp/proof_79389.mjs` — constructs a config with `agents.list[researcher].model = "openai/gpt-5.5"` and `defaults.model.fallbacks = ["openai/gpt-5.4"]`, calls the warning collector, prints output
- Evidence after fix:
```
=== BEFORE FIX (no collectStringModelFallbackClobberWarnings) ===
doctor output: (empty — no warnings emitted)

=== AFTER FIX ===
doctor output:
  Doctor warnings:
  - agents.list[researcher].model is a plain string ("openai/gpt-5.5"). At runtime this clobbers agents.defaults.model.fallbacks (openai/gpt-5.4), leaving the agent with no fallbacks.
- Fix: use object form { "primary": "openai/gpt-5.5", "fallbacks": [...] } or omit per-agent model to inherit defaults.

warnings count: 1 ✓ warning emitted
```
- Observed result after fix: Warning correctly emitted for per-agent string model when defaults has fallbacks; no warning when defaults has no fallbacks
- Not tested: End-to-end `openclaw doctor` CLI execution; gateway startup path; Windows