### PR TITLE
feat(tui,cli-runner): expose streamingWatchdogMs config + bump watchdog defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- TUI/CLI runner: expose `cli.tui.streamingWatchdogMs` config field, raise the in-code streaming watchdog default from 30s to 10m, and lift `CLI_FRESH_WATCHDOG_DEFAULTS.maxMs` (10m → 60m) and `CLI_RESUME_WATCHDOG_DEFAULTS.maxMs` (3m → 60m) so long-reasoning models, slow tool runs, and SSE keepalive gaps stop tripping false aborts; per-backend overrides at `cli.watchdog.fresh.maxMs`/`.resume.maxMs` continue to apply unchanged.
 - Chat commands: add `/think default` and `/fast default` to clear session overrides and inherit configured/provider defaults. (#79385) Thanks @VACInc.
 - Dependencies: refresh workspace dependency pins and lockfile, including `@openai/codex` `0.130.0`, `acpx` `0.7.0`, AWS SDK `3.1044.0`, OpenTelemetry `0.217.0`, `typebox` `1.1.38`, `vite` `8.0.11`, `oxfmt` `0.48.0`, and `oxlint` `1.63.0`, and update the Codex harness model snapshot for the new bundled app-server catalog.
 - Plugins/install: add guarded plugin install overrides so onboarding and repair tests can route specific plugins to registry specs or local `npm pack` artifacts via environment variables.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1145,6 +1145,9 @@ Notes:
     banner: {
       taglineMode: "off", // random | default | off
     },
+    tui: {
+      streamingWatchdogMs: 600000, // default 10m; 0 disables
+    },
   },
 }
 ```
@@ -1154,6 +1157,11 @@ Notes:
   - `"default"`: fixed neutral tagline (`All your chats, one OpenClaw.`).
   - `"off"`: no tagline text (banner title/version still shown).
 - To hide the entire banner (not just taglines), set env `OPENCLAW_HIDE_BANNER=1`.
+- `cli.tui.streamingWatchdogMs` is the no-stream-delta window after which the
+  interactive TUI resets activity status to idle and posts the "taking longer
+  than expected" notice. Default: `600000` (10 minutes). Set to `0` to disable.
+  Raise this when working with long-reasoning models, slow tool runs, or
+  upstreams with long SSE keepalive gaps.
 
 ---
 

--- a/src/agents/cli-watchdog-defaults.ts
+++ b/src/agents/cli-watchdog-defaults.ts
@@ -1,13 +1,17 @@
 export const CLI_WATCHDOG_MIN_TIMEOUT_MS = 1_000;
 
+// `maxMs` caps the "no output" watchdog ceiling. Originally 600_000 (10m) for fresh
+// runs and 180_000 (3m) for resume. Raised to 60m: long-form reasoning, tool calls
+// that legitimately take 5–10m, and SSE keepalive gaps were tripping false aborts.
+// Per-CLI-backend overrides at `cli.watchdog.fresh.maxMs` / `.resume.maxMs` still apply.
 export const CLI_FRESH_WATCHDOG_DEFAULTS = {
   noOutputTimeoutRatio: 0.8,
   minMs: 180_000,
-  maxMs: 600_000,
+  maxMs: 3_600_000,
 } as const;
 
 export const CLI_RESUME_WATCHDOG_DEFAULTS = {
   noOutputTimeoutRatio: 0.3,
   minMs: 60_000,
-  maxMs: 180_000,
+  maxMs: 3_600_000,
 } as const;

--- a/src/config/types.cli.ts
+++ b/src/config/types.cli.ts
@@ -1,5 +1,15 @@
 export type CliBannerTaglineMode = "random" | "default" | "off";
 
+export type CliTuiConfig = {
+  /**
+   * "No stream delta arrived" watchdog window for the TUI. When the upstream
+   * stream stalls for this long while a run is active, the TUI resets activity
+   * status to idle and posts the "taking longer than expected" notice.
+   * Default: 600000 (10 minutes). Set to 0 to disable.
+   */
+  streamingWatchdogMs?: number;
+};
+
 export type CliConfig = {
   banner?: {
     /**
@@ -10,4 +20,6 @@ export type CliConfig = {
      */
     taglineMode?: CliBannerTaglineMode;
   };
+  /** TUI-side runtime knobs (interactive `openclaw` chat). */
+  tui?: CliTuiConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -469,6 +469,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        tui: z
+          .object({
+            streamingWatchdogMs: z.number().int().nonnegative().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1233,6 +1233,30 @@ describe("tui-event-handlers: streaming watchdog", () => {
     handlers.dispose?.();
   });
 
+  it("falls back to the 10-minute default when streamingWatchdogMs is undefined", () => {
+    const { state, chatLog, setActivityStatus, handlers } = createHarness();
+
+    handlers.handleChatEvent({
+      runId: "run-default",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "hi" },
+    } satisfies ChatEvent);
+
+    // Old default was 30s — verify it does NOT fire at 31s anymore.
+    vi.advanceTimersByTime(31_000);
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBe("run-default");
+
+    // New default is 10m — verify it DOES fire just past the 10m boundary.
+    vi.advanceTimersByTime(600_001 - 31_000);
+    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
+    expect(state.activeChatRunId).toBeNull();
+    expect(chatLog.addSystem).toHaveBeenCalledWith(expectedTimeoutMessage);
+
+    handlers.dispose?.();
+  });
+
   it("is disabled when streamingWatchdogMs is 0", () => {
     const { state, chatLog, setActivityStatus, handlers } = createHarness({
       streamingWatchdogMs: 0,

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -48,7 +48,11 @@ type EventHandlerContext = {
   localMode?: boolean;
 };
 
-const DEFAULT_STREAMING_WATCHDOG_MS = 30_000;
+// Streaming-watchdog default fires "response is taking longer than expected" when
+// no stream delta arrives for this long. Originally 30s, raised to 10m so long
+// reasoning / tool runs and SSE keepalive gaps don't cause spurious "idle" trips.
+// Override per-install via `cli.tui.streamingWatchdogMs`.
+const DEFAULT_STREAMING_WATCHDOG_MS = 600_000;
 const STREAMING_WATCHDOG_USER_MESSAGE =
   "This response is taking longer than expected. Send another message to continue.";
 

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -19,6 +19,7 @@ import {
   resolveLocalAuthSpawnCwd,
   resolveLocalAuthSpawnOptions,
   resolveTuiSessionKey,
+  resolveTuiStreamingWatchdogMs,
   stopTuiSafely,
 } from "./tui.js";
 
@@ -496,5 +497,60 @@ describe("resolveLocalAuthSpawnCwd", () => {
         defaultCwd: "/worktree/subdir",
       }),
     ).toBe("/worktree/subdir");
+  });
+});
+
+describe("resolveTuiStreamingWatchdogMs", () => {
+  it("returns undefined when cli.tui.streamingWatchdogMs is unset", () => {
+    expect(resolveTuiStreamingWatchdogMs({} as OpenClawConfig)).toBeUndefined();
+    expect(resolveTuiStreamingWatchdogMs({ cli: {} } as OpenClawConfig)).toBeUndefined();
+    expect(resolveTuiStreamingWatchdogMs({ cli: { tui: {} } } as OpenClawConfig)).toBeUndefined();
+  });
+
+  it("returns the configured value when finite and non-negative", () => {
+    expect(
+      resolveTuiStreamingWatchdogMs({
+        cli: { tui: { streamingWatchdogMs: 900_000 } },
+      } as OpenClawConfig),
+    ).toBe(900_000);
+  });
+
+  it("preserves 0 (caller-side disable signal)", () => {
+    expect(
+      resolveTuiStreamingWatchdogMs({
+        cli: { tui: { streamingWatchdogMs: 0 } },
+      } as OpenClawConfig),
+    ).toBe(0);
+  });
+
+  it("floors fractional values", () => {
+    expect(
+      resolveTuiStreamingWatchdogMs({
+        cli: { tui: { streamingWatchdogMs: 1234.9 } },
+      } as OpenClawConfig),
+    ).toBe(1234);
+  });
+
+  it("rejects negative, NaN, Infinity, and non-number inputs", () => {
+    expect(
+      resolveTuiStreamingWatchdogMs({
+        cli: { tui: { streamingWatchdogMs: -10 } },
+      } as OpenClawConfig),
+    ).toBeUndefined();
+    expect(
+      resolveTuiStreamingWatchdogMs({
+        cli: { tui: { streamingWatchdogMs: Number.NaN } },
+      } as OpenClawConfig),
+    ).toBeUndefined();
+    expect(
+      resolveTuiStreamingWatchdogMs({
+        cli: { tui: { streamingWatchdogMs: Number.POSITIVE_INFINITY } },
+      } as OpenClawConfig),
+    ).toBeUndefined();
+    expect(
+      resolveTuiStreamingWatchdogMs({
+        cli: { tui: { streamingWatchdogMs: "600000" as unknown as number } },
+      } as OpenClawConfig),
+    ).toBeUndefined();
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -78,6 +78,14 @@ const OPENCLAW_DIST_ENTRY_MJS_PATH = fileURLToPath(
 
 const OPENAI_CODEX_PROVIDER = "openai-codex";
 
+export function resolveTuiStreamingWatchdogMs(config: OpenClawConfig): number | undefined {
+  const value = config.cli?.tui?.streamingWatchdogMs;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
 type RunTuiOptions = TuiOptions & {
   backend?: TuiBackend;
   config?: OpenClawConfig;
@@ -1083,6 +1091,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     isLocalBtwRunId,
     forgetLocalBtwRunId,
     clearLocalBtwRunIds,
+    streamingWatchdogMs: resolveTuiStreamingWatchdogMs(config),
   });
 
   const deferredFinish = createDeferredTuiFinish();


### PR DESCRIPTION
# feat(tui,cli-runner): expose `streamingWatchdogMs` config + bump watchdog defaults

## Table of Contents
- [Summary](#Summary)
- [Motivation](#Motivation)
- [Changes](#Changes)
- [Test plan](#Test%20plan)
- [Backward compatibility](#Backward%20compatibility)

## Summary

- Plumbs `cli.tui.streamingWatchdogMs` through `runTui()` → `createEventHandlers({ streamingWatchdogMs })`. The consumer site at `src/tui/tui-event-handlers.ts:80` was already reading `context.streamingWatchdogMs` but no caller ever set it, so the in-source default fired unconditionally.
- Raises in-source defaults that were tripping prematurely on long-reasoning models, multi-minute tool calls, and SSE-keepalive gaps:
  - TUI streaming watchdog: 30s → 10m
  - CLI fresh-run watchdog ceiling: 10m → 60m
  - CLI resume watchdog ceiling: 3m → 60m

## Motivation

Operators running OpenClaw against long-reasoning models (Anthropic extended thinking, OpenAI reasoning chains) and slow tool runs were seeing the TUI report `idle` and surface the "This response is taking longer than expected. Send another message to continue." prompt **mid-run, while the model was still thinking** — because the 30s streaming-delta watchdog was both (a) too short for modern models and (b) had no config knob.

The same operators were also seeing CLI runs aborted by the no-output watchdog at the 10-minute / 3-minute ceilings (fresh / resume). Per-backend overrides at `cli.watchdog.fresh.maxMs` were already supported, but the in-source defaults left every operator who hadn't tuned per-backend exposed.

This PR closes both gaps in one stroke: exposes the TUI streaming-watchdog as a first-class config knob, and lifts the CLI ceilings to a value (60m) that matches the longest legitimate run we've observed in production while still allowing per-backend overrides to dial it back.

## Changes

| File | Change |
|---|---|
| `src/tui/tui-event-handlers.ts` | `DEFAULT_STREAMING_WATCHDOG_MS`: 30_000 → 600_000 (with explanatory comment) |
| `src/tui/tui.ts` | New exported helper `resolveTuiStreamingWatchdogMs(config)`; wired into the existing `createEventHandlers({...})` call inside `runTui` |
| `src/config/types.cli.ts` | New `CliTuiConfig` type with optional `streamingWatchdogMs?: number`; added under `CliConfig.tui` |
| `src/config/zod-schema.ts` | Added strict `cli.tui.streamingWatchdogMs: z.number().int().nonnegative().optional()` |
| `src/agents/cli-watchdog-defaults.ts` | `CLI_FRESH_WATCHDOG_DEFAULTS.maxMs`: 600_000 → 3_600_000; `CLI_RESUME_WATCHDOG_DEFAULTS.maxMs`: 180_000 → 3_600_000 |
| `src/tui/tui.test.ts` | 5 new unit tests for `resolveTuiStreamingWatchdogMs` (unset, happy, zero, fractional, hostile inputs) |
| `src/tui/tui-event-handlers.test.ts` | 1 new test asserting the new 10m default fires past 600s but not at 31s |
| `docs/gateway/configuration-reference.md` | Documented the new `cli.tui.streamingWatchdogMs` knob in the existing `## CLI` section |

