### PR TITLE
fix(cli): preserve portable default workspace paths in config writes

### DIFF
--- a/src/agents/workspace-default.ts
+++ b/src/agents/workspace-default.ts
@@ -3,6 +3,14 @@ import path from "node:path";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 
+function resolvePortableDefaultAgentWorkspacePath(env: NodeJS.ProcessEnv = process.env): string {
+  const profile = env.OPENCLAW_PROFILE?.trim();
+  if (profile && normalizeOptionalLowercaseString(profile) !== "default") {
+    return `~/.openclaw/workspace-${profile}`;
+  }
+  return "~/.openclaw/workspace";
+}
+
 export function resolveDefaultAgentWorkspaceDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
@@ -13,6 +21,22 @@ export function resolveDefaultAgentWorkspaceDir(
     return path.join(home, ".openclaw", `workspace-${profile}`);
   }
   return path.join(home, ".openclaw", "workspace");
+}
+
+export function canonicalizeDefaultAgentWorkspacePath(
+  workspaceDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  const trimmed = workspaceDir.trim();
+  if (!trimmed.startsWith("~")) {
+    const resolvedInput = path.resolve(trimmed);
+    const resolvedDefault = resolveDefaultAgentWorkspaceDir(env, homedir);
+    if (resolvedInput === resolvedDefault) {
+      return resolvePortableDefaultAgentWorkspacePath(env);
+    }
+  }
+  return trimmed;
 }
 
 export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
+import {
+  canonicalizeDefaultAgentWorkspacePath,
+  resolveDefaultAgentWorkspaceDir,
+} from "./workspace.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -15,5 +18,37 @@ describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
     expect(resolveDefaultAgentWorkspaceDir()).toBe(
       path.join(path.resolve(home), ".openclaw", "workspace"),
     );
