### PR TITLE
docs(acp): clarify streaming taxonomy, broadcast layering, and session-load history model

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -802,5 +802,17 @@
   {
     "source": "fs-safe Cleanup Plan",
     "target": "fs-safe Cleanup Plan"
+  },
+  {
+    "source": "ACP streaming and session model",
+    "target": "ACP streaming and session model"
+  },
+  {
+    "source": "ACP agents",
+    "target": "ACP agents"
+  },
+  {
+    "source": "ACP agents setup",
+    "target": "ACP agents setup"
   }
 ]

--- a/docs/concepts/acp-streaming.md
+++ b/docs/concepts/acp-streaming.md
@@ -1,0 +1,118 @@
+---
+summary: "ACP streaming markers, broadcast layering, and session/load history model"
+read_when:
+  - Investigating log markers during ACP tool deliveries
+  - Debugging why stream=tool does not appear for ACP turns
+  - Understanding how each channel adapter emits WS broadcast events for ACP
+  - Understanding how session/load works and why conversation history is not on the wire
+title: "ACP streaming and session model"
+---
+
+# ACP streaming and session model
+
+This page clarifies three commonly misunderstood aspects of ACP delivery:
+the meaning of `stream=tool` log markers, the per-channel broadcast layer,
+and how `session/load` handles conversation history.
+
+## Streaming markers and the PI boundary
+
+`stream=tool` is a **PI agent marker**, not an ACP marker.
+
+It originates from `src/agents/pi-embedded-subscribe.handlers.tools.ts`,
+which handles tool events for the embedded PI runtime. When you see
+`stream=tool` in gateway logs, the event is on the PI path.
+
+ACP tool deliveries follow a different route:
+
+```
+ACP harness → dispatcher.sendToolResult(payload)
+                → enqueue("tool", payload)   [reply-dispatcher.ts:309]
+                → options.deliver callback   [reply-dispatcher.ts:264]
+                → channel-specific adapter delivery
+```
+
+There is no `stream=tool` emitted for ACP tool results. Each channel
+adapter emits its own log markers when it broadcasts to WebSocket. If
+you are tracing an ACP tool delivery and see no `stream=tool`, that is
+correct and expected.
+
+**Future work:** centralizing ACP broadcast labels into a single marker
+layer (similar to the PI path) would make cross-channel tracing easier.
+Today, narrow your log search to the adapter delivery callsite instead.
+
+## Broadcast layering: per-channel, not centralized
+
+ACP has **no centralized WebSocket broadcast layer**. Each channel adapter
+owns its delivery path and emits its own log markers.
+
+The shared plumbing stops at `options.deliver` in `reply-dispatcher.ts`.
+After that callback, delivery is adapter-specific.
+
+Adapter-level delivery notes:
+
+- **Discord** — delivery runs through the Discord channel adapter;
+  broadcast labels appear in that adapter's send path.
+- **Matrix** — delivery runs through the Matrix channel adapter;
+  broadcast labels appear in that adapter's event-send path.
+- **Slack** — delivery runs through the Slack channel adapter;
+  broadcast labels appear in that adapter's post/update path.
+- **Telegram** — delivery runs through the Telegram channel adapter;
+  broadcast labels appear in that adapter's `sendMessage`/`editMessageText` path.
+
+When adding observability for ACP tool delivery, instrument the adapter
+deliver function for the channel in question rather than searching for a
+shared broadcast label.
+
+## session/load and the history model
+
+`session/load` does **not** carry conversation history on the wire.
+
+The wire request contains only `sessionId`. The wire response carries
+config, model, and mode state. No transcript flows between OpenClaw
+and the ACP harness during `session/load`.
+
+### Parallel transcripts
+
+Each side stores its own transcript independently:
+
+| Side              | Path                                                               | Role                       |
+| ----------------- | ------------------------------------------------------------------ | -------------------------- |
+| Copilot (harness) | `~/.copilot/session-state/<acp_session_id>/events.jsonl`           | Source of truth for replay |
+| OpenClaw          | `~/.openclaw/agents/<agentId>/sessions/<openclaw-sessionId>.jsonl` | Parallel transcript        |
+
+Replace `~/.copilot` and `~/.openclaw` with the actual config roots for
+your install. In gateway environments, these default to
+`<config-root>/copilot/session-state/` and `<config-root>/openclaw/agents/`
+respectively.
+
+### Reconstruction is the harness responsibility
+
+When OpenClaw drives `session/load`, the ACP harness (for example
+Copilot) reads its own `events.jsonl` for the given `sessionId` and
+rehydrates its internal state. The transcript never crosses the wire.
+
+### Session join model
+
+Three identifiers participate in an ACP session:
+
+| Identifier                       | Where it lives                                    | What it is                                                            |
+| -------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------- |
+| OpenClaw session key             | OpenClaw session store                            | Composite key `agent:<agentId>:acp:<uuid>`                            |
+| OpenClaw session id              | OpenClaw session store                            | Filename of the parallel transcript, e.g. `<uuid>.jsonl`              |
+| ACP session id (`acpxSessionId`) | `acp.identity.acpxSessionId` on the session entry | Copilot directory name; the `acp_session_id` passed in `session/load` |
+
+Join field: `acp.identity.acpxSessionId` on the OpenClaw session store
+entry links the OpenClaw session key to the upstream harness session.
+
+To trace a full round-trip:
+
+1. Look up the OpenClaw session by key (`agent:<agentId>:acp:<uuid>`).
+2. Read `acp.identity.acpxSessionId` to get the upstream session id.
+3. Find the harness transcript at `<harness-config-root>/session-state/<acpxSessionId>/events.jsonl`.
+
+## Related
+
+- [ACP agents](/tools/acp-agents) - session lifecycle, spawn, and delivery model
+- [ACP agents setup](/tools/acp-agents-setup) - plugin setup and permissions
+- [Streaming and chunking](/concepts/streaming) - channel-level block streaming and preview streaming
+- [Messages](/concepts/messages) - message lifecycle and delivery

