### PR TITLE
fix git plugin ref checkout handling

### DIFF
--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -103,8 +103,9 @@ describe("installPluginFromGitSpec", () => {
     ]);
     expect(runCommandWithTimeoutMock.mock.calls[1][0]).toEqual([
       "git",
-      "checkout",
+      "switch",
       "--detach",
+      "--",
       "v1.2.3",
     ]);
     expect(runCommandWithTimeoutMock.mock.calls[3][0]).toEqual([
@@ -222,6 +223,30 @@ describe("installPluginFromGitSpec", () => {
       expect(result.error).not.toContain("other");
       expect(result.error).not.toContain("credential");
     }
+    expect(installPluginFromInstalledPackageDirMock).not.toHaveBeenCalled();
+  });
+
+  it("separates requested refs from git options", async () => {
+    runCommandWithTimeoutMock
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({
+        code: 128,
+        stdout: "",
+        stderr: "fatal: invalid reference: --ignore-skip-worktree-bits",
+      });
+
+    const result = await installPluginFromGitSpec({
+      spec: "git:github.com/acme/demo@--ignore-skip-worktree-bits",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(runCommandWithTimeoutMock.mock.calls[1][0]).toEqual([
+      "git",
+      "switch",
+      "--detach",
+      "--",
+      "--ignore-skip-worktree-bits",
+    ]);
     expect(installPluginFromInstalledPackageDirMock).not.toHaveBeenCalled();
   });
 

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -287,7 +287,7 @@ export async function installPluginFromGitSpec(
 
     if (parsed.ref) {
       const checkout = await runGitCommand({
-        argv: ["git", "checkout", "--detach", parsed.ref],
+        argv: ["git", "switch", "--detach", "--", parsed.ref],
         action: `checkout ${parsed.ref}`,
         source: parsed,
         cwd: repoDir,


### PR DESCRIPTION
## Summary

- Problem: `git:` plugin installs passed explicit refs to `git checkout --detach <ref>`, letting option-like values be parsed as checkout flags.
- Why it matters: an invalid option-like ref such as `--ignore-skip-worktree-bits` can return success from Git and leave the clone on the default branch, weakening the installer's ref-pinning semantics.
- What changed: git plugin ref checkout now uses `git switch --detach -- <ref>` so the requested value is interpreted as a ref and rejected when invalid.
- What did NOT change (scope boundary): npm, ClawHub, marketplace, local path, and archive plugin install flows are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79898
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `git:` plugin installs should fail invalid option-like refs instead of allowing Git to treat them as checkout flags and continue on the default branch.
- Real environment tested: macOS 15 / Darwin arm64, source checkout with the installer fix applied, Node 22.22.0, `pnpm` workspace install with a temporary `OPENCLAW_HOME` and temporary local git plugin repository.
- Exact steps or command run after this patch: `OPENCLAW_HOME="$tmp/openclaw-home" pnpm openclaw plugins install "git:file://$tmp/plugin-repo@--ignore-skip-worktree-bits"`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output:

```shell
Cloning <tmp>/plugin-repo...
failed to checkout --ignore-skip-worktree-bits <tmp>/plugin-repo: fatal: invalid reference: --ignore-skip-worktree-bits
exit=1
```

- Observed result after fix: the install fails during ref checkout before dependency installation, package scan, or install metadata persistence.
- What was not tested: full `pnpm check:changed`; the lane selector included core/coreTests, and no Testbox runner was available locally.
- Before evidence (optional but encouraged): copied Git behavior before the patch:

```shell
$ git checkout --detach --ignore-skip-worktree-bits
HEAD is now at ef8dea3 init
$ echo $?
0
```

## Root Cause (if applicable)

- Root cause: the git plugin installer passed the user-supplied ref directly after `git checkout --detach`, so Git parsed leading-dash values as checkout options.
- Missing detection / guardrail: the existing unit test asserted a normal ref checkout but did not cover option-like ref values.
- Contributing context (if known): Git accepts at least some checkout flags in this position and can return success without checking out the requested ref.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/git-install.test.ts`
- Scenario the test should lock in: option-like requested refs are passed after `--` to `git switch --detach` and do not reach plugin package install when checkout fails.
- Why this is the smallest reliable guardrail: it locks the argv boundary where the bug happened without invoking real package-manager installs.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Invalid option-like git plugin refs now fail checkout instead of potentially installing the repository default branch.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: the Git checkout command changes from `checkout --detach <ref>` to `switch --detach -- <ref>` so the command treats the supplied value as a ref instead of an option.

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin arm64
- Runtime/container: Node 22.22.0, pnpm source checkout
- Model/provider: N/A
- Integration/channel (if any): plugin installer
- Relevant config (redacted): temporary `OPENCLAW_HOME`

### Steps

1. Create a temporary local git repository with a minimal plugin package.
2. Run `OPENCLAW_HOME="$tmp/openclaw-home" pnpm openclaw plugins install "git:file://$tmp/plugin-repo@--ignore-skip-worktree-bits"`.
3. Run `pnpm test src/plugins/git-install.test.ts`.

### Expected

- The option-like ref is rejected as an invalid reference before plugin install proceeds.

### Actual

- The patched installer fails checkout with `fatal: invalid reference: --ignore-skip-worktree-bits` and exits `1`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted unit test, formatter check, diff whitespace check, and live CLI install against a temporary local git repository.
- Edge cases checked: normal refs still use detached checkout semantics through the updated argv, and option-like refs are separated from Git options.
- What you did **not** verify: full core changed gate, because the changed-lane selector requested broad core/coreTests lanes and no Testbox runner was available locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: very old Git versions may lack `git switch`.
  - Mitigation: OpenClaw targets modern Node and current Git install flows; `git switch` has been available since Git 2.23 and is supported by current Git for Windows/macOS/Linux distributions.
