### PR TITLE
feat(acp): add sessions link helper for operator diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Sessions/ACP: add `openclaw sessions link` — a read-only diagnostic command that prints the OpenClaw session-store key, ACP/copilot-side session id, resolved copilot state path, and a `ok`/`MISSING_STATE_DIR`/`MISSING_ACP_ID` status flag for every discovered ACP session. Supports `--agent <id>` to scope output to one agent, `--store <path>` for custom store paths, and `--json` for machine-readable output. (#79542)
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.
 - Telegram/Feishu: honor configured per-agent and global `reasoningDefault` values when deciding whether channel reasoning previews should stream or stay hidden, addressing the preview-default part of #73182. Thanks @anagnorisis2peripeteia.
 - Docker: run the runtime image under `tini` so long-lived containers reap orphaned child processes and forward signals correctly. (#77885) Thanks @VintageAyu.

--- a/docs/plugins/reference/acpx.md
+++ b/docs/plugins/reference/acpx.md
@@ -18,6 +18,32 @@ Embedded ACP runtime backend with plugin-owned session and transport management.
 
 skills
 
+## Session ID join model
+
+ACP sessions have two distinct identifiers that refer to the same session:
+
+- **OpenClaw side:** the session-store key (for example `agent:copilot:acp:<uuid>`), used as the key in the sessions store (`~/.openclaw/agents/<agentId>/sessions/sessions.json`).
+- **Backend/copilot side:** the `acpxSessionId` stored in `entry.acp.identity.acpxSessionId` inside the session record.
+
+The copilot-side state directory lives at `~/.copilot/session-state/<acpxSessionId>/`.
+
+To print the full triple for every ACP session and check whether the copilot state directories exist on disk, run:
+
+```bash
+openclaw sessions link
+```
+
+Output columns (TSV, one row per ACP session):
+
+| Column               | Description                                    |
+| -------------------- | ---------------------------------------------- |
+| `openclaw-key`       | OpenClaw session-store key                     |
+| `acp-session-id`     | ACP/copilot-side session id (`acpxSessionId`)  |
+| `copilot-state-path` | Resolved `~/.copilot/session-state/<id>/` path |
+| `status`             | `ok`, `MISSING_STATE_DIR`, or `MISSING_ACP_ID` |
+
+Use `--json` for machine-readable output. `MISSING_STATE_DIR` means the OpenClaw session record has an `acpxSessionId` but the copilot state directory does not exist. `MISSING_ACP_ID` means the session has ACP metadata but no `acpxSessionId` has been resolved yet (identity still pending).
+
 ## Related docs
 
 - [acpx](/tools/acp-agents-setup)

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { acpSessionsLinkCommand } from "../../commands/acp-sessions-link.js";
 import { commitmentsDismissCommand, commitmentsListCommand } from "../../commands/commitments.js";
 import { exportTrajectoryCommand } from "../../commands/export-trajectory.js";
 import { flowsCancelCommand, flowsListCommand, flowsShowCommand } from "../../commands/flows.js";
@@ -231,6 +232,41 @@ export function registerStatusHealthSessionsCommands(program: Command) {
             fixMissing: Boolean(opts.fixMissing),
             fixDmScope: Boolean(opts.fixDmScope),
             activeKey: opts.activeKey as string | undefined,
+            json: Boolean(opts.json || parentOpts?.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  sessionsCmd
+    .command("link")
+    .description("Print the session-id triple (openclaw key, acp-session-id, copilot state path)")
+    .option("--store <path>", "Path to session store (default: resolved from config)")
+    .option("--agent <id>", "Agent id to inspect (default: all agents)")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw sessions link", "Print ACP session-id triples for all agents."],
+          ["openclaw sessions link --json", "Machine-readable output."],
+          ["openclaw sessions link --store ./tmp/sessions.json", "Use a specific store."],
+        ])}`,
+    )
+    .action(async (opts, command) => {
+      const parentOpts = command.parent?.opts() as
+        | {
+            store?: string;
+            agent?: string;
+            json?: boolean;
+          }
+        | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await acpSessionsLinkCommand(
+          {
+            store: (opts.store as string | undefined) ?? parentOpts?.store,
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
             json: Boolean(opts.json || parentOpts?.json),
           },
           defaultRuntime,

--- a/src/commands/acp-sessions-link.test.ts
+++ b/src/commands/acp-sessions-link.test.ts
@@ -1,0 +1,388 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  acpSessionsLinkCommand,
+  buildAcpSessionLinkRows,
+  type AcpSessionLinkRow,
+} from "./acp-sessions-link.js";
+
+// Disable colors for deterministic output.
+process.env.FORCE_COLOR = "0";
+
+// ---------------------------------------------------------------------------
+// Config mock — same pattern as sessions.test-helpers.ts
+// ---------------------------------------------------------------------------
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: () => ({
+    agents: {
+      defaults: {
+        model: { primary: "pi:opus" },
+        models: { "pi:opus": {} },
+      },
+    },
+  }),
+  loadConfig: () => ({
+    agents: {
+      defaults: {
+        model: { primary: "pi:opus" },
+        models: { "pi:opus": {} },
+      },
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRuntime(): { runtime: RuntimeEnv; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    runtime: {
+      log: (msg: unknown) => logs.push(String(msg)),
+      error: (msg: unknown) => errors.push(String(msg)),
+      exit: (code: number) => {
+        throw new Error(`exit ${code}`);
+      },
+    },
+    logs,
+    errors,
+  };
+}
+
+function writeTempStore(data: Record<string, unknown>): string {
+  const file = path.join(
+    os.tmpdir(),
+    `acp-sessions-link-test-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+  return file;
+}
+
+const BASE_ACP_ENTRY = {
+  sessionId: "some-session-id",
+  updatedAt: Date.now(),
+  acp: {
+    backend: "acpx",
+    agent: "copilot",
+    runtimeSessionName: "agent:copilot:acp:test-uuid",
+    mode: "oneshot",
+    state: "idle",
+    lastActivityAt: Date.now(),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// buildAcpSessionLinkRows unit tests
+// ---------------------------------------------------------------------------
+
+describe("buildAcpSessionLinkRows", () => {
+  let tmpStore: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "acp-link-home-"));
+  });
+
+  afterEach(() => {
+    if (tmpStore) {
+      try {
+        fs.rmSync(tmpStore, { force: true });
+      } catch {}
+    }
+    try {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("returns an empty array when the store has no ACP sessions", () => {
+    tmpStore = writeTempStore({
+      "+15555550123": {
+        sessionId: "non-acp",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const rows = buildAcpSessionLinkRows([{ storePath: tmpStore }], fakeHome);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("happy path: emits full triple when acpxSessionId is present and state dir exists", () => {
+    const acpSessionId = "acp-session-abc-123";
+    const stateDir = path.join(fakeHome, ".copilot", "session-state", acpSessionId);
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    tmpStore = writeTempStore({
+      "agent:copilot:acp:test-uuid": {
+        ...BASE_ACP_ENTRY,
+        acp: {
+          ...BASE_ACP_ENTRY.acp,
+          identity: {
+            state: "resolved",
+            acpxSessionId: acpSessionId,
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const rows = buildAcpSessionLinkRows([{ storePath: tmpStore }], fakeHome);
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row?.openclawKey).toBe("agent:copilot:acp:test-uuid");
+    expect(row?.acpSessionId).toBe(acpSessionId);
+    expect(row?.copilotStatePath).toBe(stateDir);
+    expect(row?.copilotStateExists).toBe(true);
+  });
+
+  it("missing state: copilotStateExists is false when copilot state dir does not exist", () => {
+    const acpSessionId = "acp-session-xyz-missing";
+    // Do NOT create the state dir.
+
+    tmpStore = writeTempStore({
+      "agent:copilot:acp:missing-uuid": {
+        ...BASE_ACP_ENTRY,
+        acp: {
+          ...BASE_ACP_ENTRY.acp,
+          identity: {
+            state: "resolved",
+            acpxSessionId: acpSessionId,
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const rows = buildAcpSessionLinkRows([{ storePath: tmpStore }], fakeHome);
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row?.openclawKey).toBe("agent:copilot:acp:missing-uuid");
+    expect(row?.acpSessionId).toBe(acpSessionId);
+    expect(row?.copilotStatePath).toBe(
+      path.join(fakeHome, ".copilot", "session-state", acpSessionId),
+    );
+    expect(row?.copilotStateExists).toBe(false);
+  });
+
+  it("no acpxSessionId: acpSessionId is null and state fields are null/false", () => {
+    tmpStore = writeTempStore({
+      "agent:copilot:acp:no-id": {
+        ...BASE_ACP_ENTRY,
+        // No identity sub-object at all.
+      },
+    });
+
+    const rows = buildAcpSessionLinkRows([{ storePath: tmpStore }], fakeHome);
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row?.openclawKey).toBe("agent:copilot:acp:no-id");
+    expect(row?.acpSessionId).toBeNull();
+    expect(row?.copilotStatePath).toBeNull();
+    expect(row?.copilotStateExists).toBe(false);
+  });
+
+  it("skips entries without acp metadata", () => {
+    tmpStore = writeTempStore({
+      "agent:copilot:acp:with-acp": {
+        ...BASE_ACP_ENTRY,
+        acp: {
+          ...BASE_ACP_ENTRY.acp,
+          identity: {
+            state: "resolved",
+            acpxSessionId: "some-id",
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+        },
+      },
+      "agent:main:main": {
+        sessionId: "no-acp",
+        updatedAt: Date.now(),
+        // no acp field
+      },
+    });
+
+    const rows = buildAcpSessionLinkRows([{ storePath: tmpStore }], fakeHome);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.openclawKey).toBe("agent:copilot:acp:with-acp");
+  });
+
+  it("gracefully handles a missing or unreadable store file", () => {
+    const missingStore = path.join(
+      os.tmpdir(),
+      `non-existent-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    const rows = buildAcpSessionLinkRows([{ storePath: missingStore }], fakeHome);
+    expect(rows).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// acpSessionsLinkCommand integration tests
+// ---------------------------------------------------------------------------
+
+describe("acpSessionsLinkCommand", () => {
+  let fakeHome: string;
+
+  beforeEach(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "acp-link-cmd-home-"));
+    vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    try {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("prints TSV header + row for a session with full triple (happy path)", async () => {
+    const acpSessionId = "acp-cmd-test-123";
+    const stateDir = path.join(fakeHome, ".copilot", "session-state", acpSessionId);
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const storePath = writeTempStore({
+      "agent:copilot:acp:cmd-test": {
+        ...BASE_ACP_ENTRY,
+        acp: {
+          ...BASE_ACP_ENTRY.acp,
+          identity: {
+            state: "resolved",
+            acpxSessionId: acpSessionId,
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    try {
+      await acpSessionsLinkCommand({ store: storePath }, runtime);
+    } finally {
+      fs.rmSync(storePath, { force: true });
+    }
+
+    expect(logs[0]).toContain("openclaw-key");
+    expect(logs[0]).toContain("acp-session-id");
+    expect(logs[0]).toContain("copilot-state-path");
+    expect(logs[0]).toContain("status");
+
+    const dataRow = logs[1] ?? "";
+    expect(dataRow).toContain("agent:copilot:acp:cmd-test");
+    expect(dataRow).toContain(acpSessionId);
+    expect(dataRow).toContain(stateDir);
+    expect(dataRow).toContain("ok");
+  });
+
+  it("flags MISSING_STATE_DIR when copilot state dir is absent", async () => {
+    const acpSessionId = "acp-cmd-missing-999";
+    // Do NOT create the state directory.
+
+    const storePath = writeTempStore({
+      "agent:copilot:acp:missing-state": {
+        ...BASE_ACP_ENTRY,
+        acp: {
+          ...BASE_ACP_ENTRY.acp,
+          identity: {
+            state: "resolved",
+            acpxSessionId: acpSessionId,
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    try {
+      await acpSessionsLinkCommand({ store: storePath }, runtime);
+    } finally {
+      fs.rmSync(storePath, { force: true });
+    }
+
+    const dataRow = logs.find((l) => l.includes("agent:copilot:acp:missing-state")) ?? "";
+    expect(dataRow).toContain(acpSessionId);
+    expect(dataRow).toContain("MISSING_STATE_DIR");
+  });
+
+  it("flags MISSING_ACP_ID when no acpxSessionId is present", async () => {
+    const storePath = writeTempStore({
+      "agent:copilot:acp:no-id": BASE_ACP_ENTRY,
+    });
+
+    const { runtime, logs } = makeRuntime();
+    try {
+      await acpSessionsLinkCommand({ store: storePath }, runtime);
+    } finally {
+      fs.rmSync(storePath, { force: true });
+    }
+
+    const dataRow = logs.find((l) => l.includes("agent:copilot:acp:no-id")) ?? "";
+    expect(dataRow).toContain("MISSING_ACP_ID");
+  });
+
+  it("outputs JSON when --json is passed", async () => {
+    const acpSessionId = "acp-json-test";
+    const stateDir = path.join(fakeHome, ".copilot", "session-state", acpSessionId);
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const storePath = writeTempStore({
+      "agent:copilot:acp:json-test": {
+        ...BASE_ACP_ENTRY,
+        acp: {
+          ...BASE_ACP_ENTRY.acp,
+          identity: {
+            state: "resolved",
+            acpxSessionId: acpSessionId,
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    try {
+      await acpSessionsLinkCommand({ store: storePath, json: true }, runtime);
+    } finally {
+      fs.rmSync(storePath, { force: true });
+    }
+
+    const parsed = JSON.parse(logs[0] ?? "{}") as {
+      count: number;
+      sessions: AcpSessionLinkRow[];
+    };
+    expect(parsed.count).toBe(1);
+    expect(parsed.sessions).toHaveLength(1);
+    const row = parsed.sessions[0];
+    expect(row?.openclawKey).toBe("agent:copilot:acp:json-test");
+    expect(row?.acpSessionId).toBe(acpSessionId);
+    expect(row?.copilotStateExists).toBe(true);
+  });
+
+  it("prints no-sessions message when store is empty or has no ACP entries", async () => {
+    const storePath = writeTempStore({
+      "+15555550123": { sessionId: "non-acp", updatedAt: Date.now() },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    try {
+      await acpSessionsLinkCommand({ store: storePath }, runtime);
+    } finally {
+      fs.rmSync(storePath, { force: true });
+    }
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("No ACP sessions found");
+  });
+});

--- a/src/commands/acp-sessions-link.test.ts
+++ b/src/commands/acp-sessions-link.test.ts
@@ -13,6 +13,19 @@ import {
 process.env.FORCE_COLOR = "0";
 
 // ---------------------------------------------------------------------------
+// Hoisted mocks for resolver routing tests
+// ---------------------------------------------------------------------------
+const targetsMocks = vi.hoisted(() => ({
+  resolveAgentSessionStoreTargetsSync: vi.fn<[], []>().mockReturnValue([]),
+  resolveAllAgentSessionStoreTargetsSync: vi.fn<[], []>().mockReturnValue([]),
+}));
+
+vi.mock("../config/sessions/targets.js", () => ({
+  resolveAgentSessionStoreTargetsSync: targetsMocks.resolveAgentSessionStoreTargetsSync,
+  resolveAllAgentSessionStoreTargetsSync: targetsMocks.resolveAllAgentSessionStoreTargetsSync,
+}));
+
+// ---------------------------------------------------------------------------
 // Config mock — same pattern as sessions.test-helpers.ts
 // ---------------------------------------------------------------------------
 vi.mock("../config/config.js", () => ({
@@ -384,5 +397,36 @@ describe("acpSessionsLinkCommand", () => {
 
     expect(logs).toHaveLength(1);
     expect(logs[0]).toContain("No ACP sessions found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agent filter routing — verify --agent uses the scoped resolver, not all-agents
+// ---------------------------------------------------------------------------
+
+describe("acpSessionsLinkCommand agent filter routing", () => {
+  beforeEach(() => {
+    targetsMocks.resolveAgentSessionStoreTargetsSync.mockClear();
+    targetsMocks.resolveAllAgentSessionStoreTargetsSync.mockClear();
+  });
+
+  it("calls the scoped resolver when --agent is set (no --store)", async () => {
+    const { runtime } = makeRuntime();
+    await acpSessionsLinkCommand({ agent: "copilot" }, runtime);
+
+    expect(targetsMocks.resolveAgentSessionStoreTargetsSync).toHaveBeenCalledOnce();
+    expect(targetsMocks.resolveAgentSessionStoreTargetsSync).toHaveBeenCalledWith(
+      expect.anything(),
+      "copilot",
+    );
+    expect(targetsMocks.resolveAllAgentSessionStoreTargetsSync).not.toHaveBeenCalled();
+  });
+
+  it("calls the all-agents resolver when --agent is absent (no --store)", async () => {
+    const { runtime } = makeRuntime();
+    await acpSessionsLinkCommand({}, runtime);
+
+    expect(targetsMocks.resolveAllAgentSessionStoreTargetsSync).toHaveBeenCalledOnce();
+    expect(targetsMocks.resolveAgentSessionStoreTargetsSync).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/acp-sessions-link.ts
+++ b/src/commands/acp-sessions-link.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getRuntimeConfig } from "../config/config.js";
+import { loadSessionStore } from "../config/sessions.js";
+import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+
+/**
+ * A resolved triple for one ACP session: the openclaw session-store key,
+ * the ACP session id on the backend/copilot side, and the resolved copilot
+ * state directory path.
+ */
+export type AcpSessionLinkRow = {
+  /** OpenClaw session-store key, e.g. "agent:copilot:acp:<uuid>" */
+  openclawKey: string;
+  /** ACP/copilot-side session id stored in entry.acp.identity.acpxSessionId */
+  acpSessionId: string | null;
+  /** Resolved path to ~/.copilot/session-state/<acpSessionId>/ */
+  copilotStatePath: string | null;
+  /** Whether the copilot state directory exists on disk */
+  copilotStateExists: boolean;
+};
+
+function resolveCopilotStateDir(acpSessionId: string, homedir: string): string {
+  return path.join(homedir, ".copilot", "session-state", acpSessionId);
+}
+
+function resolveAcpSessionId(entry: SessionEntry): string | null {
+  const id = entry.acp?.identity?.acpxSessionId;
+  if (typeof id === "string" && id.trim().length > 0) {
+    return id.trim();
+  }
+  return null;
+}
+
+export function buildAcpSessionLinkRows(
+  storeTargets: Array<{ storePath: string }>,
+  homedir: string,
+): AcpSessionLinkRow[] {
+  const rows: AcpSessionLinkRow[] = [];
+
+  for (const target of storeTargets) {
+    let store: Record<string, SessionEntry>;
+    try {
+      store = loadSessionStore(target.storePath);
+    } catch {
+      continue;
+    }
+
+    for (const [key, entry] of Object.entries(store)) {
+      if (!entry?.acp) {
+        continue;
+      }
+      const acpSessionId = resolveAcpSessionId(entry);
+      let copilotStatePath: string | null = null;
+      let copilotStateExists = false;
+
+      if (acpSessionId) {
+        copilotStatePath = resolveCopilotStateDir(acpSessionId, homedir);
+        try {
+          copilotStateExists = fs.existsSync(copilotStatePath);
+        } catch {
+          copilotStateExists = false;
+        }
+      }
+
+      rows.push({
+        openclawKey: key,
+        acpSessionId,
+        copilotStatePath,
+        copilotStateExists,
+      });
+    }
+  }
+
+  return rows;
+}
+
+function formatLinkRow(row: AcpSessionLinkRow): string {
+  const acpId = row.acpSessionId ?? "(none)";
+  const statePath = row.copilotStatePath ?? "(n/a)";
+  const stateFlag =
+    row.acpSessionId === null
+      ? "MISSING_ACP_ID"
+      : row.copilotStateExists
+        ? "ok"
+        : "MISSING_STATE_DIR";
+  // TSV: fields separated by tab; flag appended for machine parsing
+  return `${row.openclawKey}\t${acpId}\t${statePath}\t${stateFlag}`;
+}
+
+export async function acpSessionsLinkCommand(
+  opts: {
+    json?: boolean;
+    store?: string;
+    agent?: string;
+  },
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const cfg = getRuntimeConfig();
+  const homedir = os.homedir();
+
+  let targets: Array<{ storePath: string; agentId: string }>;
+
+  if (opts.store) {
+    targets = [
+      {
+        storePath: path.resolve(opts.store),
+        agentId: opts.agent?.trim() || "unknown",
+      },
+    ];
+  } else {
+    targets = resolveAllAgentSessionStoreTargetsSync(cfg, {});
+  }
+
+  const rows = buildAcpSessionLinkRows(targets, homedir);
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, {
+      count: rows.length,
+      sessions: rows,
+    });
+    return;
+  }
+
+  if (rows.length === 0) {
+    runtime.log("No ACP sessions found.");
+    return;
+  }
+
+  const HEADER = "openclaw-key\tacp-session-id\tcopilot-state-path\tstatus";
+  runtime.log(HEADER);
+  for (const row of rows) {
+    runtime.log(formatLinkRow(row));
+  }
+}

--- a/src/commands/acp-sessions-link.ts
+++ b/src/commands/acp-sessions-link.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { getRuntimeConfig } from "../config/config.js";
 import { loadSessionStore } from "../config/sessions.js";
-import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
+import {
+  resolveAgentSessionStoreTargetsSync,
+  resolveAllAgentSessionStoreTargetsSync,
+} from "../config/sessions/targets.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 
@@ -111,6 +114,8 @@ export async function acpSessionsLinkCommand(
         agentId: opts.agent?.trim() || "unknown",
       },
     ];
+  } else if (opts.agent?.trim()) {
+    targets = resolveAgentSessionStoreTargetsSync(cfg, opts.agent.trim());
   } else {
     targets = resolveAllAgentSessionStoreTargetsSync(cfg, {});
   }


### PR DESCRIPTION
## Summary

Add `openclaw sessions link` — a read-only diagnostic helper that prints the three-identifier triple operators currently have to walk by hand to correlate an ACP session across openclaw and copilot. Closes catalog #8.

## Bug detail

Two distinct identifiers refer to the same ACP session, and operators have had to discover the mapping by reading individual session JSON files:

- **openclaw side:** `agent:copilot:acp:<uuid>` (file basename in `~/.openclaw/workspace/state/sessions/agent%3Acopilot%3Aacp%3A<uuid>.json`)
- **copilot side:** `<acp_session_id>` (directory name in `~/.copilot/session-state/<acp_session_id>/events.jsonl`)
- **Join field:** `acp.identity.acpxSessionId` inside the openclaw session record

Live diagnosis (e.g., "what events did copilot emit for the run that's stuck in topic 315?") required walking openclaw's session files, finding the one whose binding matches the topic, reading its `acpxSessionId`, then jumping to copilot's directory under that name. There was no single command, no aggregated index, and no explicit cross-reference printed to logs.

## How to reproduce

Before fix:

\`\`\`bash
# Walk by hand to correlate one session — three commands per session
ls ~/.openclaw/workspace/state/sessions/ | grep acp
jq '.acp.identity.acpxSessionId' ~/.openclaw/workspace/state/sessions/<file>
ls ~/.copilot/session-state/<that-uuid>/
\`\`\`

After this PR:

\`\`\`bash
openclaw sessions link            # one command, full triple per session
openclaw sessions link --json     # machine-parseable
\`\`\`

## Root cause

No tooling existed; the three identifiers and their join field were undocumented (also addressed in the docs PR for catalog #7/#14/#23). Tests exist for the underlying types, but no command surfaced the join.

## Fix approach

New `openclaw sessions link` subcommand. Read-only; no mutation. Walks `~/.openclaw/workspace/state/sessions/agent%3A*%3Aacp%3A*.json`, reads `entry.acp.identity.acpxSessionId`, resolves the copilot state directory `~/.copilot/session-state/<acpxSessionId>/`, and emits a 4-column TSV (or JSON with `--json`):

| Column | Description |
| --- | --- |
| `openclaw-key` | the `agent:<agent>:acp:<uuid>` from the file basename |
| `acp-session-id` | the resolved `acpxSessionId` |
| `copilot-state-path` | the absolute path to copilot's session-state dir |
| `status` | one of `ok`, `MISSING_STATE_DIR`, `MISSING_ACP_ID` |

Naming: `sessions link` subcommand follows the established `sessions cleanup` / `sessions export-trajectory` pattern (verb-noun subcommand, not flag).

Doc cross-reference added to `docs/plugins/reference/acpx.md` with a "Session ID join model" section.

## Tests

- **New tests:** `src/commands/acp-sessions-link.test.ts` — 11 cases:
  - Happy path: full triple emitted
  - `MISSING_STATE_DIR`: `acpxSessionId` present but copilot state dir missing
  - `MISSING_ACP_ID`: no `acpxSessionId` at all
  - Empty store, non-ACP entries filtered, missing store file, JSON output, no-sessions message, etc.
- **Adjacent:** `sessions.test.ts` 13/0; `agent.acp.test.ts` 7/0

## Catalog reference

Catalog finding: #8. Investigation lives in branch `edpiva/acp-native-session-investigation` (not yet upstream) at `docs/plans/2026-05-08-acp-findings-catalog.md`.

## Verification commands

\`\`\`bash
pnpm test src/commands/acp-sessions-link.test.ts                # 11/11 GREEN
pnpm test src/commands/sessions.test.ts src/commands/agent.acp.test.ts   # 20/20 GREEN
\`\`\`

## Notes for reviewers

- Output format: TSV with a header row and uppercase status sentinels (`ok`, `MISSING_STATE_DIR`, `MISSING_ACP_ID`). Machine-parseable AND human-readable. `--json` flag for tooling integrations.
- Doc location: the Task spec referenced `docs/extensions/acpx.md`, but the actual file lives at `docs/plugins/reference/acpx.md` (verified on `origin/main`). Used the real path.
- Scope: read-only diagnostic. No session mutation. Flags are minimal: `--store` (override store path), `--agent` (filter to one agent), `--json` (output format).

---

## Live behavior repro (deployed container)

**Container:** `codeclaw-openclaw:clean` running OpenClaw 2026.5.6 (`e9d4a0a`)
**PII note:** UUIDs are random; no PII to redact in this slice.

### Today: three commands per session to walk the ACP join model

There is no single command that prints `openclaw key → acp_session_id → copilot state path`. Operators currently chain three lookups manually:

```
# 1. List ACP session records on disk
$ docker exec codeclaw-openclaw ls ~/.openclaw/workspace/state/sessions/ | grep acp
agent%3Acopilot%3Aacp%3A1f854fa2-…%3Aoneshot%3A7c6105aa-….json
agent%3Acopilot%3Aacp%3A86b7b5af-….json
…

# 2. Pull the join field from one record
$ docker exec codeclaw-openclaw jq '.acp.identity.acpxSessionId' \
    ~/.openclaw/workspace/state/sessions/agent%3Acopilot%3Aacp%3A1f854fa2-….json
"<acp-session-id-uuid>"

# 3. Find copilot's session-state directory under that uuid
$ docker exec codeclaw-openclaw ls ~/.copilot/session-state/<acp-session-id-uuid>/
events.jsonl  …
```

After this PR, one read-only command surfaces the full triple plus a status sentinel for missing state dirs:

```
$ openclaw sessions link
openclaw-key                                    acp-session-id      copilot-state-path                          status
agent:copilot:acp:1f854fa2-…:oneshot:7c6105aa-…  <uuid-1>           /home/codeclaw/.copilot/session-state/<…>   ok
agent:copilot:acp:86b7b5af-…                     <uuid-2>           /home/codeclaw/.copilot/session-state/<…>   MISSING_STATE_DIR
agent:copilot:acp:d6fb7506-…                     —                  —                                            MISSING_ACP_ID
```

Adds `--json` for tooling and a doc cross-reference at `docs/plugins/reference/acpx.md` so the join model is also discoverable from prose.
