### PR TITLE
fix(acp): tolerate unsupported timeout config control

### DIFF
--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -10,6 +10,14 @@ import {
   resolveRuntimeOptionsFromMeta,
 } from "./runtime-options.js";
 
+function isUnsupportedOptionalTimeoutConfigOptionError(key: string, error: unknown): boolean {
+  if (key !== "timeout") {
+    return false;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("session/set_config_option") && message.includes("Method not found");
+}
+
 export async function resolveManagerRuntimeCapabilities(params: {
   runtime: AcpRuntime;
   handle: AcpRuntimeHandle;
@@ -100,11 +108,18 @@ export async function applyManagerRuntimeControls(params: {
               `ACP backend "${backend}" does not accept config key "${key}".`,
             );
           }
-          await params.runtime.setConfigOption({
-            handle: params.handle,
-            key,
-            value,
-          });
+          try {
+            await params.runtime.setConfigOption({
+              handle: params.handle,
+              key,
+              value,
+            });
+          } catch (error) {
+            if (isUnsupportedOptionalTimeoutConfigOptionError(key, error)) {
+              continue;
+            }
+            throw error;
+          }
         }
       }
     },

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -3005,6 +3005,94 @@ describe("AcpSessionManager", () => {
     );
   });
 
+  it("continues turns when only optional timeout config is unsupported by the backend", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
+      if (input.key === "timeout") {
+        throw new Error(
+          'Agent rejected session/set_config_option for "timeout"="120": "Method not found": session/set_config_option (ACP -32601)',
+        );
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:pi:acp:session-1",
+      storeSessionKey: "agent:pi:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "pi" }),
+        runtimeOptions: {
+          model: "openai-codex/gpt-5.5",
+          timeoutSeconds: 120,
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:pi:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "model",
+        value: "openai-codex/gpt-5.5",
+      }),
+    );
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "timeout",
+        value: "120",
+      }),
+    );
+    expect(runtimeState.runTurn).toHaveBeenCalled();
+  });
+
+  it("still fails when non-timeout runtime config options are unsupported by the backend", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.setConfigOption.mockRejectedValue(
+      new Error(
+        'Agent rejected session/set_config_option for "model"="gpt": "Method not found": session/set_config_option (ACP -32601)',
+      ),
+    );
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:pi:acp:session-1",
+      storeSessionKey: "agent:pi:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "pi" }),
+        runtimeOptions: {
+          model: "gpt",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:pi:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_TURN_FAILED",
+    });
+    expect(runtimeState.runTurn).not.toHaveBeenCalled();
+  });
+
   it("re-ensures runtime handles after cwd runtime option updates", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({


### PR DESCRIPTION
# PR draft: tolerate unsupported optional ACP timeout config control

## Title

Tolerate unsupported ACP timeout config control before turns

## Summary

This change lets ACP turns continue when a backend rejects only the optional `timeout` runtime config option because it does not implement `session/set_config_option`.

The motivating case is Pi ACP: normal turns work, but `sessions_spawn(runtime="acp", agentId="pi", timeoutSeconds=..., runTimeoutSeconds=...)` currently fails before the turn because Pi rejects `session/set_config_option` for `timeout` with ACP `-32601 Method not found`.

## Behavior

- Continue to apply supported runtime config options normally.
- If the config key is exactly `timeout` and the backend error says `session/set_config_option` + `Method not found`, skip only that optional timeout control and continue the turn.
- Preserve existing fail-fast behavior for:
  - unsupported model/thinking/approval config controls;
  - advertised-key mismatches;
  - timeout errors that are not `Method not found` for `session/set_config_option`.

## Files changed in source patch

- `src/acp/control-plane/manager.runtime-controls.ts`
- `src/acp/control-plane/manager.test.ts`

## Real behavior proof

- **Behavior or issue addressed**: Pi ACP turns failed before execution when OpenClaw sent the optional `timeout` runtime config through `session/set_config_option`; Pi ACP returned ACP `-32601 Method not found` for that method even though normal turns worked.
- **Real environment tested**: Local OpenClaw setup on macOS with the same compatibility behavior applied to `/opt/homebrew/lib/node_modules/openclaw/dist/manager-COKTdQPh.js`, using real `sessions_spawn(runtime="acp", agentId="pi", runTimeoutSeconds=60, timeoutSeconds=20)` against Pi ACP.
- **Exact steps or command run after this patch**:

```text
sessions_spawn(runtime="acp", agentId="pi", runTimeoutSeconds=60, timeoutSeconds=20)
python3 scripts/ensure_pi_acp_timeout_patch.py --check
node --check /opt/homebrew/lib/node_modules/openclaw/dist/manager-COKTdQPh.js
```

- **Evidence after fix**:

```text
Real Pi ACP spawn completed with timeout controls present.
Observed live output: pi-timeout-patch-ok
OK patch present: /opt/homebrew/lib/node_modules/openclaw/dist/manager-COKTdQPh.js
```

- **Observed result after fix**: The real Pi ACP turn no longer failed on `session/set_config_option` for `timeout`; it continued and returned `pi-timeout-patch-ok`.
- **What was not tested**: Full repository CI was not run locally; targeted Vitest/lint and the live Pi ACP timeout spawn were tested.

Before-fix evidence optional:

```text
AcpRuntimeError: Agent rejected session/set_config_option for "timeout"="120": "Method not found": session/set_config_option (ACP -32601).
```

## Local verification completed

```text
npm install --prefix workspace-local .tools --no-save pnpm@10.33.2
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/acp/control-plane/manager.test.ts
pnpm exec oxlint src/acp/control-plane/manager.runtime-controls.ts src/acp/control-plane/manager.test.ts
git diff --check
git apply --reverse --check reports/acp-evals/openclaw-source-pi-acp-timeout-compatibility.patch
python3 scripts/ensure_pi_acp_timeout_patch.py --check
node --check /opt/homebrew/lib/node_modules/openclaw/dist/manager-COKTdQPh.js
```

Targeted Vitest result:

```text
1 passed, 59 passed tests
```

Also previously verified against the live local hotfix:

```text
sessions_spawn(runtime="acp", agentId="pi", runTimeoutSeconds=60, timeoutSeconds=20)
→ pi-timeout-patch-ok
```

## Verification not completed

Full repository CI was not run locally. The broad local gate wrapper was stopped because it invokes full repo `npm test`/lint and exceeded the useful targeted validation scope for this two-file change.
