### PR TITLE
Warn on shared Slack Socket Mode connections

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -23,23 +23,27 @@ Production-ready for DMs and channels via Slack app integrations. Default mode i
 
 Both transports are production-ready and reach feature parity for messaging, slash commands, App Home, and interactivity. Pick by deployment shape, not features.
 
-| Concern                      | Socket Mode (default)                                                                | HTTP Request URLs                                                                                              |
-| ---------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| Public Gateway URL           | Not required                                                                         | Required (DNS, TLS, reverse proxy or tunnel)                                                                   |
-| Outbound network             | Outbound WSS to `wss-primary.slack.com` must be reachable                            | No outbound WS; inbound HTTPS only                                                                             |
-| Tokens needed                | Bot token (`xoxb-...`) + App-Level Token (`xapp-...`) with `connections:write`       | Bot token (`xoxb-...`) + Signing Secret                                                                        |
-| Dev laptop / behind firewall | Works as-is                                                                          | Needs a public tunnel (ngrok, Cloudflare Tunnel, Tailscale Funnel) or staging Gateway                          |
-| Horizontal scaling           | One Socket Mode session per app per host; multiple Gateways need separate Slack apps | Stateless POST handler; multiple Gateway replicas can share one app behind a load balancer                     |
-| Multi-account on one Gateway | Supported; each account opens its own WS                                             | Supported; each account needs a unique `webhookPath` (default `/slack/events`) so registrations do not collide |
-| Slash command transport      | Delivered over the WS connection; `slash_commands[].url` is ignored                  | Slack POSTs to `slash_commands[].url`; field is required for the command to dispatch                           |
-| Request signing              | Not used (auth is the App-Level Token)                                               | Slack signs every request; OpenClaw verifies with `signingSecret`                                              |
-| Recovery on connection drop  | Slack SDK auto-reconnects; the gateway's pong-timeout transport tuning applies       | No persistent connection to drop; retries are per-request from Slack                                           |
+| Concern                      | Socket Mode (default)                                                                 | HTTP Request URLs                                                                                              |
+| ---------------------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Public Gateway URL           | Not required                                                                          | Required (DNS, TLS, reverse proxy or tunnel)                                                                   |
+| Outbound network             | Outbound WSS to `wss-primary.slack.com` must be reachable                             | No outbound WS; inbound HTTPS only                                                                             |
+| Tokens needed                | Bot token (`xoxb-...`) + App-Level Token (`xapp-...`) with `connections:write`        | Bot token (`xoxb-...`) + Signing Secret                                                                        |
+| Dev laptop / behind firewall | Works as-is                                                                           | Needs a public tunnel (ngrok, Cloudflare Tunnel, Tailscale Funnel) or staging Gateway                          |
+| Horizontal scaling           | One Socket Mode owner per Slack app token; multiple Gateways need separate Slack apps | Stateless POST handler; multiple Gateway replicas can share one app behind a load balancer                     |
+| Multi-account on one Gateway | Supported; each account opens its own WS                                              | Supported; each account needs a unique `webhookPath` (default `/slack/events`) so registrations do not collide |
+| Slash command transport      | Delivered over the WS connection; `slash_commands[].url` is ignored                   | Slack POSTs to `slash_commands[].url`; field is required for the command to dispatch                           |
+| Request signing              | Not used (auth is the App-Level Token)                                                | Slack signs every request; OpenClaw verifies with `signingSecret`                                              |
+| Recovery on connection drop  | Slack SDK auto-reconnects; the gateway's pong-timeout transport tuning applies        | No persistent connection to drop; retries are per-request from Slack                                           |
 
 <Note>
   **Pick Socket Mode** for single-Gateway hosts, dev laptops, and on-prem networks that can reach `*.slack.com` outbound but cannot accept inbound HTTPS.
 
 **Pick HTTP Request URLs** when running multiple Gateway replicas behind a load balancer, when outbound WSS is blocked but inbound HTTPS is allowed, or when you already terminate Slack webhooks at a reverse proxy.
 </Note>