--- a/docs/concepts/acp-streaming.md
+++ b/docs/concepts/acp-streaming.md
@@ -4,7 +4,7 @@ read_when:
   - Investigating log markers during ACPX channel-adapter tool deliveries
   - Debugging which runtime path produced a stream=tool event in gateway logs
   - Understanding how each channel adapter emits WS broadcast events for ACPX
-  - Understanding how session/load works and why conversation history is not carried on the wire
+  - Understanding how session/load works and how conversation history is replayed for ACP bridge vs ACPX harness sessions
 title: "ACP streaming and session model"
 ---
 
@@ -55,7 +55,7 @@ owns its delivery path and emits its own log markers.
 The shared plumbing stops at `options.deliver` in `reply-dispatcher.ts`.
 After that callback, delivery is adapter-specific.
 
-Adapter-level delivery notes:
+Adapter-level delivery notes (examples — OpenClaw has many more channel plugins):
 
 - **Discord** — delivery runs through the Discord channel adapter;
   broadcast labels appear in that adapter's send path.
@@ -66,24 +66,35 @@ Adapter-level delivery notes:
 - **Telegram** — delivery runs through the Telegram channel adapter;
   broadcast labels appear in that adapter's `sendMessage`/`editMessageText` path.
 
-When adding observability for ACP tool delivery, instrument the adapter
-deliver function for the channel in question rather than searching for a
-shared broadcast label.
+The same pattern applies to every other channel plugin (Mattermost, MS Teams,
+WhatsApp, and so on). When adding observability for ACP tool delivery, instrument
+the adapter deliver function for the channel in question rather than searching for
+a shared broadcast label.
 
 ## session/load and the history model
 
-`session/load` does **not** carry conversation history on the wire.
+`session/load` behavior differs between the two ACP runtime modes:
 
-The wire request includes `sessionId` plus optional setup fields
-(`cwd`, `mcpServers`, `_meta`). The wire response carries config,
-model, and mode state. No conversation transcript is exchanged between
-OpenClaw and the ACP harness on the wire during `session/load`.
+| Mode                        | session/load behavior                                                                                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ACPX harness                | Each side maintains its own transcript. The harness replays locally from `events.jsonl`. No conversation history flows on the wire.                                                       |
+| ACP bridge (`openclaw acp`) | `loadSession` replays event-ledger history (or transcript fallback) to the ACP client via `session-update` notifications. History **does** flow on the wire as ACP session-update events. |
 
