### PR TITLE
docs(install): clarify install-cli.sh manages its own Node 22.22.0 runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/install: clarify that `install-cli.sh` manages its own Node LTS runtime (currently `22.22.0`) separately from the Node 24 default in `install.sh`; add a warning about potential native ABI mismatches when mixing Node versions, and document how to opt into Node 24 via `--node-version`. Fixes #79558.
 - CLI: make parser, startup, config, guardrail, channel, agent, task, session, and MCP failures explain what happened and point to the next recovery command.
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.
 - Telegram/Feishu: honor configured per-agent and global `reasoningDefault` values when deciding whether channel reasoning previews should stream or stay hidden, addressing the preview-default part of #73182. Thanks @anagnorisis2peripeteia.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Docs/install: clarify that `install-cli.sh` manages its own Node LTS runtime (currently `22.22.0`) separately from the Node 24 default in `install.sh`; add a warning about potential native ABI mismatches when mixing Node versions, and document how to opt into Node 24 via `--node-version`. Fixes #79558.
+- Docs/install: clarify that `install-cli.sh` manages its own Node LTS runtime (currently `22.22.0`) separately from the Node 24 default in `install.sh`; add a warning about potential native ABI mismatches when mixing Node versions, and document how to opt into Node 24 via `--node-version`. Fixes #79558. Thanks @McoreD.
 - CLI: make parser, startup, config, guardrail, channel, agent, task, session, and MCP failures explain what happened and point to the next recovery command.
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.
 - Telegram/Feishu: honor configured per-agent and global `reasoningDefault` values when deciding whether channel reasoning previews should stream or stay hidden, addressing the preview-default part of #73182. Thanks @anagnorisis2peripeteia.

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -183,11 +183,15 @@ Designed for environments where you want everything under a local prefix
 by default, plus git-checkout installs under the same prefix flow.
 </Info>
 
+<Warning>
+`install-cli.sh` manages its own Node runtime pinned to **Node 22.22.0** by default. This is intentionally separate from your system Node and from `install.sh`, which installs Node 24. If you install native add-ons (like OpenClaw memory plugins) outside the local prefix and they are rebuilt with your system Node, you may see native ABI errors (`NODE_MODULE_VERSION` mismatches) when OpenClaw loads them with its managed Node 22. To opt into Node 24, pass `--node-version 24.x.x` (see flags below).
+</Warning>
+
 ### Flow (install-cli.sh)
 
 <Steps>
   <Step title="Install local Node runtime">
-    Downloads a pinned supported Node LTS tarball (the version is embedded in the script and updated independently) to `<prefix>/tools/node-v<version>` and verifies SHA-256.
+    Downloads a pinned Node LTS tarball (currently **22.22.0** by default; pass `--node-version` to override) to `<prefix>/tools/node-v<version>` and verifies SHA-256. Skips the download if an existing managed Node at `<prefix>/tools/` has a major version ≥ 22.
   </Step>
   <Step title="Ensure Git">
     If Git is missing, attempts install via apt/dnf/yum on Linux or Homebrew on macOS.
@@ -237,20 +241,20 @@ by default, plus git-checkout installs under the same prefix flow.
 <AccordionGroup>
   <Accordion title="Flags reference">
 
