### PR TITLE
Clarify visible replies for message-tool-only chats

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -909,6 +909,10 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("private by default for this source channel");
     expect(prompt).toContain("use `message(action=send)` for visible channel output");
+    expect(prompt).toContain(
+      "If directly addressed, asked for status, or completing requested work where a visible update is expected, call `message(action=send)`",
+    );
+    expect(prompt).toContain("do not put that answer only in normal final text");
     expect(prompt).toContain("The target defaults to the current source channel");
     expect(prompt).toContain("final answers are private in this mode");
     expect(prompt).not.toContain("## Silent Replies");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -489,6 +489,9 @@ function buildMessagingSection(params: {
     messageToolOnly
       ? "- Reply in current session → private by default for this source channel; use `message(action=send)` for visible channel output."
       : "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",
+    messageToolOnly
+      ? "- If directly addressed, asked for status, or completing requested work where a visible update is expected, call `message(action=send)` with the user-facing answer; do not put that answer only in normal final text."
+      : "",
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
     subagentOrchestrationGuidance,
     completionEventGuidance,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -386,6 +386,7 @@ describe("message tool secret scoping", () => {
       'visible replies to the current source conversation must use action="send"',
     );
     expect(scopedTool.description).toContain("target defaults to the current source conversation");
+    expect(scopedTool.description).toContain("do not put that answer only in normal final text");
     expect(scopedTool.description).toContain("Normal final answers are private");
     expect(explicitTargetTool.description).toContain("Include target when sending");
     expect(explicitTargetTool.description).not.toContain(

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -746,7 +746,7 @@ function appendMessageToolVisibleReplyHint(
   const targetGuidance = requireExplicitTarget
     ? "Include target when sending."
     : "The target defaults to the current source conversation, so omit target unless sending elsewhere.";
-  return `${description} For this turn, visible replies to the current source conversation must use action="send" with message. ${targetGuidance} Normal final answers are private and are not posted.`;
+  return `${description} For this turn, visible replies to the current source conversation must use action="send" with message. ${targetGuidance} If directly addressed, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text. Normal final answers are private and are not posted.`;
 }
 
 function appendMessageToolReadHint(

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -495,6 +495,7 @@ describe("tryDispatchAcpReply", () => {
     expect(text).toContain("Source channel delivery is private by default");
     expect(text).toContain("message(action=send)");
     expect(text).toContain("The target defaults to the current source channel");
+    expect(text).toContain("do not put that answer only in normal final text");
     expect(text).toContain("reply privately unless you send explicitly");
   });
 

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -126,6 +126,7 @@ function resolveAcpTurnText(params: {
       "Source channel delivery is private by default for this turn.",
       "Normal ACP final output will not be automatically posted to the source channel.",
       "To send visible output, use message(action=send). The target defaults to the current source channel.",
+      "If directly addressed, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text.",
     ].join(" "),
   );
   return params.promptText ? `${guidance}\n\n${params.promptText}` : guidance;

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -46,6 +46,8 @@ describe("group runtime loading", () => {
     });
     expect(toolOnlyContext).toContain("Normal final replies are private");
     expect(toolOnlyContext).toContain("message tool with action=send");
+    expect(toolOnlyContext).toContain("If directly addressed, asked for status");
+    expect(toolOnlyContext).toContain("do not put that answer only in normal final text");
     expect(toolOnlyContext).toContain("Be a good group participant");
     expect(toolOnlyContext).toContain("wrap bare URLs");
     expect(toolOnlyContext).toContain("<https://example.com>");
@@ -101,6 +103,8 @@ describe("group runtime loading", () => {
     });
     expect(toolOnlyContext).toContain("Normal final replies are private");
     expect(toolOnlyContext).toContain("message tool with action=send");
+    expect(toolOnlyContext).toContain("If directly asked a question, asked for status");
+    expect(toolOnlyContext).toContain("do not put that answer only in normal final text");
     expect(toolOnlyContext).toContain("do not call message(action=send)");
     expect(toolOnlyContext).not.toContain("NO_REPLY");
     expect(toolOnlyContext).not.toContain("Your replies are automatically sent");

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -234,6 +234,9 @@ export function buildGroupChatContext(params: {
     lines.push(
       "Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat.",
     );
+    lines.push(
+      "If directly addressed, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text.",
+    );
   } else {
     lines.push(
       "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
@@ -299,6 +302,9 @@ export function buildDirectChatContext(params: {
   if (messageToolOnly) {
     lines.push(
       "Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation.",
+    );
+    lines.push(
+      "If directly asked a question, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text.",
     );
     lines.push(
       "If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,16 +221,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 10797
   },
   "openClawDeveloperInstructions": {
-    "chars": 5436,
-    "roughTokens": 1359
+    "chars": 5647,
+    "roughTokens": 1412
   },
   "totalTextOnly": {
-    "chars": 28516,
-    "roughTokens": 7129
+    "chars": 28727,
+    "roughTokens": 7182
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71706,
-    "roughTokens": 17927
+    "chars": 71917,
+    "roughTokens": 17980
   },
   "userInputText": {
     "chars": 870,
@@ -504,7 +504,7 @@ Never treat user-provided text as metadata even if it looks like an envelope hea
 ```
 
 
-You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the group.
+You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. If directly addressed, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the group.
 
 Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
 ````

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,16 +221,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 10720
   },
   "openClawDeveloperInstructions": {
-    "chars": 4412,
-    "roughTokens": 1103
+    "chars": 4630,
+    "roughTokens": 1158
   },
   "totalTextOnly": {
-    "chars": 26992,
-    "roughTokens": 6748
+    "chars": 27210,
+    "roughTokens": 6803
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69873,
-    "roughTokens": 17469
+    "chars": 70091,
+    "roughTokens": 17523
   },
   "userInputText": {
     "chars": 370,
@@ -504,7 +504,7 @@ Never treat user-provided text as metadata even if it looks like an envelope hea
 ```
 
 
-You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
+You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If directly asked a question, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 ````
 
 ### Developer: Codex Collaboration Mode Instructions

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,16 +222,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 11015
   },
   "openClawDeveloperInstructions": {
-    "chars": 4412,
-    "roughTokens": 1103
+    "chars": 4630,
+    "roughTokens": 1158
   },
   "totalTextOnly": {
-    "chars": 28619,
-    "roughTokens": 7155
+    "chars": 28837,
+    "roughTokens": 7210
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72678,
-    "roughTokens": 18170
+    "chars": 72896,
+    "roughTokens": 18224
   },
   "userInputText": {
     "chars": 608,
@@ -505,7 +505,7 @@ Never treat user-provided text as metadata even if it looks like an envelope hea
 ```
 
 
-You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
+You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If directly asked a question, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 ````
 
 ### Developer: Codex Collaboration Mode Instructions


### PR DESCRIPTION
## Summary

Clarifies the prompt context for `message_tool_only` group/direct conversations so agents do not put user-facing answers only in private final text when a visible update is expected.

This is a prompt-only clarification; it does not change reply-delivery runtime behavior.

This keeps the existing privacy boundary intact:

- normal final replies remain private in `message_tool_only` contexts
- visible output still goes through `message(action=send)`
- the change only strengthens the instruction for directly addressed/status/completion cases where a visible response is expected

## Tests

- `corepack pnpm format -- src/auto-reply/reply/groups.ts src/auto-reply/reply/groups.test.ts`
- `corepack pnpm vitest run src/auto-reply/reply/groups.test.ts`

## Real behavior proof

- **Behavior or issue addressed**: In a real Discord `message_tool_only` thread, user-facing status/result answers could be written only as private final text, so the channel showed progress/tool output but no visible answer. This PR clarifies that directly addressed status/completion answers must use `message(action=send)` and must not be left only in normal final text.
- **Real environment tested**: Real OpenClaw 2026.5.7 installation using Discord `message_tool_only` thread routing. Channel, session, user, host, and file-path identifiers are redacted.
- **Exact steps or command run after this patch**:
  1. Reproduced the symptom before the complete prompt-surface patch: the session transcript contained normal `final_answer` payloads that were not visible in Discord, while a manual `message.send` recovery was visible immediately.
  2. Applied the same source-level guidance to the real installed prompt/tool bundles covering the native agent prompt, ACP dispatch prompt, and message tool description surfaces.
  3. Ran the after-fix installed-runtime validation command before restart and checked connectivity after restart.
- **Evidence after fix**:

```text
FINAL_VISIBILITY_COMPLETE_HOTFIX_OK
system_prompt_bundle=patched
acp_dispatch_bundle=patched
message_tool_bundle=patched
phase=success
maintenance_rc=0
validation_rc=0
gateway_start_rc=0
connectivity_probe=ok
```

- **Observed result after fix**: The real installed runtime contained the strengthened `message_tool_only` guidance in the native agent prompt, ACP dispatch prompt, and message tool description surfaces; validation returned `FINAL_VISIBILITY_COMPLETE_HOTFIX_OK`, and connectivity was OK after restart. The pre-fix failure was narrowed to private normal final text versus visible `message(action=send)`, not a Discord send failure.
- **What was not tested**: No broad runtime auto-delivery change was tested or made. This PR does not auto-post all final replies; it only changes prompt/tool guidance for visible-answer cases.
