### PR TITLE
Prune completed Codex Responses tool replay

### DIFF
--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -117,7 +117,7 @@ inter-session user turns that only have provenance metadata.
 - Image sanitization only.
 - Drop orphaned reasoning signatures (standalone reasoning items without a following content block) for OpenAI Responses/Codex transcripts, and drop replayable OpenAI reasoning after a model route switch.
 - Preserve replayable OpenAI Responses reasoning item payloads, including encrypted empty-summary items, so manual/WebSocket replay keeps required `rs_*` state paired with assistant output items.
-- Native ChatGPT Codex Responses follows Codex wire parity by replaying prior Responses reasoning/message/function payloads without prior item IDs while preserving session `prompt_cache_key`.
+- Native ChatGPT Codex Responses prunes completed tool-call outputs to prevent stale `function_call_output` serialization; prior Responses reasoning and message payloads are replayed without prior item IDs while preserving session `prompt_cache_key`.
 - No tool call id sanitization.
 - Tool result pairing repair may move real matched outputs and synthesize Codex-style `aborted` outputs for missing tool calls.
 - No turn validation or reordering.

--- a/src/agents/openai-transport-stream.responses-tool-replay.test.ts
+++ b/src/agents/openai-transport-stream.responses-tool-replay.test.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage, Context, Model, ToolResultMessage } from "@mariozechner/pi-ai";
+import type { AssistantMessage, Context, Model, ToolResultMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { buildOpenAIResponsesParams } from "./openai-transport-stream.js";
 

--- a/src/agents/openai-transport-stream.responses-tool-replay.test.ts
+++ b/src/agents/openai-transport-stream.responses-tool-replay.test.ts
@@ -1,0 +1,132 @@
+import type { AssistantMessage, Context, Model, ToolResultMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { buildOpenAIResponsesParams } from "./openai-transport-stream.js";
+
+const ZERO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} as const;
+
+function buildNativeCodexModel(): Model<"openai-codex-responses"> {
+  return {
+    id: "gpt-5.5",
+    name: "gpt-5.5",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 4096,
+  };
+}
+
+function buildAssistantMessage(params: {
+  stopReason: AssistantMessage["stopReason"];
+  content: AssistantMessage["content"];
+}): AssistantMessage {
+  return {
+    role: "assistant",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    usage: ZERO_USAGE,
+    stopReason: params.stopReason,
+    timestamp: 1,
+    content: params.content,
+  };
+}
+
+function buildToolResult(toolCallId: string): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName: "lookup",
+    content: [{ type: "text", text: "tool output" }],
+    isError: false,
+    timestamp: 1,
+  };
+}
+
+function buildParams(messages: Context["messages"]) {
+  return buildOpenAIResponsesParams(
+    buildNativeCodexModel(),
+    {
+      systemPrompt: "You are concise.",
+      messages,
+    },
+    { cacheRetention: "none" },
+  );
+}
+
+function inputItems(params: ReturnType<typeof buildParams>) {
+  return Array.isArray(params.input) ? (params.input as Array<Record<string, unknown>>) : [];
+}
+
+function inputTypes(params: ReturnType<typeof buildParams>) {
+  return inputItems(params).map((item) => item.type);
+}
+
+describe("OpenAI Codex Responses tool replay", () => {
+  it("does not replay completed function call outputs after the turn was consumed", () => {
+    const params = buildParams([
+      { role: "user", content: "look something up", timestamp: 1 },
+      buildAssistantMessage({
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "thinking",
+            thinking: "need lookup",
+            thinkingSignature: JSON.stringify({ type: "reasoning", id: "rs_old", summary: [] }),
+          },
+          {
+            type: "toolCall",
+            id: "call_old|fc_old",
+            name: "lookup",
+            arguments: { query: "example" },
+          },
+        ],
+      }),
+      buildToolResult("call_old|fc_old"),
+      buildAssistantMessage({
+        stopReason: "stop",
+        content: [{ type: "text", text: "done", textSignature: "msg_done" }],
+      }),
+      { role: "user", content: "next turn", timestamp: 1 },
+    ]);
+
+    expect(inputTypes(params)).not.toContain("function_call");
+    expect(inputTypes(params)).not.toContain("function_call_output");
+  });
+
+  it("keeps the active tail function call output for tool continuation", () => {
+    const params = buildParams([
+      { role: "user", content: "look something up", timestamp: 1 },
+      buildAssistantMessage({
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_active|fc_active",
+            name: "lookup",
+            arguments: { query: "example" },
+          },
+        ],
+      }),
+      buildToolResult("call_active|fc_active"),
+    ]);
+
+    const functionCall = inputItems(params).find((item) => item.type === "function_call");
+    const functionCallOutput = inputItems(params).find(
+      (item) => item.type === "function_call_output",
+    );
+
+    expect(functionCall?.call_id).toBe("call_active");
+    expect(functionCallOutput?.call_id).toBe("call_active");
+  });
+});

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1003,6 +1003,70 @@ function parseTextSignature(
   return { id: signature };
 }
 
