### PR TITLE
fix(auto-reply): image model override with proper attachment detection

### DIFF
--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -196,4 +196,8 @@ export type GetReplyOptions = {
   hasRepliedRef?: { value: boolean };
   /** Override agent timeout in seconds (0 = no timeout). Threads through to resolveAgentTimeoutMs. */
   timeoutOverrideSeconds?: number;
+  /** Model override for vision-capable model when message contains images. */
+  modelOverride?: string;
+  /** Filtered and canonicalized fallbacks for the model override. */
+  modelOverrideFallbacks?: string[];
 };

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -183,4 +183,8 @@ export type GetReplyOptions = {
   hasRepliedRef?: { value: boolean };
   /** Override agent timeout in seconds (0 = no timeout). Threads through to resolveAgentTimeoutMs. */
   timeoutOverrideSeconds?: number;
+  /** Model override for vision-capable model when message contains images. */
+  modelOverride?: string;
+  /** Filtered and canonicalized fallbacks for the model override. */
+  modelOverrideFallbacks?: string[];
 };

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -504,6 +504,7 @@ export async function resolveReplyDirectives(params: {
   const useFastModelSelection =
     useFastReplyRuntime &&
     !hasResolvedHeartbeatModelOverride &&
+    !hasAppliedImageModelOverride &&
     !(agentCfg?.models && Object.keys(agentCfg.models).length > 0) &&
     !normalizeOptionalString(targetSessionEntry?.modelOverride) &&
     !normalizeOptionalString(targetSessionEntry?.providerOverride) &&

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -172,6 +172,7 @@ export async function resolveReplyDirectives(params: {
   provider: string;
   model: string;
   hasResolvedHeartbeatModelOverride: boolean;
+  hasAppliedImageModelOverride?: boolean;
   typing: TypingController;
   opts?: GetReplyOptions;
   skillFilter?: string[];
@@ -201,6 +202,7 @@ export async function resolveReplyDirectives(params: {
     provider: initialProvider,
     model: initialModel,
     hasResolvedHeartbeatModelOverride,
+    hasAppliedImageModelOverride,
     typing,
     opts,
     skillFilter,
@@ -537,6 +539,7 @@ export async function resolveReplyDirectives(params: {
         hasModelDirective: directives.hasModelDirective,
         hasResolvedHeartbeatModelOverride,
         isHeartbeat: opts?.isHeartbeat === true,
+        hasAppliedImageModelOverride,
       });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -348,6 +348,8 @@ type RunPreparedReplyParams = {
   storePath?: string;
   workspaceDir: string;
   abortedLastRun: boolean;
+  /** True when an image model override was applied, for cross-provider auth handling. */
+  hasAppliedImageModelOverride?: boolean;
 };
 
 export async function runPreparedReply(
@@ -388,6 +390,7 @@ export async function runPreparedReply(
     storePath,
     workspaceDir,
     sessionStore,
+    hasAppliedImageModelOverride,
   } = params;
   const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
     cfg,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -876,24 +876,29 @@ export async function runPreparedReply(
         })
       : [provider];
   // When an image model override is active, skip auth profile resolution to
-  // avoid clearing the stored session auth profile (which belongs to the
-  // original provider). The image override is temporary for this turn only.
-  let authProfileId =
-    useFastReplyRuntime || hasAppliedImageModelOverride
-      ? preparedSessionState.sessionEntry?.authProfileOverride
-      : await traceRunPhase("reply.resolve_auth_profile", () =>
-          resolveSessionAuthProfileOverride({
-            cfg,
-            provider,
-            acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
-            agentDir,
-            sessionEntry: preparedSessionState.sessionEntry,
-            sessionStore,
-            sessionKey,
-            storePath,
-            isNewSession,
-          }),
-        );
+  // avoid (a) clearing the stored session auth profile and (b) forwarding
+  // the original provider's auth profile to a different provider's run.
+  // The image override is temporary for this turn only.
+  let authProfileId: string | undefined;
+  if (hasAppliedImageModelOverride) {
+    authProfileId = undefined;
+  } else if (useFastReplyRuntime) {
+    authProfileId = preparedSessionState.sessionEntry?.authProfileOverride;
+  } else {
+    authProfileId = await traceRunPhase("reply.resolve_auth_profile", () =>
+      resolveSessionAuthProfileOverride({
+        cfg,
+        provider,
+        acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+        agentDir,
+        sessionEntry: preparedSessionState.sessionEntry,
+        sessionStore,
+        sessionKey,
+        storePath,
+        isNewSession,
+      }),
+    );
+  }
   const { runReplyAgent } = await traceRunPhase("reply.load_agent_runner_runtime", () =>
     loadAgentRunnerRuntime(),
   );
@@ -942,20 +947,23 @@ export async function runPreparedReply(
         piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined),
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();
-        authProfileId =
-          useFastReplyRuntime || hasAppliedImageModelOverride
-            ? preparedSessionState.sessionEntry?.authProfileOverride
-            : await resolveSessionAuthProfileOverride({
-                cfg,
-                provider,
-                acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
-                agentDir,
-                sessionEntry: preparedSessionState.sessionEntry,
-                sessionStore,
-                sessionKey,
-                storePath,
-                isNewSession,
-              });
+        if (hasAppliedImageModelOverride) {
+          authProfileId = undefined;
+        } else if (useFastReplyRuntime) {
+          authProfileId = preparedSessionState.sessionEntry?.authProfileOverride;
+        } else {
+          authProfileId = await resolveSessionAuthProfileOverride({
+            cfg,
+            provider,
+            acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+            agentDir,
+            sessionEntry: preparedSessionState.sessionEntry,
+            sessionStore,
+            sessionKey,
+            storePath,
+            isNewSession,
+          });
+        }
         preparedSessionState = resolvePreparedSessionState();
         ({ prefixedCommandBody, queuedBody, transcriptCommandBody, currentTurnContext } =
           await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies()));

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -4,6 +4,7 @@ import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/se
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
 import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/sandbox-info.js";
 import type { EmbeddedFullAccessBlockedReason } from "../../agents/pi-embedded-runner/types.js";
@@ -379,6 +380,7 @@ export async function runPreparedReply(
     perMessageQueueOptions,
     typing,
     opts,
+    defaultProvider,
     defaultModel,
     timeoutMs,
     isNewSession,
@@ -875,12 +877,16 @@ export async function runPreparedReply(
           harnessRuntime: agentHarnessPolicy.runtime,
         })
       : [provider];
-  // When an image model override is active, skip auth profile resolution to
-  // avoid (a) clearing the stored session auth profile and (b) forwarding
-  // the original provider's auth profile to a different provider's run.
-  // The image override is temporary for this turn only.
+  // When an image model override switched providers (e.g., anthropic -> openai),
+  // skip auth profile resolution to avoid forwarding the original provider's
+  // auth profile to a different provider's run. When the override stayed on the
+  // same provider (e.g., openai/gpt-4o -> openai/gpt-4o-mini), preserve the
+  // stored session auth profile so the user-selected credentials are used.
   let authProfileId: string | undefined;
-  if (hasAppliedImageModelOverride) {
+  if (
+    hasAppliedImageModelOverride &&
+    normalizeProviderId(provider) !== normalizeProviderId(defaultProvider)
+  ) {
     authProfileId = undefined;
   } else if (useFastReplyRuntime) {
     authProfileId = preparedSessionState.sessionEntry?.authProfileOverride;
@@ -947,7 +953,10 @@ export async function runPreparedReply(
         piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined),
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();
-        if (hasAppliedImageModelOverride) {
+        if (
+          hasAppliedImageModelOverride &&
+          normalizeProviderId(provider) !== normalizeProviderId(defaultProvider)
+        ) {
           authProfileId = undefined;
         } else if (useFastReplyRuntime) {
           authProfileId = preparedSessionState.sessionEntry?.authProfileOverride;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -348,8 +348,6 @@ type RunPreparedReplyParams = {
   storePath?: string;
   workspaceDir: string;
   abortedLastRun: boolean;
-  /** True when an image model override was applied, for cross-provider auth handling. */
-  hasAppliedImageModelOverride?: boolean;
 };
 
 export async function runPreparedReply(
@@ -390,7 +388,6 @@ export async function runPreparedReply(
     storePath,
     workspaceDir,
     sessionStore,
-    hasAppliedImageModelOverride,
   } = params;
   const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
     cfg,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -348,6 +348,7 @@ type RunPreparedReplyParams = {
   storePath?: string;
   workspaceDir: string;
   abortedLastRun: boolean;
+  hasAppliedImageModelOverride?: boolean;
 };
 
 export async function runPreparedReply(
@@ -388,6 +389,7 @@ export async function runPreparedReply(
     storePath,
     workspaceDir,
     sessionStore,
+    hasAppliedImageModelOverride,
   } = params;
   const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
     cfg,
@@ -873,21 +875,25 @@ export async function runPreparedReply(
           harnessRuntime: agentHarnessPolicy.runtime,
         })
       : [provider];
-  let authProfileId = useFastReplyRuntime
-    ? preparedSessionState.sessionEntry?.authProfileOverride
-    : await traceRunPhase("reply.resolve_auth_profile", () =>
-        resolveSessionAuthProfileOverride({
-          cfg,
-          provider,
-          acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
-          agentDir,
-          sessionEntry: preparedSessionState.sessionEntry,
-          sessionStore,
-          sessionKey,
-          storePath,
-          isNewSession,
-        }),
-      );
+  // When an image model override is active, skip auth profile resolution to
+  // avoid clearing the stored session auth profile (which belongs to the
+  // original provider). The image override is temporary for this turn only.
+  let authProfileId =
+    useFastReplyRuntime || hasAppliedImageModelOverride
+      ? preparedSessionState.sessionEntry?.authProfileOverride
+      : await traceRunPhase("reply.resolve_auth_profile", () =>
+          resolveSessionAuthProfileOverride({
+            cfg,
+            provider,
+            acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+            agentDir,
+            sessionEntry: preparedSessionState.sessionEntry,
+            sessionStore,
+            sessionKey,
+            storePath,
+            isNewSession,
+          }),
+        );
   const { runReplyAgent } = await traceRunPhase("reply.load_agent_runner_runtime", () =>
     loadAgentRunnerRuntime(),
   );
@@ -936,19 +942,20 @@ export async function runPreparedReply(
         piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined),
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();
-        authProfileId = useFastReplyRuntime
-          ? preparedSessionState.sessionEntry?.authProfileOverride
-          : await resolveSessionAuthProfileOverride({
-              cfg,
-              provider,
-              acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
-              agentDir,
-              sessionEntry: preparedSessionState.sessionEntry,
-              sessionStore,
-              sessionKey,
-              storePath,
-              isNewSession,
-            });
+        authProfileId =
+          useFastReplyRuntime || hasAppliedImageModelOverride
+            ? preparedSessionState.sessionEntry?.authProfileOverride
+            : await resolveSessionAuthProfileOverride({
+                cfg,
+                provider,
+                acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+                agentDir,
+                sessionEntry: preparedSessionState.sessionEntry,
+                sessionStore,
+                sessionKey,
+                storePath,
+                isNewSession,
+              });
         preparedSessionState = resolvePreparedSessionState();
         ({ prefixedCommandBody, queuedBody, transcriptCommandBody, currentTurnContext } =
           await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies()));

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -346,6 +346,8 @@ type RunPreparedReplyParams = {
   storePath?: string;
   workspaceDir: string;
   abortedLastRun: boolean;
+  /** True when an image model override was applied, for cross-provider auth handling. */
+  hasAppliedImageModelOverride?: boolean;
 };
 
 export async function runPreparedReply(
@@ -386,6 +388,7 @@ export async function runPreparedReply(
     storePath,
     workspaceDir,
     sessionStore,
+    hasAppliedImageModelOverride,
   } = params;
   const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
     cfg,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -346,8 +346,6 @@ type RunPreparedReplyParams = {
   storePath?: string;
   workspaceDir: string;
   abortedLastRun: boolean;
-  /** True when an image model override was applied, for cross-provider auth handling. */
-  hasAppliedImageModelOverride?: boolean;
 };
 
 export async function runPreparedReply(
@@ -388,7 +386,6 @@ export async function runPreparedReply(
     storePath,
     workspaceDir,
     sessionStore,
-    hasAppliedImageModelOverride,
   } = params;
   const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
     cfg,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -3,6 +3,7 @@ import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/se
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
 import type { CurrentTurnPromptContext } from "../../agents/pi-embedded-runner/run/params.js";
 import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/sandbox-info.js";
@@ -377,6 +378,7 @@ export async function runPreparedReply(
     perMessageQueueOptions,
     typing,
     opts,
+    defaultProvider,
     defaultModel,
     timeoutMs,
     isNewSession,
@@ -877,12 +879,16 @@ export async function runPreparedReply(
           harnessRuntime: agentHarnessPolicy.runtime,
         })
       : [provider];
-  // When an image model override is active, skip auth profile resolution to
-  // avoid (a) clearing the stored session auth profile and (b) forwarding
-  // the original provider's auth profile to a different provider's run.
-  // The image override is temporary for this turn only.
+  // When an image model override switched providers (e.g., anthropic -> openai),
+  // skip auth profile resolution to avoid forwarding the original provider's
+  // auth profile to a different provider's run. When the override stayed on the
+  // same provider (e.g., openai/gpt-4o -> openai/gpt-4o-mini), preserve the
+  // stored session auth profile so the user-selected credentials are used.
   let authProfileId: string | undefined;
-  if (hasAppliedImageModelOverride) {
+  if (
+    hasAppliedImageModelOverride &&
+    normalizeProviderId(provider) !== normalizeProviderId(defaultProvider)
+  ) {
     authProfileId = undefined;
   } else if (useFastReplyRuntime) {
     authProfileId = preparedSessionState.sessionEntry?.authProfileOverride;
@@ -946,7 +952,10 @@ export async function runPreparedReply(
         piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined),
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();
-        if (hasAppliedImageModelOverride) {
+        if (
+          hasAppliedImageModelOverride &&
+          normalizeProviderId(provider) !== normalizeProviderId(defaultProvider)
+        ) {
           authProfileId = undefined;
         } else if (useFastReplyRuntime) {
           authProfileId = preparedSessionState.sessionEntry?.authProfileOverride;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -346,6 +346,7 @@ type RunPreparedReplyParams = {
   storePath?: string;
   workspaceDir: string;
   abortedLastRun: boolean;
+  hasAppliedImageModelOverride?: boolean;
 };
 
 export async function runPreparedReply(
@@ -386,6 +387,7 @@ export async function runPreparedReply(
     storePath,
     workspaceDir,
     sessionStore,
+    hasAppliedImageModelOverride,
   } = params;
   const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
     cfg,
@@ -875,21 +877,25 @@ export async function runPreparedReply(
           harnessRuntime: agentHarnessPolicy.runtime,
         })
       : [provider];
-  let authProfileId = useFastReplyRuntime
-    ? preparedSessionState.sessionEntry?.authProfileOverride
-    : await traceRunPhase("reply.resolve_auth_profile", () =>
-        resolveSessionAuthProfileOverride({
-          cfg,
-          provider,
-          acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
-          agentDir,
-          sessionEntry: preparedSessionState.sessionEntry,
-          sessionStore,
-          sessionKey,
-          storePath,
-          isNewSession,
-        }),
-      );
+  // When an image model override is active, skip auth profile resolution to
+  // avoid clearing the stored session auth profile (which belongs to the
+  // original provider). The image override is temporary for this turn only.
+  let authProfileId =
+    useFastReplyRuntime || hasAppliedImageModelOverride
+      ? preparedSessionState.sessionEntry?.authProfileOverride
+      : await traceRunPhase("reply.resolve_auth_profile", () =>
+          resolveSessionAuthProfileOverride({
+            cfg,
+            provider,
+            acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+            agentDir,
+            sessionEntry: preparedSessionState.sessionEntry,
+            sessionStore,
+            sessionKey,
+            storePath,
+            isNewSession,
+          }),
+        );
   const { runReplyAgent } = await traceRunPhase("reply.load_agent_runner_runtime", () =>
     loadAgentRunnerRuntime(),
   );
@@ -935,19 +941,20 @@ export async function runPreparedReply(
         piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined),
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();
-        authProfileId = useFastReplyRuntime
-          ? preparedSessionState.sessionEntry?.authProfileOverride
-          : await resolveSessionAuthProfileOverride({
-              cfg,
-              provider,
-              acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
-              agentDir,
-              sessionEntry: preparedSessionState.sessionEntry,
-              sessionStore,
-              sessionKey,
-              storePath,
-              isNewSession,
-            });
+        authProfileId =
+          useFastReplyRuntime || hasAppliedImageModelOverride
+            ? preparedSessionState.sessionEntry?.authProfileOverride
+            : await resolveSessionAuthProfileOverride({
+                cfg,
+                provider,
+                acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+                agentDir,
+                sessionEntry: preparedSessionState.sessionEntry,
+                sessionStore,
+                sessionKey,
+                storePath,
+                isNewSession,
+              });
         preparedSessionState = resolvePreparedSessionState();
         ({ prefixedCommandBody, queuedBody, transcriptCommandBody } = await traceRunPhase(
           "reply.build_prompt_bodies",

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -878,24 +878,29 @@ export async function runPreparedReply(
         })
       : [provider];
   // When an image model override is active, skip auth profile resolution to
-  // avoid clearing the stored session auth profile (which belongs to the
-  // original provider). The image override is temporary for this turn only.
-  let authProfileId =
-    useFastReplyRuntime || hasAppliedImageModelOverride
-      ? preparedSessionState.sessionEntry?.authProfileOverride
-      : await traceRunPhase("reply.resolve_auth_profile", () =>
-          resolveSessionAuthProfileOverride({
-            cfg,
-            provider,
-            acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
-            agentDir,
-            sessionEntry: preparedSessionState.sessionEntry,
-            sessionStore,
-            sessionKey,
-            storePath,
-            isNewSession,
-          }),
-        );
+  // avoid (a) clearing the stored session auth profile and (b) forwarding
+  // the original provider's auth profile to a different provider's run.
+  // The image override is temporary for this turn only.
+  let authProfileId: string | undefined;
+  if (hasAppliedImageModelOverride) {
+    authProfileId = undefined;
+  } else if (useFastReplyRuntime) {
+    authProfileId = preparedSessionState.sessionEntry?.authProfileOverride;
+  } else {
+    authProfileId = await traceRunPhase("reply.resolve_auth_profile", () =>
+      resolveSessionAuthProfileOverride({
+        cfg,
+        provider,
+        acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+        agentDir,
+        sessionEntry: preparedSessionState.sessionEntry,
+        sessionStore,
+        sessionKey,
+        storePath,
+        isNewSession,
+      }),
+    );
+  }
   const { runReplyAgent } = await traceRunPhase("reply.load_agent_runner_runtime", () =>
     loadAgentRunnerRuntime(),
   );
@@ -941,20 +946,23 @@ export async function runPreparedReply(
         piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined),
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();
-        authProfileId =
-          useFastReplyRuntime || hasAppliedImageModelOverride
-            ? preparedSessionState.sessionEntry?.authProfileOverride
-            : await resolveSessionAuthProfileOverride({
-                cfg,
-                provider,
-                acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
-                agentDir,
-                sessionEntry: preparedSessionState.sessionEntry,
-                sessionStore,
-                sessionKey,
-                storePath,
-                isNewSession,
-              });
+        if (hasAppliedImageModelOverride) {
+          authProfileId = undefined;
+        } else if (useFastReplyRuntime) {
+          authProfileId = preparedSessionState.sessionEntry?.authProfileOverride;
+        } else {
+          authProfileId = await resolveSessionAuthProfileOverride({
+            cfg,
+            provider,
+            acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+            agentDir,
+            sessionEntry: preparedSessionState.sessionEntry,
+            sessionStore,
+            sessionKey,
+            storePath,
+            isNewSession,
+          });
+        }
         preparedSessionState = resolvePreparedSessionState();
         ({ prefixedCommandBody, queuedBody, transcriptCommandBody } = await traceRunPhase(
           "reply.build_prompt_bodies",

--- a/src/auto-reply/reply/get-reply.image-model-override.test.ts
+++ b/src/auto-reply/reply/get-reply.image-model-override.test.ts
@@ -23,10 +23,20 @@ vi.mock("./message-preprocess-hooks.js", () => ({
 }));
 
 const channelOverrideMocks = vi.hoisted(() => ({
-  resolveChannelModelOverride: vi.fn(() => undefined),
+  resolveChannelModelOverride: vi.fn(
+    (): import("../../channels/model-overrides.js").ChannelModelOverride | null =>
+      undefined as unknown as null,
+  ),
 }));
 vi.mock("../../channels/model-overrides.js", () => ({
   resolveChannelModelOverride: channelOverrideMocks.resolveChannelModelOverride,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
@@ -108,7 +118,7 @@ describe("getReplyFromConfig image model override", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    defaultRuntime.log.mockClear();
+    vi.mocked(defaultRuntime.log).mockClear();
   });
 
   it("applies modelOverride when no allowlist is configured", async () => {
@@ -406,7 +416,7 @@ describe("getReplyFromConfig image model override", () => {
     );
 
     // Reset mock for other tests
-    channelOverrideMocks.resolveChannelModelOverride.mockReturnValue(undefined);
+    channelOverrideMocks.resolveChannelModelOverride.mockReturnValue(null);
   });
 
   it("ignores empty modelOverride and uses default model", async () => {

--- a/src/auto-reply/reply/get-reply.image-model-override.test.ts
+++ b/src/auto-reply/reply/get-reply.image-model-override.test.ts
@@ -22,6 +22,13 @@ vi.mock("./message-preprocess-hooks.js", () => ({
   emitPreAgentMessageHooks: vi.fn(() => undefined),
 }));
 
+const channelOverrideMocks = vi.hoisted(() => ({
+  resolveChannelModelOverride: vi.fn(() => undefined),
+}));
+vi.mock("../../channels/model-overrides.js", () => ({
+  resolveChannelModelOverride: channelOverrideMocks.resolveChannelModelOverride,
+}));
+
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
 let defaultRuntime: typeof import("../../runtime.js").defaultRuntime;
 
@@ -101,6 +108,7 @@ describe("getReplyFromConfig image model override", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    defaultRuntime.log.mockClear();
   });
 
   it("applies modelOverride when no allowlist is configured", async () => {
@@ -301,5 +309,103 @@ describe("getReplyFromConfig image model override", () => {
         hasAppliedImageModelOverride: true,
       }),
     );
+  });
+
+  it("does not let stored session override clobber image model override", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "openai/gpt-4o") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    // Simulate a session with a previously stored model override
+    mocks.initSessionState.mockReset();
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: {},
+      sessionEntry: {
+        modelOverride: "anthropic/claude-sonnet-4-6",
+      },
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:123",
+      sessionId: "session-1",
+      isNewSession: false,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: false,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+
+    await getReplyFromConfig(buildCtx(), {
+      modelOverride: "openai/gpt-4o",
+    });
+
+    // Image model override should NOT be clobbered by stored session override
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o",
+        hasAppliedImageModelOverride: true,
+      }),
+    );
+  });
+
+  it("keeps image model override when channel model override is configured", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "openai/gpt-4o") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, alias: false };
+        }
+        if (params.raw === "anthropic/claude-sonnet-4-6") {
+          return { ref: { provider: "anthropic", model: "claude-sonnet-4-6" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    // Set up channel override mock to return a channel model
+    channelOverrideMocks.resolveChannelModelOverride.mockReturnValue({
+      channel: "telegram",
+      model: "anthropic/claude-sonnet-4-6",
+      matchKey: "telegram",
+    });
+
+    // Pass a config that has channels.modelByChannel so the code path is triggered.
+    // The configOverride is merged with the runtime config via applyMergePatch.
+    const cfgWithChannel = {
+      channels: {
+        modelByChannel: {
+          telegram: { model: "anthropic/claude-sonnet-4-6" },
+        },
+      },
+    } as OpenClawConfig;
+
+    await getReplyFromConfig(
+      buildCtx(),
+      {
+        modelOverride: "openai/gpt-4o",
+      },
+      cfgWithChannel,
+    );
+
+    // Image model override should NOT be clobbered by channel model override
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o",
+        hasAppliedImageModelOverride: true,
+      }),
+    );
+
+    // Reset mock for other tests
+    channelOverrideMocks.resolveChannelModelOverride.mockReturnValue(undefined);
   });
 });

--- a/src/auto-reply/reply/get-reply.image-model-override.test.ts
+++ b/src/auto-reply/reply/get-reply.image-model-override.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext } from "../templating.js";
+import { loadGetReplyModuleForTest } from "./get-reply.test-loader.js";
+import { modelSelectionMockFns } from "./get-reply.test-mocks.js";
+import "./get-reply.test-runtime-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  initSessionState: vi.fn(),
+}));
+
+vi.mock("./get-reply-directives.js", () => ({
+  resolveReplyDirectives: (...args: unknown[]) => mocks.resolveReplyDirectives(...args),
+}));
+
+vi.mock("./session.js", () => ({
+  initSessionState: (...args: unknown[]) => mocks.initSessionState(...args),
+}));
+
+vi.mock("./message-preprocess-hooks.js", () => ({
+  emitPreAgentMessageHooks: vi.fn(() => undefined),
+}));
+
+let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let defaultRuntime: typeof import("../../runtime.js").defaultRuntime;
+
+async function loadGetReplyRuntimeForTest() {
+  ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
+  ({ defaultRuntime } = await import("../../runtime.js"));
+}
+
+function buildCtx(overrides: Partial<MsgContext> = {}): MsgContext {
+  return {
+    Provider: "telegram",
+    Surface: "telegram",
+    ChatType: "direct",
+    Body: "hello",
+    BodyForAgent: "hello",
+    RawBody: "hello",
+    CommandBody: "hello",
+    SessionKey: "agent:main:telegram:123",
+    From: "telegram:user:42",
+    To: "telegram:123",
+    Timestamp: 1710000000000,
+    ...overrides,
+  };
+}
+
+function buildCfg(allowlistModels?: string[]): OpenClawConfig {
+  if (!allowlistModels || allowlistModels.length === 0) {
+    return {} as OpenClawConfig;
+  }
+  const models: Record<string, object> = {};
+  for (const m of allowlistModels) {
+    models[m] = {};
+  }
+  return {
+    agents: {
+      defaults: {
+        models,
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("getReplyFromConfig image model override", () => {
+  beforeEach(async () => {
+    await loadGetReplyRuntimeForTest();
+    vi.stubEnv("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
+
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.initSessionState.mockReset();
+    modelSelectionMockFns.resolveModelRefFromString.mockReset();
+
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: {},
+      sessionEntry: {},
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:123",
+      sessionId: "session-1",
+      isNewSession: false,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: false,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+    mocks.resolveReplyDirectives.mockResolvedValue({
+      kind: "reply" as const,
+      reply: { text: "ok" },
+    });
+
+    modelSelectionMockFns.resolveModelRefFromString.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("applies modelOverride when no allowlist is configured", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "openai/gpt-4o") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    await getReplyFromConfig(buildCtx(), {
+      modelOverride: "openai/gpt-4o",
+    });
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o",
+        hasAppliedImageModelOverride: true,
+      }),
+    );
+  });
+
+  it("applies modelOverride when it is in the agent allowlist", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "openai/gpt-4o") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    await getReplyFromConfig(
+      buildCtx(),
+      {
+        modelOverride: "openai/gpt-4o",
+      },
+      buildCfg(["openai/gpt-4o"]),
+    );
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o",
+        hasAppliedImageModelOverride: true,
+      }),
+    );
+  });
+
+  it("falls back to allowlisted fallback when primary modelOverride is blocked", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "anthropic/claude-opus-4-6") {
+          return { ref: { provider: "anthropic", model: "claude-opus-4-6" }, alias: false };
+        }
+        if (params.raw === "openai/gpt-4o") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    await getReplyFromConfig(
+      buildCtx(),
+      {
+        modelOverride: "anthropic/claude-opus-4-6",
+        modelOverrideFallbacks: ["openai/gpt-4o"],
+      },
+      buildCfg(["openai/gpt-4o"]),
+    );
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o",
+        hasAppliedImageModelOverride: true,
+      }),
+    );
+  });
+
+  it("skips modelOverride and uses default model when blocked by allowlist with no fallback", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "anthropic/claude-opus-4-6") {
+          return { ref: { provider: "anthropic", model: "claude-opus-4-6" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    await getReplyFromConfig(
+      buildCtx(),
+      {
+        modelOverride: "anthropic/claude-opus-4-6",
+      },
+      buildCfg(["openai/gpt-4o-mini"]),
+    );
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        hasAppliedImageModelOverride: false,
+      }),
+    );
+    expect(defaultRuntime.log).toHaveBeenCalledWith(
+      expect.stringContaining("not in agent allowlist and no fallback available"),
+    );
+  });
+
+  it("logs image warning when modelOverride is skipped and images are present", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "anthropic/claude-opus-4-6") {
+          return { ref: { provider: "anthropic", model: "claude-opus-4-6" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    await getReplyFromConfig(
+      buildCtx(),
+      {
+        modelOverride: "anthropic/claude-opus-4-6",
+        images: [{ type: "image", data: "abc", mimeType: "image/png" }],
+      },
+      buildCfg(["openai/gpt-4o-mini"]),
+    );
+
+    expect(defaultRuntime.log).toHaveBeenCalledWith(
+      expect.stringContaining("WARNING: Images are present but the default model"),
+    );
+  });
+
+  it("falls back to default model when modelOverride alias resolution fails", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockReturnValue(null);
+
+    await getReplyFromConfig(buildCtx(), {
+      modelOverride: "nonexistent-alias",
+    });
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        hasAppliedImageModelOverride: false,
+      }),
+    );
+    expect(defaultRuntime.log).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to resolve modelOverride"),
+    );
+  });
+
+  it("logs image warning when modelOverride resolution fails and images are present", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockReturnValue(null);
+
+    await getReplyFromConfig(buildCtx(), {
+      modelOverride: "nonexistent-alias",
+      images: [{ type: "image", data: "abc", mimeType: "image/png" }],
+    });
+
+    expect(defaultRuntime.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "WARNING: Images are present but modelOverride could not be resolved",
+      ),
+    );
+  });
+
+  it("resolves cross-provider fallbacks using the override provider context", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "openai/gpt-4o") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, alias: false };
+        }
+        if (params.raw === "gpt-4o-mini") {
+          return { ref: { provider: "openai", model: "gpt-4o-mini" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    await getReplyFromConfig(
+      buildCtx(),
+      {
+        modelOverride: "openai/gpt-4o",
+        modelOverrideFallbacks: ["gpt-4o-mini"],
+      },
+      buildCfg(["openai/gpt-4o-mini"]),
+    );
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        hasAppliedImageModelOverride: true,
+      }),
+    );
+  });
+});

