### PR TITLE
fix(model-auth): resolve per-entry apiKey profile ID references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auth: resolve per-entry `apiKey` profile ID references (`"provider:name"`) in `resolveApiKeyForProvider` so a provider entry like `openrouter-minimax.apiKey: "openrouter:key-b"` resolves the actual stored credential instead of using the profile ID string as a literal bearer token. Fixes #67423.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -21,6 +21,7 @@ export {
 } from "./auth-profiles/oauth.js";
 export {
   isConfiguredAwsSdkAuthProfileForProvider,
+  isStoredCredentialCompatibleWithAuthProvider,
   resolveAuthProfileEligibility,
   resolveAuthProfileOrder,
 } from "./auth-profiles/order.js";

--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -7,7 +7,10 @@ const mocks = vi.hoisted(() => ({
   loadAuthProfileStoreWithoutExternalProfiles: vi.fn(),
   resolveAuthProfileOrder: vi.fn(),
   resolveAuthProfileDisplayLabel: vi.fn(),
-  resolveUsableCustomProviderApiKey: vi.fn(() => null),
+  resolveProviderEntryApiKeyProfileReference: vi.fn<() => unknown>(() => ({ kind: "none" })),
+  resolveUsableCustomProviderApiKey: vi.fn<() => { apiKey: string; source: string } | null>(
+    () => null,
+  ),
   resolveEnvApiKey: vi.fn<() => { apiKey: string; source: string } | null>(() => null),
   readClaudeCliCredentialsCached: vi.fn<(options?: unknown) => unknown>(() => null),
   readCodexCliCredentialsCached: vi.fn<(options?: unknown) => unknown>(() => null),
@@ -22,6 +25,7 @@ vi.mock("./auth-profiles.js", () => ({
 }));
 
 vi.mock("./model-auth.js", () => ({
+  resolveProviderEntryApiKeyProfileReference: mocks.resolveProviderEntryApiKeyProfileReference,
   resolveUsableCustomProviderApiKey: mocks.resolveUsableCustomProviderApiKey,
   resolveEnvApiKey: mocks.resolveEnvApiKey,
 }));
@@ -39,6 +43,8 @@ describe("resolveModelAuthLabel", () => {
     mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReset();
     mocks.resolveAuthProfileOrder.mockReset();
     mocks.resolveAuthProfileDisplayLabel.mockReset();
+    mocks.resolveProviderEntryApiKeyProfileReference.mockReset();
+    mocks.resolveProviderEntryApiKeyProfileReference.mockReturnValue({ kind: "none" });
     mocks.resolveUsableCustomProviderApiKey.mockReset();
     mocks.resolveUsableCustomProviderApiKey.mockReturnValue(null);
     mocks.resolveEnvApiKey.mockReset();
@@ -254,5 +260,66 @@ describe("resolveModelAuthLabel", () => {
       config: cfg,
       workspaceDir: "/tmp/workspace",
     });
+  });
+
+  it("shows per-entry apiKey profile-reference labels before literal models.json fallback", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "openrouter:key-b": {
+          type: "api_key",
+          provider: "openrouter",
+          key: "sk-or-actual-key-b",
+        },
+      },
+    };
+    mocks.ensureAuthProfileStore.mockReturnValue(store as never);
+    mocks.resolveAuthProfileOrder.mockReturnValue([]);
+    mocks.resolveAuthProfileDisplayLabel.mockReturnValue("openrouter:key-b");
+    mocks.resolveProviderEntryApiKeyProfileReference.mockReturnValue({
+      kind: "profile",
+      profileId: "openrouter:key-b",
+      credential: store.profiles["openrouter:key-b"],
+      mode: "api-key",
+    });
+    mocks.resolveUsableCustomProviderApiKey.mockReturnValue({
+      apiKey: "openrouter:key-b",
+      source: "models.json",
+    });
+
+    const label = resolveModelAuthLabel({
+      provider: "openrouter-minimax",
+      cfg: {},
+    });
+
+    expect(label).toBe("api-key (openrouter:key-b)");
+    expect(mocks.resolveUsableCustomProviderApiKey).not.toHaveBeenCalled();
+  });
+
+  it("does not report incompatible per-entry profile references as literal models.json keys", () => {
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    } as never);
+    mocks.resolveAuthProfileOrder.mockReturnValue([]);
+    mocks.resolveProviderEntryApiKeyProfileReference.mockReturnValue({
+      kind: "profile-incompatible",
+      profileId: "google:oauth-a",
+      credentialProvider: "google",
+      credentialType: "oauth",
+      reason: "credential-class",
+    });
+    mocks.resolveUsableCustomProviderApiKey.mockReturnValue({
+      apiKey: "google:oauth-a",
+      source: "models.json",
+    });
+
+    const label = resolveModelAuthLabel({
+      provider: "openrouter-minimax",
+      cfg: {},
+    });
+
+    expect(label).toBe("unknown");
+    expect(mocks.resolveUsableCustomProviderApiKey).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -13,7 +13,11 @@ import {
   readClaudeCliCredentialsCached,
   readCodexCliCredentialsCached,
 } from "./cli-credentials.js";
-import { resolveEnvApiKey, resolveUsableCustomProviderApiKey } from "./model-auth.js";
+import {
+  resolveEnvApiKey,
+  resolveProviderEntryApiKeyProfileReference,
+  resolveUsableCustomProviderApiKey,
+} from "./model-auth.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 export function resolveModelAuthLabel(params: {
@@ -83,6 +87,26 @@ export function resolveModelAuthLabel(params: {
       return `token${label ? ` (${label})` : ""}`;
     }
     return `api-key${label ? ` (${label})` : ""}`;
+  }
+
+  const providerEntryProfileRef = resolveProviderEntryApiKeyProfileReference({
+    cfg: params.cfg,
+    provider: providerKey,
+    store,
+  });
+  if (providerEntryProfileRef.kind === "profile") {
+    const label = resolveAuthProfileDisplayLabel({
+      cfg: params.cfg,
+      store,
+      profileId: providerEntryProfileRef.profileId,
+    });
+    if (providerEntryProfileRef.mode === "token") {
+      return `token${label ? ` (${label})` : ""}`;
+    }
+    return `api-key${label ? ` (${label})` : ""}`;
+  }
+  if (providerEntryProfileRef.kind === "profile-incompatible") {
+    return "unknown";
   }
 
   const envKey = resolveEnvApiKey(providerKey, process.env, {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -1660,6 +1660,40 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
     });
   });
 
