### PR TITLE
fix(gateway): accept http gateway URL overrides

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -464,6 +464,23 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.password).toBeUndefined();
   });
 
+  it("normalizes browser-facing http env URL overrides before connecting", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback" },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    process.env.OPENCLAW_GATEWAY_URL = "http://localhost:18789";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+
+    await callGateway({
+      method: "health",
+    });
+
+    expect(lastClientOptions?.url).toBe("ws://localhost:18789/");
+    expect(lastClientOptions?.token).toBe("env-token");
+  });
+
   it("uses env URL override credentials without resolving local password SecretRefs", async () => {
     getRuntimeConfig.mockReturnValue({
       gateway: {
@@ -745,6 +762,46 @@ describe("buildGatewayConnectionDetails", () => {
       expect(details.url).toBe("wss://browser-gateway.local:9443/ws");
       expect(details.urlSource).toBe("env OPENCLAW_GATEWAY_URL");
       expect(details.bindDetail).toBeUndefined();
+    } finally {
+      if (prevUrl === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_URL;
+      } else {
+        process.env.OPENCLAW_GATEWAY_URL = prevUrl;
+      }
+    }
+  });
+
+  it("normalizes browser-facing http gateway env URLs to ws URLs", () => {
+    getRuntimeConfig.mockReturnValue({ gateway: { mode: "local", bind: "loopback" } });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    const prevUrl = process.env.OPENCLAW_GATEWAY_URL;
+    try {
+      process.env.OPENCLAW_GATEWAY_URL = "http://localhost:18789";
+
+      const details = buildGatewayConnectionDetails();
+
+      expect(details.url).toBe("ws://localhost:18789/");
+      expect(details.urlSource).toBe("env OPENCLAW_GATEWAY_URL");
+      expect(details.bindDetail).toBeUndefined();
+    } finally {
+      if (prevUrl === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_URL;
+      } else {
+        process.env.OPENCLAW_GATEWAY_URL = prevUrl;
+      }
+    }
+  });
+
+  it("still rejects browser-facing http gateway env URLs for remote hosts", () => {
+    getRuntimeConfig.mockReturnValue({ gateway: { mode: "local", bind: "loopback" } });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    const prevUrl = process.env.OPENCLAW_GATEWAY_URL;
+    try {
+      process.env.OPENCLAW_GATEWAY_URL = "http://remote.example.com:18789";
+
+      expect(() => buildGatewayConnectionDetails()).toThrow(/SECURITY ERROR/);
     } finally {
       if (prevUrl === undefined) {
         delete process.env.OPENCLAW_GATEWAY_URL;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -22,6 +22,7 @@ import { startGatewayClientWhenEventLoopReady } from "./client-start-readiness.j
 import { GatewayClient, type GatewayClientOptions } from "./client.js";
 import {
   buildGatewayConnectionDetailsWithResolvers,
+  normalizeGatewayWebSocketUrl,
   type GatewayConnectionDetails,
 } from "./connection-details.js";
 import { resolveGatewayCredentialsWithSecretInputs } from "./credentials-secret-inputs.js";
@@ -402,7 +403,7 @@ function resolveGatewayCallContext(opts: CallGatewayBaseOptions): ResolvedGatewa
   const envUrlOverride = cliUrlOverride
     ? undefined
     : trimToUndefined(process.env.OPENCLAW_GATEWAY_URL);
-  const urlOverride = cliUrlOverride ?? envUrlOverride;
+  const urlOverride = normalizeGatewayWebSocketUrl(cliUrlOverride ?? envUrlOverride);
   const urlOverrideSource = cliUrlOverride ? "cli" : envUrlOverride ? "env" : undefined;
   const canSkipConfigLoad = canSkipGatewayConfigLoad({
     config: opts.config,

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -17,6 +17,26 @@ type GatewayConnectionDetailResolvers = {
   resolveGatewayPort?: (cfg?: OpenClawConfig, env?: NodeJS.ProcessEnv) => number;
 };
 
+export function normalizeGatewayWebSocketUrl(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === "http:") {
+      parsed.protocol = "ws:";
+      return parsed.toString();
+    }
+    if (parsed.protocol === "https:") {
+      parsed.protocol = "wss:";
+      return parsed.toString();
+    }
+  } catch {
+    return value;
+  }
+  return value;
+}
+
 export function buildGatewayConnectionDetailsWithResolvers(
   options: {
     config?: OpenClawConfig;
@@ -40,11 +60,11 @@ export function buildGatewayConnectionDetailsWithResolvers(
   const bindMode = config.gateway?.bind ?? "loopback";
   const scheme = tlsEnabled ? "wss" : "ws";
   const localUrl = `${scheme}://127.0.0.1:${localPort}`;
-  const cliUrlOverride = normalizeOptionalString(options.url);
+  const cliUrlOverride = normalizeGatewayWebSocketUrl(normalizeOptionalString(options.url));
   const envUrlOverride =
     cliUrlOverride || options.ignoreEnvUrlOverride
       ? undefined
-      : normalizeOptionalString(process.env.OPENCLAW_GATEWAY_URL);
+      : normalizeGatewayWebSocketUrl(normalizeOptionalString(process.env.OPENCLAW_GATEWAY_URL));
   const urlOverride = cliUrlOverride ?? envUrlOverride;
   const remoteUrl = normalizeOptionalString(remote?.url);
   const remoteMisconfigured = isRemoteMode && !urlOverride && !remoteUrl;


### PR DESCRIPTION
## Summary
- Normalize http(s) gateway URL overrides to ws(s) before browser/gateway clients connect.
- Keep plaintext remote-host protection intact after normalization.

## Verification
- OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/gateway/call.test.ts

## Real behavior proof
- Behavior or issue addressed: Browser/gateway clients may receive an operator-friendly http(s) Gateway URL override even though the control transport uses WebSocket URLs.
- Real environment tested: AJ's local ABPclaw/OpenClaw host on macOS, with live Gateway, managed browser, and video pipeline running.
- Exact steps or command run after this patch: curl http://127.0.0.1:18789/healthz; curl http://127.0.0.1:18800/json/version; curl http://127.0.0.1:8787/healthz; OPENCLAW_GATEWAY_URL=http://localhost:18789 OPENCLAW_GATEWAY_TOKEN=dummy pnpm openclaw gateway status --json.
- Evidence after fix: Terminal output from the real host: gateway health returned {"ok":true,"status":"live"}; browser CDP returned HeadlessChrome/145.0.7632.6 and ws://127.0.0.1:18800/devtools/browser/...; video health returned {"ok":true,"service":"abp-video-pipeline","mockUpload":false,"transcriptionMode":"local_whisper"}.
- Observed result after fix: The live services are reachable, and the branch CLI run with OPENCLAW_GATEWAY_URL=http://localhost:18789 reached OpenClaw config validation instead of failing on the http URL shape; the remaining stop was unrelated local config-schema drift for tools.web.search.{perplexity,exa}.
- What was not tested: A fully authenticated WebSocket RPC against the ABPclaw Gateway from this branch, because AJ's current local config is still on the older Exa search shape and the ABPclaw Gateway token is not readable from this user account.
