### PR TITLE
feat(training-export): overhaul trigger system and message conversion

### DIFF
--- a/docs/training-export.md
+++ b/docs/training-export.md
@@ -1,0 +1,173 @@
+---
+summary: "Opt-in runtime training data export that produces episode-level JSONL from compaction, session reset, and trajectory export triggers"
+read_when:
+  - Enabling or configuring the training export feature
+  - Understanding the trigger architecture and episode format
+  - Debugging training export output or missing episodes
+  - Reviewing the privacy and retention implications of unredacted training data
+title: "Training Export"
+---
+
+# Training Export
+
+## Overview
+
+The training export system produces episode-level JSONL training data from the OpenClaw runtime trajectory. Each line in the output file is a self-contained training sample — either a **task episode** capturing an agent turn, or a **compact-summary episode** capturing how the agent compresses conversation context.
+
+**Output:** `~/.openclaw/training-export/episodes.jsonl`
+
+### Design Principles
+
+- **Trajectory-first.** All training-required fields (system prompt, messages, tools, model metadata) are sourced from runtime trajectory events, not reconstructed offline.
+- **Trigger-driven.** Export is invoked at well-defined trigger points (compaction hooks, session reset, manual export command). No separate offline pipeline.
+- **Provider-owned conversion.** Message and tool conversion delegates to the Pi SDK / provider layer wherever possible, minimizing duplicated conversion logic.
+- **Unified compaction hook.** Training export for all compaction modes streams through a single pair of Pi SDK hooks (`session_before_compact` + `session_compact`), rather than being called from individual compaction paths.
+- **Pair-export guarantee.** For compaction-triggered exports, a task episode and a compact-summary episode must appear as a complete pair. If either is filtered by quality checks, the entire batch is discarded.
+- **Config-gated at call sites.** Callers check `trainingExport.enabled` before invoking export, so the intent is visible at every entry point without digging into implementation details.
+
+---
+
+## Trigger Architecture
+
+### Compaction Hooks (Primary Trigger)
+
+The training export extension registers two Pi SDK hooks that fire for **all** compaction modes:
+
+| Hook                     | When                       | Action                                                          | Coverage                                      |
+| ------------------------ | -------------------------- | --------------------------------------------------------------- | --------------------------------------------- |
+| `session_before_compact` | Before compaction executes | Stash pre-compaction snapshot + Pi SDK `preparation` (no write) | default, safeguard, manual                    |
+| `session_compact`        | After compaction completes | Validate summary, build task + summary pair, write              | default, safeguard, manual, overflow, timeout |
+
+**Pair-export flow:**
+
+1. `session_before_compact` — stash the current runtime snapshot and Pi SDK's `preparation` object (which provides `messagesToSummarize`, `previousSummary`, and `customInstructions`)
+2. `session_compact`:
+   - If the compaction summary is empty (boundary-only compaction where `keepRecentTokens` covers all messages) → discard stash, no export
+   - If the summary is valid → build both episodes; if **either** is filtered by quality checks, discard the entire batch
+   - On success → atomically write both episodes
+
+### Non-Compaction Triggers
+
+| Trigger             | Call Site                                            | Exports      |
+| ------------------- | ---------------------------------------------------- | ------------ |
+| `before_reset`      | `src/gateway/session-reset-service.ts`               | task episode |
+| `trajectory_export` | `src/auto-reply/reply/commands-export-trajectory.ts` | task episode |
+
+Both call sites guard on `getTrainingExportConfig(cfg)?.enabled === true` before calling `runTrainingExport`.
+
+### Extension Registration
+
+The extension is registered in `src/agents/pi-embedded-runner/extensions.ts`, gated on `trainingExport.enabled`:
+
+```typescript
+if (getTrainingExportConfig(params.cfg)?.enabled === true) {
+  setCompactionTrainingExportRuntime(params.sessionManager, params.cfg ?? null);
+  factories.push(compactionTrainingExportExtension);
+}
+```
+
+---
+
+## Episode Types
+
+### Task Episode
+
+Triggered by `on_compaction` (without `compactionEntry`), `before_reset`, or `trajectory_export`.
+
+Built from the runtime snapshot collected from the latest `context.compiled` trajectory event:
+
+- System prompt
+- Runtime messages (with trailing non-assistant messages trimmed for `on_compaction` — see below)
+- Runtime tools
+- Model metadata and trace info
+
+**Trailing trim.** For all trigger types, if the snapshot ends mid-turn at a non-`assistant` message (e.g. `toolResult`), trailing non-`assistant` messages are removed. The `trainExampleMessagesAreUsable` check requires ≥1 user + ≥1 assistant; if trimming leaves the episode unusable, it is discarded. This is a training-data quality requirement, not a trigger-specific behavior.
+
+### Compact-Summary Episode
+
+Triggered by `on_compaction` (with `compactionEntry`).
+
+Payload is built from the Pi SDK `preparation` object stashed during `session_before_compact`:
+
+| Field          | Source                                                                                    |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `systemPrompt` | `COMPACT_SUMMARIZATION_SYSTEM_PROMPT` (local constant)                                    |
+| `promptText`   | `buildCompactSummaryPrompt({ messagesToSummarize, previousSummary, customInstructions })` |
+| `responseText` | `compactionEntry.summary`                                                                 |
+| `compaction`   | `tokensBefore`, `firstKeptEntryId`, `fromExtension`                                       |
+
+**Empty-summary guard.** When `messagesToSummarize` is empty (short conversations where `keepRecentTokens` covers all messages), `serializeCompactSummaryConversation` returns an empty string, producing `<conversation>\n\n</conversation>`. The `compactConversationTextIsNonEmpty` regex (`/<conversation>\s*[\s\S]*\S[\s\S]*<\/conversation>/`) requires at least one non-whitespace character between the tags, so the summary episode fails validation and is filtered. Combined with pair-export, both task and summary episodes are correctly discarded for this boundary case.
+
+---
+
+## Message Conversion Pipeline
+
+Messages are converted via the `chat_completions` format pipeline:
+
+```
+runtime messages (Pi SDK format)
+  ↓
+1. Pre-process (single map over messages)
+   a. Strip thinking blocks from assistant messages
+   b. Convert compactionSummary → user message
+  ↓
+2. Upstream convertMessages() from @mariozechner/pi-ai/openai-completions
+  ↓
+3. adaptChatCompletionsMessagesToExportMessages()
+  ↓
+4. Append reasoning_content (scanned from original runtimeMessages)
+  ↓
+5. developer role → system role (training format compatibility)
+```
+
+### Why CompactionSummary Conversion is Needed
+
+Pi SDK's `convertToLlm` (`@mariozechner/pi-coding-agent/dist/core/messages.js:103-108`) converts `compactionSummary` messages to user messages with wrapper text. However, the upstream `convertMessages` from `@mariozechner/pi-ai/openai-completions` does **not** handle the `compactionSummary` role. Without pre-processing, compaction summary messages are silently dropped from task episodes, losing critical context.
+
+The pre-processing step mirrors Pi SDK's conversion format:
+
+```
+The conversation history before this point was compacted into the following summary:
+
+<summary>
+{summary text}
+</summary>
+```
+
+---
+
+## Configuration
+
+```typescript
+interface TrainingExportConfig {
+  enabled?: boolean; // default: false (opt-in)
+  compat?: ModelCompatConfig; // model compatibility overrides for export
+}
+```
+
+The `enabled` check is applied at every entry point (call sites + extension registration).
+
+---
+
+## Trigger Types
+
+| Kind                | Scenario              | Distinction                                                       |
+| ------------------- | --------------------- | ----------------------------------------------------------------- |
+| `on_compaction`     | Compaction event      | Has `compactionEntry` → summary episode; otherwise → task episode |
+| `before_reset`      | Session reset         | task episode                                                      |
+| `trajectory_export` | Manual export command | task episode                                                      |
+
+---
+
+## Key Files
+
+| File                                                 | Responsibility                                                                                                                                                                      |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/training-export.ts`                             | Core: snapshot collection, episode construction, JSONL I/O, prompt constants, compaction extension (merged from `compaction-summary-prompt.ts` and `compaction-training-export.ts`) |
+| `src/agents/pi-embedded-runner/extensions.ts`        | Extension registration (config-gated)                                                                                                                                               |
+| `src/agents/pi-hooks/compaction-safeguard.ts`        | Safeguard compaction logic (no longer contains training export calls)                                                                                                               |
+| `src/agents/pi-embedded-runner/compact.ts`           | Manual compaction (no longer contains training export calls)                                                                                                                        |
+| `src/gateway/session-reset-service.ts`               | `before_reset` trigger → `runTrainingExport`                                                                                                                                        |
+| `src/auto-reply/reply/commands-export-trajectory.ts` | `trajectory_export` trigger → `runTrainingExport`                                                                                                                                   |
+
+---

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -214,7 +214,7 @@ function parseTextSignature(
   return { id: signature };
 }
 
-function convertResponsesMessages(
+export function convertResponsesMessages(
   model: Model<Api>,
   context: Context,
   allowedToolCallProviders: Set<string>,
@@ -386,7 +386,7 @@ function convertResponsesMessages(
   return messages;
 }
 
-function convertResponsesTools(
+export function convertResponsesTools(
   tools: NonNullable<Context["tools"]>,
   model: OpenAIModeModel,
   options?: { strict?: boolean | null },

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -3,6 +3,11 @@ import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import {
+  compactionTrainingExportExtension,
+  getTrainingExportConfig,
+  setCompactionTrainingExportRuntime,
+} from "../../training-export.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { createAgentToolResultMiddlewareRunner } from "../harness/tool-result-middleware.js";
@@ -155,6 +160,11 @@ export function buildEmbeddedExtensionFactories(params: {
       provider: compactionCfg?.provider,
     });
     factories.push(compactionSafeguardExtension);
+  }
+  // Register compaction training export only when enabled.
+  if (getTrainingExportConfig(params.cfg)?.enabled === true) {
+    setCompactionTrainingExportRuntime(params.sessionManager, params.cfg ?? null);
+    factories.push(compactionTrainingExportExtension);
   }
   const pruningFactory = buildContextPruningFactory(params);
   if (pruningFactory) {

--- a/src/auto-reply/reply/commands-export-trajectory.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.ts
@@ -4,6 +4,7 @@ import type { ExecToolDetails } from "../../agents/bash-tools.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { ExecApprovalRequest } from "../../infra/exec-approvals.js";
 import { pathExists } from "../../infra/fs-safe.js";
+import { getTrainingExportConfig, runTrainingExport } from "../../training-export.js";
 import {
   exportTrajectoryForCommand,
   formatTrajectoryCommandExportSummary,
@@ -167,6 +168,18 @@ export async function buildExportTrajectoryReply(
     return {
       text: `❌ Failed to export trajectory: ${formatErrorMessage(err)}`,
     };
+  }
+
+  if (getTrainingExportConfig(params.cfg)?.enabled === true) {
+    runTrainingExport({
+      trigger: {
+        kind: "trajectory_export",
+        sessionId: entry.sessionId,
+        sessionFile,
+        command: params.command.commandBodyNormalized,
+      },
+      config: params.cfg,
+    });
   }
 
   return {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -643,6 +643,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Include full message payloads in trace output (default: true).",
   "diagnostics.cacheTrace.includePrompt": "Include prompt text in trace output (default: true).",
   "diagnostics.cacheTrace.includeSystem": "Include system prompt in trace output (default: true).",
+  "trainingExport.enabled":
+    "Enable or disable built-in training export at trigger points driven by session semantics and explicit trajectory export commands (compaction, reset, and trajectory export).",
+  "trainingExport.compat":
+    "Optional model-compat override applied only to training export when calling provider-owned converters from collected trajectory snapshots. Reuses the system ModelCompatConfig shape.",
   "tools.exec.applyPatch.enabled":
     "Enable or disable apply_patch for OpenAI and OpenAI Codex models when allowed by tool policy (default: true).",
   "tools.exec.applyPatch.workspaceOnly":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -67,6 +67,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "diagnostics.cacheTrace.includeMessages": "Cache Trace Include Messages",
   "diagnostics.cacheTrace.includePrompt": "Cache Trace Include Prompt",
   "diagnostics.cacheTrace.includeSystem": "Cache Trace Include System",
+  "trainingExport.enabled": "Training Export Enabled",
+  "trainingExport.compat": "Training Export Compat Override",
   "agents.list.*.identity.avatar": "Identity Avatar",
   "agents.list.*.skills": "Agent Skill Filter",
   "agents.list[].runtime": "Agent Runtime",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -24,6 +24,7 @@ import type {
   CommandsConfig,
   MessagesConfig,
 } from "./types.messages.js";
+import type { ModelCompatConfig } from "./types.models.js";
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
@@ -129,6 +130,10 @@ export type OpenClawConfig = {
   cron?: CronConfig;
   commitments?: CommitmentsConfig;
   hooks?: HooksConfig;
+  trainingExport?: {
+    enabled?: boolean;
+    compat?: ModelCompatConfig;
+  };
   discovery?: DiscoveryConfig;
   talk?: TalkConfig;
   gateway?: GatewayConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -441,6 +441,13 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    trainingExport: z
+      .object({
+        enabled: z.boolean().optional(),
+        compat: z.object({}).passthrough().optional(),
+      })
+      .strict()
+      .optional(),
     logging: z
       .object({
         level: LoggingLevelSchema.optional(),

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -37,6 +37,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { getTrainingExportConfig, runTrainingExport } from "../training-export.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
 import {
   archiveSessionTranscriptsDetailed,
@@ -451,6 +452,7 @@ export async function emitGatewayBeforeResetPluginHook(params: {
   const sessionFile = params.entry?.sessionFile;
   const agentId = normalizeAgentId(params.target.agentId ?? resolveDefaultAgentId(params.cfg));
   const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
+
   let messages: unknown[] = [];
   try {
     if (typeof sessionId === "string" && sessionId.trim().length > 0) {
@@ -636,6 +638,19 @@ export async function performGatewaySessionReset(params: {
     store[primaryKey] = nextEntry;
     return nextEntry;
   });
+  // Training export for before_reset trigger — independent of plugin hooks.
+  if (getTrainingExportConfig(cfg)?.enabled === true) {
+    runTrainingExport({
+      trigger: {
+        kind: "before_reset",
+        sessionId: resetSourceEntry?.sessionId,
+        sessionFile: resetSourceEntry?.sessionFile,
+        reason: params.reason,
+      },
+      config: cfg,
+    });
+  }
+
   await emitGatewayBeforeResetPluginHook({
     cfg,
     key: params.key,

--- a/src/training-export.test.ts
+++ b/src/training-export.test.ts
@@ -1,0 +1,506 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Context } from "@mariozechner/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __testing } from "./training-export.js";
+
+const ts = 1713916800000;
+const userMessage = (content: string): Context["messages"][number] => ({
+  role: "user",
+  content,
+  timestamp: ts,
+});
+const assistantMessage = (content: string, model = "gpt-5"): Context["messages"][number] => ({
+  role: "assistant",
+  content: [{ type: "text", text: content }],
+  api: "responses",
+  provider: "openai",
+  model,
+  usage: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason: "stop",
+  timestamp: ts,
+});
+const assistantMessageWithThinking = (params: {
+  thinking: string;
+  reasoningId: string;
+  text: string;
+  model?: string;
+}): Context["messages"][number] => ({
+  role: "assistant",
+  content: [
+    {
+      type: "thinking",
+      thinking: params.thinking,
+      thinkingSignature: JSON.stringify({ type: "reasoning", id: params.reasoningId, summary: [] }),
+    },
+    { type: "text", text: params.text },
+  ],
+  api: "responses",
+  provider: "openai",
+  model: params.model ?? "gpt-5",
+  usage: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason: "stop",
+  timestamp: ts,
+});
+
+describe("training-export trajectory snapshot collection", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "training-export-refactor-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("collects the latest compiled/completed snapshot from trajectory events", async () => {
+    const trajectoryPath = path.join(tmpDir, "session.trajectory.jsonl");
+    await fs.writeFile(
+      trajectoryPath,
+      [
+        JSON.stringify({
+          traceSchema: "openclaw-trajectory",
+          schemaVersion: 1,
+          traceId: "trace-1",
+          source: "runtime",
+          type: "context.compiled",
+          ts: new Date().toISOString(),
+          seq: 11,
+          sessionId: "sess-1",
+          runId: "run-1",
+          data: {
+            systemPrompt: "sys-1",
+            transcriptLeafId: "leaf-1",
+            messages: [userMessage("u1")],
+            tools: [{ name: "exec", description: "run", parameters: { type: "object" } }],
+          },
+        }),
+        JSON.stringify({
+          traceSchema: "openclaw-trajectory",
+          schemaVersion: 1,
+          traceId: "trace-1",
+          source: "runtime",
+          type: "model.completed",
+          ts: new Date().toISOString(),
+          seq: 12,
+          sessionId: "sess-1",
+          runId: "run-1",
+          modelId: "gpt-5",
+          data: {
+            messagesSnapshot: [userMessage("u1"), assistantMessage("a1", "gpt-5")],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const events = __testing.readTrajectoryEvents({
+      sessionId: "sess-1",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+    });
+    expect(events).toHaveLength(2);
+
+    const snapshot = __testing.collectLatestRuntimeSnapshot(
+      [
+        {
+          traceSchema: "openclaw-trajectory",
+          schemaVersion: 1,
+          traceId: "trace-1",
+          source: "runtime",
+          type: "context.compiled",
+          ts: new Date().toISOString(),
+          seq: 11,
+          sessionId: "sess-1",
+          runId: "run-1",
+          data: {
+            systemPrompt: "sys-1",
+            transcriptLeafId: "leaf-1",
+            messages: [userMessage("u1")],
+            tools: [{ name: "exec", description: "run", parameters: { type: "object" } }],
+          },
+        },
+        {
+          traceSchema: "openclaw-trajectory",
+          schemaVersion: 1,
+          traceId: "trace-1",
+          source: "runtime",
+          type: "model.completed",
+          ts: new Date().toISOString(),
+          seq: 12,
+          sessionId: "sess-1",
+          runId: "run-1",
+          modelId: "gpt-5",
+          data: {
+            messagesSnapshot: [userMessage("u1"), assistantMessage("a1", "gpt-5")],
+          },
+        },
+      ],
+      "sess-1",
+    );
+
+    expect(snapshot).toMatchObject({
+      sessionId: "sess-1",
+      runId: "run-1",
+      traceId: "trace-1",
+      transcriptLeafId: "leaf-1",
+      systemPrompt: "sys-1",
+      model: "gpt-5",
+      lastContextSeq: 11,
+      lastCompletedSeq: 12,
+    });
+    expect(snapshot?.runtimeTools).toEqual([
+      { name: "exec", description: "run", parameters: { type: "object" } },
+    ]);
+    expect(snapshot?.runtimeMessages).toHaveLength(2);
+  });
+});
+
+describe("training-export provider-owned conversion", () => {
+  it("converts runtime messages through the chat_completions path", () => {
+    const messages = __testing.convertRuntimeMessagesToExportMessages({
+      runtimeMessages: [userMessage("u1"), assistantMessage("a1")],
+      systemPrompt: "sys",
+      runtimeTools: [],
+    });
+
+    expect(messages[0]).toMatchObject({ content: "sys" });
+    expect(["system", "developer"]).toContain(messages[0]?.role);
+    expect(messages[1]).toMatchObject({ role: "user" });
+    expect(messages[2]).toMatchObject({ role: "assistant" });
+  });
+
+  it("exports assistant thinking blocks as reasoning_content beside content for chat_completions", () => {
+    const messages = __testing.convertRuntimeMessagesToExportMessages({
+      runtimeMessages: [
+        userMessage("u1"),
+        assistantMessageWithThinking({
+          thinking: "think-1",
+          reasoningId: "rs_1",
+          text: "a1",
+        }),
+      ],
+      systemPrompt: "sys",
+      runtimeTools: [],
+    });
+
+    expect(messages.at(-1)).toMatchObject({
+      role: "assistant",
+      reasoning_content: "think-1",
+      content: "a1",
+    });
+  });
+
+  it("exports assistant thinking blocks as reasoning_content beside content for responses", () => {
+    const messages = __testing.convertRuntimeMessagesToExportMessages({
+      runtimeMessages: [
+        userMessage("u1"),
+        assistantMessageWithThinking({
+          thinking: "think-1",
+          reasoningId: "rs_1",
+          text: "a1",
+        }),
+      ],
+      systemPrompt: "sys",
+      runtimeTools: [],
+    });
+
+    expect(messages.at(-1)).toMatchObject({
+      role: "assistant",
+      reasoning_content: "think-1",
+      content: "a1",
+    });
+  });
+
+  it("preserves reasoning_content for all assistant turns, not only the latest", () => {
+    const messages = __testing.convertRuntimeMessagesToExportMessages({
+      runtimeMessages: [
+        userMessage("u1"),
+        assistantMessageWithThinking({ thinking: "old", reasoningId: "rs_old", text: "a1" }),
+        userMessage("u2"),
+        assistantMessageWithThinking({ thinking: "new", reasoningId: "rs_new", text: "a2" }),
+      ],
+      runtimeTools: [],
+    });
+
+    const assistantMessages = messages.filter((message) => message.role === "assistant");
+    expect(assistantMessages).toMatchObject([
+      { role: "assistant", reasoning_content: "old", content: "a1" },
+      { role: "assistant", reasoning_content: "new", content: "a2" },
+    ]);
+    expect(messages.at(-1)).toMatchObject({
+      role: "assistant",
+      reasoning_content: "new",
+      content: "a2",
+    });
+  });
+
+  it("converts runtime tools through the chat_completions path", () => {
+    const tools = __testing.convertRuntimeToolsToExportTools([
+      { name: "exec", description: "run", parameters: { type: "object" } },
+    ]);
+
+    expect(tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "exec",
+          description: "run",
+          parameters: {
+            type: "object",
+            properties: {},
+            additionalProperties: false,
+            required: [],
+          },
+          strict: true,
+        },
+      },
+    ]);
+  });
+});
+
+describe("training-export episode assembly", () => {
+  it("builds an episode id from trigger + trajectory snapshot", () => {
+    const snapshot = {
+      sessionId: "sess-1",
+      runId: "run-1",
+      traceId: "trace-1",
+      transcriptLeafId: "leaf-1",
+      systemPrompt: "sys",
+      runtimeMessages: [userMessage("u1")],
+      runtimeTools: [{ name: "exec", parameters: { type: "object" } }],
+      lastContextSeq: 1,
+      lastCompletedSeq: 2,
+    };
+
+    const id1 = __testing.buildEpisodeId({
+      trigger: { kind: "trajectory_export", sessionId: "sess-1", command: "/trajectory" },
+      snapshot,
+    });
+    const id2 = __testing.buildEpisodeId({
+      trigger: { kind: "trajectory_export", sessionId: "sess-1", command: "/trajectory" },
+      snapshot,
+    });
+
+    expect(id1).toBe(id2);
+  });
+
+  it("builds a train example with trajectory metadata", () => {
+    const example = __testing.buildTrainExample({
+      snapshot: {
+        sessionId: "sess-1",
+        runId: "run-1",
+        traceId: "trace-1",
+        transcriptLeafId: "leaf-1",
+        systemPrompt: "sys",
+        runtimeMessages: [userMessage("u1"), assistantMessage("a1", "gpt-5")],
+        runtimeTools: [{ name: "exec", description: "run", parameters: { type: "object" } }],
+        model: "gpt-5",
+        lastContextSeq: 11,
+        lastCompletedSeq: 12,
+      },
+      trigger: { kind: "on_compaction", sessionId: "sess-1" },
+    });
+
+    expect(example?.meta).toMatchObject({
+      sessionId: "sess-1",
+      model: "gpt-5",
+      trigger: "on_compaction",
+      trajectory: {
+        traceId: "trace-1",
+        runId: "run-1",
+        transcriptLeafId: "leaf-1",
+        lastContextSeq: 11,
+        lastCompletedSeq: 12,
+      },
+    });
+    expect(example?.messages.length).toBeGreaterThan(0);
+    expect(example?.tools).toHaveLength(1);
+  });
+
+  it("trims trailing non-assistant messages and still produces a valid example when a completed turn remains", () => {
+    const example = __testing.buildTrainExample({
+      snapshot: {
+        sessionId: "sess-1",
+        systemPrompt: "sys",
+        runtimeMessages: [userMessage("u1"), assistantMessage("a1"), userMessage("u2")],
+        runtimeTools: [],
+      },
+      trigger: { kind: "trajectory_export", sessionId: "sess-1" },
+    });
+
+    expect(example).toBeDefined();
+  });
+
+  it("skips task episodes without any assistant message", () => {
+    const example = __testing.buildTrainExample({
+      snapshot: {
+        sessionId: "sess-1",
+        systemPrompt: "sys",
+        runtimeMessages: [userMessage("u1")],
+        runtimeTools: [],
+      },
+      trigger: { kind: "trajectory_export", sessionId: "sess-1" },
+    });
+
+    expect(example).toBeUndefined();
+  });
+
+  it("builds before_compaction task episode as a standalone training example", () => {
+    const examples = __testing.buildTrainExamplesForTrigger({
+      snapshot: {
+        sessionId: "sess-1",
+        runId: "run-1",
+        traceId: "trace-1",
+        transcriptLeafId: "leaf-pre-compact",
+        systemPrompt: "task system",
+        runtimeMessages: [
+          userMessage("task user prompt"),
+          assistantMessage("task assistant reply", "gpt-5"),
+        ],
+        runtimeTools: [],
+        model: "gpt-5",
+        lastContextSeq: 11,
+        lastCompletedSeq: 12,
+      },
+      trigger: {
+        kind: "on_compaction",
+        sessionId: "sess-1",
+      },
+    });
+
+    expect(examples).toHaveLength(1);
+    expect(examples[0]?.messages[0]).toMatchObject({ content: "task system" });
+    expect(examples[0]?.messages[1]).toMatchObject({ role: "user", content: "task user prompt" });
+    expect(examples[0]?.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: "task assistant reply",
+    });
+  });
+
+  it("builds after_compaction summary episode as a standalone training example", () => {
+    const examples = __testing.buildTrainExamplesForTrigger({
+      snapshot: {
+        sessionId: "sess-1",
+        runId: "run-1",
+        traceId: "trace-1",
+        transcriptLeafId: "leaf-post-compact",
+        systemPrompt: "task system",
+        runtimeMessages: [assistantMessage("compacted session state", "gpt-5")],
+        runtimeTools: [],
+        model: "gpt-5",
+        lastContextSeq: 21,
+        lastCompletedSeq: 22,
+      },
+      trigger: {
+        kind: "on_compaction",
+        sessionId: "sess-1",
+        compactionEntry: {
+          summary: `## Goal
+Summarized`,
+          tokensBefore: 5000,
+          firstKeptEntryId: "entry-5",
+          fromExtension: false,
+          systemPrompt: "summary system",
+          promptText: `<conversation>
+[User]: task user prompt
+
+[Assistant]: task assistant reply
+</conversation>
+
+Summarize it.`,
+        },
+      },
+    });
+
+    expect(examples).toHaveLength(1);
+    expect(examples[0]?.messages).toEqual([
+      { role: "system", content: "summary system" },
+      {
+        role: "user",
+        content: `<conversation>
+[User]: task user prompt
+
+[Assistant]: task assistant reply
+</conversation>
+
+Summarize it.`,
+      },
+      {
+        role: "assistant",
+        content: `## Goal
+Summarized`,
+      },
+    ]);
+  });
+});
+
+describe("training-export __testing compact summary train example", () => {
+  it("builds a compact summary example for non-empty prompt/response", () => {
+    const example = __testing.buildCompactSummaryTrainExample({
+      payload: {
+        sessionId: "sess-1",
+        systemPrompt: "system prompt",
+        promptText: `<conversation>
+[User]: hello
+</conversation>
+
+Summarize it.`,
+        responseText: `## Goal
+Test goal`,
+        model: { provider: "openai", id: "gpt-5" },
+      },
+    });
+
+    expect(example).toBeDefined();
+    expect(example?.messages).toEqual([
+      { role: "system", content: "system prompt" },
+      {
+        role: "user",
+        content: `<conversation>
+[User]: hello
+</conversation>
+
+Summarize it.`,
+      },
+      {
+        role: "assistant",
+        content: `## Goal
+Test goal`,
+      },
+    ]);
+    expect(example?.tools).toEqual([]);
+    expect(example?.meta.sessionId).toBe("sess-1");
+    expect(example?.meta.trigger).toBe("on_compaction");
+    expect(example?.meta.model).toBe("openai/gpt-5");
+  });
+
+  it("skips compact summary export for empty conversation payload", () => {
+    const example = __testing.buildCompactSummaryTrainExample({
+      payload: {
+        sessionId: "sess-1",
+        promptText: `<conversation>
+
+</conversation>`,
+        responseText: `## Goal
+Test goal`,
+      },
+    });
+    expect(example).toBeUndefined();
+  });
+});

--- a/src/training-export.ts
+++ b/src/training-export.ts
@@ -1,0 +1,1220 @@
+/**
+ * Training Export (trajectory-first, trigger-driven)
+ *
+ * Minimal responsibilities on the new base:
+ * 1. when enabled and a trigger fires, collect training-required fields from trajectory runtime
+ * 2. format them via provider-owned OpenAI conversion helpers and append to episodes.jsonl
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { Api, Context, Model } from "@mariozechner/pi-ai";
+import { convertMessages } from "@mariozechner/pi-ai/openai-completions";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { detectOpenAICompletionsCompat } from "./agents/openai-completions-compat.js";
+import {
+  buildOpenAICompletionsParams,
+  convertResponsesMessages,
+} from "./agents/openai-transport-stream.js";
+import { createSessionManagerRuntimeRegistry } from "./agents/pi-hooks/session-manager-runtime-registry.js";
+import type { AnyAgentTool } from "./agents/tools/common.js";
+import { resolveStateDir } from "./config/paths.js";
+import type { ModelCompatConfig } from "./config/types.models.js";
+import type { OpenClawConfig } from "./config/types.openclaw.js";
+import { formatErrorMessage } from "./infra/errors.js";
+import { createSubsystemLogger } from "./logging/subsystem.js";
+import type { PluginLogger } from "./plugins/types.js";
+import { resolveTrajectoryFilePath } from "./trajectory/runtime.js";
+import type { TrajectoryEvent } from "./trajectory/types.js";
+
+type OpenAIStyleMessage = {
+  role: "system" | "developer" | "user" | "assistant" | "tool";
+  content?: unknown;
+  reasoning_content?: string;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: unknown[];
+};
+
+function getExportMessageRole(message: OpenAIStyleMessage): string | undefined {
+  return "role" in message && typeof message.role === "string" ? message.role : undefined;
+}
+
+type ChatCompletionsToolDefinition = {
+  type: "function";
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+    strict?: boolean;
+  };
+};
+
+type ResponsesToolDefinition = {
+  type: "function";
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+  strict?: boolean;
+};
+
+type ExportedToolDefinition = ChatCompletionsToolDefinition | ResponsesToolDefinition;
+export type TrainingExportConfig = {
+  enabled?: boolean;
+  compat?: ModelCompatConfig;
+};
+
+type CompactSummaryModelInfo = {
+  provider?: string;
+  id?: string;
+};
+
+type CompactSummaryPayload = {
+  systemPrompt?: string;
+  promptText: string;
+  responseText: string;
+  model?: CompactSummaryModelInfo;
+  sessionId?: string;
+  compaction?: {
+    tokensBefore: number;
+    firstKeptEntryId: string;
+    fromExtension: boolean;
+  };
+};
+
+export type TrainingExportTrigger =
+  | {
+      kind: "before_reset";
+      sessionId?: string;
+      sessionFile?: string;
+      reason?: string;
+    }
+  | {
+      kind: "trajectory_export";
+      sessionId?: string;
+      sessionFile?: string;
+      command?: string;
+    }
+  | {
+      kind: "on_compaction";
+      sessionId?: string;
+      sessionFile?: string;
+      compactionEntry?: {
+        summary: string;
+        tokensBefore: number;
+        firstKeptEntryId: string;
+        fromExtension: boolean;
+        systemPrompt?: string;
+        promptText?: string;
+      };
+    };
+
+type RuntimeToolObject = {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+};
+
+export type RuntimeSnapshot = {
+  sessionId?: string;
+  runId?: string;
+  traceId?: string;
+  transcriptLeafId?: string;
+  systemPrompt?: string;
+  runtimeMessages: AgentMessage[];
+  runtimeTools: RuntimeToolObject[];
+  model?: string;
+  lastContextSeq?: number;
+  lastCompletedSeq?: number;
+};
+
+type TrainExampleMeta = {
+  episodeId: string;
+  sessionId?: string;
+  exportedAt: string;
+  openclawVersion?: string;
+  model?: string;
+  messageCount: number;
+  turnCount?: number;
+  trigger: TrainingExportTrigger["kind"];
+  trajectory?: {
+    traceId?: string;
+    runId?: string;
+    transcriptLeafId?: string;
+    lastContextSeq?: number;
+    lastCompletedSeq?: number;
+  };
+};
+
+type TrainExample = {
+  messages: OpenAIStyleMessage[];
+  tools: ExportedToolDefinition[];
+  meta: TrainExampleMeta;
+};
+
+type TrainingExportRunResult = {
+  status: "exported" | "skipped" | "error";
+  exportedCount?: number;
+  outputJsonlPath?: string;
+  reason?: string;
+  error?: string;
+};
+
+const DEFAULT_EXPORT_OUTPUT_FILENAME = "episodes.jsonl";
+
+export function getTrainingExportConfig(config?: OpenClawConfig): TrainingExportConfig | undefined {
+  return (config as OpenClawConfig & { trainingExport?: TrainingExportConfig })?.trainingExport;
+}
+
+export function resolveTrainingExportPaths(): { outputJsonlPath: string } {
+  const exportDir = path.join(resolveStateDir(), "training-export");
+  fs.mkdirSync(exportDir, { recursive: true, mode: 0o700 });
+  return { outputJsonlPath: path.join(exportDir, DEFAULT_EXPORT_OUTPUT_FILENAME) };
+}
+
+export function appendJsonl(filePath: string, rows: unknown[]): void {
+  if (rows.length === 0) {
+    return;
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  try {
+    fs.accessSync(filePath);
+  } catch {
+    fs.writeFileSync(filePath, "", { mode: 0o600 });
+  }
+  const payload = rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+  fs.appendFileSync(filePath, payload, "utf8");
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).toSorted(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    return `{${entries
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function readJsonl(filePath: string): unknown[] {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+  return fs
+    .readFileSync(filePath, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line)];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function shouldKeepRuntimeMessageForTrainingExport(message: Context["messages"][number]): boolean {
+  return !(
+    message &&
+    typeof message === "object" &&
+    "provider" in message &&
+    message.provider === "openclaw"
+  );
+}
+
+function normalizeRuntimeMessages(value: unknown): Context["messages"] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (message): message is Context["messages"][number] =>
+      Boolean(message) &&
+      typeof message === "object" &&
+      shouldKeepRuntimeMessageForTrainingExport(message as Context["messages"][number]),
+  );
+}
+
+function normalizeRuntimeTools(value: unknown): RuntimeToolObject[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") {
+      return [];
+    }
+    const record = item as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    if (!name) {
+      return [];
+    }
+    return [
+      {
+        name,
+        ...(typeof record.description === "string" ? { description: record.description } : {}),
+        ...(record.parameters && typeof record.parameters === "object"
+          ? { parameters: record.parameters as Record<string, unknown> }
+          : {}),
+      },
+    ];
+  });
+}
+
+export function readTrajectoryEvents(params: {
+  sessionFile?: string;
+  sessionId?: string;
+}): TrajectoryEvent[] {
+  const sessionId = params.sessionId?.trim();
+  if (!sessionId) {
+    return [];
+  }
+  const filePath = resolveTrajectoryFilePath({
+    sessionFile: params.sessionFile,
+    sessionId,
+  });
+  return readJsonl(filePath).flatMap((item) => {
+    if (!item || typeof item !== "object") {
+      return [];
+    }
+    return [item as TrajectoryEvent];
+  });
+}
+
+function resolveLastAssistantModel(runtimeMessages: Context["messages"]): string | undefined {
+  for (let i = runtimeMessages.length - 1; i >= 0; i--) {
+    const message = runtimeMessages[i];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    if (message.role !== "assistant") {
+      continue;
+    }
+    return typeof message.model === "string" && message.model.trim().length > 0
+      ? message.model
+      : undefined;
+  }
+  return undefined;
+}
+
+export function collectLatestRuntimeSnapshot(
+  events: TrajectoryEvent[],
+  fallbackSessionId?: string,
+): RuntimeSnapshot | undefined {
+  const compiled = [...events]
+    .toReversed()
+    .find(
+      (event) => event.type === "context.compiled" && event.data && typeof event.data === "object",
+    );
+  const completed = [...events]
+    .toReversed()
+    .find(
+      (event) => event.type === "model.completed" && event.data && typeof event.data === "object",
+    );
+
+  if (!compiled && !completed) {
+    return undefined;
+  }
+
+  const compiledData = compiled?.data ?? {};
+  const completedData = completed?.data ?? {};
+  const runtimeMessages = normalizeRuntimeMessages(
+    completedData.messagesSnapshot ?? compiledData.messages,
+  );
+  const runtimeTools = normalizeRuntimeTools(compiledData.tools);
+  const sessionId =
+    compiled?.sessionId ?? completed?.sessionId ?? (fallbackSessionId?.trim() || undefined);
+
+  return {
+    sessionId,
+    runId: compiled?.runId ?? completed?.runId,
+    traceId: compiled?.traceId ?? completed?.traceId,
+    transcriptLeafId:
+      typeof compiledData.transcriptLeafId === "string" ? compiledData.transcriptLeafId : undefined,
+    systemPrompt:
+      typeof compiledData.systemPrompt === "string" ? compiledData.systemPrompt : undefined,
+    runtimeMessages,
+    runtimeTools,
+    model: resolveLastAssistantModel(runtimeMessages) ?? compiled?.modelId ?? completed?.modelId,
+    lastContextSeq: typeof compiled?.seq === "number" ? compiled.seq : undefined,
+    lastCompletedSeq: typeof completed?.seq === "number" ? completed.seq : undefined,
+  };
+}
+
+function buildRuntimeContext(params: {
+  runtimeMessages: Context["messages"];
+  systemPrompt?: string;
+  runtimeTools: RuntimeToolObject[];
+}): Context {
+  return {
+    messages: params.runtimeMessages,
+    ...(params.systemPrompt ? { systemPrompt: params.systemPrompt } : {}),
+    ...(params.runtimeTools.length > 0
+      ? { tools: params.runtimeTools as unknown as AnyAgentTool[] }
+      : {}),
+  } as Context;
+}
+
+function compactConversationTextIsNonEmpty(promptText: string): boolean {
+  return /<conversation>\s*[\s\S]*\S[\s\S]*<\/conversation>/.test(promptText);
+}
+
+function resolveCompactSummaryModel(model?: CompactSummaryModelInfo): string | undefined {
+  if (!model) {
+    return undefined;
+  }
+  const provider = typeof model.provider === "string" ? model.provider.trim() : "";
+  const id = typeof model.id === "string" ? model.id.trim() : "";
+  if (provider && id) {
+    return `${provider}/${id}`;
+  }
+  return provider || id || undefined;
+}
+
+function buildCompactSummaryEpisodeId(payload: CompactSummaryPayload): string {
+  return createHash("sha256")
+    .update(
+      stableStringify({
+        sessionId: payload.sessionId,
+        systemPrompt: payload.systemPrompt,
+        promptText: payload.promptText,
+        responseText: payload.responseText,
+        model: payload.model,
+      }),
+    )
+    .digest("hex");
+}
+
+function buildCompactSummaryTrainExample(params: {
+  payload: CompactSummaryPayload;
+  openclawVersion?: string;
+}): TrainExample | undefined {
+  const promptText = params.payload.promptText.trim();
+  const responseText = params.payload.responseText.trim();
+  if (!promptText || !responseText) {
+    return undefined;
+  }
+  if (!compactConversationTextIsNonEmpty(promptText)) {
+    return undefined;
+  }
+  if (/\(No conversation(?: content)? to summarize\)/.test(responseText)) {
+    return undefined;
+  }
+  const messages: OpenAIStyleMessage[] = [];
+  if (params.payload.systemPrompt) {
+    messages.push({ role: "system", content: params.payload.systemPrompt });
+  }
+  messages.push({ role: "user", content: promptText });
+  messages.push({ role: "assistant", content: responseText });
+  const model = resolveCompactSummaryModel(params.payload.model);
+  return {
+    messages,
+    tools: [],
+    meta: {
+      episodeId: buildCompactSummaryEpisodeId(params.payload),
+      ...(params.payload.sessionId ? { sessionId: params.payload.sessionId } : {}),
+      exportedAt: new Date().toISOString(),
+      ...(params.openclawVersion ? { openclawVersion: params.openclawVersion } : {}),
+      ...(model ? { model } : {}),
+      ...(params.payload.compaction ? { compaction: params.payload.compaction } : {}),
+      messageCount: messages.length,
+      turnCount: 1,
+      trigger: "on_compaction",
+    },
+  };
+}
+
+function resolveTrainingExportToolModel(config?: OpenClawConfig): Model<Api> & {
+  compat?: Record<string, unknown>;
+} {
+  const defaultModel = config?.agents?.defaults?.model;
+  const provider = "openai";
+  const baseUrl = "https://api.openai.com/v1";
+  const modelId = typeof defaultModel === "string" ? defaultModel : "gpt-5";
+  const compat = {
+    ...detectOpenAICompletionsCompat({ provider, baseUrl, id: modelId, compat: undefined })
+      .defaults,
+    // Training export handles thinking blocks itself as reasoning_content;
+    // tell upstream convertMessages not to merge thinking into text content.
+    requiresThinkingAsText: false,
+    ...getTrainingExportConfig(config)?.compat,
+  };
+
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    provider,
+    baseUrl,
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 8192,
+    compat,
+  } as Model<Api> & { compat?: Record<string, unknown> };
+}
+
+function normalizeTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((item) => {
+      if (!item || typeof item !== "object") {
+        return [];
+      }
+      const record = item as Record<string, unknown>;
+      if (typeof record.text === "string") {
+        return [record.text];
+      }
+      return [];
+    })
+    .join("\n");
+}
+
+function adaptChatCompletionsMessagesToExportMessages(items: unknown[]): OpenAIStyleMessage[] {
+  const messages: OpenAIStyleMessage[] = [];
+  for (const item of items as Array<Record<string, unknown>>) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const role = typeof item.role === "string" ? item.role : undefined;
+    if (!role) {
+      continue;
+    }
+    if (role === "system" || role === "developer" || role === "user") {
+      messages.push({ role, content: normalizeTextContent(item.content) });
+      continue;
+    }
+    if (role === "assistant") {
+      messages.push({
+        role: "assistant",
+        content: normalizeTextContent(item.content),
+        ...(Array.isArray(item.tool_calls) ? { tool_calls: item.tool_calls } : {}),
+      });
+      continue;
+    }
+    if (role === "tool") {
+      messages.push({
+        role: "tool",
+        content: normalizeTextContent(item.content),
+        name: typeof item.name === "string" ? item.name : undefined,
+        tool_call_id: typeof item.tool_call_id === "string" ? item.tool_call_id : undefined,
+      });
+    }
+  }
+  return messages;
+}
+
+function convertRuntimeToolsToExportTools(
+  tools: RuntimeToolObject[],
+  config?: OpenClawConfig,
+): ExportedToolDefinition[] {
+  if (tools.length === 0) {
+    return [];
+  }
+  const model = resolveTrainingExportToolModel(config);
+  const params = buildOpenAICompletionsParams(
+    model as never,
+    { systemPrompt: "", messages: [], tools: tools as unknown as AnyAgentTool[] } as never,
+    undefined,
+  ) as { tools?: ExportedToolDefinition[] };
+  return Array.isArray(params.tools) ? params.tools : [];
+}
+
+function trainExampleMessagesAreUsable(messages: OpenAIStyleMessage[]): boolean {
+  return (
+    messages.some((message) => getExportMessageRole(message) === "user") &&
+    messages.some((message) => getExportMessageRole(message) === "assistant")
+  );
+}
+
+function appendReasoningContent(
+  message: OpenAIStyleMessage,
+  reasoningContent: string | undefined,
+): void {
+  const trimmed = reasoningContent?.trim();
+  if (!trimmed) {
+    return;
+  }
+  message.reasoning_content = message.reasoning_content
+    ? `${message.reasoning_content}\n${trimmed}`
+    : trimmed;
+}
+
+/**
+ * Convert runtime messages to export messages by reusing upstream
+ * `convertMessages` from `@mariozechner/pi-ai/openai-completions`, then
+ * post-processing to add `reasoning_content` from thinking blocks.
+ *
+ * Upstream handles: system/developer role, user content (text + image),
+ * assistant text/toolCalls, toolResult, id normalization, sanitization,
+ * compat quirks (requiresAssistantAfterToolResult, etc.).
+ *
+ * We strip thinking blocks *before* calling upstream to avoid
+ * requiresThinkingAsText / thinkingFormat merging thinking text into
+ * content. Then we add `reasoning_content` as a post-processing step by
+ * matching original assistant messages to exported ones by position.
+ *
+ * Reference: node_modules/@mariozechner/pi-ai/dist/providers/openai-completions.js
+ *   → export function convertMessages(model, context, compat)
+ */
+function convertRuntimeMessagesToExportMessages(params: {
+  runtimeMessages: AgentMessage[];
+  systemPrompt?: string;
+  runtimeTools: RuntimeToolObject[];
+  config?: OpenClawConfig;
+}): OpenAIStyleMessage[] {
+  const model = resolveTrainingExportToolModel(params.config);
+
+  // Pre-process messages: strip thinking blocks, convert compactionSummary → user.
+  // CompactionSummary → user mirrors Pi SDK's convertToLlm (messages.js:7-13, 103-108);
+  // needed because the upstream convertMessages from @mariozechner/pi-ai/openai-completions
+  // does not handle compactionSummary role.
+  const processedMessages = params.runtimeMessages.map((msg) => {
+    // Strip thinking blocks from assistant messages
+    if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      const filtered = msg.content.filter((block: { type: string }) => block.type !== "thinking");
+      if (filtered.length !== msg.content.length) {
+        return { ...msg, content: filtered } as typeof msg;
+      }
+    }
+    // Convert compactionSummary to user message
+    if (
+      msg.role === "compactionSummary" &&
+      typeof msg.summary === "string" &&
+      msg.summary.trim().length > 0
+    ) {
+      return {
+        role: "user" as const,
+        content: `The conversation history before this point was compacted into the following summary:\n\n<summary>\n${msg.summary}\n</summary>`,
+      };
+    }
+    return msg;
+  });
+
+  const runtimeContext = buildRuntimeContext({
+    runtimeMessages: processedMessages as Context["messages"],
+    systemPrompt: params.systemPrompt,
+    runtimeTools: params.runtimeTools,
+  });
+
+  // Step 1: Use upstream convertMessages to get ChatCompletionMessageParam[]
+  const upstreamMessages = convertMessages(
+    model as never,
+    runtimeContext,
+    (model as unknown as { compat: unknown }).compat as never,
+  );
+
+  // Step 2: Convert upstream format to our export format
+  const messages = adaptChatCompletionsMessagesToExportMessages(upstreamMessages as unknown[]);
+
+  // Step 3: Append reasoning_content by scanning original runtime messages
+  // for thinking blocks and matching them to exported assistant messages
+  // by position.
+  let msgIdx = 0;
+  for (const message of params.runtimeMessages) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+    while (msgIdx < messages.length && messages[msgIdx].role !== "assistant") {
+      msgIdx++;
+    }
+    if (msgIdx >= messages.length) {
+      break;
+    }
+    const exported = messages[msgIdx];
+    if (Array.isArray(message.content)) {
+      for (const block of message.content) {
+        if (block.type === "thinking" && typeof block.thinking === "string") {
+          appendReasoningContent(exported, block.thinking);
+        }
+      }
+    }
+    msgIdx++;
+  }
+
+  // Step 4: Convert developer role to system for training format compatibility.
+  // OpenAI uses "developer" for system messages with developer privileges,
+  // but training pipelines expect "system".
+  for (const message of messages) {
+    if (message.role === "developer") {
+      message.role = "system";
+    }
+  }
+
+  return messages;
+}
+
+function buildEpisodeId(params: {
+  trigger: TrainingExportTrigger;
+  snapshot: RuntimeSnapshot;
+}): string {
+  return createHash("sha256")
+    .update(
+      stableStringify({
+        trigger: params.trigger,
+        sessionId: params.snapshot.sessionId,
+        traceId: params.snapshot.traceId,
+        runId: params.snapshot.runId,
+        transcriptLeafId: params.snapshot.transcriptLeafId,
+        lastContextSeq: params.snapshot.lastContextSeq,
+        lastCompletedSeq: params.snapshot.lastCompletedSeq,
+        systemPrompt: params.snapshot.systemPrompt,
+        runtimeMessages: params.snapshot.runtimeMessages,
+        runtimeTools: params.snapshot.runtimeTools,
+      }),
+    )
+    .digest("hex");
+}
+
+function buildTrainExample(params: {
+  snapshot: RuntimeSnapshot;
+  trigger: TrainingExportTrigger;
+  config?: OpenClawConfig;
+  openclawVersion?: string;
+}): TrainExample | undefined {
+  if (params.snapshot.runtimeMessages.length === 0) {
+    return undefined;
+  }
+
+  const messages = convertRuntimeMessagesToExportMessages({
+    runtimeMessages: params.snapshot.runtimeMessages,
+    systemPrompt: params.snapshot.systemPrompt,
+    runtimeTools: params.snapshot.runtimeTools,
+    config: params.config,
+  });
+  // Trim trailing non-assistant messages. Training episodes must end with an
+  // assistant message regardless of trigger type — mid-turn snapshots from any
+  // source are incomplete turns, not meaningful training data.
+  while (
+    messages.length > 0 &&
+    getExportMessageRole(messages.at(-1) as OpenAIStyleMessage) !== "assistant"
+  ) {
+    messages.pop();
+  }
+  if (messages.length === 0 || !trainExampleMessagesAreUsable(messages)) {
+    return undefined;
+  }
+
+  const tools = convertRuntimeToolsToExportTools(params.snapshot.runtimeTools, params.config);
+
+  return {
+    messages,
+    tools,
+    meta: {
+      episodeId: buildEpisodeId({
+        trigger: params.trigger,
+        snapshot: params.snapshot,
+      }),
+      sessionId: params.snapshot.sessionId,
+      exportedAt: new Date().toISOString(),
+      ...(params.openclawVersion ? { openclawVersion: params.openclawVersion } : {}),
+      ...(params.snapshot.model ? { model: params.snapshot.model } : {}),
+      messageCount: messages.length,
+      turnCount: messages.filter((message) => getExportMessageRole(message) === "user").length,
+      trigger: params.trigger.kind,
+      trajectory: {
+        ...(params.snapshot.traceId ? { traceId: params.snapshot.traceId } : {}),
+        ...(params.snapshot.runId ? { runId: params.snapshot.runId } : {}),
+        ...(params.snapshot.transcriptLeafId
+          ? { transcriptLeafId: params.snapshot.transcriptLeafId }
+          : {}),
+        ...(typeof params.snapshot.lastContextSeq === "number"
+          ? { lastContextSeq: params.snapshot.lastContextSeq }
+          : {}),
+        ...(typeof params.snapshot.lastCompletedSeq === "number"
+          ? { lastCompletedSeq: params.snapshot.lastCompletedSeq }
+          : {}),
+      },
+    },
+  };
+}
+
+export function buildTrainExamplesForTrigger(params: {
+  snapshot: RuntimeSnapshot;
+  trigger: TrainingExportTrigger;
+  config?: OpenClawConfig;
+  openclawVersion?: string;
+}): TrainExample[] {
+  const taskEpisode =
+    (params.trigger.kind === "on_compaction" && !params.trigger.compactionEntry) ||
+    params.trigger.kind === "before_reset" ||
+    params.trigger.kind === "trajectory_export"
+      ? buildTrainExample({
+          snapshot: params.snapshot,
+          trigger: params.trigger,
+          config: params.config,
+          openclawVersion: params.openclawVersion,
+        })
+      : undefined;
+  const compactSummaryEpisode =
+    params.trigger.kind === "on_compaction" &&
+    params.trigger.compactionEntry &&
+    params.trigger.compactionEntry.summary
+      ? buildCompactSummaryTrainExample({
+          payload: {
+            systemPrompt: params.trigger.compactionEntry.systemPrompt ?? "",
+            promptText: params.trigger.compactionEntry.promptText ?? "",
+            responseText: params.trigger.compactionEntry.summary,
+            sessionId: params.trigger.sessionId,
+            compaction: {
+              tokensBefore: params.trigger.compactionEntry.tokensBefore,
+              firstKeptEntryId: params.trigger.compactionEntry.firstKeptEntryId,
+              fromExtension: params.trigger.compactionEntry.fromExtension,
+            },
+          },
+          openclawVersion: params.openclawVersion,
+        })
+      : undefined;
+  return [taskEpisode, compactSummaryEpisode].filter((item): item is TrainExample => Boolean(item));
+}
+
+export function runTrainingExport(params: {
+  trigger: TrainingExportTrigger;
+  config?: OpenClawConfig;
+  logger?: PluginLogger;
+  openclawVersion?: string;
+}): TrainingExportRunResult {
+  if (!params.trigger.sessionFile || !params.trigger.sessionId) {
+    return { status: "skipped", reason: "trainingExport.missing_session_target" };
+  }
+
+  try {
+    const paths = resolveTrainingExportPaths();
+    const events = readTrajectoryEvents({
+      sessionFile: params.trigger.sessionFile,
+      sessionId: params.trigger.sessionId,
+    });
+    const snapshot = collectLatestRuntimeSnapshot(events, params.trigger.sessionId);
+
+    if (!snapshot) {
+      return {
+        status: "skipped",
+        reason: "trainingExport.no_trajectory_snapshot",
+        outputJsonlPath: paths.outputJsonlPath,
+      };
+    }
+
+    const examples = buildTrainExamplesForTrigger({
+      snapshot,
+      trigger: params.trigger,
+      config: params.config,
+      openclawVersion: params.openclawVersion,
+    });
+
+    if (examples.length === 0) {
+      return {
+        status: "skipped",
+        reason: "trainingExport.empty_snapshot",
+        outputJsonlPath: paths.outputJsonlPath,
+      };
+    }
+
+    appendJsonl(paths.outputJsonlPath, examples);
+    params.logger?.info?.(
+      `[training-export] exported ${examples.length} episode(s) -> ${paths.outputJsonlPath}`,
+    );
+    return {
+      status: "exported",
+      exportedCount: examples.length,
+      outputJsonlPath: paths.outputJsonlPath,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    params.logger?.warn?.(`[training-export] export failed: ${message}`);
+    return { status: "error", error: message };
+  }
+}
+
+export const COMPACT_SUMMARIZATION_SYSTEM_PROMPT = `You are a context summarization assistant. Your task is to read a conversation between a user and an AI coding assistant, then produce a structured summary following the exact format specified.
+
+Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.`;
+
+export const COMPACT_SUMMARIZATION_PROMPT = `The messages above are a conversation to summarize. Create a structured context checkpoint summary that another LLM will use to continue the work.
+
+Use this EXACT format:
+
+## Goal
+[What is the user trying to accomplish? Can be multiple items if the session covers different tasks.]
+
+## Constraints & Preferences
+- [Any constraints, preferences, or requirements mentioned by user]
+- [Or "(none)" if none were mentioned]
+
+## Progress
+### Done
+- [x] [Completed tasks/changes]
+
+### In Progress
+- [ ] [Current work]
+
+### Blocked
+- [Issues preventing progress, if any]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale]
+
+## Next Steps
+1. [Ordered list of what should happen next]
+
+## Critical Context
+- [Any data, examples, or references needed to continue]
+- [Or "(none)" if not applicable]
+
+Keep each section concise. Preserve exact file paths, function names, and error messages.`;
+
+export const COMPACT_UPDATE_SUMMARIZATION_PROMPT = `The messages above are NEW conversation messages to incorporate into the existing summary provided in <previous-summary> tags.
+
+Update the existing structured summary with new information. RULES:
+- PRESERVE all existing information from the previous summary
+- ADD new progress, decisions, and context from the new messages
+- UPDATE the Progress section: move items from "In Progress" to "Done" when completed
+- UPDATE "Next Steps" based on what was accomplished
+- PRESERVE exact file paths, function names, and error messages
+- If something is no longer relevant, you may remove it
+
+Use this EXACT format:
+
+## Goal
+[Preserve existing goals, add new ones if the task expanded]
+
+## Constraints & Preferences
+- [Preserve existing, add new ones discovered]
+
+## Progress
+### Done
+- [x] [Include previously done items AND newly completed items]
+
+### In Progress
+- [ ] [Current work - update based on progress]
+
+### Blocked
+- [Current blockers - remove if resolved]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale] (preserve all previous, add new)
+
+## Next Steps
+1. [Update based on current state]
+
+## Critical Context
+- [Preserve important context, add new if needed]
+
+Keep each section concise. Preserve exact file paths, function names, and error messages.`;
+
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((part) => {
+      if (!part || typeof part !== "object") {
+        return "";
+      }
+      const block = part as Record<string, unknown>;
+      if (block.type === "text") {
+        return typeof block.text === "string" ? block.text : "";
+      }
+      if (block.type === "thinking") {
+        return typeof block.thinking === "string" ? block.thinking : "";
+      }
+      return "";
+    })
+    .filter((part) => part.length > 0)
+    .join("\n");
+}
+
+function serializeCompactSummaryConversation(messages: AgentMessage[]): string {
+  const lines: string[] = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object" || !("role" in msg)) {
+      continue;
+    }
+    const role = msg.role;
+    if (role === "user") {
+      const text = extractTextContent((msg as { content?: unknown }).content);
+      if (text) {
+        lines.push(`[User]: ${text}`);
+      }
+      continue;
+    }
+    if (role === "assistant") {
+      const content = (msg as { content?: unknown }).content;
+      const text = extractTextContent(content);
+      if (text) {
+        lines.push(`[Assistant]: ${text}`);
+      }
+      if (Array.isArray(content)) {
+        const toolCalls = content
+          .filter(
+            (part): part is Record<string, unknown> => Boolean(part) && typeof part === "object",
+          )
+          .filter((part) => part.type === "toolCall")
+          .map((part) => {
+            const name = typeof part.name === "string" ? part.name : "unknown_tool";
+            const args =
+              part.arguments && typeof part.arguments === "object"
+                ? JSON.stringify(part.arguments)
+                : "{}";
+            return `${name}(${args})`;
+          });
+        if (toolCalls.length > 0) {
+          lines.push(`[Assistant tool calls]: ${toolCalls.join("; ")}`);
+        }
+      }
+      continue;
+    }
+    if (role === "toolResult") {
+      const toolMsg = msg as { toolName?: unknown; content?: unknown };
+      const name = typeof toolMsg.toolName === "string" ? toolMsg.toolName : "tool";
+      const text = extractTextContent(toolMsg.content);
+      if (text) {
+        lines.push(`[Tool result ${name}]: ${text}`);
+      }
+      continue;
+    }
+    if (role === "compactionSummary") {
+      const summary =
+        typeof (msg as { summary?: unknown }).summary === "string"
+          ? (msg as { summary: string }).summary
+          : "";
+      if (summary) {
+        lines.push(`[Previous compaction summary]: ${summary}`);
+      }
+      continue;
+    }
+    if (role === "branchSummary") {
+      const summary =
+        typeof (msg as { summary?: unknown }).summary === "string"
+          ? (msg as { summary: string }).summary
+          : "";
+      if (summary) {
+        lines.push(`[Branch summary]: ${summary}`);
+      }
+      continue;
+    }
+    if (role === "custom") {
+      const text = extractTextContent((msg as { content?: unknown }).content);
+      if (text) {
+        lines.push(`[Custom]: ${text}`);
+      }
+    }
+  }
+  return lines.join("\n\n");
+}
+
+export function buildCompactSummaryPrompt(params: {
+  messagesToSummarize: AgentMessage[];
+  previousSummary?: string;
+  customInstructions?: string;
+}): string {
+  let basePrompt = params.previousSummary
+    ? COMPACT_UPDATE_SUMMARIZATION_PROMPT
+    : COMPACT_SUMMARIZATION_PROMPT;
+  if (params.customInstructions) {
+    basePrompt = `${basePrompt}
+
+Additional focus: ${params.customInstructions}`;
+  }
+  const conversationText = serializeCompactSummaryConversation(params.messagesToSummarize);
+  let promptText = `<conversation>
+${conversationText}
+</conversation>
+
+`;
+  if (params.previousSummary) {
+    promptText += `<previous-summary>
+${params.previousSummary}
+</previous-summary>
+
+`;
+  }
+  promptText += basePrompt;
+  return promptText;
+}
+
+const log = createSubsystemLogger("compaction-training-export");
+
+const registry = createSessionManagerRuntimeRegistry<OpenClawConfig>();
+
+export const setCompactionTrainingExportRuntime = registry.set;
+
+type CompactionPreparation = {
+  firstKeptEntryId: string;
+  messagesToSummarize: AgentMessage[];
+  previousSummary?: string;
+  tokensBefore: number;
+};
+
+type PreCompactStash = {
+  trigger: TrainingExportTrigger;
+  snapshot: RuntimeSnapshot;
+  preparation: CompactionPreparation;
+  customInstructions?: string;
+};
+
+const preCompactStash = new WeakMap<object, PreCompactStash>();
+
+/**
+ * Extension that triggers training export for all compaction events.
+ *
+ * Strategy: task episode + summary episode must appear as a complete pair.
+ * If either is filtered by quality checks, both are discarded.
+ */
+export function compactionTrainingExportExtension(api: ExtensionAPI): void {
+  api.on("session_before_compact", (event, ctx) => {
+    const sessionId = ctx.sessionManager.getSessionId();
+    const sessionFile = ctx.sessionManager.getSessionFile();
+    const config = registry.get(ctx.sessionManager) ?? undefined;
+
+    if (!sessionId || !sessionFile) return;
+
+    try {
+      const events = readTrajectoryEvents({ sessionFile, sessionId });
+      const snapshot = collectLatestRuntimeSnapshot(events, sessionId);
+      if (snapshot) {
+        const trigger: TrainingExportTrigger = { kind: "on_compaction", sessionId, sessionFile };
+        preCompactStash.set(ctx.sessionManager, {
+          trigger,
+          snapshot,
+          preparation: event.preparation as CompactionPreparation,
+          customInstructions: event.customInstructions,
+        });
+        log.info("[training-export] stashed pre-compaction snapshot + preparation", {
+          sessionId: sessionId.slice(0, 8),
+        });
+      }
+    } catch (err) {
+      log.warn("[training-export] failed to stash pre-compaction snapshot", {
+        errorMessage: formatErrorMessage(err),
+      });
+    }
+  });
+
+  api.on("session_compact", (event, ctx) => {
+    const sessionId = ctx.sessionManager.getSessionId();
+    const sessionFile = ctx.sessionManager.getSessionFile();
+    const config = registry.get(ctx.sessionManager) ?? undefined;
+    const summary = event.compactionEntry.summary;
+
+    if (!sessionId || !sessionFile) return;
+
+    const discardStash = () => {
+      preCompactStash.delete(ctx.sessionManager);
+    };
+
+    if (!summary || typeof summary !== "string" || summary.trim().length === 0) {
+      discardStash();
+      log.info("[training-export] no valid summary, discarding stash", {
+        sessionId: sessionId.slice(0, 8),
+      });
+      return;
+    }
+
+    try {
+      const stashed = preCompactStash.get(ctx.sessionManager);
+
+      // Build task episode
+      const taskExamples = stashed
+        ? buildTrainExamplesForTrigger({
+            snapshot: stashed.snapshot,
+            trigger: stashed.trigger,
+            config,
+          })
+        : [];
+
+      // Build summary episode
+      const promptText = stashed
+        ? buildCompactSummaryPrompt({
+            messagesToSummarize: stashed.preparation.messagesToSummarize,
+            previousSummary: stashed.preparation.previousSummary,
+            customInstructions: stashed.customInstructions,
+          })
+        : "";
+
+      const summaryTrigger: TrainingExportTrigger = {
+        kind: "on_compaction",
+        sessionId,
+        sessionFile,
+        compactionEntry: {
+          summary,
+          tokensBefore: event.compactionEntry.tokensBefore,
+          firstKeptEntryId: event.compactionEntry.firstKeptEntryId,
+          fromExtension: event.compactionEntry.fromHook ?? false,
+          systemPrompt: COMPACT_SUMMARIZATION_SYSTEM_PROMPT,
+          promptText,
+        },
+      };
+
+      const fallbackSnapshot: RuntimeSnapshot = {
+        runtimeMessages: [],
+        runtimeTools: [],
+      };
+      const summaryExamples = buildTrainExamplesForTrigger({
+        snapshot: stashed?.snapshot ?? fallbackSnapshot,
+        trigger: summaryTrigger,
+        config,
+      });
+
+      discardStash();
+
+      // Both must be present — if either is filtered, discard the whole batch.
+      if (taskExamples.length === 0 || summaryExamples.length === 0) {
+        log.info("[training-export] incomplete pair, discarding batch", {
+          sessionId: sessionId.slice(0, 8),
+          taskCount: taskExamples.length,
+          summaryCount: summaryExamples.length,
+        });
+        return;
+      }
+
+      const examples = [...taskExamples, ...summaryExamples];
+      const paths = resolveTrainingExportPaths();
+      appendJsonl(paths.outputJsonlPath, examples);
+      log.info(
+        `[training-export] exported ${examples.length} episode(s) -> ${paths.outputJsonlPath}`,
+        { sessionId: sessionId.slice(0, 8) },
+      );
+    } catch (err) {
+      log.warn("[training-export] failed to export on_compaction episodes", {
+        errorMessage: formatErrorMessage(err),
+      });
+    }
+  });
+}
+
+export const __testing = {
+  stableStringify,
+  readTrajectoryEvents,
+  collectLatestRuntimeSnapshot,
+  buildRuntimeContext,
+  compactConversationTextIsNonEmpty,
+  resolveCompactSummaryModel,
+  buildCompactSummaryTrainExample,
+  resolveTrainingExportToolModel,
+  adaptChatCompletionsMessagesToExportMessages,
+  trainExampleMessagesAreUsable,
+  appendReasoningContent,
+  convertRuntimeMessagesToExportMessages,
+  convertRuntimeToolsToExportTools,
+  buildEpisodeId,
+  buildTrainExample,
+  buildTrainExamplesForTrigger,
+  buildOpenAICompletionsParams,
+  convertMessages,
+  convertResponsesMessages,
+};