+
+<Warning>
+  Socket Mode is a single-owner transport. If the same Slack app token is running on Mac Mini, Mac Studio, and Mac Studio 2 at the same time, Slack can deliver each event to any one active socket. The host that receives the event may then drop it because its agent/channel allowlist does not match, which looks like OpenClaw "saw nothing." Create a separate Slack app/app-level token per OpenClaw host, run a single Slack ingress Gateway, or switch multi-host deployments to HTTP Request URLs behind a load balancer. Slack documents this behavior in [Using Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode).
+</Warning>
 
 ## Quick setup
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -41,6 +41,10 @@ Both transports are production-ready and reach feature parity for messaging, sla
 **Pick HTTP Request URLs** when running multiple Gateway replicas behind a load balancer, when outbound WSS is blocked but inbound HTTPS is allowed, or when you already terminate Slack webhooks at a reverse proxy.
 </Note>
 
+<Warning>
+  Slack can maintain multiple Socket Mode connections for one app and may deliver each payload to any connection. Separate OpenClaw gateways that share an app token therefore need equivalent routing and authorization configuration. Otherwise, use a separate Slack app per gateway, a single relay ingress, or HTTP Request URLs behind a load balancer. See [Using Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode#using-multiple-connections).
+</Warning>
+
 ### Relay mode
 
 Relay mode separates Slack ingress from the OpenClaw gateway. A trusted router owns the

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -42,7 +42,7 @@ Both transports are production-ready and reach feature parity for messaging, sla
 </Note>
 
 <Warning>
-  Slack can maintain multiple Socket Mode connections for one app and may deliver each payload to any connection. Separate OpenClaw gateways that share an app token therefore need equivalent routing and authorization configuration. Otherwise, use a separate Slack app per gateway, a single relay ingress, or HTTP Request URLs behind a load balancer. See [Using Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode#using-multiple-connections).
+  Slack can maintain multiple Socket Mode connections for one app and may deliver each payload to any connection. Separate OpenClaw gateways that share a Slack app therefore need equivalent routing and authorization configuration. Otherwise, use a separate Slack app per gateway, a single relay ingress, or HTTP Request URLs behind a load balancer. See [Using Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode#using-multiple-connections).
 </Warning>
 
 ### Relay mode

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -9,7 +9,13 @@ import {
   formatSlackSocketReconnectMessage,
   formatSlackSocketStartRetryMessage,
 } from "./provider.js";
-import { formatUnknownError, waitForSlackSocketDisconnect } from "./reconnect-policy.js";
+import {
+  formatSlackSocketModeSharedConnectionWarning,
+  formatUnknownError,
+  registerSlackSocketModeConnectionDiagnostics,
+  resolveSlackSocketModeConnectionCount,
+  waitForSlackSocketDisconnect,
+} from "./reconnect-policy.js";
 
 class FakeEmitter {
   private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -133,6 +139,53 @@ describe("slack socket reconnect helpers", () => {
     ).toBe(
       "code: slack_webapi_platform_error; slack error: missing_scope; needed: connections:write; slack message: [ERROR] missing required scope",
     );
+  });
+
+  it("extracts Socket Mode connection counts from raw hello frames", () => {
+    expect(
+      resolveSlackSocketModeConnectionCount(
+        Buffer.from(JSON.stringify({ type: "hello", num_connections: 3 })),
+      ),
+    ).toBe(3);
+    expect(
+      resolveSlackSocketModeConnectionCount(
+        JSON.stringify({ type: "hello", num_connections: "4" }),
+      ),
+    ).toBe(4);
+    expect(resolveSlackSocketModeConnectionCount(JSON.stringify({ type: "events_api" }))).toBe(
+      undefined,
+    );
+    expect(resolveSlackSocketModeConnectionCount("not json")).toBe(undefined);
+  });
+
+  it("formats shared Socket Mode connection warnings with remediation", () => {
+    expect(formatSlackSocketModeSharedConnectionWarning(2)).toContain(
+      "slack socket mode reports 2 active connections for this app token",
+    );
+    expect(formatSlackSocketModeSharedConnectionWarning(2)).toContain(
+      "create a separate Slack app/token for each host",
+    );
+  });
+
+  it("warns once when Slack reports a shared Socket Mode app token", () => {
+    const client = new FakeEmitter();
+    const onSharedConnection = vi.fn();
+    const unregister = registerSlackSocketModeConnectionDiagnostics({
+      app: { receiver: { client } },
+      onSharedConnection,
+    });
+
+    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 1 }), false);
+    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 2 }), false);
+    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 3 }), false);
+
+    expect(onSharedConnection).toHaveBeenCalledTimes(1);
+    expect(onSharedConnection).toHaveBeenCalledWith(2);
+
+    unregister();
+    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 2 }), false);
+    expect(onSharedConnection).toHaveBeenCalledTimes(1);
+    expect(client.listenerCount("ws_message")).toBe(0);
   });
 
   it("formats socket start retries with an explicit reason field", () => {

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -10,7 +10,13 @@ import {
   formatSlackSocketReconnectMessage,
   formatSlackSocketStartRetryMessage,
 } from "./provider.js";
-import { formatUnknownError, waitForSlackSocketDisconnect } from "./reconnect-policy.js";
+import {
+  formatSlackSocketModeSharedConnectionWarning,
+  formatUnknownError,
+  registerSlackSocketModeConnectionDiagnostics,
+  resolveSlackSocketModeConnectionCount,
+  waitForSlackSocketDisconnect,
+} from "./reconnect-policy.js";
 
 class FakeEmitter {
   private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -140,6 +146,53 @@ describe("slack socket reconnect helpers", () => {
     ).toBe(
       "code: slack_webapi_platform_error; slack error: missing_scope; needed: connections:write; slack message: [ERROR] missing required scope",
     );
+  });
+
+  it("extracts Socket Mode connection counts from raw hello frames", () => {
+    expect(
+      resolveSlackSocketModeConnectionCount(
+        Buffer.from(JSON.stringify({ type: "hello", num_connections: 3 })),
+      ),
+    ).toBe(3);
+    expect(
+      resolveSlackSocketModeConnectionCount(
+        JSON.stringify({ type: "hello", num_connections: "4" }),
+      ),
+    ).toBe(4);
+    expect(resolveSlackSocketModeConnectionCount(JSON.stringify({ type: "events_api" }))).toBe(
+      undefined,
+    );
+    expect(resolveSlackSocketModeConnectionCount("not json")).toBe(undefined);
+  });
+
+  it("formats shared Socket Mode connection warnings with remediation", () => {
+    expect(formatSlackSocketModeSharedConnectionWarning(2)).toContain(
+      "slack socket mode reports 2 active connections for this app token",
+    );
+    expect(formatSlackSocketModeSharedConnectionWarning(2)).toContain(
+      "create a separate Slack app/token for each host",
+    );
+  });
+
+  it("warns once when Slack reports a shared Socket Mode app token", () => {
+    const client = new FakeEmitter();
+    const onSharedConnection = vi.fn();
+    const unregister = registerSlackSocketModeConnectionDiagnostics({
+      app: { receiver: { client } },
+      onSharedConnection,
+    });
+
+    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 1 }), false);
+    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 2 }), false);
+    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 3 }), false);
+
+    expect(onSharedConnection).toHaveBeenCalledTimes(1);
+    expect(onSharedConnection).toHaveBeenCalledWith(2);
+
+    unregister();
+    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 2 }), false);
+    expect(onSharedConnection).toHaveBeenCalledTimes(1);
+    expect(client.listenerCount("ws_message")).toBe(0);
   });
 
   it("formats socket start retries with an explicit reason field", () => {

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -14,7 +14,6 @@ import {
   formatSlackSocketModeSharedConnectionWarning,
   formatUnknownError,
   registerSlackSocketModeConnectionDiagnostics,
-  resolveSlackSocketModeConnectionCount,
   waitForSlackSocketDisconnect,
 } from "./reconnect-policy.js";
 
@@ -148,29 +147,12 @@ describe("slack socket reconnect helpers", () => {
     );
   });
 
-  it("extracts Socket Mode connection counts from raw hello frames", () => {
-    expect(
-      resolveSlackSocketModeConnectionCount(
-        Buffer.from(JSON.stringify({ type: "hello", num_connections: 3 })),
-      ),
-    ).toBe(3);
-    expect(
-      resolveSlackSocketModeConnectionCount(
-        JSON.stringify({ type: "hello", num_connections: "4" }),
-      ),
-    ).toBe(4);
-    expect(resolveSlackSocketModeConnectionCount(JSON.stringify({ type: "events_api" }))).toBe(
-      undefined,
-    );
-    expect(resolveSlackSocketModeConnectionCount("not json")).toBe(undefined);
-  });
-
   it("formats shared Socket Mode connection warnings with remediation", () => {
     expect(formatSlackSocketModeSharedConnectionWarning(2)).toContain(
-      "slack socket mode reports 2 active connections for this app token",
+      "slack socket mode reports 2 active connections for this Slack app",
     );
     expect(formatSlackSocketModeSharedConnectionWarning(2)).toContain(
-      "create a separate Slack app/token for each host",
+      "equivalent routing and authorization",
     );
   });
 
@@ -182,15 +164,41 @@ describe("slack socket reconnect helpers", () => {
       onSharedConnection,
     });
 
-    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 1 }), false);
-    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 2 }), false);
-    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 3 }), false);
+    client.emit(
+      "ws_message",
+      Buffer.from(JSON.stringify({ type: "events_api", payload: { text: "hello" } })),
+      false,
+    );
+    client.emit(
+      "ws_message",
+      Buffer.from(JSON.stringify({ type: "hello", num_connections: "2" })),
+      false,
+    );
+    client.emit(
+      "ws_message",
+      Buffer.from(JSON.stringify({ type: "hello", num_connections: 1 })),
+      false,
+    );
+    client.emit(
+      "ws_message",
+      Buffer.from(JSON.stringify({ type: "hello", num_connections: 2 })),
+      false,
+    );
+    client.emit(
+      "ws_message",
+      Buffer.from(JSON.stringify({ type: "hello", num_connections: 3 })),
+      false,
+    );
 
     expect(onSharedConnection).toHaveBeenCalledTimes(1);
     expect(onSharedConnection).toHaveBeenCalledWith(2);
 
     unregister();
