### PR TITLE
test(model-usage): make helper tests runnable from repo root

### DIFF
--- a/skills/model-usage/scripts/test_model_usage.py
+++ b/skills/model-usage/scripts/test_model_usage.py
@@ -4,8 +4,14 @@ Tests for model_usage helpers.
 """
 
 import argparse
+import sys
 from datetime import date, timedelta
+from pathlib import Path
 from unittest import TestCase, main
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
 from model_usage import filter_by_days, positive_int
 


### PR DESCRIPTION
## Summary

- Add the model-usage script directory to `sys.path` before importing `model_usage` in its unittest file.
- Keep the change scoped to the test harness so runtime script behavior is unchanged.

## Reproduction

Before this change, running the checked-in test from the repository root fails:

```console
$ python3 -m unittest skills/model-usage/scripts/test_model_usage.py
ModuleNotFoundError: No module named 'model_usage'
```

## Real behavior proof

- **Behavior or issue addressed:** Repo-root execution of `skills/model-usage/scripts/test_model_usage.py` could not import its sibling `model_usage.py`, so the checked-in helper verification was unusable from the repository root.
- **Real environment tested:** Local OpenClaw checkout at `/Users/ming/code/openclaw-openclaw` on macOS, Python 3.12.13.
- **Exact steps or command run after this patch:** `python3 -m unittest skills/model-usage/scripts/test_model_usage.py`
- **Evidence after fix:** Terminal output from the real local checkout after applying this branch:

  ```console
  $ python3 -m unittest skills/model-usage/scripts/test_model_usage.py
  ...
  ----------------------------------------------------------------------
  Ran 3 tests in 0.003s

  OK
  ```

- **Observed result after fix:** The command imports `model_usage.py` through the script-local path and completes the three model-usage helper checks instead of raising `ModuleNotFoundError`.
- **What was not tested:** No additional runtime OpenClaw gateway behavior was exercised; this patch only changes the Python test harness import path.

## Tests

```console
$ python3 -m unittest skills/model-usage/scripts/test_model_usage.py
Ran 3 tests in 0.003s
OK
```
