### PR TITLE
test(qa-lab): remove redundant non-null assertion on stagedRoot

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -972,7 +972,7 @@ describe("qa bundled plugin dir", () => {
     expect(stagedRoot).toBe(
       path.join(repoRoot, ".artifacts", "qa-runtime", path.basename(tempRoot)),
     );
-    await expect(readFile(path.join(stagedRoot!, "package.json"), "utf8")).resolves.toContain(
+    await expect(readFile(path.join(stagedRoot, "package.json"), "utf8")).resolves.toContain(
       '"name": "openclaw"',
     );
     await expect(


### PR DESCRIPTION
## Problem

Commit f56f1dd16 ("test: tighten qa lab staged root assertion") replaced a null guard with `stagedRoot!` at `extensions/qa-lab/src/gateway-child.test.ts:975`. However, `stagedRoot` is already typed as `string` (returned from `path.join(...)`), making the `!` a no-op that oxlint flags:

```
× typescript-eslint(no-unnecessary-type-assertion): This assertion is unnecessary since it does not change the type of the expression.
   ,-[extensions/qa-lab/src/gateway-child.test.ts:975:47]
   await expect(readFile(path.join(stagedRoot!, "package.json"), "utf8")).resolves.toContain(
```

This causes all PRs that rebase onto main ≥ f56f1dd16 to fail check-lint and check-additional-extension-bundled.

## Fix

Remove the redundant `!` — `stagedRoot` is returned from `createQaBundledPluginsDir()` as a `string` (via `path.join()`). The preceding `expect(stagedRoot).toBe(...)` assertion already validates the value; no non-null assertion is needed.

## Real behavior proof

- Behavior or issue addressed: check-lint fails with no-unnecessary-type-assertion on any PR rebased onto main since f56f1dd16, blocking all in-flight PRs from passing CI. The stagedRoot! at gateway-child.test.ts:975 is unnecessary since path.join() always returns string.
- Environment: Linux 6.11.0-1016-nvidia x86_64, Node v22.14.0, oxlint via scripts/run-oxlint-shards.mjs
- Exact steps or command run after this patch: node scripts/run-oxlint-shards.mjs
- Evidence after fix:
```
$ node scripts/run-oxlint-shards.mjs
[oxlint:scripts] starting
Found 0 warnings and 0 errors.
Finished in 953ms on 408 files with 213 rules using 1 threads.
[oxlint:scripts] finished
Found 0 warnings and 0 errors.
Finished in 9.1s on 8337 files with 213 rules using 1 threads.
[oxlint:core] finished
Found 0 warnings and 0 errors.
Finished in 11.5s on 5176 files with 213 rules using 1 threads.
[oxlint:extensions] finished
```
- Observed result after fix: All 3 oxlint shards return 'Found 0 warnings and 0 errors.' (extensions shard was previously returning 1 error)
- What was not tested: runtime behavior of gateway-child test (removing unnecessary ! from a value already typed as string is cosmetic)