### PR TITLE
fix(feishu): set CommandSource and GroupId for group messages

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1087,6 +1087,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ChatType: "group",
         CommandAuthorized: false,
+        GroupId: "oc-group",
         SenderId: "ou-attacker",
       }),
     );
@@ -1171,6 +1172,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ChatType: "group",
         CommandAuthorized: true,
+        CommandSource: "text",
         SenderId: "ou-admin",
       }),
     );

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1,10 +1,5 @@
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
-import {
-  ensureConfiguredBindingRouteReady,
-  resolveConfiguredBindingRoute,
-  resolveRuntimeConversationBindingRoute,
-} from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveAgentOutboundIdentity } from "openclaw/plugin-sdk/outbound-runtime";
 import {
   buildPendingHistoryContextFromMap,
@@ -20,6 +15,11 @@ import {
 } from "openclaw/plugin-sdk/runtime-group-policy";
 import { resolveOpenDmAllowlistAccess } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import {
+  ensureConfiguredBindingRouteReady,
+  resolveConfiguredBindingRoute,
+  resolveRuntimeConversationBindingRoute,
+} from "../../../plugin-sdk/conversation-runtime";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import {
   checkBotMentioned,
@@ -1237,6 +1237,9 @@ export async function handleFeishuMessage(params: {
       return threadContext;
     };
 
+    // Determine if this message is a text command (starts with /)
+    const isTextCommand = effectiveCommandProbeBody.trim().startsWith("/");
+
     // --- Shared context builder for dispatch ---
     const buildCtxPayloadForAgent = async (
       agentId: string,
@@ -1277,6 +1280,7 @@ export async function handleFeishuMessage(params: {
         Timestamp: messageCreateTimeMs,
         WasMentioned: wasMentioned,
         CommandAuthorized: commandAuthorized,
+        ...(isTextCommand ? { CommandSource: "text" as const } : {}),
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
         GroupSystemPrompt: isGroup ? normalizeOptionalString(groupConfig?.systemPrompt) : undefined,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1,5 +1,10 @@
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
+import {
+  ensureConfiguredBindingRouteReady,
+  resolveConfiguredBindingRoute,
+  resolveRuntimeConversationBindingRoute,
+} from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveAgentOutboundIdentity } from "openclaw/plugin-sdk/outbound-runtime";
 import {
   buildPendingHistoryContextFromMap,
@@ -15,11 +20,6 @@ import {
 } from "openclaw/plugin-sdk/runtime-group-policy";
 import { resolveOpenDmAllowlistAccess } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import {
-  ensureConfiguredBindingRouteReady,
-  resolveConfiguredBindingRoute,
-  resolveRuntimeConversationBindingRoute,
-} from "../../../plugin-sdk/conversation-runtime";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import {
   checkBotMentioned,
@@ -1283,6 +1283,7 @@ export async function handleFeishuMessage(params: {
         ...(isTextCommand ? { CommandSource: "text" as const } : {}),
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
+        GroupId: isGroup ? ctx.chatId : undefined,
         GroupSystemPrompt: isGroup ? normalizeOptionalString(groupConfig?.systemPrompt) : undefined,
         ...mediaPayload,
         ...(preflightAudioIndex >= 0 ? { MediaTranscribedIndexes: [preflightAudioIndex] } : {}),


### PR DESCRIPTION
## Summary

修复飞书群组消息的两个问题：

1. **bug #79409**: 飞书群组消息缺少 `CommandSource` 字段，导致 slash 命令无法被正确识别
2. **bug #78826**: 飞书群组消息的 `groupId` 被错误设置为发送者的 `open_id`，导致工具策略校验失败

## Changes

### bug #79409 修复
- 在 `buildCtxPayloadForAgent` 中，当消息是文本命令（以 `/` 开头）时，设置 `CommandSource: "text"`
- 这使得 `isExplicitSourceReplyCommand()` 能正确识别飞书的文本命令

### bug #78826 修复
- 在 `finalizeInboundContext` 调用中添加 `GroupId: ctx.chatId`（仅对群组消息）
- 这确保工具策略解析时使用正确的群组 ID，而不是从格式不正确的 `From` 字段解析

## Testing

本地测试验证：
- 群组消息的 `From` 格式：`feishu:${senderOpenId}`（不包含群组信息）
- 添加 `GroupId` 字段后，`resolveGroupSessionKey()` 能正确获取群组 ID

## Files Changed

| File | Change |
|------|--------|
| `extensions/feishu/src/bot.ts` | 添加 `CommandSource: "text"` 和 `GroupId` 字段 |

Fixes #79409
Fixes #78826