## Test plan

```bash
pnpm install
pnpm build:strict-smoke
pnpm vitest run --config test/vitest/vitest.tui.config.ts \
  src/tui/tui-event-handlers.test.ts src/tui/tui.test.ts
pnpm vitest run --config test/vitest/vitest.agents-core.config.ts \
  src/agents/cli-runner.reliability.test.ts
pnpm vitest run --config test/vitest/vitest.runtime-config.config.ts \
  src/config/schema.test.ts
pnpm tsgo:test
pnpm lint
```

Manual verification:

1. `openclaw configure` → set `cli.tui.streamingWatchdogMs: 60000` → run a long-reasoning prompt → confirm the "taking longer" notice fires at 60s.
2. Remove the override → confirm it now fires at 10 minutes (not 30s).
3. Set `cli.tui.streamingWatchdogMs: 0` → confirm the watchdog is disabled.

## Backward compatibility

- `cli.tui.streamingWatchdogMs` is **optional**. Configs that don't set it pick up the new in-source default of 10 minutes (was 30 seconds). This is a user-facing default change, justified above; flagged in the changelog.
- `CLI_*_WATCHDOG_DEFAULTS.maxMs` changes only affect callers that did not set their own per-backend `cli.watchdog.fresh.maxMs` / `.resume.maxMs`. The existing `resolveCliNoOutputTimeoutMs` test at `src/agents/cli-runner.reliability.test.ts:999` still passes because its computed value (480000 = 600000 * 0.8) sits below both the old and new ceilings.
- No schema removals, no field renames, no deprecations. Pure addition + default-tuning.
