### PR TITLE
fix(acp): forward non-output events and surface errors after turn-timeout gate closes

### DIFF
--- a/src/acp/control-plane/manager.turn-stream.test.ts
+++ b/src/acp/control-plane/manager.turn-stream.test.ts
@@ -28,7 +28,7 @@ describe("consumeAcpTurnStream", () => {
   it("delivers all events when gate stays open", async () => {
     const received: AcpRuntimeEvent[] = [];
     const runtime = mockRuntime([
-      { type: "text_delta", text: "hello", stream: "reply" },
+      { type: "text_delta", text: "hello", stream: "output" },
       { type: "done" },
     ]);
     await consumeAcpTurnStream({
@@ -47,7 +47,7 @@ describe("consumeAcpTurnStream", () => {
     const outputReceived: AcpRuntimeEvent[] = [];
     const gate = { open: true };
     const runtime = mockRuntime([
-      { type: "text_delta", text: "before", stream: "reply" },
+      { type: "text_delta", text: "before", stream: "output" },
       { type: "done" },
     ]);
     // Close gate before stream starts

--- a/src/acp/control-plane/manager.turn-stream.test.ts
+++ b/src/acp/control-plane/manager.turn-stream.test.ts
@@ -17,7 +17,12 @@ function mockRuntime(events: AcpRuntimeEvent[]): AcpRuntime {
   } as unknown as AcpRuntime;
 }
 
-const turn = { handle: {} as AcpRuntimeHandle, text: "test" };
+const turn = {
+  handle: {} as AcpRuntimeHandle,
+  text: "test",
+  mode: "prompt" as const,
+  requestId: "req-test",
+};
 
 describe("consumeAcpTurnStream", () => {
   it("delivers all events when gate stays open", async () => {

--- a/src/acp/control-plane/manager.turn-stream.test.ts
+++ b/src/acp/control-plane/manager.turn-stream.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { AcpRuntime, AcpRuntimeEvent, AcpRuntimeHandle } from "../runtime/types.js";
+import { consumeAcpTurnStream } from "./manager.turn-stream.js";
+
+function mockRuntime(events: AcpRuntimeEvent[]): AcpRuntime {
+  return {
+    async ensureSession() {
+      return { sessionKey: "s1", backend: "acpx", runtimeSessionName: "runtime:s1" };
+    },
+    async *runTurn() {
+      for (const event of events) {
+        yield event;
+      }
+    },
+    async cancel() {},
+    async close() {},
+  } as unknown as AcpRuntime;
+}
+
+const turn = { handle: {} as AcpRuntimeHandle, text: "test" };
+
+describe("consumeAcpTurnStream", () => {
+  it("delivers all events when gate stays open", async () => {
+    const received: AcpRuntimeEvent[] = [];
+    const runtime = mockRuntime([
+      { type: "text_delta", text: "hello", stream: "reply" },
+      { type: "done" },
+    ]);
+    await consumeAcpTurnStream({
+      runtime,
+      turn,
+      eventGate: { open: true },
+      onEvent: (e) => void received.push(e),
+    });
+    expect(received).toHaveLength(2);
+    expect(received[0]).toMatchObject({ type: "text_delta" });
+    expect(received[1]).toMatchObject({ type: "done" });
+  });
+
+  it("delivers non-output events to onEvent after gate closes", async () => {
+    const received: AcpRuntimeEvent[] = [];
+    const outputReceived: AcpRuntimeEvent[] = [];
+    const gate = { open: true };
+    const runtime = mockRuntime([
+      { type: "text_delta", text: "before", stream: "reply" },
+      { type: "done" },
+    ]);
+    // Close gate before stream starts
+    gate.open = false;
+    await consumeAcpTurnStream({
+      runtime,
+      turn,
+      eventGate: gate,
+      onEvent: (e) => void received.push(e),
+      onOutputEvent: (e) => void outputReceived.push(e),
+    });
+    // onEvent receives events even after gate closes
+    expect(received).toHaveLength(2);
+    // onOutputEvent is skipped when gate is closed
+    expect(outputReceived).toHaveLength(0);
+  });
+
+  it("surfaces error events arriving after gate closes", async () => {
+    const gate = { open: true };
+    const runtime = mockRuntime([
+      { type: "error", code: "ACP_TURN_FAILED", message: "runtime error after timeout" },
+    ]);
+    gate.open = false;
+    await expect(consumeAcpTurnStream({ runtime, turn, eventGate: gate })).rejects.toMatchObject({
+      message: "runtime error after timeout",
+    });
+  });
+
+  it("surfaces error events arriving before gate closes", async () => {
+    const runtime = mockRuntime([
+      { type: "error", code: "ACP_TURN_FAILED", message: "turn error" },
+    ]);
+    await expect(
+      consumeAcpTurnStream({ runtime, turn, eventGate: { open: true } }),
+    ).rejects.toMatchObject({ message: "turn error" });
+  });
+
+  it("returns sawTerminalEvent=true when done event arrives while gate is open", async () => {
+    const runtime = mockRuntime([{ type: "done" }]);
+    const outcome = await consumeAcpTurnStream({
+      runtime,
+      turn,
+      eventGate: { open: true },
+    });
+    expect(outcome.sawTerminalEvent).toBe(true);
+  });
+});

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -27,6 +27,15 @@ export async function consumeAcpTurnStream(params: {
 
   for await (const event of params.runtime.runTurn(params.turn)) {
     if (!params.eventGate.open) {
+      // Gate closed by timeout: still deliver non-output events so callers can
+      // observe errors and terminal signals that cross the deadline boundary.
+      await params.onEvent?.(event);
+      if (event.type === "error") {
+        streamError = new AcpRuntimeError(
+          normalizeAcpErrorCode(event.code),
+          normalizeText(event.message) || "ACP turn failed before completion.",
+        );
+      }
       continue;
     }
     if (event.type === "done") {
@@ -43,7 +52,7 @@ export async function consumeAcpTurnStream(params: {
     await params.onEvent?.(event);
   }
 
-  if (params.eventGate.open && streamError) {
+  if (streamError) {
     throw streamError;
   }
 

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -237,6 +237,13 @@
       "kind": "object-property",
       "name": "label",
       "path": "ui/src/ui/chat/grouped-render.ts",
+      "text": "Tool output"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/chat/grouped-render.ts",
       "text": "Unknown date"
     },
     {


### PR DESCRIPTION
## Problem

fix(acp): forward non-output events and surface errors after turn-timeout gate closes

## Real behavior proof

- **Behavior or issue addressed:** `consumeAcpTurnStream` silently discarded all events (including `error` and `done` signals) when the `eventGate` was closed after turn-timeout. Callers lost recovery information; errors captured post-gate were swallowed and the function returned normally.
- **Real environment tested:** Local checkout of openclaw main (2026.5.10), Node 22, `pnpm vitest run src/acp/control-plane/manager.turn-stream.test.ts`.
- **Exact steps or command run after this patch:**
  ```
  pnpm vitest run src/acp/control-plane/manager.turn-stream.test.ts
  ```
- **Evidence after fix:**
  ```
$ pnpm vitest run src/acp/control-plane/manager.turn-stream.test.ts
 ✓ src/acp/control-plane/manager.turn-stream.test.ts (5 tests)

Test Files  1 passed (1)
     Tests  5 passed (5)
```
Tests cover: normal delivery when gate open, `onEvent` delivery after gate closes, `onOutputEvent` skipped after gate closes, error events after gate-close thrown (not swallowed), error before gate-close thrown, `sawTerminalEvent` set on `done`. All 5 pass.
- **Observed result after fix:** 5/5 tests pass. Post-gate `onEvent` callbacks fire for non-output events; post-gate `error` events are captured into `streamError` and re-thrown; the `params.eventGate.open` guard on the final throw is removed.
- **What was not tested:** Live ACP turn with a real network timeout mid-stream — this is unit-tested with a mock event gate and event source.
