### PR TITLE
fix(gateway): include reason and stderr in auto-update failure log

### DIFF
--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -475,12 +475,18 @@ export async function runGatewayUpdateCheck(params: {
             tag,
           });
         } else {
-          params.log.info("auto-update attempt failed", {
-            channel,
-            version: resolved.version,
-            tag,
-            reason: outcome.reason ?? `exit:${outcome.code}`,
-          });
+          const reason = outcome.reason ?? `exit:${outcome.code}`;
+          const stderrTail = (outcome.stderr ?? "")
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0)
+            .slice(-5)
+            .join(" | ");
+          const suffix = stderrTail ? ` stderr=${JSON.stringify(stderrTail)}` : "";
+          params.log.info(
+            `auto-update attempt failed: reason=${reason} version=${resolved.version} tag=${tag}${suffix}`,
+            { channel, version: resolved.version, tag, reason },
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary

`runGatewayUpdateCheck` logs `auto-update attempt failed` with the diagnostic fields (`reason`, `version`, `tag`) only in a structured-meta object. Log sinks that flatten or drop the meta record only the bare message — so silent hourly auto-update failures show up in `gateway.log` as:

```
2026-05-09T19:54:10.563+08:00 [gateway] auto-update attempt failed
```

…with no way to recover the cause after the fact. Five days of hourly failures on my install left no breadcrumb for diagnosis. The success and "deferred" sibling logs have the same shape but they're inherently less useful to inspect than failures.

## Change

Inline the same fields into the log **message string** and append a 5-line tail of the spawned child's stderr. The structured meta is preserved unchanged for any sink that consumes it.

After the patch:

```
2026-05-09T19:54:10.563+08:00 [gateway] auto-update attempt failed: reason=non-zero-exit version=2026.5.7 tag=latest stderr="<actual error>"
```

## Test plan

- [x] `node scripts/test-projects.mjs src/infra/update-startup.test.ts` — 11/11 pass
- [x] `pnpm tsgo:core`
- [x] Manual/local runtime proof below

## Real behavior proof

- **Behavior or issue addressed**: Auto-update failure logs now carry the failure reason, target version, channel tag, and stderr tail in the log message string, so flattened/plain log sinks do not lose the diagnostic details.
- **Real environment tested**: Local OpenClaw source checkout at commit `25a8d9689d0505374ec1cbe54341af10e2ff9c79` on macOS, Node.js runtime via `node --import tsx`, isolated temporary `OPENCLAW_STATE_DIR` under `/tmp`.
- **Exact steps or command run after this patch**: Ran `runGatewayUpdateCheck` from the checked-out OpenClaw runtime with beta auto-update enabled, an isolated state dir, and a nonzero auto-update child result so the failure branch was exercised without modifying the installed OpenClaw package.
- **Evidence after fix**: Terminal output from the post-patch run:

```text
update available (beta): v2026.5.10-beta.3 (current v2026.5.8). Run: openclaw update {}
auto-update attempt failed: reason=non-zero-exit version=2026.5.10-beta.3 tag=beta stderr="npm ERR! code E403 | npm ERR! forbidden scoped token | npm ERR! audit endpoint unavailable | npm ERR! retry later | npm ERR! final failure line" {"channel":"beta","version":"2026.5.10-beta.3","tag":"beta","reason":"non-zero-exit"}
```

- **Observed result after fix**: The emitted failure message itself includes `reason=non-zero-exit`, `version=2026.5.10-beta.3`, `tag=beta`, and the 5-line stderr tail. The structured metadata remains present as `{"channel":"beta","version":"2026.5.10-beta.3","tag":"beta","reason":"non-zero-exit"}`.
- **What was not tested**: I did not run a real package self-update that replaces the installed OpenClaw package; the failure branch was exercised with an isolated state dir to avoid mutating the installed package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)