### PR TITLE
fix: expire automatic model fallback pins

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -60,7 +60,7 @@ OpenClaw separates the selected provider/model from why it was selected. That so
 
 - **Configured default**: `agents.defaults.model.primary` uses `agents.defaults.model.fallbacks`.
 - **Agent primary**: `agents.list[].model` is strict unless that agent model object includes its own `fallbacks`. Use `fallbacks: []` to make the strict behavior explicit, or provide a non-empty list to opt that agent into model fallback.
-- **Auto fallback override**: a runtime fallback writes `providerOverride`, `modelOverride`, and `modelOverrideSource: "auto"` before retrying. That auto override can keep walking the configured fallback chain and is cleared by `/new`, `/reset`, and `sessions.reset`.
+- **Auto fallback override**: a runtime fallback writes `providerOverride`, `modelOverride`, `modelOverrideSource: "auto"`, and a short `modelOverrideExpiresAt` TTL before retrying. That auto override can keep walking the configured fallback chain while it is fresh, then expires automatically so the next turn retries the configured default/primary model. `/new`, `/reset`, and `sessions.reset` also clear auto-sourced overrides immediately.
 - **User session override**: `/model`, the model picker, `session_status(model=...)`, and `sessions.patch` write `modelOverrideSource: "user"`. That is an exact session selection. If the selected provider/model fails before producing a reply, OpenClaw reports the failure instead of answering from an unrelated configured fallback.
 - **Legacy session override**: older session entries may have `modelOverride` without `modelOverrideSource`. OpenClaw treats those as user overrides so an explicit old selection is not silently converted into fallback behavior.
 - **Cron payload model**: a cron job `payload.model` / `--model` is a job primary, not a user session override. It uses configured fallbacks unless the job provides `payload.fallbacks`; `payload.fallbacks: []` makes the cron run strict.
@@ -282,7 +282,7 @@ That means fallback retries have to coordinate with live model switching:
 - System-driven model changes such as fallback rotation, heartbeat overrides, or compaction never mark a pending live switch on their own.
 - User-driven model overrides are treated as exact selections for fallback policy, so an unreachable selected provider surfaces as a failure instead of being masked by `agents.defaults.model.fallbacks`.
 - Before a fallback retry starts, the reply runner persists the selected fallback override fields to the session entry.
-- Auto fallback overrides remain selected on subsequent turns so OpenClaw does not probe a known-bad primary on every message. `/new`, `/reset`, and `sessions.reset` clear auto-sourced overrides and return the session to the configured default.
+- Auto fallback overrides remain selected briefly on subsequent turns so OpenClaw does not probe a known-bad primary on every immediate retry. New fallback pins carry a short expiry (`modelOverrideExpiresAt`, currently 30 seconds); after that TTL, model selection clears the auto-sourced override and retries the configured default/primary model. `/new`, `/reset`, and `sessions.reset` clear auto-sourced overrides immediately.
 - `/status` shows the selected model and, when fallback state differs, the active fallback model and reason.
 - Live-session reconciliation prefers persisted session overrides over stale runtime model fields.
 - If a live-switch error points at a later candidate in the active fallback chain, OpenClaw jumps directly to that selected model instead of walking unrelated candidates first.

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -24,7 +24,10 @@ import {
 } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
-import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  clearExpiredAutoModelOverrideFromSessionEntry,
+} from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -725,6 +728,19 @@ async function agentCommandInternal(
       cfg,
       agentId: sessionAgentId,
     });
+    if (sessionEntry && sessionStore && sessionKey) {
+      const expiredAutoOverride = clearExpiredAutoModelOverrideFromSessionEntry({
+        entry: sessionEntry,
+      });
+      if (expiredAutoOverride.updated) {
+        await persistSessionEntry({
+          sessionStore,
+          sessionKey,
+          storePath,
+          entry: sessionEntry,
+        });
+      }
+    }
     const { provider: defaultProvider, model: defaultModel } = normalizeModelRef(
       configuredDefaultRef.provider,
       configuredDefaultRef.model,

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3282,6 +3282,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionEntry.providerOverride).toBe("openai-codex");
     expect(sessionEntry.modelOverride).toBe("gpt-5.4");
     expect(sessionEntry.modelOverrideSource).toBe("auto");
