### PR TITLE
fix(acp): fail progress-only spawned turns

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -148,6 +148,26 @@ function resolveBackgroundTaskTerminalResult(progressSummary: string): {
   return {};
 }
 
+function isLikelyBackgroundTaskProgressAnnouncement(progressSummary: string): boolean {
+  const normalized = normalizeText(progressSummary)?.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.length > ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH) {
+    return false;
+  }
+  if (
+    /^(?:i(?:'|’)?ll|i will|i(?:'|’)?m going to|i am going to|vou|voy a|je vais)\b/i.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+  return /^(?:let me|starting|checking|looking|mapping|locating|investigating|analyzing|reviewing|scanning|searching|working on)\b/i.test(
+    normalized,
+  );
+}
+
 type BackgroundTaskContext = {
   requesterSessionKey: string;
   requesterOrigin?: DeliveryContext;
@@ -852,11 +872,18 @@ export class AcpSessionManager {
                 "ACP turn ended without a terminal done event.",
               );
             }
-            this.recordTurnCompletion({
-              startedAt: turnStartedAt,
-            });
             if (taskContext) {
               const terminalResult = resolveBackgroundTaskTerminalResult(taskProgressSummary);
+              if (
+                !turnOutcome.sawToolCall &&
+                !terminalResult.terminalOutcome &&
+                isLikelyBackgroundTaskProgressAnnouncement(taskProgressSummary)
+              ) {
+                throw new AcpRuntimeError(
+                  "ACP_TURN_FAILED",
+                  "ACP turn ended after only progress text, with no tool activity or final result.",
+                );
+              }
               this.markBackgroundTaskTerminal(taskContext.runId, {
                 sessionKey,
                 status: "succeeded",
@@ -868,6 +895,9 @@ export class AcpSessionManager {
                 terminalOutcome: terminalResult.terminalOutcome,
               });
             }
+            this.recordTurnCompletion({
+              startedAt: turnStartedAt,
+            });
             await this.setSessionState({
               cfg: input.cfg,
               sessionKey,

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -402,6 +402,79 @@ describe("AcpSessionManager", () => {
     });
   }, 300_000);
 
+  it("fails parented ACP turns that finish after only progress text", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runTurn.mockImplementation(async function* () {
+        yield {
+          type: "text_delta" as const,
+          stream: "output" as const,
+          text: "Vou localizar o fluxo de inbound do WhatsApp até a detecção/autorização de comandos...",
+        };
+        yield { type: "done" as const };
+      });
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "WhatsApp flow",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-1",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      const manager = new AcpSessionManager();
+      await expect(
+        manager.runTurn({
+          cfg: baseCfg,
+          sessionKey: "agent:codex:acp:child-1",
+          text: "Investigate the inbound WhatsApp command authorization flow",
+          mode: "prompt",
+          requestId: "direct-parented-progress-only-run",
+        }),
+      ).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP turn ended after only progress text, with no tool activity or final result.",
+      });
+      await flushMicrotasks();
+
+      expect(findTaskByRunId("direct-parented-progress-only-run")).toMatchObject({
+        runtime: "acp",
+        ownerKey: "agent:quant:telegram:quant:direct:822430204",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child-1",
+        label: "WhatsApp flow",
+        task: "Investigate the inbound WhatsApp command authorization flow",
+        status: "failed",
+        error: "ACP turn ended after only progress text, with no tool activity or final result.",
+        progressSummary:
+          "Vou localizar o fluxo de inbound do WhatsApp até a detecção/autorização de comandos...",
+      });
+    });
+  }, 300_000);
+
   it("preserves token-streamed ACP progress boundaries in parented task summaries", async () => {
     await withAcpManagerTaskStateDir(async () => {
       const runtimeState = createRuntime();

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -9,6 +9,7 @@ export type AcpTurnEventGate = {
 
 export type AcpTurnStreamOutcome = {
   sawOutput: boolean;
+  sawToolCall: boolean;
   sawTerminalEvent: boolean;
 };
 
@@ -23,6 +24,7 @@ export async function consumeAcpTurnStream(params: {
 }): Promise<AcpTurnStreamOutcome> {
   let streamError: AcpRuntimeError | null = null;
   let sawOutput = false;
+  let sawToolCall = false;
   let sawTerminalEvent = false;
 
   for await (const event of params.runtime.runTurn(params.turn)) {
@@ -38,6 +40,9 @@ export async function consumeAcpTurnStream(params: {
       );
     } else if (event.type === "text_delta" || event.type === "tool_call") {
       sawOutput = true;
+      if (event.type === "tool_call") {
+        sawToolCall = true;
+      }
       await params.onOutputEvent?.(event);
     }
     await params.onEvent?.(event);
@@ -49,6 +54,7 @@ export async function consumeAcpTurnStream(params: {
 
   return {
     sawOutput,
+    sawToolCall,
     sawTerminalEvent,
   };
 }


### PR DESCRIPTION
## Summary
- Track whether an ACP turn emitted any tool call activity in the turn stream outcome.
- Treat parented/background ACP turns as failed when they finish after only a likely progress announcement with no tool activity and no terminal blocked result.
- Add a regression test for the issue shape where a spawned Codex task emits only `Vou localizar...` text and then `done`.

## Root cause
Parented ACP turns only required a terminal `done` event before marking the backing task run as succeeded. That allowed initial progress text from a spawned Codex session to be reported as successful completion even when no investigation, tool use, or final report occurred.

## Real behavior proof
The regression test builds a parented child ACP session and makes the runtime emit exactly one output delta: `Vou localizar o fluxo de inbound do WhatsApp até a detecção/autorização de comandos...`, followed by `done`. Before this fix that shape satisfied the success path. With this change, `manager.runTurn` rejects with `ACP_TURN_FAILED` and the task registry record for `direct-parented-progress-only-run` is `status: "failed"` with the same progress summary preserved.

## Validation
- `pnpm install` (worktree dependency setup; downloaded one missing cached package)
- `pnpm test src/acp/control-plane/manager.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/acp/control-plane/manager.core.ts src/acp/control-plane/manager.turn-stream.ts src/acp/control-plane/manager.test.ts`
- `git diff --check`
- `pnpm check:changed --base upstream/main`

Fixes #79522