### PR TITLE
fix(cron): avoid delivered status for empty outbound receipts

### DIFF
--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -1,7 +1,11 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
 import type { MsgContext } from "../templating.js";
-import { buildInboundDedupeKey, resetInboundDedupe } from "./inbound-dedupe.js";
+import {
+  buildInboundDedupeKey,
+  resetInboundDedupe,
+  type InboundDedupeClaimResult,
+} from "./inbound-dedupe.js";
 
 const sharedInboundContext: MsgContext = {
   Provider: "discord",
@@ -13,6 +17,14 @@ const sharedInboundContext: MsgContext = {
   SessionKey: "agent:main:discord:channel:c1",
   MessageSid: "msg-1",
 };
+
+function expectClaimedDedupeKey(result: InboundDedupeClaimResult): string {
+  expect(result).toMatchObject({ status: "claimed" });
+  if (!("key" in result) || result.status !== "claimed") {
+    throw new Error("expected claimed inbound dedupe result");
+  }
+  return result.key;
+}
 
 describe("inbound dedupe", () => {
   afterEach(() => {
@@ -70,14 +82,11 @@ describe("inbound dedupe", () => {
 
     try {
       const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
-      expect(firstClaim).toMatchObject({ status: "claimed" });
+      const firstClaimKey = expectClaimedDedupeKey(firstClaim);
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toMatchObject({
         status: "inflight",
       });
-      if (firstClaim.status !== "claimed") {
-        throw new Error("expected claimed inbound dedupe result");
-      }
-      inboundB.releaseInboundDedupe(firstClaim.key);
+      inboundB.releaseInboundDedupe(firstClaimKey);
       expect(inboundA.claimInboundDedupe(sharedInboundContext)).toMatchObject({
         status: "claimed",
       });
@@ -102,11 +111,8 @@ describe("inbound dedupe", () => {
 
     try {
       const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
-      expect(firstClaim).toMatchObject({ status: "claimed" });
-      if (firstClaim.status !== "claimed") {
-        throw new Error("expected claimed inbound dedupe result");
-      }
-      inboundA.commitInboundDedupe(firstClaim.key);
+      const firstClaimKey = expectClaimedDedupeKey(firstClaim);
+      inboundA.commitInboundDedupe(firstClaimKey);
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toMatchObject({
         status: "duplicate",
       });

--- a/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
@@ -1,6 +1,6 @@
 // Direct delivery tests cover isolated agent delivery through core channel targets.
 import "./isolated-agent.mocks.js";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
 import type { ChannelOutboundAdapter, ChannelOutboundContext } from "../channels/plugins/types.js";
 import type { CliDeps } from "../cli/deps.js";
@@ -452,6 +452,55 @@ describe("runCronIsolatedAgentTurn telegram forum-topic direct delivery", () => 
         text: "topic 47 completion",
         messageThreadId: 47,
       },
+    });
+  });
+
+  it("does not report delivered when telegram announce produces no platform result", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const sendText = vi.fn(async () => ({ channel: "telegram", messageId: "" }));
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "telegram",
+            plugin: createOutboundTestPlugin({
+              id: "telegram",
+              outbound: {
+                deliveryMode: "direct",
+                preferFinalAssistantVisibleText: true,
+                sendText,
+                resolveTarget: ({ to }) =>
+                  to?.trim()
+                    ? { ok: true, to: to.trim() }
+                    : { ok: false, error: new Error("target is required") },
+              },
+              messaging: {
+                parseExplicitTarget: ({ raw }) => ({ to: raw.trim() }),
+              },
+            }),
+            source: "test",
+          },
+        ]),
+      );
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "cron message with no platform receipt" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(res.delivery).toMatchObject({
+        fallbackUsed: true,
+        delivered: false,
+      });
+      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
     });
   });
 

