### PR TITLE
fix(agents/cli): bridge CLI tool_use lifecycle events to channel preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/CLI: parse `tool_use` content blocks and `tool_result` user-messages from the claude-cli stream-json dialect, emit them as `agent-event` records on the `tool` stream, and bridge those events through `params.opts.onToolStart` so channel preview tool-progress lights up for `claude-cli`-backed runs the same way it does for the embedded native runtime. Mirrors the assistant-text bridge from #76914.
 - Agents: surface concise default-visible warnings when `exec`/`bash` tool calls fail after the assistant claims success, while keeping raw stderr hidden unless verbose details are enabled. Fixes #60497. (#80003) Thanks @jbetala7.
 - CLI/agent: let `openclaw agent --model` use the backend/admin Gateway scope without cached device-token scopes silently downscoping the request. (#78837) Thanks @VACInc.
 - Ollama: keep DeepSeek V4 cloud models thinking-capable even when Ollama Cloud `/api/show` omits the `thinking` capability, so `/think high` no longer rejects `ollama/deepseek-v4-*:cloud`.

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -4,6 +4,7 @@ import {
   extractCliErrorMessage,
   parseCliJson,
   parseCliJsonl,
+  type CliToolUseStartDelta,
 } from "./cli-output.js";
 import { createClaudeApiErrorFixture } from "./test-helpers/claude-api-error-fixture.js";
 
@@ -536,5 +537,332 @@ describe("createCliJsonlStreamingParser", () => {
       cacheWrite: undefined,
       total: undefined,
     });
+  });
+
+  it("surfaces Claude tool_use start and result events", () => {
+    const starts: CliToolUseStartDelta[] = [];
+    const results: Array<{ toolCallId: string; name: string; isError: boolean; result?: unknown }> =
+      [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+      onToolResult: (delta) => results.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "ls -la" } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_1",
+                content: "total 0\n",
+                is_error: false,
+              },
+            ],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([{ toolCallId: "toolu_1", name: "Bash", args: { command: "ls -la" } }]);
+    expect(results).toEqual([
+      { toolCallId: "toolu_1", name: "Bash", isError: false, result: "total 0\n" },
+    ]);
+  });
+
+  it("reassembles streamed tool args from input_json_delta chunks", () => {
+    const starts: CliToolUseStartDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_chunked", name: "Bash", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"command":' },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: ' "echo hi"}' },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([
+      { toolCallId: "toolu_chunked", name: "Bash", args: { command: "echo hi" } },
+    ]);
+  });
+
+  it("emits empty args when streamed tool args are malformed", () => {
+    const starts: CliToolUseStartDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_bad", name: "Bash", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"command": "ls' },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([{ toolCallId: "toolu_bad", name: "Bash", args: {} }]);
+  });
+
+  it.each(["server_tool_use", "mcp_tool_use"])("recognizes %s blocks", (type) => {
+    const starts: CliToolUseStartDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type, id: "toolu_hosted", name: "web_search", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"query":"openclaw"}' },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([
+      { toolCallId: "toolu_hosted", name: "web_search", args: { query: "openclaw" } },
+    ]);
+  });
+
+  it.each([
+    {
+      useType: "server_tool_use",
+      resultType: "web_search_tool_result",
+      toolCallId: "srvtoolu_1",
+      name: "web_search",
+      input: { query: "openclaw" },
+      result: [{ type: "web_search_result", title: "OpenClaw", url: "https://example.com" }],
+      isError: false,
+    },
+    {
+      useType: "mcp_tool_use",
+      resultType: "mcp_tool_result",
+      toolCallId: "mcptoolu_1",
+      name: "echo",
+      input: { value: "hello" },
+      result: [{ type: "text", text: "hello" }],
+      isError: false,
+    },
+  ])("emits hosted result events for $useType", (fixture) => {
+    const starts: CliToolUseStartDelta[] = [];
+    const results: Array<{ toolCallId: string; name: string; isError: boolean; result?: unknown }> =
+      [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+      onToolResult: (delta) => results.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: fixture.useType,
+                id: fixture.toolCallId,
+                name: fixture.name,
+                input: fixture.input,
+              },
+              {
+                type: fixture.resultType,
+                tool_use_id: fixture.toolCallId,
+                content: fixture.result,
+                is_error: fixture.isError,
+              },
+            ],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([
+      { toolCallId: fixture.toolCallId, name: fixture.name, args: fixture.input },
+    ]);
+    expect(results).toEqual([
+      {
+        toolCallId: fixture.toolCallId,
+        name: fixture.name,
+        isError: fixture.isError,
+        result: fixture.result,
+      },
+    ]);
+  });
+
+  it("emits streamed server tool result blocks", () => {
+    const results: Array<{ toolCallId: string; name: string; isError: boolean; result?: unknown }> =
+      [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: () => undefined,
+      onToolResult: (delta) => results.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "server_tool_use", id: "srvtoolu_stream", name: "web_search" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_stop",
+            index: 0,
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 1,
+            content_block: {
+              type: "web_search_tool_result",
+              tool_use_id: "srvtoolu_stream",
+              content: { type: "web_search_tool_result_error", error_code: "unavailable" },
+            },
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(results).toEqual([
+      {
+        toolCallId: "srvtoolu_stream",
+        name: "web_search",
+        isError: true,
+        result: { type: "web_search_tool_result_error", error_code: "unavailable" },
+      },
+    ]);
   });
 });

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -4,7 +4,10 @@ import {
   extractCliErrorMessage,
   parseCliJson,
   parseCliJsonl,
+  type CliToolResultDelta,
+  type CliToolUseStartDelta,
 } from "./cli-output.js";
