### PR TITLE
fix(feishu): suppress stale tool-error warning payloads from Feishu channel delivery

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1432,4 +1432,35 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       nowSpy.mockRestore();
     }
   });
+
+  it("suppresses tool-kind error payloads so stale mutating-tool warnings do not appear in Feishu", async () => {
+    const { options } = createDispatcherHarness();
+
+    // Simulate a tool-error warning payload (kind="tool", isError=true) followed
+    // by a successful final reply — matches the workspace AGENTS.md edit scenario.
+    await options.deliver(
+      { text: "⚠️ 📝 Edit: in workspace/AGENTS.md failed", isError: true },
+      { kind: "tool" },
+    );
+    await options.deliver({ text: "Done." }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text: "Done." }));
+  });
+
+  it("still delivers final error replies even when isError is true", async () => {
+    const { options } = createDispatcherHarness();
+
+    await options.deliver(
+      { text: "⚠️ Agent failed before reply: model unavailable.", isError: true },
+      { kind: "final" },
+    );
+    await options.onIdle?.();
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "⚠️ Agent failed before reply: model unavailable." }),
+    );
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -514,6 +514,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         await typingCallbacks?.onReplyStart?.();
       },
       deliver: async (payload: ReplyPayload, info) => {
+        // Tool-result error payloads (kind="tool", isError=true) are stale
+        // mutating-tool failure warnings that the LLM already recovered from.
+        // Suppress them in Feishu so they don't surface as visible channel
+        // messages — Telegram uses the same guard (#79804).
+        // Final error replies (kind="final") are still delivered unchanged.
+        if (payload.isError && info?.kind === "tool") {
+          return;
+        }
         const payloadText =
           payload.isReasoning && payload.text ? formatReasoningMessage(payload.text) : payload.text;
         const reply = resolveSendableOutboundReplyParts({ ...payload, text: payloadText });


### PR DESCRIPTION
## Problem

fix(feishu): suppress stale tool-error warning payloads from Feishu channel delivery (#80066)

## Real behavior proof

- **Behavior or issue addressed:** Feishu's `deliver()` method was forwarding `isError=true, kind="tool"` payloads — stale mutating-tool failure warnings the LLM already recovered from. These appeared as confusing mid-conversation error messages in Feishu chats. The Telegram dispatcher already suppressed this pattern.
- **Real environment tested:** Local checkout of openclaw main (2026.5.10), Node 22, `pnpm vitest run extensions/feishu/src/reply-dispatcher.test.ts`.
- **Exact steps or command run after this patch:**
  ```
  pnpm vitest run extensions/feishu/src/reply-dispatcher.test.ts
  ```
- **Evidence after fix:**
  ```
$ pnpm vitest run extensions/feishu/src/reply-dispatcher.test.ts
 ✓ extensions/feishu/src/reply-dispatcher.test.ts (39 tests)

Test Files  1 passed (1)
     Tests  39 passed (39)
```
Tests added: "suppresses tool-kind error payloads..." and "still delivers final error replies..." — both pass. `sendMessageFeishuMock` called exactly once (the `kind=final` payload), not for the `kind=tool` warning.
- **Observed result after fix:** `isError=true, kind="tool"` payloads are silently dropped; `isError=true, kind="final"` payloads still reach the user. 39/39 tests pass.
- **What was not tested:** Live Feishu workspace with a real mutating-tool failure mid-conversation — this is unit-tested with the existing dispatcher harness.
