### PR TITLE
Expose resolved subagent model metadata

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -142,6 +142,7 @@ observation-only.
 **Subagents**
 
 - `subagent_spawning` / `subagent_delivery_target` / `subagent_spawned` / `subagent_ended` - coordinate subagent routing and completion delivery
+- `subagent_spawned` includes `resolvedModel` and `resolvedProvider` when OpenClaw has resolved the child session's native model before launch.
 
 **Lifecycle**
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -144,6 +144,10 @@ session to confirm the effective tool list.
 - **Run timeout:** if `sessions_spawn.runTimeoutSeconds` is omitted, OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout).
 - **Task delivery:** native sub-agents receive the delegated task in their first visible `[Subagent Task]` message. The sub-agent system prompt carries runtime rules and routing context, not a hidden duplicate of the task.
 
+Accepted native sub-agent spawns include the resolved child model metadata in
+the tool result: `resolvedModel` contains the applied model ref and
+`resolvedProvider` contains the provider prefix when the ref has one.
+
 ### Delegation prompt mode
 
 `agents.defaults.subagents.delegationMode` controls prompt guidance only; it does not change tool policy or enforce delegation.

--- a/src/agents/sessions-spawn-hooks.test.ts
+++ b/src/agents/sessions-spawn-hooks.test.ts
@@ -83,6 +83,7 @@ async function spawn(params?: {
   toolCallId?: string;
   task?: string;
   label?: string;
+  model?: string;
   runTimeoutSeconds?: number;
   thread?: boolean;
   mode?: "run" | "session";
@@ -97,6 +98,7 @@ async function spawn(params?: {
     {
       task: params?.task ?? "do thing",
       ...(params?.label ? { label: params.label } : {}),
+      ...(params?.model ? { model: params.model } : {}),
       ...(typeof params?.runTimeoutSeconds === "number"
         ? { runTimeoutSeconds: params.runTimeoutSeconds }
         : {}),
@@ -246,6 +248,7 @@ describe("sessions_spawn subagent lifecycle hooks", () => {
   it("runs subagent_spawning and emits subagent_spawned with requester metadata", async () => {
     const result = await spawn({
       label: "research",
+      model: "openai-codex/gpt-5.4",
       runTimeoutSeconds: 1,
       thread: true,
       agentAccountId: "work",
@@ -254,7 +257,16 @@ describe("sessions_spawn subagent lifecycle hooks", () => {
       context: "isolated",
     });
 
-    expectFields(result, { status: "accepted", runId: "run-1" }, "spawn result");
+    expectFields(
+      result,
+      {
+        status: "accepted",
+        runId: "run-1",
+        resolvedModel: "openai-codex/gpt-5.4",
+        resolvedProvider: "openai-codex",
+      },
+      "spawn result",
+    );
     expect(hookRunnerMocks.runSubagentSpawning).toHaveBeenCalledTimes(1);
     const [spawningEvent, spawningContext] = (hookRunnerMocks.runSubagentSpawning.mock.calls.at(
       0,
@@ -299,6 +311,8 @@ describe("sessions_spawn subagent lifecycle hooks", () => {
         label: "research",
         mode: "session",
         threadRequested: true,
+        resolvedModel: "openai-codex/gpt-5.4",
+        resolvedProvider: "openai-codex",
       },
       "spawned event",
     );

--- a/src/agents/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagent-spawn.model-session.test.ts
@@ -81,6 +81,8 @@ describe("spawnSubagentDirect runtime model persistence", () => {
 
     expect(result.status).toBe("accepted");
     expect(result.modelApplied).toBe(true);
+    expect(result.resolvedModel).toBe("openai-codex/gpt-5.4");
+    expect(result.resolvedProvider).toBe("openai-codex");
     expect(updateSessionStoreMock).toHaveBeenCalledTimes(3);
     expectPersistedRuntimeModel({
       persistedStore,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -177,6 +177,10 @@ export type SpawnSubagentResult = {
   mode?: SpawnSubagentMode;
   taskName?: string;
   note?: string;
+  /** Fully resolved model ref applied to the spawned child session. */
+  resolvedModel?: string;
+  /** Provider prefix parsed from resolvedModel when the ref includes one. */
+  resolvedProvider?: string;
   modelApplied?: boolean;
   error?: string;
   attachments?: {
@@ -221,6 +225,20 @@ function readGatewayRunId(response: Awaited<ReturnType<typeof callGateway>>): st
   }
   const { runId } = response as { runId?: unknown };
   return typeof runId === "string" && runId ? runId : undefined;
+}
+
+function buildResolvedSubagentModelMetadata(
+  resolvedModel?: string,
+): Pick<SpawnSubagentResult, "resolvedModel" | "resolvedProvider"> {
+  const modelRef = resolvedModel?.trim();
+  if (!modelRef) {
+    return {};
+  }
+  const { provider } = splitModelRef(modelRef);
+  return {
+    resolvedModel: modelRef,
+    ...(provider ? { resolvedProvider: provider } : {}),
+  };
 }
 
 function resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds: number): number {
@@ -926,6 +944,7 @@ export async function spawnSubagentDirect(
     };
   }
   const { resolvedModel, thinkingOverride } = plan;
+  const resolvedModelMetadata = buildResolvedSubagentModelMetadata(resolvedModel);
   const patchChildSession = async (patch: Record<string, unknown>): Promise<string | undefined> => {
     try {
       const target = resolveGatewaySessionStoreTarget({
@@ -1337,6 +1356,7 @@ export async function spawnSubagentDirect(
           },
           threadRequested: requestThreadBinding,
           mode: spawnMode,
+          ...resolvedModelMetadata,
         },
         {
           runId: childRunId,
@@ -1370,6 +1390,7 @@ export async function spawnSubagentDirect(
     note: preparedSpawnContext.forkFallbackNote
       ? `${acceptedNote} ${preparedSpawnContext.forkFallbackNote}`
       : acceptedNote,
+    ...resolvedModelMetadata,
     modelApplied: resolvedModel ? modelApplied : undefined,
     attachments: attachmentsReceipt,
   };

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -670,6 +670,10 @@ export type PluginHookSubagentDeliveryTargetResult = {
 
 export type PluginHookSubagentSpawnedEvent = PluginHookSubagentSpawnBase & {
   runId: string;
+  /** Fully resolved provider/model ref applied to the spawned child session. */
+  resolvedModel?: string;
+  /** Provider prefix parsed from resolvedModel when the ref includes one. */
+  resolvedProvider?: string;
 };
 
 export type PluginHookSubagentEndedEvent = {


### PR DESCRIPTION
## Summary

- Return the resolved native child model ref/provider from accepted `sessions_spawn` results.
- Include the same model metadata on `subagent_spawned` plugin hook events.
- Document the tool result and hook metadata, with targeted coverage for the accepted spawn path.

## Verification

- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/agents/subagent-spawn.ts src/plugins/hook-types.ts src/agents/subagent-spawn.model-session.test.ts src/agents/sessions-spawn-hooks.test.ts`
- `pnpm format:docs:check`
- `pnpm test src/agents/subagent-spawn.model-session.test.ts src/agents/sessions-spawn-hooks.test.ts`
- TypeScript diagnostics: modified TS files reported 0 errors

## Real behavior proof

- **Behavior addressed**: Accepted native `sessions_spawn` results and the `subagent_spawned` lifecycle hook expose the resolved child model metadata instead of only `modelApplied`.
- **Real environment tested**: Local macOS development checkout at commit `f8c9bff`, Node `v25.9.0`, OpenClaw config loaded from the local user setup. This was a source-level runtime smoke with the gateway call boundary stubbed so the command could exercise the production spawn path without launching a real child LLM turn.
- **Exact steps or command run after this patch**: Ran a local `pnpm exec tsx -e ...` smoke that imported `src/agents/subagent-spawn.ts`, invoked `spawnSubagentDirect` with `model: "openai-codex/gpt-5.4"`, and captured the accepted result plus the `subagent_spawned` hook event.
- **Evidence after fix**:

```text
Config warnings:
- plugins.entries.active-memory: plugin disabled (disabled in config) but config is present
{
  "result": {
    "status": "accepted",
    "runId": "real-proof-run",
    "resolvedModel": "openai-codex/gpt-5.4",
    "resolvedProvider": "openai-codex",
    "modelApplied": true
  },
  "hookEvent": {
    "runId": "real-proof-run",
    "resolvedModel": "openai-codex/gpt-5.4",
    "resolvedProvider": "openai-codex"
  }
}
```

- **Observed result after fix**: The accepted tool result and the emitted `subagent_spawned` event both contained `resolvedModel: "openai-codex/gpt-5.4"` and `resolvedProvider: "openai-codex"`.
- **What was not tested**: Full live model execution and completion announce delivery; this change only exposes model metadata resolved before the child run starts.
