### PR TITLE
fix(logging): exit on stdout/stderr EPIPE instead of spinning

### DIFF
--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -198,6 +198,24 @@ describe("enableConsoleCapture", () => {
     }
   });
 
+  it("preserves an existing nonzero exit code on async EPIPE", () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as typeof process.exit);
+    const originalExitCode = process.exitCode;
+    try {
+      process.exitCode = 2;
+      setLoggerOverride({ level: "info", file: tempLogPath() });
+      loggingState.streamErrorHandlersInstalled = false;
+      enableConsoleCapture();
+      const epipe = new Error("write EPIPE") as NodeJS.ErrnoException;
+      epipe.code = "EPIPE";
+      process.stderr.emit("error", epipe);
+      expect(exitSpy).toHaveBeenCalledWith(2);
+    } finally {
+      process.exitCode = originalExitCode;
+      exitSpy.mockRestore();
+    }
+  });
+
   it("rethrows non-EPIPE errors on stdout", () => {
     setLoggerOverride({ level: "info", file: tempLogPath() });
     enableConsoleCapture();

--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -183,12 +183,19 @@ describe("enableConsoleCapture", () => {
   it.each([
     { name: "stdout", stream: process.stdout },
     { name: "stderr", stream: process.stderr },
-  ])("swallows async EPIPE on $name", ({ stream }) => {
-    setLoggerOverride({ level: "info", file: tempLogPath() });
-    enableConsoleCapture();
-    const epipe = new Error("write EPIPE") as NodeJS.ErrnoException;
-    epipe.code = "EPIPE";
-    expect(stream.emit("error", epipe)).toBe(true);
+  ])("exits on async EPIPE on $name", ({ stream }) => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as typeof process.exit);
+    try {
+      setLoggerOverride({ level: "info", file: tempLogPath() });
+      loggingState.streamErrorHandlersInstalled = false;
+      enableConsoleCapture();
+      const epipe = new Error("write EPIPE") as NodeJS.ErrnoException;
+      epipe.code = "EPIPE";
+      stream.emit("error", epipe);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 
   it("rethrows non-EPIPE errors on stdout", () => {

--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -172,12 +172,19 @@ describe("enableConsoleCapture", () => {
   it.each([
     { name: "stdout", stream: process.stdout },
     { name: "stderr", stream: process.stderr },
-  ])("swallows async EPIPE on $name", ({ stream }) => {
-    setLoggerOverride({ level: "info", file: tempLogPath() });
-    enableConsoleCapture();
-    const epipe = new Error("write EPIPE") as NodeJS.ErrnoException;
-    epipe.code = "EPIPE";
-    expect(stream.emit("error", epipe)).toBe(true);
+  ])("exits on async EPIPE on $name", ({ stream }) => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as typeof process.exit);
+    try {
+      setLoggerOverride({ level: "info", file: tempLogPath() });
+      loggingState.streamErrorHandlersInstalled = false;
+      enableConsoleCapture();
+      const epipe = new Error("write EPIPE") as NodeJS.ErrnoException;
+      epipe.code = "EPIPE";
+      stream.emit("error", epipe);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 
   it("rethrows non-EPIPE errors on stdout", () => {

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -198,6 +198,10 @@ export function enableConsoleCapture(): void {
     for (const stream of [process.stdout, process.stderr]) {
       stream.on("error", (err) => {
         if (isEpipeError(err)) {
+          // stdout/stderr broken means the process is orphaned (e.g. the parent
+          // service restarted and closed the journal pipe). Exit cleanly instead
+          // of spinning in a tight loop where every log attempt re-triggers EPIPE.
+          process.exit(0);
           return;
         }
         throw err;

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -202,7 +202,7 @@ export function enableConsoleCapture(): void {
           // service restarted and closed the journal pipe). Exit cleanly instead
           // of spinning in a tight loop where every log attempt re-triggers EPIPE.
           const exitCode = process.exitCode;
-          process.exit(typeof exitCode === "number" && exitCode !== 0 ? exitCode : 0);
+          process.exit(exitCode !== undefined && exitCode !== 0 && exitCode !== "0" ? exitCode : 0);
           return;
         }
         throw err;

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -201,7 +201,8 @@ export function enableConsoleCapture(): void {
           // stdout/stderr broken means the process is orphaned (e.g. the parent
           // service restarted and closed the journal pipe). Exit cleanly instead
           // of spinning in a tight loop where every log attempt re-triggers EPIPE.
-          process.exit(0);
+          const exitCode = process.exitCode;
+          process.exit(typeof exitCode === "number" && exitCode !== 0 ? exitCode : 0);
           return;
         }
         throw err;


### PR DESCRIPTION
## Summary

- When the gateway process is orphaned after a systemd service restart, the parent's journal pipe closes and every write to stdout/stderr returns `EPIPE`
- The previous stream error handler swallowed it with a bare `return`, so background loops (chokidar config file watcher, etc.) kept firing and the process spun at ~100% CPU indefinitely — confirmed via `strace`: 6,000 `faccessat` calls/sec + failing `write` to fd 2 in a tight loop
- Exit cleanly with code 0 instead — a process whose own output streams are broken has nowhere to log and no reason to keep running

## Changes

- `src/logging/console.ts`: stream error handler now calls `process.exit(0)` on EPIPE/EIO for stdout/stderr instead of swallowing
- `src/logging/console-capture.test.ts`: updated test from `"swallows async EPIPE"` → `"exits on async EPIPE"`, mocks `process.exit` and asserts it is called with `0`

## Real behavior proof

**Behavior or issue addressed**: After `systemctl --user restart openclaw-gateway`, the previous worker process is orphaned — its stdout/stderr pipe to journald closes. Every log attempt returned EPIPE, which was swallowed, so the chokidar config-file watcher kept looping at ~100% CPU indefinitely. The process ignored SIGTERM and had to be killed with `kill -9`.

**Real environment tested**: Raspberry Pi 5 (arm64, Raspberry Pi OS Bookworm), Node 22, `openclaw-gateway.service` systemd user service, gateway built from this branch.

**Exact steps or command run after this patch**:
1. Applied fix, rebuilt with `pnpm build`
2. `systemctl --user restart openclaw-gateway`
3. `pgrep -a node | grep 'dist/index.js gateway'`

**Evidence after fix**:

Before fix — strace on orphaned process PID 2505087 showed tight EPIPE loop:

```
$ sudo strace -p 2505087 -e trace=faccessat,write
faccessat(AT_FDCWD, "/home/pavel/.openclaw", F_OK) = 0
faccessat(AT_FDCWD, "/home/pavel/.openclaw/openclaw.json", F_OK) = 0
write(2, "...", 64)                     = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER} ---
faccessat(AT_FDCWD, "/home/pavel/.openclaw", F_OK) = 0
faccessat(AT_FDCWD, "/home/pavel/.openclaw/openclaw.json", F_OK) = 0
write(2, "...", 64)                     = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER} ---
[repeating ~6000 syscalls/sec, process at 99.8% CPU]
```

After fix — only the new worker remains after restart:

```
$ pgrep -a node | grep 'dist/index.js gateway'
3142891 node /home/pavel/openclaw/openclaw/dist/index.js gateway --port 18789
```

**Observed result after fix**: Single gateway process after service restart. No orphaned process accumulates CPU. `top` shows stable <5% CPU at idle. No need for `kill -9`.

**What was not tested**: Windows and macOS — both use stdout/stderr differently (no systemd journal pipe). The EPIPE scenario is Linux-specific but `process.exit(0)` on a broken output stream is safe on all platforms.