+  });
+
+  it("canonicalizes the resolved default workspace back to a portable path", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+
+    expect(
+      canonicalizeDefaultAgentWorkspacePath(
+        path.join(path.resolve(home), ".openclaw", "workspace"),
+      ),
+    ).toBe("~/.openclaw/workspace");
+  });
+
+  it("preserves explicit custom absolute workspaces", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+
+    expect(canonicalizeDefaultAgentWorkspacePath("/tmp/custom-workspace")).toBe(
+      "/tmp/custom-workspace",
+    );
+  });
+
+  it("canonicalizes profile-specific default workspaces", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    vi.stubEnv("OPENCLAW_PROFILE", "dev");
+
+    expect(
+      canonicalizeDefaultAgentWorkspacePath(
+        path.join(path.resolve(home), ".openclaw", "workspace-dev"),
+      ),
+    ).toBe("~/.openclaw/workspace-dev");
   });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -15,6 +15,7 @@ import { resolveUserPath } from "../utils.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "./workspace-default.js";
 import { resolveWorkspaceTemplateDir } from "./workspace-templates.js";
 export {
+  canonicalizeDefaultAgentWorkspacePath,
   DEFAULT_AGENT_WORKSPACE_DIR,
   resolveDefaultAgentWorkspaceDir,
 } from "./workspace-default.js";

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -626,7 +626,7 @@ describe("runConfigureWizard", () => {
     expect(retryCall.nextConfig).toMatchObject({
       agents: {
         defaults: {
-          workspace: expect.stringContaining("/.openclaw/workspace"),
+          workspace: "~/.openclaw/workspace",
         },
       },
       plugins: {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -2,6 +2,7 @@ import fsPromises from "node:fs/promises";
 import nodePath from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { describeCodexNativeWebSearch } from "../agents/codex-native-web-search.shared.js";
+import { canonicalizeDefaultAgentWorkspacePath } from "../agents/workspace-default.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { commitConfigWithPendingPluginInstalls } from "../cli/plugins-install-record-commit.js";
 import { readConfigFileSnapshot, resolveGatewayPort } from "../config/config.js";
@@ -585,7 +586,7 @@ export async function runConfigureWizard(
           ...nextConfig.agents,
           defaults: {
             ...nextConfig.agents?.defaults,
-            workspace: workspaceDir,
+            workspace: canonicalizeDefaultAgentWorkspacePath(workspaceDir),
           },
         },
       };

--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   applyLocalSetupWorkspaceConfig,
@@ -7,6 +8,13 @@ import {
 } from "./onboard-config.js";
 
 describe("applyLocalSetupWorkspaceConfig", () => {
+  it("persists the recognized default workspace as a portable path", () => {
+    const baseConfig: OpenClawConfig = {};
+    const result = applyLocalSetupWorkspaceConfig(baseConfig, resolveDefaultAgentWorkspaceDir());
+
+    expect(result.agents?.defaults?.workspace).toBe("~/.openclaw/workspace");
+  });
+
   it("defaults local setup tool profile to coding", () => {
     expect(ONBOARDING_DEFAULT_TOOLS_PROFILE).toBe("coding");
   });

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -1,3 +1,4 @@
+import { canonicalizeDefaultAgentWorkspacePath } from "../agents/workspace-default.js";
 import { setConfigValueAtPath } from "../config/config-paths.js";
 import type { DmScope } from "../config/types.base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -10,13 +11,14 @@ export function applyLocalSetupWorkspaceConfig(
   baseConfig: OpenClawConfig,
   workspaceDir: string,
 ): OpenClawConfig {
+  const persistedWorkspaceDir = canonicalizeDefaultAgentWorkspacePath(workspaceDir);
   return {
     ...baseConfig,
     agents: {
       ...baseConfig.agents,
       defaults: {
         ...baseConfig.agents?.defaults,
-        workspace: workspaceDir,
+        workspace: persistedWorkspaceDir,
       },
     },
     gateway: {

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -186,7 +186,7 @@ describe("setupCommand", () => {
         gateway?: { mode?: string };
       };
 
-      expect(raw.agents?.defaults?.workspace).toBe(workspace);
+      expect(raw.agents?.defaults?.workspace).toBe("~/.openclaw/workspace");
       expect(raw.gateway?.mode).toBe("local");
     });
   });

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -48,6 +48,30 @@ describe("setupCommand", () => {
     });
   });
 
+  it("persists the default workspace as a portable path on first run", async () => {
+    await withTempHome(async (home) => {
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      const deps = createSetupDeps(home);
+      const workspace = path.join(home, ".openclaw", "workspace");
+
+      await setupCommand({ workspace }, runtime, deps);
+
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const raw = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        agents?: { defaults?: { workspace?: string } };
+      };
+
+      expect(raw.agents?.defaults?.workspace).toBe("~/.openclaw/workspace");
+      expect(deps.ensureAgentWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({ dir: workspace }),
+      );
+    });
+  });
+
   it("explains that plain setup only initializes local files", async () => {
     await withTempHome(async (home) => {
       const runtime = {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -40,11 +40,15 @@ type SetupCommandDeps = {
 };
 
 type AgentWorkspaceModule = typeof import("../agents/workspace.js");
+type AgentWorkspaceDefaultModule = typeof import("../agents/workspace-default.js");
 type ConfigIOModule = typeof import("../config/config.js");
 type ConfigLoggingModule = typeof import("../config/logging.js");
 
 const agentWorkspaceModuleLoader = createLazyImportLoader<AgentWorkspaceModule>(
   () => import("../agents/workspace.js"),
+);
+const agentWorkspaceDefaultModuleLoader = createLazyImportLoader<AgentWorkspaceDefaultModule>(
+  () => import("../agents/workspace-default.js"),
 );
 const configIOModuleLoader = createLazyImportLoader<ConfigIOModule>(
   () => import("../config/config.js"),
@@ -55,6 +59,10 @@ const configLoggingModuleLoader = createLazyImportLoader<ConfigLoggingModule>(
 
 function loadAgentWorkspaceModule(): Promise<AgentWorkspaceModule> {
   return agentWorkspaceModuleLoader.load();
+}
+
+function loadAgentWorkspaceDefaultModule(): Promise<AgentWorkspaceDefaultModule> {
+  return agentWorkspaceDefaultModuleLoader.load();
 }
 
 function loadConfigIOModule(): Promise<ConfigIOModule> {
@@ -146,6 +154,8 @@ export async function setupCommand(
 
   const workspace =
     desiredWorkspace ?? defaults.workspace ?? (await resolveDefaultAgentWorkspaceDir(deps));
+  const { canonicalizeDefaultAgentWorkspacePath } = await loadAgentWorkspaceDefaultModule();
+  const persistedWorkspace = canonicalizeDefaultAgentWorkspacePath(workspace);
 
   const next: OpenClawConfig = {
     ...cfg,
@@ -153,7 +163,7 @@ export async function setupCommand(
       ...cfg.agents,
       defaults: {
         ...defaults,
-        workspace,
+        workspace: persistedWorkspace,
       },
     },
     gateway: {
@@ -164,7 +174,7 @@ export async function setupCommand(
 
   if (
     !existingRaw.exists ||
-    defaults.workspace !== workspace ||
+    defaults.workspace !== persistedWorkspace ||
     cfg.gateway?.mode !== next.gateway?.mode
   ) {
     const replaceConfig =
@@ -178,7 +188,7 @@ export async function setupCommand(
       runtime.log(`Wrote ${await formatConfigPath(configPath)}`);
     } else {
       const updates: string[] = [];
-      if (defaults.workspace !== workspace) {
+      if (defaults.workspace !== persistedWorkspace) {
         updates.push("set agents.defaults.workspace");
       }
       if (cfg.gateway?.mode !== next.gateway?.mode) {


### PR DESCRIPTION
## Summary
- canonicalize recognized default workspace paths back to portable `~/.openclaw/...` forms when writing config
- preserve explicit custom absolute workspaces unchanged
- cover setup/onboarding/configure write paths with focused tests

## Problem
Issue #51429 reports that default workspace paths are being persisted as machine-specific absolute home paths instead of portable `~/.openclaw/workspace` values. Runtime resolution is fine; the bug is in config serialization during setup/onboarding/configure flows.

## Changes
- add `canonicalizeDefaultAgentWorkspacePath()` alongside default workspace helpers
- thread that canonicalization through config write points in:
  - `src/commands/onboard-config.ts`
  - `src/commands/setup.ts`
  - `src/commands/configure.wizard.ts`
- export the helper through `src/agents/workspace.ts`
- add tests for:
  - default workspace canonicalization
  - profile-specific default workspace canonicalization
  - preserving custom absolute workspaces
  - setup/onboarding/configure persistence behavior

## Testing
- `pnpm exec oxlint src/agents/workspace-default.ts src/agents/workspace.defaults.test.ts src/agents/workspace.ts src/commands/configure.wizard.test.ts src/commands/configure.wizard.ts src/commands/onboard-config.test.ts src/commands/onboard-config.ts src/commands/setup.test.ts src/commands/setup.ts`
- attempted focused Vitest, but the repo-local test harness is currently failing in this environment before these tests execute:
  - `src/commands/onboard-config.test.ts` import chain fails on missing `@openclaw/fs-safe/config`
  - separate focused runs also hit `test/non-isolated-runner.ts` runner initialization failure

Closes #51429
