### PR TITLE
feat(tui): add --quiet-status flag to suppress animated spinner for recording-friendly output

### DIFF
--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -20,6 +20,11 @@ export function registerTuiCli(program: Command) {
     .option("--message <text>", "Send an initial message after connecting")
     .option("--timeout-ms <ms>", "Agent timeout in ms (defaults to agents.defaults.timeoutSeconds)")
     .option("--history-limit <n>", "History entries to load", "200")
+    .option(
+      "--quiet-status",
+      "Suppress animated spinner and elapsed counter (recording-friendly)",
+      false,
+    )
     .addHelpText(
       "after",
       () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/tui", "docs.openclaw.ai/cli/tui")}\n`,
@@ -54,6 +59,7 @@ export function registerTuiCli(program: Command) {
           message: opts.message as string | undefined,
           timeoutMs,
           historyLimit: Number.isNaN(historyLimit) ? undefined : historyLimit,
+          quietStatus: Boolean(opts.quietStatus),
         });
       } catch (err) {
         defaultRuntime.error(String(err));

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -9,6 +9,8 @@ export type TuiOptions = {
   timeoutMs?: number;
   historyLimit?: number;
   message?: string;
+  /** Suppress animated spinner, elapsed counter, and shimmer for recording-friendly output. */
+  quietStatus?: boolean;
 };
 
 export type TuiExitReason = "exit" | "return-to-crestodian";

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -877,15 +877,24 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       if (!statusStartedAt || lastActivityStatus !== activityStatus) {
         statusStartedAt = Date.now();
       }
-      ensureStatusLoader();
-      if (activityStatus === "waiting") {
+      if (opts.quietStatus) {
         stopStatusTimer();
-        startWaitingTimer();
-      } else {
         stopWaitingTimer();
-        startStatusTimer();
+        statusLoader?.stop();
+        statusLoader = null;
+        ensureStatusText();
+        statusText?.setText(theme.dim(`${activityStatus} | ${connectionStatus}`));
+      } else {
+        ensureStatusLoader();
+        if (activityStatus === "waiting") {
+          stopStatusTimer();
+          startWaitingTimer();
+        } else {
+          stopWaitingTimer();
+          startStatusTimer();
+        }
+        updateBusyStatusMessage();
       }
-      updateBusyStatusMessage();
     } else {
       statusStartedAt = null;
       stopStatusTimer();


### PR DESCRIPTION
Fixes #79859

## Problem

The TUI status line continuously repaints during any active run: the elapsed-seconds counter increments every second, the spinner animates, and the waiting shimmer updates every 120ms. This constant repaint makes asciinema recordings noisy — the terminal is never truly idle, so silence detection fails and the output has unnecessary motion during otherwise static moments.

## Fix

Three commits:

1. **`feat(tui/types)`** — add `quietStatus?: boolean` to `TuiOptions`
2. **`feat(tui)`** — gate animated rendering in `renderStatus()`: when `quietStatus` is set, use a static `Text` widget instead of `Loader`, skip both the 1s status timer and the 120ms waiting shimmer, emit a plain `<activity> | <connection>` string on state change only
3. **`feat(cli)`** — add `--quiet-status` flag to `oc tui` / `oc chat` / `oc terminal`

When `quietStatus` is false (the default), behavior is completely unchanged.

## Usage

```
oc tui --quiet-status
```

The status line will show static text like `waiting | connected` during runs, with no elapsed counter and no animation loop.

## Real behavior proof

- Behavior or issue addressed: TUI status bar animated continuously (spinner, elapsed counter, shimmer), causing asciinema and similar recorders to see constant terminal repaints even when the assistant was silent.

- Real environment tested: openclaw 2026.5.6 (d31d7c5), node v22.15.0, linux x64. Built from this branch with `pnpm build`.

- Exact steps or command run after this patch:
  ```
  pnpm build && node openclaw.mjs tui --help
  ```

- Evidence after fix (live oc tui --help from this branch build):
  ```
  Usage: openclaw tui|terminal [options]

  Open a terminal UI connected to the Gateway

  Options:
    --quiet-status         Suppress animated spinner and elapsed counter
                           (recording-friendly) (default: false)
    --deliver              Deliver assistant replies (default: false)
    --history-limit <n>    History entries to load (default: "200")
    --local                Run against the local embedded agent runtime
    --message <text>       Send an initial message after connecting
    --session <key>        Session key (default: "main")
    --timeout-ms <ms>      Agent timeout in ms
    --token <token>        Gateway token (if required)
    --url <url>            Gateway WebSocket URL
  ```

- Observed result after fix: Flag appears in CLI help output. In quiet mode, renderStatus() calls ensureStatusText() with a static dim string — neither startStatusTimer nor startWaitingTimer is called, so no interval fires.

- What was not tested: End-to-end asciinema recording on a live session; crestodian embedded-backend path.
