### PR TITLE
Add ambient initiative mode to heartbeat

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -46,6 +46,8 @@ Example config:
     defaults: {
       heartbeat: {
         every: "30m",
+        // mode: "ambient", // optional: low-priority natural initiative wake
+        // maxMessages: 3, // optional ambient visible-message budget
         target: "last", // explicit delivery to last contact (default is "none")
         directPolicy: "allow", // default: allow direct/DM targets; set "block" to suppress
         lightContext: true, // optional: only inject HEARTBEAT.md from bootstrap files
@@ -67,6 +69,7 @@ Example config:
 - When heartbeats are disabled with `0m`, normal runs also omit `HEARTBEAT.md` from bootstrap context so the model does not see heartbeat-only instructions.
 - Active hours (`heartbeat.activeHours`) are checked in the configured timezone. Outside the window, heartbeats are skipped until the next tick inside the window.
 - Heartbeats automatically defer while cron work is active or queued. Set `heartbeat.skipWhenBusy: true` to defer on extra busy lanes (subagent or nested command work) as well; this is useful for local Ollama and other constrained single-runtime hosts.
+- Ambient mode (`heartbeat.mode: "ambient"`) reuses the heartbeat scheduler and delivery path, but changes the prompt contract: each wake is a low-priority ambient initiative. The agent may decide to do nothing, or send up to `heartbeat.maxMessages` concise natural messages before recording the outcome with `heartbeat_respond`.
 
 ## What the heartbeat prompt is for
 
@@ -102,6 +105,8 @@ Outside heartbeats, stray `HEARTBEAT_OK` at the start/end of a message is stripp
         lightContext: false, // default: false; true keeps only HEARTBEAT.md from workspace bootstrap files
         isolatedSession: false, // default: false; true runs each heartbeat in a fresh session (no conversation history)
         skipWhenBusy: false, // default: false; true also waits for subagent/nested lanes
+        mode: "heartbeat", // default; set "ambient" for low-priority initiative wakes
+        maxMessages: 3, // ambient mode visible-message budget
         target: "last", // default: none | options: last | none | <channel id> (core or plugin, e.g. "imessage")
         to: "+15551234567", // optional channel-specific override
         accountId: "ops-bot", // optional multi-account channel id

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -4,6 +4,7 @@ import {
   HEARTBEAT_RESPONSE_TOOL_PROMPT,
   isHeartbeatContentEffectivelyEmpty,
   parseHeartbeatTasks,
+  resolveAmbientInitiativePromptForResponseTool,
   resolveHeartbeatPromptForResponseTool,
   stripHeartbeatToken,
 } from "./heartbeat.js";
@@ -285,6 +286,21 @@ describe("resolveHeartbeatPromptForResponseTool", () => {
     expect(prompt).toContain("Check the deployment queue");
     expect(prompt).toContain("heartbeat_respond");
     expect(prompt).toContain("notify=false");
+  });
+});
+
+describe("resolveAmbientInitiativePromptForResponseTool", () => {
+  it("builds an ambient wake contract on top of the heartbeat response tool", () => {
+    const prompt = resolveAmbientInitiativePromptForResponseTool(
+      "Use HEARTBEAT.md and recent context.",
+      2,
+    );
+
+    expect(prompt).toContain("Use HEARTBEAT.md and recent context.");
+    expect(prompt).toContain("ambient initiative wake");
+    expect(prompt).toContain("heartbeat_respond");
+    expect(prompt).toContain("Visible message budget for this wake: 2");
+    expect(prompt).toContain("Do not send messages just to use the budget");
   });
 });
 

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -17,6 +17,8 @@ export const HEARTBEAT_PROMPT = `${HEARTBEAT_CONTEXT_PROMPT} If nothing needs at
 export const HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS =
   "Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.";
 export const HEARTBEAT_RESPONSE_TOOL_PROMPT = `${HEARTBEAT_CONTEXT_PROMPT} ${HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS}`;
+export const AMBIENT_INITIATIVE_RESPONSE_TOOL_INSTRUCTIONS =
+  "You are running an ambient initiative wake. First decide whether any action is natural and useful from persona, memory, HEARTBEAT.md, and recent context. You may send no visible message, or send a short natural message sequence within the configured message budget. Do not send messages just to use the budget. After any work, use heartbeat_respond to record the outcome; set notify=false if you already used the message tool or if nothing should be sent.";
 export const HEARTBEAT_TRANSCRIPT_PROMPT = "[OpenClaw heartbeat poll]";
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
@@ -92,6 +94,21 @@ export function resolveHeartbeatPromptForResponseTool(raw?: string): string {
   return trimmed
     ? appendHeartbeatResponseToolInstructions(trimmed)
     : HEARTBEAT_RESPONSE_TOOL_PROMPT;
+}
+
+export function resolveAmbientInitiativePromptForResponseTool(
+  raw?: string,
+  maxMessages = 3,
+): string {
+  const budget = Math.max(0, Math.floor(maxMessages));
+  const base = (normalizeOptionalString(raw) ?? "") || HEARTBEAT_CONTEXT_PROMPT;
+  const zeroBudgetNote =
+    "A budget of 0 means observe/write internal state only and do not send a visible message.";
+  return `${base}
+
+${AMBIENT_INITIATIVE_RESPONSE_TOOL_INSTRUCTIONS}
+
+Visible message budget for this wake: ${budget}. ${zeroBudgetNote}`;
 }
 
 type StripHeartbeatMode = "heartbeat" | "message";

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -360,6 +360,15 @@ export type AgentDefaultsConfig = {
   heartbeat?: {
     /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */
     every?: string;
+    /**
+     * Heartbeat behavior mode.
+     *
+     * "heartbeat" keeps the traditional task/check-in semantics.
+     * "ambient" treats each wake as a low-priority ambient initiative:
+     * inspect context, decide whether to do nothing, and optionally send a
+     * short natural message sequence before recording the outcome.
+     */
+    mode?: "heartbeat" | "ambient";
     /** Optional active-hours window (local time); heartbeats run only inside this window. */
     activeHours?: {
       /** Start time (24h, HH:MM). Inclusive. */
@@ -383,6 +392,8 @@ export type AgentDefaultsConfig = {
     accountId?: string;
     /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."). */
     prompt?: string;
+    /** Max visible messages an ambient heartbeat may send in one wake (default: 3). */
+    maxMessages?: number;
     /** Include the ## Heartbeats system prompt section for the default agent (default: true). */
     includeSystemPromptSection?: boolean;
     /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -176,6 +176,21 @@ describe("agent defaults schema", () => {
     expect(agent.heartbeat?.skipWhenBusy).toBe(true);
   });
 
+  it("accepts ambient heartbeat mode and message budgets on defaults and agent entries", () => {
+    const defaults = AgentDefaultsSchema.parse({
+      heartbeat: { mode: "ambient", maxMessages: 2 },
+    })!;
+    const agent = AgentEntrySchema.parse({
+      id: "ops",
+      heartbeat: { mode: "ambient", maxMessages: 1 },
+    });
+
+    expect(defaults.heartbeat?.mode).toBe("ambient");
+    expect(defaults.heartbeat?.maxMessages).toBe(2);
+    expect(agent.heartbeat?.mode).toBe("ambient");
+    expect(agent.heartbeat?.maxMessages).toBe(1);
+  });
+
   it("accepts per-agent TTS overrides", () => {
     const agent = AgentEntrySchema.parse({
       id: "reader",

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -22,6 +22,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 export const HeartbeatSchema = z
   .object({
     every: z.string().optional(),
+    mode: z.union([z.literal("heartbeat"), z.literal("ambient")]).optional(),
     activeHours: z
       .object({
         start: z.string().optional(),
@@ -40,6 +41,7 @@ export const HeartbeatSchema = z
     prompt: z.string().optional(),
     includeSystemPromptSection: z.boolean().optional(),
     ackMaxChars: z.number().int().nonnegative().optional(),
+    maxMessages: z.number().int().nonnegative().optional(),
     suppressToolErrorWarnings: z.boolean().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     lightContext: z.boolean().optional(),

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -29,6 +29,7 @@ import {
   isHeartbeatContentEffectivelyEmpty,
   isTaskDue,
   parseHeartbeatTasks,
+  resolveAmbientInitiativePromptForResponseTool,
   resolveHeartbeatPrompt as resolveHeartbeatPromptText,
   resolveHeartbeatPromptForResponseTool,
   stripHeartbeatToken,
@@ -333,6 +334,12 @@ export function resolveHeartbeatPrompt(cfg: OpenClawConfig, heartbeat?: Heartbea
 }
 
 function resolveHeartbeatResponseToolPrompt(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
+  if (heartbeat?.mode === "ambient") {
+    return resolveAmbientInitiativePromptForResponseTool(
+      resolveHeartbeatPromptRaw(cfg, heartbeat),
+      heartbeat.maxMessages,
+    );
+  }
   return resolveHeartbeatPromptForResponseTool(resolveHeartbeatPromptRaw(cfg, heartbeat));
 }
 


### PR DESCRIPTION
## Summary

- Add `heartbeat.mode = "ambient"` as a low-priority initiative mode on top of the existing heartbeat runner.
- Let the model decide on each scheduled wake whether to stay silent or proactively send a natural message, so OpenClaw can support model-driven, not-always-on proactive outreach without adding a separate skill.
- Add `heartbeat.maxMessages` as the visible-message budget for ambient wakes, so an agent can send a short burst when useful but is not forced to use the budget.
- Reuse the existing heartbeat scheduler, delivery path, and `heartbeat_respond` outcome tool.
- Accept the new ambient heartbeat keys in the runtime config schema and document them.

## Real behavior proof

**Behavior or issue addressed:** Ambient heartbeat config should be accepted by the real OpenClaw CLI schema path, and the ambient wake prompt should carry the low-priority initiative contract, visible-message budget, and `heartbeat_respond` outcome tool. The important behavior change is that a scheduled wake no longer implies a visible message: the model is explicitly allowed to decide, from persona, memory, `HEARTBEAT.md`, and recent context, whether this is a natural moment to proactively reach out or to remain silent.

**Real environment tested:** Local OpenClaw checkout on macOS, Node v22.22.0, pnpm via Corepack, commit `40ec7fe4b6` on branch `ambient-initiative-skill`.

**Exact steps or command run after this patch:**

```text
node scripts/run-node.mjs --profile ambient-proof config patch --file .ambient-proof.json5 --dry-run --json
corepack pnpm exec tsx -e "import { resolveAmbientInitiativePromptForResponseTool } from './src/auto-reply/heartbeat.ts'; const prompt = resolveAmbientInitiativePromptForResponseTool('Check HEARTBEAT.md and recent context; only send if useful.', 2); console.log('ambient:', prompt.includes('ambient initiative wake')); console.log('budget:', prompt.includes('Visible message budget for this wake: 2')); console.log('tool:', prompt.includes('heartbeat_respond'));"
```

**Evidence after fix:** Terminal output from the real OpenClaw CLI dry-run and prompt contract check:

```text
$ node scripts/run-node.mjs --profile ambient-proof config patch --file .ambient-proof.json5 --dry-run --json
[openclaw] Building TypeScript (dist is stale: dirty_watched_tree - dirty watched source tree).
[openclaw] Building bundled plugin assets.
runtime-postbuild: plugin SDK root alias completed in 1ms
runtime-postbuild: bundled plugin metadata completed in 320ms
runtime-postbuild: official channel catalog completed in 5ms
runtime-postbuild: bundled plugin runtime overlay completed in 375ms
runtime-postbuild: stable root runtime imports completed in 578ms
runtime-postbuild: stable root runtime aliases completed in 40ms
runtime-postbuild: legacy root runtime compat aliases completed in 9ms
runtime-postbuild: legacy CLI exit compat chunks completed in 0ms
runtime-postbuild: static extension assets completed in 22ms
{
  "ok": true,
  "operations": 4,
  "configPath": "~/.openclaw-ambient-proof/openclaw.json",
  "inputModes": [
    "json"
  ],
  "checks": {
    "schema": true,
    "resolvability": true,
    "resolvabilityComplete": true
  },
  "refsChecked": 0,
  "skippedExecRefs": 0
}

