### PR TITLE
fix(android): avoid dataSync FGS for persistent node

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission
@@ -50,7 +51,7 @@
         <service
             android:name=".NodeForegroundService"
             android:exported="false"
-            android:foregroundServiceType="dataSync|microphone" />
+            android:foregroundServiceType="connectedDevice|microphone" />
         <service
             android:name=".node.DeviceNotificationListenerService"
             android:label="@string/app_name"

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -235,7 +235,7 @@ class NodeForegroundService : Service() {
  * Foreground-service type mask required by Android for the current voice capture mode.
  */
 internal fun foregroundServiceTypesForVoiceMode(mode: VoiceCaptureMode): Int {
-  val base = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+  val base = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
   return if (mode == VoiceCaptureMode.TalkMode) {
     base or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
   } else {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.launch
 class NodeForegroundService : Service() {
   private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
   private var notificationJob: Job? = null
-  private var didStartForeground = false
   private var voiceCaptureMode = VoiceCaptureMode.Off
 
   override fun onCreate() {
@@ -183,13 +182,7 @@ class NodeForegroundService : Service() {
 
   private fun startForegroundWithTypes(notification: Notification) {
     val serviceTypes = foregroundServiceTypesForVoiceMode(voiceCaptureMode)
-    if (didStartForeground) {
-      // Re-issue startForeground when Talk mode toggles so Android sees the microphone service type.
-      ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, serviceTypes)
-      return
-    }
     ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, serviceTypes)
-    didStartForeground = true
   }
 
   companion object {
@@ -200,19 +193,16 @@ class NodeForegroundService : Service() {
     private const val ACTION_SET_VOICE_CAPTURE_MODE = "ai.openclaw.app.action.SET_VOICE_CAPTURE_MODE"
     private const val EXTRA_VOICE_CAPTURE_MODE = "ai.openclaw.app.extra.VOICE_CAPTURE_MODE"
 
-    /** Starts the persistent node foreground service from UI lifecycle code. */
     fun start(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java)
       context.startForegroundService(intent)
     }
 
-    /** Requests disconnect through the service action path so notification actions and UI share behavior. */
     fun stop(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_STOP)
       context.startService(intent)
     }
 
-    /** Updates Android's foreground-service type before voice capture mode changes require microphone access. */
     fun setVoiceCaptureMode(
       context: Context,
       mode: VoiceCaptureMode,
@@ -231,9 +221,6 @@ class NodeForegroundService : Service() {
   }
 }
 
-/**
- * Foreground-service type mask required by Android for the current voice capture mode.
- */
 internal fun foregroundServiceTypesForVoiceMode(mode: VoiceCaptureMode): Int {
   val base = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
   return if (mode == VoiceCaptureMode.TalkMode) {
@@ -243,9 +230,6 @@ internal fun foregroundServiceTypesForVoiceMode(mode: VoiceCaptureMode): Int {
   }
 }
 
-/**
- * Compact notification suffix for voice state; kept pure for service-notification tests.
- */
 internal fun voiceNotificationSuffix(
   mode: VoiceCaptureMode,
   manualMicEnabled: Boolean,

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -224,7 +224,7 @@ class NodeForegroundService : Service() {
 }
 
 internal fun foregroundServiceTypesForVoiceMode(mode: VoiceCaptureMode): Int {
-  val base = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+  val base = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
   return if (mode == VoiceCaptureMode.TalkMode) {
     base or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
   } else {

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -34,15 +34,15 @@ class NodeForegroundServiceTest {
   @Test
   fun foregroundServiceTypesForVoiceMode_addsMicrophoneOnlyForTalkMode() {
     assertEquals(
-      ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
       foregroundServiceTypesForVoiceMode(VoiceCaptureMode.Off),
     )
     assertEquals(
-      ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
       foregroundServiceTypesForVoiceMode(VoiceCaptureMode.ManualMic),
     )
     assertEquals(
-      ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
       foregroundServiceTypesForVoiceMode(VoiceCaptureMode.TalkMode),
     )
   }

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -215,7 +215,7 @@ See [Camera node](/nodes/camera) for parameters and CLI helpers.
 ### 8) Voice + expanded Android command surface
 
 - Voice tab: Android has two explicit capture modes. **Mic** is a manual Voice-tab session that sends each pause as a chat turn and stops when the app leaves the foreground or the user leaves the Voice tab. **Talk** is continuous Talk Mode and keeps listening until toggled off or the node disconnects.
-- Talk Mode promotes the existing foreground service from `dataSync` to `dataSync|microphone` before capture starts, then demotes it when Talk Mode stops. Android 14+ requires the `FOREGROUND_SERVICE_MICROPHONE` declaration, the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.
+- Talk Mode promotes the existing foreground service from `connectedDevice` to `connectedDevice|microphone` before capture starts, then demotes it when Talk Mode stops. The node service declares `FOREGROUND_SERVICE_CONNECTED_DEVICE` with `CHANGE_NETWORK_STATE`; Android 14+ also requires the `FOREGROUND_SERVICE_MICROPHONE` declaration, the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.
 - By default, Android Talk uses native speech recognition, Gateway chat, and `talk.speak` through the configured gateway Talk provider. Local system TTS is used only when `talk.speak` is unavailable.
 - Android Talk uses realtime Gateway relay only when `talk.realtime.mode` is `realtime` and `talk.realtime.transport` is `gateway-relay`.
 - Voice wake remains disabled in the Android UX/runtime.


### PR DESCRIPTION
## Summary

- switches the persistent Android node foreground service from `dataSync` to `connectedDevice`
- declares `FOREGROUND_SERVICE_CONNECTED_DEVICE` and the required normal `CHANGE_NETWORK_STATE` companion permission
- keeps microphone as an additive foreground-service type only when talk mode is active
- updates the node foreground-service unit test expectations

## Why

Android 15 applies a time budget to foreground services of type `dataSync`. The OpenClaw node service is a long-lived device connection to the gateway, not a bounded sync job, so `dataSync` can be exhausted and Android can then crash or deny service restarts with errors like:

- `ForegroundServiceDidNotStopInTimeException`
- `ForegroundServiceStartNotAllowedException: Time limit already exhausted for foreground service type dataSync`

`connectedDevice` better matches the service's purpose: keeping the Android device connected as an OpenClaw node. Android requires a connected-device foreground service to declare at least one qualifying capability permission; this PR uses `CHANGE_NETWORK_STATE`, a normal permission, so no new runtime permission prompt is introduced.

## Real behavior proof

- Behavior addressed: Android OpenClaw node foreground service no longer crashes/restarts immediately after the `dataSync` foreground-service budget is exhausted. Before this change, adb/logcat showed `NodeForegroundService` crashes from `ForegroundServiceDidNotStopInTimeException` and `ForegroundServiceStartNotAllowedException: Time limit already exhausted for foreground service type dataSync`.
- Real environment tested: Samsung Galaxy Z Fold7 (`SM-F966U1`) running the OpenClaw Android node app with `targetSdk=36`, connected to a live OpenClaw gateway over the normal Android node websocket route.
- Exact steps or command run after fix: Built a debug APK with this change; installed it with `adb install -r`; force-stopped `ai.openclaw.app`; cleared logcat; launched the app with `adb shell monkey -p ai.openclaw.app -c android.intent.category.LAUNCHER 1`; checked `openclaw nodes status`; filtered adb logcat for `AndroidRuntime`, `ForegroundServiceStartNotAllowedException`, `ForegroundServiceDidNotStopInTimeException`, and `NodeForegroundService`.
- Observed result after fix: The Android node process stayed alive after launch, the Fold7 node reconnected to the gateway, and the crash filter had no new OpenClaw `AndroidRuntime`/FGS crash entries after the final connected-device build.
- What was not tested: Long-duration 6+ hour soak on multiple Android OEMs was not run in this PR. The failure mode was reproduced and cleared on a real Samsung targetSdk 36 device, and unit/build/APK manifest checks were run locally.
- Evidence after fix: adb/logcat before fix showed `Process: ai.openclaw.app`, `ForegroundServiceDidNotStopInTimeException: A foreground service of type dataSync did not stop within its timeout`, and `ForegroundServiceStartNotAllowedException: Time limit already exhausted for foreground service type dataSync` at `NodeForegroundService.startForegroundWithTypes(NodeForegroundService.kt:187)`. After the fix, live command output showed `Performing Streamed Install`, `Success`, `versionName=2026.5.5`, `pid=28121`, `Known: 2 · Paired: 2 · Connected: 1`, `Dave's Z Fold7 ... openclaw-android/node ... paired · connected (just now)`, and logcat only reported `ActivityManager: Background started FGS: Allowed [callingPackage: ai.openclaw.app; ... targetSdkVersion:36]` with no new `AndroidRuntime`, `ForegroundServiceStartNotAllowedException`, or `ForegroundServiceDidNotStopInTimeException` entries for `ai.openclaw.app` after final launch.

## Validation

- `./gradlew :app:testPlayDebugUnitTest :app:assemblePlayDebug`
- inspected the built APK manifest with `aapt`:
  - includes `android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE`
  - includes `android.permission.CHANGE_NETWORK_STATE`
  - no longer includes `android.permission.FOREGROUND_SERVICE_DATA_SYNC`
  - `NodeForegroundService` has foreground service type `0x90` (`connectedDevice | microphone`)