### PR TITLE
Prefer task-tracked Codex delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,7 +181,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: invalidate cached assembled context views when source history shrinks or assembly fails, preventing stale pre-reset history from being reused. Fixes #77968. (#78163) Thanks @brokemac79 and @ChrisBot2026.
 - Plugin SDK: add a generic `api.runtime.llm.complete` host completion helper with runtime-derived caller attribution, config-gated model/agent overrides, session-bound context-engine access, request-scoped config, audit metadata, and normalized usage attribution. (#64294) Thanks @DaevMithran.
 - Control UI/exec approvals: highlight parsed shell command fragments that may deserve extra review in approval prompts. (#77153) Thanks @jesse-merhi.
-- Codex app-server: nudge delegated/background work toward `sessions_spawn` when available so Codex uses OpenClaw task tracking and completion delivery by default.
+- Codex app-server: nudge delegated/background work toward `sessions_spawn` when available so Codex uses OpenClaw task tracking and completion delivery by default. (#79518)
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: invalidate cached assembled context views when source history shrinks or assembly fails, preventing stale pre-reset history from being reused. Fixes #77968. (#78163) Thanks @brokemac79 and @ChrisBot2026.
 - Plugin SDK: add a generic `api.runtime.llm.complete` host completion helper with runtime-derived caller attribution, config-gated model/agent overrides, session-bound context-engine access, request-scoped config, audit metadata, and normalized usage attribution. (#64294) Thanks @DaevMithran.
 - Control UI/exec approvals: highlight parsed shell command fragments that may deserve extra review in approval prompts. (#77153) Thanks @jesse-merhi.
+- Codex app-server: nudge delegated/background work toward `sessions_spawn` when available so Codex uses OpenClaw task tracking and completion delivery by default.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,7 +181,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: invalidate cached assembled context views when source history shrinks or assembly fails, preventing stale pre-reset history from being reused. Fixes #77968. (#78163) Thanks @brokemac79 and @ChrisBot2026.
 - Plugin SDK: add a generic `api.runtime.llm.complete` host completion helper with runtime-derived caller attribution, config-gated model/agent overrides, session-bound context-engine access, request-scoped config, audit metadata, and normalized usage attribution. (#64294) Thanks @DaevMithran.
 - Control UI/exec approvals: highlight parsed shell command fragments that may deserve extra review in approval prompts. (#77153) Thanks @jesse-merhi.
-- Codex app-server: nudge delegated/background work toward `sessions_spawn` when available so Codex uses OpenClaw task tracking and completion delivery by default. (#79518)
+- Codex app-server: nudge delegated/background work toward `sessions_spawn` when available so Codex uses OpenClaw task tracking and completion delivery by default. (#79518) Thanks @mbelinky.
 
 ### Breaking
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -111,7 +111,7 @@ import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
 import { clearSharedCodexAppServerClientIfCurrent } from "./shared-client.js";
 import {
   areCodexDynamicToolFingerprintsCompatible,
-  buildDeveloperInstructions,
+  buildDeveloperInstructionsWithDynamicTools,
   buildTurnStartParams,
   codexDynamicToolsFingerprint,
   startOrResumeThread,
@@ -565,7 +565,9 @@ export async function runCodexAppServerAttempt(
     historyMessages =
       (await readMirroredSessionHistoryMessages(params.sessionFile)) ?? historyMessages;
   }
-  const baseDeveloperInstructions = buildDeveloperInstructions(params);
+  const baseDeveloperInstructions = buildDeveloperInstructionsWithDynamicTools(params, {
+    availableDynamicToolNames: new Set(toolBridge.specs.map((tool) => tool.name)),
+  });
   // Build the workspace bootstrap block before finalizing developer
   // instructions so persona files (SOUL.md, IDENTITY.md, ...) reach Codex
   // through the explicit `developerInstructions` field.

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { describe, expect, it } from "vitest";
 import {
+  buildDeveloperInstructionsWithDynamicTools,
   buildThreadResumeParams,
   buildThreadStartParams,
   resolveReasoningEffort,
@@ -46,6 +47,34 @@ function createAppServerOptions() {
     sandbox: "workspace-write",
   } as const;
 }
+
+describe("Codex app-server developer instructions", () => {
+  it("nudges delegated work through sessions_spawn when the OpenClaw dynamic tool is available", () => {
+    const prompt = buildDeveloperInstructionsWithDynamicTools(
+      createAttemptParams({ provider: "codex" }),
+      {
+        availableDynamicToolNames: new Set(["sessions_spawn", "message"]),
+      },
+    );
+
+    expect(prompt).toContain("## OpenClaw Delegation");
+    expect(prompt).toContain("prefer the OpenClaw `sessions_spawn` dynamic tool");
+    expect(prompt).toContain("Task Registry records");
+    expect(prompt).toContain("Use Codex native `spawnAgent` only");
+  });
+
+  it("omits the sessions_spawn nudge when the OpenClaw dynamic tool is unavailable", () => {
+    const prompt = buildDeveloperInstructionsWithDynamicTools(
+      createAttemptParams({ provider: "codex" }),
+      {
+        availableDynamicToolNames: new Set(["message"]),
+      },
+    );
+
+    expect(prompt).not.toContain("## OpenClaw Delegation");
+    expect(prompt).not.toContain("spawnAgent");
+  });
+});
 
 describe("Codex app-server model provider selection", () => {
   it.each(["openai", "openai-codex"])(

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -461,10 +461,26 @@ function compareJsonFingerprint(left: JsonValue, right: JsonValue): number {
 }
 
 export function buildDeveloperInstructions(params: EmbeddedRunAttemptParams): string {
+  return buildDeveloperInstructionsWithDynamicTools(params);
+}
+
+export function buildDeveloperInstructionsWithDynamicTools(
+  params: EmbeddedRunAttemptParams,
+  options: { availableDynamicToolNames?: ReadonlySet<string> } = {},
+): string {
   const promptOverlay = renderCodexRuntimePromptOverlay(params);
+  const delegationGuidance = options.availableDynamicToolNames?.has("sessions_spawn")
+    ? [
+        "## OpenClaw Delegation",
+        "If the user asks you to spawn, delegate, run background work, or continue work and let them know when it is done, prefer the OpenClaw `sessions_spawn` dynamic tool when available.",
+        "`sessions_spawn` creates OpenClaw Task Registry records and handles completion delivery back to the requester.",
+        "Use Codex native `spawnAgent` only when the user explicitly asks for Codex-native collaboration or when `sessions_spawn` is unavailable or unsuitable.",
+      ].join("\n")
+    : undefined;
   const sections = [
     "You are running inside OpenClaw. Use OpenClaw dynamic tools for OpenClaw-specific integrations such as messaging, cron, sessions, media, gateway, and nodes when available.",
     "Preserve the user's existing channel/session context. If sending a channel reply, use the OpenClaw messaging tool instead of describing that you would reply.",
+    delegationGuidance,
     promptOverlay,
     params.extraSystemPrompt,
     params.skillsSnapshot?.prompt,

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -42,6 +42,7 @@ export function describeSessionsSpawnTool(options?: {
     options?.threadAvailable
       ? '`mode="run"` is one-shot and `mode="session"` is persistent and thread-bound.'
       : '`mode="run"` is one-shot background work.',
+    "Use this for delegated/background work that should be tracked as an OpenClaw task and report completion back to the requester.",
     "Subagents inherit the parent workspace directory automatically.",
     'For native subagents only, set `context="fork"` when the child needs the current transcript context; otherwise omit it or use `context="isolated"`.',
     "Use this when the work should happen in a fresh child session instead of the current one.",

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -92,6 +92,8 @@ describe("sessions_spawn tool", () => {
     };
 
     expect(tool.displaySummary).toBe("Spawn sub-agent sessions.");
+    expect(tool.description).toContain("tracked as an OpenClaw task");
+    expect(tool.description).toContain("report completion back to the requester");
     expect(tool.description).not.toContain("ACP");
     expect(tool.description).not.toContain('runtime="acp"');
     expect(schema.properties?.runtime?.enum).toEqual(["subagent"]);


### PR DESCRIPTION
## Summary
- Add a Codex app-server developer-instruction guardrail that prefers OpenClaw `sessions_spawn` for delegated/background/"let me know when done" work when that dynamic tool is available.
- Keep native Codex `spawnAgent` available for explicit Codex-native collaboration requests or fallback cases.
- Update the `sessions_spawn` tool description to say it is the tracked OpenClaw task/completion-delivery path.

## Scope
- This is intentionally separate from #79512.
- #79512 is the deterministic Task Registry mirror for native Codex app-server subagent events.
- This PR is the probabilistic prompt/tool-description guardrail that nudges Codex toward the OpenClaw-tracked path when `sessions_spawn` is available.

## Real behavior proof
- Behavior addressed: Codex app-server prompt construction now steers ordinary delegated/background work toward `sessions_spawn`, and the runtime tool description advertises OpenClaw task tracking/completion delivery.
- Real environment tested: Local OpenClaw dev gateway from this branch, started on loopback with `--dev --auth none --bind loopback`.
- Exact steps or command run after this patch: Started the local gateway with `pnpm openclaw --dev gateway run --port 19124 --auth none --bind loopback --allow-unconfigured`, called `pnpm openclaw --dev gateway call tools.catalog --url ws://127.0.0.1:19124 --token dev --params '{"includePlugins":false}' --json`, then stopped the gateway.
- Evidence after fix: Copied terminal output from the local gateway run and RPC call:

```text
[gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 2.6s)
[gateway] ready

$ pnpm openclaw --dev gateway call tools.catalog --url ws://127.0.0.1:19124 --token dev --params '{"includePlugins":false}' --json
{
  "id": "sessions_spawn",
  "description": "Spawn sub-agent or ACP sessions.",
  "defaultProfiles": ["coding"]
}
[ws] ⇄ res ✓ tools.catalog 94ms
[shutdown] completed cleanly
```

- Observed result after fix: The branch starts a real dev gateway and exposes `sessions_spawn` through the live tool catalog. The catalog exposes the short display summary; targeted prompt/tool-description tests verify the full model-facing developer guidance and tool wording.
- What was not tested: I did not run a full model turn to statistically measure whether Codex chooses `sessions_spawn`; this PR is intentionally only the probabilistic prompt/tool-description guardrail.

## Verification
- `pnpm test extensions/codex/src/app-server/thread-lifecycle.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/agents/system-prompt.test.ts` - passed, 125 tests.
- `pnpm build` - passed during prepare.
- `node scripts/run-oxlint.mjs CHANGELOG.md extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/thread-lifecycle.test.ts src/agents/tool-description-presets.ts src/agents/tools/sessions-spawn-tool.test.ts --threads=1` - passed.
- `git diff --check` - passed.

## Prepare note
- `scripts/pr-prepare gates 79518` passed changelog validation and `pnpm build`, then hit the same unrelated current-main lint failure in `src/auto-reply/commands-registry.test.ts` (`no-unnecessary-type-assertion`). That file is unchanged by this PR; touched-file lint is green.
