### PR TITLE
fix(config): persist explicitly set values that equal the runtime default

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1791,7 +1791,7 @@ describe("config cli", () => {
           .channels as Record<string, unknown>,
       ).toEqual({ maintainers: { enabled: true, requireMention: true } });
       expect((written.channels as Record<string, unknown>).slack).not.toHaveProperty("appToken");
-      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toEqual({
+      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toMatchObject({
         unsetPaths: [["channels", "slack", "appToken"]],
       });
     });

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1447,12 +1447,14 @@ async function runConfigOperations(params: {
   // This prevents runtime defaults from leaking into the written config file (issue #6070)
   const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
   const unsetPaths: PathSegment[][] = [];
+  const explicitSetPaths: PathSegment[][] = [];
   for (const operation of operations) {
     if (operation.mutation === "delete") {
       unsetAtPath(next, operation.setPath);
       unsetPaths.push(operation.setPath);
       continue;
     }
+    explicitSetPaths.push(operation.setPath);
     if (operation.mutation === "merge" || (options.merge && operation.mutation !== "replace")) {
       mergeAtPath(next, operation.setPath, operation.value);
     } else {
@@ -1582,7 +1584,14 @@ async function runConfigOperations(params: {
   await replaceConfigFile({
     nextConfig,
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
-    ...(unsetPaths.length > 0 ? { writeOptions: { unsetPaths } } : {}),
+    ...(unsetPaths.length > 0 || explicitSetPaths.length > 0
+      ? {
+          writeOptions: {
+            ...(unsetPaths.length > 0 ? { unsetPaths } : {}),
+            ...(explicitSetPaths.length > 0 ? { explicitSetPaths } : {}),
+          },
+        }
+      : {}),
   });
   if (removedGatewayAuthPaths.length > 0) {
     runtime.log(

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -197,6 +197,13 @@ export type ConfigWriteOptions = {
    */
   unsetPaths?: string[][];
   /**
+   * Paths that were explicitly set by the caller. Values at these paths are
+   * persisted even when they equal the runtime default, preventing silent data
+   * loss when `config set` is used to anchor schema-required fields at their
+   * default values (issue #79856).
+   */
+  explicitSetPaths?: readonly (readonly string[])[];
+  /**
    * Internal fast path for callers that already hold a fresh config snapshot.
    * Avoids rereading the full config just to prepare an immediate write.
    */
@@ -1995,6 +2002,7 @@ export function createConfigIO(
         nextConfig: cfg,
         rootAuthoredConfig: snapshot.parsed,
         unsetPaths,
+        explicitSetPaths: options.explicitSetPaths,
       });
       try {
         const resolvedIncludes = resolveConfigIncludes(

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -757,4 +757,52 @@ describe("config io write prepare", () => {
     expect(persisted.$schema).toBe(123);
     expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
   });
+
+  it("persists explicitly set keys whose values match the runtime default (not silent data loss)", () => {
+    // Reproduces: `openclaw config set channels.telegram.dmPolicy pairing` discards the write
+    // when dmPolicy is absent from the authored config but equals the runtime-applied default.
+    const runtimeConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-abc",
+          dmPolicy: "pairing",
+          groupPolicy: "allowlist",
+        },
+      },
+      gateway: { port: 18789 },
+    };
+    const sourceConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-abc",
+        },
+      },
+      gateway: { port: 18789 },
+    };
+    // User explicitly sets dmPolicy and groupPolicy to their runtime-default values.
+    const nextConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-abc",
+          dmPolicy: "pairing",
+          groupPolicy: "allowlist",
+        },
+      },
+      gateway: { port: 18789 },
+    };
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig,
+      sourceConfig,
+      nextConfig,
+      explicitSetPaths: [
+        ["channels", "telegram", "dmPolicy"],
+        ["channels", "telegram", "groupPolicy"],
+      ],
+    }) as { channels?: { telegram?: Record<string, unknown> } };
+
+    expect(persisted.channels?.telegram?.dmPolicy).toBe("pairing");
+    expect(persisted.channels?.telegram?.groupPolicy).toBe("allowlist");
+    expect(persisted.channels?.telegram?.botToken).toBe("tok-abc");
+  });
 });

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -329,21 +329,79 @@ function preserveUntouchedIncludes(params: {
   return next;
 }
 
+/**
+ * Inject values at explicitly-set paths that equal the runtime default and therefore
+ * produced an empty merge-patch entry. Without this, a caller that explicitly sets a
+ * key to its runtime default value sees the write silently dropped because
+ * createMergePatch(runtimeConfig, nextConfig) emits no diff for equal values.
+ *
+ * Only injects path segments that:
+ * 1. Were explicitly declared by the caller via explicitSetPaths.
+ * 2. Are absent from the persisted candidate (not already included via the normal patch).
+ */
+function injectExplicitlySetPaths(
+  nextConfig: unknown,
+  persistedCandidate: unknown,
+  explicitSetPaths: readonly (readonly string[])[],
+): unknown {
+  if (explicitSetPaths.length === 0 || !isRecord(persistedCandidate)) {
+    return persistedCandidate;
+  }
+  let result: Record<string, unknown> | null = null;
+  for (const path of explicitSetPaths) {
+    if (path.length === 0) {
+      continue;
+    }
+    const [head, ...tail] = path;
+    if (isBlockedObjectKey(head)) {
+      continue;
+    }
+    const nextValue = isRecord(nextConfig) ? nextConfig[head] : undefined;
+    if (nextValue === undefined || nextValue === null) {
+      continue;
+    }
+    const persistedValue = (result ?? persistedCandidate)[head];
+    if (tail.length === 0) {
+      if (!(head in (result ?? persistedCandidate))) {
+        result ??= { ...persistedCandidate };
+        result[head] = cloneUnknown(nextValue);
+      }
+    } else {
+      const injected = injectExplicitlySetPaths(nextValue, persistedValue ?? {}, [tail]);
+      if (injected !== persistedValue) {
+        result ??= { ...persistedCandidate };
+        result[head] = injected;
+      }
+    }
+  }
+  return result ?? persistedCandidate;
+}
+
 export function resolvePersistCandidateForWrite(params: {
   runtimeConfig: unknown;
   sourceConfig: unknown;
   nextConfig: unknown;
   rootAuthoredConfig?: unknown;
   unsetPaths?: readonly string[][];
+  /**
+   * Paths that were explicitly set by the caller. Values at these paths are
+   * injected into the persisted candidate even when they equal the runtime
+   * default (which would otherwise produce an empty merge-patch and be dropped).
+   */
+  explicitSetPaths?: readonly (readonly string[])[];
 }): unknown {
   const patch = createMergePatch(params.runtimeConfig, params.nextConfig);
   const projectedSource = projectSourceOntoRuntimeShape(params.sourceConfig, params.runtimeConfig);
   const rootAuthoredConfig = params.rootAuthoredConfig ?? params.sourceConfig;
-  const persisted = preserveUntouchedIncludes({
+  const persistedBase = preserveUntouchedIncludes({
     patch,
     rootAuthoredConfig,
     persistedCandidate: applyMergePatch(projectedSource, patch),
   });
+  const persisted =
+    params.explicitSetPaths && params.explicitSetPaths.length > 0
+      ? injectExplicitlySetPaths(params.nextConfig, persistedBase, params.explicitSetPaths)
+      : persistedBase;
   const withSchema = preserveRootSchemaUri({
     rootAuthoredConfig,
     nextConfig: params.nextConfig,


### PR DESCRIPTION
Fixes #79856

## Problem

`openclaw config set` silently discards writes whose value equals the runtime-injected schema default. When the Gateway is running, AJV fills missing required fields with their defaults into `runtimeConfig` (e.g., `channels.telegram.dmPolicy = "pairing"`). `createMergePatch(runtimeConfig, nextConfig)` then produces an empty patch — and the key is never written to disk — even though the CLI reports success.

Root cause: `resolvePersistCandidateForWrite` applies `createMergePatch(runtimeConfig, nextConfig)` → `applyMergePatch(projectedSource, patch)`. When the user-set value equals the runtime default, the patch is empty and the key does not appear in the persisted candidate.

## Fix

Thread `explicitSetPaths` — the set of key paths the caller explicitly wrote — from `config set` operations → `ConfigWriteOptions` → `writeConfigFile` → `resolvePersistCandidateForWrite` → new `injectExplicitlySetPaths` helper.

`injectExplicitlySetPaths` adds any explicitly-set key that is absent from the persisted candidate (after the merge-patch step), pulling the value from `nextConfig`. It only injects at paths the caller declared; it does not blindly inject all keys from `nextConfig`, so plugin-AJV defaults not in the authored config are still excluded.

## Real behavior proof

- Behavior or issue addressed: `oc config set channels.telegram.dmPolicy pairing` silently discards the write when the gateway runtime has AJV-injected default `dmPolicy = "pairing"`. The file is unchanged but the CLI reports success — silent data loss.

- Real environment tested: node v22.22.0, npx tsx v4.19.4, linux x64. Loaded the compiled TypeScript source directly via tsx on this branch.

- Exact steps or command run after this patch: Run via `node` tsx to call `resolvePersistCandidateForWrite` from source with a mocked gateway runtimeConfig containing AJV-injected defaults.

- Evidence after fix: Terminal output from `node` tsx showing BEFORE (bug) and AFTER (fix) behavior:

```
$ npx tsx --import ./node_modules/tsx/dist/esm/index.cjs -e "
import { resolvePersistCandidateForWrite } from './src/config/io.write-prepare.ts';
const runtimeConfig = { channels: { telegram: { botToken: 'tok-abc', dmPolicy: 'pairing', groupPolicy: 'allowlist' } } };
const sourceConfig  = { channels: { telegram: { botToken: 'tok-abc' } } };
const nextConfig    = { channels: { telegram: { botToken: 'tok-abc', dmPolicy: 'pairing', groupPolicy: 'allowlist' } } };
const before = resolvePersistCandidateForWrite({ runtimeConfig, sourceConfig, nextConfig });
const after  = resolvePersistCandidateForWrite({ runtimeConfig, sourceConfig, nextConfig,
  explicitSetPaths: [['channels','telegram','dmPolicy'],['channels','telegram','groupPolicy']] });
console.log('BEFORE (no explicitSetPaths):', JSON.stringify(before?.channels?.telegram));
console.log('AFTER  (with explicitSetPaths):', JSON.stringify(after?.channels?.telegram));
"

BEFORE (no explicitSetPaths): {"botToken":"tok-abc"}
AFTER  (with explicitSetPaths): {"botToken":"tok-abc","dmPolicy":"pairing","groupPolicy":"allowlist"}
```

- Observed result after fix: `dmPolicy` and `groupPolicy` appear in the persisted candidate when the caller explicitly set them via `explicitSetPaths`, even though their values equal the AJV-injected runtime defaults. The BEFORE output confirms the bug (dmPolicy absent). The AFTER output confirms the fix (dmPolicy persisted). The fix is scoped to caller-declared paths only.

- What was not tested: Live round-trip through a running gateway instance. The `resolvePersistCandidateForWrite` function is the exact layer where the bug manifests and is tested directly here.