### PR TITLE
fix(acpx): ignore Gemini ACP timeout controls

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -475,36 +475,39 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
-  it("ignores unsupported Gemini ACP timeout config controls", async () => {
-    const baseStore: TestSessionStore = {
-      load: vi.fn(async () => ({
+  it.each(["gemini --acp", "gemini --experimental-acp"])(
+    "ignores unsupported Gemini ACP timeout config controls for %s",
+    async (agentCommand) => {
+      const baseStore: TestSessionStore = {
+        load: vi.fn(async () => ({
+          acpxRecordId: "agent:gemini:acp:test",
+          agentCommand,
+        })),
+        save: vi.fn(async () => {}),
+      };
+      const { runtime, delegate } = makeRuntime(baseStore);
+      const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+      const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+        sessionKey: "agent:gemini:acp:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:gemini:acp:test",
         acpxRecordId: "agent:gemini:acp:test",
-        agentCommand: "gemini --acp",
-      })),
-      save: vi.fn(async () => {}),
-    };
-    const { runtime, delegate } = makeRuntime(baseStore);
-    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
-    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
-      sessionKey: "agent:gemini:acp:test",
-      backend: "acpx",
-      runtimeSessionName: "agent:gemini:acp:test",
-      acpxRecordId: "agent:gemini:acp:test",
-    };
+      };
 
-    await runtime.setConfigOption({
-      handle,
-      key: "timeout",
-      value: "60000",
-    });
-    await runtime.setConfigOption({
-      handle,
-      key: "Timeout_Seconds",
-      value: "60",
-    });
+      await runtime.setConfigOption({
+        handle,
+        key: "timeout",
+        value: "60000",
+      });
+      await runtime.setConfigOption({
+        handle,
+        key: "Timeout_Seconds",
+        value: "60",
+      });
 
-    expect(setConfigOption).not.toHaveBeenCalled();
-  });
+      expect(setConfigOption).not.toHaveBeenCalled();
+    },
+  );
 
   it("forwards timeout config controls for non-Codex and non-Gemini ACP agents", async () => {
     const baseStore: TestSessionStore = {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -475,7 +475,38 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
-  it("forwards timeout config controls for non-Codex ACP agents", async () => {
+  it("ignores unsupported Gemini ACP timeout config controls", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:gemini:acp:test",
+        agentCommand: "gemini --acp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:gemini:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:gemini:acp:test",
+      acpxRecordId: "agent:gemini:acp:test",
+    };
+
+    await runtime.setConfigOption({
+      handle,
+      key: "timeout",
+      value: "60000",
+    });
+    await runtime.setConfigOption({
+      handle,
+      key: "Timeout_Seconds",
+      value: "60",
+    });
+
+    expect(setConfigOption).not.toHaveBeenCalled();
+  });
+
+  it("forwards timeout config controls for non-Codex and non-Gemini ACP agents", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:claude:acp:test",

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -390,6 +390,22 @@ function isCodexAcpCommand(command: string | undefined): boolean {
   return /^codex-acp(?:-wrapper)?(?:\.[cm]?js)?$/i.test(scriptName);
 }
 
+function isGeminiAcpCommand(command: string | undefined): boolean {
+  if (!command) {
+    return false;
+  }
+  const parts = unwrapEnvCommand(splitCommandParts(command.trim()));
+  if (!parts.length) {
+    return false;
+  }
+  const commandName = basename(parts[0] ?? "");
+  return /^gemini(?:\.exe)?$/i.test(commandName) && parts.some((part) => part === "--acp");
+}
+
+function shouldIgnoreTimeoutConfigOption(command: string | undefined): boolean {
+  return isCodexAcpCommand(command) || isGeminiAcpCommand(command);
+}
+
 function failUnsupportedCodexAcpModel(rawModel: string, detail?: string): never {
   throw new AcpRuntimeError(
     "ACP_INVALID_RUNTIME_OPTION",
@@ -889,10 +905,12 @@ export class AcpxRuntime implements AcpRuntime {
     const delegate = await this.resolveDelegateForHandle(input.handle);
     const command = await this.resolveCommandForHandle(input.handle);
     const key = input.key.trim().toLowerCase();
-    if (isCodexAcpCommand(command)) {
-      if (key === "timeout" || key === "timeout_seconds") {
+    if (key === "timeout" || key === "timeout_seconds") {
+      if (shouldIgnoreTimeoutConfigOption(command)) {
         return;
       }
+    }
+    if (isCodexAcpCommand(command)) {
       if (
         key === "model" ||
         key === "thinking" ||

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -399,7 +399,10 @@ function isGeminiAcpCommand(command: string | undefined): boolean {
     return false;
   }
   const commandName = basename(parts[0] ?? "");
-  return /^gemini(?:\.exe)?$/i.test(commandName) && parts.some((part) => part === "--acp");
+  return (
+    /^gemini(?:\.exe)?$/i.test(commandName) &&
+    parts.some((part) => part === "--acp" || part === "--experimental-acp")
+  );
 }
 
 function shouldIgnoreTimeoutConfigOption(command: string | undefined): boolean {


### PR DESCRIPTION
## Summary

Gemini ACP currently does not support `session/set_config_option` for timeout controls. When OpenClaw applies persisted ACP runtime options before a turn, that unsupported timeout control can fail the Gemini lane before prompt execution.

This mirrors the existing Codex ACP behavior and treats Gemini `timeout` / `timeout_seconds` config controls as no-ops at the OpenClaw ACPX adapter boundary. Other config controls and other ACP agents continue to be forwarded normally.

## Real behavior proof

- **Behavior or issue addressed:** Gemini ACP timeout config controls should be ignored by OpenClaw's ACPX adapter instead of being forwarded as unsupported `session/set_config_option` calls.
- **Real environment tested:** Disposable OpenClaw source checkout on Linux using the real ACPX runtime class and a staged Gemini ACP command record (`gemini --acp`). No production Gateway, production session store, or live runtime state was used.
- **Exact steps or command run after this patch:** Ran a standalone stage smoke that creates an ACPX runtime with a Gemini ACP session record, calls `setConfigOption` for `timeout`, `Timeout_Seconds`, and a non-timeout option, and records what reaches the delegate.
- **Evidence after fix:** Terminal capture from the stage smoke:

```text
ACPX_GEMINI_TIMEOUT_NOOP_STAGE_OK
gemini_timeout_forwarded=false
gemini_timeout_seconds_forwarded=false
non_timeout_option_forwarded=true
```

- **Observed result after fix:** The Gemini timeout controls were no-oped before delegate forwarding, while an unrelated config option still reached the delegate. This confirms the adapter boundary change is scoped to unsupported Gemini timeout controls.
- **What was not tested:** I did not run a credentialed external Gemini model turn from this maintenance environment. The proof exercises the OpenClaw ACPX adapter seam with a staged Gemini ACP command record, not the remote Gemini service.

## Tests

- `corepack pnpm format -- extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts`
- `corepack pnpm vitest run extensions/acpx/src/runtime.test.ts -t "timeout config"`
- Stage smoke captured above: `node --import tsx <stage-smoke-script>`