+  it("keeps env-first precedence ahead of per-entry profile references", async () => {
+    await withEnvAsync({ OPENAI_API_KEY: "sk-env-first" }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "openai",
+        credentialPrecedence: "env-first",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-completions" as const,
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "openai:key-b",
+                models: [],
+              },
+            },
+          },
+        },
+        store: {
+          version: 1,
+          profiles: {
+            "openai:key-b": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-profile-key",
+            },
+          },
+        },
+      });
+
+      expect(resolved.apiKey).toBe("sk-env-first");
+      expect(resolved.source).toContain("OPENAI_API_KEY");
+    });
+  });
+
   it("does not bleed auth.order canonical provider profiles into a per-entry provider", async () => {
     // auth.order.openrouter should not be selected when resolving openrouter-minimax
     // that has its own per-entry apiKey = "openrouter:key-b" profile reference.

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -1560,6 +1560,11 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
       cfg: {
         models: {
           providers: {
+            openrouter: {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              models: [],
+            },
             "openrouter-minimax": {
               api: "openai-completions" as const,
               baseUrl: "https://openrouter.ai/api/v1",
@@ -1593,6 +1598,11 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
       cfg: {
         models: {
           providers: {
+            openrouter: {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              models: [],
+            },
             "openrouter-minimax": {
               api: "openai-completions" as const,
               baseUrl: "https://openrouter.ai/api/v1",
@@ -1621,6 +1631,11 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
       cfg: {
         models: {
           providers: {
+            openrouter: {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              models: [],
+            },
             "openrouter-minimax": {
               api: "openai-completions" as const,
               baseUrl: "https://openrouter.ai/api/v1",
@@ -1672,6 +1687,11 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
       cfg: {
         models: {
           providers: {
+            openrouter: {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              models: [],
+            },
             "openrouter-minimax": {
               api: "openai-completions" as const,
               baseUrl: "https://openrouter.ai/api/v1",
@@ -1733,6 +1753,41 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
     );
   });
 
+  it("throws when a bearer profile points at a different provider endpoint", async () => {
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "custom-proxy",
+        cfg: {
+          models: {
+            providers: {
+              openrouter: {
+                api: "openai-completions" as const,
+                baseUrl: "https://openrouter.ai/api/v1",
+                models: [],
+              },
+              "custom-proxy": {
+                api: "openai-completions" as const,
+                baseUrl: "https://example.invalid/v1",
+                apiKey: "openrouter:key-b",
+                models: [],
+              },
+            },
+          },
+        },
+        store: {
+          version: 1,
+          profiles: {
+            "openrouter:key-b": {
+              type: "api_key",
+              provider: "openrouter",
+              key: "sk-or-actual-key-b",
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(/not compatible with this provider entry's auth binding/);
+  });
+
   it("throws (does not fall through to literal bearer) when matched profile resolution fails (clawsweeper P2)", async () => {
     // Profile is matched on ID but its credential has no usable api key material
     // (no `key` and no `keyRef`). Pre-fix, this would fall through to the late
@@ -1744,6 +1799,11 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
         cfg: {
           models: {
             providers: {
+              openrouter: {
+                api: "openai-completions" as const,
+                baseUrl: "https://openrouter.ai/api/v1",
+                models: [],
+              },
               "openrouter-minimax": {
                 api: "openai-completions" as const,
                 baseUrl: "https://openrouter.ai/api/v1",

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -1662,4 +1662,108 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
     expect(resolved.profileId).toBe("openrouter:key-b");
     expect(resolved.source).toBe("profile:openrouter:key-b");
   });
+
+  it("resolves profile reference even when provider sets auth: api-key explicitly (regression for clawsweeper P3)", async () => {
+    // Before the fix the explicit `auth: "api-key"` early-return short-circuited
+    // resolveUsableCustomProviderApiKey and sent "openrouter:key-b" as a literal bearer
+    // before the profile-ref logic could run. Verify the profile-ref lookup wins.
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openrouter-minimax",
+      cfg: {
+        models: {
+          providers: {
+            "openrouter-minimax": {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "openrouter:key-b",
+              auth: "api-key" as const,
+              models: [],
+            },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openrouter:key-b": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-actual-key-b",
+          },
+        },
+      },
+    });
+
+    expect(resolved.apiKey).toBe("sk-or-actual-key-b");
+    expect(resolved.profileId).toBe("openrouter:key-b");
+    expect(resolved.source).toBe("profile:openrouter:key-b");
+  });
+
+  it("throws when matched profile is an OAuth credential routed to an api-key provider (clawsweeper P1)", async () => {
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "openrouter-minimax",
+        cfg: {
+          models: {
+            providers: {
+              "openrouter-minimax": {
+                api: "openai-completions" as const,
+                baseUrl: "https://openrouter.ai/api/v1",
+                apiKey: "google:oauth-a",
+                models: [],
+              },
+            },
+          },
+        },
+        store: {
+          version: 1,
+          profiles: {
+            "google:oauth-a": {
+              type: "oauth",
+              provider: "google",
+              access: "oauth-access",
+              refresh: "oauth-refresh",
+              expires: 0,
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      /references a "oauth" credential for provider "google", which is not a bearer-style auth class/,
+    );
+  });
+
+  it("throws (does not fall through to literal bearer) when matched profile resolution fails (clawsweeper P2)", async () => {
+    // Profile is matched on ID but its credential has no usable api key material
+    // (no `key` and no `keyRef`). Pre-fix, this would fall through to the late
+    // `resolveUsableCustomProviderApiKey` and send "openrouter:key-b" itself as the
+    // literal bearer — the original #67423 failure mode. Verify it throws instead.
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "openrouter-minimax",
+        cfg: {
+          models: {
+            providers: {
+              "openrouter-minimax": {
+                api: "openai-completions" as const,
+                baseUrl: "https://openrouter.ai/api/v1",
+                apiKey: "openrouter:key-b",
+                models: [],
+              },
+            },
+          },
+        },
+        store: {
+          version: 1,
+          profiles: {
+            "openrouter:key-b": {
+              type: "api_key",
+              provider: "openrouter",
+              // no `key` and no `keyRef` -> resolveApiKeyForProfile returns null
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(/matched a stored profile but failed to resolve/);
+  });
 });

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -1623,6 +1623,43 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
     expect(resolved.source).toBe("models.json");
   });
 
+  it("does not treat env SecretRef ids as profile references", async () => {
+    await withEnvAsync({ OPENROUTER_PROFILE: "sk-or-env-secret" }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "openrouter-minimax",
+        cfg: {
+          models: {
+            providers: {
+              "openrouter-minimax": {
+                api: "openai-completions" as const,
+                baseUrl: "https://openrouter.ai/api/v1",
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "OPENROUTER_PROFILE",
+                },
+                models: [],
+              },
+            },
+          },
+        },
+        store: {
+          version: 1,
+          profiles: {
+            OPENROUTER_PROFILE: {
+              type: "api_key",
+              provider: "openrouter",
+              key: "sk-or-wrong-profile",
+            },
+          },
+        },
+      });
+
+      expect(resolved.apiKey).toBe("sk-or-env-secret");
+      expect(resolved.source).toContain("OPENROUTER_PROFILE");
+    });
+  });
+
   it("does not bleed auth.order canonical provider profiles into a per-entry provider", async () => {
     // auth.order.openrouter should not be selected when resolving openrouter-minimax
     // that has its own per-entry apiKey = "openrouter:key-b" profile reference.
@@ -1717,6 +1754,37 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
     expect(resolved.apiKey).toBe("sk-or-actual-key-b");
     expect(resolved.profileId).toBe("openrouter:key-b");
     expect(resolved.source).toBe("profile:openrouter:key-b");
+  });
+
+  it("applies model auth-mode guards to per-entry token profile references", async () => {
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "openai",
+        modelApi: "openai-responses",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses" as const,
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "openai:token",
+                models: [],
+              },
+            },
+          },
+        },
+        store: {
+          version: 1,
+          profiles: {
+            "openai:token": {
+              type: "token",
+              provider: "openai",
+              token: "oauth-token",
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(/requires an OpenAI API key profile/);
   });
 
   it("throws when matched profile is an OAuth credential routed to an api-key provider (clawsweeper P1)", async () => {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -1550,3 +1550,116 @@ describe("getApiKeyForModel", () => {
     ).toBe(false);
   });
 });
+
+describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference", () => {
+  it("resolves actual credential when per-entry apiKey matches a profile ID in the store", async () => {
+    // Scenario from #67423: openrouter-minimax.apiKey = "openrouter:key-b"
+    // should resolve the actual key from that profile, not use the string literally.
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openrouter-minimax",
+      cfg: {
+        models: {
+          providers: {
+            "openrouter-minimax": {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "openrouter:key-b",
+              models: [],
+            },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openrouter:key-b": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-actual-key-b",
+          },
+        },
+      },
+    });
+
+    expect(resolved.apiKey).toBe("sk-or-actual-key-b");
+    expect(resolved.profileId).toBe("openrouter:key-b");
+    expect(resolved.source).toBe("profile:openrouter:key-b");
+    expect(resolved.mode).toBe("api-key");
+  });
+
+  it("does not treat a literal API key as a profile ID when no matching profile exists", async () => {
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openrouter-minimax",
+      cfg: {
+        models: {
+          providers: {
+            "openrouter-minimax": {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "sk-or-literal-key",
+              models: [],
+            },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {},
+      },
+    });
+
+    expect(resolved.apiKey).toBe("sk-or-literal-key");
+    expect(resolved.profileId).toBeUndefined();
+    expect(resolved.source).toBe("models.json");
+  });
+
+  it("does not bleed auth.order canonical provider profiles into a per-entry provider", async () => {
+    // auth.order.openrouter should not be selected when resolving openrouter-minimax
+    // that has its own per-entry apiKey = "openrouter:key-b" profile reference.
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openrouter-minimax",
+      cfg: {
+        models: {
+          providers: {
+            "openrouter-minimax": {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "openrouter:key-b",
+              models: [],
+            },
+          },
+        },
+        auth: {
+          order: {
+            openrouter: ["openrouter:key-a", "openrouter:key-b", "openrouter:key-c"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openrouter:key-a": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-key-a",
+          },
+          "openrouter:key-b": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-actual-key-b",
+          },
+          "openrouter:key-c": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-key-c",
+          },
+        },
+      },
+    });
+
+    // Should select key-b (from per-entry apiKey reference), not key-a (first in auth.order)
+    expect(resolved.apiKey).toBe("sk-or-actual-key-b");
+    expect(resolved.profileId).toBe("openrouter:key-b");
+    expect(resolved.source).toBe("profile:openrouter:key-b");
+  });
+});

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -1333,3 +1333,116 @@ describe("getApiKeyForModel", () => {
     expect(resolved?.source).toBe("gcloud adc");
   });
 });
+
+describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference", () => {
+  it("resolves actual credential when per-entry apiKey matches a profile ID in the store", async () => {
+    // Scenario from #67423: openrouter-minimax.apiKey = "openrouter:key-b"
+    // should resolve the actual key from that profile, not use the string literally.
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openrouter-minimax",
+      cfg: {
+        models: {
+          providers: {
+            "openrouter-minimax": {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "openrouter:key-b",
+              models: [],
+            },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openrouter:key-b": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-actual-key-b",
+          },
+        },
+      },
+    });
+
+    expect(resolved.apiKey).toBe("sk-or-actual-key-b");
+    expect(resolved.profileId).toBe("openrouter:key-b");
+    expect(resolved.source).toBe("profile:openrouter:key-b");
+    expect(resolved.mode).toBe("api-key");
+  });
+
+  it("does not treat a literal API key as a profile ID when no matching profile exists", async () => {
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openrouter-minimax",
+      cfg: {
+        models: {
+          providers: {
+            "openrouter-minimax": {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "sk-or-literal-key",
+              models: [],
+            },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {},
+      },
+    });
+
+    expect(resolved.apiKey).toBe("sk-or-literal-key");
+    expect(resolved.profileId).toBeUndefined();
+    expect(resolved.source).toBe("models.json");
+  });
+
+  it("does not bleed auth.order canonical provider profiles into a per-entry provider", async () => {
+    // auth.order.openrouter should not be selected when resolving openrouter-minimax
+    // that has its own per-entry apiKey = "openrouter:key-b" profile reference.
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openrouter-minimax",
+      cfg: {
+        models: {
+          providers: {
+            "openrouter-minimax": {
+              api: "openai-completions" as const,
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "openrouter:key-b",
+              models: [],
+            },
+          },
+        },
+        auth: {
+          order: {
+            openrouter: ["openrouter:key-a", "openrouter:key-b", "openrouter:key-c"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openrouter:key-a": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-key-a",
+          },
+          "openrouter:key-b": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-actual-key-b",
+          },
+          "openrouter:key-c": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-key-c",
+          },
+        },
+      },
+    });
+
+    // Should select key-b (from per-entry apiKey reference), not key-a (first in auth.order)
+    expect(resolved.apiKey).toBe("sk-or-actual-key-b");
+    expect(resolved.profileId).toBe("openrouter:key-b");
+    expect(resolved.source).toBe("profile:openrouter:key-b");
+  });
+});

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1030,6 +1030,29 @@ export async function resolveApiKeyForProvider(params: {
     return resolveAwsSdkAuthInfo();
   }
 
+  if (params.credentialPrecedence === "env-first") {
+    const envResolved = resolveConfigAwareEnvApiKey(cfg, provider, params.workspaceDir);
+    if (envResolved) {
+      const resolvedMode: ResolvedProviderAuth["mode"] = envResolved.source.includes("OAUTH_TOKEN")
+        ? "oauth"
+        : "api-key";
+      if (
+        !isAuthModeAllowedForModel({
+          provider,
+          modelApi: params.modelApi,
+          mode: resolvedMode,
+        })
+      ) {
+        return resolveApiKeyForProvider({ ...params, credentialPrecedence: "profile-first" });
+      }
+      return {
+        apiKey: envResolved.apiKey,
+        source: envResolved.source,
+        mode: resolvedMode,
+      };
+    }
+  }
+
   // Resolve stored profile-id references before literal apiKey fallbacks.
   // Matched profile references are terminal so bad bindings cannot silently
   // fall through to a different credential or to the profile id as bearer text.
@@ -1086,29 +1109,6 @@ export async function resolveApiKeyForProvider(params: {
       };
     }
   }
