### PR TITLE
Fix Discord queue backpressure and related read-path bottlenecks

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -134,6 +134,22 @@ describe("CodexAppServerClient", () => {
     expect(harness.writes).toHaveLength(1);
   });
 
+  it("rejects requests that exceed the default RPC timeout", async () => {
+    vi.useFakeTimers();
+    const harness = createClientHarness();
+    clients.push(harness.client);
+
+    const request = harness.client.request("model/list", {});
+    const outbound = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
+    const assertion = expect(request).rejects.toThrow("model/list timed out");
+
+    await vi.advanceTimersByTimeAsync(__testing.DEFAULT_CODEX_APP_SERVER_RPC_TIMEOUT_MS);
+    await assertion;
+
+    harness.send({ id: outbound.id, result: { data: [] } });
+    expect(harness.writes).toHaveLength(1);
+  });
+
   it("rejects aborted requests and ignores late responses", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);
@@ -344,6 +360,54 @@ describe("CodexAppServerClient", () => {
 
     // Subsequent requests keep the original close reason so startup logs stay actionable.
     await expect(harness.client.request("another/method")).rejects.toThrow("write EPIPE");
+  });
+
+  it("serializes app-server writes until backpressured stdin drains", async () => {
+    const stdout = new PassThrough();
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn((chunk: string, callback?: (error?: Error | null) => void) => {
+        writes.push(chunk);
+        callbacks.push(callback);
+        return writes.length !== 1;
+      }),
+      end: vi.fn(),
+      destroy: vi.fn(),
+      unref: vi.fn(),
+    });
+    const process = Object.assign(new EventEmitter(), {
+      stdin,
+      stdout,
+      stderr: new PassThrough(),
+      killed: false,
+      kill: vi.fn(() => {
+        process.killed = true;
+      }),
+    });
+    const writes: string[] = [];
+    const callbacks: Array<((error?: Error | null) => void) | undefined> = [];
+    const client = CodexAppServerClient.fromTransportForTests(process);
+    clients.push(client);
+
+    const first = client.request("first/method", {}, { timeoutMs: 0 });
+    const second = client.request("second/method", {}, { timeoutMs: 0 });
+
+    await vi.waitFor(() => expect(stdin.write).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(writes[0] ?? "{}")).toMatchObject({ method: "first/method" });
+
+    callbacks.shift()?.();
+    stdin.emit("drain");
+
+    await vi.waitFor(() => expect(stdin.write).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(writes[1] ?? "{}")).toMatchObject({ method: "second/method" });
+    callbacks.shift()?.();
+
+    const firstOutbound = JSON.parse(writes[0] ?? "{}") as { id?: number };
+    const secondOutbound = JSON.parse(writes[1] ?? "{}") as { id?: number };
+    stdout.write(`${JSON.stringify({ id: firstOutbound.id, result: { ok: "first" } })}\n`);
+    stdout.write(`${JSON.stringify({ id: secondOutbound.id, result: { ok: "second" } })}\n`);
+
+    await expect(first).resolves.toEqual({ ok: "first" });
+    await expect(second).resolves.toEqual({ ok: "second" });
   });
 
   it("preserves redacted app-server stderr on exit errors", async () => {

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -28,6 +28,7 @@ const CODEX_APP_SERVER_PARSE_LOG_MAX = 500;
 const CODEX_APP_SERVER_PARSE_BUFFER_MAX = 1_000_000;
 const CODEX_APP_SERVER_PARSE_BUFFER_MAX_LINES = 1_000;
 const CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_CODEX_APP_SERVER_RPC_TIMEOUT_MS = 60_000;
 const CODEX_APP_SERVER_STDERR_TAIL_MAX = 2_000;
 
 type PendingRequest = {
@@ -75,6 +76,7 @@ export class CodexAppServerClient {
   private readonly notificationHandlers = new Set<CodexServerNotificationHandler>();
   private readonly closeHandlers = new Set<(client: CodexAppServerClient) => void>();
   private nextId = 1;
+  private writeChain: Promise<void> | undefined;
   private initialized = false;
   private closed = false;
   private closeError: Error | undefined;
@@ -151,7 +153,7 @@ export class CodexAppServerClient {
       },
     } satisfies CodexInitializeParams);
     assertSupportedCodexAppServerVersion(response);
-    this.notify("initialized");
+    await this.writeMessage({ method: "initialized" });
     this.initialized = true;
   }
 
@@ -198,11 +200,9 @@ export class CodexAppServerClient {
         cleanup();
         reject(error);
       };
-      if (options.timeoutMs && Number.isFinite(options.timeoutMs) && options.timeoutMs > 0) {
-        timeout = setTimeout(
-          () => rejectPending(new Error(`${method} timed out`)),
-          Math.max(100, options.timeoutMs),
-        );
+      const timeoutMs = resolveCodexAppServerRpcTimeoutMs(options.timeoutMs);
+      if (timeoutMs !== undefined) {
+        timeout = setTimeout(() => rejectPending(new Error(`${method} timed out`)), timeoutMs);
         timeout.unref?.();
       }
       if (options.signal) {
@@ -226,16 +226,19 @@ export class CodexAppServerClient {
         rejectPending(new Error(`${method} aborted`));
         return;
       }
-      try {
-        this.writeMessage(message);
-      } catch (error) {
+      void this.writeMessage(message).catch((error: unknown) => {
         rejectPending(error instanceof Error ? error : new Error(String(error)));
-      }
+      });
     });
   }
 
   notify(method: string, params?: JsonValue): void {
-    this.writeMessage({ method, params });
+    void this.writeMessage({ method, params }).catch((error: unknown) => {
+      embeddedAgentLog.warn("codex app-server notify write failed", {
+        error,
+        method,
+      });
+    });
   }
 
   addRequestHandler(handler: CodexServerRequestHandler): () => void {
@@ -268,15 +271,80 @@ export class CodexAppServerClient {
     await closeCodexAppServerTransportAndWait(this.child, options);
   }
 
-  private writeMessage(message: RpcRequest | RpcResponse): void {
+  private writeMessage(message: RpcRequest | RpcResponse): Promise<void> {
     if (this.closed) {
-      return;
+      return Promise.resolve();
+    }
+    const write = () => this.writeMessageNow(message);
+    const previous = this.writeChain;
+    const next = previous ? previous.catch(() => undefined).then(write) : write();
+    const stored = next
+      .catch(() => undefined)
+      .finally(() => {
+        if (this.writeChain === stored) {
+          this.writeChain = undefined;
+        }
+      });
+    this.writeChain = stored;
+    return next;
+  }
+
+  private writeMessageNow(message: RpcRequest | RpcResponse): Promise<void> {
+    if (this.closed) {
+      return Promise.resolve();
     }
     const id = "id" in message ? message.id : undefined;
     const method = "method" in message ? message.method : undefined;
-    this.child.stdin.write(`${JSON.stringify(message)}\n`, (error?: Error | null) => {
-      if (error) {
-        embeddedAgentLog.warn("codex app-server write failed", { error, id, method });
+    const payload = `${JSON.stringify(message)}\n`;
+    return new Promise<void>((resolve, reject) => {
+      let writeCallbackSettled = false;
+      let drainSettled = true;
+      let settled = false;
+      let onDrain: (() => void) | undefined;
+      const cleanup = () => {
+        if (onDrain) {
+          this.child.stdin.off?.("drain", onDrain);
+          onDrain = undefined;
+        }
+      };
+      const finish = (error?: Error | null) => {
+        if (settled) {
+          return;
+        }
+        if (error) {
+          settled = true;
+          cleanup();
+          embeddedAgentLog.warn("codex app-server write failed", { error, id, method });
+          reject(error);
+          return;
+        }
+        if (!writeCallbackSettled || !drainSettled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve();
+      };
+      onDrain = () => {
+        drainSettled = true;
+        finish();
+      };
+
+      try {
+        const writeResult = this.child.stdin.write(payload, (error?: Error | null) => {
+          writeCallbackSettled = true;
+          finish(error);
+        });
+        if (writeResult === false) {
+          drainSettled = false;
+          if (this.child.stdin.once) {
+            this.child.stdin.once("drain", onDrain);
+          } else {
+            drainSettled = true;
+          }
+        }
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
       }
     });
   }
@@ -376,12 +444,12 @@ export class CodexAppServerClient {
     try {
       const result = await this.runServerRequestHandlers(request);
       if (result !== undefined) {
-        this.writeMessage({ id: request.id, result });
+        await this.writeMessage({ id: request.id, result });
         return;
       }
-      this.writeMessage({ id: request.id, result: defaultServerRequestResponse(request) });
+      await this.writeMessage({ id: request.id, result: defaultServerRequestResponse(request) });
     } catch (error) {
-      this.writeMessage({
+      await this.writeMessage({
         id: request.id,
         error: {
           message: error instanceof Error ? error.message : String(error),
@@ -468,6 +536,14 @@ export class CodexAppServerClient {
       handler(this);
     }
   }
+}
+
+function resolveCodexAppServerRpcTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  const resolved = timeoutMs ?? DEFAULT_CODEX_APP_SERVER_RPC_TIMEOUT_MS;
+  if (!Number.isFinite(resolved) || resolved <= 0) {
+    return undefined;
+  }
+  return Math.max(100, Math.floor(resolved));
 }
 
 function defaultServerRequestResponse(
@@ -671,5 +747,6 @@ export const __testing = {
   closeCodexAppServerTransport,
   closeCodexAppServerTransportAndWait,
   CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS,
+  DEFAULT_CODEX_APP_SERVER_RPC_TIMEOUT_MS,
   redactCodexAppServerLinePreview,
 } as const;

--- a/extensions/codex/src/app-server/transport.ts
+++ b/extensions/codex/src/app-server/transport.ts
@@ -5,6 +5,8 @@ export type CodexAppServerTransport = {
     destroy?: () => unknown;
     unref?: () => unknown;
     on?: (event: "error", listener: (error: Error) => void) => unknown;
+    once?: (event: "drain", listener: () => void) => unknown;
+    off?: (event: "drain", listener: () => void) => unknown;
   };
   stdout: NodeJS.ReadableStream & {
     destroy?: () => unknown;

--- a/extensions/discord/src/config-schema.test.ts
+++ b/extensions/discord/src/config-schema.test.ts
@@ -76,6 +76,18 @@ describe("discord config schema", () => {
     expect(cfg.historyLimit).toBe(3);
   });
 
+  it("accepts Discord inbound worker queue caps", () => {
+    const cfg = expectValidDiscordConfig({
+      inboundWorker: {
+        maxPendingPerSession: 2,
+        maxQueuedAgeMs: 30_000,
+      },
+    });
+
+    expect(cfg.inboundWorker?.maxPendingPerSession).toBe(2);
+    expect(cfg.inboundWorker?.maxQueuedAgeMs).toBe(30_000);
+  });
+
   it("accepts Discord application IDs at top-level and account scope", () => {
     const cfg = expectValidDiscordConfig({
       applicationId: "123456789012345678",

--- a/extensions/discord/src/config-ui-hints.ts
+++ b/extensions/discord/src/config-ui-hints.ts
@@ -113,6 +113,14 @@ export const discordChannelConfigUiHints = {
     label: "Discord Thread Parent Inheritance",
     help: "If true, Discord thread sessions inherit the parent channel transcript (default: false).",
   },
+  "inboundWorker.maxPendingPerSession": {
+    label: "Discord Session Queue Max Pending",
+    help: "Optional max pending inbound agent runs per Discord session before new jobs are dropped. Leave unset to preserve the existing unbounded queue.",
+  },
+  "inboundWorker.maxQueuedAgeMs": {
+    label: "Discord Session Queue Max Age (ms)",
+    help: "Optional max time a Discord inbound agent run may wait in a per-session queue before being skipped as stale. Leave unset to preserve existing behavior.",
+  },
   "eventQueue.listenerTimeout": {
     label: "Discord EventQueue Listener Timeout (ms)",
     help: "Canonical Discord listener timeout control in ms for gateway normalization/enqueue handlers. Default is 120000 in OpenClaw; set per account via channels.discord.accounts.<id>.eventQueue.listenerTimeout.",

--- a/extensions/discord/src/draft-stream.test.ts
+++ b/extensions/discord/src/draft-stream.test.ts
@@ -2,6 +2,14 @@ import { Routes } from "discord-api-types/v10";
 import { describe, expect, it, vi } from "vitest";
 import { createDiscordDraftStream } from "./draft-stream.js";
 
+function createDeferred<T = void>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
 describe("createDiscordDraftStream", () => {
   it("holds the first preview until minInitialChars is reached", async () => {
     const rest = {
@@ -55,6 +63,64 @@ describe("createDiscordDraftStream", () => {
       body: { content: "second draft", allowed_mentions: { parse: [] } },
     });
     expect(stream.messageId()).toBe("m1");
+  });
+
+  it("coalesces same-turn preview updates before the first write", async () => {
+    const rest = {
+      post: vi.fn(async () => ({ id: "m1" })),
+      patch: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    };
+    const stream = createDiscordDraftStream({
+      rest: rest as never,
+      channelId: "c1",
+      throttleMs: 250,
+    });
+
+    stream.update("first draft");
+    stream.update("second draft");
+    stream.update("final draft");
+    await stream.flush();
+
+    expect(rest.post).toHaveBeenCalledTimes(1);
+    expect(rest.post).toHaveBeenCalledWith(Routes.channelMessages("c1"), {
+      body: {
+        content: "final draft",
+        allowed_mentions: { parse: [] },
+      },
+    });
+    expect(rest.patch).not.toHaveBeenCalled();
+  });
+
+  it("keeps only the latest queued edit while a preview write is in flight", async () => {
+    const firstWrite = createDeferred<{ id: string }>();
+    const rest = {
+      post: vi.fn(async () => await firstWrite.promise),
+      patch: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    };
+    const stream = createDiscordDraftStream({
+      rest: rest as never,
+      channelId: "c1",
+      throttleMs: 250,
+    });
+
+    stream.update("first draft");
+    await Promise.resolve();
+    expect(rest.post).toHaveBeenCalledTimes(1);
+
+    stream.update("second draft");
+    stream.update("final draft");
+    firstWrite.resolve({ id: "m1" });
+    await stream.flush();
+
+    expect(rest.patch).toHaveBeenCalledTimes(1);
+    expect(rest.patch).toHaveBeenCalledWith(Routes.channelMessage("c1", "m1"), {
+      body: {
+        content: "final draft",
+        allowed_mentions: { parse: [] },
+      },
+    });
   });
 
   it("suppresses mentions in preview creates and edits", async () => {

--- a/extensions/discord/src/draft-stream.ts
+++ b/extensions/discord/src/draft-stream.ts
@@ -132,22 +132,68 @@ export function createDiscordDraftStream(params: {
     warn: params.warn,
     warnPrefix: "discord stream preview cleanup failed",
   });
+  let pendingCoalescedText: string | undefined;
+  let coalesceScheduled = false;
+
+  const drainCoalescedUpdate = () => {
+    coalesceScheduled = false;
+    const text = pendingCoalescedText;
+    pendingCoalescedText = undefined;
+    if (text !== undefined) {
+      update(text);
+    }
+  };
+
+  const clearCoalescedUpdate = () => {
+    pendingCoalescedText = undefined;
+    coalesceScheduled = false;
+  };
+
+  const updateCoalesced = (text: string) => {
+    if (streamState.stopped || streamState.final) {
+      return;
+    }
+    pendingCoalescedText = text;
+    if (coalesceScheduled) {
+      return;
+    }
+    coalesceScheduled = true;
+    queueMicrotask(drainCoalescedUpdate);
+  };
+
+  const flushCoalesced = async () => {
+    if (pendingCoalescedText !== undefined) {
+      drainCoalescedUpdate();
+    }
+    await loop.flush();
+  };
+
+  const discardPendingCoalesced = async () => {
+    clearCoalescedUpdate();
+    await discardPending();
+  };
+
+  const sealCoalesced = async () => {
+    clearCoalescedUpdate();
+    await seal();
+  };
 
   const forceNewMessage = () => {
     streamMessageId = undefined;
     lastSentText = "";
+    clearCoalescedUpdate();
     loop.resetPending();
   };
 
   params.log?.(`discord stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
 
   return {
-    update,
-    flush: loop.flush,
+    update: updateCoalesced,
+    flush: flushCoalesced,
     messageId: () => streamMessageId,
     clear,
-    discardPending,
-    seal,
+    discardPending: discardPendingCoalesced,
+    seal: sealCoalesced,
     stop,
     forceNewMessage,
   };

--- a/extensions/discord/src/internal/event-queue.test.ts
+++ b/extensions/discord/src/internal/event-queue.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { DiscordEventQueue } from "./event-queue.js";
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("DiscordEventQueue", () => {
+  it("reports only pending jobs after the queue head advances", async () => {
+    const queue = new DiscordEventQueue({ maxConcurrency: 1, listenerTimeout: 1_000 });
+    const releases: Array<() => void> = [];
+    const started: string[] = [];
+
+    const enqueue = (listenerName: string) =>
+      queue.enqueue({
+        eventType: "READY",
+        listenerName,
+        run: async () => {
+          started.push(listenerName);
+          const release = createDeferred();
+          releases.push(() => release.resolve());
+          await release.promise;
+        },
+      });
+
+    const first = enqueue("first");
+    const second = enqueue("second");
+    const third = enqueue("third");
+
+    await vi.waitFor(() => expect(started).toEqual(["first"]));
+    expect(queue.getMetrics()).toEqual(expect.objectContaining({ processing: 1, queueSize: 2 }));
+
+    releases.shift()?.();
+    await vi.waitFor(() => expect(started).toEqual(["first", "second"]));
+    expect(queue.getMetrics()).toEqual(expect.objectContaining({ processing: 1, queueSize: 1 }));
+
+    releases.shift()?.();
+    await vi.waitFor(() => expect(started).toEqual(["first", "second", "third"]));
+    releases.shift()?.();
+    await expect(Promise.all([first, second, third])).resolves.toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it("applies maxQueueSize to pending jobs after the queue head advances", async () => {
+    const queue = new DiscordEventQueue({
+      maxConcurrency: 1,
+      maxQueueSize: 2,
+      listenerTimeout: 1_000,
+    });
+    const releases: Array<() => void> = [];
+    const started: string[] = [];
+
+    const enqueue = (listenerName: string) =>
+      queue.enqueue({
+        eventType: "MESSAGE_CREATE",
+        listenerName,
+        run: async () => {
+          started.push(listenerName);
+          const release = createDeferred();
+          releases.push(() => release.resolve());
+          await release.promise;
+        },
+      });
+
+    const first = enqueue("first");
+    const second = enqueue("second");
+    const third = enqueue("third");
+
+    await vi.waitFor(() => expect(started).toEqual(["first"]));
+    releases.shift()?.();
+    await vi.waitFor(() => expect(started).toEqual(["first", "second"]));
+
+    const fourth = enqueue("fourth");
+    expect(queue.getMetrics()).toEqual(expect.objectContaining({ processing: 1, queueSize: 2 }));
+    await expect(enqueue("fifth")).rejects.toThrow(
+      "Discord event queue is full for MESSAGE_CREATE; maxQueueSize=2",
+    );
+
+    releases.shift()?.();
+    await vi.waitFor(() => expect(started).toEqual(["first", "second", "third"]));
+    releases.shift()?.();
+    await vi.waitFor(() => expect(started).toEqual(["first", "second", "third", "fourth"]));
+    releases.shift()?.();
+
+    await expect(Promise.all([first, second, third, fourth])).resolves.toEqual([
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+});

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -112,6 +112,8 @@ export function createDiscordMessageHandler(
     runtime: params.runtime,
     setStatus: params.setStatus,
     abortSignal: params.abortSignal,
+    maxPendingPerSession: params.discordConfig?.inboundWorker?.maxPendingPerSession,
+    maxQueuedAgeMs: params.discordConfig?.inboundWorker?.maxQueuedAgeMs,
     replayGuard,
     __testing: params.__testing,
   });

--- a/extensions/discord/src/monitor/message-media.ts
+++ b/extensions/discord/src/monitor/message-media.ts
@@ -330,14 +330,15 @@ async function mapWithConcurrency<T, R>(
   mapper: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
   const limit = Math.max(1, Math.floor(concurrency));
-  const results = new Array<R>(items.length);
+  const results: R[] = [];
+  results.length = items.length;
   let nextIndex = 0;
 
   const worker = async () => {
     while (nextIndex < items.length) {
       const index = nextIndex;
       nextIndex += 1;
-      results[index] = await mapper(items[index]!, index);
+      results[index] = await mapper(items[index], index);
     }
   };
 

--- a/extensions/discord/src/monitor/message-media.ts
+++ b/extensions/discord/src/monitor/message-media.ts
@@ -47,6 +47,7 @@ const AUDIO_ATTACHMENT_EXTENSIONS = new Set([
 ]);
 
 const DISCORD_STICKER_ASSET_BASE_URL = "https://media.discordapp.net/stickers";
+const DEFAULT_DISCORD_MEDIA_DOWNLOAD_CONCURRENCY = 3;
 
 export type DiscordMediaInfo = {
   path: string;
@@ -271,47 +272,77 @@ async function appendResolvedMediaFromAttachments(params: {
   if (!attachments || attachments.length === 0) {
     return;
   }
-  for (const attachment of attachments) {
-    const attachmentUrl = normalizeOptionalString(attachment.url);
-    if (!attachmentUrl) {
-      logVerbose(
-        `${params.errorPrefix} ${attachment.id ?? attachment.filename ?? "attachment"}: missing url`,
-      );
-      continue;
+  const resolved = await mapWithConcurrency(
+    attachments,
+    DEFAULT_DISCORD_MEDIA_DOWNLOAD_CONCURRENCY,
+    async (attachment) => {
+      const attachmentUrl = normalizeOptionalString(attachment.url);
+      if (!attachmentUrl) {
+        logVerbose(
+          `${params.errorPrefix} ${attachment.id ?? attachment.filename ?? "attachment"}: missing url`,
+        );
+        return undefined;
+      }
+      try {
+        const fetched = await fetchDiscordMedia({
+          url: attachmentUrl,
+          filePathHint: attachment.filename ?? attachmentUrl,
+          maxBytes: params.maxBytes,
+          fetchImpl: params.fetchImpl,
+          ssrfPolicy: params.ssrfPolicy,
+          readIdleTimeoutMs: params.readIdleTimeoutMs,
+          totalTimeoutMs: params.totalTimeoutMs,
+          abortSignal: params.abortSignal,
+        });
+        const saved = await saveMediaBuffer(
+          fetched.buffer,
+          fetched.contentType ?? attachment.content_type,
+          "inbound",
+          params.maxBytes,
+          attachment.filename,
+        );
+        return {
+          path: saved.path,
+          contentType: saved.contentType,
+          placeholder: inferPlaceholder(attachment),
+        };
+      } catch (err) {
+        const id = attachment.id ?? attachmentUrl;
+        logVerbose(`${params.errorPrefix} ${id}: ${String(err)}`);
+        return {
+          path: attachmentUrl,
+          contentType: attachment.content_type,
+          placeholder: inferPlaceholder(attachment),
+        };
+      }
+    },
+  );
+  params.out.push(...resolved.filter((media): media is DiscordMediaInfo => media !== undefined));
+}
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const limit = Math.max(1, Math.floor(concurrency));
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index]!, index);
     }
-    try {
-      const fetched = await fetchDiscordMedia({
-        url: attachmentUrl,
-        filePathHint: attachment.filename ?? attachmentUrl,
-        maxBytes: params.maxBytes,
-        fetchImpl: params.fetchImpl,
-        ssrfPolicy: params.ssrfPolicy,
-        readIdleTimeoutMs: params.readIdleTimeoutMs,
-        totalTimeoutMs: params.totalTimeoutMs,
-        abortSignal: params.abortSignal,
-      });
-      const saved = await saveMediaBuffer(
-        fetched.buffer,
-        fetched.contentType ?? attachment.content_type,
-        "inbound",
-        params.maxBytes,
-        attachment.filename,
-      );
-      params.out.push({
-        path: saved.path,
-        contentType: saved.contentType,
-        placeholder: inferPlaceholder(attachment),
-      });
-    } catch (err) {
-      const id = attachment.id ?? attachmentUrl;
-      logVerbose(`${params.errorPrefix} ${id}: ${String(err)}`);
-      params.out.push({
-        path: attachmentUrl,
-        contentType: attachment.content_type,
-        placeholder: inferPlaceholder(attachment),
-      });
-    }
-  }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      await worker();
+    }),
+  );
+  return results;
 }
 
 function resolveStickerAssetCandidates(sticker: APIStickerItem): DiscordStickerAssetCandidate[] {

--- a/extensions/discord/src/monitor/message-media.ts
+++ b/extensions/discord/src/monitor/message-media.ts
@@ -317,7 +317,11 @@ async function appendResolvedMediaFromAttachments(params: {
       }
     },
   );
-  params.out.push(...resolved.filter((media): media is DiscordMediaInfo => media !== undefined));
+  for (const media of resolved) {
+    if (media !== undefined) {
+      params.out.push(media);
+    }
+  }
 }
 
 async function mapWithConcurrency<T, R>(

--- a/extensions/discord/src/monitor/message-run-queue.test.ts
+++ b/extensions/discord/src/monitor/message-run-queue.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { DiscordInboundJob } from "./inbound-job.js";
-import type { RuntimeEnv } from "./message-handler.preflight.types.js";
+import type {
+  DiscordMessagePreflightContext,
+  RuntimeEnv,
+} from "./message-handler.preflight.types.js";
 import { createDiscordMessageRunQueue } from "./message-run-queue.js";
 
 function createDeferred() {
@@ -46,9 +49,9 @@ describe("createDiscordMessageRunQueue", () => {
     const queue = createDiscordMessageRunQueue({
       runtime: createRuntime(),
       __testing: {
-        processDiscordMessage: vi.fn(async (ctx: { messageId?: string }) => {
-          processed.push(ctx.messageId ?? "unknown");
-          if (ctx.messageId === "m-1") {
+        processDiscordMessage: vi.fn(async (ctx: DiscordMessagePreflightContext) => {
+          processed.push(ctx.message.id ?? "unknown");
+          if (ctx.message.id === "m-1") {
             await firstRun.promise;
           }
         }),
@@ -76,9 +79,9 @@ describe("createDiscordMessageRunQueue", () => {
       runtime,
       maxPendingPerSession: 1,
       __testing: {
-        processDiscordMessage: vi.fn(async (ctx: { messageId?: string }) => {
-          processed.push(ctx.messageId ?? "unknown");
-          if (ctx.messageId === "m-1") {
+        processDiscordMessage: vi.fn(async (ctx: DiscordMessagePreflightContext) => {
+          processed.push(ctx.message.id ?? "unknown");
+          if (ctx.message.id === "m-1") {
             await firstRun.promise;
           }
         }),
@@ -113,9 +116,9 @@ describe("createDiscordMessageRunQueue", () => {
         runtime,
         maxQueuedAgeMs: 100,
         __testing: {
-          processDiscordMessage: vi.fn(async (ctx: { messageId?: string }) => {
-            processed.push(ctx.messageId ?? "unknown");
-            if (ctx.messageId === "m-1") {
+          processDiscordMessage: vi.fn(async (ctx: DiscordMessagePreflightContext) => {
+            processed.push(ctx.message.id ?? "unknown");
+            if (ctx.message.id === "m-1") {
               await firstRun.promise;
             }
           }),

--- a/extensions/discord/src/monitor/message-run-queue.test.ts
+++ b/extensions/discord/src/monitor/message-run-queue.test.ts
@@ -126,7 +126,7 @@ describe("createDiscordMessageRunQueue", () => {
       });
 
       queue.enqueue(createJob({ messageId: "m-1" }));
-      await vi.runAllTicks();
+      vi.runAllTicks();
       await flushQueueWork();
       queue.enqueue(createJob({ messageId: "m-2" }));
 

--- a/extensions/discord/src/monitor/message-run-queue.test.ts
+++ b/extensions/discord/src/monitor/message-run-queue.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DiscordInboundJob } from "./inbound-job.js";
+import type { RuntimeEnv } from "./message-handler.preflight.types.js";
+import { createDiscordMessageRunQueue } from "./message-run-queue.js";
+
+function createDeferred() {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+async function flushQueueWork(): Promise<void> {
+  for (let i = 0; i < 40; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: (code: number): never => {
+      throw new Error(`exit ${code}`);
+    },
+  };
+}
+
+function createJob(params: { messageId: string; queueKey?: string }): DiscordInboundJob {
+  return {
+    queueKey: params.queueKey ?? "session-1",
+    payload: {
+      messageId: params.messageId,
+      message: { id: params.messageId },
+      data: { message: { id: params.messageId } },
+    },
+    runtime: {},
+  } as unknown as DiscordInboundJob;
+}
+
+describe("createDiscordMessageRunQueue", () => {
+  it("preserves FIFO execution for queued jobs in the same session", async () => {
+    const firstRun = createDeferred();
+    const processed: string[] = [];
+    const queue = createDiscordMessageRunQueue({
+      runtime: createRuntime(),
+      __testing: {
+        processDiscordMessage: vi.fn(async (ctx: { messageId?: string }) => {
+          processed.push(ctx.messageId ?? "unknown");
+          if (ctx.messageId === "m-1") {
+            await firstRun.promise;
+          }
+        }),
+      },
+    });
+
+    queue.enqueue(createJob({ messageId: "m-1" }));
+    queue.enqueue(createJob({ messageId: "m-2" }));
+
+    await flushQueueWork();
+    expect(processed).toEqual(["m-1"]);
+
+    firstRun.resolve?.();
+    await firstRun.promise;
+    await flushQueueWork();
+
+    expect(processed).toEqual(["m-1", "m-2"]);
+  });
+
+  it("drops new jobs when a session reaches the configured pending limit", async () => {
+    const firstRun = createDeferred();
+    const runtime = createRuntime();
+    const processed: string[] = [];
+    const queue = createDiscordMessageRunQueue({
+      runtime,
+      maxPendingPerSession: 1,
+      __testing: {
+        processDiscordMessage: vi.fn(async (ctx: { messageId?: string }) => {
+          processed.push(ctx.messageId ?? "unknown");
+          if (ctx.messageId === "m-1") {
+            await firstRun.promise;
+          }
+        }),
+      },
+    });
+
+    queue.enqueue(createJob({ messageId: "m-1" }));
+    await flushQueueWork();
+    queue.enqueue(createJob({ messageId: "m-2" }));
+    queue.enqueue(createJob({ messageId: "m-3" }));
+
+    await flushQueueWork();
+    expect(processed).toEqual(["m-1"]);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("discord message queue full for session session-1"),
+    );
+
+    firstRun.resolve?.();
+    await firstRun.promise;
+    await flushQueueWork();
+
+    expect(processed).toEqual(["m-1", "m-2"]);
+  });
+
+  it("skips stale queued jobs when maxQueuedAgeMs is configured", async () => {
+    vi.useFakeTimers();
+    try {
+      const firstRun = createDeferred();
+      const runtime = createRuntime();
+      const processed: string[] = [];
+      const queue = createDiscordMessageRunQueue({
+        runtime,
+        maxQueuedAgeMs: 100,
+        __testing: {
+          processDiscordMessage: vi.fn(async (ctx: { messageId?: string }) => {
+            processed.push(ctx.messageId ?? "unknown");
+            if (ctx.messageId === "m-1") {
+              await firstRun.promise;
+            }
+          }),
+        },
+      });
+
+      queue.enqueue(createJob({ messageId: "m-1" }));
+      await vi.runAllTicks();
+      await flushQueueWork();
+      queue.enqueue(createJob({ messageId: "m-2" }));
+
+      await vi.advanceTimersByTimeAsync(101);
+      firstRun.resolve?.();
+      await firstRun.promise;
+      await flushQueueWork();
+
+      expect(processed).toEqual(["m-1"]);
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("discord message queue dropped stale job for session session-1"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -18,6 +18,8 @@ type DiscordMessageRunQueueParams = {
   runtime: RuntimeEnv;
   setStatus?: DiscordMonitorStatusSink;
   abortSignal?: AbortSignal;
+  maxPendingPerSession?: number;
+  maxQueuedAgeMs?: number;
   replayGuard?: ClaimableDedupe;
   __testing?: DiscordMessageRunQueueTestingHooks;
 };
@@ -29,6 +31,11 @@ type DiscordMessageRunQueue = {
 
 export type DiscordMessageRunQueueTestingHooks = {
   processDiscordMessage?: ProcessDiscordMessage;
+};
+
+type QueuedDiscordInboundJob = {
+  job: DiscordInboundJob;
+  enqueuedAt: number;
 };
 
 let messageProcessRuntimePromise:
@@ -77,6 +84,9 @@ export function createDiscordMessageRunQueue(
   params: DiscordMessageRunQueueParams,
 ): DiscordMessageRunQueue {
   const replayGuard = params.replayGuard ?? createDiscordInboundReplayGuard();
+  const maxPendingPerSession = normalizePositiveInteger(params.maxPendingPerSession);
+  const maxQueuedAgeMs = normalizePositiveInteger(params.maxQueuedAgeMs);
+  const pendingBySession = new Map<string, QueuedDiscordInboundJob[]>();
   const runQueue = createChannelRunQueue({
     setStatus: params.setStatus,
     abortSignal: params.abortSignal,
@@ -87,7 +97,36 @@ export function createDiscordMessageRunQueue(
 
   return {
     enqueue(job) {
+      const pending = pendingBySession.get(job.queueKey) ?? [];
+      if (maxPendingPerSession !== undefined && pending.length >= maxPendingPerSession) {
+        params.runtime.error?.(
+          danger(
+            `discord message queue full for session ${job.queueKey}; maxPendingPerSession=${maxPendingPerSession}`,
+          ),
+        );
+        void commitDiscordInboundReplay({
+          replayKeys: job.replayKeys,
+          replayGuard,
+        });
+        return;
+      }
+      const queuedJob = { job, enqueuedAt: Date.now() };
+      pending.push(queuedJob);
+      pendingBySession.set(job.queueKey, pending);
       runQueue.enqueue(job.queueKey, async ({ lifecycleSignal }) => {
+        removePendingJob(pendingBySession, queuedJob);
+        if (isStaleQueuedJob(queuedJob, maxQueuedAgeMs)) {
+          params.runtime.error?.(
+            danger(
+              `discord message queue dropped stale job for session ${job.queueKey} after ${Date.now() - queuedJob.enqueuedAt}ms`,
+            ),
+          );
+          await commitDiscordInboundReplay({
+            replayKeys: job.replayKeys,
+            replayGuard,
+          });
+          return;
+        }
         await processDiscordQueuedMessage({
           job,
           lifecycleSignal,
@@ -96,6 +135,40 @@ export function createDiscordMessageRunQueue(
         });
       });
     },
-    deactivate: runQueue.deactivate,
+    deactivate() {
+      pendingBySession.clear();
+      runQueue.deactivate();
+    },
   };
+}
+
+function normalizePositiveInteger(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function removePendingJob(
+  pendingBySession: Map<string, QueuedDiscordInboundJob[]>,
+  queuedJob: QueuedDiscordInboundJob,
+): void {
+  const pending = pendingBySession.get(queuedJob.job.queueKey);
+  if (!pending) {
+    return;
+  }
+  const index = pending.indexOf(queuedJob);
+  if (index >= 0) {
+    pending.splice(index, 1);
+  }
+  if (pending.length === 0) {
+    pendingBySession.delete(queuedJob.job.queueKey);
+  }
+}
+
+function isStaleQueuedJob(
+  queuedJob: QueuedDiscordInboundJob,
+  maxQueuedAgeMs: number | undefined,
+): boolean {
+  return maxQueuedAgeMs !== undefined && Date.now() - queuedJob.enqueuedAt > maxQueuedAgeMs;
 }

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -53,6 +53,16 @@ function asMessage(payload: Record<string, unknown>): Message {
   return payload as unknown as Message;
 }
 
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject };
+}
+
 const DISCORD_CDN_HOSTNAMES = [
   "cdn.discordapp.com",
   "media.discordapp.net",
@@ -675,6 +685,124 @@ describe("resolveMediaList", () => {
         placeholder: "<media:document>",
       },
     ]);
+  });
+
+  it("downloads attachments with bounded concurrency while preserving attachment order", async () => {
+    const attachments = Array.from({ length: 4 }, (_, index) => ({
+      id: `att-${index + 1}`,
+      url: `https://cdn.discordapp.com/attachments/1/${index + 1}.png`,
+      filename: `${index + 1}.png`,
+      content_type: "image/png",
+    }));
+    const downloads = attachments.map((attachment) =>
+      createDeferred<{ buffer: Buffer; contentType: string }>(),
+    );
+    const activeUrls = new Set<string>();
+    let maxActive = 0;
+
+    fetchRemoteMedia.mockImplementation((params: { url: string }) => {
+      activeUrls.add(params.url);
+      maxActive = Math.max(maxActive, activeUrls.size);
+      const index = attachments.findIndex((attachment) => attachment.url === params.url);
+      const deferred = downloads[index];
+      if (!deferred) {
+        throw new Error(`unexpected url ${params.url}`);
+      }
+      return deferred.promise.finally(() => {
+        activeUrls.delete(params.url);
+      });
+    });
+    saveMediaBuffer.mockImplementation(
+      async (buffer: Buffer, contentType: string, _direction: string, _maxBytes: number, name) => ({
+        path: `/tmp/${buffer.toString()}`,
+        contentType,
+        fileName: name,
+      }),
+    );
+
+    const resultPromise = resolveMediaList(
+      asMessage({
+        attachments,
+      }),
+      512,
+    );
+
+    await vi.waitFor(() => expect(fetchRemoteMedia).toHaveBeenCalledTimes(3));
+    expect(maxActive).toBe(3);
+    expect(fetchRemoteMedia).not.toHaveBeenCalledWith(
+      expect.objectContaining({ url: attachments[3]?.url }),
+    );
+
+    downloads[1]?.resolve({ buffer: Buffer.from("two"), contentType: "image/png" });
+    await vi.waitFor(() => expect(fetchRemoteMedia).toHaveBeenCalledTimes(4));
+    downloads[3]?.resolve({ buffer: Buffer.from("four"), contentType: "image/png" });
+    downloads[2]?.resolve({ buffer: Buffer.from("three"), contentType: "image/png" });
+    downloads[0]?.resolve({ buffer: Buffer.from("one"), contentType: "image/png" });
+
+    await expect(resultPromise).resolves.toEqual([
+      { path: "/tmp/one", contentType: "image/png", placeholder: "<media:image>" },
+      { path: "/tmp/two", contentType: "image/png", placeholder: "<media:image>" },
+      { path: "/tmp/three", contentType: "image/png", placeholder: "<media:image>" },
+      { path: "/tmp/four", contentType: "image/png", placeholder: "<media:image>" },
+    ]);
+    expect(maxActive).toBeLessThanOrEqual(3);
+  });
+
+  it("passes maxBytes to every parallel attachment download and save", async () => {
+    const attachments = [
+      {
+        id: "att-one",
+        url: "https://cdn.discordapp.com/attachments/1/one.png",
+        filename: "one.png",
+        content_type: "image/png",
+      },
+      {
+        id: "att-two",
+        url: "https://cdn.discordapp.com/attachments/1/two.png",
+        filename: "two.png",
+        content_type: "image/png",
+      },
+    ];
+    fetchRemoteMedia.mockResolvedValue({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer
+      .mockResolvedValueOnce({ path: "/tmp/one.png", contentType: "image/png" })
+      .mockResolvedValueOnce({ path: "/tmp/two.png", contentType: "image/png" });
+
+    await resolveMediaList(
+      asMessage({
+        attachments,
+      }),
+      1234,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(2);
+    expect(fetchRemoteMedia).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ maxBytes: 1234 }),
+    );
+    expect(fetchRemoteMedia).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ maxBytes: 1234 }),
+    );
+    expect(saveMediaBuffer).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Buffer),
+      "image/png",
+      "inbound",
+      1234,
+      "one.png",
+    );
+    expect(saveMediaBuffer).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Buffer),
+      "image/png",
+      "inbound",
+      1234,
+      "two.png",
+    );
   });
 
   it("keeps sticker metadata when sticker download fails", async () => {

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -694,7 +694,7 @@ describe("resolveMediaList", () => {
       filename: `${index + 1}.png`,
       content_type: "image/png",
     }));
-    const downloads = attachments.map((attachment) =>
+    const downloads = attachments.map(() =>
       createDeferred<{ buffer: Buffer; contentType: string }>(),
     );
     const activeUrls = new Set<string>();

--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -5,8 +5,10 @@ import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { readSessionStoreCache, writeSessionStoreCache } from "./sessions/store-cache.js";
 import {
   clearSessionStoreCacheForTest,
+  loadSessionStoreEntriesAsync,
   loadSessionStore,
   saveSessionStore,
+  updateSessionStore,
 } from "./sessions/store.js";
 import type { SessionEntry } from "./sessions/types.js";
 
@@ -82,6 +84,81 @@ describe("Session Store Cache", () => {
     expect(loaded2).toEqual(testStore);
     expect(readSpy).toHaveBeenCalledTimes(0);
     readSpy.mockRestore();
+  });
+
+  it("should serve targeted async reads from cache without disk reads", async () => {
+    const testStore: Record<string, SessionEntry> = {
+      "session:1": createSessionEntry({ displayName: "Test Session 1" }),
+      "session:2": createSessionEntry({ sessionId: "id-2", displayName: "Test Session 2" }),
+    };
+
+    await saveSessionStore(storePath, testStore);
+
+    const syncReadSpy = vi.spyOn(fs, "readFileSync");
+    const asyncReadSpy = vi.spyOn(fs.promises, "readFile");
+
+    const loaded = await loadSessionStoreEntriesAsync(storePath, ["session:2"]);
+
+    expect(loaded).toEqual({ "session:2": testStore["session:2"] });
+    expect(syncReadSpy).toHaveBeenCalledTimes(0);
+    expect(asyncReadSpy).toHaveBeenCalledTimes(0);
+
+    syncReadSpy.mockRestore();
+    asyncReadSpy.mockRestore();
+  });
+
+  it("should use async disk reads for targeted cache misses", async () => {
+    process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "0";
+    clearSessionStoreCacheForTest();
+
+    const testStore: Record<string, SessionEntry> = {
+      "session:1": createSessionEntry({ displayName: "Test Session 1" }),
+      "session:2": createSessionEntry({ sessionId: "id-2", displayName: "Test Session 2" }),
+    };
+    fs.writeFileSync(storePath, JSON.stringify(testStore, null, 2));
+
+    const syncReadSpy = vi.spyOn(fs, "readFileSync");
+    const asyncReadSpy = vi.spyOn(fs.promises, "readFile");
+
+    const loaded = await loadSessionStoreEntriesAsync(storePath, ["session:2", "missing"]);
+
+    expect(loaded).toEqual({ "session:2": testStore["session:2"] });
+    expect(syncReadSpy).toHaveBeenCalledTimes(0);
+    expect(asyncReadSpy).toHaveBeenCalledTimes(1);
+
+    syncReadSpy.mockRestore();
+    asyncReadSpy.mockRestore();
+  });
+
+  it("should keep targeted async reads best-effort for missing or corrupt stores", async () => {
+    const missingPath = path.join(testDir, "missing.json");
+
+    await expect(loadSessionStoreEntriesAsync(missingPath, ["session:1"])).resolves.toEqual({});
+
+    fs.writeFileSync(storePath, "not valid json {");
+
+    await expect(loadSessionStoreEntriesAsync(storePath, ["session:1"])).resolves.toEqual({});
+  });
+
+  it("should reflect writer cache updates for targeted async reads", async () => {
+    const testStore = createSingleSessionStore(
+      createSessionEntry({ displayName: "Original Session" }),
+    );
+
+    await saveSessionStore(storePath, testStore);
+
+    const before = await loadSessionStoreEntriesAsync(storePath, ["session:1"]);
+    expect(before["session:1"].displayName).toBe("Original Session");
+
+    await updateSessionStore(storePath, (store) => {
+      store["session:1"] = {
+        ...store["session:1"],
+        displayName: "Updated Session",
+      };
+    });
+
+    const after = await loadSessionStoreEntriesAsync(storePath, ["session:1"]);
+    expect(after["session:1"].displayName).toBe("Updated Session");
   });
 
   it("should not allow cached session mutations to leak across loads", async () => {

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -32,6 +32,10 @@ function isSessionStoreRecord(value: unknown): value is Record<string, SessionEn
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function normalizeSessionEntryDelivery(entry: SessionEntry): SessionEntry {
   const normalized = normalizeSessionDeliveryFields({
     channel: entry.channel,
@@ -192,4 +196,127 @@ export function loadSessionStore(
   }
 
   return opts.clone === false ? store : cloneSessionStoreRecord(store, serializedFromDisk);
+}
+
+export async function loadSessionStoreAsync(
+  storePath: string,
+  opts: LoadSessionStoreOptions = {},
+): Promise<Record<string, SessionEntry>> {
+  if (!opts.skipCache && isSessionStoreCacheEnabled()) {
+    const currentFileStat = getFileStatSnapshot(storePath);
+    const cached = readSessionStoreCache({
+      storePath,
+      mtimeMs: currentFileStat?.mtimeMs,
+      sizeBytes: currentFileStat?.sizeBytes,
+      clone: opts.clone,
+    });
+    if (cached) {
+      return cached;
+    }
+  }
+
+  let store: Record<string, SessionEntry> = {};
+  let fileStat = getFileStatSnapshot(storePath);
+  let mtimeMs = fileStat?.mtimeMs;
+  let serializedFromDisk: string | undefined;
+  const maxReadAttempts = process.platform === "win32" ? 3 : 1;
+  for (let attempt = 0; attempt < maxReadAttempts; attempt += 1) {
+    try {
+      const raw = await fs.promises.readFile(storePath, "utf-8");
+      if (raw.length === 0 && attempt < maxReadAttempts - 1) {
+        await delay(50);
+        continue;
+      }
+      const parsed = JSON.parse(raw);
+      if (isSessionStoreRecord(parsed)) {
+        store = parsed;
+        serializedFromDisk = raw;
+      }
+      fileStat = getFileStatSnapshot(storePath) ?? fileStat;
+      mtimeMs = fileStat?.mtimeMs;
+      break;
+    } catch {
+      if (attempt < maxReadAttempts - 1) {
+        await delay(50);
+        continue;
+      }
+    }
+  }
+
+  const migrated = applySessionStoreMigrations(store);
+  const normalized = normalizeSessionStore(store);
+  if (migrated || normalized) {
+    serializedFromDisk = undefined;
+  }
+  if (opts.runMaintenance) {
+    const maintenance = opts.maintenanceConfig ?? resolveMaintenanceConfig();
+    const beforeCount = Object.keys(store).length;
+    let pruned = 0;
+    let capped = 0;
+    if (maintenance.mode === "enforce" && beforeCount > maintenance.maxEntries) {
+      pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, { log: false });
+      const countAfterPrune = Object.keys(store).length;
+      capped = shouldRunSessionEntryMaintenance({
+        entryCount: countAfterPrune,
+        maxEntries: maintenance.maxEntries,
+      })
+        ? capEntryCount(store, maintenance.maxEntries, { log: false })
+        : 0;
+    }
+    const afterCount = Object.keys(store).length;
+    if (pruned > 0 || capped > 0) {
+      serializedFromDisk = undefined;
+      log.info("applied load-time maintenance to session store", {
+        storePath,
+        before: beforeCount,
+        after: afterCount,
+        pruned,
+        capped,
+        maxEntries: maintenance.maxEntries,
+      });
+    }
+  }
+
+  setSerializedSessionStore(storePath, serializedFromDisk);
+
+  if (!opts.skipCache && isSessionStoreCacheEnabled()) {
+    writeSessionStoreCache({
+      storePath,
+      store,
+      mtimeMs,
+      sizeBytes: fileStat?.sizeBytes,
+      serialized: serializedFromDisk,
+    });
+  }
+
+  return opts.clone === false ? store : cloneSessionStoreRecord(store, serializedFromDisk);
+}
+
+export async function loadSessionStoreEntriesAsync(
+  storePath: string,
+  sessionKeys: string[],
+  opts: Omit<LoadSessionStoreOptions, "runMaintenance" | "maintenanceConfig"> = {},
+): Promise<Record<string, SessionEntry>> {
+  if (sessionKeys.length === 0) {
+    return {};
+  }
+  const store = await loadSessionStoreAsync(storePath, {
+    ...opts,
+    clone: false,
+  });
+  const selected: Record<string, SessionEntry> = {};
+  for (const sessionKey of sessionKeys) {
+    const key = sessionKey.trim();
+    if (!key || selected[key]) {
+      continue;
+    }
+    const entry = store[key];
+    if (entry) {
+      selected[key] = entry;
+    }
+  }
+  if (opts.clone === false) {
+    return selected;
+  }
+  return cloneSessionStoreRecord(selected);
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -47,7 +47,11 @@ export {
   getSessionStoreWriterQueueSizeForTest,
 } from "./store-writer-state.js";
 export { withSessionStoreWriterForTest } from "./store-writer.js";
-export { loadSessionStore } from "./store-load.js";
+export {
+  loadSessionStore,
+  loadSessionStoreAsync,
+  loadSessionStoreEntriesAsync,
+} from "./store-load.js";
 export { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
 
 const log = createSubsystemLogger("sessions/store");

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -31,6 +31,10 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     );
   }
 
+  function transcriptIdempotencyIndexPath(sessionFile: string): string {
+    return `${sessionFile}.idempotency.json`;
+  }
+
   function createExactAssistantMessage(params: {
     text?: string;
     content?: ExactAssistantMessage["content"];
@@ -145,6 +149,176 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     const messageLine = JSON.parse(lines[1]);
     expect(messageLine.message.idempotencyKey).toBe("mirror:test-source-message");
     expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");
+  });
+
+  it("creates and uses the transcript idempotency sidecar for repeated mirror writes", async () => {
+    writeTranscriptStore();
+
+    const firstResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello from delivery mirror!",
+      idempotencyKey: "mirror:test-source-message",
+      storePath: fixture.storePath(),
+    });
+
+    expect(firstResult.ok).toBe(true);
+    if (!firstResult.ok) {
+      return;
+    }
+
+    const indexPath = transcriptIdempotencyIndexPath(firstResult.sessionFile);
+    expect(fs.existsSync(indexPath)).toBe(true);
+    const index = JSON.parse(fs.readFileSync(indexPath, "utf-8")) as {
+      keys?: Record<string, { messageId?: string }>;
+    };
+    expect(index.keys?.["mirror:test-source-message"]?.messageId).toBe(firstResult.messageId);
+
+    const readSpy = vi.spyOn(fs.promises, "readFile");
+    const secondResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "This text should not be appended.",
+      idempotencyKey: "mirror:test-source-message",
+      storePath: fixture.storePath(),
+    });
+
+    expect(secondResult.ok).toBe(true);
+    if (secondResult.ok) {
+      expect(secondResult.messageId).toBe(firstResult.messageId);
+    }
+    expect(readSpy.mock.calls.some(([file]) => String(file) === firstResult.sessionFile)).toBe(
+      false,
+    );
+    readSpy.mockRestore();
+
+    const lines = fs.readFileSync(firstResult.sessionFile, "utf-8").trim().split("\n");
+    expect(lines.length).toBe(2);
+    const messageLine = JSON.parse(lines[1]);
+    expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");
+  });
+
+  it("falls back to the transcript scan and recreates the sidecar when it is missing", async () => {
+    writeTranscriptStore();
+
+    const firstResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello from delivery mirror!",
+      idempotencyKey: "mirror:test-source-message",
+      storePath: fixture.storePath(),
+    });
+
+    expect(firstResult.ok).toBe(true);
+    if (!firstResult.ok) {
+      return;
+    }
+
+    const indexPath = transcriptIdempotencyIndexPath(firstResult.sessionFile);
+    fs.unlinkSync(indexPath);
+
+    const secondResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "This text should not be appended.",
+      idempotencyKey: "mirror:test-source-message",
+      storePath: fixture.storePath(),
+    });
+
+    expect(secondResult.ok).toBe(true);
+    if (secondResult.ok) {
+      expect(secondResult.messageId).toBe(firstResult.messageId);
+    }
+    expect(fs.existsSync(indexPath)).toBe(true);
+    const lines = fs.readFileSync(firstResult.sessionFile, "utf-8").trim().split("\n");
+    expect(lines.length).toBe(2);
+  });
+
+  it("falls back to the transcript scan and rewrites a corrupt sidecar", async () => {
+    writeTranscriptStore();
+
+    const firstResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello from delivery mirror!",
+      idempotencyKey: "mirror:test-source-message",
+      storePath: fixture.storePath(),
+    });
+
+    expect(firstResult.ok).toBe(true);
+    if (!firstResult.ok) {
+      return;
+    }
+
+    const indexPath = transcriptIdempotencyIndexPath(firstResult.sessionFile);
+    fs.writeFileSync(indexPath, "{not-json", "utf-8");
+
+    const secondResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "This text should not be appended.",
+      idempotencyKey: "mirror:test-source-message",
+      storePath: fixture.storePath(),
+    });
+
+    expect(secondResult.ok).toBe(true);
+    if (secondResult.ok) {
+      expect(secondResult.messageId).toBe(firstResult.messageId);
+    }
+    const rewrittenIndex = JSON.parse(fs.readFileSync(indexPath, "utf-8")) as {
+      keys?: Record<string, { messageId?: string }>;
+    };
+    expect(rewrittenIndex.keys?.["mirror:test-source-message"]?.messageId).toBe(
+      firstResult.messageId,
+    );
+    const lines = fs.readFileSync(firstResult.sessionFile, "utf-8").trim().split("\n");
+    expect(lines.length).toBe(2);
+  });
+
+  it("falls back to the transcript scan when the sidecar is stale", async () => {
+    writeTranscriptStore();
+
+    const firstResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello from delivery mirror!",
+      idempotencyKey: "mirror:test-source-message",
+      storePath: fixture.storePath(),
+    });
+
+    expect(firstResult.ok).toBe(true);
+    if (!firstResult.ok) {
+      return;
+    }
+
+    const indexPath = transcriptIdempotencyIndexPath(firstResult.sessionFile);
+    fs.writeFileSync(
+      indexPath,
+      JSON.stringify({
+        type: "openclaw-transcript-idempotency-index",
+        version: 1,
+        indexedBytes: 1,
+        keys: {
+          "mirror:test-source-message": { messageId: "stale-sidecar-message-id" },
+        },
+      }) + "\n",
+      "utf-8",
+    );
+
+    const secondResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "This text should not be appended.",
+      idempotencyKey: "mirror:test-source-message",
+      storePath: fixture.storePath(),
+    });
+
+    expect(secondResult.ok).toBe(true);
+    if (secondResult.ok) {
+      expect(secondResult.messageId).toBe(firstResult.messageId);
+    }
+    const rewrittenIndex = JSON.parse(fs.readFileSync(indexPath, "utf-8")) as {
+      indexedBytes?: number;
+      keys?: Record<string, { messageId?: string }>;
+    };
+    expect(rewrittenIndex.indexedBytes).toBe(fs.statSync(firstResult.sessionFile).size);
+    expect(rewrittenIndex.keys?.["mirror:test-source-message"]?.messageId).toBe(
+      firstResult.messageId,
+    );
+    const lines = fs.readFileSync(firstResult.sessionFile, "utf-8").trim().split("\n");
+    expect(lines.length).toBe(2);
   });
 
   it("does not append a duplicate delivery mirror when the latest assistant message already matches", async () => {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -185,9 +185,11 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     if (secondResult.ok) {
       expect(secondResult.messageId).toBe(firstResult.messageId);
     }
-    expect(readSpy.mock.calls.some(([file]) => String(file) === firstResult.sessionFile)).toBe(
-      false,
-    );
+    expect(
+      readSpy.mock.calls.some(
+        ([file]) => typeof file === "string" && file === firstResult.sessionFile,
+      ),
+    ).toBe(false);
     readSpy.mockRestore();
 
     const lines = fs.readFileSync(firstResult.sessionFile, "utf-8").trim().split("\n");

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -67,6 +67,25 @@ type AssistantTranscriptText = {
 export type LatestAssistantTranscriptText = AssistantTranscriptText;
 export type TailAssistantTranscriptText = AssistantTranscriptText;
 
+const TRANSCRIPT_IDEMPOTENCY_INDEX_TYPE = "openclaw-transcript-idempotency-index";
+const TRANSCRIPT_IDEMPOTENCY_INDEX_VERSION = 1;
+
+type TranscriptIdempotencyIndexEntry = {
+  messageId?: string;
+};
+
+type TranscriptIdempotencyIndex = {
+  type: typeof TRANSCRIPT_IDEMPOTENCY_INDEX_TYPE;
+  version: typeof TRANSCRIPT_IDEMPOTENCY_INDEX_VERSION;
+  indexedBytes: number;
+  keys: Record<string, TranscriptIdempotencyIndexEntry>;
+};
+
+type TranscriptIdempotencyLookup =
+  | { status: "hit"; messageId: string | true }
+  | { status: "miss" }
+  | { status: "unavailable" };
+
 function parseAssistantTranscriptText(line: string): AssistantTranscriptText | undefined {
   const parsed = JSON.parse(line) as {
     id?: unknown;
@@ -298,7 +317,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
     params.idempotencyKey ??
     ((params.message as { idempotencyKey?: unknown }).idempotencyKey as string | undefined);
   const existingMessageId = explicitIdempotencyKey
-    ? await transcriptHasIdempotencyKey(sessionFile, explicitIdempotencyKey)
+    ? await findTranscriptIdempotencyKey(sessionFile, explicitIdempotencyKey)
     : undefined;
   if (existingMessageId) {
     return {
@@ -315,6 +334,9 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
     return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
   }
 
+  const idempotencyIndexBaseBytes = explicitIdempotencyKey
+    ? await getTranscriptFileSize(sessionFile)
+    : undefined;
   const message = {
     ...params.message,
     ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
@@ -335,42 +357,210 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
     case "none":
       break;
   }
+  if (explicitIdempotencyKey) {
+    await recordTranscriptIdempotencyKey({
+      transcriptPath: sessionFile,
+      idempotencyKey: explicitIdempotencyKey,
+      messageId,
+      previousIndexedBytes: idempotencyIndexBaseBytes,
+    });
+  }
   return { ok: true, sessionFile, messageId };
 }
 
-async function transcriptHasIdempotencyKey(
-  transcriptPath: string,
-  idempotencyKey: string,
-): Promise<string | true | undefined> {
-  try {
-    const raw = await fs.promises.readFile(transcriptPath, "utf-8");
-    for (const line of raw.split(/\r?\n/)) {
-      if (!line.trim()) {
-        continue;
-      }
-      try {
-        const parsed = JSON.parse(line) as {
-          id?: unknown;
-          message?: { idempotencyKey?: unknown };
-        };
-        if (
-          parsed.message?.idempotencyKey === idempotencyKey &&
-          typeof parsed.id === "string" &&
-          parsed.id
-        ) {
-          return parsed.id;
-        }
-        if (parsed.message?.idempotencyKey === idempotencyKey) {
-          return true;
-        }
-      } catch {
-        continue;
-      }
+function resolveTranscriptIdempotencyIndexPath(transcriptPath: string): string {
+  return `${transcriptPath}.idempotency.json`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseTranscriptIdempotencyIndex(raw: string): TranscriptIdempotencyIndex | undefined {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+  if (
+    parsed.type !== TRANSCRIPT_IDEMPOTENCY_INDEX_TYPE ||
+    parsed.version !== TRANSCRIPT_IDEMPOTENCY_INDEX_VERSION ||
+    typeof parsed.indexedBytes !== "number" ||
+    !Number.isSafeInteger(parsed.indexedBytes) ||
+    parsed.indexedBytes < 0 ||
+    !isRecord(parsed.keys)
+  ) {
+    return undefined;
+  }
+
+  const keys: Record<string, TranscriptIdempotencyIndexEntry> = {};
+  for (const [key, entry] of Object.entries(parsed.keys)) {
+    if (!key || !isRecord(entry)) {
+      return undefined;
     }
+    if ("messageId" in entry && typeof entry.messageId !== "string") {
+      return undefined;
+    }
+    keys[key] =
+      typeof entry.messageId === "string" && entry.messageId ? { messageId: entry.messageId } : {};
+  }
+
+  return {
+    type: TRANSCRIPT_IDEMPOTENCY_INDEX_TYPE,
+    version: TRANSCRIPT_IDEMPOTENCY_INDEX_VERSION,
+    indexedBytes: parsed.indexedBytes,
+    keys,
+  };
+}
+
+async function getTranscriptFileSize(transcriptPath: string): Promise<number | undefined> {
+  try {
+    return (await fs.promises.stat(transcriptPath)).size;
   } catch {
     return undefined;
   }
-  return undefined;
+}
+
+async function readTranscriptIdempotencyIndex(params: {
+  transcriptPath: string;
+  requireCurrentSize: boolean;
+}): Promise<TranscriptIdempotencyIndex | undefined> {
+  try {
+    const [raw, stat] = await Promise.all([
+      fs.promises.readFile(resolveTranscriptIdempotencyIndexPath(params.transcriptPath), "utf-8"),
+      fs.promises.stat(params.transcriptPath),
+    ]);
+    const index = parseTranscriptIdempotencyIndex(raw);
+    if (!index || index.indexedBytes > stat.size) {
+      return undefined;
+    }
+    if (params.requireCurrentSize && index.indexedBytes !== stat.size) {
+      return undefined;
+    }
+    return index;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeTranscriptIdempotencyIndex(
+  transcriptPath: string,
+  index: TranscriptIdempotencyIndex,
+): Promise<void> {
+  await fs.promises.writeFile(
+    resolveTranscriptIdempotencyIndexPath(transcriptPath),
+    `${JSON.stringify(index)}\n`,
+    { encoding: "utf-8", mode: 0o600 },
+  );
+}
+
+async function readTranscriptIdempotencyIndexLookup(
+  transcriptPath: string,
+  idempotencyKey: string,
+): Promise<TranscriptIdempotencyLookup> {
+  const index = await readTranscriptIdempotencyIndex({ transcriptPath, requireCurrentSize: true });
+  if (!index) {
+    return { status: "unavailable" };
+  }
+
+  const entry = index.keys[idempotencyKey];
+  if (entry) {
+    return { status: "hit", messageId: entry.messageId ?? true };
+  }
+
+  const transcriptSize = await getTranscriptFileSize(transcriptPath);
+  if (transcriptSize !== undefined && index.indexedBytes >= transcriptSize) {
+    return { status: "miss" };
+  }
+  return { status: "unavailable" };
+}
+
+async function findTranscriptIdempotencyKey(
+  transcriptPath: string,
+  idempotencyKey: string,
+): Promise<string | true | undefined> {
+  const indexedLookup = await readTranscriptIdempotencyIndexLookup(transcriptPath, idempotencyKey);
+  switch (indexedLookup.status) {
+    case "hit":
+      return indexedLookup.messageId;
+    case "miss":
+      return undefined;
+    case "unavailable":
+      return await scanTranscriptIdempotencyKey(transcriptPath, idempotencyKey);
+  }
+}
+
+async function scanTranscriptIdempotencyKey(
+  transcriptPath: string,
+  idempotencyKey: string,
+): Promise<string | true | undefined> {
+  const keys: Record<string, TranscriptIdempotencyIndexEntry> = {};
+  let foundMessageId: string | true | undefined;
+  let raw: string;
+  try {
+    raw = await fs.promises.readFile(transcriptPath, "utf-8");
+  } catch {
+    return undefined;
+  }
+
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line) as {
+        id?: unknown;
+        message?: { idempotencyKey?: unknown };
+      };
+      const key = parsed.message?.idempotencyKey;
+      if (typeof key !== "string" || !key) {
+        continue;
+      }
+      const entry = typeof parsed.id === "string" && parsed.id ? { messageId: parsed.id } : {};
+      keys[key] ??= entry;
+      if (key === idempotencyKey && !foundMessageId) {
+        foundMessageId = entry.messageId ?? true;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  await writeTranscriptIdempotencyIndex(transcriptPath, {
+    type: TRANSCRIPT_IDEMPOTENCY_INDEX_TYPE,
+    version: TRANSCRIPT_IDEMPOTENCY_INDEX_VERSION,
+    indexedBytes: Buffer.byteLength(raw, "utf-8"),
+    keys,
+  }).catch(() => undefined);
+
+  return foundMessageId;
+}
+
+async function recordTranscriptIdempotencyKey(params: {
+  transcriptPath: string;
+  idempotencyKey: string;
+  messageId: string;
+  previousIndexedBytes: number | undefined;
+}): Promise<void> {
+  if (params.previousIndexedBytes === undefined) {
+    return;
+  }
+
+  const index = await readTranscriptIdempotencyIndex({
+    transcriptPath: params.transcriptPath,
+    requireCurrentSize: false,
+  });
+  if (!index || index.indexedBytes !== params.previousIndexedBytes) {
+    return;
+  }
+
+  const transcriptSize = await getTranscriptFileSize(params.transcriptPath);
+  if (transcriptSize === undefined || transcriptSize < index.indexedBytes) {
+    return;
+  }
+
+  index.keys[params.idempotencyKey] = { messageId: params.messageId };
+  index.indexedBytes = transcriptSize;
+  await writeTranscriptIdempotencyIndex(params.transcriptPath, index).catch(() => undefined);
 }
 
 function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -487,6 +487,7 @@ async function findTranscriptIdempotencyKey(
     case "unavailable":
       return await scanTranscriptIdempotencyKey(transcriptPath, idempotencyKey);
   }
+  return undefined;
 }
 
 async function scanTranscriptIdempotencyKey(

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -396,8 +396,7 @@ export type DiscordAccountConfig = {
   /** Streaming URL (Twitch/YouTube). Required when activityType=1. */
   activityUrl?: string;
   /**
-   * Legacy compatibility block. Discord no longer enforces channel-owned
-   * timeouts for queued inbound agent runs.
+   * Discord inbound worker queue controls.
    */
   inboundWorker?: {
     /**
@@ -405,6 +404,16 @@ export type DiscordAccountConfig = {
      * lifecycle, not by Discord channel config.
      */
     runTimeoutMs?: number;
+    /**
+     * Optional max pending queued inbound agent runs per session. Unset preserves
+     * the existing unbounded per-session queue.
+     */
+    maxPendingPerSession?: number;
+    /**
+     * Optional max age in milliseconds for a pending queued inbound agent run.
+     * Unset preserves existing behavior; stale jobs are skipped only when set.
+     */
+    maxQueuedAgeMs?: number;
   };
   /**
    * Discord EventQueue configuration. Controls how Discord gateway events are processed.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -711,6 +711,8 @@ export const DiscordAccountSchema = z
     inboundWorker: z
       .object({
         runTimeoutMs: z.number().int().nonnegative().optional(),
+        maxPendingPerSession: z.number().int().positive().optional(),
+        maxQueuedAgeMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/sessions-history-http.revocation.test.ts
+++ b/src/gateway/sessions-history-http.revocation.test.ts
@@ -25,6 +25,7 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("../config/sessions.js", () => ({
   loadSessionStore: () => ({ entries: [] }),
+  loadSessionStoreEntriesAsync: async () => ({ entries: [] }),
 }));
 
 vi.mock("../sessions/transcript-events.js", () => ({

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { getRuntimeConfig } from "../config/io.js";
-import { loadSessionStore } from "../config/sessions.js";
+import { loadSessionStoreEntriesAsync } from "../config/sessions.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import {
@@ -136,7 +136,7 @@ export async function handleSessionHistoryHttpRequest(
   const { cfg } = authResult;
 
   const target = resolveGatewaySessionStoreTarget({ cfg, key: sessionKey });
-  const store = loadSessionStore(target.storePath);
+  const store = await loadSessionStoreEntriesAsync(target.storePath, target.storeKeys);
   const entry = resolveFreshestSessionEntryFromStoreKeys(store, target.storeKeys);
   if (!entry?.sessionId) {
     sendJson(res, 404, {


### PR DESCRIPTION
Adds regression coverage and targeted performance/backpressure fixes for Discord queues, media downloads, preview writes, transcript idempotency, Codex RPC writes, and session-store reads.

## Real behavior proof

Behavior or issue addressed:
This PR addresses real backpressure/read-path risk in the OpenClaw runtime: Discord queues and media handling can build up work, Codex app-server stdin writes can ignore backpressure, transcript idempotency checks can repeatedly scan transcript files, and session-history reads can synchronously load more session-store data than needed.

Real environment tested:
Real local OpenClaw checkout on macOS at /Users/openclaw/dev/openclaw, on branch fix/discord-queue-backpressure, pushed to neuroradgist/openclaw and opened as openclaw/openclaw#79562.

Exact steps or command run after this patch:
Ran these commands from the real checkout after the patch:
- git status
- git log --oneline -8
- gh pr checks 79562 --repo openclaw/openclaw --watch
- pnpm lint --threads=8
- pnpm run lint:extensions:bundled
- pnpm tsgo:core
- pnpm tsgo:test
- pnpm test src/config/sessions/transcript.test.ts extensions/discord/src/monitor/message-utils.test.ts extensions/discord/src/monitor/message-run-queue.test.ts -- --reporter=verbose

Evidence after fix:
Copied terminal output from the real checkout:

git status
On branch fix/discord-queue-backpressure
Your branch is up to date with 'neuroradgist/fix/discord-queue-backpressure'.

gh pr checks 79562 --repo openclaw/openclaw --watch
89 successful, 19 skipped, and 0 pending checks.
CI/check passed.
CI/check-additional passed.
CI/check-lint passed.
CI/check-prod-types passed.
CI/check-test-types passed.
CI/check-additional-extension-bundled passed.

pnpm lint --threads=8
Found 0 warnings and 0 errors.

pnpm run lint:extensions:bundled
Found 0 warnings and 0 errors.

pnpm tsgo:core
passed.

pnpm tsgo:test
passed.

pnpm test src/config/sessions/transcript.test.ts extensions/discord/src/monitor/message-utils.test.ts extensions/discord/src/monitor/message-run-queue.test.ts -- --reporter=verbose
[test] passed 2 Vitest shards in 4.91s.
Runtime-config transcript tests: 16 passed.
Extension-discord message/media/run-queue tests: 49 passed.

Observed result after fix:
The PR branch is pushed and the affected code checks are green on GitHub Actions. The earlier type and lint failures were fixed. The real checkout shows the branch clean/up to date after pushing, and the PR checks show no pending code checks.

What was not tested:
I did not run a live Discord bot against production Discord traffic, did not run a live Codex app-server process, and did not perform a long-duration production load test.