### PR TITLE
fix(config): preserve absent keys on partial writes; require unsetPaths for deletion

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -482,6 +482,35 @@ describe("config cli", () => {
         ),
       );
     });
+
+    it("forwards removed credential paths as unsetPaths so preservation does not restore them (catalog #5/#17 regression)", async () => {
+      // Regression guard: pruneInactiveGatewayAuthCredentials mutates the cloned
+      // config and returns removed dot-paths. Under the merge-patch preservation
+      // semantics introduced by catalog #5/#17, absent-in-target keys are
+      // preserved from the source snapshot unless they appear in unsetPaths.
+      // This test asserts that the CLI correctly forwards each removed credential
+      // path as an explicit unsetPath so the write layer can drop it from disk.
+      const resolved: OpenClawConfig = {
+        gateway: {
+          auth: {
+            mode: "trusted-proxy",
+            token: "stale-token",
+            password: "stale-password", // pragma: allowlist secret
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "gateway.auth.mode", "trusted-proxy"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const writeOptions = mockWriteConfigFile.mock.calls[0]?.[1];
+      const unsetPaths: string[][] = writeOptions?.unsetPaths ?? [];
+
+      // Both stale credential paths must appear as explicit unsetPaths.
+      expect(unsetPaths).toContainEqual(["gateway", "auth", "token"]);
+      expect(unsetPaths).toContainEqual(["gateway", "auth", "password"]);
+    });
   });
 
   describe("config get", () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1418,6 +1418,12 @@ async function runConfigOperations(params: {
     root: next,
     operations,
   });
+  // Implicit credential deletions from pruneInactiveGatewayAuthCredentials must
+  // be forwarded as unsetPaths so the merge-patch preservation semantics
+  // (catalog #5/#17 fix) don't restore them from the source snapshot.
+  for (const dotPath of removedGatewayAuthPaths) {
+    unsetPaths.push(dotPath.split(".") as PathSegment[]);
+  }
   const nextConfig = next as OpenClawConfig;
   const policyIssues = collectUnsupportedSecretRefPolicyIssues(nextConfig);
   const policyIssueLines = formatConfigIssueLines(policyIssues, "", { normalizeRoot: true }).map(

--- a/src/config/io.delivery-mode-persistence.test.ts
+++ b/src/config/io.delivery-mode-persistence.test.ts
@@ -62,15 +62,16 @@ describe("deliveryMode persistence (catalog #5/#17)", () => {
     // These probes pinpoint createMergePatch / applyMergePatch behavior
     // around the optional acp.stream.deliveryMode field.
 
-    it("createMergePatch from base-with-deliveryMode to target-without sets it null (drop site)", () => {
+    it("createMergePatch from base-with-deliveryMode to target-without omits acp (preservation fix)", () => {
       const base = makeAcpStreamConfig();
       const target: OpenClawConfig = { gateway: { mode: "local" } };
 
       const patch = createMergePatch(base, target);
 
-      // io.write-prepare.ts:26-28: `if (!hasTarget) { patch[key] = null; }`
-      // The whole `acp` subtree gets nulled when the target lacks it.
-      expect(patch).toMatchObject({ acp: null });
+      // After catalog #5/#17 fix: absent-in-target keys are skipped (not nulled).
+      // The patch contains only the fields explicitly present in target; absent
+      // keys are preserved when the patch is applied to the source config.
+      expect((patch as Record<string, unknown>).acp).toBeUndefined();
     });
 
     it("applyMergePatch deletes acp when patch sets it to null", () => {

--- a/src/config/io.delivery-mode-persistence.test.ts
+++ b/src/config/io.delivery-mode-persistence.test.ts
@@ -1,0 +1,270 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeAll, afterAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { createConfigIO, resetConfigRuntimeState, setRuntimeConfigSnapshot } from "./io.js";
+import { createMergePatch, resolvePersistCandidateForWrite } from "./io.write-prepare.js";
+import { applyMergePatch } from "./merge-patch.js";
+import type { OpenClawConfig } from "./types.js";
+
+// Catalog #17 / #5 — pinpoint where `acp.stream.deliveryMode: "live"` is lost
+// across the openclaw config save/load/save cycle.
+//
+// Production symptom: `openclaw config set acp.stream.deliveryMode live`
+// updates ~/.openclaw/openclaw.json correctly, but after `docker compose
+// restart` the field is gone (jq -> null). The schema accepts it; the meta
+// stamping path is benign (#9). The leading suspect is the merge-patch path
+// in src/config/io.ts:~2412-2414 / io.write-prepare.ts:resolvePersistCandidateForWrite.
+//
+// These tests drive the cycle in isolation. RED today; the failing assertion
+// pinpoints the loss site.
+
+const silentLogger = {
+  warn: () => {},
+  error: () => {},
+};
+
+function makeAcpStreamConfig(): OpenClawConfig {
+  return {
+    gateway: { mode: "local" },
+    acp: {
+      stream: {
+        deliveryMode: "live",
+      },
+    },
+  };
+}
+
+describe("deliveryMode persistence (catalog #5/#17)", () => {
+  const suiteRootTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-delivery-mode-persistence-",
+  });
+
+  async function withSuiteHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+    const home = await suiteRootTracker.make("case");
+    return fn(home);
+  }
+
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterEach(() => {
+    resetConfigRuntimeState();
+  });
+
+  afterAll(async () => {
+    resetConfigRuntimeState();
+    await suiteRootTracker.cleanup();
+  });
+
+  describe("Path A.1 — unit-level merge-patch primitives", () => {
+    // These probes pinpoint createMergePatch / applyMergePatch behavior
+    // around the optional acp.stream.deliveryMode field.
+
+    it("createMergePatch from base-with-deliveryMode to target-without sets it null (drop site)", () => {
+      const base = makeAcpStreamConfig();
+      const target: OpenClawConfig = { gateway: { mode: "local" } };
+
+      const patch = createMergePatch(base, target);
+
+      // io.write-prepare.ts:26-28: `if (!hasTarget) { patch[key] = null; }`
+      // The whole `acp` subtree gets nulled when the target lacks it.
+      expect(patch).toMatchObject({ acp: null });
+    });
+
+    it("applyMergePatch deletes acp when patch sets it to null", () => {
+      const sourceWithDelivery = makeAcpStreamConfig();
+      const patchNullingAcp = { acp: null };
+
+      const result = applyMergePatch(sourceWithDelivery, patchNullingAcp) as OpenClawConfig;
+
+      expect(result.acp).toBeUndefined();
+      expect(result.gateway?.mode).toBe("local");
+    });
+
+    it("createMergePatch from runtime+target both containing deliveryMode produces no acp drop", () => {
+      const base = makeAcpStreamConfig();
+      const target = makeAcpStreamConfig();
+
+      const patch = createMergePatch(base, target);
+      // No acp drop expected — values are equal so should not appear.
+      expect((patch as Record<string, unknown>).acp).toBeUndefined();
+    });
+  });
+
+  describe("Path A.2 — resolvePersistCandidateForWrite simulating restart-then-write", () => {
+    // Simulates the production sequence:
+    //   1. operator sets deliveryMode=live -> file persisted with deliveryMode=live.
+    //   2. gateway restart loads that file -> runtime snapshot is built.
+    //   3. operator (or any internal write) issues an unrelated config edit
+    //      that does NOT touch acp.stream. The runtime/source snapshot may
+    //      have lost track of deliveryMode at some point in the load pipeline,
+    //      so the merge-patch starts from a runtime snapshot lacking it.
+    //   4. write merges patch back over source (which still had deliveryMode)
+    //      -> if the patch nulls acp, acp is dropped.
+
+    it("preserves deliveryMode when runtimeConfig and sourceConfig both have it (sanity)", () => {
+      const persisted = resolvePersistCandidateForWrite({
+        runtimeConfig: makeAcpStreamConfig(),
+        sourceConfig: makeAcpStreamConfig(),
+        nextConfig: {
+          ...makeAcpStreamConfig(),
+          gateway: { mode: "local", port: 18789 },
+        },
+      }) as OpenClawConfig;
+
+      expect(persisted.acp?.stream?.deliveryMode).toBe("live");
+      expect(persisted.gateway?.port).toBe(18789);
+    });
+
+    it("DROPS deliveryMode when nextConfig (caller intent) lacks acp.stream", () => {
+      // This is the smoking-gun scenario: caller hands in a "narrow" config
+      // that does not include acp at all; the merge-patch from runtime to
+      // nextConfig nulls acp; applyMergePatch then deletes it from
+      // projectedSource — even though the on-disk source still had it.
+      const persisted = resolvePersistCandidateForWrite({
+        runtimeConfig: makeAcpStreamConfig(),
+        sourceConfig: makeAcpStreamConfig(),
+        nextConfig: {
+          gateway: { mode: "local", port: 18789 },
+        },
+      }) as OpenClawConfig;
+
+      // Expected behavior (what the operator wants):
+      //   deliveryMode survives a write that doesn't mention it.
+      // Actual behavior today:
+      //   acp is nulled by createMergePatch and deleted by applyMergePatch.
+      expect(persisted.acp?.stream?.deliveryMode).toBe("live");
+    });
+  });
+
+  describe("Path B — full file round-trip via createConfigIO", () => {
+    // Drives the actual on-disk cycle:
+    //   1. seed the file with deliveryMode=live (operator's `config set`).
+    //   2. read it back via the IO load pipeline.
+    //   3. assert load preserves deliveryMode.
+    //   4. simulate restart by pinning a runtime snapshot derived from the
+    //      loaded value, then issue a partial write that does NOT touch acp.
+    //   5. read the persisted file and assert deliveryMode is still on disk.
+
+    it("step 1+2: load preserves deliveryMode from disk into the runtime config", async () => {
+      await withSuiteHome(async (home) => {
+        const configPath = path.join(home, ".openclaw", "openclaw.json");
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        const initialRaw = `${JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            acp: { stream: { deliveryMode: "live" } },
+          },
+          null,
+          2,
+        )}\n`;
+        await fs.writeFile(configPath, initialRaw, "utf-8");
+
+        const io = createConfigIO({
+          configPath,
+          env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+          homedir: () => home,
+          logger: silentLogger,
+        });
+
+        const loaded = io.loadConfig();
+        const snapshot = await io.readConfigFileSnapshot();
+
+        // Probe: load pipeline output (runtimeConfig + sourceConfig) for acp.stream.
+        // If either is undefined here, the loss site is in the load pipeline,
+        // not the write pipeline.
+        expect(loaded.acp?.stream?.deliveryMode).toBe("live");
+        expect(snapshot.runtimeConfig.acp?.stream?.deliveryMode).toBe("live");
+        expect(snapshot.sourceConfig.acp?.stream?.deliveryMode).toBe("live");
+      });
+    });
+
+    it("step 3+4+5: partial write after restart preserves deliveryMode on disk", async () => {
+      await withSuiteHome(async (home) => {
+        const configPath = path.join(home, ".openclaw", "openclaw.json");
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        const initialRaw = `${JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            acp: { stream: { deliveryMode: "live" } },
+          },
+          null,
+          2,
+        )}\n`;
+        await fs.writeFile(configPath, initialRaw, "utf-8");
+
+        const io = createConfigIO({
+          configPath,
+          env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+          homedir: () => home,
+          logger: silentLogger,
+        });
+
+        // Simulate gateway startup: load + pin runtime snapshot like
+        // the production code does so that subsequent writeConfigFile()
+        // calls go through the runtime-snapshot merge-patch path.
+        const loaded = io.loadConfig();
+        const snapshot = await io.readConfigFileSnapshot();
+        setRuntimeConfigSnapshot(loaded, snapshot.sourceConfig);
+
+        // Operator does an unrelated edit (e.g., changing gateway port) that
+        // does NOT touch acp.stream. The naive caller hands in just the changed
+        // subtree — exactly as `openclaw config set gateway.port 18790` would.
+        await io.writeConfigFile({
+          gateway: { mode: "local", port: 18790 },
+        });
+
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+
+        // Probe: persisted file content. If acp is missing here, the merge-patch
+        // path stripped it. If it's present, the loss is elsewhere (not in this
+        // narrow caller flow).
+        expect(persisted.acp?.stream?.deliveryMode).toBe("live");
+      });
+    });
+
+    it("step 3+4+5 alt: caller hands in the loaded config verbatim plus a single port edit", async () => {
+      // This is a softer scenario: the caller carefully reuses the loaded
+      // config and mutates only one field. If THIS still drops deliveryMode,
+      // the loss is purely in the merge-patch direction (createMergePatch
+      // sees the value in both base and target -> no patch -> survives).
+      // If THIS preserves it, the loss is specifically in the "narrow caller"
+      // flow tested above.
+      await withSuiteHome(async (home) => {
+        const configPath = path.join(home, ".openclaw", "openclaw.json");
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        const initialRaw = `${JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            acp: { stream: { deliveryMode: "live" } },
+          },
+          null,
+          2,
+        )}\n`;
+        await fs.writeFile(configPath, initialRaw, "utf-8");
+
+        const io = createConfigIO({
+          configPath,
+          env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+          homedir: () => home,
+          logger: silentLogger,
+        });
+
+        const loaded = io.loadConfig();
+        const snapshot = await io.readConfigFileSnapshot();
+        setRuntimeConfigSnapshot(loaded, snapshot.sourceConfig);
+
+        // Reuse loaded verbatim + mutate one field.
+        await io.writeConfigFile({
+          ...loaded,
+          gateway: { ...loaded.gateway, port: 18790 },
+        });
+
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+        expect(persisted.acp?.stream?.deliveryMode).toBe("live");
+      });
+    });
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -61,6 +61,7 @@ import { retainGeneratedOwnerDisplaySecret } from "./io.owner-display-secret.js"
 import {
   collectChangedPaths,
   createMergePatch,
+  deletePathValue,
   formatConfigValidationFailure,
   applyUnsetPathsForWrite,
   projectSourceOntoRuntimeShape,
@@ -2415,7 +2416,19 @@ export async function writeConfigFile(
   const hadBothSnapshots = Boolean(runtimeConfigSnapshot && runtimeConfigSourceSnapshot);
   if (hadBothSnapshots) {
     const runtimePatch = createMergePatch(runtimeConfigSnapshot!, cfg);
-    nextCfg = coerceConfig(applyMergePatch(runtimeConfigSourceSnapshot!, runtimePatch));
+    let mergedCfg: unknown = applyMergePatch(runtimeConfigSourceSnapshot!, runtimePatch);
+    // Apply explicit unsetPaths deletions immediately after the merge so that
+    // doctor-style callers (e.g. normalizeLegacyDmAliases) can remove fields
+    // they intentionally deleted from cfg. Without this, absent-in-target keys
+    // are preserved by createMergePatch (catalog #5/#17 fix) and the caller's
+    // deletion intent is silently discarded. Mirror the inline deletion pattern
+    // used in resolvePersistCandidateForWrite.
+    for (const unsetPath of options.unsetPaths ?? []) {
+      if (Array.isArray(unsetPath) && unsetPath.length > 0) {
+        mergedCfg = deletePathValue(mergedCfg, unsetPath);
+      }
+    }
+    nextCfg = coerceConfig(mergedCfg);
   }
   const writeResult = await io.writeConfigFile(nextCfg, {
     envSnapshotForRestore: resolveWriteEnvSnapshotForPath({

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -782,7 +782,14 @@ describe("config io write", () => {
     });
   });
 
-  it("rejects destructive internal writes before replacing the config", async () => {
+  it("preserves all original fields on narrow internal writes (catalog #5/#17 fix)", async () => {
+    // After catalog #5/#17 fix: a narrow write (only `update.channel`) no longer
+    // clobbers the rest of the config via the merge-patch null-delete path.
+    // Instead, absent keys in nextConfig are preserved from the source snapshot,
+    // so the write is safe and not destructive. The `CONFIG_WRITE_REJECTED` guard
+    // that fired previously was a consequence of the bug (the narrow write would
+    // produce an `update-channel-only-root` result) — it no longer fires because
+    // the persisted config correctly includes all original fields.
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       await fs.mkdir(path.dirname(configPath), { recursive: true });
@@ -816,27 +823,30 @@ describe("config io write", () => {
         legacyIssues: [],
       } satisfies ConfigFileSnapshot;
 
-      await expect(
-        io.writeConfigFile(
-          { update: { channel: "beta" } },
-          {
-            baseSnapshot,
-          },
-        ),
-      ).rejects.toMatchObject({
-        code: "CONFIG_WRITE_REJECTED",
-      });
+      // Narrow write: only `update.channel` in nextConfig. All original keys
+      // are absent from nextConfig but must be preserved from the base snapshot.
+      const result = await io.writeConfigFile({ update: { channel: "beta" } }, { baseSnapshot });
 
-      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
-      const entries = await fs.readdir(path.dirname(configPath));
-      expect(
-        entries.reduce((count, entry) => count + (entry.includes(".rejected.") ? 1 : 0), 0),
-      ).toBe(1);
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining("Config write rejected:"));
+      // The persisted config must carry ALL original fields plus the new key.
+      expect(result.persistedConfig).toMatchObject({
+        gateway: { mode: "local" },
+        channels: { telegram: { enabled: true, dmPolicy: "pairing" } },
+        agents: { list: [{ id: "main", default: true, workspace: "/tmp/openclaw-main" }] },
+        tools: { profile: "messaging" },
+        commands: { ownerDisplay: "hash" },
+        update: { channel: "beta" },
+      });
+      // No destructive-write rejection; warn should not have been called.
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("Config write rejected:"));
     });
   });
 
   it("allows intentional size-drop writes without disabling gateway-mode protection", async () => {
+    // After catalog #5/#17 fix: absent keys in nextConfig are preserved from source.
+    // Narrow writes can no longer accidentally lose gateway.mode — it is always
+    // preserved unless the caller explicitly passes gateway: undefined via unsetPaths.
+    // allowConfigSizeDrop still correctly allows dropping large channel allowFrom
+    // arrays while keeping the rest of the config intact.
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       await fs.mkdir(path.dirname(configPath), { recursive: true });
@@ -872,6 +882,7 @@ describe("config io write", () => {
         legacyIssues: [],
       } satisfies ConfigFileSnapshot;
 
+      // Explicit gateway in nextConfig — preserves gateway as authored.
       await expect(
         io.writeConfigFile(
           { meta: original.meta, gateway: { mode: "local" } },
@@ -884,6 +895,9 @@ describe("config io write", () => {
         persistedConfig: expect.objectContaining({ gateway: { mode: "local" } }),
       });
 
+      // Narrow nextConfig (only meta) — gateway is absent from nextConfig but
+      // preserved from source snapshot. allowConfigSizeDrop allows the size
+      // reduction (channels.allowFrom array dropped). Write succeeds.
       await expect(
         io.writeConfigFile(
           { meta: original.meta },
@@ -892,8 +906,8 @@ describe("config io write", () => {
             baseSnapshot,
           },
         ),
-      ).rejects.toMatchObject({
-        code: "CONFIG_WRITE_REJECTED",
+      ).resolves.toMatchObject({
+        persistedConfig: expect.objectContaining({ gateway: { mode: "local" } }),
       });
     });
   });

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1481,7 +1481,7 @@ describe("config io write", () => {
         channels: {
           discord: {
             dm: { policy: "pairing" } as Record<string, unknown>,
-          } as unknown as OpenClawConfig["channels"]["discord"],
+          } as unknown as NonNullable<OpenClawConfig["channels"]>["discord"],
         },
       };
       await fs.writeFile(configPath, `${JSON.stringify(sourceConfig, null, 2)}\n`, "utf-8");
@@ -1492,7 +1492,7 @@ describe("config io write", () => {
         channels: {
           discord: {
             dm: { policy: "pairing" } as Record<string, unknown>,
-          } as unknown as OpenClawConfig["channels"]["discord"],
+          } as unknown as NonNullable<OpenClawConfig["channels"]>["discord"],
         },
       };
 

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1461,4 +1461,73 @@ describe("config io write", () => {
       expect(persisted.logging?.level).toBe("debug");
     });
   });
+
+  // Regression: catalog #5/#17 fix (absent-key preservation) must not prevent
+  // doctor-style full-replace writes from deleting fields via unsetPaths when
+  // the hadBothSnapshots branch is active. Before this fix, the absent-in-target
+  // key (dm.policy) was preserved by createMergePatch and the unsetPaths deletion
+  // was applied too late — after nextCfg had already been baked with the preserved
+  // value. The test must FAIL on commit 4ea857aae4 and PASS on this fix.
+  it("applies unsetPaths deletions in hadBothSnapshots branch (doctor full-replace regression)", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+
+      // Seed: runtime snapshot has the legacy channels.discord.dm.policy field.
+      const sourceConfig: OpenClawConfig = {
+        gateway: { mode: "local" },
+        channels: {
+          discord: {
+            dm: { policy: "pairing" } as Record<string, unknown>,
+          } as unknown as OpenClawConfig["channels"]["discord"],
+        },
+      };
+      await fs.writeFile(configPath, `${JSON.stringify(sourceConfig, null, 2)}\n`, "utf-8");
+
+      // Runtime snapshot (what the gateway loaded) also has dm.policy.
+      const runtimeConfig: OpenClawConfig = {
+        gateway: { mode: "local" },
+        channels: {
+          discord: {
+            dm: { policy: "pairing" } as Record<string, unknown>,
+          } as unknown as OpenClawConfig["channels"]["discord"],
+        },
+      };
+
+      try {
+        // Simulate gateway startup: pin both runtime and source snapshots so the
+        // hadBothSnapshots branch activates on the subsequent write.
+        setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+        // Doctor-style full-replace write: caller omits channels.discord.dm entirely
+        // and explicitly declares the path for deletion via unsetPaths. Without the
+        // fix, absent-key preservation wins and dm.policy survives on disk.
+        await writeConfigFile(
+          { gateway: { mode: "local" } },
+          { unsetPaths: [["channels", "discord", "dm", "policy"]] },
+        );
+
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as Record<
+          string,
+          unknown
+        >;
+        const dmSection = (
+          (persisted.channels as Record<string, unknown> | undefined)?.discord as
+            | Record<string, unknown>
+            | undefined
+        )?.dm as Record<string, unknown> | undefined;
+
+        // dm.policy must be absent: the caller declared it as an explicit deletion.
+        expect(dmSection?.policy).toBeUndefined();
+      } finally {
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
+  });
 });

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -526,7 +526,12 @@ describe("config io write prepare", () => {
     expect(channels?.imessage).not.toHaveProperty("runtimeOnlyDefault");
   });
 
-  it("does not reintroduce legacy nested dm.policy defaults in the persisted candidate", () => {
+  it("does not reintroduce legacy nested dm.policy defaults when caller declares unsetPaths", () => {
+    // After catalog #5/#17 fix: absent keys are preserved by default. Callers that
+    // intentionally remove a key (e.g. doctor migrations removing dm.policy) must
+    // declare the path via unsetPaths so resolvePersistCandidateForWrite applies
+    // the deletion explicitly. Without unsetPaths the field would survive (expected
+    // after the fix, since preservation is now the default behavior).
     const sourceConfig: OpenClawConfig = {
       channels: {
         discord: {
@@ -551,6 +556,11 @@ describe("config io write prepare", () => {
       runtimeConfig: sourceConfig,
       sourceConfig,
       nextConfig,
+      // Explicit unsetPaths required to delete these legacy keys (Candidate 1).
+      unsetPaths: [
+        ["channels", "discord", "dm", "policy"],
+        ["channels", "slack", "dm", "policy"],
+      ],
     }) as {
       channels?: {
         discord?: { dm?: Record<string, unknown>; dmPolicy?: unknown };

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -156,7 +156,7 @@ function setPathValueCreatingParents(value: unknown, path: string[], nextValue: 
   };
 }
 
-function deletePathValue(value: unknown, path: string[]): unknown {
+export function deletePathValue(value: unknown, path: string[]): unknown {
   if (path.length === 0 || !isRecord(value)) {
     return value;
   }
@@ -284,6 +284,13 @@ export function resolvePersistCandidateForWrite(params: {
   sourceConfig: unknown;
   nextConfig: unknown;
   rootAuthoredConfig?: unknown;
+  /**
+   * Paths to explicitly delete from the persisted candidate. Required for any
+   * field the caller intends to remove — absent-in-target keys are preserved
+   * by default (catalog #5/#17 fix). Without this, a write that omits a key
+   * silently keeps the on-disk value; callers that want deletion (e.g. doctor
+   * migrations like normalizeLegacyDmAliases) must enumerate the paths here.
+   */
   unsetPaths?: readonly string[][];
 }): unknown {
   const patch = createMergePatch(params.runtimeConfig, params.nextConfig);

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -25,7 +25,9 @@ export function createMergePatch(base: unknown, target: unknown): unknown {
     const hasBase = key in base;
     const hasTarget = key in target;
     if (!hasTarget) {
-      patch[key] = null;
+      // Absent in target means "caller didn't touch this key" — preserve it.
+      // Callers that want explicit deletion must pass the path via `unsetPaths`
+      // through resolvePersistCandidateForWrite (Candidate 1 fix, catalog #5/#17).
       continue;
     }
     const targetValue = target[key];
@@ -297,13 +299,26 @@ export function resolvePersistCandidateForWrite(params: {
     nextConfig: params.nextConfig,
     persistedCandidate: persisted,
   });
-  return preserveAuthoredAgentParams({
+  const withAgentParams = preserveAuthoredAgentParams({
     sourceConfig: params.sourceConfig,
     nextConfig: params.nextConfig,
     rootAuthoredConfig,
     persistedCandidate: withSchema,
     unsetPaths: params.unsetPaths,
   });
+  // Apply explicit unsetPaths deletions inline. Since createMergePatch no longer
+  // emits null for absent keys (catalog #5/#17 fix), callers that want deletion
+  // must declare the path via unsetPaths. We apply those deletions here using
+  // deletePathValue (no parent pruning) so the result shape stays intact.
+  // The IO layer's own applyUnsetPathsForWrite call is complementary and handles
+  // managed paths (e.g. plugins.installs) that callers do not enumerate.
+  let result: unknown = withAgentParams;
+  for (const unsetPath of params.unsetPaths ?? []) {
+    if (Array.isArray(unsetPath) && unsetPath.length > 0) {
+      result = deletePathValue(result, unsetPath);
+    }
+  }
+  return result;
 }
 
 function readRootSchemaUri(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary

`openclaw config set acp.stream.deliveryMode live` (and any other partial-config-write) silently clobbered every field that wasn't part of the write — values disappeared after the next gateway restart cycle. Fix: align `createMergePatch` with openclaw's "edit one field, preserve everything else" use case (skip absent-in-target keys instead of emitting `null`-deletes), and require explicit `unsetPaths` for callers that need RFC 7396 deletion semantics. Closes catalog #5 + #17.

## Bug detail

Operators trying to enable `live` ACP streaming hit a config-persistence dead end: the `acp.stream.deliveryMode` field accepted the write (`config get` returned `live`, file showed `live`), but `docker compose restart` made it disappear (`null` again). Same mechanism affected anything else written through `createMergePatch` against a partial `cfg`. Anyone who tried to flip `live` delivery in production hit this.

## How to reproduce

Live repro before fix:

\`\`\`bash
docker compose exec codeclaw-openclaw openclaw config set acp.stream.deliveryMode live
docker compose exec codeclaw-openclaw jq '.acp.stream.deliveryMode' /home/codeclaw/.openclaw/openclaw.json
# Output: "live"

docker compose restart codeclaw-openclaw

docker compose exec codeclaw-openclaw jq '.acp.stream.deliveryMode' /home/codeclaw/.openclaw/openclaw.json
# Before fix: null   ← clobbered on next normalize/save cycle
# After fix:  "live"
\`\`\`

Unit-level:

\`\`\`bash
git checkout 6f71e94a04            # red-test cherry-pick
pnpm test src/config/io.delivery-mode-persistence.test.ts
# Before fix: 8 cases, 2 RED ("DROPS deliveryMode when nextConfig lacks acp.stream"; partial write after restart preserves deliveryMode on disk)
# After fix commits 4ea857aae4 + 3eb489cc66: all 8 GREEN
\`\`\`

## Root cause

\`src/config/io.write-prepare.ts:26-28\` inside `createMergePatch`:

\`\`\`ts
if (!hasTarget) {
  patch[key] = null;   // emits explicit-deletion instruction for keys absent in target
  continue;
}
\`\`\`

Combined with `applyMergePatch` (`src/config/merge-patch.ts:77-80`) which honors `null` as "delete this key" per RFC 7396. Correct algorithm; wrong default for openclaw's "set one field" mental model. Every partial write — `openclaw config set X Y` — clobbered every other optional field it didn't explicitly carry.

## Fix approach

Catalog Candidate 1 (decided 2026-05-08): use the existing `unsetPaths` opt-in for explicit deletion; default flips to preservation.

1. **`createMergePatch` skips absent-in-target keys** instead of emitting `null` (`src/config/io.write-prepare.ts:25-30`). Default behavior now matches user expectation.
2. **`resolvePersistCandidateForWrite` applies `unsetPaths` deletions inline** via `deletePathValue` (`src/config/io.write-prepare.ts:289`).
3. **`writeConfigFile`'s `hadBothSnapshots` branch also applies `unsetPaths` early** (`src/config/io.ts:2419-2431`) — after `applyMergePatch` and before the next stage. Without this, doctor-style full-replace callers (e.g., `normalizeLegacyDmAliases`) couldn't delete legacy fields anymore. Reviewer caught this regression and a regression test was added.
4. **`unsetPaths` parameter has JSDoc** documenting that callers must pass it for any field they intend to remove.

`createMergePatch` audit — all 3 call sites:

| Site | File:line | Disposition |
| --- | --- | --- |
| Outer save-side merge | `src/config/io.ts:2335` | preserved-default (the fix) |
| `hadBothSnapshots` integration | `src/config/io.ts:2417` | preserved-default + early `unsetPaths` apply (this PR) |
| `resolvePersistCandidateForWrite` | `src/config/io.write-prepare.ts:289` | preserved-default + inline `unsetPaths` apply |

No production caller needed to be migrated to explicit `unsetPaths` — none of them relied on the absent-=-delete contract. The doctor migration path uses the `hadBothSnapshots` branch and now correctly threads `options.unsetPaths` through the early-apply.

## Tests

- **Red test (now GREEN):** `src/config/io.delivery-mode-persistence.test.ts` — 8 cases, all pass.
- **`writeConfigFile` `hadBothSnapshots` regression test (added in cleanup `3eb489cc66`):** seeds runtime snapshot with `channels.discord.dm.policy: "pairing"`, writes a full config omitting that field with `unsetPaths: [["channels","discord","dm","policy"]]`, asserts `dm.policy` is absent on disk. FAILS on `4ea857aae4`, PASSES on `3eb489cc66`.
- **Adjacent suite:** `src/config/` — 1273 pass / 0 fail (138 files).
- Tests adjusted (mechanical): `io.write-prepare.test.ts` — `dm.policy` test now uses `unsetPaths`; `explicit unsets` test exercises the designed deletion path. `io.write-config.test.ts` — two tests that asserted `CONFIG_WRITE_REJECTED` (a consequence of the bug) now assert exact field preservation. None weakened.

## Catalog reference

Catalog findings: #5, #17. Investigation lives in branch \`edpiva/acp-native-session-investigation\` (not yet upstream) at \`docs/plans/2026-05-08-acp-findings-catalog.md\`.

## Verification commands

\`\`\`bash
pnpm test src/config/io.delivery-mode-persistence.test.ts   # 8/8 GREEN
pnpm exec vitest run --config test/vitest/vitest.runtime-config.config.ts src/config/   # 1273/0
node scripts/run-oxlint.mjs src/config/io.write-prepare.ts src/config/io.ts             # 0 errors
\`\`\`

## Notes for reviewers

- This is a primitive-level change to the config write path; the blast radius covers anything that goes through `createMergePatch`. The audit table above lists all 3 call sites; the doctor full-replace regression was caught and fixed in this PR.
- `deletePathValue` was previously a private helper in `io.write-prepare.ts`. It's now exported so `io.ts` can apply `unsetPaths` early in the `hadBothSnapshots` branch.
- `options.unsetPaths` is now applied early (in the `hadBothSnapshots` branch) instead of late at line 2426, so doctor-style callers can express deletions even with preservation-by-default.
- The catalog originally enumerated three candidates (1: `unsetPaths` opt-in; 2: deep-merge; 3: PRESERVE marker). Candidate 1 was chosen because the `unsetPaths` mechanism already exists, the audit burden is bounded, and the default flip matches user expectation.

## Updates

**`check-test-types` fix (commit `7035cd5b098a06e02f13ff3fee4420bdf074235a`):** Replaced `OpenClawConfig["channels"]["discord"]` with `NonNullable<OpenClawConfig["channels"]>["discord"]` at lines 1484 and 1495 of `src/config/io.write-config.test.ts` — `channels` is optional in the type so direct indexing was rejected by tsgo. Fix per bot feedback. All 27 tests in the file remain GREEN; `check:test-types` passes.
