### PR TITLE
docs(notion): make allowlist examples direct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Notion skill: replace allowlist-hostile shell-wrapped `curl` examples with `NOTION_API_KEY` setup guidance and direct file-backed helper commands. Fixes #59235.
 - Chat commands: add `/think default` and `/fast default` to clear session overrides and inherit configured/provider defaults. (#79385) Thanks @VACInc.
 - Dependencies: refresh workspace dependency pins and lockfile, including `@openai/codex` `0.130.0`, `acpx` `0.7.0`, AWS SDK `3.1044.0`, OpenTelemetry `0.217.0`, `typebox` `1.1.38`, `vite` `8.0.11`, `oxfmt` `0.48.0`, and `oxlint` `1.63.0`, and update the Codex harness model snapshot for the new bundled app-server catalog.
 - Plugins/install: add guarded plugin install overrides so onboarding and repair tests can route specific plugins to registry specs or local `npm pack` artifacts via environment variables.

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -17,126 +17,184 @@ Use the Notion API to create/read/update pages, data sources (databases), and bl
 
 1. Create an integration at https://notion.so/my-integrations
 2. Copy the API key (starts with `ntn_` or `secret_`)
-3. Store it:
+3. Configure the skill with `NOTION_API_KEY`. OpenClaw injects `skills.entries.notion.apiKey` into `process.env.NOTION_API_KEY` for the agent turn because this skill declares `metadata.openclaw.primaryEnv`.
 
-```bash
-mkdir -p ~/.config/notion
-echo "ntn_your_key_here" > ~/.config/notion/api_key
+```json5
+{
+  skills: {
+    entries: {
+      notion: {
+        enabled: true,
+        apiKey: "ntn_your_key_here",
+      },
+    },
+  },
+}
 ```
 
 4. Share target pages/databases with your integration (click "..." → "Connect to" → your integration name)
 
 ## API Basics
 
-All requests need:
+All requests need the `Authorization`, `Notion-Version`, and usually `Content-Type` headers. Use `NOTION_API_KEY`; do not create a shell-local alias such as `NOTION_KEY=$(cat ...)`.
 
-```bash
-NOTION_KEY=$(cat ~/.config/notion/api_key)
-curl -X GET "https://api.notion.com/v1/..." \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
-  -H "Content-Type: application/json"
-```
+Strict exec allowlist note: avoid examples shaped like `NOTION_KEY=...; curl ...`, command substitution, shell chaining, and line continuations. In `security=allowlist` with `ask=off`, those forms can be denied as an allowlist miss even when the underlying `curl` binary is allowlisted. Prefer a direct executable invocation with secrets already supplied in the environment, or a small file-backed helper run through an allowlisted interpreter.
 
 > **Note:** The `Notion-Version` header is required. This skill uses `2025-09-03` (latest). In this version, databases are called "data sources" in the API.
+
+### Allowlist-friendly helper
+
+For strict allowlist setups, create a helper file once and run it directly with an allowlisted `python3`. The helper reads `NOTION_API_KEY` from the environment and reads request bodies from files, so command lines do not need shell variable assignment, command substitution, semicolon chaining, or continuation characters.
+
+Save as `notion_request.py`:
+
+```python
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+if len(sys.argv) not in (3, 4):
+    raise SystemExit("usage: notion_request.py METHOD /v1/path [body.json]")
+
+method, api_path = sys.argv[1], sys.argv[2]
+body_path = sys.argv[3] if len(sys.argv) == 4 else None
+api_key = os.environ["NOTION_API_KEY"]
+data = None
+if body_path:
+    with open(body_path, "rb") as body_file:
+        data = body_file.read()
+
+request = urllib.request.Request(
+    f"https://api.notion.com{api_path}",
+    data=data,
+    method=method.upper(),
+    headers={
+        "Authorization": f"Bearer {api_key}",
+        "Notion-Version": "2025-09-03",
+        "Content-Type": "application/json",
+    },
+)
+
+try:
+    with urllib.request.urlopen(request, timeout=30) as response:
+        print(response.read().decode("utf-8"))
+except urllib.error.HTTPError as error:
+    print(error.read().decode("utf-8"), file=sys.stderr)
+    raise SystemExit(error.code)
+```
 
 ## Common Operations
 
 **Search for pages and data sources:**
 
+```json
+{ "query": "page title" }
+```
+
+Save the JSON as `search.json`, then run:
+
 ```bash
-curl -X POST "https://api.notion.com/v1/search" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "page title"}'
+python3 notion_request.py POST /v1/search search.json
 ```
 
 **Get page:**
 
 ```bash
