### PR TITLE
test(browser): replace unnecessary String() conversion with nullish coalesce

### DIFF
--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -169,7 +169,7 @@ describe("pw-session ensurePageState", () => {
     expect(saveAsA.mock.calls[0]?.[0]).not.toBe(managedPathA);
     expect(saveAsB.mock.calls[0]?.[0]).not.toBe(managedPathB);
     for (const call of [saveAsA.mock.calls[0], saveAsB.mock.calls[0]]) {
-      const savedParentName = path.basename(path.dirname(String(call?.[0])));
+      const savedParentName = path.basename(path.dirname(call?.[0] ?? ""));
       expect(
         savedParentName.includes("fs-safe-output") ||
           savedParentName === path.basename(DEFAULT_DOWNLOAD_DIR),


### PR DESCRIPTION
## Problem

Commit 7cc0b21e4d ("test: restore node 26 test compatibility") introduced `String(call?.[0])` at `extensions/browser/src/browser/pw-session.test.ts:172`. The oxlint rule `no-unnecessary-type-conversion` flags this because the expression is already typed as `string`:

```
× typescript-eslint(no-unnecessary-type-conversion): This type conversion does not change the type or value of the expression.
   ,-[extensions/browser/src/browser/pw-session.test.ts:172:58]
   const savedParentName = path.basename(path.dirname(String(call?.[0])));
                                                       ^^^^^^ ^^^^^^^^^
```

This causes `check-lint` and `check-additional-extension-bundled` to fail on all PRs rebased onto main since 7cc0b21e4d.

## Fix

Replace `String(call?.[0])` with `call?.[0] ?? ""` — this is explicit about the `undefined`-to-empty-string fallback (needed since `path.dirname` requires `string`), avoids the redundant type conversion, and satisfies the lint rule.

## Real behavior proof

- Behavior or issue addressed: check-lint fails with no-unnecessary-type-conversion at pw-session.test.ts:172 on any PR rebased onto main since 7cc0b21e4d, blocking in-flight PRs from passing CI
- Real environment tested: Linux 6.11.0-1016-nvidia x64, Node v22.14.0, oxlint via scripts/run-oxlint-shards.mjs
- Exact steps or command run after this patch: node scripts/run-oxlint-shards.mjs
- Evidence after fix:
```
$ node scripts/run-oxlint-shards.mjs
[oxlint:scripts] starting
Found 0 warnings and 0 errors.
Finished in ~1s on 408 files with 213 rules using 1 threads.
[oxlint:scripts] finished
Found 0 warnings and 0 errors.
Finished in ~9s on 8337 files with 213 rules using 1 threads.
[oxlint:core] finished
Found 0 warnings and 0 errors.
Finished in ~11s on 5176 files with 213 rules using 1 threads.
[oxlint:extensions] finished
```
- Observed result after fix: All 3 oxlint shards return 'Found 0 warnings and 0 errors.' (extensions shard was previously returning 1 error for pw-session.test.ts:172)
- What was not tested: runtime behavior of pw-session test (the change is cosmetic — semantically equivalent since String(x) where x is string is identity, and the ?? "" fallback covers the undefined case path.dirname would see via the optional chain)