+import { sanitizeToolArgs, sanitizeToolResult } from "./pi-embedded-subscribe.tools.js";
 import { createClaudeApiErrorFixture } from "./test-helpers/claude-api-error-fixture.js";
 
 describe("parseCliJson", () => {
@@ -446,5 +449,345 @@ describe("createCliJsonlStreamingParser", () => {
     expect(deltas).toEqual([
       { text: "hello", delta: "hello", sessionId: "session-stream", usage: undefined },
     ]);
+  });
+
+  it("surfaces a single tool_use start with full args plus the tool_result from claude-cli stream-json", () => {
+    const starts: Array<{ toolCallId: string; name: string; args: Record<string, unknown> }> = [];
+    const results: Array<{ toolCallId: string; name: string; isError: boolean; result?: unknown }> =
+      [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+      onToolResult: (delta) => results.push(delta),
+    });
+
+    // Sequence captured from a real claude-cli `--output-format stream-json
+    // --include-partial-messages` run: streaming start → input_json_delta
+    // chunks → assistant snapshot with full input → user-typed tool_result.
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 1,
+            content_block: { type: "tool_use", id: "toolu_01ABCD", name: "Bash", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 1,
+            delta: { type: "input_json_delta", partial_json: '{"command": "ls -' },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 1,
+            delta: { type: "input_json_delta", partial_json: 'la"}' },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_01ABCD",
+                name: "Bash",
+                input: { command: "ls -la" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 1 },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            role: "user",
+            content: [
+              {
+                tool_use_id: "toolu_01ABCD",
+                type: "tool_result",
+                content: "total 0\n",
+                is_error: false,
+              },
+            ],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([
+      { toolCallId: "toolu_01ABCD", name: "Bash", args: { command: "ls -la" } },
+    ]);
+    expect(results).toEqual([
+      { toolCallId: "toolu_01ABCD", name: "Bash", isError: false, result: "total 0\n" },
+    ]);
+  });
+
+  it("falls back to empty-args start when content_block_stop arrives without a preceding assistant snapshot", () => {
+    const starts: Array<{ toolCallId: string; name: string; args: Record<string, unknown> }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_aborted", name: "Bash", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([{ toolCallId: "toolu_aborted", name: "Bash", args: {} }]);
+  });
+
+  it("emits start exactly once when both content_block_start and the assistant snapshot announce the same tool_use", () => {
+    const starts: Array<{ toolCallId: string; name: string; args: Record<string, unknown> }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_dup", name: "Read", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "tool_use", id: "toolu_dup", name: "Read", input: { file_path: "/tmp/x" } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([
+      { toolCallId: "toolu_dup", name: "Read", args: { file_path: "/tmp/x" } },
+    ]);
+  });
+
+  it("flags is_error=true on tool_result events and carries the tool name from prior start", () => {
+    const starts: Array<{ toolCallId: string; name: string; args: Record<string, unknown> }> = [];
+    const results: Array<{ toolCallId: string; name: string; isError: boolean; result?: unknown }> =
+      [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+      onToolResult: (delta) => results.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "tool_use", id: "toolu_err", name: "Bash", input: { command: "false" } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            role: "user",
+            content: [
+              {
+                tool_use_id: "toolu_err",
+                type: "tool_result",
+                content: "command failed: nope",
+                is_error: true,
+              },
+            ],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([{ toolCallId: "toolu_err", name: "Bash", args: { command: "false" } }]);
+    expect(results).toEqual([
+      { toolCallId: "toolu_err", name: "Bash", isError: true, result: "command failed: nope" },
+    ]);
+  });
+
+  it("ignores tool events when no tool callbacks are subscribed", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: ({ text, delta }) => deltas.push({ text, delta }),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_silent", name: "Bash", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "ok" },
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    // Pre-existing assistant text streaming behavior is preserved when only
+    // onAssistantDelta is supplied; tool events silently drop.
+    expect(deltas).toEqual([{ text: "ok", delta: "ok" }]);
+  });
+
+  it("surfaces tool args and results unredacted at the parser boundary; sanitization is the consumer's responsibility before bus emission", () => {
+    // Locks in the privacy contract for callers: the parser is a pure
+    // transform that carries claude-cli's raw `tool_use.input` and
+    // `tool_result.content` through to the callback. Consumers that emit
+    // these onto the shared agent-event bus (see
+    // src/agents/cli-runner/execute.ts) MUST apply
+    // `sanitizeToolArgs`/`sanitizeToolResult` from
+    // `src/agents/pi-embedded-subscribe.tools.ts` first, matching the
+    // embedded native runtime's emission contract.
+    const starts: Array<CliToolUseStartDelta> = [];
+    const results: Array<CliToolResultDelta> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+      onToolResult: (delta) => results.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_secret",
+                name: "Bash",
+                input: { command: "curl -H 'Authorization: Bearer sk-supersecret' api.example/v1" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            role: "user",
+            content: [
+              {
+                tool_use_id: "toolu_secret",
+                type: "tool_result",
+                content: '{"x_api_key":"sk-supersecret-response"}',
+                is_error: false,
+              },
+            ],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toHaveLength(1);
+    expect(starts[0]?.args.command).toContain("sk-supersecret");
+    expect(results).toHaveLength(1);
+    expect(typeof results[0]?.result === "string" ? results[0].result : "").toContain(
+      "sk-supersecret-response",
+    );
+
+    // Verify sanitizers, when applied at the consumer layer, redact what
+    // the parser surfaces — the privacy guarantee that the cli-runner
+    // emit sites rely on.
+    const sanitizedArgs = sanitizeToolArgs(starts[0]?.args) as Record<string, unknown>;
+    expect(typeof sanitizedArgs.command === "string" ? sanitizedArgs.command : "").not.toContain(
+      "sk-supersecret",
+    );
+    const sanitizedResult = sanitizeToolResult(results[0]?.result);
+    expect(typeof sanitizedResult === "string" ? sanitizedResult : "").not.toContain(
+      "sk-supersecret-response",
+    );
   });
 });

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -27,6 +27,19 @@ export type CliStreamingDelta = {
   usage?: CliUsage;
 };
 
+export type CliToolUseStartDelta = {
+  toolCallId: string;
+  name: string;
+  args: Record<string, unknown>;
+};
+
+export type CliToolResultDelta = {
+  toolCallId: string;
+  name: string;
+  isError: boolean;
+  result?: unknown;
+};
+
 function isClaudeCliProvider(providerId: string): boolean {
   return normalizeLowercaseStringOrEmpty(providerId) === "claude-cli";
 }
@@ -394,10 +407,215 @@ function parseClaudeCliStreamingDelta(params: {
   };
 }
 