-curl "https://api.notion.com/v1/pages/{page_id}" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03"
+python3 notion_request.py GET /v1/pages/{page_id}
 ```
 
 **Get page content (blocks):**
 
 ```bash
-curl "https://api.notion.com/v1/blocks/{page_id}/children" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03"
+python3 notion_request.py GET /v1/blocks/{page_id}/children
 ```
 
 **Create page in a data source:**
 
+```json
+{
+  "parent": { "database_id": "xxx" },
+  "properties": {
+    "Name": { "title": [{ "text": { "content": "New Item" } }] },
+    "Status": { "select": { "name": "Todo" } }
+  }
+}
+```
+
+Save the JSON as `create-page.json`, then run:
+
 ```bash
-curl -X POST "https://api.notion.com/v1/pages" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "parent": {"database_id": "xxx"},
-    "properties": {
-      "Name": {"title": [{"text": {"content": "New Item"}}]},
-      "Status": {"select": {"name": "Todo"}}
-    }
-  }'
+python3 notion_request.py POST /v1/pages create-page.json
 ```
 
 **Query a data source (database):**
 
+```json
+{
+  "filter": { "property": "Status", "select": { "equals": "Active" } },
+  "sorts": [{ "property": "Date", "direction": "descending" }]
+}
+```
+
+Save the JSON as `query-data-source.json`, then run:
+
 ```bash
-curl -X POST "https://api.notion.com/v1/data_sources/{data_source_id}/query" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "filter": {"property": "Status", "select": {"equals": "Active"}},
-    "sorts": [{"property": "Date", "direction": "descending"}]
-  }'
+python3 notion_request.py POST /v1/data_sources/{data_source_id}/query query-data-source.json
 ```
 
 **Create a data source (database):**
 
+```json
+{
+  "parent": { "page_id": "xxx" },
+  "title": [{ "text": { "content": "My Database" } }],
+  "properties": {
+    "Name": { "title": {} },
+    "Status": { "select": { "options": [{ "name": "Todo" }, { "name": "Done" }] } },
+    "Date": { "date": {} }
+  }
+}
+```
+
+Save the JSON as `create-data-source.json`, then run:
+
 ```bash
-curl -X POST "https://api.notion.com/v1/data_sources" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "parent": {"page_id": "xxx"},
-    "title": [{"text": {"content": "My Database"}}],
-    "properties": {
-      "Name": {"title": {}},
-      "Status": {"select": {"options": [{"name": "Todo"}, {"name": "Done"}]}},
-      "Date": {"date": {}}
-    }
-  }'
+python3 notion_request.py POST /v1/data_sources create-data-source.json
 ```
 
 **Update page properties:**
 
+```json
+{ "properties": { "Status": { "select": { "name": "Done" } } } }
+```
+
+Save the JSON as `update-page.json`, then run:
+
 ```bash
-curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
-  -H "Content-Type: application/json" \
-  -d '{"properties": {"Status": {"select": {"name": "Done"}}}}'
+python3 notion_request.py PATCH /v1/pages/{page_id} update-page.json
 ```
 
 **Add blocks to page:**
 
+```json
+{
+  "children": [
+    {
+      "object": "block",
+      "type": "paragraph",
+      "paragraph": { "rich_text": [{ "text": { "content": "Hello" } }] }
+    }
+  ]
+}
+```
+
+Save the JSON as `append-blocks.json`, then run:
+
 ```bash
