### PR TITLE
fix(agents): enforce MCP deny policy for CLI backends

### DIFF
--- a/src/agents/bundle-mcp-config.test.ts
+++ b/src/agents/bundle-mcp-config.test.ts
@@ -112,4 +112,32 @@ describe("loadMergedBundleMcpConfig", () => {
 
     expect(Object.keys(filtered.mcpServers)).toEqual(["twenty-crm"]);
   });
+
+  it("preserves profile-allowed bundle MCP servers", () => {
+    const filtered = filterBundleMcpConfigByToolPolicies({
+      config: {
+        mcpServers: {
+          "twenty-crm": { type: "sse", url: "https://crm.example.com/mcp" },
+          calendar: { type: "sse", url: "https://calendar.example.com/mcp" },
+        },
+      },
+      policies: [{ allow: ["read", "exec", "bundle-mcp"] }],
+    });
+
+    expect(Object.keys(filtered.mcpServers)).toEqual(["twenty-crm", "calendar"]);
+  });
+
+  it("lets explicit denies override profile-allowed bundle MCP servers", () => {
+    const filtered = filterBundleMcpConfigByToolPolicies({
+      config: {
+        mcpServers: {
+          "twenty-crm": { type: "sse", url: "https://crm.example.com/mcp" },
+          calendar: { type: "sse", url: "https://calendar.example.com/mcp" },
+        },
+      },
+      policies: [{ allow: ["bundle-mcp"] }, { deny: ["mcp__twenty-crm"] }],
+    });
+
+    expect(Object.keys(filtered.mcpServers)).toEqual(["calendar"]);
+  });
 });

