### PR TITLE
fix(daemon/launchd): cap unbounded gateway stdout/stderr log growth (refs #79422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Daemon/launchd: rotate the gateway stdout and stderr sinks at install, plist rewrite, and `gateway restart` once they exceed the configured cap, so a stuck dep-staging error loop can no longer grow `gateway.err.log` to tens of gigabytes between restarts. Default cap is 64 MB per stream with one archive, configurable via `OPENCLAW_GATEWAY_LOG_MAX_BYTES` and `OPENCLAW_GATEWAY_LOG_ARCHIVES`. Refs #79422 (log-retention half only; the CPU/dep-staging loop in that issue stays open for separate live-profiling). Thanks @quintusadvisorygroup-openclaw.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -52,6 +52,10 @@ const launchdRestartHandoffState = vi.hoisted(() => ({
     (_params: unknown) => { ok: boolean; pid?: number; detail?: string }
   >(() => ({ ok: true, pid: 7331 })),
 }));
+const callOrderState = vi.hoisted(() => ({ events: [] as string[] }));
+const logRetentionState = vi.hoisted(() => ({
+  applyGatewayLogRetention: vi.fn<(env: Record<string, string | undefined>) => Promise<unknown>>(),
+}));
 const cleanStaleGatewayProcessesSync = vi.hoisted(() =>
   vi.fn<(port?: number) => number[]>(() => []),
 );
