### PR TITLE
fix(btw): apply provider wrapStreamFn so /btw against Copilot adds IDE headers

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -19,6 +19,7 @@ const resolveSessionAgentIdsMock = vi.fn();
 const resolveAgentWorkspaceDirMock = vi.fn();
 const listAgentEntriesMock = vi.fn();
 const prepareProviderRuntimeAuthMock = vi.fn();
+const wrapProviderStreamFnMock = vi.fn();
 const registerProviderStreamForModelMock = vi.fn();
 const diagDebugMock = vi.fn();
 
@@ -76,6 +77,7 @@ vi.mock("./agent-scope.js", () => ({
 
 vi.mock("../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: (...args: unknown[]) => prepareProviderRuntimeAuthMock(...args),
+  wrapProviderStreamFn: (...args: unknown[]) => wrapProviderStreamFnMock(...args),
 }));
 
 vi.mock("./provider-stream.js", () => ({
@@ -302,6 +304,10 @@ describe("runBtwSideQuestion", () => {
     resolveAgentWorkspaceDirMock.mockReset();
     listAgentEntriesMock.mockReset();
     prepareProviderRuntimeAuthMock.mockReset();
+    wrapProviderStreamFnMock.mockReset();
+    // Default to no-op wrapping; tests that care about the wrapped fn can
+    // override the mock individually.
+    wrapProviderStreamFnMock.mockReturnValue(undefined);
     registerProviderStreamForModelMock.mockReset();
     diagDebugMock.mockReset();
 
@@ -526,6 +532,45 @@ describe("runBtwSideQuestion", () => {
 
     expect(result).toEqual({ text: "Fallback answer." });
     expect(streamSimpleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the provider plugin's wrapStreamFn so /btw against Copilot adds Editor-Version headers", async () => {
+    // Regression: before this fix, /btw called the base provider stream fn
+    // (or streamSimple) without invoking wrapProviderStreamFn, so github-
+    // copilot models bypassed buildCopilotIdeHeaders and the Copilot API
+    // returned 400 "missing Editor-Version header for IDE auth".
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "github-copilot",
+      id: "claude-opus-4.7-1m-internal",
+      api: "anthropic-messages",
+      baseUrl: "https://api.individual.githubcopilot.com",
+    });
+    const baseStreamFn = vi.fn();
+    const wrappedStreamFn = vi
+      .fn()
+      .mockReturnValue(makeAsyncEvents([createDoneEvent("Copilot answer.")]));
+    registerProviderStreamForModelMock.mockReturnValue(baseStreamFn);
+    wrapProviderStreamFnMock.mockReturnValue(wrappedStreamFn);
+
+    const result = await runSideQuestion({
+      provider: "github-copilot",
+      model: "claude-opus-4.7-1m-internal",
+    });
+
+    expect(result).toEqual({ text: "Copilot answer." });
+    expect(wrapProviderStreamFnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "github-copilot",
+        context: expect.objectContaining({
+          provider: "github-copilot",
+          modelId: "claude-opus-4.7-1m-internal",
+          streamFn: baseStreamFn,
+        }),
+      }),
+    );
+    expect(wrappedStreamFn).toHaveBeenCalledTimes(1);
+    expect(baseStreamFn).not.toHaveBeenCalled();
+    expect(streamSimpleMock).not.toHaveBeenCalled();
   });
 
   it("strips injected empty tools arrays from BTW payloads before sending", async () => {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -12,7 +12,7 @@ import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
 import type { SessionEntry as StoredSessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.js";
+import { prepareProviderRuntimeAuth, wrapProviderStreamFn } from "../plugins/provider-runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
@@ -397,13 +397,44 @@ export async function runBtwSideQuestion(
   // `/api/chat` or `/v1/chat/completions` paths based on api mode) construct
   // URLs correctly. Without this, streamSimple hits the provider's baseUrl
   // directly and 404s on endpoints like Ollama Cloud (#68336).
-  const providerStreamFn = registerProviderStreamForModel({
+  const providerStreamBase = registerProviderStreamForModel({
     model: runtimeModel,
     cfg: params.cfg,
     agentDir: params.agentDir,
     workspaceDir,
     env: process.env,
   });
+  // Apply the provider plugin's wrapStreamFn (e.g. github-copilot's IDE
+  // header injection). Without this, /btw against Copilot models fails with
+  // "400 bad request: missing Editor-Version header for IDE auth" because the
+  // base stream fn is the raw transport-aware fn that doesn't add the
+  // Editor-Version / Editor-Plugin-Version / User-Agent headers Copilot
+  // requires for /chat/completions.
+  //
+  // When `registerProviderStreamForModel` returns undefined (the common case
+  // for github-copilot in the btw runtime, where neither a custom transport
+  // nor a plugin-registered stream is wired up), pass `streamSimple` as the
+  // wrap base so the copilot wrap can still attach IDE headers on top of the
+  // default transport. Without this fallback, the wrap returns undefined
+  // (because `wrapCopilotAnthropicStream(undefined)` short-circuits to
+  // undefined) and the caller silently falls back to bare `streamSimple`,
+  // which has no IDE headers and 400s on the Copilot API.
+  const providerStreamWrapped = wrapProviderStreamFn({
+    provider: model.provider,
+    config: params.cfg,
+    workspaceDir,
+    env: process.env,
+    context: {
+      config: params.cfg,
+      agentDir: params.agentDir,
+      workspaceDir,
+      provider: model.provider,
+      modelId: model.id,
+      model: runtimeModel,
+      streamFn: providerStreamBase ?? streamSimple,
+    },
+  });
+  const providerStreamFn = providerStreamWrapped ?? providerStreamBase;
 
   const chunker =
     params.opts?.onBlockReply && params.blockReplyChunking


### PR DESCRIPTION
## Problem

`/btw` against `github-copilot` Anthropic-API models (e.g. `claude-opus-4.7-1m-internal`) fails with:

```
/btw failed: 400 bad request: missing Editor-Version header for IDE auth
```

**Why**: `runBtwSideQuestion` (`src/agents/btw.ts`) prepares Copilot transport auth (baseUrl, apiKey) but never wires the provider plugin's `wrapStreamFn`, so the request reaches Copilot without the IDE headers (`Editor-Version`, `Editor-Plugin-Version`, `User-Agent`) that the github-copilot extension's `wrapCopilotProviderStream` normally injects. This is the same path the main agent runtime exercises through `pi-embedded-runner/extra-params.ts:817`, but `runBtwSideQuestion` was missing it.

There's a second, less obvious leg: `registerProviderStreamForModel` returns `undefined` for github-copilot in this runtime context (no custom transport / no plugin-registered stream is wired up here). When the wrap base is `undefined`, `wrapCopilotAnthropicStream` short-circuits to `undefined`, so just adding the wrap call wasn't enough on its own - the patched code would silently fall back to bare `streamSimple` (no IDE headers) and 400 just the same. The fix has to provide `streamSimple` as the wrap base so the Copilot wrap can attach IDE headers on top of the default transport.

## Fix

After `registerProviderStreamForModel` returns the base stream, call `wrapProviderStreamFn` to layer the provider plugin's stream wrappers and pass `streamSimple` as the fallback base when no provider stream was registered. For github-copilot, this is `wrapCopilotProviderStream`, which composes `wrapCopilotOpenAIResponsesStream(wrapCopilotAnthropicStream(...))` and adds the IDE headers via `buildCopilotRequestHeaders`. Non-Copilot providers gracefully fall back to the unwrapped base stream.

## Verification

- `pnpm test -- --run src/agents/btw.test.ts` - **26/26 passing** (no regressions)
- Manually verified live by deploying the patched build to my local install and invoking `/btw test` from Discord against `github-copilot/claude-opus-4.7-1m-internal`. Before the fix: `400 bad request: missing Editor-Version header for IDE auth`. After the fix: side-question reply renders normally. Local debug output during repro confirmed `streamBase=undef wrapped=yes final=set`, so the wrap is what made the difference.

## Scope

- 1 commit, 2 files, +78/-2
- Touches only `src/agents/btw.ts` (and `src/agents/btw.test.ts` regression check)
- No effect on non-Copilot providers (they go through the same wrap with an undefined wrap result, falling back to the unwrapped base)
