### PR TITLE
fix(agents): inject workspace skills into sub-agent system prompt

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -14,6 +14,7 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { resolveAgentDir } from "./agent-scope-config.js";
 import type { BootstrapContextMode } from "./bootstrap-files.js";
+import { resolveSkillsPromptForRun, loadWorkspaceSkillEntries } from "./skills.js";
 import {
   mapToolContextToSpawnedRunMetadata,
   normalizeSpawnedRunMetadata,
@@ -997,6 +998,28 @@ export async function spawnSubagentDirect(
     childDepth,
     maxSpawnDepth,
   });
+
+  // Inject workspace skills into sub-agent system prompt
+  try {
+    const skillsWorkspaceDir = spawnedMetadata.workspaceDir ?? resolveAgentDir(cfg, targetAgentId);
+    if (skillsWorkspaceDir) {
+      const skillEntries = loadWorkspaceSkillEntries(skillsWorkspaceDir, {
+        config: cfg,
+        agentId: targetAgentId,
+      });
+      const skillsPrompt = resolveSkillsPromptForRun({
+        entries: skillEntries,
+        config: cfg,
+        workspaceDir: skillsWorkspaceDir,
+        agentId: targetAgentId,
+      });
+      if (skillsPrompt) {
+        childSystemPrompt = `${childSystemPrompt}\n\n${skillsPrompt}`;
+      }
+    }
+  } catch {
+    // Skills injection failure must not block sub-agent spawn
+  }
 
   let retainOnSessionKeep = false;
   let attachmentsReceipt:


### PR DESCRIPTION
```markdown
## Summary

- Problem: Sub-agents spawned via `sessions_spawn` had no access to workspace skills, causing silent "tool not available" failures even when `defaultSpawnContext: fork` was configured.
- Why it matters: Any user with custom workspace skills (TickTick, Gmail, calendar, pharma-regulatory, etc.) would hit a hard tool wall when the main agent delegated to a sub-agent, making sub-agent delegation unreliable for all non-trivial real-world tasks.
- What changed: `subagent-spawn.ts` now loads workspace skill entries for the target agent and appends them to the child system prompt, mirroring what `cli-runner/prepare.ts` already does for main agent runs.
- What did NOT change: Sub-agent spawn lifecycle, error handling, context modes, session forking, tool policy enforcement, and sandbox behaviour are all unchanged. Skills injection failure is caught silently and never blocks a spawn.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Sub-agents receiving tasks that required workspace skills (e.g. TickTick task creation, Gmail draft, calendar lookup) would fail with "tool not available" or complete silently without executing the requested action.
- Real environment tested: macOS 15, OpenClaw 2026.5.4, LM Studio with Gemma 4 27B Q4, Telegram channel, custom workspace skills including TickTick, Gmail-OAuth, Google Calendar.
- Exact steps or command run after this patch: Stop gateway, apply patch to `src/agents/subagent-spawn.ts`, run `rm -rf dist && pnpm build`, restart gateway, then ask main agent to delegate a TickTick task to a sub-agent and observe the result.
- Evidence after fix: Sub-agent returned a complete TickTick work task list including 15 open items, confirming direct skill access. Previously the same delegation returned "I can't use the tool 'ticktick' here because it isn't available."
- Observed result after fix: Sub-agent successfully accessed TickTick, Gmail, and other workspace skills without any tool wall errors.
- What was not tested: Cross-agent spawns (different targetAgentId vs requesterAgentId), sandboxed sub-agents, skill filter edge cases.
- Before evidence (optional but encouraged): Sub-agent session logs showed repeated "tool not available" errors for all workspace skills. Main agent session worked correctly with identical skills.

## Root Cause

- Root cause: `buildSubagentSystemPrompt()` has no `skillsPrompt` parameter and `subagent-spawn.ts` never calls `resolveSkillsPromptForRun()`. The `fork` context mode copies the session transcript but skill definitions are loaded separately via the system prompt pipeline which sub-agents never enter.
- Missing detection / guardrail: No test coverage for sub-agent skill availability. The spawn succeeds silently; the tool wall only appears at task execution time inside the sub-agent session.
- Contributing context: `cli-runner/prepare.ts` correctly calls `resolveSkillsPromptForRun()` for main agent runs. The sub-agent spawn path was never updated to match.

## Regression Test Plan

- Coverage level that should catch this:
  - [ ] Unit test
  - [x] Seam / integration test
- Target test or file: `src/agents/subagent-spawn.test.ts` or `src/agents/openclaw-tools.subagents.scope.test.ts`
- Scenario the test should lock in: Sub-agent system prompt contains `<available_skills>` block when workspace skills exist.
- Why this is the smallest reliable guardrail: Inspecting `extraSystemPrompt` in the gateway call params confirms injection without requiring a live LLM.
- Existing test that already covers this: None found.
- If no new test is added, why not: No new test added in this PR; existing integration test suite is the appropriate place and requires maintainer guidance on test harness conventions.

## User-visible / Behavior Changes

Sub-agents now have access to all workspace skills the main agent has access to. No config change required. No breaking change — if skill loading fails the spawn continues unchanged.

## Diagram

```text
Before:
[main agent] -> [sessions_spawn] -> [sub-agent: no skills] -> [tool wall]

After:
[main agent] -> [sessions_spawn] -> [load workspace skills] -> [sub-agent: full skill access] -> [task completes]
```

## Security Impact

- New permissions/capabilities? No — sub-agents already had implicit access to the workspace directory via `workspaceDir` inheritance. This change makes skill definitions visible; it does not grant new execution permissions beyond what the tool policy already allows.
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — skill definitions are prompt text only; actual tool execution is still gated by the existing tool policy.
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15 (Apple Silicon M2)
- Runtime: Node.js via pnpm, OpenClaw 2026.5.4
- Model/provider: LM Studio — Gemma 4 27B Q4 @ `http://192.168.x.x:1234`
- Integration/channel: Telegram (direct message)
- Relevant config: `session.threadBindings.defaultSpawnContext: "fork"`

### Steps

1. Install custom workspace skills in `~/.openclaw/workspace/skills/` (e.g. TickTick, Gmail-OAuth)
2. Configure `session.threadBindings.defaultSpawnContext: "fork"` in `openclaw.json`
3. Send main agent a task requiring delegation: "Add a task to TickTick to follow up on the Q2 report"
4. Observe sub-agent session — before patch it fails with "tool not available", after patch it completes successfully

### Expected

- Sub-agent completes the delegated task using the workspace skill

### Actual (before fix)

- Sub-agent reports: "I can't use the tool 'ticktick' here because it isn't available."

### Actual (after fix)

- Sub-agent successfully retrieves and manipulates TickTick tasks

## Evidence

- [x] Trace/log snippets — sub-agent returned 15 open TickTick work tasks confirming live skill execution post-fix.

## Human Verification

- Verified scenarios: TickTick task listing via sub-agent, Gmail draft creation via sub-agent, main agent skill access unchanged.
- Edge cases checked: Skills injection try/catch confirmed — deliberately broke workspace path, spawn completed successfully with no skills rather than failing.
- What you did not verify: Cross-agent spawns, sandboxed environments, skill filter allowlists.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Workspace skill loading adds a synchronous filesystem read to the sub-agent spawn hot path.
  - Mitigation: Wrapped in try/catch; failure is silent and non-blocking. For large skill sets the overhead is negligible compared to LLM inference latency.
- Risk: Sub-agents inheriting all skills may attempt tool calls the parent did not intend to delegate.
  - Mitigation: Existing tool policy enforcement (`agents.subagents.tools`) remains the authoritative gate. Skill visibility does not bypass tool execution policy.
```