### PR TITLE
Add paperclip property to AgentParamsSchema

### DIFF
--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -174,6 +174,8 @@ export const AgentParamsSchema = Type.Object(
     voiceWakeTrigger: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
+    // Allow Paperclip (and future adapters) to pass opaque adapter context
+    paperclip: Type.Optional(Type.Unknown()),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
Paperclip's openclaw-gateway adapter unconditionally injects an `agentParams.paperclip` field containing `paperclipPayload` wake context. Previously this caused schema validation failures because `additionalProperties: false` rejected the field.

This adds an optional, loosely-typed `paperclip` property so that Paperclip-driven agent runs pass validation natively, without needing a local hot-patch. It also provides a clear extension point for future adapter-specific opaque metadata.