### PR TITLE
feat(plugins): expose ACP spawn and prompt in plugin runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins: add a trusted `api.runtime.acp` runtime namespace for per-plugin ACP spawn and channel-delivered prompt turns.
 - Agents: clarify that fixes should default to clean bounded refactors, lean internals, and explicit plugin SDK/API deprecation paths.
 - Dependencies: update `@openclaw/proxyline` to 0.3.3.
 - Dependencies: update Pi packages to 0.75.1 and raise the minimum supported Node.js 22 line to 22.19.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -231,6 +231,7 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
 - `plugins.entries.<id>.llm.allowModelOverride`: explicitly trust this plugin to request model overrides for `api.runtime.llm.complete`.
 - `plugins.entries.<id>.llm.allowedModels`: optional allowlist of canonical `provider/model` targets for trusted plugin LLM completion overrides. Use `"*"` only when you intentionally want to allow any model.
 - `plugins.entries.<id>.llm.allowAgentIdOverride`: explicitly trust this plugin to run `api.runtime.llm.complete` against a non-default agent id.
+- `plugins.entries.<id>.acp.allowSpawn`: explicitly trust this plugin to call `api.runtime.acp.spawn()` and `api.runtime.acp.prompt()` for ACP-backed coding sessions and channel-delivered turns.
 - `plugins.entries.<id>.config`: plugin-defined config object (validated by native OpenClaw plugin schema when available).
 - Channel plugin account/runtime settings live under `channels.<id>` and should be described by the owning plugin's manifest `channelConfigs` metadata, not by a central OpenClaw option registry.
 

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -3,7 +3,7 @@ summary: "api.runtime -- the injected runtime helpers available to plugins"
 title: "Plugin runtime helpers"
 sidebarTitle: "Runtime helpers"
 read_when:
-  - You need to call core helpers from a plugin (TTS, STT, image gen, web search, subagent, nodes)
+  - You need to call core helpers from a plugin (TTS, STT, ACP, image gen, web search, subagent, nodes)
   - You want to understand what api.runtime exposes
   - You are accessing config, agent, or media helpers from plugin code
 ---
@@ -233,6 +233,41 @@ two-party event loops that do not go through the shared channel-turn kernel.
     </Warning>
 
     `deleteSession(...)` can delete sessions created by the same plugin through `api.runtime.subagent.run(...)`. Deleting arbitrary user or operator sessions still requires an admin-scoped Gateway request.
+
+  </Accordion>
+  <Accordion title="api.runtime.acp">
+    Dispatch ACP-backed agent sessions from trusted plugins, including follow-up turns that can deliver back into a channel thread.
+
+    ```typescript
+    const spawned = await api.runtime.acp.spawn(
+      {
+        task: "Review the latest PR and report findings.",
+        agentId: "opencode",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:discord:thread:123",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentThreadId: "123",
+      },
+    );
+
+    const { runId } = await api.runtime.acp.prompt({
+      sessionKey: spawned.childSessionKey,
+      text: "Continue with the implementation.",
+      channel: "discord",
+      accountId: "default",
+      threadId: "123",
+    });
+    ```
+
+    <Warning>
+    ACP dispatch can start host-side coding harnesses and deliver into operator channels. It is disabled unless the operator explicitly trusts the calling plugin with `plugins.entries.<id>.acp.allowSpawn: true` in config. Do not enable this for untrusted third-party plugins.
+    </Warning>
+
+    `prompt(...)` uses the Gateway agent delivery path and marks the request as an explicit ACP turn, so a trusted plugin can continue an existing ACP session without being blocked by automatic-dispatch policy.
 
   </Accordion>
   <Accordion title="api.runtime.nodes">

--- a/src/agents/acp-spawn-contract.ts
+++ b/src/agents/acp-spawn-contract.ts
@@ -1,0 +1,90 @@
+export const ACP_SPAWN_MODES = ["run", "session"] as const;
+export type SpawnAcpMode = (typeof ACP_SPAWN_MODES)[number];
+
+export const ACP_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
+export type SpawnAcpSandboxMode = (typeof ACP_SPAWN_SANDBOX_MODES)[number];
+
+export const ACP_SPAWN_STREAM_TARGETS = ["parent"] as const;
+export type SpawnAcpStreamTarget = (typeof ACP_SPAWN_STREAM_TARGETS)[number];
+
+export type SpawnAcpParams = {
+  task: string;
+  label?: string;
+  agentId?: string;
+  resumeSessionId?: string;
+  model?: string;
+  thinking?: string;
+  runTimeoutSeconds?: number;
+  cwd?: string;
+  mode?: SpawnAcpMode;
+  thread?: boolean;
+  sandbox?: SpawnAcpSandboxMode;
+  streamTo?: SpawnAcpStreamTarget;
+};
+
+export type SpawnAcpContext = {
+  agentSessionKey?: string;
+  agentChannel?: string;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+  /** Group chat ID for channels that distinguish group vs. topic (for example Telegram). */
+  agentGroupId?: string;
+  /** Group space label (guild/team id) from the originating channel context. */
+  agentGroupSpace?: string | null;
+  /** Trusted provider role ids for the requester in this group turn. */
+  agentMemberRoleIds?: string[];
+  sandboxed?: boolean;
+  inheritedToolAllowlist?: string[];
+  inheritedToolDenylist?: string[];
+};
+
+export const ACP_SPAWN_ERROR_CODES = [
+  "acp_disabled",
+  "requester_session_required",
+  "runtime_policy",
+  "resume_forbidden",
+  "subagent_policy",
+  "thread_required",
+  "target_agent_required",
+  "runtime_agent_mismatch",
+  "agent_forbidden",
+  "cwd_resolution_failed",
+  "thread_binding_invalid",
+  "spawn_failed",
+  "dispatch_failed",
+] as const;
+export type SpawnAcpErrorCode = (typeof ACP_SPAWN_ERROR_CODES)[number];
+
+type SpawnAcpResultFields = {
+  childSessionKey?: string;
+  runId?: string;
+  mode?: SpawnAcpMode;
+  inlineDelivery?: boolean;
+  streamLogPath?: string;
+  note?: string;
+};
+
+export type SpawnAcpAcceptedResult = SpawnAcpResultFields & {
+  status: "accepted";
+  childSessionKey: string;
+  runId: string;
+  mode: SpawnAcpMode;
+};
+
+export type SpawnAcpFailedResult = SpawnAcpResultFields & {
+  status: "forbidden" | "error";
+  error: string;
+  errorCode: SpawnAcpErrorCode;
+};
+
+export type SpawnAcpResult = SpawnAcpAcceptedResult | SpawnAcpFailedResult;
+
+export function isSpawnAcpAcceptedResult(result: SpawnAcpResult): result is SpawnAcpAcceptedResult {
+  return result.status === "accepted";
+}
+
+export const ACP_SPAWN_ACCEPTED_NOTE =
+  "initial ACP task queued in isolated session; follow-ups continue in the bound thread.";
+export const ACP_SPAWN_SESSION_ACCEPTED_NOTE =
+  "thread-bound ACP session stays active after this task; continue in-thread for follow-ups.";

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -65,6 +65,16 @@ import {
   normalizeDeliveryContext,
   resolveConversationDeliveryTarget,
 } from "../utils/delivery-context.js";