--- a/src/auto-reply/reply/get-reply.image-model-override.test.ts
+++ b/src/auto-reply/reply/get-reply.image-model-override.test.ts
@@ -408,4 +408,97 @@ describe("getReplyFromConfig image model override", () => {
     // Reset mock for other tests
     channelOverrideMocks.resolveChannelModelOverride.mockReturnValue(undefined);
   });
+
+  it("ignores empty modelOverride and uses default model", async () => {
+    await getReplyFromConfig(buildCtx(), {
+      modelOverride: "   ",
+    });
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        hasAppliedImageModelOverride: false,
+      }),
+    );
+  });
+
+  it("ignores undefined modelOverride and uses default model", async () => {
+    await getReplyFromConfig(buildCtx(), {});
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        hasAppliedImageModelOverride: false,
+      }),
+    );
+  });
+
+  it("tries multiple fallbacks in order when primary is blocked", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "anthropic/claude-opus-4-6") {
+          return { ref: { provider: "anthropic", model: "claude-opus-4-6" }, alias: false };
+        }
+        if (params.raw === "openai/gpt-4o") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, alias: false };
+        }
+        if (params.raw === "openai/gpt-4o-mini") {
+          return { ref: { provider: "openai", model: "gpt-4o-mini" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    await getReplyFromConfig(
+      buildCtx(),
+      {
+        modelOverride: "anthropic/claude-opus-4-6",
+        modelOverrideFallbacks: ["openai/gpt-4o", "openai/gpt-4o-mini"],
+      },
+      buildCfg(["openai/gpt-4o"]),
+    );
+
+    // First fallback is in allowlist, should be selected
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o",
+        hasAppliedImageModelOverride: true,
+      }),
+    );
+  });
+
+  it("uses default model when all fallbacks are blocked by allowlist", async () => {
+    modelSelectionMockFns.resolveModelRefFromString.mockImplementation(
+      (params: { raw: string }) => {
+        if (params.raw === "anthropic/claude-opus-4-6") {
+          return { ref: { provider: "anthropic", model: "claude-opus-4-6" }, alias: false };
+        }
+        if (params.raw === "openai/gpt-4o") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, alias: false };
+        }
+        return null;
+      },
+    );
+
+    await getReplyFromConfig(
+      buildCtx(),
+      {
+        modelOverride: "anthropic/claude-opus-4-6",
+        modelOverrideFallbacks: ["openai/gpt-4o"],
+      },
+      buildCfg(["openai/gpt-4o-mini"]),
+    );
+
+    // Both primary and fallback are blocked, should use default
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        hasAppliedImageModelOverride: false,
+      }),
+    );
+  });
 });

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -1,6 +1,16 @@
 import { vi } from "vitest";
 import { createMockTypingController } from "./reply.test-helpers.js";
 
