### PR TITLE
feat(gateway): allow chat.inject to override provider attribution via originAgent

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5910,21 +5910,25 @@ public struct ChatInjectParams: Codable, Sendable {
     public let sessionkey: String
     public let message: String
     public let label: String?
+    public let originagent: String?
 
     public init(
         sessionkey: String,
         message: String,
-        label: String?)
+        label: String?,
+        originagent: String?)
     {
         self.sessionkey = sessionkey
         self.message = message
         self.label = label
+        self.originagent = originagent
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case message
         case label
+        case originagent = "originAgent"
     }
 }
 

--- a/scripts/proof-chat-inject-origin-agent.mts
+++ b/scripts/proof-chat-inject-origin-agent.mts
@@ -1,0 +1,99 @@
+#!/usr/bin/env tsx
+/**
+ * Real-behavior proof for chat.inject originAgent attribution patch.
+ *
+ * Exercises the patched code path in `appendInjectedAssistantMessageToTranscript`
+ * against a synthetic transcript fixture. No real session keys, no real
+ * channel ids, nothing from the running OpenClaw install.
+ *
+ * Output:
+ *   1) baseline call (no originAgent)         -> provider = "openclaw"
+ *   2) patched call  (originAgent: "hermes")  -> provider = "hermes"
+ *   3) patched call  (originAgent: "codex")   -> provider = "codex"
+ *
+ * Each line of the resulting transcript jsonl is read back and the `provider`
+ * field is printed verbatim, proving the patched code path stamps the value.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { appendInjectedAssistantMessageToTranscript } from "../src/gateway/server-methods/chat-transcript-inject.js";
+import { createTranscriptFixtureSync } from "../src/gateway/server-methods/chat.test-helpers.js";
+
+function readLast(transcriptPath: string): Record<string, unknown> | null {
+  const raw = fs.readFileSync(transcriptPath, "utf-8");
+  const lines = raw.split(/\r?\n/).filter((l) => l.length > 0);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const obj = JSON.parse(lines[i]) as Record<string, unknown>;
+    if (obj.type === "message") {
+      return obj;
+    }
+  }
+  return null;
+}
+
+function extractProvider(entry: Record<string, unknown> | null): string {
+  if (!entry) return "<no-message-entry>";
+  const msg = (entry as { message?: Record<string, unknown> }).message;
+  if (msg && typeof msg === "object" && typeof msg.provider === "string") {
+    return msg.provider;
+  }
+  return JSON.stringify(msg ?? entry).slice(0, 200);
+}
+
+async function runCase(
+  caseLabel: string,
+  originAgent: string | undefined,
+): Promise<void> {
+  const { dir, transcriptPath } = createTranscriptFixtureSync({
+    prefix: "proof-chat-inject-",
+    sessionId: `synthetic-${caseLabel}`,
+  });
+  try {
+    const result = await appendInjectedAssistantMessageToTranscript({
+      transcriptPath,
+      message: `synthetic test body for case=${caseLabel}`,
+      label: "proof-fixture",
+      ...(originAgent !== undefined ? { originAgent } : {}),
+    });
+
+    const last = readLast(transcriptPath);
+    const provider = extractProvider(last);
+
+    console.log("=================================================");
+    console.log(`CASE          : ${caseLabel}`);
+    console.log(`originAgent   : ${originAgent === undefined ? "<unset>" : `"${originAgent}"`}`);
+    console.log(`append.ok     : ${result.ok}`);
+    console.log(`messageId     : ${result.messageId ?? "<none>"}`);
+    console.log(`stamped.provider : ${provider}`);
+    console.log("");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  console.log("");
+  console.log("OpenClaw chat.inject originAgent attribution — real-behavior proof");
+  console.log("Patched modules under test:");
+  console.log("  src/gateway/server-methods/chat-transcript-inject.ts");
+  console.log("  src/gateway/protocol/schema/logs-chat.ts (schema field)");
+  console.log("  src/gateway/server-methods/chat.ts (handler threading)");
+  console.log("");
+
+  await runCase("baseline-no-origin", undefined);
+  await runCase("hermes", "hermes");
+  await runCase("codex", "codex");
+
+  console.log("=================================================");
+  console.log("Expected: provider = \"openclaw\" when originAgent unset,");
+  console.log("          provider = \"<originAgent>\" when set.");
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error("FAILED:", err);
+  process.exit(1);
+});

--- a/scripts/proof-chat-inject-origin-agent.mts
+++ b/scripts/proof-chat-inject-origin-agent.mts
@@ -1,55 +1,44 @@
 #!/usr/bin/env tsx
 /**
- * Real-behavior proof for chat.inject originAgent attribution patch.
+ * Real-behavior proof for the chat.inject originAgent attribution patch.
  *
- * Exercises the patched code path in `appendInjectedAssistantMessageToTranscript`
- * against a synthetic transcript fixture. No real session keys, no real
- * channel ids, nothing from the running OpenClaw install.
+ * Exercises `appendInjectedAssistantMessageToTranscript` against synthetic
+ * transcript fixtures and reads the persisted jsonl back to confirm:
  *
- * Output:
- *   1) baseline call (no originAgent)         -> provider = "openclaw"
- *   2) patched call  (originAgent: "hermes")  -> provider = "hermes"
- *   3) patched call  (originAgent: "codex")   -> provider = "codex"
+ *   1. provider stays "openclaw" in every case (replay-filter sentinel preserved)
+ *   2. originAgent is absent on baseline calls
+ *   3. originAgent is stamped verbatim when a non-empty value is passed
+ *   4. blank/whitespace originAgent is normalized to absent
  *
- * Each line of the resulting transcript jsonl is read back and the `provider`
- * field is printed verbatim, proving the patched code path stamps the value.
+ * Synthetic fixtures only — no real session keys, no tokens, no production data.
  */
 
 import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
 
 import { appendInjectedAssistantMessageToTranscript } from "../src/gateway/server-methods/chat-transcript-inject.js";
 import { createTranscriptFixtureSync } from "../src/gateway/server-methods/chat.test-helpers.js";
 
