### PR TITLE
fix(github-copilot): expose thinking profile via bundled provider-policy-api

### DIFF
--- a/extensions/github-copilot/provider-policy-api.test.ts
+++ b/extensions/github-copilot/provider-policy-api.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { resolveThinkingProfile } from "./provider-policy-api.js";
+
+describe("github-copilot provider-policy-api", () => {
+  it("returns the base level set for non-xhigh github-copilot models", () => {
+    expect(
+      resolveThinkingProfile({
+        provider: "github-copilot",
+        modelId: "claude-opus-4.6",
+      })?.levels.map((level) => level.id),
+    ).toEqual(["off", "minimal", "low", "medium", "high"]);
+  });
+
+  it("appends xhigh for the long-context Opus 4.7 1m variant", () => {
+    expect(
+      resolveThinkingProfile({
+        provider: "github-copilot",
+        modelId: "claude-opus-4.7-1m-internal",
+      })?.levels.map((level) => level.id),
+    ).toEqual(["off", "minimal", "low", "medium", "high", "xhigh"]);
+  });
+
+  it("appends xhigh for GPT-5.4 / 5.3-codex / 5.2 variants", () => {
+    for (const modelId of ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-codex"]) {
+      expect(
+        resolveThinkingProfile({
+          provider: "github-copilot",
+          modelId,
+        })?.levels.map((level) => level.id),
+        `model=${modelId}`,
+      ).toContain("xhigh");
+    }
+  });
+
+  it("normalizes the model id casing before xhigh membership check", () => {
+    expect(
+      resolveThinkingProfile({
+        provider: "github-copilot",
+        modelId: "CLAUDE-OPUS-4.7-1M-INTERNAL",
+      })?.levels.map((level) => level.id),
+    ).toContain("xhigh");
+  });
+
+  it("returns null for non-github-copilot providers", () => {
+    expect(
+      resolveThinkingProfile({
+        provider: "openai",
+        modelId: "gpt-5.4",
+      }),
+    ).toBeNull();
+    expect(
+      resolveThinkingProfile({
+        provider: "anthropic",
+        modelId: "claude-opus-4.6",
+      }),
+    ).toBeNull();
+  });
+});

--- a/extensions/github-copilot/provider-policy-api.test.ts
+++ b/extensions/github-copilot/provider-policy-api.test.ts
@@ -20,8 +20,8 @@ describe("github-copilot provider-policy-api", () => {
     ).toEqual(["off", "minimal", "low", "medium", "high", "xhigh"]);
   });
 