--- a/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
@@ -1,5 +1,5 @@
 import "./isolated-agent.mocks.js";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
 import type { ChannelOutboundAdapter, ChannelOutboundContext } from "../channels/plugins/types.js";
 import type { CliDeps } from "../cli/deps.js";
@@ -400,6 +400,55 @@ describe("runCronIsolatedAgentTurn telegram forum-topic direct delivery", () => 
         chatId: "123",
         text: "plain message",
       },
+    });
+  });
+
+  it("does not report delivered when telegram announce produces no platform result", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const sendText = vi.fn(async () => ({ channel: "telegram", messageId: "" }));
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "telegram",
+            plugin: createOutboundTestPlugin({
+              id: "telegram",
+              outbound: {
+                deliveryMode: "direct",
+                preferFinalAssistantVisibleText: true,
+                sendText,
+                resolveTarget: ({ to }) =>
+                  to?.trim()
+                    ? { ok: true, to: to.trim() }
+                    : { ok: false, error: new Error("target is required") },
+              },
+              messaging: {
+                parseExplicitTarget: ({ raw }) => ({ to: raw.trim() }),
+              },
+            }),
+            source: "test",
+          },
+        ]),
+      );
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "cron message with no platform receipt" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(res.delivery).toMatchObject({
+        fallbackUsed: true,
+        delivered: false,
+      });
+      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
     });
   });
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -3598,6 +3598,54 @@ describe("deliverOutboundPayloads", () => {
     expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
+  it("does not reuse a previous payload message id for a suppressed text send", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    const sendText = vi
+      .fn()
+      .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-1" })
+      .mockResolvedValueOnce({ channel: "matrix", messageId: "" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [{ text: "first" }, { text: "second" }],
+    });
+
+    expect(results).toStrictEqual([{ channel: "matrix", messageId: "mx-1" }]);
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledTimes(2);
+    expect(hookMocks.runner.runMessageSent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        content: "first",
+        success: true,
+        messageId: "mx-1",
+      }),
+      expect.objectContaining({ channelId: "matrix" }),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        content: "second",
+        success: false,
+      }),
+      expect.objectContaining({ channelId: "matrix" }),
+    );
+    expect(hookMocks.runner.runMessageSent.mock.calls[1]?.[0]).not.toHaveProperty("messageId");
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2791,6 +2791,54 @@ describe("deliverOutboundPayloads", () => {
     expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
+  it("does not reuse a previous payload message id for a suppressed text send", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    const sendText = vi
+      .fn()
+      .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-1" })
+      .mockResolvedValueOnce({ channel: "matrix", messageId: "" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [{ text: "first" }, { text: "second" }],
+    });
+
+    expect(results).toStrictEqual([{ channel: "matrix", messageId: "mx-1" }]);
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledTimes(2);
+    expect(hookMocks.runner.runMessageSent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        content: "first",
+        success: true,
+        messageId: "mx-1",
+      }),
+      expect.objectContaining({ channelId: "matrix" }),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        content: "second",
+        success: false,
+      }),
+      expect.objectContaining({ channelId: "matrix" }),
+    );
+    expect(hookMocks.runner.runMessageSent.mock.calls[1]?.[0]).not.toHaveProperty("messageId");
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -868,6 +868,23 @@ function hasDeliveryResultIdentity(result: OutboundDeliveryResult): boolean {
   );
 }
 
