### PR TITLE
Allow validated TXT/JSON/YAML media sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,8 +139,6 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: mark memory-specific embedding provider registration as deprecated compatibility and surface non-bundled usage in plugin compatibility diagnostics. (#85072) Thanks @mbelinky.
 - Pixverse: add video generation provider support, API region selection, and external plugin publishing.
 - Plugins: expose approval action metadata for plugin-driven approval surfaces.
-- Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.
-- Media: allow host-read local attachment sends for validated TXT, JSON, YAML, and YML documents while keeping full-buffer text validation and binary-disguise rejection.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,8 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: mark memory-specific embedding provider registration as deprecated compatibility and surface non-bundled usage in plugin compatibility diagnostics. (#85072) Thanks @mbelinky.
 - Pixverse: add video generation provider support, API region selection, and external plugin publishing.
 - Plugins: expose approval action metadata for plugin-driven approval surfaces.
+- Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.
+- Media: allow host-read local attachment sends for validated TXT, JSON, YAML, and YML documents while keeping full-buffer text validation and binary-disguise rejection.
 
 ### Fixes
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1775,7 +1775,7 @@ lives on the [Models FAQ](/help/faq-models).
     - The target channel supports outbound media and isn't blocked by allowlists.
     - The file is within the provider's size limits (images are resized to max 2048px).
     - `tools.fs.workspaceOnly=true` keeps local-path sends limited to workspace, temp/media-store, and sandbox-validated files.
-    - `tools.fs.workspaceOnly=false` lets structured local media sends use host-local files the agent can already read, but only for media plus safe document types (images, audio, video, PDF, and Office docs). Plain text and secret-like files are still blocked.
+    - `tools.fs.workspaceOnly=false` lets structured local media sends use host-local files the agent can already read, but only for media plus safe document types (images, audio, video, PDF, Office docs, and validated text documents such as TXT, JSON, YAML, and YML). Secret-like files are still blocked.
 
     See [Images](/nodes/images).
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1775,7 +1775,7 @@ lives on the [Models FAQ](/help/faq-models).
     - The target channel supports outbound media and isn't blocked by allowlists.
     - The file is within the provider's size limits (images are resized to max 2048px).
     - `tools.fs.workspaceOnly=true` keeps local-path sends limited to workspace, temp/media-store, and sandbox-validated files.
-    - `tools.fs.workspaceOnly=false` lets structured local media sends use host-local files the agent can already read, but only for media plus safe document types (images, audio, video, PDF, Office docs, and validated text documents such as TXT, JSON, YAML, and YML). This is not a secret scanner: an agent-readable `secret.txt` or `config.json` can be attached when the extension and content validation match. Keep sensitive files outside agent-readable paths, or keep `tools.fs.workspaceOnly=true` for stricter local-path sends.
+    - `tools.fs.workspaceOnly=false` lets structured local media sends use host-local files the agent can already read, but only for media plus safe document types (images, audio, video, PDF, Office docs, and validated text documents such as Markdown/MD, TXT, JSON, YAML, and YML). This is not a secret scanner: an agent-readable `secret.txt` or `config.json` can be attached when the extension and content validation match. Keep sensitive files outside agent-readable paths, or keep `tools.fs.workspaceOnly=true` for stricter local-path sends.
 
     See [Images](/nodes/images).
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1775,7 +1775,7 @@ lives on the [Models FAQ](/help/faq-models).
     - The target channel supports outbound media and isn't blocked by allowlists.
     - The file is within the provider's size limits (images are resized to max 2048px).
     - `tools.fs.workspaceOnly=true` keeps local-path sends limited to workspace, temp/media-store, and sandbox-validated files.
-    - `tools.fs.workspaceOnly=false` lets structured local media sends use host-local files the agent can already read, but only for media plus safe document types (images, audio, video, PDF, Office docs, and validated text documents such as TXT, JSON, YAML, and YML). Secret-like files are still blocked.
+    - `tools.fs.workspaceOnly=false` lets structured local media sends use host-local files the agent can already read, but only for media plus safe document types (images, audio, video, PDF, Office docs, and validated text documents such as TXT, JSON, YAML, and YML). This is not a secret scanner: an agent-readable `secret.txt` or `config.json` can be attached when the extension and content validation match. Keep sensitive files outside agent-readable paths, or keep `tools.fs.workspaceOnly=true` for stricter local-path sends.
 
     See [Images](/nodes/images).
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -212,7 +212,7 @@ Local-path behavior follows the same file-read trust model as the agent:
 - If `tools.fs.workspaceOnly` is `true`, outbound local media paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and sandbox-generated files.
 - If `tools.fs.workspaceOnly` is `false`, outbound local media can use host-local files the agent is already allowed to read.
 - Local paths can be absolute, workspace-relative, or home-relative with `~/`.
-- Host-local sends still only allow media and safe document types (images, audio, video, PDF, Office documents, and validated text documents such as TXT, JSON, YAML, and YML). This is an extension of the existing host-read trust boundary, not a secret scanner: if the agent can read a host-local `secret.txt` or `config.json`, it can attach that file when the extension and content validation match.
+- Host-local sends still only allow media and safe document types (images, audio, video, PDF, Office documents, and validated text documents such as Markdown/MD, TXT, JSON, YAML, and YML). This is an extension of the existing host-read trust boundary, not a secret scanner: if the agent can read a host-local `secret.txt` or `config.json`, it can attach that file when the extension and content validation match.
 
 That means generated images/files outside the workspace can now send when your fs policy already allows those reads, while arbitrary host-local text extensions remain blocked. Keep sensitive files outside the agent-readable filesystem, or keep `tools.fs.workspaceOnly=true` for stricter local-path sends.
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -212,9 +212,9 @@ Local-path behavior follows the same file-read trust model as the agent:
 - If `tools.fs.workspaceOnly` is `true`, outbound local media paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and sandbox-generated files.
 - If `tools.fs.workspaceOnly` is `false`, outbound local media can use host-local files the agent is already allowed to read.
 - Local paths can be absolute, workspace-relative, or home-relative with `~/`.
-- Host-local sends still only allow media and safe document types (images, audio, video, PDF, Office documents, and validated text documents such as TXT, JSON, YAML, and YML). Secret-like files are not treated as sendable media.
+- Host-local sends still only allow media and safe document types (images, audio, video, PDF, Office documents, and validated text documents such as TXT, JSON, YAML, and YML). This is an extension of the existing host-read trust boundary, not a secret scanner: if the agent can read a host-local `secret.txt` or `config.json`, it can attach that file when the extension and content validation match.
 
-That means generated images/files outside the workspace can now send when your fs policy already allows those reads, without reopening arbitrary host-text attachment exfiltration.
+That means generated images/files outside the workspace can now send when your fs policy already allows those reads, while arbitrary host-local text extensions remain blocked. Keep sensitive files outside the agent-readable filesystem, or keep `tools.fs.workspaceOnly=true` for stricter local-path sends.
 
 ## Operations checklist
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -212,7 +212,7 @@ Local-path behavior follows the same file-read trust model as the agent:
 - If `tools.fs.workspaceOnly` is `true`, outbound local media paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and sandbox-generated files.
 - If `tools.fs.workspaceOnly` is `false`, outbound local media can use host-local files the agent is already allowed to read.
 - Local paths can be absolute, workspace-relative, or home-relative with `~/`.
-- Host-local sends still only allow media and safe document types (images, audio, video, PDF, and Office documents). Plain text and secret-like files are not treated as sendable media.
+- Host-local sends still only allow media and safe document types (images, audio, video, PDF, Office documents, and validated text documents such as TXT, JSON, YAML, and YML). Secret-like files are not treated as sendable media.
 
 That means generated images/files outside the workspace can now send when your fs policy already allows those reads, without reopening arbitrary host-text attachment exfiltration.
 

--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -109,6 +109,20 @@ describe("mime detection", () => {
       }),
       expected: "text/javascript",
     },
+    {
+      name: "uses extension mapping for YAML assets",
+      input: async () => ({
+        filePath: "/tmp/config.yml",
+      }),
+      expected: "application/yaml",
+    },
+    {
+      name: "uses extension mapping for YAML documents",
+      input: async () => ({
+        filePath: "/tmp/config.yaml",
+      }),
+      expected: "application/yaml",
+    },
   ] as const)("$name", async ({ input, expected }) => {
     await expectDetectedMime({
       input: await input(),
@@ -182,6 +196,8 @@ describe("mimeTypeFromFilePath", () => {
     { filePath: "clip.flv", expected: "video/x-flv" },
     { filePath: "clip.wmv", expected: "video/x-ms-wmv" },
     { filePath: "debug.log", expected: "text/plain" },
+    { filePath: "config.yml", expected: "application/yaml" },
+    { filePath: "config.yaml", expected: "application/yaml" },
     { filePath: "page.xml", expected: "text/xml" },
     { filePath: "unknown.bin", expected: undefined },
   ] as const)("maps $filePath", ({ filePath, expected }) => {
@@ -221,6 +237,7 @@ describe("extensionForMime", () => {
     { mime: "video/x-ms-wmv", expected: ".wmv" },
     { mime: "video/quicktime", expected: ".mov" },
     { mime: "application/pdf", expected: ".pdf" },
+    { mime: "application/yaml", expected: ".yaml" },
     { mime: "text/plain", expected: ".txt" },
     { mime: "text/markdown", expected: ".md" },
     { mime: "text/html", expected: ".html" },

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -38,6 +38,7 @@ const EXT_BY_MIME: Record<string, string> = {
   "video/quicktime": ".mov",
   "application/pdf": ".pdf",
   "application/json": ".json",
+  "application/yaml": ".yaml",
   "application/zip": ".zip",
   "application/gzip": ".gz",
   "application/x-tar": ".tar",
@@ -79,6 +80,7 @@ const MIME_BY_EXT: Record<string, string> = {
   ".log": "text/plain",
   ".htm": "text/html",
   ".xml": "text/xml",
+  ".yml": "application/yaml",
 };
 
 const AUDIO_FILE_EXTENSIONS = new Set([

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -515,7 +515,7 @@ describe("runMessageAction media behavior", () => {
       }
     });
 
-    it("rejects host-local text attachments even when fs root expansion is enabled", async () => {
+    it("hydrates validated host-local text attachments when fs root expansion is enabled", async () => {
       await restoreRealMediaLoader();
 
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-attachment-text-"));
@@ -523,21 +523,30 @@ describe("runMessageAction media behavior", () => {
         const outsidePath = path.join(tempDir, "secret.txt");
         await fs.writeFile(outsidePath, "secret", "utf8");
 
-        await expect(
-          runMessageAction({
-            cfg: {
-              ...cfg,
-              tools: { fs: { workspaceOnly: false } },
-            },
-            action: "sendAttachment",
-            params: {
-              channel: "attachmentchat",
-              target: "+15551234567",
-              media: outsidePath,
-              message: "caption",
-            },
-          }),
-        ).rejects.toThrow(/Host-local media sends only allow/i);
+        const result = await runMessageAction({
+          cfg: {
+            ...cfg,
+            tools: { fs: { workspaceOnly: false } },
+          },
+          action: "sendAttachment",
+          params: {
+            channel: "attachmentchat",
+            target: "+15551234567",
+            media: outsidePath,
+            message: "caption",
+          },
+        });
+
+        expect(result.kind).toBe("action");
+        expect(result.payload).toMatchObject({
+          ok: true,
+          filename: "secret.txt",
+          caption: "caption",
+          contentType: "text/plain",
+        });
+        expect((result.payload as { buffer?: string }).buffer).toBe(
+          Buffer.from("secret").toString("base64"),
+        );
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
       }

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -610,6 +610,21 @@ describe("loadWebMedia", () => {
     expect(result.contentType).toBe("text/plain");
   });
 
+  it("rejects host-read LOG files even though they map to text/plain", async () => {
+    const logFile = path.join(fixtureRoot, "debug.log");
+    await fs.writeFile(logFile, "plain text\n", "utf8");
+    await expect(
+      loadWebMedia(logFile, {
+        maxBytes: 1024 * 1024,
+        localRoots: "any",
+        readFile: async (filePath) => await fs.readFile(filePath),
+        hostReadCapability: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "path-not-allowed",
+    });
+  });
+
   it("rejects renamed host-read text files even when the extension looks allowed", async () => {
     const disguisedPdf = path.join(fixtureRoot, "secret.pdf");
     await fs.writeFile(disguisedPdf, "secret", "utf8");

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -597,18 +597,17 @@ describe("loadWebMedia", () => {
     }
   });
 
-  it("rejects host-read text files outside local roots", async () => {
-    const secretFile = path.join(fixtureRoot, "secret.txt");
-    await fs.writeFile(secretFile, "secret", "utf8");
-    await expectLoadWebMediaErrorCode(
-      loadWebMedia(secretFile, {
-        maxBytes: 1024 * 1024,
-        localRoots: "any",
-        readFile: async (filePath) => await fs.readFile(filePath),
-        hostReadCapability: true,
-      }),
-      "path-not-allowed",
-    );
+  it("allows validated host-read TXT files", async () => {
+    const txtFile = path.join(fixtureRoot, "notes.txt");
+    await fs.writeFile(txtFile, "plain text\n", "utf8");
+    const result = await loadWebMedia(txtFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: "any",
+      readFile: async (filePath) => await fs.readFile(filePath),
+      hostReadCapability: true,
+    });
+    expect(result.kind).toBe("document");
+    expect(result.contentType).toBe("text/plain");
   });
 
   it("rejects renamed host-read text files even when the extension looks allowed", async () => {
@@ -771,40 +770,51 @@ describe("loadWebMedia", () => {
     {
       label: "ZIP",
       fileName: "archive.zip",
+      body: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
       contentType: "application/zip",
-      buffer: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
     },
     {
       label: "gzip",
       fileName: "archive.gz",
+      body: Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0, 0, 0, 0, 0, 0x03]),
       contentType: "application/gzip",
-      buffer: Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0, 0, 0, 0, 0, 0x03]),
     },
     {
       label: "tar",
       fileName: "archive.tar",
-      contentType: "application/x-tar",
-      buffer: (() => {
+      body: (() => {
         const buffer = Buffer.alloc(512);
         buffer.write("ustar", 257, "ascii");
         return buffer;
       })(),
+      contentType: "application/x-tar",
     },
     {
       label: "7z",
       fileName: "archive.7z",
+      body: Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0, 4]),
       contentType: "application/x-7z-compressed",
-      buffer: Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0, 4]),
     },
-  ])("allows host-read $label files", async ({ fileName, contentType, buffer }) => {
-    const archiveFile = path.join(fixtureRoot, fileName);
-    await fs.writeFile(archiveFile, buffer);
-    const result = await loadWebMedia(archiveFile, {
-      maxBytes: 1024 * 1024,
-      localRoots: "any",
-      readFile: async (filePath) => await fs.readFile(filePath),
-      hostReadCapability: true,
-    });
+    {
+      label: "JSON",
+      fileName: "data.json",
+      body: '{"ok":true}\n',
+      contentType: "application/json",
+    },
+    {
+      label: "YAML",
+      fileName: "config.yaml",
+      body: "ok: true\n",
+      contentType: "application/yaml",
+    },
+    {
+      label: "YML",
+      fileName: "config.yml",
+      body: "ok: true\n",
+      contentType: "application/yaml",
+    },
+  ])("allows host-read $label files", async ({ fileName, body, contentType }) => {
+    const result = await loadDocumentWithHostRead(fileName, body);
     expect(result.kind).toBe("document");
     expect(result.contentType).toBe(contentType);
   });
@@ -829,7 +839,11 @@ describe("loadWebMedia", () => {
     { label: "CSV", fileName: "opaque.csv" },
     { label: "HTML", fileName: "opaque.html" },
     { label: "Markdown", fileName: "opaque.md" },
-  ])("rejects opaque non-NUL binary data disguised as %s", async ({ fileName }) => {
+    { label: "TXT", fileName: "opaque.txt" },
+    { label: "JSON", fileName: "opaque.json" },
+    { label: "YAML", fileName: "opaque.yaml" },
+    { label: "YML", fileName: "opaque.yml" },
+  ])("rejects opaque non-NUL binary data disguised as $label", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
     const opaqueBinary = Buffer.alloc(9000);
     for (let i = 0; i < opaqueBinary.length; i += 1) {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -327,7 +327,7 @@ function isAllowedHostReadTextAlias(mime: string | undefined, filePath?: string)
     return true;
   }
   const ext = getFileExtension(filePath);
-  return !!ext && allowedExtensions.includes(ext);
+  return ext !== undefined && allowedExtensions.includes(ext);
 }
 
 function formatMb(bytes: number, digits = 2): string {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -172,6 +172,9 @@ const HOST_READ_DECLARED_TEXT_MIMES = new Set([...HOST_READ_TEXT_PLAIN_ALIASES, 
 const HOST_READ_DECLARED_TEXT_ERROR =
   "hostReadCapability permits only validated plain-text documents " +
   "and trusted generated HTML reports for local reads";
+const HOST_READ_TEXT_PLAIN_EXTENSION_BY_MIME: Record<string, readonly string[]> = {
+  "text/plain": [".txt"],
+};
 const MB = 1024 * 1024;
 
 function stripLegacyMediaDirectivePrefix(mediaUrl: string): string {
@@ -315,6 +318,18 @@ function isTrustedGeneratedHostReadHtml(params: {
   return text !== undefined && hasHtmlDocumentShape(text);
 }
 
+function isAllowedHostReadTextAlias(mime: string | undefined, filePath?: string): boolean {
+  if (!mime || !HOST_READ_TEXT_PLAIN_ALIASES.has(mime)) {
+    return false;
+  }
+  const allowedExtensions = HOST_READ_TEXT_PLAIN_EXTENSION_BY_MIME[mime];
+  if (!allowedExtensions) {
+    return true;
+  }
+  const ext = getFileExtension(filePath);
+  return !!ext && allowedExtensions.includes(ext);
+}
+
 function formatMb(bytes: number, digits = 2): string {
   return (bytes / MB).toFixed(digits);
 }
@@ -364,7 +379,7 @@ function assertHostReadMediaAllowed(params: {
       return;
     }
     if (
-      HOST_READ_TEXT_PLAIN_ALIASES.has(declaredMime) &&
+      isAllowedHostReadTextAlias(declaredMime, params.filePath) &&
       !params.sniffedContentType &&
       params.buffer &&
       isValidatedHostReadText(params.buffer)
@@ -399,7 +414,7 @@ function assertHostReadMediaAllowed(params: {
   if (
     !sniffedMime &&
     normalizedMime &&
-    HOST_READ_TEXT_PLAIN_ALIASES.has(normalizedMime) &&
+    isAllowedHostReadTextAlias(normalizedMime, params.filePath) &&
     params.buffer &&
     isValidatedHostReadText(params.buffer)
   ) {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -151,16 +151,26 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/zip",
   "text/csv",
   "text/markdown",
+  "text/plain",
+  "application/json",
+  "application/yaml",
 ]);
-// file-type returns undefined (no magic bytes) for plain-text formats like CSV
-// and Markdown, so host-read needs an explicit text validation fallback.
-const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown"]);
+// file-type returns undefined (no magic bytes) for plain-text formats like CSV,
+// Markdown, TXT, JSON, and YAML, so host-read needs an explicit "this really
+// decodes as text" fallback.
+const HOST_READ_TEXT_PLAIN_ALIASES = new Set([
+  "text/csv",
+  "text/markdown",
+  "text/plain",
+  "application/json",
+  "application/yaml",
+]);
 // HTML remains deliberately outside the host-read allowlist pending a separate
 // security-boundary review, but extension-declared .html files still need to
 // fail closed instead of falling through to binary/media sniffing.
 const HOST_READ_DECLARED_TEXT_MIMES = new Set([...HOST_READ_TEXT_PLAIN_ALIASES, "text/html"]);
 const HOST_READ_DECLARED_TEXT_ERROR =
-  "hostReadCapability permits only validated plain-text CSV/Markdown documents " +
+  "hostReadCapability permits only validated plain-text documents " +
   "and trusted generated HTML reports for local reads";
 const MB = 1024 * 1024;
 
@@ -381,10 +391,10 @@ function assertHostReadMediaAllowed(params: {
   ) {
     return;
   }
-  // CSV / Markdown exception: file-type v22 returns undefined (not "text/plain") for
-  // plain-text buffers that have no binary magic bytes. Allow these formats when:
+  // Plain-text document exception: file-type v22 returns undefined (not "text/plain")
+  // for text buffers that have no binary magic bytes. Allow these formats when:
   // - sniffedMime is undefined (no binary signature detected by file-type)
-  // - The extension-derived MIME is text/csv or text/markdown (operator intent)
+  // - The extension-derived MIME is an allowed text/document MIME (operator intent)
   // - The buffer decodes as actual text instead of opaque binary bytes
   if (
     !sniffedMime &&
@@ -407,7 +417,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, CSV, and Markdown (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, and validated plain-text documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 


### PR DESCRIPTION
## Summary
- allow host-read local media sends for validated TXT, JSON, YAML, and YML documents
- add YAML MIME/extension mapping for `.yaml` / `.yml`
- keep binary-disguise rejection coverage for the newly allowed text document extensions
- update attachment hydration coverage for the new allowed host-local text document behavior

## Real behavior proof
- **Behavior or issue addressed:** host-read local media sends can attach validated TXT, JSON, YAML, and YML documents while still rejecting binary data disguised with those text extensions.
- **Real environment tested:** local OpenClaw checkout on Linux 6.11 / Node v22.22.2, PR head `1b0b35121e5df831217c9003a62fc0a25ef0bee8`.
- **Exact steps or command run after this patch:** ran a live Node/tsx script against `src/media/web-media.ts` that wrote real temporary local files (`note.txt`, `payload.json`, `config.yaml`, `config.yml`, and binary-disguised `evil.json`) and called `loadWebMedia(..., { localRoots: "any", readFile: fs.readFile, hostReadCapability: true })` on each file.
- **Evidence after fix:** terminal output from the live local-file run:

  ```text
  note.txt: kind=document contentType=text/plain bytes=34
  payload.json: kind=document contentType=application/json bytes=39
  config.yaml: kind=document contentType=application/yaml bytes=33
  config.yml: kind=document contentType=application/yaml bytes=37
  evil.json: rejected binary disguise with code=path-not-allowed
  ```

- **Observed result after fix:** real local TXT/JSON/YAML/YML files loaded as `document` media with the expected MIME types; a ZIP-signature binary payload named `evil.json` was rejected with `path-not-allowed`.
- **What was not tested:** no end-to-end delivery to an external chat provider in this proof; this verifies the shared host-read media loader path used before provider send.

## Validation
- `node --import tsx ./.tmp-openclaw-real-media-proof.mjs` (temporary local proof script; output included above)
- `corepack pnpm exec node scripts/test-projects.mjs test/vitest/vitest.infra.config.ts test/vitest/vitest.hooks.config.ts test/vitest/vitest.secrets.config.ts` — passed 3 Vitest shards
- `corepack pnpm exec node scripts/test-projects.mjs src/media/web-media.test.ts src/media/mime.test.ts src/infra/outbound/message-action-runner.media.test.ts` — passed 3 Vitest shards
