### PR TITLE
fix(gateway): handle exec approvals persistence errors

### DIFF
--- a/src/gateway/server-methods/exec-approvals.test.ts
+++ b/src/gateway/server-methods/exec-approvals.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExecApprovalsFile } from "../../infra/exec-approvals.js";
+
+const ensureExecApprovalsMock = vi.hoisted(() => vi.fn());
+const readExecApprovalsSnapshotMock = vi.hoisted(() => vi.fn());
+const saveExecApprovalsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../infra/exec-approvals.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/exec-approvals.js")>();
+  return {
+    ...actual,
+    ensureExecApprovals: ensureExecApprovalsMock,
+    readExecApprovalsSnapshot: readExecApprovalsSnapshotMock,
+    saveExecApprovals: saveExecApprovalsMock,
+  };
+});
+
+const { execApprovalsHandlers } = await import("./exec-approvals.js");
+
+function makeSnapshot(file: ExecApprovalsFile = { version: 1, agents: {} }) {
+  return {
+    path: "/tmp/exec-approvals.json",
+    exists: true,
+    raw: JSON.stringify(file),
+    file,
+    hash: "base-hash",
+  };
+}
+
+describe("exec approvals gateway methods", () => {
+  it("returns a structured unavailable error when local approvals get cannot read state", async () => {
+    ensureExecApprovalsMock.mockImplementationOnce(() => {
+      throw new Error("permission denied while ensuring approvals");
+    });
+    const respond = vi.fn();
+
+    await execApprovalsHandlers["exec.approvals.get"]({
+      req: { type: "req", id: "req-1", method: "exec.approvals.get", params: {} },
+      params: {},
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("permission denied while ensuring approvals"),
+      }),
+    );
+  });
+
+  it("returns a structured unavailable error when local approvals set cannot persist", async () => {
+    ensureExecApprovalsMock.mockReturnValue({ version: 1, agents: {} });
+    readExecApprovalsSnapshotMock.mockReturnValue(makeSnapshot());
+    saveExecApprovalsMock.mockImplementationOnce(() => {
+      throw new Error("disk full while saving approvals");
+    });
+    const respond = vi.fn();
+
+    await execApprovalsHandlers["exec.approvals.set"]({
+      req: { type: "req", id: "req-2", method: "exec.approvals.set", params: {} },
+      params: { baseHash: "base-hash", file: { version: 1, agents: {} } },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("disk full while saving approvals"),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -126,37 +126,41 @@ async function respondWithExecApprovalsNodePayload<TParams extends { nodeId: str
 }
 
 export const execApprovalsHandlers: GatewayRequestHandlers = {
-  "exec.approvals.get": ({ params, respond }) => {
+  "exec.approvals.get": async ({ params, respond }) => {
     if (!assertValidParams(params, validateExecApprovalsGetParams, "exec.approvals.get", respond)) {
       return;
     }
-    ensureExecApprovals();
-    const snapshot = readExecApprovalsSnapshot();
-    respond(true, toExecApprovalsPayload(snapshot), undefined);
+    await respondUnavailableOnThrow(respond, async () => {
+      ensureExecApprovals();
+      const snapshot = readExecApprovalsSnapshot();
+      respond(true, toExecApprovalsPayload(snapshot), undefined);
+    });
   },
-  "exec.approvals.set": ({ params, respond }) => {
+  "exec.approvals.set": async ({ params, respond }) => {
     if (!assertValidParams(params, validateExecApprovalsSetParams, "exec.approvals.set", respond)) {
       return;
     }
-    ensureExecApprovals();
-    const snapshot = readExecApprovalsSnapshot();
-    if (!requireApprovalsBaseHash(params, snapshot, respond)) {
-      return;
-    }
-    const incoming = (params as { file?: unknown }).file;
-    if (!incoming || typeof incoming !== "object") {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "exec approvals file is required"),
-      );
-      return;
-    }
-    const normalized = normalizeExecApprovals(incoming as ExecApprovalsFile);
-    const next = mergeExecApprovalsSocketDefaults({ normalized, current: snapshot.file });
-    saveExecApprovals(next);
-    const nextSnapshot = readExecApprovalsSnapshot();
-    respond(true, toExecApprovalsPayload(nextSnapshot), undefined);
+    await respondUnavailableOnThrow(respond, async () => {
+      ensureExecApprovals();
+      const snapshot = readExecApprovalsSnapshot();
+      if (!requireApprovalsBaseHash(params, snapshot, respond)) {
+        return;
+      }
+      const incoming = (params as { file?: unknown }).file;
+      if (!incoming || typeof incoming !== "object") {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "exec approvals file is required"),
+        );
+        return;
+      }
+      const normalized = normalizeExecApprovals(incoming as ExecApprovalsFile);
+      const next = mergeExecApprovalsSocketDefaults({ normalized, current: snapshot.file });
+      saveExecApprovals(next);
+      const nextSnapshot = readExecApprovalsSnapshot();
+      respond(true, toExecApprovalsPayload(nextSnapshot), undefined);
+    });
   },
   "exec.approvals.node.get": async ({ params, respond, context }) => {
     await respondWithExecApprovalsNodePayload({

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -96,37 +96,41 @@ function resolveNodeIdOrRespond(nodeId: string, respond: RespondFn): string | nu
 }
 
 export const execApprovalsHandlers: GatewayRequestHandlers = {
-  "exec.approvals.get": ({ params, respond }) => {
+  "exec.approvals.get": async ({ params, respond }) => {
     if (!assertValidParams(params, validateExecApprovalsGetParams, "exec.approvals.get", respond)) {
       return;
     }
-    ensureExecApprovals();
-    const snapshot = readExecApprovalsSnapshot();
-    respond(true, toExecApprovalsPayload(snapshot), undefined);
+    await respondUnavailableOnThrow(respond, async () => {
+      ensureExecApprovals();
+      const snapshot = readExecApprovalsSnapshot();
+      respond(true, toExecApprovalsPayload(snapshot), undefined);
+    });
   },
-  "exec.approvals.set": ({ params, respond }) => {
+  "exec.approvals.set": async ({ params, respond }) => {
     if (!assertValidParams(params, validateExecApprovalsSetParams, "exec.approvals.set", respond)) {
       return;
     }
-    ensureExecApprovals();
-    const snapshot = readExecApprovalsSnapshot();
-    if (!requireApprovalsBaseHash(params, snapshot, respond)) {
-      return;
-    }
-    const incoming = (params as { file?: unknown }).file;
-    if (!incoming || typeof incoming !== "object") {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "exec approvals file is required"),
-      );
-      return;
-    }
-    const normalized = normalizeExecApprovals(incoming as ExecApprovalsFile);
-    const next = mergeExecApprovalsSocketDefaults({ normalized, current: snapshot.file });
-    saveExecApprovals(next);
-    const nextSnapshot = readExecApprovalsSnapshot();
-    respond(true, toExecApprovalsPayload(nextSnapshot), undefined);
+    await respondUnavailableOnThrow(respond, async () => {
+      ensureExecApprovals();
+      const snapshot = readExecApprovalsSnapshot();
+      if (!requireApprovalsBaseHash(params, snapshot, respond)) {
+        return;
+      }
+      const incoming = (params as { file?: unknown }).file;
+      if (!incoming || typeof incoming !== "object") {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "exec approvals file is required"),
+        );
+        return;
+      }
+      const normalized = normalizeExecApprovals(incoming as ExecApprovalsFile);
+      const next = mergeExecApprovalsSocketDefaults({ normalized, current: snapshot.file });
+      saveExecApprovals(next);
+      const nextSnapshot = readExecApprovalsSnapshot();
+      respond(true, toExecApprovalsPayload(nextSnapshot), undefined);
+    });
   },
   "exec.approvals.node.get": async ({ params, respond, context }) => {
     if (


### PR DESCRIPTION
## What
Wrap local `exec.approvals.get` and `exec.approvals.set` gateway handlers in structured unavailable-error handling.

## Why
May gateway logs showed approval RPC traffic (`exec.approval.list`) but local approvals persistence paths could still throw through the request handler if state read/write failed, producing only generic gateway handler failures. This hardens the local path to match node approval handlers and returns an explicit `UNAVAILABLE` response instead.

## How
- Converts local get/set handlers to async handlers using existing `respondUnavailableOnThrow`.
- Preserves existing validation/base-hash behavior.
- Adds focused regression coverage for read/ensure and persist failures.

## Real behavior proof

Behavior or issue addressed: Local gateway `exec.approvals.get` returns a structured RPC `UNAVAILABLE` response when approval state setup/read fails, instead of letting the filesystem exception bubble to the generic gateway request-handler failure path.

Real environment tested: OpenClaw checkout `rex/approval-hardening-828` on Linux (`iris-gateway`), Node v22.22.0, running the patched gateway handler directly with `node --import tsx`. Filesystem failure reproduced with a temp `OPENCLAW_HOME` whose `.openclaw` state dir is a symlink to another temp dir, triggering the real exec-approvals path safety guard.

Exact steps or command run after this patch: Created temp `OPENCLAW_HOME`; symlinked `$OPENCLAW_HOME/.openclaw` to a separate temp directory; imported `src/gateway/server-methods/exec-approvals.ts` from this patched checkout; called `execApprovalsHandlers['exec.approvals.get']` with a real handler request object and captured `respond`.

Evidence after fix: Console output from the patched checkout:
```console
$ node --import tsx .tmp-proof-exec-approvals-get.mjs
{
  "ok": false,
  "code": "UNAVAILABLE",
  "message": "Error: Refusing to traverse symlink in exec approvals path must not traverse symlinked directory: /tmp/openclaw-approval-proof-zx6W3i/.openc"
}
```

Observed result after fix: The patched local handler caught the real filesystem safety exception and returned `{ ok: false, code: "UNAVAILABLE" }` through `respond`, which is the intended structured RPC failure mode. May 2026 live gateway log review also confirmed approval RPC activity (`exec.approval.list` succeeded on May 9 at 07:18 and 07:41 ET).

What was not tested: No live gateway restart/deploy was performed, and no production approval state was mutated. `exec.approvals.set` live failure was not forced against the running gateway; it is covered by focused regression tests plus the same shared wrapper path.

## Testing
- `node scripts/test-projects.mjs --maxWorkers=1 src/gateway/server-methods/exec-approvals.test.ts src/infra/exec-approvals-store.test.ts`
- `pnpm format:check src/gateway/server-methods/exec-approvals.ts src/gateway/server-methods/exec-approvals.test.ts`
- `pnpm lint:core`
- `pnpm tsgo:core:test`