### PR TITLE
feat(nvidia): fetch featured model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- NVIDIA: fetch and cache the public featured-model catalog so setup and model pickers promote NVIDIA's current ranked build.nvidia.com models while falling back to the bundled static catalog. Fixes #79431. Thanks @eleqtrizit.
 - Telegram/Feishu: honor configured per-agent and global `reasoningDefault` values when deciding whether channel reasoning previews should stream or stay hidden, addressing the preview-default part of #73182. Thanks @anagnorisis2peripeteia.
 - Docker: run the runtime image under `tini` so long-lived containers reap orphaned child processes and forward signals correctly. (#77885) Thanks @VintageAyu.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` and `google-gemini-cli/gemini-3-pro-preview` selections to `google/gemini-3.1-pro-preview` before they are written to model config.

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -62,7 +62,19 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
 }
 ```
 
-## Built-in catalog
+## Featured catalog
+
+When OpenClaw can load the NVIDIA provider runtime, it fetches NVIDIA's public
+featured-model catalog from
+`https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` and
+caches the ranked result for 24 hours. New featured models from build.nvidia.com
+therefore appear in setup and model-selection surfaces without waiting for an
+OpenClaw release.
+
+If that public catalog is unavailable or malformed, OpenClaw falls back to the
+bundled catalog below.
+
+## Bundled fallback catalog
 
 | Model ref                                  | Name                         | Context | Max output |
 | ------------------------------------------ | ---------------------------- | ------- | ---------- |
@@ -80,8 +92,9 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
   </Accordion>
 
   <Accordion title="Catalog and pricing">
-    The bundled catalog is static. Costs default to `0` in source since NVIDIA
-    currently offers free API access for the listed models.
+    OpenClaw prefers NVIDIA's public featured-model catalog and caches it for 24
+    hours. The bundled fallback catalog is static. Costs default to `0` in source
+    since NVIDIA currently offers free API access for the listed models.
   </Accordion>
 
   <Accordion title="OpenAI-compatible endpoint">

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -3,8 +3,9 @@ import {
   registerSingleProviderPlugin,
   resolveProviderPluginChoice,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
+import { clearNvidiaFeaturedModelCacheForTests } from "./provider-catalog.js";
 
 type NvidiaManifest = {
   providerAuthChoices?: Array<{ choiceId?: string; method?: string; provider?: string }>;
@@ -19,6 +20,11 @@ function readManifest(): NvidiaManifest {
 async function registerNvidiaProvider() {
   return registerSingleProviderPlugin(plugin);
 }
+
+afterEach(() => {
+  clearNvidiaFeaturedModelCacheForTests();
+  vi.unstubAllGlobals();
+});
 
 describe("nvidia provider hooks", () => {
   it("registers the nvidia provider with correct metadata", async () => {
@@ -115,7 +121,11 @@ describe("nvidia provider hooks", () => {
     expect(provider.wrapStreamFn).toBeUndefined();
   });
 
-  it("surfaces the bundled NVIDIA models via augmentModelCatalog", async () => {
+  it("surfaces the bundled NVIDIA models when featured catalog fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 503 })),
+    );
     const provider = await registerNvidiaProvider();
 
     const entries = await provider.augmentModelCatalog?.({
@@ -130,6 +140,38 @@ describe("nvidia provider hooks", () => {
       "z-ai/glm5",
     ]);
     expect(entries?.filter((entry) => entry.provider !== "nvidia")).toEqual([]);
+  });
+
+  it("surfaces live featured NVIDIA models via augmentModelCatalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          "featured-models": [
+            {
+              model: "minimaxai/minimax-m2.7",
+              "model-name": "Minimax M2.7",
+              context: 196608,
+              "max-output": 8192,
+            },
+          ],
+        }),
+      ),
+    );
+    const provider = await registerNvidiaProvider();
+
+    const entries = await provider.augmentModelCatalog?.({
+      env: process.env,
+      entries: [],
+    });
+
+    expect(entries?.map((entry) => entry.id)).toEqual([
+      "minimaxai/minimax-m2.7",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
   });
 
   it("opts into literal provider-prefix preservation", async () => {

--- a/extensions/nvidia/index.ts
+++ b/extensions/nvidia/index.ts
@@ -1,11 +1,12 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyNvidiaConfig, NVIDIA_DEFAULT_MODEL_REF } from "./onboard.js";
-import { buildNvidiaProvider } from "./provider-catalog.js";
+import { buildLiveNvidiaProvider, buildNvidiaProvider } from "./provider-catalog.js";
 
 const PROVIDER_ID = "nvidia";
 
-function buildNvidiaCatalogModels() {
-  return buildNvidiaProvider().models.map((model) => ({
+async function buildNvidiaCatalogModels() {
+  const provider = await buildLiveNvidiaProvider();
+  return provider.models.map((model) => ({
     provider: PROVIDER_ID,
     id: model.id,
     name: model.name ?? model.id,
@@ -38,7 +39,8 @@ export default defineSingleProviderPluginEntry({
       },
     ],
     catalog: {
-      buildProvider: buildNvidiaProvider,
+      buildProvider: buildLiveNvidiaProvider,
+      buildStaticProvider: buildNvidiaProvider,
     },
     augmentModelCatalog: buildNvidiaCatalogModels,
     wizard: {

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { buildNvidiaProvider } from "./provider-catalog.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildLiveNvidiaProvider,
+  buildNvidiaProvider,
+  clearNvidiaFeaturedModelCacheForTests,
+} from "./provider-catalog.js";
+
+afterEach(() => {
+  clearNvidiaFeaturedModelCacheForTests();
+  vi.unstubAllGlobals();
+});
 
 describe("nvidia provider catalog", () => {
   it("builds the bundled NVIDIA provider defaults", () => {
@@ -17,5 +26,82 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.filter((model) => model.compat?.requiresStringContent !== true)).toEqual(
       [],
     );
+  });
+
+  it("promotes ranked models from NVIDIA's featured catalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          "featured-models": [
+            {
+              model: "z-ai/glm-5.1",
+              "model-name": "GLM 5.1",
+              context: 202752,
+              "max-output": 8192,
+            },
+            {
+              model: "nemotron-3-super-120b-a12b",
+              "model-name": "Nemotron 3 Super 120B",
+              context: 262144,
+              "max-output": 8192,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const provider = await buildLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "z-ai/glm-5.1",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
+    expect(provider.models[0]).toMatchObject({
+      name: "GLM 5.1",
+      contextWindow: 202752,
+      maxTokens: 8192,
+      compat: { requiresStringContent: true },
+    });
+  });
+
+  it("falls back to the bundled catalog when the featured catalog is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 503 })),
+    );
+
+    const provider = await buildLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
+  });
+
+  it("caches the featured catalog for repeated provider builds", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        "featured-models": [
+          {
+            model: "minimaxai/minimax-m2.7",
+            "model-name": "Minimax M2.7",
+            context: 196608,
+            "max-output": 8192,
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await buildLiveNvidiaProvider();
+    await buildLiveNvidiaProvider();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -1,8 +1,37 @@
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export const NVIDIA_DEFAULT_MODEL_ID = "nvidia/nemotron-3-super-120b-a12b";
+export const NVIDIA_FEATURED_MODELS_URL =
+  "https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json";
+
+const FEATURED_MODEL_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FEATURED_MODEL_FETCH_TIMEOUT_MS = 2500;
+const FEATURED_MODEL_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} as const;
+
+type NvidiaFeaturedModel = {
+  model: string;
+  "model-name": string;
+  context: number;
+  "max-output": number;
+};
+
+let featuredModelCache:
+  | {
+      expiresAtMs: number;
+      models: ModelDefinitionConfig[];
+    }
+  | undefined;
+let featuredModelRequest: Promise<ModelDefinitionConfig[] | null> | undefined;
 
 export function buildNvidiaProvider(): ModelProviderConfig {
   return {
@@ -12,4 +41,128 @@ export function buildNvidiaProvider(): ModelProviderConfig {
     }),
     apiKey: "NVIDIA_API_KEY",
   };
+}
+
+export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
+  const provider = buildNvidiaProvider();
+  const featuredModels = await loadNvidiaFeaturedModels();
+  if (!featuredModels || featuredModels.length === 0) {
+    return provider;
+  }
+  return {
+    ...provider,
+    models: mergeFeaturedModels(featuredModels, provider.models),
+  };
+}
+
+export function clearNvidiaFeaturedModelCacheForTests() {
+  featuredModelCache = undefined;
+  featuredModelRequest = undefined;
+}
+
+async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {
+  const now = Date.now();
+  if (featuredModelCache && featuredModelCache.expiresAtMs > now) {
+    return featuredModelCache.models;
+  }
+  featuredModelRequest ??= fetchNvidiaFeaturedModels();
+  try {
+    const models = await featuredModelRequest;
+    if (models && models.length > 0) {
+      featuredModelCache = {
+        expiresAtMs: now + FEATURED_MODEL_CACHE_TTL_MS,
+        models,
+      };
+    }
+    return models;
+  } finally {
+    featuredModelRequest = undefined;
+  }
+}
+
+async function fetchNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {
+  try {
+    const response = await fetch(NVIDIA_FEATURED_MODELS_URL, {
+      signal: AbortSignal.timeout(FEATURED_MODEL_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return parseNvidiaFeaturedModels(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+function parseNvidiaFeaturedModels(payload: unknown): ModelDefinitionConfig[] | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const rows = (payload as { "featured-models"?: unknown })["featured-models"];
+  if (!Array.isArray(rows)) {
+    return null;
+  }
+  const models = rows.map(parseNvidiaFeaturedModel).filter((model) => model !== null);
+  return models.length > 0 ? models : null;
+}
+
+function parseNvidiaFeaturedModel(row: unknown): ModelDefinitionConfig | null {
+  if (!row || typeof row !== "object") {
+    return null;
+  }
+  const entry = row as Partial<NvidiaFeaturedModel>;
+  if (
+    typeof entry.model !== "string" ||
+    typeof entry["model-name"] !== "string" ||
+    !isPositiveInteger(entry.context) ||
+    !isPositiveInteger(entry["max-output"])
+  ) {
+    return null;
+  }
+  const id = normalizeNvidiaFeaturedModelId(entry.model);
+  const name = entry["model-name"].trim();
+  if (!id || !name) {
+    return null;
+  }
+  return {
+    id,
+    name,
+    reasoning: false,
+    input: ["text"],
+    contextWindow: entry.context,
+    maxTokens: entry["max-output"],
+    cost: { ...FEATURED_MODEL_COST },
+    compat: {
+      requiresStringContent: true,
+    },
+  };
+}
+
+function normalizeNvidiaFeaturedModelId(model: string): string {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return trimmed.includes("/") ? trimmed : `nvidia/${trimmed}`;
+}
+
+function mergeFeaturedModels(
+  featuredModels: ModelDefinitionConfig[],
+  fallbackModels: ModelDefinitionConfig[],
+): ModelDefinitionConfig[] {
+  const seen = new Set<string>();
+  const merged: ModelDefinitionConfig[] = [];
+  for (const model of [...featuredModels, ...fallbackModels]) {
+    const key = model.id.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(model);
+  }
+  return merged;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
 }

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -3,6 +3,10 @@ import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export const NVIDIA_DEFAULT_MODEL_ID = "nvidia/nemotron-3-super-120b-a12b";
@@ -82,13 +86,22 @@ async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | nul
 
 async function fetchNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {
   try {
-    const response = await fetch(NVIDIA_FEATURED_MODELS_URL, {
-      signal: AbortSignal.timeout(FEATURED_MODEL_FETCH_TIMEOUT_MS),
+    const { response, release } = await fetchWithSsrFGuard({
+      url: NVIDIA_FEATURED_MODELS_URL,
+      init: {
+        signal: AbortSignal.timeout(FEATURED_MODEL_FETCH_TIMEOUT_MS),
+      },
+      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(NVIDIA_FEATURED_MODELS_URL),
+      auditContext: "nvidia-featured-model-catalog",
     });
-    if (!response.ok) {
-      return null;
+    try {
+      if (!response.ok) {
+        return null;
+      }
+      return parseNvidiaFeaturedModels(await response.json());
+    } finally {
+      release();
     }
-    return parseNvidiaFeaturedModels(await response.json());
   } catch {
     return null;
   }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
-import { mergeMockedModule } from "../test-utils/vitest-module-mocks.js";
 
 const {
   enqueueSystemEventMock,
@@ -50,14 +49,13 @@ vi.mock("../infra/system-events.js", () => ({
 }));
 
 vi.mock("../infra/heartbeat-wake.js", async () => {
-  return await mergeMockedModule(
-    await vi.importActual<typeof import("../infra/heartbeat-wake.js")>(
-      "../infra/heartbeat-wake.js",
-    ),
-    () => ({
-      requestHeartbeat,
-    }),
+  const actual = await vi.importActual<typeof import("../infra/heartbeat-wake.js")>(
+    "../infra/heartbeat-wake.js",
   );
+  return {
+    ...actual,
+    requestHeartbeat,
+  };
 });
 
 vi.mock("../infra/heartbeat-runner.js", () => ({


### PR DESCRIPTION
## Summary

- Problem: NVIDIA onboarding/model-selection surfaces used only a bundled static catalog, so newly promoted build.nvidia.com models needed an OpenClaw release before appearing.
- Why it matters: new NVIDIA users should see NVIDIA's current ranked featured models during setup instead of stale defaults.
- What changed: the NVIDIA provider now fetches NVIDIA's public featured-model catalog, validates it, caches successful results for 24 hours, promotes ranked rows ahead of bundled fallback rows, and keeps the manifest catalog as the offline/static fallback.
- What did NOT change (scope boundary): no core provider discovery behavior changed, no credentials are sent to the public catalog endpoint, and existing NVIDIA provider config/onboarding fallback defaults remain available.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79431
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenClaw can consume NVIDIA's public featured-model feed and promote ranked catalog rows while retaining a bundled fallback.
- Real environment tested: local OpenClaw checkout on Linux with Node 22 from `.local/node22/bin`.
- Exact steps or command run after this patch: `PATH=/home/ubuntu/.local/node22/bin:$PATH node -e 'fetch("https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json").then(async r=>{const j=await r.json(); console.log(JSON.stringify({status:r.status, count:j["featured-models"]?.length, first:j["featured-models"]?.[0]}, null, 2));})'`
- Evidence after fix: terminal output from the live NVIDIA public catalog fetch:

```text
$ PATH=/home/ubuntu/.local/node22/bin:$PATH node -e 'fetch("https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json").then(async r=>{const j=await r.json(); console.log(JSON.stringify({status:r.status, count:j["featured-models"]?.length, first:j["featured-models"]?.[0]}, null, 2));})'
{
  "status": 200,
  "count": 4,
  "first": {
    "model": "nemotron-3-super-120b-a12b",
    "model-name": "Nemotron 3 Super 120B",
    "context": 262144,
    "max-output": 8192
  }
}
```

- Observed result after fix: the live endpoint schema matches the provider parser contract, and the patched provider catalog promotes ranked rows ahead of bundled fallback rows.
- What was not tested: a full interactive onboarding run with a real NVIDIA API key; the change is covered at the provider catalog/plugin hook level.
- Before evidence (optional but encouraged): current main documents and implements NVIDIA as a static bundled catalog.

## Root Cause (if applicable)

- Root cause: N/A, feature request for live NVIDIA featured-model discovery.
- Missing detection / guardrail: N/A.
- Contributing context (if known): the NVIDIA plugin previously exposed only manifest-backed static model rows.

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/nvidia/provider-catalog.test.ts`, `extensions/nvidia/index.test.ts`
- Scenario the test should lock in: ranked featured rows are promoted, bare NVIDIA model ids are normalized with the NVIDIA vendor namespace, unavailable featured feeds fall back to bundled rows, and successful featured fetches are cached.
- Why this is the smallest reliable guardrail: the behavior is provider-owned catalog construction plus plugin catalog augmentation, so provider-local tests cover the contract without a full gateway run.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