-    client.emit("ws_message", JSON.stringify({ type: "hello", num_connections: 2 }), false);
+    client.emit(
+      "ws_message",
+      Buffer.from(JSON.stringify({ type: "hello", num_connections: 2 })),
+      false,
+    );
     expect(onSharedConnection).toHaveBeenCalledTimes(1);
     expect(client.listenerCount("ws_message")).toBe(0);
   });

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -60,9 +60,11 @@ import {
   type SlackBoltResolvedExports,
 } from "./provider-support.js";
 import {
+  formatSlackSocketModeSharedConnectionWarning,
   formatUnknownError,
   getSocketEmitter,
   isNonRecoverableSlackAuthError,
+  registerSlackSocketModeConnectionDiagnostics,
   SLACK_SOCKET_RECONNECT_POLICY,
   waitForSlackSocketDisconnect,
 } from "./reconnect-policy.js";
@@ -290,6 +292,15 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         }
       : null;
   let unregisterHttpHandler: (() => void) | null = null;
+  const unregisterSocketModeConnectionDiagnostics =
+    slackMode === "socket"
+      ? registerSlackSocketModeConnectionDiagnostics({
+          app,
+          onSharedConnection: (activeConnections) => {
+            runtime.log?.(warn(formatSlackSocketModeSharedConnectionWarning(activeConnections)));
+          },
+        })
+      : () => {};
 
   let botUserId = "";
   let botId = "";
