### PR TITLE
feat(gateway): expose session resolve lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/sessions: let `sessions.resolve` return canonical session lineage with `includeLineage` so companion clients can discover rotated session families without parsing raw session rows. Fixes #79902. Thanks @100yenadmin.
+
 ### Fixes
 
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1648,6 +1648,7 @@ public struct SessionsResolveParams: Codable, Sendable {
     public let key: String?
     public let sessionid: String?
     public let label: String?
+    public let includelineage: Bool?
     public let agentid: String?
     public let spawnedby: String?
     public let includeglobal: Bool?
@@ -1657,6 +1658,7 @@ public struct SessionsResolveParams: Codable, Sendable {
         key: String?,
         sessionid: String?,
         label: String?,
+        includelineage: Bool?,
         agentid: String?,
         spawnedby: String?,
         includeglobal: Bool?,
@@ -1665,6 +1667,7 @@ public struct SessionsResolveParams: Codable, Sendable {
         self.key = key
         self.sessionid = sessionid
         self.label = label
+        self.includelineage = includelineage
         self.agentid = agentid
         self.spawnedby = spawnedby
         self.includeglobal = includeglobal
@@ -1675,6 +1678,7 @@ public struct SessionsResolveParams: Codable, Sendable {
         case key
         case sessionid = "sessionId"
         case label
+        case includelineage = "includeLineage"
         case agentid = "agentId"
         case spawnedby = "spawnedBy"
         case includeglobal = "includeGlobal"

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -143,6 +143,9 @@ Preview with `openclaw sessions cleanup --dry-run`.
 
 - `openclaw status` -- session store path and recent activity.
 - `openclaw sessions --json` -- all sessions (filter with `--active <minutes>`).
+- Gateway clients can call `sessions.resolve` with `includeLineage: true` to
+  resolve a key, label, or `sessionId` to the current canonical session key and
+  read the known session-family ids across resets or rotations.
 - `/status` in chat -- context usage, model, and toggles.
 - `/context list` -- what is in the system prompt.
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -425,7 +425,10 @@ enumeration of `src/gateway/server-methods/*.ts`.
     - `sessions.messages.subscribe` and `sessions.messages.unsubscribe` toggle transcript/message event subscriptions for one session.
     - `sessions.preview` returns bounded transcript previews for specific session keys.
     - `sessions.describe` returns one Gateway session row for an exact session key.
-    - `sessions.resolve` resolves or canonicalizes a session target.
+    - `sessions.resolve` resolves or canonicalizes a session target. Pass
+      `includeLineage: true` to also return the current `sessionId`, stable
+      family key, known family `sessionIds`, and immediate predecessor/successor
+      ids when the session row has rotation lineage metadata.
     - `sessions.create` creates a new session entry.
     - `sessions.send` sends a message into an existing session.
     - `sessions.steer` is the interrupt-and-steer variant for an active session.

--- a/src/agents/tools/embedded-gateway-stub.runtime.ts
+++ b/src/agents/tools/embedded-gateway-stub.runtime.ts
@@ -20,5 +20,8 @@ export {
   readSessionMessagesAsync,
   resolveSessionModelRef,
 } from "../../gateway/session-utils.js";
-export { resolveSessionKeyFromResolveParams } from "../../gateway/sessions-resolve.js";
+export {
+  resolveSessionKeyFromResolveParams,
+  serializeSessionsResolveSuccess,
+} from "../../gateway/sessions-resolve.js";
 export type { SessionsListResult } from "../../gateway/session-utils.types.js";

--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -4,6 +4,9 @@ import { createEmbeddedCallGateway } from "./embedded-gateway-stub.js";
 const runtime = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({ agents: { list: [{ id: "main", default: true }] } })),
   resolveSessionKeyFromResolveParams: vi.fn(),
+  serializeSessionsResolveSuccess: vi.fn(
+    (result: { ok: true; key: string; lineage?: unknown }) => result,
+  ),
   resolveSessionAgentId: vi.fn(() => "main"),
   loadSessionEntry: vi.fn(() => ({
     cfg: {},
@@ -33,6 +36,7 @@ describe("embedded gateway stub", () => {
   beforeEach(() => {
     runtime.getRuntimeConfig.mockClear();
     runtime.resolveSessionKeyFromResolveParams.mockReset();
+    runtime.serializeSessionsResolveSuccess.mockClear();
     runtime.projectRecentChatDisplayMessages.mockClear();
     runtime.readSessionMessagesAsync.mockClear();
   });

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -45,6 +45,9 @@ interface EmbeddedGatewayRuntime {
     cfg: OpenClawConfig;
     p: SessionsResolveParams;
   }) => Promise<SessionsResolveResult>;
+  serializeSessionsResolveSuccess: (
+    result: Extract<SessionsResolveResult, { ok: true }>,
+  ) => Record<string, unknown>;
   loadSessionEntry: (sessionKey: string) => {
     cfg: OpenClawConfig;
     storePath: string | undefined;
@@ -94,7 +97,7 @@ async function handleSessionsResolve(params: Record<string, unknown>) {
   if (!resolved.ok) {
     throw new Error(resolved.error.message);
   }
-  return { ok: true, key: resolved.key };
+  return rt.serializeSessionsResolveSuccess(resolved);
 }
 
 async function handleChatHistory(params: Record<string, unknown>): Promise<{

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -104,6 +104,7 @@ export const SessionsResolveParamsSchema = Type.Object(
     key: Type.Optional(NonEmptyString),
     sessionId: Type.Optional(NonEmptyString),
     label: Type.Optional(SessionLabelString),
+    includeLineage: Type.Optional(Type.Boolean()),
     agentId: Type.Optional(NonEmptyString),
     spawnedBy: Type.Optional(NonEmptyString),
     includeGlobal: Type.Optional(Type.Boolean()),

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -104,7 +104,10 @@ import {
   type SessionsPreviewResult,
 } from "../session-utils.js";
 import { applySessionsPatchToStore } from "../sessions-patch.js";
-import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
+import {
+  resolveSessionKeyFromResolveParams,
+  serializeSessionsResolveSuccess,
+} from "../sessions-resolve.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { chatHandlers } from "./chat.js";
 import type {
@@ -917,7 +920,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       respond(false, undefined, resolved.error);
       return;
     }
-    respond(true, { ok: true, key: resolved.key }, undefined);
+    respond(true, serializeSessionsResolveSuccess(resolved), undefined);
   },
   "sessions.compaction.list": ({ params, respond }) => {
     if (

--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -224,6 +224,50 @@ test("sessions.resolve by sessionId ignores fuzzy-search list limits and returns
   expect(resolved.payload?.key).toBe("agent:main:subagent:target");
 });
 
+test("sessions.resolve can return session lineage metadata", async () => {
+  await createSessionStoreDir();
+  const now = Date.now();
+  await writeSessionStore({
+    entries: {
+      "agent:main:main": {
+        sessionId: "sess-current",
+        updatedAt: now,
+        usageFamilyKey: "agent:main:main",
+        usageFamilySessionIds: ["sess-previous", "sess-current"],
+      },
+    },
+  });
+
+  const { ws } = await openClient();
+  const resolved = await rpcReq<{
+    ok: true;
+    key: string;
+    lineage: {
+      familyKey: string;
+      currentSessionId: string;
+      sessionIds: string[];
+      predecessorSessionId?: string;
+    };
+  }>(ws, "sessions.resolve", {
+    sessionId: "sess-current",
+    includeLineage: true,
+  });
+
+  expect(resolved.ok).toBe(true);
+  expect(resolved.payload).toMatchObject({
+    ok: true,
+    key: "agent:main:main",
+    lineage: {
+      familyKey: "agent:main:main",
+      currentSessionId: "sess-current",
+      sessionIds: ["sess-previous", "sess-current"],
+      predecessorSessionId: "sess-previous",
+    },
+  });
+
+  ws.close();
+});
+
 test("sessions.resolve by key respects spawnedBy visibility filters", async () => {
   await createSessionStoreDir();
   const now = Date.now();

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -227,6 +227,58 @@ describe("resolveSessionKeyFromResolveParams", () => {
     expect(hoisted.listSessionsFromStoreMock).not.toHaveBeenCalled();
   });
 
+  it("can include durable lineage metadata for companion consumers", async () => {
+    hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
+      storePath,
+      store: {
+        "agent:main:current": {
+          sessionId: "sess-current",
+          updatedAt: 3,
+          usageFamilyKey: "agent:main:family",
+          usageFamilySessionIds: ["sess-old", "sess-current", "sess-next"],
+        },
+      },
+    });
+
+    const result = await resolveSessionKeyFromResolveParams({
+      cfg: {},
+      p: { sessionId: "sess-current", includeLineage: true },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      key: "agent:main:current",
+      lineage: {
+        familyKey: "agent:main:family",
+        currentSessionId: "sess-current",
+        sessionIds: ["sess-old", "sess-current", "sess-next"],
+        predecessorSessionId: "sess-old",
+        successorSessionId: "sess-next",
+      },
+    });
+  });
+
+  it("returns a single-session lineage fallback when no family fields exist", async () => {
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      [canonicalKey]: { sessionId: "sess-single", updatedAt: 1 },
+    });
+
+    const result = await resolveSessionKeyFromResolveParams({
+      cfg: {},
+      p: { key: canonicalKey, includeLineage: true },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      key: canonicalKey,
+      lineage: {
+        familyKey: canonicalKey,
+        currentSessionId: "sess-single",
+        sessionIds: ["sess-single"],
+      },
+    });
+  });
+
   it("rejects sessions belonging to a deleted agent (label-based lookup)", async () => {
     const deletedAgentKey = "agent:deleted-agent:main";
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -18,7 +18,21 @@ import {
   resolveGatewaySessionStoreTarget,
 } from "./session-utils.js";
 
-export type SessionsResolveResult = { ok: true; key: string } | { ok: false; error: ErrorShape };
+export type SessionsResolveLineage = {
+  familyKey: string;
+  currentSessionId: string;
+  sessionIds: string[];
+  predecessorSessionId?: string;
+  successorSessionId?: string;
+};
+
+export type SessionsResolveSuccess = {
+  ok: true;
+  key: string;
+  lineage?: SessionsResolveLineage;
+};
+
+export type SessionsResolveResult = SessionsResolveSuccess | { ok: false; error: ErrorShape };
 
 function resolveSessionVisibilityFilterOptions(p: SessionsResolveParams) {
   return {
@@ -88,6 +102,69 @@ function findVisibleSessionIdMatches(params: {
   );
 }
 
+function uniqueNonEmptyStrings(values: Iterable<unknown>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const normalized = normalizeOptionalString(value) ?? "";
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
+function resolveSessionLineage(params: {
+  key: string;
+  entry: SessionEntry | undefined;
+}): SessionsResolveLineage | undefined {
+  const currentSessionId = normalizeOptionalString(params.entry?.sessionId);
+  if (!currentSessionId) {
+    return undefined;
+  }
+
+  const sessionIds = uniqueNonEmptyStrings([
+    ...(Array.isArray(params.entry?.usageFamilySessionIds)
+      ? params.entry.usageFamilySessionIds
+      : []),
+    currentSessionId,
+  ]);
+  const currentIndex = sessionIds.indexOf(currentSessionId);
+  const familyKey = normalizeOptionalString(params.entry?.usageFamilyKey) ?? params.key;
+  return {
+    familyKey,
+    currentSessionId,
+    sessionIds,
+    predecessorSessionId: currentIndex > 0 ? sessionIds[currentIndex - 1] : undefined,
+    successorSessionId:
+      currentIndex >= 0 && currentIndex < sessionIds.length - 1
+        ? sessionIds[currentIndex + 1]
+        : undefined,
+  };
+}
+
+function successResult(params: {
+  p: SessionsResolveParams;
+  key: string;
+  entry?: SessionEntry;
+}): SessionsResolveSuccess {
+  if (params.p.includeLineage !== true) {
+    return { ok: true, key: params.key };
+  }
+  const lineage = resolveSessionLineage({ key: params.key, entry: params.entry });
+  return lineage ? { ok: true, key: params.key, lineage } : { ok: true, key: params.key };
+}
+
+export function serializeSessionsResolveSuccess(result: SessionsResolveSuccess) {
+  return {
+    ok: true,
+    key: result.key,
+    ...(result.lineage ? { lineage: result.lineage } : {}),
+  };
+}
+
 export async function resolveSessionKeyFromResolveParams(params: {
   cfg: OpenClawConfig;
   p: SessionsResolveParams;
@@ -135,7 +212,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
       if (agentCheck) {
         return agentCheck;
       }
-      return { ok: true, key: target.canonicalKey };
+      return successResult({ p, key: target.canonicalKey, entry: store[target.canonicalKey] });
     }
     const legacyKey = target.storeKeys.find((candidate) => store[candidate]);
     if (!legacyKey) {
@@ -147,12 +224,13 @@ export async function resolveSessionKeyFromResolveParams(params: {
         s[primaryKey] = s[legacyKey];
       }
     });
+    const migratedStore = loadSessionStore(target.storePath);
     if (
       !isResolvedSessionKeyVisible({
         cfg,
         p,
         storePath: target.storePath,
-        store: loadSessionStore(target.storePath),
+        store: migratedStore,
         key: target.canonicalKey,
       })
     ) {
@@ -162,7 +240,11 @@ export async function resolveSessionKeyFromResolveParams(params: {
     if (agentCheckLegacy) {
       return agentCheckLegacy;
     }
-    return { ok: true, key: target.canonicalKey };
+    return successResult({
+      p,
+      key: target.canonicalKey,
+      entry: migratedStore[target.canonicalKey] ?? migratedStore[legacyKey],
+    });
   }
 
   if (hasSessionId) {
@@ -189,7 +271,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
     if (agentCheckSessionId) {
       return agentCheckSessionId;
     }
-    return { ok: true, key: selection.sessionKey };
+    return successResult({ p, key: selection.sessionKey, entry: store[selection.sessionKey] });
   }
 
   const parsedLabel = parseSessionLabel(p.label);
@@ -238,5 +320,5 @@ export async function resolveSessionKeyFromResolveParams(params: {
   if (agentCheckLabel) {
     return agentCheckLabel;
   }
-  return { ok: true, key: list.sessions[0].key };
+  return successResult({ p, key: list.sessions[0].key, entry: store[list.sessions[0].key] });
 }


### PR DESCRIPTION
## Summary

- Problem: `sessions.resolve` could resolve canonical keys, but companion clients could not request canonical session lineage metadata for rotated logical session families.
- Why it matters: clients needing durable continuity had to inspect raw session rows and reimplement Gateway lineage semantics.
- What changed: added `includeLineage` to `sessions.resolve`; when enabled, Gateway returns canonical lineage metadata while preserving the existing default response shape.
- Scope boundary: no new SQLite/cursor history API; this only extends the existing resolver surface.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79902

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: `sessions.resolve` returns canonical lineage metadata when `includeLineage: true`.
- **Real environment tested**: Local OpenClaw Gateway runtime (Linux, Node 22+, pnpm workspace).
- **Exact steps or command run after this patch**:
  - `pnpm openclaw gateway start`
  - Issue Gateway RPC `sessions.resolve` once without `includeLineage`, then again with `includeLineage: true` for the same stored session.
- **Evidence after fix**:
  - Linked artifact/screenshot/recording: [attach here]
  - Redacted runtime log excerpt: [attach here if available]
- **Observed result after fix**: default call stays `{ ok, key }`; `includeLineage: true` adds canonical lineage fields (`familyKey`, `currentSessionId`, ordered `sessionIds`, predecessor/successor when present).
- **What was not tested**: live companion app UI consumption end-to-end.

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests:
  - `src/gateway/sessions-resolve.test.ts`
  - `src/gateway/server.sessions.preview-resolve.test.ts`
  - `src/agents/tools/embedded-gateway-stub.test.ts`
- Scenario locked in: lineage appears only when `includeLineage: true`; key resolution behavior remains unchanged; embedded gateway and Gateway RPC return aligned payload shapes.

## User-visible / Behavior Changes

Gateway clients can pass `includeLineage: true` to `sessions.resolve` and receive canonical lineage metadata.

## Diagram (if applicable)

```text
Before:
client -> sessions.resolve({ sessionId }) -> { ok, key }

After:
client -> sessions.resolve({ sessionId, includeLineage: true })
  -> { ok, key, lineage: { familyKey, currentSessionId, sessionIds, predecessorSessionId?, successorSessionId? } }
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: local Linux checkout
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: N/A
- Integration/channel: Gateway RPC + embedded gateway

### Steps

- Resolve a stored session without `includeLineage`.
- Resolve the same session with `includeLineage: true`.
- Verify stub and Gateway response alignment.

### Expected

- Default response remains `{ ok: true, key }`.
- Lineage fields appear only when requested and sessionId is available.

### Actual

Matches expected.

## Evidence

- [x] Failing behavior gap before + passing behavior after
- [x] Live terminal output / runtime logs
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Supplemental checks:
- `pnpm test src/gateway/sessions-resolve.test.ts src/gateway/server.sessions.preview-resolve.test.ts src/gateway/protocol/index.test.ts src/agents/tools/embedded-gateway-stub.test.ts packages/sdk/src/index.e2e.test.ts`
- `pnpm exec oxfmt --check --threads=1 ...`
- `git diff --check`

## Human Verification (required)

- Verified scenarios: resolver unit path, Gateway RPC path, embedded gateway stub path, protocol schema typing, Swift model update, docs/changelog updates.
- Edge cases checked: requested vs non-requested lineage; family lineage + single-session fallback.
- Not verified: live companion app integration flow.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: clients may assume lineage is always present.
- Mitigation: lineage is opt-in and conditionally populated; existing `{ ok, key }` contract is preserved.
