### PR TITLE
fix:Slack DM delivery mirrors can split sessions by routing bare D... IM channel IDs as channel sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI/realtime voice: honor disabled input-audio interruption locally so server VAD speech-start events do not clear Discord playback after operators set `interruptResponseOnInputAudio: false`.
 - Telegram: keep no-response DM turns quiet instead of rewriting them into visible silent-reply chatter. Fixes #78188. (#78228) Thanks @Beandon13.
 - Telegram: handle managed select button callbacks before the raw callback fallback while preserving delimiter-containing option values such as `env|prod`. (#79816) Thanks @moeedahmed.
+- Slack: canonicalize outbound delivery-mirror routes for native DM channel IDs to the peer user session, preventing `message.send` calls to `D...` targets from splitting the same Slack DM thread into a separate channel session. Fixes #80091.
 - OpenAI-compatible models: handle JSON chat-completion bodies returned to streaming requests, preserving reasoning fields and visible text instead of completing an empty agent turn. Fixes #77870.
 - xAI: expose `/think low|medium|high` for reasoning-capable Grok models and keep `reasoning.effort` on native Responses payloads while preserving off-only behavior for non-reasoning routes. Fixes #79210. Thanks @colinmcintosh.
 - CLI/media: let explicit image description model refs use bundled static provider catalogs and generic model-backed image hooks, so `openclaw infer image describe --model zai/glm-4.6v` works like direct model runs and Anthropic auth probes avoid stale Claude 3 Haiku catalog entries.

--- a/extensions/slack/src/channel-type.test.ts
+++ b/extensions/slack/src/channel-type.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { __resetSlackChannelTypeCacheForTest, resolveSlackChannelType } from "./channel-type.js";
+import {
+  __resetSlackChannelTypeCacheForTest,
+  resolveSlackChannelType,
+  resolveSlackConversationInfo,
+} from "./channel-type.js";
 
 const conversationsInfoMock = vi.fn();
 
@@ -57,5 +61,132 @@ describe("resolveSlackChannelType", () => {
     ).resolves.toBe("group");
 
     expect(conversationsInfoMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Slack IM peer user metadata from conversations.info", async () => {
+    conversationsInfoMock.mockResolvedValueOnce({
+      channel: {
+        id: "D0AEWSDHAQH",
+        is_im: true,
+        user: "U09G2DJ0275",
+      },
+    });
+
+    await expect(
+      resolveSlackConversationInfo({
+        cfg: {
+          channels: {
+            slack: {
+              botToken: "xoxb-test",
+            },
+          },
+        } as never,
+        channelId: "D0AEWSDHAQH",
+      }),
+    ).resolves.toEqual({
+      type: "dm",
+      user: "U09G2DJ0275",
+    });
+    expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "D0AEWSDHAQH" });
+  });
+
+  it("keeps D-prefixed channels typed as dm when Slack lookup fails", async () => {
+    conversationsInfoMock.mockRejectedValueOnce(new Error("missing_scope"));
+
+    await expect(
+      resolveSlackConversationInfo({
+        cfg: {
+          channels: {
+            slack: {
+              botToken: "xoxb-test",
+            },
+          },
+        } as never,
+        channelId: "D0AEWSDHAQH",
+      }),
+    ).resolves.toEqual({
+      type: "dm",
+    });
+  });
+
+  it("does not cache incomplete native IM channel lookups", async () => {
+    conversationsInfoMock
+      .mockRejectedValueOnce(new Error("temporary_failure"))
+      .mockResolvedValueOnce({
+        channel: {
+          id: "D0AEWSDHAQH",
+          is_im: true,
+          user: "U09G2DJ0275",
+        },
+      });
+
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+        },
+      },
+    } as never;
+
+    await expect(
+      resolveSlackConversationInfo({
+        cfg,
+        channelId: "D0AEWSDHAQH",
+      }),
+    ).resolves.toEqual({
+      type: "dm",
+    });
+    await expect(
+      resolveSlackConversationInfo({
+        cfg,
+        channelId: "D0AEWSDHAQH",
+      }),
+    ).resolves.toEqual({
+      type: "dm",
+      user: "U09G2DJ0275",
+    });
+    expect(conversationsInfoMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let group-channel overrides reclassify native IM channel ids", async () => {
+    await expect(
+      resolveSlackConversationInfo({
+        cfg: {
+          channels: {
+            slack: {
+              dm: {
+                groupChannels: ["D0AEWSDHAQH"],
+              },
+            },
+          },
+        } as never,
+        channelId: "D0AEWSDHAQH",
+      }),
+    ).resolves.toEqual({
+      type: "dm",
+    });
+    expect(conversationsInfoMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the channel-type wrapper contract", async () => {
+    conversationsInfoMock.mockResolvedValueOnce({
+      channel: {
+        id: "G123",
+        is_mpim: true,
+      },
+    });
+
+    await expect(
+      resolveSlackChannelType({
+        cfg: {
+          channels: {
+            slack: {
+              botToken: "xoxb-test",
+            },
+          },
+        } as never,
+        channelId: "G123",
+      }),
+    ).resolves.toBe("group");
   });
 });

