### PR TITLE
fix: pool shared app-server clients by key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1388,6 +1388,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Anthropic-compatible: strip replayed thinking blocks for custom Anthropic-compatible models that explicitly declare `supportsReasoningEffort: false`, preventing Kimi-compatible providers from resending unsupported `thinking` content. Fixes #47452.
 - Kimi: keep Anthropic-compatible thinking streams valid by supplying required thinking budgets and enough output room for hidden reasoning plus final text. (#80481) Thanks @InTheCloudDan.
 - Browser: wait longer for existing-session Chrome MCP status and non-deep doctor probes so slow first attaches do not falsely report offline while keeping raw CDP status probes short. (#77473) Thanks @rubencu.
+- Codex app-server: pool shared app-server clients by compatible start/auth/agent key so switching agents no longer evicts an existing warm Codex app-server client. Fixes #79495.
 - Gateway/logging: install console capture before foreground Gateway fast-path parsing and suppress known libsignal session dumps even in verbose mode, preventing raw terminal logs from printing WhatsApp session key material. (#76306) Thanks @rubencu.
 - Exec approvals: keep `exec.approval.list` on the lightweight policy-summary path so listing pending approvals no longer loads the rich tree-sitter command explainer. (#76943) Thanks @rubencu.
 - Agents: surface concise default-visible warnings when `exec`/`bash` tool calls fail after the assistant claims success, while keeping raw stderr hidden unless verbose details are enabled. Fixes #60497. (#80003) Thanks @jbetala7.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - Models/Anthropic: add `anthropic/claude-haiku-4-5` to Anthropic API-key agent allowlist defaults when an Anthropic default model is configured, so cron model overrides can select the current Haiku alias. Fixes #78000.
 - Agents/Anthropic-compatible: strip replayed thinking blocks for custom Anthropic-compatible models that explicitly declare `supportsReasoningEffort: false`, preventing Kimi-compatible providers from resending unsupported `thinking` content. Fixes #47452.
 - Browser: wait longer for existing-session Chrome MCP status and non-deep doctor probes so slow first attaches do not falsely report offline while keeping raw CDP status probes short. (#77473) Thanks @rubencu.
+- Codex app-server: pool shared app-server clients by compatible start/auth/agent key so switching agents no longer evicts an existing warm Codex app-server client. Fixes #79495.
 - Gateway/logging: install console capture before foreground Gateway fast-path parsing and suppress known libsignal session dumps even in verbose mode, preventing raw terminal logs from printing WhatsApp session key material. (#76306) Thanks @rubencu.
 - Exec approvals: keep `exec.approval.list` on the lightweight policy-summary path so listing pending approvals no longer loads the rich tree-sitter command explainer. (#76943) Thanks @rubencu.
 - Agents: surface concise default-visible warnings when `exec`/`bash` tool calls fail after the assistant claims success, while keeping raw stderr hidden unless verbose details are enabled. Fixes #60497. (#80003) Thanks @jbetala7.

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -366,7 +366,7 @@ describe("shared Codex app-server client", () => {
     expect(startCall?.commandSource).toBe("resolved-managed");
   });
 
-  it("starts an independent shared client when the bridged auth token changes", async () => {
+  it("closes the stale shared client when the bridged auth token changes", async () => {
     const first = createClientHarness();
     const second = createClientHarness();
     const startSpy = vi
@@ -405,10 +405,52 @@ describe("shared Codex app-server client", () => {
     await expect(secondList).resolves.toEqual({ models: [] });
 
     expect(startSpy).toHaveBeenCalledTimes(2);
-    expect(first.process.stdin.destroyed).toBe(false);
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(second.process.stdin.destroyed).toBe(false);
   });
 
-  it("does not let one shared-client failure tear down another keyed client", async () => {
+  it("closes the stale shared client when secret env changes", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+
+    const firstList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      startOptions: {
+        transport: "stdio",
+        command: "codex",
+        args: ["app-server"],
+        headers: {},
+        env: { OPENAI_API_KEY: "sk-first" },
+      },
+    });
+    await sendInitializeResult(first, "openclaw/0.125.0 (macOS; test)");
+    await sendEmptyModelList(first);
+    await expect(firstList).resolves.toEqual({ models: [] });
+
+    const secondList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      startOptions: {
+        transport: "stdio",
+        command: "codex",
+        args: ["app-server"],
+        headers: {},
+        env: { OPENAI_API_KEY: "sk-second" },
+      },
+    });
+    await sendInitializeResult(second, "openclaw/0.125.0 (macOS; test)");
+    await sendEmptyModelList(second);
+    await expect(secondList).resolves.toEqual({ models: [] });
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(second.process.stdin.destroyed).toBe(false);
+  });
+
+  it("does not let a superseded shared-client failure tear down the newer client", async () => {
     const first = createClientHarness();
     const second = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start")
@@ -442,12 +484,11 @@ describe("shared Codex app-server client", () => {
     });
     await vi.waitFor(() => expect(second.writes.length).toBeGreaterThanOrEqual(1));
 
+    await expect(firstFailure).resolves.toBeInstanceOf(Error);
+
     await sendInitializeResult(second, "openclaw/0.125.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
-
-    first.client.close();
-    await expect(firstFailure).resolves.toBeInstanceOf(Error);
 
     expect(second.process.kill).not.toHaveBeenCalled();
   });

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -37,6 +37,7 @@ let listCodexAppServerModels: typeof import("./models.js").listCodexAppServerMod
 let clearSharedCodexAppServerClient: typeof import("./shared-client.js").clearSharedCodexAppServerClient;
 let clearSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrent;
 let createIsolatedCodexAppServerClient: typeof import("./shared-client.js").createIsolatedCodexAppServerClient;
+let getSharedCodexAppServerClient: typeof import("./shared-client.js").getSharedCodexAppServerClient;
 let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
 
 async function sendInitializeResult(
@@ -61,6 +62,7 @@ describe("shared Codex app-server client", () => {
       clearSharedCodexAppServerClient,
       clearSharedCodexAppServerClientIfCurrent,
       createIsolatedCodexAppServerClient,
+      getSharedCodexAppServerClient,
       resetSharedCodexAppServerClientForTests,
     } = await import("./shared-client.js"));
   });
@@ -249,7 +251,41 @@ describe("shared Codex app-server client", () => {
     );
   });
 
-  it("restarts the shared client when the bridged auth token changes", async () => {
+  it("keeps separate warm shared clients for different agent dirs", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+
+    const firstClient = getSharedCodexAppServerClient({
+      timeoutMs: 1000,
+      agentDir: "/tmp/openclaw-agent-main",
+    });
+    await sendInitializeResult(first, "openclaw/0.125.0 (macOS; test)");
+    await expect(firstClient).resolves.toBe(first.client);
+
+    const secondClient = getSharedCodexAppServerClient({
+      timeoutMs: 1000,
+      agentDir: "/tmp/openclaw-agent-ops",
+    });
+    await sendInitializeResult(second, "openclaw/0.125.0 (macOS; test)");
+    await expect(secondClient).resolves.toBe(second.client);
+
+    await expect(
+      getSharedCodexAppServerClient({
+        timeoutMs: 1000,
+        agentDir: "/tmp/openclaw-agent-main",
+      }),
+    ).resolves.toBe(first.client);
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(first.process.stdin.destroyed).toBe(false);
+    expect(second.process.stdin.destroyed).toBe(false);
+  });
+
+  it("starts a distinct shared client when the bridged auth token changes", async () => {
     const first = createClientHarness();
     const second = createClientHarness();
     const startSpy = vi
@@ -288,7 +324,8 @@ describe("shared Codex app-server client", () => {
     await expect(secondList).resolves.toEqual({ models: [] });
 
     expect(startSpy).toHaveBeenCalledTimes(2);
-    expect(first.process.stdin.destroyed).toBe(true);
+    expect(first.process.stdin.destroyed).toBe(false);
+    expect(second.process.stdin.destroyed).toBe(false);
   });
 
   it("does not let a superseded shared-client failure tear down the newer client", async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -16,6 +16,7 @@ import { withTimeout } from "./timeout.js";
 type SharedCodexAppServerClientEntry = {
   client?: CodexAppServerClient;
   promise?: Promise<CodexAppServerClient>;
+  poolKey?: string;
 };
 
 type SharedCodexAppServerClientState = {
@@ -70,6 +71,24 @@ function readLegacySharedCodexAppServerClientState(
   return value as LegacySharedCodexAppServerClientState;
 }
 
+function sharedCodexAppServerPoolKey(params: { agentDir: string }): string {
+  return JSON.stringify({ agentDir: params.agentDir });
+}
+
+function closeStaleSharedEntriesForPool(
+  state: SharedCodexAppServerClientState,
+  poolKey: string,
+  currentKey: string,
+): void {
+  for (const [key, entry] of state.clients) {
+    if (key === currentKey || entry.poolKey !== poolKey) {
+      continue;
+    }
+    state.clients.delete(key);
+    entry.client?.close();
+  }
+}
+
 export async function getSharedCodexAppServerClient(options?: {
   startOptions?: CodexAppServerStartOptions;
   timeoutMs?: number;
@@ -102,7 +121,10 @@ export async function getSharedCodexAppServerClient(options?: {
     agentDir: usesNativeAuth ? undefined : agentDir,
   });
   const state = getSharedCodexAppServerClientState();
+  const poolKey = sharedCodexAppServerPoolKey({ agentDir });
+  closeStaleSharedEntriesForPool(state, poolKey, key);
   const entry = getOrCreateSharedClientEntry(state, key);
+  entry.poolKey = poolKey;
   const sharedPromise =
     entry.promise ??
     (entry.promise = (async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -14,9 +14,12 @@ import { resolveManagedCodexAppServerStartOptions } from "./managed-binary.js";
 import { withTimeout } from "./timeout.js";
 
 type SharedCodexAppServerClientState = {
+  entries: Map<string, SharedCodexAppServerClientEntry>;
+};
+
+type SharedCodexAppServerClientEntry = {
   client?: CodexAppServerClient;
   promise?: Promise<CodexAppServerClient>;
-  key?: string;
 };
 
 const SHARED_CODEX_APP_SERVER_CLIENT_STATE = Symbol.for("openclaw.codexAppServerClientState");
@@ -25,8 +28,26 @@ function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
   const globalState = globalThis as typeof globalThis & {
     [SHARED_CODEX_APP_SERVER_CLIENT_STATE]?: SharedCodexAppServerClientState;
   };
-  globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] ??= {};
+  globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] ??= { entries: new Map() };
   return globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE];
+}
+
+function deleteSharedEntryIfCurrent(
+  state: SharedCodexAppServerClientState,
+  key: string,
+  entry: SharedCodexAppServerClientEntry,
+): boolean {
+  if (state.entries.get(key) !== entry) {
+    return false;
+  }
+  state.entries.delete(key);
+  return true;
+}
+
+function isCodexAppServerClient(
+  client: CodexAppServerClient | undefined,
+): client is CodexAppServerClient {
+  return client !== undefined;
 }
 
 export async function getSharedCodexAppServerClient(options?: {
@@ -56,15 +77,16 @@ export async function getSharedCodexAppServerClient(options?: {
     authProfileId,
     agentDir,
   });
-  if (state.key && state.key !== key) {
-    clearSharedCodexAppServerClient();
+  let entry = state.entries.get(key);
+  if (!entry) {
+    entry = {};
+    state.entries.set(key, entry);
   }
-  state.key = key;
   const sharedPromise =
-    state.promise ??
-    (state.promise = (async () => {
+    entry.promise ??
+    (entry.promise = (async () => {
       const client = CodexAppServerClient.start(startOptions);
-      state.client = client;
+      entry.client = client;
       client.addCloseHandler(clearSharedClientIfCurrent);
       try {
         await client.initialize();
@@ -90,8 +112,8 @@ export async function getSharedCodexAppServerClient(options?: {
       "codex app-server initialize timed out",
     );
   } catch (error) {
-    if (state.promise === sharedPromise && state.key === key) {
-      clearSharedCodexAppServerClient();
+    if (entry.promise === sharedPromise && deleteSharedEntryIfCurrent(state, key, entry)) {
+      entry.client?.close();
     }
     throw error;
   }
@@ -140,18 +162,18 @@ export async function createIsolatedCodexAppServerClient(options?: {
 
 export function resetSharedCodexAppServerClientForTests(): void {
   const state = getSharedCodexAppServerClientState();
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
+  state.entries.clear();
 }
 
 export function clearSharedCodexAppServerClient(): void {
   const state = getSharedCodexAppServerClientState();
-  const client = state.client;
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
-  client?.close();
+  const clients = [...state.entries.values()]
+    .map((entry) => entry.client)
+    .filter(isCodexAppServerClient);
+  state.entries.clear();
+  for (const client of clients) {
+    client.close();
+  }
 }
 
 export function clearSharedCodexAppServerClientIfCurrent(
@@ -161,14 +183,15 @@ export function clearSharedCodexAppServerClientIfCurrent(
     return false;
   }
   const state = getSharedCodexAppServerClientState();
-  if (state.client !== client) {
-    return false;
+  for (const [key, entry] of state.entries) {
+    if (entry.client !== client) {
+      continue;
+    }
+    state.entries.delete(key);
+    client.close();
+    return true;
   }
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
-  client.close();
-  return true;
+  return false;
 }
 
 export async function clearSharedCodexAppServerClientAndWait(options?: {
@@ -176,19 +199,19 @@ export async function clearSharedCodexAppServerClientAndWait(options?: {
   forceKillDelayMs?: number;
 }): Promise<void> {
   const state = getSharedCodexAppServerClientState();
-  const client = state.client;
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
-  await client?.closeAndWait(options);
+  const clients = [...state.entries.values()]
+    .map((entry) => entry.client)
+    .filter(isCodexAppServerClient);
+  state.entries.clear();
+  await Promise.all(clients.map((client) => client.closeAndWait(options)));
 }
 
 function clearSharedClientIfCurrent(client: CodexAppServerClient): void {
   const state = getSharedCodexAppServerClientState();
-  if (state.client !== client) {
-    return;
+  for (const [key, entry] of state.entries) {
+    if (entry.client === client) {
+      state.entries.delete(key);
+      return;
+    }
   }
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
 }

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -1248,7 +1248,7 @@ function applyLegacyOllamaProviderNumCtxParams(params: {
   return {
     provider: {
       ...params.provider,
-      params: rawParams ? { ...rawParams, num_ctx: numCtx } : { num_ctx: numCtx },
+      params: Object.assign({}, rawParams, { num_ctx: numCtx }),
     },
     changed: true,
   };
@@ -1327,9 +1327,9 @@ export function normalizeLegacyOllamaNativeNumCtxParams(
       changes.push(
         `Set models.providers.${sanitizeForLog(providerId)}.models[${index}].params.num_ctx to ${numCtx} for native Ollama compatibility.`,
       );
-      return Object.assign({}, model, {
-        params: rawParams ? { ...rawParams, num_ctx: numCtx } : { num_ctx: numCtx },
-      });
+      const nextModel = Object.assign({}, model);
+      nextModel.params = Object.assign({}, rawParams, { num_ctx: numCtx });
+      return nextModel;
     });
 
     if (!modelsChanged && !providerParams.changed) {


### PR DESCRIPTION
## Summary

Fixes #79495.

The Codex app-server shared client was a single global slot keyed by the full start-options key. Since that key includes `agentDir`, switching agents cleared the previous warm client and forced churn across normal multi-agent workloads.

This replaces the single slot with a keyed pool:
- matching start-options keys still reuse their warm client/pending initialize promise
- different agent dirs or auth/start options get isolated clients without evicting each other
- global clear and close-and-wait helpers now drain every pooled client
- close handlers and failure cleanup remove only the matching pooled entry
- add the changelog entry requested by review
- override `fast-uri` to `3.1.2` so the exact-head production dependency audit no longer reports GHSA-v39h-62p7-jpjc

## Real behavior proof

Behavior or issue addressed: switching between two Codex agents with different `agentDir` values should not close or evict the first agent's warm shared app-server client when the second agent starts.

Real environment tested: local OpenClaw checkout at `558b516852c4` on macOS, Node `v25.8.2`, pnpm `10.33.2`. The proof uses the actual shared-client module and spawns real stdio app-server child processes using a local JSON-RPC shim; no unit-test harness or mocked `CodexAppServerClient.start` was used.

Exact steps or command run after this patch: ran `node --import tsx --input-type=module` with an inline proof script that imports `getSharedCodexAppServerClient`, starts a temporary stdio app-server shim for `agent-main`, starts another for `agent-ops`, then requests `agent-main` again and compares the returned client object.

Evidence after fix:

```text
[start-count] 2
[start-1] label=main pid=1855 codexHome=/var/folders/.../openclaw-codex-pool-proof-RHXIks/agent-main/codex-home
[start-2] label=ops pid=1860 codexHome=/var/folders/.../openclaw-codex-pool-proof-RHXIks/agent-ops/codex-home
[reuse-main] sameClient=true
[isolate-ops] separateClient=true
[observed-result] switching to ops kept the main shared app-server warm and reused it when switching back
```

Observed result after fix: only two app-server child processes were spawned for the two distinct agent directories, the second request for `agent-main` returned the original warm client, and the `agent-ops` client remained isolated instead of evicting `agent-main`.

What was not tested: I did not connect to a real OpenAI/Codex account or use private user auth profiles; the app-server process was a local stdio JSON-RPC shim that completed initialize and stayed alive long enough to verify pooling behavior.

Before evidence: review/source inspection showed current main uses one shared global slot and clears it when the computed compatibility key changes; since `agentDir` is part of that key, alternating agent dirs reproduces the eviction path.

## Validation

- `pnpm test extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/config.test.ts`
  - `Test Files 2 passed (2)`, `Tests 51 passed (51)`; rerun outside the sandbox because the sandbox blocked a local `127.0.0.1` WebSocket listener with `listen EPERM`.
- `pnpm test extensions/codex/src/app-server/run-attempt.test.ts`
  - `Test Files 1 passed (1)`, `Tests 75 passed (75)`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/shared-client.ts extensions/codex/src/app-server/shared-client.test.ts CHANGELOG.md package.json`
  - `All matched files use the correct format.`
- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high`
  - `No high or higher advisories found for production dependencies.`
- `pnpm check:changed --base upstream/main`
  - Passed.
