### PR TITLE
feat(status): show active subagent details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: mark memory-specific embedding provider registration as deprecated compatibility and surface non-bundled usage in plugin compatibility diagnostics. (#85072) Thanks @mbelinky.
 - Pixverse: add video generation provider support, API region selection, and external plugin publishing.
 - Plugins: expose approval action metadata for plugin-driven approval surfaces.
+- Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.
+- Status: show up to three active subagent labels with elapsed runtime in `/status` while preserving verbose completed-subagent summaries.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: mark memory-specific embedding provider registration as deprecated compatibility and surface non-bundled usage in plugin compatibility diagnostics. (#85072) Thanks @mbelinky.
 - Pixverse: add video generation provider support, API region selection, and external plugin publishing.
 - Plugins: expose approval action metadata for plugin-driven approval surfaces.
-- Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.
-- Status: show up to three active subagent labels with elapsed runtime in `/status` while preserving verbose completed-subagent summaries.
 
 ### Fixes
 

--- a/src/auto-reply/reply/commands-status-subagents.ts
+++ b/src/auto-reply/reply/commands-status-subagents.ts
@@ -1,27 +1,59 @@
 import type { SubagentRunRecord } from "../../agents/subagent-registry.types.js";
-import { resolveSubagentLabel } from "./subagents-utils.js";
+import { formatDurationCompact } from "../../infra/format-time/format-duration.ts";
+import { formatRunLabel, sortSubagentRuns } from "./subagents-utils.js";
+
+function formatActiveSubagentDetail(params: {
+  entry: SubagentRunRecord;
+  now: number;
+  pendingDescendants: number;
+}): string {
+  const { entry, now, pendingDescendants } = params;
+  const startedAt = entry.startedAt ?? entry.sessionStartedAt ?? entry.createdAt;
+  const durationMs = Math.max(
+    0,
+    (entry.endedAt && pendingDescendants === 0 ? entry.endedAt : now) - startedAt,
+  );
+  const duration = formatDurationCompact(durationMs, { spaced: true }) ?? "0s";
+  const label = formatRunLabel(entry, { maxLength: 56 });
+  const descendantText =
+    pendingDescendants > 0
+      ? ` · ${pendingDescendants} child${pendingDescendants === 1 ? "" : "ren"} active`
+      : "";
+  return `  • ${label} · ${duration}${descendantText}`;
+}
 
 export function buildSubagentsStatusLine(params: {
   runs: SubagentRunRecord[];
   verboseEnabled: boolean;
   pendingDescendantsForRun: (entry: SubagentRunRecord) => number;
+  now?: number;
 }): string | undefined {
-  const { runs, verboseEnabled, pendingDescendantsForRun } = params;
+  const { runs, pendingDescendantsForRun, verboseEnabled } = params;
   if (runs.length === 0) {
     return undefined;
   }
-  const active = runs.filter((entry) => !entry.endedAt || pendingDescendantsForRun(entry) > 0);
+  const activeWithDescendants = runs
+    .map((entry) => ({ entry, pendingDescendants: pendingDescendantsForRun(entry) }))
+    .filter(({ entry, pendingDescendants }) => !entry.endedAt || pendingDescendants > 0);
+  const active = activeWithDescendants.map(({ entry }) => entry);
   const done = runs.length - active.length;
-  if (verboseEnabled) {
-    const labels = active
-      .map((entry) => resolveSubagentLabel(entry, ""))
-      .filter(Boolean)
-      .slice(0, 3);
-    const labelText = labels.length ? ` (${labels.join(", ")})` : "";
-    return `🤖 Subagents: ${active.length} active${labelText} · ${done} done`;
+  if (active.length === 0) {
+    return verboseEnabled && done > 0 ? `🤖 Subagents: 0 active · ${done} done` : undefined;
   }
-  if (active.length > 0) {
-    return `🤖 Subagents: ${active.length} active`;
-  }
-  return undefined;
+
+  const summary = `🤖 Subagents: ${active.length} active${done > 0 ? ` · ${done} done` : ""}`;
+  const now = params.now ?? Date.now();
+  const detailLookup = new Map(
+    activeWithDescendants.map(({ entry, pendingDescendants }) => [entry.runId, pendingDescendants]),
+  );
+  const detailLines = sortSubagentRuns(active)
+    .slice(0, 3)
+    .map((entry) =>
+      formatActiveSubagentDetail({
+        entry,
+        now,
+        pendingDescendants: detailLookup.get(entry.runId) ?? 0,
+      }),
+    );
+  return [summary, ...detailLines].join("\n");
 }

--- a/src/auto-reply/reply/commands-subagents-status.test.ts
+++ b/src/auto-reply/reply/commands-subagents-status.test.ts
@@ -25,7 +25,7 @@ describe("subagents status", () => {
       unexpectedText: ["Subagents:"],
     },
     {
-      name: "includes subagent count in /status when active",
+      name: "includes subagent count and active detail in /status when active",
       seedRuns: () => {
         addSubagentRunForTests({
           runId: "run-1",
@@ -39,7 +39,7 @@ describe("subagents status", () => {
         });
       },
       verboseLevel: "off" as const,
-      expectedText: ["🤖 Subagents: 1 active"],
+      expectedText: ["🤖 Subagents: 1 active", "  • do thing · 4s"],
       unexpectedText: [] as string[],
     },
     {
@@ -69,8 +69,28 @@ describe("subagents status", () => {
         });
       },
       verboseLevel: "on" as const,
-      expectedText: ["🤖 Subagents: 1 active", "· 1 done"],
+      expectedText: ["🤖 Subagents: 1 active", "· 1 done", "  • do thing · 4s"],
       unexpectedText: [] as string[],
+    },
+    {
+      name: "preserves verbose done-only summary",
+      seedRuns: () => {
+        addSubagentRunForTests({
+          runId: "run-1",
+          childSessionKey: "agent:main:subagent:done-a",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "finished task",
+          cleanup: "keep",
+          createdAt: 1000,
+          startedAt: 1000,
+          endedAt: 2000,
+          outcome: { status: "ok" },
+        });
+      },
+      verboseLevel: "on" as const,
+      expectedText: ["🤖 Subagents: 0 active · 1 done"],
+      unexpectedText: ["  • finished task"],
     },
   ])("$name", ({ seedRuns, verboseLevel, expectedText, unexpectedText }) => {
     seedRuns();
@@ -82,6 +102,7 @@ describe("subagents status", () => {
         verboseEnabled: verboseLevel === "on",
         pendingDescendantsForRun: (entry) =>
           countPendingDescendantRunsFromRuns(runsSnapshot, entry.childSessionKey),
+        now: 5000,
       }) ?? "";
     for (const expected of expectedText) {
       expect(text).toContain(expected);


### PR DESCRIPTION
## Problem

The session status card only showed a subagent count, so long-running delegated work could look like it had disappeared or stalled.

## Fix

- Keep the active subagent count in `/status`.
- Add up to three active subagent detail rows with label/task and elapsed runtime.
- Preserve active accounting for completed orchestrators that still have pending descendants.

Example:

```text
🤖 Subagents: 2 active · 1 done
  • research current options · 3m
  • update docs · 45s
```

## Validation

- `node scripts/run-vitest.mjs run src/auto-reply/reply/commands-subagents-status.test.ts src/auto-reply/reply/commands-status.test.ts`
- `pnpm check:test-types`
- `pnpm exec oxlint src/auto-reply/reply/commands-status-subagents.ts src/auto-reply/reply/commands-subagents-status.test.ts`

## Real behavior proof

- **Behavior or issue addressed**: `/status` now shows active subagent details, not only a count, so delegated work is visible while it is still running.
- **Real environment tested**: Local OpenClaw checkout on the PR branch `fix/session-status-active-subagents`, Node v22.22.2, Linux x64.
- **Exact steps or command run after this patch**: Ran a live Node/tsx smoke command against the patched status formatter in the PR checkout:

```bash
PATH=/home/clever/.openclaw/workspace/tmp/bin:$PATH node --import tsx - <<'EOF'
import { buildSubagentsStatusLine } from './src/auto-reply/reply/commands-status-subagents.ts';

const output = buildSubagentsStatusLine({
  runs: [
    {
      runId: 'run-live-status-research',
      childSessionKey: 'agent:main:subagent:live-status-research',
      requesterSessionKey: 'agent:main:main',
      requesterDisplayKey: 'main',
      task: 'research current options',
      label: 'research current options',
      cleanup: 'keep',
      createdAt: 1_000,
      startedAt: 1_000,
    },
    {
      runId: 'run-live-status-docs',
      childSessionKey: 'agent:main:subagent:live-status-docs',
      requesterSessionKey: 'agent:main:main',
      requesterDisplayKey: 'main',
      task: 'update docs',
      label: 'update docs',
      cleanup: 'keep',
      createdAt: 61_000,
      startedAt: 61_000,
    },
    {
      runId: 'run-live-status-finished',
      childSessionKey: 'agent:main:subagent:live-status-finished',
      requesterSessionKey: 'agent:main:main',
      requesterDisplayKey: 'main',
      task: 'finished worker',
      cleanup: 'keep',
      createdAt: 500,
      startedAt: 500,
      endedAt: 900,
      outcome: { status: 'ok' },
    },
  ],
  verboseEnabled: false,
  pendingDescendantsForRun: () => 0,
  now: 181_000,
});
console.log('/status subagent section after patch:');
console.log(output);
EOF
```

- **Evidence after fix**: Terminal output from the command above:

```text
/status subagent section after patch:
🤖 Subagents: 2 active · 1 done
  • update docs · 2m
  • research current options · 3m
```

- **Observed result after fix**: The status section includes the active subagent count, done count, and two active detail rows with labels and elapsed time.
- **What was not tested**: Full end-to-end Telegram delivery with this branch installed into a running gateway was not tested; the status formatting path and `/status` tests were covered locally.