@@ -636,6 +647,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     }
   } finally {
     opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+    unregisterSocketModeConnectionDiagnostics();
     unregisterHttpHandler?.();
     await gracefulStop();
   }

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -69,9 +69,11 @@ import {
   type SlackBoltResolvedExports,
 } from "./provider-support.js";
 import {
+  formatSlackSocketModeSharedConnectionWarning,
   formatUnknownError,
   getSocketEmitter,
   isNonRecoverableSlackAuthError,
+  registerSlackSocketModeConnectionDiagnostics,
   SLACK_SOCKET_RECONNECT_POLICY,
   waitForSlackSocketDisconnect,
 } from "./reconnect-policy.js";
@@ -334,6 +336,15 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         }
       : null;
   let unregisterHttpHandler: (() => void) | null = null;
+  const unregisterSocketModeConnectionDiagnostics =
+    slackMode === "socket"
+      ? registerSlackSocketModeConnectionDiagnostics({
+          app,
+          onSharedConnection: (activeConnections) => {
+            runtime.log?.(warn(formatSlackSocketModeSharedConnectionWarning(activeConnections)));
+          },
+        })
+      : () => {};
 
   let botUserId = "";
   let botId = "";
@@ -707,6 +718,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       setSlackDefaultSendIdentity(account.accountId, undefined);
     }
     opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+    unregisterSocketModeConnectionDiagnostics();
     unregisterHttpHandler?.();
     await gracefulStop();
   }