--- a/extensions/slack/src/channel-type.ts
+++ b/extensions/slack/src/channel-type.ts
@@ -7,38 +7,47 @@ import { createSlackWebClient } from "./client.js";
 import { normalizeAllowListLower } from "./monitor/allow-list.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
-const SLACK_CHANNEL_TYPE_CACHE = new Map<string, "channel" | "group" | "dm" | "unknown">();
+export type SlackConversationInfo = {
+  type: "channel" | "group" | "dm" | "unknown";
+  user?: string;
+};
 
-export async function resolveSlackChannelType(params: {
+const SLACK_CONVERSATION_INFO_CACHE = new Map<string, SlackConversationInfo>();
+
+export async function resolveSlackConversationInfo(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   channelId: string;
-}): Promise<"channel" | "group" | "dm" | "unknown"> {
+}): Promise<SlackConversationInfo> {
   const channelId = params.channelId.trim();
   if (!channelId) {
-    return "unknown";
+    return { type: "unknown" };
   }
   const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
   const cacheKey = `${account.accountId}:${channelId}`;
-  const cached = SLACK_CHANNEL_TYPE_CACHE.get(cacheKey);
+  const cached = SLACK_CONVERSATION_INFO_CACHE.get(cacheKey);
   if (cached) {
     return cached;
   }
+  const isNativeImChannel = /^D/i.test(channelId);
   const groupChannels = normalizeAllowListLower(account.dm?.groupChannels);
   const channelIdLower = normalizeLowercaseStringOrEmpty(channelId);
   if (
-    groupChannels.includes(channelIdLower) ||
-    groupChannels.includes(`slack:${channelIdLower}`) ||
-    groupChannels.includes(`channel:${channelIdLower}`) ||
-    groupChannels.includes(`group:${channelIdLower}`) ||
-    groupChannels.includes(`mpim:${channelIdLower}`)
+    !isNativeImChannel &&
+    (groupChannels.includes(channelIdLower) ||
+      groupChannels.includes(`slack:${channelIdLower}`) ||
+      groupChannels.includes(`channel:${channelIdLower}`) ||
+      groupChannels.includes(`group:${channelIdLower}`) ||
+      groupChannels.includes(`mpim:${channelIdLower}`))
   ) {
-    SLACK_CHANNEL_TYPE_CACHE.set(cacheKey, "group");
-    return "group";
+    const result = { type: "group" } as const;
+    SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+    return result;
   }
 
   const channelKeys = Object.keys(account.channels ?? {});
   if (
+    !isNativeImChannel &&
     channelKeys.some((key) => {
       const normalized = normalizeLowercaseStringOrEmpty(key);
       return (
@@ -48,8 +57,9 @@ export async function resolveSlackChannelType(params: {
       );
     })
   ) {
-    SLACK_CHANNEL_TYPE_CACHE.set(cacheKey, "channel");
-    return "channel";
+    const result = { type: "channel" } as const;
+    SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+    return result;
   }
 
   const token =
@@ -57,23 +67,45 @@ export async function resolveSlackChannelType(params: {
     normalizeOptionalString(account.config.userToken) ??
     "";
   if (!token) {
-    SLACK_CHANNEL_TYPE_CACHE.set(cacheKey, "unknown");
-    return "unknown";
+    const result = { type: isNativeImChannel ? "dm" : "unknown" } as const;
+    if (!isNativeImChannel) {
+      SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+    }
+    return result;
   }
 
   try {
     const client = createSlackWebClient(token);
     const info = await client.conversations.info({ channel: channelId });
-    const channel = info.channel as { is_im?: boolean; is_mpim?: boolean } | undefined;
-    const type = channel?.is_im ? "dm" : channel?.is_mpim ? "group" : "channel";
-    SLACK_CHANNEL_TYPE_CACHE.set(cacheKey, type);
-    return type;
+    const channel = info.channel as
+      | { is_im?: boolean; is_mpim?: boolean; user?: unknown }
+      | undefined;
+    const type =
+      isNativeImChannel || channel?.is_im ? "dm" : channel?.is_mpim ? "group" : "channel";
+    const user =
+      typeof channel?.user === "string" && channel.user.trim() ? channel.user.trim() : undefined;
+    const result: SlackConversationInfo = user ? { type, user } : { type };
+    if (type !== "dm" || user) {
+      SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+    }
+    return result;
   } catch {
-    SLACK_CHANNEL_TYPE_CACHE.set(cacheKey, "unknown");
-    return "unknown";
+    const result = { type: isNativeImChannel ? "dm" : "unknown" } as const;
+    if (!isNativeImChannel) {
+      SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+    }
+    return result;
   }
 }
 
+export async function resolveSlackChannelType(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  channelId: string;
+}): Promise<"channel" | "group" | "dm" | "unknown"> {
+  return (await resolveSlackConversationInfo(params)).type;
+}
+
 export function __resetSlackChannelTypeCacheForTest(): void {
-  SLACK_CHANNEL_TYPE_CACHE.clear();
+  SLACK_CONVERSATION_INFO_CACHE.clear();
 }

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -12,6 +12,10 @@ const { handleSlackActionMock } = vi.hoisted(() => ({
 const { sendMessageSlackMock } = vi.hoisted(() => ({
   sendMessageSlackMock: vi.fn(),
 }));
+const { resolveSlackChannelTypeMock, resolveSlackConversationInfoMock } = vi.hoisted(() => ({
+  resolveSlackChannelTypeMock: vi.fn(),
+  resolveSlackConversationInfoMock: vi.fn(),
+}));
 
 vi.mock("./action-runtime.js", async () => {
   const actual = await vi.importActual<typeof import("./action-runtime.js")>("./action-runtime.js");
@@ -25,10 +29,19 @@ vi.mock("./send.runtime.js", () => ({
   sendMessageSlack: sendMessageSlackMock,
 }));
 
+vi.mock("./channel-type.js", () => ({
+  resolveSlackChannelType: resolveSlackChannelTypeMock,
+  resolveSlackConversationInfo: resolveSlackConversationInfoMock,
+}));
+
 beforeEach(async () => {
   handleSlackActionMock.mockReset();
   sendMessageSlackMock.mockReset();
   sendMessageSlackMock.mockResolvedValue({ messageId: "msg-1", channelId: "D123" });
+  resolveSlackChannelTypeMock.mockReset();
+  resolveSlackChannelTypeMock.mockResolvedValue("unknown");
+  resolveSlackConversationInfoMock.mockReset();
+  resolveSlackConversationInfoMock.mockResolvedValue({ type: "unknown" });
   setSlackRuntime({
     channel: {
       slack: {
@@ -377,6 +390,116 @@ describe("slackPlugin status", () => {
       sessionKey: "agent:main:slack:channel:c1:thread:1712345678.123456",
       baseSessionKey: "agent:main:slack:channel:c1",
       threadId: "1712345678.123456",
+    });
+  });
+
+  it("canonicalizes bare Slack IM channel targets to direct user session routes", async () => {
+    const resolveRoute = slackPlugin.messaging?.resolveOutboundSessionRoute;
+    if (!resolveRoute) {
+      throw new Error("slack messaging.resolveOutboundSessionRoute unavailable");
+    }
+    resolveSlackConversationInfoMock.mockResolvedValueOnce({
+      type: "dm",
+      user: "U09G2DJ0275",
+    });
+
+    const route = await resolveRoute({
+      cfg: {
+        session: { dmScope: "per-channel-peer" },
+        channels: {
+          slack: {
+            botToken: "xoxb-test",
+            appToken: "xapp-test",
+          },
+        },
+      } as OpenClawConfig,
+      agentId: "main",
+      target: "D0AEWSDHAQH",
+      threadId: "1778110574.653649",
+    });
+
+    expect(resolveSlackConversationInfoMock).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: undefined,
+      channelId: "D0AEWSDHAQH",
+    });
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:slack:direct:u09g2dj0275:thread:1778110574.653649",
+      baseSessionKey: "agent:main:slack:direct:u09g2dj0275",
+      peer: { kind: "direct", id: "U09G2DJ0275" },
+      chatType: "direct",
+      from: "slack:U09G2DJ0275",
+      to: "user:U09G2DJ0275",
+      threadId: "1778110574.653649",
+    });
+  });
+
+  it("canonicalizes explicit channel-prefixed Slack IM targets for mirror routing", async () => {
+    const resolveRoute = slackPlugin.messaging?.resolveOutboundSessionRoute;
+    if (!resolveRoute) {
+      throw new Error("slack messaging.resolveOutboundSessionRoute unavailable");
+    }
+    resolveSlackConversationInfoMock.mockResolvedValueOnce({
+      type: "dm",
+      user: "U123",
+    });
+
+    const route = await resolveRoute({
+      cfg: {
+        session: { dmScope: "per-channel-peer" },
+        channels: {
+          slack: {
+            botToken: "xoxb-test",
+            appToken: "xapp-test",
+          },
+        },
+      } as OpenClawConfig,
+      agentId: "main",
+      target: "channel:D123",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:slack:direct:u123",
+      peer: { kind: "direct", id: "U123" },
+    });
+  });
+
+  it("skips mirror routing for unresolved Slack IM channel targets", async () => {
+    const resolveRoute = slackPlugin.messaging?.resolveOutboundSessionRoute;
+    if (!resolveRoute) {
+      throw new Error("slack messaging.resolveOutboundSessionRoute unavailable");
+    }
+    resolveSlackConversationInfoMock.mockResolvedValueOnce({ type: "dm" });
+
+    await expect(
+      resolveRoute({
+        cfg: {} as OpenClawConfig,
+        agentId: "main",
+        target: "D0AEWSDHAQH",
+        threadId: "1778110574.653649",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("keeps Slack MPIM outbound routing as group", async () => {
+    const resolveRoute = slackPlugin.messaging?.resolveOutboundSessionRoute;
+    if (!resolveRoute) {
+      throw new Error("slack messaging.resolveOutboundSessionRoute unavailable");
+    }
+    resolveSlackChannelTypeMock.mockResolvedValueOnce("group");
+
+    const route = await resolveRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "main",
+      target: "G123",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:slack:group:g123",
+      peer: { kind: "group", id: "G123" },
+      chatType: "channel",
+      from: "slack:group:G123",
+      to: "channel:G123",
     });
   });
 });

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -47,7 +47,7 @@ import {
   type ChannelPlugin,
   type OpenClawConfig,
 } from "./channel-api.js";
-import { resolveSlackChannelType } from "./channel-type.js";
+import { resolveSlackChannelType, resolveSlackConversationInfo } from "./channel-type.js";
 import { shouldSuppressLocalSlackExecApprovalPrompt } from "./exec-approvals.js";
 import { resolveSlackGroupRequireMention, resolveSlackGroupToolPolicy } from "./group-policy.js";
 import {
@@ -276,7 +276,19 @@ async function resolveSlackOutboundSessionRoute(params: {
   }
   const isDm = parsed.kind === "user";
   let peerKind: "direct" | "channel" | "group" = isDm ? "direct" : "channel";
-  if (!isDm && /^G/i.test(parsed.id)) {
+  let peerId = parsed.id;
+  if (!isDm && /^D/i.test(parsed.id)) {
+    const conversation = await resolveSlackConversationInfo({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      channelId: parsed.id,
+    });
+    if (conversation.type !== "dm" || !conversation.user) {
+      return null;
+    }
+    peerKind = "direct";
+    peerId = conversation.user;
+  } else if (!isDm && /^G/i.test(parsed.id)) {
     const channelType = await resolveSlackChannelType({
       cfg: params.cfg,
       accountId: params.accountId,
@@ -291,7 +303,7 @@ async function resolveSlackOutboundSessionRoute(params: {
   }
   const peer: RoutePeer = {
     kind: peerKind,
-    id: parsed.id,
+    id: peerId,
   };
   const baseSessionKey = buildSlackBaseSessionKey({
     cfg: params.cfg,
@@ -307,11 +319,11 @@ async function resolveSlackOutboundSessionRoute(params: {
       chatType: peerKind === "direct" ? ("direct" as const) : ("channel" as const),
       from:
         peerKind === "direct"
-          ? `slack:${parsed.id}`
+          ? `slack:${peerId}`
           : peerKind === "group"
-            ? `slack:group:${parsed.id}`
-            : `slack:channel:${parsed.id}`,
-      to: peerKind === "direct" ? `user:${parsed.id}` : `channel:${parsed.id}`,
+            ? `slack:group:${peerId}`
+            : `slack:channel:${peerId}`,
+      to: peerKind === "direct" ? `user:${peerId}` : `channel:${peerId}`,
     },
     replyToId: params.replyToId,
     threadId: params.threadId,


### PR DESCRIPTION
## Summary

Fixes Slack outbound delivery-mirror session reconstruction for native Slack IM channel IDs (`D...`). A `message.send` call can legitimately target Slack’s concrete DM channel, but OpenClaw session routing should treat that same conversation as a direct Slack user session keyed by the peer `U...` user ID.

This PR updates the Slack outbound route resolver so `D...` and `channel:D...` targets resolve through Slack conversation metadata and only create a mirror route when Slack confirms `channel.is_im` plus `channel.user`. In that case the mirror session is canonicalized to `slack:direct:<u...>`, matching inbound Slack DM routing. If the lookup fails or Slack does not return the peer user, the mirror route is skipped instead of writing a known-wrong `slack:channel:<d...>` session key.

Fixes #80091.

## Root Cause

Inbound Slack DM routing already treats D-prefixed Slack channels as IMs and keys the route by the message sender user ID. The outbound delivery-mirror path did not do the same. It parsed bare outbound targets with `defaultKind: "channel"`, only reclassified `G...` IDs, and therefore allowed a Slack IM channel ID such as `D0AEWSDHAQH` to produce a session key like:

```text
agent:main:slack:channel:d0aewsdhaqh:thread:1778110574.653649
```

Later inbound messages in the same visible Slack DM thread route to the canonical direct user session, for example:

```text
agent:main:slack:direct:u09g2dj0275:thread:1778110574.653649
```

That split loses prior thread context even though the Slack UI shows one DM thread.

## What Changed

- Added Slack conversation metadata lookup that can return both conversation type and the IM peer user.
- Kept the existing `resolveSlackChannelType()` contract as a compatibility wrapper.
- Canonicalized outbound mirror routes for bare `D...` and `channel:D...` targets to `direct:U...` when Slack confirms the mapping.
- Preserved Slack send delivery behavior. `channel:D...` can still be used as the concrete Slack delivery target; only mirror/session reconstruction changes.
- Preserved existing channel and MPIM behavior for `C...` and `G...` targets.
- Avoided caching incomplete native IM metadata so transient Slack lookup failures do not suppress later successful mirror routing.
- Added regression coverage for the affected paths.

## User Impact

After this change, sending into a Slack DM thread through `message.send` with a native `D...` target no longer creates a separate channel-scoped OpenClaw session. Outbound delivery mirrors and later inbound DM turns resolve to the same direct user session whenever Slack exposes the peer user mapping.

Existing bad `agent:*:slack:channel:d...` sessions are not migrated in this PR. This PR prevents new bad mirror sessions from being created.

## Real Behavior Proof

Pending live after-fix proof from a real Slack-connected OpenClaw setup.

Planned proof:

1. Use a real Slack IM channel ID (`D...`) and real thread timestamp from a Slack DM where OpenClaw is configured.
2. Confirm live Slack metadata resolves the IM channel to the peer user:

```text
conversations.info(channel=D...)
  channel.is_im: true
  channel.user: U...
```

3. Run the same outbound mirror route probe before and after this fix.
4. Record copied terminal output showing the route changes from the pre-fix channel session:

```text
agent:main:slack:channel:<d...>:thread:<thread_ts>
```

to the post-fix direct user session:

```text
agent:main:slack:direct:<u...>:thread:<thread_ts>
```

Unit tests, typechecks, and CI below are supplemental only and do not replace this live proof.

## Validation

- `git diff --check`
- `pnpm test extensions/slack/src/channel.test.ts extensions/slack/src/channel-type.test.ts`
- `pnpm test:extension slack`
- `pnpm tsgo:extensions`
- `pnpm exec oxfmt --check --threads=1 extensions/slack/src/channel.ts extensions/slack/src/channel-type.ts extensions/slack/src/channel.test.ts extensions/slack/src/channel-type.test.ts CHANGELOG.md`
- `codex review --base origin/main`

`codex review` result: no discrete correctness issues found.

## AI Assistance

Implemented with Codex. I understand the submitted change and verified the behavior at the code and targeted validation level; live real-behavior proof is pending as noted above.