### PR TITLE
feat(reply): emit structured runtime incidents

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../infra/agent-events.js", async () => {
   return {
     ...actual,
     emitAgentEvent: vi.fn(),
+    emitAgentRuntimeIncidentEvent: vi.fn(),
     registerAgentRunContext: vi.fn(),
   };
 });
@@ -2645,6 +2646,68 @@ describe("runAgentTurnWithFallback", () => {
     if (result.kind === "final") {
       expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
     }
+  });
+
+  it("emits a structured runtime incident for generic runner failures", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const emitAgentRuntimeIncidentEvent = vi.mocked(agentEvents.emitAgentRuntimeIncidentEvent);
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error("openai-codex/gpt-5.5 ended with an incomplete terminal response"),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "direct",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+        opts: { runId: "run-generic-failure" } as GetReplyOptions,
+      }),
+    );
+
+    expect(result.kind).toBe("final");
+    expect(emitAgentRuntimeIncidentEvent).toHaveBeenCalledWith({
+      runId: "run-generic-failure",
+      sessionKey: "main",
+      data: expect.objectContaining({
+        phase: "detected",
+        kind: "runtime_fallback",
+        incidentType: "generic_runner_failure",
+        severity: "warning",
+        suspectedLayer: "agent reply fallback",
+        recommendedNext: "triage_runtime_first",
+        userVisibleText: GENERIC_RUN_FAILURE_TEXT,
+      }),
+    });
+  });
+
+  it("classifies command lane timeouts as runtime incidents", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const emitAgentRuntimeIncidentEvent = vi.mocked(agentEvents.emitAgentRuntimeIncidentEvent);
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error(
+        'lane task error: lane=main durationMs=629999 error="CommandLaneTaskTimeoutError: Command lane main task timed out after 630000ms"',
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        opts: { runId: "run-lane-timeout" } as GetReplyOptions,
+      }),
+    );
+
+    expect(emitAgentRuntimeIncidentEvent).toHaveBeenCalledWith({
+      runId: "run-lane-timeout",
+      sessionKey: "main",
+      data: expect.objectContaining({
+        incidentType: "command_lane_timeout",
+        suspectedLayer: "OpenClaw command lane / main run timeout",
+      }),
+    });
   });
 
   it("keeps raw runner failure guidance visible in verbose Discord direct chats", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -40,7 +40,12 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
-import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import {
+  emitAgentEvent,
+  emitAgentRuntimeIncidentEvent,
+  registerAgentRunContext,
+  type AgentRuntimeIncidentEventData,
+} from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
@@ -411,6 +416,72 @@ type ExternalRunFailureReply = {
   text: string;
   isGenericRunnerFailure: boolean;
 };
+
+function classifyRuntimeFallbackIncident(
+  message: string,
+): Pick<AgentRuntimeIncidentEventData, "incidentType" | "suspectedLayer" | "impact"> {
+  if (/CommandLaneTaskTimeoutError|lane task error|task timed out|Command lane/iu.test(message)) {
+    return {
+      incidentType: "command_lane_timeout",
+      suspectedLayer: "OpenClaw command lane / main run timeout",
+      impact:
+        "The main run may have timed out before the assistant could explain or finish the task.",
+    };
+  }
+  if (/Request timed out before a response was generated/iu.test(message)) {
+    return {
+      incidentType: "response_generation_timeout",
+      suspectedLayer: "agent response generation",
+      impact: "The model/run did not produce a final response before timeout.",
+    };
+  }
+  if (
+    CLI_BACKEND_NO_OUTPUT_STALL_RE.test(message) ||
+    CLI_BACKEND_OVERALL_TIMEOUT_RE.test(message)
+  ) {
+    return {
+      incidentType: "response_generation_timeout",
+      suspectedLayer: "CLI backend subprocess",
+      impact: "The CLI backend timed out before producing a complete assistant response.",
+    };
+  }
+  if (isToolResultTurnMismatchError(message)) {
+    return {
+      incidentType: "session_history_out_of_sync",
+      suspectedLayer: "session history synchronization",
+      impact:
+        "The session context may be inconsistent; continuing blindly risks acting on stale state.",
+    };
+  }
+  return {
+    incidentType: "generic_runner_failure",
+    suspectedLayer: "agent reply fallback",
+    impact: "A user-visible fallback may have replaced the real failure detail.",
+  };
+}
+
+function emitRuntimeFallbackIncident(params: {
+  runId: string;
+  sessionKey?: string;
+  message: string;
+  userVisibleText: string;
+  recommendedNext?: AgentRuntimeIncidentEventData["recommendedNext"];
+}) {
+  const classification = classifyRuntimeFallbackIncident(params.message);
+  emitAgentRuntimeIncidentEvent({
+    runId: params.runId,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    data: {
+      phase: "detected",
+      kind: "runtime_fallback",
+      severity: "warning",
+      recommendedNext: params.recommendedNext ?? "triage_runtime_first",
+      error: sanitizeUserFacingText(params.message, { errorContext: true }).slice(0, 900),
+      userVisibleText: params.userVisibleText,
+      ...classification,
+    },
+  });
+}
 
 function isNonDirectConversationContext(ctx: TemplateContext): boolean {
   const chatType = normalizeLowercaseStringOrEmpty(ctx.ChatType);
@@ -2188,6 +2259,20 @@ export async function runAgentTurnWithFallback(params: {
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
       });
+      const runtimeIncidentClassification = classifyRuntimeFallbackIncident(message);
+      if (
+        externalRunFailureReply?.isGenericRunnerFailure ||
+        runtimeIncidentClassification.incidentType === "command_lane_timeout" ||
+        runtimeIncidentClassification.incidentType === "response_generation_timeout" ||
+        runtimeIncidentClassification.incidentType === "session_history_out_of_sync"
+      ) {
+        emitRuntimeFallbackIncident({
+          runId,
+          sessionKey: params.sessionKey,
+          message,
+          userVisibleText: userVisibleFallbackText,
+        });
+      }
 
       params.replyOperation?.fail("run_failed", err);
       return {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -99,6 +99,22 @@ export type AgentPatchSummaryEventData = {
   summary: string;
 };
 
+export type AgentRuntimeIncidentEventData = {
+  phase: "detected";
+  kind: "runtime_fallback";
+  incidentType:
+    | "command_lane_timeout"
+    | "response_generation_timeout"
+    | "session_history_out_of_sync"
+    | "generic_runner_failure";
+  severity: "warning" | "error";
+  suspectedLayer: string;
+  impact: string;
+  recommendedNext: "resume_original_task_first_then_triage_runtime" | "triage_runtime_first";
+  error?: string;
+  userVisibleText?: string;
+};
+
 export type AgentEventPayload = {
   runId: string;
   seq: number;
@@ -294,6 +310,19 @@ export function emitAgentPatchSummaryEvent(params: {
   emitAgentEvent({
     runId: params.runId,
     stream: "patch",
+    data: params.data as unknown as Record<string, unknown>,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+  });
+}
+
+export function emitAgentRuntimeIncidentEvent(params: {
+  runId: string;
+  data: AgentRuntimeIncidentEventData;
+  sessionKey?: string;
+}) {
+  emitAgentEvent({
+    runId: params.runId,
+    stream: "incident",
     data: params.data as unknown as Record<string, unknown>,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
   });


### PR DESCRIPTION
## Summary
- add a typed `incident` agent event for runtime fallback failures
- classify reply-runner fallbacks into command lane timeouts, response-generation timeouts, session-history desync, or generic runner failures
- keep the existing user-visible fallback text unchanged while emitting structured metadata for watchdogs/observers

## Why
Generic fallback copy such as “Something went wrong…” is useful for users but hard for monitoring code to distinguish from ordinary assistant output. Emitting a structured incident event lets downstream watchdogs decide whether to resume the original task, triage runtime health, or surface a clearer owner alert.

## Real behavior proof
- **Behavior or issue addressed**: Runtime fallback failures can now be emitted as structured `incident` agent events instead of only appearing as generic user-visible fallback copy.
- **Real environment tested**: Local OpenClaw setup on Linux, `openclaw --version` output `OpenClaw 2026.5.5 (b1abf9d)`, running this branch from `/home/openclaw-01/.openclaw/workspace/tmp/openclaw-runtime-incident-work`.
- **Exact steps or command run after this patch**:
  ```bash
  openclaw --version
  corepack pnpm exec tsx --no-warnings -e 'import { emitAgentRuntimeIncidentEvent, onAgentEvent, resetAgentEventsForTest } from "./src/infra/agent-events.ts"; resetAgentEventsForTest(); const off = onAgentEvent((evt) => { console.log(JSON.stringify({ stream: evt.stream, runId: evt.runId, sessionKey: evt.sessionKey, data: evt.data }, null, 2)); }); emitAgentRuntimeIncidentEvent({ runId: "real-proof-runtime-incident", sessionKey: "agent:main:proof", data: { phase: "detected", kind: "runtime_fallback", incidentType: "command_lane_timeout", severity: "warning", suspectedLayer: "OpenClaw command lane / main run timeout", impact: "The main run may have timed out before the assistant could explain or finish the task.", recommendedNext: "triage_runtime_first", error: "CommandLaneTaskTimeoutError: Command lane main task timed out after 630000ms", userVisibleText: "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session." } }); off();'
  ```
- **Evidence after fix**: Terminal output from the real local OpenClaw worktree:
  ```text
  OpenClaw 2026.5.5 (b1abf9d)
  {
    "stream": "incident",
    "runId": "real-proof-runtime-incident",
    "sessionKey": "agent:main:proof",
    "data": {
      "phase": "detected",
      "kind": "runtime_fallback",
      "incidentType": "command_lane_timeout",
      "severity": "warning",
      "suspectedLayer": "OpenClaw command lane / main run timeout",
      "impact": "The main run may have timed out before the assistant could explain or finish the task.",
      "recommendedNext": "triage_runtime_first",
      "error": "CommandLaneTaskTimeoutError: Command lane main task timed out after 630000ms",
      "userVisibleText": "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session."
    }
  }
  ```
- **Observed result after fix**: The agent event listener received a structured `stream: "incident"` payload with `incidentType: "command_lane_timeout"`, `suspectedLayer`, `impact`, `recommendedNext`, the sanitized error, and the unchanged user-visible fallback text.
- **What was not tested**: Full end-to-end live gateway timeout reproduction; that path is covered by the targeted fallback tests below.

## Tests
- `corepack pnpm exec vitest run --config test/vitest/vitest.unit.config.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `corepack pnpm exec oxfmt --check src/infra/agent-events.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `corepack pnpm exec oxlint src/infra/agent-events.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `git diff --check`

## Notes
- `corepack pnpm run tsgo:test:src` was attempted but the local worktree currently fails before this change on missing optional/generated modules such as `@openclaw/fs-safe/*`, `sharp`, and `esbuild`; no new diagnostics pointed at the changed files.
- This intentionally does not include the separate post-update smoke-check workflow.
- Related resilience context: #58348; checked #11044 but it is a separate outbound ordering issue.