+    expect(sessionEntry.modelOverrideExpiresAt).toBeGreaterThan(Date.now());
     expect(sessionEntry.authProfileOverride).toBeUndefined();
     expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
     expect(sessionStore.main.authProfileOverride).toBeUndefined();
@@ -3450,6 +3451,7 @@ describe("runAgentTurnWithFallback", () => {
       providerOverride: "anthropic",
       modelOverride: "claude-sonnet",
       modelOverrideSource: "auto",
+      modelOverrideExpiresAt: expect.any(Number),
       authProfileOverride: "anthropic:openclaw",
       authProfileOverrideSource: "user",
     });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -45,6 +45,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
+import { resolveAutoModelOverrideExpiresAt } from "../../sessions/model-overrides.js";
 import {
   hasNonEmptyString,
   normalizeLowercaseStringOrEmpty,
@@ -130,6 +131,7 @@ type FallbackSelectionState = Pick<
   | "providerOverride"
   | "modelOverride"
   | "modelOverrideSource"
+  | "modelOverrideExpiresAt"
   | "authProfileOverride"
   | "authProfileOverrideSource"
   | "authProfileOverrideCompactionCount"
@@ -139,6 +141,7 @@ const FALLBACK_SELECTION_STATE_KEYS = [
   "providerOverride",
   "modelOverride",
   "modelOverrideSource",
+  "modelOverrideExpiresAt",
   "authProfileOverride",
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",
@@ -165,6 +168,12 @@ function setFallbackSelectionStateField(
     case "modelOverrideSource":
       if (entry.modelOverrideSource !== value) {
         entry.modelOverrideSource = value as SessionEntry["modelOverrideSource"];
+        return true;
+      }
+      return false;
+    case "modelOverrideExpiresAt":
+      if (entry.modelOverrideExpiresAt !== value) {
+        entry.modelOverrideExpiresAt = value as SessionEntry["modelOverrideExpiresAt"];
         return true;
       }
       return false;
@@ -196,6 +205,7 @@ function snapshotFallbackSelectionState(entry: SessionEntry): FallbackSelectionS
     providerOverride: entry.providerOverride,
     modelOverride: entry.modelOverride,
     modelOverrideSource: entry.modelOverrideSource,
+    modelOverrideExpiresAt: entry.modelOverrideExpiresAt,
     authProfileOverride: entry.authProfileOverride,
     authProfileOverrideSource: entry.authProfileOverrideSource,
     authProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount,
@@ -212,6 +222,7 @@ function buildFallbackSelectionState(params: {
     providerOverride: params.provider,
     modelOverride: params.model,
     modelOverrideSource: "auto",
+    modelOverrideExpiresAt: resolveAutoModelOverrideExpiresAt(),
     authProfileOverride: params.authProfileId,
     authProfileOverrideSource: params.authProfileId ? params.authProfileIdSource : undefined,
     authProfileOverrideCompactionCount: undefined,

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -741,6 +741,45 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(state.resetModelOverride).toBe(false);
   });
 
+  it("clears expired auto-failover overrides and returns to the default model", async () => {
+    const now = Date.now();
+    const cfg = {} as OpenClawConfig;
+    const sessionEntry = makeEntry({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      modelOverrideExpiresAt: now - 1,
+      fallbackNoticeSelectedModel: `${defaultProvider}/${defaultModel}`,
+      fallbackNoticeActiveModel: "openrouter/minimax/minimax-m2.7",
+      fallbackNoticeReason: "rate limit",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideExpiresAt).toBeUndefined();
+    expect(sessionStore[sessionKey]?.fallbackNoticeSelectedModel).toBeUndefined();
+    expect(sessionStore[sessionKey]?.fallbackNoticeActiveModel).toBeUndefined();
+    expect(sessionStore[sessionKey]?.fallbackNoticeReason).toBeUndefined();
+    expect(state.resetModelOverride).toBe(false);
+  });
+
   it("still clears disallowed auto-failover overrides through allowlist validation", async () => {
     const cfg = {
       agents: {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -17,7 +17,10 @@ import {
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  clearExpiredAutoModelOverrideFromSessionEntry,
+} from "../../sessions/model-overrides.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { ThinkLevel } from "./directives.js";
 export {
@@ -134,6 +137,21 @@ export async function createModelSelectionState(params: {
   let resetModelOverride = false;
   let resetModelOverrideRef: string | undefined;
   const agentEntry = params.agentId ? resolveAgentConfig(cfg, params.agentId) : undefined;
+  if (sessionEntry && sessionStore && sessionKey) {
+    const expiredAutoOverride = clearExpiredAutoModelOverrideFromSessionEntry({
+      entry: sessionEntry,
+    });
+    if (expiredAutoOverride.updated) {
+      sessionStore[sessionKey] = sessionEntry;
+      if (params.storePath) {
+        await (
+          await loadSessionStoreRuntime()
+        ).updateSessionStore(params.storePath, (store) => {
+          store[sessionKey] = sessionEntry;
+        });
+      }
+    }
+  }
   const directStoredOverride = resolvePersistedOverrideModelRef({
     defaultProvider,
     overrideProvider: sessionEntry?.providerOverride,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -261,6 +261,8 @@ export type SessionEntry = {
   responseUsage?: "on" | "off" | "tokens" | "full";
   providerOverride?: string;
   modelOverride?: string;
+  /** Epoch ms when an auto-created fallback model override expires and should fail back to the default model. */
+  modelOverrideExpiresAt?: number;
   /** Session-scoped agent runtime/harness override selected with the model picker. */
   agentRuntimeOverride?: string;
   /**

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -54,6 +54,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "modelOverride",
   "agentRuntimeOverride",
   "modelOverrideSource",
+  "modelOverrideExpiresAt",
   "authProfileOverride",
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
-import { applyModelOverrideToSessionEntry } from "./model-overrides.js";
+import {
+  AUTO_MODEL_OVERRIDE_FAILBACK_MS,
+  applyModelOverrideToSessionEntry,
+  clearExpiredAutoModelOverrideFromSessionEntry,
+  isAutoModelOverrideExpired,
+} from "./model-overrides.js";
 
 function applyOpenAiSelection(entry: SessionEntry) {
   return applyModelOverrideToSessionEntry({
@@ -140,6 +145,103 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.providerOverride).toBe("anthropic");
     expect(entry.modelOverride).toBe("claude-sonnet-4-6");
     expect(entry.modelOverrideSource).toBe("auto");
+    expect(entry.modelOverrideExpiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("clears model override expiry for user and default selections", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-5b",
+      updatedAt: Date.now() - 5_000,
+      providerOverride: "anthropic",
+      modelOverride: "claude-haiku-4-5",
+      modelOverrideSource: "auto",
+      modelOverrideExpiresAt: Date.now() + 10_000,
+    };
+
+    applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: "openai", model: "gpt-5.4" },
+    });
+
+    expect(entry.modelOverrideSource).toBe("user");
+    expect(entry.modelOverrideExpiresAt).toBeUndefined();
+
+    applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: "openai", model: "gpt-5.4", isDefault: true },
+    });
+
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.modelOverrideSource).toBeUndefined();
+    expect(entry.modelOverrideExpiresAt).toBeUndefined();
+  });
+
+  it("expires auto fallback overrides after the failback TTL", () => {
+    const now = 1_000_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-5c",
+      updatedAt: now - 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-haiku-4-5",
+      modelOverrideSource: "auto",
+      modelOverrideExpiresAt: now + AUTO_MODEL_OVERRIDE_FAILBACK_MS,
+      fallbackNoticeSelectedModel: "openai/gpt-5.4",
+      fallbackNoticeActiveModel: "anthropic/claude-haiku-4-5",
+      fallbackNoticeReason: "rate limit",
+      authProfileOverride: "anthropic:fallback",
+      authProfileOverrideSource: "auto",
+    };
+
+    expect(isAutoModelOverrideExpired(entry, now + AUTO_MODEL_OVERRIDE_FAILBACK_MS - 1)).toBe(
+      false,
+    );
+    expect(isAutoModelOverrideExpired(entry, now + AUTO_MODEL_OVERRIDE_FAILBACK_MS)).toBe(true);
+
+    const result = clearExpiredAutoModelOverrideFromSessionEntry({
+      entry,
+      now: now + AUTO_MODEL_OVERRIDE_FAILBACK_MS,
+    });
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.modelOverrideSource).toBeUndefined();
+    expect(entry.modelOverrideExpiresAt).toBeUndefined();
+    expect(entry.fallbackNoticeSelectedModel).toBeUndefined();
+    expect(entry.fallbackNoticeActiveModel).toBeUndefined();
+    expect(entry.fallbackNoticeReason).toBeUndefined();
+    expect(entry.authProfileOverride).toBeUndefined();
+    expect(entry.authProfileOverrideSource).toBeUndefined();
+    expect(entry.updatedAt).toBe(now + AUTO_MODEL_OVERRIDE_FAILBACK_MS);
+  });
+
+  it("does not expire user overrides or legacy auto overrides without an expiry", () => {
+    const now = 1_000_000;
+    const userEntry: SessionEntry = {
+      sessionId: "sess-5d",
+      updatedAt: now - 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+      modelOverrideSource: "user",
+      modelOverrideExpiresAt: now - 1,
+    };
+    const legacyAutoEntry: SessionEntry = {
+      sessionId: "sess-5e",
+      updatedAt: now - 1,
+      providerOverride: "minimax",
+      modelOverride: "MiniMax-M2.7",
+      modelOverrideSource: "auto",
+    };
+
+    expect(clearExpiredAutoModelOverrideFromSessionEntry({ entry: userEntry, now }).updated).toBe(
+      false,
+    );
+    expect(
+      clearExpiredAutoModelOverrideFromSessionEntry({ entry: legacyAutoEntry, now }).updated,
+    ).toBe(false);
+    expect(userEntry.modelOverride).toBe("claude-opus-4-6");
+    expect(legacyAutoEntry.modelOverride).toBe("MiniMax-M2.7");
   });
 
   it("sets liveModelSwitchPending only when explicitly requested", () => {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,6 +1,67 @@
 import type { SessionEntry } from "../config/sessions.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
+export const AUTO_MODEL_OVERRIDE_FAILBACK_MS = 30_000;
+
+export function resolveAutoModelOverrideExpiresAt(now = Date.now()): number {
+  return now + AUTO_MODEL_OVERRIDE_FAILBACK_MS;
+}
+
+export function isAutoModelOverrideExpired(
+  entry:
+    | Pick<SessionEntry, "modelOverride" | "modelOverrideSource" | "modelOverrideExpiresAt">
+    | undefined,
+  now = Date.now(),
+): boolean {
+  if (!entry?.modelOverride || entry.modelOverrideSource !== "auto") {
+    return false;
+  }
+  const expiresAt = entry.modelOverrideExpiresAt;
+  // Older auto overrides predate the expiry field and may include non-fallback
+  // selections (for example spawned sub-agent defaults). Preserve them until a
+  // new fallback pin records an explicit expiry.
+  if (expiresAt === undefined) {
+    return false;
+  }
+  return typeof expiresAt !== "number" || !Number.isFinite(expiresAt) || expiresAt <= now;
+}
+
+export function clearExpiredAutoModelOverrideFromSessionEntry(params: {
+  entry: SessionEntry | undefined;
+  now?: number;
+}): { updated: boolean } {
+  const { entry } = params;
+  const now = params.now ?? Date.now();
+  if (!isAutoModelOverrideExpired(entry, now)) {
+    return { updated: false };
+  }
+
+  let updated = false;
+  const clear = (key: keyof SessionEntry) => {
+    if (Object.hasOwn(entry!, key)) {
+      delete entry![key];
+      updated = true;
+    }
+  };
+
+  clear("providerOverride");
+  clear("modelOverride");
+  clear("modelOverrideSource");
+  clear("modelOverrideExpiresAt");
+  clear("fallbackNoticeSelectedModel");
+  clear("fallbackNoticeActiveModel");
+  clear("fallbackNoticeReason");
+  if (entry!.authProfileOverrideSource !== "user") {
+    clear("authProfileOverride");
+    clear("authProfileOverrideSource");
+    clear("authProfileOverrideCompactionCount");
+  }
+  if (updated) {
+    entry!.updatedAt = now;
+  }
+  return { updated };
+}
+
 export type ModelOverrideSelection = {
   provider: string;
   model: string;
@@ -36,6 +97,10 @@ export function applyModelOverrideToSessionEntry(params: {
       delete entry.modelOverrideSource;
       updated = true;
     }
+    if (entry.modelOverrideExpiresAt !== undefined) {
+      delete entry.modelOverrideExpiresAt;
+      updated = true;
+    }
   } else {
     if (entry.providerOverride !== selection.provider) {
       entry.providerOverride = selection.provider;
@@ -49,6 +114,17 @@ export function applyModelOverrideToSessionEntry(params: {
     }
     if (entry.modelOverrideSource !== selectionSource) {
       entry.modelOverrideSource = selectionSource;
+      updated = true;
+    }
+    const nextExpiresAt =
+      selectionSource === "auto" ? resolveAutoModelOverrideExpiresAt() : undefined;
+    if (nextExpiresAt === undefined) {
+      if (entry.modelOverrideExpiresAt !== undefined) {
+        delete entry.modelOverrideExpiresAt;
+        updated = true;
+      }
+    } else if (entry.modelOverrideExpiresAt !== nextExpiresAt) {
+      entry.modelOverrideExpiresAt = nextExpiresAt;
       updated = true;
     }
   }


### PR DESCRIPTION
## Summary
- add a 30s TTL to automatic model fallback pins (`modelOverrideSource: "auto"`)
- clear expired automatic fallback pins before agent/auto-reply model selection so the next turn retries the configured default/primary model
- preserve explicit user overrides and legacy auto overrides without an expiry field
- document the automatic fallback-pin expiry in `docs/concepts/model-failover.md`

## Real behavior proof
Redacted local proof against the PR branch using OpenClaw's actual `createModelSelectionState` path and a temporary session store:

```text
$ node --import tsx scripts/proof-model-fallback-ttl.mjs
OpenClaw automatic model fallback TTL proof
tempSessionStore $TMPDIR/sessions.json
before {"providerOverride":"fallback-provider","modelOverride":"fallback-model","modelOverrideSource":"auto","modelOverrideExpiresAtState":"expired timestamp present","updatedAtChanged":false}
selected primary-provider/primary-model
after {"providerOverride":null,"modelOverride":null,"modelOverrideSource":null,"modelOverrideExpiresAtState":null,"updatedAtChanged":true}
result PASS expired auto fallback pin cleared; configured primary retried
```

What this proves:
- the session store started with a persisted auto fallback pin (`fallback-provider/fallback-model`) and an expired `modelOverrideExpiresAt`
- model selection cleared the auto-owned override fields from the session store
- the selected model for the turn returned to the configured primary/default (`primary-provider/primary-model`)
- the persisted session entry was updated after clearing the expired auto pin

## Verification
- `pnpm test -- --run src/sessions/model-overrides.test.ts src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
  - `src/sessions/model-overrides.test.ts`: 9 passed
  - `src/auto-reply/reply/model-selection.test.ts`: 32 passed
  - `src/auto-reply/reply/agent-runner-execution.test.ts`: 68 passed
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:core:test`
- `pnpm format:check docs/concepts/model-failover.md src/sessions/model-overrides.ts src/sessions/model-overrides.test.ts src/agents/agent-command.ts src/auto-reply/reply/model-selection.ts src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts src/config/sessions/types.ts src/plugins/session-entry-slot-keys.ts`
