### PR TITLE
fix(agent): detect CJK terminal continuation promises

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -30,9 +30,11 @@ import {
   resolveIncompleteTurnPayloadText,
   resolveReasoningOnlyRetryInstruction,
   STRICT_AGENTIC_BLOCKED_TEXT,
+  STRICT_AGENTIC_UNSAFE_CONTINUATION_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
   resolveSilentToolResultReplyPayload,
+  resolveUnsafeTerminalContinuationText,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
@@ -2215,5 +2217,91 @@ describe("resolvePlanningOnlyRetryInstruction single-action loophole", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it("retries Chinese planning-only continuation promises", () => {
+    const result = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt: "请确认当前问题核心在哪，然后继续修复并验证。",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptWithTools(
+        [],
+        "我下一步会直接拿这个控制循环去做真实验证，而不是继续停在聊天里。",
+      ),
+    });
+
+    expect(result).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it("retries Chinese continuation promises after one replay-safe read", () => {
+    const result = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt: "请看一下日志，然后继续验证。",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptWithTools(
+        ["read"],
+        "我已经看到了日志。接下来我会继续检查失败路径并跑验证。",
+      ),
+    });
+
+    expect(result).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it("does not retry completed Chinese result text", () => {
+    const result = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt: "请验证修复结果。",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptWithTools([], "已经完成验证，结果是通过。核心原因也已经确认。"),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("blocks Chinese continuation promises after a side-effecting tool", () => {
+    const attempt = makeAttemptWithTools(
+      ["edit"],
+      "我已经改了文档。下一步我会继续跑真实验证，而不是停在这里。",
+    );
+
+    expect(
+      resolvePlanningOnlyRetryInstruction({
+        ...openaiParams,
+        prompt: "请修复这个问题并验证。",
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveUnsafeTerminalContinuationText({
+        ...openaiParams,
+        prompt: "请修复这个问题并验证。",
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(STRICT_AGENTIC_UNSAFE_CONTINUATION_TEXT);
+  });
+
+  it("blocks the observed Chinese incident text after a side-effecting tool", () => {
+    const attempt = makeAttemptWithTools(
+      ["edit"],
+      "所以我现在不再解释原因。\n我下一步会直接拿这个控制循环去做真实验证，而不是继续停在聊天里。",
+    );
+
+    expect(
+      resolveUnsafeTerminalContinuationText({
+        ...openaiParams,
+        prompt: "不是把规则写上去，而是验证这套东西能不能真的让任务持续推进到完成。",
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(STRICT_AGENTIC_UNSAFE_CONTINUATION_TEXT);
   });
 });

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -2304,4 +2304,45 @@ describe("resolvePlanningOnlyRetryInstruction single-action loophole", () => {
       }),
     ).toBe(STRICT_AGENTIC_UNSAFE_CONTINUATION_TEXT);
   });
+
+  it("blocks a long Chinese unfinished test report that hands off obvious next work", () => {
+    const attempt = makeAttemptWithTools(
+      ["edit"],
+      [
+        "结果：**A 和 B 这次重测都没有完成。**",
+        "",
+        "证据，不是感觉：",
+        "",
+        "```json",
+        "{",
+        '  "task_id": "east-asia-visa-test",',
+        '  "all_exist": true,',
+        '  "all_delivered": false,',
+        '  "should_continue": false',
+        "}",
+        "```",
+        "",
+        "所以 A 不只是控制流没闭环，**内容本身也还是半成品**。",
+        "",
+        "## 下一步正确动作",
+        "现在不该再空聊“能不能完成”，而是二选一：",
+        "",
+        "1. **继续把 A 和 B 真正做完**",
+        "2. **把这次测试结果整理成验证报告，明确 CodeX 做到了什么、没做到什么**",
+        "",
+        "我的建议是 **1**，因为你要的是结果，不是再多一份评价文档。",
+      ].join("\n"),
+    );
+
+    expect(
+      resolveUnsafeTerminalContinuationText({
+        ...openaiParams,
+        prompt:
+          "请给我完整可行的方案，并给出测试的用例。最后执行完成过后，再跑一遍测试用例，看一下效果是否符合预期。",
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(STRICT_AGENTIC_UNSAFE_CONTINUATION_TEXT);
+  });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -149,6 +149,7 @@ import {
   resolvePlanningOnlyRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
   resolveSilentToolResultReplyPayload,
+  resolveUnsafeTerminalContinuationText,
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
@@ -2496,6 +2497,17 @@ export async function runEmbeddedPiAgent(
                 timedOut,
                 attempt,
               });
+          const unsafeTerminalContinuationText = emptyAssistantReplyIsSilent
+            ? null
+            : resolveUnsafeTerminalContinuationText({
+                provider,
+                modelId,
+                executionContract,
+                prompt: params.prompt,
+                aborted,
+                timedOut,
+                attempt,
+              });
           if (
             nextPlanningOnlyRetryInstruction &&
             planningOnlyRetryAttempts < maxPlanningOnlyRetryAttempts
@@ -2632,6 +2644,52 @@ export async function runEmbeddedPiAgent(
               payloads: [
                 {
                   text: STRICT_AGENTIC_BLOCKED_TEXT,
+                  isError: true,
+                },
+              ],
+              meta: {
+                durationMs: Date.now() - started,
+                agentMeta,
+                aborted,
+                systemPromptReport: attempt.systemPromptReport,
+                finalPromptText: attempt.finalPromptText,
+                finalAssistantVisibleText,
+                finalAssistantRawText,
+                replayInvalid,
+                livenessState,
+                toolSummary: attemptToolSummary,
+                ...(failureSignal ? { failureSignal } : {}),
+                agentHarnessResultClassification: attempt.agentHarnessResultClassification,
+              },
+              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+              messagingToolSentTexts: attempt.messagingToolSentTexts,
+              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+              messagingToolSentTargets: attempt.messagingToolSentTargets,
+              heartbeatToolResponse: attempt.heartbeatToolResponse,
+              successfulCronAdds: attempt.successfulCronAdds,
+            };
+          }
+          if (
+            !incompleteTurnText &&
+            !nextPlanningOnlyRetryInstruction &&
+            unsafeTerminalContinuationText &&
+            strictAgenticActive
+          ) {
+            log.warn(
+              `strict-agentic unsafe terminal continuation detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                `provider=${provider}/${modelId} configured=${configuredExecutionContract} — surfacing blocked state`,
+            );
+            const replayInvalid = resolveReplayInvalidForAttempt(unsafeTerminalContinuationText);
+            const livenessState: EmbeddedRunLivenessState = "blocked";
+            attempt.setTerminalLifecycleMeta?.({
+              replayInvalid,
+              livenessState,
+            });
+            return {
+              payloads: [
+                {
+                  text: unsafeTerminalContinuationText,
                   isError: true,
                 },
               ],

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -102,15 +102,23 @@ const PLANNING_ONLY_PROMISE_RE =
   /\b(?:i(?:'ll| will)|let me|i(?:'m| am)\s+going to|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will)|i can do that)\b/i;
 const PLANNING_ONLY_COMPLETION_RE =
   /\b(?:done|finished|implemented|updated|fixed|changed|ran|verified|found|here(?:'s| is) what|blocked by|the blocker is)\b/i;
+const CJK_PLANNING_ONLY_PROMISE_RE =
+  /(?:我(?:接下来|下一步|之后|随后|现在|会|将|要|准备|打算|继续|马上|直接)|(?:接下来|下一步|随后|之后|后面|然后|现在)(?:我)?|(?:不再|不会再)[^。！？\n]{0,60}(?:解释|停|停留)[^。！？\n]{0,80}(?:而是|直接|去|继续)|(?:继续|开始|马上|直接)(?:去|来|做|执行|验证|测试|查|看|处理|推进))/u;
+const CJK_PLANNING_ONLY_COMPLETION_RE =
+  /(?:已(?:经)?(?:完成|修复|验证|确认|处理)|完成了|修好了|验证(?:通过|完成)|结果是|结论是|原因是|阻塞(?:是|在于)|无法继续|不能继续|被阻塞)/u;
 const PLANNING_ONLY_HEADING_RE = /^(?:plan|steps?|next steps?)\s*:/i;
 const PLANNING_ONLY_BULLET_RE = /^(?:[-*•]\s+|\d+[.)]\s+)/u;
 const PLANNING_ONLY_MAX_VISIBLE_TEXT = 700;
 const PLANNING_ONLY_ACTION_VERB_RE =
   /\b(?:inspect|investigate|check|look(?:\s+into|\s+at)?|read|search|find|debug|fix|patch|update|change|edit|write|implement|run|test|verify|review|analy(?:s|z)e|summari(?:s|z)e|explain|answer|show|share|report|prepare|capture|take|refactor|restart|deploy|ship)\b/i;
+const CJK_PLANNING_ONLY_ACTION_VERB_RE =
+  /(?:查|查看|检查|确认|验证|测试|执行|跑|做|推进|处理|修复|修改|改|写|更新|分析|定位|排查|读取|搜索|查找|比较|复现|实现|编辑|提交|部署|看一下|跑一遍)/u;
 const SINGLE_ACTION_EXPLICIT_CONTINUATION_RE =
   /\b(?:going to|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will)|then[, ]+i(?:'ll| will)|i can do that next|let me (?!know\b)\w+(?:\s+\w+){0,3}\s+(?:next|then|first)\b)/i;
 const SINGLE_ACTION_MULTI_STEP_PROMISE_RE =
   /\bi(?:'ll| will)\b(?=[^.!?]{0,160}\b(?:next|then|after(?:wards)?|once)\b)/i;
+const CJK_SINGLE_ACTION_EXPLICIT_CONTINUATION_RE =
+  /(?:接下来|下一步|然后|随后|后面|现在)(?:我)?[^。！？\n]{0,80}(?:会|将|要|继续|去|来|开始|直接|马上)[^。！？\n]{0,100}(?:继续|查|查看|检查|确认|验证|测试|执行|跑|做|推进|处理|修复|修改|改|写|更新|分析|定位|排查|读取|搜索|查找|比较|复现|实现|编辑|提交|部署)|(?:不再|不会再)[^。！？\n]{0,60}(?:解释|停|停留)[^。！？\n]{0,80}(?:而是|直接|去|继续)[^。！？\n]{0,100}(?:查|验证|测试|执行|跑|做|推进|处理|分析)/u;
 const SINGLE_ACTION_RESULT_STYLE_RE =
   /\b(?:i(?:'ll| will)\s+(?:summarize|explain|share|show|report|describe|clarify|answer|recap)(?:\s+\w+){0,4}\s*:|(?:here(?:'s| is)|summary|result|answer|findings?|root cause)\s*:)/i;
 const SINGLE_ACTION_RETRY_SAFE_TOOL_NAMES = new Set([
@@ -177,11 +185,24 @@ const ACK_EXECUTION_NORMALIZED_SET = new Set([
   "해줘",
   "진행해",
   "계속해",
+  "继续",
+  "继续做",
+  "继续执行",
+  "开始",
+  "做吧",
+  "可以",
+  "好的",
+  "好",
+  "直接做",
+  "去做",
+  "修吧",
 ]);
 const ACTIONABLE_PROMPT_DIRECTIVE_RE =
   /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare)\b/i;
 const ACTIONABLE_PROMPT_REQUEST_RE =
   /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
+const CJK_ACTIONABLE_PROMPT_RE =
+  /(?:请|帮我|麻烦|能否|能不能|可以|你可以|你能|给我|需要你|确认|检查|查看|分析|修复|解决|执行|继续|测试|验证|实现|更新|写|改|跑|搜索|查找|总结|解释|告诉我|给出|连|看一下|跑一遍)/u;
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
@@ -193,6 +214,8 @@ export const ACK_EXECUTION_FAST_PATH_INSTRUCTION =
   "The latest user message is a short approval to proceed. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
 export const STRICT_AGENTIC_BLOCKED_TEXT =
   "Agent stopped after repeated plan-only turns without taking a concrete action. No concrete tool action or external side effect advanced the task.";
+export const STRICT_AGENTIC_UNSAFE_CONTINUATION_TEXT =
+  "Agent stopped after promising a next action without taking it. The last turn already produced side effects, so OpenClaw blocked the normal stop instead of replaying the action. Continue from the current state or inspect the last side effect before retrying.";
 
 export type PlanningOnlyPlanDetails = {
   explanation: string;
@@ -677,7 +700,11 @@ function isLikelyActionableUserPrompt(text: string): boolean {
   if (isLikelyExecutionAckPrompt(trimmed) || trimmed.includes("?")) {
     return true;
   }
-  return ACTIONABLE_PROMPT_DIRECTIVE_RE.test(trimmed) || ACTIONABLE_PROMPT_REQUEST_RE.test(trimmed);
+  return (
+    ACTIONABLE_PROMPT_DIRECTIVE_RE.test(trimmed) ||
+    ACTIONABLE_PROMPT_REQUEST_RE.test(trimmed) ||
+    CJK_ACTIONABLE_PROMPT_RE.test(trimmed)
+  );
 }
 
 export function resolveAckExecutionFastPathInstruction(params: {
@@ -724,9 +751,32 @@ function hasStructuredPlanningOnlyFormat(text: string): boolean {
     return false;
   }
   const bulletLineCount = lines.filter((line) => PLANNING_ONLY_BULLET_RE.test(line)).length;
-  const hasPlanningCueLine = lines.some((line) => PLANNING_ONLY_PROMISE_RE.test(line));
+  const hasPlanningCueLine = lines.some((line) => hasPlanningOnlyPromiseCue(line));
   const hasPlanningHeading = PLANNING_ONLY_HEADING_RE.test(lines[0] ?? "");
   return (hasPlanningHeading && hasPlanningCueLine) || (bulletLineCount >= 2 && hasPlanningCueLine);
+}
+
+function hasPlanningOnlyPromiseCue(text: string): boolean {
+  return PLANNING_ONLY_PROMISE_RE.test(text) || CJK_PLANNING_ONLY_PROMISE_RE.test(text);
+}
+
+function hasPlanningOnlyActionVerb(text: string): boolean {
+  return PLANNING_ONLY_ACTION_VERB_RE.test(text) || CJK_PLANNING_ONLY_ACTION_VERB_RE.test(text);
+}
+
+function hasPlanningOnlyCompletionCue(text: string): boolean {
+  return PLANNING_ONLY_COMPLETION_RE.test(text) || CJK_PLANNING_ONLY_COMPLETION_RE.test(text);
+}
+
+function isTerminalContinuationCommitmentText(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > 900 || trimmed.includes("```")) {
+    return false;
+  }
+  if (hasPlanningOnlyCompletionCue(trimmed)) {
+    return false;
+  }
+  return hasPlanningOnlyPromiseCue(trimmed) && hasPlanningOnlyActionVerb(trimmed);
 }
 
 export function extractPlanningOnlyPlanDetails(text: string): PlanningOnlyPlanDetails | null {
@@ -794,7 +844,8 @@ function isSingleActionThenNarrativePattern(params: {
   }
   return (
     SINGLE_ACTION_EXPLICIT_CONTINUATION_RE.test(text) ||
-    SINGLE_ACTION_MULTI_STEP_PROMISE_RE.test(text)
+    SINGLE_ACTION_MULTI_STEP_PROMISE_RE.test(text) ||
+    CJK_SINGLE_ACTION_EXPLICIT_CONTINUATION_RE.test(text)
   );
 }
 
@@ -854,18 +905,54 @@ export function resolvePlanningOnlyRetryInstruction(params: {
     return null;
   }
   const hasStructuredPlanningFormat = hasStructuredPlanningOnlyFormat(text);
-  if (!PLANNING_ONLY_PROMISE_RE.test(text) && !hasStructuredPlanningFormat) {
+  if (!hasPlanningOnlyPromiseCue(text) && !hasStructuredPlanningFormat) {
     return null;
   }
-  if (
-    !hasStructuredPlanningFormat &&
-    !singleActionNarrative &&
-    !PLANNING_ONLY_ACTION_VERB_RE.test(text)
-  ) {
+  if (!hasStructuredPlanningFormat && !singleActionNarrative && !hasPlanningOnlyActionVerb(text)) {
     return null;
   }
-  if (PLANNING_ONLY_COMPLETION_RE.test(text)) {
+  if (hasPlanningOnlyCompletionCue(text)) {
     return null;
   }
   return PLANNING_ONLY_RETRY_INSTRUCTION;
+}
+
+export function resolveUnsafeTerminalContinuationText(params: {
+  provider?: string;
+  modelId?: string;
+  executionContract?: string;
+  prompt?: string;
+  aborted: boolean;
+  timedOut: boolean;
+  attempt: PlanningOnlyAttempt;
+}): string | null {
+  if (
+    !shouldApplyPlanningOnlyRetryGuard({
+      provider: params.provider,
+      modelId: params.modelId,
+      executionContract: params.executionContract,
+    }) ||
+    (typeof params.prompt === "string" && !isLikelyActionableUserPrompt(params.prompt)) ||
+    params.aborted ||
+    params.timedOut ||
+    params.attempt.clientToolCalls ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.lastToolError ||
+    !resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects
+  ) {
+    return null;
+  }
+
+  const stopReason = params.attempt.lastAssistant?.stopReason;
+  if (stopReason && stopReason !== "stop") {
+    return null;
+  }
+
+  const text = (params.attempt.assistantTexts ?? []).join("\n\n").trim();
+  if (!isTerminalContinuationCommitmentText(text)) {
+    return null;
+  }
+
+  return STRICT_AGENTIC_UNSAFE_CONTINUATION_TEXT;
 }

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -109,6 +109,8 @@ const CJK_PLANNING_ONLY_COMPLETION_RE =
 const PLANNING_ONLY_HEADING_RE = /^(?:plan|steps?|next steps?)\s*:/i;
 const PLANNING_ONLY_BULLET_RE = /^(?:[-*•]\s+|\d+[.)]\s+)/u;
 const PLANNING_ONLY_MAX_VISIBLE_TEXT = 700;
+const TERMINAL_CONTINUATION_MAX_VISIBLE_TEXT = 900;
+const TERMINAL_UNFINISHED_HANDOFF_MAX_VISIBLE_TEXT = 4000;
 const PLANNING_ONLY_ACTION_VERB_RE =
   /\b(?:inspect|investigate|check|look(?:\s+into|\s+at)?|read|search|find|debug|fix|patch|update|change|edit|write|implement|run|test|verify|review|analy(?:s|z)e|summari(?:s|z)e|explain|answer|show|share|report|prepare|capture|take|refactor|restart|deploy|ship)\b/i;
 const CJK_PLANNING_ONLY_ACTION_VERB_RE =
@@ -203,6 +205,10 @@ const ACTIONABLE_PROMPT_REQUEST_RE =
   /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
 const CJK_ACTIONABLE_PROMPT_RE =
   /(?:请|帮我|麻烦|能否|能不能|可以|你可以|你能|给我|需要你|确认|检查|查看|分析|修复|解决|执行|继续|测试|验证|实现|更新|写|改|跑|搜索|查找|总结|解释|告诉我|给出|连|看一下|跑一遍)/u;
+const CJK_UNFINISHED_WORK_RE =
+  /(?:没有完成|没完成|未完成|还没(?:有)?(?:完成|做完|达标|落地|闭环)|不算(?:闭环)?完成|不能算(?:闭环)?完成|无法判定(?:为)?完成|仍(?:未|没)[^。！？\n]{0,80}(?:完成|做完|达标|核(?:实|死)|落地)|连产物都(?:还)?没(?:有)?落地)/u;
+const CJK_NEXT_ACTION_HANDOFF_RE =
+  /(?:下一步(?:正确)?动作|现在不该[^。！？\n]{0,120}而是|二选一|选一|我的建议是|建议是|继续把[^。！？\n]{0,120}(?:做完|补完|完成|跑完|推进|验证|落地)|把[^。！？\n]{0,120}(?:整理成|写成|补成|做成))/u;
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
@@ -768,15 +774,35 @@ function hasPlanningOnlyCompletionCue(text: string): boolean {
   return PLANNING_ONLY_COMPLETION_RE.test(text) || CJK_PLANNING_ONLY_COMPLETION_RE.test(text);
 }
 
+function stripMarkdownCodeFences(text: string): string {
+  return text.replace(/```[\s\S]*?```/g, " ");
+}
+
 function isTerminalContinuationCommitmentText(text: string): boolean {
   const trimmed = text.trim();
-  if (!trimmed || trimmed.length > 900 || trimmed.includes("```")) {
+  if (
+    !trimmed ||
+    trimmed.length > TERMINAL_CONTINUATION_MAX_VISIBLE_TEXT ||
+    trimmed.includes("```")
+  ) {
     return false;
   }
   if (hasPlanningOnlyCompletionCue(trimmed)) {
     return false;
   }
   return hasPlanningOnlyPromiseCue(trimmed) && hasPlanningOnlyActionVerb(trimmed);
+}
+
+function isTerminalUnfinishedWorkHandoffText(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > TERMINAL_UNFINISHED_HANDOFF_MAX_VISIBLE_TEXT) {
+    return false;
+  }
+  const prose = stripMarkdownCodeFences(trimmed).trim();
+  if (!prose) {
+    return false;
+  }
+  return CJK_UNFINISHED_WORK_RE.test(prose) && CJK_NEXT_ACTION_HANDOFF_RE.test(prose);
 }
 
 export function extractPlanningOnlyPlanDetails(text: string): PlanningOnlyPlanDetails | null {
@@ -950,7 +976,10 @@ export function resolveUnsafeTerminalContinuationText(params: {
   }
 
   const text = (params.attempt.assistantTexts ?? []).join("\n\n").trim();
-  if (!isTerminalContinuationCommitmentText(text)) {
+  if (
+    !isTerminalContinuationCommitmentText(text) &&
+    !isTerminalUnfinishedWorkHandoffText(text)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

This PR fixes terminal-turn holes in strict-agentic recovery for Chinese/CJK conversations.

Today the planning-only guard recognizes English future-action promises such as `I'll ...`, `next I'll ...`, and `let me ...`, but it does not recognize common Chinese continuation language such as:

- `我下一步会直接 ... 验证`
- `接下来我会继续检查 ...`
- `不再解释，而是继续 ...`

A second real failure shape is a longer Chinese test/report reply that says work is still unfinished, then hands off obvious next work as options instead of continuing, for example:

- `A 和 B 这次重测都没有完成`
- `下一步正确动作`
- `继续把 A 和 B 真正做完`
- `我的建议是 1`

In real conversations these can produce a confusing failure mode: the assistant says or implies it should continue, but the run exits with `stopReason: "stop"` and no following tool action. From the user's perspective, OpenClaw says “I should keep working” while the invocation is already over.

## What changed

- Add CJK continuation/action/completion/actionable-prompt detection to the planning-only retry classifier.
- Reuse the existing act-now retry path for replay-safe CJK plan-only turns.
- Extend the single-safe-tool loophole guard so `read`/`search` + Chinese “next I will continue” prose is retried instead of accepted as terminal output.
- Add a fail-closed terminal path for unsafe continuation promises after side effects. If a turn already performed side effects and then ends with “I will continue” instead of actually continuing, OpenClaw surfaces a blocked error instead of accepting the stop or replaying the side-effecting turn.
- Add a fail-closed terminal path for long Chinese unfinished-work handoff reports after side effects. If a turn says the requested validation/work is not complete and then presents obvious next work as choices or a recommendation, OpenClaw blocks the normal stop instead of treating the report as completed.

## Why fail closed after side effects

For replay-safe turns, retrying is fine. For turns that already edited files, ran mutating commands, sent messages, or created durable side effects, blindly replaying can duplicate work. The safer behavior is to mark the stop as blocked/incomplete and ask the caller to continue from the current state or inspect the last side effect before retrying.

## Real behavior proof

- **Behavior or issue addressed:** CJK terminal continuation promises and long CJK unfinished-work handoffs are no longer accepted as normal completed stops. Replay-safe CJK continuations retry; CJK continuations or unfinished-work handoffs after side effects fail closed as blocked instead of being treated as done.
- **Real environment tested:** Real cloud OpenClaw installation, redacted host details, OpenClaw `2026.4.15`, model `openai-codex/gpt-5.4`, gateway service restarted after applying the equivalent runtime patch to the installed runner bundle.
- **Exact steps or command run after fix:** Reproduced the original failure in a stored OpenClaw session log; verified the failing assistant message contained `我下一步会直接拿这个控制循环去做真实验证，而不是继续停在聊天里。`; verified that same assistant message ended with `stopReason: "stop"` and no following tool call; applied the equivalent runtime fix to the cloud installation; restarted `openclaw-gateway.service`; ran the CJK continuation classifier harness against the installed `pi-embedded-runner` bundle. After a follow-up user test exposed a second failure, reproduced the newer session message containing `A 和 B 这次重测都没有完成`, `下一步正确动作`, `继续把 A 和 B 真正做完`, and `我的建议是 1`; verified it also ended with `stopReason: "stop"`; added it as a regression case.
- **Evidence after fix:** Before fix, redacted real session evidence showed assistant text `我下一步会直接拿这个控制循环去做真实验证，而不是继续停在聊天里。`, `stopReason: "stop"`, previous event `toolResult` from an edit, and no following tool action. After fix, copied live output from the cloud OpenClaw host showed `systemctl --user is-active openclaw-gateway.service` returned `active`; the installed runner bundle passed the CJK continuation classifier harness. Follow-up local validation against the updated PR source showed the newer long report had a raw text length over the old limit, included a Markdown code fence, matched the new unfinished-work and next-action handoff detectors, and would now block by the new guard.
- **Observed result after fix:** The runtime no longer classifies the observed Chinese “I will continue” failure shape as a successful terminal completion. It retries when replay-safe and blocks when the previous attempt had side effects. The updated PR source also no longer accepts the observed long Chinese “A/B not complete, choose next action” handoff shape as a successful terminal completion after side effects.
- **What was not tested:** Full upstream CI was not run locally because this patch was prepared through the GitHub API after local `git clone` to GitHub failed with a TLS connection error. The PR CI is running the full repository checks.

## Tests

Added coverage for:

- Chinese actionable prompts being recognized.
- Chinese pure planning-only continuation promises retrying.
- Chinese continuation promises after one replay-safe `read` retrying.
- Completed Chinese result text not being misclassified as continuation.
- Chinese continuation promises after an `edit` being blocked instead of accepted as done.
- The observed incident shape: side effect followed by `我下一步会直接拿这个控制循环去做真实验证...`.
- The observed follow-up incident shape: long Chinese test report with code fences saying A/B are not complete, then handing off `继续把 A 和 B 真正做完` as a recommended next option.

Local targeted validation:

- Standalone classifier harness against `src/agents/pi-embedded-runner/run/incomplete-turn.ts`: all 6 existing CJK continuation cases passed.
- Follow-up source check against the real `e98ea300` failure text: matched unfinished-work detector, matched next-action handoff detector, and would block by the new guard.
- `npx --yes esbuild src/agents/pi-embedded-runner/run/incomplete-turn.ts --format=esm --platform=node --outfile=/tmp/openclaw-incomplete-turn-updated.js`
- `npx --yes esbuild src/agents/pi-embedded-runner/run.incomplete-turn.test.ts --format=esm --platform=node --outfile=/tmp/openclaw-incomplete-turn-test-updated.js`