### PR DESCRIPTION
> **Draft / work-in-progress** — this PR is under active development. Feedback welcome on the overall direction.

## Summary

Introduce a **trajectory-first, trigger-driven training export system** that produces episode-level JSONL data from the OpenClaw runtime — no offline reconstruction, no separate pipeline. The system is **opt-in** (`trainingExport.enabled: true`) and writes to:

```
~/.openclaw/training-export/episodes.jsonl
```

Each line is a self-contained training sample: a **task episode** (full agent turn with system prompt, messages, tools, metadata) or a **compact-summary episode** (compression prompt → summary pair for RL compaction training).

## Relationship to Existing Systems

### `/export-trajectory` (human-facing debug bundles)

The existing `/export-trajectory` command (docs at `docs/tools/trajectory.md`) produces **redacted interactive support bundles** for human debugging — prompt timelines, tool traces, transcript snapshots, usage metadata. It is triggered manually by users or support staff.

The training export introduced here is **complementary and non-overlapping**:

| | `/export-trajectory` | Training Export |
|---|---|---|
| **Purpose** | Human debugging, support | Machine training data |
| **Trigger** | Manual command | Automatic (compaction, reset, export command) |
| **Output** | Redacted bundle directory | JSONL episodes |
| **Format** | Directory of text/markdown files | One JSON line per episode |
| **Privacy** | Redacted (best-effort) | Full content (machine-consumed; opt-in) |
| **Audience** | Developers, support | RL training pipelines |

