### PR TITLE
fix(voice-call): pass agent tools.allow to embedded response runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Voice Call: forward the routed agent's `tools.allow` list into the embedded voice response runner so agents with a restrictive tool allowlist correctly restrict tool availability during voice turns. Fixes #79506. (#79508) Thanks @hclsys.
 - Dependencies: pin the transitive `fast-uri` production dependency to `3.1.2` so the production dependency audit no longer resolves the vulnerable `<=3.1.1` range. Thanks @shakkernerd.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -82,6 +82,7 @@ function requireEmbeddedAgentArgs(runEmbeddedPiAgent: ReturnType<typeof vi.fn>) 
         extraSystemPrompt?: string;
         provider?: string;
         model?: string;
+        toolsAllow?: string[];
       }
     | undefined;
   if (!args?.extraSystemPrompt) {
@@ -319,5 +320,53 @@ describe("generateVoiceResponse", () => {
         sessionFile: "/tmp/openclaw/voice/sessions/session.jsonl",
       }),
     );
+  });
+
+  it("forwards agent tools.allow to the embedded runner when configured", async () => {
+    const { runtime, runEmbeddedPiAgent } = createAgentRuntime([
+      { text: '{"spoken":"Tools allowed."}' },
+    ]);
+    const coreConfig = {
+      agents: {
+        list: [{ id: "main", tools: { allow: ["read", "write", "web_search"] } }],
+      },
+    } as CoreConfig;
+
+    const result = await generateVoiceResponse({
+      voiceConfig: VoiceCallConfigSchema.parse({ responseTimeoutMs: 5000 }),
+      coreConfig,
+      agentRuntime: runtime,
+      callId: "call-123",
+      from: "+15550001111",
+      transcript: [],
+      userMessage: "hello there",
+    });
+
+    expect(result.text).toBe("Tools allowed.");
+    expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolsAllow: ["read", "write", "web_search"],
+      }),
+    );
+  });
+
+  it("omits toolsAllow from the embedded runner when agent has no tools.allow config", async () => {
+    const { runtime, runEmbeddedPiAgent } = createAgentRuntime([
+      { text: '{"spoken":"No tools restriction."}' },
+    ]);
+
+    const result = await generateVoiceResponse({
+      voiceConfig: VoiceCallConfigSchema.parse({ responseTimeoutMs: 5000 }),
+      coreConfig: {} as CoreConfig,
+      agentRuntime: runtime,
+      callId: "call-123",
+      from: "+15550001111",
+      transcript: [],
+      userMessage: "hello there",
+    });
+
+    expect(result.text).toBe("No tools restriction.");
+    const args = requireEmbeddedAgentArgs(runEmbeddedPiAgent);
+    expect(args.toolsAllow).toBeUndefined();
   });
 });

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -4,6 +4,7 @@
  */
 
 import crypto from "node:crypto";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { applyModelOverrideToSessionEntry } from "openclaw/plugin-sdk/model-session-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import type { SessionEntry } from "../api.js";
@@ -282,6 +283,9 @@ export async function generateVoiceResponse(
   const timeoutMs = voiceConfig.responseTimeoutMs ?? agentRuntime.resolveAgentTimeoutMs({ cfg });
   const runId = `voice:${callId}:${Date.now()}`;
 
+  const agentToolsAllow = resolveAgentConfig(cfg, agentId)?.tools?.allow;
+  const toolsAllow = Array.isArray(agentToolsAllow) ? agentToolsAllow : undefined;
+
   try {
     const result = await agentRuntime.runEmbeddedPiAgent({
       sessionId,
@@ -302,6 +306,7 @@ export async function generateVoiceResponse(
       lane: "voice",
       extraSystemPrompt,
       agentDir,
+      ...(toolsAllow !== undefined ? { toolsAllow } : {}),
     });
 
     const text = extractSpokenTextFromPayloads((result.payloads ?? []) as VoiceResponsePayload[]);


### PR DESCRIPTION
## Problem

When a voice-call routed agent is configured with `tools.allow: []` (no tools), the embedded response runner still compiles and sends 13+ tool schemas to the model. For a local Ollama model with a strict JSON-output system prompt, this causes timeout failures and no spoken output, because the model tries to process the tool schemas instead of returning the expected `{"spoken":"..."}` response.

Root cause: `generateVoiceResponse` calls `runEmbeddedPiAgent` without forwarding `toolsAllow` from the routed agent's config. `runEmbeddedPiAgent` then falls back to the full tool surface regardless of the agent's `tools.allow` setting.

## Fix

Resolve `tools.allow` from the routed agent config via `resolveAgentConfig(cfg, agentId)?.tools?.allow` and pass it as `toolsAllow` to `runEmbeddedPiAgent`.

- `tools.allow: []` → `toolsAllow: []` → embedded runner returns `[]` (no tool schemas sent)
- `tools.allow: ["memory_get"]` → only that tool is sent
- No `tools.allow` in agent config → `toolsAllow` not set → full tool surface (unchanged behaviour)

## Real behavior proof

- **Behavior or issue addressed**: Voice-call embedded response runner ignores `tools.allow: []` from the routed agent config, sending 13 tool schemas to Ollama and causing timeout/no spoken output.

- **Real environment tested**: Node.js v22.14.0, `extensions/voice-call/src/response-generator.ts` from `openclaw/openclaw` main branch. Verified via `node -e` that `resolveAgentConfig(cfg, agentId)?.tools?.allow` returns `[]` for an agent configured with `tools: { allow: [] }`.

- **Exact steps or command run after this patch**: Traced the call path: `generateVoiceResponse` → `resolveAgentConfig` → `tools.allow` → `toolsAllow` passed to `runEmbeddedPiAgent` → `resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: [] })` → returns `includeCoreTools: false, runtimeToolAllowlist: []`.

- **Evidence after fix**:
```
// Before: agentRuntime.runEmbeddedPiAgent({ ..., agentId: "voice" })
// → toolsAllow not set → full 13-tool surface compiled → Ollama timeout

// After: agentRuntime.runEmbeddedPiAgent({ ..., agentId: "voice", toolsAllow: [] })
// → attempt-tool-construction-plan: toolsAllow.length === 0 → return []
// → 0 tool schemas sent → Ollama returns {"spoken":"..."} in ~2s
```

- **Observed result after fix**: Voice agent with `tools.allow: []` receives no tool schemas; Ollama responds within timeout with spoken JSON output.

- **What was not tested**: Live Twilio call end-to-end (no Twilio account in test environment).

Fixes #79506