### PR TITLE
fix(sessions): display ACP-runtime model sentinel for ACP-keyed sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/runtime: attribute deprecated runtime config load/write warnings to the plugin id and source that triggered them so logs and plugin doctor runs are actionable. Refs #81394. (#81425) Thanks @BKF-Gitty.
 - Memory/LanceDB: make auto-capture recognize short CJK memory phrases and configurable literal triggers, so Chinese, Japanese, and Korean users can capture memories without regex or LLM intent detection. Fixes #75680. Thanks @vyctorbrzezowski and @guokewuming.
 - Plugins doctor: report stale plugin config warnings and avoid claiming full plugin health when config warnings remain. (#81515) Thanks @BKF-Gitty.
+- Sessions: display `model: "<agentId>-acp"` / `modelProvider: "acpx"` (ACP-runtime sentinel) for ACP control-plane sessions in `openclaw sessions` output, instead of the agent's configured model which was misleading. Catalog finding 20. (#79543)
 
 ### Changes
 

--- a/src/commands/sessions.acp-model-display.test.ts
+++ b/src/commands/sessions.acp-model-display.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions/types.js";
+import {
+  mockSessionsConfig,
+  resetMockSessionsConfig,
+  runSessionsJson,
+  setMockSessionsConfig,
+  writeStore,
+} from "./sessions.test-helpers.js";
+
+/**
+ * Catalog #20 — `model` / `modelProvider` reported as agent-config, not ACP runtime actuals.
+ *
+ * Bug summary: For ACP-keyed sessions (e.g. `agent:copilot:acp:<uuid>`), the
+ * `--json` listing reports the AGENT's configured model
+ * (e.g. `model: "gpt-5.3-codex"`, `modelProvider: "microsoft-foundry"`) — but
+ * those are the values the openclaw-agent-driven flow would have used. When
+ * the same agent runs as an ACP child via `copilot --acp --stdio`, the actual
+ * underlying model selection lives inside copilot CLI and is independent of
+ * the agent's configured model. The listing happily reports the agent default
+ * regardless of whether the session actually ran via ACP.
+ *
+ * `resolveSessionDisplayModelRef` (`src/commands/sessions-display-model.ts:123-148`)
+ * has zero ACP-awareness: it only consults the session entry's persisted
+ * `model` / `modelProvider` / `modelOverride` and the agent's configured
+ * default. It never inspects the session key.
+ *
+ * Decided fix shape (catalog #20, mirrors #18): SENTINEL OVERLAY at the call
+ * site. When `isAcpSessionKey(row.key)` is true, the JSON-emit path overlays
+ * `{ provider: "acpx", model: "copilot-acp" }` on top of the resolver result.
+ * The resolver itself stays pure (a config-policy resolver); the call site
+ * applies the runtime-aware overlay.
+ *
+ * NOTE ON DRIVING SURFACE: `resolveSessionDisplayModelRef` is exported, but
+ * the bug as observed by operators surfaces through `sessions --json`, so we
+ * drive the test end-to-end through `sessionsCommand --json` (mirroring the
+ * #19 test pattern). This proves the bug at the actual emit site that
+ * operators see, not just in the resolver in isolation.
+ */
+
+mockSessionsConfig();
+
+const { sessionsCommand } = await import("./sessions.js");
+
+type SessionsJsonPayload = {
+  sessions?: Array<{
+    key: string;
+    model?: string | null;
+    modelProvider?: string | null;
+  }>;
+};
+
+const ACP_SESSION_KEY = "agent:copilot:acp:86b7b5af-3773-4a56-b244-069d6c5d3db9";
+const NON_ACP_SESSION_KEY = "agent:copilot:main";
+
+const AGENT_CONFIGURED_MODEL = "gpt-5.3-codex";
+const AGENT_CONFIGURED_PROVIDER = "microsoft-foundry";
+
+/**
+ * Mock config with a `copilot` agent whose configured model is
+ * `microsoft-foundry/gpt-5.3-codex` (the deployed scenario from the catalog).
+ *
+ * Both the ACP and the non-ACP session entries below leave `model` /
+ * `modelProvider` unset, so `resolveSessionDisplayModelRef` falls through to
+ * the agent's configured default. That is precisely the path under test:
+ * for ACP sessions the agent default is the WRONG answer.
+ */
+function mockAgentConfigWithCopilotModel(): void {
+  setMockSessionsConfig(() => ({
+    agents: {
+      list: [
+        {
+          id: "copilot",
+          model: { primary: `${AGENT_CONFIGURED_PROVIDER}/${AGENT_CONFIGURED_MODEL}` },
+        },
+      ],
+      defaults: {
+        contextTokens: 200_000,
+      },
+    },
+  }));
+}
+
+/**
+ * Minimal ACP session entry: just a session id and an updatedAt timestamp.
+ * No `model` / `modelProvider` set on the entry — the listing falls through
+ * to the agent's configured default, which is the buggy path for ACP keys.
+ */
+function buildAcpSessionEntry(): SessionEntry {
+  return {
+    sessionId: "acp-session-id",
+    updatedAt: Date.now() - 2 * 60_000,
+  };
+}
+
+/**
+ * Minimal non-ACP session entry, same shape as the ACP entry. Used as the
+ * GREEN-control case below. The agent default is the correct answer for
+ * non-ACP sessions — those run through the openclaw-agent-driven flow that
+ * actually uses the configured model.
+ */
+function buildNonAcpSessionEntry(): SessionEntry {
+  return {
+    sessionId: "non-acp-session-id",
+    updatedAt: Date.now() - 3 * 60_000,
+  };
+}
+
+describe("sessionsCommand model/modelProvider display for ACP sessions (catalog #20)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-06T00:00:00Z"));
+    mockAgentConfigWithCopilotModel();
+  });
+
+  afterEach(() => {
+    resetMockSessionsConfig();
+    vi.useRealTimers();
+  });
+
+  it("RED: ACP session must NOT report the agent-configured model", async () => {
+    // RED today. The session is plainly ACP (key has the `:acp:` segment),
+    // but `resolveSessionDisplayModelRef` (`src/commands/sessions-display-model.ts:123`)
+    // ignores the key and returns the agent default. Operators relying on
+    // `sessions --json` model fields see the model the openclaw-agent-driven
+    // flow would have used, NOT what copilot actually selected internally
+    // when it ran via ACP.
+    //
+    // The discriminator the fix should consult is `isAcpSessionKey(row.key)`
+    // (re-exported from `src/routing/session-key.ts:9`, defined at
+    // `src/sessions/session-key-utils.ts:86`). Mirrors catalog #18's overlay
+    // pattern.
+    const store = writeStore(
+      { [ACP_SESSION_KEY]: buildAcpSessionEntry() },
+      "sessions-acp-model-display-red",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === ACP_SESSION_KEY);
+
+    expect(
+      row,
+      `Expected sessionsCommand --json to include a row for ${ACP_SESSION_KEY}; got none.`,
+    ).toBeDefined();
+    expect(
+      row?.model,
+      `ACP session ${ACP_SESSION_KEY} reports model="${row?.model}" — that is the agent-configured ` +
+        `model (${AGENT_CONFIGURED_MODEL}), not what copilot actually used inside ACP. ` +
+        `resolveSessionDisplayModelRef (src/commands/sessions-display-model.ts:123) has zero ` +
+        `ACP-awareness; the call site at src/commands/sessions.ts:335 should consult ` +
+        `isAcpSessionKey(row.key) and overlay an ACP-runtime sentinel before serialization.`,
+    ).not.toBe(AGENT_CONFIGURED_MODEL);
+    expect(
+      row?.modelProvider,
+      `ACP session ${ACP_SESSION_KEY} reports modelProvider="${row?.modelProvider}" — the ` +
+        `agent-configured provider (${AGENT_CONFIGURED_PROVIDER}), not the ACP runtime. ` +
+        `Same fix site as above: src/commands/sessions-display-model.ts:123 has no key awareness; ` +
+        `apply the overlay at the call site using isAcpSessionKey.`,
+    ).not.toBe(AGENT_CONFIGURED_PROVIDER);
+  });
+
+  it("RED (fix-shape): ACP session should report the ACP runtime sentinel", async () => {
+    // RED today; flips GREEN once the catalog-#20 sentinel-overlay fix lands.
+    //
+    // The catalog's chosen fix shape is option (a): when `isAcpSessionKey(row.key)`
+    // is true, overlay `{ provider: "acpx", model: "copilot-acp" }` (or a
+    // similar sentinel). This trades model-name accuracy for "this is ACP,
+    // not the agent default" clarity. Plumbing the actual copilot-side model
+    // selection into the openclaw record would require capturing ACP
+    // `session.model_change` events (catalog notes this as deferrable).
+    //
+    // If the fix author chooses different sentinel names ("acp-runtime" vs
+    // "acpx", "copilot-acp" vs "<acp-runtime>"), update both expectations to
+    // match. The structural point is that for ACP-keyed sessions the values
+    // MUST be different from the agent default and clearly mark the ACP
+    // origin.
+    const store = writeStore(
+      { [ACP_SESSION_KEY]: buildAcpSessionEntry() },
+      "sessions-acp-model-display-fix-shape",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === ACP_SESSION_KEY);
+
+    expect(row).toBeDefined();
+    expect(
+      row?.model,
+      `ACP session ${ACP_SESSION_KEY} should resolve model to "copilot-acp" (the catalog-chosen ` +
+        `sentinel). Got "${row?.model}". Fix lands at the call site in src/commands/sessions.ts:335 ` +
+        `which already has row.key in scope — gate on isAcpSessionKey(row.key) and overlay ` +
+        `{ provider: "acpx", model: "copilot-acp" }. Keeps resolveSessionDisplayModelRef pure.`,
+    ).toBe("copilot-acp");
+    expect(
+      row?.modelProvider,
+      `ACP session ${ACP_SESSION_KEY} should resolve modelProvider to "acpx". Got ` +
+        `"${row?.modelProvider}". Same fix as the model assertion above; the overlay sets both ` +
+        `fields together so they remain internally consistent.`,
+    ).toBe("acpx");
+  });
+
+  it("GREEN control: non-ACP session correctly reports the agent-configured model", async () => {
+    // GREEN today. The same agent configuration drives a non-ACP session
+    // (`agent:copilot:main`) — and for that session the agent-configured
+    // model IS the right answer because the openclaw-agent-driven flow
+    // actually runs that model. This control proves:
+    //   1. The test infrastructure is exercising the real resolver path
+    //      (not a mock that would silently pass either way).
+    //   2. The configured-model branch of resolveSessionDisplayModelRef
+    //      remains correct for non-ACP keys; the proposed sentinel overlay
+    //      must NOT break this case (it should only fire when
+    //      isAcpSessionKey(row.key) is true).
+    const store = writeStore(
+      { [NON_ACP_SESSION_KEY]: buildNonAcpSessionEntry() },
+      "sessions-acp-model-display-green-control",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === NON_ACP_SESSION_KEY);
+
+    expect(row).toBeDefined();
+    expect(row?.model).toBe(AGENT_CONFIGURED_MODEL);
+    expect(row?.modelProvider).toBe(AGENT_CONFIGURED_PROVIDER);
+  });
+});

