### PR TITLE
fix(sessions): report ACP-runtime metadata for ACP-keyed sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Sessions/status: classify ACP spawn-child sessions as `kind: "spawn-child"` instead of `"direct"` in `openclaw sessions` and status output; extract the duplicated session-kind classifier into a shared helper (`src/sessions/classify-session-kind.ts`) so both surfaces stay in sync. Fixes catalog #19. (#79544)
+- Sessions/Gateway: report `agentRuntime.id: "acpx"` (or stored backend id) with `source: "session-key"` for ACP control-plane session rows in `openclaw sessions --json`, `openclaw status`, and Gateway session RPC responses instead of the incorrect `"auto"` / `"pi"` implicit fallback. Fixes catalog #18. (#79550)
 - Telegram: delete tool-progress-only draft bubbles before rotating to the real answer, preventing orphaned progress messages in streamed replies.
 - Codex app-server: keep per-agent `CODEX_HOME` isolation without rewriting `HOME` by default, so Codex-run subprocesses can still find normal user-home config, tokens, and CLI state unless the launch explicitly overrides `HOME`. Thanks @pashpashpash.
 - ACP: preserve redacted numeric JSON-RPC `RequestError` details in runtime failure text, so backend diagnostics are visible instead of only `Internal error`. Fixes #81126. (#81188) Thanks @vyctorbrzezowski.

--- a/src/agents/acp-runtime-overlay.ts
+++ b/src/agents/acp-runtime-overlay.ts
@@ -13,16 +13,17 @@ export type AgentRuntimeMetadata = {
 };
 
 /**
- * When a session key unambiguously identifies an ACP session (contains the `:acp:`
- * segment), override the resolved runtime metadata to report the ACP runtime id
- * with a "session-key" source — regardless of what the agent-config policy
- * resolved to.  Without this overlay, callers that only have agent-config context
- * (no model/provider) fall back to `id: "pi"` even though the session key makes
- * the actual runtime unambiguous.
+ * When a session key and persisted session metadata identify an ACP
+ * control-plane session, override the resolved runtime metadata to report the
+ * ACP runtime id with a "session-key" source — regardless of what the
+ * agent-config policy resolved to.
  *
  * Callers that already have model/provider context (resolveModelAgentRuntimeMetadata)
  * still benefit here because the model-runtime policy chain does not inspect session
  * keys for the ACP indicator.
+ *
+ * Key shape alone is not sufficient: ACP bridge sessions may use ACP-shaped
+ * keys without persisted SessionAcpMeta and still run the configured model.
  *
  * When `acpBackend` is provided and non-empty, it is used as the runtime id so that
  * sessions backed by a configured non-default ACP backend (e.g. a custom registered
@@ -32,9 +33,10 @@ export type AgentRuntimeMetadata = {
 export function applyAcpRuntimeOverlay(
   meta: AgentRuntimeMetadata,
   sessionKey: string | undefined | null,
+  acpRuntime: boolean | undefined,
   acpBackend?: string,
 ): AgentRuntimeMetadata {
-  if (isAcpSessionKey(sessionKey)) {
+  if (acpRuntime === true && isAcpSessionKey(sessionKey)) {
     const id = acpBackend && acpBackend.length > 0 ? acpBackend : "acpx";
     return { id, source: "session-key" };
   }

--- a/src/agents/acp-runtime-overlay.ts
+++ b/src/agents/acp-runtime-overlay.ts
@@ -4,7 +4,7 @@ import type { AgentRuntimeMetadata } from "./agent-runtime-metadata.js";
 /**
  * When a session key unambiguously identifies an ACP session (contains the `:acp:`
  * segment), override the resolved runtime metadata to report the ACP runtime id
- * ("acpx") with a "session-key" source — regardless of what the agent-config policy
+ * with a "session-key" source — regardless of what the agent-config policy
  * resolved to.  Without this overlay, callers that only have agent-config context
  * (no model/provider) fall back to `id: "pi"` even though the session key makes
  * the actual runtime unambiguous.
@@ -12,13 +12,20 @@ import type { AgentRuntimeMetadata } from "./agent-runtime-metadata.js";
  * Callers that already have model/provider context (resolveModelAgentRuntimeMetadata)
  * still benefit here because the model-runtime policy chain does not inspect session
  * keys for the ACP indicator.
+ *
+ * When `acpBackend` is provided and non-empty, it is used as the runtime id so that
+ * sessions backed by a configured non-default ACP backend (e.g. a custom registered
+ * backend) are reported faithfully instead of always being labelled "acpx".
+ * Falls back to "acpx" when no backend is known.
  */
 export function applyAcpRuntimeOverlay(
   meta: AgentRuntimeMetadata,
   sessionKey: string | undefined | null,
+  acpBackend?: string,
 ): AgentRuntimeMetadata {
   if (isAcpSessionKey(sessionKey)) {
-    return { id: "acpx", source: "session-key" };
+    const id = acpBackend && acpBackend.length > 0 ? acpBackend : "acpx";
+    return { id, source: "session-key" };
   }
   return meta;
 }

--- a/src/agents/acp-runtime-overlay.ts
+++ b/src/agents/acp-runtime-overlay.ts
@@ -1,5 +1,16 @@
 import { isAcpSessionKey } from "../routing/session-key.js";
-import type { AgentRuntimeMetadata } from "./agent-runtime-metadata.js";
+
+/**
+ * Leaf type for agent runtime classification. Defined here so that
+ * agent-runtime-metadata.ts can import applyAcpRuntimeOverlay without
+ * creating a circular dependency (agent-runtime-metadata → acp-runtime-overlay
+ * → agent-runtime-metadata).  agent-runtime-metadata.ts re-exports this type
+ * so all existing consumers remain unaffected.
+ */
+export type AgentRuntimeMetadata = {
+  id: string;
+  source: "implicit" | "model" | "provider" | "session-key";
+};
 
 /**
  * When a session key unambiguously identifies an ACP session (contains the `:acp:`

--- a/src/agents/acp-runtime-overlay.ts
+++ b/src/agents/acp-runtime-overlay.ts
@@ -1,0 +1,24 @@
+import { isAcpSessionKey } from "../routing/session-key.js";
+import type { AgentRuntimeMetadata } from "./agent-runtime-metadata.js";
+
+/**
+ * When a session key unambiguously identifies an ACP session (contains the `:acp:`
+ * segment), override the resolved runtime metadata to report the ACP runtime id
+ * ("acpx") with a "session-key" source — regardless of what the agent-config policy
+ * resolved to.  Without this overlay, callers that only have agent-config context
+ * (no model/provider) fall back to `id: "pi"` even though the session key makes
+ * the actual runtime unambiguous.
+ *
+ * Callers that already have model/provider context (resolveModelAgentRuntimeMetadata)
+ * still benefit here because the model-runtime policy chain does not inspect session
+ * keys for the ACP indicator.
+ */
+export function applyAcpRuntimeOverlay(
+  meta: AgentRuntimeMetadata,
+  sessionKey: string | undefined | null,
+): AgentRuntimeMetadata {
+  if (isAcpSessionKey(sessionKey)) {
+    return { id: "acpx", source: "session-key" };
+  }
+  return meta;
+}

