### PR TITLE
fix(cron): scope all-run job names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: keep `cron.runs` all-scope job-name enrichment scoped to the requested or default agent so run history does not reveal other agents' job names. Fixes #49175. Thanks @antonio-mello-ai.
 - Agents/exec approvals: forward approval-runtime credentials on agent-owned Gateway approval calls so approved async commands complete through the existing runtime path instead of stalling on unauthenticated follow-up calls. Thanks @IWhatsskill, @Patrick-Erichsen, and @jesse-merhi.
 - Gateway/skills: preflight remote macOS skill-bin refreshes with a WebSocket connectivity check so stale node sessions skip quickly instead of logging slow `system.which` timeout warnings.
 - GitHub Copilot: drop unsafe native Responses reasoning replay items with non-replayable IDs before dispatch, preventing affected Copilot sessions from failing with `invalid_request_body`. Fixes #83220. Thanks @galiniliev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: keep `cron.runs` all-scope job-name enrichment scoped to the requested or default agent so run history does not reveal other agents' job names. Fixes #49175. Thanks @antonio-mello-ai.
 - Plugin SDK: keep activated linked plugin runtime facades loadable when bundled plugin fallback is disabled. Thanks @shakkernerd.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5307,6 +5307,7 @@ public struct CronRunsParams: Codable, Sendable {
     public let id: String?
     public let jobid: String?
     public let runid: String?
+    public let agentid: String?
     public let limit: Int?
     public let offset: Int?
     public let statuses: [AnyCodable]?
@@ -5321,6 +5322,7 @@ public struct CronRunsParams: Codable, Sendable {
         id: String?,
         jobid: String?,
         runid: String?,
+        agentid: String?,
         limit: Int?,
         offset: Int?,
         statuses: [AnyCodable]?,
@@ -5334,6 +5336,7 @@ public struct CronRunsParams: Codable, Sendable {
         self.id = id
         self.jobid = jobid
         self.runid = runid
+        self.agentid = agentid
         self.limit = limit
         self.offset = offset
         self.statuses = statuses
@@ -5349,6 +5352,7 @@ public struct CronRunsParams: Codable, Sendable {
         case id
         case jobid = "jobId"
         case runid = "runId"
+        case agentid = "agentId"
         case limit
         case offset
         case statuses

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5058,6 +5058,7 @@ public struct CronRunsParams: Codable, Sendable {
     public let scope: AnyCodable?
     public let id: String?
     public let jobid: String?
+    public let agentid: String?
     public let limit: Int?
     public let offset: Int?
     public let statuses: [AnyCodable]?
@@ -5071,6 +5072,7 @@ public struct CronRunsParams: Codable, Sendable {
         scope: AnyCodable?,
         id: String?,
         jobid: String?,
+        agentid: String?,
         limit: Int?,
         offset: Int?,
         statuses: [AnyCodable]?,
@@ -5083,6 +5085,7 @@ public struct CronRunsParams: Codable, Sendable {
         self.scope = scope
         self.id = id
         self.jobid = jobid
+        self.agentid = agentid
         self.limit = limit
         self.offset = offset
         self.statuses = statuses
@@ -5097,6 +5100,7 @@ public struct CronRunsParams: Codable, Sendable {
         case scope
         case id
         case jobid = "jobId"
+        case agentid = "agentId"
         case limit
         case offset
         case statuses

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -462,6 +462,7 @@ enumeration of `src/gateway/server-methods/*.ts`.
     - Automation: `wake` schedules an immediate or next-heartbeat wake text injection; `cron.get`, `cron.list`, `cron.status`, `cron.add`, `cron.update`, `cron.remove`, `cron.run`, `cron.runs` manage scheduled work.
     - `cron.run` remains an enqueue-style RPC for manual runs. Clients that need completion semantics should read the returned `runId` and poll `cron.runs`.
     - `cron.runs` accepts an optional non-empty `runId` filter so clients can follow one queued manual run without racing against other history entries for the same job.
+    - `cron.runs` accepts an optional non-empty `agentId` for all-scope history job-name enrichment; omitted values use the cron service default agent.
     - Skills and tools: `commands.list`, `skills.*`, `tools.catalog`, `tools.effective`, `tools.invoke`.
 
   </Accordion>

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -160,6 +160,7 @@ describe("cron protocol validators", () => {
     expect(
       validateCronRunsParams({
         scope: "all",
+        agentId: "main",
         limit: 25,
         statuses: ["ok", "error"],
         deliveryStatuses: ["delivered", "not-requested"],

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -150,6 +150,7 @@ describe("cron protocol validators", () => {
     expect(
       validateCronRunsParams({
         scope: "all",
+        agentId: "main",
         limit: 25,
         statuses: ["ok", "error"],
         deliveryStatuses: ["delivered", "not-requested"],

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -413,6 +413,7 @@ export const CronRunsParamsSchema = Type.Object(
     id: Type.Optional(CronRunLogJobIdSchema),
     jobId: Type.Optional(CronRunLogJobIdSchema),
     runId: Type.Optional(NonEmptyString),
+    agentId: Type.Optional(NonEmptyString),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
     offset: Type.Optional(Type.Integer({ minimum: 0 })),
     statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, { minItems: 1, maxItems: 3 })),

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -395,6 +395,7 @@ export const CronRunsParamsSchema = Type.Object(
     scope: Type.Optional(Type.Union([Type.Literal("job"), Type.Literal("all")])),
     id: Type.Optional(CronRunLogJobIdSchema),
     jobId: Type.Optional(CronRunLogJobIdSchema),
+    agentId: Type.Optional(NonEmptyString),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
     offset: Type.Optional(Type.Integer({ minimum: 0 })),
     statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, { minItems: 1, maxItems: 3 })),

--- a/src/gateway/server-methods/cron.runs.test.ts
+++ b/src/gateway/server-methods/cron.runs.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readCronRunLogEntriesPageAllMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../cron/run-log.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../cron/run-log.js")>("../../cron/run-log.js");
+  return {
+    ...actual,
+    readCronRunLogEntriesPageAll: readCronRunLogEntriesPageAllMock,
+  };
+});
+
+describe("cron.runs server method", () => {
+  beforeEach(() => {
+    readCronRunLogEntriesPageAllMock.mockReset();
+  });
+
+  it("builds all-scope job names from agent-scoped cron list pages", async () => {
+    const { cronHandlers } = await import("./cron.js");
+    const list = vi.fn();
+    const listPage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        jobs: [{ id: "main-job", name: "visible main job" }],
+        total: 2,
+        offset: 0,
+        limit: 1,
+        hasMore: true,
+        nextOffset: 1,
+      })
+      .mockResolvedValueOnce({
+        jobs: [{ id: "main-disabled-job", name: "visible disabled job" }],
+        total: 2,
+        offset: 1,
+        limit: 1,
+        hasMore: false,
+        nextOffset: null,
+      });
+    readCronRunLogEntriesPageAllMock.mockResolvedValueOnce({
+      entries: [],
+      total: 0,
+      offset: 0,
+      limit: 50,
+      hasMore: false,
+      nextOffset: null,
+    });
+    const respond = vi.fn();
+
+    await cronHandlers["cron.runs"]({
+      req: {} as never,
+      params: { scope: "all", agentId: "main", query: "visible", limit: 50 },
+      respond,
+      context: {
+        cron: {
+          list,
+          listPage,
+          getDefaultAgentId: vi.fn(() => "ops"),
+        },
+        cronStorePath: "/tmp/openclaw-cron/jobs.json",
+      } as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(list).not.toHaveBeenCalled();
+    expect(listPage).toHaveBeenNthCalledWith(1, {
+      includeDisabled: true,
+      agentId: "main",
+      limit: 200,
+      offset: 0,
+    });
+    expect(listPage).toHaveBeenNthCalledWith(2, {
+      includeDisabled: true,
+      agentId: "main",
+      limit: 200,
+      offset: 1,
+    });
+    expect(readCronRunLogEntriesPageAllMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/tmp/openclaw-cron/jobs.json",
+        query: "visible",
+        jobNameById: {
+          "main-job": "visible main job",
+          "main-disabled-job": "visible disabled job",
+        },
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        entries: [],
+        total: 0,
+        offset: 0,
+        limit: 50,
+        hasMore: false,
+        nextOffset: null,
+      },
+      undefined,
+    );
+  });
+
+  it("defaults all-scope job-name lookup to the default agent", async () => {
+    const { cronHandlers } = await import("./cron.js");
+    const listPage = vi.fn().mockResolvedValueOnce({
+      jobs: [{ id: "default-job", name: "default agent job" }],
+      total: 1,
+      offset: 0,
+      limit: 1,
+      hasMore: false,
+      nextOffset: null,
+    });
+    readCronRunLogEntriesPageAllMock.mockResolvedValueOnce({
+      entries: [],
+      total: 0,
+      offset: 0,
+      limit: 50,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    await cronHandlers["cron.runs"]({
+      req: {} as never,
+      params: { scope: "all" },
+      respond: vi.fn(),
+      context: {
+        cron: {
+          listPage,
+          getDefaultAgentId: vi.fn(() => "ops"),
+        },
+        cronStorePath: "/tmp/openclaw-cron/jobs.json",
+      } as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(listPage).toHaveBeenCalledWith({
+      includeDisabled: true,
+      agentId: "ops",
+      limit: 200,
+      offset: 0,
+    });
+    expect(readCronRunLogEntriesPageAllMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobNameById: {
+          "default-job": "default agent job",
+        },
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -6,6 +6,7 @@ import {
   readCronRunLogEntriesPageAll,
   resolveCronRunLogPath,
 } from "../../cron/run-log.js";
+import type { CronServiceContract } from "../../cron/service-contract.js";
 import { applyJobPatch } from "../../cron/service/jobs.js";
 import { isInvalidCronSessionTargetIdError } from "../../cron/session-target.js";
 import type { CronDelivery, CronJob, CronJobCreate, CronJobPatch } from "../../cron/types.js";
@@ -16,7 +17,7 @@ import {
   validateTargetProviderPrefix,
 } from "../../infra/outbound/channel-target-prefix.js";
 import { listConfiguredAnnounceChannelIdsForConfig } from "../../plugins/channel-plugin-ids.js";
-import { isSubagentSessionKey } from "../../routing/session-key.js";
+import { DEFAULT_AGENT_ID, isSubagentSessionKey } from "../../routing/session-key.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import {
   ErrorCodes,
@@ -159,6 +160,30 @@ function assertValidCronUpdateDelivery(params: {
     cfg: params.cfg,
     delivery: nextJob.delivery,
   });
+}
+
+async function listCronJobsForRunNameLookup(params: {
+  cron: CronServiceContract;
+  agentId?: string;
+}): Promise<CronJob[]> {
+  const jobs: CronJob[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const page = await params.cron.listPage({
+      includeDisabled: true,
+      agentId: params.agentId,
+      limit: 200,
+      offset,
+    });
+    jobs.push(...page.jobs);
+    if (!page.hasMore || page.nextOffset === null) {
+      break;
+    }
+    offset = page.nextOffset;
+  }
+
+  return jobs;
 }
 
 export const cronHandlers: GatewayRequestHandlers = {
@@ -539,6 +564,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       status?: "all" | "ok" | "error" | "skipped";
       deliveryStatuses?: Array<"delivered" | "not-delivered" | "unknown" | "not-requested">;
       deliveryStatus?: "delivered" | "not-delivered" | "unknown" | "not-requested";
+      agentId?: string;
       query?: string;
       sortDir?: "asc" | "desc";
     };
@@ -554,7 +580,11 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     if (scope === "all") {
-      const jobs = await context.cron.list({ includeDisabled: true });
+      const jobNameAgentId = p.agentId ?? context.cron.getDefaultAgentId() ?? DEFAULT_AGENT_ID;
+      const jobs = await listCronJobsForRunNameLookup({
+        cron: context.cron,
+        agentId: jobNameAgentId,
+      });
       const jobNameById = Object.fromEntries(
         jobs
           .filter((job) => typeof job.id === "string" && typeof job.name === "string")

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -6,6 +6,7 @@ import {
   readCronRunLogEntriesPageAll,
   resolveCronRunLogPath,
 } from "../../cron/run-log.js";
+import type { CronServiceContract } from "../../cron/service-contract.js";
 import { applyJobPatch } from "../../cron/service/jobs.js";
 import { isInvalidCronSessionTargetIdError } from "../../cron/session-target.js";
 import type { CronDelivery, CronJob, CronJobCreate, CronJobPatch } from "../../cron/types.js";
@@ -16,6 +17,7 @@ import {
   validateTargetProviderPrefix,
 } from "../../infra/outbound/channel-target-prefix.js";
 import { listConfiguredAnnounceChannelIdsForConfig } from "../../plugins/channel-plugin-ids.js";
+import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import {
   ErrorCodes,
@@ -157,6 +159,30 @@ function assertValidCronUpdateDelivery(params: {
     cfg: params.cfg,
     delivery: nextJob.delivery,
   });
+}
+
+async function listCronJobsForRunNameLookup(params: {
+  cron: CronServiceContract;
+  agentId?: string;
+}): Promise<CronJob[]> {
+  const jobs: CronJob[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const page = await params.cron.listPage({
+      includeDisabled: true,
+      agentId: params.agentId,
+      limit: 200,
+      offset,
+    });
+    jobs.push(...page.jobs);
+    if (!page.hasMore || page.nextOffset === null) {
+      break;
+    }
+    offset = page.nextOffset;
+  }
+
+  return jobs;
 }
 
 export const cronHandlers: GatewayRequestHandlers = {
@@ -489,6 +515,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       status?: "all" | "ok" | "error" | "skipped";
       deliveryStatuses?: Array<"delivered" | "not-delivered" | "unknown" | "not-requested">;
       deliveryStatus?: "delivered" | "not-delivered" | "unknown" | "not-requested";
+      agentId?: string;
       query?: string;
       sortDir?: "asc" | "desc";
     };
@@ -504,7 +531,11 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     if (scope === "all") {
-      const jobs = await context.cron.list({ includeDisabled: true });
+      const jobNameAgentId = p.agentId ?? context.cron.getDefaultAgentId() ?? DEFAULT_AGENT_ID;
+      const jobs = await listCronJobsForRunNameLookup({
+        cron: context.cron,
+        agentId: jobNameAgentId,
+      });
       const jobNameById = Object.fromEntries(
         jobs
           .filter((job) => typeof job.id === "string" && typeof job.name === "string")


### PR DESCRIPTION
## Summary

Fixes #49175.

`cron.runs` with `scope: "all"` still returns global run-log rows, but job-name enrichment now uses the same agent-scoped job visibility path as `cron.list` instead of reading every job through the unfiltered `cron.list()` shortcut.

## Problem summary

`cron.runs(scope=all)` built `jobNameById` from `context.cron.list({ includeDisabled: true })`. That list is not caller/agent filtered, so run-history responses could attach another agent's cron job name to otherwise global run entries.

## Root cause

The all-scope run-log reader intentionally scans all run logs, but the server method reused an unscoped job list to enrich those entries and to make job names searchable. The leak was in the enrichment map, not in scheduler execution or run-log storage.

## Architectural reasoning

- Reuses `context.cron.listPage()` for the job-name lookup because it already applies `agentId` filtering and effective default-agent handling.
- Paginates through visible jobs with `limit: 200` so the enrichment map remains complete for large visible job lists.
- Accepts optional `agentId` on `CronRunsParams`; when omitted, enrichment defaults to the cron service default agent, then the canonical `main` default.
- Leaves run-log scanning, job-specific `cron.runs`, scheduling, delivery, cleanup, retry, and background-task behavior unchanged.
- Keeps backward compatibility for the run-history shape: global entries still return, but entries outside the visible agent scope are not enriched with private job names.

## Testing performed

- `pnpm test src/gateway/server-methods/cron.runs.test.ts src/gateway/protocol/cron-validators.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/gateway/protocol/schema/cron.ts src/gateway/protocol/cron-validators.test.ts src/gateway/server-methods/cron.ts src/gateway/server-methods/cron.runs.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint:core`
- `OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
- `pnpm check:changelog-attributions`
- `git diff --check upstream/main...HEAD`

## Real behavior proof

- Behavior or issue addressed: `cron.runs(scope=all)` no longer builds its job-name enrichment map from every cron job across all agents.
- Real environment tested: Local Windows source checkout, Node `v22.15.0`, pnpm `10.33.2`. The repo warns that Node `>=22.16.0` is preferred on this machine; the targeted proof below completed.
- Exact steps or command run after this patch: Ran the patched `cron.runs` server handler from the source checkout with `scope: "all"` and `agentId: "main"`; the command throws if the old unscoped `cron.list()` path is used and records the actual listing call made by the handler.
- Evidence after fix: Terminal output copied from the patched checkout:

```json
{
  "unscopedListCalls": 0,
  "listPageCalls": [
    {
      "includeDisabled": true,
      "agentId": "main",
      "limit": 200,
      "offset": 0
    }
  ],
  "response": {
    "ok": true,
    "result": {
      "entries": [],
      "total": 0,
      "offset": 0,
      "limit": 1,
      "hasMore": false,
      "nextOffset": null
    }
  }
}
```

- Observed result after fix: The patched handler did not call the old unscoped list path (`unscopedListCalls: 0`) and used the agent-scoped paginated list path with `agentId: "main"`; the call returned successfully.
- What was not tested: A full live gateway/UI cron-history session was not run on this Windows host. The existing `src/gateway/server.cron.test.ts -t "writes cron run history"` integration test was attempted locally and still fails here because the pre-existing all-scope run-log directory listing path returns no entries under the local fs-safe/root implementation. That failure is independent of this privacy fix; the added regression directly tests the changed handler contract.

## Risk analysis

Risk is low-to-medium. The changed runtime path is limited to all-scope `cron.runs` job-name enrichment. It does not alter run execution, scheduler concurrency, cleanup, delivery, retries, or job-specific run-history reads. The main compatibility change is intentionally privacy-preserving: callers still receive all-scope run entries, but job names are only attached for the requested/default agent scope.

## Backward compatibility

Additive protocol change: `CronRunsParams` now accepts optional `agentId`. Existing `cron.runs` callers remain valid.