### PR TITLE
fix: add default 120s request timeout when provider timeoutSeconds is not configured

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -65,6 +65,9 @@ type ProviderRuntimeHooks = {
   normalizeProviderTransportWithPlugin: typeof normalizeProviderTransportWithPlugin;
 };
 
+/** 当 provider timeoutSeconds 未配置时使用的默认请求超时时间（毫秒） */
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
 const TARGET_PROVIDER_RUNTIME_HOOKS: ProviderRuntimeHooks = {
   buildProviderUnknownModelHintWithPlugin,
   prepareProviderDynamicModel,
@@ -336,13 +339,14 @@ function resolveConfiguredProviderDefaultApi(
   return providerConfig?.baseUrl ? "openai-completions" : undefined;
 }
 
-function resolveProviderRequestTimeoutMs(timeoutSeconds: unknown): number | undefined {
+function resolveProviderRequestTimeoutMs(timeoutSeconds: unknown): number {
   if (
     typeof timeoutSeconds !== "number" ||
     !Number.isFinite(timeoutSeconds) ||
     timeoutSeconds <= 0
   ) {
-    return undefined;
+    // provider timeoutSeconds 未配置或 <=0 时，回退到 120 秒默认超时，避免 HTTP 请求无限等待
+    return DEFAULT_REQUEST_TIMEOUT_MS;
   }
   return Math.floor(timeoutSeconds) * 1000;
 }


### PR DESCRIPTION
## Problem

When `models.providers.<id>.timeoutSeconds` is not configured, `resolveProviderRequestTimeoutMs()` returns `undefined`. This cascades through the entire timeout chain:
- `buildTimeoutAbortSignal({timeoutMs: undefined})` returns `{signal: undefined}`
- `fetch()` called without any abort signal
- TCP connection hangs indefinitely when upstream API (e.g. DeepSeek) is slow

This is a **P0 defect**: a slow API response blocks the session forever, causing event loop congestion (CPU 68%+) and system unresponsiveness until Gateway restart.

## Fix

Return `DEFAULT_REQUEST_TIMEOUT_MS` (120 seconds) when `timeoutSeconds` is not configured/invalid, instead of `undefined`.

The code already has full timeout infrastructure (`buildTimeoutAbortSignal`, `AbortController`, `fetchWithSsrFGuard`), it just lacked a safe default fallback.

## Testing

- `npx tsc --noEmit` passes
- Only affects the fallback branch of `resolveProviderRequestTimeoutMs`

## Related

Fixes a P0 production incident where slow DeepSeek API responses caused session-level deadlock in OpenClaw Gateway (see investigation report).