### PR TITLE
[codex] Fix image describe MIME detection

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1227,6 +1227,20 @@ describe("capability cli", () => {
     expect(describeCall?.timeoutMs).toBe(90000);
   });
 
+  it("passes detected image describe MIME types through media understanding", async () => {
+    const tempInput = path.join(os.tmpdir(), `openclaw-image-describe-${Date.now()}.png`);
+    await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "image", "describe", "--file", tempInput, "--json"],
+    });
+
+    const describeCall = imageDescribeCall();
+    expect(describeCall?.filePath).toBe(tempInput);
+    expect(describeCall?.mime).toBe("image/png");
+  });
+
   it("keeps image describe URL files as remote media references", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,
@@ -1275,6 +1289,31 @@ describe("capability cli", () => {
     expect(mocks.describeImageFile).not.toHaveBeenCalled();
     expect(firstJsonOutput()?.provider).toBe("ollama");
     expect(firstJsonOutput()?.model).toBe("gpt-4.1-mini");
+  });
+
+  it("passes detected MIME types through explicit image describe model overrides", async () => {
+    const tempInput = path.join(os.tmpdir(), `openclaw-image-describe-model-${Date.now()}.png`);
+    await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "image",
+        "describe",
+        "--file",
+        tempInput,
+        "--model",
+        "ollama/qwen2.5vl:7b",
+        "--json",
+      ],
+    });
+
+    const describeCall = firstImageDescribeWithModelCall();
+    expect(describeCall?.filePath).toBe(tempInput);
+    expect(describeCall?.provider).toBe("ollama");
+    expect(describeCall?.model).toBe("qwen2.5vl:7b");
+    expect(describeCall?.mime).toBe("image/png");
   });
 
   it("keeps explicit-model image describe URL files as remote media references", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -514,6 +514,7 @@ describe("capability cli", () => {
   type ImageDescribeParams = {
     filePath?: string;
     mediaUrl?: string;
+    mime?: unknown;
     model?: unknown;
     prompt?: unknown;
     provider?: unknown;

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -996,6 +996,23 @@ describe("capability cli", () => {
     );
   });
 
+  it("passes detected image describe MIME types through media understanding", async () => {
+    const tempInput = path.join(os.tmpdir(), `openclaw-image-describe-${Date.now()}.png`);
+    await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "image", "describe", "--file", tempInput, "--json"],
+    });
+
+    expect(mocks.describeImageFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: tempInput,
+        mime: "image/png",
+      }),
+    );
+  });
+
   it("uses the explicit media-understanding provider for image describe model overrides", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,
@@ -1029,6 +1046,34 @@ describe("capability cli", () => {
       expect.objectContaining({
         provider: "ollama",
         model: "gpt-4.1-mini",
+      }),
+    );
+  });
+
+  it("passes detected MIME types through explicit image describe model overrides", async () => {
+    const tempInput = path.join(os.tmpdir(), `openclaw-image-describe-model-${Date.now()}.png`);
+    await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "image",
+        "describe",
+        "--file",
+        tempInput,
+        "--model",
+        "ollama/qwen2.5vl:7b",
+        "--json",
+      ],
+    });
+
+    expect(mocks.describeImageFileWithModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: tempInput,
+        provider: "ollama",
+        model: "qwen2.5vl:7b",
+        mime: "image/png",
       }),
     );
   });

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1039,6 +1039,18 @@ async function runImageGenerate(params: {
   } satisfies CapabilityEnvelope;
 }
 
