### PR TITLE
fix(clawhub): time out stalled skill archive body downloads

### DIFF
--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -484,6 +484,69 @@ describe("clawhub helpers", () => {
     ).rejects.toThrow(/Rate limit exceeded$/);
   });
 
+  it("times out stalled skill archive body reads", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      downloadClawHubSkillArchive({
+        slug: "agentreceipt",
+        version: "1.0.0",
+        timeoutMs: 5,
+        fetchImpl: async () =>
+          ({
+            ok: true,
+            status: 200,
+            headers: new Headers({ "content-type": "application/zip" }),
+            body: { cancel },
+            arrayBuffer: () => new Promise<ArrayBuffer>(() => undefined),
+          }) as unknown as Response,
+      }),
+    ).rejects.toThrow(/skill archive download for agentreceipt body timed out after 5ms/i);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out stalled package archive body reads", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      downloadClawHubPackageArchive({
+        name: "@hyf/zai-external-alpha",
+        version: "0.0.1",
+        timeoutMs: 5,
+        fetchImpl: async () =>
+          ({
+            ok: true,
+            status: 200,
+            headers: new Headers({ "content-type": "application/zip" }),
+            body: { cancel },
+            arrayBuffer: () => new Promise<ArrayBuffer>(() => undefined),
+          }) as unknown as Response,
+      }),
+    ).rejects.toThrow(
+      /package archive download for @hyf\/zai-external-alpha body timed out after 5ms/i,
+    );
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out stalled ClawPack artifact body reads", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      downloadClawHubPackageArchive({
+        name: "demo",
+        version: "1.2.3",
+        artifact: "clawpack",
+        timeoutMs: 5,
+        fetchImpl: async () =>
+          ({
+            ok: true,
+            status: 200,
+            headers: new Headers({ "content-type": "application/octet-stream" }),
+            body: { cancel },
+            arrayBuffer: () => new Promise<ArrayBuffer>(() => undefined),
+          }) as unknown as Response,
+      }),
+    ).rejects.toThrow(/ClawPack download for demo@1.2.3 body timed out after 5ms/i);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
   it("downloads skill archives to sanitized temp paths and cleans them up", async () => {
     const archive = await downloadClawHubSkillArchive({
       slug: "agentreceipt",

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -636,6 +636,31 @@ async function fetchJson<T>(params: ClawHubRequestParams): Promise<T> {
   return (await response.json()) as T;
 }
 
+async function readResponseArrayBufferWithTimeout(params: {
+  response: Response;
+  timeoutMs?: number;
+  resourceLabel: string;
+}): Promise<ArrayBuffer> {
+  const timeoutMs = params.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  let timeout: NodeJS.Timeout | null = null;
+  try {
+    return await new Promise<ArrayBuffer>((resolve, reject) => {
+      timeout = setTimeout(() => {
+        const err = new Error(
+          `ClawHub ${params.resourceLabel} body timed out after ${timeoutMs}ms`,
+        );
+        void params.response.body?.cancel(err).catch(() => undefined);
+        reject(err);
+      }, timeoutMs);
+      void params.response.arrayBuffer().then(resolve).catch(reject);
+    });
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 export function resolveClawHubBaseUrl(baseUrl?: string): string {
   return normalizeBaseUrl(baseUrl);
 }
@@ -902,7 +927,13 @@ export async function downloadClawHubPackageArchive(params: {
     if (!response.ok) {
       throw await buildClawHubError(response, url, hasToken);
     }
-    const bytes = new Uint8Array(await response.arrayBuffer());
+    const bytes = new Uint8Array(
+      await readResponseArrayBufferWithTimeout({
+        response,
+        timeoutMs: params.timeoutMs,
+        resourceLabel: `ClawPack download for ${params.name}@${params.version}`,
+      }),
+    );
     const sha256Hex = formatSha256Hex(bytes);
     const npmIntegrity = formatSha512Integrity(bytes);
     const npmShasum = formatSha1Hex(bytes);
@@ -977,7 +1008,13 @@ export async function downloadClawHubPackageArchive(params: {
   if (!response.ok) {
     throw await buildClawHubError(response, url, hasToken);
   }
-  const bytes = new Uint8Array(await response.arrayBuffer());
+  const bytes = new Uint8Array(
+    await readResponseArrayBufferWithTimeout({
+      response,
+      timeoutMs: params.timeoutMs,
+      resourceLabel: `package archive download for ${params.name}`,
+    }),
+  );
   const sha256Hex = formatSha256Hex(bytes);
   const target = await createTempDownloadTarget({
     prefix: "openclaw-clawhub-package",
@@ -1018,7 +1055,13 @@ export async function downloadClawHubSkillArchive(params: {
   if (!response.ok) {
     throw await buildClawHubError(response, url, hasToken);
   }
-  const bytes = new Uint8Array(await response.arrayBuffer());
+  const bytes = new Uint8Array(
+    await readResponseArrayBufferWithTimeout({
+      response,
+      timeoutMs: params.timeoutMs,
+      resourceLabel: `skill archive download for ${params.slug}`,
+    }),
+  );
   const sha256Hex = formatSha256Hex(bytes);
   const target = await createTempDownloadTarget({
     prefix: "openclaw-clawhub-skill",


### PR DESCRIPTION
## Summary
- time out stalled ClawHub archive body reads instead of waiting forever after headers succeed
- apply the shared body-read timeout to skill zip, package zip, and ClawPack artifact downloads
- add regression coverage for stalled skill, package, and ClawPack body reads

## Testing
- pnpm exec oxlint src/infra/clawhub.ts src/infra/clawhub.test.ts
- pnpm exec vitest run src/infra/clawhub.test.ts --config test/vitest/vitest.unit.config.ts --reporter=dot

## Real behavior proof
I reproduced the stalled-body scenario against a local ClawHub stub.

The stub returned `200 OK`, sent response headers plus an initial body chunk, and then intentionally never completed the response body.

Running the real download path with `timeoutMs: 5000` produced:

```text
elapsed_ms=5020
Error: ClawHub ClawPack download for demo@2026.3.22 body timed out after 5000ms
```

This is not full live-service proof because the upstream is a local stub.
It is still useful integration evidence because it exercises the real download path under the exact stalled-body condition this patch fixes, and shows the client times out instead of hanging indefinitely.

Closes #52073.
