### PR TITLE
fix(sessions): classify spawn-child sessions correctly; extract shared classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/status: classify ACP spawn-child sessions as `kind: "spawn-child"` instead of `"direct"` in `openclaw sessions` and status output; extract the duplicated session-kind classifier into a shared helper (`src/sessions/classify-session-kind.ts`) so both surfaces stay in sync. Fixes catalog #19. (#79544)
 - Telegram: delete tool-progress-only draft bubbles before rotating to the real answer, preventing orphaned progress messages in streamed replies.
 - ACP: preserve redacted numeric JSON-RPC `RequestError` details in runtime failure text, so backend diagnostics are visible instead of only `Internal error`. Fixes #81126. (#81188) Thanks @vyctorbrzezowski.
 - Agents: cache unchanged PI model discovery stores and model lookups, reducing repeated model-resolution startup latency under large model configs. Fixes #78851.

--- a/src/commands/sessions.kind-classification.test.ts
+++ b/src/commands/sessions.kind-classification.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions/types.js";
+import {
+  mockSessionsConfig,
+  resetMockSessionsConfig,
+  runSessionsJson,
+  writeStore,
+} from "./sessions.test-helpers.js";
+
+/**
+ * Catalog #19 — `kind` misclassified as `"direct"` for ACP spawn-child sessions.
+ *
+ * Bug summary: `classifySessionKey` (defined twice — `src/commands/sessions.ts:136-152`
+ * and `src/commands/status.summary.runtime.ts:129-145`) classifies a session
+ * based ONLY on the key shape (`:group:` / `:channel:` substrings) plus
+ * `entry.chatType`. It ignores `entry.spawnedBy` and `entry.deliveryContext`,
+ * so ACP spawn-child sessions (e.g., `agent:copilot:acp:<uuid>` with
+ * `spawnedBy: "agent:main:telegram:group:..."` and
+ * `deliveryContext: { channel: "telegram", to: <groupId>, threadId: <topic> }`)
+ * are misclassified as `kind: "direct"` even though they were spawned from a
+ * group/topic-bound parent.
+ *
+ * Available kinds today:
+ *   "global" | "unknown" | "cron" | "group" | "direct"
+ *
+ * The fix shape proposed in the catalog is to add a new `"spawn-child"` kind
+ * (or, alternatively, fall through to the parent's classification — but the
+ * catalog calls out `"spawn-child"` as the cleanest minimal fix).
+ *
+ * NOTE ON DUPLICATION: the same logic lives in two places —
+ *   - `src/commands/sessions.ts:136-152`        (called by `sessionsCommand`,
+ *     the path under test here)
+ *   - `src/commands/status.summary.runtime.ts:129-145`
+ * The eventual fix MUST update both, or extract a shared helper.
+ *
+ * NOTE ON SURFACE: `classifySessionKey` is private to each file (not exported),
+ * so this test drives the classification through the exposed seam:
+ * `sessionsCommand --json` and inspects the `kind` field of each session row
+ * (mirroring `src/commands/sessions.test.ts` and `sessions.acp-runtime-metadata.test.ts`).
+ */
+
+mockSessionsConfig();
+
+const { sessionsCommand } = await import("./sessions.js");
+
+type SessionRowKind = "global" | "unknown" | "cron" | "group" | "direct" | "spawn-child";
+
+type SessionsJsonPayload = {
+  sessions?: Array<{
+    key: string;
+    kind: SessionRowKind;
+  }>;
+};
+
+const ACP_SPAWN_CHILD_KEY = "agent:copilot:acp:7de23a0a-799d-4d63-b1b1-a7de9d4cd840";
+const ACP_DM_KEY = "agent:copilot:acp:86b7b5af-3773-4a56-b244-069d6c5d3db9";
+const TELEGRAM_GROUP_KEY = "agent:main:telegram:group:-1003967207344:topic:1";
+
+/**
+ * SessionEntry shape mirroring the deployed-container record described in
+ * the catalog (a copilot ACP session spawned by a telegram supergroup parent).
+ * Only the fields the classifier and the JSON emit path care about are set;
+ * everything else stays unset / default.
+ */
+function buildAcpSpawnChildEntry(): SessionEntry {
+  return {
+    sessionId: "spawn-child-session-id",
+    updatedAt: Date.now() - 2 * 60_000,
+    spawnedBy: TELEGRAM_GROUP_KEY,
+    deliveryContext: {
+      channel: "telegram",
+      to: "-1003967207344",
+      threadId: 323,
+    },
+    // No chatType — ACP spawn-child entries don't carry one. The classifier
+    // must infer "this came from a group" from spawnedBy / deliveryContext.
+  };
+}
+
+/**
+ * Plain DM-driven ACP session: same key shape (`agent:copilot:acp:<uuid>`)
+ * but no `spawnedBy` and a direct delivery context. Today's classifier
+ * correctly reports `"direct"` for this; that behavior should be preserved
+ * after the fix.
+ */
+function buildAcpDirectEntry(): SessionEntry {
+  return {
+    sessionId: "dm-session-id",
+    updatedAt: Date.now() - 5 * 60_000,
+    deliveryContext: {
+      channel: "telegram",
+      to: "+15555550123",
+    },
+  };
+}
+
+/**
+ * Group session with a key that explicitly embeds `:group:` — the
+ * classifier's existing key-shape branch picks this up correctly today
+ * and reports `"group"`.
+ */
+function buildTelegramGroupEntry(): SessionEntry {
+  return {
+    sessionId: "group-session-id",
+    updatedAt: Date.now() - 10 * 60_000,
+    chatType: "group",
+  };
+}
+
+describe("sessionsCommand kind classification (catalog #19)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-06T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    resetMockSessionsConfig();
+    vi.useRealTimers();
+  });
+
+  it("RED: ACP spawn-child session must NOT be classified as 'direct'", async () => {
+    // RED today. The classifier ignores `spawnedBy` and `deliveryContext`,
+    // so an ACP key with no `:group:` substring and no `chatType` falls
+    // through to `"direct"`. Operators see this session in
+    // `openclaw sessions --json` as `kind: "direct"` even though it was
+    // plainly spawned from a group/topic. See `src/commands/sessions.ts:136-152`.
+    const store = writeStore(
+      { [ACP_SPAWN_CHILD_KEY]: buildAcpSpawnChildEntry() },
+      "sessions-kind-spawn-child-red",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === ACP_SPAWN_CHILD_KEY);
+
+    expect(
+      row,
+      `Expected sessionsCommand --json to include a row for ${ACP_SPAWN_CHILD_KEY}; got none.`,
+    ).toBeDefined();
+    expect(
+      row?.kind,
+      `ACP spawn-child session ${ACP_SPAWN_CHILD_KEY} is misclassified: kind="${row?.kind}". ` +
+        `It carries spawnedBy="${TELEGRAM_GROUP_KEY}" and deliveryContext.channel="telegram", ` +
+        `which clearly mark it as a non-direct origin. The classifier at ` +
+        `src/commands/sessions.ts:136-152 ignores these fields and returns "direct".`,
+    ).not.toBe("direct");
+  });
+
+  it("RED (fix-shape): ACP spawn-child session should resolve to 'spawn-child'", async () => {
+    // RED today; flips GREEN once the proposed fix lands.
+    //
+    // The catalog's recommended fix introduces a new `"spawn-child"` kind
+    // checked BEFORE the key-shape branch so spawn-child ACP sessions take
+    // precedence over the fallback `"direct"` classification.
+    //
+    // If the fix author chooses a different label (e.g., `"acp-child"`) or
+    // a different shape (e.g., fall through to the parent's classification
+    // and report `"group"`), update this assertion to match. The structural
+    // point is that `entry.spawnedBy` / `entry.deliveryContext` MUST drive
+    // the classification for ACP children.
+    const store = writeStore(
+      { [ACP_SPAWN_CHILD_KEY]: buildAcpSpawnChildEntry() },
+      "sessions-kind-spawn-child-fix-shape",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === ACP_SPAWN_CHILD_KEY);
+
+    expect(row).toBeDefined();
+    expect(
+      row?.kind,
+      `ACP spawn-child session ${ACP_SPAWN_CHILD_KEY} should classify as "spawn-child" ` +
+        `(or whichever non-direct label the fix author chooses). Got "${row?.kind}". ` +
+        `Fix locations: src/commands/sessions.ts:136-152 AND ` +
+        `src/commands/status.summary.runtime.ts:129-145 (the same logic is duplicated; ` +
+        `extract to a shared helper or update both).`,
+    ).toBe("spawn-child");
+  });
+
+  it("GREEN control: non-spawn-child ACP DM session resolves to 'direct'", async () => {
+    // GREEN today. An ACP-keyed session WITHOUT `spawnedBy` and with a
+    // direct delivery context (or none) correctly resolves to `"direct"`.
+    // This control proves the test infrastructure exercises the real
+    // classification path; if it accidentally regressed to a different
+    // value, that would indicate the test harness was broken.
+    const store = writeStore(
+      { [ACP_DM_KEY]: buildAcpDirectEntry() },
+      "sessions-kind-acp-direct-control",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === ACP_DM_KEY);
+
+    expect(row).toBeDefined();
+    expect(row?.kind).toBe("direct");
+  });
+
+  it("GREEN control: telegram group key with chatType='group' resolves to 'group'", async () => {
+    // GREEN today. The classifier's key-shape branch (`:group:` substring)
+    // and the `chatType === "group"` branch both fire for this entry,
+    // yielding `"group"`. This control proves the existing happy-path
+    // classification still works and is not silently broken by the test
+    // harness.
+    const store = writeStore(
+      { [TELEGRAM_GROUP_KEY]: buildTelegramGroupEntry() },
+      "sessions-kind-group-control",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === TELEGRAM_GROUP_KEY);
+
+    expect(row).toBeDefined();
+    expect(row?.kind).toBe("group");
+  });
+});

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -49,7 +49,7 @@ describe("sessionsCommand", () => {
 
     const row = logs.find((line) => line.includes("+15555550123")) ?? "";
     expect(row).toBe(
-      "direct +15555550123               45m ago   pi:opus        OpenAI Codex       2.0k/32k (6%)        id:abc123",
+      "direct      +15555550123               45m ago   pi:opus        OpenAI Codex       2.0k/32k (6%)        id:abc123",
     );
   });
 