+function pushIdentifiedDeliveryResult(
+  results: OutboundDeliveryResult[],
+  delivery: OutboundDeliveryResult,
+): boolean {
+  if (!hasDeliveryResultIdentity(delivery)) {
+    return false;
+  }
+  results.push(delivery);
+  return true;
+}
+
+function filterIdentifiedDeliveryResults(
+  results: readonly OutboundDeliveryResult[],
+): OutboundDeliveryResult[] {
+  return results.filter((result) => hasDeliveryResultIdentity(result));
+}
+
 function normalizeDeliveryPin(payload: ReplyPayload): ReplyPayloadDeliveryPin | undefined {
   const pin = payload.delivery?.pin;
   if (pin === true) {
@@ -1529,7 +1546,7 @@ async function deliverOutboundPayloadsCore(
         continue;
       }
       throwIfAborted(abortSignal);
-      results.push(await sendHandler.sendText(unit.text, unit.overrides));
+      pushIdentifiedDeliveryResult(results, await sendHandler.sendText(unit.text, unit.overrides));
     }
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(outboundPayloadPlan, handler);
@@ -1783,10 +1800,12 @@ async function deliverOutboundPayloadsCore(
         const beforeCount = results.length;
         if (deliveryHandler.sendFormattedText) {
           results.push(
-            ...(await deliveryHandler.sendFormattedText(
-              payloadSummary.text,
-              applySendReplyToConsumption(sendOverrides),
-            )),
+            ...filterIdentifiedDeliveryResults(
+              await deliveryHandler.sendFormattedText(
+                payloadSummary.text,
+                applySendReplyToConsumption(sendOverrides),
+              ),
+            ),
           );
         } else {
           await sendTextChunks(deliveryHandler, payloadSummary.text, sendOverrides);
@@ -1807,7 +1826,7 @@ async function deliverOutboundPayloadsCore(
             }),
           );
         }
-        const messageId = results.at(-1)?.messageId;
+        const messageId = deliveredResults.at(-1)?.messageId;
         const pinMessageId = deliveredResults.find((entry) => entry.messageId)?.messageId;
         await maybePinDeliveredMessage({
           handler: deliveryHandler,
@@ -1824,7 +1843,7 @@ async function deliverOutboundPayloadsCore(
         });
         completeDeliveryDiagnostics(deliveredResults.length);
         emitMessageSent({
-          success: results.length > beforeCount,
+          success: deliveredResults.length > 0,
           content: payloadSummary.hookContent ?? payloadSummary.text,
           messageId,
         });
@@ -1864,7 +1883,7 @@ async function deliverOutboundPayloadsCore(
             }),
           );
         }