--- a/extensions/slack/src/monitor/reconnect-policy.ts
+++ b/extensions/slack/src/monitor/reconnect-policy.ts
@@ -19,6 +19,9 @@ type EmitterLike = {
   off: (event: string, listener: (...args: unknown[]) => void) => unknown;
 };
 
+const SLACK_SOCKET_SHARED_CONNECTION_DOCS_URL =
+  "https://docs.slack.dev/apis/events-api/using-socket-mode";
+
 export function getSocketEmitter(app: unknown): EmitterLike | null {
   const receiver = (app as { receiver?: unknown }).receiver;
   const client =
@@ -42,6 +45,96 @@ export function getSocketEmitter(app: unknown): EmitterLike | null {
       (
         off as (this: unknown, event: string, listener: (...args: unknown[]) => void) => unknown
       ).call(client, event, listener),
+  };
+}
+
+function socketMessageToString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString("utf8");
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("utf8");
+  }
+  if (value instanceof ArrayBuffer) {
+    return Buffer.from(value).toString("utf8");
+  }
+  if (isBufferArray(value)) {
+    return Buffer.concat(value).toString("utf8");
+  }
+  return undefined;
+}
+
+function isBufferArray(value: unknown): value is Buffer[] {
+  return Array.isArray(value) && value.every((entry) => Buffer.isBuffer(entry));
+}
+
+function normalizeSocketConnectionCount(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+export function resolveSlackSocketModeConnectionCount(message: unknown): number | undefined {
+  const text = socketMessageToString(message);
+  if (!text) {
+    return undefined;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(payload) || payload.type !== "hello") {
+    return undefined;
+  }
+  return normalizeSocketConnectionCount(payload.num_connections);
+}
+
+export function formatSlackSocketModeSharedConnectionWarning(activeConnections: number): string {
+  return [
+    `slack socket mode reports ${activeConnections} active connections for this app token`,
+    "Slack may deliver each event to any one connection, so messages can land on another OpenClaw gateway and appear to vanish.",
+    "Run exactly one OpenClaw gateway per Slack app token, create a separate Slack app/token for each host, or use HTTP Request URLs behind a load balancer.",
+    `See ${SLACK_SOCKET_SHARED_CONNECTION_DOCS_URL}`,
+  ].join("; ");
+}
+
+export function registerSlackSocketModeConnectionDiagnostics(params: {
+  app: unknown;
+  onSharedConnection: (activeConnections: number) => void;
+}): () => void {
+  const emitter = getSocketEmitter(params.app);
+  if (!emitter) {
+    return () => {};
+  }
+  let hasWarned = false;
+  const listener = (message: unknown, isBinary?: unknown) => {
+    if (isBinary === true || hasWarned) {
+      return;
+    }
+    const activeConnections = resolveSlackSocketModeConnectionCount(message);
+    if (activeConnections === undefined || activeConnections <= 1) {
+      return;
+    }
+    hasWarned = true;
+    params.onSharedConnection(activeConnections);
+  };
+  emitter.on("ws_message", listener);
+  return () => {
+    emitter.off("ws_message", listener);
   };
 }
 

--- a/extensions/slack/src/monitor/reconnect-policy.ts
+++ b/extensions/slack/src/monitor/reconnect-policy.ts
@@ -18,6 +18,9 @@ type EmitterLike = {
   off: (event: string, listener: (...args: unknown[]) => void) => unknown;
 };
 
+const SLACK_SOCKET_SHARED_CONNECTION_DOCS_URL =
+  "https://docs.slack.dev/apis/events-api/using-socket-mode";
+
 export function getSocketEmitter(app: unknown): EmitterLike | null {
   const receiver = (app as { receiver?: unknown }).receiver;
   const client =
@@ -41,6 +44,96 @@ export function getSocketEmitter(app: unknown): EmitterLike | null {
       (
         off as (this: unknown, event: string, listener: (...args: unknown[]) => void) => unknown
       ).call(client, event, listener),
+  };
+}
+
+function socketMessageToString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString("utf8");
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("utf8");
+  }
+  if (value instanceof ArrayBuffer) {
+    return Buffer.from(value).toString("utf8");
+  }
+  if (isBufferArray(value)) {
+    return Buffer.concat(value).toString("utf8");
+  }
+  return undefined;
+}
+
+function isBufferArray(value: unknown): value is Buffer[] {
+  return Array.isArray(value) && value.every((entry) => Buffer.isBuffer(entry));
+}
+
+function normalizeSocketConnectionCount(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+export function resolveSlackSocketModeConnectionCount(message: unknown): number | undefined {
+  const text = socketMessageToString(message);
+  if (!text) {
+    return undefined;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(payload) || payload.type !== "hello") {
+    return undefined;
+  }
+  return normalizeSocketConnectionCount(payload.num_connections);
+}
+
+export function formatSlackSocketModeSharedConnectionWarning(activeConnections: number): string {
+  return [
+    `slack socket mode reports ${activeConnections} active connections for this app token`,
+    "Slack may deliver each event to any one connection, so messages can land on another OpenClaw gateway and appear to vanish.",
+    "Run exactly one OpenClaw gateway per Slack app token, create a separate Slack app/token for each host, or use HTTP Request URLs behind a load balancer.",
+    `See ${SLACK_SOCKET_SHARED_CONNECTION_DOCS_URL}`,
+  ].join("; ");
+}
+
+export function registerSlackSocketModeConnectionDiagnostics(params: {
+  app: unknown;
+  onSharedConnection: (activeConnections: number) => void;
+}): () => void {
+  const emitter = getSocketEmitter(params.app);
+  if (!emitter) {
+    return () => {};
+  }
+  let hasWarned = false;
+  const listener = (message: unknown, isBinary?: unknown) => {
+    if (isBinary === true || hasWarned) {
+      return;
+    }
+    const activeConnections = resolveSlackSocketModeConnectionCount(message);
+    if (activeConnections === undefined || activeConnections <= 1) {
+      return;
+    }
+    hasWarned = true;
+    params.onSharedConnection(activeConnections);
+  };
+  emitter.on("ws_message", listener);
+  return () => {
+    emitter.off("ws_message", listener);
   };
 }
 

--- a/extensions/slack/src/monitor/reconnect-policy.ts
+++ b/extensions/slack/src/monitor/reconnect-policy.ts
@@ -1,4 +1,5 @@
 // Slack plugin module implements reconnect policy behavior.
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatSlackError } from "../errors.js";
 
 const SLACK_AUTH_ERROR_RE =