-  if (params.credentialPrecedence === "env-first") {
-    const envResolved = resolveConfigAwareEnvApiKey(cfg, provider, params.workspaceDir);
-    if (envResolved) {
-      const resolvedMode: ResolvedProviderAuth["mode"] = envResolved.source.includes("OAUTH_TOKEN")
-        ? "oauth"
-        : "api-key";
-      if (
-        !isAuthModeAllowedForModel({
-          provider,
-          modelApi: params.modelApi,
-          mode: resolvedMode,
-        })
-      ) {
-        return resolveApiKeyForProvider({ ...params, credentialPrecedence: "profile-first" });
-      }
-      return {
-        apiKey: envResolved.apiKey,
-        source: envResolved.source,
-        mode: resolvedMode,
-      };
-    }
-  }
-
   const providerConfig = resolveProviderConfig(cfg, provider);
   const configuredLocalKey = resolveUsableCustomProviderApiKey({ cfg, provider });
   if (configuredLocalKey && isNonSecretApiKeyMarker(configuredLocalKey.apiKey)) {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -479,7 +479,11 @@ export function resolveProviderEntryApiKeyProfileReference(params: {
   provider: string;
   store: AuthProfileStore;
 }): ProviderEntryApiKeyProfileReference {
-  const perEntryRawKey = getCustomProviderApiKey(params.cfg, params.provider);
+  const providerConfig = resolveProviderConfig(params.cfg, params.provider);
+  if (coerceSecretRef(providerConfig?.apiKey)) {
+    return { kind: "none" };
+  }
+  const perEntryRawKey = normalizeOptionalSecretInput(providerConfig?.apiKey);
   if (!perEntryRawKey) {
     return { kind: "none" };
   }
@@ -1042,6 +1046,12 @@ export async function resolveApiKeyForProvider(params: {
     agentDir,
   });
   if (providerEntryBinding.kind === "profile-resolved") {
+    assertAuthModeAllowedForModel({
+      provider,
+      modelApi: params.modelApi,
+      profileId: providerEntryBinding.auth.profileId ?? provider,
+      mode: providerEntryBinding.auth.mode,
+    });
     return providerEntryBinding.auth;
   }
   if (providerEntryBinding.kind === "profile-incompatible") {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -380,119 +380,182 @@ function profileTypeToAuthMode(type: AuthProfileCredential["type"]): ResolvedPro
   return type === "oauth" ? "oauth" : type === "token" ? "token" : "api-key";
 }
 
-/**
- * Outcome of evaluating whether `models.providers.<id>.apiKey` is a stored-
- * profile-ID reference (`"<provider>:<name>"`) rather than a literal bearer.
- *
- * - `no-match`: the configured value is missing, a non-secret marker, or does
- *   not name any stored profile — fall through to the normal credential paths.
- * - `matched-resolved`: the value names a stored profile and credential
- *   resolution succeeded — return the resulting auth.
- * - `matched-incompatible`: the value names a stored profile whose credential
- *   targets a categorically different auth class (OAuth or AWS SDK while the
- *   per-entry provider expects an api-key-style bearer). Routing those would
- *   send the wrong kind of secret to the endpoint, so this is surfaced as an
- *   error instead of falling through. *Same-class cross-provider references*
- *   (e.g. `openrouter:key-b` on `openrouter-minimax`, the documented split-
- *   provider pattern) are allowed — the explicit profile reference is itself
- *   the user's safe-mapping declaration.
- * - `matched-failed`: the value names a stored profile but credential
- *   resolution returned null or threw. Falling through here would either pick
- *   a *different* profile (silent wrong-credential) or eventually send the
- *   profile-ID string itself as the literal bearer (the original #67423 bug).
- *   Surface as an error so the operator can fix the referenced profile.
- */
-type PerEntryProfileReferenceResolution =
-  | { kind: "no-match" }
-  | { kind: "matched-resolved"; auth: ResolvedProviderAuth }
+type ProviderEntryApiKeyProfileReference =
+  | { kind: "none" }
+  | { kind: "literal"; apiKey: string; source: string }
   | {
-      kind: "matched-incompatible";
+      kind: "profile";
+      profileId: string;
+      credential: AuthProfileCredential;
+      mode: ResolvedProviderAuth["mode"];
+    }
+  | {
+      kind: "profile-incompatible";
       profileId: string;
       credentialProvider: string;
       credentialType: AuthProfileCredential["type"];
+      reason: "credential-class" | "provider-binding";
     }
-  | { kind: "matched-failed"; profileId: string; error?: unknown };
+  | { kind: "marker" };
 
-/**
- * Returns true when the credential's auth class is compatible with the
- * per-entry provider's expected bearer-style auth. The check is intentionally
- * coarser than `isStoredCredentialCompatibleWithAuthProvider`: explicit
- * profile-ID references are the documented split-provider pattern (e.g.
- * `openrouter-minimax.apiKey: "openrouter:key-b"`) and would fail a strict
- * id-equality check despite being the exact case this code path was added to
- * support. We only block when the credential class itself is wrong (OAuth
- * tokens or AWS SDK profiles routed to an api-key-style endpoint), and rely
- * on the explicit reference as the user's safe-mapping declaration for the
- * cross-provider id case.
- */
-function isProfileReferenceCredentialClassCompatible(params: {
+export type ProviderEntryApiKeyBindingResolution =
+  | { kind: "none" }
+  | { kind: "literal"; apiKey: string; source: string }
+  | { kind: "profile-resolved"; auth: ResolvedProviderAuth }
+  | {
+      kind: "profile-incompatible";
+      profileId: string;
+      credentialProvider: string;
+      credentialType: AuthProfileCredential["type"];
+      reason: "credential-class" | "provider-binding";
+    }
+  | { kind: "profile-unresolved"; profileId: string; error?: unknown };
+
+function normalizeProviderEntryBaseUrlForBinding(baseUrl: string | undefined): string | undefined {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    parsed.hash = "";
+    parsed.search = "";
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return trimmed.toLowerCase().replace(/\/+$/, "");
+  }
+}
+
+function providerEntriesShareBaseUrl(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  credentialProvider: string;
+}): boolean {
+  const providerBaseUrl = normalizeProviderEntryBaseUrlForBinding(
+    resolveProviderConfig(params.cfg, params.provider)?.baseUrl,
+  );
+  const credentialProviderBaseUrl = normalizeProviderEntryBaseUrlForBinding(
+    resolveProviderConfig(params.cfg, params.credentialProvider)?.baseUrl,
+  );
+  return Boolean(
+    providerBaseUrl && credentialProviderBaseUrl && providerBaseUrl === credentialProviderBaseUrl,
+  );
+}
+
+function isBearerProfileCredential(credential: AuthProfileCredential): boolean {
+  return credential.type === "api_key" || credential.type === "token";
+}
+
+export function canUseProfileAsProviderEntryApiKey(params: {
   cfg?: OpenClawConfig;
   provider: string;
   credential: AuthProfileCredential;
 }): boolean {
-  if (params.credential.type === "api_key" || params.credential.type === "token") {
+  if (!isBearerProfileCredential(params.credential)) {
+    return false;
+  }
+  if (
+    isStoredCredentialCompatibleWithAuthProvider({
+      cfg: params.cfg,
+      provider: params.provider,
+      credential: params.credential,
+    })
+  ) {
     return true;
   }
-  // OAuth or AWS SDK credentials reaching this branch would be sent as a
-  // bearer-style header by the api-key call sites, which is the wrong shape
-  // for those credential classes. The strict alias check still applies here
-  // because we cannot trust an OAuth refresh token to be a usable api key.
-  return isStoredCredentialCompatibleWithAuthProvider({
+  // Split-provider entries may intentionally point at the same upstream endpoint
+  // with different profile ids. Require a matching configured base URL before
+  // allowing a bearer profile to cross provider ids.
+  return providerEntriesShareBaseUrl({
     cfg: params.cfg,
     provider: params.provider,
-    credential: params.credential,
+    credentialProvider: params.credential.provider,
   });
 }
 
-async function resolvePerEntryProviderApiKeyReference(params: {
+export function resolveProviderEntryApiKeyProfileReference(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  store: AuthProfileStore;
+}): ProviderEntryApiKeyProfileReference {
+  const perEntryRawKey = getCustomProviderApiKey(params.cfg, params.provider);
+  if (!perEntryRawKey) {
+    return { kind: "none" };
+  }
+  if (isNonSecretApiKeyMarker(perEntryRawKey)) {
+    return { kind: "marker" };
+  }
+  const credential = params.store.profiles[perEntryRawKey];
+  if (!credential) {
+    return { kind: "literal", apiKey: perEntryRawKey, source: "models.json" };
+  }
+  if (!isBearerProfileCredential(credential)) {
+    return {
+      kind: "profile-incompatible",
+      profileId: perEntryRawKey,
+      credentialProvider: credential.provider,
+      credentialType: credential.type,
+      reason: "credential-class",
+    };
+  }
+  if (
+    !canUseProfileAsProviderEntryApiKey({ cfg: params.cfg, provider: params.provider, credential })
+  ) {
+    return {
+      kind: "profile-incompatible",
+      profileId: perEntryRawKey,
+      credentialProvider: credential.provider,
+      credentialType: credential.type,
+      reason: "provider-binding",
+    };
+  }
+  return {
+    kind: "profile",
+    profileId: perEntryRawKey,
+    credential,
+    mode: profileTypeToAuthMode(credential.type),
+  };
+}
+
+export async function resolveProviderEntryApiKeyBinding(params: {
   cfg?: OpenClawConfig;
   provider: string;
   store: AuthProfileStore;
   agentDir?: string;
-}): Promise<PerEntryProfileReferenceResolution> {
-  const perEntryRawKey = getCustomProviderApiKey(params.cfg, params.provider);
-  if (!perEntryRawKey || isNonSecretApiKeyMarker(perEntryRawKey)) {
-    return { kind: "no-match" };
+}): Promise<ProviderEntryApiKeyBindingResolution> {
+  const reference = resolveProviderEntryApiKeyProfileReference(params);
+  if (reference.kind === "none" || reference.kind === "marker") {
+    return { kind: "none" };
   }
-  const credential = params.store.profiles[perEntryRawKey];
-  if (!credential) {
-    return { kind: "no-match" };
+  if (reference.kind === "literal") {
+    return reference;
   }
-  if (
-    !isProfileReferenceCredentialClassCompatible({
-      cfg: params.cfg,
-      provider: params.provider,
-      credential,
-    })
-  ) {
-    return {
-      kind: "matched-incompatible",
-      profileId: perEntryRawKey,
-      credentialProvider: credential.provider,
-      credentialType: credential.type,
-    };
+  if (reference.kind === "profile-incompatible") {
+    return reference;
   }
   try {
     const resolved = await resolveApiKeyForProfile({
       cfg: params.cfg,
       store: params.store,
-      profileId: perEntryRawKey,
+      profileId: reference.profileId,
       agentDir: params.agentDir,
     });
     if (!resolved) {
-      return { kind: "matched-failed", profileId: perEntryRawKey };
+      return { kind: "profile-unresolved", profileId: reference.profileId };
     }
+    const resolvedProfileId = resolved.profileId ?? reference.profileId;
     return {
-      kind: "matched-resolved",
+      kind: "profile-resolved",
       auth: {
         apiKey: resolved.apiKey,
-        profileId: perEntryRawKey,
-        source: `profile:${perEntryRawKey}`,
-        mode: profileTypeToAuthMode(credential.type),
+        profileId: resolvedProfileId,
+        source: `profile:${resolvedProfileId}`,
+        mode: resolved.profileType ? profileTypeToAuthMode(resolved.profileType) : reference.mode,
       },
     };
   } catch (err) {
-    return { kind: "matched-failed", profileId: perEntryRawKey, error: err };
+    return { kind: "profile-unresolved", profileId: reference.profileId, error: err };
   }
 }
 
@@ -963,40 +1026,43 @@ export async function resolveApiKeyForProvider(params: {
     return resolveAwsSdkAuthInfo();
   }
 
-  // A per-entry apiKey can be a profile-ID reference (e.g. "openrouter:key-b")
-  // rather than a literal bearer token. Resolve that **before** the explicit
-  // `auth: "api-key"` early-return below, otherwise `resolveUsableCustomProviderApiKey`
-  // would return the profile-ID string itself as a literal bearer (the
-  // original #67423 failure mode). The helper is also terminal — a matched
-  // reference must either resolve cleanly with a provider-compatible
-  // credential or surface an explicit error, never fall through to other
-  // credential paths that could silently use a different key.
+  // Resolve stored profile-id references before literal apiKey fallbacks.
+  // Matched profile references are terminal so bad bindings cannot silently
+  // fall through to a different credential or to the profile id as bearer text.
   scopedStore ??= resolveScopedAuthProfileStore({
-    agentDir: params.agentDir,
+    agentDir,
     cfg,
     provider,
     preferredProfile,
   });
-  const perEntryProfileRef = await resolvePerEntryProviderApiKeyReference({
+  const providerEntryBinding = await resolveProviderEntryApiKeyBinding({
     cfg,
     provider,
     store: scopedStore,
-    agentDir: params.agentDir,
+    agentDir,
   });
-  if (perEntryProfileRef.kind === "matched-resolved") {
-    return perEntryProfileRef.auth;
+  if (providerEntryBinding.kind === "profile-resolved") {
+    return providerEntryBinding.auth;
   }
-  if (perEntryProfileRef.kind === "matched-incompatible") {
+  if (providerEntryBinding.kind === "profile-incompatible") {
+    const reason =
+      providerEntryBinding.reason === "credential-class"
+        ? "which is not a bearer-style auth class"
+        : "which is not compatible with this provider entry's auth binding";
+    const action =
+      providerEntryBinding.reason === "credential-class"
+        ? "Use an api-key or token profile, or set apiKey to a literal bearer token."
+        : "Use a compatible provider auth alias, configure the referenced provider entry with the same baseUrl, or set apiKey to a literal bearer token.";
     throw new Error(
-      `Per-entry apiKey "${perEntryProfileRef.profileId}" for provider "${provider}" references a "${perEntryProfileRef.credentialType}" credential for provider "${perEntryProfileRef.credentialProvider}", which is not a bearer-style auth class. Use an api-key or token profile, or set apiKey to a literal bearer token.`,
+      `Per-entry apiKey "${providerEntryBinding.profileId}" for provider "${provider}" references a "${providerEntryBinding.credentialType}" credential for provider "${providerEntryBinding.credentialProvider}", ${reason}. ${action}`,
     );
   }
-  if (perEntryProfileRef.kind === "matched-failed") {
-    const cause = perEntryProfileRef.error
-      ? formatErrorMessage(perEntryProfileRef.error)
+  if (providerEntryBinding.kind === "profile-unresolved") {
+    const cause = providerEntryBinding.error
+      ? formatErrorMessage(providerEntryBinding.error)
       : "credential resolution returned no key";
     throw new Error(
-      `Per-entry apiKey "${perEntryProfileRef.profileId}" for provider "${provider}" matched a stored profile but failed to resolve: ${cause}. Fix the referenced profile or set apiKey to a literal bearer token.`,
+      `Per-entry apiKey "${providerEntryBinding.profileId}" for provider "${provider}" matched a stored profile but failed to resolve: ${cause}. Fix the referenced profile or set apiKey to a literal bearer token.`,
     );
   }
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -902,6 +902,37 @@ export async function resolveApiKeyForProvider(params: {
       provider,
       preferredProfile,
     });
+  // A per-entry apiKey can be a profile ID reference (e.g. "openrouter:key-b")
+  // rather than a literal bearer token. If the raw value matches an existing
+  // profile in the store, resolve the actual credential through that profile.
+  const perEntryRawKey = getCustomProviderApiKey(cfg, provider);
+  if (
+    perEntryRawKey &&
+    !isNonSecretApiKeyMarker(perEntryRawKey) &&
+    store.profiles[perEntryRawKey]
+  ) {
+    try {
+      const resolved = await resolveApiKeyForProfile({
+        cfg,
+        store,
+        profileId: perEntryRawKey,
+        agentDir: params.agentDir,
+      });
+      if (resolved) {
+        const mode = store.profiles[perEntryRawKey]?.type;
+        return {
+          apiKey: resolved.apiKey,
+          profileId: perEntryRawKey,
+          source: `profile:${perEntryRawKey}`,
+          mode: mode ? profileTypeToAuthMode(mode) : "api-key",
+        };
+      }
+    } catch (err) {
+      log.debug?.(
+        `per-entry apiKey profile "${perEntryRawKey}" failed for "${provider}": ${String(err)}`,
+      );
+    }
+  }
   const order = resolveAuthProfileOrder({
     cfg,
     store,

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -28,6 +28,7 @@ import {
   externalCliDiscoveryForProviderAuth,
   ensureAuthProfileStore,
   isConfiguredAwsSdkAuthProfileForProvider,
+  isStoredCredentialCompatibleWithAuthProvider,
   listProfilesForProvider,
   resolveApiKeyForProfile,
   resolveAuthProfileOrder,
@@ -376,6 +377,122 @@ function shouldUseImplicitAwsSdkAuth(params: {
 
 function profileTypeToAuthMode(type: AuthProfileCredential["type"]): ResolvedProviderAuth["mode"] {
   return type === "oauth" ? "oauth" : type === "token" ? "token" : "api-key";
+}
+
+/**
+ * Outcome of evaluating whether `models.providers.<id>.apiKey` is a stored-
+ * profile-ID reference (`"<provider>:<name>"`) rather than a literal bearer.
+ *
+ * - `no-match`: the configured value is missing, a non-secret marker, or does
+ *   not name any stored profile — fall through to the normal credential paths.
+ * - `matched-resolved`: the value names a stored profile and credential
+ *   resolution succeeded — return the resulting auth.
+ * - `matched-incompatible`: the value names a stored profile whose credential
+ *   targets a categorically different auth class (OAuth or AWS SDK while the
+ *   per-entry provider expects an api-key-style bearer). Routing those would
+ *   send the wrong kind of secret to the endpoint, so this is surfaced as an
+ *   error instead of falling through. *Same-class cross-provider references*
+ *   (e.g. `openrouter:key-b` on `openrouter-minimax`, the documented split-
+ *   provider pattern) are allowed — the explicit profile reference is itself
+ *   the user's safe-mapping declaration.
+ * - `matched-failed`: the value names a stored profile but credential
+ *   resolution returned null or threw. Falling through here would either pick
+ *   a *different* profile (silent wrong-credential) or eventually send the
+ *   profile-ID string itself as the literal bearer (the original #67423 bug).
+ *   Surface as an error so the operator can fix the referenced profile.
+ */
+type PerEntryProfileReferenceResolution =
+  | { kind: "no-match" }
+  | { kind: "matched-resolved"; auth: ResolvedProviderAuth }
+  | {
+      kind: "matched-incompatible";
+      profileId: string;
+      credentialProvider: string;
+      credentialType: AuthProfileCredential["type"];
+    }
+  | { kind: "matched-failed"; profileId: string; error?: unknown };
+
+/**
+ * Returns true when the credential's auth class is compatible with the
+ * per-entry provider's expected bearer-style auth. The check is intentionally
+ * coarser than `isStoredCredentialCompatibleWithAuthProvider`: explicit
+ * profile-ID references are the documented split-provider pattern (e.g.
+ * `openrouter-minimax.apiKey: "openrouter:key-b"`) and would fail a strict
+ * id-equality check despite being the exact case this code path was added to
+ * support. We only block when the credential class itself is wrong (OAuth
+ * tokens or AWS SDK profiles routed to an api-key-style endpoint), and rely
+ * on the explicit reference as the user's safe-mapping declaration for the
+ * cross-provider id case.
+ */
+function isProfileReferenceCredentialClassCompatible(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  credential: AuthProfileCredential;
+}): boolean {
+  if (params.credential.type === "api_key" || params.credential.type === "token") {
+    return true;
+  }
+  // OAuth or AWS SDK credentials reaching this branch would be sent as a
+  // bearer-style header by the api-key call sites, which is the wrong shape
+  // for those credential classes. The strict alias check still applies here
+  // because we cannot trust an OAuth refresh token to be a usable api key.
+  return isStoredCredentialCompatibleWithAuthProvider({
+    cfg: params.cfg,
+    provider: params.provider,
+    credential: params.credential,
+  });
+}
+
+async function resolvePerEntryProviderApiKeyReference(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  store: AuthProfileStore;
+  agentDir?: string;
+}): Promise<PerEntryProfileReferenceResolution> {
+  const perEntryRawKey = getCustomProviderApiKey(params.cfg, params.provider);
+  if (!perEntryRawKey || isNonSecretApiKeyMarker(perEntryRawKey)) {
+    return { kind: "no-match" };
+  }
+  const credential = params.store.profiles[perEntryRawKey];
+  if (!credential) {
+    return { kind: "no-match" };
+  }
+  if (
+    !isProfileReferenceCredentialClassCompatible({
+      cfg: params.cfg,
+      provider: params.provider,
+      credential,
+    })
+  ) {
+    return {
+      kind: "matched-incompatible",
+      profileId: perEntryRawKey,
+      credentialProvider: credential.provider,
+      credentialType: credential.type,
+    };
+  }
+  try {
+    const resolved = await resolveApiKeyForProfile({
+      cfg: params.cfg,
+      store: params.store,
+      profileId: perEntryRawKey,
+      agentDir: params.agentDir,
+    });
+    if (!resolved) {
+      return { kind: "matched-failed", profileId: perEntryRawKey };
+    }
+    return {
+      kind: "matched-resolved",
+      auth: {
+        apiKey: resolved.apiKey,
+        profileId: perEntryRawKey,
+        source: `profile:${perEntryRawKey}`,
+        mode: profileTypeToAuthMode(credential.type),
+      },
+    };
+  } catch (err) {
+    return { kind: "matched-failed", profileId: perEntryRawKey, error: err };
+  }
 }
 
 function resolveConfiguredAwsSdkProfileAuth(params: {
@@ -844,6 +961,47 @@ export async function resolveApiKeyForProvider(params: {
   if (shouldUseImplicitAwsSdkAuth({ cfg, provider, modelApi: params.modelApi })) {
     return resolveAwsSdkAuthInfo();
   }
+
+  // A per-entry apiKey can be a profile-ID reference (e.g. "openrouter:key-b")
+  // rather than a literal bearer token. Resolve that **before** the explicit
+  // `auth: "api-key"` early-return below, otherwise `resolveUsableCustomProviderApiKey`
+  // would return the profile-ID string itself as a literal bearer (the
+  // original #67423 failure mode). The helper is also terminal — a matched
+  // reference must either resolve cleanly with a provider-compatible
+  // credential or surface an explicit error, never fall through to other
+  // credential paths that could silently use a different key.
+  scopedStore ??= resolveScopedAuthProfileStore({
+    agentDir: params.agentDir,
+    cfg,
+    provider,
+    preferredProfile,
+  });
+  const perEntryProfileRef = await resolvePerEntryProviderApiKeyReference({
+    cfg,
+    provider,
+    store: scopedStore,
+    agentDir: params.agentDir,
+  });
+  if (perEntryProfileRef.kind === "matched-resolved") {
+    return perEntryProfileRef.auth;
+  }
+  if (perEntryProfileRef.kind === "matched-incompatible") {
+    throw new Error(
+      `Per-entry apiKey "${perEntryProfileRef.profileId}" for provider "${provider}" references a "${perEntryProfileRef.credentialType}" credential for provider "${perEntryProfileRef.credentialProvider}", which is not a bearer-style auth class. Use an api-key or token profile, or set apiKey to a literal bearer token.`,
+    );
+  }
+  if (perEntryProfileRef.kind === "matched-failed") {
+    const cause =
+      perEntryProfileRef.error instanceof Error
+        ? perEntryProfileRef.error.message
+        : perEntryProfileRef.error
+          ? String(perEntryProfileRef.error)
+          : "credential resolution returned no key";
+    throw new Error(
+      `Per-entry apiKey "${perEntryProfileRef.profileId}" for provider "${provider}" matched a stored profile but failed to resolve: ${cause}. Fix the referenced profile or set apiKey to a literal bearer token.`,
+    );
+  }
+
   if (shouldPreferExplicitConfigApiKeyAuth(cfg, provider)) {
     const customKey = resolveUsableCustomProviderApiKey({ cfg, provider });
     if (customKey) {
@@ -902,37 +1060,6 @@ export async function resolveApiKeyForProvider(params: {
       provider,
       preferredProfile,
     });
-  // A per-entry apiKey can be a profile ID reference (e.g. "openrouter:key-b")
-  // rather than a literal bearer token. If the raw value matches an existing
-  // profile in the store, resolve the actual credential through that profile.
-  const perEntryRawKey = getCustomProviderApiKey(cfg, provider);
-  if (
-    perEntryRawKey &&
-    !isNonSecretApiKeyMarker(perEntryRawKey) &&
-    store.profiles[perEntryRawKey]
-  ) {
-    try {
-      const resolved = await resolveApiKeyForProfile({
-        cfg,
-        store,
-        profileId: perEntryRawKey,
-        agentDir: params.agentDir,
-      });
-      if (resolved) {
-        const mode = store.profiles[perEntryRawKey]?.type;
-        return {
-          apiKey: resolved.apiKey,
-          profileId: perEntryRawKey,
-          source: `profile:${perEntryRawKey}`,
-          mode: mode ? profileTypeToAuthMode(mode) : "api-key",
-        };
-      }
-    } catch (err) {
-      log.debug?.(
-        `per-entry apiKey profile "${perEntryRawKey}" failed for "${provider}": ${String(err)}`,
-      );
-    }
-  }
   const order = resolveAuthProfileOrder({
     cfg,
     store,

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -9,6 +9,7 @@ import { getRuntimeConfigSnapshot } from "../config/config.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import type { Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -991,12 +992,9 @@ export async function resolveApiKeyForProvider(params: {
     );
   }
   if (perEntryProfileRef.kind === "matched-failed") {
-    const cause =
-      perEntryProfileRef.error instanceof Error
-        ? perEntryProfileRef.error.message
-        : perEntryProfileRef.error
-          ? String(perEntryProfileRef.error)
-          : "credential resolution returned no key";
+    const cause = perEntryProfileRef.error
+      ? formatErrorMessage(perEntryProfileRef.error)
+      : "credential resolution returned no key";
     throw new Error(
       `Per-entry apiKey "${perEntryProfileRef.profileId}" for provider "${provider}" matched a stored profile but failed to resolve: ${cause}. Fix the referenced profile or set apiKey to a literal bearer token.`,
     );

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -683,6 +683,37 @@ export async function resolveApiKeyForProvider(params: {
       provider,
       preferredProfile,
     });
+  // A per-entry apiKey can be a profile ID reference (e.g. "openrouter:key-b")
+  // rather than a literal bearer token. If the raw value matches an existing
+  // profile in the store, resolve the actual credential through that profile.
+  const perEntryRawKey = getCustomProviderApiKey(cfg, provider);
+  if (
+    perEntryRawKey &&
+    !isNonSecretApiKeyMarker(perEntryRawKey) &&
+    store.profiles[perEntryRawKey]
+  ) {
+    try {
+      const resolved = await resolveApiKeyForProfile({
+        cfg,
+        store,
+        profileId: perEntryRawKey,
+        agentDir: params.agentDir,
+      });
+      if (resolved) {
+        const mode = store.profiles[perEntryRawKey]?.type;
+        return {
+          apiKey: resolved.apiKey,
+          profileId: perEntryRawKey,
+          source: `profile:${perEntryRawKey}`,
+          mode: mode ? profileTypeToAuthMode(mode) : "api-key",
+        };
+      }
+    } catch (err) {
+      log.debug?.(
+        `per-entry apiKey profile "${perEntryRawKey}" failed for "${provider}": ${String(err)}`,
+      );
+    }
+  }
   const order = resolveAuthProfileOrder({
     cfg,
     store,


### PR DESCRIPTION
## Summary

A `models.providers.<id>.apiKey` value can be a **stored-profile-ID reference** (e.g. `"openrouter:key-b"`) rather than a literal bearer token. Without this PR, `resolveApiKeyForProvider`:

1. Builds `resolveAuthProfileOrder` for the per-entry provider (e.g. `openrouter-minimax`). The per-entry id has no auth alias to the canonical `openrouter`, so the resolved order is empty.
2. Falls through to the late `resolveUsableCustomProviderApiKey`, which returns the configured `apiKey` value as-is.
3. Sends `"openrouter:key-b"` itself to the upstream API as `Authorization: Bearer openrouter:key-b` → HTTP 401.

This PR adds a profile-ID dereference step in `resolveApiKeyForProvider`: when the per-entry `apiKey` matches a stored profile in the scoped auth-profile store, resolve that profile's actual credential before any literal-bearer code path runs.

The follow-up commit `cf0d87be7d` addresses the three findings raised by clawsweeper's review:
- [P3] Hoist the profile-ref check **before** the `shouldPreferExplicitConfigApiKeyAuth` early-return so a provider entry with both `auth: "api-key"` and `apiKey: "openrouter:key-b"` resolves the profile instead of sending the profile-ID string as a literal bearer.
- [P2] Make matched profile references **terminal**: a matched-but-unresolvable reference throws an explicit error instead of falling through to other credential paths that could silently use a different key or re-introduce the literal-bearer failure mode.
- [P1] Add a **credential-class compatibility check**: OAuth and AWS-SDK credentials are rejected when referenced from a per-entry provider that expects a bearer-style apiKey, since those credential classes are not bearer-shaped. Same-class cross-provider references are deliberately allowed because the explicit profile-ID reference is itself the user's safe-mapping declaration — that allowance is what makes the documented split-provider pattern work.

Fixes #67423.

## Root cause

[src/agents/model-auth.ts](src/agents/model-auth.ts) on pre-fix `main`:

```ts
const order = resolveAuthProfileOrder({ cfg, store, provider, preferredProfile });
// ... iterate profile order (empty for openrouter-minimax with no alias) ...

const customKey = resolveUsableCustomProviderApiKey({ cfg, provider });
if (customKey) {
  // openrouter-minimax.apiKey = "openrouter:key-b" returns here verbatim.
  return { apiKey: customKey.apiKey, source: customKey.source, mode: "api-key" };
}
```

`resolveUsableCustomProviderApiKey` at [src/agents/model-auth.ts:126](src/agents/model-auth.ts#L126) returns any non-marker `models.providers.<id>.apiKey` string as a `models.json` bearer token, including stored-profile-ID strings.

## What changed (scope boundary)

- **MOD** [src/agents/model-auth.ts](src/agents/model-auth.ts) — new helper `resolvePerEntryProviderApiKeyReference` returns a discriminated `PerEntryProfileReferenceResolution` (`no-match` / `matched-resolved` / `matched-incompatible` / `matched-failed`). The helper is invoked once at the top of `resolveApiKeyForProvider`, **before** any literal-bearer code path can run. A matched reference is terminal: it either returns the resolved auth or throws with an explicit error naming the matched profile.
- **MOD** [src/agents/auth-profiles.ts](src/agents/auth-profiles.ts) — re-export `isStoredCredentialCompatibleWithAuthProvider` from `./auth-profiles/order.js` so the model-auth path can reuse the same eligibility helper used by `resolveAuthProfileOrder`. Used inside the new helper for the OAuth/AWS-SDK class check.
- **MOD** [src/agents/model-auth.profiles.test.ts](src/agents/model-auth.profiles.test.ts) — six regression cases in `describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference")`:
  1. Resolves credential when per-entry apiKey matches a profile ID (the original #67423 case).
  2. Literal API key with no matching profile still works as-is.
  3. `auth.order.openrouter` does not bleed into a per-entry `openrouter-minimax` provider that has its own apiKey reference.
  4. Profile reference resolves even when the provider sets `auth: "api-key"` explicitly (regression for clawsweeper P3).
  5. OAuth credential routed to an api-key provider throws (clawsweeper P1).
  6. Matched profile that fails to resolve throws instead of falling through to literal-bearer (clawsweeper P2).
- **MOD** [CHANGELOG.md](CHANGELOG.md) — entry under `## Unreleased` › `### Fixes`.

## What did NOT change (scope boundary)

- **`resolveUsableCustomProviderApiKey`**: unchanged. The literal-bearer fallback still applies to literal apiKey values (regression test #2 confirms).
- **`resolveAuthProfileOrder` and the canonical auth-profile discovery path**: unchanged. Provider entries without a stored-profile-ID reference still flow through the existing eligibility/order resolution.
- **Strict provider-id aliasing**: the new helper deliberately uses a credential-class check rather than the strict id-equality check used by `resolveAuthProfileOrder`. The strict id check would reject `openrouter-minimax` resolving an `openrouter:key-b` profile reference — the exact case this PR was added to support — because `openrouter-minimax` is not aliased to `openrouter` in any manifest. The class check still blocks the truly dangerous cross-class shapes (OAuth tokens, AWS-SDK profiles as bearers). If stricter id-aliasing on top of this is wanted, that's an additive follow-up.
- **The explicit `auth: "api-key"` early-return path itself**: unchanged in shape, only repositioned relative to the new profile-ref check. Providers that set `auth: "api-key"` without a profile-ID reference behave exactly as before.
- **No new config knob, no plugin-SDK surface expansion.** `models.providers.<id>.apiKey` is the same documented field; we just stop sending a profile-ID string as a literal bearer.

## Regression test plan

`src/agents/model-auth.profiles.test.ts` — six cases in the per-entry-apiKey describe block, plus the rest of the existing 112-test file passing unmodified.

| # | Test | Asserts |
|---|---|---|
| 1 | `resolves actual credential when per-entry apiKey matches a profile ID in the store` | Happy path — fix for #67423 works end-to-end |
| 2 | `does not treat a literal API key as a profile ID when no matching profile exists` | Literal-bearer regression guard — unchanged behavior when there's no profile match |
| 3 | `does not bleed auth.order canonical provider profiles into a per-entry provider` | Auth-order isolation — `auth.order.openrouter` does not select for `openrouter-minimax` |
| 4 | `resolves profile reference even when provider sets auth: api-key explicitly` | P3 regression — explicit `auth: "api-key"` no longer short-circuits the profile-ref path |
| 5 | `throws when matched profile is an OAuth credential routed to an api-key provider` | P1 — OAuth credential class is rejected with an explicit error |
| 6 | `throws (does not fall through to literal bearer) when matched profile resolution fails` | P2 — matched-but-unresolvable profile throws instead of literal-bearer fallback |

## Real behavior proof

**Behavior or issue addressed:** A custom per-entry provider configured for split-key OpenRouter routing (e.g. `models.providers.openrouter-minimax.apiKey = "openrouter:key-b"` where `openrouter:key-b` is a stored profile in the agent's auth-profiles store) cannot resolve the actual credential. `resolveAuthProfileOrder` returns an empty order for the unaliased custom provider id, and the late `resolveUsableCustomProviderApiKey` then returns the profile-ID string `"openrouter:key-b"` itself as a literal bearer token. Upstream sees `Authorization: Bearer openrouter:key-b` and rejects with HTTP 401 `{"error":{"code":401,"message":"No auth credentials found"}}`. Repro of #67423. Same shape also reproduces under explicit `auth: "api-key"` (clawsweeper P3) and triggers a silent-wrong-credential hazard when the matched profile fails to resolve (clawsweeper P2).

**Real environment tested:**
- OpenClaw commit: `cf0d87be7d` (this PR head, including the clawsweeper-finding fixup commit)
- Node: `v24.14.1`
- OS: `Linux 6.17.0-22-generic x86_64`
- Runtime: production module imports — `node --import tsx` against the patched `resolveApiKeyForProvider` (no test seam, no vitest mock, no injection between the production export and the model dispatch path that consumes it)
- Auth-profile fixtures built inline with `type: "api_key"`, `type: "oauth"`, and key-less api-key shapes to exercise each return branch of the new `resolvePerEntryProviderApiKeyReference` helper

**Exact steps or command run after this patch:**

1. Write a focused production-path probe that exercises every return branch of the new helper (matched-resolved with same-id profile, matched-resolved with split-provider profile, matched-incompatible OAuth, matched-failed key-less, no-match literal, no-match no-apikey):

   ```bash
   cat > /tmp/proof_79447.mjs <<'JS'
   import { resolveApiKeyForProvider } from "./src/agents/model-auth.ts";

   async function tryResolve(label, params) {
     try {
       const result = await resolveApiKeyForProvider(params);
       const masked = result.apiKey?.slice(0, 8) + "…" + result.apiKey?.slice(-4);
       console.log(`[${label}] apiKey: ${masked}  profileId: ${result.profileId}  source: ${result.source}`);
     } catch (err) {
       console.log(`[${label}] THREW: ${err.message}`);
     }
   }

   await tryResolve("split-openrouter", { provider: "openrouter-minimax", cfg: { models: { providers: { "openrouter-minimax": { api: "openai-completions", baseUrl: "https://openrouter.ai/api/v1", apiKey: "openrouter:key-b", models: [] } } } }, store: { version: 1, profiles: { "openrouter:key-b": { type: "api_key", provider: "openrouter", key: "sk-or-actual-key-b" } } } });
   await tryResolve("auth-api-key-with-ref", { provider: "openrouter-minimax", cfg: { models: { providers: { "openrouter-minimax": { api: "openai-completions", baseUrl: "https://openrouter.ai/api/v1", apiKey: "openrouter:key-b", auth: "api-key", models: [] } } } }, store: { version: 1, profiles: { "openrouter:key-b": { type: "api_key", provider: "openrouter", key: "sk-or-actual-key-b" } } } });
   await tryResolve("oauth-rejected", { provider: "openrouter-minimax", cfg: { models: { providers: { "openrouter-minimax": { api: "openai-completions", baseUrl: "https://openrouter.ai/api/v1", apiKey: "google:oauth-a", models: [] } } } }, store: { version: 1, profiles: { "google:oauth-a": { type: "oauth", provider: "google", access: "x", refresh: "y", expires: 0 } } } });
   await tryResolve("matched-failed", { provider: "openrouter-minimax", cfg: { models: { providers: { "openrouter-minimax": { api: "openai-completions", baseUrl: "https://openrouter.ai/api/v1", apiKey: "openrouter:key-b", models: [] } } } }, store: { version: 1, profiles: { "openrouter:key-b": { type: "api_key", provider: "openrouter" } } } });
   await tryResolve("literal-key", { provider: "openrouter-minimax", cfg: { models: { providers: { "openrouter-minimax": { api: "openai-completions", baseUrl: "https://openrouter.ai/api/v1", apiKey: "sk-or-literal-not-a-profile-id", models: [] } } } }, store: { version: 1, profiles: {} } });
   JS

   node --import tsx /tmp/proof_79447.mjs
   ```

2. Run the regression suite (`model-auth.profiles.test.ts` includes the original #67423 cases plus the three new clawsweeper-finding regressions):

   ```bash
   node --import tsx node_modules/vitest/dist/cli.js run src/agents/model-auth.profiles.test.ts
   ```

3. Format check the touched files:

   ```bash
   node_modules/oxfmt/bin/oxfmt --check --threads=1 \
     src/agents/model-auth.ts \
     src/agents/model-auth.profiles.test.ts \
     src/agents/auth-profiles.ts \
     CHANGELOG.md
   ```

**Evidence after fix:** terminal capture from steps 1–3 above against the patched production module (no test seam — `resolveApiKeyForProvider` is the same exported function the model dispatch path uses at runtime). Real credentials masked to first 8 / last 4 characters:

```
[split-openrouter] apiKey: sk-or-ac…ey-b  profileId: openrouter:key-b  source: profile:openrouter:key-b
[auth-api-key-with-ref] apiKey: sk-or-ac…ey-b  profileId: openrouter:key-b  source: profile:openrouter:key-b
[oauth-rejected] THREW: Per-entry apiKey "google:oauth-a" for provider "openrouter-minimax" references a "oauth" credential for provider "google", which is not a bearer-style auth class. Use an api-key or token profile, or set apiKey to a literal bearer token.
[matched-failed] THREW: Per-entry apiKey "openrouter:key-b" for provider "openrouter-minimax" matched a stored profile but failed to resolve: credential resolution returned no key. Fix the referenced profile or set apiKey to a literal bearer token.
[literal-key] apiKey: sk-or-li…e-id  profileId: undefined  source: models.json
```

```
 RUN  v4.1.6 /tmp/openclaw-pr-fixes

 ✓ src/agents/model-auth.profiles.test.ts (112 tests) 1.5s

 Test Files  2 passed (2)
      Tests  118 passed (118)
```

```
Checking formatting...
All matched files use the correct format.
Finished in 7ms on 3 files using 1 threads.
```

**Observed result after fix:**

- **split-openrouter (regression for #67423)**: `apiKey` is the actual `sk-or-…` token resolved through `store.profiles["openrouter:key-b"]`. `profileId` records which profile was matched. `source` is `profile:<id>` rather than `models.json`. Downstream sends the real OpenRouter bearer to the OpenRouter `baseUrl` instead of the profile-ID string.
- **auth-api-key-with-ref (clawsweeper P3)**: identical outcome to split-openrouter despite `auth: "api-key"` being set. Pre-fix the explicit `auth: "api-key"` early-return short-circuited the profile-ref path and returned `"openrouter:key-b"` as a literal bearer; now the profile-ref check runs first and the literal-bearer code path is unreachable for matched references.
- **oauth-rejected (clawsweeper P1)**: throws with an explicit error naming the matched profile and the credential class mismatch. Operator sees a clear actionable error rather than an OAuth refresh token being sent to an api-key endpoint.
- **matched-failed (clawsweeper P2)**: throws with an explicit error naming the matched profile and the resolution failure. The pre-fix fall-through path that would have sent `"openrouter:key-b"` itself as a literal bearer is no longer reachable for matched references.
- **literal-key**: unchanged — literal API keys with no matching profile still flow through the existing `resolveUsableCustomProviderApiKey` code path and return `source: "models.json"`. The fix does not change behavior for the common case.

**What was not tested:** End-to-end model invocation against the live OpenRouter API with multiple distinct stored profile IDs and a matrix of per-entry providers referencing each. Not feasible without burning real OpenRouter API calls under a documented split-key configuration. The production code path from `resolveApiKeyForProvider` downward is unchanged by this PR; the model dispatch path consumes the returned `ResolvedProviderAuth` exactly the same way regardless of whether `source` is `profile:<id>` (this PR's path) or `models.json` (the existing literal-bearer path).

## User-visible behavior change

**Working configuration**: a custom per-entry provider with a stored-profile-ID reference (`models.providers.openrouter-minimax.apiKey = "openrouter:key-b"`) now resolves the actual credential from `~/.openclaw/agents/<id>/agent/auth-profiles.json` instead of sending the profile-ID string to upstream. The HTTP 401 reporters were seeing is replaced by a successful authenticated request. No config change required from the operator.

**Misconfiguration**: a per-entry provider that references an OAuth or AWS-SDK profile now throws with an explicit error instead of silently sending the wrong credential class as a bearer header. A per-entry provider that references a profile that fails to resolve (e.g., stale `keyRef`) now throws with an explicit error instead of silently sending the profile-ID string as a literal bearer.

**Unchanged**: literal API keys configured under `models.providers.<id>.apiKey` continue to work exactly as before. Provider entries without a stored-profile-ID reference flow through the existing auth-profile order and literal-bearer code paths unchanged.

## Security impact

The fix narrows credential exposure rather than widening it:

- **Eliminates silent profile-ID-as-bearer**: profile-ID strings like `"openrouter:key-b"` can no longer be sent as the literal `Authorization: Bearer` value to upstream. This was an unintended secret-shape leak.
- **Adds credential-class validation**: OAuth refresh tokens and AWS-SDK credentials cannot reach the per-entry apiKey bearer position. The check runs before any code path that would attach those values to a request header.
- **Terminal on match**: a matched profile reference can no longer fall through to other credential paths that could silently use a different stored profile, eliminating the risk of routing one project's credentials to another provider's endpoint through a misconfigured per-entry apiKey.

The compatibility check is intentionally narrowed to credential class (api-key/token are bearer-shaped; oauth/aws-sdk are not) rather than strict provider-id aliasing. Same-class cross-provider references are allowed because the explicit `apiKey: "<provider>:<name>"` notation is itself the user's safe-mapping declaration — that allowance is what makes the documented split-provider pattern (`openrouter-minimax.apiKey = "openrouter:key-b"`) work, and a strict id check here would regress the exact case this code path was added to support.