--- a/src/agents/bundle-mcp-config.test.ts
+++ b/src/agents/bundle-mcp-config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { loadMergedBundleMcpConfig, toCliBundleMcpServerConfig } from "./bundle-mcp-config.js";
+import {
+  filterBundleMcpConfigByToolPolicies,
+  loadMergedBundleMcpConfig,
+  toCliBundleMcpServerConfig,
+} from "./bundle-mcp-config.js";
 
 const mocks = vi.hoisted(() => ({
   bundleMcp: {
@@ -59,5 +63,53 @@ describe("loadMergedBundleMcpConfig", () => {
     expect(toCliBundleMcpServerConfig({ type: "sse", transport: "streamable-http" })).toEqual({
       type: "sse",
     });
+  });
+
+  it("filters MCP servers with tool deny policy entries", () => {
+    const filtered = filterBundleMcpConfigByToolPolicies({
+      config: {
+        mcpServers: {
+          "twenty-crm": {
+            type: "sse",
+            url: "https://crm.example.com/mcp",
+          },
+          calendar: {
+            type: "sse",
+            url: "https://calendar.example.com/mcp",
+          },
+        },
+      },
+      policies: [{ deny: ["mcp__twenty-crm"] }],
+    });
+
+    expect(Object.keys(filtered.mcpServers)).toEqual(["calendar"]);
+  });
+
+  it("treats MCP tool wildcards as server-level deny entries", () => {
+    const filtered = filterBundleMcpConfigByToolPolicies({
+      config: {
+        mcpServers: {
+          openclaw: { type: "http", url: "http://127.0.0.1:3000/mcp" },
+          docs: { type: "sse", url: "https://docs.example.com/mcp" },
+        },
+      },
+      policies: [{ deny: ["mcp__openclaw__*"] }],
+    });
+
+    expect(Object.keys(filtered.mcpServers)).toEqual(["docs"]);
+  });
+
+  it("honors MCP server allowlists without widening to unrelated servers", () => {
+    const filtered = filterBundleMcpConfigByToolPolicies({
+      config: {
+        mcpServers: {
+          "twenty-crm": { type: "sse", url: "https://crm.example.com/mcp" },
+          docs: { type: "sse", url: "https://docs.example.com/mcp" },
+        },
+      },
+      policies: [{ allow: ["mcp__twenty-crm__*"] }],
+    });
+
+    expect(Object.keys(filtered.mcpServers)).toEqual(["twenty-crm"]);
   });
 });

--- a/src/agents/bundle-mcp-config.ts
+++ b/src/agents/bundle-mcp-config.ts
@@ -21,6 +21,8 @@ type BundleMcpToolPolicy = {
 
 type BundleMcpServerMapper = (server: BundleMcpServerConfig, name: string) => BundleMcpServerConfig;
 
+const BUNDLE_MCP_PLUGIN_POLICY_ENTRIES = new Set(["bundle-mcp", "group:plugins"]);
+
 const OPENCLAW_TRANSPORT_TO_CLI_BUNDLE_TYPE: Record<string, string> = {
   "streamable-http": "http",
   http: "http",
@@ -64,6 +66,9 @@ function policyEntryTargetsMcpServer(entry: string, serverName: string): boolean
   const normalizedServerName = normalizeToolName(serverName);
   if (!normalizedEntry || !normalizedServerName) {
     return false;
+  }
+  if (BUNDLE_MCP_PLUGIN_POLICY_ENTRIES.has(normalizedEntry)) {
+    return true;
   }
   if (normalizedEntry === "*") {
     return true;

--- a/src/agents/bundle-mcp-config.ts
+++ b/src/agents/bundle-mcp-config.ts
@@ -6,10 +6,17 @@ import {
   type BundleMcpDiagnostic,
   type BundleMcpServerConfig,
 } from "../plugins/bundle-mcp.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { normalizeToolName } from "./tool-policy.js";
 
 type MergedBundleMcpConfig = {
   config: BundleMcpConfig;
   diagnostics: BundleMcpDiagnostic[];
+};
+
+type BundleMcpToolPolicy = {
+  allow?: string[];
+  deny?: string[];
 };
 
 type BundleMcpServerMapper = (server: BundleMcpServerConfig, name: string) => BundleMcpServerConfig;
@@ -41,6 +48,69 @@ export function toCliBundleMcpServerConfig(server: BundleMcpServerConfig): Bundl
     }
   }
   return next as BundleMcpServerConfig;
+}
+
+function buildMcpServerPolicyCandidates(name: string): string[] {
+  const serverName = normalizeToolName(name);
+  if (!serverName) {
+    return [];
+  }
+  const mcpServerName = serverName.startsWith("mcp__") ? serverName : `mcp__${serverName}`;
+  return Array.from(new Set([serverName, mcpServerName, `${mcpServerName}__tool`]));
+}
+
+function policyEntryTargetsMcpServer(entry: string, serverName: string): boolean {
+  const normalizedEntry = normalizeToolName(entry);
+  const normalizedServerName = normalizeToolName(serverName);
+  if (!normalizedEntry || !normalizedServerName) {
+    return false;
+  }
+  if (normalizedEntry === "*") {
+    return true;
+  }
+  const mcpServerName = normalizedServerName.startsWith("mcp__")
+    ? normalizedServerName
+    : `mcp__${normalizedServerName}`;
+  if (normalizedEntry === normalizedServerName || normalizedEntry === mcpServerName) {
+    return true;
+  }
+  if (normalizedEntry.startsWith(`${mcpServerName}__`)) {
+    return true;
+  }
+  return buildMcpServerPolicyCandidates(serverName).some(
+    (candidate) => !isToolAllowedByPolicyName(candidate, { deny: [entry] }),
+  );
+}
+
+function isMcpServerAllowedByToolPolicy(name: string, policy: BundleMcpToolPolicy): boolean {
+  const deny = policy.deny ?? [];
+  if (deny.some((entry) => policyEntryTargetsMcpServer(entry, name))) {
+    return false;
+  }
+  const allow = policy.allow ?? [];
+  if (allow.length === 0) {
+    return true;
+  }
+  return allow.some((entry) => policyEntryTargetsMcpServer(entry, name));
+}
+
+export function filterBundleMcpConfigByToolPolicies(params: {
+  config: BundleMcpConfig;
+  policies?: Array<BundleMcpToolPolicy | undefined>;
+}): BundleMcpConfig {
+  const policies = (params.policies ?? []).filter((policy): policy is BundleMcpToolPolicy =>
+    Boolean(policy?.allow || policy?.deny),
+  );
+  if (policies.length === 0) {
+    return params.config;
+  }
+  return {
+    mcpServers: Object.fromEntries(
+      Object.entries(params.config.mcpServers).filter(([name]) =>
+        policies.every((policy) => isMcpServerAllowedByToolPolicy(name, policy)),
+      ),
+    ),
+  };
 }
 
 export function loadMergedBundleMcpConfig(params: {

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -8,7 +8,11 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { tryReadJson } from "../../infra/json-files.js";
 import { extractMcpServerMap, type BundleMcpConfig } from "../../plugins/bundle-mcp.js";
 import type { CliBundleMcpMode } from "../../plugins/types.js";
-import { loadMergedBundleMcpConfig, toCliBundleMcpServerConfig } from "../bundle-mcp-config.js";
+import {
+  filterBundleMcpConfigByToolPolicies,
+  loadMergedBundleMcpConfig,
+  toCliBundleMcpServerConfig,
+} from "../bundle-mcp-config.js";
 import { isRecord } from "./bundle-mcp-adapter-shared.js";
 import { findClaudeMcpConfigPath, injectClaudeMcpConfigArgs } from "./bundle-mcp-claude.js";
 import { injectCodexMcpConfigArgs } from "./bundle-mcp-codex.js";
@@ -143,6 +147,7 @@ export async function prepareCliBundleMcpConfig(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
   additionalConfig?: BundleMcpConfig;
+  toolPolicies?: Array<{ allow?: string[]; deny?: string[] } | undefined>;
   env?: Record<string, string>;
   warn?: (message: string) => void;
 }): Promise<PreparedCliBundleMcpConfig> {
@@ -180,6 +185,10 @@ export async function prepareCliBundleMcpConfig(params: {
   if (params.additionalConfig) {
     mergedConfig = applyMergePatch(mergedConfig, params.additionalConfig) as BundleMcpConfig;
   }
+  mergedConfig = filterBundleMcpConfigByToolPolicies({
+    config: mergedConfig,
+    policies: params.toolPolicies,
+  });
 
   return await prepareModeSpecificBundleMcpConfig({
     mode,

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -781,6 +781,80 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("applies per-agent tools.deny before writing CLI bundle MCP config", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "test-cli",
+            pluginId: "test",
+            bundleMcp: true,
+            bundleMcpMode: "claude-config-file",
+            config: {
+              command: "test-cli",
+              args: ["--print"],
+              systemPromptArg: "--system-prompt",
+              systemPromptWhen: "first",
+              sessionMode: "existing",
+              output: "text",
+              input: "arg",
+            },
+          },
+        ],
+      });
+      const config = createCliBackendConfig({ bundleMcp: true });
+      config.agents = {
+        ...config.agents,
+        list: [
+          {
+            id: "sales",
+            tools: { deny: ["mcp__twenty-crm"] },
+          },
+        ],
+      };
+      config.mcp = {
+        servers: {
+          "twenty-crm": {
+            type: "sse",
+            url: "https://crm.example.com/mcp",
+          },
+          calendar: {
+            type: "sse",
+            url: "https://calendar.example.com/mcp",
+          },
+        },
+      };
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-agent-mcp-policy",
+        agentId: "sales",
+        config,
+      });
+
+      const configFlagIndex = context.preparedBackend.backend.args?.indexOf("--mcp-config") ?? -1;
+      expect(configFlagIndex).toBeGreaterThanOrEqual(0);
+      const generatedConfigPath = context.preparedBackend.backend.args?.[configFlagIndex + 1];
+      const raw = JSON.parse(fs.readFileSync(generatedConfigPath as string, "utf-8")) as {
+        mcpServers?: Record<string, unknown>;
+      };
+
+      expect(Object.keys(raw.mcpServers ?? {})).toEqual(["calendar"]);
+
+      await context.preparedBackend.cleanup?.();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when a runtime toolsAllow is requested for CLI backends", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -855,6 +855,80 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("preserves profile-allowed CLI bundle MCP servers before explicit denies", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "test-cli",
+            pluginId: "test",
+            bundleMcp: true,
+            bundleMcpMode: "claude-config-file",
+            config: {
+              command: "test-cli",
+              args: ["--print"],
+              systemPromptArg: "--system-prompt",
+              systemPromptWhen: "first",
+              sessionMode: "existing",
+              output: "text",
+              input: "arg",
+            },
+          },
+        ],
+      });
+      const config = createCliBackendConfig({ bundleMcp: true });
+      config.agents = {
+        ...config.agents,
+        list: [
+          {
+            id: "sales",
+            tools: { profile: "coding", deny: ["mcp__twenty-crm"] },
+          },
+        ],
+      };
+      config.mcp = {
+        servers: {
+          "twenty-crm": {
+            type: "sse",
+            url: "https://crm.example.com/mcp",
+          },
+          calendar: {
+            type: "sse",
+            url: "https://calendar.example.com/mcp",
+          },
+        },
+      };
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-profile-agent-mcp-policy",
+        agentId: "sales",
+        config,
+      });
+
+      const configFlagIndex = context.preparedBackend.backend.args?.indexOf("--mcp-config") ?? -1;
+      expect(configFlagIndex).toBeGreaterThanOrEqual(0);
+      const generatedConfigPath = context.preparedBackend.backend.args?.[configFlagIndex + 1];
+      const raw = JSON.parse(fs.readFileSync(generatedConfigPath as string, "utf-8")) as {
+        mcpServers?: Record<string, unknown>;
+      };
+
+      expect(Object.keys(raw.mcpServers ?? {})).toEqual(["calendar"]);
+
+      await context.preparedBackend.cleanup?.();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when a runtime toolsAllow is requested for CLI backends", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -40,11 +40,13 @@ import { resolvePromptBuildHookResult } from "../pi-embedded-runner/run/attempt.
 import { resolveAttemptPrependSystemContext } from "../pi-embedded-runner/run/attempt.prompt-helpers.js";
 import { composeSystemPromptWithHookContext } from "../pi-embedded-runner/run/attempt.thread-helpers.js";
 import { buildCurrentTurnPrompt } from "../pi-embedded-runner/run/runtime-context-prompt.js";
