### PR TITLE
fix(opencode-go): add supportedReasoningEfforts to DeepSeek V4 model entries

### DIFF
--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -9,6 +9,10 @@ import {
   resolveOpencodeGoSupplementalModel,
 } from "./provider-catalog.js";
 import { createOpencodeGoDeepSeekV4Wrapper } from "./stream.js";
+import {
+  resolveOpencodeGoDeepSeekV4ThinkingProfile,
+  supportsOpencodeGoDeepSeekV4XHighThinking,
+} from "./thinking-policy.js";
 
 const PROVIDER_ID = "opencode-go";
 const OPENCODE_SHARED_PROFILE_IDS = ["opencode:default", "opencode-go:default"] as const;
@@ -86,6 +90,10 @@ export default definePluginEntry({
       resolveDynamicModel: ({ modelId }) => resolveOpencodeGoSupplementalModel(modelId),
       augmentModelCatalog: () => listOpencodeGoSupplementalModelCatalogEntries(),
       ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+      supportsXHighThinking: ({ modelId }) =>
+        supportsOpencodeGoDeepSeekV4XHighThinking(modelId),
+      resolveThinkingProfile: ({ modelId }) =>
+        resolveOpencodeGoDeepSeekV4ThinkingProfile(modelId),
       wrapStreamFn: (ctx) => createOpencodeGoDeepSeekV4Wrapper(ctx.streamFn, ctx.thinkingLevel),
       isModernModelRef: () => true,
     });

--- a/extensions/opencode-go/thinking-policy.ts
+++ b/extensions/opencode-go/thinking-policy.ts
@@ -1,0 +1,38 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+
+const DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
+
+function isDeepSeekV4ModelId(modelId: string): boolean {
+  return DEEPSEEK_V4_MODEL_IDS.has(modelId);
+}
+
+const OPCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_IDS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+function buildThinkingLevel(id: (typeof OPCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_IDS)[number]) {
+  return { id };
+}
+
+const OPCODE_GO_DEEPSEEK_V4_THINKING_PROFILE: ProviderThinkingProfile = {
+  levels: OPCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_IDS.map(buildThinkingLevel),
+  defaultLevel: "high",
+};
+
+export function supportsOpencodeGoDeepSeekV4XHighThinking(modelId: string): boolean {
+  return isDeepSeekV4ModelId(modelId);
+}
+
+export function resolveOpencodeGoDeepSeekV4ThinkingProfile(
+  modelId: string,
+): ProviderThinkingProfile | undefined {
+  return isDeepSeekV4ModelId(modelId)
+    ? OPCODE_GO_DEEPSEEK_V4_THINKING_PROFILE
+    : undefined;
+}


### PR DESCRIPTION
## Problem

DeepSeek V4 Flash and V4 Pro natively support reasoning_effort: "max" at the API level. OpenClaw's stream layer already maps xhigh/max to "max" on the wire via resolveDeepSeekV4ReasoningEffort(). However, the opencode-go provider did not expose these levels through the thinking validation layer, causing /think xhigh and /think max to be rejected.

## Solution

Follow the same pattern used by the OpenRouter extension: add supportsXHighThinking and resolveThinkingProfile hooks to the opencode-go provider registration, declaring a thinking profile that includes xhigh and max for DeepSeek V4 models.

## Changes

- extensions/opencode-go/thinking-policy.ts (new) — Thinking level definitions for DeepSeek V4 models (off through max).
- extensions/opencode-go/index.ts — Added supportsXHighThinking and resolveThinkingProfile hooks.

## Real behavior proof

### behavior

Thinking level "max" was previously rejected for opencode-go/deepseek-v4-flash with the error "Thinking level "max" is not supported". After the fix, setting thinkingDefault: "max" is accepted and the session activates with Think: max without errors.

### environment

- OpenClaw v2026.5.7 (eeef486)
- Provider: opencode-go
- Model: deepseek-v4-flash
- OS: Ubuntu 24.04 LTS (Linux 6.8.0-111-generic x64)
- Running as systemd user service on a KVM VPS

### steps

1. Applied the equivalent patch to the compiled extension JS at dist/extensions/opencode-go/index.js, adding supportsXHighThinking and resolveThinkingProfile hooks matching the source change in this PR.
2. Set thinkingDefault: "max" in openclaw.json.
3. Restarted the OpenClaw gateway.
4. Verified session status shows Think: max active.
5. Verified no "not supported" errors from the thinking validation layer.

### evidence

Session status output:

```
Model: opencode-go/deepseek-v4-flash
Think: max
```

Config:

```
"thinkingDefault": "max"
```

### observedResult

Think: max is accepted and active. The session applies thinking level "max" and the stream wrapper sends reasoning_effort: "max" on the wire for all API requests.

### notTested

Stream-level reasoning_effort payload was verified via code inspection of resolveDeepSeekV4ReasoningEffort() which maps both xhigh and max to the string "max". Actual wire capture was not performed.

Related: #76482