@@ -210,9 +214,22 @@ vi.mock("./exec-file.js", () => ({
 vi.mock("./launchd-restart-handoff.js", () => ({
   isCurrentProcessLaunchdServiceLabel: (label: string) =>
     launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel(label),
-  scheduleDetachedLaunchdRestartHandoff: (params: unknown) =>
-    launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff(params),
+  scheduleDetachedLaunchdRestartHandoff: (params: unknown) => {
+    callOrderState.events.push("handoff");
+    return launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff(params);
+  },
 }));
+
+vi.mock("./log-retention.js", async () => {
+  const actual = await vi.importActual<typeof import("./log-retention.js")>("./log-retention.js");
+  return {
+    ...actual,
+    applyGatewayLogRetention: (env: Record<string, string | undefined>) => {
+      callOrderState.events.push("retention");
+      return logRetentionState.applyGatewayLogRetention(env);
+    },
+  };
+});
 
 vi.mock("../infra/restart-stale-pids.js", () => ({
   cleanStaleGatewayProcessesSync: (port?: number) => cleanStaleGatewayProcessesSync(port),
@@ -313,6 +330,13 @@ beforeEach(() => {
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReturnValue({
     ok: true,
     pid: 7331,
+  });
+  callOrderState.events.length = 0;
+  logRetentionState.applyGatewayLogRetention.mockReset();
+  logRetentionState.applyGatewayLogRetention.mockResolvedValue({
+    stdout: { rotated: false, reason: "missing" },
+    stderr: { rotated: false, reason: "missing" },
+    limits: { maxBytes: 0, archives: 0 },
   });
   vi.clearAllMocks();
 });
@@ -969,6 +993,29 @@ describe("launchd install", () => {
       waitForPid: process.pid,
     });
     expect(state.launchctlCalls).toStrictEqual([]);
+  });
+
+  it("rotates oversize launchd-owned logs before scheduling the self-handoff", async () => {
+    const env = createDefaultLaunchdEnv();
+    launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReturnValue(true);
+
+    await restartLaunchAgent({ env, stdout: new PassThrough() });
+
+    expect(logRetentionState.applyGatewayLogRetention).toHaveBeenCalledTimes(1);
+    expect(logRetentionState.applyGatewayLogRetention).toHaveBeenCalledWith(env);
+    expect(callOrderState.events).toStrictEqual(["retention", "handoff"]);
+  });
+
+  it("rotates oversize launchd-owned logs before kickstart on direct restarts", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await restartLaunchAgent({ env, stdout: new PassThrough() });
+
+    expect(logRetentionState.applyGatewayLogRetention).toHaveBeenCalledWith(env);
+    const retentionIndex = callOrderState.events.indexOf("retention");
+    const kickstartIndex = state.launchctlCalls.findIndex((call) => call[0] === "kickstart");
+    expect(retentionIndex).toBeGreaterThanOrEqual(0);
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
   });
 
   it("surfaces detached handoff failures", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -144,6 +144,9 @@ vi.mock("./exec-file.js", () => ({
   execFileUtf8: vi.fn(async (file: string, args: string[]) => {
     const call = normalizeLaunchctlArgs(file, args);
     state.launchctlCalls.push(call);
+    if (call[0] === "kickstart") {
+      callOrderState.events.push("kickstart");
+    }
     if (call[0] === "list") {
       return { stdout: state.listOutput, stderr: "", code: 0 };
     }
@@ -1012,10 +1015,7 @@ describe("launchd install", () => {
     await restartLaunchAgent({ env, stdout: new PassThrough() });
 
     expect(logRetentionState.applyGatewayLogRetention).toHaveBeenCalledWith(env);
-    const retentionIndex = callOrderState.events.indexOf("retention");
-    const kickstartIndex = state.launchctlCalls.findIndex((call) => call[0] === "kickstart");
-    expect(retentionIndex).toBeGreaterThanOrEqual(0);
-    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
+    expect(callOrderState.events).toStrictEqual(["retention", "kickstart"]);
   });
 
   it("surfaces detached handoff failures", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -20,6 +20,7 @@ import {
   isCurrentProcessLaunchdServiceLabel,
   scheduleDetachedLaunchdRestartHandoff,
 } from "./launchd-restart-handoff.js";
+import { applyGatewayLogRetention } from "./log-retention.js";
 import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
 import { resolveGatewayLogPaths } from "./restart-logs.js";
@@ -667,6 +668,7 @@ async function writeLaunchAgentPlist({
 }: Omit<GatewayServiceInstallArgs, "stdout">): Promise<{ plistPath: string; stdoutPath: string }> {
   const { logDir, stdoutPath, stderrPath } = resolveGatewayLogPaths(env);
   await ensureSecureDirectory(logDir);
+  await applyGatewayLogRetention(env);
 
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
@@ -776,6 +778,7 @@ async function rewriteLaunchAgentPlistForRestart({
 
   const { logDir, stdoutPath, stderrPath } = resolveGatewayLogPaths(env);
   await ensureSecureDirectory(logDir);
+  await applyGatewayLogRetention(env);
 
   const serviceDescription = resolveGatewayServiceDescription({
     env,
@@ -830,6 +833,13 @@ export async function restartLaunchAgent({
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
   const serviceTarget = `${domain}/${label}`;
+
+  // Rotate before any restart path runs, so both the direct kickstart and the
+  // detached self-handoff caps the unbounded launchd-owned stdout/stderr sinks
+  // before the new process starts appending to them. The detached handoff only
+  // runs `launchctl enable/kickstart/bootstrap` on a delay, so if we waited
+  // until after that branch returned an in-process restart would never rotate.
+  await applyGatewayLogRetention(serviceEnv);
 
   // Restart requests issued from inside the managed gateway process tree need a
   // detached handoff. A direct `kickstart -k` would terminate the caller before

--- a/src/daemon/log-retention.test.ts
+++ b/src/daemon/log-retention.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_GATEWAY_LOG_ARCHIVES,
+  DEFAULT_GATEWAY_LOG_MAX_BYTES,
+  MAX_GATEWAY_LOG_ARCHIVES,
+  applyGatewayLogRetention,
+  resolveGatewayLogRetentionLimits,
+  rotateOversizedDaemonLog,
+  type DaemonLogRetentionFs,
+} from "./log-retention.js";
+
+function enoent(message: string): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  return err;
+}
+
+function makeFs(initial: Map<string, number>): {
+  fs: DaemonLogRetentionFs;
+  files: Map<string, number>;
+  renames: Array<[string, string]>;
+  unlinks: string[];
+} {
+  const files = new Map(initial);
+  const renames: Array<[string, string]> = [];
+  const unlinks: string[] = [];
+  const fs: DaemonLogRetentionFs = {
+    stat: async (p) => {
+      const size = files.get(p);
+      if (size === undefined) {
+        throw enoent(`stat ${p}`);
+      }
+      return { size };
+    },
+    rename: async (from, to) => {
+      const size = files.get(from);
+      if (size === undefined) {
+        throw enoent(`rename ${from}`);
+      }
+      files.delete(from);
+      files.set(to, size);
+      renames.push([from, to]);
+    },
+    unlink: async (p) => {
+      if (!files.has(p)) {
+        throw enoent(`unlink ${p}`);
+      }
+      files.delete(p);
+      unlinks.push(p);
+    },
+  };
+  return { fs, files, renames, unlinks };
+}
+
+describe("resolveGatewayLogRetentionLimits", () => {
+  it("returns defaults for an empty env", () => {
+    expect(resolveGatewayLogRetentionLimits({})).toEqual({
+      maxBytes: DEFAULT_GATEWAY_LOG_MAX_BYTES,
+      archives: DEFAULT_GATEWAY_LOG_ARCHIVES,
+    });
+  });
+
+  it("honors OPENCLAW_GATEWAY_LOG_MAX_BYTES", () => {
+    expect(resolveGatewayLogRetentionLimits({ OPENCLAW_GATEWAY_LOG_MAX_BYTES: "1048576" })).toEqual(
+      {
+        maxBytes: 1048576,
+        archives: DEFAULT_GATEWAY_LOG_ARCHIVES,
+      },
+    );
+  });
+
+  it("treats max=0 as a disable signal", () => {
+    expect(resolveGatewayLogRetentionLimits({ OPENCLAW_GATEWAY_LOG_MAX_BYTES: "0" })).toEqual({
+      maxBytes: 0,
+      archives: DEFAULT_GATEWAY_LOG_ARCHIVES,
+    });
+  });
+
+  it("ignores junk values and falls back to defaults", () => {
+    expect(
+      resolveGatewayLogRetentionLimits({
+        OPENCLAW_GATEWAY_LOG_MAX_BYTES: "1.5MB",
+        OPENCLAW_GATEWAY_LOG_ARCHIVES: "abc",
+      }),
+    ).toEqual({
+      maxBytes: DEFAULT_GATEWAY_LOG_MAX_BYTES,
+      archives: DEFAULT_GATEWAY_LOG_ARCHIVES,
+    });
+  });
+
+  it("clamps archives to MAX_GATEWAY_LOG_ARCHIVES", () => {
+    expect(
+      resolveGatewayLogRetentionLimits({ OPENCLAW_GATEWAY_LOG_ARCHIVES: "999" }).archives,
+    ).toBe(MAX_GATEWAY_LOG_ARCHIVES);
+  });
+
+  it("accepts archives=0 to drop oversize logs without keeping a backup", () => {
+    expect(resolveGatewayLogRetentionLimits({ OPENCLAW_GATEWAY_LOG_ARCHIVES: "0" })).toEqual({
+      maxBytes: DEFAULT_GATEWAY_LOG_MAX_BYTES,
+      archives: 0,
+    });
+  });
+});
+
+describe("rotateOversizedDaemonLog", () => {
+  const limits = { maxBytes: 1024, archives: 1 };
+
+  it("is a no-op when the log file is missing", async () => {
+    const { fs, renames, unlinks } = makeFs(new Map());
+    const result = await rotateOversizedDaemonLog({ path: "/var/log/gateway.err.log", limits }, fs);
+    expect(result).toEqual({ rotated: false, reason: "missing" });
+    expect(renames).toEqual([]);
+    expect(unlinks).toEqual([]);
+  });
+
+  it("is a no-op when the log file is at or below the cap", async () => {
+    const { fs, renames, files } = makeFs(new Map([["/var/log/gateway.err.log", 1024]]));
+    const result = await rotateOversizedDaemonLog({ path: "/var/log/gateway.err.log", limits }, fs);
+    expect(result).toEqual({ rotated: false, reason: "below-cap", sizeBytes: 1024 });
+    expect(renames).toEqual([]);
+    expect(files.has("/var/log/gateway.err.log")).toBe(true);
+  });
+
+  it("rotates oversized logs to .1 and deletes any pre-existing archive", async () => {
+    const { fs, renames, unlinks, files } = makeFs(
+      new Map([
+        ["/var/log/gateway.err.log", 19_000_000_000],
+        ["/var/log/gateway.err.log.1", 4_000_000_000],
+      ]),
+    );
+    const result = await rotateOversizedDaemonLog({ path: "/var/log/gateway.err.log", limits }, fs);
+    expect(result).toEqual({
+      rotated: true,
+      archivedTo: "/var/log/gateway.err.log.1",
+      sizeBytes: 19_000_000_000,
+    });
+    expect(unlinks).toEqual(["/var/log/gateway.err.log.1"]);
+    expect(renames).toEqual([["/var/log/gateway.err.log", "/var/log/gateway.err.log.1"]]);
+    expect(files.has("/var/log/gateway.err.log")).toBe(false);
+    expect(files.get("/var/log/gateway.err.log.1")).toBe(19_000_000_000);
+  });
+
+  it("cascades older archives when archives>1", async () => {
+    const { fs, renames, files } = makeFs(
+      new Map([
+        ["/var/log/g.log", 5_000],
+        ["/var/log/g.log.1", 4_000],
+        ["/var/log/g.log.2", 3_000],
+      ]),
+    );
+    const result = await rotateOversizedDaemonLog(
+      { path: "/var/log/g.log", limits: { maxBytes: 1024, archives: 3 } },
+      fs,
+    );
+    expect(result.rotated).toBe(true);
+    expect(renames).toEqual([
+      ["/var/log/g.log.2", "/var/log/g.log.3"],
+      ["/var/log/g.log.1", "/var/log/g.log.2"],
+      ["/var/log/g.log", "/var/log/g.log.1"],
+    ]);
+    expect(files.get("/var/log/g.log.1")).toBe(5_000);
+    expect(files.get("/var/log/g.log.2")).toBe(4_000);
+    expect(files.get("/var/log/g.log.3")).toBe(3_000);
+    expect(files.has("/var/log/g.log")).toBe(false);
+  });
+
+  it("drops oversize logs without an archive when archives=0", async () => {
+    const { fs, renames, unlinks, files } = makeFs(new Map([["/var/log/gateway.err.log", 5_000]]));
+    const result = await rotateOversizedDaemonLog(
+      { path: "/var/log/gateway.err.log", limits: { maxBytes: 1024, archives: 0 } },
+      fs,
+    );
+    expect(result).toEqual({ rotated: true, archivedTo: "", sizeBytes: 5_000 });
+    expect(renames).toEqual([]);
+    expect(unlinks).toEqual(["/var/log/gateway.err.log"]);
+    expect(files.has("/var/log/gateway.err.log")).toBe(false);
+  });
+
+  it("treats maxBytes=0 as disabled even for huge files", async () => {
+    const { fs, renames, unlinks, files } = makeFs(
+      new Map([["/var/log/gateway.err.log", 19_000_000_000]]),
+    );
+    const result = await rotateOversizedDaemonLog(
+      { path: "/var/log/gateway.err.log", limits: { maxBytes: 0, archives: 1 } },
+      fs,
+    );
+    expect(result).toEqual({ rotated: false, reason: "disabled" });
+    expect(renames).toEqual([]);
+    expect(unlinks).toEqual([]);
+    expect(files.get("/var/log/gateway.err.log")).toBe(19_000_000_000);
+  });
+
+  it("does not throw when the pre-existing archive was already gone", async () => {
+    const { fs, renames, unlinks } = makeFs(new Map([["/var/log/g.log", 5_000]]));
+    const result = await rotateOversizedDaemonLog(
+      { path: "/var/log/g.log", limits: { maxBytes: 1024, archives: 1 } },
+      fs,
+    );
+    expect(result.rotated).toBe(true);
+    expect(unlinks).toEqual([]);
+    expect(renames).toEqual([["/var/log/g.log", "/var/log/g.log.1"]]);
+  });
+
+  it("propagates non-ENOENT stat errors", async () => {
+    const fs: DaemonLogRetentionFs = {
+      stat: vi.fn(async () => {
+        const err = new Error("EACCES") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      }),
+      rename: vi.fn(),
+      unlink: vi.fn(),
+    };
+    await expect(rotateOversizedDaemonLog({ path: "/var/log/g.log", limits }, fs)).rejects.toThrow(
+      "EACCES",
+    );
+  });
+});
+
+describe("applyGatewayLogRetention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rotates both stdout and stderr sinks for the resolved log paths", async () => {
+    const env = { HOME: "/Users/test", OPENCLAW_GATEWAY_LOG_MAX_BYTES: "1024" };
+    const { fs, files } = makeFs(
+      new Map([
+        ["/Users/test/.openclaw/logs/gateway.log", 5_000],
+        ["/Users/test/.openclaw/logs/gateway.err.log", 19_000_000_000],
+      ]),
+    );
+    const result = await applyGatewayLogRetention(env, fs);
+    expect(result.stdout.rotated).toBe(true);
+    expect(result.stderr.rotated).toBe(true);
+    expect(result.limits.maxBytes).toBe(1024);
+    expect(files.get("/Users/test/.openclaw/logs/gateway.log.1")).toBe(5_000);
+    expect(files.get("/Users/test/.openclaw/logs/gateway.err.log.1")).toBe(19_000_000_000);
+  });
+
+  it("is a no-op when both sinks are missing", async () => {
+    const env = { HOME: "/Users/test" };
+    const { fs } = makeFs(new Map());
+    const result = await applyGatewayLogRetention(env, fs);
+    expect(result.stdout).toEqual({ rotated: false, reason: "missing" });
+    expect(result.stderr).toEqual({ rotated: false, reason: "missing" });
+  });
+
+  it("respects OPENCLAW_PROFILE when resolving paths", async () => {
+    const env = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_GATEWAY_LOG_MAX_BYTES: "1024",
+    };
+    const { fs, files } = makeFs(
+      new Map([["/Users/test/.openclaw-work/logs/gateway.err.log", 5_000]]),
+    );
+    const result = await applyGatewayLogRetention(env, fs);
+    expect(result.stderr.rotated).toBe(true);
+    expect(files.get("/Users/test/.openclaw-work/logs/gateway.err.log.1")).toBe(5_000);
+  });
+});

--- a/src/daemon/log-retention.ts
+++ b/src/daemon/log-retention.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
+import { resolveGatewayLogPaths } from "./restart-logs.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+export const DEFAULT_GATEWAY_LOG_MAX_BYTES = 64 * 1024 * 1024;
+export const DEFAULT_GATEWAY_LOG_ARCHIVES = 1;
+export const MAX_GATEWAY_LOG_ARCHIVES = 9;
+
+export type GatewayLogRetentionLimits = {
+  maxBytes: number;
+  archives: number;
+};
+
+export function resolveGatewayLogRetentionLimits(
+  env: GatewayServiceEnv,
+): GatewayLogRetentionLimits {
+  const rawMax = parseStrictNonNegativeInteger(env.OPENCLAW_GATEWAY_LOG_MAX_BYTES ?? "");
+  const maxBytes = rawMax ?? DEFAULT_GATEWAY_LOG_MAX_BYTES;
+  const rawArchives = parseStrictNonNegativeInteger(env.OPENCLAW_GATEWAY_LOG_ARCHIVES ?? "");
+  const archives = Math.min(rawArchives ?? DEFAULT_GATEWAY_LOG_ARCHIVES, MAX_GATEWAY_LOG_ARCHIVES);
+  return { maxBytes, archives };
+}
+
+export type DaemonLogRetentionFs = {
+  stat: (path: string) => Promise<{ size: number }>;
+  rename: (from: string, to: string) => Promise<void>;
+  unlink: (path: string) => Promise<void>;
+};
+
+const defaultFs: DaemonLogRetentionFs = {
+  stat: async (p) => {
+    const info = await fs.stat(p);
+    return { size: info.size };
+  },
+  rename: (from, to) => fs.rename(from, to),
+  unlink: (p) => fs.unlink(p),
+};
+
+function isMissingFileError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+    return true;
+  }
+  const message = (err as { message?: unknown }).message;
+  return typeof message === "string" && message.startsWith("ENOENT");
+}
+
+export type RotateResult =
+  | { rotated: false; reason: "missing" | "below-cap" | "disabled"; sizeBytes?: number }
+  | { rotated: true; archivedTo: string; sizeBytes: number };
+
+export async function rotateOversizedDaemonLog(
+  params: {
+    path: string;
+    limits: GatewayLogRetentionLimits;
+  },
+  deps: DaemonLogRetentionFs = defaultFs,
+): Promise<RotateResult> {
+  const { path: logPath, limits } = params;
+  if (limits.maxBytes <= 0) {
+    return { rotated: false, reason: "disabled" };
+  }
+  let size: number;
+  try {
+    const info = await deps.stat(logPath);
+    size = info.size;
+  } catch (err) {
+    if (isMissingFileError(err)) {
+      return { rotated: false, reason: "missing" };
+    }
+    throw err;
+  }
+  if (size <= limits.maxBytes) {
+    return { rotated: false, reason: "below-cap", sizeBytes: size };
+  }
+  if (limits.archives === 0) {
+    await deps.unlink(logPath).catch((err: unknown) => {
+      if (!isMissingFileError(err)) {
+        throw err;
+      }
+    });
+    return { rotated: true, archivedTo: "", sizeBytes: size };
+  }
+  for (let i = limits.archives; i >= 2; i -= 1) {
+    const from = `${logPath}.${i - 1}`;
+    const to = `${logPath}.${i}`;
+    try {
+      await deps.rename(from, to);
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        throw err;
+      }
+    }
+  }
+  const archivedTo = `${logPath}.1`;
+  try {
+    await deps.unlink(archivedTo);
+  } catch (err) {
+    if (!isMissingFileError(err)) {
+      throw err;
+    }
+  }
+  await deps.rename(logPath, archivedTo);
+  return { rotated: true, archivedTo, sizeBytes: size };
+}
+
+export async function applyGatewayLogRetention(
+  env: GatewayServiceEnv,
+  deps: DaemonLogRetentionFs = defaultFs,
+): Promise<{ stdout: RotateResult; stderr: RotateResult; limits: GatewayLogRetentionLimits }> {
+  const limits = resolveGatewayLogRetentionLimits(env);
+  const { stdoutPath, stderrPath } = resolveGatewayLogPaths(env);
+  const [stdout, stderr] = await Promise.all([
+    rotateOversizedDaemonLog({ path: stdoutPath, limits }, deps),
+    rotateOversizedDaemonLog({ path: stderrPath, limits }, deps),
+  ]);
+  return { stdout, stderr, limits };
+}


### PR DESCRIPTION
## What this fixes

`gateway.err.log` (and `gateway.log`) under `~/.openclaw/logs/` can grow without bound on macOS because the LaunchAgent plist sets `StandardOutPath` / `StandardErrorPath` to fixed paths and launchd appends forever. The reporter on #79422 saw the stderr sink reach 18-19 GB across two separate incidents from a tight `acpx/runway/tts-local-cli` dep-staging error loop, with `openclaw gateway restart` as the only workaround.

This PR addresses the **log-retention half** of that report only. The dep-staging CPU loop itself needs live profiling against current main and is intentionally out of scope. Per clawsweeper's triage the log retention defect is independent and actionable now, so the language in this PR (commit message, CHANGELOG, references below) is deliberately non-closing for #79422 — that issue stays open for the maintainer-led CPU investigation.

## What changes

A new `src/daemon/log-retention.ts` helper:

- `rotateOversizedDaemonLog({ path, limits })`, pure, fs-injectable, async. If the file is larger than `limits.maxBytes`, it renames `path` to `path.1`, deleting any pre-existing `path.1` first. With `archives > 1` it cascades `path.{n-1}` to `path.{n}` so the oldest archive is dropped.
- `applyGatewayLogRetention(env)`, resolves the gateway log paths and runs rotation on both `stdoutPath` and `stderrPath` in parallel.
- `resolveGatewayLogRetentionLimits(env)`, reads `OPENCLAW_GATEWAY_LOG_MAX_BYTES` and `OPENCLAW_GATEWAY_LOG_ARCHIVES`. Defaults: 64 MB per stream, 1 archive. `OPENCLAW_GATEWAY_LOG_MAX_BYTES=0` disables retention. Archives are clamped to 9.

`src/daemon/launchd.ts` calls `applyGatewayLogRetention(env)` at every transition that can lead to a fresh launchd write into the sinks:

1. `writeLaunchAgentPlist` (install / stage path), right after `ensureSecureDirectory(logDir)`.
2. `rewriteLaunchAgentPlistForRestart`, same seam, so the restart-recovery rewrite path rotates too.
3. `restartLaunchAgent`, **before** the `isCurrentProcessLaunchdServiceLabel` self-handoff branch, so both the direct `launchctl kickstart -k` path and the in-process detached-handoff path rotate. The detached helper itself stays unchanged because the in-process call already rotated before scheduling.

Healthy non-oversized paths just `stat` once per stream and return. Routing semantics are unchanged: rotation only fires when the file is over the cap.

## Why this layer

Per AGENTS.md owner boundary: launchd is the daemon owner that wires `StandardErrorPath`. Linux/systemd journals through journald (already bounded), and the Windows scheduled-task path doesn't hit this sink, so the fix lives in `src/daemon/launchd.ts` rather than a generic core seam.

## Real behavior proof

**Behavior or issue addressed:** the launchd-owned gateway stderr sink at `~/.openclaw/logs/gateway.err.log` grows unbounded because nothing rotates it. With this patch, `applyGatewayLogRetention` rotates oversize sinks to `.1` at install, plist rewrite, and `gateway restart` (both kickstart and self-handoff paths), and launchd recreates a fresh sink on the next start.

**Real environment tested:** my own macOS workstation, profile `default`, the live `ai.openclaw.gateway` LaunchAgent already installed via `openclaw gateway install`. `~/.openclaw/logs/gateway.err.log` had grown to 25 MB during normal use, so I temporarily lowered the cap to 1 MB to exercise the patched helper end-to-end against the live LaunchAgent rather than synthesize a fake oversize log.

**Exact steps or command run after this patch:**

1. `ls -lh ~/.openclaw/logs/gateway.err.log* ~/.openclaw/logs/gateway.log*` to record the starting state.
2. Ran the patched `applyGatewayLogRetention` from this branch via tsx with `OPENCLAW_GATEWAY_LOG_MAX_BYTES=1048576` and `OPENCLAW_GATEWAY_LOG_ARCHIVES=1`.
3. `ls -lh ~/.openclaw/logs/gateway.err.log* ~/.openclaw/logs/gateway.log*` again to confirm the rotation happened.
4. `launchctl kickstart -k gui/$UID/ai.openclaw.gateway` to drive the live LaunchAgent through a restart, the same path the reporter uses as their workaround.
5. `ls -lh ~/.openclaw/logs/gateway.err.log* ~/.openclaw/logs/gateway.log*` once more to confirm launchd recreated the sink and the archive was preserved.

**Evidence after fix:** copied terminal output from the run on my machine.

Before the patched helper ran:

```
$ ls -lh ~/.openclaw/logs/gateway.err.log* ~/.openclaw/logs/gateway.log* 2>&1
-rw-r--r--  1 adhi  staff    25M May  9 09:57 /Users/adhi/.openclaw/logs/gateway.err.log
-rw-r--r--  1 adhi  staff   322K May  9 09:57 /Users/adhi/.openclaw/logs/gateway.log
```

Helper return value:

```
{
  "stdout": { "rotated": false, "reason": "below-cap", "sizeBytes": 329469 },
  "stderr": {
    "rotated": true,
    "archivedTo": "/Users/adhi/.openclaw/logs/gateway.err.log.1",
    "sizeBytes": 25740576
  },
  "limits": { "maxBytes": 1048576, "archives": 1 }
}
```

State right after the helper, before kickstart:

```
$ ls -lh ~/.openclaw/logs/gateway.err.log* ~/.openclaw/logs/gateway.log* 2>&1
-rw-r--r--@ 1 adhi  staff    25M May  9 09:57 /Users/adhi/.openclaw/logs/gateway.err.log.1
-rw-r--r--  1 adhi  staff   322K May  9 09:57 /Users/adhi/.openclaw/logs/gateway.log
```

State after `launchctl kickstart -k gui/$UID/ai.openclaw.gateway`:

```
$ ls -lh ~/.openclaw/logs/gateway.err.log* ~/.openclaw/logs/gateway.log* 2>&1
-rw-------  1 adhi  staff   205B May  9 10:03 /Users/adhi/.openclaw/logs/gateway.err.log
-rw-r--r--@ 1 adhi  staff    25M May  9 10:03 /Users/adhi/.openclaw/logs/gateway.err.log.1
-rw-r--r--  1 adhi  staff   322K May  9 10:03 /Users/adhi/.openclaw/logs/gateway.log
```

**Observed result after fix:**

1. The 25 MB stderr sink rotated to `.1` because it was over the 1 MB cap.
2. The 322 KB stdout sink stayed put because it was below the cap. Healthy paths are a no-op, the helper just stats once and returns.
3. After `launchctl kickstart -k`, launchd recreated `gateway.err.log` fresh (205 bytes of fresh runtime output) and the archive at `.1` was preserved with the original 25 MB intact.

This matches the design: rotation only fires when the file is over the cap, archive is kept exactly once, and the next restart starts writing into a fresh sink instead of appending to the tens-of-gigabytes file.

**What was not tested:** I did not live-reproduce the original 18-19 GB CPU/dep-staging loop on current main; that half of the linked report stays open for separate maintainer-led investigation as clawsweeper recommended. I also did not exercise the Windows or Linux daemon paths because launchd is the only daemon owner that wires `StandardErrorPath` to a fixed file (Linux journals through journald, Windows uses Scheduled Tasks).

## Validation

```
pnpm vitest run src/daemon/log-retention.test.ts src/daemon/launchd.test.ts src/daemon/launchd-restart-handoff.test.ts src/daemon/restart-logs.test.ts
```

```
Test Files  4 passed (4)
     Tests  77 passed (77)
```

`log-retention.test.ts` covers: defaults, env parsing, junk-value fallback, cap clamping, missing file, below-cap no-op, oversize rotation, archive cascade with `archives>1`, `archives=0` drop-without-backup, `maxBytes=0` disabled escape hatch, ENOENT-tolerant pre-existing-archive cleanup, and non-ENOENT stat error propagation.

`launchd.test.ts` adds two new regression tests pinning the call order in `restartLaunchAgent`: retention runs before `scheduleDetachedLaunchdRestartHandoff` on the self-handoff path, and retention runs before `launchctl kickstart` on the direct path. The existing `launchd.test.ts` suite (which mocks `node:fs/promises` without populating the log paths) keeps passing because retention sees ENOENT and no-ops on those test runs.

`pnpm format:check` and `pnpm exec oxlint` are clean on the four touched files. `pnpm check:changelog-attributions` passes with the new entry.

## Scope

What changes:
- New `applyGatewayLogRetention` helper, hooked into install, plist rewrite, and both restart paths.
- Two new env vars (`OPENCLAW_GATEWAY_LOG_MAX_BYTES`, `OPENCLAW_GATEWAY_LOG_ARCHIVES`); no new JSON config knob.
- One CHANGELOG entry under `Unreleased > Fixes`, with non-closing `Refs #79422` wording.

What does not change:
- launchd plist contents (`StandardOutPath`/`StandardErrorPath` still point at the same files).
- `restart-logs.ts` path resolution.
- The Linux/Windows daemon paths.
- Healthy-path semantics (no rotation = no behavior change).
- The status of #79422 itself: this PR uses non-closing language so the CPU/dep-staging loop investigation stays open.

## AI / vibe-coding disclosure

Per `CONTRIBUTING.md`'s AI-assisted disclosure policy:

- Model: Claude Opus 4.7 (Anthropic)
- I added the helper, the integration points, and the test suite, then hand-reviewed each file before opening this PR.
- I ran the four-file vitest suite from clawsweeper's acceptance criteria locally; all 77 tests pass.
- I did not live-reproduce the CPU/dep-staging loop on macOS. That half of the report is left to maintainer triage as clawsweeper suggested.