NVIDIA setup and model-selection surfaces can show NVIDIA's current public featured models without an OpenClaw code update. If the public feed is unavailable or malformed, users still see the bundled fallback catalog.

## Diagram (if applicable)

```text
Before:
NVIDIA provider catalog -> bundled manifest rows only

After:
NVIDIA provider catalog -> public featured feed -> ranked rows + bundled fallback rows
                        -> fetch/validation failure -> bundled fallback rows
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: the NVIDIA provider performs a credential-free GET to NVIDIA's public featured-model JSON endpoint. The response is schema-validated, bounded by a short timeout, cached only after successful parsing, and falls back to bundled static rows on failure.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 via `.local/node22/bin`, local checkout
- Model/provider: NVIDIA provider
- Integration/channel (if any): N/A
- Relevant config (redacted): no secrets required for public catalog proof

### Steps

1. Fetch NVIDIA's public featured-model JSON endpoint and inspect the returned status/count/first row.
2. Run targeted NVIDIA provider tests.
3. Run staged changed-surface validation.

### Expected

- NVIDIA's endpoint returns ranked featured model metadata.
- Provider tests pass for live-row promotion, fallback behavior, and cache reuse.
- Staged changed gate passes for extension/docs lanes.

### Actual

- NVIDIA endpoint returned `status: 200`, `count: 4`, first row `nemotron-3-super-120b-a12b` with context `262144` and max output `8192`.
- `pnpm test extensions/nvidia/provider-catalog.test.ts extensions/nvidia/index.test.ts extensions/nvidia/onboard.test.ts` passed: 3 files, 17 tests.
- `pnpm check:changed --staged` passed for lanes `extensions, extensionTests, docs`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live NVIDIA endpoint shape, ranked featured-row promotion, fallback to bundled rows on HTTP failure, cache reuse, plugin `augmentModelCatalog` fallback and live rows, extension typecheck/lint/import-cycle changed gate.
- Edge cases checked: malformed/unavailable endpoint path via HTTP 503 fallback; bare NVIDIA model id normalization from `nemotron-...` to `nvidia/nemotron-...`; duplicate fallback row suppression.
- What you did **not** verify: full onboarding against a real NVIDIA API key.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: NVIDIA's public catalog endpoint is temporarily unavailable, slow, or changes schema.
  - Mitigation: fetch uses a short timeout, validates the expected fields, caches successful results for 24 hours, and falls back to the bundled manifest catalog on any failure.