-History reconstruction happens locally on each side: the ACPX harness
-replays its own `events.jsonl`, and the OpenClaw bridge reads its
-own ledger or session transcript (see `src/acp/translator.ts` —
-`loadSession` drives ledger or transcript replay entirely from
-locally stored state, not from wire payload).
+For ACP bridge sessions, `loadSession` (`src/acp/translator.ts:725-784`) calls
+`replayLedgerSession()` (L773) when the event ledger is complete, or
+`replaySessionTranscript()` (L775) as a fallback, emitting
+`user_message_chunk`, `tool_call`, `tool_call_update`, and
+`agent_message_chunk` session-update notifications to the connected ACP
+client. The transcript fallback fetches stored messages via the Gateway
+`sessions.get` RPC (`src/acp/translator.ts:2022-2023`) — this is a wire
+call to the Gateway, not a read from local disk.
+
+For ACPX harness sessions the original claim holds: the wire request
+includes `sessionId` plus optional setup fields (`cwd`, `mcpServers`,
+`_meta`); the wire response carries config, model, and mode state; and
+no conversation transcript crosses the wire. See also
+[ACP compatibility matrix](/cli/acp#compatibility-matrix) for the current
+`loadSession` status.
 
 ### Parallel transcripts
 
@@ -99,11 +110,16 @@ your install. In gateway environments, these default to
 `<config-root>/copilot/session-state/` and `<config-root>/openclaw/agents/`
 respectively.
 
-### Reconstruction is the harness responsibility
+### Reconstruction is the harness responsibility (ACPX harness mode)
 
-When OpenClaw drives `session/load`, the ACP harness (for example
-Copilot) reads its own `events.jsonl` for the given `sessionId` and
-rehydrates its internal state. The transcript never crosses the wire.
+In ACPX harness mode, when OpenClaw drives `session/load`, the ACP
+harness (for example Copilot) reads its own `events.jsonl` for the
+given `sessionId` and rehydrates its internal state. No transcript
+crosses the wire in this direction.
+
+In ACP bridge mode the situation is reversed: OpenClaw is the
+responder, and it actively replays history to the connecting ACP client
+via session-update notifications (see the mode table above).
 
 ### Session join model
 

--- a/docs/concepts/acp-streaming.md
+++ b/docs/concepts/acp-streaming.md
@@ -1,10 +1,10 @@
 ---
 summary: "ACP streaming markers, broadcast layering, and session/load history model"
 read_when:
-  - Investigating log markers during ACP tool deliveries
-  - Debugging why stream=tool does not appear for ACP turns
-  - Understanding how each channel adapter emits WS broadcast events for ACP
-  - Understanding how session/load works and why conversation history is not on the wire
+  - Investigating log markers during ACPX channel-adapter tool deliveries
+  - Debugging which runtime path produced a stream=tool event in gateway logs
+  - Understanding how each channel adapter emits WS broadcast events for ACPX
+  - Understanding how session/load works and why conversation history is not carried on the wire
 title: "ACP streaming and session model"
 ---
 
@@ -14,31 +14,38 @@ This page clarifies three commonly misunderstood aspects of ACP delivery:
 the meaning of `stream=tool` log markers, the per-channel broadcast layer,
 and how `session/load` handles conversation history.
 
-## Streaming markers and the PI boundary
+## Streaming markers and the channel-adapter delivery boundary
 
-`stream=tool` is a **PI agent marker**, not an ACP marker.
+`stream=tool` is **not an ACPX channel-adapter delivery marker**.
 
-It originates from `src/agents/pi-embedded-subscribe.handlers.tools.ts`,
-which handles tool events for the embedded PI runtime. When you see
-`stream=tool` in gateway logs, the event is on the PI path.
+The marker appears in multiple runtime paths: it originates in the
+embedded PI runtime (`src/agents/pi-embedded-subscribe.handlers.tools.ts`),
+in the native Codex app-server (`extensions/codex/src/app-server/run-attempt.ts`
+and `event-projector.ts`), and the ACP bridge itself reads `stream === "tool"`
+in `src/acp/translator.ts` to route tool-result callbacks. Seeing `stream=tool`
+in gateway logs therefore does not uniquely identify the ACPX harness path.
 
-ACP tool deliveries follow a different route:
+What distinguishes ACPX channel-adapter delivery is the per-adapter broadcast
+path that begins at the `options.deliver` callback, not a shared `stream=tool`
+label. The ACPX delivery route is:
 
 ```
-ACP harness → dispatcher.sendToolResult(payload)
-                → enqueue("tool", payload)   [reply-dispatcher.ts:309]
-                → options.deliver callback   [reply-dispatcher.ts:264]
-                → channel-specific adapter delivery
+ACPX harness → dispatcher.sendToolResult(payload)
+                 → enqueue("tool", payload)   [reply-dispatcher.ts:309]
+                 → options.deliver callback   [reply-dispatcher.ts:264]
+                 → channel-specific adapter delivery
 ```
 
-There is no `stream=tool` emitted for ACP tool results. Each channel
-adapter emits its own log markers when it broadcasts to WebSocket. If
-you are tracing an ACP tool delivery and see no `stream=tool`, that is
-correct and expected.
+There is no `stream=tool` emitted by the channel adapters themselves for
+ACPX tool results. If you are tracing an ACPX tool delivery and see
+`stream=tool` in logs, the event is from another producer (PI, native Codex,
+or the ACP bridge callback layer), not from the channel-adapter broadcast.
+Narrow your log search to the adapter deliver callsite for the channel in
+question.
 
-**Future work:** centralizing ACP broadcast labels into a single marker
-layer (similar to the PI path) would make cross-channel tracing easier.
-Today, narrow your log search to the adapter delivery callsite instead.
+**Future work:** centralizing ACPX adapter broadcast labels into a single
+marker layer would make cross-channel tracing easier. Today, instrument the
+adapter deliver function per-channel instead.
 
 ## Broadcast layering: per-channel, not centralized
 
@@ -67,9 +74,16 @@ shared broadcast label.
 
 `session/load` does **not** carry conversation history on the wire.
 
-The wire request contains only `sessionId`. The wire response carries
-config, model, and mode state. No transcript flows between OpenClaw
-and the ACP harness during `session/load`.
+The wire request includes `sessionId` plus optional setup fields
+(`cwd`, `mcpServers`, `_meta`). The wire response carries config,
+model, and mode state. No conversation transcript is exchanged between
+OpenClaw and the ACP harness on the wire during `session/load`.
+
+History reconstruction happens locally on each side: the ACPX harness
+replays its own `events.jsonl`, and the OpenClaw bridge reads its
+own ledger or session transcript (see `src/acp/translator.ts` —
+`loadSession` drives ledger or transcript replay entirely from
+locally stored state, not from wire payload).
 
 ### Parallel transcripts
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1169,6 +1169,7 @@
                   "concepts/messages",
                   "concepts/message-lifecycle-refactor",
                   "concepts/streaming",
+                  "concepts/acp-streaming",
                   "concepts/progress-drafts",
                   "concepts/retry",
                   "concepts/queue",


### PR DESCRIPTION
## Summary

New concepts page that documents three ACP behaviors discovered during a recent investigation: (1) `stream=tool` appears in multiple runtime paths (PI, native Codex, and the ACP bridge callback layer) — it is not an ACPX channel-adapter delivery marker; (2) there is no centralized WS broadcast layer for ACP — each channel adapter owns its delivery path; (3) `session/load` history replay behavior differs by mode — ACPX harness sessions keep transcripts local, while ACP bridge sessions actively replay history via session-update notifications. Closes catalog findings #7, #14, #23 (all 📝 DOCUMENTED).

## Bug detail

These were "documented gaps," not runtime bugs. Operators trying to diagnose ACP runs were:

- Following the `stream=tool` log marker expecting it to apply only to ACP — it doesn't; it's emitted by the PI embedded runtime, native Codex app-server, and the ACP bridge callback layer.
- Looking for a single WS broadcast point for ACP traffic — there isn't one; per-channel adapters each broadcast independently.
- Asking "is my history sent across the wire on `session/load`?" — it depends on the runtime mode. For ACPX harness sessions: no, each side keeps a parallel transcript and the harness rehydrates from its own `events.jsonl`. For ACP bridge sessions: yes, `loadSession` replays history to the ACP client via session-update notifications.

These three blind spots showed up in the same investigation, so they ship as one docs PR.

## Root cause

No documentation existed for any of the three. Specifically:

- `src/agents/pi-embedded-subscribe.handlers.tools.ts` is the source of `stream=tool`; ACP tool deliveries flow through `src/auto-reply/reply/reply-dispatcher.ts:309` (`enqueue("tool", payload)`) and use per-channel WS markers.
- `reply-dispatcher.ts:264` shows the per-adapter `options.deliver` callback boundary; there is no shared WS broadcast layer past that point.
- ACP `session/load` requests carry `sessionId` plus optional setup fields (`cwd`, `mcpServers`, `_meta`); the response carries config/model/mode state. For ACPX harness sessions, no conversation transcript crosses the wire — each side keeps a parallel transcript. For ACP bridge sessions, `loadSession` actively replays event-ledger history to the connecting client via session-update notifications.

## Fix approach

Created `docs/concepts/acp-streaming.md` with three sections matching the three findings (file grew past the original 118 lines after the session/load section was expanded to cover both runtime modes). Added a nav entry in `docs/docs.json` under "Messages and delivery" right after `concepts/streaming`. Added three glossary entries to `docs/.i18n/glossary.zh-CN.json` (page title + two link labels) using the `keep-as-is` style consistent with how other ACP/protocol terms are handled in the file.

## Tests

This is documentation; no runtime tests apply. Doc gates run:

- `pnpm docs:check-mdx` — 624 files PASS
- `pnpm docs:check-i18n-glossary` — PASS (after glossary entries added)
- `pnpm docs:list` — page appears with all 4 \`read_when\` entries

## Catalog reference

Catalog findings: #7, #14, #23. Investigation lives in branch `edpiva/acp-native-session-investigation` (not yet upstream) at `docs/plans/2026-05-08-acp-findings-catalog.md`.

## Verification commands

\`\`\`bash
pnpm docs:check-mdx                 # 624 files PASS
pnpm docs:check-i18n-glossary       # PASS
pnpm docs:list                      # page listed with read_when entries
\`\`\`

## Notes for reviewers

- Page placement decision: created a new concepts page rather than extending `docs/extensions/acpx.md`, because acpx.md is a thin plugin reference stub, not a concepts-style page. Open to moving the content if you'd prefer it under `extensions/acpx`.
- Three glossary entries use `keep-as-is: true` for the zh-CN locale because they are protocol/proper-noun-like (matching how `"QA channel"`, `"Agent Runtimes"`, etc. are handled in the same file). If the i18n team prefers translations, happy to switch.

---

## Live behavior repro (deployed container)

**Container:** `codeclaw-openclaw:clean` running OpenClaw 2026.5.6 (`e9d4a0a`)
**PII note:** UUIDs are random; path prefix `/home/codeclaw/` is the public deployment user.

This PR is documentation, but the bot asked for behavior proof for each documented finding. Each section below is the live observation that motivates the corresponding doc paragraph.

### #4 — `event_log.active_path` advertised but never written

Already covered in detail in #79539. Quick recap from this container:

```
$ docker exec codeclaw-openclaw jq '.event_log.active_path' \
    /home/codeclaw/.openclaw/workspace/state/sessions/agent%3Acopilot%3Aacp%3A1f854fa2-….json
"/home/codeclaw/.acpx/sessions/agent%3Acopilot%3Aacp%3A1f854fa2-….stream.ndjson"

$ docker exec codeclaw-openclaw ls /home/codeclaw/.acpx/sessions/
ls: cannot access '/home/codeclaw/.acpx/sessions/': No such file or directory
```

Operators following the advertised path hit a dead pointer. The new doc page tells them to look at copilot's per-session `events.jsonl` and openclaw's per-session `.jsonl` instead until catalog #4 is fixed.

### #14 — No centralized WS broadcast layer for ACP

Source-level: the only shared plumbing past `reply-dispatcher.ts:264` is the per-adapter `options.deliver` callback. There is no aggregator. The new doc page uses Discord/Matrix/Slack/Telegram as examples (noting that OpenClaw has many more channel plugins) so operators know which adapter's logs to grep when an ACP message doesn't surface.

### #23 — `session/load` does not carry conversation history

Two parallel transcripts exist on the same container for the same logical session:

```
$ docker exec codeclaw-openclaw ls /home/codeclaw/.copilot/session-state/
13c05fa0-…  293eab2e-…  3bb6ca21-…  …  882435ee-…   (29 dirs, copilot-side state)

$ docker exec codeclaw-openclaw ls /home/codeclaw/.openclaw/agents/copilot/sessions/
18a09361-…jsonl  1978341a-…jsonl  24843f10-…jsonl  …   (openclaw-side parallel transcript)
```

Each side maintains its own log; the wire request for `session/load` only carries `sessionId`. The new doc explains the join model (`agent:copilot:acp:<uuid>` ↔ openclaw `sessionId` ↔ ACP `acp_session_id`) and points operators at `acp.identity.acpxSessionId` as the join field.

