### PR TITLE
Fix skill config requirements, spawn allowlists, chat stop lifecycle, and systemd status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,10 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory: close temp SQLite handles before failed atomic reindex cleanup and retry Windows EBUSY/EPERM/EACCES temp file removals, so `memory index --force` does not abort or leave temp sidecars on locked filesystems. Fixes #79708. Thanks @LobsterFarmerAmp and @hclsys.
+- Skills CLI: normalize object-shaped `metadata.openclaw.requires.config` entries by their `path` so skill info/status no longer renders `[object Object]` or blocks valid config requirements. Fixes #79488. Thanks @sebrinass.
+- Agents/subagents: honor `OPENCLAW_SPAWN_ALLOWLIST` and `SPAWN_ALLOWLIST` as fallback target-agent allowlists for `sessions_spawn` when no config allowlist is set. Fixes #79490. Thanks @baptisterou.
+- Control UI/WebChat: map backend agent run ids back to the originating chat run so context-overflow lifecycle errors clear the active run instead of leaving Stop and queued `/new` stuck. Fixes #79525. Thanks @dmak.
+- CLI/status: prefer systemd `is-active` when `systemctl show` returns a stale failed state, so active Gateway user services report as running. Fixes #79515. Thanks @holgergruenhagen.
 - Agents/CLI: add an explicit `reseedFromRawTranscriptWhenUncompacted` backend opt-in so safe invalidated CLI sessions can reseed from a bounded raw OpenClaw transcript tail before compaction while auth-boundary resets remain no-raw. Fixes #79713. (#79764) Thanks @hclsys.
 - Agents/CLI: handle resumed CLI JSONL output and bound supervisor output buffering so resumed runs stay readable without letting noisy child output grow unbounded.
 - Codex app-server: honor per-call `timeoutMs`, configured `image_generate` timeouts, and media image-understanding timeouts for dynamic tool calls, capped at 600000 ms, so slow image generation and image analysis no longer fail at the 30s bridge default. Fixes #79810. Thanks @omarshahine.

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -379,7 +379,7 @@ Experimental built-in tool flags. Default off unless a strict-agentic GPT-5 auto
 ```
 
 - `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
-- `allowAgents`: default allowlist of target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any; default: same agent only).
+- `allowAgents`: default allowlist of target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any; default: same agent only). If neither config path is set, `OPENCLAW_SPAWN_ALLOWLIST` or `SPAWN_ALLOWLIST` can provide a fallback (`*`, comma-separated ids, or a JSON array).
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 

--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -86,13 +86,13 @@ For how skills are loaded and prioritized, see [Skills](/tools/skills).
 
 The YAML frontmatter supports these fields:
 
-| Field                               | Required | Description                                                    |
-| ----------------------------------- | -------- | -------------------------------------------------------------- |
-| `name`                              | Yes      | Unique identifier using lowercase letters, digits, and hyphens |
-| `description`                       | Yes      | One-line description shown to the agent                        |
-| `metadata.openclaw.os`              | No       | OS filter (`["darwin"]`, `["linux"]`, etc.)                    |
-| `metadata.openclaw.requires.bins`   | No       | Required binaries on PATH                                      |
-| `metadata.openclaw.requires.config` | No       | Required config keys                                           |
+| Field                               | Required | Description                                                                    |
+| ----------------------------------- | -------- | ------------------------------------------------------------------------------ |
+| `name`                              | Yes      | Unique identifier using lowercase letters, digits, and hyphens                 |
+| `description`                       | Yes      | One-line description shown to the agent                                        |
+| `metadata.openclaw.os`              | No       | OS filter (`["darwin"]`, `["linux"]`, etc.)                                    |
+| `metadata.openclaw.requires.bins`   | No       | Required binaries on PATH                                                      |
+| `metadata.openclaw.requires.config` | No       | Required config keys (`"path"` strings or `{ path, access, purpose }` objects) |
 
 ## Best practices
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -244,8 +244,8 @@ Fields under `metadata.openclaw`:
 <ParamField path="requires.env" type="string[]">
   Env var must exist or be provided in config.
 </ParamField>