-| Flag                        | Description                                                                     |
-| --------------------------- | ------------------------------------------------------------------------------- |
-| `--prefix <path>`           | Install prefix (default: `~/.openclaw`)                                         |
-| `--install-method npm\|git` | Choose install method (default: `npm`). Alias: `--method`                       |
-| `--npm`                     | Shortcut for npm method                                                         |
-| `--git`, `--github`         | Shortcut for git method                                                         |
-| `--git-dir <path>`          | Git checkout directory (default: `~/openclaw`). Alias: `--dir`                  |
-| `--version <ver>`           | OpenClaw version or dist-tag (default: `latest`)                                |
-| `--node-version <ver>`      | Node version (default: `22.22.0`)                                               |
-| `--json`                    | Emit NDJSON events                                                              |
-| `--onboard`                 | Run `openclaw onboard` after install                                            |
-| `--no-onboard`              | Skip onboarding (default)                                                       |
-| `--set-npm-prefix`          | On Linux, force npm prefix to `~/.npm-global` if current prefix is not writable |
-| `--help`                    | Show usage (`-h`)                                                               |
+| Flag                        | Description                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--prefix <path>`           | Install prefix (default: `~/.openclaw`)                                                                        |
+| `--install-method npm\|git` | Choose install method (default: `npm`). Alias: `--method`                                                      |
+| `--npm`                     | Shortcut for npm method                                                                                        |
+| `--git`, `--github`         | Shortcut for git method                                                                                        |
+| `--git-dir <path>`          | Git checkout directory (default: `~/openclaw`). Alias: `--dir`                                                 |
+| `--version <ver>`           | OpenClaw version or dist-tag (default: `latest`)                                                               |
+| `--node-version <ver>`      | Node version for the managed local runtime (default: `22.22.0`; use `24.x.x` to match the recommended runtime) |
+| `--json`                    | Emit NDJSON events                                                                                             |
+| `--onboard`                 | Run `openclaw onboard` after install                                                                           |
+| `--no-onboard`              | Skip onboarding (default)                                                                                      |
+| `--set-npm-prefix`          | On Linux, force npm prefix to `~/.npm-global` if current prefix is not writable                                |
+| `--help`                    | Show usage (`-h`)                                                                                              |
 
   </Accordion>
 

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -184,7 +184,7 @@ by default, plus git-checkout installs under the same prefix flow.
 </Info>
 
 <Warning>
-`install-cli.sh` manages its own Node runtime pinned to **Node 22.22.0** by default. This is intentionally separate from your system Node and from `install.sh`, which installs Node 24. If you install native add-ons (like OpenClaw memory plugins) outside the local prefix and they are rebuilt with your system Node, you may see native ABI errors (`NODE_MODULE_VERSION` mismatches) when OpenClaw loads them with its managed Node 22. To opt into Node 24, pass `--node-version 24.x.x` (see flags below).
+`install-cli.sh` manages its own Node runtime pinned to **Node 22.22.0** by default. This is intentionally separate from your system Node and from `install.sh`, which installs Node 24 when no supported Node 22+ is already present. If you install native add-ons (like OpenClaw memory plugins) outside the local prefix and they are rebuilt with your system Node, you may see native ABI errors (`NODE_MODULE_VERSION` mismatches) when OpenClaw loads them with its managed Node 22. To opt into Node 24, pass `--node-version 24.x.x` (see flags below).
 </Warning>
 
 ### Flow (install-cli.sh)


### PR DESCRIPTION
## Problem

`install-cli.sh` downloads and uses its own pinned Node LTS runtime (`22.22.0` by default), isolated from the system Node. Meanwhile `install.sh` and `docs/install/node.md` both recommend Node 24 as the default. The docs for `install-cli.sh` didn't explain this divergence.

Users who install native add-ons (e.g. OpenClaw memory plugins) with their system Node 24 can end up with ABI mismatches (`NODE_MODULE_VERSION` errors) when OpenClaw loads them via its managed Node 22.

Closes #79558.

## Solution

- Added a `<Warning>` callout to the `install-cli.sh` section explaining that the managed runtime defaults to Node 22.22.0, why this differs from the Node 24 recommendation, and how to opt into Node 24 via `--node-version`.
- Updated the `Install local Node runtime` step description to mention the default version (`22.22.0`) and the skip condition (existing managed Node major ≥ 22).
- Updated the `--node-version` flags table entry to note the default and the Node 24 opt-in.

## Real behavior proof

- Behavior or issue addressed: `docs/install/installer.md` did not explain the Node 22 vs Node 24 default gap between `install-cli.sh` and `install.sh`/docs. Users could install with mismatched Node versions without any warning.
- Real environment tested: Linux / Node.js v22.15.0, DGX Spark
- Exact steps or command run after this patch: `pnpm docs:list && pnpm docs:check-mdx && pnpm docs:check-links && git diff --check`
- Evidence after fix:
```
$ pnpm docs:check-mdx
Docs MDX check passed (623 files, 2656ms).

$ pnpm docs:check-links
checked_internal_links=4218
broken_links=0
```
- Observed result after fix: Docs build and link check pass; the `install-cli.sh` section now prominently warns about the Node 22.22.0 default and explains the opt-in path.
- Not tested: live `install-cli.sh` run with `--node-version 24.x.x`; Windows `install.ps1` path (unaffected)