### PR TITLE
fix(gateway): track active reply runs in diagnostics

### DIFF
--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1,3 +1,7 @@
+import {
+  markDiagnosticEmbeddedRunEnded,
+  markDiagnosticEmbeddedRunStarted,
+} from "../../logging/diagnostic-run-activity.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 
@@ -180,6 +184,10 @@ function getAttachedBackend(operation: ReplyOperation): ReplyBackendHandle | und
 }
 
 function clearReplyRunState(params: { sessionKey: string; sessionId: string }): void {
+  markDiagnosticEmbeddedRunEnded({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+  });
   replyRunState.activeRunsByKey.delete(params.sessionKey);
   if (replyRunState.activeSessionIdsByKey.get(params.sessionKey) === params.sessionId) {
     replyRunState.activeSessionIdsByKey.delete(params.sessionKey);
@@ -303,11 +311,13 @@ export function createReplyOperation(params: {
         );
       }
       replyRunState.activeKeysBySessionId.delete(currentSessionId);
+      markDiagnosticEmbeddedRunEnded({ sessionId: currentSessionId, sessionKey });
       registerWaitSessionId(sessionKey, currentSessionId);
       currentSessionId = normalizedNextSessionId;
       replyRunState.activeSessionIdsByKey.set(sessionKey, currentSessionId);
       replyRunState.activeKeysBySessionId.set(currentSessionId, sessionKey);
       registerWaitSessionId(sessionKey, currentSessionId);
+      markDiagnosticEmbeddedRunStarted({ sessionId: currentSessionId, sessionKey });
     },
     attachBackend(handle) {
       if (result) {
@@ -372,6 +382,7 @@ export function createReplyOperation(params: {
   replyRunState.activeSessionIdsByKey.set(sessionKey, currentSessionId);
   replyRunState.activeKeysBySessionId.set(currentSessionId, sessionKey);
   registerWaitSessionId(sessionKey, currentSessionId);
+  markDiagnosticEmbeddedRunStarted({ sessionId: currentSessionId, sessionKey });
 
   return operation;
 }

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __testing as replyRunRegistryTesting,
+  createReplyOperation,
+} from "../auto-reply/reply/reply-run-registry.js";
+import {
   emitDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -199,11 +203,13 @@ describe("logger import side effects", () => {
 describe("stuck session diagnostics threshold", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    replyRunRegistryTesting.resetReplyRunRegistry();
     resetDiagnosticStateForTest();
     resetDiagnosticEventsForTest();
   });
 
   afterEach(() => {
+    replyRunRegistryTesting.resetReplyRunRegistry();
     resetDiagnosticEventsForTest();
     resetDiagnosticStateForTest();
     vi.restoreAllMocks();
@@ -286,6 +292,47 @@ describe("stuck session diagnostics threshold", () => {
       queueDepth: 1,
       stateGeneration: expect.any(Number),
     });
+  });
+
+  it("does not classify queued diagnostic state as stuck while reply work is active", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionKey: "main", state: "processing" });
+      createReplyOperation({
+        sessionKey: "main",
+        sessionId: "active-reply-session",
+        resetTriggered: false,
+      }).setPhase("running");
+
+      vi.advanceTimersByTime(61_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events.some((event) => event.type === "session.stuck")).toBe(false);
+    const stalledEvents = events.filter((event) => event.type === "session.stalled");
+    expect(stalledEvents).toHaveLength(1);
+    expect(stalledEvents[0]).toMatchObject({
+      classification: "stalled_agent_run",
+      reason: "active_work_without_progress",
+      activeWorkKind: "embedded_run",
+      queueDepth: 1,
+    });
+    expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
   it("does not warn while a processing session continues reporting progress", () => {


### PR DESCRIPTION
Resubmission of #79683 after it was auto-closed by the active-PR limit. Supersedes the older draft #79669.

## Summary

Fixes #79612.

Reply-run operations now register with the diagnostic active-work tracker when they begin, clear that tracker when they end, and refresh the tracker if the active operation rebinds to a new session id. This keeps the stuck-session detector and the recovery path looking at the same active-run reality, so queued diagnostic state does not emit `queued_work_without_active_run` while reply work is active for the same session key.

## Root Cause

The stuck-session detector classified sessions from diagnostic queue/activity state, but the active reply-run registry was not mirrored into the diagnostic active-work tracker. Recovery then consulted the live reply-run state and skipped with `active_reply_work`, creating the noisy detector/recovery disagreement described in the issue.

## Real behavior proof

- **Behavior or issue addressed**: Live diagnostic attention should not emit a false `session.stuck` / `queued_work_without_active_run` event while reply-run work is active for the same session key.
- **Real environment tested**: Clean detached PR-head worktree on macOS at `93ba43a858631e4bf101141f5eda0230b671fed3`, running a standalone Node/TSX process against the production OpenClaw diagnostic and reply-run modules.
- **Exact steps or command run after this patch**: `node --import tsx .proof/runtime-active-reply-diagnostics.ts`
- **Evidence after fix**: Copied terminal output from the standalone runtime execution:

  ```text
  waiting 31s so the runtime diagnostic threshold can age without fake timers
  [diagnostic] stalled session: sessionId=proof-active-reply-session sessionKey=agent:proof:gateway:channel:79695 state=processing age=61s queueDepth=1 reason=active_work_without_progress classification=stalled_agent_run activeWorkKind=embedded_run lastProgress=embedded_run:started lastProgressAge=31s recovery=none
  OpenClaw #79695 runtime proof
  replyRunRegistry.resolveSessionId=proof-active-reply-session
  diagnostic.activeWorkKind.beforeAttention=embedded_run
  classification.eventType=session.stalled
  classification.reason=active_work_without_progress
  session.stuck.count=0
  session.stalled.count=1
  session.stalled.activeWorkKind=embedded_run
  session.stalled.queueDepth=1
  diagnostic.activeWorkKind.afterComplete=none
  RESULT=PASS no false session.stuck while active reply work is registered
  ```

- **Observed result after fix**: A real Node runtime process created queued diagnostic state for `agent:proof:gateway:channel:79695`, started an active reply operation for the same key, waited through the actual 30s diagnostic threshold, and then called the production attention classifier. The emitted runtime log was `session.stalled` with `activeWorkKind=embedded_run` and `queueDepth=1`; `session.stuck.count=0`, and completion cleared `diagnostic.activeWorkKind` back to `none`.
- **What was not tested**: External Telegram/Gateway production traffic was not captured; this proof uses the same local production modules and diagnostic event path without a network channel.

## Validation

- `pnpm test src/logging/diagnostic.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/reply-run-registry.ts src/logging/diagnostic.test.ts`
- `git diff --check FETCH_HEAD`