-<ParamField path="requires.config" type="string[]">
-  List of `openclaw.json` paths that must be truthy.
+<ParamField path="requires.config" type='Array<string | { path: string; access?: string; purpose?: string }>'>
+  List of `openclaw.json` paths that must be truthy. Object entries are accepted for descriptive metadata; OpenClaw uses their `path` value for eligibility checks.
 </ParamField>
 <ParamField path="primaryEnv" type="string">
   Env var name associated with `skills.entries.<name>.apiKey`.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -286,6 +286,9 @@ See [Configuration reference](/gateway/configuration-reference) and
 <ParamField path="agents.defaults.subagents.allowAgents" type="string[]">
   Default target-agent allowlist used when the requester agent does not set its own `subagents.allowAgents`.
 </ParamField>
+<ParamField path="SPAWN_ALLOWLIST" type="string">
+  Environment fallback used only when neither per-agent nor default config sets `allowAgents`. Accepts `*`, comma-separated agent ids, or a JSON string array. `OPENCLAW_SPAWN_ALLOWLIST` is also accepted and takes precedence.
+</ParamField>
 <ParamField path="agents.defaults.subagents.requireAgentId" type="boolean" default="false">
   Block `sessions_spawn` calls that omit `agentId` (forces explicit profile selection). Per-agent override: `agents.list[].subagents.requireAgentId`.
 </ParamField>

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -82,7 +82,10 @@ import {
 } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, getSubagentRunByChildSessionKey } from "./subagent-registry.js";