+async function resolveImageDescribeMime(filePath: string): Promise<string> {
+  const buffer = await fs.readFile(filePath).catch(() => undefined);
+  return (
+    normalizeMimeType(
+      await detectMime({
+        buffer,
+        filePath,
+      }),
+    ) ?? "image/png"
+  );
+}
+
 async function runImageDescribe(params: {
   capability: "image.describe" | "image.describe-many";
   files: string[];
@@ -1057,12 +1069,14 @@ async function runImageDescribe(params: {
     params.files.map(async (filePath) => {
       const resolvedPath = resolveImageDescribeInput(filePath);
       const isRemoteUrl = /^https?:\/\//i.test(resolvedPath);
+      const mime = isRemoteUrl ? undefined : await resolveImageDescribeMime(resolvedPath);
       const result = activeModel
         ? await describeImageFileWithModel({
             filePath: resolvedPath,
             ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
             cfg,
             agentDir,
+            ...(mime ? { mime } : {}),
             provider: activeModel.provider,
             model: activeModel.model,
             prompt: prompt ?? "Describe the image.",
@@ -1073,6 +1087,7 @@ async function runImageDescribe(params: {
             ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
             cfg,
             agentDir,
+            ...(mime ? { mime } : {}),
             prompt,
             timeoutMs: params.timeoutMs,
           });

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -987,6 +987,18 @@ async function runImageGenerate(params: {
   } satisfies CapabilityEnvelope;
 }
 
+async function resolveImageDescribeMime(filePath: string): Promise<string> {
+  const buffer = await fs.readFile(filePath).catch(() => undefined);
+  return (
+    normalizeMimeType(
+      await detectMime({
+        buffer,
+        filePath,
+      }),
+    ) ?? "image/png"
+  );
+}
+
 async function runImageDescribe(params: {
   capability: "image.describe" | "image.describe-many";
   files: string[];
@@ -1001,6 +1013,7 @@ async function runImageDescribe(params: {
   const outputs = await Promise.all(
     params.files.map(async (filePath) => {
       const resolvedPath = path.resolve(filePath);
+      const mime = await resolveImageDescribeMime(resolvedPath);
       const result = activeModel
         ? await describeImageFileWithModel({
             filePath: resolvedPath,
@@ -1008,6 +1021,7 @@ async function runImageDescribe(params: {
             agentDir,
             provider: activeModel.provider,
             model: activeModel.model,
+            mime,
             prompt: prompt ?? "Describe the image.",
             timeoutMs: params.timeoutMs,
           })
@@ -1015,6 +1029,7 @@ async function runImageDescribe(params: {
             filePath: resolvedPath,
             cfg,
             agentDir,
+            mime,
             prompt,
             timeoutMs: params.timeoutMs,
           });


### PR DESCRIPTION
## Summary

Fixes `openclaw infer image describe` so local image files pass their detected MIME type into the media-understanding runtime. Previously the CLI resolved the file path but did not pass a MIME type to `describeImageFile` / `describeImageFileWithModel`; providers that validate the declared media type could default to or receive `image/jpeg` for PNG inputs and reject otherwise valid images.

## Root cause

`model run --file` already reads the file and calls `detectMime({ buffer, filePath })`, but `image describe` skipped that step before dispatching to media understanding. That made MIME propagation depend on downstream defaults instead of the actual input bytes.

## Changes

- Add MIME detection for `image describe` / `describe-many` inputs using file bytes plus path fallback.
- Pass the detected MIME through both configured media-understanding routing and explicit `--model provider/model` overrides.
- Add regression tests for PNG MIME propagation on both paths.

## Real behavior proof

- **Behavior or issue addressed**: `openclaw infer image describe --model <provider/model> --file image.png` could send a PNG image to the media-understanding provider without the real `image/png` MIME, allowing downstream defaults to declare the image as `image/jpeg`. Strict providers then rejected the request with a MIME mismatch even though the PNG itself was valid.
- **Real environment tested**: Real local OpenClaw setup on Justin's MacBook Pro, OpenClaw `2026.5.7`, configured provider `tapsvc/claude-sonnet-4-6` through `https://llm-proxy.tapsvc.com/v1`. The installed OpenClaw package was patched with the same source-level change in this PR before running the command.
- **Exact steps or command run after this patch**:

```bash
openclaw infer image describe \
  --file /tmp/openclaw-vision-retst.2N34uL/test.png \
  --model tapsvc/claude-sonnet-4-6 \
  --prompt 'What color is this square? Answer one word only.' \
  --json
```

- **Evidence after fix**: Copied live terminal output from the real OpenClaw command above:

```json
{
  "ok": true,
  "capability": "image.describe",
  "transport": "local",
  "provider": "tapsvc",
  "model": "claude-sonnet-4-6",
  "attempts": [],
  "outputs": [
    {
      "path": "/tmp/openclaw-vision-retst.2N34uL/test.png",
      "text": "**Red**",
      "provider": "tapsvc",
      "model": "claude-sonnet-4-6",
      "kind": "image.description"
    }
  ]
}
```

- **Observed result after fix**: The PNG was accepted by the real provider-backed image description path and returned `Red` instead of failing with a `image/jpeg` vs `image/png` mismatch. I also verified the default configured image-description route on the same setup with a generated green PNG, and it returned `Green` through `tapsvc/claude-sonnet-4-6`.
- **What was not tested**: No remote URL image input or HEIC conversion path was tested for this PR; the change is scoped to local file MIME propagation for `image describe` and `describe-many`.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/capability-cli.test.ts`
- `pnpm exec oxfmt --check src/cli/capability-cli.ts src/cli/capability-cli.test.ts`
