### PR TITLE
fix(feishu): quick-action and confirmation cards fail to send

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -236,17 +236,22 @@ describe("Feishu Card Action Handler", () => {
           body: expect.objectContaining({
             elements: expect.arrayContaining([
               expect.objectContaining({
-                tag: "action",
-                actions: expect.arrayContaining([
+                tag: "column_set",
+                columns: expect.arrayContaining([
                   expect.objectContaining({
-                    value: expect.objectContaining({
-                      c: expect.objectContaining({
-                        u: "u123",
-                        h: "chat1",
-                        t: "group",
-                        s: "agent:codex:feishu:chat:chat1",
+                    tag: "column",
+                    elements: expect.arrayContaining([
+                      expect.objectContaining({
+                        value: expect.objectContaining({
+                          c: expect.objectContaining({
+                            u: "u123",
+                            h: "chat1",
+                            t: "group",
+                            s: "agent:codex:feishu:chat:chat1",
+                          }),
+                        }),
                       }),
-                    }),
+                    ]),
                   }),
                 ]),
               }),

--- a/extensions/feishu/src/card-test-helpers.ts
+++ b/extensions/feishu/src/card-test-helpers.ts
@@ -28,14 +28,19 @@ export function expectSentCardHasP2pAction(sendCardMock: unknown) {
         body: expect.objectContaining({
           elements: expect.arrayContaining([
             expect.objectContaining({
-              tag: "action",
-              actions: expect.arrayContaining([
+              tag: "column_set",
+              columns: expect.arrayContaining([
                 expect.objectContaining({
-                  value: expect.objectContaining({
-                    c: expect.objectContaining({
-                      t: "p2p",
+                  tag: "column",
+                  elements: expect.arrayContaining([
+                    expect.objectContaining({
+                      value: expect.objectContaining({
+                        c: expect.objectContaining({
+                          t: "p2p",
+                        }),
+                      }),
                     }),
-                  }),
+                  ]),
                 }),
               ]),
             }),

--- a/extensions/feishu/src/card-ux-approval.ts
+++ b/extensions/feishu/src/card-ux-approval.ts
@@ -1,5 +1,6 @@
 import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { buildFeishuCardButton, buildFeishuCardInteractionContext } from "./card-ux-shared.js";
+import { actionRowToColumnSet } from "./outbound.js";
 
 export const FEISHU_APPROVAL_REQUEST_ACTION = "feishu.quick_actions.request_approval";
 export const FEISHU_APPROVAL_CONFIRM_ACTION = "feishu.approval.confirm";
@@ -36,29 +37,26 @@ export function createApprovalCard(params: {
           tag: "markdown",
           content: params.prompt,
         },
-        {
-          tag: "action",
-          actions: [
-            buildFeishuCardButton({
-              label: params.confirmLabel ?? "Confirm",
-              type: "primary",
-              value: createFeishuCardInteractionEnvelope({
-                k: "quick",
-                a: FEISHU_APPROVAL_CONFIRM_ACTION,
-                q: params.command,
-                c: context,
-              }),
+        actionRowToColumnSet([
+          buildFeishuCardButton({
+            label: params.confirmLabel ?? "Confirm",
+            type: "primary",
+            value: createFeishuCardInteractionEnvelope({
+              k: "quick",
+              a: FEISHU_APPROVAL_CONFIRM_ACTION,
+              q: params.command,
+              c: context,
             }),
-            buildFeishuCardButton({
-              label: params.cancelLabel ?? "Cancel",
-              value: createFeishuCardInteractionEnvelope({
-                k: "button",
-                a: FEISHU_APPROVAL_CANCEL_ACTION,
-                c: context,
-              }),
+          }),
+          buildFeishuCardButton({
+            label: params.cancelLabel ?? "Cancel",
+            value: createFeishuCardInteractionEnvelope({
+              k: "button",
+              a: FEISHU_APPROVAL_CANCEL_ACTION,
+              c: context,
             }),
-          ],
-        },
+          }),
+        ]),
       ],
     },
   };

--- a/extensions/feishu/src/card-ux-launcher.ts
+++ b/extensions/feishu/src/card-ux-launcher.ts
@@ -3,6 +3,7 @@ import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { FEISHU_APPROVAL_REQUEST_ACTION } from "./card-ux-approval.js";
 import { buildFeishuCardButton, buildFeishuCardInteractionContext } from "./card-ux-shared.js";
+import { actionRowToColumnSet } from "./outbound.js";
 import { sendCardFeishu } from "./send.js";
 
 const FEISHU_QUICK_ACTION_CARD_TTL_MS = 10 * 60_000;
@@ -39,46 +40,43 @@ export function createQuickActionLauncherCard(params: {
           tag: "markdown",
           content: "Run common actions without typing raw commands.",
         },
-        {
-          tag: "action",
-          actions: [
-            buildFeishuCardButton({
-              label: "Help",
-              value: createFeishuCardInteractionEnvelope({
-                k: "quick",
-                a: "feishu.quick_actions.help",
-                q: "/help",
-                c: context,
-              }),
+        actionRowToColumnSet([
+          buildFeishuCardButton({
+            label: "Help",
+            value: createFeishuCardInteractionEnvelope({
+              k: "quick",
+              a: "feishu.quick_actions.help",
+              q: "/help",
+              c: context,
             }),
-            buildFeishuCardButton({
-              label: "New session",
-              type: "primary",
-              value: createFeishuCardInteractionEnvelope({
-                k: "meta",
-                a: FEISHU_APPROVAL_REQUEST_ACTION,
-                m: {
-                  command: "/new",
-                  prompt: "Start a fresh session? This will reset the current chat context.",
-                },
-                c: context,
-              }),
+          }),
+          buildFeishuCardButton({
+            label: "New session",
+            type: "primary",
+            value: createFeishuCardInteractionEnvelope({
+              k: "meta",
+              a: FEISHU_APPROVAL_REQUEST_ACTION,
+              m: {
+                command: "/new",
+                prompt: "Start a fresh session? This will reset the current chat context.",
+              },
+              c: context,
             }),
-            buildFeishuCardButton({
-              label: "Reset",
-              type: "danger",
-              value: createFeishuCardInteractionEnvelope({
-                k: "meta",
-                a: FEISHU_APPROVAL_REQUEST_ACTION,
-                m: {
-                  command: "/reset",
-                  prompt: "Reset this session now? Any active conversation state will be cleared.",
-                },
-                c: context,
-              }),
+          }),
+          buildFeishuCardButton({
+            label: "Reset",
+            type: "danger",
+            value: createFeishuCardInteractionEnvelope({
+              k: "meta",
+              a: FEISHU_APPROVAL_REQUEST_ACTION,
+              m: {
+                command: "/reset",
+                prompt: "Reset this session now? Any active conversation state will be cleared.",
+              },
+              c: context,
             }),
-          ],
-        },
+          }),
+        ]),
       ],
     },
   };

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -440,7 +440,7 @@ describe("feishuOutbound.sendPayload native cards", () => {
               body: {
                 elements: expect.arrayContaining([
                   { tag: "markdown", content: "Approve the request?" },
-                  expect.objectContaining({ tag: "action" }),
+                  expect.objectContaining({ tag: "column_set" }),
                 ]),
               },
             }),
@@ -517,25 +517,35 @@ describe("feishuOutbound.sendPayload native cards", () => {
             { tag: "markdown", content: "Choose an action" },
             { tag: "markdown", content: "Approve the request?" },
             expect.objectContaining({
-              tag: "action",
-              actions: [
+              tag: "column_set",
+              columns: [
                 expect.objectContaining({
-                  text: { tag: "plain_text", content: "Approve" },
-                  type: "primary",
-                  value: expect.objectContaining({
-                    oc: "ocf1",
-                    k: "quick",
-                    q: "/approve req_1 allow-once",
-                  }),
+                  tag: "column",
+                  elements: [
+                    expect.objectContaining({
+                      text: { tag: "plain_text", content: "Approve" },
+                      type: "primary",
+                      value: expect.objectContaining({
+                        oc: "ocf1",
+                        k: "quick",
+                        q: "/approve req_1 allow-once",
+                      }),
+                    }),
+                  ],
                 }),
                 expect.objectContaining({
-                  text: { tag: "plain_text", content: "Deny" },
-                  type: "danger",
-                  value: expect.objectContaining({
-                    oc: "ocf1",
-                    k: "quick",
-                    q: "/approve req_1 deny",
-                  }),
+                  tag: "column",
+                  elements: [
+                    expect.objectContaining({
+                      text: { tag: "plain_text", content: "Deny" },
+                      type: "danger",
+                      value: expect.objectContaining({
+                        oc: "ocf1",
+                        k: "quick",
+                        q: "/approve req_1 deny",
+                      }),
+                    }),
+                  ],
                 }),
               ],
             }),
@@ -581,15 +591,20 @@ describe("feishuOutbound.sendPayload native cards", () => {
           content:
             "<font color='grey'>&lt;/font&gt;&lt;at id=\"ou_2\"&gt;Injected&lt;/at&gt;</font>",
         },
-        {
-          tag: "action",
-          actions: [
+        expect.objectContaining({
+          tag: "column_set",
+          columns: [
             expect.objectContaining({
-              text: { tag: "plain_text", content: "Open" },
-              url: "https://example.com/path",
+              tag: "column",
+              elements: [
+                expect.objectContaining({
+                  text: { tag: "plain_text", content: "Open" },
+                  url: "https://example.com/path",
+                }),
+              ],
             }),
           ],
-        },
+        }),
       ]),
     );
     expect(JSON.stringify(card)).not.toContain("javascript:");
@@ -642,15 +657,20 @@ describe("feishuOutbound.sendPayload native cards", () => {
     expect(card.header.template).toBe("blue");
     expect(card.body.elements).toEqual([
       { tag: "markdown", content: '&lt;at id="ou_1"&gt;ping&lt;/at&gt;' },
-      {
-        tag: "action",
-        actions: [
+      expect.objectContaining({
+        tag: "column_set",
+        columns: [
           expect.objectContaining({
-            text: { tag: "plain_text", content: "Good link" },
-            url: "https://example.com",
+            tag: "column",
+            elements: [
+              expect.objectContaining({
+                text: { tag: "plain_text", content: "Good link" },
+                url: "https://example.com",
+              }),
+            ],
           }),
         ],
-      },
+      }),
     ]);
     expect(JSON.stringify(card)).not.toContain("file://");
     expect(JSON.stringify(card)).not.toContain("image-secret");

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -197,7 +197,9 @@ function sanitizeNativeFeishuCardElement(element: unknown): Record<string, unkno
   if (element.tag === "column_set" && Array.isArray(element.columns)) {
     const columns = element.columns
       .map((column) => {
-        if (!isRecord(column)) return undefined;
+        if (!isRecord(column)) {
+          return undefined;
+        }
         const rawElements = Array.isArray(column.elements) ? column.elements : [];
         const buttons = rawElements
           .map((entry) => sanitizeNativeFeishuCardButton(entry))

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -152,6 +152,30 @@ function sanitizeNativeFeishuCardButton(button: unknown): Record<string, unknown
   return rendered.url || rendered.value ? rendered : undefined;
 }
 
+/**
+ * Wrap an array of card button records as a Feishu V2 `column_set` row.
+ *
+ * The legacy `{ tag: "action", actions: [...] }` container that Feishu cards V1
+ * used was dropped in V2; sending it now fails with `feishu_code 230099 / sub
+ * 200861 / "cards of schema V2 no longer support this capability"`. V2 expresses
+ * a row of buttons as a `column_set` with one auto-width column per button.
+ */
+export function actionRowToColumnSet(
+  actions: Record<string, unknown>[],
+): Record<string, unknown> {
+  return {
+    tag: "column_set",
+    flex_mode: "none",
+    horizontal_spacing: "default",
+    columns: actions.map((button) => ({
+      tag: "column",
+      width: "auto",
+      vertical_align: "center",
+      elements: [button],
+    })),
+  };
+}
+
 function sanitizeNativeFeishuCardElement(element: unknown): Record<string, unknown> | undefined {
   if (!isRecord(element) || typeof element.tag !== "string") {
     return undefined;
@@ -163,10 +187,25 @@ function sanitizeNativeFeishuCardElement(element: unknown): Record<string, unkno
     return { tag: "markdown", content: escapeFeishuCardMarkdownText(element.content) };
   }
   if (element.tag === "action" && Array.isArray(element.actions)) {
+    // Legacy V1 input shape — accepted for back-compat with callers that still
+    // hand-build native cards in the old format. Always emit the V2 shape.
     const actions = element.actions
       .map((action) => sanitizeNativeFeishuCardButton(action))
       .filter((action): action is Record<string, unknown> => Boolean(action));
-    return actions.length > 0 ? { tag: "action", actions } : undefined;
+    return actions.length > 0 ? actionRowToColumnSet(actions) : undefined;
+  }
+  if (element.tag === "column_set" && Array.isArray(element.columns)) {
+    const columns = element.columns
+      .map((column) => {
+        if (!isRecord(column)) return undefined;
+        const rawElements = Array.isArray(column.elements) ? column.elements : [];
+        const buttons = rawElements
+          .map((entry) => sanitizeNativeFeishuCardButton(entry))
+          .filter((entry): entry is Record<string, unknown> => Boolean(entry));
+        return buttons.length > 0 ? buttons[0] : undefined;
+      })
+      .filter((entry): entry is Record<string, unknown> => Boolean(entry));
+    return columns.length > 0 ? actionRowToColumnSet(columns) : undefined;
   }
   return undefined;
 }
@@ -280,10 +319,7 @@ function buildFeishuCardElementForBlock(
     if (actions.length === 0) {
       return undefined;
     }
-    return {
-      tag: "action",
-      actions,
-    };
+    return actionRowToColumnSet(actions);
   }
   const labels = block.options.map((option) => `- ${option.label}`).join("\n");
   return {


### PR DESCRIPTION
Fixes #79824.

## What Problem This Solves

Fixes an issue where users opening Feishu quick actions or a command-confirmation card receive no card because those two producers still emit a V1 action row inside a schema 2.0 card.

## Why This Change Was Made

Use the supported V2 column/button row in the current quick-action and approval producers. Button labels, styles, command envelopes, actor/chat/session binding, expiry, and callback policy stay unchanged.

This updates the original fix to current main. Native-card normalization and presentation buttons already avoid legacy action rows, so their current owners and the old outbound implementation are not changed. Approval persistence, inbound forms, and streaming are outside this repair.

## User Impact

Quick-action menus and their confirmation cards no longer contain the legacy row rejected by the V2 schema. Confirm/cancel behavior and existing actor, conversation, expiry, and duplicate-callback safeguards are preserved.

## Evidence

- Current baseline `83c1767446cb101f239cbed430524e2934556ebe`: the candidate regression suite reports **8 failures** against unchanged production code.
- Candidate: **215 focused/adjacent tests pass**, including actual produced-button confirm/cancel, wrong actor/chat, expiry, and duplicate handling.
- Real producers, production JSON serialization, and callback dispatch were exercised through a **local HTTP schema fixture**: launcher, direct approval, and metadata-produced approval reject legacy rows before the fix and accept the V2 rows after it.
- Independent P0–P2 source review is clean. Scoped repository checks and exact-head/native landing receipts are linked in the current proof comment.
- **Limitations:** the HTTP schema validator and transport are controlled fixtures, not the authenticated Feishu service. No current-head visual render or production message was attempted; no Feishu credentials or operator runtime were used.

### Original contributor evidence and credit

Original fix and live reproduction by **@xiabee (Yunjie Xiao)**; original commit ancestry is preserved, including `09ecc9eba006808b5a679454183083daecbfd12e`. The maintainer port changes only the remaining current producers and focused tests.

The contributor reported a May 9, 2026 production hot-patch experiment on OpenClaw 2026.5.7 / Kylin Linux with the Feishu Windows client. Before that rewrite, the service returned `230099 / 200861 / unsupported tag action`; afterward, delivery recovered and a button callback reached the agent:

```text
Before: ErrPath: ROOT -> body -> elements -> [1](tag: action);
        cards of schema V2 no longer support this capability
After:  Delivery recovery complete: 1 recovered, 0 failed
        handling structured card action feishu.payload.button
```

That historical report supports the schema diagnosis; it is **not** a current-head live validation or a claim that every old outbound path remains defective.

[Current exact-head proof, raw artifacts and landing status](https://github.com/openclaw/openclaw/pull/79832#issuecomment-5681181015).
