### PR TITLE
fix(approvals): summarize long approval prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/approvals: summarize long exec approval command prompts, keep invalid Allow Always choices out of the modal, and preserve the full sanitized command for approval matching. Fixes #58687. Thanks @ylx1314 and @icestorms.
 - ACP sessions: map canonical runtime options to backend-advertised ACP config keys like Claude's `effort` while keeping persisted OpenClaw state canonical. (#79926) Thanks @InTheCloudDan.
 - Gateway/watch: rebuild or restage missing bundled-plugin dist and runtime-postbuild outputs before launching the Gateway from a source checkout, preventing incomplete watch-mode runtime trees. (#70805) Thanks @rubencu.
 - CLI/update: allow restart health probes from the previous gateway protocol during self-update, and make plugin dry-runs report exact npm target versions instead of `unknown` while preserving unchanged status.

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -318,6 +318,7 @@ Shared behavior:
   straight to plugin approvals, everything else goes to exec approvals
 - native Telegram approval buttons follow the same bounded exec-to-plugin fallback as `/approve`
 - when native `target` enables origin-chat delivery, approval prompts include the command text
+- long command prompts are summarized for reviewability; the full sanitized command remains bound to the pending approval record for matching and resolution
 - pending exec approvals expire after 30 minutes by default
 - if no operator UI or configured approval client can accept the request, the prompt falls back to `askFallback`
 

--- a/src/infra/approval-view-model.test.ts
+++ b/src/infra/approval-view-model.test.ts
@@ -29,4 +29,26 @@ describe("buildPendingApprovalView", () => {
     }
     expect(view.commandAnalysis?.warningLines).toEqual(["Contains inline-eval: python -c"]);
   });
+
+  it("summarizes long exec commands for native approval views", () => {
+    const request: ExecApprovalRequest = {
+      id: "approval-id",
+      createdAtMs: 1,
+      expiresAtMs: 2,
+      request: {
+        command: Array.from({ length: 8 }, (_, index) => `echo line ${index + 1}\\u{A}`).join(""),
+        host: "gateway",
+      },
+    };
+
+    const view = buildPendingApprovalView(request);
+
+    expect(view.approvalKind).toBe("exec");
+    if (view.approvalKind !== "exec") {
+      throw new Error("expected exec approval view");
+    }
+    expect(view.commandText).toContain("echo line 1\\u{A}");
+    expect(view.commandText).toContain("...[truncated: showing first 5 of 9 lines");
+    expect(view.commandText).not.toContain("echo line 8");
+  });
 });

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -9,6 +9,7 @@ import type {
   ResolvedApprovalView,
 } from "./approval-view-model.types.js";
 import { resolveExecApprovalCommandDisplay } from "./exec-approval-command-display.js";