+import { ACP_SPAWN_ACCEPTED_NOTE, ACP_SPAWN_SESSION_ACCEPTED_NOTE } from "./acp-spawn-contract.js";
+import type {
+  SpawnAcpContext,
+  SpawnAcpErrorCode,
+  SpawnAcpFailedResult,
+  SpawnAcpMode,
+  SpawnAcpParams,
+  SpawnAcpResult,
+  SpawnAcpSandboxMode,
+} from "./acp-spawn-contract.js";
 import {
   type AcpSpawnParentRelayHandle,
   resolveAcpSpawnStreamLogPath,
@@ -94,96 +104,28 @@ import { countActiveRunsForSession, getSubagentRunByChildSessionKey } from "./su
 import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
+export {
+  ACP_SPAWN_ACCEPTED_NOTE,
+  ACP_SPAWN_ERROR_CODES,
+  ACP_SPAWN_MODES,
+  ACP_SPAWN_SANDBOX_MODES,
+  ACP_SPAWN_SESSION_ACCEPTED_NOTE,
+  ACP_SPAWN_STREAM_TARGETS,
+  isSpawnAcpAcceptedResult,
+} from "./acp-spawn-contract.js";
+export type {
+  SpawnAcpAcceptedResult,
+  SpawnAcpContext,
+  SpawnAcpErrorCode,
+  SpawnAcpFailedResult,
+  SpawnAcpMode,
+  SpawnAcpParams,
+  SpawnAcpResult,
+  SpawnAcpSandboxMode,
+  SpawnAcpStreamTarget,
+} from "./acp-spawn-contract.js";
+
 const log = createSubsystemLogger("agents/acp-spawn");
-
-export const ACP_SPAWN_MODES = ["run", "session"] as const;
-export type SpawnAcpMode = (typeof ACP_SPAWN_MODES)[number];
-export const ACP_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
-export type SpawnAcpSandboxMode = (typeof ACP_SPAWN_SANDBOX_MODES)[number];
-export const ACP_SPAWN_STREAM_TARGETS = ["parent"] as const;
-export type SpawnAcpStreamTarget = (typeof ACP_SPAWN_STREAM_TARGETS)[number];
-
-export type SpawnAcpParams = {
-  task: string;
-  label?: string;
-  agentId?: string;
-  resumeSessionId?: string;
-  model?: string;
-  thinking?: string;
-  runTimeoutSeconds?: number;
-  cwd?: string;
-  mode?: SpawnAcpMode;
-  thread?: boolean;
-  sandbox?: SpawnAcpSandboxMode;
-  streamTo?: SpawnAcpStreamTarget;
-};
-
-export type SpawnAcpContext = {
-  agentSessionKey?: string;
-  agentChannel?: string;
-  agentAccountId?: string;
-  agentTo?: string;
-  agentThreadId?: string | number;
-  /** Group chat ID for channels that distinguish group vs. topic (e.g. Telegram). */
-  agentGroupId?: string;
-  /** Group space label (guild/team id) from the originating channel context. */
-  agentGroupSpace?: string | null;
-  /** Trusted provider role ids for the requester in this group turn. */
-  agentMemberRoleIds?: string[];
-  sandboxed?: boolean;
-  inheritedToolAllowlist?: string[];
-  inheritedToolDenylist?: string[];
-};
-
-export const ACP_SPAWN_ERROR_CODES = [
-  "acp_disabled",
-  "requester_session_required",
-  "runtime_policy",
-  "resume_forbidden",
-  "subagent_policy",
-  "thread_required",
-  "target_agent_required",
-  "runtime_agent_mismatch",
-  "agent_forbidden",
-  "cwd_resolution_failed",
-  "thread_binding_invalid",
-  "spawn_failed",
-  "dispatch_failed",
-] as const;
-export type SpawnAcpErrorCode = (typeof ACP_SPAWN_ERROR_CODES)[number];
-
-type SpawnAcpResultFields = {
-  childSessionKey?: string;
-  runId?: string;
-  mode?: SpawnAcpMode;
-  inlineDelivery?: boolean;
-  streamLogPath?: string;
-  note?: string;
-};
-
-type SpawnAcpAcceptedResult = SpawnAcpResultFields & {
-  status: "accepted";
-  childSessionKey: string;
-  runId: string;
-  mode: SpawnAcpMode;
-};
-
-type SpawnAcpFailedResult = SpawnAcpResultFields & {
-  status: "forbidden" | "error";
-  error: string;
-  errorCode: SpawnAcpErrorCode;
-};
-
-export type SpawnAcpResult = SpawnAcpAcceptedResult | SpawnAcpFailedResult;
-
-export function isSpawnAcpAcceptedResult(result: SpawnAcpResult): result is SpawnAcpAcceptedResult {
-  return result.status === "accepted";
-}
-
-export const ACP_SPAWN_ACCEPTED_NOTE =
-  "initial ACP task queued in isolated session; follow-ups continue in the bound thread.";
-export const ACP_SPAWN_SESSION_ACCEPTED_NOTE =
-  "thread-bound ACP session stays active after this task; continue in-thread for follow-ups.";
 
 export function resolveAcpSpawnRuntimePolicyError(params: {
   cfg: OpenClawConfig;

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -382,6 +382,9 @@ export async function runPluginsInspectCommand(
       }`,
     );
   }
+  if (typeof inspect.policy.allowAcpSpawn === "boolean") {
+    policyLines.push(`allowAcpSpawn: ${inspect.policy.allowAcpSpawn}`);
+  }
   lines.push(...formatInspectSection("Policy", policyLines));
   lines.push(
     ...formatInspectSection(

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -584,6 +584,38 @@ describe("plugins.entries.*.llm", () => {
   });
 });
 
+describe("plugins.entries.*.acp", () => {
+  it("accepts trusted ACP runtime settings", () => {
+    const result = OpenClawSchema.safeParse({
+      plugins: {
+        entries: {
+          "task-dispatch": {
+            acp: {
+              allowSpawn: true,
+            },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid ACP runtime settings", () => {
+    const result = OpenClawSchema.safeParse({
+      plugins: {
+        entries: {
+          "task-dispatch": {
+            acp: {
+              allowSpawn: "yes",
+            },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("web search provider config", () => {
   it("accepts kimi provider and config", () => {
     const res = validateConfigObject(

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -380,6 +380,8 @@ const TARGET_KEYS = [
   "plugins.entries.*.llm.allowModelOverride",
   "plugins.entries.*.llm.allowedModels",
   "plugins.entries.*.llm.allowAgentIdOverride",
+  "plugins.entries.*.acp",
+  "plugins.entries.*.acp.allowSpawn",
   "plugins.entries.*.apiKey",
   "plugins.entries.*.env",
   "plugins.entries.*.config",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1361,6 +1361,10 @@ export const FIELD_HELP: Record<string, string> = {
     'Allowed override targets for trusted plugin LLM completions as canonical "provider/model" refs. Use "*" only when you intentionally allow any model.',
   "plugins.entries.*.llm.allowAgentIdOverride":
     "Explicitly allows this plugin to request api.runtime.llm.complete against a non-default agent id. Keep false unless the plugin is trusted for cross-agent model access.",
+  "plugins.entries.*.acp":
+    "Per-plugin api.runtime.acp controls for trusted ACP spawn and delivered prompt turns. Keep this unset unless a plugin must start or continue ACP-backed coding sessions.",
+  "plugins.entries.*.acp.allowSpawn":
+    "Explicitly allows this plugin to call api.runtime.acp.spawn and api.runtime.acp.prompt. Keep false unless the plugin is trusted to start host-side coding harnesses and deliver into operator channels.",
   "plugins.entries.*.apiKey":
     "Optional API key field consumed by plugins that accept direct key configuration in entry settings. Use secret/env substitution and avoid committing real credentials into config files.",
   "plugins.entries.*.env":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -1017,6 +1017,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "plugins.entries.*.llm.allowModelOverride": "Allow Plugin LLM Model Override",
   "plugins.entries.*.llm.allowedModels": "Plugin LLM Allowed Models",
   "plugins.entries.*.llm.allowAgentIdOverride": "Allow Plugin LLM Agent Override",
+  "plugins.entries.*.acp": "Plugin ACP Policy",
+  "plugins.entries.*.acp.allowSpawn": "Allow Plugin ACP Spawn",
   "plugins.entries.*.apiKey": "Plugin API Key", // pragma: allowlist secret
   "plugins.entries.*.env": "Plugin Environment Variables",
   "plugins.entries.*.config": "Plugin Config",

--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -35,6 +35,10 @@ export type PluginEntryConfig = {
     /** Explicitly allow this plugin to run completions against a non-default agent id. */
     allowAgentIdOverride?: boolean;
   };
+  acp?: {
+    /** Explicitly allow this plugin to call api.runtime.acp.spawn() and api.runtime.acp.prompt(). */
+    allowSpawn?: boolean;
+  };
   config?: Record<string, unknown>;
 };
 
@@ -62,12 +66,6 @@ export type PluginsConfig = {
   enabled?: boolean;
   /** Optional plugin allowlist (plugin ids). */
   allow?: string[];
-  /**
-   * Allow plugins to call api.runtime.acp.spawn() to dispatch ACP agents
-   * with thread-bound output. Opt-in because plugins spawning agents is a
-   * privileged operation. Set to true only for trusted plugins.
-   */
-  allowAcpSpawn?: boolean;
   /** Optional plugin denylist (plugin ids). */
   deny?: string[];
   /**

--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -62,6 +62,12 @@ export type PluginsConfig = {
   enabled?: boolean;
   /** Optional plugin allowlist (plugin ids). */
   allow?: string[];
+  /**
+   * Allow plugins to call api.runtime.acp.spawn() to dispatch ACP agents
+   * with thread-bound output. Opt-in because plugins spawning agents is a
+   * privileged operation. Set to true only for trusted plugins.
+   */
+  allowAcpSpawn?: boolean;
   /** Optional plugin denylist (plugin ids). */
   deny?: string[];
   /**

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1163,6 +1163,8 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         allow: z.array(z.string()).optional(),
         deny: z.array(z.string()).optional(),
+        /** Allow plugins to call api.runtime.acp.spawn(). Opt-in; false by default. */
+        allowAcpSpawn: z.boolean().optional(),
         load: z
           .object({
             paths: z.array(z.string()).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -259,6 +259,12 @@ const PluginEntrySchema = z
       })
       .strict()
       .optional(),
+    acp: z
+      .object({
+        allowSpawn: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     config: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
@@ -1163,8 +1169,6 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         allow: z.array(z.string()).optional(),
         deny: z.array(z.string()).optional(),
-        /** Allow plugins to call api.runtime.acp.spawn(). Opt-in; false by default. */
-        allowAcpSpawn: z.boolean().optional(),
         load: z
           .object({
             paths: z.array(z.string()).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1114,6 +1114,8 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         allow: z.array(z.string()).optional(),
         deny: z.array(z.string()).optional(),
+        /** Allow plugins to call api.runtime.acp.spawn(). Opt-in; false by default. */
+        allowAcpSpawn: z.boolean().optional(),
         load: z
           .object({
             paths: z.array(z.string()).optional(),

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -737,6 +737,10 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       flow: taskFlow,
     },
     taskFlow,
+    acp: {
+      spawn: vi.fn() as unknown as PluginRuntime["acp"]["spawn"],
+      prompt: vi.fn() as unknown as PluginRuntime["acp"]["prompt"],
+    },
     modelAuth: {
       getApiKeyForModel: vi.fn() as unknown as PluginRuntime["modelAuth"]["getApiKeyForModel"],
       getRuntimeAuthForModel:

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -708,6 +708,10 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       flow: taskFlow,
     },
     taskFlow,
+    acp: {
+      spawn: vi.fn() as unknown as PluginRuntime["acp"]["spawn"],
+      prompt: vi.fn() as unknown as PluginRuntime["acp"]["prompt"],
+    },
     modelAuth: {
       getApiKeyForModel: vi.fn() as unknown as PluginRuntime["modelAuth"]["getApiKeyForModel"],
       getRuntimeAuthForModel:

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -36,6 +36,9 @@ export type NormalizedPluginsConfig = {
         hasAllowedModelsConfig?: boolean;
         allowAgentIdOverride?: boolean;
       };
+      acp?: {
+        allowSpawn?: boolean;
+      };
       config?: unknown;
     }
   >;
@@ -206,6 +209,13 @@ function normalizePluginEntries(
               : {}),
           }
         : undefined;
+    const acpRaw = entry.acp;
+    const acp =
+      acpRaw && typeof acpRaw === "object" && !Array.isArray(acpRaw)
+        ? { allowSpawn: (acpRaw as { allowSpawn?: unknown }).allowSpawn }
+        : undefined;
+    const normalizedAcp =
+      acp && typeof acp.allowSpawn === "boolean" ? { allowSpawn: acp.allowSpawn } : undefined;
     normalized[normalizedKey] = {
       ...normalized[normalizedKey],
       enabled:
@@ -213,6 +223,7 @@ function normalizePluginEntries(
       hooks: normalizedHooks ?? normalized[normalizedKey]?.hooks,
       subagent: normalizedSubagent ?? normalized[normalizedKey]?.subagent,
       llm: normalizedLlm ?? normalized[normalizedKey]?.llm,
+      acp: normalizedAcp ?? normalized[normalizedKey]?.acp,
       config: "config" in entry ? entry.config : normalized[normalizedKey]?.config,
     };
   }

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -164,6 +164,16 @@ describe("normalizePluginsConfig", () => {
     });
   });
 
+  it("normalizes plugin ACP runtime policy settings", () => {
+    expect(
+      normalizeVoiceCallEntry({
+        acp: {
+          allowSpawn: true,
+        },
+      })?.acp,
+    ).toEqual({ allowSpawn: true });
+  });
+
   it("normalizes legacy plugin ids to their merged bundled plugin id", () => {
     const result = normalizePluginsConfig({
       allow: ["openai-codex", "google-gemini-cli", "minimax-portal-auth"],

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -51,7 +51,6 @@ import {
 import { buildPluginApi } from "./api-builder.js";
 import { normalizeRegisteredChannelPlugin } from "./channel-validation.js";
 import { CODEX_APP_SERVER_EXTENSION_RUNTIME_ID } from "./codex-app-server-extension-factory.js";
-import { getPluginCompatRecord } from "./compat/registry.js";
 import type { CodexAppServerExtensionFactory } from "./codex-app-server-extension-types.js";
 import {
   isReservedCommandName,
@@ -63,6 +62,7 @@ import {
   getRegisteredCompactionProvider,
   registerCompactionProvider,
 } from "./compaction-provider.js";
+import { getPluginCompatRecord } from "./compat/registry.js";
 import { sendPluginSessionAttachment } from "./host-hook-attachments.js";
 import {
   clearPluginRunContext,
@@ -2446,6 +2446,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
             complete: (params) =>
               withPluginRuntimePluginIdScope(pluginId, () => llm.complete(params)),
           } satisfies PluginRuntime["llm"];
+        }
+        if (prop === "acp") {
+          const acp = Reflect.get(target, prop, receiver);
+          return {
+            spawn: (params, ctx) =>
+              withPluginRuntimePluginIdScope(pluginId, () => acp.spawn(params, ctx)),
+            prompt: (params) => withPluginRuntimePluginIdScope(pluginId, () => acp.prompt(params)),
+          } satisfies PluginRuntime["acp"];
         }
         if (prop !== "subagent") {
           return Reflect.get(target, prop, receiver);

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -27,6 +27,7 @@ const runtimeModelAuthMocks = vi.hoisted(() => ({
 
 vi.mock("./runtime-model-auth.runtime.js", () => runtimeModelAuthMocks);
 
+import { withPluginRuntimePluginIdScope } from "./gateway-request-scope.js";
 import {
   clearGatewaySubagentRuntime,
   createPluginRuntime,
@@ -443,13 +444,15 @@ describe("plugin runtime command execution", () => {
     expect(nodes.list).toHaveBeenCalledWith({ connected: true });
   });
 
-  it("gates ACP runtime helpers behind plugins.allowAcpSpawn", async () => {
-    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({ plugins: {} } as never);
+  it("requires plugin identity before exposing ACP runtime helpers", async () => {
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
+      plugins: { entries: { "task-dispatch": { acp: { allowSpawn: true } } } },
+    } as never);
 
     const runtime = createPluginRuntime();
 
     await expect(runtime.acp.spawn({ task: "hello" }, {})).rejects.toThrow(
-      "api.runtime.acp helpers require plugins.allowAcpSpawn: true in openclaw.json",
+      "api.runtime.acp helpers require a loaded plugin runtime scope with plugin identity",
     );
     await expect(
       runtime.acp.prompt({
@@ -457,13 +460,39 @@ describe("plugin runtime command execution", () => {
         text: "hello",
       }),
     ).rejects.toThrow(
-      "api.runtime.acp helpers require plugins.allowAcpSpawn: true in openclaw.json",
+      "api.runtime.acp helpers require a loaded plugin runtime scope with plugin identity",
     );
   });
 
-  it("delegates ACP runtime helpers when plugins.allowAcpSpawn is enabled", async () => {
+  it("gates ACP runtime helpers behind per-plugin allowSpawn", async () => {
     vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
-      plugins: { allowAcpSpawn: true },
+      plugins: { entries: { "other-plugin": { acp: { allowSpawn: true } } } },
+    } as never);
+
+    const runtime = createPluginRuntime();
+
+    await expect(
+      withPluginRuntimePluginIdScope("task-dispatch", () =>
+        runtime.acp.spawn({ task: "hello" }, {}),
+      ),
+    ).rejects.toThrow(
+      "api.runtime.acp helpers require plugins.entries.task-dispatch.acp.allowSpawn: true in openclaw.json",
+    );
+    await expect(
+      withPluginRuntimePluginIdScope("task-dispatch", () =>
+        runtime.acp.prompt({
+          sessionKey: "session-1",
+          text: "hello",
+        }),
+      ),
+    ).rejects.toThrow(
+      "api.runtime.acp helpers require plugins.entries.task-dispatch.acp.allowSpawn: true in openclaw.json",
+    );
+  });
+
+  it("delegates ACP runtime helpers when the calling plugin is allowed", async () => {
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
+      plugins: { entries: { "task-dispatch": { acp: { allowSpawn: true } } } },
     } as never);
     const spawnAcpDirect = vi.spyOn(acpSpawnModule, "spawnAcpDirect").mockResolvedValue({
       status: "accepted",
@@ -481,9 +510,11 @@ describe("plugin runtime command execution", () => {
     const runtime = createPluginRuntime();
 
     await expect(
-      runtime.acp.spawn(
-        { task: "hello", agentId: "opencode" },
-        { agentChannel: "discord", agentAccountId: "zeus" },
+      withPluginRuntimePluginIdScope("task-dispatch", () =>
+        runtime.acp.spawn(
+          { task: "hello", agentId: "opencode" },
+          { agentChannel: "discord", agentAccountId: "zeus" },
+        ),
       ),
     ).resolves.toMatchObject({
       status: "accepted",
@@ -496,14 +527,16 @@ describe("plugin runtime command execution", () => {
     );
 
     await expect(
-      runtime.acp.prompt({
-        sessionKey: "child-session",
-        text: "follow up",
-        channel: "telegram",
-        accountId: "zeus",
-        conversationId: "topic:77",
-        parentConversationId: "-100123",
-      }),
+      withPluginRuntimePluginIdScope("task-dispatch", () =>
+        runtime.acp.prompt({
+          sessionKey: "child-session",
+          text: "follow up",
+          channel: "telegram",
+          accountId: "zeus",
+          conversationId: "topic:77",
+          parentConversationId: "-100123",
+        }),
+      ),
     ).resolves.toEqual({ runId: "prompt-run-id" });
     expect(resolveConversationDeliveryTarget).toHaveBeenCalledWith({
       channel: "telegram",
@@ -521,6 +554,7 @@ describe("plugin runtime command execution", () => {
           threadId: "77",
           to: "-100123",
           deliver: true,
+          acpTurnSource: "manual_spawn",
           idempotencyKey: expect.any(String),
         }),
       }),
@@ -529,7 +563,7 @@ describe("plugin runtime command execution", () => {
 
   it("omits delivery fields for session-only ACP prompts", async () => {
     vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
-      plugins: { allowAcpSpawn: true },
+      plugins: { entries: { "task-dispatch": { acp: { allowSpawn: true } } } },
     } as never);
     const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
       runId: "prompt-run-id",
@@ -538,10 +572,12 @@ describe("plugin runtime command execution", () => {
     const runtime = createPluginRuntime();
 
     await expect(
-      runtime.acp.prompt({
-        sessionKey: "child-session",
-        text: "follow up",
-      }),
+      withPluginRuntimePluginIdScope("task-dispatch", () =>
+        runtime.acp.prompt({
+          sessionKey: "child-session",
+          text: "follow up",
+        }),
+      ),
     ).resolves.toEqual({ runId: "prompt-run-id" });
     expect(callGateway).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -549,6 +585,7 @@ describe("plugin runtime command execution", () => {
         params: {
           message: "follow up",
           sessionKey: "child-session",
+          acpTurnSource: "manual_spawn",
           idempotencyKey: expect.any(String),
         },
       }),
@@ -557,17 +594,19 @@ describe("plugin runtime command execution", () => {
 
   it("fails loudly when ACP prompt gateway response omits runId", async () => {
     vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
-      plugins: { allowAcpSpawn: true },
+      plugins: { entries: { "task-dispatch": { acp: { allowSpawn: true } } } },
     } as never);
     vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({});
 
     const runtime = createPluginRuntime();
 
     await expect(
-      runtime.acp.prompt({
-        sessionKey: "child-session",
-        text: "follow up",
-      }),
+      withPluginRuntimePluginIdScope("task-dispatch", () =>
+        runtime.acp.prompt({
+          sessionKey: "child-session",
+          text: "follow up",
+        }),
+      ),
     ).rejects.toThrow("api.runtime.acp.prompt() expected gateway to return runId");
   });
 });

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as acpSpawnModule from "../../agents/acp-spawn.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import {
   resetConfigRuntimeState,
   setRuntimeConfigSnapshot,
   type OpenClawConfig,
 } from "../../config/config.js";
+import * as configModule from "../../config/config.js";
+import * as gatewayCallModule from "../../gateway/call.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import {
   requestHeartbeat,
@@ -437,5 +440,80 @@ describe("plugin runtime command execution", () => {
       nodes: [{ nodeId: "node-1" }],
     });
     expect(nodes.list).toHaveBeenCalledWith({ connected: true });
+  });
+
+  it("gates ACP runtime helpers behind plugins.allowAcpSpawn", async () => {
+    vi.spyOn(configModule, "loadConfig").mockReturnValue({ plugins: {} } as never);
+
+    const runtime = createPluginRuntime();
+
+    expect(() => runtime.acp.spawn({ task: "hello" }, {})).toThrow(
+      "api.runtime.acp.spawn() requires plugins.allowAcpSpawn: true in openclaw.json",
+    );
+    await expect(
+      runtime.acp.prompt({
+        sessionKey: "session-1",
+        text: "hello",
+      }),
+    ).rejects.toThrow(
+      "api.runtime.acp.prompt() requires plugins.allowAcpSpawn: true in openclaw.json",
+    );
+  });
+
+  it("delegates ACP runtime helpers when plugins.allowAcpSpawn is enabled", async () => {
+    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+      plugins: { allowAcpSpawn: true },
+    } as never);
+    const spawnAcpDirect = vi.spyOn(acpSpawnModule, "spawnAcpDirect").mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "child-session",
+      runId: "spawn-run-id",
+      mode: "run",
+    });
+    const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
+      runId: "prompt-run-id",
+    });
+
+    const runtime = createPluginRuntime();
+
+    await expect(
+      runtime.acp.spawn(
+        { task: "hello", agentId: "opencode" },
+        { agentChannel: "discord", agentAccountId: "zeus" },
+      ),
+    ).resolves.toMatchObject({
+      status: "accepted",
+      childSessionKey: "child-session",
+      runId: "spawn-run-id",
+    });
+    expect(spawnAcpDirect).toHaveBeenCalledWith(
+      { task: "hello", agentId: "opencode" },
+      { agentChannel: "discord", agentAccountId: "zeus" },
+    );
+
+    await expect(
+      runtime.acp.prompt({
+        sessionKey: "child-session",
+        text: "follow up",
+        channel: "discord",
+        accountId: "zeus",
+        threadId: "12345",
+      }),
+    ).resolves.toEqual({ runId: "prompt-run-id" });
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: "child-session",
+          message: "follow up",
+          channel: "discord",
+          accountId: "zeus",
+          threadId: "12345",
+          to: "channel:12345",
+          deliver: true,
+          idempotencyKey: expect.any(String),
+        }),
+      }),
+    );
   });
 });

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -528,7 +528,7 @@ describe("plugin runtime command execution", () => {
   });
 
   it("omits delivery fields for session-only ACP prompts", async () => {
-    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
       plugins: { allowAcpSpawn: true },
     } as never);
     const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
@@ -556,7 +556,7 @@ describe("plugin runtime command execution", () => {
   });
 
   it("fails loudly when ACP prompt gateway response omits runId", async () => {
-    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
       plugins: { allowAcpSpawn: true },
     } as never);
     vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({});

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../infra/heartbeat-wake.js";
 import * as execModule from "../../process/exec.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import * as deliveryContextModule from "../../utils/delivery-context.js";
 import { VERSION } from "../../version.js";
 
 const runtimeModelAuthMocks = vi.hoisted(() => ({
@@ -443,12 +444,12 @@ describe("plugin runtime command execution", () => {
   });
 
   it("gates ACP runtime helpers behind plugins.allowAcpSpawn", async () => {
-    vi.spyOn(configModule, "loadConfig").mockReturnValue({ plugins: {} } as never);
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({ plugins: {} } as never);
 
     const runtime = createPluginRuntime();
 
-    expect(() => runtime.acp.spawn({ task: "hello" }, {})).toThrow(
-      "api.runtime.acp.spawn() requires plugins.allowAcpSpawn: true in openclaw.json",
+    await expect(runtime.acp.spawn({ task: "hello" }, {})).rejects.toThrow(
+      "api.runtime.acp helpers require plugins.allowAcpSpawn: true in openclaw.json",
     );
     await expect(
       runtime.acp.prompt({
@@ -456,12 +457,12 @@ describe("plugin runtime command execution", () => {
         text: "hello",
       }),
     ).rejects.toThrow(
-      "api.runtime.acp.prompt() requires plugins.allowAcpSpawn: true in openclaw.json",
+      "api.runtime.acp helpers require plugins.allowAcpSpawn: true in openclaw.json",
     );
   });
 
   it("delegates ACP runtime helpers when plugins.allowAcpSpawn is enabled", async () => {
-    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
       plugins: { allowAcpSpawn: true },
     } as never);
     const spawnAcpDirect = vi.spyOn(acpSpawnModule, "spawnAcpDirect").mockResolvedValue({
@@ -473,6 +474,9 @@ describe("plugin runtime command execution", () => {
     const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
       runId: "prompt-run-id",
     });
+    const resolveConversationDeliveryTarget = vi
+      .spyOn(deliveryContextModule, "resolveConversationDeliveryTarget")
+      .mockReturnValue({ to: "-100123", threadId: "77" });
 
     const runtime = createPluginRuntime();
 
@@ -495,25 +499,75 @@ describe("plugin runtime command execution", () => {
       runtime.acp.prompt({
         sessionKey: "child-session",
         text: "follow up",
-        channel: "discord",
+        channel: "telegram",
         accountId: "zeus",
-        threadId: "12345",
+        conversationId: "topic:77",
+        parentConversationId: "-100123",
       }),
     ).resolves.toEqual({ runId: "prompt-run-id" });
+    expect(resolveConversationDeliveryTarget).toHaveBeenCalledWith({
+      channel: "telegram",
+      conversationId: "topic:77",
+      parentConversationId: "-100123",
+    });
     expect(callGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "agent",
         params: expect.objectContaining({
           sessionKey: "child-session",
           message: "follow up",
-          channel: "discord",
+          channel: "telegram",
           accountId: "zeus",
-          threadId: "12345",
-          to: "channel:12345",
+          threadId: "77",
+          to: "-100123",
           deliver: true,
           idempotencyKey: expect.any(String),
         }),
       }),
     );
+  });
+
+  it("omits delivery fields for session-only ACP prompts", async () => {
+    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+      plugins: { allowAcpSpawn: true },
+    } as never);
+    const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
+      runId: "prompt-run-id",
+    });
+
+    const runtime = createPluginRuntime();
+
+    await expect(
+      runtime.acp.prompt({
+        sessionKey: "child-session",
+        text: "follow up",
+      }),
+    ).resolves.toEqual({ runId: "prompt-run-id" });
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: {
+          message: "follow up",
+          sessionKey: "child-session",
+          idempotencyKey: expect.any(String),
+        },
+      }),
+    );
+  });
+
+  it("fails loudly when ACP prompt gateway response omits runId", async () => {
+    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+      plugins: { allowAcpSpawn: true },
+    } as never);
+    vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({});
+
+    const runtime = createPluginRuntime();
+
+    await expect(
+      runtime.acp.prompt({
+        sessionKey: "child-session",
+        text: "follow up",
+      }),
+    ).rejects.toThrow("api.runtime.acp.prompt() expected gateway to return runId");
   });
 });

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../infra/heartbeat-wake.js";
 import * as execModule from "../../process/exec.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import * as deliveryContextModule from "../../utils/delivery-context.js";
 import { VERSION } from "../../version.js";
 
 const runtimeModelAuthMocks = vi.hoisted(() => ({
@@ -446,12 +447,12 @@ describe("plugin runtime command execution", () => {
   });
 
   it("gates ACP runtime helpers behind plugins.allowAcpSpawn", async () => {
-    vi.spyOn(configModule, "loadConfig").mockReturnValue({ plugins: {} } as never);
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({ plugins: {} } as never);
 
     const runtime = createPluginRuntime();
 
-    expect(() => runtime.acp.spawn({ task: "hello" }, {})).toThrow(
-      "api.runtime.acp.spawn() requires plugins.allowAcpSpawn: true in openclaw.json",
+    await expect(runtime.acp.spawn({ task: "hello" }, {})).rejects.toThrow(
+      "api.runtime.acp helpers require plugins.allowAcpSpawn: true in openclaw.json",
     );
     await expect(
       runtime.acp.prompt({
@@ -459,12 +460,12 @@ describe("plugin runtime command execution", () => {
         text: "hello",
       }),
     ).rejects.toThrow(
-      "api.runtime.acp.prompt() requires plugins.allowAcpSpawn: true in openclaw.json",
+      "api.runtime.acp helpers require plugins.allowAcpSpawn: true in openclaw.json",
     );
   });
 
   it("delegates ACP runtime helpers when plugins.allowAcpSpawn is enabled", async () => {
-    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
       plugins: { allowAcpSpawn: true },
     } as never);
     const spawnAcpDirect = vi.spyOn(acpSpawnModule, "spawnAcpDirect").mockResolvedValue({
@@ -476,6 +477,9 @@ describe("plugin runtime command execution", () => {
     const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
       runId: "prompt-run-id",
     });
+    const resolveConversationDeliveryTarget = vi
+      .spyOn(deliveryContextModule, "resolveConversationDeliveryTarget")
+      .mockReturnValue({ to: "-100123", threadId: "77" });
 
     const runtime = createPluginRuntime();
 
@@ -498,25 +502,75 @@ describe("plugin runtime command execution", () => {
       runtime.acp.prompt({
         sessionKey: "child-session",
         text: "follow up",
-        channel: "discord",
+        channel: "telegram",
         accountId: "zeus",
-        threadId: "12345",
+        conversationId: "topic:77",
+        parentConversationId: "-100123",
       }),
     ).resolves.toEqual({ runId: "prompt-run-id" });
+    expect(resolveConversationDeliveryTarget).toHaveBeenCalledWith({
+      channel: "telegram",
+      conversationId: "topic:77",
+      parentConversationId: "-100123",
+    });
     expect(callGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "agent",
         params: expect.objectContaining({
           sessionKey: "child-session",
           message: "follow up",
-          channel: "discord",
+          channel: "telegram",
           accountId: "zeus",
-          threadId: "12345",
-          to: "channel:12345",
+          threadId: "77",
+          to: "-100123",
           deliver: true,
           idempotencyKey: expect.any(String),
         }),
       }),
     );
+  });
+
+  it("omits delivery fields for session-only ACP prompts", async () => {
+    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+      plugins: { allowAcpSpawn: true },
+    } as never);
+    const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
+      runId: "prompt-run-id",
+    });
+
+    const runtime = createPluginRuntime();
+
+    await expect(
+      runtime.acp.prompt({
+        sessionKey: "child-session",
+        text: "follow up",
+      }),
+    ).resolves.toEqual({ runId: "prompt-run-id" });
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: {
+          message: "follow up",
+          sessionKey: "child-session",
+          idempotencyKey: expect.any(String),
+        },
+      }),
+    );
+  });
+
+  it("fails loudly when ACP prompt gateway response omits runId", async () => {
+    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+      plugins: { allowAcpSpawn: true },
+    } as never);
+    vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({});
+
+    const runtime = createPluginRuntime();
+
+    await expect(
+      runtime.acp.prompt({
+        sessionKey: "child-session",
+        text: "follow up",
+      }),
+    ).rejects.toThrow("api.runtime.acp.prompt() expected gateway to return runId");
   });
 });

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as acpSpawnModule from "../../agents/acp-spawn.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import {
   resetConfigRuntimeState,
   setRuntimeConfigSnapshot,
   type OpenClawConfig,
 } from "../../config/config.js";
+import * as configModule from "../../config/config.js";
+import * as gatewayCallModule from "../../gateway/call.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import {
   requestHeartbeat,
@@ -440,5 +443,80 @@ describe("plugin runtime command execution", () => {
       nodes: [{ nodeId: "node-1" }],
     });
     expect(nodes.list).toHaveBeenCalledWith({ connected: true });
+  });
+
+  it("gates ACP runtime helpers behind plugins.allowAcpSpawn", async () => {
+    vi.spyOn(configModule, "loadConfig").mockReturnValue({ plugins: {} } as never);
+
+    const runtime = createPluginRuntime();
+
+    expect(() => runtime.acp.spawn({ task: "hello" }, {})).toThrow(
+      "api.runtime.acp.spawn() requires plugins.allowAcpSpawn: true in openclaw.json",
+    );
+    await expect(
+      runtime.acp.prompt({
+        sessionKey: "session-1",
+        text: "hello",
+      }),
+    ).rejects.toThrow(
+      "api.runtime.acp.prompt() requires plugins.allowAcpSpawn: true in openclaw.json",
+    );
+  });
+
+  it("delegates ACP runtime helpers when plugins.allowAcpSpawn is enabled", async () => {
+    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+      plugins: { allowAcpSpawn: true },
+    } as never);
+    const spawnAcpDirect = vi.spyOn(acpSpawnModule, "spawnAcpDirect").mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "child-session",
+      runId: "spawn-run-id",
+      mode: "run",
+    });
+    const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
+      runId: "prompt-run-id",
+    });
+
+    const runtime = createPluginRuntime();
+
+    await expect(
+      runtime.acp.spawn(
+        { task: "hello", agentId: "opencode" },
+        { agentChannel: "discord", agentAccountId: "zeus" },
+      ),
+    ).resolves.toMatchObject({
+      status: "accepted",
+      childSessionKey: "child-session",
+      runId: "spawn-run-id",
+    });
+    expect(spawnAcpDirect).toHaveBeenCalledWith(
+      { task: "hello", agentId: "opencode" },
+      { agentChannel: "discord", agentAccountId: "zeus" },
+    );
+
+    await expect(
+      runtime.acp.prompt({
+        sessionKey: "child-session",
+        text: "follow up",
+        channel: "discord",
+        accountId: "zeus",
+        threadId: "12345",
+      }),
+    ).resolves.toEqual({ runId: "prompt-run-id" });
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: "child-session",
+          message: "follow up",
+          channel: "discord",
+          accountId: "zeus",
+          threadId: "12345",
+          to: "channel:12345",
+          deliver: true,
+          idempotencyKey: expect.any(String),
+        }),
+      }),
+    );
   });
 });

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -531,7 +531,7 @@ describe("plugin runtime command execution", () => {
   });
 
   it("omits delivery fields for session-only ACP prompts", async () => {
-    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
       plugins: { allowAcpSpawn: true },
     } as never);
     const callGateway = vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({
@@ -559,7 +559,7 @@ describe("plugin runtime command execution", () => {
   });
 
   it("fails loudly when ACP prompt gateway response omits runId", async () => {
-    vi.spyOn(configModule, "loadConfig").mockReturnValue({
+    vi.spyOn(configModule, "getRuntimeConfig").mockReturnValue({
       plugins: { allowAcpSpawn: true },
     } as never);
     vi.spyOn(gatewayCallModule, "callGateway").mockResolvedValue({});

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,5 +1,8 @@
-import { getRuntimeConfig } from "../../config/config.js";
+import crypto from "node:crypto";
+import { spawnAcpDirect } from "../../agents/acp-spawn.js";
+import { getRuntimeConfig, loadConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
+import { callGateway } from "../../gateway/call.js";
 import {
   generateImage as generateRuntimeImage,
   listRuntimeImageGenerationProviders,
@@ -248,6 +251,50 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     channel: createRuntimeChannel(),
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
+    acp: {
+      spawn: (...args: Parameters<typeof spawnAcpDirect>) => {
+        const cfg = loadConfig();
+        if (!cfg.plugins?.allowAcpSpawn) {
+          throw new Error(
+            "api.runtime.acp.spawn() requires plugins.allowAcpSpawn: true in openclaw.json",
+          );
+        }
+        return spawnAcpDirect(...args);
+      },
+      prompt: async (params: {
+        sessionKey: string;
+        text: string;
+        channel?: string;
+        accountId?: string;
+        threadId?: string;
+      }) => {
+        const cfg = loadConfig();
+        if (!cfg.plugins?.allowAcpSpawn) {
+          throw new Error(
+            "api.runtime.acp.prompt() requires plugins.allowAcpSpawn: true in openclaw.json",
+          );
+        }
+        const deliver = Boolean(params.channel && params.threadId);
+        const to = params.threadId ? `channel:${params.threadId}` : undefined;
+        const idem = crypto.randomUUID();
+        const response = await callGateway<{ runId?: string }>({
+          method: "agent",
+          params: {
+            message: params.text,
+            sessionKey: params.sessionKey,
+            channel: deliver ? params.channel : undefined,
+            to: deliver ? to : undefined,
+            accountId: deliver ? params.accountId : undefined,
+            threadId: deliver ? params.threadId : undefined,
+            deliver,
+            idempotencyKey: idem,
+          },
+          timeoutMs: 10_000,
+        });
+        const runId = typeof response?.runId === "string" ? response.runId.trim() : idem;
+        return { runId };
+      },
+    },
     state: {
       resolveStateDir,
       openKeyedStore: () => {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -50,14 +50,6 @@ const loadModelAuthRuntime = createLazyRuntimeModule(
 );
 const loadAcpRuntime = createLazyRuntimeModule(() => import("./runtime-acp.runtime.js"));
 
-function createRuntimeAcp(): PluginRuntime["acp"] {
-  const bindAcpRuntime = createLazyRuntimeMethodBinder(loadAcpRuntime);
-  return {
-    spawn: bindAcpRuntime((runtime) => runtime.spawnPluginAcp),
-    prompt: bindAcpRuntime((runtime) => runtime.promptPluginAcp),
-  };
-}
-
 function createRuntimeTts(): PluginRuntime["tts"] {
   const bindTtsRuntime = createLazyRuntimeMethodBinder(loadTtsRuntime);
   return {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,8 +1,5 @@
-import crypto from "node:crypto";
-import { spawnAcpDirect } from "../../agents/acp-spawn.js";
-import { getRuntimeConfig, loadConfig } from "../../config/config.js";
+import { getRuntimeConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
-import { callGateway } from "../../gateway/call.js";
 import {
   generateImage as generateRuntimeImage,
   listRuntimeImageGenerationProviders,
@@ -51,6 +48,15 @@ const loadMediaUnderstandingRuntime = createLazyRuntimeModule(
 const loadModelAuthRuntime = createLazyRuntimeModule(
   () => import("./runtime-model-auth.runtime.js"),
 );
+const loadAcpRuntime = createLazyRuntimeModule(() => import("./runtime-acp.runtime.js"));
+
+function createRuntimeAcp(): PluginRuntime["acp"] {
+  const bindAcpRuntime = createLazyRuntimeMethodBinder(loadAcpRuntime);
+  return {
+    spawn: bindAcpRuntime((runtime) => runtime.spawnPluginAcp),
+    prompt: bindAcpRuntime((runtime) => runtime.promptPluginAcp),
+  };
+}
 
 function createRuntimeTts(): PluginRuntime["tts"] {
   const bindTtsRuntime = createLazyRuntimeMethodBinder(loadTtsRuntime);
@@ -155,6 +161,14 @@ function createRuntimeModelAuth(): PluginRuntime["modelAuth"] {
   };
 }
 
+function createRuntimeAcp(): PluginRuntime["acp"] {
+  const bindAcpRuntime = createLazyRuntimeMethodBinder(loadAcpRuntime);
+  return {
+    spawn: bindAcpRuntime((runtime) => runtime.spawnPluginAcp),
+    prompt: bindAcpRuntime((runtime) => runtime.promptPluginAcp),
+  };
+}
+
 function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
   const unavailable = () => {
     throw new RequestScopedSubagentRuntimeError();
@@ -251,50 +265,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     channel: createRuntimeChannel(),
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
-    acp: {
-      spawn: (...args: Parameters<typeof spawnAcpDirect>) => {
-        const cfg = loadConfig();
-        if (!cfg.plugins?.allowAcpSpawn) {
-          throw new Error(
-            "api.runtime.acp.spawn() requires plugins.allowAcpSpawn: true in openclaw.json",
-          );
-        }
-        return spawnAcpDirect(...args);
-      },
-      prompt: async (params: {
-        sessionKey: string;
-        text: string;
-        channel?: string;
-        accountId?: string;
-        threadId?: string;
-      }) => {
-        const cfg = loadConfig();
-        if (!cfg.plugins?.allowAcpSpawn) {
-          throw new Error(
-            "api.runtime.acp.prompt() requires plugins.allowAcpSpawn: true in openclaw.json",
-          );
-        }
-        const deliver = Boolean(params.channel && params.threadId);
-        const to = params.threadId ? `channel:${params.threadId}` : undefined;
-        const idem = crypto.randomUUID();
-        const response = await callGateway<{ runId?: string }>({
-          method: "agent",
-          params: {
-            message: params.text,
-            sessionKey: params.sessionKey,
-            channel: deliver ? params.channel : undefined,
-            to: deliver ? to : undefined,
-            accountId: deliver ? params.accountId : undefined,
-            threadId: deliver ? params.threadId : undefined,
-            deliver,
-            idempotencyKey: idem,
-          },
-          timeoutMs: 10_000,
-        });
-        const runId = typeof response?.runId === "string" ? response.runId.trim() : idem;
-        return { runId };
-      },
-    },
+    acp: createRuntimeAcp(),
     state: {
       resolveStateDir,
       openKeyedStore: () => {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,8 +1,5 @@
-import crypto from "node:crypto";
-import { spawnAcpDirect } from "../../agents/acp-spawn.js";
-import { getRuntimeConfig, loadConfig } from "../../config/config.js";
+import { getRuntimeConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
-import { callGateway } from "../../gateway/call.js";
 import {
   generateImage as generateRuntimeImage,
   listRuntimeImageGenerationProviders,
@@ -51,6 +48,15 @@ const loadMediaUnderstandingRuntime = createLazyRuntimeModule(
 const loadModelAuthRuntime = createLazyRuntimeModule(
   () => import("./runtime-model-auth.runtime.js"),
 );
+const loadAcpRuntime = createLazyRuntimeModule(() => import("./runtime-acp.runtime.js"));
+
+function createRuntimeAcp(): PluginRuntime["acp"] {
+  const bindAcpRuntime = createLazyRuntimeMethodBinder(loadAcpRuntime);
+  return {
+    spawn: bindAcpRuntime((runtime) => runtime.spawnPluginAcp),
+    prompt: bindAcpRuntime((runtime) => runtime.promptPluginAcp),
+  };
+}
 
 function createRuntimeTts(): PluginRuntime["tts"] {
   const bindTtsRuntime = createLazyRuntimeMethodBinder(loadTtsRuntime);
@@ -152,6 +158,14 @@ function createRuntimeModelAuth(): PluginRuntime["modelAuth"] {
   };
 }
 
+function createRuntimeAcp(): PluginRuntime["acp"] {
+  const bindAcpRuntime = createLazyRuntimeMethodBinder(loadAcpRuntime);
+  return {
+    spawn: bindAcpRuntime((runtime) => runtime.spawnPluginAcp),
+    prompt: bindAcpRuntime((runtime) => runtime.promptPluginAcp),
+  };
+}
+
 function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
   const unavailable = () => {
     throw new RequestScopedSubagentRuntimeError();
@@ -248,50 +262,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     channel: createRuntimeChannel(),
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
-    acp: {
-      spawn: (...args: Parameters<typeof spawnAcpDirect>) => {
-        const cfg = loadConfig();
-        if (!cfg.plugins?.allowAcpSpawn) {
-          throw new Error(
-            "api.runtime.acp.spawn() requires plugins.allowAcpSpawn: true in openclaw.json",
-          );
-        }
-        return spawnAcpDirect(...args);
-      },
-      prompt: async (params: {
-        sessionKey: string;
-        text: string;
-        channel?: string;
-        accountId?: string;
-        threadId?: string;
-      }) => {
-        const cfg = loadConfig();
-        if (!cfg.plugins?.allowAcpSpawn) {
-          throw new Error(
-            "api.runtime.acp.prompt() requires plugins.allowAcpSpawn: true in openclaw.json",
-          );
-        }
-        const deliver = Boolean(params.channel && params.threadId);
-        const to = params.threadId ? `channel:${params.threadId}` : undefined;
-        const idem = crypto.randomUUID();
-        const response = await callGateway<{ runId?: string }>({
-          method: "agent",
-          params: {
-            message: params.text,
-            sessionKey: params.sessionKey,
-            channel: deliver ? params.channel : undefined,
-            to: deliver ? to : undefined,
-            accountId: deliver ? params.accountId : undefined,
-            threadId: deliver ? params.threadId : undefined,
-            deliver,
-            idempotencyKey: idem,
-          },
-          timeoutMs: 10_000,
-        });
-        const runId = typeof response?.runId === "string" ? response.runId.trim() : idem;
-        return { runId };
-      },
-    },
+    acp: createRuntimeAcp(),
     state: {
       resolveStateDir,
       openKeyedStore: () => {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,5 +1,8 @@
-import { getRuntimeConfig } from "../../config/config.js";
+import crypto from "node:crypto";
+import { spawnAcpDirect } from "../../agents/acp-spawn.js";
+import { getRuntimeConfig, loadConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
+import { callGateway } from "../../gateway/call.js";
 import {
   generateImage as generateRuntimeImage,
   listRuntimeImageGenerationProviders,
@@ -245,6 +248,50 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     channel: createRuntimeChannel(),
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
+    acp: {
+      spawn: (...args: Parameters<typeof spawnAcpDirect>) => {
+        const cfg = loadConfig();
+        if (!cfg.plugins?.allowAcpSpawn) {
+          throw new Error(
+            "api.runtime.acp.spawn() requires plugins.allowAcpSpawn: true in openclaw.json",
+          );
+        }
+        return spawnAcpDirect(...args);
+      },
+      prompt: async (params: {
+        sessionKey: string;
+        text: string;
+        channel?: string;
+        accountId?: string;
+        threadId?: string;
+      }) => {
+        const cfg = loadConfig();
+        if (!cfg.plugins?.allowAcpSpawn) {
+          throw new Error(
+            "api.runtime.acp.prompt() requires plugins.allowAcpSpawn: true in openclaw.json",
+          );
+        }
+        const deliver = Boolean(params.channel && params.threadId);
+        const to = params.threadId ? `channel:${params.threadId}` : undefined;
+        const idem = crypto.randomUUID();
+        const response = await callGateway<{ runId?: string }>({
+          method: "agent",
+          params: {
+            message: params.text,
+            sessionKey: params.sessionKey,
+            channel: deliver ? params.channel : undefined,
+            to: deliver ? to : undefined,
+            accountId: deliver ? params.accountId : undefined,
+            threadId: deliver ? params.threadId : undefined,
+            deliver,
+            idempotencyKey: idem,
+          },
+          timeoutMs: 10_000,
+        });
+        const runId = typeof response?.runId === "string" ? response.runId.trim() : idem;
+        return { runId };
+      },
+    },
     state: {
       resolveStateDir,
       openKeyedStore: () => {

--- a/src/plugins/runtime/runtime-acp.runtime.ts
+++ b/src/plugins/runtime/runtime-acp.runtime.ts
@@ -1,9 +1,14 @@
 import crypto from "node:crypto";
-import type { SpawnAcpContext, SpawnAcpParams, SpawnAcpResult } from "../../agents/acp-spawn.js";
+import type {
+  SpawnAcpContext,
+  SpawnAcpParams,
+  SpawnAcpResult,
+} from "../../agents/acp-spawn-contract.js";
 import { spawnAcpDirect } from "../../agents/acp-spawn.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
 import { resolveConversationDeliveryTarget } from "../../utils/delivery-context.js";
+import { getPluginRuntimeGatewayRequestScope } from "./gateway-request-scope.js";
 
 export type RuntimeAcpPromptParams = {
   sessionKey: string;
@@ -11,8 +16,8 @@ export type RuntimeAcpPromptParams = {
   channel?: string;
   accountId?: string;
   /**
-   * Legacy alias for channels where the threaded destination is also the
-   * conversation id itself (for example Discord thread channels).
+   * Alias for channels where the threaded destination is also the conversation
+   * id itself (for example Discord thread channels).
    */
   threadId?: string;
   /** Channel-native conversation id to deliver back into. */
@@ -21,10 +26,23 @@ export type RuntimeAcpPromptParams = {
   parentConversationId?: string;
 };
 
+function resolveAcpRuntimePluginId(): string {
+  const pluginId = getPluginRuntimeGatewayRequestScope()?.pluginId?.trim();
+  if (!pluginId) {
+    throw new Error(
+      "api.runtime.acp helpers require a loaded plugin runtime scope with plugin identity",
+    );
+  }
+  return pluginId;
+}
+
 function assertAcpRuntimeEnabled(): void {
+  const pluginId = resolveAcpRuntimePluginId();
   const cfg = getRuntimeConfig();
-  if (!cfg?.plugins?.allowAcpSpawn) {
-    throw new Error("api.runtime.acp helpers require plugins.allowAcpSpawn: true in openclaw.json");
+  if (cfg?.plugins?.entries?.[pluginId]?.acp?.allowSpawn !== true) {
+    throw new Error(
+      `api.runtime.acp helpers require plugins.entries.${pluginId}.acp.allowSpawn: true in openclaw.json`,
+    );
   }
 }
 
@@ -63,6 +81,7 @@ export async function promptPluginAcp(params: RuntimeAcpPromptParams): Promise<{
             deliver: true,
           }
         : {}),
+      acpTurnSource: "manual_spawn",
       idempotencyKey,
     },
     timeoutMs: 10_000,

--- a/src/plugins/runtime/runtime-acp.runtime.ts
+++ b/src/plugins/runtime/runtime-acp.runtime.ts
@@ -1,0 +1,77 @@
+import crypto from "node:crypto";
+import type { SpawnAcpContext, SpawnAcpParams, SpawnAcpResult } from "../../agents/acp-spawn.js";
+import { spawnAcpDirect } from "../../agents/acp-spawn.js";
+import { getRuntimeConfig } from "../../config/config.js";
+import { callGateway } from "../../gateway/call.js";
+import { resolveConversationDeliveryTarget } from "../../utils/delivery-context.js";
+
+export type RuntimeAcpPromptParams = {
+  sessionKey: string;
+  text: string;
+  channel?: string;
+  accountId?: string;
+  /**
+   * Legacy alias for channels where the threaded destination is also the
+   * conversation id itself (for example Discord thread channels).
+   */
+  threadId?: string;
+  /** Channel-native conversation id to deliver back into. */
+  conversationId?: string;
+  /** Optional parent conversation id when the channel models child threads/topics separately. */
+  parentConversationId?: string;
+};
+
+function assertAcpRuntimeEnabled(): void {
+  const cfg = getRuntimeConfig();
+  if (!cfg?.plugins?.allowAcpSpawn) {
+    throw new Error("api.runtime.acp helpers require plugins.allowAcpSpawn: true in openclaw.json");
+  }
+}
+
+export async function spawnPluginAcp(
+  params: SpawnAcpParams,
+  ctx: SpawnAcpContext,
+): Promise<SpawnAcpResult> {
+  assertAcpRuntimeEnabled();
+  return await spawnAcpDirect(params, ctx);
+}
+
+export async function promptPluginAcp(params: RuntimeAcpPromptParams): Promise<{ runId: string }> {
+  assertAcpRuntimeEnabled();
+
+  const conversationId = params.conversationId?.trim() || params.threadId?.trim();
+  const hasDeliveryTarget = Boolean(params.channel && conversationId);
+  const resolvedDelivery = hasDeliveryTarget
+    ? resolveConversationDeliveryTarget({
+        channel: params.channel,
+        conversationId,
+        parentConversationId: params.parentConversationId,
+      })
+    : {};
+  const idempotencyKey = crypto.randomUUID();
+  const response = await callGateway<{ runId?: string }>({
+    method: "agent",
+    params: {
+      message: params.text,
+      sessionKey: params.sessionKey,
+      ...(hasDeliveryTarget
+        ? {
+            channel: params.channel,
+            ...(resolvedDelivery.to ? { to: resolvedDelivery.to } : {}),
+            ...(params.accountId ? { accountId: params.accountId } : {}),
+            ...(resolvedDelivery.threadId ? { threadId: resolvedDelivery.threadId } : {}),
+            deliver: true,
+          }
+        : {}),
+      idempotencyKey,
+    },
+    timeoutMs: 10_000,
+  });
+  const runId = typeof response?.runId === "string" ? response.runId.trim() : "";
+  if (!runId) {
+    throw new Error(
+      `api.runtime.acp.prompt() expected gateway to return runId for idempotencyKey ${idempotencyKey}`,
+    );
+  }
+  return { runId };
+}

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -319,7 +319,10 @@ export type PluginRuntimeCore = {
       text: string;
       channel?: string;
       accountId?: string;
+      /** Legacy alias for channels where the threaded destination is also the conversation id. */
       threadId?: string;
+      conversationId?: string;
+      parentConversationId?: string;
     }) => Promise<{ runId: string }>;
   };
   llm: {

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -1,3 +1,4 @@
+import type { SpawnAcpParams, SpawnAcpContext, SpawnAcpResult } from "../../agents/acp-spawn.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import type { LogLevel } from "../../logging/levels.js";
 import type { MediaUnderstandingRuntime } from "../../media-understanding/runtime-types.js";
@@ -311,6 +312,16 @@ export type PluginRuntimeCore = {
   };
   /** @deprecated Use runtime.tasks.flows for DTO-based TaskFlow access. */
   taskFlow: import("./runtime-taskflow.types.js").PluginRuntimeTaskFlow;
+  acp: {
+    spawn: (params: SpawnAcpParams, ctx: SpawnAcpContext) => Promise<SpawnAcpResult>;
+    prompt: (params: {
+      sessionKey: string;
+      text: string;
+      channel?: string;
+      accountId?: string;
+      threadId?: string;
+    }) => Promise<{ runId: string }>;
+  };
   llm: {
     complete: (params: LlmCompleteParams) => Promise<LlmCompleteResult>;
   };

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -1,4 +1,8 @@
-import type { SpawnAcpParams, SpawnAcpContext, SpawnAcpResult } from "../../agents/acp-spawn.js";
+import type {
+  SpawnAcpContext,
+  SpawnAcpParams,
+  SpawnAcpResult,
+} from "../../agents/acp-spawn-contract.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import type { LogLevel } from "../../logging/levels.js";
 import type { MediaUnderstandingRuntime } from "../../media-understanding/runtime-types.js";
@@ -319,7 +323,7 @@ export type PluginRuntimeCore = {
       text: string;
       channel?: string;
       accountId?: string;
-      /** Legacy alias for channels where the threaded destination is also the conversation id. */
+      /** Alias for channels where the threaded destination is also the conversation id. */
       threadId?: string;
       conversationId?: string;
       parentConversationId?: string;

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -1,3 +1,4 @@
+import type { SpawnAcpParams, SpawnAcpContext, SpawnAcpResult } from "../../agents/acp-spawn.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import type { LogLevel } from "../../logging/levels.js";
 import type { MediaUnderstandingRuntime } from "../../media-understanding/runtime-types.js";
@@ -310,6 +311,16 @@ export type PluginRuntimeCore = {
   };
   /** @deprecated Use runtime.tasks.flows for DTO-based TaskFlow access. */
   taskFlow: import("./runtime-taskflow.types.js").PluginRuntimeTaskFlow;
+  acp: {
+    spawn: (params: SpawnAcpParams, ctx: SpawnAcpContext) => Promise<SpawnAcpResult>;
+    prompt: (params: {
+      sessionKey: string;
+      text: string;
+      channel?: string;
+      accountId?: string;
+      threadId?: string;
+    }) => Promise<{ runId: string }>;
+  };
   llm: {
     complete: (params: LlmCompleteParams) => Promise<LlmCompleteResult>;
   };

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -318,7 +318,10 @@ export type PluginRuntimeCore = {
       text: string;
       channel?: string;
       accountId?: string;
+      /** Legacy alias for channels where the threaded destination is also the conversation id. */
       threadId?: string;
+      conversationId?: string;
+      parentConversationId?: string;
     }) => Promise<{ runId: string }>;
   };
   llm: {

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -586,6 +586,7 @@ describe("plugin status reports", () => {
       allowModelOverride: true,
       allowedModels: ["openai/gpt-5.5"],
       hasAllowedModelsConfig: true,
+      allowAcpSpawn: undefined,
     });
     expectPluginLoaderCall({ loadModules: true });
   });
@@ -697,6 +698,9 @@ describe("plugin status reports", () => {
               allowModelOverride: true,
               allowedModels: ["openai/gpt-5.5"],
             },
+            acp: {
+              allowSpawn: true,
+            },
           },
         },
       },
@@ -737,6 +741,7 @@ describe("plugin status reports", () => {
       allowModelOverride: true,
       allowedModels: ["openai/gpt-5.5"],
       hasAllowedModelsConfig: true,
+      allowAcpSpawn: true,
     });
     expect(inspect.diagnostics).toEqual([
       { level: "warn", pluginId: "google", message: "watch this surface" },

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -107,6 +107,7 @@ export type PluginInspectReport = {
     allowModelOverride?: boolean;
     allowedModels: string[];
     hasAllowedModelsConfig: boolean;
+    allowAcpSpawn?: boolean;
   };
   usesLegacyBeforeAgentStart: boolean;
   compatibility: PluginCompatibilityNotice[];
@@ -526,6 +527,7 @@ export function buildPluginInspectReport(params: {
       allowModelOverride: policyEntry?.subagent?.allowModelOverride,
       allowedModels: [...(policyEntry?.subagent?.allowedModels ?? [])],
       hasAllowedModelsConfig: policyEntry?.subagent?.hasAllowedModelsConfig === true,
+      allowAcpSpawn: policyEntry?.acp?.allowSpawn,
     },
     usesLegacyBeforeAgentStart,
     compatibility,


### PR DESCRIPTION
## Summary

Plugins can orchestrate subagents via `api.runtime.subagent.*` but have no way to dispatch ACP-backed agent sessions with **channel delivery**. This PR adds `api.runtime.acp.spawn()` and `api.runtime.acp.prompt()` to the plugin runtime, gated behind `plugins.entries.<id>.acp.allowSpawn` (per-plugin opt-in, default `false`).

## Why this is needed (reopening #65022)

Issue #65022 was closed with the assessment that `plugin-sdk/acp-runtime` already exposes `getAcpSessionManager`, so plugins can call `initializeSession()` + `runTurn()`. However, **`runTurn()` does not deliver output to channels**:

| API | Executes ACP | Delivers to Discord/Telegram/etc. |
|---|---|---|
| `AcpSessionManager.runTurn()` | ✅ | ❌ |
| `callGateway({ method: "agent", deliver: true })` | ✅ | ✅ |
| `api.runtime.subagent.run({ deliver: true })` | ✅ | ✅ (but no `channel`/`threadId`/`to` params) |
| **`api.runtime.acp.prompt()`** (this PR) | ✅ | ✅ |

`runTurn()` is the low-level execution primitive — it runs the AI backend and emits events internally. Channel delivery requires the gateway agent pipeline (`src/agents/agent-command.ts`) which calls `runTurn()` → accumulates visible text → calls `deliverAgentCommandResult()`.

Native ACP spawn (`src/agents/acp-spawn.ts`) uses `callGateway({ method: "agent", deliver: true })` for exactly this reason. `SubagentRunParams` has `deliver?: boolean` but lacks `channel`, `threadId`, `to`, and `accountId` — so `subagent.run()` cannot target a specific thread either.

Without this PR, plugins must either fork OpenClaw or shell out to the CLI to get ACP output delivered to a channel.

## Prior art

- **#63176** — original PR (same patchset, open, stalled on review)
- **#65022** — tracking issue (closed prematurely; closing comment checked API availability but missed the delivery gap)

## What changed

- `api.runtime.acp.spawn(params, ctx)` — starts a new ACP session with thread binding
- `api.runtime.acp.prompt({ sessionKey, text, channel, accountId, threadId })` — sends a follow-up prompt into an existing ACP session via `callGateway({ method: "agent", deliver: true })`
- Both gated behind `plugins.entries.<id>.acp.allowSpawn: true` (default `false`)
- Types, mocks, and tests updated

## Files (7 files, +253 lines)

- `src/plugins/runtime/runtime-acp.runtime.ts` — lazy-loaded ACP runtime helper (new)
- `src/plugins/runtime/index.ts` — wire `acp` namespace into plugin runtime
- `src/plugins/runtime/types-core.ts` — `acp.spawn` and `acp.prompt` types
- `src/plugins/runtime/index.test.ts` — gate + delegation tests
- `src/config/types.plugins.ts` — per-plugin `plugins.entries.<id>.acp.allowSpawn` type
- `src/config/zod-schema.ts` — validation
- `src/plugin-sdk/test-helpers/plugin-runtime-mock.ts` — mock alignment

## Real behavior proof

- **Behavior or issue addressed**: A trusted plugin can continue an ACP-backed task session through the Gateway agent delivery path so the agent response is delivered into the bound Discord thread, while untrusted plugins cannot call the ACP runtime helpers.
- **Real environment tested**: Local OpenClaw fork build with the `task-dispatch` plugin enabled and per-plugin config `plugins.entries.task-dispatch.acp.allowSpawn: true`; Discord thread delivery through the Gateway agent pipeline.
- **Exact steps or command run after this patch**: Updated the local `openclaw.json` from the old global `plugins.allowAcpSpawn` flag to `plugins.entries.task-dispatch.acp.allowSpawn: true`, then ran `pnpm openclaw config validate`, `cd ~/.openclaw/extensions/task-dispatch && bun run typecheck`, and `bun run build:plugin`. The existing task-dispatch live ACP smoke below exercises the same `api.runtime.acp.prompt({ channel: "discord", threadId })` delivery path this PR exposes.
- **Evidence after fix**: Config/build output and live runtime logs:

```text
Config valid: ~/.openclaw/openclaw.json
$ tsc --noEmit
$ bun build src/plugin/index.ts --target=node --format=esm --outfile=build/plugin.mjs --external better-sqlite3
Bundled 4926 modules in 550ms
plugin.mjs  15.81 MB  (entry point)
```

```text
[DISPATCH.ACP] task=2f025c40 initializing ACP session harness=zeus-opencode
[DISPATCH.ACP] task=2f025c40 ACP session initialized in 1766ms
[DISPATCH.ACP] task=2f025c40 binding Discord thread channel=1479519205136138476
[DISPATCH.ACP] task=2f025c40 Discord binding resolved in 1189ms, threadId=1502803134609752165
[DISPATCH.ACP] task=2f025c40 starting ACP turn pollTimeout=120000ms
[POLL] got valid output after 2 polls (18 chars)
[DISPATCH.ACP] task=2f025c40 ACP turn completed in 9209ms, text=18 chars
Result: Discord thread contains agent reply. Task status: done.
Stored output: TD_STRICT_SMOKE_OK
```

Gateway delivery confirmation:

```text
discord: delivered 1 reply to channel:1502803134609752165
message processed: reason=acp_dispatch
```

- **Observed result after fix**: `task-dispatch` still typechecks and builds against the updated per-plugin ACP trust config, OpenClaw accepts the updated config, and the live ACP prompt path delivers the ACP reply into the Discord thread instead of leaving the thread empty.
- **What was not tested**: I did not run a fresh long-lived coding task after changing the trust key from global to per-plugin; the smoke evidence above is the existing task-dispatch live ACP delivery proof for the same runtime prompt path, plus fresh config/build validation for the per-plugin trust change.

### Before (`runTurn()` only — no delivery)

```text
[DISPATCH.ACP] task=89d24685 initializing ACP session harness=zeus-opencode
[DISPATCH.ACP] task=89d24685 ACP session initialized in 2301ms
[DISPATCH.ACP] task=89d24685 binding Discord thread channel=1479519205136138476
[DISPATCH.ACP] task=89d24685 Discord binding resolved in 691ms, threadId=1502783588985344012
[ACP.TURN] starting prompt session=agent:zeus-opencode:acp:e1f7a24f thread=1502783588985344012
[ACP.TURN] ACP completion resolved for run=9c03df2b
[POLL] timed out after 23 polls, returning lastText (0 chars)
Result: Discord thread empty. Task errored.
```

## Security

- `plugins.entries.<id>.acp.allowSpawn` gate (default `false`, checked on every call with the caller plugin id)
- Delegates to the same `callGateway({ method: "agent" })` path native ACP spawn uses
- ACP prompt turns are marked with `acpTurnSource: "manual_spawn"` so explicit plugin-initiated follow-ups use the same ACP turn semantics as native spawn