--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -1,12 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { applyAcpRuntimeOverlay } from "./acp-runtime-overlay.js";
+import { applyAcpRuntimeOverlay, type AgentRuntimeMetadata } from "./acp-runtime-overlay.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import { resolveDefaultModelForAgent } from "./model-selection.js";
 
-export type AgentRuntimeMetadata = {
-  id: string;
-  source: "implicit" | "model" | "provider" | "session-key";
-};
+export type { AgentRuntimeMetadata };
 
 export function resolveAgentRuntimeMetadata(
   _cfg: OpenClawConfig,

--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -25,6 +25,13 @@ export function resolveModelAgentRuntimeMetadata(params: {
   provider?: string;
   model?: string;
   sessionKey?: string;
+  /**
+   * The ACP backend identifier stored on the session entry (`entry.acp.backend`).
+   * When provided for an ACP-keyed session, the overlay reports this value as the
+   * runtime id instead of the generic fallback "acpx", so sessions backed by a
+   * non-default registered ACP backend are classified correctly.
+   */
+  acpBackend?: string;
 }): AgentRuntimeMetadata {
   const resolved =
     params.provider && params.model
@@ -41,5 +48,5 @@ export function resolveModelAgentRuntimeMetadata(params: {
     id: policy.runtime,
     source: policy.runtimeSource ?? "implicit",
   };
-  return applyAcpRuntimeOverlay(meta, params.sessionKey);
+  return applyAcpRuntimeOverlay(meta, params.sessionKey, params.acpBackend);
 }

--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -1,67 +1,22 @@
-import type { AgentRuntimePolicyConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeAgentId } from "../routing/session-key.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { applyAcpRuntimeOverlay } from "./acp-runtime-overlay.js";
-import { listAgentEntries } from "./agent-scope-config.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import { resolveDefaultModelForAgent } from "./model-selection.js";
-import { normalizeEmbeddedAgentRuntime } from "./pi-embedded-runner/runtime.js";
 
 export type AgentRuntimeMetadata = {
   id: string;
-  source: "env" | "agent" | "defaults" | "implicit" | "model" | "provider" | "session-key";
+  source: "implicit" | "model" | "provider" | "session-key";
 };
 
-function normalizeRuntimeValue(value: unknown): string | undefined {
-  const normalized = typeof value === "string" ? normalizeLowercaseStringOrEmpty(value) : "";
-  return normalized ? normalizeEmbeddedAgentRuntime(normalized) : undefined;
-}
-
-function resolveAgentEntryRuntimePolicy(
-  cfg: OpenClawConfig,
-  agentId: string,
-): AgentRuntimePolicyConfig | undefined {
-  const normalizedId = normalizeAgentId(agentId);
-  const entry = listAgentEntries(cfg).find((e) => normalizeAgentId(e.id) === normalizedId);
-  const policy = entry?.agentRuntime;
-  return policy?.id?.trim() ? policy : undefined;
-}
-
-function resolveDefaultsRuntimePolicy(cfg: OpenClawConfig): AgentRuntimePolicyConfig | undefined {
-  const policy = cfg.agents?.defaults?.agentRuntime;
-  return policy?.id?.trim() ? policy : undefined;
-}
-
-/**
- * Resolve agent runtime metadata from agent-config policy sources (env, per-agent
- * config, defaults).  When `sessionKey` is provided the result is further patched
- * by `applyAcpRuntimeOverlay` so ACP sessions are never mislabelled as "pi".
- */
 export function resolveAgentRuntimeMetadata(
-  cfg: OpenClawConfig,
-  agentId: string,
-  env: NodeJS.ProcessEnv = process.env,
-  sessionKey?: string,
+  _cfg: OpenClawConfig,
+  _agentId: string,
+  _env: NodeJS.ProcessEnv = process.env,
 ): AgentRuntimeMetadata {
-  const envRuntime = normalizeRuntimeValue(env.OPENCLAW_AGENT_RUNTIME);
-  if (envRuntime) {
-    return applyAcpRuntimeOverlay({ id: envRuntime, source: "env" }, sessionKey);
-  }
-
-  const agentPolicy = resolveAgentEntryRuntimePolicy(cfg, agentId);
-  const agentRuntime = normalizeRuntimeValue(agentPolicy?.id);
-  if (agentRuntime) {
-    return applyAcpRuntimeOverlay({ id: agentRuntime, source: "agent" }, sessionKey);
-  }
-
-  const defaultsPolicy = resolveDefaultsRuntimePolicy(cfg);
-  const defaultsRuntime = normalizeRuntimeValue(defaultsPolicy?.id);
-  if (defaultsRuntime) {
-    return applyAcpRuntimeOverlay({ id: defaultsRuntime, source: "defaults" }, sessionKey);
-  }
-
-  return applyAcpRuntimeOverlay({ id: "pi", source: "implicit" }, sessionKey);
+  return {
+    id: "auto",
+    source: "implicit",
+  };
 }
 
 export function resolveModelAgentRuntimeMetadata(params: {

--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -23,6 +23,12 @@ export function resolveModelAgentRuntimeMetadata(params: {
   model?: string;
   sessionKey?: string;
   /**
+   * True when the loaded session entry has persisted ACP metadata. ACP-shaped
+   * keys without this marker can be bridge sessions that use the configured
+   * model/runtime.
+   */
+  acpRuntime?: boolean;
+  /**
    * The ACP backend identifier stored on the session entry (`entry.acp.backend`).
    * When provided for an ACP-keyed session, the overlay reports this value as the
    * runtime id instead of the generic fallback "acpx", so sessions backed by a
@@ -45,5 +51,5 @@ export function resolveModelAgentRuntimeMetadata(params: {
     id: policy.runtime,
     source: policy.runtimeSource ?? "implicit",
   };
-  return applyAcpRuntimeOverlay(meta, params.sessionKey, params.acpBackend);
+  return applyAcpRuntimeOverlay(meta, params.sessionKey, params.acpRuntime, params.acpBackend);
 }

--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -1,21 +1,67 @@
+import type { AgentRuntimePolicyConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { applyAcpRuntimeOverlay } from "./acp-runtime-overlay.js";
+import { listAgentEntries } from "./agent-scope-config.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import { resolveDefaultModelForAgent } from "./model-selection.js";
+import { normalizeEmbeddedAgentRuntime } from "./pi-embedded-runner/runtime.js";
 
-type AgentRuntimeMetadata = {
+export type AgentRuntimeMetadata = {
   id: string;
-  source: "implicit" | "model" | "provider";
+  source: "env" | "agent" | "defaults" | "implicit" | "model" | "provider" | "session-key";
 };
 
+function normalizeRuntimeValue(value: unknown): string | undefined {
+  const normalized = typeof value === "string" ? normalizeLowercaseStringOrEmpty(value) : "";
+  return normalized ? normalizeEmbeddedAgentRuntime(normalized) : undefined;
+}
+
+function resolveAgentEntryRuntimePolicy(
+  cfg: OpenClawConfig,
+  agentId: string,
+): AgentRuntimePolicyConfig | undefined {
+  const normalizedId = normalizeAgentId(agentId);
+  const entry = listAgentEntries(cfg).find((e) => normalizeAgentId(e.id) === normalizedId);
+  const policy = entry?.agentRuntime;
+  return policy?.id?.trim() ? policy : undefined;
+}
+
+function resolveDefaultsRuntimePolicy(cfg: OpenClawConfig): AgentRuntimePolicyConfig | undefined {
+  const policy = cfg.agents?.defaults?.agentRuntime;
+  return policy?.id?.trim() ? policy : undefined;
+}
+
+/**
+ * Resolve agent runtime metadata from agent-config policy sources (env, per-agent
+ * config, defaults).  When `sessionKey` is provided the result is further patched
+ * by `applyAcpRuntimeOverlay` so ACP sessions are never mislabelled as "pi".
+ */
 export function resolveAgentRuntimeMetadata(
-  _cfg: OpenClawConfig,
-  _agentId: string,
-  _env: NodeJS.ProcessEnv = process.env,
+  cfg: OpenClawConfig,
+  agentId: string,
+  env: NodeJS.ProcessEnv = process.env,
+  sessionKey?: string,
 ): AgentRuntimeMetadata {
-  return {
-    id: "auto",
-    source: "implicit",
-  };
+  const envRuntime = normalizeRuntimeValue(env.OPENCLAW_AGENT_RUNTIME);
+  if (envRuntime) {
+    return applyAcpRuntimeOverlay({ id: envRuntime, source: "env" }, sessionKey);
+  }
+
+  const agentPolicy = resolveAgentEntryRuntimePolicy(cfg, agentId);
+  const agentRuntime = normalizeRuntimeValue(agentPolicy?.id);
+  if (agentRuntime) {
+    return applyAcpRuntimeOverlay({ id: agentRuntime, source: "agent" }, sessionKey);
+  }
+
+  const defaultsPolicy = resolveDefaultsRuntimePolicy(cfg);
+  const defaultsRuntime = normalizeRuntimeValue(defaultsPolicy?.id);
+  if (defaultsRuntime) {
+    return applyAcpRuntimeOverlay({ id: defaultsRuntime, source: "defaults" }, sessionKey);
+  }
+
+  return applyAcpRuntimeOverlay({ id: "pi", source: "implicit" }, sessionKey);
 }
 
 export function resolveModelAgentRuntimeMetadata(params: {
@@ -36,8 +82,9 @@ export function resolveModelAgentRuntimeMetadata(params: {
     agentId: params.agentId,
     sessionKey: params.sessionKey,
   });
-  return {
+  const meta: AgentRuntimeMetadata = {
     id: policy.runtime,
     source: policy.runtimeSource ?? "implicit",
   };
+  return applyAcpRuntimeOverlay(meta, params.sessionKey);
 }

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -22,7 +22,7 @@ type AgentListEntry = {
   model?: string;
   agentRuntime?: {
     id: string;
-    source: "env" | "agent" | "defaults" | "model" | "provider" | "implicit";
+    source: "env" | "agent" | "defaults" | "model" | "provider" | "implicit" | "session-key";
   };
 };
 

--- a/src/commands/sessions.acp-runtime-metadata.test.ts
+++ b/src/commands/sessions.acp-runtime-metadata.test.ts
@@ -86,12 +86,15 @@ function computeSessionAgentRuntime(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   fallbackAgentId: string;
+  /** Mirrors `entry?.acp?.backend` passed from the session store entry. */
+  acpBackend?: string;
 }): ReturnType<typeof resolveModelAgentRuntimeMetadata> {
   const agentId = parseAgentSessionKey(params.sessionKey)?.agentId ?? params.fallbackAgentId;
   return resolveModelAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId,
     sessionKey: params.sessionKey,
+    acpBackend: params.acpBackend,
   });
 }
 
@@ -164,5 +167,37 @@ describe("sessions --json agentRuntime classifier (catalog #18)", () => {
         `(a) override at the call site in src/commands/sessions.ts:294 once isAcpSessionKey(row.key) is true, or ` +
         `(b) extend resolveAgentRuntimeMetadata to accept an optional sessionKey and apply the override centrally.`,
     ).toBe("acpx");
+  });
+
+  it("backend override: ACP session with entry.acp.backend set reports that backend id, NOT 'acpx'", () => {
+    // When the session entry carries an explicit acp.backend (e.g. a registered
+    // non-default backend), the overlay must reflect the actual backend instead
+    // of the generic "acpx" fallback.
+    const cfg = buildConfigWithoutAgentRuntimePolicy();
+    const agentRuntime = computeSessionAgentRuntime({
+      cfg,
+      sessionKey: ACP_SESSION_KEY,
+      fallbackAgentId: "copilot",
+      acpBackend: "custom-backend",
+    });
+
+    expect(agentRuntime.id).toBe("custom-backend");
+    expect(agentRuntime.source).toBe("session-key");
+  });
+
+  it("backend fallback: ACP session with no entry.acp.backend falls back to 'acpx'", () => {
+    // When the session entry has no acp.backend (entry.acp is absent or backend
+    // is not set), the overlay must fall back to the canonical "acpx" id so
+    // existing behaviour is preserved.
+    const cfg = buildConfigWithoutAgentRuntimePolicy();
+    const agentRuntime = computeSessionAgentRuntime({
+      cfg,
+      sessionKey: ACP_SESSION_KEY,
+      fallbackAgentId: "copilot",
+      // acpBackend intentionally omitted — mirrors entry with no acp.backend
+    });
+
+    expect(agentRuntime.id).toBe("acpx");
+    expect(agentRuntime.source).toBe("session-key");
   });
 });

--- a/src/commands/sessions.acp-runtime-metadata.test.ts
+++ b/src/commands/sessions.acp-runtime-metadata.test.ts
@@ -86,6 +86,8 @@ function computeSessionAgentRuntime(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   fallbackAgentId: string;
+  /** Mirrors `entry?.acp != null` passed from loaded session rows. */
+  acpRuntime?: boolean;
   /** Mirrors `entry?.acp?.backend` passed from the session store entry. */
   acpBackend?: string;
 }): ReturnType<typeof resolveModelAgentRuntimeMetadata> {
@@ -94,6 +96,7 @@ function computeSessionAgentRuntime(params: {
     cfg: params.cfg,
     agentId,
     sessionKey: params.sessionKey,
+    acpRuntime: params.acpRuntime,
     acpBackend: params.acpBackend,
   });
 }
@@ -105,6 +108,7 @@ describe("sessions --json agentRuntime classifier (catalog #18)", () => {
       cfg,
       sessionKey: ACP_SESSION_KEY,
       fallbackAgentId: "copilot",
+      acpRuntime: true,
     });
 
     // The bug was: the session key plainly contains `:acp:` and yet the
@@ -158,6 +162,7 @@ describe("sessions --json agentRuntime classifier (catalog #18)", () => {
       cfg,
       sessionKey: ACP_SESSION_KEY,
       fallbackAgentId: "copilot",
+      acpRuntime: true,
     });
 
     expect(
@@ -178,6 +183,7 @@ describe("sessions --json agentRuntime classifier (catalog #18)", () => {
       cfg,
       sessionKey: ACP_SESSION_KEY,
       fallbackAgentId: "copilot",
+      acpRuntime: true,
       acpBackend: "custom-backend",
     });
 
@@ -185,19 +191,32 @@ describe("sessions --json agentRuntime classifier (catalog #18)", () => {
     expect(agentRuntime.source).toBe("session-key");
   });
 
-  it("backend fallback: ACP session with no entry.acp.backend falls back to 'acpx'", () => {
-    // When the session entry has no acp.backend (entry.acp is absent or backend
-    // is not set), the overlay must fall back to the canonical "acpx" id so
-    // existing behaviour is preserved.
+  it("backend fallback: ACP session with entry.acp but no backend falls back to 'acpx'", () => {
+    // When the session entry has ACP metadata but no acp.backend, the overlay
+    // must fall back to the canonical "acpx" id.
     const cfg = buildConfigWithoutAgentRuntimePolicy();
     const agentRuntime = computeSessionAgentRuntime({
       cfg,
       sessionKey: ACP_SESSION_KEY,
       fallbackAgentId: "copilot",
+      acpRuntime: true,
       // acpBackend intentionally omitted — mirrors entry with no acp.backend
     });
 
     expect(agentRuntime.id).toBe("acpx");
     expect(agentRuntime.source).toBe("session-key");
+  });
+
+  it("GREEN control: ACP-shaped bridge session without entry.acp is NOT overridden", () => {
+    const cfg = buildConfigWithoutAgentRuntimePolicy();
+    const agentRuntime = computeSessionAgentRuntime({
+      cfg,
+      sessionKey: ACP_SESSION_KEY,
+      fallbackAgentId: "copilot",
+      acpRuntime: false,
+    });
+
+    expect(agentRuntime.id).not.toBe("acpx");
+    expect(agentRuntime.source).not.toBe("session-key");
   });
 });

--- a/src/commands/sessions.acp-runtime-metadata.test.ts
+++ b/src/commands/sessions.acp-runtime-metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
+import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 
@@ -76,22 +76,27 @@ function buildConfigWithoutAgentRuntimePolicy(): OpenClawConfig {
 /**
  * Mirror the per-row computation from `src/commands/sessions.ts:290-298`:
  *   const agentId = parseAgentSessionKey(row.key)?.agentId ?? target.agentId;
- *   const agentRuntime = resolveAgentRuntimeMetadata(cfg, agentId);
+ *   const agentRuntime = resolveModelAgentRuntimeMetadata({ cfg, agentId, sessionKey: row.key });
  *
  * Returns the same shape that ends up serialized to `--json` output.
+ * After commit 02fe0d8978, the production path goes through resolveModelAgentRuntimeMetadata
+ * (not resolveAgentRuntimeMetadata which is now a stub returning { id: "auto", source: "implicit" }).
  */
 function computeSessionAgentRuntime(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   fallbackAgentId: string;
-}): ReturnType<typeof resolveAgentRuntimeMetadata> {
+}): ReturnType<typeof resolveModelAgentRuntimeMetadata> {
   const agentId = parseAgentSessionKey(params.sessionKey)?.agentId ?? params.fallbackAgentId;
-  // Explicit empty-env to avoid host-leak via OPENCLAW_AGENT_RUNTIME.
-  return resolveAgentRuntimeMetadata(params.cfg, agentId, {}, params.sessionKey);
+  return resolveModelAgentRuntimeMetadata({
+    cfg: params.cfg,
+    agentId,
+    sessionKey: params.sessionKey,
+  });
 }
 
 describe("sessions --json agentRuntime classifier (catalog #18)", () => {
-  it("RED: ACP session key is misclassified as runtime id 'pi' / implicit", () => {
+  it("RED→GREEN: ACP session key is no longer misclassified (overlay applies)", () => {
     const cfg = buildConfigWithoutAgentRuntimePolicy();
     const agentRuntime = computeSessionAgentRuntime({
       cfg,
@@ -99,25 +104,25 @@ describe("sessions --json agentRuntime classifier (catalog #18)", () => {
       fallbackAgentId: "copilot",
     });
 
-    // Today's behavior (the bug): the session key plainly contains `:acp:`
-    // and yet the resolved metadata says id="pi", source="implicit".
-    // These assertions are the RED-light test — they FAIL today and will
-    // GREEN once a fix consults the session key.
+    // The bug was: the session key plainly contains `:acp:` and yet the
+    // resolved metadata said id="pi", source="implicit".
+    // After the fix (applyAcpRuntimeOverlay in resolveModelAgentRuntimeMetadata),
+    // the ACP session key overrides the runtime to id="acpx", source="session-key".
     expect(
       agentRuntime.id,
-      `ACP session ${ACP_SESSION_KEY} is misclassified: agentRuntime.id is "${agentRuntime.id}" ` +
-        `but should reflect the ACP runtime (e.g. "acpx") because the session key carries the ":acp:" segment. ` +
-        `See src/commands/sessions.ts:294 — resolveAgentRuntimeMetadata(cfg, agentId) ignores session-key context.`,
-    ).not.toBe("pi");
+      `ACP session ${ACP_SESSION_KEY} should no longer be misclassified as "auto" or "pi". ` +
+        `Got "${agentRuntime.id}". resolveModelAgentRuntimeMetadata must pass sessionKey to ` +
+        `applyAcpRuntimeOverlay so ACP sessions are classified as "acpx".`,
+    ).not.toBe("auto");
     expect(
       agentRuntime.source,
       `ACP session ${ACP_SESSION_KEY} resolved with source="${agentRuntime.source}". ` +
-        `For an ACP-keyed session, the source should not be "implicit" (the fallback for "no policy found") — ` +
+        `For an ACP-keyed session, the source should not be "implicit" — ` +
         `the session key itself is an explicit signal that the runtime is ACP.`,
     ).not.toBe("implicit");
   });
 
-  it("GREEN control: non-ACP session correctly resolves to implicit pi", () => {
+  it("GREEN control: non-ACP session is NOT overridden by ACP overlay", () => {
     const cfg = buildConfigWithoutAgentRuntimePolicy();
     const agentRuntime = computeSessionAgentRuntime({
       cfg,
@@ -125,12 +130,14 @@ describe("sessions --json agentRuntime classifier (catalog #18)", () => {
       fallbackAgentId: "main",
     });
 
-    // For a non-ACP session with no explicit policy, falling back to
-    // "pi" / "implicit" is the correct behavior. This control case proves
-    // the test infra is exercising the real code path (not a mock that
-    // would silently pass either way).
-    expect(agentRuntime.id).toBe("pi");
-    expect(agentRuntime.source).toBe("implicit");
+    // For a non-ACP session, the overlay must NOT fire — the result must
+    // not be "acpx" and source must not be "session-key".  The control
+    // proves the overlay is gated on the `:acp:` segment in the session key.
+    // (The concrete id — "codex" for the default openai/gpt-5.5 provider —
+    // is determined by resolveAgentHarnessPolicy's Codex-routing rule;
+    // what matters here is the absence of the ACP override.)
+    expect(agentRuntime.id).not.toBe("acpx");
+    expect(agentRuntime.source).not.toBe("session-key");
   });
 
   it("FIX-SHAPE expectation: ACP session should resolve to 'acpx'", () => {

--- a/src/commands/sessions.acp-runtime-metadata.test.ts
+++ b/src/commands/sessions.acp-runtime-metadata.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+/**
+ * Catalog #18 — `openclaw sessions --json` reports `agentRuntime.id: "pi"` for
+ * ACP sessions because `resolveAgentRuntimeMetadata` only consults agent-config
+ * policies (env / agent / defaults / implicit fallback to "pi"). The session
+ * key clearly carries the ACP runtime indicator (the `:acp:` segment), but
+ * `sessions.ts:294` ignores it and just calls `resolveAgentRuntimeMetadata(cfg, agentId)`.
+ *
+ * Empirical observation from a deployed openclaw container against a copilot
+ * agent that has no explicit `agentRuntime.id` policy:
+ *
+ *   {
+ *     "key": "agent:copilot:acp:86b7b5af-3773-4a56-b244-069d6c5d3db9",
+ *     "agentId": "copilot",
+ *     "agentRuntime": { "id": "pi", "source": "implicit" },
+ *     "kind": "direct"
+ *   }
+ *
+ * That is wrong: this session is plainly ACP, not PI. The runtime field is
+ * supposed to be a faithful classifier of how this session is actually being
+ * run; instead, every ACP session in the JSON output is mislabelled as `pi`.
+ *
+ * This test mirrors the exact computation `sessionsCommand` performs at
+ * `src/commands/sessions.ts:294` and proves the bug in two parts:
+ *
+ *   - RED: ACP-keyed session resolves to `id: "pi"`, `source: "implicit"`.
+ *   - GREEN control: a non-ACP `agent:main:main` session resolves to the
+ *     same implicit-pi metadata, which IS correct in that case. The control
+ *     proves the assertion infrastructure is not masking the RED case.
+ *
+ * Fix shape (see the third test): when the session key is ACP-style,
+ * agentRuntime.id should report `acpx` (or whatever runtime id is actually
+ * driving the session) so that the JSON faithfully classifies the session.
+ * The fix likely belongs at the caller (sessions.ts:294 and the other
+ * call sites in `src/gateway/server-methods/sessions.ts`,
+ * `src/gateway/session-utils.ts`) so it can pass session-key context to
+ * `resolveAgentRuntimeMetadata`, OR `resolveAgentRuntimeMetadata` itself
+ * gains an optional `sessionKey` parameter and applies a session-key-aware
+ * override.
+ */
+
+const ACP_SESSION_KEY = "agent:copilot:acp:86b7b5af-3773-4a56-b244-069d6c5d3db9";
+const NON_ACP_SESSION_KEY = "agent:main:main";
+
+/**
+ * Build a minimal `OpenClawConfig` that mirrors the deployed scenario:
+ * - a copilot agent exists in the agents.list
+ * - it has NO explicit `agentRuntime.id` policy
+ * - no top-level `agents.defaults.agentRuntime` either
+ *
+ * Result: `resolveAgentRuntimeMetadata(cfg, "copilot")` falls through to the
+ * implicit "pi" branch — which is the bug under test.
+ */
+function buildConfigWithoutAgentRuntimePolicy(): OpenClawConfig {
+  return {
+    agents: {
+      list: [
+        {
+          id: "copilot",
+          // Intentionally no `agentRuntime` field, no `runtime` descriptor.
+        },
+        {
+          id: "main",
+        },
+      ],
+      // No `defaults.agentRuntime` either.
+      defaults: {},
+    },
+  } as OpenClawConfig;
+}
+
+/**
+ * Mirror the per-row computation from `src/commands/sessions.ts:290-298`:
+ *   const agentId = parseAgentSessionKey(row.key)?.agentId ?? target.agentId;
+ *   const agentRuntime = resolveAgentRuntimeMetadata(cfg, agentId);
+ *
+ * Returns the same shape that ends up serialized to `--json` output.
+ */
+function computeSessionAgentRuntime(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  fallbackAgentId: string;
+}): ReturnType<typeof resolveAgentRuntimeMetadata> {
+  const agentId = parseAgentSessionKey(params.sessionKey)?.agentId ?? params.fallbackAgentId;
+  // Explicit empty-env to avoid host-leak via OPENCLAW_AGENT_RUNTIME.
+  return resolveAgentRuntimeMetadata(params.cfg, agentId, {});
+}
+
+describe("sessions --json agentRuntime classifier (catalog #18)", () => {
+  it("RED: ACP session key is misclassified as runtime id 'pi' / implicit", () => {
+    const cfg = buildConfigWithoutAgentRuntimePolicy();
+    const agentRuntime = computeSessionAgentRuntime({
+      cfg,
+      sessionKey: ACP_SESSION_KEY,
+      fallbackAgentId: "copilot",
+    });
+
+    // Today's behavior (the bug): the session key plainly contains `:acp:`
+    // and yet the resolved metadata says id="pi", source="implicit".
+    // These assertions are the RED-light test — they FAIL today and will
+    // GREEN once a fix consults the session key.
+    expect(
+      agentRuntime.id,
+      `ACP session ${ACP_SESSION_KEY} is misclassified: agentRuntime.id is "${agentRuntime.id}" ` +
+        `but should reflect the ACP runtime (e.g. "acpx") because the session key carries the ":acp:" segment. ` +
+        `See src/commands/sessions.ts:294 — resolveAgentRuntimeMetadata(cfg, agentId) ignores session-key context.`,
+    ).not.toBe("pi");
+    expect(
+      agentRuntime.source,
+      `ACP session ${ACP_SESSION_KEY} resolved with source="${agentRuntime.source}". ` +
+        `For an ACP-keyed session, the source should not be "implicit" (the fallback for "no policy found") — ` +
+        `the session key itself is an explicit signal that the runtime is ACP.`,
+    ).not.toBe("implicit");
+  });
+
+  it("GREEN control: non-ACP session correctly resolves to implicit pi", () => {
+    const cfg = buildConfigWithoutAgentRuntimePolicy();
+    const agentRuntime = computeSessionAgentRuntime({
+      cfg,
+      sessionKey: NON_ACP_SESSION_KEY,
+      fallbackAgentId: "main",
+    });
+
+    // For a non-ACP session with no explicit policy, falling back to
+    // "pi" / "implicit" is the correct behavior. This control case proves
+    // the test infra is exercising the real code path (not a mock that
+    // would silently pass either way).
+    expect(agentRuntime.id).toBe("pi");
+    expect(agentRuntime.source).toBe("implicit");
+  });
+
+  it("FIX-SHAPE expectation: ACP session should resolve to 'acpx'", () => {
+    // What "fixed" should look like once the bug is addressed.
+    // RED today; GREEN once the fix lands.
+    //
+    // Note: the exact id ("acpx" vs another label) is a design choice for
+    // the fix author. What matters is that it is meaningfully different
+    // from "pi" and reflects the actual runtime driving the session.
+    // If the fix picks a different label, update this assertion to match —
+    // the structural point (session-key-aware classification) is the
+    // load-bearing part.
+    const cfg = buildConfigWithoutAgentRuntimePolicy();
+    const agentRuntime = computeSessionAgentRuntime({
+      cfg,
+      sessionKey: ACP_SESSION_KEY,
+      fallbackAgentId: "copilot",
+    });
+
+    expect(
+      agentRuntime.id,
+      `ACP session ${ACP_SESSION_KEY} should resolve to runtime id "acpx" (or the canonical ACP runtime label). ` +
+        `Got "${agentRuntime.id}". Fix candidates: ` +
+        `(a) override at the call site in src/commands/sessions.ts:294 once isAcpSessionKey(row.key) is true, or ` +
+        `(b) extend resolveAgentRuntimeMetadata to accept an optional sessionKey and apply the override centrally.`,
+    ).toBe("acpx");
+  });
+});

--- a/src/commands/sessions.acp-runtime-metadata.test.ts
+++ b/src/commands/sessions.acp-runtime-metadata.test.ts
@@ -87,7 +87,7 @@ function computeSessionAgentRuntime(params: {
 }): ReturnType<typeof resolveAgentRuntimeMetadata> {
   const agentId = parseAgentSessionKey(params.sessionKey)?.agentId ?? params.fallbackAgentId;
   // Explicit empty-env to avoid host-leak via OPENCLAW_AGENT_RUNTIME.
-  return resolveAgentRuntimeMetadata(params.cfg, agentId, {});
+  return resolveAgentRuntimeMetadata(params.cfg, agentId, {}, params.sessionKey);
 }
 
 describe("sessions --json agentRuntime classifier (catalog #18)", () => {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -295,6 +295,7 @@ export async function sessionsCommand(
           provider: modelRef.provider,
           model: modelRef.model,
           sessionKey: row.key,
+          acpBackend: entry?.acp?.backend,
         });
         return Object.assign({}, row, {
           agentId,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -295,6 +295,7 @@ export async function sessionsCommand(
           provider: modelRef.provider,
           model: modelRef.model,
           sessionKey: row.key,
+          acpRuntime,
           acpBackend: entry?.acp?.backend,
         });
         return Object.assign({}, row, {

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -164,6 +164,7 @@ function resolveSessionRuntimeLabel(params: {
     provider: params.provider,
     model: params.model,
     sessionKey: params.sessionKey,
+    acpRuntime: params.entry?.acp != null,
     acpBackend: params.entry?.acp?.backend,
   });
   const id = normalizeOptionalLowercaseString(runtime.id);

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -164,6 +164,7 @@ function resolveSessionRuntimeLabel(params: {
     provider: params.provider,
     model: params.model,
     sessionKey: params.sessionKey,
+    acpBackend: params.entry?.acp?.backend,
   });
   const id = normalizeOptionalLowercaseString(runtime.id);
   const resolvedHarness = id && id !== "pi" && id !== "auto" ? id : undefined;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1817,6 +1817,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       provider: resolvedDisplayModel.provider,
       model: resolvedDisplayModel.model,
       sessionKey: target.canonicalKey ?? key,
+      acpRuntime: applied.entry?.acp != null,
       acpBackend: applied.entry?.acp?.backend,
     });
     const result: SessionsPatchResult = {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1817,6 +1817,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       provider: resolvedDisplayModel.provider,
       model: resolvedDisplayModel.model,
       sessionKey: target.canonicalKey ?? key,
+      acpBackend: applied.entry?.acp?.backend,
     });
     const result: SessionsPatchResult = {
       ok: true,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1735,6 +1735,7 @@ export function buildGatewaySessionRow(params: {
     provider: rowModelProvider,
     model: rowModel,
     sessionKey: key,
+    acpBackend: entry?.acp?.backend,
   });
   const estimatedCostUsd = lightweight
     ? resolveNonNegativeNumber(entry?.estimatedCostUsd)

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1024,6 +1024,7 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
           provider: resolvedModel.provider,
           model: resolvedModel.model,
           sessionKey: resolveAgentMainSessionKey({ cfg, agentId: id }),
+          acpRuntime: false,
         }),
       },
       model ? { model } : {},
@@ -1735,6 +1736,7 @@ export function buildGatewaySessionRow(params: {
     provider: rowModelProvider,
     model: rowModel,
     sessionKey: key,
+    acpRuntime: entry?.acp != null,
     acpBackend: entry?.acp?.backend,
   });
   const estimatedCostUsd = lightweight

--- a/src/shared/session-types.ts
+++ b/src/shared/session-types.ts
@@ -14,7 +14,7 @@ export type GatewayAgentModel = {
 export type GatewayAgentRuntime = {
   id: string;
   fallback?: "pi" | "none";
-  source: "env" | "agent" | "defaults" | "model" | "provider" | "implicit";
+  source: "env" | "agent" | "defaults" | "model" | "provider" | "implicit" | "session-key";
 };
 
 export type GatewayAgentRow = {


### PR DESCRIPTION
## Summary

ACP sessions reported `agentRuntime.id: "auto"` (post-`02fe0d8978`) — which is also wrong, since they aren't routed via the auto runtime; they're driven by `acpx`. Add a session-key-aware overlay applied at the production resolver so ACP-keyed rows report `{ id: "acpx", source: "session-key" }`. Closes catalog #18.

## Bug detail

Running `openclaw sessions --all-agents --json` against the deployed container produced (excerpt, redacted UUIDs):

```json
{
  "key": "agent:copilot:acp:86b7b5af-…",
  "agentId": "copilot",
  "agentRuntime": { "id": "auto", "source": "implicit" },
  "kind": "direct"
}
```

The `:acp:` segment unambiguously marks an ACP session, yet the JSON labels it as runtime `"auto"`. The original catalog finding documented `"pi"`, but commit `02fe0d8978` ("Keep OpenAI Codex migrations on automatic runtime routing") had already shifted the unrecognized-model default from `"pi"` to `"auto"` before this PR was opened. The remaining bug — the production path returning the wrong runtime identifier for ACP sessions — is what this PR addresses.

## How to reproduce

Live repro before fix (deployed container, OpenClaw 2026.5.6):

```bash
docker exec codeclaw-openclaw openclaw sessions --all-agents --json \
  | jq -c '.sessions[] | select(.key | startswith("agent:copilot:acp:")) | .agentRuntime'
{"id":"auto","source":"implicit"}
{"id":"auto","source":"implicit"}
{"id":"auto","source":"implicit"}
…
```

7/7 ACP sessions report `auto/implicit`.

Unit-level:

```bash
git checkout 4195dd0bf6            # red-test cherry-pick
pnpm test src/commands/sessions.acp-runtime-metadata.test.ts
# Before fix: 2 RED (resolveModelAgentRuntimeMetadata returns "auto" for ACP sessions; should be "acpx")
# After fix commits 6860ee0385 + 952afa3114: all 3 GREEN
```

## Root cause

The 6 production emit sites all call `resolveModelAgentRuntimeMetadata(...)`, which had zero session-key awareness — it routed off model identity / config policy only. ACP sessions, having no special model identity, fell into the post-`02fe0d8978` default of `"auto"`.

## Fix approach

**Caller-side overlay.** Keeps the resolver pure; aligns with the same pattern PR 7 (catalog #20) uses for the `model` / `modelProvider` columns:

1. **NEW** `src/agents/acp-runtime-overlay.ts` — exports `applyAcpRuntimeOverlay(meta, sessionKey)`. When `isAcpSessionKey(sessionKey)` is true, returns `{ id: "acpx", source: "session-key" }`; otherwise returns `meta` unchanged.
2. Extends `AgentRuntimeMetadata.source` union with `"session-key"`. Two downstream type unions (`GatewayAgentRuntime.source`, `AgentListEntry.agentRuntime.source`) needed the same `| "session-key"` addition for type compatibility — included as additive type-propagation.
3. **`resolveModelAgentRuntimeMetadata` calls the overlay** with the session key. The 6 emit sites all already call this resolver and inherit the fix automatically — no per-call-site change needed.
4. **`resolveAgentRuntimeMetadata` left untouched as the `02fe0d8978` stub.** The original implementation attempted to revert that contributor's intentional refactor (which had stubbed `resolveAgentRuntimeMetadata` to return `{ id: "auto", source: "implicit" }`); after review, the stub-revert was undone in cleanup commit `952afa3114` to respect the upstream direction. Production already routes through `resolveModelAgentRuntimeMetadata`, where the overlay correctly applies.

## Tests

- **Red test (now GREEN):** `src/commands/sessions.acp-runtime-metadata.test.ts` — 3 cases:
  - ACP session id is not `"auto"` (the post-`02fe0d8978` default) — overlay must take precedence
  - ACP session id is `"acpx"` — overlay sentinel
  - Non-ACP session does NOT receive the `"acpx"` sentinel (control)
- **Adjacent suite:** `src/commands/` (vitest.commands.config.ts shard) — passing.
- **Cleanup commit (`952afa3114`):** reverted the unauthorized stub-restoration, kept the production overlay, retargeted the test at `resolveModelAgentRuntimeMetadata`.

## Catalog reference

Catalog finding: #18. Investigation lives in branch `edpiva/acp-native-session-investigation` (not yet upstream) at `docs/plans/2026-05-08-acp-findings-catalog.md`.

## Verification commands

```bash
pnpm test src/commands/sessions.acp-runtime-metadata.test.ts   # 3/3 GREEN
pnpm exec vitest run --config test/vitest/vitest.commands.config.ts src/commands/   # passes
```

## Updates

Bot feedback addressed (P2, commit `d4a6eb0b92`): the overlay now reads `entry.acp.backend` instead of hard-coding `"acpx"`. When a session entry carries an explicit `acp.backend` (configurable ACP backend, binding/agent override, or persisted `entry.acp.backend`), that value is used as the runtime id. Fallback to `"acpx"` only when no backend is set on the entry. `acpBackend` is threaded from call sites that have the session entry in scope (`sessions.ts`, `session-utils.ts`, `server-methods/sessions.ts`, `status.summary.runtime.ts`); call sites without an entry in scope (`agents-list-tool.ts`, `session-utils.ts` agent-list path, `doctor-claude-cli.ts`) continue to receive the `"acpx"` fallback. Two new test cases added: one proving a custom backend is reported, one proving the fallback fires when no backend is set. All 5 test cases green.

## Notes for reviewers

- The original catalog framing of `"pi"` is stale — `02fe0d8978` shifted unrecognized-model default to `"auto"`. The actual production-path bug is the ACP runtime not being identified at all; this PR fixes that without touching `resolveAgentRuntimeMetadata`'s stub.
- The two downstream type-union edits (`src/shared/session-types.ts`, `src/agents/tools/agents-list-tool.ts`) add `| "session-key"` to keep the gateway/tools row types compatible with the new source variant. Additive only.
- The new `acp-runtime-overlay.ts` helper is reused by PR 7 (catalog #20 — `model`/`modelProvider` ACP-aware), which currently inlines the equivalent logic awaiting this PR. After both land, PR 7 can be slimmed via a small follow-up to import from this file.

## Real behavior proof

Behavior addressed: ACP control-plane rows from `openclaw sessions --json`, status, and Gateway session RPC metadata now report ACP runtime metadata from persisted ACP session metadata/backend instead of the implicit model runtime. ACP-shaped bridge rows without `entry.acp` are not overlaid.

Real environment tested: Maintainer Linux worktree at PR SHA `4ebbf1d7e9242924df520cdaefd1f2e3bedc91dc`, rebased on upstream/main `97ed9b2d82950dd64b94c4fd1ac732e701b54a24`. Earlier Azure Crabbox seeded-session proof for the original runtime overlay ran on `amber-lobster` / `cbx_4c7c7efb6dc7`; the new bridge guard was verified locally after the rebase fix.

Exact steps or command run after this patch: Seeded a temp `OPENCLAW_CONFIG_PATH` and explicit session store with an ACP control-plane row carrying `entry.acp.backend = "acpx"`, an ACP-shaped bridge row with no `entry.acp`, and a non-ACP control row, then ran:

```bash
OPENCLAW_CONFIG_PATH="$proof_dir/openclaw.json" OPENCLAW_HOME="$proof_dir/home" pnpm --silent openclaw sessions --store "$proof_dir/sessions.json" --json

pnpm test src/commands/sessions.acp-runtime-metadata.test.ts src/commands/sessions.acp-model-display.test.ts -- --reporter=verbose
pnpm tsgo:core
pnpm tsgo:core:test
pnpm exec oxfmt --check --threads=1 src/agents/acp-runtime-overlay.ts src/agents/agent-runtime-metadata.ts src/commands/sessions.acp-runtime-metadata.test.ts src/commands/sessions.ts src/commands/status.summary.runtime.ts src/gateway/session-utils.ts src/gateway/server-methods/sessions.ts
git diff --check upstream/main...HEAD
```

Evidence after fix: Copied terminal output from the after-fix CLI run and focused tests:

```text
AFTER_FIX_ACP_AGENT_RUNTIME={"id":"acpx","source":"session-key"}
CONTROL_ACP_BRIDGE_AGENT_RUNTIME={"id":"auto","source":"implicit"}
CONTROL_NON_ACP_AGENT_RUNTIME={"id":"auto","source":"implicit"}
AFTER_FIX_ACP_SESSION_ROW={"key":"agent:copilot:acp:proof-79550","agentId":"copilot","kind":"direct","modelProvider":"acpx","model":"copilot-acp","agentRuntime":{"id":"acpx","source":"session-key"}}
CONTROL_ACP_BRIDGE_SESSION_ROW={"key":"agent:copilot:acp:bridge-proof-79550","modelProvider":"microsoft-foundry","model":"gpt-5.3-codex","agentRuntime":{"id":"auto","source":"implicit"}}
src/commands/sessions.acp-runtime-metadata.test.ts: 6/6 tests passed
src/commands/sessions.acp-model-display.test.ts: 4/4 tests passed
pnpm tsgo:core: passed
pnpm tsgo:core:test: passed
oxfmt touched-file check: passed
git diff --check upstream/main...HEAD: passed
```

Observed result after fix: The ACP control-plane session row reports `agentRuntime.id: "acpx"` and `source: "session-key"`; the ACP-shaped bridge row keeps `modelProvider: "microsoft-foundry"`, `model: "gpt-5.3-codex"`, and normal implicit runtime metadata, so key shape alone no longer triggers the ACP runtime overlay.

What was not tested: No live ACP provider/harness turn with external credentials was run after the maintainer rebase fix; this was seeded session-store CLI proof plus focused regression/type/format checks.
