### PR TITLE
fix(nextcloud-talk): parse structured mention payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Nextcloud Talk: parse structured message bodies (`{"message":"...","parameters":{...}}`) delivered by the Talk webhook so @-mention detection and command gating operate on the plain-text content rather than the raw JSON envelope; agents in group rooms with `requireMention: true` now correctly respond to explicit @-mentions. Thanks @iclem.
 - Agents/UI: compact exec and tool progress rows by hiding redundant shell tool names, replacing known workspace paths with short context markers, and preserving Discord trace scrubbing for compact command lines.
 - ACPX: run and await the embedded ACP backend startup probe by default so the gateway `ready` signal no longer fires before the acpx runtime has either become usable or reported a probe failure; set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` to restore lazy startup. Fixes #79596. Thanks @bzelones.
 - OpenAI-compatible models: strip prior assistant reasoning fields from replayed Chat Completions history by default, preventing oMLX/vLLM Qwen follow-up turns from rejecting or stalling on stale `reasoning` payloads. Fixes #46637. Thanks @zipzagster and @lexhoefsloot.

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -234,6 +234,84 @@ describe("nextcloud-talk inbound behavior", () => {
     expect(runtime.log).toHaveBeenCalledWith("nextcloud-talk: drop room room-group (no mention)");
   });
 
+  it("does not let structured display names satisfy mention gating", async () => {
+    const matchesMentionPatterns = vi.fn((body: string) => /openclaw/i.test(body));
+    const mentionRegexes = [/openclaw/i];
+    const coreRuntime = installRuntime({
+      buildMentionRegexes: vi.fn(() => mentionRegexes),
+      matchesMentionPatterns,
+    });
+    createChannelPairingControllerMock.mockReturnValue({
+      readStoreForDmPolicy: vi.fn(async () => []),
+      issueChallenge: vi.fn(),
+    });
+    resolveNextcloudTalkRoomKindMock.mockResolvedValue("group");
+    const runtime = createRuntimeEnv();
+
+    await handleNextcloudTalkInbound({
+      message: createMessage({
+        roomToken: "room-group",
+        roomName: "Ops",
+        isGroupChat: true,
+        text: JSON.stringify({
+          message: "ask {mention0}",
+          parameters: {
+            mention0: { type: "user", id: "alice", name: "OpenClaw" },
+          },
+        }),
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "allowlist",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["user-1"],
+          apiUser: "agent",
+        },
+      }),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime,
+    });
+
+    expect(matchesMentionPatterns).toHaveBeenCalledWith("ask _", mentionRegexes);
+    expect(coreRuntime.channel.inbound.dispatchReply).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith("nextcloud-talk: drop room room-group (no mention)");
+  });
+
+  it("matches literal mention text in a structured message", async () => {
+    const mentionRegexes = [/@openclaw/i];
+    const coreRuntime = installRuntime({
+      buildMentionRegexes: vi.fn(() => mentionRegexes),
+      matchesMentionPatterns: vi.fn((body: string) => mentionRegexes[0]?.test(body) ?? false),
+    });
+    createChannelPairingControllerMock.mockReturnValue({
+      readStoreForDmPolicy: vi.fn(async () => []),
+      issueChallenge: vi.fn(),
+    });
+    resolveNextcloudTalkRoomKindMock.mockResolvedValue("group");
+
+    await handleNextcloudTalkInbound({
+      message: createMessage({
+        roomToken: "room-group",
+        roomName: "Ops",
+        isGroupChat: true,
+        text: JSON.stringify({ message: "@openclaw help", parameters: {} }),
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "allowlist",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["user-1"],
+        },
+      }),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(coreRuntime.channel.inbound.dispatchReply).toHaveBeenCalledTimes(1);
+  });
+
   it("blocks unauthorized group text control commands even when room sender access allows chat", async () => {
     const buildMentionRegexes = vi.fn(() => [/@openclaw/i]);
     const coreRuntime = installRuntime({

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -54,11 +54,8 @@ function installRuntime(params?: {
   matchesMentionPatterns?: (body: string, regexes: RegExp[]) => boolean;
   shouldHandleTextCommands?: () => boolean;
 }) {
-  const runtime = {
+  const runtime = createPluginRuntimeMock({
     channel: {
-      inbound: {
-        dispatchReply: vi.fn(async () => undefined),
-      },
       pairing: {
         readAllowFromStore: vi.fn(async () => []),
         upsertPairingRequest: vi.fn(async () => ({ code: "123456", created: true })),
@@ -74,7 +71,7 @@ function installRuntime(params?: {
         matchesMentionPatterns: params?.matchesMentionPatterns ?? vi.fn(() => false),
       },
     },
-  };
+  });
   setNextcloudTalkRuntime(runtime as unknown as PluginRuntime);
   return runtime;
 }
@@ -553,7 +550,16 @@ describe("nextcloud-talk inbound behavior", () => {
       messages: {
         groupChat: { visibleReplies: "message_tool" },
       },
-      channels: { "nextcloud-talk": {} },
+      channels: {
+        "nextcloud-talk": {
+          rooms: {
+            "room-group": {
+              allowFrom: ["user-1"],
+              requireMention: false,
+            },
+          },
+        },
+      },
     } as CoreConfig;
 
     await handleNextcloudTalkInbound({

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -1,4 +1,5 @@
 // Nextcloud Talk tests cover inbound.behavior plugin behavior.
+import { resolveChannelMessageSourceReplyDeliveryMode } from "openclaw/plugin-sdk/channel-outbound";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OutboundReplyPayload, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
@@ -421,5 +422,69 @@ describe("nextcloud-talk inbound behavior", () => {
         replyTo: "reply-1",
       },
     ]);
+  });
+
+  it("keeps group visible-reply delivery on the shared message-tool policy and its fallback", async () => {
+    const coreRuntime = createPluginRuntimeMock();
+    setNextcloudTalkRuntime(coreRuntime as unknown as PluginRuntime);
+    createChannelPairingControllerMock.mockReturnValue({
+      readStoreForDmPolicy: vi.fn(async () => []),
+      issueChallenge: vi.fn(),
+    });
+    resolveNextcloudTalkRoomKindMock.mockResolvedValue("group");
+    const cfg = {
+      messages: {
+        groupChat: { visibleReplies: "message_tool" },
+      },
+      channels: { "nextcloud-talk": {} },
+    } as CoreConfig;
+
+    await handleNextcloudTalkInbound({
+      message: createMessage({
+        roomToken: "room-group",
+        roomName: "Ops",
+        isGroupChat: true,
+        text: "hello team",
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "allowlist",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+          rooms: {
+            "room-group": {
+              allowFrom: ["user-1"],
+              requireMention: false,
+            },
+          },
+        },
+      }),
+      config: cfg,
+      runtime: createRuntimeEnv(),
+    });
+
+    const assembledRequest = requireFirstMockArg(
+      coreRuntime.channel.inbound.dispatchReply as ReturnType<typeof vi.fn>,
+      "Nextcloud Talk assembled request",
+    ) as {
+      ctxPayload: Parameters<typeof resolveChannelMessageSourceReplyDeliveryMode>[0]["ctx"];
+      replyOptions?: unknown;
+    };
+
+    expect(assembledRequest.replyOptions).not.toHaveProperty("sourceReplyDeliveryMode");
+    expect(
+      resolveChannelMessageSourceReplyDeliveryMode({
+        cfg,
+        ctx: assembledRequest.ctxPayload,
+      }),
+    ).toBe("message_tool_only");
+    expect(
+      resolveChannelMessageSourceReplyDeliveryMode({
+        cfg,
+        ctx: assembledRequest.ctxPayload,
+        messageToolAvailable: false,
+      }),
+    ).toBe("automatic");
   });
 });

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -50,7 +50,7 @@ vi.mock("./room-info.js", async () => {
 
 function installRuntime(params?: {
   buildMentionRegexes?: () => RegExp[];
-  hasControlCommand?: (body: string) => boolean;
+  hasControlCommand?: (body?: string) => boolean;
   matchesMentionPatterns?: (body: string, regexes: RegExp[]) => boolean;
   shouldHandleTextCommands?: () => boolean;
 }) {
@@ -356,7 +356,7 @@ describe("nextcloud-talk inbound behavior", () => {
   });
 
   it("does not interpret rich-object display names as control commands", async () => {
-    const hasControlCommand = vi.fn((body: string) => body.startsWith("/"));
+    const hasControlCommand = vi.fn((body = "") => body.startsWith("/"));
     const coreRuntime = installRuntime({ hasControlCommand });
     createChannelPairingControllerMock.mockReturnValue({
       readStoreForDmPolicy: vi.fn(async () => []),

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -280,6 +280,45 @@ describe("nextcloud-talk inbound behavior", () => {
     );
   });
 
+  it("does not interpret rich-object display names as control commands", async () => {
+    const hasControlCommand = vi.fn((body: string) => body.startsWith("/"));
+    const coreRuntime = installRuntime({ hasControlCommand });
+    createChannelPairingControllerMock.mockReturnValue({
+      readStoreForDmPolicy: vi.fn(async () => []),
+      issueChallenge: vi.fn(),
+    });
+
+    const config = { channels: { "nextcloud-talk": {} } } as CoreConfig;
+    await handleNextcloudTalkInbound({
+      message: createMessage({
+        text: JSON.stringify({
+          message: "{object0}",
+          parameters: {
+            object0: { type: "file", name: "/reset" },
+          },
+        }),
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "allowlist",
+          allowFrom: ["user-1"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(hasControlCommand).toHaveBeenCalledWith("_", config);
+    const assembledRequest = requireFirstMockArg(
+      coreRuntime.channel.inbound.dispatchReply as ReturnType<typeof vi.fn>,
+      "Nextcloud Talk assembled request",
+    ) as { ctxPayload: { BodyForAgent?: unknown; CommandBody?: unknown } };
+    expect(assembledRequest.ctxPayload.BodyForAgent).toBe("/reset");
+    expect(assembledRequest.ctxPayload.CommandBody).toBe("_");
+  });
+
   it("passes the shared reply pipeline for dispatched replies", async () => {
     const coreRuntime = createPluginRuntimeMock();
     setNextcloudTalkRuntime(coreRuntime as unknown as PluginRuntime);

--- a/extensions/nextcloud-talk/src/inbound.mentions.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.mentions.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+import {
+  parseStructuredNextcloudTalkBody,
+  resolveExplicitNextcloudTalkMention,
+} from "./inbound.js";
+
+// ---------------------------------------------------------------------------
+// parseStructuredNextcloudTalkBody
+// ---------------------------------------------------------------------------
+
+describe("parseStructuredNextcloudTalkBody", () => {
+  it("returns plain text unchanged with empty mentionEntries and structured=false", () => {
+    const result = parseStructuredNextcloudTalkBody("hello world");
+    expect(result.text).toBe("hello world");
+    expect(result.structured).toBe(false);
+    expect(result.mentionEntries).toEqual([]);
+  });
+
+  it("returns raw body unchanged when not JSON (leading whitespace preserved)", () => {
+    const raw = "  not json  ";
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.text).toBe(raw);
+    expect(result.structured).toBe(false);
+    expect(result.mentionEntries).toEqual([]);
+  });
+
+  it("strips bot mention placeholder and sets structured=true for a valid structured body", () => {
+    const raw = JSON.stringify({
+      message: "Hey {mention0}, how are you?",
+      parameters: {
+        mention0: { type: "user", id: "agent", name: "iClaw" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent"]));
+    expect(result.text).toBe("Hey , how are you?");
+    expect(result.structured).toBe(true);
+    expect(result.mentionEntries).toHaveLength(1);
+    expect(result.mentionEntries[0]).toMatchObject({
+      key: "mention0",
+      type: "user",
+      id: "agent",
+      name: "iClaw",
+    });
+  });
+
+  it("substitutes non-bot user mention with display name when botIds not provided", () => {
+    const raw = JSON.stringify({
+      message: "Hey {mention0}",
+      parameters: {
+        mention0: { type: "user", id: "agent", name: "iClaw" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.text).toBe("Hey iClaw");
+    expect(result.structured).toBe(true);
+  });
+
+  it("produces empty text for a mention-only structured body", () => {
+    const raw = JSON.stringify({
+      message: "{mention-user1}",
+      parameters: {
+        "mention-user1": { type: "user", id: "agent", name: "iClaw" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent"]));
+    expect(result.text).toBe("");
+    expect(result.structured).toBe(true);
+  });
+
+  it("strips bot mention before a command so command parsing can see it", () => {
+    const raw = JSON.stringify({
+      message: "{mention0} /reset",
+      parameters: {
+        mention0: { type: "user", id: "agent" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent"]));
+    expect(result.text).toBe("/reset");
+    expect(result.structured).toBe(true);
+  });
+
+  it("falls back to raw body text when JSON has no message field", () => {
+    const raw = JSON.stringify({ parameters: {} });
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.text).toBe(raw.trim());
+    expect(result.structured).toBe(true);
+    expect(result.mentionEntries).toEqual([]);
+  });
+
+  it("falls back to raw body when JSON is malformed", () => {
+    const raw = "{broken json";
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.text).toBe(raw);
+    expect(result.structured).toBe(false);
+    expect(result.mentionEntries).toEqual([]);
+  });
+
+  it("handles missing parameters key gracefully", () => {
+    const raw = JSON.stringify({ message: "hello" });
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.text).toBe("hello");
+    expect(result.structured).toBe(true);
+    expect(result.mentionEntries).toEqual([]);
+  });
+
+  it("extracts mention-id (hyphenated) field into mentionId", () => {
+    const raw = JSON.stringify({
+      message: "ping {m}",
+      parameters: {
+        m: { type: "user", "mention-id": "agent@cloud.example.com" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent@cloud.example.com"]));
+    expect(result.mentionEntries[0]?.mentionId).toBe("agent@cloud.example.com");
+    // bot mention stripped
+    expect(result.text).toBe("ping");
+  });
+
+  it("multiple mention entries are all captured; nameless user entries produce empty string", () => {
+    const raw = JSON.stringify({
+      message: "{a} and {b}",
+      parameters: {
+        a: { type: "user", id: "alice" },
+        b: { type: "user", id: "bob" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.mentionEntries).toHaveLength(2);
+    expect(result.mentionEntries.map((e) => e.id)).toEqual(
+      expect.arrayContaining(["alice", "bob"]),
+    );
+    // alice and bob have no display name — substituted with "" (name ?? "")
+    expect(result.text).toBe("and");
+  });
+
+  it("preserves non-bot user mention display name while stripping the bot mention", () => {
+    const raw = JSON.stringify({
+      message: "{mention0} ask {mention1} about deploy",
+      parameters: {
+        mention0: { type: "user", id: "openclaw-bot", name: "OpenClaw" },
+        mention1: { type: "user", id: "bob", name: "Bob" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw, new Set(["openclaw-bot"]));
+    expect(result.text).toBe("ask Bob about deploy");
+    expect(result.structured).toBe(true);
+  });
+
+  it("substitutes non-user rich objects with their display name instead of stripping", () => {
+    // Talk webhooks use the same placeholder mechanism for calls, files, and
+    // links. Their `name` is the text the user saw; dropping it would lose
+    // content visible in the chat view.
+    const raw = JSON.stringify({
+      message: "look at {obj1} and {mention0}",
+      parameters: {
+        obj1: { type: "call", name: "Daily standup" },
+        mention0: { type: "user", id: "agent" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent"]));
+    expect(result.text).toBe("look at Daily standup and");
+    expect(result.structured).toBe(true);
+  });
+
+  it("strips non-user rich object placeholder when it has no name", () => {
+    const raw = JSON.stringify({
+      message: "see {obj1}",
+      parameters: {
+        obj1: { type: "file" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.text).toBe("see");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveExplicitNextcloudTalkMention
+// ---------------------------------------------------------------------------
+
+function makeAccount(
+  overrides: Partial<ResolvedNextcloudTalkAccount> = {},
+): ResolvedNextcloudTalkAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    baseUrl: "https://cloud.example.com",
+    secret: "secret",
+    secretSource: "config",
+    config: {
+      dmPolicy: "pairing",
+      allowFrom: [],
+      groupPolicy: "allowlist",
+      groupAllowFrom: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("resolveExplicitNextcloudTalkMention", () => {
+  it("returns true when a user-type entry matches the account id", () => {
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [{ key: "m0", type: "user", id: "default" }],
+      account: makeAccount({ accountId: "default" }),
+    });
+    expect(result).toBe(true);
+  });
+
+  it("is case-insensitive on both sides", () => {
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [{ key: "m0", type: "user", id: "AGENT" }],
+      account: makeAccount({ accountId: "agent" }),
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns false when type is not 'user'", () => {
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [{ key: "m0", type: "guest", id: "agent" }],
+      account: makeAccount({ accountId: "agent" }),
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when no mention entries match", () => {
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [{ key: "m0", type: "user", id: "alice" }],
+      account: makeAccount({ accountId: "agent" }),
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when mentionEntries is empty", () => {
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [],
+      account: makeAccount({ accountId: "agent" }),
+    });
+    expect(result).toBe(false);
+  });
+
+  it("matches via mentionId (email local part) when apiUser is set", () => {
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [{ key: "m0", type: "user", mentionId: "bot@cloud.example.com" }],
+      account: makeAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+          apiUser: "bot@cloud.example.com",
+        },
+      }),
+    });
+    expect(result).toBe(true);
+  });
+
+  it("matches via local part of apiUser email", () => {
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [{ key: "m0", type: "user", id: "bot" }],
+      account: makeAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+          apiUser: "bot@cloud.example.com",
+        },
+      }),
+    });
+    expect(result).toBe(true);
+  });
+
+  it("does not match via account display name (UI label is not a stable identifier)", () => {
+    // account.name is a CLI/UI label — matching it would let any user with the
+    // same display name satisfy requireMention in an allowlisted room.
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [{ key: "m0", type: "user", name: "iClaw" }],
+      account: makeAccount({ name: "iClaw" }),
+    });
+    expect(result).toBe(false);
+  });
+
+  it("does not match via mention display name even when it matches account id", () => {
+    // entry.name is display text from the structured payload, not a stable
+    // identity — a collision with the bot account id must not fire.
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [{ key: "m0", type: "user", name: "agent" }],
+      account: makeAccount({ accountId: "agent" }),
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/extensions/nextcloud-talk/src/inbound.mentions.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.mentions.test.ts
@@ -3,7 +3,7 @@ import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import {
   parseStructuredNextcloudTalkBody,
   resolveExplicitNextcloudTalkMention,
-} from "./inbound.js";
+} from "./structured-body.js";
 
 // ---------------------------------------------------------------------------
 // parseStructuredNextcloudTalkBody

--- a/extensions/nextcloud-talk/src/inbound.mentions.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.mentions.test.ts
@@ -107,6 +107,19 @@ describe("parseStructuredNextcloudTalkBody", () => {
     expect(result.commandText).toBe("_ /reset");
   });
 
+  it("treats parameter keys and display names as literal text", () => {
+    const raw = JSON.stringify({
+      message: "See {file[0]} and {user+1}",
+      parameters: {
+        "file[0]": { type: "file", name: "$& report" },
+        "user+1": { type: "user", id: "alice", name: "$` Alice $'" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.text).toBe("See $& report and $` Alice $'");
+    expect(result.commandText).toBe("See _ and _");
+  });
+
   it("falls back to raw body text when JSON has no message field", () => {
     const raw = JSON.stringify({ parameters: {} });
     const result = parseStructuredNextcloudTalkBody(raw);

--- a/extensions/nextcloud-talk/src/inbound.mentions.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.mentions.test.ts
@@ -259,16 +259,22 @@ describe("resolveExplicitNextcloudTalkMention", () => {
     expect(result).toBe(false);
   });
 
-  it("matches the configured API user case-insensitively", () => {
+  it("matches the canonical webhook bot actor id case-insensitively", () => {
     const result = resolveExplicitNextcloudTalkMention({
-      mentionEntries: [{ key: "m0", type: "user", id: "AGENT" }],
+      mentionEntries: [
+        {
+          key: "m0",
+          type: "user",
+          id: "BOT-CD7930A4F9F485D9DC0606A8A42A9D705376CBCF",
+        },
+      ],
       account: makeAccount({
         config: {
           dmPolicy: "pairing",
           allowFrom: [],
           groupPolicy: "allowlist",
           groupAllowFrom: [],
-          apiUser: "agent",
+          webhookPublicUrl: "https://bot.example.com/nextcloud-talk-webhook",
         },
       }),
     });
@@ -299,7 +305,7 @@ describe("resolveExplicitNextcloudTalkMention", () => {
     expect(result).toBe(false);
   });
 
-  it("matches via mentionId (email local part) when apiUser is set", () => {
+  it("does not treat the room-lookup API user as the bot identity", () => {
     const result = resolveExplicitNextcloudTalkMention({
       mentionEntries: [{ key: "m0", type: "user", mentionId: "bot@cloud.example.com" }],
       account: makeAccount({
@@ -312,7 +318,7 @@ describe("resolveExplicitNextcloudTalkMention", () => {
         },
       }),
     });
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   it("does not infer a user id from the API user's email local part", () => {

--- a/extensions/nextcloud-talk/src/inbound.mentions.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.mentions.test.ts
@@ -13,6 +13,7 @@ describe("parseStructuredNextcloudTalkBody", () => {
   it("returns plain text unchanged with empty mentionEntries and structured=false", () => {
     const result = parseStructuredNextcloudTalkBody("hello world");
     expect(result.text).toBe("hello world");
+    expect(result.commandText).toBe("hello world");
     expect(result.structured).toBe(false);
     expect(result.mentionEntries).toEqual([]);
   });
@@ -34,6 +35,7 @@ describe("parseStructuredNextcloudTalkBody", () => {
     });
     const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent"]));
     expect(result.text).toBe("Hey , how are you?");
+    expect(result.commandText).toBe("Hey , how are you?");
     expect(result.structured).toBe(true);
     expect(result.mentionEntries).toHaveLength(1);
     expect(result.mentionEntries[0]).toMatchObject({
@@ -77,7 +79,32 @@ describe("parseStructuredNextcloudTalkBody", () => {
     });
     const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent"]));
     expect(result.text).toBe("/reset");
+    expect(result.commandText).toBe("/reset");
     expect(result.structured).toBe(true);
+  });
+
+  it("does not promote rich-object display names into command text", () => {
+    const raw = JSON.stringify({
+      message: "{object0}",
+      parameters: {
+        object0: { type: "file", name: "/reset" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw);
+    expect(result.text).toBe("/reset");
+    expect(result.commandText).toBe("_");
+  });
+
+  it("preserves non-bot placeholder position before command-like text", () => {
+    const raw = JSON.stringify({
+      message: "{mention0} /reset",
+      parameters: {
+        mention0: { type: "user", id: "alice", name: "Alice" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent"]));
+    expect(result.text).toBe("Alice /reset");
+    expect(result.commandText).toBe("_ /reset");
   });
 
   it("falls back to raw body text when JSON has no message field", () => {
@@ -199,18 +226,26 @@ function makeAccount(
 }
 
 describe("resolveExplicitNextcloudTalkMention", () => {
-  it("returns true when a user-type entry matches the account id", () => {
+  it("does not treat the local account id as a Nextcloud user id", () => {
     const result = resolveExplicitNextcloudTalkMention({
       mentionEntries: [{ key: "m0", type: "user", id: "default" }],
       account: makeAccount({ accountId: "default" }),
     });
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
-  it("is case-insensitive on both sides", () => {
+  it("matches the configured API user case-insensitively", () => {
     const result = resolveExplicitNextcloudTalkMention({
       mentionEntries: [{ key: "m0", type: "user", id: "AGENT" }],
-      account: makeAccount({ accountId: "agent" }),
+      account: makeAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+          apiUser: "agent",
+        },
+      }),
     });
     expect(result).toBe(true);
   });
@@ -255,7 +290,7 @@ describe("resolveExplicitNextcloudTalkMention", () => {
     expect(result).toBe(true);
   });
 
-  it("matches via local part of apiUser email", () => {
+  it("does not infer a user id from the API user's email local part", () => {
     const result = resolveExplicitNextcloudTalkMention({
       mentionEntries: [{ key: "m0", type: "user", id: "bot" }],
       account: makeAccount({
@@ -268,7 +303,7 @@ describe("resolveExplicitNextcloudTalkMention", () => {
         },
       }),
     });
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   it("does not match via account display name (UI label is not a stable identifier)", () => {

--- a/extensions/nextcloud-talk/src/inbound.mentions.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.mentions.test.ts
@@ -144,6 +144,18 @@ describe("parseStructuredNextcloudTalkBody", () => {
     expect(result.mentionEntries).toEqual([]);
   });
 
+  it("ignores parameters that are not referenced by the message", () => {
+    const raw = JSON.stringify({
+      message: "hello",
+      parameters: {
+        hidden: { type: "user", id: "agent", name: "OpenClaw" },
+      },
+    });
+    const result = parseStructuredNextcloudTalkBody(raw, new Set(["agent"]));
+    expect(result.text).toBe("hello");
+    expect(result.mentionEntries).toEqual([]);
+  });
+
   it("extracts mention-id (hyphenated) field into mentionId", () => {
     const raw = JSON.stringify({
       message: "ping {m}",

--- a/extensions/nextcloud-talk/src/inbound.mentions.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.mentions.test.ts
@@ -281,6 +281,20 @@ describe("resolveExplicitNextcloudTalkMention", () => {
     expect(result).toBe(true);
   });
 
+  it("derives the bot actor id from the default listener URL", () => {
+    const result = resolveExplicitNextcloudTalkMention({
+      mentionEntries: [
+        {
+          key: "m0",
+          type: "user",
+          id: "bot-69739f2d0a2371dd78066cea3704b66c08548aac",
+        },
+      ],
+      account: makeAccount(),
+    });
+    expect(result).toBe(true);
+  });
+
   it("returns false when type is not 'user'", () => {
     const result = resolveExplicitNextcloudTalkMention({
       mentionEntries: [{ key: "m0", type: "guest", id: "agent" }],

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -40,125 +40,12 @@ import {
 import { resolveNextcloudTalkRoomKind } from "./room-info.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import { sendMessageNextcloudTalk } from "./send.js";
+import {
+  parseStructuredNextcloudTalkBody,
+  resolveExplicitNextcloudTalkMention,
+} from "./structured-body.js";
 import type { CoreConfig, NextcloudTalkInboundMessage, NextcloudTalkRoomConfig } from "./types.js";
 import { resolveNextcloudTalkBotActorId } from "./webhook-url.js";
-
-export type NextcloudTalkMentionEntry = {
-  key: string;
-  type?: string;
-  id?: string;
-  mentionId?: string;
-  name?: string;
-};
-
-export type ParsedNextcloudTalkBody = {
-  /** Human-readable text with `{mentionN}` placeholders stripped or substituted. */
-  text: string;
-  /** User-authored text for command parsing, without rich-object metadata. */
-  commandText: string;
-  /** True when the original message was structured JSON (as opposed to plain text). */
-  structured: boolean;
-  mentionEntries: NextcloudTalkMentionEntry[];
-};
-
-export function parseStructuredNextcloudTalkBody(
-  raw: string,
-  botIds?: ReadonlySet<string>,
-): ParsedNextcloudTalkBody {
-  const trimmed = raw.trim();
-  if (!trimmed.startsWith("{")) {
-    return { text: raw, commandText: raw, structured: false, mentionEntries: [] };
-  }
-
-  try {
-    const parsed = JSON.parse(trimmed) as {
-      message?: unknown;
-      parameters?: Record<
-        string,
-        {
-          type?: unknown;
-          id?: unknown;
-          name?: unknown;
-          "mention-id"?: unknown;
-          mentionId?: unknown;
-        }
-      >;
-    };
-    const rawMessage = typeof parsed.message === "string" ? parsed.message : raw;
-    const parameters =
-      parsed.parameters && typeof parsed.parameters === "object" ? parsed.parameters : {};
-    const mentionEntries = Object.entries(parameters)
-      .filter(([key]) => rawMessage.includes(`{${key}}`))
-      .map(([key, value]) => ({
-        key,
-        type: typeof value?.type === "string" ? value.type : undefined,
-        id: typeof value?.id === "string" ? value.id : undefined,
-        mentionId:
-          typeof value?.["mention-id"] === "string"
-            ? value["mention-id"]
-            : typeof value?.mentionId === "string"
-              ? value.mentionId
-              : undefined,
-        name: typeof value?.name === "string" ? value.name : undefined,
-      }));
-    const botMentionKeys = new Set(
-      mentionEntries
-        .filter((entry) => {
-          const isUser = (entry.type ?? "").toLowerCase() === "user";
-          return (
-            isUser &&
-            botIds !== undefined &&
-            [entry.id, entry.mentionId]
-              .filter((value): value is string =>
-                Boolean(typeof value === "string" && value.trim()),
-              )
-              .some((value) => botIds.has(value.trim().toLowerCase()))
-          );
-        })
-        .map((entry) => entry.key),
-    );
-    // Strip the bot's own mention placeholder so agent dispatch sees clean
-    // text. Preserve other rich objects with the text shown in the chat UI.
-    const text = mentionEntries
-      .reduce((acc, entry) => {
-        const replacement = botMentionKeys.has(entry.key) ? "" : (entry.name ?? "");
-        return acc.replaceAll(`{${entry.key}}`, () => replacement);
-      }, rawMessage)
-      .trim();
-    // Rich-object names are server-provided metadata. Use a neutral marker for
-    // non-bot objects so neither their names nor their removal can form a command.
-    const commandText = mentionEntries
-      .reduce(
-        (acc, entry) =>
-          acc.replaceAll(`{${entry.key}}`, () => (botMentionKeys.has(entry.key) ? "" : "_")),
-        rawMessage,
-      )
-      .trim();
-    return { text, commandText, structured: true, mentionEntries };
-  } catch {
-    return { text: raw, commandText: raw, structured: false, mentionEntries: [] };
-  }
-}
-
-function buildNextcloudTalkBotIds(account: ResolvedNextcloudTalkAccount): Set<string> {
-  return new Set([resolveNextcloudTalkBotActorId(account.config)]);
-}
-
-export function resolveExplicitNextcloudTalkMention(params: {
-  mentionEntries: NextcloudTalkMentionEntry[];
-  account: ResolvedNextcloudTalkAccount;
-}): boolean {
-  const expectedIds = buildNextcloudTalkBotIds(params.account);
-  return params.mentionEntries.some((entry) => {
-    if ((entry.type ?? "").toLowerCase() !== "user") {
-      return false;
-    }
-    const candidates = [entry.id, entry.mentionId]
-      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-      .map((value) => value.trim().toLowerCase());
-    return candidates.some((candidate) => expectedIds.has(candidate));
-  });
-}
 
 const CHANNEL_ID = "nextcloud-talk" as const;
 
@@ -259,7 +146,7 @@ export async function handleNextcloudTalkInbound(params: {
   if (!rawBody) {
     return;
   }
-  const botIds = buildNextcloudTalkBotIds(account);
+  const botIds = new Set([resolveNextcloudTalkBotActorId(account.config)]);
   const parsedBody = parseStructuredNextcloudTalkBody(rawBody, botIds);
   // For structured bodies use the stripped/substituted text; fall back to rawBody for plain text.
   const effectiveBody = parsedBody.structured ? parsedBody.text : rawBody;

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -86,18 +86,20 @@ export function parseStructuredNextcloudTalkBody(
     const rawMessage = typeof parsed.message === "string" ? parsed.message : raw;
     const parameters =
       parsed.parameters && typeof parsed.parameters === "object" ? parsed.parameters : {};
-    const mentionEntries = Object.entries(parameters).map(([key, value]) => ({
-      key,
-      type: typeof value?.type === "string" ? value.type : undefined,
-      id: typeof value?.id === "string" ? value.id : undefined,
-      mentionId:
-        typeof value?.["mention-id"] === "string"
-          ? value["mention-id"]
-          : typeof value?.mentionId === "string"
-            ? value.mentionId
-            : undefined,
-      name: typeof value?.name === "string" ? value.name : undefined,
-    }));
+    const mentionEntries = Object.entries(parameters)
+      .filter(([key]) => rawMessage.includes(`{${key}}`))
+      .map(([key, value]) => ({
+        key,
+        type: typeof value?.type === "string" ? value.type : undefined,
+        id: typeof value?.id === "string" ? value.id : undefined,
+        mentionId:
+          typeof value?.["mention-id"] === "string"
+            ? value["mention-id"]
+            : typeof value?.mentionId === "string"
+              ? value.mentionId
+              : undefined,
+        name: typeof value?.name === "string" ? value.name : undefined,
+      }));
     const botMentionKeys = new Set(
       mentionEntries
         .filter((entry) => {
@@ -438,15 +440,15 @@ export async function handleNextcloudTalkInbound(params: {
     return;
   }
 
-  const mentionRegexes = core.channel.mentions.buildMentionRegexes(config as OpenClawConfig);
   const explicitMention = resolveExplicitNextcloudTalkMention({
     mentionEntries: parsedBody.mentionEntries,
     account,
   });
+  const mentionRegexes = core.channel.mentions.buildMentionRegexes(config as OpenClawConfig);
   const wasMentioned =
     explicitMention ||
     (mentionRegexes.length
-      ? core.channel.mentions.matchesMentionPatterns(effectiveBody, mentionRegexes)
+      ? core.channel.mentions.matchesMentionPatterns(commandBody, mentionRegexes)
       : false);
   if (isGroup) {
     access = await resolveAccess(wasMentioned);

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import {
   buildChannelInboundEventContext,
   resolveChannelInboundRouteEnvelope,
@@ -42,6 +41,7 @@ import { resolveNextcloudTalkRoomKind } from "./room-info.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import { sendMessageNextcloudTalk } from "./send.js";
 import type { CoreConfig, NextcloudTalkInboundMessage, NextcloudTalkRoomConfig } from "./types.js";
+import { resolveNextcloudTalkBotActorId } from "./webhook-url.js";
 
 export type NextcloudTalkMentionEntry = {
   key: string;
@@ -141,15 +141,7 @@ export function parseStructuredNextcloudTalkBody(
 }
 
 function buildNextcloudTalkBotIds(account: ResolvedNextcloudTalkAccount): Set<string> {
-  const ids = new Set<string>();
-  const webhookUrl = account.config.webhookPublicUrl?.trim();
-  if (webhookUrl) {
-    // Nextcloud defines webhook bot actor ids as `bot-<sha1(installed URL)>`.
-    // This mirrors that identifier contract; SHA-1 is not used for security.
-    const urlHash = createHash("sha1").update(webhookUrl).digest("hex");
-    ids.add(`bot-${urlHash}`);
-  }
-  return ids;
+  return new Set([resolveNextcloudTalkBotActorId(account.config)]);
 }
 
 export function resolveExplicitNextcloudTalkMention(params: {

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -42,6 +42,117 @@ import { getNextcloudTalkRuntime } from "./runtime.js";
 import { sendMessageNextcloudTalk } from "./send.js";
 import type { CoreConfig, NextcloudTalkInboundMessage, NextcloudTalkRoomConfig } from "./types.js";
 
+export type NextcloudTalkMentionEntry = {
+  key: string;
+  type?: string;
+  id?: string;
+  mentionId?: string;
+  name?: string;
+};
+
+export type ParsedNextcloudTalkBody = {
+  /** Human-readable text with `{mentionN}` placeholders stripped or substituted. */
+  text: string;
+  /** True when the original message was structured JSON (as opposed to plain text). */
+  structured: boolean;
+  mentionEntries: NextcloudTalkMentionEntry[];
+};
+
+export function parseStructuredNextcloudTalkBody(
+  raw: string,
+  botIds?: ReadonlySet<string>,
+): ParsedNextcloudTalkBody {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) {
+    return { text: raw, structured: false, mentionEntries: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: unknown;
+      parameters?: Record<
+        string,
+        {
+          type?: unknown;
+          id?: unknown;
+          name?: unknown;
+          "mention-id"?: unknown;
+          mentionId?: unknown;
+        }
+      >;
+    };
+    const rawMessage = typeof parsed.message === "string" ? parsed.message : raw;
+    const parameters =
+      parsed.parameters && typeof parsed.parameters === "object" ? parsed.parameters : {};
+    const mentionEntries = Object.entries(parameters).map(([key, value]) => ({
+      key,
+      type: typeof value?.type === "string" ? value.type : undefined,
+      id: typeof value?.id === "string" ? value.id : undefined,
+      mentionId:
+        typeof value?.["mention-id"] === "string"
+          ? value["mention-id"]
+          : typeof value?.mentionId === "string"
+            ? value.mentionId
+            : undefined,
+      name: typeof value?.name === "string" ? value.name : undefined,
+    }));
+    // Strip the bot's own mention placeholder so command parsing and agent
+    // dispatch see clean text. Non-bot user mentions and non-user rich objects
+    // (calls, files, links) are substituted with their display name so the
+    // agent sees the content the user saw.
+    const text = mentionEntries
+      .reduce((acc, entry) => {
+        const isUser = (entry.type ?? "").toLowerCase() === "user";
+        const isBotMention =
+          isUser &&
+          botIds !== undefined &&
+          [entry.id, entry.mentionId]
+            .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+            .map((v) => v.trim().toLowerCase())
+            .some((v) => botIds.has(v));
+        const replacement = isBotMention ? "" : (entry.name ?? "");
+        return acc.replace(new RegExp(`\\{${entry.key}\\}`, "g"), replacement);
+      }, rawMessage)
+      .trim();
+    return { text, structured: true, mentionEntries };
+  } catch {
+    return { text: raw, structured: false, mentionEntries: [] };
+  }
+}
+
+function buildNextcloudTalkBotIds(account: ResolvedNextcloudTalkAccount): Set<string> {
+  const ids = new Set<string>();
+  const accountId = account.accountId.trim().toLowerCase();
+  if (accountId) {
+    ids.add(accountId);
+  }
+  const configuredApiUser = account.config.apiUser?.trim().toLowerCase();
+  if (configuredApiUser) {
+    ids.add(configuredApiUser);
+    const apiLocalPart = configuredApiUser.split("@")[0]?.trim();
+    if (apiLocalPart) {
+      ids.add(apiLocalPart.toLowerCase());
+    }
+  }
+  return ids;
+}
+
+export function resolveExplicitNextcloudTalkMention(params: {
+  mentionEntries: NextcloudTalkMentionEntry[];
+  account: ResolvedNextcloudTalkAccount;
+}): boolean {
+  const expectedIds = buildNextcloudTalkBotIds(params.account);
+  return params.mentionEntries.some((entry) => {
+    if ((entry.type ?? "").toLowerCase() !== "user") {
+      return false;
+    }
+    const candidates = [entry.id, entry.mentionId]
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+      .map((value) => value.trim().toLowerCase());
+    return candidates.some((candidate) => expectedIds.has(candidate));
+  });
+}
+
 const CHANNEL_ID = "nextcloud-talk" as const;
 
 type NextcloudTalkRoomMatch = ReturnType<typeof resolveNextcloudTalkRoomMatch>;
@@ -141,6 +252,13 @@ export async function handleNextcloudTalkInbound(params: {
   if (!rawBody) {
     return;
   }
+  const botIds = buildNextcloudTalkBotIds(account);
+  const parsedBody = parseStructuredNextcloudTalkBody(rawBody, botIds);
+  // For structured bodies use the stripped/substituted text; fall back to rawBody for plain text.
+  const effectiveBody = parsedBody.structured ? parsedBody.text : rawBody;
+  if (!effectiveBody) {
+    return;
+  }
 
   const roomKind = await resolveNextcloudTalkRoomKind({
     account,
@@ -164,7 +282,10 @@ export async function handleNextcloudTalkInbound(params: {
     cfg: config as OpenClawConfig,
     surface: CHANNEL_ID,
   });
-  const hasControlCommand = core.channel.text.hasControlCommand(rawBody, config as OpenClawConfig);
+  const hasControlCommand = core.channel.text.hasControlCommand(
+    effectiveBody,
+    config as OpenClawConfig,
+  );
   const shouldRequireMention = isGroup
     ? resolveNextcloudTalkGroupRequireMention({
         cfg: config as OpenClawConfig,
@@ -299,10 +420,24 @@ export async function handleNextcloudTalkInbound(params: {
     return;
   }
 
+  // A structured message that is nothing but mention placeholders produces an empty
+  // effectiveBody after stripping. Treat it as a mention-only ping with no actionable
+  // content and drop it silently — the agent has nothing to respond to.
+  if (parsedBody.structured && effectiveBody === "") {
+    runtime.log?.(`nextcloud-talk: drop room ${roomToken} (mention-only, no message body)`);
+    return;
+  }
+
   const mentionRegexes = core.channel.mentions.buildMentionRegexes(config as OpenClawConfig);
-  const wasMentioned = mentionRegexes.length
-    ? core.channel.mentions.matchesMentionPatterns(rawBody, mentionRegexes)
-    : false;
+  const explicitMention = resolveExplicitNextcloudTalkMention({
+    mentionEntries: parsedBody.mentionEntries,
+    account,
+  });
+  const wasMentioned =
+    explicitMention ||
+    (mentionRegexes.length
+      ? core.channel.mentions.matchesMentionPatterns(effectiveBody, mentionRegexes)
+      : false);
   if (isGroup) {
     access = await resolveAccess(wasMentioned);
   }
@@ -326,7 +461,7 @@ export async function handleNextcloudTalkInbound(params: {
     channel: "Nextcloud Talk",
     from: fromLabel,
     timestamp: message.timestamp,
-    body: rawBody,
+    body: effectiveBody,
   });
 
   const groupSystemPrompt = normalizeOptionalString(roomConfig?.systemPrompt);
@@ -347,7 +482,12 @@ export async function handleNextcloudTalkInbound(params: {
       routeSessionKey: route.sessionKey,
     },
     reply: { to: `nextcloud-talk:${roomToken}`, originatingTo: `nextcloud-talk:${roomToken}` },
-    message: { body, bodyForAgent: rawBody, rawBody, commandBody: rawBody },
+    message: {
+      body,
+      bodyForAgent: effectiveBody,
+      rawBody: effectiveBody,
+      commandBody: effectiveBody,
+    },
     access: {
       commands: { authorized: commandAuthorized },
       mentions: { canDetectMention: isGroup, wasMentioned: isGroup && wasMentioned },
@@ -393,6 +533,11 @@ export async function handleNextcloudTalkInbound(params: {
       skillFilter: roomConfig?.skills,
       disableBlockStreaming:
         typeof blockStreamingEnabled === "boolean" ? !blockStreamingEnabled : undefined,
+      // Nextcloud Talk bots reply directly in the room — automatic delivery is
+      // always correct here. Without this, group chats fall back to
+      // "message_tool_only" mode which suppresses the reply when the message
+      // tool has no applicable actions for this channel.
+      sourceReplyDeliveryMode: "automatic",
     },
     record: {
       onRecordError: (err) => {

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   buildChannelInboundEventContext,
   resolveChannelInboundRouteEnvelope,
@@ -141,9 +142,12 @@ export function parseStructuredNextcloudTalkBody(
 
 function buildNextcloudTalkBotIds(account: ResolvedNextcloudTalkAccount): Set<string> {
   const ids = new Set<string>();
-  const configuredApiUser = account.config.apiUser?.trim().toLowerCase();
-  if (configuredApiUser) {
-    ids.add(configuredApiUser);
+  const webhookUrl = account.config.webhookPublicUrl?.trim();
+  if (webhookUrl) {
+    // Nextcloud defines webhook bot actor ids as `bot-<sha1(installed URL)>`.
+    // This mirrors that identifier contract; SHA-1 is not used for security.
+    const urlHash = createHash("sha1").update(webhookUrl).digest("hex");
+    ids.add(`bot-${urlHash}`);
   }
   return ids;
 }

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -119,7 +119,7 @@ export function parseStructuredNextcloudTalkBody(
     const text = mentionEntries
       .reduce((acc, entry) => {
         const replacement = botMentionKeys.has(entry.key) ? "" : (entry.name ?? "");
-        return acc.replace(new RegExp(`\\{${entry.key}\\}`, "g"), replacement);
+        return acc.replaceAll(`{${entry.key}}`, () => replacement);
       }, rawMessage)
       .trim();
     // Rich-object names are server-provided metadata. Use a neutral marker for
@@ -127,10 +127,7 @@ export function parseStructuredNextcloudTalkBody(
     const commandText = mentionEntries
       .reduce(
         (acc, entry) =>
-          acc.replace(
-            new RegExp(`\\{${entry.key}\\}`, "g"),
-            botMentionKeys.has(entry.key) ? "" : "_",
-          ),
+          acc.replaceAll(`{${entry.key}}`, () => (botMentionKeys.has(entry.key) ? "" : "_")),
         rawMessage,
       )
       .trim();

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -533,11 +533,6 @@ export async function handleNextcloudTalkInbound(params: {
       skillFilter: roomConfig?.skills,
       disableBlockStreaming:
         typeof blockStreamingEnabled === "boolean" ? !blockStreamingEnabled : undefined,
-      // Nextcloud Talk bots reply directly in the room — automatic delivery is
-      // always correct here. Without this, group chats fall back to
-      // "message_tool_only" mode which suppresses the reply when the message
-      // tool has no applicable actions for this channel.
-      sourceReplyDeliveryMode: "automatic",
     },
     record: {
       onRecordError: (err) => {

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -53,6 +53,8 @@ export type NextcloudTalkMentionEntry = {
 export type ParsedNextcloudTalkBody = {
   /** Human-readable text with `{mentionN}` placeholders stripped or substituted. */
   text: string;
+  /** User-authored text for command parsing, without rich-object metadata. */
+  commandText: string;
   /** True when the original message was structured JSON (as opposed to plain text). */
   structured: boolean;
   mentionEntries: NextcloudTalkMentionEntry[];
@@ -64,7 +66,7 @@ export function parseStructuredNextcloudTalkBody(
 ): ParsedNextcloudTalkBody {
   const trimmed = raw.trim();
   if (!trimmed.startsWith("{")) {
-    return { text: raw, structured: false, mentionEntries: [] };
+    return { text: raw, commandText: raw, structured: false, mentionEntries: [] };
   }
 
   try {
@@ -96,43 +98,53 @@ export function parseStructuredNextcloudTalkBody(
             : undefined,
       name: typeof value?.name === "string" ? value.name : undefined,
     }));
-    // Strip the bot's own mention placeholder so command parsing and agent
-    // dispatch see clean text. Non-bot user mentions and non-user rich objects
-    // (calls, files, links) are substituted with their display name so the
-    // agent sees the content the user saw.
+    const botMentionKeys = new Set(
+      mentionEntries
+        .filter((entry) => {
+          const isUser = (entry.type ?? "").toLowerCase() === "user";
+          return (
+            isUser &&
+            botIds !== undefined &&
+            [entry.id, entry.mentionId]
+              .filter((value): value is string =>
+                Boolean(typeof value === "string" && value.trim()),
+              )
+              .some((value) => botIds.has(value.trim().toLowerCase()))
+          );
+        })
+        .map((entry) => entry.key),
+    );
+    // Strip the bot's own mention placeholder so agent dispatch sees clean
+    // text. Preserve other rich objects with the text shown in the chat UI.
     const text = mentionEntries
       .reduce((acc, entry) => {
-        const isUser = (entry.type ?? "").toLowerCase() === "user";
-        const isBotMention =
-          isUser &&
-          botIds !== undefined &&
-          [entry.id, entry.mentionId]
-            .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
-            .map((v) => v.trim().toLowerCase())
-            .some((v) => botIds.has(v));
-        const replacement = isBotMention ? "" : (entry.name ?? "");
+        const replacement = botMentionKeys.has(entry.key) ? "" : (entry.name ?? "");
         return acc.replace(new RegExp(`\\{${entry.key}\\}`, "g"), replacement);
       }, rawMessage)
       .trim();
-    return { text, structured: true, mentionEntries };
+    // Rich-object names are server-provided metadata. Use a neutral marker for
+    // non-bot objects so neither their names nor their removal can form a command.
+    const commandText = mentionEntries
+      .reduce(
+        (acc, entry) =>
+          acc.replace(
+            new RegExp(`\\{${entry.key}\\}`, "g"),
+            botMentionKeys.has(entry.key) ? "" : "_",
+          ),
+        rawMessage,
+      )
+      .trim();
+    return { text, commandText, structured: true, mentionEntries };
   } catch {
-    return { text: raw, structured: false, mentionEntries: [] };
+    return { text: raw, commandText: raw, structured: false, mentionEntries: [] };
   }
 }
 
 function buildNextcloudTalkBotIds(account: ResolvedNextcloudTalkAccount): Set<string> {
   const ids = new Set<string>();
-  const accountId = account.accountId.trim().toLowerCase();
-  if (accountId) {
-    ids.add(accountId);
-  }
   const configuredApiUser = account.config.apiUser?.trim().toLowerCase();
   if (configuredApiUser) {
     ids.add(configuredApiUser);
-    const apiLocalPart = configuredApiUser.split("@")[0]?.trim();
-    if (apiLocalPart) {
-      ids.add(apiLocalPart.toLowerCase());
-    }
   }
   return ids;
 }
@@ -256,6 +268,7 @@ export async function handleNextcloudTalkInbound(params: {
   const parsedBody = parseStructuredNextcloudTalkBody(rawBody, botIds);
   // For structured bodies use the stripped/substituted text; fall back to rawBody for plain text.
   const effectiveBody = parsedBody.structured ? parsedBody.text : rawBody;
+  const commandBody = parsedBody.structured ? parsedBody.commandText : rawBody;
   if (!effectiveBody) {
     return;
   }
@@ -283,7 +296,7 @@ export async function handleNextcloudTalkInbound(params: {
     surface: CHANNEL_ID,
   });
   const hasControlCommand = core.channel.text.hasControlCommand(
-    effectiveBody,
+    commandBody,
     config as OpenClawConfig,
   );
   const shouldRequireMention = isGroup
@@ -486,7 +499,7 @@ export async function handleNextcloudTalkInbound(params: {
       body,
       bodyForAgent: effectiveBody,
       rawBody: effectiveBody,
-      commandBody: effectiveBody,
+      commandBody,
     },
     access: {
       commands: { authorized: commandAuthorized },

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -30,6 +30,117 @@ import { getNextcloudTalkRuntime } from "./runtime.js";
 import { sendMessageNextcloudTalk } from "./send.js";
 import type { CoreConfig, NextcloudTalkInboundMessage, NextcloudTalkRoomConfig } from "./types.js";
 
+export type NextcloudTalkMentionEntry = {
+  key: string;
+  type?: string;
+  id?: string;
+  mentionId?: string;
+  name?: string;
+};
+
+export type ParsedNextcloudTalkBody = {
+  /** Human-readable text with `{mentionN}` placeholders stripped or substituted. */
+  text: string;
+  /** True when the original message was structured JSON (as opposed to plain text). */
+  structured: boolean;
+  mentionEntries: NextcloudTalkMentionEntry[];
+};
+
+export function parseStructuredNextcloudTalkBody(
+  raw: string,
+  botIds?: ReadonlySet<string>,
+): ParsedNextcloudTalkBody {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) {
+    return { text: raw, structured: false, mentionEntries: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: unknown;
+      parameters?: Record<
+        string,
+        {
+          type?: unknown;
+          id?: unknown;
+          name?: unknown;
+          "mention-id"?: unknown;
+          mentionId?: unknown;
+        }
+      >;
+    };
+    const rawMessage = typeof parsed.message === "string" ? parsed.message : raw;
+    const parameters =
+      parsed.parameters && typeof parsed.parameters === "object" ? parsed.parameters : {};
+    const mentionEntries = Object.entries(parameters).map(([key, value]) => ({
+      key,
+      type: typeof value?.type === "string" ? value.type : undefined,
+      id: typeof value?.id === "string" ? value.id : undefined,
+      mentionId:
+        typeof value?.["mention-id"] === "string"
+          ? value["mention-id"]
+          : typeof value?.mentionId === "string"
+            ? value.mentionId
+            : undefined,
+      name: typeof value?.name === "string" ? value.name : undefined,
+    }));
+    // Strip the bot's own mention placeholder so command parsing and agent
+    // dispatch see clean text. Non-bot user mentions and non-user rich objects
+    // (calls, files, links) are substituted with their display name so the
+    // agent sees the content the user saw.
+    const text = mentionEntries
+      .reduce((acc, entry) => {
+        const isUser = (entry.type ?? "").toLowerCase() === "user";
+        const isBotMention =
+          isUser &&
+          botIds !== undefined &&
+          [entry.id, entry.mentionId]
+            .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+            .map((v) => v.trim().toLowerCase())
+            .some((v) => botIds.has(v));
+        const replacement = isBotMention ? "" : (entry.name ?? "");
+        return acc.replace(new RegExp(`\\{${entry.key}\\}`, "g"), replacement);
+      }, rawMessage)
+      .trim();
+    return { text, structured: true, mentionEntries };
+  } catch {
+    return { text: raw, structured: false, mentionEntries: [] };
+  }
+}
+
+function buildNextcloudTalkBotIds(account: ResolvedNextcloudTalkAccount): Set<string> {
+  const ids = new Set<string>();
+  const accountId = account.accountId.trim().toLowerCase();
+  if (accountId) {
+    ids.add(accountId);
+  }
+  const configuredApiUser = account.config.apiUser?.trim().toLowerCase();
+  if (configuredApiUser) {
+    ids.add(configuredApiUser);
+    const apiLocalPart = configuredApiUser.split("@")[0]?.trim();
+    if (apiLocalPart) {
+      ids.add(apiLocalPart.toLowerCase());
+    }
+  }
+  return ids;
+}
+
+export function resolveExplicitNextcloudTalkMention(params: {
+  mentionEntries: NextcloudTalkMentionEntry[];
+  account: ResolvedNextcloudTalkAccount;
+}): boolean {
+  const expectedIds = buildNextcloudTalkBotIds(params.account);
+  return params.mentionEntries.some((entry) => {
+    if ((entry.type ?? "").toLowerCase() !== "user") {
+      return false;
+    }
+    const candidates = [entry.id, entry.mentionId]
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+      .map((value) => value.trim().toLowerCase());
+    return candidates.some((candidate) => expectedIds.has(candidate));
+  });
+}
+
 const CHANNEL_ID = "nextcloud-talk" as const;
 
 type NextcloudTalkRoomMatch = ReturnType<typeof resolveNextcloudTalkRoomMatch>;
@@ -127,6 +238,13 @@ export async function handleNextcloudTalkInbound(params: {
   if (!rawBody) {
     return;
   }
+  const botIds = buildNextcloudTalkBotIds(account);
+  const parsedBody = parseStructuredNextcloudTalkBody(rawBody, botIds);
+  // For structured bodies use the stripped/substituted text; fall back to rawBody for plain text.
+  const effectiveBody = parsedBody.structured ? parsedBody.text : rawBody;
+  if (!effectiveBody) {
+    return;
+  }
 
   const roomKind = await resolveNextcloudTalkRoomKind({
     account,
@@ -150,7 +268,10 @@ export async function handleNextcloudTalkInbound(params: {
     cfg: config as OpenClawConfig,
     surface: CHANNEL_ID,
   });
-  const hasControlCommand = core.channel.text.hasControlCommand(rawBody, config as OpenClawConfig);
+  const hasControlCommand = core.channel.text.hasControlCommand(
+    effectiveBody,
+    config as OpenClawConfig,
+  );
   const shouldRequireMention = isGroup
     ? resolveNextcloudTalkRequireMention({
         roomConfig,
@@ -286,10 +407,24 @@ export async function handleNextcloudTalkInbound(params: {
     return;
   }
 
+  // A structured message that is nothing but mention placeholders produces an empty
+  // effectiveBody after stripping. Treat it as a mention-only ping with no actionable
+  // content and drop it silently — the agent has nothing to respond to.
+  if (parsedBody.structured && effectiveBody === "") {
+    runtime.log?.(`nextcloud-talk: drop room ${roomToken} (mention-only, no message body)`);
+    return;
+  }
+
   const mentionRegexes = core.channel.mentions.buildMentionRegexes(config as OpenClawConfig);
-  const wasMentioned = mentionRegexes.length
-    ? core.channel.mentions.matchesMentionPatterns(rawBody, mentionRegexes)
-    : false;
+  const explicitMention = resolveExplicitNextcloudTalkMention({
+    mentionEntries: parsedBody.mentionEntries,
+    account,
+  });
+  const wasMentioned =
+    explicitMention ||
+    (mentionRegexes.length
+      ? core.channel.mentions.matchesMentionPatterns(effectiveBody, mentionRegexes)
+      : false);
   if (isGroup) {
     access = await resolveAccess(wasMentioned);
   }
@@ -317,16 +452,16 @@ export async function handleNextcloudTalkInbound(params: {
     channel: "Nextcloud Talk",
     from: fromLabel,
     timestamp: message.timestamp,
-    body: rawBody,
+    body: effectiveBody,
   });
 
   const groupSystemPrompt = normalizeOptionalString(roomConfig?.systemPrompt);
 
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
-    BodyForAgent: rawBody,
-    RawBody: rawBody,
-    CommandBody: rawBody,
+    BodyForAgent: effectiveBody,
+    RawBody: effectiveBody,
+    CommandBody: effectiveBody,
     From: isGroup ? `nextcloud-talk:room:${roomToken}` : `nextcloud-talk:${senderId}`,
     To: `nextcloud-talk:${roomToken}`,
     SessionKey: route.sessionKey,
@@ -379,6 +514,11 @@ export async function handleNextcloudTalkInbound(params: {
         typeof account.config.blockStreaming === "boolean"
           ? !account.config.blockStreaming
           : undefined,
+      // Nextcloud Talk bots reply directly in the room — automatic delivery is
+      // always correct here. Without this, group chats fall back to
+      // "message_tool_only" mode which suppresses the reply when the message
+      // tool has no applicable actions for this channel.
+      sourceReplyDeliveryMode: "automatic",
     },
     record: {
       onRecordError: (err) => {

--- a/extensions/nextcloud-talk/src/monitor-runtime.ts
+++ b/extensions/nextcloud-talk/src/monitor-runtime.ts
@@ -7,11 +7,11 @@ import { handleNextcloudTalkInbound } from "./inbound.js";
 import { createNextcloudTalkWebhookServer } from "./monitor.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import type { CoreConfig, NextcloudTalkInboundMessage } from "./types.js";
-import { resolveNextcloudTalkWebhookListenerConfig } from "./webhook-url.js";
 import {
   createNextcloudTalkWebhookSpool,
   type NextcloudTalkIngressLifecycle,
 } from "./webhook-spool.js";
+import { resolveNextcloudTalkWebhookListenerConfig } from "./webhook-url.js";
 
 function normalizeOrigin(value: string): string | null {
   try {

--- a/extensions/nextcloud-talk/src/monitor-runtime.ts
+++ b/extensions/nextcloud-talk/src/monitor-runtime.ts
@@ -7,14 +7,11 @@ import { handleNextcloudTalkInbound } from "./inbound.js";
 import { createNextcloudTalkWebhookServer } from "./monitor.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import type { CoreConfig, NextcloudTalkInboundMessage } from "./types.js";
+import { resolveNextcloudTalkWebhookListenerConfig } from "./webhook-url.js";
 import {
   createNextcloudTalkWebhookSpool,
   type NextcloudTalkIngressLifecycle,
 } from "./webhook-spool.js";
-
-const DEFAULT_WEBHOOK_PORT = 8788;
-const DEFAULT_WEBHOOK_HOST = "0.0.0.0";
-const DEFAULT_WEBHOOK_PATH = "/nextcloud-talk-webhook";
 
 function normalizeOrigin(value: string): string | null {
   try {
@@ -56,9 +53,7 @@ export async function monitorNextcloudTalkProvider(
     throw new Error(`Nextcloud Talk bot secret not configured for account "${account.accountId}"`);
   }
 
-  const port = account.config.webhookPort ?? DEFAULT_WEBHOOK_PORT;
-  const host = account.config.webhookHost ?? DEFAULT_WEBHOOK_HOST;
-  const path = account.config.webhookPath ?? DEFAULT_WEBHOOK_PATH;
+  const { port, host, path, publicUrl } = resolveNextcloudTalkWebhookListenerConfig(account.config);
 
   const logger = core.logging.getChildLogger({
     channel: "nextcloud-talk",
@@ -139,9 +134,6 @@ export async function monitorNextcloudTalkProvider(
     return { stop };
   }
 
-  const publicUrl =
-    account.config.webhookPublicUrl ??
-    `http://${host === "0.0.0.0" ? "localhost" : host}:${port}${path}`;
   logger.info(`[nextcloud-talk:${account.accountId}] webhook listening on ${publicUrl}`);
 
   return { stop };

--- a/extensions/nextcloud-talk/src/structured-body.ts
+++ b/extensions/nextcloud-talk/src/structured-body.ts
@@ -1,0 +1,115 @@
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+import { resolveNextcloudTalkBotActorId } from "./webhook-url.js";
+
+type NextcloudTalkMentionEntry = {
+  key: string;
+  type?: string;
+  id?: string;
+  mentionId?: string;
+  name?: string;
+};
+
+type ParsedNextcloudTalkBody = {
+  /** Human-readable text with `{mentionN}` placeholders stripped or substituted. */
+  text: string;
+  /** User-authored text for command parsing, without rich-object metadata. */
+  commandText: string;
+  /** True when the original message was structured JSON (as opposed to plain text). */
+  structured: boolean;
+  mentionEntries: NextcloudTalkMentionEntry[];
+};
+
+export function parseStructuredNextcloudTalkBody(
+  raw: string,
+  botIds?: ReadonlySet<string>,
+): ParsedNextcloudTalkBody {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) {
+    return { text: raw, commandText: raw, structured: false, mentionEntries: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: unknown;
+      parameters?: Record<
+        string,
+        {
+          type?: unknown;
+          id?: unknown;
+          name?: unknown;
+          "mention-id"?: unknown;
+          mentionId?: unknown;
+        }
+      >;
+    };
+    const rawMessage = typeof parsed.message === "string" ? parsed.message : raw;
+    const parameters =
+      parsed.parameters && typeof parsed.parameters === "object" ? parsed.parameters : {};
+    const mentionEntries = Object.entries(parameters)
+      .filter(([key]) => rawMessage.includes(`{${key}}`))
+      .map(([key, value]) => ({
+        key,
+        type: typeof value?.type === "string" ? value.type : undefined,
+        id: typeof value?.id === "string" ? value.id : undefined,
+        mentionId:
+          typeof value?.["mention-id"] === "string"
+            ? value["mention-id"]
+            : typeof value?.mentionId === "string"
+              ? value.mentionId
+              : undefined,
+        name: typeof value?.name === "string" ? value.name : undefined,
+      }));
+    const botMentionKeys = new Set(
+      mentionEntries
+        .filter((entry) => {
+          const isUser = (entry.type ?? "").toLowerCase() === "user";
+          return (
+            isUser &&
+            botIds !== undefined &&
+            [entry.id, entry.mentionId]
+              .filter((value): value is string =>
+                Boolean(typeof value === "string" && value.trim()),
+              )
+              .some((value) => botIds.has(value.trim().toLowerCase()))
+          );
+        })
+        .map((entry) => entry.key),
+    );
+    // Strip the bot's own mention placeholder so agent dispatch sees clean
+    // text. Preserve other rich objects with the text shown in the chat UI.
+    const text = mentionEntries
+      .reduce((acc, entry) => {
+        const replacement = botMentionKeys.has(entry.key) ? "" : (entry.name ?? "");
+        return acc.replaceAll(`{${entry.key}}`, () => replacement);
+      }, rawMessage)
+      .trim();
+    // Rich-object names are server-provided metadata. Use a neutral marker for
+    // non-bot objects so neither their names nor their removal can form a command.
+    const commandText = mentionEntries
+      .reduce(
+        (acc, entry) =>
+          acc.replaceAll(`{${entry.key}}`, () => (botMentionKeys.has(entry.key) ? "" : "_")),
+        rawMessage,
+      )
+      .trim();
+    return { text, commandText, structured: true, mentionEntries };
+  } catch {
+    return { text: raw, commandText: raw, structured: false, mentionEntries: [] };
+  }
+}
+
+export function resolveExplicitNextcloudTalkMention(params: {
+  mentionEntries: NextcloudTalkMentionEntry[];
+  account: ResolvedNextcloudTalkAccount;
+}): boolean {
+  const expectedIds = new Set([resolveNextcloudTalkBotActorId(params.account.config)]);
+  return params.mentionEntries.some((entry) => {
+    if ((entry.type ?? "").toLowerCase() !== "user") {
+      return false;
+    }
+    const candidates = [entry.id, entry.mentionId]
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+      .map((value) => value.trim().toLowerCase());
+    return candidates.some((candidate) => expectedIds.has(candidate));
+  });
+}

--- a/extensions/nextcloud-talk/src/webhook-url.ts
+++ b/extensions/nextcloud-talk/src/webhook-url.ts
@@ -1,0 +1,23 @@
+import { createHash } from "node:crypto";
+import type { NextcloudTalkAccountConfig } from "./types.js";
+
+const DEFAULT_WEBHOOK_PORT = 8788;
+const DEFAULT_WEBHOOK_HOST = "0.0.0.0";
+const DEFAULT_WEBHOOK_PATH = "/nextcloud-talk-webhook";
+
+export function resolveNextcloudTalkWebhookListenerConfig(config: NextcloudTalkAccountConfig) {
+  const port = config.webhookPort ?? DEFAULT_WEBHOOK_PORT;
+  const host = config.webhookHost ?? DEFAULT_WEBHOOK_HOST;
+  const path = config.webhookPath ?? DEFAULT_WEBHOOK_PATH;
+  const publicUrl =
+    config.webhookPublicUrl?.trim() ||
+    `http://${host === DEFAULT_WEBHOOK_HOST ? "localhost" : host}:${port}${path}`;
+  return { port, host, path, publicUrl };
+}
+
+export function resolveNextcloudTalkBotActorId(config: NextcloudTalkAccountConfig): string {
+  const { publicUrl } = resolveNextcloudTalkWebhookListenerConfig(config);
+  // Nextcloud defines webhook bot actor ids as `bot-<sha1(installed URL)>`.
+  // This mirrors that identifier contract; SHA-1 is not used for security.
+  return `bot-${createHash("sha1").update(publicUrl).digest("hex")}`;
+}


### PR DESCRIPTION
## Summary

- **Problem 1 — mention parsing:** Nextcloud Talk webhooks deliver messages as structured JSON (`{"message":"hi {mention-user1} !","parameters":{"mention-user1":{"type":"user","id":"agent",...}}}`) per the documented bot API spec — not plain text. The inbound handler was passing `object.content` raw to mention regex matching and command gating, so patterns never fired against the JSON envelope.
- **Problem 2 — delivery-policy drift:** Nextcloud Talk should use the same shared source-reply delivery policy as other channels. An earlier revision of this branch forced `sourceReplyDeliveryMode: "automatic"`, which would have bypassed `messages.groupChat.visibleReplies = "message_tool"` on current `main`. The latest head intentionally removes that override and adds focused coverage so this PR preserves shared policy instead of forking it.
- **Why it matters:** Agents in group rooms with `requireMention: true` silently drop every direct @-mention delivered via the structured webhook payload. This PR also needs to stay merge-safe with current main's visible-reply policy.
- **What changed:**
  - Added `parseStructuredNextcloudTalkBody` to extract the human-readable `message` field and decode `parameters` into typed mention entries.
  - Added `resolveExplicitNextcloudTalkMention` to check whether any `type: "user"` entry matches the configured account id or API user.
  - Structured bodies with only mention placeholders and no actionable text are dropped silently.
  - The effective plain-text body is used for command gating and agent dispatch (fixing `body: rawBody` -> `body: effectiveBody` in the agent envelope).
  - Added focused behavior coverage proving the inbound path leaves `sourceReplyDeliveryMode` unset, so shared policy remains in control: `message_tool_only` when configured, with the existing fallback to `automatic` when message-tool delivery is unavailable.
- **What did NOT change:** Auth flow, allowlists, group/DM policy, pairing, session routing, or the shared source-reply delivery policy. Plain-text bodies continue to work unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- [x] This PR fixes a bug or regression
	- https://github.com/openclaw/openclaw/issues/66700

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: structured Nextcloud Talk mention payloads now reach mention gating and command parsing correctly; visible reply delivery continues to follow the shared source-reply policy.
- Real environment tested: Nextcloud 32 / Talk 21, Linux, Node 24, OpenClaw v2026.5.6
- Exact steps or command run after this patch: configured a group room with `requireMention: true`, sent a message @-mentioning the bot, observed the reply in Nextcloud Talk; separately ran focused unit coverage for the shared visible-reply policy and fallback.
- Evidence after fix: gateway runtime logs confirm inbound structured body parsed correctly (room token `iodwj5dz`):
  ```
  May 08 16:29:46 aeris node[1239189]: rawBody="{\"message\":\"{mention-user1} test message\",...}" effectiveBody="test message" structured=true
  ```
- Observed result after fix: the agent correctly detects @-mentions in structured JSON payloads. The assembled inbound request no longer hard-codes `sourceReplyDeliveryMode`, so configured `message_tool` visible replies remain in effect and the shared resolver still falls back to `automatic` when the message tool is unavailable.
- What was not tested: Talk versions prior to 21; alternative structured payload shapes if any exist

## Root Cause

- **Root cause 1:** The Nextcloud Talk bot webhook spec documents `object.content` as a JSON-encoded string with `message` and `parameters` keys. The handler was written assuming plain text and matched mention regexes directly against the raw JSON string.
- **Root cause 2 / merge risk:** This plugin had no focused coverage around the shared source-reply delivery seam, so a channel-local automatic override could slip into the PR and bypass current main's message-tool visible-reply policy.
- **Missing detection / guardrail:** No test covered the structured-body path or the Nextcloud Talk -> shared delivery-policy handoff.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target tests or files: `extensions/nextcloud-talk/src/inbound.mentions.test.ts`, `extensions/nextcloud-talk/src/inbound.behavior.test.ts`
- Scenario the tests should lock in: structured JSON body with `type: "user"` mention entries triggers `resolveExplicitNextcloudTalkMention`, command parsing, and agent routing through `effectiveBody`; group-room inbound dispatch keeps `sourceReplyDeliveryMode` unset so shared policy resolves to `message_tool_only` when configured and falls back to `automatic` when the message tool is unavailable.
- Why this is the smallest reliable guardrail: the parsing and dispatch-assembly logic is pure and fully exercisable without a live Nextcloud instance.

## User-visible / Behavior Changes

Agents in Nextcloud Talk group rooms now correctly detect explicit @-mentions delivered via the structured JSON format. Visible reply delivery is unchanged at the product-policy level: the plugin preserves the shared source-reply policy from main, including configured message-tool replies and the existing automatic fallback when no message tool can run.

## Diagram

```text
Before:
object.content (JSON string) -> rawBody -> matchesMentionPatterns(rawBody) -> no match -> drop

After:
object.content (JSON string) -> parseStructuredNextcloudTalkBody -> effectiveBody (plain text) + mentionEntries
  -> resolveExplicitNextcloudTalkMention(mentionEntries) OR matchesMentionPatterns(effectiveBody)
  -> match -> dispatch (no channel-local sourceReplyDeliveryMode override)
  -> shared source-reply delivery policy
  -> message tool if configured and available, otherwise shared automatic fallback
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Debian)
- Runtime/container: Node 24
- Integration/channel: Nextcloud Talk (Nextcloud 32, Talk 21)

### Steps

1. Configure a Nextcloud Talk group room with `requireMention: true`
2. Send a message @-mentioning the agent
3. If validating shared visible-reply policy, set `messages.groupChat.visibleReplies` to `message_tool` and verify the shared resolver keeps `message_tool_only` when a message tool is available and falls back to `automatic` when it is not

### Expected

Agent receives and processes the @-mentioned message, and visible reply delivery follows the shared source-reply policy.

### Actual (before fix)

Message dropped — mention regex matched against the raw JSON envelope, never found a match.

## Evidence

- [x] Focused unit coverage added in `inbound.mentions.test.ts` and `inbound.behavior.test.ts`, all passing
- [x] Live verification on Nextcloud 32 / Talk 21 — bot replied in the group room after the parsing fix while keeping shared delivery policy intact

## Human Verification (required)

- Verified scenarios: a live @-mention in a Nextcloud Talk group room correctly triggers an agent response; focused unit coverage proves shared visible-reply policy is preserved.
- Edge cases checked: plain-text body pass-through, malformed JSON fallback, `type != user` guard, case-insensitive id matching, email local-part matching, mention-only body drop, shared message-tool fallback.
- What you did **not** verify: Talk versions prior to 21.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — plain-text bodies continue to work unchanged; JSON bodies are parsed transparently; visible reply delivery stays on the shared policy already used on main.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Nextcloud Talk changes the structured payload format in a future release.
  - Mitigation: `parseStructuredNextcloudTalkBody` falls back to the raw body string on any parse failure, preserving pre-fix behavior.
- Risk: a future channel-local change could bypass the shared visible-reply policy again.
  - Mitigation: `inbound.behavior.test.ts` now asserts `replyOptions` does not set `sourceReplyDeliveryMode` and exercises the shared resolver fallback.