--- a/src/commands/sessions.acp-model-display.test.ts
+++ b/src/commands/sessions.acp-model-display.test.ts
@@ -23,13 +23,17 @@ import {
  * `resolveSessionDisplayModelRef` (`src/commands/sessions-display-model.ts:123-148`)
  * has zero ACP-awareness: it only consults the session entry's persisted
  * `model` / `modelProvider` / `modelOverride` and the agent's configured
- * default. It never inspects the session key.
+ * default. It never inspects the session key or the persisted ACP metadata.
  *
  * Decided fix shape (catalog #20, mirrors #18): SENTINEL OVERLAY at the call
- * site. When `isAcpSessionKey(row.key)` is true, the JSON-emit path overlays
- * `{ provider: "acpx", model: "copilot-acp" }` on top of the resolver result.
- * The resolver itself stays pure (a config-policy resolver); the call site
- * applies the runtime-aware overlay.
+ * site, gated on BOTH key shape AND persisted `entry.acp` metadata. Key shape
+ * alone is not sufficient because ACP bridge sessions (translator.ts) also use
+ * ACP-shaped keys without ever writing `SessionAcpMeta` — those sessions run
+ * the normal configured model and must not receive the sentinel.
+ *
+ * When `isAcpSessionKey(row.key)` is true AND `entry.acp != null`, the
+ * JSON-emit path overlays `{ provider: "acpx", model: "<agentId>-acp" }` on
+ * top of the resolver result. The resolver itself stays pure.
  *
  * NOTE ON DRIVING SURFACE: `resolveSessionDisplayModelRef` is exported, but
  * the bug as observed by operators surfaces through `sessions --json`, so we
@@ -82,7 +86,11 @@ function mockAgentConfigWithCopilotModel(): void {
 }
 
 /**
- * Minimal ACP session entry: just a session id and an updatedAt timestamp.
+ * ACP control-plane session entry: includes `entry.acp` as persisted by
+ * `src/acp/control-plane/manager.core.ts:365` during acpx child init. The
+ * presence of `entry.acp` is the discriminator the overlay uses to distinguish
+ * real ACP child-runtime sessions from ACP bridge sessions.
+ *
  * No `model` / `modelProvider` set on the entry — the listing falls through
  * to the agent's configured default, which is the buggy path for ACP keys.
  */
@@ -90,11 +98,35 @@ function buildAcpSessionEntry(): SessionEntry {
   return {
     sessionId: "acp-session-id",
     updatedAt: Date.now() - 2 * 60_000,
+    acp: {
+      backend: "copilot",
+      agent: "copilot",
+      runtimeSessionName: "acp-runtime-session-1",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: Date.now() - 2 * 60_000,
+    },
   };
 }
 
 /**
- * Minimal non-ACP session entry, same shape as the ACP entry. Used as the
+ * ACP bridge session entry: ACP-shaped key but no `entry.acp`. The ACP bridge
+ * (translator.ts) uses an in-memory-only session store and never writes
+ * `SessionAcpMeta` to disk. If a bridge client passes an explicit ACP-shaped
+ * key (e.g. `agent:copilot:acp:session-1`) and the Gateway persists the
+ * session, it will have an ACP key without `entry.acp`. The overlay must NOT
+ * fire for these sessions — they ran the configured model.
+ */
+function buildAcpBridgeSessionEntry(): SessionEntry {
+  return {
+    sessionId: "acp-bridge-session-id",
+    updatedAt: Date.now() - 4 * 60_000,
+    // No `acp` field: this is a bridge session, not a control-plane child session.
+  };
+}
+
+/**
+ * Minimal non-ACP session entry, same shape as the ACP bridge entry. Used as the
  * GREEN-control case below. The agent default is the correct answer for
  * non-ACP sessions — those run through the openclaw-agent-driven flow that
  * actually uses the configured model.
@@ -118,18 +150,16 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
     vi.useRealTimers();
   });
 
-  it("RED: ACP session must NOT report the agent-configured model", async () => {
-    // RED today. The session is plainly ACP (key has the `:acp:` segment),
-    // but `resolveSessionDisplayModelRef` (`src/commands/sessions-display-model.ts:123`)
-    // ignores the key and returns the agent default. Operators relying on
-    // `sessions --json` model fields see the model the openclaw-agent-driven
-    // flow would have used, NOT what copilot actually selected internally
-    // when it ran via ACP.
+  it("RED: ACP control-plane session must NOT report the agent-configured model", async () => {
+    // RED before fix. The session is a real ACP control-plane session
+    // (key has the `:acp:` segment AND entry.acp is present), but
+    // `resolveSessionDisplayModelRef` ignores both and returns the agent
+    // default. Operators relying on `sessions --json` model fields see the
+    // model the openclaw-agent-driven flow would have used, NOT what copilot
+    // actually selected internally when it ran via ACP.
     //
-    // The discriminator the fix should consult is `isAcpSessionKey(row.key)`
-    // (re-exported from `src/routing/session-key.ts:9`, defined at
-    // `src/sessions/session-key-utils.ts:86`). Mirrors catalog #18's overlay
-    // pattern.
+    // The discriminator the fix uses: `isAcpSessionKey(row.key)` AND
+    // `entry.acp != null` (persisted by the ACP control plane manager).
     const store = writeStore(
       { [ACP_SESSION_KEY]: buildAcpSessionEntry() },
       "sessions-acp-model-display-red",
@@ -147,33 +177,26 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
       `ACP session ${ACP_SESSION_KEY} reports model="${row?.model}" — that is the agent-configured ` +
         `model (${AGENT_CONFIGURED_MODEL}), not what copilot actually used inside ACP. ` +
         `resolveSessionDisplayModelRef (src/commands/sessions-display-model.ts:123) has zero ` +
-        `ACP-awareness; the call site at src/commands/sessions.ts:335 should consult ` +
-        `isAcpSessionKey(row.key) and overlay an ACP-runtime sentinel before serialization.`,
+        `ACP-awareness; the call site at src/commands/sessions.ts should consult ` +
+        `isAcpSessionKey(row.key) AND entry.acp != null, then overlay an ACP-runtime sentinel.`,
     ).not.toBe(AGENT_CONFIGURED_MODEL);
     expect(
       row?.modelProvider,
       `ACP session ${ACP_SESSION_KEY} reports modelProvider="${row?.modelProvider}" — the ` +
         `agent-configured provider (${AGENT_CONFIGURED_PROVIDER}), not the ACP runtime. ` +
-        `Same fix site as above: src/commands/sessions-display-model.ts:123 has no key awareness; ` +
-        `apply the overlay at the call site using isAcpSessionKey.`,
+        `Same fix site as above; the overlay must gate on entry.acp presence.`,
     ).not.toBe(AGENT_CONFIGURED_PROVIDER);
   });
 
-  it("RED (fix-shape): ACP session should report the ACP runtime sentinel", async () => {
-    // RED today; flips GREEN once the catalog-#20 sentinel-overlay fix lands.
+  it("RED (fix-shape): ACP control-plane session should report the ACP runtime sentinel", async () => {
+    // RED before fix; GREEN once the catalog-#20 sentinel-overlay fix lands.
     //
-    // The catalog's chosen fix shape is option (a): when `isAcpSessionKey(row.key)`
-    // is true, overlay `{ provider: "acpx", model: "copilot-acp" }` (or a
-    // similar sentinel). This trades model-name accuracy for "this is ACP,
-    // not the agent default" clarity. Plumbing the actual copilot-side model
-    // selection into the openclaw record would require capturing ACP
-    // `session.model_change` events (catalog notes this as deferrable).
-    //
-    // If the fix author chooses different sentinel names ("acp-runtime" vs
-    // "acpx", "copilot-acp" vs "<acp-runtime>"), update both expectations to
-    // match. The structural point is that for ACP-keyed sessions the values
-    // MUST be different from the agent default and clearly mark the ACP
-    // origin.
+    // The catalog's chosen fix shape: when `isAcpSessionKey(row.key)` is true
+    // AND `entry.acp != null`, overlay `{ provider: "acpx", model: "<agentId>-acp" }`.
+    // This trades model-name accuracy for "this is ACP control-plane, not the
+    // agent default" clarity. Plumbing the actual copilot-side model selection
+    // into the openclaw record would require capturing ACP `session.model_change`
+    // events (catalog notes this as deferrable).
     const store = writeStore(
       { [ACP_SESSION_KEY]: buildAcpSessionEntry() },
       "sessions-acp-model-display-fix-shape",
@@ -186,9 +209,8 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
     expect(
       row?.model,
       `ACP session ${ACP_SESSION_KEY} should resolve model to "copilot-acp" (the catalog-chosen ` +
-        `sentinel). Got "${row?.model}". Fix lands at the call site in src/commands/sessions.ts:335 ` +
-        `which already has row.key in scope — gate on isAcpSessionKey(row.key) and overlay ` +
-        `{ provider: "acpx", model: "copilot-acp" }. Keeps resolveSessionDisplayModelRef pure.`,
+        `sentinel). Got "${row?.model}". Fix gates on isAcpSessionKey(row.key) AND entry.acp != null ` +
+        `and overlays { provider: "acpx", model: "copilot-acp" }. Keeps resolveSessionDisplayModelRef pure.`,
     ).toBe("copilot-acp");
     expect(
       row?.modelProvider,
@@ -196,6 +218,34 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
         `"${row?.modelProvider}". Same fix as the model assertion above; the overlay sets both ` +
         `fields together so they remain internally consistent.`,
     ).toBe("acpx");
+  });
+
+  it("GREEN control: ACP bridge session (ACP key, no entry.acp) reports the configured model", async () => {
+    // ACP bridge sessions (translator.ts) use ACP-shaped keys but never
+    // persist SessionAcpMeta to disk. They run the normal configured model
+    // and must NOT receive the acpx sentinel. This guards against a regression
+    // where key-shape-only detection would misreport bridge sessions.
+    const ACP_BRIDGE_SESSION_KEY = "agent:copilot:acp:bridge-session-1";
+    const store = writeStore(
+      { [ACP_BRIDGE_SESSION_KEY]: buildAcpBridgeSessionEntry() },
+      "sessions-acp-model-display-bridge-control",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === ACP_BRIDGE_SESSION_KEY);
+
+    expect(row).toBeDefined();
+    expect(
+      row?.model,
+      `ACP bridge session ${ACP_BRIDGE_SESSION_KEY} has an ACP-shaped key but no entry.acp — ` +
+        `it ran the configured model. Got model="${row?.model}"; expected "${AGENT_CONFIGURED_MODEL}". ` +
+        `The overlay must gate on entry.acp != null, not key shape alone.`,
+    ).toBe(AGENT_CONFIGURED_MODEL);
+    expect(
+      row?.modelProvider,
+      `ACP bridge session ${ACP_BRIDGE_SESSION_KEY} should report the configured provider. ` +
+        `Got "${row?.modelProvider}"; expected "${AGENT_CONFIGURED_PROVIDER}".`,
+    ).toBe(AGENT_CONFIGURED_PROVIDER);
   });
 
   it("GREEN control: non-ACP session correctly reports the agent-configured model", async () => {
@@ -207,8 +257,8 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
     //      (not a mock that would silently pass either way).
     //   2. The configured-model branch of resolveSessionDisplayModelRef
     //      remains correct for non-ACP keys; the proposed sentinel overlay
-    //      must NOT break this case (it should only fire when
-    //      isAcpSessionKey(row.key) is true).
+    //      must NOT break this case (it should only fire when both
+    //      isAcpSessionKey(row.key) is true AND entry.acp is present).
     const store = writeStore(
       { [NON_ACP_SESSION_KEY]: buildNonAcpSessionEntry() },
       "sessions-acp-model-display-green-control",

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -16,7 +16,6 @@ import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 import {
   resolveSessionDisplayModelRef,
   resolveSessionDisplayDefaults,
-  resolveSessionDisplayModel,
 } from "./sessions-display-model.js";
 import {
   formatSessionAgeCell,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -34,6 +34,14 @@ type SessionRow = SessionDisplayRow & {
   kind: "cron" | "direct" | "group" | "global" | "unknown";
   agentRuntime: ReturnType<typeof resolveModelAgentRuntimeMetadata>;
   runtimeLabel: string;
+  /**
+   * True only when the session entry has persisted ACP runtime metadata
+   * (`entry.acp` is present). Key-shape alone is not sufficient because ACP
+   * bridge sessions (translator.ts) may use ACP-shaped keys without ever
+   * writing `SessionAcpMeta` — those use the normal configured model and must
+   * not be overlaid with the acpx sentinel.
+   */
+  acpRuntime: boolean;
 };
 
 const AGENT_PAD = 10;
@@ -49,11 +57,17 @@ const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_0
 /**
  * Inline ACP model overlay — catalog #20.
  *
- * When a session ran via ACP (e.g. key = `agent:copilot:acp:<uuid>`), the
- * agent's configured model is irrelevant: the actual model is selected inside
- * the ACP child process. We overlay a sentinel `{ provider: "acpx",
+ * When a session ran via the ACP control plane (e.g. key =
+ * `agent:copilot:acp:<uuid>` AND `entry.acp` is present), the agent's
+ * configured model is irrelevant: the actual model is selected inside the ACP
+ * child process. We overlay a sentinel `{ provider: "acpx",
  * model: "<agentId>-acp" }` so the listing clearly signals "ACP runtime" and
  * does not mislead operators into thinking the configured model ran.
+ *
+ * Key-shape alone is not sufficient: ACP bridge sessions (translator.ts) also
+ * use ACP-shaped keys but never persist `SessionAcpMeta` — they run the
+ * normal configured model and must not receive the sentinel. The `acpRuntime`
+ * flag is set at row-construction time from `entry.acp != null`.
  *
  * The resolver (`resolveSessionDisplayModelRef`) stays pure; this overlay
  * applies only at the emit sites in this file.
@@ -64,8 +78,9 @@ const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_0
 function applyAcpModelOverlayIfNeeded(
   modelRef: { provider: string; model: string },
   sessionKey: string,
+  acpRuntime: boolean,
 ): { provider: string; model: string } {
-  if (!isAcpSessionKey(sessionKey)) {
+  if (!acpRuntime || !isAcpSessionKey(sessionKey)) {
     return modelRef;
   }
   const agentId = parseAgentSessionKey(sessionKey)?.agentId ?? "acp";
@@ -286,9 +301,11 @@ export async function sessionsCommand(
       .map(([key, entry]) => {
         const row = toSessionDisplayRow(key, entry);
         const agentId = parseAgentSessionKey(row.key)?.agentId ?? target.agentId;
+        const acpRuntime = entry?.acp != null;
         const modelRef = applyAcpModelOverlayIfNeeded(
           resolveSessionDisplayModelRef(cfg, row),
           row.key,
+          acpRuntime,
         );
         const agentRuntime = resolveModelAgentRuntimeMetadata({
           cfg,
@@ -299,6 +316,7 @@ export async function sessionsCommand(
         });
         return Object.assign({}, row, {
           agentId,
+          acpRuntime,
           agentRuntime,
           kind: classifySessionKey(row.key, store[row.key]),
           runtimeLabel: resolveSessionRuntimeLabel({
@@ -340,6 +358,7 @@ export async function sessionsCommand(
           const modelRef = applyAcpModelOverlayIfNeeded(
             resolveSessionDisplayModelRef(cfg, r),
             r.key,
+            row.acpRuntime,
           );
           return {
             ...r,
@@ -402,6 +421,7 @@ export async function sessionsCommand(
     const model = applyAcpModelOverlayIfNeeded(
       resolveSessionDisplayModelRef(cfg, row),
       row.key,
+      row.acpRuntime,
     ).model;
     const contextTokens =
       row.contextTokens ??

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -7,7 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { info } from "../globals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
-import { isCronSessionKey } from "../sessions/session-key-utils.js";
+import { isCronSessionKey, isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { resolveAgentRuntimeLabel } from "../status/agent-runtime-label.js";
@@ -46,6 +46,32 @@ const TOP_N_SELECTION_LIMIT = 200;
 const contextLookupRuntimeLoader = createLazyImportLoader(() => import("../agents/context.js"));
 
 const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
+
+/**
+ * Inline ACP model overlay — catalog #20.
+ *
+ * When a session ran via ACP (e.g. key = `agent:copilot:acp:<uuid>`), the
+ * agent's configured model is irrelevant: the actual model is selected inside
+ * the ACP child process. We overlay a sentinel `{ provider: "acpx",
+ * model: "<agentId>-acp" }` so the listing clearly signals "ACP runtime" and
+ * does not mislead operators into thinking the configured model ran.
+ *
+ * The resolver (`resolveSessionDisplayModelRef`) stays pure; this overlay
+ * applies only at the emit sites in this file.
+ *
+ * NOTE: Will be replaced by a shared `applyAcpModelOverlay` helper from
+ * `src/agents/acp-runtime-overlay.ts` once PR 2 lands.
+ */
+function applyAcpModelOverlayIfNeeded(
+  modelRef: { provider: string; model: string },
+  sessionKey: string,
+): { provider: string; model: string } {
+  if (!isAcpSessionKey(sessionKey)) {
+    return modelRef;
+  }
+  const agentId = parseAgentSessionKey(sessionKey)?.agentId ?? "acp";
+  return { provider: "acpx", model: `${agentId}-acp` };
+}
 
 function compareSessionRowsByUpdatedAt(a: SessionRow, b: SessionRow): number {
   return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
@@ -261,7 +287,10 @@ export async function sessionsCommand(
       .map(([key, entry]) => {
         const row = toSessionDisplayRow(key, entry);
         const agentId = parseAgentSessionKey(row.key)?.agentId ?? target.agentId;
-        const modelRef = resolveSessionDisplayModelRef(cfg, row);
+        const modelRef = applyAcpModelOverlayIfNeeded(
+          resolveSessionDisplayModelRef(cfg, row),
+          row.key,
+        );
         const agentRuntime = resolveModelAgentRuntimeMetadata({
           cfg,
           agentId,
@@ -309,7 +338,10 @@ export async function sessionsCommand(
       sessions: await Promise.all(
         rows.map(async (row) => {
           const r = toJsonSessionRow(row);
-          const modelRef = resolveSessionDisplayModelRef(cfg, r);
+          const modelRef = applyAcpModelOverlayIfNeeded(
+            resolveSessionDisplayModelRef(cfg, r),
+            r.key,
+          );
           return {
             ...r,
             totalTokens: resolveSessionTotalTokens(r) ?? null,
@@ -368,7 +400,10 @@ export async function sessionsCommand(
   runtime.log(rich ? theme.heading(header) : header);
 
   for (const row of rows) {
-    const model = resolveSessionDisplayModel(cfg, row);
+    const model = applyAcpModelOverlayIfNeeded(
+      resolveSessionDisplayModelRef(cfg, row),
+      row.key,
+    ).model;
     const contextTokens =
       row.contextTokens ??
       configuredContextTokens ??


### PR DESCRIPTION
## Summary

Display `model: "<agentId>-acp"`, `provider: "acpx"` (the ACP-runtime sentinel) for ACP-keyed sessions in the `openclaw sessions` listing, instead of the agent's configured model which was misleading. Closes catalog #20.

## Bug detail

Every ACP copilot session in `openclaw sessions` listing reported `model: "gpt-5.3-codex"`, `modelProvider: "microsoft-foundry"` — but those are the **copilot agent's configured model** (used for non-ACP / openclaw-agent-driven flows). When the agent runs as an ACP child, copilot CLI selects the actual model internally. The listing was reporting a model that wasn't actually used for those sessions, causing operator confusion.

## How to reproduce

Live repro before fix:

\`\`\`bash
docker compose exec codeclaw-openclaw openclaw sessions --all-agents --json \
  | jq '.sessions[] | select(.key | contains("acp:")) | {key, model, modelProvider}'
# Before: all ACP sessions show "model": "gpt-5.3-codex", "modelProvider": "microsoft-foundry"
# After:  all ACP sessions show "model": "copilot-acp", "modelProvider": "acpx"
\`\`\`

Unit-level:

\`\`\`bash
git checkout 5f12c52485            # red-test cherry-pick
pnpm test src/commands/sessions.acp-model-display.test.ts
# Before fix: 2 RED (model is the agent default; should be copilot-acp)
# After fix commit e744c1a861 + cleanup 87b4eb7131: all 3 GREEN
\`\`\`

## Root cause

`resolveSessionDisplayModelRef` (`src/commands/sessions-display-model.ts:123-148`) had zero ACP-awareness. It returned the agent-default model regardless of session-key shape — and the resolver is intentionally pure (per its existing design contract; we don't want to teach it about ACP).

## Fix approach

Sentinel overlay at the call sites — keeps the resolver pure. Mirrors the established #18 fix pattern:

1. Added private `applyAcpModelOverlayIfNeeded` helper in `src/commands/sessions.ts` that, when `isAcpSessionKey(row.key)` is true, replaces the resolver's output with `{ provider: "acpx", model: "<agentId>-acp" }`. The agentId is extracted via `parseAgentSessionKey`, so multi-agent ACP works (`copilot-acp`, `codex-acp`, etc.).
2. Applied the overlay at three emit sites: the `allRows` construction path, the JSON `--json` emit path, and the table-display per-row path.
3. The 5 other "parallel" files in the Task's allowed list (gateway server-methods sessions, gateway session-utils, doctor-claude-cli, agents-list-tool, status.summary.runtime) were verified NOT to call `resolveSessionDisplayModelRef` and so don't need the overlay. They use a different resolver (`resolveSessionDisplayModelIdentityRef`) which is a separate surface tracked elsewhere.

The helper currently lives inline in `sessions.ts` because the related PR for catalog #18 introduces a shared `src/agents/acp-runtime-overlay.ts` that would be the natural home. A `// TODO` comment in the helper marks the planned migration once both PRs land.

## Tests

- **Red test (now GREEN):** `src/commands/sessions.acp-model-display.test.ts` — 3 cases (2 RED → GREEN, 1 GREEN control stays GREEN).
- **Adjacent suites (4 files):** `sessions.model-resolution.test.ts`, `sessions.default-agent-store.test.ts`, `sessions.test.ts`, `sessions.acp-model-display.test.ts` — 25/25 pass after the bridge-session regression case.
- **Cleanup commit:** removes a dead import that the fix replaced; oxlint now clean.

## Real behavior proof

- **Behavior or issue addressed:** ACP control-plane sessions in `openclaw sessions --all-agents --json` should display the ACP runtime sentinel instead of the agent's configured Copilot model/provider.
- **Real environment tested:** Crabbox Azure lease `blue-crayfish` / `cbx_c22caa546489`, with the after-fix capture saved in `.crabbox/captures/cbx_c22caa546489-20260513T201301Z.tar.gz` and posted by a maintainer at https://github.com/openclaw/openclaw/pull/79543#issuecomment-4445203752.
- **Exact steps or command run after this patch:** Ran the focused sessions command path in Crabbox and inspected `openclaw sessions --all-agents --json` rows for an ACP control-plane session and a direct control session; also ran `pnpm test src/commands/sessions.acp-model-display.test.ts src/commands/sessions.model-resolution.test.ts src/commands/sessions.default-agent-store.test.ts src/commands/sessions.test.ts` and touched-file oxlint.
- **Evidence after fix:** Terminal output from the Crabbox stdout capture:

```json
AFTER_FIX_ACP_ROW={"key":"agent:copilot:acp:<redacted>","model":"copilot-acp","modelProvider":"acpx"}
CONTROL_DIRECT_ROW={"key":"agent:copilot:main","model":"gpt-5.5","modelProvider":"github-copilot"}
Test Files 4 passed (4)
Tests 25 passed (25)
Found 0 warnings and 0 errors.
```

- **Observed result after fix:** The ACP row reports `model: "copilot-acp"` and `modelProvider: "acpx"`, while the direct control row still reports `model: "gpt-5.5"` and `modelProvider: "github-copilot"`.
- **What was not tested:** No additional gaps for this sessions display path; exact-head GitHub CI is still running after the maintainer rebase.

## Catalog reference

Catalog finding: #20. Investigation lives in branch `edpiva/acp-native-session-investigation` (not yet upstream) at `docs/plans/2026-05-08-acp-findings-catalog.md`.

## Verification commands

\`\`\`bash
pnpm test src/commands/sessions.acp-model-display.test.ts          # 3/3 GREEN
pnpm test src/commands/sessions.model-resolution.test.ts \
          src/commands/sessions.default-agent-store.test.ts \
          src/commands/sessions.test.ts \
          src/commands/sessions.acp-model-display.test.ts            # 24/24 GREEN
node scripts/run-oxlint.mjs src/commands/sessions.ts                 # 0 errors
\`\`\`

## Notes for reviewers

- Sentinel choice: `model: "<agentId>-acp"` (e.g., `copilot-acp`, `codex-acp`) per the catalog spec. Open to changing the format if you'd prefer something different (e.g., `acpx:<agentId>`).
- The `applyAcpModelOverlayIfNeeded` helper is intentionally inlined in `sessions.ts` until the parallel PR for catalog #18 lands its `src/agents/acp-runtime-overlay.ts` helper file. Then a small refactor PR can move the helper there.
- The resolver `resolveSessionDisplayModelRef` is intentionally unchanged — the overlay is at call sites, preserving the resolver's purity.

---

## Live behavior repro (deployed container)

**Container:** `codeclaw-openclaw:clean` running OpenClaw 2026.5.6 (`e9d4a0a`)
**PII note:** UUIDs are random-not-PII; no PII to redact in this slice.

### Every ACP session reports the agent-config model, not the ACP runtime sentinel

```
$ docker exec codeclaw-openclaw openclaw sessions --all-agents --json \
    | jq -c '.sessions[] | select(.key | startswith("agent:copilot:acp:")) | {key, model, modelProvider}'

{"key":"agent:copilot:acp:86b7b5af-…","model":"gpt-5.5","modelProvider":"github-copilot"}
{"key":"agent:copilot:acp:d6fb7506-…","model":"gpt-5.5","modelProvider":"github-copilot"}
{"key":"agent:copilot:acp:f5ab8dba-…","model":"gpt-5.5","modelProvider":"github-copilot"}
{"key":"agent:copilot:acp:1f854fa2-…","model":"gpt-5.5","modelProvider":"github-copilot"}
{"key":"agent:copilot:acp:930316f7-…","model":"gpt-5.5","modelProvider":"github-copilot"}
{"key":"agent:copilot:acp:63867cf7-…","model":"gpt-5.5","modelProvider":"github-copilot"}
{"key":"agent:copilot:acp:8fb42bab-…","model":"gpt-5.5","modelProvider":"github-copilot"}
```

`gpt-5.5` / `github-copilot` is the copilot **agent's configured model** (used for non-ACP / openclaw-agent-driven flows). Under ACP the copilot CLI selects its own model internally; the listing was misreporting a model that did not run.

After this PR, the same query returns `model: "copilot-acp"`, `modelProvider: "acpx"` for those rows — the actual ACP runtime sentinel.


