### PR TITLE
fix(onboard-custom): raise default contextWindow above reserveTokensFloor (#79428)

### DIFF
--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -106,9 +106,9 @@ it("uses expanded max_tokens for anthropic verification probes", () => {
 describe("applyCustomApiConfig", () => {
   it.each([
     {
-      name: "uses hard-min context window for newly added custom models",
+      name: "uses generous default context window for newly added custom models",
       existingContextWindow: undefined,
-      expectedContextWindow: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+      expectedContextWindow: 128_000,
     },
     {
       name: "upgrades existing custom model context window when below hard minimum",

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -1,5 +1,5 @@
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
-import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { DEFAULT_CONTEXT_TOKENS, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildModelAliasIndex, modelKey } from "../agents/model-selection.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -13,7 +13,13 @@ import {
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { normalizeAlias } from "./models/alias-name.js";
 
-const DEFAULT_CONTEXT_WINDOW = CONTEXT_WINDOW_HARD_MIN_TOKENS;
+// Default newly-onboarded custom-provider models to a generous context window.
+// The previous default (CONTEXT_WINDOW_HARD_MIN_TOKENS = 4_000) was smaller than
+// the runtime's compaction reserveTokensFloor (20_000), which made every fresh
+// custom-provider session immediately overflow and trigger an infinite
+// compaction loop (issue #79428).  Use the same default as other providers
+// (DEEPINFRA_DEFAULT_CONTEXT_WINDOW, microsoft-foundry, etc. ~ 128 k).
+const DEFAULT_CONTEXT_WINDOW = Math.min(DEFAULT_CONTEXT_TOKENS, 128_000);
 const DEFAULT_MAX_TOKENS = 4096;
 // Azure OpenAI uses the Responses API which supports larger defaults
 const AZURE_DEFAULT_CONTEXT_WINDOW = 400_000;


### PR DESCRIPTION
Fixes #79428

## Root cause

The onboard wizard hardcodes `contextWindow = 4_000` (`CONTEXT_WINDOW_HARD_MIN_TOKENS`) for newly added Custom Provider models in `src/commands/onboard-custom-config.ts`. The runtime's default compaction `reserveTokensFloor` is `20_000` (`DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR`).

Result: every fresh custom-provider session immediately classifies the first prompt as overflow (`reserve > contextWindow`) and triggers an infinite `Compacting context` loop. Reproducible with any provider added through the onboard flow (e.g. DashScope/Qwen as in the bug report).

## Fix

Default new custom-provider models to `128_000` tokens — matching the conservative defaults already used by deepinfra (`DEEPINFRA_DEFAULT_CONTEXT_WINDOW = 128000`), microsoft-foundry (`128e3`), and openai providers. Capped via `Math.min(DEFAULT_CONTEXT_TOKENS, 128_000)` so it tracks the global default if it ever shrinks.

The Azure path (`AZURE_DEFAULT_CONTEXT_WINDOW = 400_000`) is unchanged. The hard-minimum guard (`normalizeContextWindowForCustomModel`) still enforces `CONTEXT_WINDOW_HARD_MIN_TOKENS` when normalizing user-supplied values, so explicit small overrides remain bounded.

Users can still override per-model via config; this only affects the default for newly onboarded custom models.

## Test

Updated `onboard-custom-config.test.ts` to assert the new generous default (128_000) for the "newly added custom models" case. The "upgrades existing model below hard minimum" case is unchanged (still upgrades to `CONTEXT_WINDOW_HARD_MIN_TOKENS`).