Both systems **read from the same trajectory** (trajectory capture / `cache-trace`). Training export simply produces a different output format for a different consumer, alongside the existing mechanism.

### Compaction subsystem

Training export hooks into the Pi SDK compaction lifecycle (`session_before_compact` + `session_compact`) to capture:
- **Pre-compaction context** (task episode): the full conversation before compression
- **Post-compaction summary** (summary episode): the prompt sent to the summarization model + the summary it produced, with `compaction` metadata (`tokensBefore`, `firstKeptEntryId`, `fromExtension`)

This is the same data the compaction system already computes internally — training export just persists it in a structured training format before it is discarded.

## Key Design Decisions

### 1. Trajectory-first
All training fields (system prompt, messages, tools, model metadata) come from runtime trajectory `context.compiled` events. Message and tool conversion delegates to the Pi SDK / provider layer (`convertMessages` from `@mariozechner/pi-ai/openai-completions`).

### 2. Unified compaction hook
A single Pi SDK extension (`session_before_compact` + `session_compact`) handles **all** compaction modes (default, safeguard, manual, overflow, timeout). No `runTrainingExport` calls scattered across individual compaction paths.

### 3. Pair-export guarantee
For compaction-triggered exports, task and summary episodes are built as a batch. If either is filtered by quality checks, **the entire batch is discarded** — no orphaned episodes.

