### PR TITLE
feat(gateway): support hidden chat sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/WebChat: add admin-scoped `chat.send.hideUserMessage` requests for hidden bootstrap turns that do not record the triggering user prompt.
 - CLI: make parser, startup, config, guardrail, channel, agent, task, session, and MCP failures explain what happened and point to the next recovery command.
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.
 - Telegram/Feishu: honor configured per-agent and global `reasoningDefault` values when deciding whether channel reasoning previews should stream or stay hidden, addressing the preview-default part of #73182. Thanks @anagnorisis2peripeteia.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5606,6 +5606,7 @@ public struct ChatSendParams: Codable, Sendable {
     public let message: String
     public let thinking: String?
     public let deliver: Bool?
+    public let hideusermessage: Bool?
     public let originatingchannel: String?
     public let originatingto: String?
     public let originatingaccountid: String?
@@ -5622,6 +5623,7 @@ public struct ChatSendParams: Codable, Sendable {
         message: String,
         thinking: String?,
         deliver: Bool?,
+        hideusermessage: Bool?,
         originatingchannel: String?,
         originatingto: String?,
         originatingaccountid: String?,
@@ -5637,6 +5639,7 @@ public struct ChatSendParams: Codable, Sendable {
         self.message = message
         self.thinking = thinking
         self.deliver = deliver
+        self.hideusermessage = hideusermessage
         self.originatingchannel = originatingchannel
         self.originatingto = originatingto
         self.originatingaccountid = originatingaccountid
@@ -5654,6 +5657,7 @@ public struct ChatSendParams: Codable, Sendable {
         case message
         case thinking
         case deliver
+        case hideusermessage = "hideUserMessage"
         case originatingchannel = "originatingChannel"
         case originatingto = "originatingTo"
         case originatingaccountid = "originatingAccountId"

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -433,6 +433,7 @@ enumeration of `src/gateway/server-methods/*.ts`.
     - `sessions.reset`, `sessions.delete`, and `sessions.compact` perform session maintenance.
     - `sessions.get` returns the full stored session row.
     - Chat execution still uses `chat.history`, `chat.send`, `chat.abort`, and `chat.inject`. `chat.history` is display-normalized for UI clients: inline directive tags are stripped from visible text, plain-text tool-call XML payloads (including `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, `<function_calls>...</function_calls>`, and truncated tool-call blocks) and leaked ASCII/full-width model control tokens are stripped, pure silent-token assistant rows such as exact `NO_REPLY` / `no_reply` are omitted, and oversized rows can be replaced with placeholders.
+    - `chat.send` accepts optional `hideUserMessage: true` for admin-scoped operator clients that need to start a hidden bootstrap turn without recording or broadcasting the triggering user prompt. Hidden sends still require `operator.admin`, still produce normal assistant output, and cannot be combined with `deliver: true` or attachments. Omit `hideUserMessage` for normal sends.
 
   </Accordion>
 

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -39,6 +39,7 @@ export const ChatSendParamsSchema = Type.Object(
     message: Type.String(),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
+    hideUserMessage: Type.Optional(Type.Boolean()),
     originatingChannel: Type.Optional(Type.String()),
     originatingTo: Type.Optional(Type.String()),
     originatingAccountId: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -766,6 +766,11 @@ function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"
   return scopes.includes(ADMIN_SCOPE);
 }
 
+function canHideUserMessage(client: GatewayRequestHandlerOptions["client"]): boolean {
+  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+  return scopes.includes(ADMIN_SCOPE);
+}
+
 async function persistChatSendImages(params: {
   images: ChatImageContent[];
   imageOrder: PromptImageOrderEntry[];
@@ -1905,6 +1910,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       message: string;
       thinking?: string;
       deliver?: boolean;
+      hideUserMessage?: boolean;
       originatingChannel?: string;
       originatingTo?: string;
       originatingAccountId?: string;
@@ -1971,6 +1977,36 @@ export const chatHandlers: GatewayRequestHandlers = {
         false,
         undefined,
         errorShape(ErrorCodes.INVALID_REQUEST, "message or attachment required"),
+      );
+      return;
+    }
+    if (p.hideUserMessage && p.deliver === true) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "hideUserMessage cannot be combined with deliver=true",
+        ),
+      );
+      return;
+    }
+    if (p.hideUserMessage && normalizedAttachments.length > 0) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "hideUserMessage cannot be combined with attachments",
+        ),
+      );
+      return;
+    }
+    if (p.hideUserMessage && !canHideUserMessage(client)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${ADMIN_SCOPE}`),
       );
       return;
     }
@@ -2307,6 +2343,9 @@ export const chatHandlers: GatewayRequestHandlers = {
       let agentRunStarted = false;
       const hasBeforeAgentRunGate = getGlobalHookRunner()?.hasHooks("before_agent_run") === true;
       const emitUserTranscriptUpdate = async () => {
+        if (p.hideUserMessage) {
+          return;
+        }
         if (userTranscriptUpdatePromise) {
           await userTranscriptUpdatePromise;
           return;
@@ -2352,6 +2391,9 @@ export const chatHandlers: GatewayRequestHandlers = {
       };
       let transcriptMediaRewriteDone = false;
       const rewriteUserTranscriptMedia = async () => {
+        if (p.hideUserMessage) {
+          return;
+        }
         if (transcriptMediaRewriteDone) {
           return;
         }

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -714,6 +714,98 @@ describe("gateway server chat", () => {
 
     expect(roleAndText).toEqual(["assistant:real text field reply", "assistant:real reply"]);
   });
+
+  test("chat.send can hide the triggering user turn from chat history", async () => {
+    await withMainSessionStore(async () => {
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            dispatcher: {
+              sendFinalReply: (payload: { text: string }) => boolean;
+              markComplete: () => void;
+              waitForIdle: () => Promise<void>;
+              getQueuedCounts: () => { final: number; block: number; tool: number };
+            };
+          },
+        ];
+        params.dispatcher.sendFinalReply({
+          text: "Hello, I am ready to help.",
+        });
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return {
+          queuedFinal: true,
+          counts: params.dispatcher.getQueuedCounts(),
+        };
+      });
+
+      const res = await rpcReq(ws, "chat.send", {
+        sessionKey: "main",
+        message: "Please introduce yourself to the user.",
+        hideUserMessage: true,
+        idempotencyKey: "idem-hidden-user-turn-1",
+      });
+
+      expect(res.ok).toBe(true);
+      await waitForAgentRunOk("idem-hidden-user-turn-1", CHAT_RESPONSE_TIMEOUT_MS);
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalled();
+      });
+
+      const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+        sessionKey: "main",
+      });
+      expect(historyRes.ok).toBe(true);
+      expect(collectHistoryTextValues(historyRes.payload?.messages ?? [])).toEqual([
+        "Hello, I am ready to help.",
+      ]);
+    });
+  });
+
+  test("chat.send requires operator.admin to hide the triggering user turn", async () => {
+    await withGatewayServer(async ({ port }) => {
+      await withMainSessionStore(async () => {
+        let scopedWs: WebSocket | undefined;
+
+        try {
+          scopedWs = new WebSocket(`ws://127.0.0.1:${port}`);
+          trackConnectChallengeNonce(scopedWs);
+          await new Promise<void>((resolve) => scopedWs?.once("open", resolve));
+          await connectOk(scopedWs, {
+            scopes: ["operator.write"],
+          });
+
+          const res = await rpcReq(scopedWs, "chat.send", {
+            sessionKey: "main",
+            message: "Please introduce yourself to the user.",
+            hideUserMessage: true,
+            idempotencyKey: "idem-hidden-user-turn-write-scope",
+          });
+
+          expect(res.ok).toBe(false);
+          expect(res.error?.message).toBe("missing scope: operator.admin");
+        } finally {
+          scopedWs?.close();
+        }
+      });
+    });
+  });
+
+  test("chat.send rejects hideUserMessage with attachments", async () => {
+    await withMainSessionStore(async () => {
+      const res = await rpcReq(ws, "chat.send", {
+        sessionKey: "main",
+        message: "bootstrap",
+        hideUserMessage: true,
+        attachments: [{ type: "image", content: "iVBOR" }],
+        idempotencyKey: "idem-hidden-with-attachment",
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.message).toBe("hideUserMessage cannot be combined with attachments");
+    });
+  });
+
   test("routes chat.send slash commands without agent runs", async () => {
     await withMainSessionStore(async () => {
       const spy = vi.mocked(agentCommand);


### PR DESCRIPTION
## Summary
- add `chat.send.hideUserMessage` to the Gateway protocol schema and Swift protocol model
- require `operator.admin` before a hidden send can suppress the triggering user turn
- reject hidden sends with `deliver: true` or attachments so the hidden path stays narrow
- keep assistant output/history behavior intact while skipping only the user transcript write

## Why
This is the small protocol/Gateway foundation for hidden bootstrap turns. It does not add URL autostart behavior; that is intentionally split into follow-up #79653.

## Real behavior proof
- **Behavior or issue addressed**: `chat.send` accepts `hideUserMessage: true` for admin-scoped callers, does not record the triggering user prompt in chat history, and rejects attachments on the hidden path.
- **Real environment tested**: Local macOS source checkout at `a1884362174eaf72cae7b2ddcbd2430c7067a736`, foreground OpenClaw Gateway on `ws://127.0.0.1:19886` with token auth and `OPENCLAW_SKIP_CHANNELS=1`.
- **Exact steps or command run after this patch**: Started a real gateway with `pnpm openclaw gateway run --allow-unconfigured --port 19886 --bind loopback --auth token --token <redacted> --ws-log compact`, connected over the real Gateway WebSocket with admin/read/write operator scopes, called `chat.history`, called `chat.send` with `{ "sessionKey": "main", "message": "/context list", "hideUserMessage": true }`, called `chat.history` again, then attempted a hidden send with an image attachment.
- **Evidence after fix**: Terminal output from the live local gateway client run:

```json
{
  "connected": true,
  "url": "ws://127.0.0.1:19886",
  "before": {
    "sessionId": null,
    "messageCount": 0,
    "texts": []
  },
  "send": {
    "runId": "proof-hidden-send-1778301902610",
    "status": "started"
  },
  "after": {
    "sessionId": "933b48d9-d050-4337-b09f-291cd535db91",
    "messageCount": 0,
    "texts": [],
    "containsHiddenPrompt": false
  },
  "attachmentGuard": {
    "ok": false,
    "message": "hideUserMessage cannot be combined with attachments"
  }
}
```

- **Observed result after fix**: The real gateway accepted the hidden send, returned a backing `sessionId` on the next history load, did not expose `/context list` in chat history, and rejected hidden sends with attachments.
- **What was not tested**: Browser URL autostart; that is split into dependent follow-up #79653.

## Testing
- `pnpm test src/gateway/server.chat.gateway-server-chat.test.ts -t "chat.send can hide the triggering user turn from chat history|chat.send requires operator.admin to hide the triggering user turn|chat.send rejects hideUserMessage with attachments"`