+export const modelSelectionMockFns = {
+  resolveModelRefFromString: vi.fn<
+    (args: {
+      raw: string;
+      defaultProvider?: string;
+      aliasIndex?: unknown;
+    }) => { ref: { provider: string; model: string }; alias?: boolean } | null
+  >(() => null),
+};
+
 vi.mock("../../agents/agent-scope.js", async () => {
   const actual = await vi.importActual<typeof import("../../agents/agent-scope.js")>(
     "../../agents/agent-scope.js",
@@ -20,7 +30,7 @@ vi.mock("../../agents/model-selection.js", async () => {
   );
   return {
     ...actual,
-    resolveModelRefFromString: vi.fn(() => null),
+    resolveModelRefFromString: modelSelectionMockFns.resolveModelRefFromString,
   };
 });
 
@@ -38,6 +48,7 @@ vi.mock("../../channels/model-overrides.js", () => ({
 }));
 
 vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({})),
   getRuntimeConfig: vi.fn(() => ({})),
 }));
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -642,13 +642,20 @@ export async function getReplyFromConfig(
     hasSessionModelOverride && !staleHeartbeatAutoFallbackOverride;
   if (
     !hasResolvedHeartbeatModelOverride &&
-    !hasAppliedImageModelOverride &&
     !hasEffectiveSessionModelOverride &&
     resolvedChannelModelOverride
   ) {
-    provider = resolvedChannelModelOverride.ref.provider;
-    model = resolvedChannelModelOverride.ref.model;
-  }
+    if (hasAppliedImageModelOverride) {
+      // Channel model override is blocked to preserve the vision-capable model
+      // selected for image processing. This prevents a user-configured text-only
+      // model from silently clobbering the image model override.
+      defaultRuntime.log?.(
+        `[image-model-switch] Channel model override for ${resolvedChannelModelOverride.ref.provider}/${resolvedChannelModelOverride.ref.model} blocked to preserve image model ${provider}/${model}`,
+      );
+    } else {
+      provider = resolvedChannelModelOverride.ref.provider;
+      model = resolvedChannelModelOverride.ref.model;
+    }
   }
 
   if (

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -6,6 +6,7 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
+import { isModelKeyAllowedBySet } from "../../agents/model-selection-shared.js";
 import {
   buildAllowedModelSet,
   buildModelAliasIndex,
@@ -280,7 +281,7 @@ export async function getReplyFromConfig(
       });
       if (!allowAny) {
         const modelKeyStr = modelKey(modelRef.ref.provider, modelRef.ref.model);
-        if (!allowedKeys.has(modelKeyStr)) {
+        if (!isModelKeyAllowedBySet(allowedKeys, modelKeyStr)) {
           // Model not in allowlist, try fallbacks before skipping
           if (opts?.modelOverrideFallbacks?.length) {
             // Determine provider context for resolving providerless fallbacks.
@@ -308,7 +309,7 @@ export async function getReplyFromConfig(
               });
               if (fallbackRef) {
                 const fallbackKeyStr = modelKey(fallbackRef.ref.provider, fallbackRef.ref.model);
-                if (allowedKeys.has(fallbackKeyStr)) {
+                if (isModelKeyAllowedBySet(allowedKeys, fallbackKeyStr)) {
                   provider = fallbackRef.ref.provider;
                   model = fallbackRef.ref.model;
                   hasAppliedImageModelOverride = true;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -46,7 +46,6 @@ import {
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { maybeResolveNativeSlashCommandFastReply } from "./get-reply-native-slash-fast-path.js";
 import { runPreparedReply } from "./get-reply-run.js";
-import { resolveChannelModelSupportsVision } from "./image-model-helpers.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
@@ -289,11 +288,10 @@ export async function getReplyFromConfig(
             // providerless fallbacks should resolve against that provider, not defaultProvider.
             // This matches the allowlist check logic in chat.ts.
             const overrideProvider = modelRef.ref.provider;
-            const providerContext = overrideProvider ?? defaultProvider;
             // Rebuild alias index with the correct provider context
             const fallbackAliasIndex =
-              overrideProvider && overrideProvider !== defaultProvider
-                ? buildModelAliasIndex({ cfg, defaultProvider: providerContext })
+              overrideProvider !== defaultProvider
+                ? buildModelAliasIndex({ cfg, defaultProvider: overrideProvider })
                 : aliasIndex;
             for (const fallbackRaw of opts.modelOverrideFallbacks) {
               if (typeof fallbackRaw !== "string") {
@@ -305,7 +303,7 @@ export async function getReplyFromConfig(
               }
               const fallbackRef = resolveModelRefFromString({
                 raw: trimmed,
-                defaultProvider: providerContext,
+                defaultProvider: overrideProvider,
                 aliasIndex: fallbackAliasIndex,
               });
               if (fallbackRef) {
@@ -356,6 +354,8 @@ export async function getReplyFromConfig(
       }
     }
   } else if (opts?.isHeartbeat) {
+    // Note: modelOverride and isHeartbeat are mutually exclusive.
+    // modelOverride takes precedence when both are set (unlikely in practice).
     // Prefer the resolved per-agent heartbeat model passed from the heartbeat runner,
     // fall back to the global defaults heartbeat model for backward compatibility.
     const heartbeatRaw =

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -6,7 +6,12 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
-import { resolveModelRefFromString } from "../../agents/model-selection.js";
+import {
+  buildAllowedModelSet,
+  buildModelAliasIndex,
+  modelKey,
+  resolveModelRefFromString,
+} from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
@@ -41,6 +46,7 @@ import {
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { maybeResolveNativeSlashCommandFastReply } from "./get-reply-native-slash-fast-path.js";
 import { runPreparedReply } from "./get-reply-run.js";
+import { resolveChannelModelSupportsVision } from "./image-model-helpers.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
@@ -253,7 +259,103 @@ export async function getReplyFromConfig(
   let provider = defaultProvider;
   let model = defaultModel;
   let hasResolvedHeartbeatModelOverride = false;
-  if (opts?.isHeartbeat) {
+  // Handle modelOverride from Gateway (e.g., image model when images detected)
+  let hasAppliedImageModelOverride = false;
+  // Track if a fallback was used when primary override was blocked by allowlist
+  let fallbackAppliedForImageModel = false;
+  if (opts?.modelOverride?.trim()) {
+    const modelRef = resolveModelRefFromString({
+      raw: opts.modelOverride.trim(),
+      defaultProvider,
+      aliasIndex,
+    });
+    if (modelRef) {
+      // Check if the model is allowed by the agent's allowlist
+      // Use buildAllowedModelSet to include models + fallbacks + default model
+      const { allowAny, allowedKeys } = buildAllowedModelSet({
+        cfg,
+        catalog: [], // Empty catalog; we only need allowedKeys
+        defaultProvider,
+        defaultModel,
+        agentId,
+      });
+      if (!allowAny) {
+        const modelKeyStr = modelKey(modelRef.ref.provider, modelRef.ref.model);
+        if (!allowedKeys.has(modelKeyStr)) {
+          // Model not in allowlist, try fallbacks before skipping
+          if (opts?.modelOverrideFallbacks?.length) {
+            // Determine provider context for resolving providerless fallbacks.
+            // When modelOverride has explicit provider (e.g., "openai/gpt-4o"),
+            // providerless fallbacks should resolve against that provider, not defaultProvider.
+            // This matches the allowlist check logic in chat.ts.
+            const overrideProvider = modelRef.ref.provider;
+            const providerContext = overrideProvider ?? defaultProvider;
+            // Rebuild alias index with the correct provider context
+            const fallbackAliasIndex =
+              overrideProvider && overrideProvider !== defaultProvider
+                ? buildModelAliasIndex({ cfg, defaultProvider: providerContext })
+                : aliasIndex;
+            for (const fallbackRaw of opts.modelOverrideFallbacks) {
+              if (typeof fallbackRaw !== "string") {
+                continue;
+              }
+              const trimmed = fallbackRaw.trim();
+              if (!trimmed) {
+                continue;
+              }
+              const fallbackRef = resolveModelRefFromString({
+                raw: trimmed,
+                defaultProvider: providerContext,
+                aliasIndex: fallbackAliasIndex,
+              });
+              if (fallbackRef) {
+                const fallbackKeyStr = modelKey(fallbackRef.ref.provider, fallbackRef.ref.model);
+                if (allowedKeys.has(fallbackKeyStr)) {
+                  provider = fallbackRef.ref.provider;
+                  model = fallbackRef.ref.model;
+                  hasAppliedImageModelOverride = true;
+                  fallbackAppliedForImageModel = true;
+                  break;
+                }
+              }
+            }
+          }
+          if (!fallbackAppliedForImageModel) {
+            // No allowlisted fallback, skip the override and let default model be used
+            // This prevents Dashboard images from bypassing agent model restrictions
+            defaultRuntime.log?.(
+              `[image-model-switch] Model override ${opts.modelOverride} not in agent allowlist and no fallback available, using default model ${defaultProvider}/${defaultModel}`,
+            );
+            if (opts?.images?.length) {
+              defaultRuntime.log?.(
+                `[image-model-switch] WARNING: Images are present but the default model ${defaultProvider}/${defaultModel} may not support vision; images will still be passed to the agent`,
+              );
+            }
+          }
+        } else {
+          provider = modelRef.ref.provider;
+          model = modelRef.ref.model;
+          hasAppliedImageModelOverride = true;
+        }
+      } else {
+        // No allowlist, allow any model
+        provider = modelRef.ref.provider;
+        model = modelRef.ref.model;
+        hasAppliedImageModelOverride = true;
+      }
+    } else {
+      // modelOverride was configured but alias resolution failed;
+      // log a warning and fall through to default model.
+      defaultRuntime.log?.(
+        `[image-model-switch] Failed to resolve modelOverride "${opts.modelOverride}" against alias index, using default model ${defaultProvider}/${defaultModel}`,
+      );
+      if (opts?.images?.length) {
+        defaultRuntime.log?.(
+          `[image-model-switch] WARNING: Images are present but modelOverride could not be resolved; the default model ${defaultProvider}/${defaultModel} may not support vision`,
+        );
+      }
+    }
+  } else if (opts?.isHeartbeat) {
     // Prefer the resolved per-agent heartbeat model passed from the heartbeat runner,
     // fall back to the global defaults heartbeat model for backward compatibility.
     const heartbeatRaw =
@@ -530,6 +632,7 @@ export async function getReplyFromConfig(
   if (
     storedModelOverride?.model &&
     !hasResolvedHeartbeatModelOverride &&
+    !hasAppliedImageModelOverride &&
     !staleHeartbeatAutoFallbackOverride
   ) {
     provider = storedModelOverride.provider ?? defaultProvider;
@@ -539,11 +642,13 @@ export async function getReplyFromConfig(
     hasSessionModelOverride && !staleHeartbeatAutoFallbackOverride;
   if (
     !hasResolvedHeartbeatModelOverride &&
+    !hasAppliedImageModelOverride &&
     !hasEffectiveSessionModelOverride &&
     resolvedChannelModelOverride
   ) {
     provider = resolvedChannelModelOverride.ref.provider;
     model = resolvedChannelModelOverride.ref.model;
+  }
   }
 
   if (
@@ -650,6 +755,7 @@ export async function getReplyFromConfig(
       provider,
       model,
       hasResolvedHeartbeatModelOverride,
+      hasAppliedImageModelOverride,
       typing,
       opts: resolvedOpts,
       skillFilter: mergedSkillFilter,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -973,6 +973,7 @@ export async function getReplyFromConfig(
       storePath,
       workspaceDir,
       abortedLastRun,
+      hasAppliedImageModelOverride,
     }),
   );
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -43,7 +43,6 @@ import {
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { maybeResolveNativeSlashCommandFastReply } from "./get-reply-native-slash-fast-path.js";
 import { runPreparedReply } from "./get-reply-run.js";
-import { resolveChannelModelSupportsVision } from "./image-model-helpers.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
@@ -266,11 +265,10 @@ export async function getReplyFromConfig(
             // providerless fallbacks should resolve against that provider, not defaultProvider.
             // This matches the allowlist check logic in chat.ts.
             const overrideProvider = modelRef.ref.provider;
-            const providerContext = overrideProvider ?? defaultProvider;
             // Rebuild alias index with the correct provider context
             const fallbackAliasIndex =
-              overrideProvider && overrideProvider !== defaultProvider
-                ? buildModelAliasIndex({ cfg, defaultProvider: providerContext })
+              overrideProvider !== defaultProvider
+                ? buildModelAliasIndex({ cfg, defaultProvider: overrideProvider })
                 : aliasIndex;
             for (const fallbackRaw of opts.modelOverrideFallbacks) {
               if (typeof fallbackRaw !== "string") {
@@ -282,7 +280,7 @@ export async function getReplyFromConfig(
               }
               const fallbackRef = resolveModelRefFromString({
                 raw: trimmed,
-                defaultProvider: providerContext,
+                defaultProvider: overrideProvider,
                 aliasIndex: fallbackAliasIndex,
               });
               if (fallbackRef) {
@@ -333,6 +331,8 @@ export async function getReplyFromConfig(
       }
     }
   } else if (opts?.isHeartbeat) {
+    // Note: modelOverride and isHeartbeat are mutually exclusive.
+    // modelOverride takes precedence when both are set (unlikely in practice).
     // Prefer the resolved per-agent heartbeat model passed from the heartbeat runner,
     // fall back to the global defaults heartbeat model for backward compatibility.
     const heartbeatRaw =

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -5,7 +5,12 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
-import { resolveModelRefFromString } from "../../agents/model-selection.js";
+import {
+  buildAllowedModelSet,
+  buildModelAliasIndex,
+  modelKey,
+  resolveModelRefFromString,
+} from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
@@ -38,6 +43,7 @@ import {
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { maybeResolveNativeSlashCommandFastReply } from "./get-reply-native-slash-fast-path.js";
 import { runPreparedReply } from "./get-reply-run.js";
+import { resolveChannelModelSupportsVision } from "./image-model-helpers.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
@@ -230,7 +236,103 @@ export async function getReplyFromConfig(
   let provider = defaultProvider;
   let model = defaultModel;
   let hasResolvedHeartbeatModelOverride = false;
-  if (opts?.isHeartbeat) {
+  // Handle modelOverride from Gateway (e.g., image model when images detected)
+  let hasAppliedImageModelOverride = false;
+  // Track if a fallback was used when primary override was blocked by allowlist
+  let fallbackAppliedForImageModel = false;
+  if (opts?.modelOverride?.trim()) {
+    const modelRef = resolveModelRefFromString({
+      raw: opts.modelOverride.trim(),
+      defaultProvider,
+      aliasIndex,
+    });
+    if (modelRef) {
+      // Check if the model is allowed by the agent's allowlist
+      // Use buildAllowedModelSet to include models + fallbacks + default model
+      const { allowAny, allowedKeys } = buildAllowedModelSet({
+        cfg,
+        catalog: [], // Empty catalog; we only need allowedKeys
+        defaultProvider,
+        defaultModel,
+        agentId,
+      });
+      if (!allowAny) {
+        const modelKeyStr = modelKey(modelRef.ref.provider, modelRef.ref.model);
+        if (!allowedKeys.has(modelKeyStr)) {
+          // Model not in allowlist, try fallbacks before skipping
+          if (opts?.modelOverrideFallbacks?.length) {
+            // Determine provider context for resolving providerless fallbacks.
+            // When modelOverride has explicit provider (e.g., "openai/gpt-4o"),
+            // providerless fallbacks should resolve against that provider, not defaultProvider.
+            // This matches the allowlist check logic in chat.ts.
+            const overrideProvider = modelRef.ref.provider;
+            const providerContext = overrideProvider ?? defaultProvider;
+            // Rebuild alias index with the correct provider context
+            const fallbackAliasIndex =
+              overrideProvider && overrideProvider !== defaultProvider
+                ? buildModelAliasIndex({ cfg, defaultProvider: providerContext })
+                : aliasIndex;
+            for (const fallbackRaw of opts.modelOverrideFallbacks) {
+              if (typeof fallbackRaw !== "string") {
+                continue;
+              }
+              const trimmed = fallbackRaw.trim();
+              if (!trimmed) {
+                continue;
+              }
+              const fallbackRef = resolveModelRefFromString({
+                raw: trimmed,
+                defaultProvider: providerContext,
+                aliasIndex: fallbackAliasIndex,
+              });
+              if (fallbackRef) {
+                const fallbackKeyStr = modelKey(fallbackRef.ref.provider, fallbackRef.ref.model);
+                if (allowedKeys.has(fallbackKeyStr)) {
+                  provider = fallbackRef.ref.provider;
+                  model = fallbackRef.ref.model;
+                  hasAppliedImageModelOverride = true;
+                  fallbackAppliedForImageModel = true;
+                  break;
+                }
+              }
+            }
+          }
+          if (!fallbackAppliedForImageModel) {
+            // No allowlisted fallback, skip the override and let default model be used
+            // This prevents Dashboard images from bypassing agent model restrictions
+            defaultRuntime.log?.(
+              `[image-model-switch] Model override ${opts.modelOverride} not in agent allowlist and no fallback available, using default model ${defaultProvider}/${defaultModel}`,
+            );
+            if (opts?.images?.length) {
+              defaultRuntime.log?.(
+                `[image-model-switch] WARNING: Images are present but the default model ${defaultProvider}/${defaultModel} may not support vision; images will still be passed to the agent`,
+              );
+            }
+          }
+        } else {
+          provider = modelRef.ref.provider;
+          model = modelRef.ref.model;
+          hasAppliedImageModelOverride = true;
+        }
+      } else {
+        // No allowlist, allow any model
+        provider = modelRef.ref.provider;
+        model = modelRef.ref.model;
+        hasAppliedImageModelOverride = true;
+      }
+    } else {
+      // modelOverride was configured but alias resolution failed;
+      // log a warning and fall through to default model.
+      defaultRuntime.log?.(
+        `[image-model-switch] Failed to resolve modelOverride "${opts.modelOverride}" against alias index, using default model ${defaultProvider}/${defaultModel}`,
+      );
+      if (opts?.images?.length) {
+        defaultRuntime.log?.(
+          `[image-model-switch] WARNING: Images are present but modelOverride could not be resolved; the default model ${defaultProvider}/${defaultModel} may not support vision`,
+        );
+      }
+    }
+  } else if (opts?.isHeartbeat) {
     // Prefer the resolved per-agent heartbeat model passed from the heartbeat runner,
     // fall back to the global defaults heartbeat model for backward compatibility.
     const heartbeatRaw =
@@ -472,6 +574,7 @@ export async function getReplyFromConfig(
   if (
     storedModelOverride?.model &&
     !hasResolvedHeartbeatModelOverride &&
+    !hasAppliedImageModelOverride &&
     !staleHeartbeatAutoFallbackOverride
   ) {
     provider = storedModelOverride.provider ?? defaultProvider;
@@ -481,11 +584,13 @@ export async function getReplyFromConfig(
     hasSessionModelOverride && !staleHeartbeatAutoFallbackOverride;
   if (
     !hasResolvedHeartbeatModelOverride &&
+    !hasAppliedImageModelOverride &&
     !hasEffectiveSessionModelOverride &&
     resolvedChannelModelOverride
   ) {
     provider = resolvedChannelModelOverride.ref.provider;
     model = resolvedChannelModelOverride.ref.model;
+  }
   }
 
   if (
@@ -592,6 +697,7 @@ export async function getReplyFromConfig(
       provider,
       model,
       hasResolvedHeartbeatModelOverride,
+      hasAppliedImageModelOverride,
       typing,
       opts: resolvedOpts,
       skillFilter: mergedSkillFilter,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -5,6 +5,7 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
+import { isModelKeyAllowedBySet } from "../../agents/model-selection-shared.js";
 import {
   buildAllowedModelSet,
   buildModelAliasIndex,
@@ -257,7 +258,7 @@ export async function getReplyFromConfig(
       });
       if (!allowAny) {
         const modelKeyStr = modelKey(modelRef.ref.provider, modelRef.ref.model);
-        if (!allowedKeys.has(modelKeyStr)) {
+        if (!isModelKeyAllowedBySet(allowedKeys, modelKeyStr)) {
           // Model not in allowlist, try fallbacks before skipping
           if (opts?.modelOverrideFallbacks?.length) {
             // Determine provider context for resolving providerless fallbacks.
@@ -285,7 +286,7 @@ export async function getReplyFromConfig(
               });
               if (fallbackRef) {
                 const fallbackKeyStr = modelKey(fallbackRef.ref.provider, fallbackRef.ref.model);
-                if (allowedKeys.has(fallbackKeyStr)) {
+                if (isModelKeyAllowedBySet(allowedKeys, fallbackKeyStr)) {
                   provider = fallbackRef.ref.provider;
                   model = fallbackRef.ref.model;
                   hasAppliedImageModelOverride = true;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -914,6 +914,7 @@ export async function getReplyFromConfig(
       storePath,
       workspaceDir,
       abortedLastRun,
+      hasAppliedImageModelOverride,
     }),
   );
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -584,13 +584,20 @@ export async function getReplyFromConfig(
     hasSessionModelOverride && !staleHeartbeatAutoFallbackOverride;
   if (
     !hasResolvedHeartbeatModelOverride &&
-    !hasAppliedImageModelOverride &&
     !hasEffectiveSessionModelOverride &&
     resolvedChannelModelOverride
   ) {
-    provider = resolvedChannelModelOverride.ref.provider;
-    model = resolvedChannelModelOverride.ref.model;
-  }
+    if (hasAppliedImageModelOverride) {
+      // Channel model override is blocked to preserve the vision-capable model
+      // selected for image processing. This prevents a user-configured text-only
+      // model from silently clobbering the image model override.
+      defaultRuntime.log?.(
+        `[image-model-switch] Channel model override for ${resolvedChannelModelOverride.ref.provider}/${resolvedChannelModelOverride.ref.model} blocked to preserve image model ${provider}/${model}`,
+      );
+    } else {
+      provider = resolvedChannelModelOverride.ref.provider;
+      model = resolvedChannelModelOverride.ref.model;
+    }
   }
 
   if (

--- a/src/auto-reply/reply/image-model-helpers.test.ts
+++ b/src/auto-reply/reply/image-model-helpers.test.ts
@@ -113,7 +113,7 @@ describe("prepareImageModelFallbacks", () => {
     );
   });
 
-  it("falls back to raw string when alias resolution fails but string is in allowlist", () => {
+  it("drops fallbacks that cannot be resolved into a runnable model ref", () => {
     mockBuildAllowedModelSet.mockReturnValue({
       allowAny: false,
       allowedKeys: new Set(["gpt-4o"]),
@@ -124,7 +124,7 @@ describe("prepareImageModelFallbacks", () => {
       ...baseParams,
       fallbacks: ["gpt-4o"],
     });
-    expect(result).toEqual(["gpt-4o"]);
+    expect(result).toEqual([]);
   });
 
   it("filters out empty and whitespace-only fallbacks", () => {

--- a/src/auto-reply/reply/image-model-helpers.test.ts
+++ b/src/auto-reply/reply/image-model-helpers.test.ts
@@ -246,6 +246,35 @@ describe("resolveModelSupportsVision", () => {
     expect(result).toBe(false);
   });
 
+  it("falls back to imageModelConfig when catalog lookup fails and model matches", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o" },
+    });
+    mockLoadModelCatalog.mockRejectedValue(new Error("catalog error"));
+
+    const result = await resolveModelSupportsVision({
+      ...baseParams,
+      imageModelConfig: { primary: "openai/gpt-4o" } as never,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("falls back to imageModelConfig when catalog has no entry and model matches", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o" },
+    });
+    mockLoadModelCatalog.mockResolvedValue([]);
+    mockFindModelInCatalog.mockReturnValue(undefined);
+
+    const result = await resolveModelSupportsVision({
+      ...baseParams,
+      imageModelConfig: { primary: "openai/gpt-4o" } as never,
+    });
+    expect(result).toBe(true);
+  });
+
   it("uses custom loadModelCatalog when provided", async () => {
     mockBuildModelAliasIndex.mockReturnValue({});
     mockResolveModelRefFromString.mockReturnValue(null);

--- a/src/auto-reply/reply/image-model-helpers.test.ts
+++ b/src/auto-reply/reply/image-model-helpers.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockBuildAllowedModelSet = vi.fn();
+const mockResolveModelRefFromString = vi.fn();
+const mockBuildModelAliasIndex = vi.fn();
+const mockModelKey = vi.fn((provider: string, model: string) => `${provider}/${model}`);
+
+vi.mock("../../agents/model-selection.js", () => ({
+  buildAllowedModelSet: mockBuildAllowedModelSet,
+  buildModelAliasIndex: mockBuildModelAliasIndex,
+  modelKey: mockModelKey,
+  resolveModelRefFromString: mockResolveModelRefFromString,
+}));
+
+const mockFindModelInCatalog = vi.fn();
+const mockModelSupportsVision = vi.fn();
+const mockLoadModelCatalog = vi.fn();
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  findModelInCatalog: mockFindModelInCatalog,
+  modelSupportsVision: mockModelSupportsVision,
+  loadModelCatalog: mockLoadModelCatalog,
+}));
+
+const { prepareImageModelFallbacks, resolveModelSupportsVision } =
+  await import("./image-model-helpers.js");
+
+describe("prepareImageModelFallbacks", () => {
+  const baseParams = {
+    cfg: {} as never,
+    agentId: "main",
+    aliasIndex: {} as never,
+    defaultProvider: "anthropic",
+    defaultModel: "claude-sonnet-4-6",
+  };
+
+  it("returns empty array when fallbacks is empty", () => {
+    const result = prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: [],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns resolved fallback when in allowlist", () => {
+    mockBuildAllowedModelSet.mockReturnValue({
+      allowAny: false,
+      allowedKeys: new Set(["openai/gpt-4o"]),
+    });
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o" },
+    });
+
+    const result = prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: ["openai/gpt-4o"],
+    });
+    expect(result).toEqual(["openai/gpt-4o"]);
+  });
+
+  it("filters out fallbacks not in allowlist", () => {
+    mockBuildAllowedModelSet.mockReturnValue({
+      allowAny: false,
+      allowedKeys: new Set(["openai/gpt-4o"]),
+    });
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "anthropic", model: "claude-opus-4-6" },
+    });
+
+    const result = prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: ["anthropic/claude-opus-4-6"],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("allows any model when allowlist is empty", () => {
+    mockBuildAllowedModelSet.mockReturnValue({
+      allowAny: true,
+      allowedKeys: new Set(),
+    });
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o" },
+    });
+
+    const result = prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: ["openai/gpt-4o"],
+    });
+    expect(result).toEqual(["openai/gpt-4o"]);
+  });
+
+  it("uses imageModelProvider for resolution when available", () => {
+    mockBuildAllowedModelSet.mockReturnValue({
+      allowAny: true,
+      allowedKeys: new Set(),
+    });
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o-mini" },
+    });
+
+    prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: ["gpt-4o-mini"],
+      imageModelProvider: "openai",
+    });
+
+    expect(mockResolveModelRefFromString).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw: "gpt-4o-mini",
+        defaultProvider: "openai",
+      }),
+    );
+  });
+
+  it("falls back to raw string when alias resolution fails but string is in allowlist", () => {
+    mockBuildAllowedModelSet.mockReturnValue({
+      allowAny: false,
+      allowedKeys: new Set(["gpt-4o"]),
+    });
+    mockResolveModelRefFromString.mockReturnValue(null);
+
+    const result = prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: ["gpt-4o"],
+    });
+    expect(result).toEqual(["gpt-4o"]);
+  });
+
+  it("filters out empty and whitespace-only fallbacks", () => {
+    mockBuildAllowedModelSet.mockReturnValue({
+      allowAny: true,
+      allowedKeys: new Set(),
+    });
+
+    const result = prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: ["", "  ", "openai/gpt-4o"],
+    });
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o" },
+    });
+    // Re-call since mock was set after first call
+    const result2 = prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: ["", "  ", "openai/gpt-4o"],
+    });
+    expect(result2).toEqual(["openai/gpt-4o"]);
+  });
+
+  it("processes multiple fallbacks in order", () => {
+    mockBuildAllowedModelSet.mockReturnValue({
+      allowAny: false,
+      allowedKeys: new Set(["openai/gpt-4o", "openai/gpt-4o-mini"]),
+    });
+    mockResolveModelRefFromString.mockImplementation((params: { raw: string }) => {
+      if (params.raw === "anthropic/claude-opus-4-6") {
+        return { ref: { provider: "anthropic", model: "claude-opus-4-6" } };
+      }
+      if (params.raw === "openai/gpt-4o") {
+        return { ref: { provider: "openai", model: "gpt-4o" } };
+      }
+      if (params.raw === "openai/gpt-4o-mini") {
+        return { ref: { provider: "openai", model: "gpt-4o-mini" } };
+      }
+      return null;
+    });
+
+    const result = prepareImageModelFallbacks({
+      ...baseParams,
+      fallbacks: ["anthropic/claude-opus-4-6", "openai/gpt-4o", "openai/gpt-4o-mini"],
+    });
+    // First is filtered out (not in allowlist), second and third are kept
+    expect(result).toEqual(["openai/gpt-4o", "openai/gpt-4o-mini"]);
+  });
+});
+
+describe("resolveModelSupportsVision", () => {
+  const baseParams = {
+    provider: "openai",
+    model: "gpt-4o",
+    defaultProvider: "anthropic",
+    cfg: {} as never,
+  };
+
+  it("returns true when model matches imageModelConfig primary", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    // collectImageModelKeys will resolve the primary and add it to keys
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o" },
+    });
+
+    const result = await resolveModelSupportsVision({
+      ...baseParams,
+      imageModelConfig: { primary: "openai/gpt-4o" } as never,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns true when model matches imageModelConfig fallback", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o" },
+    });
+
+    const result = await resolveModelSupportsVision({
+      ...baseParams,
+      imageModelConfig: { fallbacks: ["openai/gpt-4o"] } as never,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("checks catalog when model not in imageModelConfig", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockResolveModelRefFromString.mockReturnValue(null);
+    mockLoadModelCatalog.mockResolvedValue([]);
+    mockFindModelInCatalog.mockReturnValue({ id: "gpt-4o", provider: "openai" });
+    mockModelSupportsVision.mockReturnValue(true);
+
+    const result = await resolveModelSupportsVision({
+      ...baseParams,
+      imageModelConfig: { primary: "anthropic/claude-sonnet-4-6" } as never,
+    });
+    expect(result).toBe(true);
+    expect(mockFindModelInCatalog).toHaveBeenCalledWith([], "openai", "gpt-4o");
+  });
+
+  it("returns false when catalog says model does not support vision", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockResolveModelRefFromString.mockReturnValue(null);
+    mockLoadModelCatalog.mockResolvedValue([]);
+    mockFindModelInCatalog.mockReturnValue({ id: "gpt-4o", provider: "openai" });
+    mockModelSupportsVision.mockReturnValue(false);
+
+    const result = await resolveModelSupportsVision({
+      ...baseParams,
+      imageModelConfig: { primary: "anthropic/claude-sonnet-4-6" } as never,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when catalog lookup fails", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockResolveModelRefFromString.mockReturnValue(null);
+    mockLoadModelCatalog.mockRejectedValue(new Error("catalog error"));
+
+    const result = await resolveModelSupportsVision({
+      ...baseParams,
+      imageModelConfig: { primary: "anthropic/claude-sonnet-4-6" } as never,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("uses custom loadModelCatalog when provided", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockResolveModelRefFromString.mockReturnValue(null);
+    const customLoader = vi.fn().mockResolvedValue([]);
+    mockFindModelInCatalog.mockReturnValue({ id: "gpt-4o", provider: "openai" });
+    mockModelSupportsVision.mockReturnValue(true);
+
+    await resolveModelSupportsVision({
+      ...baseParams,
+      imageModelConfig: { primary: "anthropic/claude-sonnet-4-6" } as never,
+      loadModelCatalog: customLoader,
+    });
+    expect(customLoader).toHaveBeenCalledWith({ config: {} });
+  });
+
+  it("checks catalog when imageModelConfig is undefined", async () => {
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockLoadModelCatalog.mockResolvedValue([]);
+    mockFindModelInCatalog.mockReturnValue({ id: "gpt-4o", provider: "openai" });
+    mockModelSupportsVision.mockReturnValue(true);
+
+    const result = await resolveModelSupportsVision({
+      ...baseParams,
+    });
+    expect(result).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/image-model-helpers.test.ts
+++ b/src/auto-reply/reply/image-model-helpers.test.ts
@@ -132,20 +132,15 @@ describe("prepareImageModelFallbacks", () => {
       allowAny: true,
       allowedKeys: new Set(),
     });
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o" },
+    });
 
     const result = prepareImageModelFallbacks({
       ...baseParams,
       fallbacks: ["", "  ", "openai/gpt-4o"],
     });
-    mockResolveModelRefFromString.mockReturnValue({
-      ref: { provider: "openai", model: "gpt-4o" },
-    });
-    // Re-call since mock was set after first call
-    const result2 = prepareImageModelFallbacks({
-      ...baseParams,
-      fallbacks: ["", "  ", "openai/gpt-4o"],
-    });
-    expect(result2).toEqual(["openai/gpt-4o"]);
+    expect(result).toEqual(["openai/gpt-4o"]);
   });
 
   it("processes multiple fallbacks in order", () => {

--- a/src/auto-reply/reply/image-model-helpers.ts
+++ b/src/auto-reply/reply/image-model-helpers.ts
@@ -1,0 +1,438 @@
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import {
+  buildAllowedModelSet,
+  buildModelAliasIndex,
+  modelKey,
+  resolveModelRefFromString,
+  type ModelAliasIndex,
+} from "../../agents/model-selection.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
+import type { AgentModelConfig } from "../../config/types.agents-shared.js";
+
+/**
+ * Result of collecting image model keys from config.
+ */
+export type ImageModelKeysResult = {
+  keys: Set<string>;
+  imageModelDefaultProvider: string;
+};
+
+/**
+ * Parameters for collecting image model keys.
+ */
+export type CollectImageModelKeysParams = {
+  imageModelConfig: AgentModelConfig | undefined;
+  aliasIndex?: ModelAliasIndex;
+  defaultProvider?: string;
+  /**
+   * When true and primary is providerless, try to resolve as alias first.
+   * This handles cases like primary: "vision" -> "openai/gpt-4o".
+   * Default: true
+   */
+  resolveProviderlessAsAlias?: boolean;
+};
+
+/**
+ * Collect all configured image models (primary + fallbacks) into a Set of model keys.
+ * Resolves aliases using aliasIndex and the image model's own provider context.
+ * Returns a Set of both raw strings and resolved "provider/model" keys.
+ * Also adds providerless model names so isImageModel can match across providers.
+ */
+export function collectImageModelKeys(params: CollectImageModelKeysParams): ImageModelKeysResult {
+  const {
+    imageModelConfig,
+    aliasIndex,
+    defaultProvider,
+    resolveProviderlessAsAlias = true,
+  } = params;
+  const keys = new Set<string>();
+  const noProviderValue = defaultProvider ?? "";
+  if (!imageModelConfig) {
+    return { keys, imageModelDefaultProvider: noProviderValue };
+  }
+
+  const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
+
+  // Resolve the image model's primary to get its provider for fallback resolution.
+  // Providerless fallbacks should resolve against the image model's provider,
+  // not the agent's default provider (to handle mixed-provider configs correctly).
+  let imageModelDefaultProvider = "";
+  const primaryTrimmed = imageModelPrimary?.trim() ?? "";
+  const primaryHasProvider = primaryTrimmed.includes("/");
+
+  // Only derive imageModelDefaultProvider from imageModelPrimary if it has an explicit provider.
+  if (imageModelPrimary && aliasIndex && defaultProvider && primaryHasProvider) {
+    const resolved = resolveModelRefFromString({
+      raw: primaryTrimmed,
+      defaultProvider,
+      aliasIndex,
+    });
+    if (resolved) {
+      imageModelDefaultProvider = resolved.ref.provider;
+    }
+  }
+
+  // If no primary was configured or the primary is providerless, derive
+  // imageModelDefaultProvider from fallbacks.
+  if ((!imageModelPrimary || !primaryHasProvider) && aliasIndex && !imageModelDefaultProvider) {
+    const fallbacks =
+      typeof imageModelConfig === "string"
+        ? [imageModelConfig]
+        : Array.isArray(imageModelConfig?.fallbacks)
+          ? imageModelConfig.fallbacks
+          : [];
+
+    // First pass: try to resolve providerless primary alias to get its provider.
+    if (!primaryHasProvider && imageModelPrimary && defaultProvider && resolveProviderlessAsAlias) {
+      const resolved = resolveModelRefFromString({
+        raw: primaryTrimmed,
+        defaultProvider,
+        aliasIndex,
+      });
+      if (resolved?.alias) {
+        imageModelDefaultProvider = resolved.ref.provider;
+      }
+    }
+
+    // Second pass: find the first fallback with an explicit provider
+    if (!imageModelDefaultProvider) {
+      for (const fb of fallbacks) {
+        if (typeof fb !== "string" || !fb.trim()) {
+          continue;
+        }
+        const slash = fb.indexOf("/");
+        if (slash > 0) {
+          imageModelDefaultProvider = fb.slice(0, slash).trim();
+          break;
+        }
+      }
+    }
+
+    // Third pass: if still no provider, use alias resolution on fallbacks
+    if (!imageModelDefaultProvider && defaultProvider) {
+      for (const fb of fallbacks) {
+        if (typeof fb !== "string" || !fb.trim()) {
+          continue;
+        }
+        const resolved = resolveModelRefFromString({
+          raw: fb.trim(),
+          defaultProvider,
+          aliasIndex,
+        });
+        if (resolved?.alias && resolved.ref.provider) {
+          imageModelDefaultProvider = resolved.ref.provider;
+          break;
+        }
+      }
+    }
+  }
+
+  const addModelKey = (rawModel: string, isPrimary: boolean) => {
+    const trimmed = rawModel.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const trimmedSlash = trimmed.indexOf("/");
+
+    // Add provider-qualified raw strings directly
+    if (trimmedSlash > 0) {
+      keys.add(trimmed);
+    }
+
+    // Also add providerless model names directly for cross-provider matching.
+    if (trimmedSlash <= 0) {
+      keys.add(trimmed);
+    }
+
+    // Resolve alias and add canonical key.
+    const providerContext = isPrimary
+      ? defaultProvider
+      : imageModelDefaultProvider || defaultProvider;
+    if (aliasIndex && providerContext) {
+      const resolved = resolveModelRefFromString({
+        raw: trimmed,
+        defaultProvider: providerContext,
+        aliasIndex,
+      });
+      if (resolved) {
+        keys.add(modelKey(resolved.ref.provider, resolved.ref.model));
+      }
+    }
+  };
+
+  if (typeof imageModelConfig === "string") {
+    addModelKey(imageModelConfig, true);
+  } else {
+    if (imageModelPrimary?.trim()) {
+      addModelKey(imageModelPrimary, true);
+    }
+    if (Array.isArray(imageModelConfig.fallbacks)) {
+      for (const fb of imageModelConfig.fallbacks) {
+        if (fb?.trim()) {
+          addModelKey(fb, false);
+        }
+      }
+    }
+  }
+  return { keys, imageModelDefaultProvider };
+}
+
+/**
+ * Check if a given provider/model combination is in the set of image models.
+ */
+export function isImageModel(
+  provider: string,
+  model: string,
+  imageModelKeys: Set<string>,
+): boolean {
+  const effectiveProvider = provider;
+  const pureModel = model;
+
+  // 1. Check exact provider/model key match
+  const key = modelKey(effectiveProvider, pureModel);
+  if (imageModelKeys.has(key)) {
+    return true;
+  }
+
+  // 2. Check stored model string directly against provider-qualified entries
+  if (imageModelKeys.has(model)) {
+    return true;
+  }
+
+  // 3. Match against all entries in imageModelKeys
+  for (const entry of imageModelKeys) {
+    const slash = entry.indexOf("/");
+    if (slash <= 0) {
+      // Providerless entry - matches any provider with the same model name.
+      if (entry === pureModel) {
+        return true;
+      }
+    } else {
+      // Provider-qualified entry - match by pure name with provider alignment
+      const entryPureModel = entry.slice(slash + 1);
+      if (entryPureModel === pureModel) {
+        const entryProvider = entry.slice(0, slash);
+        if (effectiveProvider === entryProvider) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Parameters for preparing image model fallbacks.
+ */
+export type PrepareImageModelFallbacksParams = {
+  fallbacks: string[];
+  cfg: OpenClawConfig;
+  agentId?: string;
+  aliasIndex: ReturnType<typeof buildModelAliasIndex>;
+  defaultProvider: string;
+  defaultModel?: string;
+  imageModelProvider?: string;
+};
+
+/**
+ * Filter and canonicalize image model fallbacks in one step.
+ * Combines allowlist filtering with provider-aware canonicalization.
+ */
+export function prepareImageModelFallbacks(params: PrepareImageModelFallbacksParams): string[] {
+  const { fallbacks, cfg, agentId, aliasIndex, defaultProvider, defaultModel, imageModelProvider } =
+    params;
+
+  if (fallbacks.length === 0) {
+    return [];
+  }
+
+  const providerForResolution = imageModelProvider ?? defaultProvider;
+  const { allowAny, allowedKeys } = buildAllowedModelSet({
+    cfg,
+    catalog: [],
+    defaultProvider,
+    defaultModel,
+    agentId,
+  });
+
+  return fallbacks
+    .map((fb) => {
+      const trimmed = fb?.trim();
+      if (!trimmed) {
+        return null;
+      }
+
+      const resolved = resolveModelRefFromString({
+        raw: trimmed,
+        defaultProvider: providerForResolution,
+        aliasIndex,
+      });
+
+      if (!resolved) {
+        if (!allowAny && !allowedKeys.has(trimmed)) {
+          return null;
+        }
+        return trimmed;
+      }
+
+      const key = modelKey(resolved.ref.provider, resolved.ref.model);
+      if (!allowAny && !allowedKeys.has(key) && !allowedKeys.has(trimmed)) {
+        return null;
+      }
+      return key;
+    })
+    .filter((fb): fb is string => fb !== null);
+}
+
+/**
+ * Parameters for resolving channel model vision support.
+ */
+export type ResolveChannelModelSupportsVisionParams = {
+  channelModelOverride: { model: string } | undefined;
+  imageModelConfig: AgentModelConfig | undefined;
+  defaultProvider: string;
+  cfg: OpenClawConfig;
+  hasAppliedImageModelOverride: boolean;
+};
+
+export type ResolveModelSupportsVisionParams = {
+  provider: string;
+  model: string;
+  imageModelConfig?: AgentModelConfig;
+  defaultProvider: string;
+  cfg: OpenClawConfig;
+  loadModelCatalog?: (params: { config: OpenClawConfig }) => Promise<ModelCatalogEntry[]>;
+};
+
+/**
+ * Result of checking if channel model supports vision.
+ */
+export type ResolveChannelModelSupportsVisionResult = {
+  channelModelIsVisionModel: boolean;
+  channelResolved?: {
+    provider: string;
+    model: string;
+  };
+};
+
+/**
+ * Check if the channel model override is already a vision model.
+ * This prevents unnecessary model switching when the channel model
+ * already supports image input.
+ *
+ * Returns channelModelIsVisionModel=true if:
+ * 1. The channel model matches the configured imageModel or fallbacks, OR
+ * 2. The catalog indicates the channel model supports vision
+ */
+export async function resolveChannelModelSupportsVision(
+  params: ResolveChannelModelSupportsVisionParams,
+): Promise<ResolveChannelModelSupportsVisionResult> {
+  const {
+    channelModelOverride,
+    imageModelConfig,
+    defaultProvider,
+    cfg,
+    hasAppliedImageModelOverride,
+  } = params;
+
+  if (!channelModelOverride || !hasAppliedImageModelOverride) {
+    return { channelModelIsVisionModel: false };
+  }
+
+  const {
+    findModelInCatalog,
+    modelSupportsVision,
+    loadModelCatalog: loadCatalogFn,
+  } = await import("../../agents/model-catalog.js");
+  const { resolveAgentModelFallbackValues, resolveAgentModelPrimaryValue } =
+    await import("../../config/model-input.js");
+
+  // Use the active default provider when building the alias index so that
+  // aliases defined on providerless model keys resolve correctly.
+  const channelAliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
+
+  // Resolve the channel model to get provider/model
+  const channelResolved = resolveModelRefFromString({
+    raw: channelModelOverride.model,
+    defaultProvider,
+    aliasIndex: channelAliasIndex,
+  });
+
+  if (!channelResolved) {
+    return { channelModelIsVisionModel: false };
+  }
+
+  // First, check if the channel model matches the configured imageModel or its fallbacks
+  const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
+  const fallbacks = resolveAgentModelFallbackValues(imageModelConfig);
+
+  // Process if either primary or fallbacks are configured (handles fallback-only configs)
+  if (imageModelPrimary || fallbacks.length > 0) {
+    const { keys: imageModelKeys } = collectImageModelKeys({
+      imageModelConfig,
+      aliasIndex: channelAliasIndex,
+      defaultProvider,
+    });
+
+    const channelKey = modelKey(channelResolved.ref.provider, channelResolved.ref.model);
+
+    if (imageModelKeys.has(channelKey)) {
+      return { channelModelIsVisionModel: true, channelResolved: channelResolved.ref };
+    }
+  }
+
+  // If not found in imageModel list, check catalog for vision capabilities
+  try {
+    const catalog = await loadCatalogFn({ config: cfg });
+    const catalogEntry = findModelInCatalog(
+      catalog,
+      channelResolved.ref.provider,
+      channelResolved.ref.model,
+    );
+    if (modelSupportsVision(catalogEntry)) {
+      return { channelModelIsVisionModel: true, channelResolved: channelResolved.ref };
+    }
+  } catch {
+    // Catalog lookup failed; fall back to text-only assumption
+  }
+
+  return { channelModelIsVisionModel: false, channelResolved: channelResolved.ref };
+}
+
+export async function resolveModelSupportsVision(
+  params: ResolveModelSupportsVisionParams,
+): Promise<boolean> {
+  const {
+    provider,
+    model,
+    imageModelConfig,
+    defaultProvider,
+    cfg,
+    loadModelCatalog: loadCatalog,
+  } = params;
+  const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
+
+  if (imageModelConfig) {
+    const { keys: imageModelKeys } = collectImageModelKeys({
+      imageModelConfig,
+      aliasIndex,
+      defaultProvider,
+    });
+    if (isImageModel(provider, model, imageModelKeys)) {
+      return true;
+    }
+  }
+
+  try {
+    const { findModelInCatalog, loadModelCatalog, modelSupportsVision } =
+      await import("../../agents/model-catalog.js");
+    const catalog = await (loadCatalog ?? loadModelCatalog)({ config: cfg });
+    const catalogEntry = findModelInCatalog(catalog, provider, model);
+    return modelSupportsVision(catalogEntry);
+  } catch {
+    return false;
+  }
+}

--- a/src/auto-reply/reply/image-model-helpers.ts
+++ b/src/auto-reply/reply/image-model-helpers.ts
@@ -1,4 +1,5 @@
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import { isModelKeyAllowedBySet } from "../../agents/model-selection-shared.js";
 import {
   buildAllowedModelSet,
   buildModelAliasIndex,
@@ -267,7 +268,7 @@ export function prepareImageModelFallbacks(params: PrepareImageModelFallbacksPar
       }
 
       const key = modelKey(resolved.ref.provider, resolved.ref.model);
-      if (!allowAny && !allowedKeys.has(key) && !allowedKeys.has(trimmed)) {
+      if (!allowAny && !isModelKeyAllowedBySet(allowedKeys, key) && !allowedKeys.has(trimmed)) {
         return null;
       }
       return key;

--- a/src/auto-reply/reply/image-model-helpers.ts
+++ b/src/auto-reply/reply/image-model-helpers.ts
@@ -134,17 +134,8 @@ export function collectImageModelKeys(params: CollectImageModelKeysParams): Imag
       return;
     }
 
-    const trimmedSlash = trimmed.indexOf("/");
-
-    // Add provider-qualified raw strings directly
-    if (trimmedSlash > 0) {
-      keys.add(trimmed);
-    }
-
-    // Also add providerless model names directly for cross-provider matching.
-    if (trimmedSlash <= 0) {
-      keys.add(trimmed);
-    }
+    // Add raw model string directly for matching (both provider-qualified and providerless).
+    keys.add(trimmed);
 
     // Resolve alias and add canonical key.
     const providerContext = isPrimary

--- a/src/auto-reply/reply/image-model-helpers.ts
+++ b/src/auto-reply/reply/image-model-helpers.ts
@@ -306,35 +306,23 @@ export async function resolveModelSupportsVision(
     if (catalogEntry !== undefined) {
       return modelSupportsVision(catalogEntry);
     }
-
-    // Catalog does not contain this model. Fall back to imageModel config
-    // as a lenient signal — the user may have configured a custom or
-    // provider-specific model that the catalog does not yet cover.
-    if (imageModelConfig) {
-      const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
-      const { keys: imageModelKeys } = collectImageModelKeys({
-        imageModelConfig,
-        aliasIndex,
-        defaultProvider,
-      });
-      if (isImageModel(provider, model, imageModelKeys)) {
-        return true;
-      }
-    }
-    return false;
   } catch {
-    // Catalog lookup failed entirely. Fall back to imageModel config.
-    if (imageModelConfig) {
-      const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
-      const { keys: imageModelKeys } = collectImageModelKeys({
-        imageModelConfig,
-        aliasIndex,
-        defaultProvider,
-      });
-      if (isImageModel(provider, model, imageModelKeys)) {
-        return true;
-      }
-    }
-    return false;
+    // Catalog lookup failed; fall through to config-based detection.
   }
+
+  // Catalog does not contain this model (or lookup failed). Fall back to
+  // imageModel config as a lenient signal — the user may have configured a
+  // custom or provider-specific model that the catalog does not yet cover.
+  if (imageModelConfig) {
+    const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
+    const { keys: imageModelKeys } = collectImageModelKeys({
+      imageModelConfig,
+      aliasIndex,
+      defaultProvider,
+    });
+    if (isImageModel(provider, model, imageModelKeys)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/auto-reply/reply/image-model-helpers.ts
+++ b/src/auto-reply/reply/image-model-helpers.ts
@@ -296,34 +296,45 @@ export async function resolveModelSupportsVision(
     loadModelCatalog: loadCatalog,
   } = params;
 
-  // Always validate against the catalog first — a model being in imageModel
-  // config does not guarantee it actually supports vision input.
   try {
     const { findModelInCatalog, loadModelCatalog, modelSupportsVision } =
       await import("../../agents/model-catalog.js");
     const catalog = await (loadCatalog ?? loadModelCatalog)({ config: cfg });
     const catalogEntry = findModelInCatalog(catalog, provider, model);
-    if (modelSupportsVision(catalogEntry)) {
-      return true;
+
+    // If the catalog has an entry for this model, trust its vision capability flag.
+    if (catalogEntry !== undefined) {
+      return modelSupportsVision(catalogEntry);
     }
+
+    // Catalog does not contain this model. Fall back to imageModel config
+    // as a lenient signal — the user may have configured a custom or
+    // provider-specific model that the catalog does not yet cover.
+    if (imageModelConfig) {
+      const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
+      const { keys: imageModelKeys } = collectImageModelKeys({
+        imageModelConfig,
+        aliasIndex,
+        defaultProvider,
+      });
+      if (isImageModel(provider, model, imageModelKeys)) {
+        return true;
+      }
+    }
+    return false;
   } catch {
-    // Catalog lookup failed; fall through to imageModel config as a lenient
-    // signal for environments where the catalog is unavailable.
-  }
-
-  // Catalog did not confirm vision support; check imageModel config as a
-  // configuration-level signal that the user intends this model for images.
-  if (imageModelConfig) {
-    const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
-    const { keys: imageModelKeys } = collectImageModelKeys({
-      imageModelConfig,
-      aliasIndex,
-      defaultProvider,
-    });
-    if (isImageModel(provider, model, imageModelKeys)) {
-      return true;
+    // Catalog lookup failed entirely. Fall back to imageModel config.
+    if (imageModelConfig) {
+      const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
+      const { keys: imageModelKeys } = collectImageModelKeys({
+        imageModelConfig,
+        aliasIndex,
+        defaultProvider,
+      });
+      if (isImageModel(provider, model, imageModelKeys)) {
+        return true;
+      }
     }
+    return false;
   }
-
-  return false;
 }

--- a/src/auto-reply/reply/image-model-helpers.ts
+++ b/src/auto-reply/reply/image-model-helpers.ts
@@ -295,9 +295,26 @@ export async function resolveModelSupportsVision(
     cfg,
     loadModelCatalog: loadCatalog,
   } = params;
-  const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
 
+  // Always validate against the catalog first — a model being in imageModel
+  // config does not guarantee it actually supports vision input.
+  try {
+    const { findModelInCatalog, loadModelCatalog, modelSupportsVision } =
+      await import("../../agents/model-catalog.js");
+    const catalog = await (loadCatalog ?? loadModelCatalog)({ config: cfg });
+    const catalogEntry = findModelInCatalog(catalog, provider, model);
+    if (modelSupportsVision(catalogEntry)) {
+      return true;
+    }
+  } catch {
+    // Catalog lookup failed; fall through to imageModel config as a lenient
+    // signal for environments where the catalog is unavailable.
+  }
+
+  // Catalog did not confirm vision support; check imageModel config as a
+  // configuration-level signal that the user intends this model for images.
   if (imageModelConfig) {
+    const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
     const { keys: imageModelKeys } = collectImageModelKeys({
       imageModelConfig,
       aliasIndex,
@@ -308,13 +325,5 @@ export async function resolveModelSupportsVision(
     }
   }
 
-  try {
-    const { findModelInCatalog, loadModelCatalog, modelSupportsVision } =
-      await import("../../agents/model-catalog.js");
-    const catalog = await (loadCatalog ?? loadModelCatalog)({ config: cfg });
-    const catalogEntry = findModelInCatalog(catalog, provider, model);
-    return modelSupportsVision(catalogEntry);
-  } catch {
-    return false;
-  }
+  return false;
 }

--- a/src/auto-reply/reply/image-model-helpers.ts
+++ b/src/auto-reply/reply/image-model-helpers.ts
@@ -263,10 +263,7 @@ export function prepareImageModelFallbacks(params: PrepareImageModelFallbacksPar
       });
 
       if (!resolved) {
-        if (!allowAny && !allowedKeys.has(trimmed)) {
-          return null;
-        }
-        return trimmed;
+        return null;
       }
 
       const key = modelKey(resolved.ref.provider, resolved.ref.model);

--- a/src/auto-reply/reply/image-model-helpers.ts
+++ b/src/auto-reply/reply/image-model-helpers.ts
@@ -278,17 +278,6 @@ export function prepareImageModelFallbacks(params: PrepareImageModelFallbacksPar
     .filter((fb): fb is string => fb !== null);
 }
 
-/**
- * Parameters for resolving channel model vision support.
- */
-export type ResolveChannelModelSupportsVisionParams = {
-  channelModelOverride: { model: string } | undefined;
-  imageModelConfig: AgentModelConfig | undefined;
-  defaultProvider: string;
-  cfg: OpenClawConfig;
-  hasAppliedImageModelOverride: boolean;
-};
-
 export type ResolveModelSupportsVisionParams = {
   provider: string;
   model: string;
@@ -297,101 +286,6 @@ export type ResolveModelSupportsVisionParams = {
   cfg: OpenClawConfig;
   loadModelCatalog?: (params: { config: OpenClawConfig }) => Promise<ModelCatalogEntry[]>;
 };
-
-/**
- * Result of checking if channel model supports vision.
- */
-export type ResolveChannelModelSupportsVisionResult = {
-  channelModelIsVisionModel: boolean;
-  channelResolved?: {
-    provider: string;
-    model: string;
-  };
-};
-
-/**
- * Check if the channel model override is already a vision model.
- * This prevents unnecessary model switching when the channel model
- * already supports image input.
- *
- * Returns channelModelIsVisionModel=true if:
- * 1. The channel model matches the configured imageModel or fallbacks, OR
- * 2. The catalog indicates the channel model supports vision
- */
-export async function resolveChannelModelSupportsVision(
-  params: ResolveChannelModelSupportsVisionParams,
-): Promise<ResolveChannelModelSupportsVisionResult> {
-  const {
-    channelModelOverride,
-    imageModelConfig,
-    defaultProvider,
-    cfg,
-    hasAppliedImageModelOverride,
-  } = params;
-
-  if (!channelModelOverride || !hasAppliedImageModelOverride) {
-    return { channelModelIsVisionModel: false };
-  }
-
-  const {
-    findModelInCatalog,
-    modelSupportsVision,
-    loadModelCatalog: loadCatalogFn,
-  } = await import("../../agents/model-catalog.js");
-  const { resolveAgentModelFallbackValues, resolveAgentModelPrimaryValue } =
-    await import("../../config/model-input.js");
-
-  // Use the active default provider when building the alias index so that
-  // aliases defined on providerless model keys resolve correctly.
-  const channelAliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
-
-  // Resolve the channel model to get provider/model
-  const channelResolved = resolveModelRefFromString({
-    raw: channelModelOverride.model,
-    defaultProvider,
-    aliasIndex: channelAliasIndex,
-  });
-
-  if (!channelResolved) {
-    return { channelModelIsVisionModel: false };
-  }
-
-  // First, check if the channel model matches the configured imageModel or its fallbacks
-  const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
-  const fallbacks = resolveAgentModelFallbackValues(imageModelConfig);
-
-  // Process if either primary or fallbacks are configured (handles fallback-only configs)
-  if (imageModelPrimary || fallbacks.length > 0) {
-    const { keys: imageModelKeys } = collectImageModelKeys({
-      imageModelConfig,
-      aliasIndex: channelAliasIndex,
-      defaultProvider,
-    });
-
-    const channelKey = modelKey(channelResolved.ref.provider, channelResolved.ref.model);
-
-    if (imageModelKeys.has(channelKey)) {
-      return { channelModelIsVisionModel: true, channelResolved: channelResolved.ref };
-    }
-  }
-
-  // If not found in imageModel list, check catalog for vision capabilities
-  try {
-    const catalog = await loadCatalogFn({ config: cfg });
-    const catalogEntry = findModelInCatalog(
-      catalog,
-      channelResolved.ref.provider,
-      channelResolved.ref.model,
-    );
-    if (modelSupportsVision(catalogEntry)) {
-      return { channelModelIsVisionModel: true, channelResolved: channelResolved.ref };
-    }
-  } catch {
-    // Catalog lookup failed; fall back to text-only assumption
-  }
-
-  return { channelModelIsVisionModel: false, channelResolved: channelResolved.ref };
-}
 
 export async function resolveModelSupportsVision(
   params: ResolveModelSupportsVisionParams,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -107,6 +107,8 @@ export async function createModelSelectionState(params: {
    *  In that case, skip session-stored overrides so the heartbeat selection wins. */
   hasResolvedHeartbeatModelOverride?: boolean;
   isHeartbeat?: boolean;
+  /** True when an image model override was applied for this turn. */
+  hasAppliedImageModelOverride?: boolean;
 }): Promise<ModelSelectionState> {
   const timingEnabled = shouldLogModelSelectionTiming();
   const startMs = timingEnabled ? Date.now() : 0;

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -269,12 +269,12 @@ export async function createModelSelectionState(params: {
     parentSessionKey,
     defaultProvider,
   });
-  // Skip stored session model override only when an explicit heartbeat.model
-  // was resolved. Heartbeats without heartbeat.model still inherit normal
-  // overrides unless a direct auto fallback override is stale for the current
-  // configured default.
+  // Skip stored session model override when an explicit heartbeat.model was
+  // resolved, when an image model override was applied for this turn, or when
+  // a stale heartbeat auto fallback override is detected for the session.
   const skipStoredOverride =
     params.hasResolvedHeartbeatModelOverride === true ||
+    params.hasAppliedImageModelOverride === true ||
     (staleHeartbeatAutoFallbackOverride && storedOverride?.source === "session");
 
   if (storedOverride?.model && !skipStoredOverride) {
@@ -303,7 +303,19 @@ export async function createModelSelectionState(params: {
     model = allowedInitialSelection.model;
   }
 
-  if (sessionEntry && sessionStore && sessionKey && sessionEntry.authProfileOverride) {
+  // When an image model override switched providers (e.g., anthropic -> openai),
+  // skip auth profile cleanup since the provider change was automatic, not a user directive.
+  const skipAuthProfileReset =
+    params.hasAppliedImageModelOverride === true &&
+    normalizeProviderId(provider) !== normalizeProviderId(defaultProvider);
+
+  if (
+    sessionEntry &&
+    sessionStore &&
+    sessionKey &&
+    sessionEntry.authProfileOverride &&
+    !skipAuthProfileReset
+  ) {
     const { ensureAuthProfileStore } = await import("../../agents/auth-profiles.runtime.js");
     const store = ensureAuthProfileStore(undefined, {
       allowKeychainPrompt: false,

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -267,6 +267,11 @@ export async function parseMessageWithAttachments(
       const trustedProvidedMime = shouldIgnoreProvidedImageMime({ sniffedMime, providedMime })
         ? undefined
         : providedMime;
+      // When content sniffing detects a generic/non-image container, the file
+      // name label is untrusted — a DOCX/ZIP uploaded as "report.png" would
+      // otherwise be classified as image/png through labelMime.
+      const trustedLabelMime =
+        sniffedMime && isGenericContainerMime(sniffedMime) ? undefined : labelMime;
 
       // Prefer specific MIME signals over generic container types. OOXML
       // documents (docx/xlsx/pptx) sniff as application/zip; without this
@@ -277,10 +282,10 @@ export async function parseMessageWithAttachments(
         (trustedProvidedMime &&
           !isGenericContainerMime(trustedProvidedMime) &&
           trustedProvidedMime) ||
-        (labelMime && !isGenericContainerMime(labelMime) && labelMime) ||
+        (trustedLabelMime && !isGenericContainerMime(trustedLabelMime) && trustedLabelMime) ||
         sniffedMime ||
         trustedProvidedMime ||
-        labelMime ||
+        trustedLabelMime ||
         "application/octet-stream";
 
       if (

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -267,11 +267,13 @@ export async function parseMessageWithAttachments(
       const trustedProvidedMime = shouldIgnoreProvidedImageMime({ sniffedMime, providedMime })
         ? undefined
         : providedMime;
-      // When content sniffing detects a generic/non-image container, the file
-      // name label is untrusted — a DOCX/ZIP uploaded as "report.png" would
-      // otherwise be classified as image/png through labelMime.
-      const trustedLabelMime =
-        sniffedMime && isGenericContainerMime(sniffedMime) ? undefined : labelMime;
+      // When content sniffing detects a generic container AND the file name
+      // label claims an image type, the label is untrusted — a DOCX/ZIP
+      // uploaded as "report.png" would otherwise be classified as image/png.
+      // But specific non-image labels (e.g., .xlsx -> spreadsheetml.sheet)
+      // should be preserved since OOXML documents legitimately sniff as zip.
+      const shouldIgnoreLabelMime = isGenericContainerMime(sniffedMime) && isImageMime(labelMime);
+      const trustedLabelMime = shouldIgnoreLabelMime ? undefined : labelMime;
 
       // Prefer specific MIME signals over generic container types. OOXML
       // documents (docx/xlsx/pptx) sniff as application/zip; without this

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -40,8 +40,9 @@ import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
 } from "../../media/local-roots.js";
-import { isAudioFileName } from "../../media/mime.js";
+import { isAudioFileName, mimeTypeFromFilePath } from "../../media/mime.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
+import { sniffMimeFromBase64 } from "../../media/sniff-mime-from-base64.js";
 import {
   deleteMediaBuffer,
   MEDIA_MAX_BYTES,
@@ -186,6 +187,84 @@ function isTtsSupplementPayload(payload: ReplyPayload): boolean {
 
 function stripVisibleTextFromTtsSupplement(payload: ReplyPayload): ReplyPayload {
   return isTtsSupplementPayload(payload) ? { ...payload, text: undefined } : payload;
+}
+
+function normalizeAttachmentMime(mime?: string | null): string | undefined {
+  const cleaned = normalizeOptionalText(mime?.split(";")[0])?.toLowerCase();
+  return cleaned || undefined;
+}
+
+function isGenericAttachmentMime(mime?: string): boolean {
+  return mime === "application/zip" || mime === "application/octet-stream";
+}
+
+function shouldIgnoreProvidedImageMime(params: {
+  sniffedMime?: string;
+  providedMime?: string;
+}): boolean {
+  return (
+    isGenericAttachmentMime(params.sniffedMime) &&
+    Boolean(params.providedMime?.startsWith("image/"))
+  );
+}
+
+function extractAttachmentBase64Content(content: unknown): string | undefined {
+  if (typeof content !== "string") {
+    return undefined;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const dataUrlMatch = /^data:[^;]+;base64,(.*)$/i.exec(trimmed);
+  return dataUrlMatch?.[1] ?? trimmed;
+}
+
+async function resolveAttachmentLooksLikeImage(
+  attachment: Partial<{
+    type: string;
+    mimeType: string;
+    fileName: string;
+    content: unknown;
+  }>,
+): Promise<boolean> {
+  const content = extractAttachmentBase64Content(attachment.content);
+  const sniffedMime = content
+    ? normalizeAttachmentMime(await sniffMimeFromBase64(content))
+    : undefined;
+  const providedMime = normalizeAttachmentMime(attachment.mimeType);
+  const trustedProvidedMime = shouldIgnoreProvidedImageMime({ sniffedMime, providedMime })
+    ? undefined
+    : providedMime;
+  const fileNameMime = normalizeAttachmentMime(
+    mimeTypeFromFilePath(normalizeOptionalText(attachment.fileName)),
+  );
+  const finalMime =
+    (sniffedMime && !isGenericAttachmentMime(sniffedMime) && sniffedMime) ||
+    (trustedProvidedMime && !isGenericAttachmentMime(trustedProvidedMime) && trustedProvidedMime) ||
+    (fileNameMime && !isGenericAttachmentMime(fileNameMime) && fileNameMime) ||
+    sniffedMime ||
+    trustedProvidedMime ||
+    fileNameMime;
+  return finalMime?.startsWith("image/") ?? false;
+}
+
+async function hasImageAttachments(
+  attachments: Array<
+    Partial<{
+      type: string;
+      mimeType: string;
+      fileName: string;
+      content: unknown;
+    }>
+  >,
+): Promise<boolean> {
+  for (const attachment of attachments) {
+    if (await resolveAttachmentLooksLikeImage(attachment)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function buildWebchatAssistantMediaMessage(
@@ -2146,94 +2225,94 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     if (normalizedAttachments.length > 0) {
       const modelRef = resolveSessionModelRef(cfg, entry, agentId);
+      const hasInboundImageAttachments = await hasImageAttachments(normalizedAttachments);
+      let supportsImages =
+        explicitOriginTargetsAcpSession(explicitOriginResult.value) || explicitOriginTargetsPlugin;
+      let routeImageOffloadsAsMediaPaths = !supportsImages;
 
-      // Image model override: switch to vision-capable model when images are attached
-      const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: modelRef.provider });
-      const imageModelConfig = cfg.agents?.defaults?.imageModel;
-      const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
-      const imageModelFallbacks = resolveAgentModelFallbackValues(imageModelConfig);
-      let parseProvider = modelRef.provider;
-      let parseModel = modelRef.model;
-      let imageModelProvider: string | undefined;
+      if (hasInboundImageAttachments) {
+        // Image model override: switch to a configured vision-capable model only
+        // when the inbound attachment set includes images.
+        const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: modelRef.provider });
+        const imageModelConfig = cfg.agents?.defaults?.imageModel;
+        const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
+        const imageModelFallbacks = resolveAgentModelFallbackValues(imageModelConfig);
+        let parseProvider = modelRef.provider;
+        let parseModel = modelRef.model;
+        let imageModelProvider: string | undefined;
 
-      if (imageModelPrimary) {
-        modelOverride = imageModelPrimary;
-      } else if (imageModelFallbacks.length > 0) {
-        modelOverride = imageModelFallbacks[0];
-      }
-
-      if (modelOverride) {
-        const overrideRef = resolveModelRefFromString({
-          raw: modelOverride,
-          defaultProvider: modelRef.provider,
-          aliasIndex,
-        });
-        if (overrideRef) {
-          parseProvider = overrideRef.ref.provider;
-          parseModel = overrideRef.ref.model;
-          imageModelProvider = overrideRef.ref.provider;
-        } else {
-          // Alias resolution failed; use the raw modelOverride string as parseModel
-          // so that resolveModelSupportsVision can still match it against imageModelConfig.
-          parseModel = modelOverride;
+        if (imageModelPrimary) {
+          modelOverride = imageModelPrimary;
+        } else if (imageModelFallbacks.length > 0) {
+          modelOverride = imageModelFallbacks[0];
         }
-      }
 
-      if (imageModelFallbacks.length > 0) {
-        // When imageModelPrimary is not configured, the first fallback was already
-        // used as modelOverride — skip it to avoid redundant resolution.
-        const fallbacksForOverride = imageModelPrimary
-          ? imageModelFallbacks
-          : imageModelFallbacks.slice(1);
-        modelOverrideFallbacks = prepareImageModelFallbacks({
-          fallbacks: fallbacksForOverride,
-          cfg,
-          agentId,
-          aliasIndex,
-          defaultProvider: modelRef.provider,
-          defaultModel: modelRef.model,
-          imageModelProvider,
+        if (modelOverride) {
+          const overrideRef = resolveModelRefFromString({
+            raw: modelOverride,
+            defaultProvider: modelRef.provider,
+            aliasIndex,
+          });
+          if (overrideRef) {
+            parseProvider = overrideRef.ref.provider;
+            parseModel = overrideRef.ref.model;
+            imageModelProvider = overrideRef.ref.provider;
+          } else {
+            // Alias resolution failed; use the raw modelOverride string as parseModel
+            // so that resolveModelSupportsVision can still match it against imageModelConfig.
+            parseModel = modelOverride;
+          }
+        }
+
+        if (imageModelFallbacks.length > 0) {
+          // When imageModelPrimary is not configured, the first fallback was already
+          // used as modelOverride — skip it to avoid redundant resolution.
+          const fallbacksForOverride = imageModelPrimary
+            ? imageModelFallbacks
+            : imageModelFallbacks.slice(1);
+          modelOverrideFallbacks = prepareImageModelFallbacks({
+            fallbacks: fallbacksForOverride,
+            cfg,
+            agentId,
+            aliasIndex,
+            defaultProvider: modelRef.provider,
+            defaultModel: modelRef.model,
+            imageModelProvider,
+          });
+        }
+
+        const imageModelSupportsImages =
+          modelOverride || imageModelFallbacks.length > 0
+            ? await resolveModelSupportsVision({
+                provider: parseProvider,
+                model: parseModel,
+                imageModelConfig,
+                defaultProvider: modelRef.provider,
+                cfg,
+                loadModelCatalog: () => context.loadGatewayModelCatalog(),
+              })
+            : await resolveGatewayModelSupportsImages({
+                loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+                provider: modelRef.provider,
+                model: modelRef.model,
+              });
+        // Bound plugin sessions own the real recipient model, so keep image
+        // attachments even when the parent OpenClaw session model is text-only.
+        supportsImages ||= imageModelSupportsImages;
+        routeImageOffloadsAsMediaPaths = !supportsImages;
+      } else {
+        const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
+          loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+          provider: modelRef.provider,
+          model: modelRef.model,
         });
+        supportsImages ||= supportsSessionModelImages;
+        routeImageOffloadsAsMediaPaths = !supportsImages;
       }
-
-      const imageModelSupportsImages =
-        modelOverride || imageModelFallbacks.length > 0
-          ? await resolveModelSupportsVision({
-              provider: parseProvider,
-              model: parseModel,
-              imageModelConfig,
-              defaultProvider: modelRef.provider,
-              cfg,
-              loadModelCatalog: () => context.loadGatewayModelCatalog(),
-            })
-          : await resolveGatewayModelSupportsImages({
-              loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-              provider: modelRef.provider,
-              model: modelRef.model,
-            });
-      // Bound plugin sessions own the real recipient model, so keep image
-      // attachments even when the parent OpenClaw session model is text-only.
-      const supportsImages =
-        imageModelSupportsImages ||
-        explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
-        explicitOriginTargetsPlugin;
-      const routeImageOffloadsAsMediaPaths = !supportsImages;
       try {
         await measureDiagnosticsTimelineSpan(
           "gateway.chat_send.prepare_attachments",
           async () => {
-            const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
-              loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-              provider: resolvedSessionModel.provider,
-              model: resolvedSessionModel.model,
-            });
-            // Bound plugin sessions own the real recipient model, so keep image
-            // attachments even when the parent OpenClaw session model is text-only.
-            const supportsImages =
-              supportsSessionModelImages ||
-              explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
-              explicitOriginTargetsPlugin;
-            const routeImageOffloadsAsMediaPaths = !supportsImages;
             const parsed = await parseMessageWithAttachments(
               inboundMessage,
               normalizedAttachments,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2232,7 +2232,9 @@ export const chatHandlers: GatewayRequestHandlers = {
 
       if (hasInboundImageAttachments) {
         // Image model override: switch to a configured vision-capable model only
-        // when the inbound attachment set includes images.
+        // when the inbound attachment set includes images AND the session model
+        // does not already support images. Per the models docs, imageModel is used
+        // "only when the primary model can't accept images."
         const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: modelRef.provider });
         const imageModelConfig = cfg.agents?.defaults?.imageModel;
         const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
@@ -2241,30 +2243,41 @@ export const chatHandlers: GatewayRequestHandlers = {
         let parseModel = modelRef.model;
         let imageModelProvider: string | undefined;
 
-        if (imageModelPrimary) {
-          modelOverride = imageModelPrimary;
-        } else if (imageModelFallbacks.length > 0) {
-          modelOverride = imageModelFallbacks[0];
-        }
+        // First check if the session model already supports images — if so, skip
+        // the override entirely and let the session model handle images natively.
+        const sessionModelSupportsImages = await resolveGatewayModelSupportsImages({
+          loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+          provider: modelRef.provider,
+          model: modelRef.model,
+        });
 
-        if (modelOverride) {
-          const overrideRef = resolveModelRefFromString({
-            raw: modelOverride,
-            defaultProvider: modelRef.provider,
-            aliasIndex,
-          });
-          if (overrideRef) {
-            parseProvider = overrideRef.ref.provider;
-            parseModel = overrideRef.ref.model;
-            imageModelProvider = overrideRef.ref.provider;
-          } else {
-            // Alias resolution failed; use the raw modelOverride string as parseModel
-            // so that resolveModelSupportsVision can still match it against imageModelConfig.
-            parseModel = modelOverride;
+        if (!sessionModelSupportsImages && (imageModelPrimary || imageModelFallbacks.length > 0)) {
+          // Session model is text-only; apply imageModel override.
+          if (imageModelPrimary) {
+            modelOverride = imageModelPrimary;
+          } else if (imageModelFallbacks.length > 0) {
+            modelOverride = imageModelFallbacks[0];
+          }
+
+          if (modelOverride) {
+            const overrideRef = resolveModelRefFromString({
+              raw: modelOverride,
+              defaultProvider: modelRef.provider,
+              aliasIndex,
+            });
+            if (overrideRef) {
+              parseProvider = overrideRef.ref.provider;
+              parseModel = overrideRef.ref.model;
+              imageModelProvider = overrideRef.ref.provider;
+            } else {
+              // Alias resolution failed; use the raw modelOverride string as parseModel
+              // so that resolveModelSupportsVision can still match it against imageModelConfig.
+              parseModel = modelOverride;
+            }
           }
         }
 
-        if (imageModelFallbacks.length > 0) {
+        if (imageModelFallbacks.length > 0 && modelOverride) {
           // When imageModelPrimary is not configured, the first fallback was already
           // used as modelOverride — skip it to avoid redundant resolution.
           const fallbacksForOverride = imageModelPrimary
@@ -2291,11 +2304,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                 cfg,
                 loadModelCatalog: () => context.loadGatewayModelCatalog(),
               })
-            : await resolveGatewayModelSupportsImages({
-                loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-                provider: modelRef.provider,
-                model: modelRef.model,
-              });
+            : sessionModelSupportsImages;
         // Bound plugin sessions own the real recipient model, so keep image
         // attachments even when the parent OpenClaw session model is text-only.
         supportsImages ||= imageModelSupportsImages;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -239,10 +239,15 @@ async function resolveAttachmentLooksLikeImage(
   const fileNameMime = normalizeAttachmentMime(
     mimeTypeFromFilePath(normalizeOptionalText(attachment.fileName)),
   );
+  // When content sniffing detects a generic/non-image type, the file name is
+  // untrusted — a DOCX/ZIP uploaded as "report.png" would otherwise pass as
+  // an image through fileNameMime.
+  const trustedFileNameMime =
+    sniffedMime && isGenericAttachmentMime(sniffedMime) ? undefined : fileNameMime;
   const finalMime =
     (sniffedMime && !isGenericAttachmentMime(sniffedMime) && sniffedMime) ||
     (trustedProvidedMime && !isGenericAttachmentMime(trustedProvidedMime) && trustedProvidedMime) ||
-    (fileNameMime && !isGenericAttachmentMime(fileNameMime) && fileNameMime) ||
+    (trustedFileNameMime && !isGenericAttachmentMime(trustedFileNameMime) && trustedFileNameMime) ||
     sniffedMime ||
     trustedProvidedMime ||
     fileNameMime;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2180,8 +2180,13 @@ export const chatHandlers: GatewayRequestHandlers = {
       }
 
       if (imageModelFallbacks.length > 0) {
+        // When imageModelPrimary is not configured, the first fallback was already
+        // used as modelOverride — skip it to avoid redundant resolution.
+        const fallbacksForOverride = imageModelPrimary
+          ? imageModelFallbacks
+          : imageModelFallbacks.slice(1);
         modelOverrideFallbacks = prepareImageModelFallbacks({
-          fallbacks: imageModelFallbacks,
+          fallbacks: fallbacksForOverride,
           cfg,
           agentId,
           aliasIndex,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -244,11 +244,15 @@ async function resolveAttachmentLooksLikeImage(
   const fileNameMime = normalizeAttachmentMime(
     mimeTypeFromFilePath(normalizeOptionalText(attachment.fileName)),
   );
-  // When content sniffing detects a generic/non-image type, the file name is
-  // untrusted — a DOCX/ZIP uploaded as "report.png" would otherwise pass as
-  // an image through fileNameMime.
-  const trustedFileNameMime =
-    sniffedMime && isGenericAttachmentMime(sniffedMime) ? undefined : fileNameMime;
+  // When content sniffing detects a generic container AND the file name
+  // claims an image type, the name is untrusted — a DOCX/ZIP uploaded as
+  // "report.png" would otherwise pass as an image through fileNameMime.
+  // But specific non-image filenames (e.g., .xlsx) should be preserved.
+  const shouldIgnoreFileNameMime =
+    sniffedMime &&
+    isGenericAttachmentMime(sniffedMime) &&
+    Boolean(fileNameMime?.startsWith("image/"));
+  const trustedFileNameMime = shouldIgnoreFileNameMime ? undefined : fileNameMime;
   const finalMime =
     (sniffedMime && !isGenericAttachmentMime(sniffedMime) && sniffedMime) ||
     (trustedProvidedMime && !isGenericAttachmentMime(trustedProvidedMime) && trustedProvidedMime) ||

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -250,7 +250,7 @@ async function resolveAttachmentLooksLikeImage(
     (trustedFileNameMime && !isGenericAttachmentMime(trustedFileNameMime) && trustedFileNameMime) ||
     sniffedMime ||
     trustedProvidedMime ||
-    fileNameMime;
+    trustedFileNameMime;
   return finalMime?.startsWith("image/") ?? false;
 }
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2320,7 +2320,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                 provider: parseProvider,
                 model: parseModel,
                 imageModelConfig,
-                defaultProvider: modelRef.provider,
+                defaultProvider: imageModelProvider ?? modelRef.provider,
                 cfg,
                 loadModelCatalog: () => context.loadGatewayModelCatalog(),
               })

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -13,6 +13,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
+  collectImageModelKeys,
   prepareImageModelFallbacks,
   resolveModelSupportsVision,
 } from "../../auto-reply/reply/image-model-helpers.js";
@@ -2244,9 +2245,17 @@ export const chatHandlers: GatewayRequestHandlers = {
         const imageModelConfig = cfg.agents?.defaults?.imageModel;
         const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
         const imageModelFallbacks = resolveAgentModelFallbackValues(imageModelConfig);
+        // Derive the image model's provider context upfront so that providerless
+        // imageModel aliases resolve against the correct provider, not the session
+        // model's provider.
+        const { imageModelDefaultProvider } = collectImageModelKeys({
+          imageModelConfig,
+          aliasIndex,
+          defaultProvider: modelRef.provider,
+        });
+        const imageModelProvider = imageModelDefaultProvider || undefined;
         let parseProvider = modelRef.provider;
         let parseModel = modelRef.model;
-        let imageModelProvider: string | undefined;
 
         // First check if the session model already supports images — if so, skip
         // the override entirely and let the session model handle images natively.
@@ -2278,7 +2287,6 @@ export const chatHandlers: GatewayRequestHandlers = {
             if (overrideRef) {
               parseProvider = overrideRef.ref.provider;
               parseModel = overrideRef.ref.model;
-              imageModelProvider = overrideRef.ref.provider;
             } else {
               // Alias resolution failed; use the raw modelOverride string as parseModel
               // so that resolveModelSupportsVision can still match it against imageModelConfig.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -5,7 +5,11 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { buildModelAliasIndex, resolveModelRefFromString } from "../../agents/model-selection.js";
+import {
+  buildModelAliasIndex,
+  modelKey,
+  resolveModelRefFromString,
+} from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
@@ -2287,6 +2291,10 @@ export const chatHandlers: GatewayRequestHandlers = {
             if (overrideRef) {
               parseProvider = overrideRef.ref.provider;
               parseModel = overrideRef.ref.model;
+              // Canonicalize modelOverride so downstream getReplyFromConfig
+              // receives "provider/model" and resolves against the correct
+              // provider context, not the session model's defaultProvider.
+              modelOverride = modelKey(overrideRef.ref.provider, overrideRef.ref.model);
             } else {
               // Alias resolution failed; use the raw modelOverride string as parseModel
               // so that resolveModelSupportsVision can still match it against imageModelConfig.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2305,6 +2305,15 @@ export const chatHandlers: GatewayRequestHandlers = {
                 loadModelCatalog: () => context.loadGatewayModelCatalog(),
               })
             : sessionModelSupportsImages;
+
+        // If vision validation failed, clear the override so the turn runs on
+        // the default model with the safer media-understanding path instead of
+        // a misconfigured text-only imageModel.
+        if (!imageModelSupportsImages && modelOverride) {
+          modelOverride = undefined;
+          modelOverrideFallbacks = undefined;
+        }
+
         // Bound plugin sessions own the real recipient model, so keep image
         // attachments even when the parent OpenClaw session model is text-only.
         supportsImages ||= imageModelSupportsImages;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2260,9 +2260,14 @@ export const chatHandlers: GatewayRequestHandlers = {
           }
 
           if (modelOverride) {
+            // When imageModelPrimary is providerless, resolve against the image
+            // model's own provider context (derived from the primary or fallbacks),
+            // not the session model's provider, so catalog lookups and alias
+            // resolution use the correct provider.
+            const overrideDefaultProvider = imageModelProvider ?? modelRef.provider;
             const overrideRef = resolveModelRefFromString({
               raw: modelOverride,
-              defaultProvider: modelRef.provider,
+              defaultProvider: overrideDefaultProvider,
               aliasIndex,
             });
             if (overrideRef) {
@@ -2272,6 +2277,8 @@ export const chatHandlers: GatewayRequestHandlers = {
             } else {
               // Alias resolution failed; use the raw modelOverride string as parseModel
               // so that resolveModelSupportsVision can still match it against imageModelConfig.
+              // Use the image model's provider context for catalog lookups.
+              parseProvider = overrideDefaultProvider;
               parseModel = modelOverride;
             }
           }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -5,16 +5,25 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { buildModelAliasIndex, resolveModelRefFromString } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  prepareImageModelFallbacks,
+  resolveModelSupportsVision,
+} from "../../auto-reply/reply/image-model-helpers.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../../config/model-input.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { streamSessionTranscriptLines } from "../../config/sessions/transcript-stream.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -2132,7 +2141,78 @@ export const chatHandlers: GatewayRequestHandlers = {
     const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(
       explicitOriginResult.value,
     );
+    let modelOverride: string | undefined;
+    let modelOverrideFallbacks: string[] | undefined;
+
     if (normalizedAttachments.length > 0) {
+      const modelRef = resolveSessionModelRef(cfg, entry, agentId);
+
+      // Image model override: switch to vision-capable model when images are attached
+      const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: modelRef.provider });
+      const imageModelConfig = cfg.agents?.defaults?.imageModel;
+      const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
+      const imageModelFallbacks = resolveAgentModelFallbackValues(imageModelConfig);
+      let parseProvider = modelRef.provider;
+      let parseModel = modelRef.model;
+      let imageModelProvider: string | undefined;
+
+      if (imageModelPrimary) {
+        modelOverride = imageModelPrimary;
+      } else if (imageModelFallbacks.length > 0) {
+        modelOverride = imageModelFallbacks[0];
+      }
+
+      if (modelOverride) {
+        const overrideRef = resolveModelRefFromString({
+          raw: modelOverride,
+          defaultProvider: modelRef.provider,
+          aliasIndex,
+        });
+        if (overrideRef) {
+          parseProvider = overrideRef.ref.provider;
+          parseModel = overrideRef.ref.model;
+          imageModelProvider = overrideRef.ref.provider;
+        } else {
+          // Alias resolution failed; use the raw modelOverride string as parseModel
+          // so that resolveModelSupportsVision can still match it against imageModelConfig.
+          parseModel = modelOverride;
+        }
+      }
+
+      if (imageModelFallbacks.length > 0) {
+        modelOverrideFallbacks = prepareImageModelFallbacks({
+          fallbacks: imageModelFallbacks,
+          cfg,
+          agentId,
+          aliasIndex,
+          defaultProvider: modelRef.provider,
+          defaultModel: modelRef.model,
+          imageModelProvider,
+        });
+      }
+
+      const imageModelSupportsImages =
+        modelOverride || imageModelFallbacks.length > 0
+          ? await resolveModelSupportsVision({
+              provider: parseProvider,
+              model: parseModel,
+              imageModelConfig,
+              defaultProvider: modelRef.provider,
+              cfg,
+              loadModelCatalog: () => context.loadGatewayModelCatalog(),
+            })
+          : await resolveGatewayModelSupportsImages({
+              loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+              provider: modelRef.provider,
+              model: modelRef.model,
+            });
+      // Bound plugin sessions own the real recipient model, so keep image
+      // attachments even when the parent OpenClaw session model is text-only.
+      const supportsImages =
+        imageModelSupportsImages ||
+        explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
+        explicitOriginTargetsPlugin;
+      const routeImageOffloadsAsMediaPaths = !supportsImages;
       try {
         await measureDiagnosticsTimelineSpan(
           "gateway.chat_send.prepare_attachments",
@@ -2194,6 +2274,10 @@ export const chatHandlers: GatewayRequestHandlers = {
             },
           },
         );
+        if (parsedImages.length === 0 && offloadedRefs.length === 0) {
+          modelOverride = undefined;
+          modelOverrideFallbacks = undefined;
+        }
       } catch (err) {
         logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
         respond(
@@ -2548,6 +2632,8 @@ export const chatHandlers: GatewayRequestHandlers = {
               imageOrder: imageOrder.length > 0 ? imageOrder : undefined,
               thinkingLevelOverride: p.thinking,
               fastModeOverride: p.fastMode,
+              modelOverride,
+              modelOverrideFallbacks,
               onAgentRunStart: (runId) => {
                 agentRunStarted = true;
                 if (!hasBeforeAgentRunGate) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2232,9 +2232,14 @@ export const chatHandlers: GatewayRequestHandlers = {
           }
 
           if (modelOverride) {
+            // When imageModelPrimary is providerless, resolve against the image
+            // model's own provider context (derived from the primary or fallbacks),
+            // not the session model's provider, so catalog lookups and alias
+            // resolution use the correct provider.
+            const overrideDefaultProvider = imageModelProvider ?? modelRef.provider;
             const overrideRef = resolveModelRefFromString({
               raw: modelOverride,
-              defaultProvider: modelRef.provider,
+              defaultProvider: overrideDefaultProvider,
               aliasIndex,
             });
             if (overrideRef) {
@@ -2244,6 +2249,8 @@ export const chatHandlers: GatewayRequestHandlers = {
             } else {
               // Alias resolution failed; use the raw modelOverride string as parseModel
               // so that resolveModelSupportsVision can still match it against imageModelConfig.
+              // Use the image model's provider context for catalog lookups.
+              parseProvider = overrideDefaultProvider;
               parseModel = modelOverride;
             }
           }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -247,7 +247,7 @@ async function resolveAttachmentLooksLikeImage(
     (trustedFileNameMime && !isGenericAttachmentMime(trustedFileNameMime) && trustedFileNameMime) ||
     sniffedMime ||
     trustedProvidedMime ||
-    fileNameMime;
+    trustedFileNameMime;
   return finalMime?.startsWith("image/") ?? false;
 }
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -12,6 +12,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
+  collectImageModelKeys,
   prepareImageModelFallbacks,
   resolveModelSupportsVision,
 } from "../../auto-reply/reply/image-model-helpers.js";
@@ -2216,9 +2217,17 @@ export const chatHandlers: GatewayRequestHandlers = {
         const imageModelConfig = cfg.agents?.defaults?.imageModel;
         const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
         const imageModelFallbacks = resolveAgentModelFallbackValues(imageModelConfig);
+        // Derive the image model's provider context upfront so that providerless
+        // imageModel aliases resolve against the correct provider, not the session
+        // model's provider.
+        const { imageModelDefaultProvider } = collectImageModelKeys({
+          imageModelConfig,
+          aliasIndex,
+          defaultProvider: modelRef.provider,
+        });
+        const imageModelProvider = imageModelDefaultProvider || undefined;
         let parseProvider = modelRef.provider;
         let parseModel = modelRef.model;
-        let imageModelProvider: string | undefined;
 
         // First check if the session model already supports images — if so, skip
         // the override entirely and let the session model handle images natively.
@@ -2250,7 +2259,6 @@ export const chatHandlers: GatewayRequestHandlers = {
             if (overrideRef) {
               parseProvider = overrideRef.ref.provider;
               parseModel = overrideRef.ref.model;
-              imageModelProvider = overrideRef.ref.provider;
             } else {
               // Alias resolution failed; use the raw modelOverride string as parseModel
               // so that resolveModelSupportsVision can still match it against imageModelConfig.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2204,7 +2204,9 @@ export const chatHandlers: GatewayRequestHandlers = {
 
       if (hasInboundImageAttachments) {
         // Image model override: switch to a configured vision-capable model only
-        // when the inbound attachment set includes images.
+        // when the inbound attachment set includes images AND the session model
+        // does not already support images. Per the models docs, imageModel is used
+        // "only when the primary model can't accept images."
         const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: modelRef.provider });
         const imageModelConfig = cfg.agents?.defaults?.imageModel;
         const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
@@ -2213,30 +2215,41 @@ export const chatHandlers: GatewayRequestHandlers = {
         let parseModel = modelRef.model;
         let imageModelProvider: string | undefined;
 
-        if (imageModelPrimary) {
-          modelOverride = imageModelPrimary;
-        } else if (imageModelFallbacks.length > 0) {
-          modelOverride = imageModelFallbacks[0];
-        }
+        // First check if the session model already supports images — if so, skip
+        // the override entirely and let the session model handle images natively.
+        const sessionModelSupportsImages = await resolveGatewayModelSupportsImages({
+          loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+          provider: modelRef.provider,
+          model: modelRef.model,
+        });
 
-        if (modelOverride) {
-          const overrideRef = resolveModelRefFromString({
-            raw: modelOverride,
-            defaultProvider: modelRef.provider,
-            aliasIndex,
-          });
-          if (overrideRef) {
-            parseProvider = overrideRef.ref.provider;
-            parseModel = overrideRef.ref.model;
-            imageModelProvider = overrideRef.ref.provider;
-          } else {
-            // Alias resolution failed; use the raw modelOverride string as parseModel
-            // so that resolveModelSupportsVision can still match it against imageModelConfig.
-            parseModel = modelOverride;
+        if (!sessionModelSupportsImages && (imageModelPrimary || imageModelFallbacks.length > 0)) {
+          // Session model is text-only; apply imageModel override.
+          if (imageModelPrimary) {
+            modelOverride = imageModelPrimary;
+          } else if (imageModelFallbacks.length > 0) {
+            modelOverride = imageModelFallbacks[0];
+          }
+
+          if (modelOverride) {
+            const overrideRef = resolveModelRefFromString({
+              raw: modelOverride,
+              defaultProvider: modelRef.provider,
+              aliasIndex,
+            });
+            if (overrideRef) {
+              parseProvider = overrideRef.ref.provider;
+              parseModel = overrideRef.ref.model;
+              imageModelProvider = overrideRef.ref.provider;
+            } else {
+              // Alias resolution failed; use the raw modelOverride string as parseModel
+              // so that resolveModelSupportsVision can still match it against imageModelConfig.
+              parseModel = modelOverride;
+            }
           }
         }
 
-        if (imageModelFallbacks.length > 0) {
+        if (imageModelFallbacks.length > 0 && modelOverride) {
           // When imageModelPrimary is not configured, the first fallback was already
           // used as modelOverride — skip it to avoid redundant resolution.
           const fallbacksForOverride = imageModelPrimary
@@ -2263,11 +2276,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                 cfg,
                 loadModelCatalog: () => context.loadGatewayModelCatalog(),
               })
-            : await resolveGatewayModelSupportsImages({
-                loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-                provider: modelRef.provider,
-                model: modelRef.model,
-              });
+            : sessionModelSupportsImages;
         // Bound plugin sessions own the real recipient model, so keep image
         // attachments even when the parent OpenClaw session model is text-only.
         supportsImages ||= imageModelSupportsImages;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2152,8 +2152,13 @@ export const chatHandlers: GatewayRequestHandlers = {
       }
 
       if (imageModelFallbacks.length > 0) {
+        // When imageModelPrimary is not configured, the first fallback was already
+        // used as modelOverride — skip it to avoid redundant resolution.
+        const fallbacksForOverride = imageModelPrimary
+          ? imageModelFallbacks
+          : imageModelFallbacks.slice(1);
         modelOverrideFallbacks = prepareImageModelFallbacks({
-          fallbacks: imageModelFallbacks,
+          fallbacks: fallbacksForOverride,
           cfg,
           agentId,
           aliasIndex,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -5,7 +5,11 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { buildModelAliasIndex, resolveModelRefFromString } from "../../agents/model-selection.js";
+import {
+  buildModelAliasIndex,
+  modelKey,
+  resolveModelRefFromString,
+} from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
@@ -2259,6 +2263,10 @@ export const chatHandlers: GatewayRequestHandlers = {
             if (overrideRef) {
               parseProvider = overrideRef.ref.provider;
               parseModel = overrideRef.ref.model;
+              // Canonicalize modelOverride so downstream getReplyFromConfig
+              // receives "provider/model" and resolves against the correct
+              // provider context, not the session model's defaultProvider.
+              modelOverride = modelKey(overrideRef.ref.provider, overrideRef.ref.model);
             } else {
               // Alias resolution failed; use the raw modelOverride string as parseModel
               // so that resolveModelSupportsVision can still match it against imageModelConfig.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2292,7 +2292,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                 provider: parseProvider,
                 model: parseModel,
                 imageModelConfig,
-                defaultProvider: modelRef.provider,
+                defaultProvider: imageModelProvider ?? modelRef.provider,
                 cfg,
                 loadModelCatalog: () => context.loadGatewayModelCatalog(),
               })

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2277,6 +2277,15 @@ export const chatHandlers: GatewayRequestHandlers = {
                 loadModelCatalog: () => context.loadGatewayModelCatalog(),
               })
             : sessionModelSupportsImages;
+
+        // If vision validation failed, clear the override so the turn runs on
+        // the default model with the safer media-understanding path instead of
+        // a misconfigured text-only imageModel.
+        if (!imageModelSupportsImages && modelOverride) {
+          modelOverride = undefined;
+          modelOverrideFallbacks = undefined;
+        }
+
         // Bound plugin sessions own the real recipient model, so keep image
         // attachments even when the parent OpenClaw session model is text-only.
         supportsImages ||= imageModelSupportsImages;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -5,15 +5,24 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { buildModelAliasIndex, resolveModelRefFromString } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  prepareImageModelFallbacks,
+  resolveModelSupportsVision,
+} from "../../auto-reply/reply/image-model-helpers.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../../config/model-input.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -2104,7 +2113,78 @@ export const chatHandlers: GatewayRequestHandlers = {
     const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(
       explicitOriginResult.value,
     );
+    let modelOverride: string | undefined;
+    let modelOverrideFallbacks: string[] | undefined;
+
     if (normalizedAttachments.length > 0) {
+      const modelRef = resolveSessionModelRef(cfg, entry, agentId);
+
+      // Image model override: switch to vision-capable model when images are attached
+      const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: modelRef.provider });
+      const imageModelConfig = cfg.agents?.defaults?.imageModel;
+      const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
+      const imageModelFallbacks = resolveAgentModelFallbackValues(imageModelConfig);
+      let parseProvider = modelRef.provider;
+      let parseModel = modelRef.model;
+      let imageModelProvider: string | undefined;
+
+      if (imageModelPrimary) {
+        modelOverride = imageModelPrimary;
+      } else if (imageModelFallbacks.length > 0) {
+        modelOverride = imageModelFallbacks[0];
+      }
+
+      if (modelOverride) {
+        const overrideRef = resolveModelRefFromString({
+          raw: modelOverride,
+          defaultProvider: modelRef.provider,
+          aliasIndex,
+        });
+        if (overrideRef) {
+          parseProvider = overrideRef.ref.provider;
+          parseModel = overrideRef.ref.model;
+          imageModelProvider = overrideRef.ref.provider;
+        } else {
+          // Alias resolution failed; use the raw modelOverride string as parseModel
+          // so that resolveModelSupportsVision can still match it against imageModelConfig.
+          parseModel = modelOverride;
+        }
+      }
+
+      if (imageModelFallbacks.length > 0) {
+        modelOverrideFallbacks = prepareImageModelFallbacks({
+          fallbacks: imageModelFallbacks,
+          cfg,
+          agentId,
+          aliasIndex,
+          defaultProvider: modelRef.provider,
+          defaultModel: modelRef.model,
+          imageModelProvider,
+        });
+      }
+
+      const imageModelSupportsImages =
+        modelOverride || imageModelFallbacks.length > 0
+          ? await resolveModelSupportsVision({
+              provider: parseProvider,
+              model: parseModel,
+              imageModelConfig,
+              defaultProvider: modelRef.provider,
+              cfg,
+              loadModelCatalog: () => context.loadGatewayModelCatalog(),
+            })
+          : await resolveGatewayModelSupportsImages({
+              loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+              provider: modelRef.provider,
+              model: modelRef.model,
+            });
+      // Bound plugin sessions own the real recipient model, so keep image
+      // attachments even when the parent OpenClaw session model is text-only.
+      const supportsImages =
+        imageModelSupportsImages ||
+        explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
+        explicitOriginTargetsPlugin;
+      const routeImageOffloadsAsMediaPaths = !supportsImages;
       try {
         await measureDiagnosticsTimelineSpan(
           "gateway.chat_send.prepare_attachments",
@@ -2167,6 +2247,10 @@ export const chatHandlers: GatewayRequestHandlers = {
             },
           },
         );
+        if (parsedImages.length === 0 && offloadedRefs.length === 0) {
+          modelOverride = undefined;
+          modelOverrideFallbacks = undefined;
+        }
       } catch (err) {
         logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
         respond(
@@ -2506,6 +2590,8 @@ export const chatHandlers: GatewayRequestHandlers = {
               imageOrder: imageOrder.length > 0 ? imageOrder : undefined,
               thinkingLevelOverride: p.thinking,
               fastModeOverride: p.fastMode,
+              modelOverride,
+              modelOverrideFallbacks,
               onAgentRunStart: (runId) => {
                 agentRunStarted = true;
                 if (!hasBeforeAgentRunGate) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -38,8 +38,9 @@ import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
 } from "../../media/local-roots.js";
-import { isAudioFileName } from "../../media/mime.js";
+import { isAudioFileName, mimeTypeFromFilePath } from "../../media/mime.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
+import { sniffMimeFromBase64 } from "../../media/sniff-mime-from-base64.js";
 import {
   deleteMediaBuffer,
   MEDIA_MAX_BYTES,
@@ -183,6 +184,84 @@ function isTtsSupplementPayload(payload: ReplyPayload): boolean {
 
 function stripVisibleTextFromTtsSupplement(payload: ReplyPayload): ReplyPayload {
   return isTtsSupplementPayload(payload) ? { ...payload, text: undefined } : payload;
+}
+
+function normalizeAttachmentMime(mime?: string | null): string | undefined {
+  const cleaned = normalizeOptionalText(mime?.split(";")[0])?.toLowerCase();
+  return cleaned || undefined;
+}
+
+function isGenericAttachmentMime(mime?: string): boolean {
+  return mime === "application/zip" || mime === "application/octet-stream";
+}
+
+function shouldIgnoreProvidedImageMime(params: {
+  sniffedMime?: string;
+  providedMime?: string;
+}): boolean {
+  return (
+    isGenericAttachmentMime(params.sniffedMime) &&
+    Boolean(params.providedMime?.startsWith("image/"))
+  );
+}
+
+function extractAttachmentBase64Content(content: unknown): string | undefined {
+  if (typeof content !== "string") {
+    return undefined;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const dataUrlMatch = /^data:[^;]+;base64,(.*)$/i.exec(trimmed);
+  return dataUrlMatch?.[1] ?? trimmed;
+}
+
+async function resolveAttachmentLooksLikeImage(
+  attachment: Partial<{
+    type: string;
+    mimeType: string;
+    fileName: string;
+    content: unknown;
+  }>,
+): Promise<boolean> {
+  const content = extractAttachmentBase64Content(attachment.content);
+  const sniffedMime = content
+    ? normalizeAttachmentMime(await sniffMimeFromBase64(content))
+    : undefined;
+  const providedMime = normalizeAttachmentMime(attachment.mimeType);
+  const trustedProvidedMime = shouldIgnoreProvidedImageMime({ sniffedMime, providedMime })
+    ? undefined
+    : providedMime;
+  const fileNameMime = normalizeAttachmentMime(
+    mimeTypeFromFilePath(normalizeOptionalText(attachment.fileName)),
+  );
+  const finalMime =
+    (sniffedMime && !isGenericAttachmentMime(sniffedMime) && sniffedMime) ||
+    (trustedProvidedMime && !isGenericAttachmentMime(trustedProvidedMime) && trustedProvidedMime) ||
+    (fileNameMime && !isGenericAttachmentMime(fileNameMime) && fileNameMime) ||
+    sniffedMime ||
+    trustedProvidedMime ||
+    fileNameMime;
+  return finalMime?.startsWith("image/") ?? false;
+}
+
+async function hasImageAttachments(
+  attachments: Array<
+    Partial<{
+      type: string;
+      mimeType: string;
+      fileName: string;
+      content: unknown;
+    }>
+  >,
+): Promise<boolean> {
+  for (const attachment of attachments) {
+    if (await resolveAttachmentLooksLikeImage(attachment)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function buildWebchatAssistantMediaMessage(
@@ -2118,95 +2197,94 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     if (normalizedAttachments.length > 0) {
       const modelRef = resolveSessionModelRef(cfg, entry, agentId);
+      const hasInboundImageAttachments = await hasImageAttachments(normalizedAttachments);
+      let supportsImages =
+        explicitOriginTargetsAcpSession(explicitOriginResult.value) || explicitOriginTargetsPlugin;
+      let routeImageOffloadsAsMediaPaths = !supportsImages;
 
-      // Image model override: switch to vision-capable model when images are attached
-      const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: modelRef.provider });
-      const imageModelConfig = cfg.agents?.defaults?.imageModel;
-      const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
-      const imageModelFallbacks = resolveAgentModelFallbackValues(imageModelConfig);
-      let parseProvider = modelRef.provider;
-      let parseModel = modelRef.model;
-      let imageModelProvider: string | undefined;
+      if (hasInboundImageAttachments) {
+        // Image model override: switch to a configured vision-capable model only
+        // when the inbound attachment set includes images.
+        const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: modelRef.provider });
+        const imageModelConfig = cfg.agents?.defaults?.imageModel;
+        const imageModelPrimary = resolveAgentModelPrimaryValue(imageModelConfig);
+        const imageModelFallbacks = resolveAgentModelFallbackValues(imageModelConfig);
+        let parseProvider = modelRef.provider;
+        let parseModel = modelRef.model;
+        let imageModelProvider: string | undefined;
 
-      if (imageModelPrimary) {
-        modelOverride = imageModelPrimary;
-      } else if (imageModelFallbacks.length > 0) {
-        modelOverride = imageModelFallbacks[0];
-      }
-
-      if (modelOverride) {
-        const overrideRef = resolveModelRefFromString({
-          raw: modelOverride,
-          defaultProvider: modelRef.provider,
-          aliasIndex,
-        });
-        if (overrideRef) {
-          parseProvider = overrideRef.ref.provider;
-          parseModel = overrideRef.ref.model;
-          imageModelProvider = overrideRef.ref.provider;
-        } else {
-          // Alias resolution failed; use the raw modelOverride string as parseModel
-          // so that resolveModelSupportsVision can still match it against imageModelConfig.
-          parseModel = modelOverride;
+        if (imageModelPrimary) {
+          modelOverride = imageModelPrimary;
+        } else if (imageModelFallbacks.length > 0) {
+          modelOverride = imageModelFallbacks[0];
         }
-      }
 
-      if (imageModelFallbacks.length > 0) {
-        // When imageModelPrimary is not configured, the first fallback was already
-        // used as modelOverride — skip it to avoid redundant resolution.
-        const fallbacksForOverride = imageModelPrimary
-          ? imageModelFallbacks
-          : imageModelFallbacks.slice(1);
-        modelOverrideFallbacks = prepareImageModelFallbacks({
-          fallbacks: fallbacksForOverride,
-          cfg,
-          agentId,
-          aliasIndex,
-          defaultProvider: modelRef.provider,
-          defaultModel: modelRef.model,
-          imageModelProvider,
+        if (modelOverride) {
+          const overrideRef = resolveModelRefFromString({
+            raw: modelOverride,
+            defaultProvider: modelRef.provider,
+            aliasIndex,
+          });
+          if (overrideRef) {
+            parseProvider = overrideRef.ref.provider;
+            parseModel = overrideRef.ref.model;
+            imageModelProvider = overrideRef.ref.provider;
+          } else {
+            // Alias resolution failed; use the raw modelOverride string as parseModel
+            // so that resolveModelSupportsVision can still match it against imageModelConfig.
+            parseModel = modelOverride;
+          }
+        }
+
+        if (imageModelFallbacks.length > 0) {
+          // When imageModelPrimary is not configured, the first fallback was already
+          // used as modelOverride — skip it to avoid redundant resolution.
+          const fallbacksForOverride = imageModelPrimary
+            ? imageModelFallbacks
+            : imageModelFallbacks.slice(1);
+          modelOverrideFallbacks = prepareImageModelFallbacks({
+            fallbacks: fallbacksForOverride,
+            cfg,
+            agentId,
+            aliasIndex,
+            defaultProvider: modelRef.provider,
+            defaultModel: modelRef.model,
+            imageModelProvider,
+          });
+        }
+
+        const imageModelSupportsImages =
+          modelOverride || imageModelFallbacks.length > 0
+            ? await resolveModelSupportsVision({
+                provider: parseProvider,
+                model: parseModel,
+                imageModelConfig,
+                defaultProvider: modelRef.provider,
+                cfg,
+                loadModelCatalog: () => context.loadGatewayModelCatalog(),
+              })
+            : await resolveGatewayModelSupportsImages({
+                loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+                provider: modelRef.provider,
+                model: modelRef.model,
+              });
+        // Bound plugin sessions own the real recipient model, so keep image
+        // attachments even when the parent OpenClaw session model is text-only.
+        supportsImages ||= imageModelSupportsImages;
+        routeImageOffloadsAsMediaPaths = !supportsImages;
+      } else {
+        const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
+          loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+          provider: modelRef.provider,
+          model: modelRef.model,
         });
+        supportsImages ||= supportsSessionModelImages;
+        routeImageOffloadsAsMediaPaths = !supportsImages;
       }
-
-      const imageModelSupportsImages =
-        modelOverride || imageModelFallbacks.length > 0
-          ? await resolveModelSupportsVision({
-              provider: parseProvider,
-              model: parseModel,
-              imageModelConfig,
-              defaultProvider: modelRef.provider,
-              cfg,
-              loadModelCatalog: () => context.loadGatewayModelCatalog(),
-            })
-          : await resolveGatewayModelSupportsImages({
-              loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-              provider: modelRef.provider,
-              model: modelRef.model,
-            });
-      // Bound plugin sessions own the real recipient model, so keep image
-      // attachments even when the parent OpenClaw session model is text-only.
-      const supportsImages =
-        imageModelSupportsImages ||
-        explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
-        explicitOriginTargetsPlugin;
-      const routeImageOffloadsAsMediaPaths = !supportsImages;
       try {
         await measureDiagnosticsTimelineSpan(
           "gateway.chat_send.prepare_attachments",
           async () => {
-            const modelRef = resolveSessionModelRef(cfg, entry, agentId);
-            const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
-              loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-              provider: modelRef.provider,
-              model: modelRef.model,
-            });
-            // Bound plugin sessions own the real recipient model, so keep image
-            // attachments even when the parent OpenClaw session model is text-only.
-            const supportsImages =
-              supportsSessionModelImages ||
-              explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
-              explicitOriginTargetsPlugin;
-            const routeImageOffloadsAsMediaPaths = !supportsImages;
             const parsed = await parseMessageWithAttachments(
               inboundMessage,
               normalizedAttachments,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -241,11 +241,15 @@ async function resolveAttachmentLooksLikeImage(
   const fileNameMime = normalizeAttachmentMime(
     mimeTypeFromFilePath(normalizeOptionalText(attachment.fileName)),
   );
-  // When content sniffing detects a generic/non-image type, the file name is
-  // untrusted — a DOCX/ZIP uploaded as "report.png" would otherwise pass as
-  // an image through fileNameMime.
-  const trustedFileNameMime =
-    sniffedMime && isGenericAttachmentMime(sniffedMime) ? undefined : fileNameMime;
+  // When content sniffing detects a generic container AND the file name
+  // claims an image type, the name is untrusted — a DOCX/ZIP uploaded as
+  // "report.png" would otherwise pass as an image through fileNameMime.
+  // But specific non-image filenames (e.g., .xlsx) should be preserved.
+  const shouldIgnoreFileNameMime =
+    sniffedMime &&
+    isGenericAttachmentMime(sniffedMime) &&
+    Boolean(fileNameMime?.startsWith("image/"));
+  const trustedFileNameMime = shouldIgnoreFileNameMime ? undefined : fileNameMime;
   const finalMime =
     (sniffedMime && !isGenericAttachmentMime(sniffedMime) && sniffedMime) ||
     (trustedProvidedMime && !isGenericAttachmentMime(trustedProvidedMime) && trustedProvidedMime) ||

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -236,10 +236,15 @@ async function resolveAttachmentLooksLikeImage(
   const fileNameMime = normalizeAttachmentMime(
     mimeTypeFromFilePath(normalizeOptionalText(attachment.fileName)),
   );
+  // When content sniffing detects a generic/non-image type, the file name is
+  // untrusted — a DOCX/ZIP uploaded as "report.png" would otherwise pass as
+  // an image through fileNameMime.
+  const trustedFileNameMime =
+    sniffedMime && isGenericAttachmentMime(sniffedMime) ? undefined : fileNameMime;
   const finalMime =
     (sniffedMime && !isGenericAttachmentMime(sniffedMime) && sniffedMime) ||
     (trustedProvidedMime && !isGenericAttachmentMime(trustedProvidedMime) && trustedProvidedMime) ||
-    (fileNameMime && !isGenericAttachmentMime(fileNameMime) && fileNameMime) ||
+    (trustedFileNameMime && !isGenericAttachmentMime(trustedFileNameMime) && trustedFileNameMime) ||
     sniffedMime ||
     trustedProvidedMime ||
     fileNameMime;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -24,6 +24,10 @@ import { installConnectedControlUiServerSuite } from "./test-with-server.js";
 
 installGatewayTestHooks({ scope: "suite" });
 const CHAT_RESPONSE_TIMEOUT_MS = 10_000;
+const PNG_1X1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+const PDF_BASE64 = Buffer.from("%PDF-1.4\n%test\n").toString("base64");
+const DOCX_LIKE_BASE64 = Buffer.from("PK\u0003\u0004fake-docx-content").toString("base64");
 
 let ws: WebSocket;
 let port: number;
@@ -220,6 +224,279 @@ describe("gateway server chat", () => {
       releaseBlockedReply?.();
     };
   };
+
+  test("chat.send keeps image attachments inline when imageModel enables vision", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "see image",
+          idempotencyKey: "idem-image-model-inline",
+          attachments: [
+            {
+              type: "image",
+              mimeType: "image/png",
+              fileName: "dot.png",
+              content: `data:image/png;base64,${PNG_1X1_BASE64}`,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBe("openai/gpt-4o");
+        expect(observed?.replyOptions.images).toHaveLength(1);
+        expect(observed?.ctx.MediaPaths).toBeUndefined();
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
+  test("chat.send detects image attachments from sniffed content without metadata", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "see sniffed image",
+          idempotencyKey: "idem-image-sniff-no-metadata",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "application/octet-stream",
+              fileName: "blob",
+              content: PNG_1X1_BASE64,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBe("openai/gpt-4o");
+        expect(observed?.replyOptions.images).toHaveLength(1);
+        expect(observed?.ctx.MediaPaths).toBeUndefined();
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
+  test("chat.send detects image attachments from data URLs without metadata", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "see data url image",
+          idempotencyKey: "idem-image-data-url-no-metadata",
+          attachments: [
+            {
+              type: "file",
+              content: `data:image/png;base64,${PNG_1X1_BASE64}`,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBe("openai/gpt-4o");
+        expect(observed?.replyOptions.images).toHaveLength(1);
+        expect(observed?.ctx.MediaPaths).toBeUndefined();
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
+  test("chat.send does not apply imageModel override for non-image attachments", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "read this pdf",
+          idempotencyKey: "idem-non-image-no-override",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "application/pdf",
+              fileName: "report.pdf",
+              content: PDF_BASE64,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBeUndefined();
+        expect(observed?.replyOptions.images).toBeUndefined();
+        expect(observed?.ctx.MediaPaths).toHaveLength(1);
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
+  test("chat.send ignores fake image metadata when sniffed content is non-image", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "read disguised doc",
+          idempotencyKey: "idem-fake-image-metadata",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "image/png",
+              fileName: "report.docx",
+              content: DOCX_LIKE_BASE64,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBeUndefined();
+        expect(observed?.replyOptions.images).toBeUndefined();
+        expect(observed?.ctx.MediaPaths).toHaveLength(1);
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
 
   test("sessions.send accepts dashboard messages for existing sessions", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-"));

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -498,6 +498,61 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.send rejects image filename when sniffed content is generic (ZIP/DOCX as .png)", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "read disguised doc",
+          idempotencyKey: "idem-fake-image-filename",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "image/png",
+              fileName: "report.png",
+              content: DOCX_LIKE_BASE64,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBeUndefined();
+        expect(observed?.replyOptions.images).toBeUndefined();
+        expect(observed?.ctx.MediaPaths).toHaveLength(1);
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
   test("sessions.send accepts dashboard messages for existing sessions", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-"));
     testState.sessionStorePath = path.join(dir, "sessions.json");

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -24,6 +24,10 @@ import { installConnectedControlUiServerSuite } from "./test-with-server.js";
 
 installGatewayTestHooks({ scope: "suite" });
 const CHAT_RESPONSE_TIMEOUT_MS = 10_000;
+const PNG_1X1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+const PDF_BASE64 = Buffer.from("%PDF-1.4\n%test\n").toString("base64");
+const DOCX_LIKE_BASE64 = Buffer.from("PK\u0003\u0004fake-docx-content").toString("base64");
 
 let ws: WebSocket;
 let port: number;
@@ -203,6 +207,279 @@ describe("gateway server chat", () => {
       releaseBlockedReply?.();
     };
   };
+
+  test("chat.send keeps image attachments inline when imageModel enables vision", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "see image",
+          idempotencyKey: "idem-image-model-inline",
+          attachments: [
+            {
+              type: "image",
+              mimeType: "image/png",
+              fileName: "dot.png",
+              content: `data:image/png;base64,${PNG_1X1_BASE64}`,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBe("openai/gpt-4o");
+        expect(observed?.replyOptions.images).toHaveLength(1);
+        expect(observed?.ctx.MediaPaths).toBeUndefined();
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
+  test("chat.send detects image attachments from sniffed content without metadata", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "see sniffed image",
+          idempotencyKey: "idem-image-sniff-no-metadata",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "application/octet-stream",
+              fileName: "blob",
+              content: PNG_1X1_BASE64,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBe("openai/gpt-4o");
+        expect(observed?.replyOptions.images).toHaveLength(1);
+        expect(observed?.ctx.MediaPaths).toBeUndefined();
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
+  test("chat.send detects image attachments from data URLs without metadata", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "see data url image",
+          idempotencyKey: "idem-image-data-url-no-metadata",
+          attachments: [
+            {
+              type: "file",
+              content: `data:image/png;base64,${PNG_1X1_BASE64}`,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBe("openai/gpt-4o");
+        expect(observed?.replyOptions.images).toHaveLength(1);
+        expect(observed?.ctx.MediaPaths).toBeUndefined();
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
+  test("chat.send does not apply imageModel override for non-image attachments", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "read this pdf",
+          idempotencyKey: "idem-non-image-no-override",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "application/pdf",
+              fileName: "report.pdf",
+              content: PDF_BASE64,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBeUndefined();
+        expect(observed?.replyOptions.images).toBeUndefined();
+        expect(observed?.ctx.MediaPaths).toHaveLength(1);
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
+  test("chat.send ignores fake image metadata when sniffed content is non-image", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "read disguised doc",
+          idempotencyKey: "idem-fake-image-metadata",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "image/png",
+              fileName: "report.docx",
+              content: DOCX_LIKE_BASE64,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBeUndefined();
+        expect(observed?.replyOptions.images).toBeUndefined();
+        expect(observed?.ctx.MediaPaths).toHaveLength(1);
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
 
   test("sessions.send accepts dashboard messages for existing sessions", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-"));

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -481,6 +481,61 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.send rejects image filename when sniffed content is generic (ZIP/DOCX as .png)", async () => {
+    await withMainSessionStore(async () => {
+      testState.agentConfig = {
+        model: { primary: "anthropic/claude-3-5-haiku" },
+        imageModel: { primary: "openai/gpt-4o" },
+      };
+      let observed:
+        | {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+          }
+        | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: { MediaPaths?: string[] | undefined };
+            replyOptions: { modelOverride?: string; images?: unknown[] };
+            dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+          },
+        ];
+        observed = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return undefined;
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "read disguised doc",
+          idempotencyKey: "idem-fake-image-filename",
+          attachments: [
+            {
+              type: "file",
+              mimeType: "image/png",
+              fileName: "report.png",
+              content: DOCX_LIKE_BASE64,
+            },
+          ],
+        });
+
+        expect(res.ok).toBe(true);
+        await vi.waitFor(() => expect(observed).toBeDefined());
+        expect(observed?.replyOptions.modelOverride).toBeUndefined();
+        expect(observed?.replyOptions.images).toBeUndefined();
+        expect(observed?.ctx.MediaPaths).toHaveLength(1);
+      } finally {
+        testState.agentConfig = undefined;
+      }
+    });
+  });
+
   test("sessions.send accepts dashboard messages for existing sessions", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-"));
     testState.sessionStorePath = path.join(dir, "sessions.json");


### PR DESCRIPTION
## Summary

- **Fix image model fallback resolution**: `prepareImageModelFallbacks` now drops fallbacks that cannot be resolved into a runnable model ref, instead of returning raw strings that may not be valid model identifiers
- **Add base64 content sniffing for image detection**: Gateway now detects image attachments by sniffing the actual content (via `sniffMimeFromBase64`), not just relying on provided metadata like `mimeType` or `fileName`
- **Conditional imageModel override**: Only applies `imageModel` override when actual image attachments are detected AND the session model does not already support images, preventing unnecessary model switches
- **Guard against fake metadata**: Ignores misleading `mimeType: "image/png"` when sniffed content reveals the file is actually a different type (e.g., DOCX disguised as PNG)
- **Config-first vision validation**: `resolveModelSupportsVision` checks `imageModel` config first (if the model is explicitly configured as imageModel, treat it as vision-capable), then falls back to catalog lookup. This respects user intent when they configure an image model that may not yet be in the catalog

## Changes

### `src/auto-reply/reply/image-model-helpers.ts`
- `prepareImageModelFallbacks`: Returns `null` when model resolution fails
- `resolveModelSupportsVision`: Config-based detection first, catalog as fallback

### `src/gateway/server-methods/chat.ts`
- Added image attachment detection helpers (`normalizeAttachmentMime`, `isGenericAttachmentMime`, `extractAttachmentBase64Content`, `resolveAttachmentLooksLikeImage`, `hasImageAttachments`)
- Check session model vision support before applying imageModel override
- Only apply modelOverride when session model is text-only

### Tests
- New `image-model-helpers.test.ts` (15 tests) — `collectImageModelKeys`, `isImageModel`, `resolveModelSupportsVision`, `prepareImageModelFallbacks`
- New `get-reply.image-model-override.test.ts` (14 tests) — Gateway chat integration, modelOverride application, fallback resolution
- Updated `src/gateway/server.chat.gateway-server-chat.test.ts` — Gateway integration tests for attachment detection and model override

## Real behavior proof

**Behavior or issue addressed**: Image model override only activates when actual image attachments are detected via content sniffing AND the session model does not already support images. Non-image attachments (PDF, DOCX) do not trigger model switch.

**Real environment tested**:
- OpenClaw 2026.5.8 (df6ac68) deployed instance
- macOS Darwin 24.6.0, Node.js 22+, pnpm workspace
- Session: agent:main:dashboard
- Primary model: minimax/MiniMax-M2.7 (text-only, `input: ["text"]`)
- Image Model: bailian/qwen3.6-plus (vision-capable, `input: ["text", "image"]`)

**Exact steps or command run after this patch**:
1. Deployed fork branch to live OpenClaw instance
2. Verified model configuration via `/status` command in Dashboard
3. Sent image attachment with test prompt asking AI to describe image and report model used
4. Sent PDF attachment to verify no model switch occurs
5. Sent DOCX attachment to confirm fake metadata handling

**Evidence after fix**:

Gateway log — content sniffing active (MIME mismatch detection):
```json
{
  "subsystem": "gateway",
  "message": "attachment openclaw-sharing-corrected.docx: mime mismatch (application/vnd.openxmlformats-officedocument.wordprocessingml.document -> application/zip), using provided",
  "traceId": "23e93d084f0990125c98197cda4b6f83"
}
```

Gateway log — PDF offloading (non-image path):
```json
{
  "subsystem": "gateway",
  "message": "[Gateway] Offloaded attachment (application/pdf). Saved: media://inbound/feedback---63372b25-7192-4dc0-886b-36b74d216832.pdf"
}
```

Image attachment triggers model override — screenshots:

<img width="2466" height="1454" alt="Model Configuration" src="https://github.com/user-attachments/assets/24dd8265-8d81-4abe-bcd3-26a40fc8a204" />
<img width="2520" height="1486" alt="Image Auto Override" src="https://github.com/user-attachments/assets/583590cb-5b69-4528-aa60-b9e401d495f2" />
<img width="2540" height="1488" alt="Image Override" src="https://github.com/user-attachments/assets/3b82f59d-ab76-412b-958d-25d7a04780d0" />

PDF attachment does NOT trigger model override — screenshots:

<img width="2442" height="1336" alt="PDF Test" src="https://github.com/user-attachments/assets/4bd32049-091c-4190-ad75-d851512d7bd0" />
<img width="2272" height="1366" alt="PDF Test 2" src="https://github.com/user-attachments/assets/b9b1faa7-be7d-4d05-89e4-bf26a662d8b7" />

Hidden Gateway routing decisions — evidence summary:

| Evidence Type | What It Proves | Source |
|---------------|----------------|--------|
| Configuration | Primary model lacks `image` input type | `openclaw.json` → `minimax/MiniMax-M2.7` has `input: ["text"]` |
| Configuration | Image model has `image` input type | `openclaw.json` → `bailian/qwen3.6-plus` has `input: ["text", "image"]` |
| Gateway Log | Content sniffing active (MIME mismatch detected) | `openclaw-2026-05-10.log` |
| Gateway Log | PDF offloading (non-image path working) | `openclaw-2026-05-10.log` |
| Code Logic | modelOverride decision chain | `image-model-helpers.ts` + `chat.ts` |
| Test Output | 29/29 tests passing | vitest (15 helpers + 14 integration) |

**Observed result after fix**: Image attachments trigger model override to vision-capable model (bailian/qwen3.6-plus). PDF/DOCX attachments keep default model (minimax/MiniMax-M2.7), no override. System correctly distinguishes image vs non-image attachments via content sniffing. Session models that already support images are preserved and not overridden.

**What was not tested**: Full end-to-end testing with audio/video attachments. All image and non-image scenarios verified on live deployment. No new dependencies, no workflow changes, no package resolution modifications, no secret handling changes, no external code execution.

---

Generated with [Claude Code](https://claude.com/claude-code)