### 4. Config-gated at every call site
`getTrainingExportConfig(cfg)?.enabled === true` is checked at all three entry points (extension registration, session reset, trajectory export command), so reviewers can see the opt-in gating logic without digging into implementation details.

### 5. `compactionSummary` bridging
Pi SDK's `convertToLlm` converts `compactionSummary` → `user` messages, but the upstream `convertMessages` from `@mariozechner/pi-ai/openai-completions` does not handle the `compactionSummary` role. A pre-processing step (sharing a single map with thinking-block stripping) mirrors Pi SDK's conversion format before handing off to the upstream converter.

### 6. Training-quality message filtering (all triggers)
Training episodes must end with a complete `assistant` message — regardless of trigger type. Any snapshot (compaction, reset, or trajectory export) may end mid-turn at a non-`assistant` message (e.g. `toolResult`). Trailing non-assistant messages are trimmed from every trigger's output. The `trainExampleMessagesAreUsable` check requires ≥1 user + ≥1 assistant; if trimming leaves the episode unusable, it is discarded entirely. This is a universal training-data quality requirement, not a compaction-specific behavior.

### 7. Reset export is independent of plugin hooks
The `before_reset` training export call is placed **outside** `emitGatewayBeforeResetPluginHook`, so it fires regardless of whether any `before_reset` plugin hooks are registered.