@@ -86,7 +86,7 @@ describe("sessionsCommand", () => {
 
     const row = logs.find((line) => line.includes("agent:main:main")) ?? "";
     expect(row).toBe(
-      "direct agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    id:main-session",
+      "direct      agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    id:main-session",
     );
   });
 
@@ -121,7 +121,7 @@ describe("sessionsCommand", () => {
 
     const row = logs.find((line) => line.includes("agent:main:main")) ?? "";
     expect(row).toBe(
-      "direct agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    id:main-session",
+      "direct      agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    id:main-session",
     );
   });
 
@@ -141,7 +141,7 @@ describe("sessionsCommand", () => {
 
     const row = logs.find((line) => line.includes("quietchat:group:demo")) ?? "";
     expect(row).toBe(
-      "group  quietchat:group:demo       5m ago    pi:opus        OpenAI Codex       unknown/32k (?%)     think:high id:xyz",
+      "group       quietchat:group:demo       5m ago    pi:opus        OpenAI Codex       unknown/32k (?%)     think:high id:xyz",
     );
   });
 

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -46,7 +46,7 @@ type SessionRow = SessionDisplayRow & {
 };
 
 const AGENT_PAD = 10;
-const KIND_PAD = 6;
+const KIND_PAD = 11; // "spawn-child".length — longest kind label
 const RUNTIME_PAD = 18;
 const TOKENS_PAD = 20;
 const DEFAULT_SESSIONS_LIMIT = 100;
