### PR TITLE
fix(acp): capture and persist usage_update tokens for ACP sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP/sessions: capture and persist numeric `usage_update` token snapshots from ACP turns so `openclaw sessions --json` reports numeric `totalTokens` instead of permanently `null` for ACP sessions, and budget/cost tracking is no longer inoperative for ACP. Thanks @efpiva.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -165,6 +165,12 @@ export type AcpReplyProjector = {
   flush: (force?: boolean) => Promise<void>;
 };
 
+export type AcpTokenUsage = {
+  used: number;
+  size: number;
+  total: number;
+};
+
 export function createAcpReplyProjector(params: {
   cfg: OpenClawConfig;
   shouldSendToolSummaries: boolean;
@@ -174,6 +180,7 @@ export function createAcpReplyProjector(params: {
     meta?: AcpProjectedDeliveryMeta,
   ) => Promise<boolean>;
   onProgress?: () => void;
+  onTokenUsage?: (usage: AcpTokenUsage) => void | Promise<void>;
   provider?: string;
   accountId?: string;
 }): AcpReplyProjector {
@@ -465,6 +472,14 @@ export function createAcpReplyProjector(params: {
     }
 
     if (event.type === "status") {
+      if (
+        event.tag === "usage_update" &&
+        typeof event.used === "number" &&
+        typeof event.size === "number" &&
+        params.onTokenUsage
+      ) {
+        await params.onTokenUsage({ used: event.used, size: event.size, total: event.used });
+      }
       if (!isAcpTagVisible(settings, event.tag)) {
         return;
       }

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -478,6 +478,7 @@ export function createAcpReplyProjector(params: {
         typeof event.size === "number" &&
         params.onTokenUsage
       ) {
+        // Fire BEFORE the display dedupe/visibility gate so persistence always receives the latest values regardless of repeat-suppression.
         await params.onTokenUsage({ used: event.used, size: event.size, total: event.used });
       }
       if (!isAcpTagVisible(settings, event.tag)) {

--- a/src/auto-reply/reply/acp-projector.usage-update-tokens.test.ts
+++ b/src/auto-reply/reply/acp-projector.usage-update-tokens.test.ts
@@ -34,33 +34,11 @@ import { createAcpTestConfig as createCfg } from "./test-fixtures/acp-runtime.js
  * after the fix.
  */
 
-/**
- * Future-shape of the projector params with the `onTokenUsage` callback the
- * fix will add. Defined locally so the test compiles today without modifying
- * production code. After the fix lands, this `type` can be removed and the
- * test can call `createAcpReplyProjector` directly with `onTokenUsage`.
- */
 type AcpTokenUsage = {
   used: number;
   size: number;
   total: number;
 };
-
-type AcpProjectorParamsWithUsage = Parameters<typeof createAcpReplyProjector>[0] & {
-  onTokenUsage?: (usage: AcpTokenUsage) => void | Promise<void>;
-};
-
-type CreateAcpProjectorWithUsage = (
-  params: AcpProjectorParamsWithUsage,
-) => ReturnType<typeof createAcpReplyProjector>;
-
-/**
- * Cast the production factory through the future-shape param type. The runtime
- * value is unchanged — this is purely a compile-time shim so we can pass
- * `onTokenUsage` without `any` and without editing production code.
- */
-const createProjector: CreateAcpProjectorWithUsage =
-  createAcpReplyProjector as unknown as CreateAcpProjectorWithUsage;
 
 type Delivery = { kind: string; text?: string };
 
@@ -69,7 +47,7 @@ function createHarness(params?: {
   onTokenUsage?: (usage: AcpTokenUsage) => void | Promise<void>;
 }) {
   const deliveries: Delivery[] = [];
-  const projector = createProjector({
+  const projector = createAcpReplyProjector({
     cfg: createCfg(params?.cfgOverrides),
     shouldSendToolSummaries: true,
     deliver: async (kind, payload) => {

--- a/src/auto-reply/reply/acp-projector.usage-update-tokens.test.ts
+++ b/src/auto-reply/reply/acp-projector.usage-update-tokens.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAcpReplyProjector } from "./acp-projector.js";
+import { createAcpTestConfig as createCfg } from "./test-fixtures/acp-runtime.js";
+
+/**
+ * RED-LIGHT TDD spec for catalog finding #21:
+ *   "totalTokens always null (totalTokensFresh: false) for ACP sessions".
+ *
+ * Symptom on main today:
+ *   - Wire probe shows ACP sessionUpdates carry numeric `used` / `size` fields
+ *     on `usage_update` events.
+ *   - `acp-projector.ts` lines 462-474 extract those numbers ONLY for
+ *     repeat-suppression hashing — they are not surfaced or persisted.
+ *   - The acpx session record's `cumulative_token_usage` stays `{}`, and the
+ *     listing's `resolveSessionTotalTokens(...)` falls back to `null`.
+ *
+ * Recommended fix shape (this spec assumes it):
+ *   - `createAcpReplyProjector` accepts a new optional callback,
+ *     `onTokenUsage?: (usage: { used: number; size: number; total: number })
+ *      => void | Promise<void>`.
+ *   - On every `status` event with `tag: "usage_update"` that carries numeric
+ *     `used` / `size`, the projector calls `onTokenUsage` with the structured
+ *     usage. `total` is the cumulative tokens used (= `used`); `size` is the
+ *     advertised context window. Repeat-suppression for display still applies,
+ *     but the structured callback fires regardless of dedupe state because
+ *     persistence wants the latest known usage on every turn end.
+ *   - The fix surface around this seam (NOT covered here, owner of the next
+ *     test): `dispatch-acp.ts` will pass `onTokenUsage` so the dispatcher can
+ *     persist the numbers into the acpx session record's
+ *     `cumulative_token_usage` field, and `resolveSessionTotalTokens` falls
+ *     back to that field when entry-level `totalTokens` is null.
+ *
+ * Each `it` below states explicitly why it is RED today and why it should pass
+ * after the fix.
+ */
+
+/**
+ * Future-shape of the projector params with the `onTokenUsage` callback the
+ * fix will add. Defined locally so the test compiles today without modifying
+ * production code. After the fix lands, this `type` can be removed and the
+ * test can call `createAcpReplyProjector` directly with `onTokenUsage`.
+ */
+type AcpTokenUsage = {
+  used: number;
+  size: number;
+  total: number;
+};
+
+type AcpProjectorParamsWithUsage = Parameters<typeof createAcpReplyProjector>[0] & {
+  onTokenUsage?: (usage: AcpTokenUsage) => void | Promise<void>;
+};
+
+type CreateAcpProjectorWithUsage = (
+  params: AcpProjectorParamsWithUsage,
+) => ReturnType<typeof createAcpReplyProjector>;
+
+/**
+ * Cast the production factory through the future-shape param type. The runtime
+ * value is unchanged — this is purely a compile-time shim so we can pass
+ * `onTokenUsage` without `any` and without editing production code.
+ */
+const createProjector: CreateAcpProjectorWithUsage =
+  createAcpReplyProjector as unknown as CreateAcpProjectorWithUsage;
+
+type Delivery = { kind: string; text?: string };
+
+function createHarness(params?: {
+  cfgOverrides?: Parameters<typeof createCfg>[0];
+  onTokenUsage?: (usage: AcpTokenUsage) => void | Promise<void>;
+}) {
+  const deliveries: Delivery[] = [];
+  const projector = createProjector({
+    cfg: createCfg(params?.cfgOverrides),
+    shouldSendToolSummaries: true,
+    deliver: async (kind, payload) => {
+      deliveries.push({ kind, text: payload.text });
+      return true;
+    },
+    onTokenUsage: params?.onTokenUsage,
+  });
+  return { deliveries, projector };
+}
+
+describe("createAcpReplyProjector — usage_update token capture (catalog #21)", () => {
+  // RED today: production projector does not accept `onTokenUsage`, and even
+  // if it did the `usage_update` handler at acp-projector.ts:462-474 only
+  // hashes `used`/`size` for dedupe — it never invokes any structured callback.
+  //
+  // Expected GREEN after fix: the projector exposes the captured numeric token
+  // usage through the `onTokenUsage` callback exactly once, with the right
+  // shape, on a single `usage_update` event carrying `used`/`size`.
+  it("RED: surfaces structured token data from usage_update via onTokenUsage", async () => {
+    const onTokenUsage = vi.fn<(usage: AcpTokenUsage) => void>();
+    const { projector } = createHarness({ onTokenUsage });
+
+    await projector.onEvent({
+      type: "status",
+      text: "usage updated: 1500/4096",
+      tag: "usage_update",
+      used: 1500,
+      size: 4096,
+    });
+    await projector.flush(true);
+
+    expect(
+      onTokenUsage,
+      "Projector dropped numeric used/size from usage_update — see acp-projector.ts:462-474. " +
+        "Fix should call onTokenUsage with the parsed numbers so the dispatcher can " +
+        "persist them into the acpx record's cumulative_token_usage.",
+    ).toHaveBeenCalledTimes(1);
+    expect(onTokenUsage).toHaveBeenCalledWith({
+      used: 1500,
+      size: 4096,
+      total: 1500,
+    });
+  });
+
+  // RED today: same root cause as above. This scenario simulates the real
+  // dispatcher integration shape — the dispatcher would capture token usage
+  // into a record-shaped object on each turn end, then write it through to the
+  // acpx session record.
+  //
+  // We model the persistence target as a local `acpxRecord` whose
+  // `cumulative_token_usage.total` should reflect the most recent usage_update.
+  // Today nothing wires usage data into it. After the fix, the projector's
+  // `onTokenUsage` callback feeds the shape directly into the persistence
+  // bucket, mirroring how the dispatcher fix will write the acpx record.
+  //
+  // Expected GREEN after fix: `acpxRecord.cumulative_token_usage.total === 1500`.
+  it("RED (fix-shape): persistence bucket receives cumulative_token_usage on turn end", async () => {
+    type AcpxRecordShape = {
+      cumulative_token_usage: { total?: number; size?: number };
+    };
+    const acpxRecord: AcpxRecordShape = { cumulative_token_usage: {} };
+
+    const onTokenUsage = (usage: AcpTokenUsage) => {
+      acpxRecord.cumulative_token_usage = {
+        total: usage.total,
+        size: usage.size,
+      };
+    };
+    const { projector } = createHarness({ onTokenUsage });
+
+    await projector.onEvent({
+      type: "status",
+      text: "usage updated: 1500/4096",
+      tag: "usage_update",
+      used: 1500,
+      size: 4096,
+    });
+    await projector.onEvent({ type: "done", stopReason: "end_turn" });
+
+    expect(
+      acpxRecord.cumulative_token_usage.total,
+      "acpx record's cumulative_token_usage.total stayed unset because the projector " +
+        "never invoked onTokenUsage. Fix shape: projector calls onTokenUsage with parsed " +
+        "{ used, size, total }, dispatch-acp.ts persists into SessionAcpMeta and writes the " +
+        "acpx record on turn-end.",
+    ).toBe(1500);
+    expect(acpxRecord.cumulative_token_usage.size).toBe(4096);
+  });
+
+  // GREEN control: tool_call events have nothing to do with usage. The
+  // callback must NOT fire. This proves the test is sharp — failures of the
+  // RED tests cannot be explained by the callback being trigger-happy.
+  //
+  // GREEN today AND GREEN after fix: the projector should never invoke
+  // `onTokenUsage` for non-usage events. Today the callback isn't even
+  // accepted, so it never fires; after the fix, the callback is plumbed only
+  // for `usage_update`-tagged status events with numeric used/size.
+  it("GREEN control: tool_call event does NOT invoke onTokenUsage", async () => {
+    const onTokenUsage = vi.fn<(usage: AcpTokenUsage) => void>();
+    const { projector } = createHarness({
+      cfgOverrides: {
+        acp: {
+          enabled: true,
+          stream: {
+            coalesceIdleMs: 0,
+            maxChunkChars: 256,
+            deliveryMode: "live",
+            tagVisibility: { tool_call: true },
+          },
+        },
+      } as Parameters<typeof createCfg>[0],
+      onTokenUsage,
+    });
+
+    await projector.onEvent({
+      type: "tool_call",
+      tag: "tool_call",
+      toolCallId: "call_no_usage",
+      status: "in_progress",
+      title: "Run command",
+      text: "Run command (in_progress)",
+    });
+    await projector.onEvent({ type: "done", stopReason: "end_turn" });
+
+    expect(
+      onTokenUsage,
+      "tool_call must not trigger token-usage capture — only usage_update with numeric " +
+        "used/size should. If this fires, the fix's tag check is too broad.",
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -425,7 +425,7 @@ export async function tryDispatchAcpReply(params: {
     deliver: delivery.deliver,
     onProgress: markAcpProgress,
     onTokenUsage: (usage) => {
-      void persistSessionUsageUpdate({
+      return persistSessionUsageUpdate({
         storePath: acpSessionStorePath,
         sessionKey: canonicalSessionKey,
         cfg: params.cfg,

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -7,6 +7,7 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -39,6 +40,7 @@ import {
 } from "./dispatch-acp-delivery.js";
 import { hasInboundMedia } from "./inbound-media.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
+import { persistSessionUsageUpdate } from "./session-usage.js";
 
 const dispatchAcpManagerRuntimeLoader = createLazyImportLoader(
   () => import("./dispatch-acp-manager.runtime.js"),
@@ -414,11 +416,25 @@ export async function tryDispatchAcpReply(params: {
       : dispatchChannels?.[normalizedDispatchChannel]?.defaultAccount;
   const effectiveDispatchAccountId =
     explicitDispatchAccountId ?? normalizeOptionalString(defaultDispatchAccount);
+  const acpSessionStorePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: acpAgentId,
+  });
   const projector = createAcpReplyProjector({
     cfg: params.cfg,
     shouldSendToolSummaries: params.shouldSendToolSummaries,
     deliver: delivery.deliver,
     onProgress: markAcpProgress,
+    onTokenUsage: (usage) => {
+      void persistSessionUsageUpdate({
+        storePath: acpSessionStorePath,
+        sessionKey: canonicalSessionKey,
+        cfg: params.cfg,
+        usage: { input: usage.used, output: 0 },
+        usageIsContextSnapshot: true,
+        contextTokensUsed: usage.size,
+        logLabel: "acp-token-usage",
+      });
+    },
     provider: params.ctx.Surface ?? params.ctx.Provider,
     accountId: effectiveDispatchAccountId,
   });


### PR DESCRIPTION
## Summary

Plumb token usage from ACP `usage_update` events into the openclaw session record so `totalTokens` is no longer permanently `null` for ACP sessions. Closes catalog #21.

## Bug detail

Every ACP session in the listing reported `totalTokens: null`, `totalTokensFresh: false`, regardless of how many turns it had run. The acpx session record carried `cumulative_token_usage: {}` and `request_token_usage: {}` (empty), confirming token usage was never being persisted from the copilot ACP runtime into the openclaw session entry. Token-cost tracking and budget guards were inoperative for any ACP session.

## How to reproduce

Live repro before fix:

\`\`\`bash
docker compose exec codeclaw-openclaw openclaw sessions --all-agents --json \
  | jq '.sessions[] | select(.key | contains("acp:")) | {key, totalTokens, totalTokensFresh}'
# Before: all ACP sessions show "totalTokens": null, "totalTokensFresh": false
# After: ACP sessions that completed a turn show numeric totalTokens
\`\`\`

Unit-level repro:

\`\`\`bash
git checkout 5e083f0510            # red-test cherry-pick
pnpm test src/auto-reply/reply/acp-projector.usage-update-tokens.test.ts
# Before fix: 2 RED (callback never fires; persistence bucket stays unset)
# After fix commit d292fa7199: all 3 GREEN
\`\`\`

## Root cause

`src/auto-reply/reply/acp-projector.ts:462-474` consumed `usage_update` events for **display only** (`emitSystemStatus(event.text, ...)`). Numeric `event.used` / `event.size` were extracted just for repeat-suppression hashing — never persisted. There was no callback or write path from the projector back to the session record. `resolveSessionTotalTokens` (`src/config/sessions/types.ts:506-514`) reads `entry?.totalTokens` which therefore stayed `null`.

## Fix approach

Catalog Option 1 — write entry-level `totalTokens` via the existing `persistSessionUsageUpdate` helper. No new schema fields:

1. Added optional `onTokenUsage?: (usage: AcpTokenUsage) => void | Promise<void>` parameter to `createAcpReplyProjector`. Existing callers compile unchanged.
2. The projector fires `onTokenUsage({ used, size, total: used })` BEFORE the display dedupe/visibility gate, so persistence always receives the latest values regardless of repeat-suppression. Guarded by `event.tag === "usage_update" && typeof event.used === "number" && typeof event.size === "number"` — text-only `usage_update` events do not trigger the callback.
3. `dispatch-acp.ts` wires the callback to call `persistSessionUsageUpdate({ usage: { input: usage.used, output: 0 }, usageIsContextSnapshot: true, contextTokensUsed: usage.size })`. Because `usageIsContextSnapshot: true`, `deriveSessionTotalTokens` writes the captured value to `entry.totalTokens` — the exact field `resolveSessionTotalTokens` already reads.
4. ACP `usage_update` events do not separate input from output, so all tokens are lumped into `input` (with `output: 0`). The `usageIsContextSnapshot` semantics treat this as a context snapshot rather than incremental usage.

## Tests

- **Red test (now GREEN):** `src/auto-reply/reply/acp-projector.usage-update-tokens.test.ts` — 3 cases: 2 formerly-red flip GREEN, 1 GREEN control stays GREEN.
- **Adjacent suite:** `src/auto-reply/reply/` — 1538 pass / 0 fail / 115 files. No regressions.
- **Cleanup commit (`1ba8b529a5`):** removed dead pre-fix shim from the test file and added a one-line WHY comment at the projector's `onTokenUsage` call site.

## Catalog reference

Catalog finding: #21. Investigation lives in branch `edpiva/acp-native-session-investigation` (not yet upstream) at `docs/plans/2026-05-08-acp-findings-catalog.md`.

## Verification commands

\`\`\`bash
pnpm test src/auto-reply/reply/acp-projector.usage-update-tokens.test.ts   # 3/3 GREEN
pnpm test src/auto-reply/reply/                                            # 1538/0
\`\`\`

## Notes for reviewers

- ACP doesn't separate input/output token counts, so the persisted value lumps everything into `input` with `output: 0`. This matches what the catalog finding flagged as the trade-off for option 1; if you'd prefer extending `SessionAcpMeta` with explicit fields instead, I can switch (option 2 in the catalog).
- The optional callback parameter is intentionally additive — no breaking change to existing projector callers.
- `resolveSessionTotalTokens` was reached without modification: option 1 writes `entry.totalTokens` and the existing reader handles it.

---

## Live behavior repro (deployed container)

**Container:** `codeclaw-openclaw:clean` running OpenClaw 2026.5.6 (`e9d4a0a`)

### `totalTokens` permanently `null` for every ACP session

```
$ docker exec codeclaw-openclaw openclaw sessions --all-agents --json \
    | jq -c '.sessions[] | select(.key | startswith("agent:copilot:acp:")) | {key, totalTokens, totalTokensFresh}'

{"key":"agent:copilot:acp:86b7b5af-…","totalTokens":null,"totalTokensFresh":false}
{"key":"agent:copilot:acp:d6fb7506-…","totalTokens":null,"totalTokensFresh":false}
{"key":"agent:copilot:acp:f5ab8dba-…","totalTokens":null,"totalTokensFresh":false}
{"key":"agent:copilot:acp:1f854fa2-…","totalTokens":null,"totalTokensFresh":false}
{"key":"agent:copilot:acp:930316f7-…","totalTokens":null,"totalTokensFresh":false}
{"key":"agent:copilot:acp:63867cf7-…","totalTokens":null,"totalTokensFresh":false}
{"key":"agent:copilot:acp:8fb42bab-…","totalTokens":null,"totalTokensFresh":false}
```

7/7 ACP sessions report `null` even after multiple turns. The acpx record carries `cumulative_token_usage: {}` and `request_token_usage: {}` (empty) — token usage was never plumbed from the copilot ACP runtime into the openclaw entry. Token-cost tracking and budget guards were inoperative for any ACP session.

After this PR (fix commit `d292fa7199`), the projector fires `onTokenUsage` whenever a `usage_update` event lands with numeric `used`/`size`, which triggers `persistSessionUsageUpdate` → `entry.totalTokens` is populated and `resolveSessionTotalTokens` returns the correct value.
