### PR TITLE
plugin SDK: add inbound_activity hook + discord emit points

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -125,6 +125,7 @@ observation-only.
 
 **Messages and delivery**
 
+- **`inbound_activity`** - observe raw channel inbound activity before a pending inbound debounce flush and optionally extend or cancel the pending debounce window
 - **`inbound_claim`** - claim an inbound message before agent routing (synthetic replies)
 - `message_received` - observe inbound content, sender, thread, and metadata
 - **`message_sending`** - rewrite outbound content or cancel delivery
@@ -147,6 +148,34 @@ observation-only.
 - `gateway_start` / `gateway_stop` - start or stop plugin-owned services with the Gateway
 - `cron_changed` - observe gateway-owned cron lifecycle changes (added, updated, removed, started, finished, scheduled)
 - **`before_install`** - inspect skill or plugin install scans and optionally block
+
+## Inbound activity
+
+`inbound_activity` fires before debounced inbound channel messages flush into
+the normal `inbound_claim` / `message_received` flow. Discord emits it for
+`MESSAGE_CREATE`, `TYPING_START`, and `MESSAGE_DELETE` activity, using the
+same per-channel debounce key as the pending message buffer when Discord can
+resolve one.
+
+The event shape is:
+
+```ts
+{
+  source: "message" | "typing" | "delete" | "update";
+  key: string;
+  authorId?: string;
+  messageId?: string;
+  channelId: string;
+  timestamp: number;
+  raw?: unknown;
+}
+```
+
+The context includes runtime metadata (`config`, `logger`, `runId`,
+`sessionKey`) plus `ctx.extend(ms)` and `ctx.cancel()`. `extend(ms)` moves the
+pending fire time for the activity key to `max(currentFireAt, Date.now() + ms)`.
+Plugins that need a max window should clamp `ms` before calling `extend()`.
+`cancel()` drops the pending debounce buffer for the activity key.
 
 ## Tool call policy
 

--- a/extensions/discord/src/internal/listeners.ts
+++ b/extensions/discord/src/internal/listeners.ts
@@ -4,6 +4,7 @@ import {
   type APIReaction,
   type GatewayPresenceUpdateDispatchData,
   type GatewayThreadUpdateDispatchData,
+  type GatewayTypingStartDispatchData,
 } from "discord-api-types/v10";
 import type { Client } from "./client.js";
 import { Guild, Message, User } from "./structures.js";
@@ -36,6 +37,12 @@ export type DiscordReactionDispatchData = {
   rawMessage?: APIMessage;
 };
 