@@ -186,9 +186,6 @@ const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
   }
   if (kind === "direct") {
     return theme.accent(label);
-  }
-  if (kind === "spawn-child") {
-    return theme.muted(label);
   }
   return theme.muted(label);
 };

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -7,7 +7,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { info } from "../globals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
-import { isCronSessionKey, isAcpSessionKey } from "../sessions/session-key-utils.js";
+import { classifySessionKind, type SessionKind } from "../sessions/classify-session-kind.js";
+import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { resolveAgentRuntimeLabel } from "../status/agent-runtime-label.js";
@@ -31,7 +32,7 @@ import {
 
 type SessionRow = SessionDisplayRow & {
   agentId: string;
-  kind: "cron" | "direct" | "group" | "global" | "unknown";
+  kind: SessionKind;
   agentRuntime: ReturnType<typeof resolveModelAgentRuntimeMetadata>;
   runtimeLabel: string;
   /**
@@ -172,25 +173,6 @@ async function lookupContextTokensForDisplay(model: string): Promise<number | un
   return lookupContextTokens(model, { allowAsyncLoad: false });
 }
 
-function classifySessionKey(key: string, entry?: { chatType?: string | null }): SessionRow["kind"] {
-  if (key === "global") {
-    return "global";
-  }
-  if (key === "unknown") {
-    return "unknown";
-  }
-  if (isCronSessionKey(key)) {
-    return "cron";
-  }
-  if (entry?.chatType === "group" || entry?.chatType === "channel") {
-    return "group";
-  }
-  if (key.includes(":group:") || key.includes(":channel:")) {
-    return "group";
-  }
-  return "direct";
-}
-
 const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
   const label = kind.padEnd(KIND_PAD);
   if (!rich) {
@@ -204,6 +186,9 @@ const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
   }
   if (kind === "direct") {
     return theme.accent(label);
+  }
+  if (kind === "spawn-child") {
+    return theme.muted(label);
   }
   return theme.muted(label);
 };
@@ -318,7 +303,7 @@ export async function sessionsCommand(
           agentId,
           acpRuntime,
           agentRuntime,
-          kind: classifySessionKey(row.key, store[row.key]),
+          kind: classifySessionKind(row.key, store[row.key]),
           runtimeLabel: resolveSessionRuntimeLabel({
             cfg,
             entry,

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -6,7 +6,7 @@ import { normalizeProviderId } from "../agents/provider-id.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { isCronSessionKey } from "../sessions/session-key-utils.js";
+import { classifySessionKind } from "../sessions/classify-session-kind.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -125,25 +125,6 @@ function resolveConfiguredProviderContextTokens(
   return undefined;
 }
 
-function classifySessionKey(key: string, entry?: SessionEntry) {
-  if (key === "global") {
-    return "global";
-  }
-  if (key === "unknown") {
-    return "unknown";
-  }
-  if (isCronSessionKey(key)) {
-    return "cron";
-  }
-  if (entry?.chatType === "group" || entry?.chatType === "channel") {
-    return "group";
-  }
-  if (key.includes(":group:") || key.includes(":channel:")) {
-    return "group";
-  }
-  return "direct";
-}
-
 function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
@@ -221,7 +202,7 @@ function resolveContextTokensForModel(params: {
 
 export const statusSummaryRuntime = {
   resolveContextTokensForModel,
-  classifySessionKey,
+  classifySessionKey: classifySessionKind,
   resolveSessionModelRef,
   resolveSessionRuntimeLabel,
   resolveConfiguredStatusModelRef,

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -1,11 +1,12 @@
 import type { ChannelId } from "../channels/plugins/types.public.js";
+import type { SessionKind } from "../sessions/classify-session-kind.js";
 import type { TaskAuditSummary } from "../tasks/task-registry.audit.js";
 import type { TaskRegistrySummary } from "../tasks/task-registry.types.js";
 
 export type SessionStatus = {
   agentId?: string;
   key: string;
-  kind: "cron" | "direct" | "group" | "global" | "unknown";
+  kind: SessionKind;
   sessionId?: string;
   updatedAt: number | null;
   age: number | null;

--- a/src/sessions/classify-session-kind.ts
+++ b/src/sessions/classify-session-kind.ts
@@ -1,0 +1,39 @@
+import { isCronSessionKey } from "./session-key-utils.js";
+
+export type SessionKind = "cron" | "direct" | "group" | "global" | "spawn-child" | "unknown";
+
+/**
+ * Classify a session key + entry into a display kind.
+ *
+ * Evaluation order matters — more-specific signals take priority:
+ *   1. sentinel keys ("global", "unknown")
+ *   2. cron key shape
+ *   3. spawn-child (entry has `spawnedBy`) — checked before key-shape so ACP
+ *      spawn-child sessions with opaque keys are not misclassified as "direct"
+ *   4. group/channel chatType or key-shape substring
+ *   5. fallback: "direct"
+ */
+export function classifySessionKind(
+  key: string,
+  entry?: { chatType?: string | null; spawnedBy?: string | null },
+): SessionKind {
+  if (key === "global") {
+    return "global";
+  }
+  if (key === "unknown") {
+    return "unknown";
+  }
+  if (isCronSessionKey(key)) {
+    return "cron";
+  }
+  if (entry?.spawnedBy) {
+    return "spawn-child";
+  }
+  if (entry?.chatType === "group" || entry?.chatType === "channel") {
+    return "group";
+  }
+  if (key.includes(":group:") || key.includes(":channel:")) {
+    return "group";
+  }
+  return "direct";
+}


### PR DESCRIPTION
## Summary

ACP spawn-child sessions (Telegram supergroup-spawned children, etc.) were misclassified as `kind: "direct"` in `openclaw sessions` listings. Add a new `"spawn-child"` kind, extract the duplicated session classifier into a shared helper, and make the new kind authoritative when `entry.spawnedBy` is set. Closes catalog #19.

## Bug detail

ACP sessions with `spawnedBy: "agent:main:telegram:group:-1003967207344:topic:1"` and a populated `deliveryContext` were reported as `kind: "direct"` in `openclaw sessions --json`. Most ACP sessions in deployed listings showed `direct` even though they had been spawned from a group with a bound thread context. Operators relying on the `kind` field for dashboards / triage filters were missing spawn-child sessions entirely.

## How to reproduce

Live repro before fix:

\`\`\`bash
docker compose exec codeclaw-openclaw openclaw sessions --all-agents --json \
  | jq '.sessions[] | select(.key | contains("acp:")) | {key, kind, deliveryContext}'
# Before: ACP sessions with spawnedBy still show "kind": "direct"
# After:  sessions with spawnedBy show "kind": "spawn-child"
\`\`\`

Unit-level:

\`\`\`bash
git checkout 8e48d27f54           # red-test cherry-pick
pnpm test src/commands/sessions.kind-classification.test.ts
# Before fix: 2 RED + 2 GREEN controls
# After fix commits a48d6d5e03 + d89ec0cafe: all 4 GREEN
\`\`\`

## Root cause

`classifySessionKey` was implemented twice — at `src/commands/sessions.ts:136-152` and duplicated at `src/commands/status.summary.runtime.ts:129-145`. Both classified by session-key shape only, not by entry metadata. ACP-style keys carry no embedded channel/thread indicator, so spawn-child ACP entries fell through to `"direct"`. The `spawnedBy` field on the entry was never consulted.

## Fix approach

1. **Extract** the duplicated classifier into a new shared helper at `src/sessions/classify-session-kind.ts` (`classifySessionKind`). Existing logic preserved.
2. **Add** an early `entry?.spawnedBy` truthy check that returns `"spawn-child"` BEFORE the key-shape branch — so spawn-child ACP sessions take precedence over the (now-correct but no-longer-default) shape-based fallback.
3. **Add** `"spawn-child"` to the `SessionKind` union and to `SessionRow["kind"]` in `src/commands/sessions.ts`.
4. **Replace** the inline classifier in `src/commands/status.summary.runtime.ts` with the shared import. The existing public `classifySessionKey` API surface is preserved via an alias on `statusSummaryRuntime`, so the existing test in `status.summary.runtime.test.ts` and the consumer in `status.summary.ts` need no changes.
5. **Widen** the `KIND_PAD` constant in `sessions.ts` from 6 to 11 to fit the new longest label and keep the table column aligned.

## Tests

- **Red test (now GREEN):** `src/commands/sessions.kind-classification.test.ts` — 4 cases (2 RED → GREEN, 2 GREEN controls stay GREEN).
- **Adjacent suite:** `src/commands/` — 196 files / 1502 tests pass.

## Catalog reference

Catalog finding: #19. Investigation lives in branch `edpiva/acp-native-session-investigation` (not yet upstream) at `docs/plans/2026-05-08-acp-findings-catalog.md`.

## Verification commands

\`\`\`bash
pnpm test src/commands/sessions.kind-classification.test.ts   # 4/4 GREEN
pnpm test src/commands/                                       # 1502/0
\`\`\`

## Notes for reviewers

- A separate classifier exists at `src/gateway/session-utils.ts:858` for the gateway RPC surface (`GatewaySessionRow["kind"]` = `"direct" | "group" | "global" | "unknown"` — narrower contract). It is intentionally NOT touched by this PR; if the gateway listing surface should also expose `"spawn-child"`, that's a separate follow-up.
- `SessionKind` is intentionally a different name than the existing `SessionKind` in `src/agents/tools/sessions-helpers.ts` — different domains, different unions, no shared imports. They co-exist safely.
- `formatKindCell` has a fallthrough that handles `"spawn-child"` by displaying it muted. The explicit `"spawn-child"` branch was removed because it was identical to the fallthrough.

---

## Live behavior repro (deployed container)

**Container:** `codeclaw-openclaw:clean` running OpenClaw 2026.5.6 (`e9d4a0a`)
**PII note:** Telegram chat/group/topic IDs redacted to `<chat-id>` / `<topic-id>`.

### Underlying store DOES carry `spawnedBy`, but `openclaw sessions --json` projects it away → kind defaults to `"direct"`

The disk-side store at `~/.openclaw/agents/copilot/sessions/sessions.json` records the spawning context for every spawn-child entry:

```
agent:copilot:acp:8fb42bab-…   sessionFile=…/e421061f-…   spawnedBy=agent:main:telegram:default:direct:<chat-id>
agent:copilot:acp:f5ab8dba-…   sessionFile=…/18a09361-…   spawnedBy=agent:main:telegram:group:<chat-id>:topic:<topic-id>
agent:copilot:acp:d6fb7506-…   sessionFile=…/1978341a-…   spawnedBy=agent:main:telegram:group:<chat-id>:topic:<topic-id>
agent:copilot:acp:86b7b5af-…   sessionFile=…/7de23a0a-…   spawnedBy=agent:main:telegram:group:<chat-id>:topic:<topic-id>
```

But the same sessions in `openclaw sessions --all-agents --json` report `spawnedBy: null` and `kind: "direct"` (or `"group"` for some) — the underlying signal isn't reaching the row classifier:

```json
{"key":"agent:copilot:acp:86b7b5af-…","kind":"direct","spawnedBy":null,"deliveryContext":null,…}
{"key":"agent:copilot:acp:f5ab8dba-…","kind":"direct","spawnedBy":null,"deliveryContext":null,…}
{"key":"agent:copilot:acp:d6fb7506-…","kind":"group","spawnedBy":null,"deliveryContext":null,…}
```

After this PR, `classifySessionKind` checks `entry?.spawnedBy` truthy BEFORE the key-shape branch, so spawn-child rows resolve to `kind: "spawn-child"` and operators can filter dashboards correctly.

(The follow-up gap noted by the reviewer — `src/gateway/session-utils.ts` still uses the narrower `GatewaySessionRow["kind"]` enum without `"spawn-child"` — is intentionally out of scope for this PR; tracked for a follow-up.)

---

## Updates

**2026-05-08 (follow-up commit `14c84f2bf8`):** Fixed post-push CI regression.

`src/commands/status.types.ts` had `SessionStatus.kind` typed as a hardcoded literal union `"cron" | "direct" | "group" | "global" | "unknown"` — the PR's new `"spawn-child"` member was not included, causing `TS2322` across all type-check and build shards (`check-prod-types`, `check-test-types`, `check-lint`, `build-artifacts`, `check-strict-smoke`, `check-additional-extension-*`, `build-smoke`). Fix: import and use the canonical `SessionKind` type from `src/sessions/classify-session-kind.ts` so the union stays in sync automatically. The `security-dependency-audit` failure (`fast-uri` CVE GHSA-v39h-62p7-jpjc) is pre-existing on `main` (green on commit `ac5acaeb`) and unrelated to this PR.

---

## Real behavior proof

- Behavior or issue addressed: ACP spawn-child sessions with persisted `spawnedBy` metadata classify as `kind: "spawn-child"` instead of falling through to `"direct"` in `openclaw sessions` and status output.
- Real environment tested: Azure Crabbox Linux lease `brisk-barnacle` / `cbx_5c3278f7e9f2`, fresh checkout of PR head `996e78598f958efb2e86ab381eda6c08eefdd8cc`, Node 22.22.2, seeded OpenClaw session store with ACP spawn-child and direct-control rows.
- Exact steps or command run after this patch:

```bash
pnpm test src/commands/sessions.kind-classification.test.ts
pnpm build
pnpm openclaw sessions --all-agents --json  # against a seeded ACP spawn-child session store
pnpm openclaw status --json                 # against the same seeded store
node scripts/run-oxlint.mjs src/sessions/classify-session-kind.ts src/commands/sessions.ts src/commands/status.summary.runtime.ts src/commands/status.types.ts src/commands/sessions.kind-classification.test.ts
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Maintainer-collected terminal output from Azure Crabbox:

```text
AFTER_FIX_ACP_ROW={"key":"agent:copilot:acp:<redacted>","kind":"spawn-child"}
CONTROL_DIRECT_ROW={"key":"agent:copilot:acp:<redacted-direct>","kind":"direct"}
STATUS_AFTER_FIX_ACP_ROW={"key":"agent:copilot:acp:<redacted>","kind":"spawn-child"}
Test Files 1 passed
Tests 4 passed
pnpm build passed
Found 0 warnings and 0 errors.
```

- Observed result after fix: `openclaw sessions --all-agents --json` reported the seeded ACP child row as `kind: "spawn-child"`; the ACP direct-control row stayed `kind: "direct"`; `openclaw status --json` also reported the ACP child row as `kind: "spawn-child"`.
- What was not tested: Live Telegram/Copilot ACP auth was not exercised in this maintainer proof; the after-fix behavior proof used a seeded session store that mirrors the deployed store shape from the before-fix repro.
