### PR TITLE
fix(agents): suppress raw subagent tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/subagents: stop completion announces from falling back to raw child tool output when no assistant text was produced. Fixes #79986. Thanks @blaspat and @dudaefj.
 - OpenAI/realtime voice: accept Codex-compatible legacy audio and transcript event aliases so provider protocol drift does not drop assistant audio or captions.
 - Discord/voice: keep default agent-proxy realtime sessions from auto-speaking filler before the forced OpenClaw consult answer, finish Discord playback on realtime response completion, and queue later exact-speech answers until playback idles to avoid mid-sentence replacement.
 - Gateway: return deterministic `400 invalid_request_error` responses for malformed encoded session-kill HTTP paths instead of letting route-shaped requests fall through to later Gateway handlers. (#72439) Thanks @rubencu.

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -257,7 +257,7 @@ openclaw tasks notify <lookup> state_changes
     - Subagent completion best-effort closes tracked browser tabs/processes for the child session before announce cleanup continues.
     - Isolated cron completion best-effort closes tracked browser tabs/processes for the cron session before the run fully tears down.
     - Isolated cron delivery waits out descendant subagent follow-up when needed and suppresses stale parent acknowledgement text instead of announcing it.
-    - Subagent completion delivery prefers the latest visible assistant text; if that is empty it falls back to sanitized latest tool/toolResult text, and timeout-only tool-call runs can collapse to a short partial-progress summary. Terminal failed runs announce failure status without replaying captured reply text.
+    - Subagent completion delivery prefers the latest visible assistant text; if that is empty it reports `(no output)`, and timeout-only tool-call runs can collapse to a short partial-progress summary. Terminal failed runs announce failure status without replaying captured reply text.
     - Cleanup failures do not mask the real task outcome.
 
     When applying maintenance, OpenClaw also removes stale `cron:<jobId>:run:<uuid>` session registry rows older than 7 days, while preserving rows for currently running cron jobs and leaving non-cron session rows untouched.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -96,7 +96,7 @@ requester chat when the run finishes.
     The completion handoff to the requester session is runtime-generated
     internal context (not user-authored text) and includes:
 
-    - `Result` — latest visible `assistant` reply text, otherwise sanitized latest tool/toolResult text. Terminal failed runs do not reuse captured reply text.
+    - `Result` — latest visible `assistant` reply text, otherwise `(no output)`. Terminal failed runs do not reuse captured reply text.
     - `Status` — `completed successfully` / `failed` / `timed out` / `unknown`.
     - Compact runtime/token stats.
     - A delivery instruction telling the requester agent to rewrite in normal assistant voice (not forward raw internal metadata).
@@ -486,7 +486,7 @@ Announce context is normalized to a stable internal event block:
 | Session ids    | Child session key/id                                                                                          |
 | Type           | Announce type + task label                                                                                    |
 | Status         | Derived from runtime outcome (`success`, `error`, `timeout`, or `unknown`) — **not** inferred from model text |
-| Result content | Latest visible assistant text, otherwise sanitized latest tool/toolResult text                                |
+| Result content | Latest visible assistant text; `(no output)` if no assistant text is available                                |
 | Follow-up      | Instruction describing when to reply vs stay silent                                                           |
 
 Terminal failed runs report failure status without replaying captured

--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -104,6 +104,40 @@ describe("readSubagentOutput", () => {
       "Mapped the code path.",
     );
   });