-        const messageId = results.at(-1)?.messageId;
+        const messageId = deliveredResults.at(-1)?.messageId;
         const pinMessageId = deliveredResults.find((entry) => entry.messageId)?.messageId;
         await maybePinDeliveredMessage({
           handler: deliveryHandler,
@@ -1881,7 +1900,7 @@ async function deliverOutboundPayloadsCore(
         });
         completeDeliveryDiagnostics(deliveredResults.length);
         emitMessageSent({
-          success: results.length > beforeCount,
+          success: deliveredResults.length > 0,
           content: payloadSummary.hookContent ?? payloadSummary.text,
           messageId,
         });
@@ -1909,9 +1928,10 @@ async function deliverOutboundPayloadsCore(
               unit.overrides,
             )
           : await deliveryHandler.sendMedia(unit.caption ?? "", unit.mediaUrl, unit.overrides);
-        results.push(delivery);
-        firstMessageId ??= delivery.messageId;
-        lastMessageId = delivery.messageId;
+        if (pushIdentifiedDeliveryResult(results, delivery)) {
+          firstMessageId ??= delivery.messageId;
+          lastMessageId = delivery.messageId;
+        }
       }
       await maybePinDeliveredMessage({
         handler: deliveryHandler,
@@ -1944,7 +1964,7 @@ async function deliverOutboundPayloadsCore(
       }
       completeDeliveryDiagnostics(results.length - beforeCount);
       emitMessageSent({
-        success: true,
+        success: results.length > beforeCount,
         content: payloadSummary.hookContent ?? payloadSummary.text,
         messageId: lastMessageId,
       });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -836,6 +836,23 @@ function hasDeliveryResultIdentity(result: OutboundDeliveryResult): boolean {
   );
 }
 
+function pushIdentifiedDeliveryResult(
+  results: OutboundDeliveryResult[],
+  delivery: OutboundDeliveryResult,
+): boolean {
+  if (!hasDeliveryResultIdentity(delivery)) {
+    return false;
+  }
+  results.push(delivery);
+  return true;
+}
+
+function filterIdentifiedDeliveryResults(
+  results: readonly OutboundDeliveryResult[],
+): OutboundDeliveryResult[] {
+  return results.filter((result) => hasDeliveryResultIdentity(result));
+}
+
 function normalizeDeliveryPin(payload: ReplyPayload): ReplyPayloadDeliveryPin | undefined {
   const pin = payload.delivery?.pin;
   if (pin === true) {
@@ -1399,7 +1416,7 @@ async function deliverOutboundPayloadsCore(
         continue;
       }
       throwIfAborted(abortSignal);
-      results.push(await handler.sendText(unit.text, unit.overrides));
+      pushIdentifiedDeliveryResult(results, await handler.sendText(unit.text, unit.overrides));
     }
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(outboundPayloadPlan, handler);
@@ -1604,10 +1621,12 @@ async function deliverOutboundPayloadsCore(
         const beforeCount = results.length;
         if (handler.sendFormattedText) {
           results.push(
-            ...(await handler.sendFormattedText(
-              payloadSummary.text,
-              applySendReplyToConsumption(sendOverrides),
-            )),
+            ...filterIdentifiedDeliveryResults(
+              await handler.sendFormattedText(
+                payloadSummary.text,
+                applySendReplyToConsumption(sendOverrides),
+              ),
+            ),
           );
         } else {
           await sendTextChunks(payloadSummary.text, sendOverrides);
@@ -1722,9 +1741,10 @@ async function deliverOutboundPayloadsCore(
         const delivery = handler.sendFormattedMedia
           ? await handler.sendFormattedMedia(unit.caption ?? "", unit.mediaUrl, unit.overrides)
           : await handler.sendMedia(unit.caption ?? "", unit.mediaUrl, unit.overrides);
-        results.push(delivery);
-        firstMessageId ??= delivery.messageId;
-        lastMessageId = delivery.messageId;
+        if (pushIdentifiedDeliveryResult(results, delivery)) {
+          firstMessageId ??= delivery.messageId;
+          lastMessageId = delivery.messageId;
+        }
       }
       await maybePinDeliveredMessage({
         handler,
@@ -1755,7 +1775,7 @@ async function deliverOutboundPayloadsCore(
       }
       completeDeliveryDiagnostics(results.length - beforeCount);
       emitMessageSent({
-        success: true,
+        success: results.length > beforeCount,
         content: payloadSummary.hookContent ?? payloadSummary.text,
         messageId: lastMessageId,
       });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1646,7 +1646,7 @@ async function deliverOutboundPayloadsCore(
             }),
           );
         }
-        const messageId = results.at(-1)?.messageId;
+        const messageId = deliveredResults.at(-1)?.messageId;
         const pinMessageId = deliveredResults.find((entry) => entry.messageId)?.messageId;
         await maybePinDeliveredMessage({
           handler,
@@ -1662,7 +1662,7 @@ async function deliverOutboundPayloadsCore(
         });
         completeDeliveryDiagnostics(deliveredResults.length);
         emitMessageSent({
-          success: results.length > beforeCount,
+          success: deliveredResults.length > 0,
           content: payloadSummary.hookContent ?? payloadSummary.text,
           messageId,
         });
@@ -1701,7 +1701,7 @@ async function deliverOutboundPayloadsCore(
             }),
           );
         }
-        const messageId = results.at(-1)?.messageId;
+        const messageId = deliveredResults.at(-1)?.messageId;
         const pinMessageId = deliveredResults.find((entry) => entry.messageId)?.messageId;
         await maybePinDeliveredMessage({
           handler,
@@ -1717,7 +1717,7 @@ async function deliverOutboundPayloadsCore(
         });
         completeDeliveryDiagnostics(deliveredResults.length);
         emitMessageSent({
-          success: results.length > beforeCount,
+          success: deliveredResults.length > 0,
           content: payloadSummary.hookContent ?? payloadSummary.text,
           messageId,
         });


### PR DESCRIPTION
## Summary

Fixes #79753.

Cron announce/direct delivery could still treat an outbound adapter result with no platform delivery identity as a successful send on text/media paths. That lets a run show `delivered: true` even though the channel adapter produced no usable message receipt.

This tightens the shared outbound delivery result handling so only results with a real delivery identity (`messageId`, `chatId`, `channelId`, `roomId`, `conversationId`, `toJid`, or `pollId`) are counted as sent. Empty/identity-less results now flow through the existing suppressed/no-visible-result path, so cron records `delivered: false` instead of a false positive.

## Real behavior proof

- **Behavior addressed**: A cron announce/direct delivery path must not report a channel delivery as successful when the outbound channel adapter returns no platform message identity.
- **Real environment tested**: Local OpenClaw checkout on macOS, branch `codex/cron-announce-not-delivered-regression`, Node `v25.7.0`, using the patched shared outbound delivery runtime through `sendDurableMessageBatch`.
- **Exact steps or command run after this patch**: Ran a local OpenClaw runtime smoke command that registers a Telegram outbound adapter returning `{ channel: "telegram", messageId: "" }`, then calls `sendDurableMessageBatch` with `skipQueue: true`.
- **Evidence after fix**: Terminal output from the patched checkout:

```console
$ pnpm exec tsx -e '(async () => { const { sendDurableMessageBatch } = await import("./src/channels/message/send.ts"); const { setActivePluginRegistry } = await import("./src/plugins/runtime.ts"); const { createOutboundTestPlugin, createTestRegistry } = await import("./src/test-utils/channel-plugins.ts"); const sendText = async () => ({ channel: "telegram", messageId: "" }); setActivePluginRegistry(createTestRegistry([{ pluginId: "telegram", source: "local-smoke", plugin: createOutboundTestPlugin({ id: "telegram", outbound: { deliveryMode: "direct", sendText } }) }])); const result = await sendDurableMessageBatch({ cfg: {}, channel: "telegram", to: "123", payloads: [{ text: "cron receipt smoke" }], skipQueue: true }); console.log(JSON.stringify(result, null, 2)); })();'
{
  "status": "suppressed",
  "results": [],
  "receipt": {
    "platformMessageIds": [],
    "parts": [],
    "sentAt": 1778397010778,
    "raw": []
  },
  "reason": "adapter_returned_no_identity",
  "payloadOutcomes": [
    {
      "index": 0,
      "status": "suppressed",
      "reason": "adapter_returned_no_identity"
    }
  ]
}
```

- **Observed result after fix**: The outbound runtime suppressed the empty platform receipt (`status: "suppressed"`, `results: []`, `reason: "adapter_returned_no_identity"`) instead of returning a sent result. The cron regression test on the same branch verifies this maps to `delivered: false` with `deliveryAttempted: true`.
- **What was not tested**: I did not run a live WeChat or Feishu cron announce job locally because I do not have those channel credentials in this environment.

## Tests

- `pnpm test src/cron/isolated-agent.direct-delivery-core-channels.test.ts`
- `pnpm test src/channels/message/send.test.ts src/infra/outbound/deliver.test.ts`
- `pnpm test src/cron/isolated-agent.direct-delivery-core-channels.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/channels/message/send.test.ts src/infra/outbound/deliver.test.ts`
- `pnpm test src/cron/isolated-agent.direct-delivery-core-channels.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/channels/message/send.test.ts src/infra/outbound/deliver.test.ts extensions/telegram/src/outbound-adapter.test.ts extensions/feishu/src/outbound.test.ts extensions/slack/src/outbound-delivery.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/outbound/deliver.ts src/cron/isolated-agent.direct-delivery-core-channels.test.ts`
- `git diff --check`