-import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
+import {
+  resolveConfiguredSubagentAllowAgents,
+  resolveSubagentTargetPolicy,
+} from "./subagent-target-policy.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
@@ -793,9 +796,11 @@ function resolveAcpSubagentEnvelopeState(params: {
     requesterAgentId,
     targetAgentId: params.targetAgentId,
     requestedAgentId: params.requestedAgentId,
-    allowAgents:
-      resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.allowAgents ??
-      params.cfg.agents?.defaults?.subagents?.allowAgents,
+    allowAgents: resolveConfiguredSubagentAllowAgents({
+      agentAllowAgents: resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.allowAgents,
+      defaultAllowAgents: params.cfg.agents?.defaults?.subagents?.allowAgents,
+      env: process.env,
+    }),
   });
   if (!targetPolicy.ok) {
     return {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   createSubagentSpawnTestConfig,
   loadSubagentSpawnModuleForTest,
@@ -127,6 +128,21 @@ describe("subagent spawn allowlist + sandbox guards", () => {
       },
     });
     const result = await spawn({ agentId: "beta" });
+    expect(result).toMatchObject({
+      status: "accepted",
+      childSessionKey: expect.stringMatching(/^agent:beta:subagent:/),
+    });
+  });
+
+  it("falls back to SPAWN_ALLOWLIST when config omits allowAgents", async () => {
+    setConfig({
+      agents: {
+        list: [{ id: "main" }, { id: "beta" }],
+      },
+    });
+
+    const result = await withEnvAsync({ SPAWN_ALLOWLIST: "*" }, () => spawn({ agentId: "beta" }));
+
     expect(result).toMatchObject({
       status: "accepted",
       childSessionKey: expect.stringMatching(/^agent:beta:subagent:/),

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -147,6 +147,28 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(skill.install[0]?.bins).toEqual(["fakebin"]);
   });
 
+  it("normalizes object-shaped config requirements from skill metadata", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "object-config-skill"),
+      name: "object-config-skill",
+      description: "Object config metadata",
+      metadata:
+        '{"openclaw":{"requires":{"config":[{"path":"browser.enabled","access":"read","purpose":"Check browser config"}]}}}',
+    });
+
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      config: { browser: { enabled: true } },
+    });
+    const skill = requireReportedSkill(report, "object-config-skill");
+
+    expect(skill.eligible).toBe(true);
+    expect(skill.requirements.config).toEqual(["browser.enabled"]);
+    expect(skill.missing.config).toEqual([]);
+    expect(skill.configChecks).toEqual([{ path: "browser.enabled", satisfied: true }]);
+  });
+
   it("respects OS-gated skills", () => {
     const entry = makeEntry({
       name: "os-skill",

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -29,7 +29,10 @@ import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
-import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
+import {
+  resolveConfiguredSubagentAllowAgents,
+  resolveSubagentTargetPolicy,
+} from "./subagent-target-policy.js";
 export {
   SUBAGENT_SPAWN_ACCEPTED_NOTE,
   SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE,
@@ -805,9 +808,11 @@ export async function spawnSubagentDirect(
     requesterAgentId,
     targetAgentId,
     requestedAgentId,
-    allowAgents:
-      resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
-      cfg?.agents?.defaults?.subagents?.allowAgents,
+    allowAgents: resolveConfiguredSubagentAllowAgents({
+      agentAllowAgents: resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents,
+      defaultAllowAgents: cfg?.agents?.defaults?.subagents?.allowAgents,
+      env: process.env,
+    }),
   });
   if (!targetPolicy.ok) {
     return {

--- a/src/agents/subagent-target-policy.test.ts
+++ b/src/agents/subagent-target-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveConfiguredSubagentAllowAgents,
   resolveSubagentAllowedTargetIds,
   resolveSubagentTargetPolicy,
 } from "./subagent-target-policy.js";
@@ -63,5 +64,34 @@ describe("subagent target policy", () => {
       allowAny: false,
       allowedIds: ["planner"],
     });
+  });
+
+  it("uses SPAWN_ALLOWLIST as a fallback allowlist when config omits one", () => {
+    expect(
+      resolveConfiguredSubagentAllowAgents({
+        env: { SPAWN_ALLOWLIST: " planner, checker " },
+      }),
+    ).toEqual(["planner", "checker"]);
+    expect(
+      resolveConfiguredSubagentAllowAgents({
+        env: { OPENCLAW_SPAWN_ALLOWLIST: '["research", "*"]', SPAWN_ALLOWLIST: "ignored" },
+      }),
+    ).toEqual(["research", "*"]);
+  });
+
+  it("keeps explicit config ahead of SPAWN_ALLOWLIST", () => {
+    expect(
+      resolveConfiguredSubagentAllowAgents({
+        agentAllowAgents: ["agent-specific"],
+        defaultAllowAgents: ["default"],
+        env: { SPAWN_ALLOWLIST: "*" },
+      }),
+    ).toEqual(["agent-specific"]);
+    expect(
+      resolveConfiguredSubagentAllowAgents({
+        defaultAllowAgents: ["default"],
+        env: { SPAWN_ALLOWLIST: "*" },
+      }),
+    ).toEqual(["default"]);
   });
 });

--- a/src/agents/subagent-target-policy.ts
+++ b/src/agents/subagent-target-policy.ts
@@ -1,6 +1,49 @@
 import { normalizeAgentId } from "../routing/session-key.js";
+import { normalizeStringEntries } from "../shared/string-normalization.js";
 
 type SubagentTargetPolicyResult = { ok: true } | { ok: false; allowedText: string; error: string };
+
+type SubagentAllowlistEnv = {
+  OPENCLAW_SPAWN_ALLOWLIST?: string;
+  SPAWN_ALLOWLIST?: string;
+};
+
+export function parseSubagentAllowlistEnv(raw: string | undefined): string[] | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        const normalized = normalizeStringEntries(parsed);
+        return normalized.length > 0 ? normalized : undefined;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+  const normalized = normalizeStringEntries(trimmed.split(","));
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function resolveConfiguredSubagentAllowAgents(params: {
+  agentAllowAgents?: readonly string[];
+  defaultAllowAgents?: readonly string[];
+  env?: SubagentAllowlistEnv;
+}): readonly string[] | undefined {
+  if (params.agentAllowAgents !== undefined) {
+    return params.agentAllowAgents;
+  }
+  if (params.defaultAllowAgents !== undefined) {
+    return params.defaultAllowAgents;
+  }
+  return (
+    parseSubagentAllowlistEnv(params.env?.OPENCLAW_SPAWN_ALLOWLIST) ??
+    parseSubagentAllowlistEnv(params.env?.SPAWN_ALLOWLIST)
+  );
+}
 
 function normalizeAllowAgents(allowAgents: readonly string[] | undefined): {
   configured: boolean;

--- a/src/agents/tools/agents-list-tool.test.ts
+++ b/src/agents/tools/agents-list-tool.test.ts
@@ -90,6 +90,27 @@ describe("agents_list tool", () => {
     expect(details.agents?.[0]?.configured).toBe(true);
   });
 
+  it("uses SPAWN_ALLOWLIST as the default allowed target set when config omits allowAgents", async () => {
+    vi.stubEnv("SPAWN_ALLOWLIST", "*");
+    loadConfigMock.mockReturnValue({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "codex" }],
+      },
+    } satisfies OpenClawConfig);
+
+    const { createAgentsListTool } = await import("./agents-list-tool.js");
+    const result = await createAgentsListTool({ agentSessionKey: "agent:main:main" }).execute(
+      "call",
+      {},
+    );
+
+    expect(result.details).toMatchObject({
+      requester: "main",
+      allowAny: true,
+      agents: [{ id: "main" }, { id: "codex" }],
+    });
+  });
+
   it("ignores legacy env-forced plugin runtime selections", async () => {
     vi.stubEnv("OPENCLAW_AGENT_RUNTIME", "codex");
     loadConfigMock.mockReturnValue({

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -8,7 +8,10 @@ import {
 import { resolveModelAgentRuntimeMetadata } from "../agent-runtime-metadata.js";
 import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "../agent-scope.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
-import { resolveSubagentAllowedTargetIds } from "../subagent-target-policy.js";
+import {
+  resolveConfiguredSubagentAllowAgents,
+  resolveSubagentAllowedTargetIds,
+} from "../subagent-target-policy.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
@@ -54,9 +57,11 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents =
-        resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
-        cfg?.agents?.defaults?.subagents?.allowAgents;
+      const allowAgents = resolveConfiguredSubagentAllowAgents({
+        agentAllowAgents: resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents,
+        defaultAllowAgents: cfg?.agents?.defaults?.subagents?.allowAgents,
+        env: process.env,
+      });
 
       const configuredAgents = Array.isArray(cfg.agents?.list) ? cfg.agents?.list : [];
       const configuredIds = configuredAgents.map((entry) => normalizeAgentId(entry.id));

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -23,6 +23,7 @@ import {
   isSystemdUnitActive,
   isSystemdUserServiceAvailable,
   parseSystemdShow,
+  readSystemdServiceRuntime,
   readSystemdServiceExecStart,
   restartSystemdService,
   resolveSystemdUserUnitPath,
@@ -466,6 +467,10 @@ describe("isNonFatalSystemdInstallProbeError", () => {
 });
 
 describe("systemd runtime parsing", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
   it("parses active state details", () => {
     const output = [
       "ActiveState=inactive",
@@ -494,6 +499,40 @@ describe("systemd runtime parsing", () => {
       activeState: "inactive",
       subState: "dead",
       execMainCode: "exited",
+    });
+  });
+
+  it("prefers is-active when show reports a stale failed state", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(
+          args,
+          "show",
+          GATEWAY_SERVICE,
+          "--no-page",
+          "--property",
+          "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",
+        );
+        cb(
+          null,
+          ["ActiveState=failed", "SubState=failed", "MainPID=42", "ExecMainStatus=0"].join("\n"),
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "is-active", "--quiet", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+
+    await expect(readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME })).resolves.toMatchObject({
+      status: "running",
+      state: "active",
+      pid: 42,
+      lastExitStatus: 0,
     });
   });
 });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -888,10 +888,12 @@ export async function readSystemdServiceRuntime(
   }
   const parsed = parseSystemdShow(res.stdout || "");
   const activeState = normalizeLowercaseStringOrEmpty(parsed.activeState);
-  const status = activeState === "active" ? "running" : activeState ? "stopped" : "unknown";
+  const activeByProbe =
+    activeState === "active" ? true : await isSystemdUnitActive(env, unitName).catch(() => false);
+  const status = activeByProbe ? "running" : activeState ? "stopped" : "unknown";
   return {
     status,
-    state: parsed.activeState,
+    state: activeByProbe ? "active" : parsed.activeState,
     subState: parsed.subState,
     pid: parsed.mainPid,
     lastExitStatus: parsed.execMainStatus,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2084,6 +2084,31 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(finalBroadcast).toBeUndefined();
   });
 
+  it("maps the agent runtime run id back to the chat.send client run", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-run-map-");
+    mockState.triggerAgentRunStart = true;
+    mockState.agentRunId = "agent-run-context-overflow";
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "client-run-context-overflow",
+      message: "hello from dashboard",
+      expectBroadcast: false,
+    });
+
+    expect(context.addChatRun).toHaveBeenCalledWith("client-run-context-overflow", {
+      sessionKey: "main",
+      clientRunId: "client-run-context-overflow",
+    });
+    expect(context.addChatRun).toHaveBeenCalledWith("agent-run-context-overflow", {
+      sessionKey: "main",
+      clientRunId: "client-run-context-overflow",
+    });
+  });
+
   it("does not emit pre-gate user transcript content when before_agent_run hooks are registered", async () => {
     createTranscriptFixture("openclaw-chat-send-user-transcript-before-run-gate-");
     mockState.finalText = "ok";

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2508,6 +2508,12 @@ export const chatHandlers: GatewayRequestHandlers = {
               fastModeOverride: p.fastMode,
               onAgentRunStart: (runId) => {
                 agentRunStarted = true;
+                if (runId !== clientRunId) {
+                  context.addChatRun(runId, {
+                    sessionKey,
+                    clientRunId,
+                  });
+                }
                 if (!hasBeforeAgentRunGate) {
                   void emitUserTranscriptUpdate();
                 }

--- a/src/shared/frontmatter.test.ts
+++ b/src/shared/frontmatter.test.ts
@@ -98,14 +98,19 @@ describe("shared/frontmatter", () => {
           bins: "bun, node",
           anyBins: [" ffmpeg ", ""],
           env: ["OPENCLAW_TOKEN", " OPENCLAW_URL "],
-          config: null,
+          config: [
+            " browser.enabled ",
+            { path: "skills.entries.example.enabled", access: "read", purpose: "status" },
+            { access: "read" },
+            42,
+          ],
         },
       }),
     ).toEqual({
       bins: ["bun", "node"],
       anyBins: ["ffmpeg"],
       env: ["OPENCLAW_TOKEN", "OPENCLAW_URL"],
-      config: [],
+      config: ["browser.enabled", "skills.entries.example.enabled", "42"],
     });
     expect(resolveOpenClawManifestRequires({})).toBeUndefined();
     expect(resolveOpenClawManifestOs({ os: [" darwin ", "linux", ""] })).toEqual([

--- a/src/shared/frontmatter.ts
+++ b/src/shared/frontmatter.ts
@@ -8,6 +8,19 @@ export function normalizeStringList(input: unknown): string[] {
   return normalizeCsvOrLooseStringList(input);
 }
 
+function normalizeConfigRequirementList(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return normalizeStringList(input);
+  }
+  return input.flatMap((entry) => {
+    if (entry && typeof entry === "object") {
+      const path = readStringValue((entry as Record<string, unknown>).path)?.trim();
+      return path ? [path] : [];
+    }
+    return normalizeStringList([entry]);
+  });
+}
+
 export function getFrontmatterString(
   frontmatter: Record<string, unknown>,
   key: string,
@@ -69,7 +82,7 @@ export function resolveOpenClawManifestRequires(
     bins: normalizeStringList(requiresRaw.bins),
     anyBins: normalizeStringList(requiresRaw.anyBins),
     env: normalizeStringList(requiresRaw.env),
-    config: normalizeStringList(requiresRaw.config),
+    config: normalizeConfigRequirementList(requiresRaw.config),
   };
 }
 


### PR DESCRIPTION
## Summary
- Fixes #79488 by normalizing object-shaped `metadata.openclaw.requires.config` entries through their `path` field so skill status/info no longer prints `[object Object]` or blocks valid documented requirements.
- Fixes #79490 by honoring `OPENCLAW_SPAWN_ALLOWLIST` / `SPAWN_ALLOWLIST` as fallback subagent target allowlists when config does not provide one.
- Fixes #79525 by mapping backend agent run ids back to originating WebChat client runs so context-overflow/error completions clear the active run and unblock Stop / queued `/new` lifecycle state.
- Fixes #79515 by preferring `systemctl is-active` when `systemctl show` reports a stale failed state for the Gateway user service.
- Rebased onto current `upstream/main` so the production dependency audit includes the `fast-uri` pin already present on main.

## Real behavior proof
- **Behavior or issue addressed:** Four user-facing regressions: skill config requirements rendered object metadata as `[object Object]`, subagent spawn env allowlists were ignored, WebChat run state could stay active after backend error/context-overflow completion, and `openclaw status` could report a systemd Gateway service failed even when `systemctl is-active` reported active.
- **Real environment tested:** Local Windows checkout at `705723b9d0` after rebasing onto `upstream/main`; Node v22.15.0 for repo test wrappers; WSL Ubuntu has systemd installed but no user bus and no Linux Node, so it could not provide honest live user-systemd proof on this host.
- **Exact steps or command run after this patch:** Ran the touched skill/subagent/chat/frontmatter tests in one grouped repo invocation, ran the focused systemd stale-state regression, ran production dependency audit, and ran the changed gate from the rebased branch.
- **Evidence after fix:** Copied terminal output summary from the final local run:
```text
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/skills.buildworkspaceskillstatus.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts src/agents/subagent-target-policy.test.ts src/agents/tools/agents-list-tool.test.ts src/shared/frontmatter.test.ts src/gateway/server-methods/chat.directive-tags.test.ts -- --reporter=verbose
[test] passed 3 Vitest shards in 84.38s
unit-fast: 17 passed
agents: 30 passed
gateway: 74 passed

OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/daemon/systemd.test.ts -t "prefers is-active" -- --reporter=verbose
✓ systemd runtime parsing > prefers is-active when show reports a stale failed state
Test Files 1 passed (1); Tests 1 passed | 60 skipped (61)

node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high
No high or higher advisories found for production dependencies.
```
- **Observed result after fix:** Object-shaped skill requirements normalize correctly, `SPAWN_ALLOWLIST` fallback allowlists are respected, chat final/error lifecycle maps the backend run id to the client run, and the systemd parser prefers active `is-active` output over stale failed `show` state. The dependency-audit failure from the old branch base is gone after rebase.
- **What was not tested:** A live Linux user-systemd `openclaw status` run could not be executed on this Windows host because WSL reports `systemctl --user` bus unavailable and has no Linux Node/pnpm. The full `src/daemon/systemd.test.ts` file also has unrelated Windows-only failures around `process.geteuid` and quoted Windows `EnvironmentFile` paths; the new stale-state regression passed in isolation.

## Verification
- `pnpm docs:list`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/gateway/config-tools.md docs/tools/creating-skills.md docs/tools/skills.md docs/tools/subagents.md src/agents/acp-spawn.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts src/agents/skills.buildworkspaceskillstatus.test.ts src/agents/subagent-spawn.ts src/agents/subagent-target-policy.test.ts src/agents/subagent-target-policy.ts src/agents/tools/agents-list-tool.test.ts src/agents/tools/agents-list-tool.ts src/daemon/systemd.test.ts src/daemon/systemd.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat.ts src/shared/frontmatter.test.ts src/shared/frontmatter.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/skills.buildworkspaceskillstatus.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts src/agents/subagent-target-policy.test.ts src/agents/tools/agents-list-tool.test.ts src/shared/frontmatter.test.ts src/gateway/server-methods/chat.directive-tags.test.ts -- --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/daemon/systemd.test.ts -t "prefers is-active" -- --reporter=verbose`
- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high`
- `pnpm check:changed --base upstream/main`
- `git diff --check upstream/main..HEAD`

Note: this shell's default Node is v22.15.0, so pnpm emitted the repo engine warning (`>=22.16.0` required); the commands above completed with that warning.