$ corepack pnpm exec tsx -e "import { resolveAmbientInitiativePromptForResponseTool } from './src/auto-reply/heartbeat.ts'; const prompt = resolveAmbientInitiativePromptForResponseTool('Check HEARTBEAT.md and recent context; only send if useful.', 2); console.log('ambient:', prompt.includes('ambient initiative wake')); console.log('budget:', prompt.includes('Visible message budget for this wake: 2')); console.log('tool:', prompt.includes('heartbeat_respond'));"
ambient: true
budget: true
tool: true
```

The dry-run patch used this ambient heartbeat config:

```json5
{
  agents: {
    defaults: {
      heartbeat: {
        every: "30m",
        mode: "ambient",
        maxMessages: 2,
        prompt: "Check HEARTBEAT.md and recent context; only send if useful."
      }
    }
  }
}
```

**Observed result after fix:** The CLI returned `"ok": true` with schema and resolvability checks enabled, so `heartbeat.mode = "ambient"` and `heartbeat.maxMessages = 2` are accepted by the real config path. The prompt contract check returned `ambient: true`, `budget: true`, and `tool: true`, confirming that the wake contract supports proactive messages only when the model judges them useful, while still allowing no visible message.

**What was not tested:** No live channel delivery was tested; this change reuses the existing heartbeat delivery path and only changes the heartbeat prompt/config contract for ambient mode.

## Testing

```text
$ corepack pnpm exec vitest run src/auto-reply/heartbeat.test.ts src/config/zod-schema.agent-defaults.test.ts

 Test Files  2 passed (2)
      Tests  52 passed (52)
   Duration  2.05s
```
