### PR TITLE
fix(auto-reply): cleanup rejected followup typing

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -107,6 +107,7 @@ beforeEach(() => {
     meta: { agentMeta: { usage: { input: 1, output: 1 } } },
   });
   vi.mocked(enqueueFollowupRun).mockClear();
+  vi.mocked(enqueueFollowupRun).mockReturnValue(true);
   vi.mocked(refreshQueuedFollowupSession).mockClear();
   vi.mocked(scheduleFollowupDrain).mockClear();
   vi.stubEnv("OPENCLAW_TEST_FAST", "1");
@@ -254,6 +255,27 @@ describe("runReplyAgent heartbeat followup guard", () => {
     expect(typing.cleanup).not.toHaveBeenCalled();
   });
 
+  it("cleans typing when followup enqueue is rejected behind a live active run", async () => {
+    vi.mocked(enqueueFollowupRun).mockReturnValueOnce(false);
+    const { run, typing } = createMinimalRun({
+      opts: { isHeartbeat: false },
+      isActive: true,
+      isRunActive: () => true,
+      shouldFollowup: true,
+      resolvedQueueMode: "collect",
+    });
+
+    const result = await run();
+
+    expect(result).toBeUndefined();
+    expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(scheduleFollowupDrain)).not.toHaveBeenCalled();
+    expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+    expect(typing.cleanup).toHaveBeenCalledTimes(1);
+  });
+
   it("starts draining immediately when the active snapshot is already stale", async () => {
     const { run, typing } = createMinimalRun({
       opts: { isHeartbeat: false },
@@ -269,6 +291,27 @@ describe("runReplyAgent heartbeat followup guard", () => {
     expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(scheduleFollowupDrain)).toHaveBeenCalledTimes(1);
     expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+    expect(typing.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("still schedules stale-active drain when followup enqueue is rejected", async () => {
+    vi.mocked(enqueueFollowupRun).mockReturnValueOnce(false);
+    const { run, typing } = createMinimalRun({
+      opts: { isHeartbeat: false },
+      isActive: true,
+      isRunActive: () => false,
+      shouldFollowup: true,
+      resolvedQueueMode: "collect",
+    });
+
+    const result = await run();
+
+    expect(result).toBeUndefined();
+    expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(scheduleFollowupDrain)).toHaveBeenCalledTimes(1);
+    expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
     expect(typing.cleanup).toHaveBeenCalledTimes(1);
   });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1080,7 +1080,7 @@ export async function runReplyAgent(params: {
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
-    enqueueFollowupRun(
+    const enqueued = enqueueFollowupRun(
       queueKey,
       followupRun,
       resolvedQueue,
@@ -1095,7 +1095,7 @@ export async function runReplyAgent(params: {
       scheduleFollowupDrain(queueKey, queuedRunFollowupTurn);
     }
     await touchActiveSessionEntry();
-    if (queuedBehindActiveRun) {
+    if (queuedBehindActiveRun && enqueued) {
       await typingSignals.signalToolStart();
     } else {
       typing.cleanup();


### PR DESCRIPTION
## Summary

- Problem: queued followups could start typing keepalive even when `enqueueFollowupRun` rejected the item.
- Why it matters: duplicate or dropped followups during an active run could leave per-message typing controllers alive until TTL, bypassing the queue cap's intended resource bound.
- What changed: `runReplyAgent` now checks the enqueue result and only keeps typing alive when a followup was actually accepted behind a live active run.
- What did NOT change (scope boundary): stale-active followup drain scheduling, queue policy, typing TTL behavior, and normal accepted-followup typing behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the enqueue-followup branch ignored `enqueueFollowupRun`'s boolean result.
- Missing detection / guardrail: existing tests covered accepted queued followups and stale active snapshots, but not rejected enqueue while the active run remained live.
- Contributing context (if known): `enqueueFollowupRun` can reject duplicates or drop-policy/cap-limited items while the caller still owns a fresh typing controller.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
- Scenario the test should lock in: rejected followup enqueue behind a live active run cleans typing and does not start the typing loop.
- Why this is the smallest reliable guardrail: the bug is in `runReplyAgent`'s branch logic around the mocked queue seam and typing controller signals.
- Existing test that already covers this (if any): none for rejected enqueue behind a live active run.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Queued duplicate or dropped followup messages should no longer keep channel typing indicators alive when no followup work was accepted.

## Diagram (if applicable)

```text
Before:
[active run] -> [enqueue rejected] -> [typing loop starts] -> [cleanup only after TTL]

After:
[active run] -> [enqueue rejected] -> [typing cleanup] -> [no keepalive loop]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux local workspace
- Runtime/container: Node/pnpm
- Model/provider: N/A
- Integration/channel (if any): auto-reply channel runtime
- Relevant config (redacted): active run with followup queue mode `collect`

### Steps

1. Enter `runReplyAgent` while another run is active and followup queueing is selected.
2. Make `enqueueFollowupRun` reject the followup.
3. Keep `isRunActive()` returning true.

### Expected

- The per-message typing controller is cleaned up and no typing loop starts.

### Actual

- Before this patch, typing was started despite the rejected enqueue.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: accepted live followup still keeps typing alive; rejected live followup cleans typing; stale active snapshot still schedules drain.
- Edge cases checked: formatter, lint, and whitespace checks on touched files.
- What you did **not** verify: live provider/channel typing API behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Over-cleaning typing for rejected enqueue could stop a typing indicator for a duplicate followup while the original run is still active.
  - Mitigation: this controller belongs to the rejected inbound handling path; accepted queued followups still keep their own typing controller alive.


## Real Behavior Proof

- Behavior or issue addressed: rejected queued followups during a live active run now clean up the per-message typing controller instead of starting a typing keepalive loop.
- Real environment tested: local OpenClaw checkout on Linux, running the patched `runReplyAgent` module with the real followup queue implementation and a counter-based typing controller; no Vitest runner or queue mock was used for this proof.
- Exact steps or command run after this patch: executed `node --import tsx --input-type=module` from the repository root with a script that first enqueues one real followup, then calls `runReplyAgent` with the same message id while `isRunActive()` remains true.
- Evidence after fix: terminal output from that live Node command:

```json
{
  "firstEnqueue": true,
  "beforeDepth": 1,
  "afterDepth": 1,
  "typing": {
    "startTypingLoop": 0,
    "refreshTypingTtl": 0,
    "cleanup": 1
  }
}
```

- Observed result after fix: the duplicate followup was rejected without increasing queue depth; the typing controller did not start a typing loop or refresh TTL, and cleanup ran exactly once.
- What was not tested: a live messaging provider API call was not exercised; the proof targets the OpenClaw auto-reply runner and queue behavior before channel adapter delivery.
