### PR TITLE
fix(launcher): stop respawn children after parent death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/CLI: add the optional bundled `oc-path` plugin, providing `openclaw path` for surgical `oc://` access to markdown, JSONC, and JSONL workspace files.
 - Plugins/SDK: add unified model catalog registration for text, image, video, and music providers, including `providerCatalogEntry` manifests, shared media list help, live catalog caching, and per-model video capability overlays.
 - Plugin SDK: add presentation helpers for controls-only interactive rendering and opt-in empty fallback text so rich channel renderers can share `MessagePresentation` semantics without duplicating native cards or components.
+- Launcher: stop respawned children after their wrapper parent exits or is killed, and keep the internal parent PID guard out of nested child command environments. Fixes #79534.
 - CLI: make parser, startup, config, guardrail, channel, agent, task, session, and MCP failures explain what happened and point to the next recovery command.
 - GitHub Copilot: refresh the model catalog from `${baseUrl}/models` so per-account entitlement and accurate context windows surface at runtime; static manifest catalog (now including `gpt-5.5`) remains the fallback when discovery is disabled or the API is unreachable.
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -90,11 +90,51 @@ const respawnSignals =
     : ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"];
 const respawnSignalExitGraceMs = 1_000;
 const respawnSignalForceKillGraceMs = 1_000;
