### PR TITLE
fix(discord): log silent reply drops; allow archives in host-read media

### DIFF
--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -15,10 +15,13 @@ import {
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import type { RequestClient } from "../internal/discord.js";
 import { sendMessageDiscord, sendVoiceMessageDiscord } from "../send.js";
 import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
+
+const replyDeliveryLogger = createSubsystemLogger("discord/reply-delivery");
 
 export type DiscordThreadBindingLookupRecord = {
   accountId: string;
@@ -178,6 +181,9 @@ export async function deliverDiscordReply(params: {
   const delivery = resolveDiscordDeliveryOptions(params);
   const payloads = sanitizeDiscordFrontChannelReplyPayloads(params.replies);
   if (payloads.length === 0) {
+    replyDeliveryLogger.warn(
+      `dropping discord reply: no sendable payloads after sanitization (input=${params.replies.length}, sessionKey=${params.sessionKey ?? "?"}, target=${params.target})`,
+    );
     return;
   }
 

--- a/extensions/discord/src/monitor/reply-safety.ts
+++ b/extensions/discord/src/monitor/reply-safety.ts
@@ -1,6 +1,9 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-runtime";
+
+const replySafetyLogger = createSubsystemLogger("discord/reply-safety");
 
 const DISCORD_INTERNAL_TRACE_LINE_RE =
   /^(?:>\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
@@ -81,6 +84,9 @@ export function sanitizeDiscordFrontChannelReplyPayloads(
         : ({ ...payload, text: safeText || undefined } as ReplyPayload);
     const nextParts = resolveSendableOutboundReplyParts(nextPayload);
     if (!nextParts.hasContent && !hasNonTextReplyPayloadContent(nextPayload)) {
+      replySafetyLogger.warn(
+        `skipping discord reply payload: no sendable content after sanitization (originalLen=${typeof payload.text === "string" ? payload.text.length : 0}, sanitizedLen=${typeof safeText === "string" ? safeText.length : 0})`,
+      );
       continue;
     }
     safePayloads.push(nextPayload);

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -123,6 +123,10 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/zip",
+  "application/gzip",
+  "application/x-tar",
+  "application/x-7z-compressed",
   "text/csv",
   "text/markdown",
 ]);
@@ -317,7 +321,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, and common archives (zip/gzip/tar/7z) (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 


### PR DESCRIPTION
## Summary

Two related fixes that surfaced while debugging an operator's Discord bot that
appeared to "stop replying" mid-conversation.

- **`fix(discord)`** — Reply payloads were being silently dropped at two
  sanitization gates: `sanitizeDiscordFrontChannelReplyPayloads` (when no
  sendable content remained after sanitization) and the zero-payloads
  early-return inside `deliverDiscordFrontChannelReplyPayloads`. Neither
  emitted any log entry, so the gateway log had nothing to explain why an
  agent's generated reply never reached the channel — symptoms looked like
  a frozen channel session. Add `warn`-level logs in the new
  `discord/reply-safety` and `discord/reply-delivery` subsystems including
  the originating `sessionKey`/`target` and the input vs. sanitized lengths.
  No behavior change beyond log lines.

- **`feat(media)`** — `HOST_READ_ALLOWED_DOCUMENT_MIMES` rejected
  `application/zip` (and other common archive MIMEs), so any agent flow that
  built a `.zip` artifact and tried to deliver it via a channel hit
  `"Host-local media sends only allow buffer-verified images, audio, video,
  PDF, and Office documents (got application/zip)."` and the delivery got
  stuck in the queue indefinitely. Widen the allowlist to also accept zip /
  gzip / tar / 7z. Buffer-verification (file-type magic-byte sniffing) is
  unchanged: a file claimed to be a zip must still actually have a PK
  signature to pass — spoofing protection is preserved.

## Verification

- [x] `pnpm test src/media/web-media.test.ts extensions/discord/src/monitor/reply-delivery.test.ts` — 51 passed (39 + 12).
- [x] `pnpm build` — clean.
- [x] Built dist deployed to a local managed gateway (`openclaw gateway restart`); `gateway call health` returned `ok=true`, `eventLoop.degraded=false`, 12 plugins loaded, no errors.
- [x] End-to-end reply test via `openclaw agent` (no `--deliver`) — full path CLI → gateway → agent → model returned `PONG` from claude-opus-4-7, `stopReason: stop`.
- [ ] Live discord delivery proof — operator will validate by sending a fresh message in the affected channel after merge.

## Notes

- The third silent-return site flagged during recon
  (`outbound-adapter.ts:71-86` in `maybeSendDiscordWebhookText`) is an
  intentional fallback path that cascades to the regular `sendMessageDiscord`
  send when no webhook binding applies — not actually a drop. Left untouched
  to avoid log noise.
- Archive types deliberately do **not** include `application/octet-stream`
  or other un-sniffable MIMEs; an operator who needs truly opaque uploads
  should opt in via a separate config flag (out of scope here).