### PR TITLE
Memory/QMD: isolate mcporter sidecars per agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/agent: pass the session-key agent id into inline image attachment validation so the first image in a fresh per-agent session uses the agent's vision-capable model override instead of the text-only system default. Fixes #79407. Thanks @pandadev66.
 - Gateway/maintenance: prune dedupe overflow against a stable excess count and keep active agent retries from starting duplicate runs after cache eviction. (#73841) Thanks @thesomewhatyou.
 - Control UI/subagents: suppress internal `subagent_announce` handoff prompts from requester transcripts and hide legacy inter-session wrapper rows so completed subagent results no longer surface runtime context in WebChat history. (#79618) Thanks @joshavant.
+- Memory/QMD: isolate mcporter daemon configs per agent and tolerate mcporter daemon log lines before JSON responses, so multi-agent QMD recall can stay enabled without cross-agent state collisions.
 - Discord: preserve username target resolution for Discord outbound sends. (#79076) Thanks @vincentkoc.
 - Gateway/sessions: rotate generated transcript paths when gateway sessions reset, complementing the daily-rollover transcript persistence. (#79076) Thanks @vincentkoc.
 - Dependencies: pin the transitive `fast-uri` production dependency to `3.1.2` so the production dependency audit no longer resolves the vulnerable `<=3.1.1` range. Thanks @shakkernerd.

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -201,6 +201,10 @@ const spawnMock = mockedSpawn as unknown as Mock;
 const originalPath = process.env.PATH;
 const originalPathExt = process.env.PATHEXT;
 const originalWindowsPath = process.env.Path;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalQmdConfigDir = process.env.QMD_CONFIG_DIR;
+const originalMcporterConfig = process.env.MCPORTER_CONFIG;
 
 describe("QmdMemoryManager", () => {
   let fixtureRoot: string;
@@ -388,6 +392,26 @@ describe("QmdMemoryManager", () => {
       delete process.env.Path;
     } else {
       process.env.Path = originalWindowsPath;
+    }
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    if (originalXdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME;
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+    }
+    if (originalQmdConfigDir === undefined) {
+      delete process.env.QMD_CONFIG_DIR;
+    } else {
+      process.env.QMD_CONFIG_DIR = originalQmdConfigDir;
+    }
+    if (originalMcporterConfig === undefined) {
+      delete process.env.MCPORTER_CONFIG;
+    } else {
+      process.env.MCPORTER_CONFIG = originalMcporterConfig;
     }
     delete (globalThis as Record<PropertyKey, unknown>)[MCPORTER_STATE_KEY];
     delete (globalThis as Record<PropertyKey, unknown>)[QMD_EMBED_QUEUE_KEY];
@@ -2917,7 +2941,6 @@ describe("QmdMemoryManager", () => {
         },
       },
     } as OpenClawConfig;
-
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
@@ -2961,7 +2984,6 @@ describe("QmdMemoryManager", () => {
         },
       },
     } as OpenClawConfig;
-
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
@@ -3803,6 +3825,9 @@ describe("QmdMemoryManager", () => {
         },
       },
     } as OpenClawConfig;
+    const originalMcporterXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    const originalMcporterQmdConfigDir = process.env.QMD_CONFIG_DIR;
+    const originalMcporterXdgCacheHome = process.env.XDG_CACHE_HOME;
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -3823,9 +3848,11 @@ describe("QmdMemoryManager", () => {
     const searchCall = requireValue(mcporterCall, "mcporter search call missing");
     const spawnOpts = searchCall[2] as { env?: NodeJS.ProcessEnv } | undefined;
     const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
-    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
-    expect(spawnOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
-    expect(spawnOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toBe(originalMcporterXdgConfigHome);
+    expect(spawnOpts?.env?.QMD_CONFIG_DIR).toBe(originalMcporterQmdConfigDir);
+    expect(spawnOpts?.env?.XDG_CACHE_HOME).toBe(originalMcporterXdgCacheHome);
+    expect(normalizePath(spawnOpts?.env?.XDG_CONFIG_HOME)).not.toContain("/agents/main/qmd/");
+    expect(normalizePath(spawnOpts?.env?.XDG_CACHE_HOME)).not.toContain("/agents/main/qmd/");
     expect(spawnOpts?.env?.PATH?.split(path.delimiter)).toContain(path.dirname(process.execPath));
 
     const args = mcporterCall?.[1] as string[] | undefined;
@@ -3862,6 +3889,15 @@ describe("QmdMemoryManager", () => {
   });
 
   it("preserves a configured stdio mcporter server in the agent-scoped config", async () => {
+    const userXdgConfigHome = path.join(tmpRoot, "user-xdg-config");
+    const userXdgCacheHome = path.join(tmpRoot, "user-xdg-cache");
+    const userQmdConfigDir = path.join(tmpRoot, "user-qmd-config");
+    const userMcporterConfig = path.join(tmpRoot, "user-mcporter.json");
+    process.env.XDG_CONFIG_HOME = userXdgConfigHome;
+    process.env.XDG_CACHE_HOME = userXdgCacheHome;
+    process.env.QMD_CONFIG_DIR = userQmdConfigDir;
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
+
     cfg = {
       ...cfg,
       memory: {
@@ -3945,14 +3981,15 @@ describe("QmdMemoryManager", () => {
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "config",
     );
     const probeOpts = configProbe?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
-    expect(probeOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
-    expect(probeOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
-    expect(probeOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    expect(probeOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
+    expect(probeOpts?.env?.XDG_CACHE_HOME).toBe(userXdgCacheHome);
+    expect(probeOpts?.env?.QMD_CONFIG_DIR).toBe(userQmdConfigDir);
+    expect(probeOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
 
     await manager.close();
   });
 
-  it("adds keep-alive lifecycle when configured stdio mcporter JSON omits it", async () => {
+  it("does not invent lifecycle when configured stdio mcporter JSON omits it", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -4007,6 +4044,70 @@ describe("QmdMemoryManager", () => {
       >;
     };
 
+    expect(config.mcpServers?.["custom-qmd"]?.lifecycle).toBeUndefined();
+
+    await manager.close();
+  });
+
+  it("adds keep-alive lifecycle for configured stdio mcporter servers when starting the daemon", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "custom-qmd", startDaemon: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "custom-qmd",
+            source: "user",
+            command: "node",
+            args: ["/opt/qmd-wrapper.js", "mcp"],
+            env: { CUSTOM_KEEP: "1" },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "daemon") {
+        emitAndClose(child, "stdout", "");
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const configPath = args[args.indexOf("--config") + 1];
+    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
+      mcpServers?: Record<
+        string,
+        {
+          lifecycle?: { mode?: string; idleTimeoutMs?: number };
+        }
+      >;
+    };
+
     expect(config.mcpServers?.["custom-qmd"]?.lifecycle).toEqual({
       mode: "keep-alive",
       idleTimeoutMs: 300_000,
@@ -4015,7 +4116,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("preserves a configured remote mcporter server, including headers, without injecting QMD env", async () => {
+  it("preserves a configured remote mcporter server without auth material or QMD env", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -4040,7 +4141,6 @@ describe("QmdMemoryManager", () => {
             source: "user",
             transport: "http",
             baseUrl: "https://qmd.example.invalid/mcp",
-            headers: { "x-qmd": "remote" },
           }),
         );
         return child;
@@ -4075,8 +4175,113 @@ describe("QmdMemoryManager", () => {
     const remote = config.mcpServers?.["remote-qmd"];
     expect(remote?.transport).toBe("http");
     expect(remote?.baseUrl).toBe("https://qmd.example.invalid/mcp");
-    expect(remote?.headers).toEqual({ "x-qmd": "remote" });
+    expect(remote?.headers).toBeUndefined();
     expect(remote?.env).toBeUndefined();
+
+    await manager.close();
+  });
+
+  it("uses the original mcporter config for remote servers with auth material", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "remote-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "remote-qmd",
+            source: "user",
+            transport: "http",
+            baseUrl: "https://qmd.example.invalid/mcp",
+            bearer_token: "secret",
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
+
+    await manager.close();
+  });
+
+  it("uses the original mcporter config for remote URLs with embedded credentials", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "remote-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "remote-qmd",
+            source: "user",
+            transport: "http",
+            baseUrl: "https://user:pass@qmd.example.invalid/mcp",
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
 
     await manager.close();
   });

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3813,6 +3813,11 @@ describe("QmdMemoryManager", () => {
   });
 
   it("keeps manager-scoped QMD env in generated config but not mcporter commands", async () => {
+    process.env.XDG_CONFIG_HOME = path.join(tmpRoot, "user-xdg-config");
+    process.env.XDG_CACHE_HOME = path.join(tmpRoot, "user-xdg-cache");
+    process.env.QMD_CONFIG_DIR = path.join(tmpRoot, "user-qmd-config");
+    process.env.MCPORTER_CONFIG = path.join(tmpRoot, "user-mcporter.json");
+
     cfg = {
       ...cfg,
       memory: {
@@ -3825,9 +3830,6 @@ describe("QmdMemoryManager", () => {
         },
       },
     } as OpenClawConfig;
-    const originalMcporterXdgConfigHome = process.env.XDG_CONFIG_HOME;
-    const originalMcporterQmdConfigDir = process.env.QMD_CONFIG_DIR;
-    const originalMcporterXdgCacheHome = process.env.XDG_CACHE_HOME;
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
@@ -3848,11 +3850,10 @@ describe("QmdMemoryManager", () => {
     const searchCall = requireValue(mcporterCall, "mcporter search call missing");
     const spawnOpts = searchCall[2] as { env?: NodeJS.ProcessEnv } | undefined;
     const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
-    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toBe(originalMcporterXdgConfigHome);
-    expect(spawnOpts?.env?.QMD_CONFIG_DIR).toBe(originalMcporterQmdConfigDir);
-    expect(spawnOpts?.env?.XDG_CACHE_HOME).toBe(originalMcporterXdgCacheHome);
-    expect(normalizePath(spawnOpts?.env?.XDG_CONFIG_HOME)).not.toContain("/agents/main/qmd/");
-    expect(normalizePath(spawnOpts?.env?.XDG_CACHE_HOME)).not.toContain("/agents/main/qmd/");
+    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    expect(spawnOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(spawnOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    expect(spawnOpts?.env?.MCPORTER_CONFIG).toBeUndefined();
     expect(spawnOpts?.env?.PATH?.split(path.delimiter)).toContain(path.dirname(process.execPath));
 
     const args = mcporterCall?.[1] as string[] | undefined;
@@ -3982,8 +3983,8 @@ describe("QmdMemoryManager", () => {
     );
     const probeOpts = configProbe?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
     expect(probeOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
-    expect(probeOpts?.env?.XDG_CACHE_HOME).toBe(userXdgCacheHome);
-    expect(probeOpts?.env?.QMD_CONFIG_DIR).toBe(userQmdConfigDir);
+    expect(probeOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    expect(probeOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
     expect(probeOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
 
     await manager.close();
@@ -4050,6 +4051,11 @@ describe("QmdMemoryManager", () => {
   });
 
   it("adds keep-alive lifecycle for configured stdio mcporter servers when starting the daemon", async () => {
+    process.env.XDG_CONFIG_HOME = path.join(tmpRoot, "user-xdg-config");
+    process.env.XDG_CACHE_HOME = path.join(tmpRoot, "user-xdg-cache");
+    process.env.QMD_CONFIG_DIR = path.join(tmpRoot, "user-qmd-config");
+    process.env.MCPORTER_CONFIG = path.join(tmpRoot, "user-mcporter.json");
+
     cfg = {
       ...cfg,
       memory: {
@@ -4112,6 +4118,15 @@ describe("QmdMemoryManager", () => {
       mode: "keep-alive",
       idleTimeoutMs: 300_000,
     });
+
+    const daemonStart = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "daemon",
+    );
+    const daemonOpts = daemonStart?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(daemonOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    expect(daemonOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(daemonOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    expect(daemonOpts?.env?.MCPORTER_CONFIG).toBeUndefined();
 
     await manager.close();
   });
@@ -4182,6 +4197,15 @@ describe("QmdMemoryManager", () => {
   });
 
   it("uses the original mcporter config for remote servers with auth material", async () => {
+    const userXdgConfigHome = path.join(tmpRoot, "remote-user-xdg-config");
+    const userXdgCacheHome = path.join(tmpRoot, "remote-user-xdg-cache");
+    const userQmdConfigDir = path.join(tmpRoot, "remote-user-qmd-config");
+    const userMcporterConfig = path.join(tmpRoot, "remote-user-mcporter.json");
+    process.env.XDG_CONFIG_HOME = userXdgConfigHome;
+    process.env.XDG_CACHE_HOME = userXdgCacheHome;
+    process.env.QMD_CONFIG_DIR = userQmdConfigDir;
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
+
     cfg = {
       ...cfg,
       memory: {
@@ -4227,6 +4251,11 @@ describe("QmdMemoryManager", () => {
     );
     const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
     expect(args).not.toContain("--config");
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(callOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    expect(callOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(callOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
     await expect(
       fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
     ).rejects.toThrow();

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4037,6 +4037,70 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("generates agent-scoped config for absolute qmd stdio servers", async () => {
+    const absoluteQmdCommand = path.join(tmpRoot, "node", "v24.15.0", "bin", "qmd");
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "custom-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "custom-qmd",
+            source: "user",
+            command: absoluteQmdCommand,
+            args: ["mcp"],
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).toContain("--config");
+    const configPath = requireValue(args[args.indexOf("--config") + 1], "config path missing");
+    const config = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+      mcpServers?: Record<
+        string,
+        { command?: string; args?: string[]; env?: Record<string, string> }
+      >;
+    };
+    const generatedServer = config.mcpServers?.["custom-qmd"];
+    expect(generatedServer?.command).toBe(absoluteQmdCommand);
+    expect(generatedServer?.args).toEqual(["mcp"]);
+    expect(generatedServer?.env?.QMD_CONFIG_DIR?.replace(/\\/g, "/")).toContain(
+      "/agents/main/qmd/xdg-config/qmd",
+    );
+
+    await manager.close();
+  });
+
   it("starts configured stdio daemons with generated agent-scoped config", async () => {
     const userXdgConfigHome = path.join(tmpRoot, "stdio-user-xdg-config");
     const userXdgCacheHome = path.join(tmpRoot, "stdio-user-xdg-cache");

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3790,7 +3790,7 @@ describe("QmdMemoryManager", () => {
     });
   });
 
-  it("passes manager-scoped XDG env to mcporter commands", async () => {
+  it("keeps manager-scoped QMD env in generated config but not mcporter commands", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -3823,14 +3823,424 @@ describe("QmdMemoryManager", () => {
     const searchCall = requireValue(mcporterCall, "mcporter search call missing");
     const spawnOpts = searchCall[2] as { env?: NodeJS.ProcessEnv } | undefined;
     const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
-    expect(normalizePath(spawnOpts?.env?.XDG_CONFIG_HOME)).toContain("/agents/main/qmd/xdg-config");
-    expect(normalizePath(spawnOpts?.env?.QMD_CONFIG_DIR)).toContain(
-      "/agents/main/qmd/xdg-config/qmd",
-    );
-    expect(normalizePath(spawnOpts?.env?.XDG_CACHE_HOME)).toContain("/agents/main/qmd/xdg-cache");
+    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    expect(spawnOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(spawnOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
     expect(spawnOpts?.env?.PATH?.split(path.delimiter)).toContain(path.dirname(process.execPath));
 
+    const args = mcporterCall?.[1] as string[] | undefined;
+    const configPath = args?.[args.indexOf("--config") + 1];
+    expect(normalizePath(configPath)).toContain("/agents/main/qmd/mcporter/mcporter.json");
+    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
+      mcpServers?: Record<
+        string,
+        {
+          command?: string;
+          args?: string[];
+          env?: Record<string, string>;
+          lifecycle?: { mode?: string; idleTimeoutMs?: number };
+        }
+      >;
+    };
+    expect(config.mcpServers?.qmd?.command).toBe("qmd");
+    expect(config.mcpServers?.qmd?.args).toEqual(["mcp"]);
+    expect(normalizePath(config.mcpServers?.qmd?.env?.XDG_CONFIG_HOME)).toContain(
+      "/agents/main/qmd/xdg-config",
+    );
+    expect(normalizePath(config.mcpServers?.qmd?.env?.QMD_CONFIG_DIR)).toContain(
+      "/agents/main/qmd/xdg-config/qmd",
+    );
+    expect(normalizePath(config.mcpServers?.qmd?.env?.XDG_CACHE_HOME)).toContain(
+      "/agents/main/qmd/xdg-cache",
+    );
+    expect(config.mcpServers?.qmd?.lifecycle).toEqual({
+      mode: "keep-alive",
+      idleTimeoutMs: 300_000,
+    });
+
     await manager.close();
+  });
+
+  it("preserves a configured stdio mcporter server in the agent-scoped config", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "custom-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "custom-qmd",
+            source: "user",
+            command: "node",
+            args: ["/opt/qmd-wrapper.js", "mcp"],
+            cwd: "/opt/qmd",
+            env: { CUSTOM_KEEP: "1", XDG_CONFIG_HOME: "/user/qmd/config" },
+            lifecycle: { mode: "keep-alive", idleTimeoutMs: 123_000 },
+            allowedTools: ["query"],
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const configPath = args[args.indexOf("--config") + 1];
+    const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
+    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
+      imports?: unknown[];
+      mcpServers?: Record<
+        string,
+        {
+          name?: string;
+          source?: string;
+          command?: string;
+          args?: string[];
+          cwd?: string;
+          env?: Record<string, string>;
+          lifecycle?: { mode?: string; idleTimeoutMs?: number };
+          allowedTools?: string[];
+        }
+      >;
+    };
+    const custom = config.mcpServers?.["custom-qmd"];
+    expect(config.imports).toEqual([]);
+    expect(custom?.name).toBeUndefined();
+    expect(custom?.source).toBeUndefined();
+    expect(custom?.command).toBe("node");
+    expect(custom?.args).toEqual(["/opt/qmd-wrapper.js", "mcp"]);
+    expect(custom?.cwd).toBe("/opt/qmd");
+    expect(custom?.env?.CUSTOM_KEEP).toBe("1");
+    expect(normalizePath(custom?.env?.XDG_CONFIG_HOME)).toContain("/agents/main/qmd/xdg-config");
+    expect(normalizePath(custom?.env?.QMD_CONFIG_DIR)).toContain("/agents/main/qmd/xdg-config/qmd");
+    expect(normalizePath(custom?.env?.XDG_CACHE_HOME)).toContain("/agents/main/qmd/xdg-cache");
+    expect(custom?.lifecycle).toEqual({ mode: "keep-alive", idleTimeoutMs: 123_000 });
+    expect(custom?.allowedTools).toEqual(["query"]);
+
+    const configProbe = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "config",
+    );
+    const probeOpts = configProbe?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(probeOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    expect(probeOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(probeOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+
+    await manager.close();
+  });
+
+  it("adds keep-alive lifecycle when configured stdio mcporter JSON omits it", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "custom-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "custom-qmd",
+            source: "user",
+            command: "node",
+            args: ["/opt/qmd-wrapper.js", "mcp"],
+            env: { CUSTOM_KEEP: "1" },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const configPath = args[args.indexOf("--config") + 1];
+    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
+      mcpServers?: Record<
+        string,
+        {
+          lifecycle?: { mode?: string; idleTimeoutMs?: number };
+        }
+      >;
+    };
+
+    expect(config.mcpServers?.["custom-qmd"]?.lifecycle).toEqual({
+      mode: "keep-alive",
+      idleTimeoutMs: 300_000,
+    });
+
+    await manager.close();
+  });
+
+  it("preserves a configured remote mcporter server without injecting QMD env", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "remote-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "remote-qmd",
+            source: "user",
+            transport: "http",
+            baseUrl: "https://qmd.example.invalid/mcp",
+            headers: { "x-qmd": "remote" },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const configPath = args[args.indexOf("--config") + 1];
+    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
+      mcpServers?: Record<
+        string,
+        {
+          env?: Record<string, string>;
+          transport?: string;
+          baseUrl?: string;
+          headers?: Record<string, string>;
+        }
+      >;
+    };
+    const remote = config.mcpServers?.["remote-qmd"];
+    expect(remote?.transport).toBe("http");
+    expect(remote?.baseUrl).toBe("https://qmd.example.invalid/mcp");
+    expect(remote?.headers).toEqual({ "x-qmd": "remote" });
+    expect(remote?.env).toBeUndefined();
+
+    await manager.close();
+  });
+
+  it("parses mcporter JSON responses after daemon log lines", async () => {
+    const expectedDocId = "warm-doc";
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(
+          child,
+          "stdout",
+          `[mcporter] connected to warm daemon\n${JSON.stringify({
+            results: [
+              {
+                docid: expectedDocId,
+                collection: "workspace-main",
+                score: 0.7,
+                snippet: "warm hit",
+              },
+            ],
+          })}\n`,
+        );
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    const inner = manager as unknown as {
+      db: { prepare: (query: string) => { all: (arg: unknown) => unknown }; close: () => void };
+    };
+    inner.db = {
+      prepare: (_query: string) => ({
+        all: (arg: unknown) =>
+          typeof arg === "string" && arg.startsWith(expectedDocId)
+            ? [{ collection: "workspace-main", path: "notes.md" }]
+            : [],
+      }),
+      close: () => {},
+    };
+    const results = await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+    expect(results[0]?.snippet).toBe("warm hit");
+
+    await manager.close();
+  });
+
+  it("uses distinct mcporter configs and daemon starts for different agents", async () => {
+    cfg = {
+      ...cfg,
+      agents: {
+        ...cfg.agents,
+        list: [
+          { id: "hex", default: true, workspace: path.join(tmpRoot, "workspace-hex") },
+          { id: "trump", workspace: path.join(tmpRoot, "workspace-trump") },
+        ],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(path.join(tmpRoot, "workspace-hex"), { recursive: true });
+    await fs.mkdir(path.join(tmpRoot, "workspace-trump"), { recursive: true });
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "daemon") {
+        emitAndClose(child, "stdout", "");
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const resolvedHex = resolveMemoryBackendConfig({ cfg, agentId: "hex" });
+    const hex = trackManager(
+      await QmdMemoryManager.create({ cfg, agentId: "hex", resolved: resolvedHex, mode: "status" }),
+    );
+    const resolvedTrump = resolveMemoryBackendConfig({ cfg, agentId: "trump" });
+    const trump = trackManager(
+      await QmdMemoryManager.create({
+        cfg,
+        agentId: "trump",
+        resolved: resolvedTrump,
+        mode: "status",
+      }),
+    );
+    expect(hex).toBeTruthy();
+    expect(trump).toBeTruthy();
+    if (!hex || !trump) {
+      throw new Error("manager missing");
+    }
+
+    await hex.search("hello", { sessionKey: "agent:hex:slack:dm:u123" });
+    await trump.search("hello", { sessionKey: "agent:trump:slack:dm:u123" });
+
+    const mcporterCalls = spawnMock.mock.calls.filter((call: unknown[]) =>
+      isMcporterCommand(call[0]),
+    );
+    const configPaths = mcporterCalls
+      .map((call: unknown[]) => {
+        const args = call[1] as string[];
+        const configFlagIndex = args.indexOf("--config");
+        return configFlagIndex >= 0 ? args[configFlagIndex + 1] : undefined;
+      })
+      .filter((value): value is string => typeof value === "string");
+    expect(new Set(configPaths).size).toBe(2);
+    expect(
+      configPaths.some((value) => value.replace(/\\/g, "/").includes("/agents/hex/qmd/")),
+    ).toBe(true);
+    expect(
+      configPaths.some((value) => value.replace(/\\/g, "/").includes("/agents/trump/qmd/")),
+    ).toBe(true);
+
+    const daemonStarts = spawnMock.mock.calls.filter(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "daemon",
+    );
+    expect(daemonStarts).toHaveLength(2);
+
+    const hexConfigPath = configPaths.find((value) =>
+      value.replace(/\\/g, "/").includes("/agents/hex/qmd/"),
+    );
+    const trumpConfigPath = configPaths.find((value) =>
+      value.replace(/\\/g, "/").includes("/agents/trump/qmd/"),
+    );
+    const hexConfig = JSON.parse(await fs.readFile(hexConfigPath ?? "", "utf8")) as {
+      mcpServers?: { qmd?: { env?: Record<string, string> } };
+    };
+    const trumpConfig = JSON.parse(await fs.readFile(trumpConfigPath ?? "", "utf8")) as {
+      mcpServers?: { qmd?: { env?: Record<string, string> } };
+    };
+    expect(hexConfig.mcpServers?.qmd?.env?.QMD_CONFIG_DIR?.replace(/\\/g, "/")).toContain(
+      "/agents/hex/qmd/xdg-config/qmd",
+    );
+    expect(trumpConfig.mcpServers?.qmd?.env?.QMD_CONFIG_DIR?.replace(/\\/g, "/")).toContain(
+      "/agents/trump/qmd/xdg-config/qmd",
+    );
+
+    await hex.close();
+    await trump.close();
   });
 
   it("retries mcporter daemon start after a failure", async () => {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4015,7 +4015,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("preserves a configured remote mcporter server without injecting QMD env", async () => {
+  it("preserves a configured remote mcporter server, including headers, without injecting QMD env", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -4077,6 +4077,59 @@ describe("QmdMemoryManager", () => {
     expect(remote?.baseUrl).toBe("https://qmd.example.invalid/mcp");
     expect(remote?.headers).toEqual({ "x-qmd": "remote" });
     expect(remote?.env).toBeUndefined();
+
+    await manager.close();
+  });
+
+  it("does not rewrite unchanged generated mcporter config on repeated searches", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "daemon") {
+        emitAndClose(child, "stdout", "");
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("one", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    const configPath = requireValue(args[args.indexOf("--config") + 1], "config path missing");
+    const firstContents = await fs.readFile(configPath, "utf8");
+    const stableTimestamp = new Date("2026-01-02T03:04:05.123Z");
+    await fs.utimes(configPath, stableTimestamp, stableTimestamp);
+    const beforeSecondSearch = await fs.stat(configPath);
+
+    await manager.search("two", { sessionKey: "agent:main:slack:dm:u123" });
+
+    expect(await fs.readFile(configPath, "utf8")).toBe(firstContents);
+    expect((await fs.stat(configPath)).mtimeMs).toBe(beforeSecondSearch.mtimeMs);
+    const daemonStarts = spawnMock.mock.calls.filter(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "daemon",
+    );
+    expect(daemonStarts).toHaveLength(1);
 
     await manager.close();
   });

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4037,6 +4037,241 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("keeps configured stdio qmd with keep-alive lifecycle external", async () => {
+    const userMcporterConfig = path.join(tmpRoot, "stdio-lifecycle-user-mcporter.json");
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
+    await fs.writeFile(
+      userMcporterConfig,
+      JSON.stringify({
+        mcpServers: {
+          "custom-qmd": {
+            command: "qmd",
+            args: ["mcp"],
+            lifecycle: { mode: "keep-alive", idleTimeoutMs: 60_000 },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "custom-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "custom-qmd",
+            source: "user",
+            command: "qmd",
+            args: ["mcp"],
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+
+    await manager.close();
+  });
+
+  it("keeps configured stdio qmd with daemon logging external", async () => {
+    const userMcporterConfig = path.join(tmpRoot, "stdio-logging-user-mcporter.json");
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
+    await fs.writeFile(
+      userMcporterConfig,
+      JSON.stringify({
+        mcpServers: {
+          "custom-qmd": {
+            command: "qmd",
+            args: ["mcp"],
+            logging: { enabled: true, level: "info" },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "custom-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "custom-qmd",
+            source: "user",
+            command: "qmd",
+            args: ["mcp"],
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+
+    await manager.close();
+  });
+
+  it("tolerates warm-daemon log lines before JSON", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", '[info] daemon warm\n{"results": []}');
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    const results = await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+    expect(results).toEqual([]);
+
+    await manager.close();
+  });
+
+  it("does not misparse log lines containing { and [", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", 'log: {foo: [bar]}\n{"results": []}');
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    const results = await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+    expect(results).toEqual([]);
+
+    await manager.close();
+  });
+
+  it("parses JSON at end of multi-line prefix", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", 'line 1\nline 2\n{"results": []}');
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    // Should not throw despite the log prefix before the JSON body.
+    await expect(
+      manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toEqual([]);
+
+    await manager.close();
+  });
+
   it("generates agent-scoped config for absolute qmd stdio servers", async () => {
     const absoluteQmdCommand = path.join(tmpRoot, "node", "v24.15.0", "bin", "qmd");
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3889,7 +3889,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("preserves a configured stdio mcporter server without persisting user env", async () => {
+  it("uses the original mcporter config for configured stdio servers with env", async () => {
     const userXdgConfigHome = path.join(tmpRoot, "user-xdg-config");
     const userXdgCacheHome = path.join(tmpRoot, "user-xdg-cache");
     const userQmdConfigDir = path.join(tmpRoot, "user-qmd-config");
@@ -3946,49 +3946,27 @@ describe("QmdMemoryManager", () => {
 
     const { manager } = await createManager();
     await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+    await manager.search("again", { sessionKey: "agent:main:slack:dm:u123" });
 
     const mcporterCall = spawnMock.mock.calls.find(
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
     );
     const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
-    const configPath = args[args.indexOf("--config") + 1];
-    const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
-    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
-      imports?: unknown[];
-      mcpServers?: Record<
-        string,
-        {
-          name?: string;
-          source?: string;
-          command?: string;
-          args?: string[];
-          cwd?: string;
-          env?: Record<string, string>;
-          lifecycle?: { mode?: string; idleTimeoutMs?: number };
-          allowedTools?: string[];
-        }
-      >;
-    };
-    const custom = config.mcpServers?.["custom-qmd"];
-    expect(config.imports).toEqual([]);
-    expect(custom?.name).toBeUndefined();
-    expect(custom?.source).toBeUndefined();
-    expect(custom?.command).toBe("node");
-    expect(custom?.args).toEqual(["/opt/qmd-wrapper.js", "mcp"]);
-    expect(custom?.cwd).toBe("/opt/qmd");
-    expect(custom?.env?.CUSTOM_KEEP).toBeUndefined();
-    expect(custom?.env?.API_KEY).toBeUndefined();
-    expect(custom?.env?.TOKEN).toBeUndefined();
-    expect(normalizePath(custom?.env?.XDG_CONFIG_HOME)).toContain("/agents/main/qmd/xdg-config");
-    expect(normalizePath(custom?.env?.QMD_CONFIG_DIR)).toContain("/agents/main/qmd/xdg-config/qmd");
-    expect(normalizePath(custom?.env?.XDG_CACHE_HOME)).toContain("/agents/main/qmd/xdg-cache");
-    expect(custom?.lifecycle).toEqual({ mode: "keep-alive", idleTimeoutMs: 123_000 });
-    expect(custom?.allowedTools).toEqual(["query"]);
+    expect(args).not.toContain("--config");
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(callOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    expect(callOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(callOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
 
-    const configProbe = spawnMock.mock.calls.find(
+    const configProbes = spawnMock.mock.calls.filter(
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "config",
     );
-    const probeOpts = configProbe?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(configProbes).toHaveLength(1);
+    const probeOpts = configProbes[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
     expect(probeOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
     expect(probeOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
     expect(probeOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
@@ -4022,7 +4000,6 @@ describe("QmdMemoryManager", () => {
             source: "user",
             command: "node",
             args: ["/opt/qmd-wrapper.js", "mcp"],
-            env: { CUSTOM_KEEP: "1" },
           }),
         );
         return child;
@@ -4087,7 +4064,6 @@ describe("QmdMemoryManager", () => {
             source: "user",
             command: "node",
             args: ["/opt/qmd-wrapper.js", "mcp"],
-            env: { CUSTOM_KEEP: "1" },
           }),
         );
         return child;

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3975,7 +3975,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("does not invent lifecycle when configured stdio mcporter JSON omits it", async () => {
+  it("uses the original mcporter config for configured stdio servers without env", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -4019,26 +4019,23 @@ describe("QmdMemoryManager", () => {
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
     );
     const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
-    const configPath = args[args.indexOf("--config") + 1];
-    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
-      mcpServers?: Record<
-        string,
-        {
-          lifecycle?: { mode?: string; idleTimeoutMs?: number };
-        }
-      >;
-    };
-
-    expect(config.mcpServers?.["custom-qmd"]?.lifecycle).toBeUndefined();
+    expect(args).not.toContain("--config");
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
 
     await manager.close();
   });
 
-  it("adds keep-alive lifecycle for configured stdio mcporter servers when starting the daemon", async () => {
-    process.env.XDG_CONFIG_HOME = path.join(tmpRoot, "user-xdg-config");
-    process.env.XDG_CACHE_HOME = path.join(tmpRoot, "user-xdg-cache");
-    process.env.QMD_CONFIG_DIR = path.join(tmpRoot, "user-qmd-config");
-    process.env.MCPORTER_CONFIG = path.join(tmpRoot, "user-mcporter.json");
+  it("uses the original mcporter config for configured stdio daemon servers", async () => {
+    const userXdgConfigHome = path.join(tmpRoot, "stdio-user-xdg-config");
+    const userXdgCacheHome = path.join(tmpRoot, "stdio-user-xdg-cache");
+    const userQmdConfigDir = path.join(tmpRoot, "stdio-user-qmd-config");
+    const userMcporterConfig = path.join(tmpRoot, "stdio-user-mcporter.json");
+    process.env.XDG_CONFIG_HOME = userXdgConfigHome;
+    process.env.XDG_CACHE_HOME = userXdgCacheHome;
+    process.env.QMD_CONFIG_DIR = userQmdConfigDir;
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
 
     cfg = {
       ...cfg,
@@ -4087,29 +4084,19 @@ describe("QmdMemoryManager", () => {
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
     );
     const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
-    const configPath = args[args.indexOf("--config") + 1];
-    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
-      mcpServers?: Record<
-        string,
-        {
-          lifecycle?: { mode?: string; idleTimeoutMs?: number };
-        }
-      >;
-    };
-
-    expect(config.mcpServers?.["custom-qmd"]?.lifecycle).toEqual({
-      mode: "keep-alive",
-      idleTimeoutMs: 300_000,
-    });
+    expect(args).not.toContain("--config");
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
 
     const daemonStart = spawnMock.mock.calls.find(
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "daemon",
     );
     const daemonOpts = daemonStart?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
-    expect(daemonOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    expect(daemonOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
+    expect(daemonOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
     expect(daemonOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
     expect(daemonOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
-    expect(daemonOpts?.env?.MCPORTER_CONFIG).toBeUndefined();
 
     await manager.close();
   });
@@ -4139,6 +4126,7 @@ describe("QmdMemoryManager", () => {
             source: "user",
             transport: "http",
             baseUrl: "https://qmd.example.invalid/mcp",
+            headers: { accept: "application/json, text/event-stream" },
           }),
         );
         return child;
@@ -4173,7 +4161,7 @@ describe("QmdMemoryManager", () => {
     const remote = config.mcpServers?.["remote-qmd"];
     expect(remote?.transport).toBe("http");
     expect(remote?.baseUrl).toBe("https://qmd.example.invalid/mcp");
-    expect(remote?.headers).toBeUndefined();
+    expect(remote?.headers).toEqual({ accept: "application/json, text/event-stream" });
     expect(remote?.env).toBeUndefined();
 
     await manager.close();
@@ -4239,6 +4227,62 @@ describe("QmdMemoryManager", () => {
     expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
     expect(callOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
     expect(callOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
+
+    await manager.close();
+  });
+
+  it("uses the original mcporter config for remote servers with auth headers", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "remote-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "remote-qmd",
+            source: "user",
+            transport: "http",
+            baseUrl: "https://qmd.example.invalid/mcp",
+            headers: {
+              accept: "application/json, text/event-stream",
+              authorization: "Bearer secret",
+            },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
     await expect(
       fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
     ).rejects.toThrow();

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3952,8 +3952,8 @@ describe("QmdMemoryManager", () => {
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
     );
     const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
-    expect(args).not.toContain("--config");
     const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(args).not.toContain("--config");
     expect(callOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
     expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
     expect(callOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
@@ -3975,7 +3975,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("uses the original mcporter config for configured stdio servers without env", async () => {
+  it("generates agent-scoped config for configured stdio servers without original env", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -3998,8 +3998,8 @@ describe("QmdMemoryManager", () => {
           JSON.stringify({
             name: "custom-qmd",
             source: "user",
-            command: "node",
-            args: ["/opt/qmd-wrapper.js", "mcp"],
+            command: "qmd",
+            args: ["mcp"],
           }),
         );
         return child;
@@ -4019,15 +4019,25 @@ describe("QmdMemoryManager", () => {
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
     );
     const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
-    expect(args).not.toContain("--config");
-    await expect(
-      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
-    ).rejects.toThrow();
+    expect(args).toContain("--config");
+    const configPath = requireValue(args[args.indexOf("--config") + 1], "config path missing");
+    const config = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+      mcpServers?: Record<
+        string,
+        { command?: string; args?: string[]; env?: Record<string, string> }
+      >;
+    };
+    const generatedServer = config.mcpServers?.["custom-qmd"];
+    expect(generatedServer?.command).toBe("qmd");
+    expect(generatedServer?.args).toEqual(["mcp"]);
+    expect(generatedServer?.env?.QMD_CONFIG_DIR?.replace(/\\/g, "/")).toContain(
+      "/agents/main/qmd/xdg-config/qmd",
+    );
 
     await manager.close();
   });
 
-  it("uses the original mcporter config for configured stdio daemon servers", async () => {
+  it("starts configured stdio daemons with generated agent-scoped config", async () => {
     const userXdgConfigHome = path.join(tmpRoot, "stdio-user-xdg-config");
     const userXdgCacheHome = path.join(tmpRoot, "stdio-user-xdg-cache");
     const userQmdConfigDir = path.join(tmpRoot, "stdio-user-qmd-config");
@@ -4059,8 +4069,8 @@ describe("QmdMemoryManager", () => {
           JSON.stringify({
             name: "custom-qmd",
             source: "user",
-            command: "node",
-            args: ["/opt/qmd-wrapper.js", "mcp"],
+            command: "qmd",
+            args: ["mcp"],
           }),
         );
         return child;
@@ -4084,19 +4094,150 @@ describe("QmdMemoryManager", () => {
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
     );
     const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
-    expect(args).not.toContain("--config");
-    await expect(
-      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
-    ).rejects.toThrow();
+    expect(args).toContain("--config");
 
     const daemonStart = spawnMock.mock.calls.find(
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "daemon",
     );
+    const daemonArgs = (requireValue(daemonStart, "mcporter daemon start missing")[1] ?? []) as
+      | string[]
+      | undefined;
+    expect(daemonArgs).toContain("--config");
     const daemonOpts = daemonStart?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
-    expect(daemonOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
-    expect(daemonOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    expect(daemonOpts?.env?.XDG_CONFIG_HOME).toBeUndefined();
+    expect(daemonOpts?.env?.MCPORTER_CONFIG).toBeUndefined();
     expect(daemonOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
     expect(daemonOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+
+    await manager.close();
+  });
+
+  it("uses the original mcporter config for configured stdio servers with relative paths", async () => {
+    const userXdgConfigHome = path.join(tmpRoot, "stdio-relative-user-xdg-config");
+    const userXdgCacheHome = path.join(tmpRoot, "stdio-relative-user-xdg-cache");
+    const userQmdConfigDir = path.join(tmpRoot, "stdio-relative-user-qmd-config");
+    const userMcporterConfig = path.join(tmpRoot, "stdio-relative-user-mcporter.json");
+    process.env.XDG_CONFIG_HOME = userXdgConfigHome;
+    process.env.XDG_CACHE_HOME = userXdgCacheHome;
+    process.env.QMD_CONFIG_DIR = userQmdConfigDir;
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "custom-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "custom-qmd",
+            source: "user",
+            command: "node",
+            args: ["./mcp.js"],
+            cwd: "packages/qmd",
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+
+    await manager.close();
+  });
+
+  it("uses the original mcporter config for configured stdio servers with auth-like args", async () => {
+    const userXdgConfigHome = path.join(tmpRoot, "stdio-auth-user-xdg-config");
+    const userXdgCacheHome = path.join(tmpRoot, "stdio-auth-user-xdg-cache");
+    const userQmdConfigDir = path.join(tmpRoot, "stdio-auth-user-qmd-config");
+    const userMcporterConfig = path.join(tmpRoot, "stdio-auth-user-mcporter.json");
+    process.env.XDG_CONFIG_HOME = userXdgConfigHome;
+    process.env.XDG_CACHE_HOME = userXdgCacheHome;
+    process.env.QMD_CONFIG_DIR = userQmdConfigDir;
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "custom-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "custom-qmd",
+            source: "user",
+            command: "qmd",
+            args: ["--password", "secret", "mcp"],
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(callOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    expect(callOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(callOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
 
     await manager.close();
   });
@@ -4163,6 +4304,74 @@ describe("QmdMemoryManager", () => {
     expect(remote?.baseUrl).toBe("https://qmd.example.invalid/mcp");
     expect(remote?.headers).toEqual({ accept: "application/json, text/event-stream" });
     expect(remote?.env).toBeUndefined();
+
+    await manager.close();
+  });
+
+  it("uses the original mcporter config for remote servers with env material", async () => {
+    const userXdgConfigHome = path.join(tmpRoot, "remote-env-user-xdg-config");
+    const userXdgCacheHome = path.join(tmpRoot, "remote-env-user-xdg-cache");
+    const userQmdConfigDir = path.join(tmpRoot, "remote-env-user-qmd-config");
+    const userMcporterConfig = path.join(tmpRoot, "remote-env-user-mcporter.json");
+    process.env.XDG_CONFIG_HOME = userXdgConfigHome;
+    process.env.XDG_CACHE_HOME = userXdgCacheHome;
+    process.env.QMD_CONFIG_DIR = userQmdConfigDir;
+    process.env.MCPORTER_CONFIG = userMcporterConfig;
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "remote-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "remote-qmd",
+            source: "user",
+            transport: "http",
+            baseUrl: "https://qmd.example.invalid/mcp",
+            headers: { accept: "application/json, text/event-stream" },
+            env: { REMOTE_TOKEN: "secret" },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    const callOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(callOpts?.env?.XDG_CONFIG_HOME).toBe(userXdgConfigHome);
+    expect(callOpts?.env?.MCPORTER_CONFIG).toBe(userMcporterConfig);
+    expect(callOpts?.env?.QMD_CONFIG_DIR).toBeUndefined();
+    expect(callOpts?.env?.XDG_CACHE_HOME).toBeUndefined();
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
 
     await manager.close();
   });

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3889,7 +3889,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("preserves a configured stdio mcporter server in the agent-scoped config", async () => {
+  it("preserves a configured stdio mcporter server without persisting user env", async () => {
     const userXdgConfigHome = path.join(tmpRoot, "user-xdg-config");
     const userXdgCacheHome = path.join(tmpRoot, "user-xdg-cache");
     const userQmdConfigDir = path.join(tmpRoot, "user-qmd-config");
@@ -3924,7 +3924,12 @@ describe("QmdMemoryManager", () => {
             command: "node",
             args: ["/opt/qmd-wrapper.js", "mcp"],
             cwd: "/opt/qmd",
-            env: { CUSTOM_KEEP: "1", XDG_CONFIG_HOME: "/user/qmd/config" },
+            env: {
+              CUSTOM_KEEP: "1",
+              API_KEY: "secret",
+              TOKEN: "secret",
+              XDG_CONFIG_HOME: "/user/qmd/config",
+            },
             lifecycle: { mode: "keep-alive", idleTimeoutMs: 123_000 },
             allowedTools: ["query"],
           }),
@@ -3971,7 +3976,9 @@ describe("QmdMemoryManager", () => {
     expect(custom?.command).toBe("node");
     expect(custom?.args).toEqual(["/opt/qmd-wrapper.js", "mcp"]);
     expect(custom?.cwd).toBe("/opt/qmd");
-    expect(custom?.env?.CUSTOM_KEEP).toBe("1");
+    expect(custom?.env?.CUSTOM_KEEP).toBeUndefined();
+    expect(custom?.env?.API_KEY).toBeUndefined();
+    expect(custom?.env?.TOKEN).toBeUndefined();
     expect(normalizePath(custom?.env?.XDG_CONFIG_HOME)).toContain("/agents/main/qmd/xdg-config");
     expect(normalizePath(custom?.env?.QMD_CONFIG_DIR)).toContain("/agents/main/qmd/xdg-config/qmd");
     expect(normalizePath(custom?.env?.XDG_CACHE_HOME)).toContain("/agents/main/qmd/xdg-cache");

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4298,6 +4298,114 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("uses the original mcporter config for remote URLs with token query params", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "remote-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "remote-qmd",
+            source: "user",
+            transport: "http",
+            baseUrl: "https://qmd.example.invalid/mcp?access_token=secret",
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
+
+    await manager.close();
+  });
+
+  it("uses the original mcporter config for remote servers with refresh metadata", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "remote-qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "config") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            name: "remote-qmd",
+            source: "user",
+            transport: "http",
+            baseUrl: "https://qmd.example.invalid/mcp",
+            refresh: {
+              tokenEndpoint: "https://auth.example.invalid/token",
+              clientSecretEnv: "QMD_CLIENT_SECRET",
+            },
+          }),
+        );
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    const args = (requireValue(mcporterCall, "mcporter search call missing")[1] ?? []) as string[];
+    expect(args).not.toContain("--config");
+    await expect(
+      fs.stat(path.join(stateDir, "agents", "main", "qmd", "mcporter", "mcporter.json")),
+    ).rejects.toThrow();
+
+    await manager.close();
+  });
+
   it("does not rewrite unchanged generated mcporter config on repeated searches", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3218,7 +3218,198 @@ describe("QmdMemoryManager", () => {
     expect(normalizePath(spawnOpts?.env?.XDG_CACHE_HOME)).toContain("/agents/main/qmd/xdg-cache");
     expect(spawnOpts?.env?.PATH?.split(path.delimiter)).toContain(path.dirname(process.execPath));
 
+    const args = mcporterCall?.[1] as string[] | undefined;
+    const configPath = args?.[args.indexOf("--config") + 1];
+    expect(normalizePath(configPath)).toContain("/agents/main/qmd/mcporter/mcporter.json");
+    const config = JSON.parse(await fs.readFile(configPath ?? "", "utf8")) as {
+      mcpServers?: Record<
+        string,
+        {
+          command?: string;
+          args?: string[];
+          env?: Record<string, string>;
+          lifecycle?: { mode?: string; idleTimeoutMs?: number };
+        }
+      >;
+    };
+    expect(config.mcpServers?.qmd?.command).toBe("qmd");
+    expect(config.mcpServers?.qmd?.args).toEqual(["mcp"]);
+    expect(normalizePath(config.mcpServers?.qmd?.env?.XDG_CONFIG_HOME)).toContain(
+      "/agents/main/qmd/xdg-config",
+    );
+    expect(normalizePath(config.mcpServers?.qmd?.env?.QMD_CONFIG_DIR)).toContain(
+      "/agents/main/qmd/xdg-config/qmd",
+    );
+    expect(normalizePath(config.mcpServers?.qmd?.env?.XDG_CACHE_HOME)).toContain(
+      "/agents/main/qmd/xdg-cache",
+    );
+    expect(config.mcpServers?.qmd?.lifecycle).toEqual({
+      mode: "keep-alive",
+      idleTimeoutMs: 300_000,
+    });
+
     await manager.close();
+  });
+
+  it("parses mcporter JSON responses after daemon log lines", async () => {
+    const expectedDocId = "warm-doc";
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(
+          child,
+          "stdout",
+          `[mcporter] connected to warm daemon\n${JSON.stringify({
+            results: [
+              {
+                docid: expectedDocId,
+                collection: "workspace-main",
+                score: 0.7,
+                snippet: "warm hit",
+              },
+            ],
+          })}\n`,
+        );
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    const inner = manager as unknown as {
+      db: { prepare: (query: string) => { all: (arg: unknown) => unknown }; close: () => void };
+    };
+    inner.db = {
+      prepare: (_query: string) => ({
+        all: (arg: unknown) =>
+          typeof arg === "string" && arg.startsWith(expectedDocId)
+            ? [{ collection: "workspace-main", path: "notes.md" }]
+            : [],
+      }),
+      close: () => {},
+    };
+    const results = await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+    expect(results[0]?.snippet).toBe("warm hit");
+
+    await manager.close();
+  });
+
+  it("uses distinct mcporter configs and daemon starts for different agents", async () => {
+    cfg = {
+      ...cfg,
+      agents: {
+        ...cfg.agents,
+        list: [
+          { id: "hex", default: true, workspace: path.join(tmpRoot, "workspace-hex") },
+          { id: "trump", workspace: path.join(tmpRoot, "workspace-trump") },
+        ],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(path.join(tmpRoot, "workspace-hex"), { recursive: true });
+    await fs.mkdir(path.join(tmpRoot, "workspace-trump"), { recursive: true });
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "daemon") {
+        emitAndClose(child, "stdout", "");
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const resolvedHex = resolveMemoryBackendConfig({ cfg, agentId: "hex" });
+    const hex = trackManager(
+      await QmdMemoryManager.create({ cfg, agentId: "hex", resolved: resolvedHex, mode: "status" }),
+    );
+    const resolvedTrump = resolveMemoryBackendConfig({ cfg, agentId: "trump" });
+    const trump = trackManager(
+      await QmdMemoryManager.create({
+        cfg,
+        agentId: "trump",
+        resolved: resolvedTrump,
+        mode: "status",
+      }),
+    );
+    expect(hex).toBeTruthy();
+    expect(trump).toBeTruthy();
+    if (!hex || !trump) {
+      throw new Error("manager missing");
+    }
+
+    await hex.search("hello", { sessionKey: "agent:hex:slack:dm:u123" });
+    await trump.search("hello", { sessionKey: "agent:trump:slack:dm:u123" });
+
+    const mcporterCalls = spawnMock.mock.calls.filter((call: unknown[]) =>
+      isMcporterCommand(call[0]),
+    );
+    const configPaths = mcporterCalls
+      .map((call: unknown[]) => {
+        const args = call[1] as string[];
+        return args[args.indexOf("--config") + 1];
+      })
+      .filter((value): value is string => typeof value === "string");
+    expect(new Set(configPaths).size).toBe(2);
+    expect(
+      configPaths.some((value) => value.replace(/\\/g, "/").includes("/agents/hex/qmd/")),
+    ).toBe(true);
+    expect(
+      configPaths.some((value) => value.replace(/\\/g, "/").includes("/agents/trump/qmd/")),
+    ).toBe(true);
+
+    const daemonStarts = spawnMock.mock.calls.filter(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "daemon",
+    );
+    expect(daemonStarts).toHaveLength(2);
+
+    const hexConfigPath = configPaths.find((value) =>
+      value.replace(/\\/g, "/").includes("/agents/hex/qmd/"),
+    );
+    const trumpConfigPath = configPaths.find((value) =>
+      value.replace(/\\/g, "/").includes("/agents/trump/qmd/"),
+    );
+    const hexConfig = JSON.parse(await fs.readFile(hexConfigPath ?? "", "utf8")) as {
+      mcpServers?: { qmd?: { env?: Record<string, string> } };
+    };
+    const trumpConfig = JSON.parse(await fs.readFile(trumpConfigPath ?? "", "utf8")) as {
+      mcpServers?: { qmd?: { env?: Record<string, string> } };
+    };
+    expect(hexConfig.mcpServers?.qmd?.env?.QMD_CONFIG_DIR?.replace(/\\/g, "/")).toContain(
+      "/agents/hex/qmd/xdg-config/qmd",
+    );
+    expect(trumpConfig.mcpServers?.qmd?.env?.QMD_CONFIG_DIR?.replace(/\\/g, "/")).toContain(
+      "/agents/trump/qmd/xdg-config/qmd",
+    );
+
+    await hex.close();
+    await trump.close();
   });
 
   it("retries mcporter daemon start after a failure", async () => {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -237,11 +237,46 @@ function hasMcporterRemoteAuthMaterial(server: Record<string, unknown>): boolean
     return true;
   }
   return Object.entries(server).some(([key, value]) => {
+    if (normalizeMcporterConfigKey(key) === "env") {
+      return true;
+    }
     if (normalizeMcporterConfigKey(key) === "headers") {
       return hasMcporterHeaderAuthMaterial(value);
     }
     return isMcporterAuthLikeKey(key);
   });
+}
+
+function hasMcporterStdioUserOwnedMaterial(server: Record<string, unknown>): boolean {
+  return Object.entries(server).some(([key, value]) => {
+    const normalizedKey = normalizeMcporterConfigKey(key);
+    if (normalizedKey === "env") {
+      return true;
+    }
+    if (normalizedKey === "command") {
+      return hasMcporterAuthLikeText(value);
+    }
+    if (normalizedKey === "args") {
+      return hasMcporterAuthLikeArgs(value);
+    }
+    return isMcporterAuthLikeKey(key);
+  });
+}
+
+function isGeneratedMcporterQmdStdioServer(server: Record<string, unknown>): boolean {
+  if (normalizeMcporterConfigKey(String(server.command)) !== "qmd") {
+    return false;
+  }
+  const args = server.args;
+  return Array.isArray(args) && args.length === 1 && args[0] === "mcp";
+}
+
+function hasMcporterAuthLikeArgs(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => hasMcporterAuthLikeText(entry));
+}
+
+function hasMcporterAuthLikeText(value: unknown): boolean {
+  return typeof value === "string" && isMcporterAuthLikeKey(value);
 }
 
 function hasMcporterRemoteUrlCredentials(server: Record<string, unknown>): boolean {
@@ -2437,7 +2472,10 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
 
     if (typeof server.command === "string" && server.command.length > 0) {
-      return { mode: "external" };
+      if (!isGeneratedMcporterQmdStdioServer(server) || hasMcporterStdioUserOwnedMaterial(server)) {
+        return { mode: "external" };
+      }
+      return { mode: "generated", server: this.toGeneratedMcporterStdioServer(server) };
     }
 
     const hasRemoteEndpoint =
@@ -2455,6 +2493,13 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
 
     return null;
+  }
+
+  private toGeneratedMcporterStdioServer(server: Record<string, unknown>): Record<string, unknown> {
+    return {
+      ...server,
+      env: this.buildMcporterQmdEnv(),
+    };
   }
 
   private buildMcporterQmdEnv(): Record<string, string> {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -139,6 +139,7 @@ type McporterState = {
 };
 
 type McporterConfigMode = "generated" | "external";
+type McporterEnvMode = "discovery" | McporterConfigMode;
 
 type ConfiguredMcporterServer =
   | { mode: "generated"; server: Record<string, unknown> }
@@ -2268,6 +2269,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       daemonStart = (async () => {
         try {
           await this.runMcporterCommand(["daemon", "start"], {
+            envMode: configMode,
             includeGeneratedConfig: configMode === "generated",
             timeoutMs: 10_000,
           });
@@ -2326,6 +2328,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     let result: { stdout: string; stderr: string };
     try {
       result = await this.runMcporterCommand(["config", "get", serverName, "--json"], {
+        envMode: "discovery",
         includeGeneratedConfig: false,
         timeoutMs: 5_000,
       });
@@ -2432,8 +2435,15 @@ export class QmdMemoryManager implements MemorySearchManager {
     return env;
   }
 
-  private buildMcporterProcessEnv(): NodeJS.ProcessEnv {
-    return { ...this.mcporterEnv };
+  private buildMcporterProcessEnv(mode: McporterEnvMode): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...this.mcporterEnv };
+    delete env.QMD_CONFIG_DIR;
+    delete env.XDG_CACHE_HOME;
+    if (mode === "generated") {
+      delete env.XDG_CONFIG_HOME;
+      delete env.MCPORTER_CONFIG;
+    }
+    return env;
   }
 
   private mcporterDaemonKey(configMode: McporterConfigMode): string {
@@ -2451,13 +2461,17 @@ export class QmdMemoryManager implements MemorySearchManager {
 
   private async runMcporterCommand(
     args: string[],
-    opts?: { includeGeneratedConfig?: boolean; timeoutMs?: number },
+    opts?: {
+      envMode?: McporterEnvMode;
+      includeGeneratedConfig?: boolean;
+      timeoutMs?: number;
+    },
   ): Promise<{ stdout: string; stderr: string }> {
     const mcporterArgs =
       opts?.includeGeneratedConfig === false
         ? args
         : [...args, "--config", this.mcporterConfigPath];
-    const env = this.buildMcporterProcessEnv();
+    const env = this.buildMcporterProcessEnv(opts?.envMode ?? "generated");
     const spawnInvocation = resolveCliSpawnInvocation({
       command: "mcporter",
       args: mcporterArgs,
@@ -2481,6 +2495,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     const configMode = await this.ensureMcporterConfig();
     return await this.runMcporterCommand(args, {
       ...opts,
+      envMode: configMode,
       includeGeneratedConfig: configMode === "generated",
     });
   }

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -145,6 +145,11 @@ type ConfiguredMcporterServer =
   | { mode: "generated"; server: Record<string, unknown> }
   | { mode: "external" };
 
+type RawMcporterEntry = {
+  lifecycle?: unknown;
+  logging?: unknown;
+};
+
 const MCPORTER_REMOTE_AUTH_KEYS = new Set(
   [
     "auth",
@@ -372,6 +377,92 @@ function extractFirstJsonValue(raw: string): JsonExtractionResult {
     }
   }
   return { found: false };
+}
+
+function expandMcporterHome(input: string): string {
+  if (!input.startsWith("~")) {
+    return input;
+  }
+  const home = os.homedir();
+  if (input === "~") {
+    return home;
+  }
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return path.join(home, input.slice(2));
+  }
+  return input;
+}
+
+function resolveMcporterConfigCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates: string[] = [];
+  const explicitConfig = env.MCPORTER_CONFIG;
+  if (explicitConfig && explicitConfig.trim().length > 0) {
+    candidates.push(path.resolve(expandMcporterHome(explicitConfig.trim())));
+  }
+
+  const xdgConfigHome = env.XDG_CONFIG_HOME;
+  let baseDir: string;
+  if (xdgConfigHome && xdgConfigHome.trim().length > 0) {
+    const resolved = expandMcporterHome(xdgConfigHome.trim());
+    if (path.isAbsolute(resolved)) {
+      baseDir = path.join(resolved, "mcporter");
+    } else {
+      baseDir = path.join(os.homedir(), ".mcporter");
+    }
+  } else {
+    baseDir = path.join(os.homedir(), ".mcporter");
+  }
+  candidates.push(path.join(baseDir, "mcporter.json"));
+  candidates.push(path.join(baseDir, "mcporter.jsonc"));
+  return candidates;
+}
+
+async function readRawMcporterEntry(
+  serverName: string,
+  env: NodeJS.ProcessEnv,
+): Promise<RawMcporterEntry | null> {
+  for (const candidate of resolveMcporterConfigCandidates(env)) {
+    let text: string;
+    try {
+      text = await fs.readFile(candidate, "utf8");
+    } catch (err) {
+      if (isFileMissingError(err)) {
+        continue;
+      }
+      throw err;
+    }
+    // Strip trailing commas and comments for JSONC files; mcporter accepts
+    // both JSON and JSONC. A minimal cleanup is enough for our read-only
+    // lifecycle/logging probe.
+    const cleaned = candidate.endsWith(".jsonc")
+      ? text
+          .replace(/\/\*[\s\S]*?\*\//g, "")
+          .replace(/\/\/.*$/gm, "")
+          .replace(/,(\s*[}\]])/g, "$1")
+      : text;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(cleaned) as unknown;
+    } catch {
+      continue;
+    }
+    const record = asRecord(parsed);
+    const servers = record ? asRecord(record.mcpServers) : null;
+    const entry = servers ? asRecord(servers[serverName]) : null;
+    if (entry) {
+      return entry as RawMcporterEntry;
+    }
+  }
+  return null;
+}
+
+function hasMcporterStdioLifecycleOrLogging(server: RawMcporterEntry): boolean {
+  return (
+    server.lifecycle !== undefined ||
+    (typeof server.logging === "object" &&
+      server.logging !== null &&
+      (server.logging as Record<string, unknown>).enabled === true)
+  );
 }
 
 function getQmdEmbedQueueState(): QmdEmbedQueueState {
@@ -2459,7 +2550,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       throw new Error(`mcporter server "${serverName}" returned an invalid JSON definition`);
     }
 
-    const server = this.toMcporterRawServerEntry(serialized);
+    const rawEntry = await readRawMcporterEntry(serverName, this.mcporterEnv);
+    const server = this.toMcporterRawServerEntry(serialized, rawEntry);
     if (!server) {
       if (serverName === "qmd") {
         return null;
@@ -2471,6 +2563,7 @@ export class QmdMemoryManager implements MemorySearchManager {
 
   private toMcporterRawServerEntry(
     serialized: Record<string, unknown>,
+    rawEntry: RawMcporterEntry | null,
   ): ConfiguredMcporterServer | null {
     const server: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(serialized)) {
@@ -2481,7 +2574,11 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
 
     if (typeof server.command === "string" && server.command.length > 0) {
-      if (!isGeneratedMcporterQmdStdioServer(server) || hasMcporterStdioUserOwnedMaterial(server)) {
+      if (
+        !isGeneratedMcporterQmdStdioServer(server) ||
+        hasMcporterStdioUserOwnedMaterial(server) ||
+        (rawEntry !== null && hasMcporterStdioLifecycleOrLogging(rawEntry))
+      ) {
         return { mode: "external" };
       }
       return { mode: "generated", server: this.toGeneratedMcporterStdioServer(server) };
@@ -2495,7 +2592,10 @@ export class QmdMemoryManager implements MemorySearchManager {
       // The generated per-agent config is persisted under OpenClaw state. Do not
       // copy remote auth material from a user's mcporter config into that file;
       // keep using the original mcporter config for authenticated remotes.
-      if (hasMcporterRemoteAuthMaterial(server)) {
+      if (
+        hasMcporterRemoteAuthMaterial(server) ||
+        (rawEntry !== null && hasMcporterStdioLifecycleOrLogging(rawEntry))
+      ) {
         return { mode: "external" };
       }
       return { mode: "generated", server };

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -276,7 +276,7 @@ function isQmdExecutableCommand(command: unknown): boolean {
     return false;
   }
   const normalized = command.replace(/\\/g, "/");
-  const commandName = normalized.split("/").filter(Boolean).at(-1) ?? normalized;
+  const commandName = normalized.split("/").findLast(Boolean) ?? normalized;
   return normalizeMcporterConfigKey(commandName) === "qmd";
 }
 

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -517,6 +517,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private vectorStatusDetail: string | null = null;
   private attemptedNullByteCollectionRepair = false;
   private attemptedDuplicateDocumentRepair = false;
+  private mcporterConfigMode: Promise<McporterConfigMode> | null = null;
   private readonly sessionWarm = new Set<string>();
   private collectionPatternFlag: QmdCollectionPatternFlag | null = "--mask";
   private multiCollectionFilterSupported: boolean | null = null;
@@ -2285,6 +2286,16 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private async ensureMcporterConfig(): Promise<McporterConfigMode> {
+    if (!this.mcporterConfigMode) {
+      this.mcporterConfigMode = this.resolveMcporterConfigMode().catch((err: unknown) => {
+        this.mcporterConfigMode = null;
+        throw err;
+      });
+    }
+    return await this.mcporterConfigMode;
+  }
+
+  private async resolveMcporterConfigMode(): Promise<McporterConfigMode> {
     await fs.mkdir(path.dirname(this.mcporterConfigPath), { recursive: true });
     const configured = await this.resolveConfiguredMcporterServer();
     if (configured?.mode === "external") {
@@ -2383,6 +2394,9 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
 
     if (typeof server.command === "string" && server.command.length > 0) {
+      if (server.env !== undefined) {
+        return { mode: "external" };
+      }
       server.env = this.buildMcporterQmdEnv();
       // startDaemon=true depends on mcporter treating the configured stdio
       // server as daemon-warm; without lifecycle, mcporter keeps it ephemeral.

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -135,7 +135,7 @@ function buildQmdProcessPath(rawPath: string | undefined): string {
 
 type McporterState = {
   coldStartWarned: boolean;
-  daemonStart: Promise<void> | null;
+  daemonStarts: Map<string, Promise<void>>;
 };
 
 function normalizePositiveInteger(value: number | undefined, fallback: number): number {
@@ -152,11 +152,74 @@ type QmdUpdateQueueState = {
   tails: Map<string, Promise<void>>;
 };
 
+type JsonExtractionResult = { found: true; value: unknown } | { found: false };
+
 function getMcporterState(): McporterState {
   return resolveGlobalSingleton<McporterState>(MCPORTER_STATE_KEY, () => ({
     coldStartWarned: false,
-    daemonStart: null,
+    daemonStarts: new Map(),
   }));
+}
+
+function parseMcporterResponseJson(stdout: string): unknown {
+  const trimmed = stdout.trim();
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch (err) {
+    const payload = extractFirstJsonValue(trimmed);
+    if (payload.found) {
+      return payload.value;
+    }
+    throw err;
+  }
+}
+
+function extractFirstJsonValue(raw: string): JsonExtractionResult {
+  for (let start = 0; start < raw.length; start += 1) {
+    const opening = raw[start];
+    if (opening !== "{" && opening !== "[") {
+      continue;
+    }
+    const closing = opening === "{" ? "}" : "]";
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = start; index < raw.length; index += 1) {
+      const char = raw[index];
+      if (char === undefined) {
+        break;
+      }
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (char === "\\") {
+          escaped = true;
+        } else if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
+      if (char === opening) {
+        depth += 1;
+      } else if (char === closing) {
+        depth -= 1;
+        if (depth === 0) {
+          try {
+            return { found: true, value: JSON.parse(raw.slice(start, index + 1)) as unknown };
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return { found: false };
 }
 
 function getQmdEmbedQueueState(): QmdEmbedQueueState {
@@ -346,6 +409,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private readonly xdgConfigHome: string;
   private readonly xdgCacheHome: string;
   private readonly indexPath: string;
+  private readonly mcporterConfigPath: string;
   private readonly env: NodeJS.ProcessEnv;
   private readonly syncSettings: ReturnType<typeof resolveMemorySearchSyncConfig>;
   private readonly managedCollectionNames: string[];
@@ -411,6 +475,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     this.xdgConfigHome = path.join(this.qmdDir, "xdg-config");
     this.xdgCacheHome = path.join(this.qmdDir, "xdg-cache");
     this.indexPath = path.join(this.xdgCacheHome, "qmd", "index.sqlite");
+    this.mcporterConfigPath = path.join(this.qmdDir, "mcporter", "mcporter.json");
 
     this.env = {
       ...process.env,
@@ -2116,6 +2181,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!mcporter.enabled) {
       return;
     }
+    await this.ensureMcporterConfig();
     const state = getMcporterState();
     if (!mcporter.startDaemon) {
       if (!state.coldStartWarned) {
@@ -2126,39 +2192,187 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       return;
     }
-    if (!state.daemonStart) {
-      state.daemonStart = (async () => {
+    const daemonKey = this.mcporterConfigPath;
+    let daemonStart = state.daemonStarts.get(daemonKey);
+    if (!daemonStart) {
+      daemonStart = (async () => {
         try {
           await this.runMcporter(["daemon", "start"], { timeoutMs: 10_000 });
         } catch (err) {
           log.warn(`mcporter daemon start failed: ${String(err)}`);
           // Allow future searches to retry daemon start on transient failures.
-          state.daemonStart = null;
+          state.daemonStarts.delete(daemonKey);
         }
       })();
+      state.daemonStarts.set(daemonKey, daemonStart);
     }
-    await state.daemonStart;
+    await daemonStart;
+  }
+
+  private async ensureMcporterConfig(): Promise<void> {
+    await fs.mkdir(path.dirname(this.mcporterConfigPath), { recursive: true });
+    const server =
+      (await this.resolveConfiguredMcporterServer()) ?? this.buildDefaultMcporterQmdServer();
+    const config = {
+      imports: [],
+      mcpServers: {
+        [this.qmd.mcporter.serverName]: server,
+      },
+    };
+    await fs.writeFile(this.mcporterConfigPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  }
+
+  private buildDefaultMcporterQmdServer(): Record<string, unknown> {
+    return {
+      command: this.qmd.command,
+      args: ["mcp"],
+      env: this.buildMcporterQmdEnv(),
+      lifecycle: { mode: "keep-alive", idleTimeoutMs: 300_000 },
+    };
+  }
+
+  private async resolveConfiguredMcporterServer(): Promise<Record<string, unknown> | null> {
+    const serverName = this.qmd.mcporter.serverName;
+    let result: { stdout: string; stderr: string };
+    try {
+      result = await this.runMcporterCommand(["config", "get", serverName, "--json"], {
+        includeGeneratedConfig: false,
+        timeoutMs: 5_000,
+      });
+    } catch (err) {
+      if (serverName === "qmd") {
+        return null;
+      }
+      throw new Error(
+        `mcporter server "${serverName}" is not configured or could not be read: ${formatErrorMessage(
+          err,
+        )}`,
+        { cause: err },
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = parseMcporterResponseJson(result.stdout);
+    } catch (err) {
+      if (serverName === "qmd") {
+        return null;
+      }
+      throw new Error(`mcporter server "${serverName}" returned invalid JSON`, { cause: err });
+    }
+    const serialized = asRecord(parsed);
+    if (!serialized) {
+      if (serverName === "qmd") {
+        return null;
+      }
+      throw new Error(`mcporter server "${serverName}" returned an invalid JSON definition`);
+    }
+
+    const server = this.toMcporterRawServerEntry(serialized);
+    if (!server) {
+      if (serverName === "qmd") {
+        return null;
+      }
+      throw new Error(`mcporter server "${serverName}" returned an unsupported definition`);
+    }
+    return server;
+  }
+
+  private toMcporterRawServerEntry(
+    serialized: Record<string, unknown>,
+  ): Record<string, unknown> | null {
+    const server: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(serialized)) {
+      if (key === "name" || key === "source" || value === undefined) {
+        continue;
+      }
+      server[key] = value;
+    }
+
+    if (typeof server.command === "string" && server.command.length > 0) {
+      const copiedEnv = asRecord(server.env) ?? {};
+      server.env = { ...copiedEnv, ...this.buildMcporterQmdEnv() };
+      if (server.lifecycle === undefined) {
+        server.lifecycle = { mode: "keep-alive", idleTimeoutMs: 300_000 };
+      }
+      return server;
+    }
+
+    const hasRemoteEndpoint =
+      typeof server.baseUrl === "string" ||
+      typeof server.url === "string" ||
+      typeof server.serverUrl === "string";
+    if (hasRemoteEndpoint) {
+      return server;
+    }
+
+    return null;
+  }
+
+  private buildMcporterQmdEnv(): Record<string, string> {
+    const keys = [
+      "PATH",
+      "XDG_CONFIG_HOME",
+      "QMD_CONFIG_DIR",
+      "XDG_CACHE_HOME",
+      "QMD_EMBED_MODEL",
+      "QMD_RERANK_MODEL",
+      "QMD_GENERATE_MODEL",
+      "QMD_LLAMA_GPU",
+      "QMD_EMBED_CONTEXT_SIZE",
+      "QMD_RERANK_CONTEXT_SIZE",
+      "QMD_EXPAND_CONTEXT_SIZE",
+      "NO_COLOR",
+    ];
+    const env: Record<string, string> = {};
+    for (const key of keys) {
+      const value = this.env[key];
+      if (typeof value === "string" && value.length > 0) {
+        env[key] = value;
+      }
+    }
+    return env;
+  }
+
+  private buildMcporterProcessEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...this.env };
+    delete env.XDG_CONFIG_HOME;
+    delete env.QMD_CONFIG_DIR;
+    delete env.XDG_CACHE_HOME;
+    return env;
+  }
+
+  private async runMcporterCommand(
+    args: string[],
+    opts?: { includeGeneratedConfig?: boolean; timeoutMs?: number },
+  ): Promise<{ stdout: string; stderr: string }> {
+    const mcporterArgs =
+      opts?.includeGeneratedConfig === false
+        ? args
+        : [...args, "--config", this.mcporterConfigPath];
+    const env = this.buildMcporterProcessEnv();
+    const spawnInvocation = resolveCliSpawnInvocation({
+      command: "mcporter",
+      args: mcporterArgs,
+      env,
+      packageName: "mcporter",
+    });
+    return await runCliCommand({
+      commandSummary: `${spawnInvocation.command} ${spawnInvocation.argv.join(" ")}`,
+      spawnInvocation,
+      env,
+      cwd: this.workspaceDir,
+      timeoutMs: opts?.timeoutMs,
+      maxOutputChars: this.maxQmdOutputChars,
+    });
   }
 
   private async runMcporter(
     args: string[],
     opts?: { timeoutMs?: number },
   ): Promise<{ stdout: string; stderr: string }> {
-    const spawnInvocation = resolveCliSpawnInvocation({
-      command: "mcporter",
-      args,
-      env: this.env,
-      packageName: "mcporter",
-    });
-    return await runCliCommand({
-      commandSummary: `${spawnInvocation.command} ${spawnInvocation.argv.join(" ")}`,
-      spawnInvocation,
-      // Keep mcporter and direct qmd commands on the same agent-scoped XDG state.
-      env: this.env,
-      cwd: this.workspaceDir,
-      timeoutMs: opts?.timeoutMs,
-      maxOutputChars: this.maxQmdOutputChars,
-    });
+    await this.ensureMcporterConfig();
+    return await this.runMcporterCommand(args, opts);
   }
 
   private async runQmdSearchViaMcporter(
@@ -2254,7 +2468,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       throw err;
     }
 
-    const parsedUnknown: unknown = JSON.parse(result.stdout);
+    const parsedUnknown = parseMcporterResponseJson(result.stdout);
     const parsedRecord = asRecord(parsedUnknown);
     const structuredContent = parsedRecord ? asRecord(parsedRecord.structuredContent) : null;
     const structured: unknown = structuredContent ?? parsedUnknown;

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -138,6 +138,30 @@ type McporterState = {
   daemonStarts: Map<string, Promise<void>>;
 };
 
+type McporterConfigMode = "generated" | "external";
+
+type ConfiguredMcporterServer =
+  | { mode: "generated"; server: Record<string, unknown> }
+  | { mode: "external" };
+
+const MCPORTER_REMOTE_AUTH_KEYS = new Set(
+  [
+    "auth",
+    "authProvider",
+    "authProviderEnv",
+    "bearerToken",
+    "bearerTokenEnv",
+    "headers",
+    "oauth",
+    "oauthClientId",
+    "oauthClientSecret",
+    "oauthClientSecretEnv",
+    "refreshToken",
+    "refreshTokenEnv",
+    "tokenCacheDir",
+  ].map(normalizeMcporterConfigKey),
+);
+
 function normalizePositiveInteger(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value)
     ? Math.max(1, Math.floor(value))
@@ -159,6 +183,46 @@ function getMcporterState(): McporterState {
     coldStartWarned: false,
     daemonStarts: new Map(),
   }));
+}
+
+function normalizeMcporterConfigKey(key: string): string {
+  return key.toLowerCase().replace(/[_-]/g, "");
+}
+
+function hasMcporterRemoteAuthMaterial(server: Record<string, unknown>): boolean {
+  if (hasMcporterRemoteUrlCredentials(server)) {
+    return true;
+  }
+  return Object.keys(server).some((key) => {
+    const normalized = normalizeMcporterConfigKey(key);
+    return (
+      MCPORTER_REMOTE_AUTH_KEYS.has(normalized) ||
+      normalized.includes("auth") ||
+      normalized.includes("header") ||
+      normalized.includes("secret") ||
+      normalized.includes("token")
+    );
+  });
+}
+
+function hasMcporterRemoteUrlCredentials(server: Record<string, unknown>): boolean {
+  for (const key of ["baseUrl", "url", "serverUrl"]) {
+    const value = server[key];
+    if (typeof value !== "string" || value.length === 0) {
+      continue;
+    }
+    try {
+      const parsed = new URL(value);
+      if (parsed.username.length > 0 || parsed.password.length > 0) {
+        return true;
+      }
+    } catch {
+      if (/^[a-z][a-z0-9+.-]*:\/\/[^/?#@]+@/i.test(value)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 function parseMcporterResponseJson(stdout: string): unknown {
@@ -411,6 +475,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private readonly indexPath: string;
   private readonly mcporterConfigPath: string;
   private readonly env: NodeJS.ProcessEnv;
+  private readonly mcporterEnv: NodeJS.ProcessEnv;
   private readonly syncSettings: ReturnType<typeof resolveMemorySearchSyncConfig>;
   private readonly managedCollectionNames: string[];
   private readonly collectionRoots = new Map<string, CollectionRoot>();
@@ -485,6 +550,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       // Point it at the nested qmd config directory so per-agent collections are visible.
       QMD_CONFIG_DIR: path.join(this.xdgConfigHome, "qmd"),
       XDG_CACHE_HOME: this.xdgCacheHome,
+      NO_COLOR: "1",
+    };
+    this.mcporterEnv = {
+      ...process.env,
+      PATH: buildQmdProcessPath(process.env.PATH),
       NO_COLOR: "1",
     };
     this.closeSignal = new Promise<void>((resolve) => {
@@ -2181,7 +2251,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!mcporter.enabled) {
       return;
     }
-    await this.ensureMcporterConfig();
+    const configMode = await this.ensureMcporterConfig();
     const state = getMcporterState();
     if (!mcporter.startDaemon) {
       if (!state.coldStartWarned) {
@@ -2192,12 +2262,15 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       return;
     }
-    const daemonKey = this.mcporterConfigPath;
+    const daemonKey = this.mcporterDaemonKey(configMode);
     let daemonStart = state.daemonStarts.get(daemonKey);
     if (!daemonStart) {
       daemonStart = (async () => {
         try {
-          await this.runMcporter(["daemon", "start"], { timeoutMs: 10_000 });
+          await this.runMcporterCommand(["daemon", "start"], {
+            includeGeneratedConfig: configMode === "generated",
+            timeoutMs: 10_000,
+          });
         } catch (err) {
           log.warn(`mcporter daemon start failed: ${String(err)}`);
           // Allow future searches to retry daemon start on transient failures.
@@ -2209,10 +2282,13 @@ export class QmdMemoryManager implements MemorySearchManager {
     await daemonStart;
   }
 
-  private async ensureMcporterConfig(): Promise<void> {
+  private async ensureMcporterConfig(): Promise<McporterConfigMode> {
     await fs.mkdir(path.dirname(this.mcporterConfigPath), { recursive: true });
-    const server =
-      (await this.resolveConfiguredMcporterServer()) ?? this.buildDefaultMcporterQmdServer();
+    const configured = await this.resolveConfiguredMcporterServer();
+    if (configured?.mode === "external") {
+      return "external";
+    }
+    const server = configured?.server ?? this.buildDefaultMcporterQmdServer();
     const config = {
       imports: [],
       mcpServers: {
@@ -2220,6 +2296,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       },
     };
     await this.writeMcporterConfigIfChanged(`${JSON.stringify(config, null, 2)}\n`);
+    return "generated";
   }
 
   private async writeMcporterConfigIfChanged(contents: string): Promise<void> {
@@ -2244,7 +2321,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     };
   }
 
-  private async resolveConfiguredMcporterServer(): Promise<Record<string, unknown> | null> {
+  private async resolveConfiguredMcporterServer(): Promise<ConfiguredMcporterServer | null> {
     const serverName = this.qmd.mcporter.serverName;
     let result: { stdout: string; stderr: string };
     try {
@@ -2293,7 +2370,7 @@ export class QmdMemoryManager implements MemorySearchManager {
 
   private toMcporterRawServerEntry(
     serialized: Record<string, unknown>,
-  ): Record<string, unknown> | null {
+  ): ConfiguredMcporterServer | null {
     const server: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(serialized)) {
       if (key === "name" || key === "source" || value === undefined) {
@@ -2305,10 +2382,12 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (typeof server.command === "string" && server.command.length > 0) {
       const copiedEnv = asRecord(server.env) ?? {};
       server.env = { ...copiedEnv, ...this.buildMcporterQmdEnv() };
-      if (server.lifecycle === undefined) {
+      // startDaemon=true depends on mcporter treating the configured stdio
+      // server as daemon-warm; without lifecycle, mcporter keeps it ephemeral.
+      if (server.lifecycle === undefined && this.qmd.mcporter.startDaemon) {
         server.lifecycle = { mode: "keep-alive", idleTimeoutMs: 300_000 };
       }
-      return server;
+      return { mode: "generated", server };
     }
 
     const hasRemoteEndpoint =
@@ -2316,9 +2395,13 @@ export class QmdMemoryManager implements MemorySearchManager {
       typeof server.url === "string" ||
       typeof server.serverUrl === "string";
     if (hasRemoteEndpoint) {
-      // The explicit generated mcporter config must contain the selected remote
-      // server entry, including its auth metadata, inside this agent's state dir.
-      return server;
+      // The generated per-agent config is persisted under OpenClaw state. Do not
+      // copy remote auth material from a user's mcporter config into that file;
+      // keep using the original mcporter config for authenticated remotes.
+      if (hasMcporterRemoteAuthMaterial(server)) {
+        return { mode: "external" };
+      }
+      return { mode: "generated", server };
     }
 
     return null;
@@ -2350,11 +2433,20 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private buildMcporterProcessEnv(): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = { ...this.env };
-    delete env.XDG_CONFIG_HOME;
-    delete env.QMD_CONFIG_DIR;
-    delete env.XDG_CACHE_HOME;
-    return env;
+    return { ...this.mcporterEnv };
+  }
+
+  private mcporterDaemonKey(configMode: McporterConfigMode): string {
+    if (configMode === "generated") {
+      return this.mcporterConfigPath;
+    }
+    return [
+      "external",
+      this.qmd.mcporter.serverName,
+      this.mcporterEnv.MCPORTER_CONFIG ?? "",
+      this.mcporterEnv.XDG_CONFIG_HOME ?? "",
+      this.workspaceDir,
+    ].join(":");
   }
 
   private async runMcporterCommand(
@@ -2386,8 +2478,11 @@ export class QmdMemoryManager implements MemorySearchManager {
     args: string[],
     opts?: { timeoutMs?: number },
   ): Promise<{ stdout: string; stderr: string }> {
-    await this.ensureMcporterConfig();
-    return await this.runMcporterCommand(args, opts);
+    const configMode = await this.ensureMcporterConfig();
+    return await this.runMcporterCommand(args, {
+      ...opts,
+      includeGeneratedConfig: configMode === "generated",
+    });
   }
 
   private async runQmdSearchViaMcporter(

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -264,11 +264,20 @@ function hasMcporterStdioUserOwnedMaterial(server: Record<string, unknown>): boo
 }
 
 function isGeneratedMcporterQmdStdioServer(server: Record<string, unknown>): boolean {
-  if (normalizeMcporterConfigKey(String(server.command)) !== "qmd") {
+  if (!isQmdExecutableCommand(server.command)) {
     return false;
   }
   const args = server.args;
   return Array.isArray(args) && args.length === 1 && args[0] === "mcp";
+}
+
+function isQmdExecutableCommand(command: unknown): boolean {
+  if (typeof command !== "string" || command.length === 0) {
+    return false;
+  }
+  const normalized = command.replace(/\\/g, "/");
+  const commandName = normalized.split("/").filter(Boolean).at(-1) ?? normalized;
+  return normalizeMcporterConfigKey(commandName) === "qmd";
 }
 
 function hasMcporterAuthLikeArgs(value: unknown): boolean {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -152,7 +152,6 @@ const MCPORTER_REMOTE_AUTH_KEYS = new Set(
     "authProviderEnv",
     "bearerToken",
     "bearerTokenEnv",
-    "headers",
     "oauth",
     "oauthClientId",
     "oauthClientSecret",
@@ -209,11 +208,40 @@ function isMcporterAuthLikeKey(key: string): boolean {
   );
 }
 
+function hasMcporterHeaderAuthMaterial(value: unknown): boolean {
+  const headers = asRecord(value);
+  if (!headers) {
+    return true;
+  }
+  for (const [key, headerValue] of Object.entries(headers)) {
+    const normalized = normalizeMcporterConfigKey(key);
+    if (
+      normalized === "accept" &&
+      typeof headerValue === "string" &&
+      hasRequiredMcporterAcceptTokens(headerValue)
+    ) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+function hasRequiredMcporterAcceptTokens(value: string): boolean {
+  const lower = value.toLowerCase();
+  return lower.includes("application/json") && lower.includes("text/event-stream");
+}
+
 function hasMcporterRemoteAuthMaterial(server: Record<string, unknown>): boolean {
   if (hasMcporterRemoteUrlCredentials(server)) {
     return true;
   }
-  return Object.keys(server).some((key) => isMcporterAuthLikeKey(key));
+  return Object.entries(server).some(([key, value]) => {
+    if (normalizeMcporterConfigKey(key) === "headers") {
+      return hasMcporterHeaderAuthMaterial(value);
+    }
+    return isMcporterAuthLikeKey(key);
+  });
 }
 
 function hasMcporterRemoteUrlCredentials(server: Record<string, unknown>): boolean {
@@ -2409,16 +2437,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
 
     if (typeof server.command === "string" && server.command.length > 0) {
-      if (server.env !== undefined) {
-        return { mode: "external" };
-      }
-      server.env = this.buildMcporterQmdEnv();
-      // startDaemon=true depends on mcporter treating the configured stdio
-      // server as daemon-warm; without lifecycle, mcporter keeps it ephemeral.
-      if (server.lifecycle === undefined && this.qmd.mcporter.startDaemon) {
-        server.lifecycle = { mode: "keep-alive", idleTimeoutMs: 300_000 };
-      }
-      return { mode: "generated", server };
+      return { mode: "external" };
     }
 
     const hasRemoteEndpoint =

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2383,8 +2383,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
 
     if (typeof server.command === "string" && server.command.length > 0) {
-      const copiedEnv = asRecord(server.env) ?? {};
-      server.env = { ...copiedEnv, ...this.buildMcporterQmdEnv() };
+      server.env = this.buildMcporterQmdEnv();
       // startDaemon=true depends on mcporter treating the configured stdio
       // server as daemon-warm; without lifecycle, mcporter keeps it ephemeral.
       if (server.lifecycle === undefined && this.qmd.mcporter.startDaemon) {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2219,7 +2219,20 @@ export class QmdMemoryManager implements MemorySearchManager {
         [this.qmd.mcporter.serverName]: server,
       },
     };
-    await fs.writeFile(this.mcporterConfigPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+    await this.writeMcporterConfigIfChanged(`${JSON.stringify(config, null, 2)}\n`);
+  }
+
+  private async writeMcporterConfigIfChanged(contents: string): Promise<void> {
+    try {
+      if ((await fs.readFile(this.mcporterConfigPath, "utf8")) === contents) {
+        return;
+      }
+    } catch (err) {
+      if (!isFileMissingError(err)) {
+        throw err;
+      }
+    }
+    await fs.writeFile(this.mcporterConfigPath, contents, "utf8");
   }
 
   private buildDefaultMcporterQmdServer(): Record<string, unknown> {
@@ -2303,6 +2316,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       typeof server.url === "string" ||
       typeof server.serverUrl === "string";
     if (hasRemoteEndpoint) {
+      // The explicit generated mcporter config must contain the selected remote
+      // server entry, including its auth metadata, inside this agent's state dir.
       return server;
     }
 

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -157,6 +157,7 @@ const MCPORTER_REMOTE_AUTH_KEYS = new Set(
     "oauthClientId",
     "oauthClientSecret",
     "oauthClientSecretEnv",
+    "refresh",
     "refreshToken",
     "refreshTokenEnv",
     "tokenCacheDir",
@@ -190,20 +191,29 @@ function normalizeMcporterConfigKey(key: string): string {
   return key.toLowerCase().replace(/[_-]/g, "");
 }
 
+function isMcporterAuthLikeKey(key: string): boolean {
+  const normalized = normalizeMcporterConfigKey(key);
+  return (
+    MCPORTER_REMOTE_AUTH_KEYS.has(normalized) ||
+    normalized.includes("apikey") ||
+    normalized.includes("auth") ||
+    normalized.includes("bearer") ||
+    normalized.includes("credential") ||
+    normalized.includes("header") ||
+    normalized.includes("jwt") ||
+    normalized.includes("secret") ||
+    normalized.includes("signature") ||
+    normalized.includes("token") ||
+    normalized === "key" ||
+    normalized === "sig"
+  );
+}
+
 function hasMcporterRemoteAuthMaterial(server: Record<string, unknown>): boolean {
   if (hasMcporterRemoteUrlCredentials(server)) {
     return true;
   }
-  return Object.keys(server).some((key) => {
-    const normalized = normalizeMcporterConfigKey(key);
-    return (
-      MCPORTER_REMOTE_AUTH_KEYS.has(normalized) ||
-      normalized.includes("auth") ||
-      normalized.includes("header") ||
-      normalized.includes("secret") ||
-      normalized.includes("token")
-    );
-  });
+  return Object.keys(server).some((key) => isMcporterAuthLikeKey(key));
 }
 
 function hasMcporterRemoteUrlCredentials(server: Record<string, unknown>): boolean {
@@ -216,6 +226,11 @@ function hasMcporterRemoteUrlCredentials(server: Record<string, unknown>): boole
       const parsed = new URL(value);
       if (parsed.username.length > 0 || parsed.password.length > 0) {
         return true;
+      }
+      for (const queryKey of parsed.searchParams.keys()) {
+        if (isMcporterAuthLikeKey(queryKey)) {
+          return true;
+        }
       }
     } catch {
       if (/^[a-z][a-z0-9+.-]*:\/\/[^/?#@]+@/i.test(value)) {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -118,7 +118,7 @@ function buildQmdProcessPath(rawPath: string | undefined): string {
 
 type McporterState = {
   coldStartWarned: boolean;
-  daemonStart: Promise<void> | null;
+  daemonStarts: Map<string, Promise<void>>;
 };
 
 type QmdEmbedQueueState = {
@@ -132,8 +132,69 @@ type QmdUpdateQueueState = {
 function getMcporterState(): McporterState {
   return resolveGlobalSingleton<McporterState>(MCPORTER_STATE_KEY, () => ({
     coldStartWarned: false,
-    daemonStart: null,
+    daemonStarts: new Map(),
   }));
+}
+
+function parseMcporterResponseJson(stdout: string): unknown {
+  const trimmed = stdout.trim();
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch (err) {
+    const payload = extractFirstJsonValue(trimmed);
+    if (payload !== null) {
+      return payload;
+    }
+    throw err;
+  }
+}
+
+function extractFirstJsonValue(raw: string): unknown | null {
+  for (let start = 0; start < raw.length; start += 1) {
+    const opening = raw[start];
+    if (opening !== "{" && opening !== "[") {
+      continue;
+    }
+    const closing = opening === "{" ? "}" : "]";
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = start; index < raw.length; index += 1) {
+      const char = raw[index];
+      if (char === undefined) {
+        break;
+      }
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (char === "\\") {
+          escaped = true;
+        } else if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
+      if (char === opening) {
+        depth += 1;
+      } else if (char === closing) {
+        depth -= 1;
+        if (depth === 0) {
+          try {
+            return JSON.parse(raw.slice(start, index + 1)) as unknown;
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return null;
 }
 
 function getQmdEmbedQueueState(): QmdEmbedQueueState {
@@ -306,6 +367,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private readonly xdgConfigHome: string;
   private readonly xdgCacheHome: string;
   private readonly indexPath: string;
+  private readonly mcporterConfigPath: string;
   private readonly env: NodeJS.ProcessEnv;
   private readonly syncSettings: ReturnType<typeof resolveMemorySearchSyncConfig>;
   private readonly managedCollectionNames: string[];
@@ -369,6 +431,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     this.xdgConfigHome = path.join(this.qmdDir, "xdg-config");
     this.xdgCacheHome = path.join(this.qmdDir, "xdg-cache");
     this.indexPath = path.join(this.xdgCacheHome, "qmd", "index.sqlite");
+    this.mcporterConfigPath = path.join(this.qmdDir, "mcporter", "mcporter.json");
 
     this.env = {
       ...process.env,
@@ -1957,6 +2020,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!mcporter.enabled) {
       return;
     }
+    await this.ensureMcporterConfig();
     const state = getMcporterState();
     if (!mcporter.startDaemon) {
       if (!state.coldStartWarned) {
@@ -1967,27 +2031,73 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       return;
     }
-    if (!state.daemonStart) {
-      state.daemonStart = (async () => {
+    const daemonKey = this.mcporterConfigPath;
+    let daemonStart = state.daemonStarts.get(daemonKey);
+    if (!daemonStart) {
+      daemonStart = (async () => {
         try {
           await this.runMcporter(["daemon", "start"], { timeoutMs: 10_000 });
         } catch (err) {
           log.warn(`mcporter daemon start failed: ${String(err)}`);
           // Allow future searches to retry daemon start on transient failures.
-          state.daemonStart = null;
+          state.daemonStarts.delete(daemonKey);
         }
       })();
+      state.daemonStarts.set(daemonKey, daemonStart);
     }
-    await state.daemonStart;
+    await daemonStart;
+  }
+
+  private async ensureMcporterConfig(): Promise<void> {
+    await fs.mkdir(path.dirname(this.mcporterConfigPath), { recursive: true });
+    const env = this.buildMcporterQmdEnv();
+    const config = {
+      mcpServers: {
+        [this.qmd.mcporter.serverName]: {
+          command: this.qmd.command,
+          args: ["mcp"],
+          env,
+          lifecycle: { mode: "keep-alive", idleTimeoutMs: 300_000 },
+        },
+      },
+    };
+    await fs.writeFile(this.mcporterConfigPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  }
+
+  private buildMcporterQmdEnv(): Record<string, string> {
+    const keys = [
+      "PATH",
+      "XDG_CONFIG_HOME",
+      "QMD_CONFIG_DIR",
+      "XDG_CACHE_HOME",
+      "QMD_EMBED_MODEL",
+      "QMD_RERANK_MODEL",
+      "QMD_GENERATE_MODEL",
+      "QMD_LLAMA_GPU",
+      "QMD_EMBED_CONTEXT_SIZE",
+      "QMD_RERANK_CONTEXT_SIZE",
+      "QMD_EXPAND_CONTEXT_SIZE",
+      "NO_COLOR",
+    ];
+    const env: Record<string, string> = {};
+    for (const key of keys) {
+      const value = this.env[key];
+      if (typeof value === "string" && value.length > 0) {
+        env[key] = value;
+      }
+    }
+    return env;
   }
 
   private async runMcporter(
     args: string[],
     opts?: { timeoutMs?: number },
   ): Promise<{ stdout: string; stderr: string }> {
+    await this.ensureMcporterConfig();
+    const mcporterArgs = [...args, "--config", this.mcporterConfigPath];
     const spawnInvocation = resolveCliSpawnInvocation({
       command: "mcporter",
-      args,
+      args: mcporterArgs,
       env: this.env,
       packageName: "mcporter",
     });
@@ -2087,7 +2197,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       throw err;
     }
 
-    const parsedUnknown: unknown = JSON.parse(result.stdout);
+    const parsedUnknown = parseMcporterResponseJson(result.stdout);
     const parsedRecord = asRecord(parsedUnknown);
     const structuredContent = parsedRecord ? asRecord(parsedRecord.structuredContent) : null;
     const structured: unknown = structuredContent ?? parsedUnknown;


### PR DESCRIPTION
## Summary

- Isolate QMD mcporter daemon/config state per agent by writing an agent-scoped mcporter config and passing it to mcporter calls.
- Preserve the configured mcporter server definition instead of replacing custom/remote server config with a hard-coded local `qmd mcp` entry.
- Keep QMD model/env settings flowing only through the generated stdio server entry, while stripping QMD-scoped XDG env from mcporter's own process environment.
- Tolerate mcporter daemon log lines before JSON responses so warm daemon calls do not break memory search parsing.
- **Added:** Detect `logging.daemon.enabled` on mcporter stdio servers to preserve daemon logging config.
- **Added:** Read project-scoped `config/mcporter.json` from workspace directory as an additional mcporter config layer.
- **Added:** Doctor contract scaffold for memory-core plugin.
- **Added:** Public docs explaining mcporter integration and config discovery order.

## reviewMetrics

```
configSurfaces:
  added: 0
  changed: 1    # mcporter probe routing: now reads project config + detects daemon logging
  removed: 0
userVisibleBehavior:
  changed: 2    # (1) logging.daemon.enabled no longer silently dropped
                # (2) project-scoped config/mcporter.json is now consulted
whyItMatters:
  - Existing mcporter setups with project config/mcporter.json are preserved
  - Users who customized daemon logging keep their settings across upgrades
  - Config discovery order now matches mcporter's documented behavior
```

## Verification

- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts`
- `pnpm run lint:extensions:bundled`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`

## Real behavior proof

**Behavior addressed:** QMD memory search through mcporter must keep each agent on its own mcporter config/daemon state while preserving a configured stdio `qmd` server even when mcporter stores the command as an absolute executable path.

**Real environment tested:** Local OpenClaw checkout on Linux with Node `v24.15.0`, `mcporter 0.10.2`, `qmd 2.1.0`, and the configured mcporter `qmd` stdio server whose command is an absolute qmd binary path. Home/state/workspace paths are redacted.

**Exact steps or command run after this patch:**

```text
node --version
mcporter --version
qmd --version
mcporter config get qmd --json
pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/qmd-manager.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/memory-core/src/memory/qmd-manager.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts
git diff --check
pnpm build
node --input-type=module '<create QmdMemoryManager in status mode for agents hex/trump, call ensureMcporterConfig(), read generated mcporter.json, print redacted command/env summary>'
.agents/skills/autoreview/scripts/autoreview --mode local
```

**Evidence after fix:** Copied terminal output, redacted:

```text
node --version -> v24.15.0
mcporter --version -> 0.10.2
qmd --version -> qmd 2.1.0 (bab86d5)

mcporter config get qmd --json
{
  "name": "qmd",
  "source": { "kind": "local", "path": "~/.mcporter/mcporter.json" },
  "transport": "stdio",
  "command": "~/.nvm/versions/node/v24.15.0/bin/qmd",
  "args": ["mcp"]
}

Focused tests:
- extensions/memory-core/src/memory/qmd-manager.test.ts: 138 tests passed
- src/agents/agent-bundle-mcp-runtime.test.ts: 30 tests passed

Build:
- pnpm build completed successfully

Runtime classifier/config proof:
node=v24.15.0
mcporterConfig.command=~/.nvm/versions/node/v24.15.0/bin/qmd
mcporterConfig.args=["mcp"]
{"agentId":"hex","mode":"generated","configPath":"$STATE/agents/hex/qmd/mcporter/mcporter.json","imports":[],"command":"~/.nvm/versions/node/v24.15.0/bin/qmd","args":["mcp"],"xdgConfigHome":"$STATE/agents/hex/qmd/xdg-config","qmdConfigDir":"$STATE/agents/hex/qmd/xdg-config/qmd","xdgCacheHome":"$STATE/agents/hex/qmd/xdg-cache"}
{"agentId":"trump","mode":"generated","configPath":"$STATE/agents/trump/qmd/mcporter/mcporter.json","imports":[],"command":"~/.nvm/versions/node/v24.15.0/bin/qmd","args":["mcp"],"xdgConfigHome":"$STATE/agents/trump/qmd/xdg-config","qmdConfigDir":"$STATE/agents/trump/qmd/xdg-config/qmd","xdgCacheHome":"$STATE/agents/trump/qmd/xdg-cache"}

Autoreview:
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.87)
```

**Observed result after fix:** The manager classified the absolute-command mcporter `qmd` server as `generated` for both agents, wrote separate per-agent mcporter configs, preserved the absolute qmd command and `["mcp"]` args, and injected per-agent `XDG_CONFIG_HOME`, `QMD_CONFIG_DIR`, and `XDG_CACHE_HOME` values.

**What was not tested:** I did not run the full product `openclaw memory ...` CLI in this linked checkout because the local user config is currently invalid on this branch and plugin commands do not register before config validation. I also did not test a live remote HTTP mcporter server; that preservation path remains covered by the focused unit tests already in this PR.

**Branch update:** This PR has been rebased onto latest upstream/main. The original branch was recreated with rebased commits.