+const respawnParentPidEnv = "OPENCLAW_RESPAWN_PARENT_PID";
+const respawnParentDeathGuardIntervalMs = 250;
+
+const installRespawnParentDeathGuard = () => {
+  if (process.platform === "win32") {
+    return;
+  }
+  const parentPid = Number(process.env[respawnParentPidEnv]);
+  if (!Number.isSafeInteger(parentPid) || parentPid <= 0 || parentPid === process.pid) {
+    return;
+  }
+  let detached = false;
+  let timer = null;
+  const detach = () => {
+    detached = true;
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+  const terminateIfOrphaned = () => {
+    if (detached || process.ppid === parentPid) {
+      return;
+    }
+    detach();
+    process.exit(1);
+  };
+  timer = setInterval(terminateIfOrphaned, respawnParentDeathGuardIntervalMs);
+  timer.unref?.();
+  terminateIfOrphaned();
+};
+
+installRespawnParentDeathGuard();
 
 const runRespawnedChild = (command, args, env) => {
+  const childEnv =
+    process.platform === "win32"
+      ? env
+      : {
+          ...env,
+          [respawnParentPidEnv]: String(process.pid),
+        };
   const child = spawn(command, args, {
     stdio: "inherit",
-    env,
+    env: childEnv,
   });
   const listeners = new Map();
   // This intentionally overlaps with src/entry.compile-cache.ts; keep the

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -12,6 +12,7 @@ import {
   runOpenClawCompileCacheRespawnPlan,
   shouldEnableOpenClawCompileCache,
 } from "./entry.compile-cache.js";
+import { OPENCLAW_RESPAWN_PARENT_PID } from "./process/child-process-bridge.js";
 
 describe("entry compile cache", () => {
   const tempDirs: string[] = [];
@@ -152,7 +153,10 @@ describe("entry compile cache", () => {
       ["/repo/openclaw/dist/entry.js", "status"],
       {
         stdio: "inherit",
-        env: { NODE_DISABLE_COMPILE_CACHE: "1" },
+        env: {
+          NODE_DISABLE_COMPILE_CACHE: "1",
+          [OPENCLAW_RESPAWN_PARENT_PID]: String(process.pid),
+        },
       },
     );
     expect(attachChildProcessBridge.mock.calls[0]?.[0]).toBe(child);

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -3,7 +3,10 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { enableCompileCache, getCompileCacheDir } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { attachChildProcessBridge } from "./process/child-process-bridge.js";
+import {
+  attachChildProcessBridge,
+  withChildProcessParentGuardEnv,
+} from "./process/child-process-bridge.js";
 
 const COMPILE_CACHE_RESPAWN_SIGNAL_EXIT_GRACE_MS = 1_000;
 const COMPILE_CACHE_RESPAWN_SIGNAL_FORCE_KILL_GRACE_MS = 1_000;
@@ -164,7 +167,7 @@ export function runOpenClawCompileCacheRespawnPlan(
 ): ChildProcess {
   const child = runtime.spawn(plan.command, plan.args, {
     stdio: "inherit",
-    env: plan.env,
+    env: withChildProcessParentGuardEnv({ env: plan.env }),
   });
   // Give the child a moment to honor forwarded signals, then exit the parent so
   // a child that ignores SIGTERM cannot keep the compile-cache wrapper alive indefinitely.

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -9,6 +9,7 @@ import {
   resolveCliRespawnCommand,
   runCliRespawnPlan,
 } from "./entry.respawn.js";
+import { OPENCLAW_RESPAWN_PARENT_PID } from "./process/child-process-bridge.js";
 
 type CliRespawnPlan = NonNullable<ReturnType<typeof buildCliRespawnPlan>>;
 
@@ -183,7 +184,10 @@ describe("runCliRespawnPlan", () => {
       ["/repo/openclaw/dist/entry.js", "status"],
       {
         stdio: "inherit",
-        env: { OPENCLAW_NODE_OPTIONS_READY: "1" },
+        env: {
+          OPENCLAW_NODE_OPTIONS_READY: "1",
+          [OPENCLAW_RESPAWN_PARENT_PID]: String(process.pid),
+        },
       },
     );
     expect(attachChildProcessBridge.mock.calls[0]?.[0]).toBe(child);

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -6,7 +6,10 @@ import {
   shouldSkipStartupEnvironmentRespawnForArgv,
 } from "./cli/respawn-policy.js";
 import { isTruthyEnvValue } from "./infra/env.js";
-import { attachChildProcessBridge } from "./process/child-process-bridge.js";
+import {
+  attachChildProcessBridge,
+  withChildProcessParentGuardEnv,
+} from "./process/child-process-bridge.js";
 
 export const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
 export const OPENCLAW_NODE_OPTIONS_READY = "OPENCLAW_NODE_OPTIONS_READY";
@@ -138,7 +141,7 @@ export function runCliRespawnPlan(
 ): ChildProcess {
   const child = runtime.spawn(plan.command, plan.argv, {
     stdio: "inherit",
-    env: plan.env,
+    env: withChildProcessParentGuardEnv({ env: plan.env }),
   });
   let signalExitTimer: NodeJS.Timeout | undefined;
   let signalForceKillTimer: NodeJS.Timeout | undefined;

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -17,6 +17,7 @@ import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
 import { isMainModule } from "./infra/is-main.js";
 import { ensureOpenClawExecMarkerOnProcess } from "./infra/openclaw-exec-env.js";
 import { installProcessWarningFilter } from "./infra/warning-filter.js";
+import { installChildProcessParentDeathGuard } from "./process/child-process-bridge.js";
 
 const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
@@ -81,6 +82,7 @@ if (
 ) {
   // Imported as a dependency — skip all entry-point side effects.
 } else {
+  installChildProcessParentDeathGuard();
   const entryFile = fileURLToPath(import.meta.url);
   const installRoot = resolveEntryInstallRoot(entryFile);
   const waitingForCompileCacheRespawn = respawnWithoutOpenClawCompileCacheIfNeeded({

--- a/src/process/child-process-bridge.ts
+++ b/src/process/child-process-bridge.ts
@@ -60,6 +60,7 @@ export function installChildProcessParentDeathGuard(
     return null;
   }
   const parentPid = Number(runtime.env[OPENCLAW_RESPAWN_PARENT_PID]);
+  delete runtime.env[OPENCLAW_RESPAWN_PARENT_PID];
   if (!Number.isSafeInteger(parentPid) || parentPid <= 0 || parentPid === runtime.pid) {
     return null;
   }

--- a/src/process/child-process-bridge.ts
+++ b/src/process/child-process-bridge.ts
@@ -6,10 +6,90 @@ export type ChildProcessBridgeOptions = {
   onSignal?: (signal: NodeJS.Signals) => void;
 };
 
+export const OPENCLAW_RESPAWN_PARENT_PID = "OPENCLAW_RESPAWN_PARENT_PID";
+const DEFAULT_PARENT_DEATH_GUARD_INTERVAL_MS = 250;
+
+type ParentDeathGuardTimer = ReturnType<typeof setInterval>;
+
+type ParentDeathGuardRuntime = {
+  env: NodeJS.ProcessEnv;
+  exit: (code?: number) => never;
+  pid: number;
+  platform: NodeJS.Platform;
+  ppid: () => number;
+  setInterval: typeof setInterval;
+  clearInterval: typeof clearInterval;
+};
+
 const defaultSignals: NodeJS.Signals[] =
   process.platform === "win32"
     ? ["SIGTERM", "SIGINT", "SIGBREAK"]
     : ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"];
+
+export function withChildProcessParentGuardEnv(params: {
+  env: NodeJS.ProcessEnv;
+  parentPid?: number;
+  platform?: NodeJS.Platform;
+}): NodeJS.ProcessEnv {
+  if ((params.platform ?? process.platform) === "win32") {
+    return params.env;
+  }
+  return {
+    ...params.env,
+    [OPENCLAW_RESPAWN_PARENT_PID]: String(params.parentPid ?? process.pid),
+  };
+}
+
+export function installChildProcessParentDeathGuard(
+  params: {
+    intervalMs?: number;
+    runtime?: Partial<ParentDeathGuardRuntime>;
+  } = {},
+): { detach: () => void } | null {
+  const runtime: ParentDeathGuardRuntime = {
+    env: process.env,
+    exit: process.exit.bind(process) as (code?: number) => never,
+    pid: process.pid,
+    platform: process.platform,
+    ppid: () => process.ppid,
+    setInterval,
+    clearInterval,
+    ...params.runtime,
+  };
+  if (runtime.platform === "win32") {
+    return null;
+  }
+  const parentPid = Number(runtime.env[OPENCLAW_RESPAWN_PARENT_PID]);
+  if (!Number.isSafeInteger(parentPid) || parentPid <= 0 || parentPid === runtime.pid) {
+    return null;
+  }
+
+  let detached = false;
+  let timer: ParentDeathGuardTimer | undefined;
+  const detach = (): void => {
+    detached = true;
+    if (timer) {
+      runtime.clearInterval(timer);
+      timer = undefined;
+    }
+  };
+  const terminateIfOrphaned = (): void => {
+    if (detached || runtime.ppid() === parentPid) {
+      return;
+    }
+    detach();
+    runtime.exit(1);
+  };
+
+  timer = runtime.setInterval(
+    terminateIfOrphaned,
+    params.intervalMs ?? DEFAULT_PARENT_DEATH_GUARD_INTERVAL_MS,
+  );
+  timer.unref?.();
+  terminateIfOrphaned();
+
+  return { detach };
+}
 
 export function attachChildProcessBridge(
   child: ChildProcess,

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -282,10 +282,11 @@ describe("child process parent-death guard", () => {
     const clearInterval = vi.fn();
     const exit = vi.fn();
 
+    const env = { [OPENCLAW_RESPAWN_PARENT_PID]: "12345" };
     const guard = installChildProcessParentDeathGuard({
       intervalMs: 10,
       runtime: {
-        env: { [OPENCLAW_RESPAWN_PARENT_PID]: "12345" },
+        env,
         exit: exit as unknown as (code?: number) => never,
         pid: 67890,
         platform: "linux",
@@ -299,6 +300,7 @@ describe("child process parent-death guard", () => {
     });
 
     expect(guard).not.toBeNull();
+    expect(env).toEqual({});
     expect(exit).not.toHaveBeenCalled();
 
     ppid = 1;
@@ -306,5 +308,34 @@ describe("child process parent-death guard", () => {
 
     expect(clearInterval).toHaveBeenCalledWith(timer);
     expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("consumes the guard env before generic child env inheritance", async () => {
+    await loadExecModules();
+    const env = {
+      [OPENCLAW_RESPAWN_PARENT_PID]: "12345",
+      OPENCLAW_NODE_OPTIONS_READY: "1",
+    };
+
+    const guard = installChildProcessParentDeathGuard({
+      runtime: {
+        env,
+        exit: vi.fn() as unknown as (code?: number) => never,
+        pid: 67890,
+        platform: "linux",
+        ppid: () => 12345,
+        setInterval: vi.fn(() => ({ unref: vi.fn() })) as unknown as typeof setInterval,
+        clearInterval: vi.fn(),
+      },
+    });
+
+    expect(guard).not.toBeNull();
+    expect(env).toEqual({ OPENCLAW_NODE_OPTIONS_READY: "1" });
+    expect(
+      resolveCommandEnv({
+        argv: ["openclaw", "status"],
+        baseEnv: env,
+      }),
+    ).not.toHaveProperty(OPENCLAW_RESPAWN_PARENT_PID);
   });
 });

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -7,6 +7,9 @@ import { OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
 const spawnMock = vi.hoisted(() => vi.fn());
 
 let attachChildProcessBridge: typeof import("./child-process-bridge.js").attachChildProcessBridge;
+let installChildProcessParentDeathGuard: typeof import("./child-process-bridge.js").installChildProcessParentDeathGuard;
+let withChildProcessParentGuardEnv: typeof import("./child-process-bridge.js").withChildProcessParentGuardEnv;
+let OPENCLAW_RESPAWN_PARENT_PID: typeof import("./child-process-bridge.js").OPENCLAW_RESPAWN_PARENT_PID;
 let resolveCommandEnv: typeof import("./exec.js").resolveCommandEnv;
 let resolveProcessExitCode: typeof import("./exec.js").resolveProcessExitCode;
 let runCommandWithTimeout: typeof import("./exec.js").runCommandWithTimeout;
@@ -26,7 +29,12 @@ async function loadExecModules(options?: { mockSpawn?: boolean }) {
   } else {
     vi.doUnmock("node:child_process");
   }
-  ({ attachChildProcessBridge } = await import("./child-process-bridge.js"));
+  ({
+    attachChildProcessBridge,
+    installChildProcessParentDeathGuard,
+    withChildProcessParentGuardEnv,
+    OPENCLAW_RESPAWN_PARENT_PID,
+  } = await import("./child-process-bridge.js"));
   ({ resolveCommandEnv, resolveProcessExitCode, runCommandWithTimeout, shouldSpawnWithShell } =
     await import("./exec.js"));
 }
@@ -247,5 +255,56 @@ describe("attachChildProcessBridge", () => {
 
     // Detached already via exit; should remain a safe no-op.
     detach();
+  });
+});
+
+describe("child process parent-death guard", () => {
+  it("adds the parent pid to Unix child environments", async () => {
+    await loadExecModules();
+
+    expect(
+      withChildProcessParentGuardEnv({
+        env: { OPENCLAW_NODE_OPTIONS_READY: "1" },
+        parentPid: 12345,
+        platform: "linux",
+      }),
+    ).toEqual({
+      OPENCLAW_NODE_OPTIONS_READY: "1",
+      [OPENCLAW_RESPAWN_PARENT_PID]: "12345",
+    });
+  });
+
+  it("exits when a guarded child is reparented", async () => {
+    await loadExecModules();
+    let ppid = 12345;
+    let intervalCallback: (() => void) | undefined;
+    const timer = { unref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+    const clearInterval = vi.fn();
+    const exit = vi.fn();
+
+    const guard = installChildProcessParentDeathGuard({
+      intervalMs: 10,
+      runtime: {
+        env: { [OPENCLAW_RESPAWN_PARENT_PID]: "12345" },
+        exit: exit as unknown as (code?: number) => never,
+        pid: 67890,
+        platform: "linux",
+        ppid: () => ppid,
+        setInterval: vi.fn((callback: () => void) => {
+          intervalCallback = callback;
+          return timer;
+        }) as unknown as typeof setInterval,
+        clearInterval,
+      },
+    });
+
+    expect(guard).not.toBeNull();
+    expect(exit).not.toHaveBeenCalled();
+
+    ppid = 1;
+    intervalCallback?.();
+
+    expect(clearInterval).toHaveBeenCalledWith(timer);
+    expect(exit).toHaveBeenCalledWith(1);
   });
 });

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -271,6 +271,64 @@ describe("openclaw launcher", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "terminates source-checkout compile-cache respawn children after parent SIGKILL",
+    async () => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      await addGitMarker(fixtureRoot);
+      const childInfoPath = path.join(fixtureRoot, "child-info.json");
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          `writeFileSync(${JSON.stringify(
+            childInfoPath,
+          )}, JSON.stringify({ pid: process.pid, parentPid: process.env.OPENCLAW_RESPAWN_PARENT_PID, ppid: process.ppid }) + "\\n");`,
+          'process.title = "openclaw-launcher-parent-death-test-child";',
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const launcher = spawn(process.execPath, [path.join(fixtureRoot, "openclaw.mjs")], {
+        cwd: fixtureRoot,
+        env: launcherEnv({
+          NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-compile-cache"),
+        }),
+        stdio: "ignore",
+      });
+      let respawnChildPid: number | undefined;
+
+      try {
+        const childInfo = JSON.parse(await waitForFile(childInfoPath, 5000)) as {
+          pid: number;
+          parentPid?: string;
+          ppid: number;
+        };
+        respawnChildPid = childInfo.pid;
+        expect(childInfo.parentPid).toBe(String(launcher.pid));
+        expect(childInfo.ppid).toBe(launcher.pid);
+
+        launcher.kill("SIGKILL");
+
+        await waitUntil(
+          () => !isProcessAlive(launcher.pid) && !isProcessAlive(respawnChildPid),
+          5000,
+        );
+        expect(isProcessAlive(launcher.pid)).toBe(false);
+        expect(isProcessAlive(respawnChildPid)).toBe(false);
+      } finally {
+        if (isProcessAlive(respawnChildPid)) {
+          process.kill(respawnChildPid!, "SIGKILL");
+        }
+        if (isProcessAlive(launcher.pid)) {
+          process.kill(launcher.pid!, "SIGKILL");
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "respawns symlinked source-checkout launchers without inherited NODE_COMPILE_CACHE",
     async () => {
       const fixtureRoot = await makeLauncherFixture(fixtureRoots);


### PR DESCRIPTION
## Summary

- Add a parent-death guard for respawned launcher children by passing the wrapper PID in the child environment and exiting if the child is reparented.
- Apply the same guard to the TypeScript compile-cache and CLI respawn paths so respawned children share the lifecycle protection.
- Add regression coverage for `openclaw.mjs` source-checkout compile-cache respawns when the parent launcher is killed with `SIGKILL`.
- Follow-up after review: consume `OPENCLAW_RESPAWN_PARENT_PID` as soon as the guarded child starts so nested commands cannot inherit a stale wrapper PID.

## Root cause

`openclaw.mjs` already forwards catchable signals to respawn children, but an uncatchable parent exit such as `SIGKILL` or a crash cannot run that forwarding path. The respawn child could then continue serving independently and keep gateway ports bound, which makes supervisor restarts fail with `EADDRINUSE`.

## Real behavior proof

Behavior or issue addressed: respawned launcher children should exit when their wrapper parent dies, and the internal parent-PID marker must not leak into later child command environments.

Real environment tested: local OpenClaw checkout at `855ebe632b44` on macOS, Node `v25.8.2`, pnpm `10.33.2`.

Exact steps or command run after this patch: ran the launcher/process validation command:

```text
pnpm test test/openclaw-launcher.e2e.test.ts src/entry.respawn.test.ts src/entry.compile-cache.test.ts src/process/exec.test.ts src/cli/root-guard.test.ts src/daemon/systemd-unit.test.ts
```

Evidence after fix:

```text
Test Files  3 passed (3)  // unit-fast shard
Tests  29 passed (29)
Test Files  1 passed (1)  // process shard
Tests  12 passed (12)
Test Files  1 passed (1)  // cli shard
Tests  11 passed (11)
Test Files  1 passed (1)  // launcher e2e shard
Tests  13 passed (13)
```

Observed result after fix: the launcher E2E SIGKILL scenario completes with both wrapper and respawn child gone, and the new process test proves `OPENCLAW_RESPAWN_PARENT_PID` is deleted before generic command env inheritance.

What was not tested: I did not run a live systemd/root-owned gateway restart on Linux; this proof uses the existing launcher E2E fixture plus process-level env inheritance coverage.

Before evidence: review showed the guard marker was read but left in `process.env`, so later subprocesses could inherit a stale wrapper PID and exit immediately.

## Validation

- `pnpm test test/openclaw-launcher.e2e.test.ts src/entry.respawn.test.ts src/entry.compile-cache.test.ts src/process/exec.test.ts src/cli/root-guard.test.ts src/daemon/systemd-unit.test.ts`
- `pnpm exec oxfmt --check --threads=1 openclaw.mjs src/entry.ts src/entry.respawn.ts src/entry.compile-cache.ts src/process/child-process-bridge.ts test/openclaw-launcher.e2e.test.ts src/entry.respawn.test.ts src/entry.compile-cache.test.ts src/process/exec.test.ts`
- `git diff --check`
- `pnpm check:changed --base upstream/main`

Fixes #79534