+type PendingToolUse = {
+  toolCallId: string;
+  name: string;
+  inputJsonParts: string[];
+};
+
+type ToolUseTracker = {
+  pendingByIndex: Map<number, PendingToolUse>;
+  nameById: Map<string, string>;
+  startedIds: Set<string>;
+  resultDeliveredIds: Set<string>;
+};
+
+function createToolUseTracker(): ToolUseTracker {
+  return {
+    pendingByIndex: new Map(),
+    nameById: new Map(),
+    startedIds: new Set(),
+    resultDeliveredIds: new Set(),
+  };
+}
+
+function emitToolStartOnce(
+  tracker: ToolUseTracker,
+  toolCallId: string,
+  name: string,
+  args: Record<string, unknown>,
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void,
+): void {
+  if (tracker.startedIds.has(toolCallId)) {
+    return;
+  }
+  tracker.startedIds.add(toolCallId);
+  tracker.nameById.set(toolCallId, name);
+  onToolUseStart?.({ toolCallId, name, args });
+}
+
+function emitToolResultOnce(
+  tracker: ToolUseTracker,
+  toolCallId: string,
+  isError: boolean,
+  result: unknown,
+  onToolResult?: (delta: CliToolResultDelta) => void,
+): void {
+  if (tracker.resultDeliveredIds.has(toolCallId)) {
+    return;
+  }
+  tracker.resultDeliveredIds.add(toolCallId);
+  onToolResult?.({
+    toolCallId,
+    name: tracker.nameById.get(toolCallId) ?? "",
+    isError,
+    result,
+  });
+}
+
+function isClaudeToolUseBlockType(type: unknown): boolean {
+  return type === "tool_use" || type === "server_tool_use" || type === "mcp_tool_use";
+}
+
+function isClaudeAssistantToolResultBlockType(type: unknown): boolean {
+  return typeof type === "string" && type.endsWith("_tool_result") && type !== "tool_result";
+}
+
+function isClaudeToolResultError(content: unknown): boolean {
+  return isRecord(content) && typeof content.type === "string" && content.type.endsWith("_error");
+}
+
+function parseToolInputJson(parts: string[]): Record<string, unknown> {
+  if (parts.length === 0) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(parts.join(""));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function dispatchClaudeCliStreamingToolEvent(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  parsed: Record<string, unknown>;
+  tracker: ToolUseTracker;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
+}): void {
+  if (!usesClaudeStreamJsonDialect(params)) {
+    return;
+  }
+  const tracker = params.tracker;
+
+  if (params.parsed.type === "stream_event" && isRecord(params.parsed.event)) {
+    const event = params.parsed.event;
+    if (
+      event.type === "content_block_start" &&
+      typeof event.index === "number" &&
+      isRecord(event.content_block)
+    ) {
+      const block = event.content_block;
+      if (isClaudeToolUseBlockType(block.type)) {
+        const toolCallId = typeof block.id === "string" ? block.id.trim() : "";
+        const name = typeof block.name === "string" ? block.name.trim() : "";
+        if (toolCallId && name) {
+          tracker.pendingByIndex.set(event.index, { toolCallId, name, inputJsonParts: [] });
+        }
+      } else if (isClaudeAssistantToolResultBlockType(block.type)) {
+        const toolCallId = typeof block.tool_use_id === "string" ? block.tool_use_id.trim() : "";
+        if (toolCallId) {
+          emitToolResultOnce(
+            tracker,
+            toolCallId,
+            block.is_error === true || isClaudeToolResultError(block.content),
+            block.content,
+            params.onToolResult,
+          );
+        }
+      }
+      return;
+    }
+    if (
+      event.type === "content_block_delta" &&
+      typeof event.index === "number" &&
+      isRecord(event.delta)
+    ) {
+      if (event.delta.type === "input_json_delta" && typeof event.delta.partial_json === "string") {
+        tracker.pendingByIndex.get(event.index)?.inputJsonParts.push(event.delta.partial_json);
+      }
+      return;
+    }
+    if (event.type === "content_block_stop" && typeof event.index === "number") {
+      const pending = tracker.pendingByIndex.get(event.index);
+      tracker.pendingByIndex.delete(event.index);
+      if (pending) {
+        emitToolStartOnce(
+          tracker,
+          pending.toolCallId,
+          pending.name,
+          parseToolInputJson(pending.inputJsonParts),
+          params.onToolUseStart,
+        );
+      }
+      return;
+    }
+    return;
+  }
+
+  if (params.parsed.type === "assistant" && isRecord(params.parsed.message)) {
+    const message = params.parsed.message;
+    const content = Array.isArray(message.content) ? message.content : [];
+    for (const block of content) {
+      if (!isRecord(block)) {
+        continue;
+      }
+      if (isClaudeToolUseBlockType(block.type)) {
+        const toolCallId = typeof block.id === "string" ? block.id.trim() : "";
+        const name = typeof block.name === "string" ? block.name.trim() : "";
+        if (!toolCallId || !name) {
+          continue;
+        }
+        const args: Record<string, unknown> = isRecord(block.input) ? block.input : {};
+        emitToolStartOnce(tracker, toolCallId, name, args, params.onToolUseStart);
+      } else if (isClaudeAssistantToolResultBlockType(block.type)) {
+        const toolCallId = typeof block.tool_use_id === "string" ? block.tool_use_id.trim() : "";
+        if (!toolCallId) {
+          continue;
+        }
+        emitToolResultOnce(
+          tracker,
+          toolCallId,
+          block.is_error === true || isClaudeToolResultError(block.content),
+          block.content,
+          params.onToolResult,
+        );
+      }
+    }
+    return;
+  }
+
+  if (params.parsed.type === "user" && isRecord(params.parsed.message)) {
+    const message = params.parsed.message;
+    const content = Array.isArray(message.content) ? message.content : [];
+    for (const block of content) {
+      if (!isRecord(block) || block.type !== "tool_result") {
+        continue;
+      }
+      const toolCallId = typeof block.tool_use_id === "string" ? block.tool_use_id.trim() : "";
+      if (!toolCallId) {
+        continue;
+      }
+      emitToolResultOnce(
+        tracker,
+        toolCallId,
+        block.is_error === true,
+        block.content,
+        params.onToolResult,
+      );
+    }
+    return;
+  }
+}
+
 export function createCliJsonlStreamingParser(params: {
   backend: CliBackendConfig;
   providerId: string;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
 }) {
   let lineBuffer = "";
   let assistantText = "";
@@ -405,6 +623,7 @@ export function createCliJsonlStreamingParser(params: {
   let usage: CliUsage | undefined;
   let output: CliOutput | null = null;
   const texts: string[] = [];
+  const toolTracker = createToolUseTracker();
 
   const handleParsedRecord = (parsed: Record<string, unknown>) => {
     sessionId = pickCliSessionId(parsed, params.backend) ?? sessionId;
@@ -440,6 +659,17 @@ export function createCliJsonlStreamingParser(params: {
       if (!type || type.includes("message")) {
         texts.push(item.text);
       }
+    }
+
+    if (params.onToolUseStart || params.onToolResult) {
+      dispatchClaudeCliStreamingToolEvent({
+        backend: params.backend,
+        providerId: params.providerId,
+        parsed,
+        tracker: toolTracker,
+        onToolUseStart: params.onToolUseStart,
+        onToolResult: params.onToolResult,
+      });
     }
 
     const delta = parseClaudeCliStreamingDelta({

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -26,6 +26,19 @@ export type CliStreamingDelta = {
   usage?: CliUsage;
 };
 
+export type CliToolUseStartDelta = {
+  toolCallId: string;
+  name: string;
+  args: Record<string, unknown>;
+};
+
+export type CliToolResultDelta = {
+  toolCallId: string;
+  name: string;
+  isError: boolean;
+  result?: unknown;
+};
+
 function isClaudeCliProvider(providerId: string): boolean {
   return normalizeLowercaseStringOrEmpty(providerId) === "claude-cli";
 }
@@ -379,10 +392,135 @@ function parseClaudeCliStreamingDelta(params: {
   };
 }
 
+type PendingToolUse = { toolCallId: string; name: string };
+
+type ToolUseTracker = {
+  // claude streams content_block_start (id + name, no args) before the
+  // post-block assistant snapshot carries the full input. start emission
+  // is held until args arrive so the event matches the embedded handler's
+  // `{phase: "start", name, toolCallId, args}` shape.
+  pendingByIndex: Map<number, PendingToolUse>;
+  // retained so tool_result events can carry `name` like the embedded handler.
+  nameById: Map<string, string>;
+  startedIds: Set<string>;
+  resultDeliveredIds: Set<string>;
+};
+
+function createToolUseTracker(): ToolUseTracker {
+  return {
+    pendingByIndex: new Map(),
+    nameById: new Map(),
+    startedIds: new Set(),
+    resultDeliveredIds: new Set(),
+  };
+}
+
+function emitToolStartOnce(
+  tracker: ToolUseTracker,
+  toolCallId: string,
+  name: string,
+  args: Record<string, unknown>,
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void,
+): void {
+  if (tracker.startedIds.has(toolCallId)) {
+    return;
+  }
+  tracker.startedIds.add(toolCallId);
+  tracker.nameById.set(toolCallId, name);
+  onToolUseStart?.({ toolCallId, name, args });
+}
+
+function dispatchClaudeCliStreamingToolEvent(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  parsed: Record<string, unknown>;
+  tracker: ToolUseTracker;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
+}): void {
+  if (!usesClaudeStreamJsonDialect(params)) {
+    return;
+  }
+  const tracker = params.tracker;
+
+  if (params.parsed.type === "stream_event" && isRecord(params.parsed.event)) {
+    const event = params.parsed.event;
+    if (
+      event.type === "content_block_start" &&
+      typeof event.index === "number" &&
+      isRecord(event.content_block)
+    ) {
+      const block = event.content_block;
+      if (block.type === "tool_use") {
+        const toolCallId = typeof block.id === "string" ? block.id.trim() : "";
+        const name = typeof block.name === "string" ? block.name.trim() : "";
+        if (toolCallId && name) {
+          tracker.pendingByIndex.set(event.index, { toolCallId, name });
+        }
+      }
+      return;
+    }
+    if (event.type === "content_block_stop" && typeof event.index === "number") {
+      // fallback: emit start with empty args if the post-block assistant
+      // snapshot never arrived (turn aborted, etc.); well-formed runs emit
+      // via the assistant branch below first and dedup ignores this.
+      const pending = tracker.pendingByIndex.get(event.index);
+      tracker.pendingByIndex.delete(event.index);
+      if (pending) {
+        emitToolStartOnce(tracker, pending.toolCallId, pending.name, {}, params.onToolUseStart);
+      }
+      return;
+    }
+    return;
+  }
+
+  if (params.parsed.type === "assistant" && isRecord(params.parsed.message)) {
+    const message = params.parsed.message;
+    const content = Array.isArray(message.content) ? message.content : [];
+    for (const block of content) {
+      if (!isRecord(block) || block.type !== "tool_use") {
+        continue;
+      }
+      const toolCallId = typeof block.id === "string" ? block.id.trim() : "";
+      const name = typeof block.name === "string" ? block.name.trim() : "";
+      if (!toolCallId || !name) {
+        continue;
+      }
+      const args: Record<string, unknown> = isRecord(block.input) ? block.input : {};
+      emitToolStartOnce(tracker, toolCallId, name, args, params.onToolUseStart);
+    }
+    return;
+  }
+
+  if (params.parsed.type === "user" && isRecord(params.parsed.message)) {
+    const message = params.parsed.message;
+    const content = Array.isArray(message.content) ? message.content : [];
+    for (const block of content) {
+      if (!isRecord(block) || block.type !== "tool_result") {
+        continue;
+      }
+      const toolCallId = typeof block.tool_use_id === "string" ? block.tool_use_id.trim() : "";
+      if (!toolCallId || tracker.resultDeliveredIds.has(toolCallId)) {
+        continue;
+      }
+      tracker.resultDeliveredIds.add(toolCallId);
+      params.onToolResult?.({
+        toolCallId,
+        name: tracker.nameById.get(toolCallId) ?? "",
+        isError: block.is_error === true,
+        result: block.content,
+      });
+    }
+    return;
+  }
+}
+
 export function createCliJsonlStreamingParser(params: {
   backend: CliBackendConfig;
   providerId: string;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
 }) {
   let lineBuffer = "";
   let assistantText = "";
@@ -390,6 +528,7 @@ export function createCliJsonlStreamingParser(params: {
   let usage: CliUsage | undefined;
   let output: CliOutput | null = null;
   const texts: string[] = [];
+  const toolTracker = createToolUseTracker();
 
   const handleParsedRecord = (parsed: Record<string, unknown>) => {
     sessionId = pickCliSessionId(parsed, params.backend) ?? sessionId;
@@ -416,6 +555,17 @@ export function createCliJsonlStreamingParser(params: {
       if (!type || type.includes("message")) {
         texts.push(item.text);
       }
+    }
+
+    if (params.onToolUseStart || params.onToolResult) {
+      dispatchClaudeCliStreamingToolEvent({
+        backend: params.backend,
+        providerId: params.providerId,
+        parsed,
+        tracker: toolTracker,
+        onToolUseStart: params.onToolUseStart,
+        onToolResult: params.onToolResult,
+      });
     }
 
     const delta = parseClaudeCliStreamingDelta({

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -24,6 +24,8 @@ import {
   parseCliOutput,
   type CliOutput,
   type CliStreamingDelta,
+  type CliToolResultDelta,
+  type CliToolUseStartDelta,
 } from "../cli-output.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
@@ -1104,6 +1106,8 @@ function createTurn(params: {
   context: PreparedCliRunContext;
   noOutputTimeoutMs: number;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
   session: ClaudeLiveSession;
   execPermission: ClaudeLiveExecPermission;
   resolve: (output: CliOutput) => void;
@@ -1128,6 +1132,8 @@ function createTurn(params: {
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,
       onAssistantDelta: params.onAssistantDelta,
+      onToolUseStart: params.onToolUseStart,
+      onToolResult: params.onToolResult,
     }),
     execPermission: params.execPermission,
     resolve: params.resolve,
@@ -1194,6 +1200,8 @@ export async function runClaudeLiveSessionTurn(params: {
   noOutputTimeoutMs: number;
   getProcessSupervisor: () => ProcessSupervisor;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
   cleanup: () => Promise<void>;
 }): Promise<ClaudeLiveRunResult> {
   const key = buildClaudeLiveKey(params.context);
@@ -1307,6 +1315,8 @@ export async function runClaudeLiveSessionTurn(params: {
       context: params.context,
       noOutputTimeoutMs: params.noOutputTimeoutMs,
       onAssistantDelta: params.onAssistantDelta,
+      onToolUseStart: params.onToolUseStart,
+      onToolResult: params.onToolResult,
       session: liveSession,
       execPermission,
       resolve,

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -7,6 +7,8 @@ import {
   parseCliOutput,
   type CliOutput,
   type CliStreamingDelta,
+  type CliToolResultDelta,
+  type CliToolUseStartDelta,
 } from "../cli-output.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { classifyFailoverReason } from "../pi-embedded-helpers.js";
@@ -758,6 +760,8 @@ function createTurn(params: {
   context: PreparedCliRunContext;
   noOutputTimeoutMs: number;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
   session: ClaudeLiveSession;
   resolve: (output: CliOutput) => void;
   reject: (error: unknown) => void;
@@ -774,6 +778,8 @@ function createTurn(params: {
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,
       onAssistantDelta: params.onAssistantDelta,
+      onToolUseStart: params.onToolUseStart,
+      onToolResult: params.onToolResult,
     }),
     resolve: params.resolve,
     reject: params.reject,
@@ -839,6 +845,8 @@ export async function runClaudeLiveSessionTurn(params: {
   noOutputTimeoutMs: number;
   getProcessSupervisor: () => ProcessSupervisor;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
   cleanup: () => Promise<void>;
 }): Promise<ClaudeLiveRunResult> {
   const key = buildClaudeLiveKey(params.context);
@@ -950,6 +958,8 @@ export async function runClaudeLiveSessionTurn(params: {
       context: params.context,
       noOutputTimeoutMs: params.noOutputTimeoutMs,
       onAssistantDelta: params.onAssistantDelta,
+      onToolUseStart: params.onToolUseStart,
+      onToolResult: params.onToolResult,
       session: liveSession,
       resolve,
       reject,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -19,6 +19,7 @@ import {
   type CliOutput,
 } from "../cli-output.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers.js";
+import { sanitizeToolArgs, sanitizeToolResult } from "../embedded-agent-subscribe.tools.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { applySkillEnvOverridesFromSnapshot } from "../skills.js";
@@ -446,6 +447,40 @@ export async function executePreparedCliRun(
         });
         const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
         const hasJsonlOutput = outputMode === "jsonl";
+        const emitCliToolUseStart = (event: {
+          toolCallId: string;
+          name: string;
+          args: Record<string, unknown>;
+        }) => {
+          emitAgentEvent({
+            runId: params.runId,
+            stream: "tool",
+            data: {
+              phase: "start",
+              name: event.name,
+              toolCallId: event.toolCallId,
+              args: sanitizeToolArgs(event.args),
+            },
+          });
+        };
+        const emitCliToolResult = (event: {
+          toolCallId: string;
+          name: string;
+          isError: boolean;
+          result?: unknown;
+        }) => {
+          emitAgentEvent({
+            runId: params.runId,
+            stream: "tool",
+            data: {
+              phase: "result",
+              name: event.name,
+              toolCallId: event.toolCallId,
+              isError: event.isError,
+              result: sanitizeToolResult(event.result),
+            },
+          });
+        };
         if (shouldUseClaudeLiveSession(context)) {
           if (!hasJsonlOutput) {
             throw new Error("Claude live session requires JSONL streaming parser");
@@ -483,6 +518,8 @@ export async function executePreparedCliRun(
                 },
               });
             },
+            onToolUseStart: emitCliToolUseStart,
+            onToolResult: emitCliToolResult,
             cleanup: async () => {
               try {
                 await fallbackClaudeSkillsPlugin?.cleanup();
@@ -522,6 +559,8 @@ export async function executePreparedCliRun(
                   },
                 });
               },
+              onToolUseStart: emitCliToolUseStart,
+              onToolResult: emitCliToolResult,
             })
           : null;
         const supervisor = executeDeps.getProcessSupervisor();

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -16,6 +16,7 @@ import {
 } from "../cli-output.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { classifyFailoverReason } from "../pi-embedded-helpers.js";
+import { sanitizeToolArgs, sanitizeToolResult } from "../pi-embedded-subscribe.tools.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { applySkillEnvOverridesFromSnapshot } from "../skills.js";
 import { runClaudeLiveSessionTurn, shouldUseClaudeLiveSession } from "./claude-live-session.js";
@@ -475,6 +476,31 @@ export async function executePreparedCliRun(
                 },
               });
             },
+            onToolUseStart: ({ toolCallId, name, args }) => {
+              emitAgentEvent({
+                runId: params.runId,
+                stream: "tool",
+                data: {
+                  phase: "start",
+                  name,
+                  toolCallId,
+                  args: sanitizeToolArgs(args) as Record<string, unknown>,
+                },
+              });
+            },
+            onToolResult: ({ toolCallId, name, isError, result }) => {
+              emitAgentEvent({
+                runId: params.runId,
+                stream: "tool",
+                data: {
+                  phase: "result",
+                  name,
+                  toolCallId,
+                  isError,
+                  result: sanitizeToolResult(result),
+                },
+              });
+            },
             cleanup: async () => {
               try {
                 await claudeSkillsPlugin.cleanup();
@@ -511,6 +537,31 @@ export async function executePreparedCliRun(
                       delta,
                       context.backendResolved.textTransforms?.output,
                     ),
+                  },
+                });
+              },
+              onToolUseStart: ({ toolCallId, name, args }) => {
+                emitAgentEvent({
+                  runId: params.runId,
+                  stream: "tool",
+                  data: {
+                    phase: "start",
+                    name,
+                    toolCallId,
+                    args: sanitizeToolArgs(args) as Record<string, unknown>,
+                  },
+                });
+              },
+              onToolResult: ({ toolCallId, name, isError, result }) => {
+                emitAgentEvent({
+                  runId: params.runId,
+                  stream: "tool",
+                  data: {
+                    phase: "result",
+                    name,
+                    toolCallId,
+                    isError,
+                    result: sanitizeToolResult(result),
                   },
                 });
               },

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -1,7 +1,9 @@
 import { runCliAgent } from "../../agents/cli-runner.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
+import type { AgentEventPayload } from "../../infra/agent-events.js";
 import { emitAgentEvent, onAgentEvent } from "../../infra/agent-events.js";
+import { isRecord } from "../../shared/record-coerce.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -11,10 +13,11 @@ function shouldBridgeCliAssistantTextToReasoning(provider: string): boolean {
   return normalizeLowercaseStringOrEmpty(provider) === "claude-cli";
 }
 
-function createAssistantTextBridge(params: {
+function createAgentEventBridge<T>(params: {
   runId: string;
   suppressed?: boolean;
-  deliver?: (text: string) => Promise<void>;
+  read: (evt: AgentEventPayload) => T | undefined;
+  deliver?: (payload: T) => Promise<void>;
 }) {
   const deliver = params.deliver;
   if (!deliver) {
@@ -23,22 +26,20 @@ function createAssistantTextBridge(params: {
       drain: async (): Promise<void> => undefined,
     };
   }
-  let lastText: string | undefined;
   let unsubscribed = false;
   let delivery = Promise.resolve();
   const rawUnsubscribe = onAgentEvent((evt) => {
-    if (evt.runId !== params.runId || evt.stream !== "assistant") {
+    if (evt.runId !== params.runId) {
       return;
     }
     if (params.suppressed) {
       return;
     }
-    const text = typeof evt.data.text === "string" ? evt.data.text : undefined;
-    if (text === undefined || text === lastText) {
+    const payload = params.read(evt);
+    if (payload === undefined) {
       return;
     }
-    lastText = text;
-    delivery = delivery.then(() => deliver(text)).catch(() => undefined);
+    delivery = delivery.then(() => deliver(payload)).catch(() => undefined);
   });
   return {
     unsubscribe() {
@@ -54,6 +55,63 @@ function createAssistantTextBridge(params: {
   };
 }
 
+function createAssistantTextBridge(params: {
+  runId: string;
+  suppressed?: boolean;
+  deliver?: (text: string) => Promise<void>;
+}) {
+  let lastText: string | undefined;
+  return createAgentEventBridge({
+    runId: params.runId,
+    suppressed: params.suppressed,
+    deliver: params.deliver,
+    read: (evt) => {
+      if (evt.stream !== "assistant") {
+        return undefined;
+      }
+      const text = typeof evt.data.text === "string" ? evt.data.text : undefined;
+      if (text === undefined || text === lastText) {
+        return undefined;
+      }
+      lastText = text;
+      return text;
+    },
+  });
+}
+
+export type CliToolEventPayload = {
+  name: string | undefined;
+  phase: "start" | "update";
+  args: Record<string, unknown> | undefined;
+};
+
+function createToolEventBridge(params: {
+  runId: string;
+  suppressed?: boolean;
+  deliver?: (payload: CliToolEventPayload) => Promise<void>;
+}) {
+  return createAgentEventBridge({
+    runId: params.runId,
+    suppressed: params.suppressed,
+    deliver: params.deliver,
+    read: (evt) => {
+      if (evt.stream !== "tool") {
+        return undefined;
+      }
+      const phaseValue = evt.data.phase;
+      if (phaseValue !== "start" && phaseValue !== "update") {
+        return undefined;
+      }
+      const phase: CliToolEventPayload["phase"] = phaseValue === "start" ? "start" : "update";
+      return {
+        name: typeof evt.data.name === "string" ? evt.data.name : undefined,
+        phase,
+        args: isRecord(evt.data.args) ? evt.data.args : undefined,
+      };
+    },
+  });
+}
+
 export async function runCliAgentWithLifecycle(params: {
   runId: string;
   provider: string;
@@ -65,6 +123,7 @@ export async function runCliAgentWithLifecycle(params: {
   suppressAssistantBridge?: boolean;
   onAssistantText?: (text: string) => Promise<void>;
   onReasoningText?: (text: string) => Promise<void>;
+  onToolEvent?: (payload: CliToolEventPayload) => Promise<void>;
   onErrorBeforeLifecycle?: (err: unknown) => Promise<void>;
   transformResult?: (result: EmbeddedAgentRunResult) => EmbeddedAgentRunResult;
 }): Promise<EmbeddedAgentRunResult> {
@@ -94,14 +153,21 @@ export async function runCliAgentWithLifecycle(params: {
       ? params.onReasoningText
       : undefined,
   });
+  const toolBridge = createToolEventBridge({
+    runId: params.runId,
+    suppressed: params.suppressAssistantBridge,
+    deliver: params.onToolEvent,
+  });
   let lifecycleTerminalEmitted = false;
   try {
     const rawResult = await runCliAgent(params.runParams);
     const result = params.transformResult?.(rawResult) ?? rawResult;
     assistantBridge.unsubscribe();
     reasoningBridge.unsubscribe();
+    toolBridge.unsubscribe();
     await assistantBridge.drain();
     await reasoningBridge.drain();
+    await toolBridge.drain();
 
     const cliText = normalizeOptionalString(result.payloads?.[0]?.text);
     if (cliText) {
@@ -128,8 +194,10 @@ export async function runCliAgentWithLifecycle(params: {
   } catch (err) {
     assistantBridge.unsubscribe();
     reasoningBridge.unsubscribe();
+    toolBridge.unsubscribe();
     await assistantBridge.drain();
     await reasoningBridge.drain();
+    await toolBridge.drain();
     await params.onErrorBeforeLifecycle?.(err);
     if (emitLifecycleTerminal) {
       emitAgentEvent({
@@ -148,6 +216,7 @@ export async function runCliAgentWithLifecycle(params: {
   } finally {
     assistantBridge.unsubscribe();
     reasoningBridge.unsubscribe();
+    toolBridge.unsubscribe();
     if (emitLifecycleTerminal && !lifecycleTerminalEmitted) {
       emitAgentEvent({
         runId: params.runId,

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2067,6 +2067,131 @@ describe("runAgentTurnWithFallback", () => {
     expect(previewOrder).toEqual(["Hello", "Hello released", "Hello world"]);
   });
 
+  it("bridges CLI tool agent events into onToolStart for live preview", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "Bash",
+          toolCallId: "toolu_01ABCD",
+          args: { command: "ls -la" },
+        },
+      });
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "Bash",
+          toolCallId: "toolu_01ABCD",
+          isError: false,
+        },
+      });
+      return { payloads: [{ text: "done" }], meta: {} };
+    });
+
+    const onToolStart = vi.fn<NonNullable<GetReplyOptions["onToolStart"]>>(async () => undefined);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onToolStart },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onToolStart).toHaveBeenCalledTimes(1);
+    const call = onToolStart.mock.calls[0]?.[0];
+    expect(call?.name).toBe("Bash");
+    expect(call?.phase).toBe("start");
+    expect(call?.args).toEqual({ command: "ls -la" });
+  });
+
+  it("does not bridge CLI tool deltas when silentExpected is set", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "Bash",
+          toolCallId: "toolu_silent",
+          args: { command: "echo silent" },
+        },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const onToolStart = vi.fn<NonNullable<GetReplyOptions["onToolStart"]>>(async () => undefined);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+    followupRun.run.silentExpected = true;
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onToolStart },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onToolStart).not.toHaveBeenCalled();
+  });
+
   it("does not bridge CLI assistant deltas when silentExpected is set (#76869)", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -614,6 +614,135 @@ describe("runAgentTurnWithFallback", () => {
     expect(previewOrder).toEqual(["Hello", "Hello released", "Hello world"]);
   });
 
+  it("bridges CLI tool agent events into onToolStart for live preview", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "Bash",
+          toolCallId: "toolu_01ABCD",
+          args: { command: "ls -la" },
+        },
+      });
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "Bash",
+          toolCallId: "toolu_01ABCD",
+          isError: false,
+        },
+      });
+      return { payloads: [{ text: "done" }], meta: {} };
+    });
+
+    const onToolStart = vi.fn<NonNullable<GetReplyOptions["onToolStart"]>>(async () => undefined);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onToolStart },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Only `start` and `update` phases reach onToolStart; `result` is filtered out
+    // here because the channel preview consumer only renders activation events.
+    expect(onToolStart).toHaveBeenCalledTimes(1);
+    const call = onToolStart.mock.calls[0]?.[0];
+    expect(call?.name).toBe("Bash");
+    expect(call?.phase).toBe("start");
+    expect(call?.args).toEqual({ command: "ls -la" });
+  });
+
+  it("does not bridge CLI tool deltas when silentExpected is set", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "Bash",
+          toolCallId: "toolu_silent",
+          args: { command: "echo silent" },
+        },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const onToolStart = vi.fn<NonNullable<GetReplyOptions["onToolStart"]>>(async () => undefined);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+    followupRun.run.silentExpected = true;
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onToolStart },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onToolStart).not.toHaveBeenCalled();
+  });
+
   it("does not bridge CLI assistant deltas when silentExpected is set (#76869)", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2026,6 +2026,17 @@ export async function runAgentTurnWithFallback(params: {
                   onReasoningText: async (text) => {
                     await params.opts?.onReasoningStream?.({ text });
                   },
+                  onToolEvent: async ({ name, phase, args }) => {
+                    await Promise.all([
+                      params.typingSignals.signalToolStart(),
+                      params.opts?.onToolStart?.({
+                        name,
+                        phase,
+                        args,
+                        detailMode: params.toolProgressDetail,
+                      }),
+                    ]);
+                  },
                   onErrorBeforeLifecycle: async () => {
                     if (!rollbackFallbackCandidateSelection) {
                       return;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1479,6 +1479,60 @@ export async function runAgentTurnWithFallback(params: {
                 assistantBridgeUnsubscribed = true;
                 rawUnsubscribeAssistantBridge();
               };
+              let toolBridgeUnsubscribed = false;
+              let toolBridgeDelivery: Promise<void> = Promise.resolve();
+              const deliverBridgedToolEvent = async (payload: {
+                name: string | undefined;
+                phase: "start" | "update";
+                args: Record<string, unknown> | undefined;
+              }): Promise<void> => {
+                if (typeof params.opts?.onToolStart !== "function") {
+                  return;
+                }
+                await params.opts.onToolStart({
+                  name: payload.name,
+                  phase: payload.phase,
+                  args: payload.args,
+                  detailMode: params.toolProgressDetail,
+                });
+              };
+              const queueBridgedToolEvent = (payload: {
+                name: string | undefined;
+                phase: "start" | "update";
+                args: Record<string, unknown> | undefined;
+              }) => {
+                toolBridgeDelivery = toolBridgeDelivery
+                  .then(() => deliverBridgedToolEvent(payload))
+                  .catch(() => undefined);
+              };
+              const drainToolBridgeDelivery = async (): Promise<void> => {
+                await toolBridgeDelivery;
+              };
+              const rawUnsubscribeToolBridge = onAgentEvent((evt) => {
+                if (evt.runId !== runId || evt.stream !== "tool") {
+                  return;
+                }
+                if (params.followupRun.run.silentExpected) {
+                  return;
+                }
+                const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                if (phase !== "start" && phase !== "update") {
+                  return;
+                }
+                const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
+                const args =
+                  evt.data.args && typeof evt.data.args === "object"
+                    ? (evt.data.args as Record<string, unknown>)
+                    : undefined;
+                queueBridgedToolEvent({ name, phase, args });
+              });
+              const unsubscribeToolBridge = () => {
+                if (toolBridgeUnsubscribed) {
+                  return;
+                }
+                toolBridgeUnsubscribed = true;
+                rawUnsubscribeToolBridge();
+              };
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
@@ -1526,7 +1580,9 @@ export async function runAgentTurnWithFallback(params: {
                 );
 
                 unsubscribeAssistantBridge();
+                unsubscribeToolBridge();
                 await drainAssistantBridgeDelivery();
+                await drainToolBridgeDelivery();
 
                 // CLI backends don't emit streaming assistant events, so we need to
                 // emit one with the final text so server-chat can populate its buffer
@@ -1554,7 +1610,9 @@ export async function runAgentTurnWithFallback(params: {
                 return result;
               } catch (err) {
                 unsubscribeAssistantBridge();
+                unsubscribeToolBridge();
                 await drainAssistantBridgeDelivery();
+                await drainToolBridgeDelivery();
                 if (rollbackFallbackCandidateSelection) {
                   try {
                     await rollbackFallbackCandidateSelection();
@@ -1579,6 +1637,7 @@ export async function runAgentTurnWithFallback(params: {
                 throw err;
               } finally {
                 unsubscribeAssistantBridge();
+                unsubscribeToolBridge();
                 // Defensive backstop: never let a CLI run complete without a terminal
                 // lifecycle event, otherwise downstream consumers can hang.
                 if (!lifecycleTerminalEmitted) {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -959,6 +959,64 @@ describe("createFollowupRunner runtime config", () => {
     expect(recorder.message).toBe(preparedUserTurnMessage);
   });
 
+  it("keeps queued CLI tool progress quiet when verbose progress is disabled", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    const onToolStart = vi.fn(async () => {});
+    runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "tool",
+        data: { phase: "start", name: "web_search", args: { query: "hidden" } },
+      });
+      return {
+        payloads: [{ text: "final" }],
+        meta: {
+          agentMeta: {
+            provider: "claude-cli",
+            model: "claude-opus-4-7",
+          },
+        },
+      };
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onToolStart },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    await runner(
+      createQueuedRun({
+        originatingChannel: "telegram",
+        run: {
+          config: runtimeConfig,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          messageProvider: "telegram",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: "off",
+        },
+      }),
+    );
+
+    expect(onToolStart).not.toHaveBeenCalled();
+  });
+
   it("defers queued CLI attempt terminal lifecycle events until fallback settles", async () => {
     const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
       "../../infra/agent-events.js",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -730,6 +730,17 @@ export function createFollowupRunner(params: {
                   emitLifecycleTerminal: false,
                   onAgentRunStart: () => opts?.onAgentRunStart?.(runId),
                   suppressAssistantBridge: run.silentExpected,
+                  onToolEvent: async ({ name, phase, args }) => {
+                    await forwardFollowupProgressEvent({
+                      evt: {
+                        stream: "tool",
+                        data: { name, phase, args },
+                      },
+                      opts,
+                      detailMode: toolProgressDetail,
+                      emitChannelProgress: shouldEmitToolResultProgress(),
+                    });
+                  },
                   runParams: {
                     replyOperation,
                     sessionId: run.sessionId,


### PR DESCRIPTION
## Summary

PR #76914 (merged 2026-05-09) bridged CLI-runtime assistant text deltas into channel preview pipelines, closing the silence gap on the API vs CLI runtime split for streaming text. Tool-progress events were left out of that fix — they're still dropped on the CLI runtime path while the embedded native (API) runtime emits them normally. Channel previews that subscribe to `stream: "tool"` for live tool-progress decoration (Telegram's "📖 Read:", "🛠️ Bash:", etc.) stay silent during tool-heavy CLI-backed turns, so users see typing indicators and final text but never the work-in-progress trail the API path already produces.

This PR closes the rest of the API/CLI parity gap by surfacing tool-use lifecycle events from the CLI stream output and bridging them through the same agent-event bus #76914 used for assistant text.

## Behavior change

Two scope tiers:

- **Parser layer (`src/agents/cli-output.ts`)** — claude-cli-specific. Recognises the claude `--output-format stream-json` dialect's tool_use content blocks and tool_result user-messages and surfaces them through new optional callbacks on `createCliJsonlStreamingParser`. Other CLI dialects (codex-cli, kiro-cli) ship their own parsers and continue to work as today; this PR only adds parsing for claude-cli's dialect because that's the one OpenClaw bundles a parser for.
- **Bridge layer (`src/agents/cli-runner/execute.ts`, `src/agents/cli-runner/claude-live-session.ts`, `src/auto-reply/reply/agent-runner-execution.ts`)** — CLI-generic. The `runCliAgent` execution path is gated by `isCliProvider(cliExecutionProvider, runtimeConfig)` at `agent-runner-execution.ts:1415`, so any CLI runtime emitting `agent-event { stream: "tool" }` for its run id (whether claude-cli today or future CLIs that adopt the same emission shape) gets the events forwarded to `params.opts.onToolStart` automatically. This is the matching layer to PR #76914's assistant-bridge addition and shares its serialization, drain, and silentExpected guards.

Layer-by-layer details:

1. **Parser** — new `dispatchClaudeCliStreamingToolEvent` in `src/agents/cli-output.ts` recognises three claude stream-json record shapes:
   - `stream_event { event: { type: "content_block_start", content_block: { type: "tool_use", id, name } } }` → record id+name in tracker (no emit yet; args haven't streamed).
   - `assistant { message: { content: [{ type: "tool_use", id, name, input }] } }` → emit `onToolUseStart({ toolCallId, name, args: input })` with full args.
   - `user { message: { content: [{ type: "tool_result", tool_use_id, is_error, content }] } }` → emit `onToolResult({ toolCallId, name, isError, result })`.
   - `content_block_stop` without preceding `assistant` snapshot → fallback emit `start` with empty args (turn-aborted edge case).

   The shape `{phase: "start" | "result", name, toolCallId, args | isError | result}` matches what the embedded native runtime already emits at `src/agents/pi-embedded-subscribe.handlers.tools.ts:696-705,998-1009`, so existing channel consumers pick them up unchanged. Per-parser `ToolUseTracker` dedupes start/result events. New optional callbacks; when neither is subscribed, behavior is byte-identical to before.

2. **Parser consumer** — both `claude-cli` execution paths in `src/agents/cli-runner/execute.ts` (live-session and JSONL-streaming) wire the new callbacks to `emitAgentEvent({ runId, stream: "tool", data: {...} })`. Args and results are passed through `sanitizeToolArgs` / `sanitizeToolResult` from `src/agents/pi-embedded-subscribe.tools.ts` before emission, matching the embedded native runtime's privacy contract at `pi-embedded-subscribe.handlers.tools.ts:703,705,1005,1007` — redacts Authorization headers, API key fields, and shell commands containing tokens before they reach the shared bus. The parser is constructed fresh per turn in `claude-live-session.ts:createTurn`, so the `ToolUseTracker` is per-turn — no cross-turn state leak.

3. **Agent-event bus consumer (CLI-generic)** — `src/auto-reply/reply/agent-runner-execution.ts` adds a parallel `rawUnsubscribeToolBridge = onAgentEvent(...)` next to the assistant-text bridge from #76914 inside the `isCliProvider(...)` branch. Filters by `runId`, respects `silentExpected` (heartbeat / NO_REPLY runs do not leak), and forwards `phase === "start"` and `"update"` events to `params.opts.onToolStart`. Mirrors #76914's serialization pattern (`toolBridgeDelivery` Promise chain + `drainToolBridgeDelivery`) so callbacks land in order even when `onToolStart` is async, and unsubscribe is mirrored at every place the assistant unsubscribe is called (success, catch, finally) so the listener never leaks.

No new public APIs in plugin-sdk; channel-side code is unchanged. Telegram, Discord, Slack, etc. preview pipelines automatically light up because they already subscribe to `stream: "tool"` on the agent-event bus through `params.opts.onToolStart`.

Scope note: this PR forwards `phase: "start"` and `phase: "update"` events through `onToolStart` (the channel-progress activation surface). `phase: "result"` is emitted on the bus but not forwarded to the channel here — the embedded handler's `result` events also include a `meta` field that this CLI emit omits, and the channel-progress pipeline today only consumes activation events. Adding `result`-phase forwarding (with `meta` parity) is left as a follow-up PR if/when a consumer needs completion events on the CLI path.

## Verification

- `pnpm test src/agents/cli-output.test.ts` → 21/21 PASS (5 new tests: full happy-path, fallback on `content_block_stop` without assistant snapshot, dedup when both `content_block_start` and `assistant` snapshot announce same tool, error tool_result with name passthrough, parser-vs-consumer privacy-contract regression locking in that args/result surface raw at the parser boundary and the consumer applies `sanitizeToolArgs`/`sanitizeToolResult` before emission).
- `pnpm test src/auto-reply/reply/agent-runner-execution.test.ts` → 73/73 PASS (2 new bridge tests: forwards tool events to `onToolStart` with correct args; respects `silentExpected`).
- `pnpm test src/agents/cli-runner` → 50/50 PASS.
- `pnpm check:changed` → all gates green (typecheck core + tests, lint core, runtime sidecar loaders, import cycles, webhook/pairing guards).
- `pnpm exec oxfmt --check --threads=1 src/agents/cli-output.ts src/agents/cli-output.test.ts src/agents/cli-runner/execute.ts src/agents/cli-runner/claude-live-session.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts` → clean.
- Pre-existing failures on `origin/main@cb86388cec`: `pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts` has 3 failures + 1 unhandled rejection on clean main (verified by stashing this branch and re-running). Backoff/auth-rotation assertion `expected "vi.fn()" to be called 2 times, but got 3 times`. Unrelated.

## Real behavior proof

**Behavior or issue addressed:** CLI-runtime turns silently dropping `tool_use` content blocks and `tool_result` user-messages between `cli-output.ts` and the channel preview pipeline, so Telegram's tool-progress UI never lights up for CLI-backed turns even though the underlying CLI is producing the data.

**Real environment tested:** Live OpenClaw `2026.5.7` deployment on macOS with the `claude-cli` backend driving Telegram. Same setup I used for the proof on #76914.

**Exact steps or command run after this patch:** I hand-applied this PR's three structural changes to the installed `2026.5.7` dist files (`claude-live-session-*.js`, `execute.runtime-*.js`, `agent-runner.runtime-*.js`), instrumented each layer with a tracing log, restarted the OpenClaw gateway via `launchctl kickstart -k "gui/$(id -u)/ai.openclaw.gateway"`, and sent a real Telegram turn: *"Read /etc/hosts, then read /etc/zshrc, then count their combined lines. Use Bash for the count."* — three tool calls per turn, driven through the live gateway. I also captured the parser layer in isolation by piping a real claude-cli `--output-format stream-json` JSONL fixture through the patched `createCliJsonlStreamingParser`:

```bash
echo "Run 'ls /' and tell me how many entries." \
  | claude -p --output-format stream-json --include-partial-messages \
           --verbose --setting-sources user --allowedTools Bash \
  > /tmp/claude-stream-fixture.jsonl
node --import tsx ./proof.mts
```

`proof.mts`:

```ts
import { readFileSync } from "node:fs";
import { createCliJsonlStreamingParser } from "./src/agents/cli-output.ts";
const raw = readFileSync("/tmp/claude-stream-fixture.jsonl", "utf-8");
const events: Array<{ kind: string; data: unknown }> = [];
const parser = createCliJsonlStreamingParser({
  backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
  providerId: "claude-cli",
  onAssistantDelta: () => undefined,
  onToolUseStart: (d) => events.push({ kind: "tool.start", data: d }),
  onToolResult: (d) => events.push({ kind: "tool.result", data: d }),
});
parser.push(raw); parser.finish();
for (const e of events) console.log(`${e.kind}: ${JSON.stringify(e.data)}`);
```

**Evidence after fix:** Redacted runtime logs from the live Telegram + claude-cli turn, captured directly from `~/.openclaw/logs/gateway.err.log` with the dist hand-patches in place. Each layer of the pipeline writes a `[demo-trace]` line so the chain is visible end-to-end:

```
[claude-cli stream-json record arrives on stdout]
parser → dispatchClaudeCliStreamingToolEvent type=stream_event
parser → emitToolStart name=Read toolCallId=toolu_...01 hasCallback=true
runtime onToolUseStart name=Read toolCallId=toolu_...01 runId=8be3085a-...
agent-runner BUS evt stream=tool phase=start name=Read
agent-runner forward to onToolStart hasCallback=true name=Read
[Telegram channel] PREVIEW partial-branch enabled=true suppressed=false normalized=📖 Read: from /etc/hosts
[Telegram editMessageText emitted]
```

Same chain fires for the second `Read`, then for the `Bash` call, then for tool results. The parser-isolation harness captured this terminal output for the same kind of turn driven through the real `claude` CLI:

```
Captured 2 tool events from 29 JSONL records:
  - tool.start: {"toolCallId":"toolu_01EXAMPLE","name":"Bash","args":{"command":"ls / | wc -l","description":"Count entries in root directory"}}
  - tool.result: {"toolCallId":"toolu_01EXAMPLE","name":"Bash","isError":false,"result":"      16"}
```

**Observed result after fix:** With this PR's structural change applied, my Telegram turn against the live gateway showed the bot's preview message updating with `📖 Read: from /etc/hosts`, then `📖 Read: from /etc/zshrc`, then `🛠️ Bash: ...` lines while the agent worked, before delivering the final answer — the same per-tool decoration users already see on embedded-native-runtime agents. With `streaming.mode: "progress"` the lines accumulate for the full turn; with `streaming.mode: "partial"` (the default) they flash before the streaming answer text replaces the preview, matching the existing embedded-runtime behavior. Without the patch (stock `2026.5.7`), the same prompt produces zero `[demo-trace] BUS evt stream=tool` log lines and the Telegram preview shows only the assistant text — the `onToolStart` callback the channel pipeline already exposes is never invoked because no CLI-side emitter publishes to it.

**What was not tested:** I did not exercise non-claude CLI runtimes (codex-cli, kiro-cli) against the bridge layer — those don't ship a stream-json parser in this repo, so the parser layer change doesn't apply to them. The bridge layer at `agent-runner-execution.ts` is gated by `isCliProvider(...)` and would forward any `stream: "tool"` events those runtimes might emit in the future, but that future is not exercised here. I also did not test the `phase: "result"` channel-side rendering — the bridge filters `result` to keep parity with #76914's activation-only forwarding (see Scope note above), so this PR's change is invisible to consumers that only handle `start`/`update` today.
