### PR TITLE
fix(voice-call): tighten realtime stream upgrade path

### DIFF
--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -609,12 +609,15 @@ async function requestWebSocketUpgrade(
 }
 
 describe("VoiceCallWebhookServer realtime WebSocket routing", () => {
-  it("does not route sibling paths through the realtime stream handler", async () => {
+  function createRealtimeRoutingServer(streamPathPattern: string): {
+    server: VoiceCallWebhookServer;
+    handleWebSocketUpgrade: ReturnType<typeof vi.fn<RealtimeCallHandler["handleWebSocketUpgrade"]>>;
+  } {
     const { manager } = createManager([]);
     const config = createConfig({
       realtime: {
         enabled: true,
-        streamPath: "/voice/stream/realtime",
+        streamPath: streamPathPattern,
         instructions: "Be helpful.",
         toolPolicy: "safe-read-only",
         tools: [],
@@ -634,11 +637,17 @@ describe("VoiceCallWebhookServer realtime WebSocket routing", () => {
         headers: { "Content-Type": "text/xml" },
         body: "<Response />",
       }),
-      getStreamPathPattern: () => "/voice/stream/realtime",
+      getStreamPathPattern: () => streamPathPattern,
       handleWebSocketUpgrade,
       registerToolHandler: () => {},
       setPublicUrl: () => {},
     } as unknown as RealtimeCallHandler);
+    return { server, handleWebSocketUpgrade };
+  }
+
+  it("does not route sibling paths through the realtime stream handler", async () => {
+    const { server, handleWebSocketUpgrade } =
+      createRealtimeRoutingServer("/voice/stream/realtime");
 
     try {
       const baseUrl = await server.start();
@@ -647,6 +656,19 @@ describe("VoiceCallWebhookServer realtime WebSocket routing", () => {
       expect(handleWebSocketUpgrade).toHaveBeenCalledTimes(1);
 
       await requestWebSocketUpgrade(server, baseUrl, "/voice/stream/realtime-extra/token");
+      expect(handleWebSocketUpgrade).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("routes root stream child paths through the realtime stream handler", async () => {
+    const { server, handleWebSocketUpgrade } = createRealtimeRoutingServer("/");
+
+    try {
+      const baseUrl = await server.start();
+      const valid = await requestWebSocketUpgrade(server, baseUrl, "/token");
+      expect(valid).toMatchObject({ kind: "response", statusCode: 401 });
       expect(handleWebSocketUpgrade).toHaveBeenCalledTimes(1);
     } finally {
       await server.stop();

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -536,6 +536,124 @@ async function postWebhookFormWithHeadersResult(
   });
 }
 
+async function requestWebSocketUpgrade(
+  server: VoiceCallWebhookServer,
+  baseUrl: string,
+  pathname: string,
+): Promise<
+  | { kind: "response"; statusCode: number; body: string }
+  | { kind: "upgrade"; statusCode: number }
+  | { kind: "error"; code: string | undefined }
+> {
+  const requestUrl = requireBoundRequestUrl(server, baseUrl);
+  requestUrl.pathname = pathname;
+  requestUrl.search = "";
+  return await new Promise((resolve) => {
+    let settled = false;
+    let req: ReturnType<typeof request> | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (
+      result:
+        | { kind: "response"; statusCode: number; body: string }
+        | { kind: "upgrade"; statusCode: number }
+        | { kind: "error"; code: string | undefined },
+    ) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      resolve(result);
+    };
+    timer = setTimeout(() => {
+      req?.destroy();
+      finish({ kind: "error", code: "timeout" });
+    }, 2_000);
+    req = request(
+      {
+        hostname: requestUrl.hostname,
+        port: requestUrl.port,
+        path: requestUrl.pathname,
+        method: "GET",
+        headers: {
+          connection: "Upgrade",
+          upgrade: "websocket",
+        },
+      },
+      (res) => {
+        res.setEncoding("utf8");
+        let responseBody = "";
+        res.on("data", (chunk) => {
+          responseBody += chunk;
+        });
+        res.on("end", () => {
+          finish({
+            kind: "response",
+            statusCode: res.statusCode ?? 0,
+            body: responseBody,
+          });
+        });
+      },
+    );
+    req.on("upgrade", (res, socket) => {
+      socket.destroy();
+      finish({ kind: "upgrade", statusCode: res.statusCode ?? 0 });
+    });
+    req.on("error", (error: NodeJS.ErrnoException) => {
+      finish({ kind: "error", code: error.code });
+    });
+    req.end();
+  });
+}
+
+describe("VoiceCallWebhookServer realtime WebSocket routing", () => {
+  it("does not route sibling paths through the realtime stream handler", async () => {
+    const { manager } = createManager([]);
+    const config = createConfig({
+      realtime: {
+        enabled: true,
+        streamPath: "/voice/stream/realtime",
+        instructions: "Be helpful.",
+        toolPolicy: "safe-read-only",
+        tools: [],
+        providers: {},
+      },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, provider);
+    const handleWebSocketUpgrade = vi.fn<RealtimeCallHandler["handleWebSocketUpgrade"]>(
+      (_req, socket) => {
+        socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+        socket.destroy();
+      },
+    );
+    server.setRealtimeHandler({
+      buildTwiMLPayload: () => ({
+        statusCode: 200,
+        headers: { "Content-Type": "text/xml" },
+        body: "<Response />",
+      }),
+      getStreamPathPattern: () => "/voice/stream/realtime",
+      handleWebSocketUpgrade,
+      registerToolHandler: () => {},
+      setPublicUrl: () => {},
+    } as unknown as RealtimeCallHandler);
+
+    try {
+      const baseUrl = await server.start();
+      const valid = await requestWebSocketUpgrade(server, baseUrl, "/voice/stream/realtime/token");
+      expect(valid).toMatchObject({ kind: "response", statusCode: 401 });
+      expect(handleWebSocketUpgrade).toHaveBeenCalledTimes(1);
+
+      await requestWebSocketUpgrade(server, baseUrl, "/voice/stream/realtime-extra/token");
+      expect(handleWebSocketUpgrade).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
 describe("VoiceCallWebhookServer stale call reaper", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -177,6 +177,14 @@ function buildRealtimeRejectedTwiML(): WebhookResponsePayload {
   };
 }
 
+function isRealtimeStreamPath(pathname: string, pattern: string): boolean {
+  const normalizedPattern = pattern.replace(/\/+$/u, "") || "/";
+  if (normalizedPattern === "/") {
+    return pathname === "/";
+  }
+  return pathname === normalizedPattern || pathname.startsWith(`${normalizedPattern}/`);
+}
+
 /**
  * HTTP server for receiving voice call webhooks from providers.
  * Supports WebSocket upgrades for media streams when streaming is enabled.
@@ -801,7 +809,7 @@ export class VoiceCallWebhookServer {
     try {
       const pathname = buildRequestUrl(req.url, req.headers.host).pathname;
       const pattern = this.realtimeHandler?.getStreamPathPattern();
-      return Boolean(pattern && pathname.startsWith(pattern));
+      return Boolean(pattern && isRealtimeStreamPath(pathname, pattern));
     } catch {
       return false;
     }

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -180,7 +180,7 @@ function buildRealtimeRejectedTwiML(): WebhookResponsePayload {
 function isRealtimeStreamPath(pathname: string, pattern: string): boolean {
   const normalizedPattern = pattern.replace(/\/+$/u, "") || "/";
   if (normalizedPattern === "/") {
-    return pathname === "/";
+    return pathname.startsWith("/");
   }
   return pathname === normalizedPattern || pathname.startsWith(`${normalizedPattern}/`);
 }


### PR DESCRIPTION
## Summary

- Problem: voice-call realtime WebSocket upgrades used a raw prefix check for `realtime.streamPath`, so sibling paths such as `/voice/stream/realtime-extra/<token>` reached the realtime handler.
- Why it matters: the configured stream path is the route boundary for realtime call media; accepting sibling prefixes can confuse path-scoped proxy or ingress policy.
- What changed: realtime upgrades now match the configured path exactly or as a slash-delimited child path, while preserving root `realtime.streamPath=/` child routes such as `/<token>`.
- What did NOT change (scope boundary): no stream token format, TwiML generation, provider behavior, or changelog changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79918
- Related #79575
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: voice-call realtime WebSocket upgrades no longer route sibling paths such as `/voice/stream/realtime-extra/<token>` into the realtime stream handler, and root stream paths still route generated token child paths.
- Real environment tested: macOS 26.4.1, Node v22.22.0, pnpm 10.33.2, local OpenClaw checkout on commit `f466a073b4861df7452a5d0b37a123e5f0cd7525`.
- Exact steps or command run after this patch: `pnpm test extensions/voice-call/src/webhook.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output: `Test Files 1 passed (1); Tests 36 passed (36); [test] passed 1 Vitest shard in 4.81s`.
- Observed result after fix: the realtime WebSocket routing tests reach the handler for `/voice/stream/realtime/token` and root `/<token>`, then send `/voice/stream/realtime-extra/token` and confirm the handler call count does not increase.
- What was not tested: a live Twilio media stream and remote reverse-proxy ingress were not exercised locally.
- Before evidence (optional but encouraged): the previous code used `pathname.startsWith(pattern)`, so `/voice/stream/realtime-extra/token` satisfied the same predicate as `/voice/stream/realtime/token`.

## Root Cause (if applicable)

- Root cause: the realtime upgrade classifier treated a configured stream path as a raw string prefix instead of a path segment boundary.
- Missing detection / guardrail: there was no regression test covering sibling stream paths with the same textual prefix or root stream-path child routes.
- Contributing context (if known): realtime stream URLs append a token as a child path, so prefix matching looked convenient but was broader than the route contract.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/voice-call/src/webhook.test.ts`
- Scenario the test should lock in: valid `/voice/stream/realtime/<token>` and root `/<token>` upgrades reach the handler, while sibling `/voice/stream/realtime-extra/<token>` upgrades do not.
- Why this is the smallest reliable guardrail: it exercises the actual `VoiceCallWebhookServer` upgrade router without requiring a live telephony provider.
- Existing test that already covers this (if any): none found for sibling realtime upgrade paths or root stream-path child routes.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Realtime voice WebSocket upgrades are now limited to the configured stream path and slash-delimited children. Root stream paths continue to route token child paths.

## Diagram (if applicable)

```text
Before:
/voice/stream/realtime-extra/token -> startsWith(/voice/stream/realtime) -> realtime handler

After:
/voice/stream/realtime-extra/token -> not an exact or child path match -> no realtime handler
/token with streamPath=/ -> root child path match -> realtime handler
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node v22.22.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): voice-call realtime WebSocket route
- Relevant config (redacted): `realtime.streamPath=/voice/stream/realtime`, `realtime.streamPath=/`

### Steps

1. Configure the realtime stream path as `/voice/stream/realtime`.
2. Send a WebSocket upgrade to `/voice/stream/realtime/token`.
3. Send a WebSocket upgrade to `/voice/stream/realtime-extra/token`.
4. Configure the realtime stream path as `/`.
5. Send a WebSocket upgrade to `/token`.

### Expected

- Only the exact stream path or slash-delimited child route reaches the realtime handler.
- Root stream paths route token child paths.

### Actual

- Before this patch, the sibling path also reached the realtime handler through raw prefix matching.
- The first patch rejected the sibling path but failed to route root stream-path child routes.
- After this patch, the sibling path does not reach the realtime handler and root child paths still route.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted voice-call webhook test, targeted formatter check, `git diff --check`, and changed-lane classification.
- Edge cases checked: exact stream path remains routed; sibling prefix path is rejected by the router; root stream-path child path remains routed.
- What you did **not** verify: live telephony provider media stream and remote reverse-proxy deployment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: callers relying on non-segment sibling paths will no longer be routed to realtime.
  - Mitigation: generated TwiML uses the configured stream path with the token as a slash-delimited child, and the regression tests verify that intended route still reaches the handler.
