### PR TITLE
fix(android): wait for gateway connect before node events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Android: wait for the Gateway connect handshake before publishing node websocket connections, and replay queued notification node events after reconnect. Fixes #79552.
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.
 - Telegram/Feishu: honor configured per-agent and global `reasoningDefault` values when deciding whether channel reasoning previews should stream or stay hidden, addressing the preview-default part of #73182. Thanks @anagnorisis2peripeteia.
 - Docker: run the runtime image under `tini` so long-lived containers reap orphaned child processes and forward signals correctly. (#77885) Thanks @VintageAyu.

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -67,6 +67,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import java.util.ArrayDeque
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
@@ -80,6 +81,15 @@ class NodeRuntime(
     val bootstrapToken: String?,
     val password: String?,
   )
+
+  private data class PendingForwardedNodeEvent(
+    val event: String,
+    val payloadJson: String?,
+  )
+
+  private companion object {
+    private const val MAX_PENDING_FORWARDED_NODE_EVENTS = 64
+  }
 
   private val appContext = context.applicationContext
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -304,6 +314,9 @@ class NodeRuntime(
   private var operatorConnected = false
   private var operatorStatusText: String = "Offline"
   private var nodeStatusText: String = "Offline"
+  private val pendingForwardedNodeEvents = ArrayDeque<PendingForwardedNodeEvent>()
+  private val pendingForwardedNodeEventsLock = Any()
+  private var flushingForwardedNodeEvents = false
 
   private val operatorSession =
     GatewaySession(
@@ -357,6 +370,7 @@ class NodeRuntime(
         updateStatus()
         showLocalCanvasOnConnect()
         publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Connect)
+        flushPendingForwardedNodeEvents()
         val endpoint = connectedEndpoint
         val auth = activeGatewayAuth
         if (endpoint != null && auth != null) {
@@ -384,8 +398,74 @@ class NodeRuntime(
 
   init {
     DeviceNotificationListenerService.setNodeEventSink { event, payloadJson ->
-      scope.launch {
-        nodeSession.sendNodeEvent(event = event, payloadJson = payloadJson)
+      enqueueForwardedNodeEvent(event = event, payloadJson = payloadJson)
+    }
+  }
+
+  private fun enqueueForwardedNodeEvent(
+    event: String,
+    payloadJson: String?,
+  ) {
+    scope.launch {
+      val sent = nodeSession.sendNodeEvent(event = event, payloadJson = payloadJson)
+      if (sent) {
+        return@launch
+      }
+      rememberPendingForwardedNodeEvent(
+        PendingForwardedNodeEvent(
+          event = event,
+          payloadJson = payloadJson,
+        ),
+      )
+    }
+  }
+
+  private fun rememberPendingForwardedNodeEvent(event: PendingForwardedNodeEvent) {
+    synchronized(pendingForwardedNodeEventsLock) {
+      while (pendingForwardedNodeEvents.size >= MAX_PENDING_FORWARDED_NODE_EVENTS) {
+        pendingForwardedNodeEvents.removeFirst()
+      }
+      pendingForwardedNodeEvents.addLast(event)
+    }
+  }
+
+  private fun flushPendingForwardedNodeEvents() {
+    synchronized(pendingForwardedNodeEventsLock) {
+      if (flushingForwardedNodeEvents || pendingForwardedNodeEvents.isEmpty()) {
+        return
+      }
+      flushingForwardedNodeEvents = true
+    }
+    scope.launch {
+      val events =
+        synchronized(pendingForwardedNodeEventsLock) {
+          val drained = pendingForwardedNodeEvents.toList()
+          pendingForwardedNodeEvents.clear()
+          drained
+        }
+      try {
+        for ((index, event) in events.withIndex()) {
+          val sent =
+            nodeSession.sendNodeEvent(
+              event = event.event,
+              payloadJson = event.payloadJson,
+            )
+          if (!sent) {
+            synchronized(pendingForwardedNodeEventsLock) {
+              for (remaining in events.drop(index)) {
+                while (pendingForwardedNodeEvents.size >= MAX_PENDING_FORWARDED_NODE_EVENTS) {
+                  pendingForwardedNodeEvents.removeFirst()
+                }
+                pendingForwardedNodeEvents.addLast(remaining)
+              }
+            }
+            return@launch
+          }
+        }
+      } finally {
+        synchronized(pendingForwardedNodeEventsLock) {
+          flushingForwardedNodeEvents = false
+        }
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -77,6 +77,12 @@ private data class SelectedConnectAuth(
   val attemptedDeviceTokenRetry: Boolean,
 )
 
+private data class GatewayConnectionReadyInfo(
+  val serverName: String?,
+  val remoteAddress: String?,
+  val mainSessionKey: String?,
+)
+
 private class GatewayConnectFailure(
   val gatewayError: GatewaySession.ErrorShape,
 ) : IllegalStateException(gatewayError.message)
@@ -336,11 +342,12 @@ class GatewaySession(
     private val connectNonceDeferred = CompletableDeferred<String>()
     private val client: OkHttpClient = buildClient()
     private var socket: WebSocket? = null
+    private var readyInfo: GatewayConnectionReadyInfo? = null
     private val loggerTag = "OpenClawGateway"
 
     val remoteAddress: String = formatGatewayAuthority(endpoint.host, endpoint.port)
 
-    suspend fun connect() {
+    suspend fun connect(): GatewayConnectionReadyInfo {
       val url = buildGatewayWebSocketUrl(endpoint.host, endpoint.port, tls != null)
       val request = Request.Builder().url(url).build()
       socket = client.newWebSocket(request, Listener())
@@ -349,6 +356,7 @@ class GatewaySession(
       } catch (err: Throwable) {
         throw err
       }
+      return readyInfo ?: throw IllegalStateException("connect failed: missing ready info")
     }
 
     suspend fun request(
@@ -509,7 +517,7 @@ class GatewaySession(
         }
         throw GatewayConnectFailure(error)
       }
-      handleConnectSuccess(res, identity.deviceId, selectedAuth.authSource)
+      readyInfo = handleConnectSuccess(res, identity.deviceId, selectedAuth.authSource)
       connectDeferred.complete(Unit)
     }
 
@@ -567,7 +575,7 @@ class GatewaySession(
       res: RpcResponse,
       deviceId: String,
       authSource: GatewayConnectAuthSource,
-    ) {
+    ): GatewayConnectionReadyInfo {
       val payloadJson = res.payloadJson ?: throw IllegalStateException("connect failed: missing payload")
       val obj = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: throw IllegalStateException("connect failed")
       pendingDeviceTokenRetry = false
@@ -617,7 +625,7 @@ class GatewaySession(
           ?.get("sessionDefaults")
           .asObjectOrNull()
       mainSessionKey = sessionDefaults?.get("mainSessionKey").asStringOrNull()
-      onConnected(serverName, remoteAddress, mainSessionKey)
+      return GatewayConnectionReadyInfo(serverName, remoteAddress, mainSessionKey)
     }
 
     private fun buildConnectParams(
@@ -897,10 +905,11 @@ class GatewaySession(
           target.password,
           target.options,
           target.tls,
-        )
+      )
       try {
-        conn.connect()
+        val readyInfo = conn.connect()
         currentConnection = conn
+        onConnected(readyInfo.serverName, readyInfo.remoteAddress, readyInfo.mainSessionKey)
         conn.awaitClose()
       } finally {
         if (currentConnection === conn) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -898,12 +898,14 @@ class GatewaySession(
           target.options,
           target.tls,
         )
-      currentConnection = conn
       try {
         conn.connect()
+        currentConnection = conn
         conn.awaitClose()
       } finally {
-        currentConnection = null
+        if (currentConnection === conn) {
+          currentConnection = null
+        }
         pluginSurfaceUrls = emptyMap()
         mainSessionKey = null
       }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -21,6 +21,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -529,6 +530,72 @@ class GatewaySessionInvokeTest {
         assertEquals("123", payload["sentAtMs"]?.jsonPrimitive?.content)
         assertEquals(true, response["handled"]?.jsonPrimitive?.content?.toBooleanStrict())
         assertEquals("persisted", response["reason"]?.jsonPrimitive?.content)
+      } finally {
+        shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun sendNodeEventDetailed_doesNotSendBeforeConnectHandshakeCompletes() =
+    runBlocking {
+      val json = testJson()
+      val connected = CompletableDeferred<Unit>()
+      val connectRequest = CompletableDeferred<Pair<WebSocket, String>>()
+      val nodeEventParams = CompletableDeferred<JsonObject>()
+      val lastDisconnect = AtomicReference("")
+      val server =
+        startGatewayServer(json) { webSocket, id, method, frame ->
+          when (method) {
+            "connect" -> {
+              if (!connectRequest.isCompleted) {
+                connectRequest.complete(webSocket to id)
+              }
+            }
+            "node.event" -> {
+              if (!nodeEventParams.isCompleted) {
+                nodeEventParams.complete(frame["params"]?.jsonObject ?: JsonObject(emptyMap()))
+              }
+              webSocket.send(
+                """{"type":"res","id":"$id","ok":true,"payload":{"handled":true}}""",
+              )
+              webSocket.close(1000, "done")
+            }
+          }
+        }
+
+      val harness =
+        createNodeHarness(
+          connected = connected,
+          lastDisconnect = lastDisconnect,
+        ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        val (webSocket, connectId) = withTimeout(TEST_TIMEOUT_MS) { connectRequest.await() }
+
+        val result =
+          harness.session.sendNodeEventDetailed(
+            event = "notifications.changed",
+            payloadJson = """{"change":"posted"}""",
+            timeoutMs = 50,
+          )
+
+        assertFalse(result.ok)
+        assertNull(withTimeoutOrNull(250) { nodeEventParams.await() })
+
+        webSocket.send(connectResponseFrame(connectId))
+        awaitConnectedOrThrow(connected, lastDisconnect, server)
+
+        val afterConnect =
+          harness.session.sendNodeEventDetailed(
+            event = "notifications.changed",
+            payloadJson = """{"change":"posted"}""",
+            timeoutMs = TEST_TIMEOUT_MS,
+          )
+        val params = withTimeout(TEST_TIMEOUT_MS) { nodeEventParams.await() }
+
+        assertEquals(true, afterConnect.ok)
+        assertEquals("notifications.changed", params["event"]?.jsonPrimitive?.content)
       } finally {
         shutdownHarness(harness, server)
       }


### PR DESCRIPTION
## Summary

Fixes #79552.

Android now publishes `GatewaySession.currentConnection` only after the gateway `connect` RPC has completed, so reconnect-window callers cannot send `node.event` as the first websocket request before the handshake. Notification listener events that arrive while reconnect is still in flight are retained in a bounded queue and flushed once the node session reconnects.

Follow-up after review:
- `Connection.connect()` now returns the parsed ready metadata instead of firing `onConnected` internally.
- `connectOnce()` assigns `currentConnection = conn` before invoking `onConnected`, so `NodeRuntime.flushPendingForwardedNodeEvents()` runs only after the ready connection is visible to `sendNodeEvent`.

## Real behavior proof

Behavior or issue addressed: `notifications.changed` must not be sent as `node.event` before the node gateway connection finishes the `connect` RPC, and queued notification events must flush only after the ready connection is visible.

Real environment tested: local OpenClaw checkout at `f5fb8104d11a` on macOS. Local Android test execution is blocked on this machine because no Java runtime is installed, so the Android unit test is expected to be verified by CI after this push.

Exact steps or command run after this patch: inspected and patched the real Android runtime path so `GatewaySession.Connection.connect()` completes handshake parsing, `GatewaySession.connectOnce()` publishes `currentConnection`, and only then invokes `onConnected`, which is the callback that starts notification queue flushing in `NodeRuntime`.

Evidence after fix:

```text
Connection.connect() -> returns GatewayConnectionReadyInfo after connect RPC success
connectOnce() -> currentConnection = conn
connectOnce() -> onConnected(readyInfo.serverName, readyInfo.remoteAddress, readyInfo.mainSessionKey)
NodeRuntime.onConnected -> flushPendingForwardedNodeEvents()
```

Observed result after fix: the queue flush callback now happens after `currentConnection` is populated, so a retained `notifications.changed` event can be sent through the newly ready connection instead of being drained while `sendNodeEvent` still sees no connection.

What was not tested: I did not run a live Android device or local Robolectric shard on this Mac because Java is unavailable locally. CI should run `android-test-play` for the pushed head.

Before evidence: the previous PR head failed `android-test-play` on `GatewaySessionInvokeTest > sendNodeEventDetailed_doesNotSendBeforeConnectHandshakeCompletes`, matching the review finding that the queue could flush while `currentConnection` was still null.

## Validation

- `git diff --check`
- Attempted `./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest.sendNodeEventDetailed_doesNotSendBeforeConnectHandshakeCompletes` from `apps/android`; local machine has no Java runtime installed: `Unable to locate a Java Runtime`.
- CI `android-test-play` should verify the Android test after the pushed follow-up commit.

## Notes

The notification retry buffer is bounded to 64 events and drops the oldest entries under sustained reconnect/offline pressure to avoid unbounded memory growth.
