### PR TITLE
fix(nextcloud-talk): detect missing bot response feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.
 - Native commands: handle slash commands before workspace and agent-reply bootstrap so Telegram `/status` and other command-only native replies do not wait behind full agent turn setup.
 - Plugins/Nix: allow externally configured plugin roots under `/nix/store` to load in `OPENCLAW_NIX_MODE=1` while keeping normal external plugin hardlink rejection unchanged. Thanks @joshp123.
+- Nextcloud Talk: include the required bot `response` feature in setup, explain missing `--feature response` on rejected sends, and surface missing response capability in doctor/status checks. Fixes #78935. (#79657) Thanks @joshavant.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Infra/fetch-timeout: pass `operation` and `url` context to `buildTimeoutAbortSignal` from the music-generate reference fetch and the Matrix guarded redirect transport, so the `fetch timeout reached; aborting operation` warning carries actionable structured fields instead of a bare line. Fixes #79195. Thanks @pandadev66.

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -40,7 +40,7 @@ Details: [Plugins](/tools/plugin)
 2. On your Nextcloud server, create a bot:
 
    ```bash
-   ./occ talk:bot:install "OpenClaw" "<shared-secret>" "<webhook-url>" --feature reaction
+   ./occ talk:bot:install "OpenClaw" "<shared-secret>" "<webhook-url>" --feature webhook --feature response --feature reaction
    ```
 
 3. Enable the bot in the target room settings.

