### PR TITLE
feat(qwen): enable qwen3.6-plus for Coding Plan subscriptions

### DIFF
--- a/extensions/qwen/api.ts
+++ b/extensions/qwen/api.ts
@@ -4,7 +4,6 @@ export {
   buildQwenModelDefinition,
   buildQwenModelCatalogForBaseUrl,
   isNativeQwenBaseUrl,
-  isQwen36PlusSupportedBaseUrl,
   isQwenCodingPlanBaseUrl,
   QWEN_36_PLUS_MODEL_ID,
   QWEN_BASE_URL,

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -1,6 +1,5 @@
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
-import { QWEN_36_PLUS_MODEL_ID, QWEN_BASE_URL } from "./api.js";
 import qwenPlugin from "./index.js";
 
 async function registerQwenProvider() {
@@ -9,20 +8,6 @@ async function registerQwenProvider() {
 }
 
 describe("qwen provider plugin", () => {
-  it("keeps qwen3.6-plus out of Coding Plan normalized catalogs", async () => {
-    const provider = await registerQwenProvider();
-
-    const normalized = provider.normalizeConfig?.({
-      provider: "qwen",
-      providerConfig: {
-        baseUrl: QWEN_BASE_URL,
-        models: [{ id: "qwen3.5-plus" }, { id: QWEN_36_PLUS_MODEL_ID }],
-      },
-    } as never);
-
-    expect(normalized?.models?.map((model) => model.id)).toEqual(["qwen3.5-plus"]);
-  });
-
   it("does not expose runtime model suppression hooks", async () => {
     const provider = await registerQwenProvider();
 

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -124,16 +124,11 @@ export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
-export function isQwen36PlusSupportedBaseUrl(baseUrl: string | undefined): boolean {
-  return !isQwenCodingPlanBaseUrl(baseUrl);
-}
-
 export function buildQwenModelCatalogForBaseUrl(
-  baseUrl: string | undefined,
+  _baseUrl: string | undefined,
 ): ReadonlyArray<ModelDefinitionConfig> {
-  return isQwen36PlusSupportedBaseUrl(baseUrl)
-    ? QWEN_MODEL_CATALOG
-    : QWEN_MODEL_CATALOG.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
+  // qwen3.6-plus is now supported on all subscriptions including Coding Plan
+  return QWEN_MODEL_CATALOG;
 }
 
 export function isNativeQwenBaseUrl(baseUrl: string | undefined): boolean {


### PR DESCRIPTION
## Summary

qwen3.6-plus is now supported on all subscriptions including Coding Plan.

## Changes

- Remove the restriction that filtered out qwen3.6-plus for Coding Plan URLs
- Delete `isQwen36PlusSupportedBaseUrl` function (no longer needed)
- Simplify `buildQwenModelCatalogForBaseUrl` to return full catalog

## Testing

All core CI checks pass (lint, types, tests).