+function getAssistantToolCallIds(message: Context["messages"][number]): Set<string> {
+  const ids = new Set<string>();
+  if (message.role !== "assistant") {
+    return ids;
+  }
+  for (const block of message.content) {
+    if (block.type === "toolCall") {
+      ids.add(block.id);
+    }
+  }
+  return ids;
+}
+
+function hasLaterNonToolResultMessage(messages: Context["messages"], index: number): boolean {
+  for (let i = index + 1; i < messages.length; i += 1) {
+    if (messages[i]?.role !== "toolResult") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function stripCompletedToolReplayBlocks(
+  message: Extract<Context["messages"][number], { role: "assistant" }>,
+): Extract<Context["messages"][number], { role: "assistant" }> | undefined {
+  const content = message.content.filter(
+    (block) => block.type !== "toolCall" && block.type !== "thinking",
+  );
+  if (content.length === 0) {
+    return undefined;
+  }
+  return { ...message, content };
+}
+
+function pruneCompletedResponsesToolReplay(messages: Context["messages"]): Context["messages"] {
+  const consumedToolCallIds = new Set<string>();
+  const pruned: Context["messages"] = [];
+  let changed = false;
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (message.role === "assistant") {
+      const toolCallIds = getAssistantToolCallIds(message);
+      if (toolCallIds.size > 0 && hasLaterNonToolResultMessage(messages, i)) {
+        for (const id of toolCallIds) {
+          consumedToolCallIds.add(id);
+        }
+        const stripped = stripCompletedToolReplayBlocks(message);
+        if (stripped) {
+          pruned.push(stripped);
+        }
+        changed = true;
+        continue;
+      }
+    } else if (message.role === "toolResult" && consumedToolCallIds.has(message.toolCallId)) {
+      changed = true;
+      continue;
+    }
+    pruned.push(message);
+  }
+
+  return changed ? pruned : messages;
+}
+
 function convertResponsesMessages(
   model: Model<Api>,
   context: Context,
@@ -1014,6 +1078,7 @@ function convertResponsesMessages(
     replayResponsesItemIds?: boolean;
     sessionId?: string;
     authProfileId?: string;
+    pruneCompletedToolReplay?: boolean;
   },
 ): ResponseInput {
   const messages: ResponseInput = [];
@@ -1069,6 +1134,10 @@ function convertResponsesMessages(
     normalizeToolCallId,
     { normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds },
   );
+  const replayMessages =
+    options?.pruneCompletedToolReplay === true
+      ? pruneCompletedResponsesToolReplay(transformedMessages)
+      : transformedMessages;
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
     messages.push({
@@ -1077,7 +1146,8 @@ function convertResponsesMessages(
     });
   }
   let msgIndex = 0;
-  for (const msg of transformedMessages) {
+  const pendingFunctionCallIds = new Set<string>();
+  for (const msg of replayMessages) {
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
         messages.push({
@@ -1164,6 +1234,7 @@ function convertResponsesMessages(
             shouldReplayResponsesItemIds && !(isDifferentModel && itemIdRaw?.startsWith("fc_"))
               ? itemIdRaw
               : undefined;
+          pendingFunctionCallIds.add(callId);
           output.push({
             type: "function_call",
             id: itemId,
@@ -1186,6 +1257,10 @@ function convertResponsesMessages(
         .join("\n");
       const hasImages = msg.content.some((item) => item.type === "image");
       const [callId] = msg.toolCallId.split("|");
+      if (!pendingFunctionCallIds.has(callId)) {
+        msgIndex += 1;
+        continue;
+      }
       messages.push({
         type: "function_call_output",
         call_id: callId,
@@ -1205,6 +1280,7 @@ function convertResponsesMessages(
               ] as ResponseFunctionCallOutputItemList)
             : sanitizeTransportPayloadText(textResult || "(see attached image)"),
       });
+      pendingFunctionCallIds.delete(callId);
     }
     msgIndex += 1;
   }
@@ -2036,6 +2112,7 @@ export function buildOpenAIResponsesParams(
       replayResponsesItemIds: !isNativeCodexResponses,
       authProfileId: options?.authProfileId,
       sessionId: options?.sessionId,
+      pruneCompletedToolReplay: isNativeCodexResponses,
     },
   );
   if (isCodexResponses) {
@@ -3670,6 +3747,8 @@ export const testing = {
   createOpenAIResponsesClient,
   enforceCodeModeResponsesToolSurface,
   sanitizeOpenAICodexResponsesParams,
+  buildOpenAICompletionsClientConfig,
+  processOpenAICompletionsStream,
   buildOpenAICompletionsClientConfig,
   processOpenAICompletionsStream,
   processResponsesStream,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -214,6 +214,70 @@ function parseTextSignature(
   return { id: signature };
 }
 
+function getAssistantToolCallIds(message: Context["messages"][number]): Set<string> {
+  const ids = new Set<string>();
+  if (message.role !== "assistant") {
+    return ids;
+  }
+  for (const block of message.content) {
+    if (block.type === "toolCall") {
+      ids.add(block.id);
+    }
+  }
+  return ids;
+}
+
+function hasLaterNonToolResultMessage(messages: Context["messages"], index: number): boolean {
+  for (let i = index + 1; i < messages.length; i += 1) {
+    if (messages[i]?.role !== "toolResult") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function stripCompletedToolReplayBlocks(
+  message: Extract<Context["messages"][number], { role: "assistant" }>,
+): Extract<Context["messages"][number], { role: "assistant" }> | undefined {
+  const content = message.content.filter(
+    (block) => block.type !== "toolCall" && block.type !== "thinking",
+  );
+  if (content.length === 0) {
+    return undefined;
+  }
+  return { ...message, content };
+}
+
+function pruneCompletedResponsesToolReplay(messages: Context["messages"]): Context["messages"] {
+  const consumedToolCallIds = new Set<string>();
+  const pruned: Context["messages"] = [];
+  let changed = false;
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (message.role === "assistant") {
+      const toolCallIds = getAssistantToolCallIds(message);
+      if (toolCallIds.size > 0 && hasLaterNonToolResultMessage(messages, i)) {
+        for (const id of toolCallIds) {
+          consumedToolCallIds.add(id);
+        }
+        const stripped = stripCompletedToolReplayBlocks(message);
+        if (stripped) {
+          pruned.push(stripped);
+        }
+        changed = true;
+        continue;
+      }
+    } else if (message.role === "toolResult" && consumedToolCallIds.has(message.toolCallId)) {
+      changed = true;
+      continue;
+    }
+    pruned.push(message);
+  }
+
+  return changed ? pruned : messages;
+}
+
 function convertResponsesMessages(
   model: Model<Api>,
   context: Context,
@@ -223,6 +287,7 @@ function convertResponsesMessages(
     supportsDeveloperRole?: boolean;
     replayReasoningItems?: boolean;
     replayResponsesItemIds?: boolean;
+    pruneCompletedToolReplay?: boolean;
   },
 ): ResponseInput {
   const messages: ResponseInput = [];
@@ -264,6 +329,10 @@ function convertResponsesMessages(
     model,
     normalizeToolCallId,
   );
+  const replayMessages =
+    options?.pruneCompletedToolReplay === true
+      ? pruneCompletedResponsesToolReplay(transformedMessages)
+      : transformedMessages;
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
     messages.push({
@@ -272,7 +341,8 @@ function convertResponsesMessages(
     });
   }
   let msgIndex = 0;
-  for (const msg of transformedMessages) {
+  const pendingFunctionCallIds = new Set<string>();
+  for (const msg of replayMessages) {
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
         messages.push({
@@ -339,6 +409,7 @@ function convertResponsesMessages(
             shouldReplayResponsesItemIds && !(isDifferentModel && itemIdRaw?.startsWith("fc_"))
               ? itemIdRaw
               : undefined;
+          pendingFunctionCallIds.add(callId);
           output.push({
             type: "function_call",
             id: itemId,
@@ -361,6 +432,10 @@ function convertResponsesMessages(
         .join("\n");
       const hasImages = msg.content.some((item) => item.type === "image");
       const [callId] = msg.toolCallId.split("|");
+      if (!pendingFunctionCallIds.has(callId)) {
+        msgIndex += 1;
+        continue;
+      }
       messages.push({
         type: "function_call_output",
         call_id: callId,
@@ -380,6 +455,7 @@ function convertResponsesMessages(
               ] as ResponseFunctionCallOutputItemList)
             : sanitizeTransportPayloadText(textResult || "(see attached image)"),
       });
+      pendingFunctionCallIds.delete(callId);
     }
     msgIndex += 1;
   }
@@ -998,6 +1074,7 @@ export function buildOpenAIResponsesParams(
       supportsDeveloperRole,
       replayReasoningItems: true,
       replayResponsesItemIds: !isNativeCodexResponses,
+      pruneCompletedToolReplay: isNativeCodexResponses,
     },
   );
   if (isCodexResponses) {


### PR DESCRIPTION
## Summary
- prune completed OpenAI Codex native Responses tool-call replay after a later assistant/user turn has consumed the tool output
- keep active tail function call outputs so tool continuation still works
- add synthetic regression coverage for completed replay pruning and active tail preservation

## Root cause
Native Codex Responses rejects `function_call_output` items when the request is not currently continuing the matching `function_call`. Long-lived session histories can contain already-consumed tool calls and tool results from earlier turns, so replaying those historical outputs can make later turns fail before the model responds.

## Real behavior proof
- Behavior or issue addressed: Long-lived OpenClaw channel and main-agent follow-up turns no longer fail by replaying an already-consumed Codex Responses `function_call_output`.
- Real environment tested: Local OpenClaw gateway with the OpenAI Codex native Responses provider, using the installed runtime patched with the same replay-pruning logic. Account details, paths, channel names, session identifiers, prompts, and concrete call IDs are redacted.
- Exact steps or command run after this patch: `openclaw gateway restart`; `openclaw config validate`; `openclaw health`; `openclaw agent --session-id <redacted-channel-session> --message <redacted> --thinking low --json`; `openclaw agent --session-id <redacted-main-session> --message <redacted> --thinking low --json`; `rg "No tool call found for function call output" <redacted-gateway-error-log>`.
- Evidence after fix: Terminal transcript, redacted:

```text
$ openclaw config validate
Config valid

$ openclaw health
gateway ok; default agent available

$ openclaw agent --session-id <redacted-channel-session> --message <redacted> --thinking low --json
text: received
provider: openai-codex
model: gpt-5.5
fallbackUsed: false
stopReason: stop

$ openclaw agent --session-id <redacted-main-session> --message <redacted> --thinking low --json
text: received
provider: openai-codex
model: gpt-5.5
fallbackUsed: false
stopReason: stop

$ rg "No tool call found for function call output" <redacted-gateway-error-log>
no new matches during the post-fix smoke checks
```

- Observed result after fix: The previously failing follow-up path returned normal assistant text in both the channel-originated conversation and the main-agent conversation, stayed on `openai-codex/gpt-5.5`, did not use fallback routing, and did not add new gateway errors for the rejected `function_call_output` shape during the smoke checks.
- What was not tested: No known runtime gaps for the reproduced channel/main follow-up path. Full upstream CI is left to the repository workflow.

## Checks
- `pnpm exec oxfmt --check src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.responses-tool-replay.test.ts`
- `pnpm exec oxlint src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.responses-tool-replay.test.ts`

## Notes
- Targeted vitest was attempted from a sparse checkout but did not reach the test body because the local install lacked the built `@openclaw/fs-safe/config` artifact from the git dependency. The regression test is included for CI/full-checkout execution.