### PR TITLE
fix(acp): honor tagVisibility.agent_thought_chunk for thought-stream events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP: honor `tagVisibility.agent_thought_chunk` for thought-stream `text_delta` events; the projector previously dropped all non-`output` streams before consulting operator-tunable visibility, so `stream: "thought"` events were silently discarded even when `agent_thought_chunk: true` was configured. Fixes catalog #12.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -416,10 +416,15 @@ export function createAcpReplyProjector(params: {
   const onEvent = async (event: AcpRuntimeEvent): Promise<void> => {
     params.onProgress?.();
     if (event.type === "text_delta") {
-      if (event.stream && event.stream !== "output") {
+      // Visibility is authoritative: check it first so the operator-tunable
+      // tagVisibility flag is never bypassed by a stream discriminator.
+      if (!isAcpTagVisible(settings, event.tag)) {
         return;
       }
-      if (!isAcpTagVisible(settings, event.tag)) {
+      // Only "output" and "thought" streams are routed to delivery. Any future
+      // unknown stream requires an explicit opt-in via a new stream case below
+      // rather than accidentally leaking through.
+      if (event.stream && event.stream !== "output" && event.stream !== "thought") {
         return;
       }
       let text = event.text;

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -416,6 +416,14 @@ export function createAcpReplyProjector(params: {
   const onEvent = async (event: AcpRuntimeEvent): Promise<void> => {
     params.onProgress?.();
     if (event.type === "text_delta") {
+      // Thought-stream events must carry the agent_thought_chunk tag to reach
+      // delivery. Requiring the explicit tag prevents an untagged backend
+      // thought emission from defaulting visible (isAcpTagVisible returns true
+      // for undefined tags). This is checked before the generic visibility path
+      // so that missing-tag thought events are dropped before any default kicks in.
+      if (event.stream === "thought" && event.tag !== "agent_thought_chunk") {
+        return;
+      }
       // Visibility is authoritative: check it first so the operator-tunable
       // tagVisibility flag is never bypassed by a stream discriminator.
       if (!isAcpTagVisible(settings, event.tag)) {

--- a/src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts
@@ -1,0 +1,414 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpRuntimeError } from "../../acp/runtime/errors.js";
+import type { AcpSessionStoreEntry } from "../../acp/runtime/session-meta.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
+import type { MediaUnderstandingSkipError } from "../../media-understanding/errors.js";
+import { tryDispatchAcpReply } from "./dispatch-acp.js";
+import type { ReplyDispatcher } from "./reply-dispatcher.js";
+import { buildTestCtx } from "./test-ctx.js";
+import { createAcpSessionMeta, createAcpTestConfig } from "./test-fixtures/acp-runtime.js";
+
+// Catalog finding #12 — red-light TDD spec for `agent_thought_chunk` delivery.
+//
+// Hypothesis: the projector unconditionally drops `text_delta` events whose
+// `stream` is not "output" (acp-projector.ts:408-411). When the acpx
+// translator emits a thought chunk it sets `stream: "thought"` and
+// `tag: "agent_thought_chunk"`. So even when an operator overrides
+// `tagVisibility.agent_thought_chunk = true`, the visibility flag is never
+// consulted — the event is dropped before the visibility check at line 412.
+//
+// Three scenarios:
+//   1. default visibility (false) — thought is hidden → GREEN today.
+//   2. visibility true — thought should be delivered → RED today (drop
+//      happens before visibility check).
+//   3. control: an output-stream agent_message_chunk delivers normally →
+//      GREEN today; sanity-checks the test infrastructure.
+//
+// Preamble duplicated from dispatch-acp.tool-stream-supergroup.test.ts and
+// dispatch-acp.spawn-child-delivery.test.ts. TODO: share via test-fixtures
+// helper if a fourth copy lands.
+
+const managerMocks = vi.hoisted(() => ({
+  resolveSession: vi.fn(),
+  runTurn: vi.fn(),
+  getObservabilitySnapshot: vi.fn(() => ({
+    turns: { queueDepth: 0 },
+    runtimeCache: { activeSessions: 0 },
+  })),
+}));
+
+const policyMocks = vi.hoisted(() => ({
+  resolveAcpDispatchPolicyError: vi.fn<(cfg: OpenClawConfig) => AcpRuntimeError | null>(() => null),
+  resolveAcpAgentPolicyError: vi.fn<(cfg: OpenClawConfig, agent: string) => AcpRuntimeError | null>(
+    () => null,
+  ),
+}));
+
+const routeMocks = vi.hoisted(() => ({
+  routeReply: vi.fn<
+    (_params: unknown) => Promise<{ ok: true; messageId: string } | { ok: false; error: string }>
+  >(async () => ({ ok: true, messageId: "mock" })),
+}));
+
+const channelPluginMocks = vi.hoisted(() => ({
+  getChannelPlugin: vi.fn((channelId: string) => {
+    if (channelId !== "discord" && channelId !== "slack" && channelId !== "telegram") {
+      return undefined;
+    }
+    return {
+      outbound: {
+        shouldTreatDeliveredTextAsVisible: ({
+          kind,
+          text,
+        }: {
+          kind: "tool" | "block" | "final";
+          text?: string;
+        }) => kind === "block" && typeof text === "string" && text.trim().length > 0,
+      },
+    };
+  }),
+}));
+
+const messageActionMocks = vi.hoisted(() => ({
+  runMessageAction: vi.fn(async (_params: unknown) => ({ ok: true as const })),
+}));
+
+const ttsMocks = vi.hoisted(() => ({
+  maybeApplyTtsToPayload: vi.fn(async (paramsUnknown: unknown) => {
+    const params = paramsUnknown as { payload: unknown };
+    return params.payload;
+  }),
+  resolveTtsConfig: vi.fn((_cfg: OpenClawConfig) => ({ mode: "final" })),
+}));
+
+const mediaUnderstandingMocks = vi.hoisted(() => ({
+  applyMediaUnderstanding: vi.fn(async (_params: unknown) => undefined),
+}));
+
+const diagnosticMocks = vi.hoisted(() => ({
+  markDiagnosticSessionProgress: vi.fn(),
+}));
+
+const sessionMetaMocks = vi.hoisted(() => ({
+  readAcpSessionEntry: vi.fn<
+    (params: { sessionKey: string; cfg?: OpenClawConfig }) => AcpSessionStoreEntry | null
+  >(() => null),
+}));
+
+const transcriptMocks = vi.hoisted(() => ({
+  persistAcpDispatchTranscript: vi.fn(async (_params: unknown) => undefined),
+}));
+
+const bindingServiceMocks = vi.hoisted(() => ({
+  listBySession: vi.fn<(sessionKey: string) => SessionBindingRecord[]>(() => []),
+  unbind: vi.fn<(input: unknown) => Promise<SessionBindingRecord[]>>(async () => []),
+}));
+
+vi.mock("./dispatch-acp-manager.runtime.js", () => ({
+  getAcpSessionManager: () => managerMocks,
+  getSessionBindingService: () => ({
+    listBySession: (targetSessionKey: string) =>
+      bindingServiceMocks.listBySession(targetSessionKey),
+    unbind: (input: unknown) => bindingServiceMocks.unbind(input),
+  }),
+}));
+
+vi.mock("../../acp/policy.js", () => ({
+  resolveAcpDispatchPolicyError: (cfg: OpenClawConfig) =>
+    policyMocks.resolveAcpDispatchPolicyError(cfg),
+  resolveAcpAgentPolicyError: (cfg: OpenClawConfig, agent: string) =>
+    policyMocks.resolveAcpAgentPolicyError(cfg, agent),
+}));
+
+vi.mock("./route-reply.runtime.js", () => ({
+  routeReply: (params: unknown) => routeMocks.routeReply(params),
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: (channelId: string) => channelPluginMocks.getChannelPlugin(channelId),
+  getLoadedChannelPlugin: (channelId: string) => channelPluginMocks.getChannelPlugin(channelId),
+  normalizeChannelId: (channelId?: string | null) => channelId?.trim().toLowerCase() || null,
+}));
+
+vi.mock("../../infra/outbound/message-action-runner.js", () => ({
+  runMessageAction: (params: unknown) => messageActionMocks.runMessageAction(params),
+}));
+
+vi.mock("./dispatch-acp-tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
+}));
+
+vi.mock("../../tts/status-config.js", () => ({
+  resolveStatusTtsSnapshot: () => ({
+    autoMode: "always",
+    provider: "auto",
+    maxLength: 1500,
+    summarize: true,
+  }),
+}));
+
+vi.mock("./dispatch-acp-media.runtime.js", () => ({
+  applyMediaUnderstanding: (params: unknown) =>
+    mediaUnderstandingMocks.applyMediaUnderstanding(params),
+  isMediaUnderstandingSkipError: (error: unknown): error is MediaUnderstandingSkipError =>
+    error instanceof Error && error.name === "MediaUnderstandingSkipError",
+  normalizeAttachments: (ctx: { MediaPath?: string; MediaType?: string }) =>
+    ctx.MediaPath
+      ? [
+          {
+            path: ctx.MediaPath,
+            mime: ctx.MediaType,
+            index: 0,
+          },
+        ]
+      : [],
+  resolveMediaAttachmentLocalRoots: (params: {
+    cfg: { channels?: Record<string, { attachmentRoots?: string[] } | undefined> };
+    ctx: { Provider?: string; Surface?: string };
+  }) => {
+    const channel = params.ctx.Provider ?? params.ctx.Surface ?? "";
+    return params.cfg.channels?.[channel]?.attachmentRoots ?? [];
+  },
+  MediaAttachmentCache: class {
+    async getBuffer(): Promise<never> {
+      const error = new Error("outside allowed roots");
+      error.name = "MediaUnderstandingSkipError";
+      throw error;
+    }
+  },
+}));
+
+vi.mock("./dispatch-acp-session.runtime.js", () => ({
+  readAcpSessionEntry: (params: { sessionKey: string; cfg?: OpenClawConfig }) =>
+    sessionMetaMocks.readAcpSessionEntry(params),
+}));
+
+vi.mock("../../logging/diagnostic.js", () => ({
+  markDiagnosticSessionProgress: diagnosticMocks.markDiagnosticSessionProgress,
+}));
+
+vi.mock("./dispatch-acp-transcript.runtime.js", () => ({
+  persistAcpDispatchTranscript: (params: unknown) =>
+    transcriptMocks.persistAcpDispatchTranscript(params),
+}));
+
+const sessionKey = "agent:copilot:acp:thought-chunk-1";
+
+function createDispatcher(): {
+  dispatcher: ReplyDispatcher;
+  toolResultMock: ReturnType<typeof vi.fn>;
+  blockReplyMock: ReturnType<typeof vi.fn>;
+  finalReplyMock: ReturnType<typeof vi.fn>;
+  counts: Record<"tool" | "block" | "final", number>;
+} {
+  const counts = { tool: 0, block: 0, final: 0 };
+  const toolResultMock = vi.fn(() => true);
+  const blockReplyMock = vi.fn(() => true);
+  const finalReplyMock = vi.fn(() => true);
+  const dispatcher: ReplyDispatcher = {
+    sendToolResult: toolResultMock,
+    sendBlockReply: blockReplyMock,
+    sendFinalReply: finalReplyMock,
+    waitForIdle: vi.fn(async () => {}),
+    getQueuedCounts: vi.fn(() => counts),
+    getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+    markComplete: vi.fn(),
+  };
+  return { dispatcher, toolResultMock, blockReplyMock, finalReplyMock, counts };
+}
+
+function setReadyAcpResolution() {
+  managerMocks.resolveSession.mockReturnValue({
+    kind: "ready",
+    sessionKey,
+    meta: createAcpSessionMeta({ agent: "copilot" }),
+  });
+}
+
+// Live mode so we observe intermediate flushes rather than only an
+// end-of-turn consolidated payload (final_only would mask whether the
+// thought-stream event reached the deliver path before `done`).
+function createLiveStreamConfig(params: { thoughtVisible: boolean }): OpenClawConfig {
+  return createAcpTestConfig({
+    acp: {
+      enabled: true,
+      stream: {
+        deliveryMode: "live",
+        coalesceIdleMs: 0,
+        maxChunkChars: 1024,
+        tagVisibility: {
+          agent_message_chunk: true,
+          agent_thought_chunk: params.thoughtVisible,
+        },
+      },
+    },
+  });
+}
+
+async function runThoughtDispatch(params: {
+  bodyForAgent: string;
+  cfg: OpenClawConfig;
+  dispatcher: ReplyDispatcher;
+}) {
+  return tryDispatchAcpReply({
+    ctx: buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      IsForum: true,
+      SessionKey: sessionKey,
+      BodyForAgent: params.bodyForAgent,
+    }),
+    cfg: params.cfg,
+    dispatcher: params.dispatcher,
+    sessionKey,
+    inboundAudio: false,
+    shouldRouteToOriginating: false,
+    shouldSendToolSummaries: true,
+    bypassForCommand: false,
+    recordProcessed: vi.fn(),
+    markIdle: vi.fn(),
+  });
+}
+
+describe("tryDispatchAcpReply agent_thought_chunk delivery (catalog #12)", () => {
+  beforeEach(() => {
+    managerMocks.resolveSession.mockReset();
+    managerMocks.runTurn.mockReset();
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
+        await onEvent?.({ type: "done" });
+      },
+    );
+    managerMocks.getObservabilitySnapshot.mockReset();
+    managerMocks.getObservabilitySnapshot.mockReturnValue({
+      turns: { queueDepth: 0 },
+      runtimeCache: { activeSessions: 0 },
+    });
+    policyMocks.resolveAcpDispatchPolicyError.mockReset();
+    policyMocks.resolveAcpDispatchPolicyError.mockReturnValue(null);
+    policyMocks.resolveAcpAgentPolicyError.mockReset();
+    policyMocks.resolveAcpAgentPolicyError.mockReturnValue(null);
+    routeMocks.routeReply.mockReset();
+    routeMocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+    channelPluginMocks.getChannelPlugin.mockClear();
+    messageActionMocks.runMessageAction.mockReset();
+    messageActionMocks.runMessageAction.mockResolvedValue({ ok: true as const });
+    ttsMocks.maybeApplyTtsToPayload.mockClear();
+    ttsMocks.resolveTtsConfig.mockReset();
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockReset();
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockResolvedValue(undefined);
+    diagnosticMocks.markDiagnosticSessionProgress.mockReset();
+    sessionMetaMocks.readAcpSessionEntry.mockReset();
+    sessionMetaMocks.readAcpSessionEntry.mockReturnValue(null);
+    transcriptMocks.persistAcpDispatchTranscript.mockClear();
+    bindingServiceMocks.listBySession.mockReset();
+    bindingServiceMocks.listBySession.mockReturnValue([]);
+    bindingServiceMocks.unbind.mockReset();
+    bindingServiceMocks.unbind.mockResolvedValue([]);
+  });
+
+  it("hides thought chunks when tagVisibility.agent_thought_chunk defaults to false", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({
+          type: "text_delta",
+          tag: "agent_thought_chunk",
+          stream: "thought",
+          text: "Thinking about the problem...",
+        });
+        await onEvent({ type: "done" });
+      },
+    );
+
+    const { dispatcher, toolResultMock, blockReplyMock, finalReplyMock } = createDispatcher();
+    await runThoughtDispatch({
+      bodyForAgent: "think out loud",
+      cfg: createLiveStreamConfig({ thoughtVisible: false }),
+      dispatcher,
+    });
+
+    // No deliver call should carry the thought content when visibility=false.
+    expect(toolResultMock).not.toHaveBeenCalled();
+    expect(blockReplyMock).not.toHaveBeenCalled();
+    expect(finalReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers thought chunks when tagVisibility.agent_thought_chunk=true (expected RED today)", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({
+          type: "text_delta",
+          tag: "agent_thought_chunk",
+          stream: "thought",
+          text: "Thinking about the problem...",
+        });
+        await onEvent({ type: "done" });
+      },
+    );
+
+    const { dispatcher, toolResultMock, blockReplyMock, finalReplyMock } = createDispatcher();
+    await runThoughtDispatch({
+      bodyForAgent: "think out loud",
+      cfg: createLiveStreamConfig({ thoughtVisible: true }),
+      dispatcher,
+    });
+
+    // Expected RED today: the projector drops events with stream="thought"
+    // before the visibility check fires (acp-projector.ts:408-411). Once the
+    // projector honors tagVisibility.agent_thought_chunk for thought-stream
+    // text_delta events, this assertion goes green. Asserting on the union
+    // of dispatcher calls (any of tool/block/final) carrying the thought
+    // text avoids over-specifying which kind the future fix routes through.
+    const thoughtCalls = [
+      ...toolResultMock.mock.calls,
+      ...blockReplyMock.mock.calls,
+      ...finalReplyMock.mock.calls,
+    ].filter((call) => {
+      const payload = call[0] as { text?: string } | undefined;
+      return (
+        typeof payload?.text === "string" && payload.text.includes("Thinking about the problem")
+      );
+    });
+    expect(thoughtCalls.length).toBeGreaterThan(0);
+  });
+
+  it("control: delivers visible output-stream agent_message_chunk text_delta", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({
+          type: "text_delta",
+          tag: "agent_message_chunk",
+          stream: "output",
+          text: "Visible output text.",
+        });
+        await onEvent({ type: "done" });
+      },
+    );
+
+    const { dispatcher, toolResultMock, blockReplyMock, finalReplyMock } = createDispatcher();
+    await runThoughtDispatch({
+      bodyForAgent: "say something",
+      cfg: createLiveStreamConfig({ thoughtVisible: true }),
+      dispatcher,
+    });
+
+    // Sanity check: this proves the test infrastructure can route a
+    // text_delta event to a deliver call. If this fails, the RED in the
+    // previous test is a setup bug, not a real finding.
+    const visibleCalls = [
+      ...toolResultMock.mock.calls,
+      ...blockReplyMock.mock.calls,
+      ...finalReplyMock.mock.calls,
+    ].filter((call) => {
+      const payload = call[0] as { text?: string } | undefined;
+      return typeof payload?.text === "string" && payload.text.includes("Visible output text");
+    });
+    expect(visibleCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts
@@ -377,6 +377,36 @@ describe("tryDispatchAcpReply agent_thought_chunk delivery (catalog #12)", () =>
     expect(thoughtCalls.length).toBeGreaterThan(0);
   });
 
