### PR TITLE
fix(gateway): deliver targeted exec-event wakes when heartbeat.every is disabled

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1861,6 +1861,10 @@ tasks:
     enqueueSystemEvent("exec finished: backup completed", {
       sessionKey,
       contextKey: "exec:backup",
+      deliveryContext: {
+        channel: "whatsapp",
+        to: "120363401234567890@g.us",
+      },
     });
 
     const replySpy = vi.fn();
@@ -1881,8 +1885,10 @@ tasks:
         deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
       });
       expect(res.status).toBe("ran");
-      const calledCtx = replySpy.mock.calls[0]?.[0] as { Provider?: string };
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { Provider?: string; Body?: string };
       expect(calledCtx.Provider).toBe("exec-event");
+      expect(calledCtx.Body).toContain("Please relay the command output to the user");
     } finally {
       replySpy.mockReset();
     }

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1832,4 +1832,59 @@ tasks:
       replySpy.mockReset();
     }
   });
+
+  it("runs targeted exec-event wakes even when heartbeat every is 0m", async () => {
+    const tmpDir = await createCaseDir("hb-exec-zero-interval");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "0m", target: "none" },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "120363401234567890@g.us",
+        },
+      }),
+    );
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup",
+    });
+
+    const replySpy = vi.fn();
+    replySpy.mockResolvedValue({ text: "Handled internally" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        sessionKey,
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+      expect(res.status).toBe("ran");
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { Provider?: string };
+      expect(calledCtx.Provider).toBe("exec-event");
+    } finally {
+      replySpy.mockReset();
+    }
+  });
 });

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -513,6 +513,33 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("dispatches targeted exec-event wakes even when heartbeat every is 0m", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = await expectWakeDispatch({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "0m" } },
+        },
+      } as OpenClawConfig,
+      runSpy,
+      wake: {
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        sessionKey: "agent:main:main",
+        coalesceMs: 0,
+      },
+      expectedCall: {
+        agentId: "main",
+        reason: "exec-event",
+        sessionKey: "agent:main:main",
+      },
+    });
+
+    runner.stop();
+  });
+
   // Regression for runaway heartbeat loop: backgrounded `process.start` exits
   // call `requestHeartbeat({reason: "exec-event"})` from
   // `bash-tools.exec-runtime.ts:347` (`maybeNotifyOnExit`). If a heartbeat run

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -593,6 +593,47 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("keeps cooldown bookkeeping for repeated zero-interval exec-event wakes", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "0m" } },
+        },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeat({
+      source: "exec-event",
+      intent: "event",
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    for (let i = 0; i < 3; i++) {
+      await vi.advanceTimersByTimeAsync(10_000);
+      requestHeartbeat({
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        sessionKey: "agent:main:main",
+        coalesceMs: 0,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+    }
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    runner.stop();
+  });
+
   it("preserves immediate delivery for repeated bare wake reasons", async () => {
     // 'wake' is the immediate-path reason from `openclaw system event --mode now`
     // and must NOT be deferred. Verify the runner allows multiple back-to-back

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -207,6 +207,10 @@ type HeartbeatAgent = {
 
 export { isCronSystemEvent };
 
+function isExecEventWake(params: { source?: HeartbeatWakeSource; reason?: string }): boolean {
+  return params.source === "exec-event" || params.reason === "exec-event";
+}
+
 function canHeartbeatDeliverCommitments(heartbeat?: HeartbeatConfig): boolean {
   return (normalizeOptionalString(heartbeat?.target) ?? "none") !== "none";
 }
@@ -1187,7 +1191,7 @@ export async function runHeartbeatOnce(opts: {
   if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
     return { status: "skipped", reason: "disabled" };
   }
-  if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
+  if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat) && !isExecEventWake(opts)) {
     return { status: "skipped", reason: "disabled" };
   }
 
@@ -2163,7 +2167,15 @@ export function startHeartbeatRunner(opts: {
         reason: "disabled",
       } satisfies HeartbeatRunResult;
     }
-    if (state.agents.size === 0) {
+    const requestedAgentId = params?.agentId ? normalizeAgentId(params.agentId) : undefined;
+    const requestedSessionKey = normalizeOptionalString(params?.sessionKey);
+    const requestedHeartbeat = params?.heartbeat;
+    const resolveRequestedHeartbeat = (heartbeat?: HeartbeatConfig) =>
+      requestedHeartbeat ? { ...heartbeat, ...requestedHeartbeat } : heartbeat;
+    const isTargetedExecEventWake =
+      isExecEventWake(params ?? {}) && Boolean(requestedSessionKey || requestedAgentId);
+
+    if (state.agents.size === 0 && !isTargetedExecEventWake) {
       return {
         status: "skipped",
         reason: "disabled",
@@ -2172,11 +2184,6 @@ export function startHeartbeatRunner(opts: {
 
     const reason = params?.reason;
     const intent = params.intent;
-    const requestedAgentId = params?.agentId ? normalizeAgentId(params.agentId) : undefined;
-    const requestedSessionKey = normalizeOptionalString(params?.sessionKey);
-    const requestedHeartbeat = params?.heartbeat;
-    const resolveRequestedHeartbeat = (heartbeat?: HeartbeatConfig) =>
-      requestedHeartbeat ? { ...heartbeat, ...requestedHeartbeat } : heartbeat;
     const isInterval = reason === "interval";
     const startedAt = Date.now();
     const now = startedAt;
@@ -2190,7 +2197,19 @@ export function startHeartbeatRunner(opts: {
         const targetAgentId = requestedAgentId ?? resolveAgentIdFromSessionKey(requestedSessionKey);
         const targetAgent = state.agents.get(targetAgentId);
         if (!targetAgent) {
-          return { status: "skipped", reason: "disabled" };
+          if (!isTargetedExecEventWake) {
+            return { status: "skipped", reason: "disabled" };
+          }
+          return await runOnce({
+            cfg: state.cfg,
+            agentId: targetAgentId,
+            heartbeat: resolveRequestedHeartbeat(resolveHeartbeatConfig(state.cfg, targetAgentId)),
+            source: params.source,
+            intent,
+            reason,
+            sessionKey: requestedSessionKey,
+            deps: { runtime: state.runtime },
+          });
         }
         const deferral = evaluateWakeDeferral(targetAgent, now, reason, intent);
         if (deferral.defer) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -91,7 +91,12 @@ import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/t
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
 import { formatErrorMessage, hasErrnoCode } from "./errors.js";
 import { isWithinActiveHours, resolveActiveHoursTimezone } from "./heartbeat-active-hours.js";
-import { recordRunStart, shouldDeferWake, type DeferDecision } from "./heartbeat-cooldown.js";
+import {
+  DEFAULT_MIN_WAKE_SPACING_MS,
+  recordRunStart,
+  shouldDeferWake,
+  type DeferDecision,
+} from "./heartbeat-cooldown.js";
 import {
   buildCronEventPrompt,
   buildExecEventPrompt,
@@ -1296,9 +1301,19 @@ export async function runHeartbeatOnce(opts: {
         threadId: firstDueCommitment.threadId,
       }
     : undefined;
+  const shouldRelayTargetedExecEventDelivery =
+    isExecEventWake(opts) &&
+    Boolean(opts.sessionKey || opts.agentId) &&
+    !resolveHeartbeatIntervalMs(cfg, undefined, heartbeat) &&
+    (normalizeOptionalString(heartbeat?.target) ?? "none") === "none" &&
+    Boolean(
+      preflight.turnSourceDeliveryContext?.channel || preflight.turnSourceDeliveryContext?.to,
+    );
   const heartbeatForDelivery = commitmentDeliveryContext
     ? { ...heartbeat, target: "last", to: undefined, accountId: undefined }
-    : heartbeat;
+    : shouldRelayTargetedExecEventDelivery
+      ? { ...heartbeat, target: "last", to: undefined, accountId: undefined }
+      : heartbeat;
   const delivery = resolveHeartbeatDeliveryTarget({
     cfg,
     entry,
@@ -1954,6 +1969,7 @@ export function startHeartbeatRunner(opts: {
     runtime,
     schedulerSeed: resolveHeartbeatSchedulerSeed(opts.stableSchedulerSeed),
     agents: new Map<string, HeartbeatAgentState>(),
+    execEventAgents: new Map<string, HeartbeatAgentState>(),
     timer: null as NodeJS.Timeout | null,
     stopped: false,
   };
@@ -2038,6 +2054,26 @@ export function startHeartbeatRunner(opts: {
     agent.lastRunStartedAtMs = now;
     recordRunStart(agent.recentRunStarts, now);
     agent.floodLoggedSinceLastRun = false;
+  };
+
+  const resolveExecEventAgentState = (
+    agentId: string,
+    heartbeat?: HeartbeatConfig,
+  ): HeartbeatAgentState => {
+    const prevState = state.execEventAgents.get(agentId);
+    const nextState: HeartbeatAgentState = {
+      agentId,
+      heartbeat,
+      activeHoursSchedule: resolveActiveHoursSchedule(state.cfg, heartbeat),
+      intervalMs: prevState?.intervalMs ?? DEFAULT_MIN_WAKE_SPACING_MS,
+      phaseMs: prevState?.phaseMs ?? 0,
+      nextDueMs: prevState?.nextDueMs ?? 0,
+      lastRunStartedAtMs: prevState?.lastRunStartedAtMs,
+      recentRunStarts: prevState?.recentRunStarts ?? [],
+      floodLoggedSinceLastRun: prevState?.floodLoggedSinceLastRun ?? false,
+    };
+    state.execEventAgents.set(agentId, nextState);
+    return nextState;
   };
 
   const scheduleNext = () => {
@@ -2197,19 +2233,51 @@ export function startHeartbeatRunner(opts: {
         const targetAgentId = requestedAgentId ?? resolveAgentIdFromSessionKey(requestedSessionKey);
         const targetAgent = state.agents.get(targetAgentId);
         if (!targetAgent) {
-          if (!isTargetedExecEventWake) {
+          if (!isTargetedExecEventWake || !targetAgentId) {
             return { status: "skipped", reason: "disabled" };
           }
-          return await runOnce({
-            cfg: state.cfg,
-            agentId: targetAgentId,
-            heartbeat: resolveRequestedHeartbeat(resolveHeartbeatConfig(state.cfg, targetAgentId)),
-            source: params.source,
-            intent,
-            reason,
-            sessionKey: requestedSessionKey,
-            deps: { runtime: state.runtime },
-          });
+          const fallbackHeartbeat = resolveRequestedHeartbeat(
+            resolveHeartbeatConfig(state.cfg, targetAgentId),
+          );
+          const fallbackAgent = resolveExecEventAgentState(targetAgentId, fallbackHeartbeat);
+          const deferral = evaluateWakeDeferral(fallbackAgent, now, reason, intent);
+          if (deferral.defer) {
+            return { status: "skipped", reason: deferral.reason };
+          }
+          try {
+            const res = await runOnce({
+              cfg: state.cfg,
+              agentId: targetAgentId,
+              heartbeat: fallbackHeartbeat,
+              source: params.source,
+              intent,
+              reason,
+              sessionKey: requestedSessionKey,
+              deps: { runtime: state.runtime },
+            });
+            if (res.status === "skipped" && isRetryableHeartbeatBusySkipReason(res.reason)) {
+              retryableBusySkip = true;
+              return res;
+            }
+            recordRunBookkeeping(fallbackAgent, now);
+            if (res.status !== "skipped" || res.reason !== "disabled") {
+              advanceAgentSchedule(fallbackAgent, now, reason);
+            }
+            return res.status === "ran"
+              ? { status: "ran", durationMs: Date.now() - startedAt }
+              : res;
+          } catch (err) {
+            const errMsg = formatErrorMessage(err);
+            log.error(
+              `heartbeat runner: targeted zero-interval runOnce threw unexpectedly: ${errMsg}`,
+              {
+                error: errMsg,
+              },
+            );
+            recordRunBookkeeping(fallbackAgent, now);
+            advanceAgentSchedule(fallbackAgent, now, reason);
+            return { status: "failed", reason: errMsg };
+          }
         }
         const deferral = evaluateWakeDeferral(targetAgent, now, reason, intent);
         if (deferral.defer) {


### PR DESCRIPTION
## Summary
- allow targeted `exec-event` heartbeat wakes to run even when `heartbeat.every` resolves disabled (`0m`)
- keep ordinary disabled heartbeats disabled by limiting the bypass to targeted exec-event wakes
- add regression coverage for both scheduler dispatch and `runHeartbeatOnce`

## Problem
Issue #62505 reports that coding-agent/background work can appear to never complete. One narrow cause is that background exec completion already enqueues an `exec-event` wake, but heartbeat dispatch drops it when `heartbeat.every` is disabled. That blocks the one-shot completion wake even though it is not a periodic heartbeat run.

## Changes
- in `src/infra/heartbeat-runner.ts`
  - allow `runHeartbeatOnce(...)` to proceed for `exec-event` wakes when the interval is otherwise disabled
  - allow targeted/session-scoped `exec-event` wakes through the runner even when no interval-backed agent state exists
- add focused regression tests in:
  - `src/infra/heartbeat-runner.scheduler.test.ts`
  - `src/infra/heartbeat-runner.returns-default-unset.test.ts`

## Testing
- `pnpm exec oxlint src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
- attempted focused Vitest, but the repo-local test harness is currently failing in this environment before these tests execute:
  - `test/non-isolated-runner.ts` throws `Class extends value undefined is not a constructor or null`

Closes #62505
