### PR TITLE
fix(control-ui): emit sessions.changed when session_status mutates model (#79613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Control UI/agents: emit a `sessions.changed` event when `session_status(model=...)` mutates a session's model override, so the top-bar model picker (and other Control UI sessions-list subscribers) refresh immediately instead of showing the stale model until the page is reloaded. Fixes #79613.
 - CLI: make parser, startup, config, guardrail, channel, agent, task, session, and MCP failures explain what happened and point to the next recovery command.
 - GitHub Copilot: refresh the model catalog from `${baseUrl}/models` so per-account entitlement and accurate context windows surface at runtime; static manifest catalog (now including `gpt-5.5`) remains the fallback when discovery is disabled or the API is unreachable.
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../sessions/session-id-resolution.js";
+import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { buildTaskStatusSnapshot } from "../tasks/task-status.js";
 
@@ -879,6 +880,34 @@ describe("session_status tool", () => {
         }),
       }),
     );
+  });
+
+  it("emits a sessions.changed lifecycle event when session_status mutates the session model (issue #79613)", async () => {
+    resetSessionStore({});
+    const events: Array<{ sessionKey: string; reason: string }> = [];
+    const unsubscribe = onSessionLifecycleEvent((evt) => {
+      events.push({ sessionKey: evt.sessionKey, reason: evt.reason });
+    });
+    try {
+      const tool = getSessionStatusTool("agent:main:scope:scopy:direct:scopy");
+      const result = await tool.execute("call-79613-emit", {
+        sessionKey: "current",
+        model: "anthropic/claude-sonnet-4-6",
+      });
+      const details = result.details as { ok?: boolean; changedModel?: boolean };
+      expect(details.ok).toBe(true);
+      expect(details.changedModel).toBe(true);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sessionKey: "agent:main:scope:scopy:direct:scopy",
+            reason: "model",
+          }),
+        ]),
+      );
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("materializes a valid persisted session entry when implicit current fallback mutates model state", async () => {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -22,6 +22,7 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import { emitSessionLifecycleEvent } from "../../sessions/session-lifecycle-events.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import type { BuildStatusTextParams } from "../../status/status-text.types.js";
@@ -636,6 +637,20 @@ export function createSessionStatusTool(opts?: {
           });
           resolved.entry = persistedEntry;
           changedModel = true;
+          // Notify subscribers (e.g. Control UI sessions list / model picker) that
+          // the session's model changed. Without this, the dropdown shows stale
+          // values until the page is refreshed (issue #79613).
+          emitSessionLifecycleEvent({
+            sessionKey: resolved.key,
+            reason: "model",
+            ...(persistedEntry.parentSessionKey
+              ? { parentSessionKey: persistedEntry.parentSessionKey }
+              : {}),
+            ...(persistedEntry.label ? { label: persistedEntry.label } : {}),
+            ...(persistedEntry.displayName
+              ? { displayName: persistedEntry.displayName }
+              : {}),
+          });
         }
       }
 


### PR DESCRIPTION
Fixes #79613.

## Root cause

The Control UI top-bar model picker resolves its current value from the local optimistic override cache and otherwise from the active sessionsResult row's `model` / `modelProvider`. `sessionsResult` rows are refreshed when the gateway broadcasts `sessions.changed` (e.g. on `sessions.patch`, lifecycle events, transcript updates).

The `session_status` tool also accepts a `model` parameter and is documented as a session model switch. Its handler mutates the session store directly via `applyModelOverrideToSessionEntry` and `updateSessionStore`, but it never notifies subscribers — so the picker keeps showing the previously-selected model until the page is reloaded, even though subsequent turns already use the new model. The dropdown / `/model` / `sessions.patch` paths all emit `sessions.changed`; the `session_status(model=...)` path was the missing one.

## Fix

After the persisted entry is written in the `session_status` model branch, emit a `SessionLifecycleEvent` with `reason: "model"` via `emitSessionLifecycleEvent`. The gateway's existing lifecycle broadcast handler (`createLifecycleEventBroadcastHandler` in `src/gateway/server-session-events.ts`) turns that into the same `sessions.changed` payload that the Control UI sessions controller already handles — including `model` and `modelProvider` fields — so the picker refreshes without any UI changes.

This reuses the same notification contract the Codex review recommended (`sessions.changed` row refresh) rather than adding UI polling or a new model-cache special case.

## Files

- `src/agents/tools/session-status-tool.ts` — emit lifecycle event after store update.
- `src/agents/openclaw-tools.session-status.test.ts` — regression test asserting the event fires with `reason: "model"` on the canonical session key.
- `CHANGELOG.md` — Unreleased entry referencing #79613.

No `dist/` edits, no full-repo prettier, targeted only.