-curl -X PATCH "https://api.notion.com/v1/blocks/{page_id}/children" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "children": [
-      {"object": "block", "type": "paragraph", "paragraph": {"rich_text": [{"text": {"content": "Hello"}}]}}
-    ]
-  }'
+python3 notion_request.py PATCH /v1/blocks/{page_id}/children append-blocks.json
 ```
 
 ## Property Types


### PR DESCRIPTION
## Summary

- Problem: the bundled Notion skill documented shell-local `NOTION_KEY=$(cat ...)` setup and multi-line `curl` examples that are hostile to strict exec allowlists.
- Why it matters: users running `security=allowlist` with `ask=off` can follow the bundled docs and still hit `exec denied: allowlist miss`, even after allowlisting the underlying `curl` binary.
- What changed: the skill now points setup at `skills.entries.notion.apiKey` / `NOTION_API_KEY`, explains the strict-allowlist pitfall, and gives a file-backed `python3 notion_request.py ...` helper flow for common operations.
- What did NOT change (scope boundary): no exec-approval policy, Notion API behavior, runtime code, or bundled helper file was added; this is a docs-only repair for the bundled skill guidance.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59235
- Related #59254, #59870
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: The bundled `skills/notion/SKILL.md` no longer teaches the allowlist-hostile `NOTION_KEY=$(cat ...)` / shell-wrapped multi-line `curl` workflow. It now documents `NOTION_API_KEY` setup and direct `python3 notion_request.py ...` helper invocations for strict allowlist setups.
- Real environment tested: Local OpenClaw source checkout on Windows, branch `feat/notion-allowlist-friendly-docs`, inspecting the updated bundled Notion skill file after the patch and running the repo docs/format gates.
- Exact steps or command run after this patch:

```powershell
Select-String -LiteralPath skills\notion\SKILL.md -Pattern "Strict exec allowlist note|Allowlist-friendly helper|python3 notion_request|NOTION_API_KEY|curl" -Context 0,2
rg "curl -X|NOTION_KEY=|\$\(cat|; curl|\\\s*$" skills/notion/SKILL.md
pnpm exec oxfmt --check --threads=1 skills/notion/SKILL.md
git diff --check
pnpm docs:list
pnpm check:changed
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live terminal output from the patched checkout:

```text
skills\notion\SKILL.md:20:3. Configure the skill with `NOTION_API_KEY`. OpenClaw injects `skills.entries.notion.apiKey` into `process.env.NOTION_API_KEY` for the agent turn because this skill declares `metadata.openclaw.primaryEnv`.
skills\notion\SKILL.md:39:All requests need the `Authorization`, `Notion-Version`, and usually `Content-Type` headers. Use `NOTION_API_KEY`; do not create a shell-local alias such as `NOTION_KEY=$(cat ...)`.
skills\notion\SKILL.md:41:Strict exec allowlist note: avoid examples shaped like `NOTION_KEY=...; curl ...`, command substitution, shell chaining, and line continuations. In `security=allowlist` with `ask=off`, those forms can be denied as an allowlist miss even when the underlying `curl` binary is allowlisted. Prefer a direct executable invocation with secrets already supplied in the environment, or a small file-backed helper run through an allowlisted interpreter.
skills\notion\SKILL.md:45:### Allowlist-friendly helper
skills\notion\SKILL.md:47:For strict allowlist setups, create a helper file once and run it directly with an allowlisted `python3`. The helper reads `NOTION_API_KEY` from the environment and reads request bodies from files, so command lines do not need shell variable assignment, command substitution, semicolon chaining, or continuation characters.
skills\notion\SKILL.md:64:api_key = os.environ["NOTION_API_KEY"]
skills\notion\SKILL.md:100:python3 notion_request.py POST /v1/search search.json
skills\notion\SKILL.md:106:python3 notion_request.py GET /v1/pages/{page_id}
skills\notion\SKILL.md:112:python3 notion_request.py GET /v1/blocks/{page_id}/children
skills\notion\SKILL.md:130:python3 notion_request.py POST /v1/pages create-page.json
skills\notion\SKILL.md:145:python3 notion_request.py POST /v1/data_sources/{data_source_id}/query query-data-source.json
skills\notion\SKILL.md:165:python3 notion_request.py POST /v1/data_sources create-data-source.json
skills\notion\SKILL.md:177:python3 notion_request.py PATCH /v1/pages/{page_id} update-page.json
skills\notion\SKILL.md:197:python3 notion_request.py PATCH /v1/blocks/{page_id}/children append-blocks.json

rg "curl -X|NOTION_KEY=|\$\(cat|; curl|\\\s*$" skills/notion/SKILL.md
All requests need the `Authorization`, `Notion-Version`, and usually `Content-Type` headers. Use `NOTION_API_KEY`; do not create a shell-local alias such as `NOTION_KEY=$(cat ...)`.
Strict exec allowlist note: avoid examples shaped like `NOTION_KEY=...; curl ...`, command substitution, shell chaining, and line continuations. In `security=allowlist` with `ask=off`, those forms can be denied as an allowlist miss even when the underlying `curl` binary is allowlisted. Prefer a direct executable invocation with secrets already supplied in the environment, or a small file-backed helper run through an allowlisted interpreter.
```