-function readLast(transcriptPath: string): Record<string, unknown> | null {
+function readLastMessageBody(transcriptPath: string): Record<string, unknown> | null {
   const raw = fs.readFileSync(transcriptPath, "utf-8");
   const lines = raw.split(/\r?\n/).filter((l) => l.length > 0);
   for (let i = lines.length - 1; i >= 0; i -= 1) {
     const obj = JSON.parse(lines[i]) as Record<string, unknown>;
     if (obj.type === "message") {
-      return obj;
+      const msg = (obj as { message?: Record<string, unknown> }).message;
+      return msg ?? null;
     }
   }
   return null;
 }
 
-function extractProvider(entry: Record<string, unknown> | null): string {
-  if (!entry) return "<no-message-entry>";
-  const msg = (entry as { message?: Record<string, unknown> }).message;
-  if (msg && typeof msg === "object" && typeof msg.provider === "string") {
-    return msg.provider;
-  }
-  return JSON.stringify(msg ?? entry).slice(0, 200);
-}
-
 async function runCase(
   caseLabel: string,
   originAgent: string | undefined,
+  expectedOriginAgentField: string | "absent",
 ): Promise<void> {
   const { dir, transcriptPath } = createTranscriptFixtureSync({
     prefix: "proof-chat-inject-",
-    sessionId: `synthetic-${caseLabel}`,
+    sessionId: `synthetic-${caseLabel.replace(/\s+/g, "-")}`,
   });
   try {
     const result = await appendInjectedAssistantMessageToTranscript({
@@ -59,15 +48,39 @@ async function runCase(
       ...(originAgent !== undefined ? { originAgent } : {}),
     });
 
-    const last = readLast(transcriptPath);
-    const provider = extractProvider(last);
+    const body = readLastMessageBody(transcriptPath);
+    const provider = (body && typeof body.provider === "string") ? body.provider : "<missing>";
+    const model = (body && typeof body.model === "string") ? body.model : "<missing>";
+    const persistedOriginAgent =
+      body && Object.prototype.hasOwnProperty.call(body, "originAgent")
+        ? String((body as { originAgent: unknown }).originAgent)
+        : "<absent>";
+
+    let pass = true;
+    if (provider !== "openclaw") {
+      pass = false;
+    }
+    if (model !== "gateway-injected") {
+      pass = false;
+    }
+    if (expectedOriginAgentField === "absent") {
+      if (persistedOriginAgent !== "<absent>") {
+        pass = false;
+      }
+    } else if (persistedOriginAgent !== expectedOriginAgentField) {
+      pass = false;
+    }
 
     console.log("=================================================");
-    console.log(`CASE          : ${caseLabel}`);
-    console.log(`originAgent   : ${originAgent === undefined ? "<unset>" : `"${originAgent}"`}`);
-    console.log(`append.ok     : ${result.ok}`);
-    console.log(`messageId     : ${result.messageId ?? "<none>"}`);
-    console.log(`stamped.provider : ${provider}`);
+    console.log(`CASE                  : ${caseLabel}`);
+    console.log(`input.originAgent     : ${originAgent === undefined ? "<unset>" : JSON.stringify(originAgent)}`);
+    console.log(`append.ok             : ${result.ok}`);
+    console.log(`messageId             : ${result.messageId ?? "<none>"}`);
+    console.log(`stamped.provider      : ${provider}`);
+    console.log(`stamped.model         : ${model}`);
+    console.log(`stamped.originAgent   : ${persistedOriginAgent}`);
+    console.log(`expected.originAgent  : ${expectedOriginAgentField}`);
+    console.log(`result                : ${pass ? "PASS" : "FAIL"}`);
     console.log("");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -82,15 +95,18 @@ async function main(): Promise<void> {
   console.log("  src/gateway/protocol/schema/logs-chat.ts (schema field)");
   console.log("  src/gateway/server-methods/chat.ts (handler threading)");
   console.log("");
-
-  await runCase("baseline-no-origin", undefined);
-  await runCase("hermes", "hermes");
-  await runCase("codex", "codex");
-
-  console.log("=================================================");
-  console.log("Expected: provider = \"openclaw\" when originAgent unset,");
-  console.log("          provider = \"<originAgent>\" when set.");
+  console.log("Design:");
+  console.log("  provider stays 'openclaw' (replay-filter sentinel preserved)");
+  console.log("  originAgent is a NEW persisted field for display-only attribution");
+  console.log("  empty/whitespace originAgent is normalized to absent");
   console.log("");
+
+  await runCase("baseline-no-origin", undefined, "absent");
+  await runCase("hermes", "hermes", "hermes");
+  await runCase("codex", "codex", "codex");
+  await runCase("blank-empty-string", "", "absent");
+  await runCase("whitespace-only", "   ", "absent");
+  await runCase("trim-surrounding-whitespace", "  hermes  ", "hermes");
 }
 
 main().catch((err) => {

--- a/scripts/proof-chat-inject-origin-agent.mts
+++ b/scripts/proof-chat-inject-origin-agent.mts
@@ -34,7 +34,7 @@ function readLastMessageBody(transcriptPath: string): Record<string, unknown> | 
 async function runCase(
   caseLabel: string,
   originAgent: string | undefined,
-  expectedOriginAgentField: string | "absent",
+  expectedOriginAgentField: string,
 ): Promise<void> {
   const { dir, transcriptPath } = createTranscriptFixtureSync({
     prefix: "proof-chat-inject-",

--- a/scripts/proof-chat-inject-schema.mts
+++ b/scripts/proof-chat-inject-schema.mts
@@ -1,0 +1,43 @@
+#!/usr/bin/env tsx
+/**
+ * Schema-half proof: ChatInjectParamsSchema accepts originAgent.
+ *
+ * Before patch: validateChatInjectParams({ ..., originAgent }) returns false
+ *               with `additionalProperties` error from AJV.
+ * After patch:  returns true.
+ */
+
+import { validateChatInjectParams } from "../src/gateway/protocol/index.js";
+
+function show(label: string, params: unknown): void {
+  const ok = validateChatInjectParams(params as never);
+  const errs = (validateChatInjectParams as { errors?: Array<Record<string, unknown>> }).errors;
+  console.log(`---`);
+  console.log(`CASE     : ${label}`);
+  console.log(`accepted : ${ok}`);
+  if (!ok) {
+    console.log(`errors   : ${JSON.stringify(errs)}`);
+  }
+}
+
+console.log("ChatInjectParamsSchema validator behavior:");
+console.log("");
+
+show("legacy params (sessionKey + message + label)", {
+  sessionKey: "synthetic:fixture",
+  message: "hello",
+  label: "proof",
+});
+
+show("patched params (with originAgent)", {
+  sessionKey: "synthetic:fixture",
+  message: "hello",
+  label: "proof",
+  originAgent: "hermes",
+});
+
+show("rejects unknown extra fields (additionalProperties:false preserved)", {
+  sessionKey: "synthetic:fixture",
+  message: "hello",
+  somethingMadeUp: "should-fail",
+});

--- a/scripts/proof-chat-inject-schema.mts
+++ b/scripts/proof-chat-inject-schema.mts
@@ -1,10 +1,8 @@
 #!/usr/bin/env tsx
 /**
- * Schema-half proof: ChatInjectParamsSchema accepts originAgent.
- *
- * Before patch: validateChatInjectParams({ ..., originAgent }) returns false
- *               with `additionalProperties` error from AJV.
- * After patch:  returns true.
+ * Schema-half proof: ChatInjectParamsSchema accepts non-empty originAgent,
+ * rejects empty/whitespace-only originAgent, and still rejects unknown
+ * extra fields (additionalProperties:false invariant preserved).
  */
 
 import { validateChatInjectParams } from "../src/gateway/protocol/index.js";
@@ -29,11 +27,17 @@ show("legacy params (sessionKey + message + label)", {
   label: "proof",
 });
 
-show("patched params (with originAgent)", {
+show("patched params (with non-empty originAgent)", {
   sessionKey: "synthetic:fixture",
   message: "hello",
   label: "proof",
   originAgent: "hermes",
+});
+
+show("rejects empty-string originAgent (minLength:1)", {
+  sessionKey: "synthetic:fixture",
+  message: "hello",
+  originAgent: "",
 });
 
 show("rejects unknown extra fields (additionalProperties:false preserved)", {

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -66,7 +66,7 @@ export const ChatInjectParamsSchema = Type.Object(
     sessionKey: NonEmptyString,
     message: NonEmptyString,
     label: Type.Optional(Type.String({ maxLength: 100 })),
-    originAgent: Type.Optional(Type.String({ maxLength: 100 })),
+    originAgent: Type.Optional(Type.String({ minLength: 1, maxLength: 100 })),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -66,6 +66,7 @@ export const ChatInjectParamsSchema = Type.Object(
     sessionKey: NonEmptyString,
     message: NonEmptyString,
     label: Type.Optional(Type.String({ maxLength: 100 })),
+    originAgent: Type.Optional(Type.String({ maxLength: 100 })),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -48,9 +48,12 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
   message: string;
   label?: string;
   /**
-   * When set, stamps the persisted assistant entry's `provider` field so
+   * When set, persists a separate `originAgent` field on the assistant entry so
    * downstream UIs (avatar/handle resolvers) can attribute the inject to a
-   * non-OpenClaw source (e.g. "hermes", "codex"). Default remains "openclaw".
+   * non-OpenClaw source (e.g. "hermes", "codex"). The sentinel `provider:
+   * "openclaw"` + `model: "gateway-injected"` pair is preserved unchanged so
+   * the replay-history filter still drops these rows from model replay.
+   * Whitespace-only or empty values are treated as unset.
    */
   originAgent?: string;
   /** When set, used as the assistant `content` array (e.g. text + embedded audio blocks). */

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -80,6 +80,12 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
     label: params.label,
     content: params.content,
   });
+  // Normalize: trim whitespace, treat empty as unset. Keeps malformed attribution
+  // values out of the persisted transcript even if the schema is permissive.
+  const normalizedOriginAgent =
+    typeof params.originAgent === "string" && params.originAgent.trim().length > 0
+      ? params.originAgent.trim()
+      : undefined;
   const messageBody: AppendMessageArg & Record<string, unknown> = {
     role: "assistant",
     // Gateway-injected assistant messages can include non-model content blocks (e.g. embedded TTS audio).
@@ -93,9 +99,17 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
     stopReason: "stop",
     usage,
     // Make these explicit so downstream tooling never treats this as model output.
+    // `provider: "openclaw"` + `model: "gateway-injected"` is the sentinel pair the
+    // replay-history filter (replay-history.ts) keys off to drop transcript-only
+    // injected rows from being replayed back to the next model. Do not change these.
     api: "openai-responses",
-    provider: params.originAgent ?? "openclaw",
+    provider: "openclaw",
     model: "gateway-injected",
+    // Display-only attribution. UI avatar/handle resolvers may key off this to render
+    // the true source of a cross-agent inject (e.g. "hermes", "codex"). It does NOT
+    // participate in replay filtering; the sentinel provider/model pair above continues
+    // to mark this as transcript-only output regardless of originAgent.
+    ...(normalizedOriginAgent ? { originAgent: normalizedOriginAgent } : {}),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
     ...(params.abortMeta
       ? {

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -47,6 +47,12 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
   transcriptPath: string;
   message: string;
   label?: string;
+  /**
+   * When set, stamps the persisted assistant entry's `provider` field so
+   * downstream UIs (avatar/handle resolvers) can attribute the inject to a
+   * non-OpenClaw source (e.g. "hermes", "codex"). Default remains "openclaw".
+   */
+  originAgent?: string;
   /** When set, used as the assistant `content` array (e.g. text + embedded audio blocks). */
   content?: Array<Record<string, unknown>>;
   idempotencyKey?: string;
@@ -88,7 +94,7 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
     usage,
     // Make these explicit so downstream tooling never treats this as model output.
     api: "openai-responses",
-    provider: "openclaw",
+    provider: params.originAgent ?? "openclaw",
     model: "gateway-injected",
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
     ...(params.abortMeta

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1375,6 +1375,7 @@ async function transcriptHasIdempotencyKey(
 async function appendAssistantTranscriptMessage(params: {
   message: string;
   label?: string;
+  originAgent?: string;
   content?: Array<Record<string, unknown>>;
   sessionId: string;
   storePath: string | undefined;
@@ -1423,6 +1424,7 @@ async function appendAssistantTranscriptMessage(params: {
     transcriptPath,
     message: params.message,
     label: params.label,
+    originAgent: params.originAgent,
     content: params.content,
     idempotencyKey: params.idempotencyKey,
     abortMeta: params.abortMeta,
@@ -2836,6 +2838,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionKey: string;
       message: string;
       label?: string;
+      originAgent?: string;
     };
 
     // Load session to find transcript file
@@ -2850,6 +2853,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     const appended = await appendAssistantTranscriptMessage({
       message: p.message,
       label: p.label,
+      originAgent: p.originAgent,
       sessionId,
       storePath,
       sessionFile: entry?.sessionFile,


### PR DESCRIPTION
## Summary

Adds an optional `originAgent` field to `ChatInjectParamsSchema` and persists it as a **separate, dedicated attribution field** on the injected assistant transcript entry. The pre-existing `(provider: "openclaw", model: "gateway-injected")` sentinel pair is **preserved unchanged**, so the runtime replay filter at `src/agents/pi-embedded-runner/replay-history.ts:271` continues to correctly drop these rows from being replayed back to the next model call.

UI avatar/handle resolvers can key off the new persisted `originAgent` field to render the true source of a cross-agent inject (e.g. Hermes, Codex) instead of always showing the OpenClaw avatar.

## Why

`chat.inject` is the canonical RPC for cross-agent transcript writes. Today the persisted entry has `provider: "openclaw"` hard-coded, with `additionalProperties: false` on the schema closing the door on any caller-supplied attribution. When external agents (Hermes, Codex, Claude Code, etc.) inject via this RPC, the message renders with OpenClaw's avatar and the only visible attribution is whatever the caller embeds in body text. This breaks the "who said what" guarantee in long transcripts.

Discovered in production by an external agent (Hermes) attempting a cross-agent verify ping into a webchat session. The body-tag workaround ("FROM: Hermes —") works at-a-glance but degrades attribution clarity over time and across many entries.

## Behavior

- **With `originAgent` set:** persisted entry gets a new `originAgent: "<value>"` field. `provider` and `model` are unchanged.
- **Without `originAgent`:** behavior is byte-identical to current main. No new field is written. Fully backward compatible.
- **Empty / whitespace-only input:** schema rejects literal `""` (`minLength: 1`); persistence helper additionally trims whitespace and treats blanks as absent, so a malformed value never lands on disk even if a future schema change loosens validation.

## Why a separate field, not provider override

The Codex review on the prior commit caught a real correctness defect: `provider` is part of the runtime replay contract, not just display. `normalizeAssistantReplayContent` (`src/agents/pi-embedded-runner/replay-history.ts:271`) drops gateway-injected rows from model replay only when `provider === "openclaw"` and the model is one of `{ "delivery-mirror", "gateway-injected" }`. Overwriting `provider` would have caused transcript-only injects to leak into model context, duplicating content and risking provider ordering rejections.

The redesigned patch keeps the sentinel pair untouched and adds attribution as a dedicated parallel field. UI consumers read the new field; the replay filter is unaffected.

## Security

`chat.inject` is already gated at operator-privilege scope (`src/gateway/method-scopes.ts`). Anyone who can call it can already write arbitrary assistant content into a session transcript. `originAgent` is **purely presentational** and introduces no new impersonation surface beyond what current authorized callers already possess. Because the sentinel pair is preserved, the previously-flagged security risk (UI-only injects entering model replay) does not apply to this revision.

## Files

- `src/gateway/protocol/schema/logs-chat.ts` — schema field with `minLength: 1`, `maxLength: 100`
- `src/gateway/server-methods/chat.ts` — handler param + helper threading
- `src/gateway/server-methods/chat-transcript-inject.ts` — new persisted field, sentinel preserved, trim+empty normalization
- `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift` — regenerated via `pnpm protocol:gen:swift`

## Real behavior proof

**Behavior or issue addressed:** Cross-agent `chat.inject` calls render with the OpenClaw avatar in the operator's webchat UI because the persisted assistant entry has no caller-controlled attribution field. External agents currently have no way to mark the inject as their own without putting "FROM: Hermes —" inline in body text, which degrades transcript clarity. This patch adds a dedicated `originAgent` persisted field while preserving the `(provider: "openclaw", model: "gateway-injected")` sentinel that the replay-history filter relies on.

**Real environment tested:** Sandboxed checkout of openclaw main at `/tmp/openclaw-pr/openclaw-fresh` with the patched files and the regenerated protocol bindings. Used the actual openclaw runtime — `appendInjectedAssistantMessageToTranscript` and `validateChatInjectParams` are invoked via `node` through `tsx` against synthetic transcript fixtures created with the project's own `createTranscriptFixtureSync` helper. No mocks, no stubs, no real session keys, no production data.

**Exact steps or command run after this patch:**

```
node node_modules/.bin/tsx scripts/proof-chat-inject-origin-agent.mts
node node_modules/.bin/tsx scripts/proof-chat-inject-schema.mts
```

Both scripts are committed under `scripts/` in this PR so a maintainer can rerun them.

**Evidence after fix:** Live stdout captured from the runtime invocations above. Persistence-layer output shows the actual `provider`, `model`, and `originAgent` fields read back from the jsonl transcript file on disk after the patched code wrote to it. Schema-layer output is the AJV validator's verdict on real input shapes.

Persistence-layer terminal output (live runtime, the patched code path actually executed):

```
OpenClaw chat.inject originAgent attribution — real-behavior proof
Patched modules under test:
  src/gateway/server-methods/chat-transcript-inject.ts
  src/gateway/protocol/schema/logs-chat.ts (schema field)
  src/gateway/server-methods/chat.ts (handler threading)

Design:
  provider stays 'openclaw' (replay-filter sentinel preserved)
  originAgent is a NEW persisted field for display-only attribution
  empty/whitespace originAgent is normalized to absent

=================================================
CASE                  : baseline-no-origin
input.originAgent     : <unset>
append.ok             : true
messageId             : 09641925-2611-4401-86c6-d369a045b518
stamped.provider      : openclaw
stamped.model         : gateway-injected
stamped.originAgent   : <absent>
expected.originAgent  : absent
result                : PASS

=================================================
CASE                  : hermes
input.originAgent     : "hermes"
append.ok             : true
messageId             : fcd260be-a790-489b-82e5-f393d136e321
stamped.provider      : openclaw
stamped.model         : gateway-injected
stamped.originAgent   : hermes
expected.originAgent  : hermes
result                : PASS

=================================================
CASE                  : codex
input.originAgent     : "codex"
append.ok             : true
messageId             : ef02a786-0e71-48d3-aafb-b861049d8301
stamped.provider      : openclaw
stamped.model         : gateway-injected
stamped.originAgent   : codex
expected.originAgent  : codex
result                : PASS

=================================================
CASE                  : blank-empty-string
input.originAgent     : ""
append.ok             : true
messageId             : 9943b96b-9bfc-4050-a997-b362c10e2422
stamped.provider      : openclaw
stamped.model         : gateway-injected
stamped.originAgent   : <absent>
expected.originAgent  : absent
result                : PASS

=================================================
CASE                  : whitespace-only
input.originAgent     : "   "
append.ok             : true
messageId             : 2aa2899d-a2f7-4679-a404-4236009f8c79
stamped.provider      : openclaw
stamped.model         : gateway-injected
stamped.originAgent   : <absent>
expected.originAgent  : absent
result                : PASS

=================================================
CASE                  : trim-surrounding-whitespace
input.originAgent     : "  hermes  "
append.ok             : true
messageId             : 4b1f86b7-060d-4cce-a81a-0cfcfb70ddca
stamped.provider      : openclaw
stamped.model         : gateway-injected
stamped.originAgent   : hermes
expected.originAgent  : hermes
result                : PASS
```

Schema-layer terminal output (live AJV validator on patched schema):

```
ChatInjectParamsSchema validator behavior:

---
CASE     : legacy params (sessionKey + message + label)
accepted : true
---
CASE     : patched params (with non-empty originAgent)
accepted : true
---
CASE     : rejects empty-string originAgent (minLength:1)
accepted : false
errors   : [{"instancePath":"/originAgent","schemaPath":"#/properties/originAgent/minLength","keyword":"minLength","params":{"limit":1},"message":"must NOT have fewer than 1 characters"}]
---
CASE     : rejects unknown extra fields (additionalProperties:false preserved)
accepted : false
errors   : [{"instancePath":"","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"somethingMadeUp"},"message":"must NOT have additional properties"}]
```

**Observed result after fix:**

- Baseline call (no `originAgent`) → persisted entry has `provider: "openclaw"`, `model: "gateway-injected"`, no `originAgent` field. Byte-identical to current-main behavior; replay filter still matches.
- Patched call (`originAgent: "hermes"`) → persisted entry has `provider: "openclaw"`, `model: "gateway-injected"`, **and** a new `originAgent: "hermes"` field. Replay filter still matches the sentinel pair and drops the row; UI consumers can attribute it to Hermes via the new field.
- Patched call (`originAgent: "codex"`) → same as above with `originAgent: "codex"`. Confirms the field is not Hermes-specific.
- Blank input (`""` or whitespace-only) → persisted entry has no `originAgent` field. The persistence helper trims and normalizes, so malformed input cannot land on disk.
- Trimmed input (`"  hermes  "`) → persisted entry has `originAgent: "hermes"` (whitespace-stripped).
- Schema validator accepts non-empty `originAgent`, rejects literal `""` via the new `minLength: 1`, and continues to reject unknown extra fields via the unchanged `additionalProperties: false`.

**What was not tested:** End-to-end UI render in the actual webchat surface (visually confirming a Hermes avatar/handle in the live React UI keyed off the new `originAgent` field) is intentionally out of scope for this PR — the patch only adds the persisted attribution field; UI consumption is a follow-up that will pick up the field from the transcript. The replay-filter regression that the prior PR revision would have introduced is now structurally impossible because the sentinel pair is unchanged; no run-time replay test was added because the contract being preserved already has coverage in `src/agents/pi-embedded-runner/replay-history.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