### 8. Private file permissions
The export directory (`~/.openclaw/training-export`) and JSONL file are created with private filesystem modes (`0o700` / `0o600`) to prevent world-readable access to training data.

## Files Changed

| File | Change |
|------|--------|
| `src/training-export.ts` | **New** — core module: snapshot collection, episode construction, JSONL I/O, prompt constants, compaction extension |
| `src/training-export.test.ts` | **New** — test suite |
| `docs/training-export.md` | **New** — formal feature documentation |
| `src/config/types.openclaw.ts` | Add `trainingExport` config type (`enabled`, `compat`) |
| `src/config/zod-schema.ts` | Add `trainingExport` schema |
| `src/config/schema.help.ts` | Add field help text |
| `src/config/schema.labels.ts` | Add field labels |
| `src/agents/pi-embedded-runner/extensions.ts` | Register compaction extension (config-gated, opt-in) |
| `src/gateway/session-reset-service.ts` | `before_reset` trigger (config-gated, outside hook function) |
| `src/auto-reply/reply/commands-export-trajectory.ts` | `trajectory_export` trigger (config-gated, alongside existing command) |
| `src/agents/openai-transport-stream.ts` | Minor: export `convertResponsesMessages` for use in conversion pipeline |

## Configuration

```yaml
trainingExport:
  enabled: true            # default: false (opt-in)
  compat: {}               # optional ModelCompatConfig override for export path
```

When `enabled` is `false` (the default), the extension is not registered and `runTrainingExport` is never called — zero overhead.

## How to Test

1. Enable via `trainingExport.enabled: true`
2. Trigger a compaction in a session long enough to exceed the context threshold
3. Check `~/.openclaw/training-export/episodes.jsonl` — should contain paired task + summary episodes with `compaction` metadata
4. Reset a session — should produce a task episode
5. Run `/export-trajectory` — should produce a task episode via the training export path as well
6. Disable via `trainingExport.enabled: false` — episodes file should receive no new entries

## Open Questions for Review

1. **Default to opt-in (`enabled: false`)** — is this the right default, or should we consider a different approach?
2. **Privacy and retention policy** — the training export writes full (non-redacted) session content to disk. Should there be a retention/cleanup mechanism?