- Observed result after fix: The patched Notion skill presents the allowlist-safe `NOTION_API_KEY` setup and direct helper-command examples for every common operation. The old executable examples no longer include multi-line `curl -X ...`, `NOTION_KEY=...; curl ...`, or command-substitution setup; the remaining `curl`/`NOTION_KEY` mentions are warnings describing what to avoid.
- What was not tested: No live Notion API request was sent because that would require a real Notion workspace/integration secret. The changed behavior is documentation guidance and command shape, so validation focused on the bundled skill content and docs checks.
- Before evidence (optional but encouraged): Before this patch, `skills/notion/SKILL.md` told users to run `NOTION_KEY=$(cat ~/.config/notion/api_key)` and then use multi-line `curl` commands with `$NOTION_KEY`, which matches the allowlist-miss shape reported in #59235.

## Root Cause (if applicable)

- Root cause: The Notion skill docs predated the stricter allowlist guidance and used shell-local variable assignment, command substitution, and multi-line `curl` examples even though strict allowlist parsing can reject shell control/expansion shapes before reaching the underlying executable.
- Missing detection / guardrail: The skill doc did not call out strict exec allowlist constraints or prefer a direct executable/helper shape for secure configurations.
- Contributing context (if known): Prior fix attempts (#59254 and #59870) were closed unmerged, and the current bundled skill still contained the reported pattern.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `skills/notion/SKILL.md`
- Scenario the test should lock in: The Notion skill should not recommend shell-substitution/chained `curl` examples for strict allowlist users.
- Why this is the smallest reliable guardrail: This is a docs-only issue; the existing exec-approval tests already cover why command substitution, shell chaining, and line continuations are allowlist-hostile.
- Existing test that already covers this (if any): `src/infra/exec-approvals-analysis.test.ts` covers the parser constraints; this PR updates the skill docs to respect them.
- If no new test is added, why not: No runtime behavior changed; markdown formatting and docs listing are the relevant local gates.

## User-visible / Behavior Changes

Users reading the bundled Notion skill now get allowlist-friendly setup and request examples instead of a shell-wrapped `curl` workflow that can fail under strict exec policies.

## Diagram (if applicable)

```text
Before:
Notion skill docs -> NOTION_KEY=$(cat ...) + multi-line curl -> strict allowlist miss risk

After:
Notion skill docs -> NOTION_API_KEY + file-backed python3 helper -> direct allowlist-friendly command shape
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No runtime change`; docs now point at the existing `skills.entries.notion.apiKey` / `NOTION_API_KEY` secret path instead of suggesting a separate shell-local alias.
- New/changed network calls? `No`
- Command/tool execution surface changed? `No runtime change`; docs recommend direct helper invocation instead of shell wrappers.
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local checkout
- Runtime/container: Node/pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): bundled Notion skill docs
- Relevant config (redacted): N/A; no Notion secret used

### Steps

1. Inspect the patched Notion skill content for `NOTION_API_KEY`, strict allowlist guidance, and direct helper invocations.
2. Search for remaining bad executable examples (`curl -X`, `NOTION_KEY=`, `$(`, `; curl`, line-continuation command endings).
3. Run docs/format gates.

### Expected

- The skill docs guide strict allowlist users toward direct executable/helper commands and avoid the old shell-wrapped `curl` examples.

### Actual

- The patched skill includes the helper flow and the bad patterns only remain inside the explanatory “avoid this” note.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: inspected the patched skill output, confirmed helper commands are present for search/page/block/data-source operations, confirmed `oxfmt`, `git diff --check`, `docs:list`, and `check:changed` pass.
- Edge cases checked: confirmed the old bad command shapes are not still presented as runnable examples; remaining `curl`/`NOTION_KEY` text is warning-only.
- What I did **not** verify: live Notion API auth/request behavior with a real workspace, because this PR changes docs only and no Notion secret was used.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No runtime config change`; docs now recommend the existing `skills.entries.notion.apiKey` path.
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Users may copy the helper without setting `NOTION_API_KEY` in their environment/config first.
  - Mitigation: Setup now explicitly documents `skills.entries.notion.apiKey` and says OpenClaw injects it as `NOTION_API_KEY`.