+  it("drops unknown-stream events even when the tag is explicitly visible", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({
+          type: "text_delta",
+          tag: "agent_thought_chunk",
+          stream: "diagnostic",
+          text: "Internal diagnostic trace.",
+        });
+        await onEvent({ type: "done" });
+      },
+    );
+
+    const { dispatcher, toolResultMock, blockReplyMock, finalReplyMock } = createDispatcher();
+    await runThoughtDispatch({
+      bodyForAgent: "think out loud",
+      cfg: createLiveStreamConfig({ thoughtVisible: true }),
+      dispatcher,
+    });
+
+    // The stream allow-list ("output" | "thought") is enforced before the
+    // visibility check. An event with stream="diagnostic" must be dropped
+    // regardless of tagVisibility.agent_thought_chunk=true. This proves the
+    // visibility flag cannot bypass the stream allow-list.
+    expect(toolResultMock).not.toHaveBeenCalled();
+    expect(blockReplyMock).not.toHaveBeenCalled();
+    expect(finalReplyMock).not.toHaveBeenCalled();
+  });
+
   it("control: delivers visible output-stream agent_message_chunk text_delta", async () => {
     setReadyAcpResolution();
     managerMocks.runTurn.mockImplementation(

--- a/src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts
@@ -9,21 +9,11 @@ import type { ReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
 import { createAcpSessionMeta, createAcpTestConfig } from "./test-fixtures/acp-runtime.js";
 
-// Catalog finding #12 — red-light TDD spec for `agent_thought_chunk` delivery.
+// Catalog finding #12 — regression spec for `agent_thought_chunk` delivery.
 //
-// Hypothesis: the projector unconditionally drops `text_delta` events whose
-// `stream` is not "output" (acp-projector.ts:408-411). When the acpx
-// translator emits a thought chunk it sets `stream: "thought"` and
-// `tag: "agent_thought_chunk"`. So even when an operator overrides
-// `tagVisibility.agent_thought_chunk = true`, the visibility flag is never
-// consulted — the event is dropped before the visibility check at line 412.
-//
-// Three scenarios:
-//   1. default visibility (false) — thought is hidden → GREEN today.
-//   2. visibility true — thought should be delivered → RED today (drop
-//      happens before visibility check).
-//   3. control: an output-stream agent_message_chunk delivers normally →
-//      GREEN today; sanity-checks the test infrastructure.
+// Fix: reorder guards in acp-projector.ts so the operator-tunable
+// tagVisibility.agent_thought_chunk flag is authoritative for stream="thought"
+// events. Also guards against untagged thought-stream leakage (security).
 //
 // Preamble duplicated from dispatch-acp.tool-stream-supergroup.test.ts and
 // dispatch-acp.spawn-child-delivery.test.ts. TODO: share via test-fixtures
@@ -337,7 +327,7 @@ describe("tryDispatchAcpReply agent_thought_chunk delivery (catalog #12)", () =>
     expect(finalReplyMock).not.toHaveBeenCalled();
   });
 
-  it("delivers thought chunks when tagVisibility.agent_thought_chunk=true (expected RED today)", async () => {
+  it("delivers thought chunks when tagVisibility.agent_thought_chunk=true", async () => {
     setReadyAcpResolution();
     managerMocks.runTurn.mockImplementation(
       async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
@@ -358,12 +348,9 @@ describe("tryDispatchAcpReply agent_thought_chunk delivery (catalog #12)", () =>
       dispatcher,
     });
 
-    // Expected RED today: the projector drops events with stream="thought"
-    // before the visibility check fires (acp-projector.ts:408-411). Once the
-    // projector honors tagVisibility.agent_thought_chunk for thought-stream
-    // text_delta events, this assertion goes green. Asserting on the union
-    // of dispatcher calls (any of tool/block/final) carrying the thought
-    // text avoids over-specifying which kind the future fix routes through.
+    // Asserting on the union of dispatcher calls (any of tool/block/final)
+    // carrying the thought text avoids over-specifying which kind the fix
+    // routes through.
     const thoughtCalls = [
       ...toolResultMock.mock.calls,
       ...blockReplyMock.mock.calls,
@@ -402,6 +389,36 @@ describe("tryDispatchAcpReply agent_thought_chunk delivery (catalog #12)", () =>
     // visibility check. An event with stream="diagnostic" must be dropped
     // regardless of tagVisibility.agent_thought_chunk=true. This proves the
     // visibility flag cannot bypass the stream allow-list.
+    expect(toolResultMock).not.toHaveBeenCalled();
+    expect(blockReplyMock).not.toHaveBeenCalled();
+    expect(finalReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("drops thought-stream events that carry no tag even when agent_thought_chunk visibility=true", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({
+          type: "text_delta",
+          // no tag — backend omitted it
+          stream: "thought",
+          text: "Untagged internal reasoning.",
+        });
+        await onEvent({ type: "done" });
+      },
+    );
+
+    const { dispatcher, toolResultMock, blockReplyMock, finalReplyMock } = createDispatcher();
+    await runThoughtDispatch({
+      bodyForAgent: "think out loud",
+      cfg: createLiveStreamConfig({ thoughtVisible: true }),
+      dispatcher,
+    });
+
+    // Security gate: isAcpTagVisible returns true for undefined tags, so
+    // without an explicit thought-tag guard an untagged stream="thought" event
+    // would reach delivery even though no operator opt-in can be verified.
+    // The projector must drop it before consulting visibility.
     expect(toolResultMock).not.toHaveBeenCalled();
     expect(blockReplyMock).not.toHaveBeenCalled();
     expect(finalReplyMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Honor the operator-tunable `tagVisibility.agent_thought_chunk` flag for ACP thought-stream `text_delta` events. Closes catalog finding #12.

## Bug detail

Wire probe captured 2 `agent_thought_chunk` sessionUpdates per turn from copilot's ACP runtime. The deployed openclaw config set `tagVisibility.agent_thought_chunk: true`, but the operator never saw the thoughts in any channel. The projector at `src/auto-reply/reply/acp-projector.ts:408-411` had a hard `event.stream !== "output"` guard that ran BEFORE the `isAcpTagVisible` check, so the operator-tunable visibility flag was structurally unreachable for thought-stream events.

## How to reproduce

Unit-level repro in this branch before the fix commit (`f0180a023c`):

```bash
git checkout f0180a023c
pnpm test src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts
# Expected: 'delivers thought chunks when tagVisibility.agent_thought_chunk=true' FAILS
```

After the fix commit (`379320c173`) the same test passes.

## Root cause

`src/auto-reply/reply/acp-projector.ts:408-411` (pre-fix):

```ts
if (event.type === \"text_delta\") {
  if (event.stream && event.stream !== \"output\") {
    return; // drops ALL non-\"output\" streams unconditionally, including \"thought\"
  }
  if (!isAcpTagVisible(settings, event.tag)) {
    return;
  }
}
```

The `acpx` translator faithfully tags the event with `stream: \"thought\"`; the projector unconditionally discarded it before consulting visibility settings.

## Fix approach

Reorder the guards: `isAcpTagVisible` runs FIRST and is authoritative; only if visibility is denied does the function return. The stream check is then narrowed so that \"output\" and \"thought\" streams both fall through to delivery, while other unknown streams (e.g., a hypothetical `stream: \"diagnostic\"`) still drop. Default behavior unchanged: `tagVisibility.agent_thought_chunk: false` (default) keeps thought events hidden.

## Tests

- **Red test (now GREEN):** `src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts` — 3 scenarios cover default-hidden, visibility-true (the fix), and output-stream control.
- **Adjacent suite:** `src/auto-reply/reply/` — 1538 tests pass / 0 fail (115 files).

## Catalog reference

Catalog finding: #12. Investigation lives in branch `edpiva/acp-native-session-investigation` (not yet upstream) at `docs/plans/2026-05-08-acp-findings-catalog.md`.

## Verification commands

\`\`\`bash
pnpm test src/auto-reply/reply/dispatch-acp.thought-chunk-delivery.test.ts   # GREEN
pnpm test src/auto-reply/reply/                                              # 1538 pass / 0 fail
\`\`\`

## Notes for reviewers

The new guard correctly drops unknown-stream events (e.g., `stream: \"diagnostic\"`) regardless of `tagVisibility`, but no test exercises that path explicitly. The behavior is the desired one — coverage gap only, not a wrong fix. Happy to add a fourth test case if you want it.

---

## Live behavior repro (deployed container)

**Container:** `codeclaw-openclaw:clean` running OpenClaw 2026.5.6 (`e9d4a0a`)
**PII note:** UUIDs are random; nothing to redact in this slice.

### Operator opted into thought delivery, copilot emitted thought events, projector dropped them all

Live config in the container:

```
$ docker exec codeclaw-openclaw jq '.acp.stream.tagVisibility' /home/codeclaw/.openclaw/openclaw.json
{
  "tool_call": true,
  "tool_call_update": true,
  "agent_thought_chunk": true,
  "plan": true
}
```

Operator has `agent_thought_chunk: true` set (i.e., wants thoughts delivered).

Copilot's `events.jsonl` for the relevant ACP session shows the events arrived on the wire:

```
$ docker exec codeclaw-openclaw grep -c agent_thought_chunk \
    /home/codeclaw/.copilot/session-state/882435ee-…/events.jsonl
2
```

Pre-fix, those events were silently dropped at `acp-projector.ts:408-411` because the unconditional `event.stream !== "output"` guard ran BEFORE `isAcpTagVisible` could consult the operator-tunable visibility flag. Operator never saw a thought chunk, even after explicitly opting in.

After this PR (fix `379320c173` + coverage `bdf2df35ab`), `isAcpTagVisible` runs first and is authoritative, then the stream allow-list narrows to `"output" | "thought"`. Hypothetical unknown streams (e.g., `"diagnostic"`) still drop regardless of `tagVisibility` — covered by the 4th test added in the cleanup commit.