+
+  it("does not return raw tool-only history as completion output", async () => {
+    const deps = installOutputDeps({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "" }],
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "raw grep output" }],
+        },
+      ],
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
+    expect(deps.readLatestAssistantReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to post-compaction assistant reply instead of raw tool output", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "tool",
+          content: [{ type: "text", text: "raw exec output" }],
+        },
+      ],
+      latestAssistantReply: "post-compaction final answer",
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBe(
+      "post-compaction final answer",
+    );
+  });
 });
 
 describe("buildChildCompletionFindings", () => {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -301,7 +301,12 @@ function selectSubagentOutputText(
   if (partialProgress) {
     return partialProgress;
   }
-  return snapshot.latestRawText;
+  // Do not fall through to snapshot.latestRawText: raw tool output is not
+  // user-facing content and must not be delivered as completion text. If no
+  // assistant-produced text is available, the caller should fall back to
+  // readLatestAssistantReply (post-compaction result) or synthesize a bounded
+  // failure summary.
+  return undefined;
 }
 
 export async function readSubagentOutput(

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -607,7 +607,7 @@ describe("subagent announce formatting", () => {
     { role: "toolResult", toolOutput: "tool output line 1", childRunId: "run-tool-fallback-1" },
     { role: "tool", toolOutput: "tool output line 2", childRunId: "run-tool-fallback-2" },
   ] as const)(
-    "falls back to latest $role output when assistant reply is empty",
+    "uses no-output fallback for $role-only history when assistant reply is empty",
     async (testCase) => {
       chatHistoryMock.mockResolvedValueOnce({
         messages: [
@@ -634,7 +634,8 @@ describe("subagent announce formatting", () => {
 
       const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
       const msg = call?.params?.message as string;
-      expect(msg).toContain(testCase.toolOutput);
+      expect(msg).toContain("(no output)");
+      expect(msg).not.toContain(testCase.toolOutput);
     },
   );
 
@@ -1992,7 +1993,7 @@ describe("subagent announce formatting", () => {
     expect(msg).not.toContain("old tool output");
   });
 
-  it("falls back to latest tool output for completion-mode when assistant output is empty", async () => {
+  it("uses no-output fallback for completion-mode when assistant output is empty", async () => {
     chatHistoryMock.mockResolvedValueOnce({
       messages: [
         {
@@ -2022,7 +2023,8 @@ describe("subagent announce formatting", () => {
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
     const msg = call?.params?.message as string;
-    expect(msg).toContain("tool output only");
+    expect(msg).toContain("(no output)");
+    expect(msg).not.toContain("tool output only");
   });
 
   it("ignores user text when deriving fallback completion output", async () => {


### PR DESCRIPTION
## Summary

- Closes #79986
- Replaces #80049 with the maintainer patch for the same reported behavior
- [x] This PR fixes a bug or regression

This keeps the correct core fix from #80049: `selectSubagentOutputText()` must not fall through to `snapshot.latestRawText` when a child subagent produced only tool/toolResult output. Tool output is not user-facing completion text, so the requester session should receive `(no output)` or a post-compaction assistant reply instead of raw command/search output.

The replacement also fixes the gaps in #80049:

- updates both public docs pages that described sanitized tool/toolResult fallback
- adds direct regression coverage for `readSubagentOutput()`
- strengthens announce-format e2e assertions to prove raw tool text is absent
- adds a changelog entry with contributor and reporter credit
- includes fresh Crabbox proof from a real Linux Testbox run

## Verification

- `pnpm test src/agents/subagent-announce-output.test.ts src/agents/subagent-announce.format.e2e.test.ts src/agents/subagent-announce-delivery.test.ts src/gateway/server-methods/agent.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/automation/tasks.md docs/tools/subagents.md src/agents/subagent-announce-output.ts src/agents/subagent-announce-output.test.ts src/agents/subagent-announce.format.e2e.test.ts`
- Crabbox/Testbox `tbx_01kr83we61rvr3xjxxbtdme3x2`, workflow run https://github.com/openclaw/openclaw/actions/runs/25620248580

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Subagent completion announce could select raw child `tool`/`toolResult` content as completion text when no assistant-produced text existed. In Telegram this can surface code/search/exec dumps from the child transcript. This PR makes tool-only histories produce no selected completion output, so the existing announce fallback reports `(no output)` instead of leaking raw tool text.
- Real environment tested: Blacksmith Testbox via Crabbox, Linux runner, Node 24.13.0, repo branch `maint/subagent-no-raw-output` synced from this PR checkout.
- Exact steps or command run after this patch: Ran `/Users/steipete/Projects/crabbox/bin/crabbox run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json --shell -- '<probe tool-only child history>; oxfmt --check; targeted pnpm test ...'`. The probe imports `src/agents/subagent-announce-output.ts`, stubs Gateway `chat.history` with assistant-empty + `toolResult: raw grep output`, calls `readSubagentOutput("agent:main:subagent:child")`, and fails if the result contains raw tool output or returns any non-undefined text.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Crabbox/Testbox terminal capture from `tbx_01kr83we61rvr3xjxxbtdme3x2`, workflow run https://github.com/openclaw/openclaw/actions/runs/25620248580:

```text
{"scenario":"replacement-tool-only-subagent-output","result":null,"leaked":false}
Checking formatting...
All matched files use the correct format.
[test] passed 3 Vitest shards in 15.91s
blacksmith run summary sync=delegated command=1m2.483s total=1m4.837s exit=0
```

Pre-fix comparison from Crabbox/Testbox `tbx_01kr83fbqn923dkp3zja0stp6d`:

```text
{"scenario":"prefix-tool-only-subagent-output","result":"raw grep output","leaked":true}
```

- Observed result after fix: Tool-only subagent completion history no longer returns raw tool output from `readSubagentOutput()`. The Crabbox probe result is `null`/undefined with `leaked:false`, and the announce-format tests verify requester completion handoff contains `(no output)` and does not contain the raw tool text.
- What was not tested: A live Telegram bot DM was not exercised. The tested path covers the runtime selector that fed raw child tool text into subagent completion announces; the separate duplicate parent progress symptom in #79986 is not claimed fixed by this PR.
- Before evidence (optional but encouraged): Pre-fix Crabbox/Testbox probe returned raw tool output with `leaked:true`, shown above.

## Root Cause

- Root cause: The completion-output selector kept a sanitized raw-text fallback for tool-only child transcripts, even though tool/toolResult content is not assistant-authored completion text.
- Missing detection / guardrail: Existing e2e coverage checked formatted completion output but did not directly assert that `readSubagentOutput()` rejects tool-only histories or that post-compaction assistant text still wins over raw tool text.
- Contributing context (if known): Public docs still documented tool/toolResult fallback behavior, so the selector and docs drifted together.

## Regression Test Plan

- Coverage level that should have caught this: Unit test and seam/e2e announce-format test.
- Target test or file: `src/agents/subagent-announce-output.test.ts` and `src/agents/subagent-announce.format.e2e.test.ts`.
- Scenario the test should lock in: Tool-only child histories produce no selected completion text; post-compaction assistant replies still produce selected text; requester handoff does not include raw tool output.
- Why this is the smallest reliable guardrail: The bug is in the selector seam, with one e2e announce-format check to prove the user-visible fallback text.
- Existing test that already covers this (if any): None covered the selector directly before this patch.
- If no new test is added, why not: New tests are added.

## User-visible / Behavior Changes

Subagent completion announces no longer surface raw tool output when the child produced no assistant text. They now use the existing `(no output)` fallback for that case.

## Diagram

N/A