+import { resolveEffectiveToolPolicy } from "../pi-tools.policy.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { resolveSkillsPromptForRun } from "../skills.js";
 import { resolveSystemPromptOverride } from "../system-prompt-override.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt } from "../system-prompt.js";
+import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../tool-policy.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { buildCliAgentSystemPrompt, normalizeCliModel } from "./helpers.js";
@@ -196,6 +198,38 @@ export async function prepareCliRunContext(
     }
     mcpLoopbackRuntime = prepareDeps.getActiveMcpLoopbackRuntime();
   }
+  let bundleMcpToolPolicies: Array<{ allow?: string[]; deny?: string[] } | undefined> | undefined;
+  if (bundleMcpEnabled) {
+    const {
+      globalPolicy,
+      globalProviderPolicy,
+      agentPolicy,
+      agentProviderPolicy,
+      profile,
+      providerProfile,
+      profileAlsoAllow,
+      providerProfileAlsoAllow,
+    } = resolveEffectiveToolPolicy({
+      config: params.config,
+      sessionKey: params.sessionKey,
+      agentId: sessionAgentId,
+      modelProvider: params.provider,
+      modelId,
+    });
+    const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow);
+    const providerProfilePolicy = mergeAlsoAllowPolicy(
+      resolveToolProfilePolicy(providerProfile),
+      providerProfileAlsoAllow,
+    );
+    bundleMcpToolPolicies = [
+      profilePolicy,
+      providerProfilePolicy,
+      globalPolicy,
+      globalProviderPolicy,
+      agentPolicy,
+      agentProviderPolicy,
+    ];
+  }
   const preparedBackend = await prepareCliBundleMcpConfig({
     enabled: bundleMcpEnabled,
     mode: backendResolved.bundleMcpMode,
@@ -217,6 +251,7 @@ export async function prepareCliRunContext(
           OPENCLAW_MCP_MESSAGE_CHANNEL: params.messageChannel ?? params.messageProvider ?? "",
         }
       : undefined,
+    toolPolicies: bundleMcpToolPolicies,
     warn: (message) => cliBackendLog.warn(message),
   });
   const preparedExecution = await backendResolved.prepareExecution?.({


### PR DESCRIPTION
## Summary

Fixes #79451.

- Applies the effective OpenClaw tool policy before writing CLI backend MCP config files.
- Preserves profile-level bundle MCP allow semantics for CLI backends (`bundle-mcp` / `group:plugins`), so `coding` and `messaging` profiles keep profile-allowed MCP servers available.
- Removes MCP servers targeted by global, provider, profile, or per-agent `tools.deny` entries.
- Preserves deny-wins behavior for server names like `mcp__twenty-crm` and wildcard MCP tool entries like `mcp__openclaw__*`.

## Root cause

Embedded runtimes filter MCP-style tools after tool construction, where plugin metadata makes the profile-level `bundle-mcp` allow entry apply to bundle MCP tools. CLI backends such as `claude-cli` read MCP tools directly from the generated config file, so the effective policy has to be applied before writing that config.

The original CLI filter only matched allow entries against server-name candidates. That meant `tools.profile: "coding"` or `"messaging"` supplied an allowlist containing `bundle-mcp`, but no individual server name matched it, so profile-allowed CLI MCP servers could be filtered down to an empty config. The fix treats bundle MCP plugin-level policy entries as targeting CLI MCP servers before applying deny-wins filtering.

## Real behavior proof

- Behavior or issue addressed: `tools.profile: "coding"` / `"messaging"` should preserve profile-allowed bundle MCP servers for CLI backends, while explicit entries such as `deny: ["mcp__twenty-crm"]` still remove the denied server from the generated Claude MCP config.
- Real environment tested: Local OpenClaw checkout on this branch, actual `prepareCliRunContext` / `prepareCliBundleMcpConfig` path for a `claude-cli` backend, and the real installed Claude Code binary (`claude --version` reported `2.1.128 (Claude Code)`).
- Exact steps or command run after this patch: Ran a local `node --import tsx --input-type=module` proof harness that configured an agent with `tools: { profile: "coding", deny: ["mcp__twenty-crm"] }`, configured two stdio MCP servers named `twenty-crm` and `calendar`, called the CLI backend prepare path, copied the generated Claude MCP config content into the proof workspace `.mcp.json`, and ran `claude mcp list` from that workspace.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[openclaw-generated-mcp-config] servers=calendar
[claude-version] 2.1.128 (Claude Code)
[claude-mcp-list-exit] 0
Checking MCP server health...

calendar: node <proof-temp>/mcp/bundle-probe.mjs - connected
```

- Observed result after fix: The generated config contained only `calendar`, not `twenty-crm`, and the real Claude Code MCP health check connected to `calendar`. That shows the denied server is absent while the profile-allowed MCP server remains available to Claude MCP.
- What was not tested: A full Anthropic model-response turn was not run because the local Claude CLI auth returned `Not logged in`; the no-auth Claude MCP health-check path was used instead to exercise the real Claude Code MCP client against the generated config content. The Docker live CLI lane was also not run locally.

Additional regression coverage verifies:

- `allow: ["bundle-mcp"]` preserves configured MCP servers.
- explicit `deny: ["mcp__twenty-crm"]` overrides the profile-level bundle MCP allow entry.
- the CLI prepare path keeps `calendar` when `tools.profile: "coding"` and `deny: ["mcp__twenty-crm"]` are both present.
- `mcp__openclaw__*` removes the `openclaw` server and `allow: ["mcp__twenty-crm__*"]` does not widen access to unrelated MCP servers.

## Validation

- `pnpm test src/agents/bundle-mcp-config.test.ts src/agents/cli-runner/prepare.test.ts src/agents/cli-runner/bundle-mcp.user-config.test.ts src/agents/pi-embedded-runner/effective-tool-policy.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/bundle-mcp-config.ts src/agents/bundle-mcp-config.test.ts src/agents/cli-runner/bundle-mcp.ts src/agents/cli-runner/prepare.ts src/agents/cli-runner/prepare.test.ts`
- `pnpm check:changed --base upstream/main`