--- a/extensions/nextcloud-talk/src/api-credentials.ts
+++ b/extensions/nextcloud-talk/src/api-credentials.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { normalizeResolvedSecretInputString } from "./secret-input.js";
+
+export function resolveNextcloudTalkApiCredentials(params: {
+  apiUser?: string;
+  apiPassword?: unknown;
+  apiPasswordFile?: string;
+}): { apiUser: string; apiPassword: string } | undefined {
+  const apiUser = params.apiUser?.trim();
+  if (!apiUser) {
+    return undefined;
+  }
+
+  const inlinePassword = normalizeResolvedSecretInputString({
+    value: params.apiPassword,
+    path: "channels.nextcloud-talk.apiPassword",
+  });
+  if (inlinePassword) {
+    return { apiUser, apiPassword: inlinePassword };
+  }
+
+  if (!params.apiPasswordFile) {
+    return undefined;
+  }
+  try {
+    const filePassword = readFileSync(params.apiPasswordFile, "utf-8").trim();
+    return filePassword ? { apiUser, apiPassword: filePassword } : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/extensions/nextcloud-talk/src/bot-preflight.test.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+
+const hoisted = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+  ssrfPolicyFromPrivateNetworkOptIn: vi.fn(() => undefined),
+}));
+
+vi.mock("../runtime-api.js", () => ({
+  fetchWithSsrFGuard: hoisted.fetchWithSsrFGuard,
+}));
+
+vi.mock("./send.runtime.js", () => ({
+  ssrfPolicyFromPrivateNetworkOptIn: hoisted.ssrfPolicyFromPrivateNetworkOptIn,
+}));
+
+const { probeNextcloudTalkBotResponseFeature } = await import("./bot-preflight.js");
+
+function account(
+  overrides: Partial<ResolvedNextcloudTalkAccount> = {},
+): ResolvedNextcloudTalkAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    baseUrl: "https://cloud.example.com",
+    secret: "secret",
+    secretSource: "config",
+    config: {
+      baseUrl: "https://cloud.example.com",
+      botSecret: "secret",
+      apiUser: "admin",
+      apiPassword: "app-password",
+      webhookPublicUrl: "https://bot.example.com/nextcloud-talk-webhook",
+    },
+    ...overrides,
+  };
+}
+
+function mockBotAdmin(features: number): void {
+  hoisted.fetchWithSsrFGuard.mockResolvedValueOnce({
+    response: new Response(
+      JSON.stringify({
+        ocs: {
+          data: [
+            {
+              id: 7,
+              name: "OpenClaw",
+              url: "https://bot.example.com/nextcloud-talk-webhook",
+              features,
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ),
+    release: async () => {},
+    finalUrl: "https://cloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/admin",
+  });
+}
+
+describe("probeNextcloudTalkBotResponseFeature", () => {
+  beforeEach(() => {
+    hoisted.fetchWithSsrFGuard.mockClear();
+  });
+
+  afterEach(() => {
+    hoisted.fetchWithSsrFGuard.mockReset();
+  });
+
+  it("passes when the matching bot has the response feature bit", async () => {
+    mockBotAdmin(1 | 2 | 8);
+
+    await expect(
+      probeNextcloudTalkBotResponseFeature({ account: account() }),
+    ).resolves.toMatchObject({
+      ok: true,
+      code: "ok",
+      botId: "7",
+      features: 11,
+    });
+  });
+
+  it("reports missing response feature for the matching webhook bot", async () => {
+    mockBotAdmin(1 | 8);
+
+    await expect(
+      probeNextcloudTalkBotResponseFeature({ account: account() }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "missing_response_feature",
+      botId: "7",
+      features: 9,
+      message: expect.stringContaining("--feature response"),
+    });
+  });
+
+  it("skips when API credentials are absent", async () => {
+    await expect(
+      probeNextcloudTalkBotResponseFeature({
+        account: account({
+          config: {
+            baseUrl: "https://cloud.example.com",
+            botSecret: "secret",
+            webhookPublicUrl: "https://bot.example.com/nextcloud-talk-webhook",
+          },
+        }),
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      skipped: true,
+      code: "missing_api_credentials",
+    });
+    expect(hoisted.fetchWithSsrFGuard).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/nextcloud-talk/src/bot-preflight.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.ts
@@ -1,0 +1,181 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { fetchWithSsrFGuard } from "../runtime-api.js";
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+import { resolveNextcloudTalkApiCredentials } from "./api-credentials.js";
+import { ssrfPolicyFromPrivateNetworkOptIn } from "./send.runtime.js";
+
+const BOT_FEATURE_RESPONSE = 2;
+
+type NextcloudTalkBotAdminEntry = {
+  id?: number | string;
+  name?: string;
+  url?: string;
+  features?: number | string;
+};
+
+export type NextcloudTalkBotResponseFeatureProbe = {
+  ok: boolean;
+  skipped?: boolean;
+  code:
+    | "ok"
+    | "missing_api_credentials"
+    | "missing_webhook_url"
+    | "missing_base_url"
+    | "bot_not_found"
+    | "missing_response_feature"
+    | "api_error"
+    | "request_failed";
+  message: string;
+  botId?: string;
+  botName?: string;
+  features?: number;
+  status?: number;
+};
+
+function normalizeUrlForMatch(value: string | undefined): string {
+  if (!value?.trim()) {
+    return "";
+  }
+  try {
+    const url = new URL(value.trim());
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return value.trim().replace(/\/$/, "");
+  }
+}
+
+function coerceFeatureMask(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function formatMissingResponseFeatureMessage(bot: NextcloudTalkBotAdminEntry, features?: number) {
+  const id = bot.id == null ? "unknown" : String(bot.id);
+  const name = bot.name?.trim() || "matching bot";
+  const featureText = typeof features === "number" ? ` (features=${features})` : "";
+  return `Nextcloud Talk bot "${name}" (${id}) is missing the response feature${featureText}; outbound replies will fail. Run ./occ talk:bot:state --feature webhook --feature response --feature reaction ${id} 1 or reinstall the bot with --feature response.`;
+}
+
+export async function probeNextcloudTalkBotResponseFeature(params: {
+  account: ResolvedNextcloudTalkAccount;
+  timeoutMs?: number;
+}): Promise<NextcloudTalkBotResponseFeatureProbe> {
+  const { account, timeoutMs } = params;
+  const baseUrl = account.baseUrl?.trim();
+  if (!baseUrl) {
+    return {
+      ok: true,
+      skipped: true,
+      code: "missing_base_url",
+      message: "Nextcloud Talk bot response feature probe skipped: baseUrl is not configured.",
+    };
+  }
+
+  const webhookUrl = normalizeUrlForMatch(account.config.webhookPublicUrl);
+  if (!webhookUrl) {
+    return {
+      ok: true,
+      skipped: true,
+      code: "missing_webhook_url",
+      message:
+        "Nextcloud Talk bot response feature probe skipped: webhookPublicUrl is not configured.",
+    };
+  }
+
+  const credentials = resolveNextcloudTalkApiCredentials({
+    apiUser: account.config.apiUser,
+    apiPassword: account.config.apiPassword,
+    apiPasswordFile: account.config.apiPasswordFile,
+  });
+  if (!credentials) {
+    return {
+      ok: true,
+      skipped: true,
+      code: "missing_api_credentials",
+      message:
+        "Nextcloud Talk bot response feature probe skipped: apiUser/apiPassword are not configured.",
+    };
+  }
+
+  const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/admin`;
+  const auth = Buffer.from(`${credentials.apiUser}:${credentials.apiPassword}`, "utf-8").toString(
+    "base64",
+  );
+
+  try {
+    const { response, release } = await fetchWithSsrFGuard({
+      url,
+      init: {
+        method: "GET",
+        headers: {
+          Authorization: `Basic ${auth}`,
+          "OCS-APIRequest": "true",
+          Accept: "application/json",
+        },
+      },
+      auditContext: "nextcloud-talk.bot-response-preflight",
+      policy: ssrfPolicyFromPrivateNetworkOptIn(account.config),
+      timeoutMs,
+    });
+    try {
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        return {
+          ok: false,
+          code: "api_error",
+          status: response.status,
+          message: `Nextcloud Talk bot response feature probe failed (${response.status})${body ? `: ${body}` : ""}`,
+        };
+      }
+
+      const payload = (await response.json()) as {
+        ocs?: { data?: NextcloudTalkBotAdminEntry[] };
+      };
+      const bots = Array.isArray(payload.ocs?.data) ? payload.ocs.data : [];
+      const bot = bots.find((entry) => normalizeUrlForMatch(entry.url) === webhookUrl);
+      if (!bot) {
+        return {
+          ok: false,
+          code: "bot_not_found",
+          message: `Nextcloud Talk bot response feature probe could not find a bot with webhook URL ${webhookUrl}.`,
+        };
+      }
+
+      const features = coerceFeatureMask(bot.features);
+      if (features == null || (features & BOT_FEATURE_RESPONSE) !== BOT_FEATURE_RESPONSE) {
+        return {
+          ok: false,
+          code: "missing_response_feature",
+          botId: bot.id == null ? undefined : String(bot.id),
+          botName: bot.name,
+          features,
+          message: formatMissingResponseFeatureMessage(bot, features),
+        };
+      }
+
+      return {
+        ok: true,
+        code: "ok",
+        botId: bot.id == null ? undefined : String(bot.id),
+        botName: bot.name,
+        features,
+        message: `Nextcloud Talk bot "${bot.name ?? bot.id ?? "matching bot"}" has the response feature.`,
+      };
+    } finally {
+      await release();
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      code: "request_failed",
+      message: `Nextcloud Talk bot response feature probe failed: ${formatErrorMessage(error)}`,
+    };
+  }
+}

--- a/extensions/nextcloud-talk/src/channel.status.test.ts
+++ b/extensions/nextcloud-talk/src/channel.status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { nextcloudTalkPlugin } from "./channel.js";
+
+describe("nextcloud-talk channel status", () => {
+  it("surfaces missing response feature probes as config issues", () => {
+    const issues = nextcloudTalkPlugin.status?.collectStatusIssues?.([
+      {
+        accountId: "default",
+        configured: true,
+        probe: {
+          ok: false,
+          code: "missing_response_feature",
+          message: "Nextcloud Talk bot is missing --feature response.",
+        },
+      },
+    ]);
+
+    expect(issues).toEqual([
+      {
+        channel: "nextcloud-talk",
+        accountId: "default",
+        kind: "config",
+        message: "Nextcloud Talk bot is missing --feature response.",
+        fix: "Add --feature response to the Talk bot.",
+      },
+    ]);
+  });
+});

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/status-helpers";
 import { resolveNextcloudTalkAccount, type ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { nextcloudTalkApprovalAuth } from "./approval-auth.js";
+import { probeNextcloudTalkBotResponseFeature } from "./bot-preflight.js";
 import { buildChannelConfigSchema, DEFAULT_ACCOUNT_ID, type ChannelPlugin } from "./channel-api.js";
 import {
   nextcloudTalkConfigAdapter,
@@ -138,6 +139,31 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
           buildWebhookChannelStatusSummary(snapshot, {
             secretSource: snapshot.secretSource ?? "none",
           }),
+        collectStatusIssues: (accounts) =>
+          accounts.flatMap((account) => {
+            const probe = account.probe as
+              | { ok?: boolean; code?: string; message?: string }
+              | undefined;
+            if (
+              !probe ||
+              probe.ok !== false ||
+              probe.code !== "missing_response_feature" ||
+              !probe.message
+            ) {
+              return [];
+            }
+            return [
+              {
+                channel: "nextcloud-talk",
+                accountId: account.accountId ?? DEFAULT_ACCOUNT_ID,
+                kind: "config",
+                message: probe.message,
+                fix: "Add --feature response to the Talk bot.",
+              } as const,
+            ];
+          }),
+        probeAccount: async ({ account, timeoutMs }) =>
+          await probeNextcloudTalkBotResponseFeature({ account, timeoutMs }),
         resolveAccountSnapshot: ({ account }) => ({
           accountId: account.accountId,
           name: account.name,

--- a/extensions/nextcloud-talk/src/doctor.test.ts
+++ b/extensions/nextcloud-talk/src/doctor.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { nextcloudTalkDoctor } from "./doctor.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  probeNextcloudTalkBotResponseFeature: vi.fn(),
+}));
+
+vi.mock("./bot-preflight.js", () => ({
+  probeNextcloudTalkBotResponseFeature: hoisted.probeNextcloudTalkBotResponseFeature,
+}));
+
+const { nextcloudTalkDoctor } = await import("./doctor.js");
 
 function getNextcloudTalkCompatibilityNormalizer(): NonNullable<
   typeof nextcloudTalkDoctor.normalizeCompatibilityConfig
@@ -12,6 +21,10 @@ function getNextcloudTalkCompatibilityNormalizer(): NonNullable<
 }
 
 describe("nextcloud-talk doctor", () => {
+  beforeEach(() => {
+    hoisted.probeNextcloudTalkBotResponseFeature.mockReset();
+  });
+
   it("normalizes legacy private-network aliases", () => {
     const normalize = getNextcloudTalkCompatibilityNormalizer();
 
@@ -42,5 +55,31 @@ describe("nextcloud-talk doctor", () => {
     ).toEqual({
       dangerouslyAllowPrivateNetwork: false,
     });
+  });
+
+  it("warns when the configured bot is missing the response feature", async () => {
+    hoisted.probeNextcloudTalkBotResponseFeature.mockResolvedValueOnce({
+      ok: false,
+      code: "missing_response_feature",
+      message:
+        'Nextcloud Talk bot "OpenClaw" (1) is missing the response feature (features=9); outbound replies will fail.',
+    });
+
+    await expect(
+      nextcloudTalkDoctor.collectPreviewWarnings?.({
+        cfg: {
+          channels: {
+            "nextcloud-talk": {
+              baseUrl: "https://cloud.example.com",
+              botSecret: "secret",
+              apiUser: "admin",
+              apiPassword: "app-password",
+              webhookPublicUrl: "https://gateway.example.com/nextcloud-talk-webhook",
+            },
+          },
+        } as never,
+        doctorFixCommand: "openclaw doctor --fix",
+      }),
+    ).resolves.toEqual([expect.stringContaining("missing the response feature")]);
   });
 });

--- a/extensions/nextcloud-talk/src/doctor.ts
+++ b/extensions/nextcloud-talk/src/doctor.ts
@@ -1,10 +1,40 @@
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
+import { listNextcloudTalkAccountIds, resolveNextcloudTalkAccount } from "./accounts.js";
+import { probeNextcloudTalkBotResponseFeature } from "./bot-preflight.js";
 import {
   legacyConfigRules as NEXTCLOUD_TALK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig as normalizeNextcloudTalkCompatibilityConfig,
 } from "./doctor-contract.js";
+import type { CoreConfig } from "./types.js";
+
+async function collectNextcloudTalkBotResponseWarnings(params: {
+  cfg: CoreConfig;
+}): Promise<string[]> {
+  const warnings: string[] = [];
+  for (const accountId of listNextcloudTalkAccountIds(params.cfg)) {
+    const account = resolveNextcloudTalkAccount({ cfg: params.cfg, accountId });
+    if (!account.enabled || !account.secret || !account.baseUrl) {
+      continue;
+    }
+    const result = await probeNextcloudTalkBotResponseFeature({
+      account,
+      timeoutMs: 5_000,
+    });
+    if (
+      result.code === "missing_response_feature" ||
+      result.code === "bot_not_found" ||
+      result.code === "api_error" ||
+      result.code === "request_failed"
+    ) {
+      warnings.push(`- channels.nextcloud-talk.${account.accountId}: ${result.message}`);
+    }
+  }
+  return warnings;
+}
 
 export const nextcloudTalkDoctor: ChannelDoctorAdapter = {
   legacyConfigRules: NEXTCLOUD_TALK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig: normalizeNextcloudTalkCompatibilityConfig,
+  collectPreviewWarnings: async ({ cfg }) =>
+    await collectNextcloudTalkBotResponseWarnings({ cfg: cfg as CoreConfig }),
 };

--- a/extensions/nextcloud-talk/src/room-info.ts
+++ b/extensions/nextcloud-talk/src/room-info.ts
@@ -1,9 +1,8 @@
-import { readFileSync } from "node:fs";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { ssrfPolicyFromPrivateNetworkOptIn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { fetchWithSsrFGuard, type RuntimeEnv } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
-import { normalizeResolvedSecretInputString } from "./secret-input.js";
+import { resolveNextcloudTalkApiCredentials } from "./api-credentials.js";
 
 const ROOM_CACHE_TTL_MS = 5 * 60 * 1000;
 const ROOM_CACHE_ERROR_TTL_MS = 30 * 1000;
@@ -21,28 +20,6 @@ export const __testing = {
 
 function resolveRoomCacheKey(params: { accountId: string; roomToken: string }) {
   return `${params.accountId}:${params.roomToken}`;
-}
-
-function readApiPassword(params: {
-  apiPassword?: unknown;
-  apiPasswordFile?: string;
-}): string | undefined {
-  const inlinePassword = normalizeResolvedSecretInputString({
-    value: params.apiPassword,
-    path: "channels.nextcloud-talk.apiPassword",
-  });
-  if (inlinePassword) {
-    return inlinePassword;
-  }
-  if (!params.apiPasswordFile) {
-    return undefined;
-  }
-  try {
-    const value = readFileSync(params.apiPasswordFile, "utf-8").trim();
-    return value || undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function coerceRoomType(value: unknown): number | undefined {
@@ -84,12 +61,12 @@ export async function resolveNextcloudTalkRoomKind(params: {
     }
   }
 
-  const apiUser = account.config.apiUser?.trim();
-  const apiPassword = readApiPassword({
+  const apiCredentials = resolveNextcloudTalkApiCredentials({
+    apiUser: account.config.apiUser,
     apiPassword: account.config.apiPassword,
     apiPasswordFile: account.config.apiPasswordFile,
   });
-  if (!apiUser || !apiPassword) {
+  if (!apiCredentials) {
     return undefined;
   }
 
@@ -99,7 +76,10 @@ export async function resolveNextcloudTalkRoomKind(params: {
   }
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v4/room/${roomToken}`;
-  const auth = Buffer.from(`${apiUser}:${apiPassword}`, "utf-8").toString("base64");
+  const auth = Buffer.from(
+    `${apiCredentials.apiUser}:${apiCredentials.apiPassword}`,
+    "utf-8",
+  ).toString("base64");
 
   try {
     const { response, release } = await fetchWithSsrFGuard({

--- a/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
+++ b/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
@@ -177,6 +177,18 @@ describe("nextcloud-talk send cfg threading", () => {
     });
   });
 
+  it("explains that 401 sends can mean the response feature is missing", async () => {
+    const cfg = { source: "provided" } as const;
+    fetchMock.mockResolvedValueOnce(new Response("{}", { status: 401 }));
+
+    await expect(
+      sendMessageNextcloudTalk("room:abc123", "hello", {
+        cfg,
+        accountId: "work",
+      }),
+    ).rejects.toThrow("--feature response");
+  });
+
   it("declares message adapter durable text, media, and reply with receipt proofs", async () => {
     const cfg = { source: "provided" } as const;
     mockNextcloudMessageResponse(22345, 1_706_000_003);

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -167,7 +167,8 @@ export async function sendMessageNextcloudTalk(
       if (status === 400) {
         errorMsg = `Nextcloud Talk: bad request - ${errorBody || "invalid message format"}`;
       } else if (status === 401) {
-        errorMsg = "Nextcloud Talk: authentication failed - check bot secret";
+        errorMsg =
+          "Nextcloud Talk: bot send was rejected - check the bot secret and ensure the bot was installed with --feature response";
       } else if (status === 403) {
         errorMsg = "Nextcloud Talk: forbidden - bot may not have permission in this room";
       } else if (status === 404) {

--- a/extensions/nextcloud-talk/src/setup-surface.ts
+++ b/extensions/nextcloud-talk/src/setup-surface.ts
@@ -40,7 +40,7 @@ export const nextcloudTalkSetupWizard: ChannelSetupWizard = {
     title: "Nextcloud Talk bot setup",
     lines: [
       "1) SSH into your Nextcloud server",
-      '2) Run: ./occ talk:bot:install "OpenClaw" "<shared-secret>" "<webhook-url>" --feature reaction',
+      '2) Run: ./occ talk:bot:install "OpenClaw" "<shared-secret>" "<webhook-url>" --feature webhook --feature response --feature reaction',
       "3) Copy the shared secret you used in the command",
       "4) Enable the bot in your Nextcloud Talk room settings",
       "Tip: you can also set NEXTCLOUD_TALK_BOT_SECRET in your env.",

--- a/extensions/nextcloud-talk/src/setup.test.ts
+++ b/extensions/nextcloud-talk/src/setup.test.ts
@@ -16,6 +16,12 @@ import { nextcloudTalkSetupWizard } from "./setup-surface.js";
 import type { CoreConfig } from "./types.js";
 
 describe("nextcloud talk setup", () => {
+  it("shows a bot install command with webhook, response, and reaction features", () => {
+    expect(nextcloudTalkSetupWizard.introNote?.lines.join("\n")).toContain(
+      "--feature webhook --feature response --feature reaction",
+    );
+  });
+
   it("normalizes and validates base urls", () => {
     expect(normalizeNextcloudTalkBaseUrl(" https://cloud.example.com/// ")).toBe(
       "https://cloud.example.com",


### PR DESCRIPTION
## Summary

- Problem: Nextcloud Talk bots installed without the `response` feature accept webhooks but cannot send replies, producing a vague 401 send failure.
- Why it matters: users can complete setup and receive inbound messages, but OpenClaw cannot answer in Talk until the bot is reconfigured.
- What changed: setup/docs now include `--feature response`; rejected bot sends mention missing `--feature response`; doctor/status can preflight the configured Talk bot and flag missing response capability.
- What did NOT change: no core channel contract changes and no startup-time config migration.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78935
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Nextcloud Talk bot missing `response` feature fails outbound replies.
- Real environment tested: disposable Nextcloud 33 container with Talk 23.0.4; OpenClaw gateway run locally; OpenAI `gpt-5.4-mini` through an API key stored in a private temp file.
- Exact steps or command run after this patch: installed Talk bot first with `--feature webhook --feature reaction`, sent a live Talk message through OpenClaw, then changed bot state with `talk:bot:state --feature webhook --feature response --feature reaction 1 1` and sent another live Talk message.
- Evidence after fix: current main-point validation stored bot reply `MAIN78935-OK`; patched `v2026.5.7` validation stored bot reply `REL78935-OK`.
- Observed result after fix: doctor/status preflight changed from `missing_response_feature` with features mask `9` to OK with features mask `11`; live Nextcloud chat stored bot replies after the response feature was enabled.
- What was not tested: no third-party hosted Nextcloud instance; validation used disposable local containers.
- Before evidence: live send path reached `message.send` and failed with the new message: `Nextcloud Talk: bot send was rejected - check the bot secret and ensure the bot was installed with --feature response`.

## Root Cause (if applicable)

- Root cause: Nextcloud Talk bots need the `response` capability bit to send replies, but OpenClaw setup only documented/configured webhook and reaction features.
- Missing detection / guardrail: doctor/status did not inspect the registered Talk bot feature mask.
- Contributing context (if known): the same missing feature can look like a generic auth/secret 401 from the send endpoint.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/nextcloud-talk/src/bot-preflight.test.ts`, `extensions/nextcloud-talk/src/channel.status.test.ts`, `extensions/nextcloud-talk/src/doctor.test.ts`, `extensions/nextcloud-talk/src/setup.test.ts`, `extensions/nextcloud-talk/src/send.cfg-threading.test.ts`.
- Scenario the test should lock in: setup includes `response`; 401 send errors mention `--feature response`; doctor/status preflight reports missing response feature.
- Why this is the smallest reliable guardrail: feature-mask parsing and status mapping are isolated in the Nextcloud Talk plugin; live proof covers the external dependency behavior.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Nextcloud Talk setup command includes `--feature response`.
- Nextcloud Talk 401 send failures include a more actionable `--feature response` hint.
- `openclaw doctor` / channel status can report a configured Talk bot that lacks response capability when API credentials are available.

## Diagram (if applicable)

```text
Before:
Talk bot lacks response -> inbound webhook works -> outbound send fails with vague 401

After:
Talk bot lacks response -> doctor/status flags it, send failure names --feature response
Talk bot has response -> live outbound reply is stored in Nextcloud
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: doctor/status may call Nextcloud Talk's bot admin API using already-configured admin API credentials. The probe is read-only, skips when credentials are missing, and only runs in status/doctor paths.

## Repro + Verification

### Environment

- OS: macOS local host with Docker.
- Runtime/container: Nextcloud 33 Apache container, Talk 23.0.4.
- Model/provider: OpenAI `gpt-5.4-mini`.
- Integration/channel: Nextcloud Talk.
- Relevant config (redacted): Nextcloud Talk base URL, admin API credentials, bot secret, webhook public URL, and room allowlist; OpenAI key via private temp file.

### Steps

1. Install Talk bot with `--feature webhook --feature reaction`.
2. Run `openclaw channels capabilities --channel nextcloud-talk --json`.
3. Start OpenClaw gateway and send a live message in the Talk room.
4. Add `response` with `talk:bot:state --feature webhook --feature response --feature reaction 1 1`.
5. Re-run capabilities and send another live message.

### Expected

- Missing `response` is detected before fix.
- Send failure explains `--feature response`.
- After Talk bot state is fixed, OpenClaw sends a real reply.

### Actual

- Current main branch point plus this patch: preflight reported `missing_response_feature` with features mask `9`; after adding response, preflight reported features mask `11` and Nextcloud stored `MAIN78935-OK`.
- Patched `v2026.5.7`: same preflight/failure behavior; after adding response, Nextcloud stored `REL78935-OK`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused regression tests; changed checks; live main-point reproduction/fix; live patched-2026.5.7 reproduction/fix.
- Edge cases checked: missing API credentials skip preflight; matching webhook bot without response reports the specific issue; matching webhook bot with response passes.
- What you did not verify: hosted Nextcloud variants outside the disposable container.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: Existing affected Nextcloud Talk installs should run `./occ talk:bot:state --feature webhook --feature response --feature reaction <bot-id> 1` or reinstall the Talk bot with `--feature response`.

## Risks and Mitigations

- Risk: status/doctor probe may fail on older or differently configured Talk servers.
  - Mitigation: probe reports a warning instead of blocking runtime and skips when API credentials or webhook URL are absent.
