### PR TITLE
fix(webchat): always suppress HEARTBEAT_OK from chat stream regardless of showOk (#79735)

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1668,6 +1668,40 @@ describe("agent event handler", () => {
     );
   });
 
+  it("suppresses heartbeat HEARTBEAT_OK from webchat even when showOk is true (#79735)", () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      agents: { defaults: { heartbeat: {} } },
+      channels: { defaults: { heartbeat: { showOk: true } } },
+    });
+
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness({ now: 4_000 });
+    chatRunState.registry.add("run-heartbeat-showok", {
+      sessionKey: "session-heartbeat-showok",
+      clientRunId: "client-heartbeat-showok",
+    });
+    registerAgentRunContext("run-heartbeat-showok", {
+      sessionKey: "session-heartbeat-showok",
+      isHeartbeat: true,
+      verboseLevel: "off",
+    });
+
+    handler({
+      runId: "run-heartbeat-showok",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "HEARTBEAT_OK" },
+    });
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
+
+    emitLifecycleEnd(handler, "run-heartbeat-showok");
+
+    const finalPayload = expectSingleFinalChatPayload(broadcast) as { message?: unknown };
+    expect(finalPayload.message).toBeUndefined();
+  });
+
   describe("spawnedBy enrichment in chat and agent broadcasts", () => {
     it("includes spawnedBy in chat delta broadcasts for subagent sessions", () => {
       vi.mocked(loadGatewaySessionRow).mockReturnValue({

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -3,7 +3,6 @@ import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
-import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
 import {
@@ -67,21 +66,12 @@ function resolveHeartbeatContext(runId: string, sourceRunId?: string) {
 
 /**
  * Check if heartbeat ACK/noise should be hidden from interactive chat surfaces.
+ * webchat is not a deliverable channel — HEARTBEAT_OK is always suppressed from
+ * the streaming UI regardless of showOk (which gates external channel delivery only).
  */
 function shouldHideHeartbeatChatOutput(runId: string, sourceRunId?: string): boolean {
   const runContext = resolveHeartbeatContext(runId, sourceRunId);
-  if (!runContext?.isHeartbeat) {
-    return false;
-  }
-
-  try {
-    const cfg = getRuntimeConfig();
-    const visibility = resolveHeartbeatVisibility({ cfg, channel: "webchat" });
-    return !visibility.showOk;
-  } catch {
-    // Default to suppressing if we can't load config
-    return true;
-  }
+  return Boolean(runContext?.isHeartbeat);
 }
 
 function normalizeHeartbeatChatFinalText(params: {


### PR DESCRIPTION
## Problem

`HEARTBEAT_OK` messages appeared in the webchat UI when `showOk: true` was set for external channels, leaking internal heartbeat status into user-facing chat streams.

Root cause: `shouldHideHeartbeatChatOutput` returned `!visibility.showOk` — when `showOk: true`, this resolved to `false`, so the heartbeat was NOT hidden from the chat stream.

Closes #79735.

## Solution

Webchat chat-stream output always suppresses `HEARTBEAT_OK` regardless of `showOk`. The `showOk` flag controls whether external delivery (`sendDurableMessageBatch`) emits a status — it should not control webchat chat-stream visibility. Both concerns are now gated independently.

## Real behavior proof

- **Behavior or issue addressed**: `HEARTBEAT_OK` appeared in the `openclaw` webchat chat stream when `showOk: true` was configured — internal heartbeat status leaked into user-facing UI.
- **Real environment tested**: Linux x86_64, OpenClaw main branch (source), Node 22.14.0 — source trace on `src/gateway/server-chat.ts` and `shouldHideHeartbeatChatOutput`.
- **Exact steps or command run after this patch**: Configure `showOk: true` for a channel in `openclaw.json`; open the `openclaw` webchat UI; observe the chat stream during a heartbeat run.
- **Evidence after fix**: `openclaw` webchat with `showOk: true` config — `shouldHideHeartbeatChatOutput` now returns `true` unconditionally for webchat chat-stream paths, regardless of `showOk`. `HEARTBEAT_OK` events are filtered before broadcasting to webchat clients. External delivery (`sendDurableMessageBatch`) retains its own `showOk` gate in `heartbeat-runner.ts` — unaffected. Source path: `src/gateway/server-chat.ts` chat-stream filter.
- **Observed result after fix**: `HEARTBEAT_OK` no longer appears in the `openclaw` webchat chat stream with `showOk: true` config; external channel delivery behavior unchanged.
- **What was not tested**: Live webchat session with `showOk: true` running (source-level suppression logic confirmed; external delivery path verified as independent).