### PR TITLE
fix(gateway): allow config.patch to set tools.web.search.maxResults

### DIFF
--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -286,6 +286,42 @@ describe("gateway tool", () => {
     });
   });
 
+  it("passes config.patch through when changing tools.web.search.maxResults", async () => {
+    vi.mocked(callGatewayTool).mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { hash: "hash-1", config: { tools: { web: { search: { maxResults: 5 } } } } };
+      }
+      if (method === "config.patch") {
+        return {
+          ok: true,
+          noop: false,
+          path: "/tmp/openclaw.json",
+          config: { tools: { web: { search: { maxResults: 10 } } } },
+        };
+      }
+      return { ok: true };
+    });
+    const sessionKey = "agent:main:telegram:dm:123";
+    const tool = requireGatewayTool(sessionKey);
+
+    const raw = "{ tools: { web: { search: { maxResults: 10 } } } }";
+    const result = await tool.execute("call-web-maxresults-patch", {
+      action: "config.patch",
+      raw,
+    });
+
+    expect(result.details).toEqual({
+      ok: true,
+      result: { ok: true, noop: false, path: "/tmp/openclaw.json" },
+    });
+    expectConfigMutationCall({
+      callGatewayTool: vi.mocked(callGatewayTool),
+      action: "config.patch",
+      raw,
+      sessionKey,
+    });
+  });
+
   it("rejects config.patch when it changes exec approval settings", async () => {
     const tool = requireGatewayTool();
 

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -57,6 +57,10 @@ const ALLOWED_GATEWAY_CONFIG_PATHS = [
   // or privilege boundary. Let agents repair silent group/channel rooms.
   "messages.visibleReplies",
   "messages.groupChat.visibleReplies",
+  // Web search result count is a non-sensitive UX tuning knob (schema: 1-10 positive int).
+  // Omitting it from this list forces the operator to restart the gateway to change it,
+  // even though the field carries no auth or privilege implications.
+  "tools.web.search.maxResults",
 ] as const;
 
 /** @internal Exposed for regression tests only; do not import from runtime code. */


### PR DESCRIPTION
## Problem

`tools.web.search.maxResults` is documented in the config schema (`types.tools.ts`) and labelled in `schema.labels.ts` as \"Web Search Max Results\", but it is absent from `ALLOWED_GATEWAY_CONFIG_PATHS`. Any `gateway config.patch` that changes this field is rejected:

```
gateway config.patch cannot change protected config paths: maxResults
```

The field is a non-sensitive UX tuning knob (schema: positive int, documented range 1–10) with no auth or privilege implications. Operators are forced to restart the gateway to change it, even for trivial tuning.

Closes #79384.

## Solution

Add `"tools.web.search.maxResults"` to `ALLOWED_GATEWAY_CONFIG_PATHS` in `src/agents/tools/gateway-tool.ts`. No other changes needed — the field is already in the TypeScript type, zod schema, and label registry.

## Real behavior proof

- Behavior or issue addressed: Before this patch, `gateway config.patch '{ tools: { web: { search: { maxResults: 10 } } } }'` was rejected with "cannot change protected config paths: maxResults". After, it passes through to the gateway.
- Real environment tested: Local OpenClaw source on DGX Spark (Linux, Node v22), vitest v4.1.5. Test calls `createGatewayTool(...).execute(...)` with `action: "config.patch"` and a payload that changes `tools.web.search.maxResults`, asserting the patch is forwarded to `callGatewayTool` rather than rejected.
- Exact steps or command run after this patch: `node --experimental-vm-modules node_modules/.bin/vitest run src/agents/openclaw-gateway-tool.test.ts`
- Evidence after fix:
```
 RUN  v4.1.5

 ✓ gateway tool (54)
   ✓ passes config.patch through when changing tools.web.search.maxResults

 Test Files  2 passed (2)
      Tests  54 passed (54)
   Duration  2.26s
```
- Observed result after fix: `tool.execute("call", { action: "config.patch", raw: "{ tools: { web: { search: { maxResults: 10 } } } }" })` resolves (no throw) and `callGatewayTool` is called with `"config.patch"`, confirming the patch is forwarded.
- What was not tested: A live `openclaw gateway config.patch` CLI call against a running gateway instance was not performed.