### PR TITLE
Fix ACP command bypass for channel text commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP/Codex: prefer clean channel command text when deciding whether text commands bypass ACP handling, so WhatsApp `/status`, `/help`, and other local commands do not disappear behind envelope-shaped channel prompts. Thanks @RoeeJ.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.

--- a/src/auto-reply/reply/context-text.ts
+++ b/src/auto-reply/reply/context-text.ts
@@ -19,3 +19,12 @@ export function resolveFirstContextText(
   }
   return "";
 }
+
+export function resolveCommandContextText(ctx: FinalizedMsgContext): string {
+  return resolveFirstContextText(ctx, ["BodyForCommands", "CommandBody", "RawBody", "Body"]).trim();
+}
+
+export function hasExplicitCommandContextText(ctx: FinalizedMsgContext): boolean {
+  const text = resolveCommandContextText(ctx);
+  return text.startsWith("/") || text.startsWith("!");
+}

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -73,6 +73,30 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
+  it("returns true for registry-backed local help commands", () => {
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      CommandBody: "/help",
+      BodyForCommands: "/help",
+      BodyForAgent: "/help",
+    });
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+  });
+
+  it("prefers clean command text over channel envelopes", () => {
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      CommandBody: "[WhatsApp +15551234567 +1m Fri 2026-05-08 16:12 UTC] /status",
+      BodyForCommands: "/status",
+      BodyForAgent: "/status",
+    });
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+  });
+
   it("returns true for local unfocus commands", () => {
     const ctx = buildTestCtx({
       Provider: "discord",

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -73,6 +73,30 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
+  it("returns true for registry-backed local help commands", () => {
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      CommandBody: "/help",
+      BodyForCommands: "/help",
+      BodyForAgent: "/help",
+    });
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+  });
+
+  it("prefers the clean command body over channel envelopes", () => {
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      CommandBody: "[WhatsApp +15551234567 +1m Fri 2026-05-08 16:12 UTC] /status",
+      BodyForCommands: "/status",
+      BodyForAgent: "/status",
+    });
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+  });
+
   it("returns true for local unfocus commands", () => {
     const ctx = buildTestCtx({
       Provider: "discord",

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.ts
@@ -1,13 +1,10 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { hasControlCommand } from "../command-detection.js";
 import { isCommandEnabled } from "../commands-registry-list.js";
 import { maybeResolveTextAlias } from "../commands-registry-normalize.js";
 import { shouldHandleTextCommands } from "../commands-text-routing.js";
 import type { FinalizedMsgContext } from "../templating.js";
-import { resolveFirstContextText } from "./context-text.js";
-
-function resolveCommandCandidateText(ctx: FinalizedMsgContext): string {
-  return resolveFirstContextText(ctx, ["CommandBody", "BodyForCommands", "RawBody", "Body"]).trim();
-}
+import { resolveCommandContextText } from "./context-text.js";
 
 function isResetCommandCandidate(text: string): boolean {
   return /^\/(?:new|reset)(?:\s|$)/i.test(text);
@@ -17,15 +14,15 @@ function isAcpCommandCandidate(text: string): boolean {
   return /^\/acp(?:\s|$)/i.test(text);
 }
 
-function isLocalCommandCandidate(text: string): boolean {
-  return /^\/(?:status|unfocus)(?:\s|$)/i.test(text) || /^\/(?:verbose|v)(?:[\s:]|$)/i.test(text);
+function isLocalCommandCandidate(text: string, cfg: OpenClawConfig): boolean {
+  return hasControlCommand(text, cfg);
 }
 
 export function shouldBypassAcpDispatchForCommand(
   ctx: FinalizedMsgContext,
   cfg: OpenClawConfig,
 ): boolean {
-  const candidate = resolveCommandCandidateText(ctx);
+  const candidate = resolveCommandContextText(ctx);
   if (!candidate) {
     return false;
   }
@@ -47,7 +44,7 @@ export function shouldBypassAcpDispatchForCommand(
     return true;
   }
 
-  if (isLocalCommandCandidate(normalized)) {
+  if (isLocalCommandCandidate(normalized, cfg)) {
     return allowTextCommands;
   }
 

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { hasControlCommand } from "../command-detection.js";
 import { isCommandEnabled } from "../commands-registry-list.js";
 import { maybeResolveTextAlias } from "../commands-registry-normalize.js";
 import { shouldHandleTextCommands } from "../commands-text-routing.js";
@@ -18,7 +19,7 @@ function resolveFirstContextText(
 }
 
 function resolveCommandCandidateText(ctx: FinalizedMsgContext): string {
-  return resolveFirstContextText(ctx, ["CommandBody", "BodyForCommands", "RawBody", "Body"]).trim();
+  return resolveFirstContextText(ctx, ["BodyForCommands", "CommandBody", "RawBody", "Body"]).trim();
 }
 
 function isResetCommandCandidate(text: string): boolean {
@@ -29,8 +30,8 @@ function isAcpCommandCandidate(text: string): boolean {
   return /^\/acp(?:\s|$)/i.test(text);
 }
 
-function isLocalCommandCandidate(text: string): boolean {
-  return /^\/(?:status|unfocus)(?:\s|$)/i.test(text);
+function isLocalCommandCandidate(text: string, cfg: OpenClawConfig): boolean {
+  return hasControlCommand(text, cfg);
 }
 
 export function shouldBypassAcpDispatchForCommand(
@@ -59,7 +60,7 @@ export function shouldBypassAcpDispatchForCommand(
     return true;
   }
 
-  if (isLocalCommandCandidate(normalized)) {
+  if (isLocalCommandCandidate(normalized, cfg)) {
     return allowTextCommands;
   }
 

--- a/src/plugin-sdk/acp-runtime-backend.ts
+++ b/src/plugin-sdk/acp-runtime-backend.ts
@@ -1,6 +1,6 @@
 // Lightweight ACP runtime backend helpers for startup-loaded plugins.
 
-import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
+import { hasExplicitCommandContextText } from "../auto-reply/reply/context-text.js";
 import type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
@@ -40,20 +40,6 @@ function loadDispatchAcpRuntime() {
   return dispatchAcpRuntimePromise;
 }
 
-function hasExplicitCommandCandidate(ctx: PluginHookReplyDispatchEvent["ctx"]): boolean {
-  const commandBody = normalizeOptionalString(ctx.CommandBody);
-  if (commandBody) {
-    return true;
-  }
-
-  const normalized = normalizeOptionalString(ctx.BodyForCommands);
-  if (!normalized) {
-    return false;
-  }
-
-  return normalized.startsWith("!") || normalized.startsWith("/");
-}
-
 export async function tryDispatchAcpReplyHook(
   event: PluginHookReplyDispatchEvent,
   ctx: PluginHookReplyDispatchContext,
@@ -64,7 +50,7 @@ export async function tryDispatchAcpReplyHook(
   if (
     event.sendPolicy === "deny" &&
     !event.suppressUserDelivery &&
-    !hasExplicitCommandCandidate(event.ctx) &&
+    !hasExplicitCommandContextText(event.ctx) &&
     !event.isTailDispatch
   ) {
     return;

--- a/src/plugin-sdk/acp-runtime-backend.ts
+++ b/src/plugin-sdk/acp-runtime-backend.ts
@@ -38,17 +38,16 @@ function loadDispatchAcpRuntime() {
 }
 
 function hasExplicitCommandCandidate(ctx: PluginHookReplyDispatchEvent["ctx"]): boolean {
-  const commandBody = normalizeOptionalString(ctx.CommandBody);
-  if (commandBody) {
-    return true;
+  for (const value of [ctx.BodyForCommands, ctx.CommandBody]) {
+    const normalized = normalizeOptionalString(value);
+    if (!normalized) {
+      continue;
+    }
+    if (normalized.startsWith("!") || normalized.startsWith("/")) {
+      return true;
+    }
   }
-
-  const normalized = normalizeOptionalString(ctx.BodyForCommands);
-  if (!normalized) {
-    return false;
-  }
-
-  return normalized.startsWith("!") || normalized.startsWith("/");
+  return false;
 }
 
 export async function tryDispatchAcpReplyHook(

--- a/src/plugin-sdk/acp-runtime.test.ts
+++ b/src/plugin-sdk/acp-runtime.test.ts
@@ -83,6 +83,26 @@ describe("tryDispatchAcpReplyHook", () => {
     expect(dispatchMock).not.toHaveBeenCalled();
   });
 
+  it("skips ACP runtime lookup for non-command deny turns even when CommandBody is populated", async () => {
+    const result = await tryDispatchAcpReplyHook(
+      {
+        ...event,
+        sendPolicy: "deny",
+        ctx: buildTestCtx({
+          SessionKey: "agent:test:session",
+          CommandBody: "write a test",
+          BodyForCommands: "write a test",
+          BodyForAgent: "write a test",
+        }),
+      },
+      ctx,
+    );
+
+    expect(result).toBeUndefined();
+    expect(bypassMock).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
   it("skips ACP dispatch when send policy denies delivery and no bypass applies", async () => {
     bypassMock.mockResolvedValue(false);
 
@@ -90,6 +110,40 @@ describe("tryDispatchAcpReplyHook", () => {
 
     expect(result).toBeUndefined();
     expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("checks command bypass when BodyForCommands has the clean command and CommandBody has an envelope", async () => {
+    bypassMock.mockResolvedValue(true);
+    dispatchMock.mockResolvedValue({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+
+    const wrappedEvent = {
+      ...event,
+      sendPolicy: "deny" as const,
+      ctx: buildTestCtx({
+        SessionKey: "agent:test:session",
+        CommandBody: "[WhatsApp +15551234567 +1m Fri 2026-05-08 16:12 UTC] /status",
+        BodyForCommands: "/status",
+        BodyForAgent: "/status",
+      }),
+    };
+
+    const result = await tryDispatchAcpReplyHook(wrappedEvent, ctx);
+
+    expect(bypassMock).toHaveBeenCalledWith(wrappedEvent.ctx, ctx.cfg);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: wrappedEvent.ctx,
+        bypassForCommand: true,
+      }),
+    );
+    expect(result).toEqual({
+      handled: true,
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
   });
 
   it("dispatches through ACP when command bypass applies", async () => {

--- a/src/plugin-sdk/acp-runtime.test.ts
+++ b/src/plugin-sdk/acp-runtime.test.ts
@@ -74,6 +74,26 @@ describe("tryDispatchAcpReplyHook", () => {
     expect(dispatchMock).not.toHaveBeenCalled();
   });
 
+  it("skips ACP runtime lookup for non-command deny turns even when CommandBody is populated", async () => {
+    const result = await tryDispatchAcpReplyHook(
+      {
+        ...event,
+        sendPolicy: "deny",
+        ctx: buildTestCtx({
+          SessionKey: "agent:test:session",
+          CommandBody: "write a test",
+          BodyForCommands: "write a test",
+          BodyForAgent: "write a test",
+        }),
+      },
+      ctx,
+    );
+
+    expect(result).toBeUndefined();
+    expect(bypassMock).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
   it("skips ACP dispatch when send policy denies delivery and no bypass applies", async () => {
     bypassMock.mockResolvedValue(false);
 
@@ -81,6 +101,40 @@ describe("tryDispatchAcpReplyHook", () => {
 
     expect(result).toBeUndefined();
     expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("checks command bypass when BodyForCommands has the clean command and CommandBody has an envelope", async () => {
+    bypassMock.mockResolvedValue(true);
+    dispatchMock.mockResolvedValue({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+
+    const wrappedEvent = {
+      ...event,
+      sendPolicy: "deny" as const,
+      ctx: buildTestCtx({
+        SessionKey: "agent:test:session",
+        CommandBody: "[WhatsApp +15551234567 +1m Fri 2026-05-08 16:12 UTC] /status",
+        BodyForCommands: "/status",
+        BodyForAgent: "/status",
+      }),
+    };
+
+    const result = await tryDispatchAcpReplyHook(wrappedEvent, ctx);
+
+    expect(bypassMock).toHaveBeenCalledWith(wrappedEvent.ctx, ctx.cfg);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: wrappedEvent.ctx,
+        bypassForCommand: true,
+      }),
+    );
+    expect(result).toEqual({
+      handled: true,
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
   });
 
   it("dispatches through ACP when command bypass applies", async () => {


### PR DESCRIPTION
## Summary

- Problem: ACP/Codex-backed channel turns can swallow text control commands when the command body is wrapped in channel envelope text, e.g. WhatsApp `/status`.
- Why it matters: owner commands such as `/status`, `/help`, `/commands`, and related local controls should be handled by OpenClaw even when an ACP/Codex harness is active.
- What changed: ACP command bypass now prefers clean `BodyForCommands`, recognizes all registry-backed control commands instead of only `/status` and `/unfocus`, and avoids ACP runtime lookup for denied non-command turns whose `CommandBody` is normal text.
- What did NOT change (scope boundary): no channel routing, command authorization, WhatsApp delivery, or ACP execution behavior was broadened beyond deciding whether local command handling should bypass ACP.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: WhatsApp DM text commands such as `/status` were received but produced no visible command reply when ACP/Codex handling was active.
- Real environment tested: Linux OpenClaw gateway `2026.5.7`, WhatsApp Web channel, direct WhatsApp chat, Codex/ACP harness enabled.
- Exact steps or command run after this patch: reproduced the affected shape with a live WhatsApp `/status` message, then verified the fixed command-bypass logic with focused tests covering clean `BodyForCommands` plus envelope-shaped `CommandBody`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
2026-05-08T16:12:40.114Z info web-inbound {"from":"+[redacted]","to":"+[redacted]","body":"/status"} inbound message
2026-05-08T16:12:40.118Z info web-auto-reply {"body":"[WhatsApp +[redacted] +1m Fri 2026-05-08 16:12 UTC] /status"} inbound web message
2026-05-08T16:12:41.299Z info web-auto-reply {"to":"+[redacted]","text":"🦞 OpenClaw 2026.5.7 ..."} auto-reply sent (text)
```

```text
RUN  v4.1.5 /home/claw/agents/claw/projects/openclaw-pr

Test Files  2 passed (2)
     Tests  26 passed (26)
  Duration  4.82s
```

- Observed result after fix: local command bypass recognizes the clean `/status` command even if `CommandBody` contains a channel envelope, and registry-backed commands like `/help` are local bypass candidates.
- What was not tested: a full upstream-built OpenClaw package installed over the live gateway; this was verified with focused unit tests and a live-runtime symptom/log capture.
- Before evidence (optional but encouraged):

```text
2026-05-08T15:33:47.343Z info web-inbound {"from":"+[redacted]","to":"+[redacted]","body":"/status"} inbound message
2026-05-08T15:33:47.347Z info web-auto-reply {"body":"[WhatsApp +[redacted] +15m Fri 2026-05-08 15:33 UTC] /status"} inbound web message
```

No `auto-reply sent` log followed until a later non-command message.

## Root Cause (if applicable)

- Root cause: ACP bypass command detection preferred `CommandBody` before `BodyForCommands`, so an envelope-shaped `CommandBody` could hide the clean command body from bypass detection. The local command candidate list was also hardcoded to `/status` and `/unfocus`, excluding other registry-backed local commands such as `/help`.
- Missing detection / guardrail: no test covered `BodyForCommands: "/status"` with an envelope-shaped `CommandBody`, and no test asserted that registry-backed local commands beyond `/status`/`/unfocus` bypass ACP.
- Contributing context (if known): channel monitors can retain user-visible envelope text for model/session context while also carrying a clean command body for command parsing.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-acp-command-bypass.test.ts` and `src/plugin-sdk/acp-runtime.test.ts`
- Scenario the test should lock in: ACP command bypass uses clean `BodyForCommands` when `CommandBody` is envelope-shaped, and registry-backed local text commands bypass ACP when text commands are enabled.
- Why this is the smallest reliable guardrail: the bug is in ACP bypass admission logic before provider dispatch, so unit coverage directly exercises the decision without requiring live channel credentials.
- Existing test that already covers this (if any): existing ACP bypass tests covered `/status`, `/unfocus`, `/new`, `/reset`, and ACP commands, but not clean-body precedence or registry-backed local commands such as `/help`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Text control commands that previously disappeared into ACP/Codex handling can now be handled by OpenClaw's local command path.

## Diagram (if applicable)

```text
Before:
[WhatsApp /status] -> [CommandBody envelope checked first] -> [ACP path] -> [no visible command reply]

After:
[WhatsApp /status] -> [BodyForCommands clean command checked first] -> [local command bypass] -> [status reply]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js `v22.22.1`, OpenClaw gateway `2026.5.7`
- Model/provider: OpenAI Codex/ACP harness active
- Integration/channel (if any): WhatsApp Web direct message
- Relevant config (redacted): WhatsApp direct allowlist enabled; owner command allowlist contains the sender identity; `commands.text` enabled.

### Steps

1. Run OpenClaw with WhatsApp and ACP/Codex handling enabled.
2. Send `/status` from an authorized WhatsApp DM sender.
3. Observe whether the local status command sends a visible reply.
4. Run focused regression tests:

```sh
PATH="/tmp/openclaw-pnpm-wrapper:$PATH" corepack pnpm exec vitest run src/auto-reply/reply/dispatch-acp-command-bypass.test.ts src/plugin-sdk/acp-runtime.test.ts
```

### Expected

- Clean command text in `BodyForCommands` is sufficient for ACP bypass, even if `CommandBody` includes channel envelope text.
- Registry-backed local commands such as `/help` are local command candidates.

### Actual

- Tests pass and cover the envelope/clean-body command case plus registry-backed `/help` handling.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Vitest coverage for ACP command bypass and runtime hook admission; live WhatsApp logs showing the affected envelope shape and a subsequent visible `/status` reply.
- Edge cases checked: non-command deny turns with populated `CommandBody` no longer trigger ACP runtime lookup; `/help` is treated as a registry-backed local command candidate; envelope-shaped `CommandBody` does not mask clean `BodyForCommands`.
- What you did **not** verify: full upstream package release/install cycle or cross-channel E2E runs for every native-command-capable integration.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: More registry-backed text commands bypass ACP than the previous hardcoded `/status` and `/unfocus` list.
  - Mitigation: bypass still honors `shouldHandleTextCommands`, existing command registry detection, and command authorization later in the local command path.