@@ -20,7 +21,8 @@ type EmitterLike = {
 };
 
 const SLACK_SOCKET_SHARED_CONNECTION_DOCS_URL =
-  "https://docs.slack.dev/apis/events-api/using-socket-mode";
+  "https://docs.slack.dev/apis/events-api/using-socket-mode#using-multiple-connections";
+const SLACK_SOCKET_HELLO_MARKER = Buffer.from('"hello"');
 
 export function getSocketEmitter(app: unknown): EmitterLike | null {
   const receiver = (app as { receiver?: unknown }).receiver;
@@ -48,66 +50,36 @@ export function getSocketEmitter(app: unknown): EmitterLike | null {
   };
 }
 
-function socketMessageToString(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (Buffer.isBuffer(value)) {
-    return value.toString("utf8");
-  }
-  if (value instanceof Uint8Array) {
-    return Buffer.from(value).toString("utf8");
-  }
-  if (value instanceof ArrayBuffer) {
-    return Buffer.from(value).toString("utf8");
-  }
-  if (isBufferArray(value)) {
-    return Buffer.concat(value).toString("utf8");
-  }
-  return undefined;
-}
-
 function isBufferArray(value: unknown): value is Buffer[] {
   return Array.isArray(value) && value.every((entry) => Buffer.isBuffer(entry));
 }
 