-  it("appends xhigh for GPT-5.4 / 5.3-codex / 5.2 variants", () => {
-    for (const modelId of ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-codex"]) {
+  it("appends xhigh for GPT-5.5 / 5.4 / 5.3-codex / 5.2 variants", () => {
+    for (const modelId of ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-codex"]) {
       expect(
         resolveThinkingProfile({
           provider: "github-copilot",

--- a/extensions/github-copilot/provider-policy-api.ts
+++ b/extensions/github-copilot/provider-policy-api.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runti
 // `getSessionDefaults` calls). Without this artifact, callers fall through to
 // the stock thinking profile and xhigh disappears from the dashboard.
 const COPILOT_XHIGH_MODEL_IDS = [
+  "gpt-5.5",
   "gpt-5.4",
   "gpt-5.3-codex",
   "gpt-5.2",

--- a/extensions/github-copilot/provider-policy-api.ts
+++ b/extensions/github-copilot/provider-policy-api.ts
@@ -1,0 +1,34 @@
+import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
+
+// Mirror of the COPILOT_XHIGH_MODEL_IDS list maintained in `./index.ts`. Keep
+// these two lists in sync; this surface is consulted via the bundled provider
+// public artifact path when the active plugin registry has not registered the
+// github-copilot plugin entry yet (e.g. dashboard `sessions.list` /
+// `getSessionDefaults` calls). Without this artifact, callers fall through to
+// the stock thinking profile and xhigh disappears from the dashboard.
+const COPILOT_XHIGH_MODEL_IDS = [
+  "gpt-5.4",
+  "gpt-5.3-codex",
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "claude-opus-4.7-1m-internal",
+] as const;
+
+export function resolveThinkingProfile(params: { provider: string; modelId: string }) {
+  if (params.provider.trim().toLowerCase() !== "github-copilot") {
+    return null;
+  }
+  const normalizedModelId = normalizeOptionalLowercaseString(params.modelId) ?? "";
+  return {
+    levels: [
+      { id: "off" as const },
+      { id: "minimal" as const },
+      { id: "low" as const },
+      { id: "medium" as const },
+      { id: "high" as const },
+      ...(COPILOT_XHIGH_MODEL_IDS.includes(normalizedModelId as never)
+        ? [{ id: "xhigh" as const }]
+        : []),
+    ],
+  };
+}


### PR DESCRIPTION
## Problem

`/think xhigh` works on Discord (`#general`, `#fitness`, etc.) for `github-copilot/claude-opus-4.7-1m-internal` and other xhigh-eligible Copilot models, but the dashboard:

- Drops `xhigh` from the thinking-level dropdown for these models
- Rejects `/think xhigh` from the dashboard slash command with: `Unsupported thinking level "xhigh" for this model. Valid levels: off, minimal, low, medium, high.`
- Silently downgrades sessions previously set to `xhigh` back to `high` after a refresh

## Root cause

Other extensions (`anthropic`, `openai`, `deepseek`, `google`, `ollama`, `opencode`, `openrouter`, `deepinfra`) all ship a `provider-policy-api.ts` artifact at `extensions/<id>/provider-policy-api.ts` that gets bundled to `dist/extensions/<id>/provider-policy-api.js` and loaded synchronously by `resolveBundledProviderPolicySurface` whenever something needs to know a provider's thinking profile **without** going through the lazy plugin loader.

`extensions/github-copilot` is the odd one out — no `provider-policy-api.ts` was ever shipped. As a result, callers like `getSessionDefaults` and `resolveSessionRowThinkingLevels` (used by `sessions.list` for the dashboard) hit `resolveProviderThinkingProfile` in `src/auto-reply/thinking.ts`, which:

1. Tries the active plugin registry (`globalThis[Symbol.for("openclaw.pluginRegistryState")].activeRegistry.providers`) — which has `providers: []` at gateway-startup time for these calls
2. Falls back to `resolveBundledProviderPolicySurface("github-copilot")` — which returns null because the artifact is missing
3. Falls through to the generic base profile `[off, minimal, low, medium, high]` — dropping `xhigh` from the dashboard's thinking-level dropdown

Discord-side and main-agent calls work because they go through `resolveProviderRuntimePlugin` → `resolveProviderPluginsForHooks`, which lazily loads the plugin's runtime entry. That's a **different code path** and sees the in-process `resolveThinkingProfile` from `extensions/github-copilot/index.ts`.

## Fix

Add `extensions/github-copilot/provider-policy-api.ts`, mirroring the pattern in `extensions/anthropic/provider-policy-api.ts` and `extensions/openai/provider-policy-api.ts`. Exports a `resolveThinkingProfile` that returns the same level list as the in-process one in `extensions/github-copilot/index.ts`, including `xhigh` for the xhigh-supporting model ids (`gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2`, `gpt-5.2-codex`, `claude-opus-4.7-1m-internal`).

The `COPILOT_XHIGH_MODEL_IDS` list is intentionally duplicated rather than re-exported from `./index.ts` because that module pulls in the full plugin runtime, while `provider-policy-api.ts` is loaded synchronously by the bundled-policy-surface path and must stay lightweight. The new file flags the requirement to keep the two lists in sync.

## Verification

- `pnpm test -- --run extensions/github-copilot/provider-policy-api.test.ts` — **5/5 passing**, covering:
  - Base level set for non-xhigh models (`claude-opus-4.6`)
  - `xhigh` appended for `claude-opus-4.7-1m-internal`
  - `xhigh` appended for each GPT-5.4 / 5.3-codex / 5.2 / 5.2-codex variant
  - Case-insensitive normalization of the model id
  - `null` for non-`github-copilot` providers
- Manually verified live by deploying the patched build to my local install and reloading the dashboard. Before the fix: dashboard `/think xhigh` rejected with "Unsupported thinking level". After the fix: `xhigh` appears in the dropdown for `claude-opus-4.7-1m-internal` and `/think xhigh` accepts cleanly.

## Scope

- 1 commit, 2 files, +92/-0
- New file only — no behaviour change for other providers
- Mirrors the existing pattern; no API surface changes