+import { summarizeExecApprovalCommandForPrompt } from "./exec-approval-command-summary.js";
 import { buildExecApprovalActionDescriptors } from "./exec-approval-reply.js";
 import {
   resolveExecApprovalRequestAllowedDecisions,
@@ -62,6 +63,7 @@ function buildExecViewBase<TPhase extends ApprovalPhase>(
   phase: TPhase,
 ): ExecApprovalViewBase & { phase: TPhase } {
   const { commandText, commandPreview } = resolveExecApprovalCommandDisplay(request.request);
+  const commandSummary = summarizeExecApprovalCommandForPrompt(commandText);
   return {
     approvalId: request.id,
     approvalKind: "exec",
@@ -73,7 +75,7 @@ function buildExecViewBase<TPhase extends ApprovalPhase>(
     agentId: request.request.agentId ?? null,
     warningText: request.request.warningText ?? null,
     commandAnalysis: request.request.commandAnalysis ?? null,
-    commandText,
+    commandText: commandSummary.text,
     commandPreview,
     cwd: request.request.cwd ?? null,
     envKeys: request.request.envKeys ?? undefined,

--- a/src/infra/exec-approval-command-summary.test.ts
+++ b/src/infra/exec-approval-command-summary.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { summarizeExecApprovalCommandForPrompt } from "./exec-approval-command-summary.js";
+
+describe("summarizeExecApprovalCommandForPrompt", () => {
+  it("leaves short commands unchanged", () => {
+    expect(summarizeExecApprovalCommandForPrompt("echo hello")).toEqual({
+      text: "echo hello",
+      truncated: false,
+      totalLineCount: 1,
+      shownLineCount: 1,
+      hiddenLineCount: 0,
+      totalCharCount: 10,
+      hiddenCharCount: 0,
+    });
+  });
+
+  it("shows only the first logical lines and keeps escaped newline markers visible", () => {
+    const command = [
+      "line 1\\u{A}",
+      "line 2\\u{A}",
+      "line 3\\u{A}",
+      "line 4\\u{A}",
+      "line 5\\u{A}",
+      "line 6\\u{A}",
+      "line 7",
+    ].join("");
+
+    const summary = summarizeExecApprovalCommandForPrompt(command, {
+      maxLines: 3,
+      maxChars: 1_000,
+    });
+
+    expect(summary.text).toBe(
+      "line 1\\u{A}\nline 2\\u{A}\nline 3\\u{A}\n...[truncated: showing first 3 of 7 lines; 43 chars hidden]",
+    );
+    expect(summary.truncated).toBe(true);
+    expect(summary.hiddenLineCount).toBe(4);
+    expect(summary.text).not.toContain("line 6");
+  });
+
+  it("bounds long single-line commands", () => {
+    const command = `python -c "${"x".repeat(200)}"`;
+
+    const summary = summarizeExecApprovalCommandForPrompt(command, {
+      maxLines: 5,
+      maxChars: 40,
+    });
+
+    expect(summary.text).toMatch(/^python -c "x+/u);
+    expect(summary.text).toContain("...[truncated:");
+    expect(summary.text).toContain("chars hidden");
+    expect(summary.text).not.toContain("x".repeat(80));
+  });
+});

--- a/src/infra/exec-approval-command-summary.ts
+++ b/src/infra/exec-approval-command-summary.ts
@@ -1,0 +1,112 @@
+export type ExecApprovalCommandPromptSummary = {
+  text: string;
+  truncated: boolean;
+  totalLineCount: number;
+  shownLineCount: number;
+  hiddenLineCount: number;
+  totalCharCount: number;
+  hiddenCharCount: number;
+};
+
+export const EXEC_APPROVAL_PROMPT_COMMAND_MAX_LINES = 5;
+export const EXEC_APPROVAL_PROMPT_COMMAND_MAX_CHARS = 1_200;
+
+const LOGICAL_LINE_BREAK_PATTERN =
+  /\\u\{D\}\\u\{A\}|\\u\{A\}|\\u\{D\}|\\u\{2028\}|\\u\{2029\}|\r\n?|\n/gu;
+
+function positiveLimit(value: number | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && typeof value === "number" && value > 0 ? value : fallback;
+}
+
+function plural(count: number, singular: string): string {
+  return count === 1 ? singular : `${singular}s`;
+}
+
+function splitDisplayLines(text: string): string[] {
+  const lines: string[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(LOGICAL_LINE_BREAK_PATTERN)) {
+    const index = match.index;
+    if (typeof index !== "number") {
+      continue;
+    }
+    const marker = match[0];
+    const markerText = marker.startsWith("\\u{") ? marker : "";
+    lines.push(text.slice(cursor, index) + markerText);
+    cursor = index + marker.length;
+  }
+  lines.push(text.slice(cursor));
+  return lines;
+}
+
+function buildTruncationMarker(params: {
+  totalLineCount: number;
+  shownLineCount: number;
+  hiddenLineCount: number;
+  hiddenCharCount: number;
+}): string {
+  const details: string[] = [];
+  if (params.hiddenLineCount > 0) {
+    details.push(`showing first ${params.shownLineCount} of ${params.totalLineCount} lines`);
+  }
+  if (params.hiddenCharCount > 0) {
+    details.push(`${params.hiddenCharCount} ${plural(params.hiddenCharCount, "char")} hidden`);
+  }
+  return `...[truncated: ${details.join("; ")}]`;
+}
+
+export function summarizeExecApprovalCommandForPrompt(
+  commandText: string,
+  options?: { maxLines?: number; maxChars?: number },
+): ExecApprovalCommandPromptSummary {
+  const maxLines = positiveLimit(options?.maxLines, EXEC_APPROVAL_PROMPT_COMMAND_MAX_LINES);
+  const maxChars = positiveLimit(options?.maxChars, EXEC_APPROVAL_PROMPT_COMMAND_MAX_CHARS);
+  const lines = splitDisplayLines(commandText);
+  const shownLines = lines.slice(0, maxLines);
+  const lineTruncated = lines.length > shownLines.length;
+  if (!lineTruncated && commandText.length <= maxChars) {
+    return {
+      text: commandText,
+      truncated: false,
+      totalLineCount: lines.length,
+      shownLineCount: lines.length,
+      hiddenLineCount: 0,
+      totalCharCount: commandText.length,
+      hiddenCharCount: 0,
+    };
+  }
+  let text = shownLines.join("\n");
+  const totalText = lines.join("\n");
+  if (text.length > maxChars) {
+    text = text.slice(0, maxChars).trimEnd();
+  }
+  const hiddenLineCount = lineTruncated ? lines.length - shownLines.length : 0;
+  const hiddenCharCount = Math.max(0, totalText.length - text.length);
+  const truncated = hiddenLineCount > 0 || hiddenCharCount > 0;
+  if (!truncated) {
+    return {
+      text,
+      truncated: false,
+      totalLineCount: lines.length,
+      shownLineCount: lines.length,
+      hiddenLineCount: 0,
+      totalCharCount: totalText.length,
+      hiddenCharCount: 0,
+    };
+  }
+  const marker = buildTruncationMarker({
+    totalLineCount: lines.length,
+    shownLineCount: shownLines.length,
+    hiddenLineCount,
+    hiddenCharCount,
+  });
+  return {
+    text: text ? `${text}\n${marker}` : marker,
+    truncated: true,
+    totalLineCount: lines.length,
+    shownLineCount: shownLines.length,
+    hiddenLineCount,
+    totalCharCount: totalText.length,
+    hiddenCharCount,
+  };
+}

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -600,6 +600,23 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("- Contains inline-eval: python3 -c");
   });
 
+  it("summarizes long commands in fallback delivery text", () => {
+    const text = buildExecApprovalRequestMessage(
+      {
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          command: Array.from({ length: 8 }, (_, index) => `echo line ${index + 1}\\u{A}`).join(""),
+        },
+      },
+      1000,
+    );
+
+    expect(text).toContain("echo line 1\\u{A}");
+    expect(text).toContain("...[truncated: showing first 5 of 9 lines");
+    expect(text).not.toContain("echo line 8");
+  });
+
   it("omits allow-always from forwarded fallback text when ask=always", async () => {
     vi.useFakeTimers();
     const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -28,6 +28,7 @@ import {
   resolveExecApprovalCommandDisplay,
   sanitizeExecApprovalWarningText,
 } from "./exec-approval-command-display.js";
+import { summarizeExecApprovalCommandForPrompt } from "./exec-approval-command-summary.js";
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
 import {
   resolveExecApprovalRequestAllowedDecisions,
@@ -250,7 +251,9 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
     }
   }
   const command = formatApprovalCommand(
-    resolveExecApprovalCommandDisplay(request.request).commandText,
+    summarizeExecApprovalCommandForPrompt(
+      resolveExecApprovalCommandDisplay(request.request).commandText,
+    ).text,
   );
   if (command.inline) {
     lines.push(`Command: ${command.text}`);

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -302,6 +302,19 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).not.toContain("C:\\Users\\alice");
   });
 
+  it("summarizes long commands in pending reply payloads", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-long",
+      approvalSlug: "slug-long",
+      command: Array.from({ length: 8 }, (_, index) => `echo line ${index + 1}\\u{A}`).join(""),
+      host: "gateway",
+    });
+
+    expect(payload.text).toContain("echo line 1\\u{A}");
+    expect(payload.text).toContain("...[truncated: showing first 5 of 9 lines");
+    expect(payload.text).not.toContain("echo line 8");
+  });
+
   it("omits allow-always actions when the effective policy requires approval every time", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-ask-always",

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -6,6 +6,7 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { formatApprovalDisplayPath } from "./approval-display-paths.js";
+import { summarizeExecApprovalCommandForPrompt } from "./exec-approval-command-summary.js";
 import {
   describeNativeExecApprovalClientSetup,
   listNativeExecApprovalClientLabels,
@@ -305,8 +306,9 @@ export function buildExecApprovalPendingReplyPayload(
     lines.push("Run:");
     lines.push(buildFence(primaryAction.command, "txt"));
   }
+  const commandSummary = summarizeExecApprovalCommandForPrompt(params.command).text;
   lines.push("Pending command:");
-  lines.push(buildFence(params.command, "sh"));
+  lines.push(buildFence(commandSummary, "sh"));
   const secondaryFence = buildApprovalCommandFence(secondaryActions);
   if (secondaryFence) {
     lines.push("Other options:");

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -5,14 +5,28 @@ describe("parseExecApprovalRequested", () => {
   it("returns entries with kind 'exec'", () => {
     const result = parseExecApprovalRequested({
       id: "exec-1",
-      request: { command: "rm -rf /" },
+      request: { command: "rm -rf /", allowedDecisions: ["allow-once", "deny"] },
       createdAtMs: 1000,
       expiresAtMs: 2000,
     });
     expect(result).toMatchObject({
       kind: "exec",
-      request: { command: "rm -rf /" },
+      request: { command: "rm -rf /", allowedDecisions: ["allow-once", "deny"] },
     });
+  });
+
+  it("drops invalid and duplicate allowed decisions", () => {
+    const result = parseExecApprovalRequested({
+      id: "exec-1",
+      request: {
+        command: "rm -rf /",
+        allowedDecisions: ["allow-once", "allow-once", "invalid", "deny"],
+      },
+      createdAtMs: 1000,
+      expiresAtMs: 2000,
+    });
+
+    expect(result?.request.allowedDecisions).toEqual(["allow-once", "deny"]);
   });
 });
 
@@ -28,6 +42,7 @@ describe("parsePluginApprovalRequested", () => {
       description: "chmod 777 script.sh modifies file permissions",
       severity: "high",
       pluginId: "sage",
+      allowedDecisions: ["allow-once", "deny"],
       agentId: "agent-1",
       sessionKey: "sess-1",
     },
@@ -43,6 +58,7 @@ describe("parsePluginApprovalRequested", () => {
       pluginId: "sage",
       request: {
         command: "Dangerous command detected",
+        allowedDecisions: ["allow-once", "deny"],
         agentId: "agent-1",
         sessionKey: "sess-1",
       },

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -1,5 +1,7 @@
 import { normalizeOptionalString } from "../string-coerce.ts";
 
+export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
+
 export type ExecApprovalRequestPayload = {
   command: string;
   cwd?: string | null;
@@ -13,6 +15,7 @@ export type ExecApprovalRequestPayload = {
     startIndex: number;
     endIndex: number;
   }[];
+  allowedDecisions?: readonly ExecApprovalDecision[];
 };
 
 export type ExecApprovalRequest = {
@@ -75,6 +78,22 @@ function parseCommandSpans(
   return spans.length > 0 ? spans : undefined;
 }
 
+function parseAllowedDecisions(value: unknown): ExecApprovalDecision[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const decisions: ExecApprovalDecision[] = [];
+  for (const item of value) {
+    if (
+      (item === "allow-once" || item === "allow-always" || item === "deny") &&
+      !decisions.includes(item)
+    ) {
+      decisions.push(item);
+    }
+  }
+  return decisions.length > 0 ? decisions : undefined;
+}
+
 export function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
@@ -106,6 +125,7 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       resolvedPath: typeof request.resolvedPath === "string" ? request.resolvedPath : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
       commandSpans: parseCommandSpans(request.commandSpans, command.length),
+      allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
     },
     createdAtMs,
     expiresAtMs,
@@ -158,6 +178,7 @@ export function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequ
       command: title,
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
+      allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
     },
     pluginTitle: title,
     pluginDescription: description,

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -168,6 +168,37 @@ describe("approval and confirmation modals", () => {
     expect(spans).toEqual(["ls", "python -c"]);
   });
 
+  it("summarizes long commands in exec approvals", async () => {
+    const request = createExecRequest();
+    request.request.command = Array.from({ length: 8 }, (_, index) => {
+      const line = index + 1;
+      return `echo line ${line}\\u{A}`;
+    }).join("");
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    const command = container.querySelector(".exec-approval-command")?.textContent ?? "";
+    expect(command).toContain("echo line 1\\u{A}");
+    expect(command).toContain("...[truncated: showing first 5 of 9 lines");
+    expect(command).not.toContain("echo line 8");
+  });
+
+  it("only renders approval decisions allowed by the gateway", async () => {
+    const request = createExecRequest();
+    request.request.allowedDecisions = ["allow-once", "deny"];
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    const actions = [...container.querySelectorAll(".exec-approval-actions button")].map((button) =>
+      button.textContent?.trim(),
+    );
+    expect(actions).toEqual(["Allow once", "Deny"]);
+  });
+
   it("maps Escape to exec denial when approval is idle", async () => {
     const handleExecApprovalDecision = vi.fn(async () => undefined);
     render(renderExecApprovalPrompt(createExecState({ handleExecApprovalDecision })), container);

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -1,12 +1,16 @@
 import { html, nothing } from "lit";
 import { formatApprovalDisplayPath } from "../../../../src/infra/approval-display-paths.ts";
+import { summarizeExecApprovalCommandForPrompt } from "../../../../src/infra/exec-approval-command-summary.ts";
 import { t } from "../../i18n/index.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import "../components/modal-dialog.ts";
 import type {
+  ExecApprovalDecision,
   ExecApprovalRequest,
   ExecApprovalRequestPayload,
 } from "../controllers/exec-approval.ts";
+
+const DEFAULT_ALLOWED_DECISIONS = ["allow-once", "allow-always", "deny"] as const;
 
 function formatRemaining(ms: number): string {
   const remaining = Math.max(0, ms);
@@ -33,6 +37,10 @@ function renderMetaRow(label: string, value?: string | null, opts?: { path?: boo
 }
 
 function renderCommandWithSpans(request: ExecApprovalRequestPayload) {
+  const commandSummary = summarizeExecApprovalCommandForPrompt(request.command);
+  if (commandSummary.truncated || commandSummary.text !== request.command) {
+    return html`<div class="exec-approval-command mono">${commandSummary.text}</div>`;
+  }
   const commandSpans = [...(request.commandSpans ?? [])]
     .filter(
       (span) =>
@@ -72,6 +80,13 @@ function renderCommandWithSpans(request: ExecApprovalRequestPayload) {
     parts.push(request.command.slice(cursor));
   }
   return html`<div class="exec-approval-command mono">${parts}</div>`;
+}
+
+function isDecisionAllowed(
+  allowedDecisions: readonly ExecApprovalDecision[],
+  decision: ExecApprovalDecision,
+): boolean {
+  return allowedDecisions.includes(decision);
 }
 
 function renderExecBody(request: ExecApprovalRequestPayload) {
@@ -125,6 +140,7 @@ export function renderExecApprovalPrompt(state: AppViewState) {
     : t("execApproval.execApprovalNeeded");
   const titleId = "exec-approval-title";
   const descriptionId = "exec-approval-description";
+  const allowedDecisions = request.allowedDecisions ?? DEFAULT_ALLOWED_DECISIONS;
   const handleCancel = () => {
     if (!state.execApprovalBusy) {
       void state.handleExecApprovalDecision("deny");
@@ -149,27 +165,33 @@ export function renderExecApprovalPrompt(state: AppViewState) {
           ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
           : nothing}
         <div class="exec-approval-actions">
-          <button
-            class="btn primary"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-once")}
-          >
-            ${t("execApproval.allowOnce")}
-          </button>
-          <button
-            class="btn"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-always")}
-          >
-            ${t("execApproval.alwaysAllow")}
-          </button>
-          <button
-            class="btn danger"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("deny")}
-          >
-            ${t("execApproval.deny")}
-          </button>
+          ${isDecisionAllowed(allowedDecisions, "allow-once")
+            ? html`<button
+                class="btn primary"
+                ?disabled=${state.execApprovalBusy}
+                @click=${() => state.handleExecApprovalDecision("allow-once")}
+              >
+                ${t("execApproval.allowOnce")}
+              </button>`
+            : nothing}
+          ${isDecisionAllowed(allowedDecisions, "allow-always")
+            ? html`<button
+                class="btn"
+                ?disabled=${state.execApprovalBusy}
+                @click=${() => state.handleExecApprovalDecision("allow-always")}
+              >
+                ${t("execApproval.alwaysAllow")}
+              </button>`
+            : nothing}
+          ${isDecisionAllowed(allowedDecisions, "deny")
+            ? html`<button
+                class="btn danger"
+                ?disabled=${state.execApprovalBusy}
+                @click=${() => state.handleExecApprovalDecision("deny")}
+              >
+                ${t("execApproval.deny")}
+              </button>`
+            : nothing}
         </div>
       </div>
     </openclaw-modal-dialog>


### PR DESCRIPTION
## Problem summary

Fixes #58687. Long exec approval prompts can render enough command text that the approval controls become hard to reach or review, especially for inline scripts. The Control UI also rendered an Allow Always button even when the gateway omitted `allow-always` from the request's allowed decisions, making that action look ineffective.

## Root cause

Exec approval request payloads were already sanitized/redacted before display, but presentation surfaces still rendered the whole sanitized command up to the existing display cap. The Control UI parser also ignored `request.allowedDecisions`, so it could offer a decision that the gateway would reject for `ask: "always"` or other restricted approval modes.

## Architectural reasoning

- Adds a browser-safe command prompt summarizer in `src/infra` and uses it only at presentation boundaries: fallback forwarded approval text, shared approval reply payloads, native approval view models, and the Control UI modal.
- Leaves the pending approval record, sanitized command payload, `systemRunPlan`, bindings, and resolution path unchanged, so command identity and allow-always matching are not loosened.
- Preserves short command rendering exactly and only summarizes when the prompt exceeds five logical lines or 1,200 display chars.
- Teaches the Control UI approval parser to carry `allowedDecisions` for exec and plugin approval requests, then renders only those actions in the modal.

## Real behavior proof

- Behavior or issue addressed: long exec approval command text is summarized before prompt rendering, and Control UI approval parsing preserves the gateway-provided allowed decisions so unavailable Allow Always choices can be omitted.
- Real environment tested: local OpenClaw checkout on Windows, Node v22.15.0, pnpm 10.33.2, branch `hemant/58687-approval-prompt-summary` at `aaa32699bfff52d4147d2850f456eaa2c88f3dbe`.
- Exact steps or command run after this patch:
  1. Imported the actual runtime helper from `src/infra/exec-approval-command-summary.ts` with `pnpm exec tsx`.
  2. Built an eight-line approval command using the same escaped line-break marker shape that sanitized approval command text can contain.
  3. Parsed a synthetic gateway `exec.approval.requested` payload through the actual Control UI parser with `allowedDecisions: ["allow-once", "deny"]`.
  4. Printed the resulting prompt summary and parsed decisions.
- Evidence after fix:
```console
$ pnpm exec tsx -e "import { summarizeExecApprovalCommandForPrompt } from './src/infra/exec-approval-command-summary.ts'; import { parseExecApprovalRequested } from './ui/src/ui/controllers/exec-approval.ts'; const command = Array.from({ length: 8 }, (_, i) => 'echo line ' + (i + 1) + '\\u{A}').join(''); const summary = summarizeExecApprovalCommandForPrompt(command); const parsed = parseExecApprovalRequested({ id: 'proof-1', request: { command: 'echo ok', allowedDecisions: ['allow-once', 'deny'] }, createdAtMs: 1, expiresAtMs: 2 }); console.log(JSON.stringify({ summaryTruncated: summary.truncated, hiddenLineCount: summary.hiddenLineCount, includesLine8: summary.text.includes('line 8'), summaryPreview: summary.text.split('\n').slice(0, 6), parsedAllowedDecisions: parsed?.request.allowedDecisions }, null, 2));"
{
  "summaryTruncated": true,
  "hiddenLineCount": 4,
  "includesLine8": false,
  "summaryPreview": [
    "echo line 1\\u{A}",
    "echo line 2\\u{A}",
    "echo line 3\\u{A}",
    "echo line 4\\u{A}",
    "echo line 5\\u{A}",
    "...[truncated: showing first 5 of 9 lines; 52 chars hidden]"
  ],
  "parsedAllowedDecisions": [
    "allow-once",
    "deny"
  ]
}
```
- Observed result after fix: the prompt summary is truncated, hides the tail (`includesLine8: false`), reports the hidden content, and the parser returns only `allow-once` and `deny`, which is the decision set the modal will render.
- What was not tested: I did not attach a screenshot because the browser modal path is covered by `ui/src/ui/views/exec-approval.browser.test.ts`; I did not run a live gateway approval through an external chat account because the changed code is presentation-only and the native adapter tests cover Matrix, Slack, and Telegram rendering.

## Testing performed

- `pnpm test src/infra/exec-approval-command-summary.test.ts src/infra/exec-approval-reply.test.ts src/infra/exec-approval-forwarder.test.ts src/infra/approval-view-model.test.ts ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/views/exec-approval.test.ts ui/src/ui/views/exec-approval.browser.test.ts src/infra/approval-handler-runtime.test.ts extensions/matrix/src/approval-handler.runtime.test.ts extensions/slack/src/approval-handler.runtime.test.ts extensions/telegram/src/approval-handler.runtime.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/tools/exec-approvals-advanced.md src/infra/exec-approval-command-summary.ts src/infra/exec-approval-command-summary.test.ts src/infra/approval-view-model.ts src/infra/approval-view-model.test.ts src/infra/exec-approval-forwarder.ts src/infra/exec-approval-forwarder.test.ts src/infra/exec-approval-reply.ts src/infra/exec-approval-reply.test.ts ui/src/ui/controllers/exec-approval.ts ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/views/exec-approval.ts ui/src/ui/views/exec-approval.test.ts`
- `pnpm lint:core`
- `pnpm docs:check-mdx`
- `pnpm lint:docs`
- `pnpm tsgo:core` via temporary `P:\` mapping because direct execution from `C:\Projects\Personal Project\openclaw` still trips the path-with-spaces launcher issue
- `pnpm tsgo:core:test` via temporary `P:\` mapping
- `pnpm tsgo:test:ui` via temporary `P:\` mapping
- `pnpm check:changed`
- `git diff --check upstream/main...HEAD`

`pnpm test:changed` fanned out to the broad `unit-fast` shard and failed on unrelated Windows/local-environment assumptions: POSIX path expectation mismatches, table glyph fallback expectations, SQLite temp cleanup `EBUSY`, missing A2UI scaffold returning 404, and Testbox local-key fixture assumptions. The focused approval, UI, and native adapter tests above passed.

## Risk analysis

Low-to-medium. The changed behavior is intentionally display-only except for honoring already-present `allowedDecisions` in the Control UI. Approval matching, pending record storage, node/gateway resolution, command binding, and execution semantics are unchanged. The main risk is that native approval clients now receive summarized `view.commandText` for long commands, covered by native handler tests across Matrix, Slack, and Telegram.

## Screenshots/logs

No screenshot was needed; the browser approval modal regression test covers the rendered modal path. The real behavior proof and test command summaries above are the relevant logs.

## Backward compatibility

Existing approval request payload shape is compatible. Clients that do not send `allowedDecisions` still see the historical default actions. Short command prompts render unchanged; long prompts are summarized only in human-facing approval surfaces while the full sanitized command remains bound to the approval record.