-function normalizeSocketConnectionCount(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
-    return value;
-  }
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!/^\d+$/.test(trimmed)) {
-    return undefined;
-  }
-  const parsed = Number(trimmed);
-  return Number.isSafeInteger(parsed) ? parsed : undefined;
-}
-
-export function resolveSlackSocketModeConnectionCount(message: unknown): number | undefined {
-  const text = socketMessageToString(message);
-  if (!text) {
+function resolveSlackSocketModeConnectionCount(message: unknown): number | undefined {
+  const buffer = Buffer.isBuffer(message)
+    ? message
+    : message instanceof ArrayBuffer
+      ? Buffer.from(message)
+      : isBufferArray(message)
+        ? Buffer.concat(message)
+        : undefined;
+  if (!buffer?.includes(SLACK_SOCKET_HELLO_MARKER)) {
     return undefined;
   }
   let payload: unknown;
   try {
-    payload = JSON.parse(text);
+    payload = JSON.parse(buffer.toString("utf8"));
   } catch {
     return undefined;
   }
-  if (!isRecord(payload) || payload.type !== "hello") {
-    return undefined;
-  }
-  return normalizeSocketConnectionCount(payload.num_connections);
+  const count = isRecord(payload) && payload.type === "hello" ? payload.num_connections : undefined;
+  return typeof count === "number" && Number.isSafeInteger(count) && count >= 0 ? count : undefined;
 }
 
 export function formatSlackSocketModeSharedConnectionWarning(activeConnections: number): string {
   return [
-    `slack socket mode reports ${activeConnections} active connections for this app token`,
-    "Slack may deliver each event to any one connection, so messages can land on another OpenClaw gateway and appear to vanish.",
-    "Run exactly one OpenClaw gateway per Slack app token, create a separate Slack app/token for each host, or use HTTP Request URLs behind a load balancer.",
+    `slack socket mode reports ${activeConnections} active connections for this Slack app`,
+    "Slack may deliver each event to any one connection",
+    "ensure every OpenClaw gateway sharing this app has equivalent routing and authorization, or use a separate Slack app per gateway, one relay ingress, or HTTP Request URLs behind a load balancer",
     `See ${SLACK_SOCKET_SHARED_CONNECTION_DOCS_URL}`,
   ].join("; ");
 }


### PR DESCRIPTION
## What Problem This Solves

Slack Socket Mode can keep several connections open for one Slack app and deliver each event to any active connection. Independent OpenClaw gateways sharing that app can therefore appear to lose events when their routing or authorization differs, while current logs do not explain the competing connections.

## Why This Change Was Made

- Inspect Slack's raw Socket Mode `hello` frame because `@slack/socket-mode` otherwise reduces it to a connected event and does not expose `num_connections`.
- Warn once when Slack reports more than one active connection for the app.
- Keep the listener Socket Mode-only, ignore unrelated frames before JSON parsing, and unregister it during provider cleanup.
- Document safe deployment choices: equivalent gateway configuration, separate Slack apps, one relay ingress, or HTTP Request URLs behind a load balancer.

## User Impact

Operators with shared Slack Socket Mode apps get one actionable startup warning instead of unexplained intermittent routing. Single-connection deployments are unchanged. The warning is diagnostic only and does not change event delivery.

## Evidence

- Live Slack proof: with the configured healthy gateway connected, a temporary foreground gateway from this branch connected to the same app. Slack's `hello` reported 4 active connections; OpenClaw emitted the shared-connection warning once; the temporary gateway was then stopped.
- Focused Testbox: `tbx_01kwr0aafxn8arcgyj0my1wx3v` — `extensions/slack/src/monitor/provider.reconnect.test.ts`, 17/17 passed.
- Broad changed gate: `tbx_01kwr0393qa4nrfbxfbnnqntn0` — extension/type/lint/docs/import-cycle checks passed.
- Fresh maintainer autoreview: clean after correcting app-level scope in both runtime guidance and docs.
- Contract checked against Slack's official [Socket Mode multiple-connections documentation](https://docs.slack.dev/apis/events-api/using-socket-mode#using-multiple-connections) and installed `@slack/socket-mode` 2.0.7 source.