+export type DiscordMessageDeleteDispatchData = {
+  id: string;
+  channel_id: string;
+  guild_id?: string;
+};
+
 export abstract class BaseListener {
   abstract readonly type: string;
   abstract handle(data: unknown, client: Client): Promise<void> | void;
@@ -66,6 +73,22 @@ export abstract class MessageReactionAddListener extends BaseListener {
 export abstract class MessageReactionRemoveListener extends BaseListener {
   readonly type = GatewayDispatchEvents.MessageReactionRemove;
   abstract override handle(data: DiscordReactionDispatchData, client: Client): Promise<void> | void;
+}
+
+export abstract class TypingStartListener extends BaseListener {
+  readonly type = GatewayDispatchEvents.TypingStart;
+  abstract override handle(
+    data: GatewayTypingStartDispatchData,
+    client: Client,
+  ): Promise<void> | void;
+}
+
+export abstract class MessageDeleteListener extends BaseListener {
+  readonly type = GatewayDispatchEvents.MessageDelete;
+  abstract override handle(
+    data: DiscordMessageDeleteDispatchData,
+    client: Client,
+  ): Promise<void> | void;
 }
 
 export abstract class PresenceUpdateListener extends BaseListener {

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -84,7 +84,9 @@ export function resolveDiscordGatewayIntents(params?: ResolveDiscordGatewayInten
     discordGateway.GatewayIntents.MessageContent |
     discordGateway.GatewayIntents.DirectMessages |
     discordGateway.GatewayIntents.GuildMessageReactions |
-    discordGateway.GatewayIntents.DirectMessageReactions;
+    discordGateway.GatewayIntents.DirectMessageReactions |
+    discordGateway.GatewayIntents.GuildMessageTyping |
+    discordGateway.GatewayIntents.DirectMessageTyping;
   if (voiceStatesEnabled) {
     intents |= discordGateway.GatewayIntents.GuildVoiceStates;
   }

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -3,9 +3,11 @@ import { danger } from "openclaw/plugin-sdk/runtime-env";
 import {
   type Client,
   InteractionCreateListener,
+  MessageDeleteListener,
   MessageCreateListener,
   PresenceUpdateListener,
   ThreadUpdateListener,
+  TypingStartListener,
 } from "../internal/discord.js";
 import { discordEventQueueLog, runDiscordListenerWithSlowLog } from "./listeners.queue.js";
 export { DiscordReactionListener, DiscordReactionRemoveListener } from "./listeners.reactions.js";
@@ -17,6 +19,18 @@ type Logger = ReturnType<typeof import("openclaw/plugin-sdk/runtime-env").create
 
 export type DiscordMessageEvent = Parameters<MessageCreateListener["handle"]>[0];
 export type DiscordInteractionEvent = Parameters<InteractionCreateListener["handle"]>[0];
+export type DiscordTypingStartEvent = Parameters<TypingStartListener["handle"]>[0];
+export type DiscordMessageDeleteEvent = Parameters<MessageDeleteListener["handle"]>[0];
+
+export type DiscordInboundActivityEmitter = (event: {
+  source: "message" | "typing" | "delete" | "update";
+  key: string;
+  authorId?: string;
+  messageId?: string;
+  channelId: string;
+  timestamp: number;
+  raw?: unknown;
+}) => Promise<void>;
 
 export type DiscordMessageHandler = (
   data: DiscordMessageEvent,
@@ -51,6 +65,72 @@ export class DiscordMessageListener extends MessageCreateListener {
         const logger = this.logger ?? discordEventQueueLog;
         logger.error(danger(`discord handler failed: ${String(err)}`));
       });
+  }
+}
+
+export class DiscordTypingStartListener extends TypingStartListener {
+  constructor(
+    private accountId: string,
+    private emitActivity: DiscordInboundActivityEmitter,
+    private logger?: Logger,
+    private onEvent?: () => void,
+  ) {
+    super();
+  }
+
+  async handle(data: DiscordTypingStartEvent) {
+    this.onEvent?.();
+    const userId = typeof data.user_id === "string" ? data.user_id : undefined;
+    const channelId = typeof data.channel_id === "string" ? data.channel_id : undefined;
+    if (!userId || !channelId) {
+      return;
+    }
+    const key = `discord:${this.accountId}:${channelId}:${userId}`;
+    void this.emitActivity({
+      source: "typing",
+      key,
+      authorId: userId,
+      channelId,
+      timestamp: Date.now(),
+      raw: data,
+    }).catch((err) => {
+      const logger = this.logger ?? discordEventQueueLog;
+      logger.error(danger(`discord typing activity hook failed: ${String(err)}`));
+    });
+  }
+}
+
+export class DiscordMessageDeleteListener extends MessageDeleteListener {
+  constructor(
+    private accountId: string,
+    private emitActivity: DiscordInboundActivityEmitter,
+    private logger?: Logger,
+    private onEvent?: () => void,
+  ) {
+    super();
+  }
+
+  async handle(data: DiscordMessageDeleteEvent) {
+    this.onEvent?.();
+    const channelId = typeof data.channel_id === "string" ? data.channel_id : undefined;
+    const messageId = typeof data.id === "string" ? data.id : undefined;
+    if (!channelId || !messageId) {
+      return;
+    }
+    // Discord delete payloads do not include the original author. Use a
+    // channel-scoped key so sibling hooks can still cancel their own side state.
+    const key = `discord:${this.accountId}:${channelId}:*`;
+    void this.emitActivity({
+      source: "delete",
+      key,
+      messageId,
+      channelId,
+      timestamp: Date.now(),
+      raw: data,
+    }).catch((err) => {
+      const logger = this.logger ?? discordEventQueueLog;
+      logger.error(danger(`discord delete activity hook failed: ${String(err)}`));
+    });
   }
 }
 

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -2,6 +2,11 @@ import {
   createChannelInboundDebouncer,
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
+import type {
+  PluginHookInboundActivityContext,
+  PluginHookInboundActivityEvent,
+} from "openclaw/plugin-sdk/plugin-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { createDiscordRestClient } from "../client.js";
@@ -58,6 +63,7 @@ async function loadMessagePreflightRuntime() {
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
+  emitInboundActivity: (activity: PluginHookInboundActivityEvent) => Promise<void>;
 };
 
 function isNonEmptyString(value: string | undefined): value is string {
@@ -94,6 +100,30 @@ function queueAcceptedDiscordTypingCue(ctx: DiscordMessagePreflightContext): voi
   });
 }
 
+function createDiscordInboundActivityContext(params: {
+  event: PluginHookInboundActivityEvent;
+  cfg: DiscordMessageHandlerParams["cfg"];
+  accountId: string;
+  runtime: DiscordMessageHandlerParams["runtime"];
+  extend: (ms: number) => void;
+  cancel: () => void;
+}): PluginHookInboundActivityContext {
+  return {
+    config: params.cfg,
+    logger: {
+      info: (message) => params.runtime.log?.(message),
+      warn: (message) => params.runtime.error?.(danger(message)),
+      error: (message) => params.runtime.error?.(danger(message)),
+    },
+    channelId: params.event.channelId,
+    accountId: params.accountId,
+    senderId: params.event.authorId,
+    messageId: params.event.messageId,
+    extend: params.extend,
+    cancel: params.cancel,
+  };
+}
+
 export function createDiscordMessageHandler(
   params: DiscordMessageHandlerParams,
 ): DiscordMessageHandlerWithLifecycle {
@@ -108,6 +138,7 @@ export function createDiscordMessageHandler(
     "group-mentions";
   const preflightDiscordMessageImpl = params.__testing?.preflightDiscordMessage;
   const replayGuard = createDiscordInboundReplayGuard();
+  const pendingMessageKeys = new Map<string, string>();
   const messageRunQueue = createDiscordMessageRunQueue({
     runtime: params.runtime,
     setStatus: params.setStatus,
@@ -116,12 +147,15 @@ export function createDiscordMessageHandler(
     __testing: params.__testing,
   });
 
-  const { debouncer } = createChannelInboundDebouncer<{
-    data: DiscordMessageEvent;
-    client: Client;
-    abortSignal?: AbortSignal;
-    replayKey?: string;
-  }>({
+  const { debouncer } = createChannelInboundDebouncer<
+    {
+      data: DiscordMessageEvent;
+      client: Client;
+      abortSignal?: AbortSignal;
+      replayKey?: string;
+    },
+    PluginHookInboundActivityEvent
+  >({
     cfg: params.cfg,
     channel: "discord",
     buildKey: (entry) => {
@@ -138,6 +172,48 @@ export function createDiscordMessageHandler(
         return null;
       }
       return `discord:${params.accountId}:${channelId}:${authorId}`;
+    },
+    buildActivity: (entry, key) => {
+      const message = entry.data.message;
+      const channelId = message
+        ? resolveDiscordMessageChannelId({
+            message,
+            eventChannelId: entry.data.channel_id,
+          })
+        : entry.data.channel_id;
+      if (!channelId) {
+        return null;
+      }
+      const messageId = message?.id ?? entry.data.id;
+      if (messageId) {
+        pendingMessageKeys.set(messageId, key);
+      }
+      return {
+        source: "message",
+        key,
+        authorId: entry.data.author?.id ?? message?.author?.id,
+        messageId,
+        channelId,
+        timestamp: Date.now(),
+        raw: entry.data,
+      };
+    },
+    onActivity: async (event, controls) => {
+      const hookRunner = getGlobalHookRunner();
+      if (!hookRunner?.hasHooks("inbound_activity")) {
+        return;
+      }
+      return hookRunner.runInboundActivity(
+        event,
+        createDiscordInboundActivityContext({
+          event,
+          cfg: params.cfg,
+          accountId: params.accountId,
+          runtime: params.runtime,
+          extend: controls.extend,
+          cancel: controls.cancel,
+        }),
+      );
     },
     shouldDebounce: (entry) => {
       const message = entry.data.message;
@@ -159,6 +235,12 @@ export function createDiscordMessageHandler(
         return;
       }
       const replayKeys = entries.map((entry) => entry.replayKey).filter(isNonEmptyString);
+      for (const entry of entries) {
+        const messageId = entry.data.message?.id ?? entry.data.id;
+        if (messageId) {
+          pendingMessageKeys.delete(messageId);
+        }
+      }
       const abortSignal = last.abortSignal;
       if (abortSignal?.aborted) {
         releaseDiscordInboundReplay({
@@ -263,6 +345,20 @@ export function createDiscordMessageHandler(
     onError: (err) => {
       params.runtime.error?.(danger(`discord debounce flush failed: ${String(err)}`));
     },
+    onCancel: (entries) => {
+      const replayKeys = entries.map((entry) => entry.replayKey).filter(isNonEmptyString);
+      releaseDiscordInboundReplay({
+        replayKeys,
+        replayGuard,
+        error: new Error("discord inbound debounce cancelled by inbound_activity hook"),
+      });
+      for (const entry of entries) {
+        const messageId = entry.data.message?.id ?? entry.data.id;
+        if (messageId) {
+          pendingMessageKeys.delete(messageId);
+        }
+      }
+    },
   });
 
   const handler: DiscordMessageHandlerWithLifecycle = async (data, client, options) => {
@@ -304,6 +400,16 @@ export function createDiscordMessageHandler(
   };
 
   handler.deactivate = messageRunQueue.deactivate;
+  handler.emitInboundActivity = async (activity) => {
+    const key =
+      activity.source === "delete" && activity.messageId
+        ? (pendingMessageKeys.get(activity.messageId) ?? activity.key)
+        : activity.key;
+    await debouncer.emitActivity({ ...activity, key }, key);
+    if (activity.source === "delete" && activity.messageId) {
+      pendingMessageKeys.delete(activity.messageId);
+    }
+  };
 
   return handler;
 }

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -28,12 +28,15 @@ import {
 import { createDiscordGatewaySupervisor } from "./gateway-supervisor.js";
 import {
   DiscordMessageListener,
+  DiscordMessageDeleteListener,
+  DiscordTypingStartListener,
   DiscordInteractionListener,
   DiscordPresenceListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
   DiscordThreadUpdateListener,
   registerDiscordListener,
+  type DiscordInboundActivityEmitter,
 } from "./listeners.js";
 import { resolveDiscordPresenceUpdate } from "./presence.js";
 
@@ -251,7 +254,9 @@ export function registerDiscordMonitorListeners(params: {
   groupPolicy: "open" | "allowlist" | "disabled";
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
   logger: NonNullable<ConstructorParameters<typeof DiscordMessageListener>[1]>;
-  messageHandler: ConstructorParameters<typeof DiscordMessageListener>[0];
+  messageHandler: ConstructorParameters<typeof DiscordMessageListener>[0] & {
+    emitInboundActivity: DiscordInboundActivityEmitter;
+  };
   trackInboundEvent?: () => void;
 }) {
   registerDiscordListener(
@@ -261,6 +266,24 @@ export function registerDiscordMonitorListeners(params: {
   registerDiscordListener(
     params.client.listeners,
     new DiscordMessageListener(params.messageHandler, params.logger, params.trackInboundEvent),
+  );
+  registerDiscordListener(
+    params.client.listeners,
+    new DiscordTypingStartListener(
+      params.accountId,
+      params.messageHandler.emitInboundActivity,
+      params.logger,
+      params.trackInboundEvent,
+    ),
+  );
+  registerDiscordListener(
+    params.client.listeners,
+    new DiscordMessageDeleteListener(
+      params.accountId,
+      params.messageHandler.emitInboundActivity,
+      params.logger,
+      params.trackInboundEvent,
+    ),
   );
 
   if (shouldRegisterDiscordReactionListeners(params)) {

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -37,6 +37,7 @@ type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  fireAt: number;
   releaseReady: () => void;
   readyReleased: boolean;
   task: Promise<void>;
@@ -44,17 +45,34 @@ type DebounceBuffer<T> = {
 
 const DEFAULT_MAX_TRACKED_KEYS = 2048;
 
-export type InboundDebounceCreateParams<T> = {
+export type InboundDebounceActivityControls = {
+  extend: (ms: number) => void;
+  cancel: () => void;
+};
+
+export type InboundDebounceActivityResult = {
+  readonly [key: string]: never;
+} | void;
+
+export type InboundDebounceCreateParams<T, TActivity = never> = {
   debounceMs: number;
   maxTrackedKeys?: number;
   buildKey: (item: T) => string | null | undefined;
+  buildActivity?: (item: T, key: string) => TActivity | null | undefined;
+  onActivity?: (
+    activity: TActivity,
+    controls: InboundDebounceActivityControls,
+  ) => Promise<InboundDebounceActivityResult> | InboundDebounceActivityResult;
   shouldDebounce?: (item: T) => boolean;
   resolveDebounceMs?: (item: T) => number | undefined;
   onFlush: (items: T[]) => Promise<void>;
+  onCancel?: (items: T[], key: string) => void;
   onError?: (err: unknown, items: T[]) => void;
 };
 
-export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
+export function createInboundDebouncer<T, TActivity = never>(
+  params: InboundDebounceCreateParams<T, TActivity>,
+) {
   const buffers = new Map<string, DebounceBuffer<T>>();
   const keyChains = new Map<string, Promise<void>>();
   const defaultDebounceMs = Math.max(0, Math.trunc(params.debounceMs));
@@ -150,10 +168,53 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
     }
+    const delayMs = Math.max(0, buffer.fireAt - Date.now());
     buffer.timeout = setTimeout(async () => {
       await flushBuffer(key, buffer);
-    }, buffer.debounceMs);
+    }, delayMs);
     buffer.timeout.unref?.();
+  };
+
+  const extendKey = (key: string, ms: number) => {
+    const buffer = buffers.get(key);
+    const extensionMs = resolveMs(ms);
+    if (!buffer || extensionMs === undefined) {
+      return;
+    }
+    const nextFireAt = Date.now() + extensionMs;
+    buffer.fireAt = Math.max(buffer.fireAt, nextFireAt);
+    scheduleFlush(key, buffer);
+  };
+
+  const cancelKey = (key: string) => {
+    const buffer = buffers.get(key);
+    if (!buffer) {
+      return;
+    }
+    buffers.delete(key);
+    const items = buffer.items;
+    buffer.items = [];
+    if (buffer.timeout) {
+      clearTimeout(buffer.timeout);
+      buffer.timeout = null;
+    }
+    try {
+      params.onCancel?.(items, key);
+    } catch {
+      // Cancellation is best-effort cleanup; do not let observer cleanup throw
+      // back through plugin hook activity handling.
+    }
+    releaseBuffer(buffer);
+  };
+
+  const emitActivity = async (activity: TActivity, key: string) => {
+    if (!params.onActivity) {
+      return;
+    }
+    await params.onActivity(activity, {
+      extend: (ms) => extendKey(key, ms),
+      cancel: () => cancelKey(key),
+    });
   };
 
   const canTrackKey = (key: string) => {
@@ -167,6 +228,13 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     const key = params.buildKey(item);
     const debounceMs = resolveDebounceMs(item);
     const canDebounce = debounceMs > 0 && (params.shouldDebounce?.(item) ?? true);
+
+    if (key && params.buildActivity) {
+      const activity = params.buildActivity(item, key);
+      if (activity !== null && activity !== undefined) {
+        await emitActivity(activity, key);
+      }
+    }
 
     if (!canDebounce || !key) {
       if (key) {
@@ -201,6 +269,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     if (existing) {
       existing.items.push(item);
       existing.debounceMs = debounceMs;
+      existing.fireAt = Math.max(existing.fireAt, Date.now() + debounceMs);
       scheduleFlush(key, existing);
       return;
     }
@@ -224,6 +293,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       items: [item],
       timeout: null,
       debounceMs,
+      fireAt: Date.now() + debounceMs,
       releaseReady: reservedTask.release,
       readyReleased: false,
       task: reservedTask.task,
@@ -232,5 +302,5 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey };
+  return { enqueue, flushKey, extendKey, cancelKey, emitActivity };
 }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -229,14 +229,24 @@ export function createInboundDebouncer<T, TActivity = never>(
     const debounceMs = resolveDebounceMs(item);
     const canDebounce = debounceMs > 0 && (params.shouldDebounce?.(item) ?? true);
 
-    if (key && params.buildActivity) {
+    // The activity hook is fired AFTER the buffer is created/updated so that
+    // a plugin's `ctx.cancel()` or `ctx.extend()` call can find the live buffer
+    // and act on it. If we fired before, cancel() on the first event for a key
+    // would be a silent no-op since the buffer wouldn't exist yet.
+    const fireActivityHook = async () => {
+      if (!key || !params.buildActivity) {
+        return;
+      }
       const activity = params.buildActivity(item, key);
       if (activity !== null && activity !== undefined) {
         await emitActivity(activity, key);
       }
-    }
+    };
 
     if (!canDebounce || !key) {
+      // Non-debounced path: hook fires for observation only; cancel/extend
+      // have no buffer to act on and are no-ops by design here.
+      await fireActivityHook();
       if (key) {
         if (buffers.has(key)) {
           // Reserve the keyed immediate slot before forcing the pending buffer
@@ -271,11 +281,14 @@ export function createInboundDebouncer<T, TActivity = never>(
       existing.debounceMs = debounceMs;
       existing.fireAt = Math.max(existing.fireAt, Date.now() + debounceMs);
       scheduleFlush(key, existing);
+      // Buffer reflects this item; hook can extend/cancel it.
+      await fireActivityHook();
       return;
     }
     if (!canTrackKey(key)) {
       // When the debounce map is saturated, fall back to immediate keyed work
       // instead of buffering, but still preserve same-key ordering.
+      await fireActivityHook();
       await enqueueKeyTask(key, async () => {
         await runFlush([item]);
       });
@@ -300,6 +313,10 @@ export function createInboundDebouncer<T, TActivity = never>(
     };
     buffers.set(key, buffer);
     scheduleFlush(key, buffer);
+    // Fire the hook now that the buffer is registered; if a plugin calls
+    // `ctx.cancel()` here, `cancelKey` finds the live buffer and clears items
+    // so the reserved task no-ops on flush.
+    await fireActivityHook();
   };
 
   return { enqueue, flushKey, extendKey, cancelKey, emitActivity };

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -44,7 +44,7 @@ export function createChannelInboundDebouncer<T, TActivity = never>(
     overrideMs: params.debounceMsOverride,
   });
   const { cfg: _cfg, channel: _channel, debounceMsOverride: _override, ...rest } = params;
-  const debouncer = createInboundDebouncer<T>({
+  const debouncer = createInboundDebouncer<T, TActivity>({
     debounceMs,
     ...rest,
   });

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -28,15 +28,15 @@ export function shouldDebounceTextInbound(params: {
   return !hasControlCommand(text, params.cfg, params.commandOptions);
 }
 
-export function createChannelInboundDebouncer<T>(
-  params: Omit<InboundDebounceCreateParams<T>, "debounceMs"> & {
+export function createChannelInboundDebouncer<T, TActivity = never>(
+  params: Omit<InboundDebounceCreateParams<T, TActivity>, "debounceMs"> & {
     cfg: OpenClawConfig;
     channel: string;
     debounceMsOverride?: number;
   },
 ): {
   debounceMs: number;
-  debouncer: ReturnType<typeof createInboundDebouncer<T>>;
+  debouncer: ReturnType<typeof createInboundDebouncer<T, TActivity>>;
 } {
   const debounceMs = resolveInboundDebounceMs({
     cfg: params.cfg,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -80,6 +80,7 @@ export type PluginHookName =
   | "before_compaction"
   | "after_compaction"
   | "before_reset"
+  | "inbound_activity"
   | "inbound_claim"
   | "message_received"
   | "message_sending"
@@ -118,6 +119,7 @@ export const PLUGIN_HOOK_NAMES = [
   "before_compaction",
   "after_compaction",
   "before_reset",
+  "inbound_activity",
   "inbound_claim",
   "message_received",
   "message_sending",
@@ -197,6 +199,40 @@ export type PluginHookAgentContext = {
   trigger?: string;
   channelId?: string;
 };
+
+export type PluginHookLogger = {
+  debug?: (message: string) => void;
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+export type PluginHookInboundActivitySource = "message" | "typing" | "delete" | "update";
+
+export type PluginHookInboundActivityEvent = {
+  source: PluginHookInboundActivitySource;
+  key: string;
+  authorId?: string;
+  messageId?: string;
+  channelId: string;
+  timestamp: number;
+  raw?: unknown;
+};
+
+export type PluginHookInboundActivityContext = {
+  config?: OpenClawConfig;
+  logger?: PluginHookLogger;
+  runId?: string;
+  sessionKey?: string;
+  channelId: string;
+  accountId?: string;
+  senderId?: string;
+  messageId?: string;
+  extend: (ms: number) => void;
+  cancel: () => void;
+};
+
+export type PluginHookInboundActivityResult = Record<never, never> | void;
 
 export type PluginHookBeforeAgentReplyEvent = {
   cleanedBody: string;
@@ -900,6 +936,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeResetEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<void> | void;
+  inbound_activity: (
+    event: PluginHookInboundActivityEvent,
+    ctx: PluginHookInboundActivityContext,
+  ) => Promise<PluginHookInboundActivityResult> | PluginHookInboundActivityResult;
   inbound_claim: (
     event: PluginHookInboundClaimEvent,
     ctx: PluginHookInboundClaimContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -38,6 +38,9 @@ import type {
   PluginHookBeforeCompactionEvent,
   PluginHookModelCallEndedEvent,
   PluginHookModelCallStartedEvent,
+  PluginHookInboundActivityContext,
+  PluginHookInboundActivityEvent,
+  PluginHookInboundActivityResult,
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
@@ -112,6 +115,9 @@ export type {
   PluginHookAgentEndEvent,
   PluginHookBeforeCompactionEvent,
   PluginHookBeforeResetEvent,
+  PluginHookInboundActivityContext,
+  PluginHookInboundActivityEvent,
+  PluginHookInboundActivityResult,
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
@@ -941,6 +947,21 @@ export function createHookRunner(
   // =========================================================================
 
   /**
+   * Run inbound_activity hook.
+   * Allows plugins to observe and adjust pending channel inbound debounce state.
+   */
+  async function runInboundActivity(
+    event: PluginHookInboundActivityEvent,
+    ctx: PluginHookInboundActivityContext,
+  ): Promise<PluginHookInboundActivityResult | undefined> {
+    return runModifyingHook<"inbound_activity", PluginHookInboundActivityResult>(
+      "inbound_activity",
+      event,
+      ctx,
+    );
+  }
+
+  /**
    * Run inbound_claim hook.
    * Allows plugins to claim an inbound event before commands/agent dispatch.
    */
@@ -1492,6 +1513,7 @@ export function createHookRunner(
     // Lifecycle gate hooks
     runBeforeAgentRun,
     // Message hooks
+    runInboundActivity,
     runInboundClaim,
     runInboundClaimForPlugin,
     runInboundClaimForPluginOutcome,


### PR DESCRIPTION
## Summary

Adds a new plugin hook `inbound_activity` that lets a sibling plugin participate in per-channel inbound debouncing without owning the channel inbound flow. Currently `@openclaw/discord` owns its `createChannelInboundDebouncer` privately; `inbound_claim` only fires *after* the debouncer flushes, which is too late to extend or cancel a pending window. This PR introduces a pre-flush hook with `extend(ms)` / `cancel()` controls and wires Discord to emit through it for `MESSAGE_CREATE`, `TYPING_START`, and `MESSAGE_DELETE`.

The motivating use case is a smart-debounce sibling plugin that:
- extends the pending window when a Discord user is still typing,
- caps total wait via a plugin-side max-window clamp,
- cancels the buffer when the user deletes their pending message before any reply.

## Hook surface

```ts
type PluginHookInboundActivityEvent = {
  source: "message" | "typing" | "delete" | "update";
  key: string;             // per-channel debounce key
  authorId?: string;
  messageId?: string;
  channelId: string;
  timestamp: number;
  raw?: unknown;
};

type PluginHookInboundActivityContext = {
  config?: OpenClawConfig;
  logger?: PluginHookLogger;
  runId?: string;
  sessionKey?: string;
  channelId: string;
  accountId?: string;
  senderId?: string;
  messageId?: string;
  extend: (ms: number) => void;   // fireAt = max(currentFireAt, Date.now() + ms)
  cancel: () => void;             // drops pending buffer for this key
};

type PluginHookInboundActivityResult = Record<never, never> | void;
```

The hook result is intentionally a no-op shape. Caps, windowing, and per-channel state are plugin-side policy — plugins clamp `ms` themselves before calling `extend()`, and the runtime stays out of cross-plugin merge logic.

## What changed

- `src/plugins/hook-types.ts` — new `inbound_activity` entry in `PluginHookName` / `PLUGIN_HOOK_NAMES` / `PluginHookHandlerMap`, plus event/context/result types.
- `src/plugins/hooks.ts` — `runInboundActivity()` on the hook runner (sequential modifying hook, default merge, no shouldStop).
- `src/auto-reply/inbound-debounce.ts` — `createInboundDebouncer` now accepts `buildActivity` / `onActivity` / `onCancel` and exposes `extendKey` / `cancelKey` / `emitActivity`. `extendKey(key, ms)` sets `fireAt = max(currentFireAt, now + ms)`. `cancelKey(key)` drops buffered items and invokes `onCancel(items, key)` for replay-guard cleanup; cleanup errors are swallowed so a release failure can't throw out of the hook path.
- `src/channels/inbound-debounce-policy.ts` — threads the new `buildActivity` / `onActivity` callbacks through `createChannelInboundDebouncer` (and propagates the `TActivity` generic so the returned `emitActivity` types correctly).
- `extensions/discord/src/internal/listeners.ts` — adds `TypingStartListener` and `MessageDeleteListener` base classes.
- `extensions/discord/src/monitor/listeners.ts` — adds `DiscordInboundActivityEmitter`, `DiscordTypingStartListener`, and `DiscordMessageDeleteListener` that emit through the same `emitInboundActivity` entry point. Delete payloads do not include the original author, so deletes use a channel-wildcard key (`discord:<account>:<channel>:*`) that the message handler resolves back to the original per-author key via a small `pendingMessageKeys` map.
- `extensions/discord/src/monitor/message-handler.ts` — wires `buildActivity`/`onActivity` for `MESSAGE_CREATE`, exposes `emitInboundActivity` to typing/delete listeners, and adds an `onCancel` callback that releases inbound replay-dedupe entries and prunes `pendingMessageKeys` when a sibling plugin cancels a pending buffer (so a future event for the same message id isn't silently swallowed by the replay guard).
- `extensions/discord/src/monitor/provider.startup.ts` — registers the typing-start and message-delete listeners.
- `extensions/discord/src/monitor/gateway-plugin.ts` — adds `GuildMessageTyping` and `DirectMessageTyping` to the always-on intent set so `TYPING_START` actually arrives at the new listener (without this, the typing-extend behavior is silently dead).
- `docs/plugins/hooks.md` — documents the hook including the `extend`/`cancel` semantics.

## Design notes

- **No `maxWindowMs` in the hook result.** An earlier draft returned `{ maxWindowMs }` from handlers and merged "smallest cap wins" in the runtime. That made the runtime do plugin bookkeeping and turned the field into a footgun where any future plugin returning it would silently shrink someone else's window. Plugins clamp `ms` themselves before `extend()` instead.
- **Replay-dedupe cleanup on cancel.** Discord claims an inbound replay key (`accountId:channelId:messageId`) before enqueue, normally committed/released during flush. `onCancel` extracts each buffered entry's `replayKey` and calls `releaseDiscordInboundReplay(...)` so a cancelled buffer doesn't leave the dedupe entry pinned.
- **Hook fires after buffer setup.** In `enqueue`, `buildActivity` / `emitActivity` runs *after* the buffer is created or updated so a plugin's `ctx.cancel()` on a first event for a key acts on the live buffer rather than being a silent no-op.
- **`MESSAGE_UPDATE`** is in the event union but unwired. Future work; current consumers don't need it and Discord's edit semantics need a clear policy before opting in.
- **Author ID on delete.** Discord's delete payload doesn't include the author. The message handler maps message-id → debounce-key for pending messages so `emitInboundActivity` can resolve the original key. Deletes for messages that aren't pending fall back to the channel-wildcard key.

## Real behavior proof

Built the patched branch locally (`pnpm install && pnpm run build`) and ran `OpenClaw 2026.5.8 (24d9e16)` under an isolated dev profile against a throwaway Discord bot account in a private guild. A sibling plugin registered an `inbound_activity` handler implementing per-channel smart debounce (typing-extend, max-window cap, cancel-on-delete, bystander filter). All four behaviors were exercised against real Discord gateway traffic. Channel and message IDs redacted as `<test-channel>` / `<msg-N>`. Plugin config: `baseDebounceMs=10000`, `extendOnTypingMs=10000`, `maxWindowMs=40000`. The plugin emits `[smart-debounce] extend` and `[smart-debounce] cancel` lines on every action it takes.

### Typing extends pending flush past base debounce (live Discord output)

Sent a message and typed continuously for ~27 seconds. Each `TYPING_START` (~8s rhythm) pushed `fireAt` forward by 10s. Flush only fired ~10s after typing stopped.

```
10:00:11.266  message → extend +10000ms fireAt-in=10000ms window-elapsed=    0ms
10:00:13.308  typing  → extend +10000ms fireAt-in=10000ms window-elapsed= 2042ms
10:00:21.517  typing  → extend +10000ms fireAt-in=10000ms window-elapsed=10250ms  ← past base
10:00:29.788  typing  → extend +10000ms fireAt-in=10000ms window-elapsed=18522ms
10:00:38.130  typing  → extend +10000ms fireAt-in=10000ms window-elapsed=26864ms
10:00:48ish   flush + agent dispatch
```

### `maxWindowMs` cap clamps the extension (live Discord output)

Continuous typing past the 40s cap. Last typing ping at window-elapsed=34856ms requested +10000ms; plugin clamped via `min(10000, 40000-34856) = 5144`, fired at exactly windowStart+40000ms.

```
10:02:59.769  typing → extend +10000ms fireAt-in=10000ms window-elapsed=10309ms
10:03:08.035  typing → extend +10000ms fireAt-in=10000ms window-elapsed=18575ms
10:03:16.188  typing → extend +10000ms fireAt-in=10000ms window-elapsed=26728ms
10:03:24.315  typing → extend  +5144ms fireAt-in= 5144ms window-elapsed=34856ms  ← clamp
10:03:29.462  flush  (40.002s after the original message)
```

Cap honored to within 2ms.

### Delete cancels the pending buffer (live Discord output)

Sent a message, waited ~4s, deleted it.

```
10:04:44.434  message → extend +10000ms fireAt-in=10000ms pending=1
10:04:48.536  cancel  reason=delete-emptied-pending messageId=<msg-C>
```

No subsequent `outcome=completed` for `<msg-C>` — agent never ran. The patch's `onCancel` callback released the inbound replay-dedupe entry. A subsequent message in the same channel processed on a clean window.

### Bystander typing is ignored (live Discord output)

User A sent a message; user B typed in the same channel during the window. The `inbound_activity` hook fired for B's typing, but the plugin's `!pendingAuthors.has(authorId)` guard returned silently — no `extend` log line, flush fired at exact base 10s.

```
10:14:57.871  HOOK fired               ← user A MESSAGE_CREATE
10:14:57.873  PLUGIN extended +10000ms
10:14:58.370  HOOK fired (no extend)   ← user B TYPING_START — ignored
10:14:58.588  HOOK fired (no extend)   ← user B TYPING_START — ignored
10:15:07.875  flush at base 10s
```

Confirms chatty bystanders can't stall agent replies.

### Notes on the test environment

- Patched build: `OpenClaw 2026.5.8 (24d9e16)`, applied cleanly on top of `main`.
- Typing intent fix verified live: with the bot account's privileged `MESSAGE_CONTENT` intent enabled and the new `GuildMessageTyping` / `DirectMessageTyping` intents in `resolveDiscordGatewayIntents`, `TYPING_START` events arrived and dispatched through `inbound_activity` as expected. Without the intent change the typing listener is silently dead.
- One incidental fix landed during local typecheck: `createInboundDebouncer<T>(...)` in `inbound-debounce-policy.ts` was missing its `TActivity` generic; `pnpm run build` failed on TS2322 in `build:plugin-sdk:dts` until that was propagated. Now `<T, TActivity>`.
- Sibling plugin used for these tests is local-only and not part of this PR.

## Test plan

- [x] Build passes (`pnpm install && pnpm run build`) on the patched branch.
- [x] Smoke (real Discord): typing extends past the base debounce — see proof above.
- [x] Smoke (real Discord): max-window cap engages and clamps — see proof above.
- [x] Smoke (real Discord): delete cancels the pending buffer with no agent run — see proof above.
- [x] Smoke (real Discord): bystander typing is ignored — see proof above.
- [x] No behavior change when no plugin registers `inbound_activity` (early-return on `hasHooks("inbound_activity")` keeps the existing path identical — confirmed by reading the dispatch path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)