### PR TITLE
fix(browser): time out remote tab enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser: time out remote CDP Playwright tab enumeration and evict stuck scoped connections so unstable remote browsers fail fast instead of blocking Gateway browser requests. Fixes #58968. Thanks @KeaneYan.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.
 - Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3762,6 +3762,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 
 ### Fixes
 
+- Browser: time out remote CDP Playwright tab enumeration and evict stuck scoped connections so unstable remote browsers fail fast instead of blocking Gateway browser requests. Fixes #58968. Thanks @KeaneYan.
 - Agents/exec approvals: return approved WebChat gateway exec output inline after native approval instead of leaving the model waiting for an async follow-up. (#82019) Thanks @Zac-W.
 - CLI/node: reject invalid explicit `node run --port` values instead of silently falling back to the configured or default port. Fixes #83923. Thanks @davinci282828.
 - CLI: reject explicit port numbers above 65535 before they reach Gateway or Node bind paths. Fixes #83900. (#84008) Thanks @hclsys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3762,7 +3762,6 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 
 ### Fixes
 
-- Browser: time out remote CDP Playwright tab enumeration and evict stuck scoped connections so unstable remote browsers fail fast instead of blocking Gateway browser requests. Fixes #58968. Thanks @KeaneYan.
 - Agents/exec approvals: return approved WebChat gateway exec output inline after native approval instead of leaving the model waiting for an async follow-up. (#82019) Thanks @Zac-W.
 - CLI/node: reject invalid explicit `node run --port` values instead of silently falling back to the configured or default port. Fixes #83923. Thanks @davinci282828.
 - CLI: reject explicit port numbers above 65535 before they reach Gateway or Node bind paths. Fixes #83900. (#84008) Thanks @hclsys.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -441,7 +441,8 @@ See [Inferred commitments](/concepts/commitments).
   when your provider gives you a direct DevTools WebSocket URL.
 - `remoteCdpTimeoutMs` and `remoteCdpHandshakeTimeoutMs` apply to remote and
   `attachOnly` CDP reachability plus tab-opening requests. Managed loopback
-  profiles keep local CDP defaults.
+  profiles keep local CDP defaults. Persistent remote Playwright tab
+  enumeration uses the larger value as its operation deadline.
 - If an externally managed CDP service is reachable through loopback, set that
   profile's `attachOnly: true`; otherwise OpenClaw treats the loopback port as a
   local managed browser profile and may report local port ownership errors.

--- a/docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md
+++ b/docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md
@@ -161,6 +161,7 @@ Good result:
 | `Browser attachOnly is enabled and CDP websocket for profile "remote" is not reachable` | the HTTP endpoint answered, but the DevTools WebSocket could not be opened                                                                                                        |
 | stale viewport / dark-mode / locale / offline overrides after a remote session          | run `openclaw browser --browser-profile remote stop` to close the session and release the cached Playwright/CDP connection without restarting the Gateway or the external browser |
 | timeout around `remoteCdpTimeoutMs` (default 1500ms)                                    | usually still CDP reachability, or a slow/unreachable remote endpoint                                                                                                             |
+| `Playwright page enumeration timed out after 3000ms`                                    | the remote CDP connected, but its persistent tab read stalled; the deadline is the larger of `remoteCdpTimeoutMs` and `remoteCdpHandshakeTimeoutMs`                               |
 | `No Chrome tabs found for profile="user"`                                               | local Chrome MCP profile selected where no host-local tabs are available                                                                                                          |
 
 ## Fast triage checklist

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -255,7 +255,8 @@ main model can read the screenshot directly.
   the managed local CDP port when unset.
 - `remoteCdpTimeoutMs` applies to remote and `attachOnly` CDP HTTP reachability
   checks and tab-opening HTTP requests; `remoteCdpHandshakeTimeoutMs` applies to
-  their CDP WebSocket handshakes.
+  their CDP WebSocket handshakes. Persistent remote Playwright tab enumeration
+  uses the larger of the two as its operation deadline.
 - `localLaunchTimeoutMs` is the budget for a locally launched managed Chrome
   process to expose its CDP HTTP endpoint. `localCdpReadyTimeoutMs` is the
   follow-up budget for CDP websocket readiness after the process is discovered.

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -97,6 +97,32 @@ function makeDisconnectedReadBrowser(): BrowserMockBundle {
   return { browser, browserClose };
 }
 
+function makeStuckPageTargetBrowser(): BrowserMockBundle {
+  let context: import("playwright-core").BrowserContext;
+  const browserClose = vi.fn(async () => {});
+  const page = {
+    on: vi.fn(),
+    context: () => context,
+    title: vi.fn(async () => "never reached"),
+    url: vi.fn(() => "https://stuck.example"),
+  } as unknown as import("playwright-core").Page;
+
+  context = {
+    pages: () => [page],
+    on: vi.fn(),
+    newCDPSession: vi.fn(() => new Promise(() => {})),
+  } as unknown as import("playwright-core").BrowserContext;
+
+  const browser = {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: browserClose,
+  } as unknown as import("playwright-core").Browser;
+
+  return { browser, browserClose };
+}
+
 function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
   newPage: ReturnType<typeof vi.fn>;
 } {
@@ -249,6 +275,37 @@ describe("pw-session connection scoping", () => {
     expect(pages.map((page) => page.targetId)).toEqual(["A"]);
     expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(stale.browserClose).toHaveBeenCalledTimes(1));
+    expect(refreshed.browserClose).not.toHaveBeenCalled();
+  });
+
+  it("times out stuck page enumeration and evicts the scoped connection", async () => {
+    const stuck = makeStuckPageTargetBrowser();
+    const refreshed = makeBrowser("A", "https://a.example/recovered");
+    let connectCalls = 0;
+
+    connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
+      const endpointText = String(args[0]);
+      if (endpointText !== "http://127.0.0.1:9222") {
+        throw new Error(`unexpected endpoint: ${endpointText}`);
+      }
+      connectCalls += 1;
+      return connectCalls === 1 ? stuck.browser : refreshed.browser;
+    }) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
+    ).rejects.toThrow(/Playwright page enumeration timed out after 20ms/);
+
+    await vi.waitFor(() => expect(stuck.browserClose).toHaveBeenCalledTimes(1));
+
+    const pages = await listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1000,
+    });
+
+    expect(pages.map((page) => page.targetId)).toEqual(["A"]);
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     expect(refreshed.browserClose).not.toHaveBeenCalled();
   });
 

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -96,6 +96,32 @@ function makeDisconnectedReadBrowser(): BrowserMockBundle {
   return { browser, browserClose };
 }
 
+function makeStuckPageTargetBrowser(): BrowserMockBundle {
+  let context: import("playwright-core").BrowserContext;
+  const browserClose = vi.fn(async () => {});
+  const page = {
+    on: vi.fn(),
+    context: () => context,
+    title: vi.fn(async () => "never reached"),
+    url: vi.fn(() => "https://stuck.example"),
+  } as unknown as import("playwright-core").Page;
+
+  context = {
+    pages: () => [page],
+    on: vi.fn(),
+    newCDPSession: vi.fn(() => new Promise(() => {})),
+  } as unknown as import("playwright-core").BrowserContext;
+
+  const browser = {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: browserClose,
+  } as unknown as import("playwright-core").Browser;
+
+  return { browser, browserClose };
+}
+
 function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
   newPage: ReturnType<typeof vi.fn>;
 } {
@@ -246,6 +272,37 @@ describe("pw-session connection scoping", () => {
     expect(pages.map((page) => page.targetId)).toEqual(["A"]);
     expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(stale.browserClose).toHaveBeenCalledTimes(1));
+    expect(refreshed.browserClose).not.toHaveBeenCalled();
+  });
+
+  it("times out stuck page enumeration and evicts the scoped connection", async () => {
+    const stuck = makeStuckPageTargetBrowser();
+    const refreshed = makeBrowser("A", "https://a.example/recovered");
+    let connectCalls = 0;
+
+    connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
+      const endpointText = String(args[0]);
+      if (endpointText !== "http://127.0.0.1:9222") {
+        throw new Error(`unexpected endpoint: ${endpointText}`);
+      }
+      connectCalls += 1;
+      return connectCalls === 1 ? stuck.browser : refreshed.browser;
+    }) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
+    ).rejects.toThrow(/Playwright page enumeration timed out after 20ms/);
+
+    await vi.waitFor(() => expect(stuck.browserClose).toHaveBeenCalledTimes(1));
+
+    const pages = await listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1000,
+    });
+
+    expect(pages.map((page) => page.targetId)).toEqual(["A"]);
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     expect(refreshed.browserClose).not.toHaveBeenCalled();
   });
 

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -99,7 +99,6 @@ function makeDisconnectedReadBrowser(): BrowserMockBundle {
 function makeStuckPageTargetBrowser(): BrowserMockBundle & {
   rejectTargetRead: (error: Error) => void;
 } {
-  let context: import("playwright-core").BrowserContext;
   let rejectTargetRead: ((error: Error) => void) | undefined;
   const browserClose = vi.fn(async () => {});
   const page = {
@@ -109,7 +108,7 @@ function makeStuckPageTargetBrowser(): BrowserMockBundle & {
     url: vi.fn(() => "https://stuck.example"),
   } as unknown as import("playwright-core").Page;
 
-  context = {
+  const context = {
     pages: () => [page],
     on: vi.fn(),
     newCDPSession: vi.fn(
@@ -386,7 +385,9 @@ describe("pw-session connection scoping", () => {
     expect(recovered.map((page) => page.targetId)).toEqual(["A"]);
 
     stuck.rejectTargetRead(new Error("Target page, context or browser has been closed"));
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     const stillCached = await listPagesViaPlaywright({
       cdpUrl: "http://127.0.0.1:9222",

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -96,8 +96,11 @@ function makeDisconnectedReadBrowser(): BrowserMockBundle {
   return { browser, browserClose };
 }
 
-function makeStuckPageTargetBrowser(): BrowserMockBundle {
+function makeStuckPageTargetBrowser(): BrowserMockBundle & {
+  rejectTargetRead: (error: Error) => void;
+} {
   let context: import("playwright-core").BrowserContext;
+  let rejectTargetRead: ((error: Error) => void) | undefined;
   const browserClose = vi.fn(async () => {});
   const page = {
     on: vi.fn(),
@@ -109,7 +112,12 @@ function makeStuckPageTargetBrowser(): BrowserMockBundle {
   context = {
     pages: () => [page],
     on: vi.fn(),
-    newCDPSession: vi.fn(() => new Promise(() => {})),
+    newCDPSession: vi.fn(
+      () =>
+        new Promise((_, reject) => {
+          rejectTargetRead = reject;
+        }),
+    ),
   } as unknown as import("playwright-core").BrowserContext;
 
   const browser = {
@@ -119,7 +127,11 @@ function makeStuckPageTargetBrowser(): BrowserMockBundle {
     close: browserClose,
   } as unknown as import("playwright-core").Browser;
 
-  return { browser, browserClose };
+  return {
+    browser,
+    browserClose,
+    rejectTargetRead: (error) => rejectTargetRead?.(error),
+  };
 }
 
 function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
@@ -302,6 +314,85 @@ describe("pw-session connection scoping", () => {
     });
 
     expect(pages.map((page) => page.targetId)).toEqual(["A"]);
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
+    expect(refreshed.browserClose).not.toHaveBeenCalled();
+  });
+
+  it("does not let a timed-out connect replace or clear its successor", async () => {
+    const late = makeBrowser("LATE", "https://late.example");
+    const refreshed = makeBrowser("A", "https://a.example/recovered");
+    let resolveLate: ((browser: import("playwright-core").Browser) => void) | undefined;
+    let resolveRefreshed: ((browser: import("playwright-core").Browser) => void) | undefined;
+    let connectCalls = 0;
+
+    connectOverCdpSpy.mockImplementation((async () => {
+      connectCalls += 1;
+      return await new Promise<import("playwright-core").Browser>((resolve) => {
+        if (connectCalls === 1) {
+          resolveLate = resolve;
+        } else {
+          resolveRefreshed = resolve;
+        }
+      });
+    }) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
+    ).rejects.toThrow(/Playwright page enumeration timed out after 20ms/);
+
+    const successor = listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1000,
+    });
+    await vi.waitFor(() => expect(connectOverCdpSpy).toHaveBeenCalledTimes(2));
+
+    resolveLate?.(late.browser);
+    await vi.waitFor(() => expect(late.browserClose).toHaveBeenCalledTimes(1));
+
+    const sharedSuccessor = listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1000,
+    });
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
+
+    resolveRefreshed?.(refreshed.browser);
+    const [pages, sharedPages] = await Promise.all([successor, sharedSuccessor]);
+    expect(pages.map((page) => page.targetId)).toEqual(["A"]);
+    expect(sharedPages.map((page) => page.targetId)).toEqual(["A"]);
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
+    expect(refreshed.browserClose).not.toHaveBeenCalled();
+  });
+
+  it("does not let a timed-out read evict its healthy successor", async () => {
+    const stuck = makeStuckPageTargetBrowser();
+    const refreshed = makeBrowser("A", "https://a.example/recovered");
+    let connectCalls = 0;
+
+    connectOverCdpSpy.mockImplementation((async () => {
+      connectCalls += 1;
+      return connectCalls === 1 ? stuck.browser : refreshed.browser;
+    }) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
+    ).rejects.toThrow(/Playwright page enumeration timed out after 20ms/);
+
+    const recovered = await listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1000,
+    });
+    expect(recovered.map((page) => page.targetId)).toEqual(["A"]);
+
+    stuck.rejectTargetRead(new Error("Target page, context or browser has been closed"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const stillCached = await listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1000,
+    });
+    expect(stillCached.map((page) => page.targetId)).toEqual(["A"]);
     expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     expect(refreshed.browserClose).not.toHaveBeenCalled();
   });

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -1240,6 +1240,53 @@ async function withPlaywrightSafeReadReconnect<T>(
   }
 }
 
+function normalizePlaywrightOperationTimeoutMs(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+async function withPlaywrightOperationTimeout<T>(opts: {
+  cdpUrl: string;
+  timeoutMs?: number;
+  label: string;
+  ssrfPolicy?: SsrFPolicy;
+  run: () => Promise<T>;
+}): Promise<T> {
+  const timeoutMs = normalizePlaywrightOperationTimeoutMs(opts.timeoutMs);
+  if (timeoutMs === undefined) {
+    return await opts.run();
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutError: Error | undefined;
+  const work = opts.run();
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      timeoutError = new Error(`${opts.label} timed out after ${timeoutMs}ms`);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([work, timeout]);
+  } catch (err) {
+    if (err === timeoutError) {
+      await forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        ssrfPolicy: opts.ssrfPolicy,
+        reason: opts.label,
+      }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 /**
  * List all pages/tabs from the persistent Playwright connection.
  * Used for remote profiles where HTTP-based /json/list is ephemeral.
@@ -1247,6 +1294,7 @@ async function withPlaywrightSafeReadReconnect<T>(
 export async function listPagesViaPlaywright(opts: {
   cdpUrl: string;
   ssrfPolicy?: SsrFPolicy;
+  timeoutMs?: number;
 }): Promise<
   Array<{
     targetId: string;
@@ -1255,55 +1303,64 @@ export async function listPagesViaPlaywright(opts: {
     type: string;
   }>
 > {
-  return await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
-    const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
-    const pages = await getAllPages(browser);
-    const results: Array<{
-      targetId: string;
-      title: string;
-      url: string;
-      type: string;
-    }> = [];
+  const readPages = async () =>
+    await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
+      const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+      const pages = await getAllPages(browser);
+      const results: Array<{
+        targetId: string;
+        title: string;
+        url: string;
+        type: string;
+      }> = [];
 
-    for (const page of pages) {
-      if (isBlockedPageRef(opts.cdpUrl, page)) {
-        continue;
-      }
-      let tid: string | null;
-      try {
-        tid = await pageTargetId(page);
-      } catch (err) {
-        if (isRecoverablePlaywrightDisconnectError(err)) {
-          throw err;
+      for (const page of pages) {
+        if (isBlockedPageRef(opts.cdpUrl, page)) {
+          continue;
         }
-        tid = null;
-      }
-      if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
-        let title = "";
+        let tid: string | null;
         try {
-          title = await page.title();
+          tid = await pageTargetId(page);
         } catch (err) {
           if (isRecoverablePlaywrightDisconnectError(err)) {
             throw err;
           }
+          tid = null;
         }
-        let url = "";
-        try {
-          url = page.url();
-        } catch (err) {
-          if (isRecoverablePlaywrightDisconnectError(err)) {
-            throw err;
+        if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
+          let title = "";
+          try {
+            title = await page.title();
+          } catch (err) {
+            if (isRecoverablePlaywrightDisconnectError(err)) {
+              throw err;
+            }
           }
+          let url = "";
+          try {
+            url = page.url();
+          } catch (err) {
+            if (isRecoverablePlaywrightDisconnectError(err)) {
+              throw err;
+            }
+          }
+          results.push({
+            targetId: tid,
+            title,
+            url,
+            type: "page",
+          });
         }
-        results.push({
-          targetId: tid,
-          title,
-          url,
-          type: "page",
-        });
       }
-    }
-    return results;
+      return results;
+    });
+
+  return await withPlaywrightOperationTimeout({
+    cdpUrl: opts.cdpUrl,
+    timeoutMs: opts.timeoutMs,
+    label: "Playwright page enumeration",
+    ssrfPolicy: opts.ssrfPolicy,
+    run: readPages,
   });
 }
 

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -196,8 +196,13 @@ const MAX_NETWORK_REQUESTS = 500;
 const MAX_RECENT_DIALOGS = 20;
 const OBSERVED_DIALOG_TIMEOUT_MS = 120_000;
 
+type PendingBrowserConnection = {
+  attempt: { cancelled: boolean };
+  promise: Promise<ConnectedBrowser>;
+};
+
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
-const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
+const connectingByCdpUrl = new Map<string, PendingBrowserConnection>();
 const blockedTargetsByCdpUrl = new Set<string>();
 const blockedPageRefsByCdpUrl = new Map<string, WeakSet<Page>>();
 let cdpConnectRetryDelayMsForTests: number | undefined;
@@ -479,6 +484,12 @@ function takeCachedPlaywrightBrowserConnection(cdpUrl: string): ConnectedBrowser
   const normalized = normalizeCdpUrl(cdpUrl);
   const cur = cachedByCdpUrl.get(normalized);
   cachedByCdpUrl.delete(normalized);
+  const pending = connectingByCdpUrl.get(normalized);
+  if (pending) {
+    // Invalidation must also retire an in-flight connect. Otherwise it can
+    // resolve after cleanup and repopulate the cache with the stale pipe.
+    pending.attempt.cancelled = true;
+  }
   connectingByCdpUrl.delete(normalized);
   if (!cur) {
     return null;
@@ -489,7 +500,11 @@ function takeCachedPlaywrightBrowserConnection(cdpUrl: string): ConnectedBrowser
   return cur;
 }
 
-function evictStalePlaywrightBrowserConnection(cdpUrl: string): void {
+function evictStalePlaywrightBrowserConnection(cdpUrl: string, expectedBrowser?: Browser): void {
+  const current = cachedByCdpUrl.get(normalizeCdpUrl(cdpUrl));
+  if (expectedBrowser && current?.browser !== expectedBrowser) {
+    return;
+  }
   const cur = takeCachedPlaywrightBrowserConnection(cdpUrl);
   cur?.browser.close().catch(() => {});
 }
@@ -928,12 +943,16 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
   await assertCdpEndpointAllowed(normalized, ssrfPolicy);
   const connecting = connectingByCdpUrl.get(normalized);
   if (connecting) {
-    return await connecting;
+    return await connecting.promise;
   }
 
+  const connectionAttempt = { cancelled: false };
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
+      if (connectionAttempt.cancelled) {
+        break;
+      }
       try {
         const timeout = 5000 + attempt * 2000;
         const wsUrl = await getChromeWebSocketUrl(normalized, timeout, ssrfPolicy).catch(
@@ -956,6 +975,10 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
           }
           browser = await connectEndpoint(normalized);
         }
+        if (connectionAttempt.cancelled) {
+          browser.close().catch(() => {});
+          throw new Error("Playwright connection attempt was superseded.");
+        }
         const onDisconnected = () => {
           const current = cachedByCdpUrl.get(normalized);
           if (current?.browser === browser) {
@@ -969,6 +992,9 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
         return connected;
       } catch (err) {
         lastErr = err;
+        if (connectionAttempt.cancelled) {
+          break;
+        }
         // Don't retry rate-limit errors; retrying worsens the 429.
         const errMsg = formatErrorMessage(err);
         if (errMsg.includes("rate limit")) {
@@ -988,9 +1014,11 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
   };
 
   const pending = connectWithRetry().finally(() => {
-    connectingByCdpUrl.delete(normalized);
+    if (connectingByCdpUrl.get(normalized)?.attempt === connectionAttempt) {
+      connectingByCdpUrl.delete(normalized);
+    }
   });
-  connectingByCdpUrl.set(normalized, pending);
+  connectingByCdpUrl.set(normalized, { attempt: connectionAttempt, promise: pending });
 
   return await pending;
 }
@@ -1494,6 +1522,9 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
   }
 
   const connections = Array.from(cachedByCdpUrl.values());
+  for (const pending of connectingByCdpUrl.values()) {
+    pending.attempt.cancelled = true;
+  }
   clearBlockedTargetsForCdpUrl();
   clearBlockedPageRefsForCdpUrl();
   cachedByCdpUrl.clear();
@@ -1601,7 +1632,7 @@ async function tryTerminateExecutionViaCdp(opts: {
  * instance, preventing reconnection.
  *
  * Instead we:
- * 1. Null out `cached` so the next call triggers a fresh connectOverCDP
+ * 1. Retire the scoped cached or in-flight connection so the next call reconnects
  * 2. Fire-and-forget browser.close() — it may hang but won't block us
  * 3. The next connectBrowser() creates a completely new CDP WebSocket connection
  *
@@ -1637,77 +1668,33 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
 }
 
 async function withPlaywrightSafeReadReconnect<T>(
-  cdpUrl: string,
-  run: () => Promise<T>,
+  opts: {
+    cdpUrl: string;
+    ssrfPolicy?: SsrFPolicy;
+    attempt?: { cancelled: boolean };
+  },
+  run: (browser: Browser) => Promise<T>,
 ): Promise<T> {
+  const connected = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
   try {
-    return await run();
+    return await run(connected.browser);
   } catch (err) {
-    if (!isRecoverablePlaywrightDisconnectError(err)) {
+    if (!isRecoverablePlaywrightDisconnectError(err) || opts.attempt?.cancelled) {
       throw err;
     }
-    evictStalePlaywrightBrowserConnection(cdpUrl);
-    return await run();
-  }
-}
-
-function normalizePlaywrightOperationTimeoutMs(value: number | undefined): number | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return undefined;
-  }
-  return Math.max(1, Math.floor(value));
-}
-
-async function withPlaywrightOperationTimeout<T>(opts: {
-  cdpUrl: string;
-  timeoutMs?: number;
-  label: string;
-  ssrfPolicy?: SsrFPolicy;
-  run: () => Promise<T>;
-}): Promise<T> {
-  const timeoutMs = normalizePlaywrightOperationTimeoutMs(opts.timeoutMs);
-  if (timeoutMs === undefined) {
-    return await opts.run();
-  }
-
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let timeoutError: Error | undefined;
-  const work = opts.run();
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      timeoutError = new Error(`${opts.label} timed out after ${timeoutMs}ms`);
-      reject(timeoutError);
-    }, timeoutMs);
-  });
-
-  try {
-    return await Promise.race([work, timeout]);
-  } catch (err) {
-    if (err === timeoutError) {
-      await forceDisconnectPlaywrightForTarget({
-        cdpUrl: opts.cdpUrl,
-        ssrfPolicy: opts.ssrfPolicy,
-        reason: opts.label,
-      }).catch(() => {});
+    evictStalePlaywrightBrowserConnection(opts.cdpUrl, connected.browser);
+    if (opts.attempt?.cancelled) {
+      throw err;
     }
-    throw err;
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
+    const retry = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+    return await run(retry.browser);
   }
 }
 
-/**
- * List all pages/tabs from the persistent Playwright connection.
- * Used for remote profiles where HTTP-based /json/list is ephemeral.
- */
-/** List pages through the persistent Playwright connection. */
-export async function listPagesViaPlaywright(opts: {
-  cdpUrl: string;
-  ssrfPolicy?: SsrFPolicy;
-  timeoutMs?: number;
-}): Promise<
+async function readPagesViaPlaywright(
+  opts: { cdpUrl: string; ssrfPolicy?: SsrFPolicy },
+  attempt?: { cancelled: boolean },
+): Promise<
   Array<{
     targetId: string;
     title: string;
@@ -1715,9 +1702,9 @@ export async function listPagesViaPlaywright(opts: {
     type: string;
   }>
 > {
-  const readPages = async () =>
-    await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
-      const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+  return await withPlaywrightSafeReadReconnect(
+    { cdpUrl: opts.cdpUrl, ssrfPolicy: opts.ssrfPolicy, attempt },
+    async (browser) => {
       const pages = await getAllPages(browser);
       const results: Array<{
         targetId: string;
@@ -1768,15 +1755,55 @@ export async function listPagesViaPlaywright(opts: {
         }
       }
       return results;
-    });
+    },
+  );
+}
 
-  return await withPlaywrightOperationTimeout({
-    cdpUrl: opts.cdpUrl,
-    timeoutMs: opts.timeoutMs,
-    label: "Playwright page enumeration",
-    ssrfPolicy: opts.ssrfPolicy,
-    run: readPages,
+/**
+ * List all pages/tabs from the persistent Playwright connection.
+ * Used for remote profiles where HTTP-based /json/list is ephemeral.
+ */
+/** List pages through the persistent Playwright connection. */
+export async function listPagesViaPlaywright(opts: {
+  cdpUrl: string;
+  ssrfPolicy?: SsrFPolicy;
+  timeoutMs?: number;
+}) {
+  const timeoutMs =
+    typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
+      ? Math.max(1, Math.floor(opts.timeoutMs))
+      : undefined;
+  if (timeoutMs === undefined) {
+    return await readPagesViaPlaywright(opts);
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutError: Error | undefined;
+  const attempt = { cancelled: false };
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      attempt.cancelled = true;
+      timeoutError = new Error(`Playwright page enumeration timed out after ${timeoutMs}ms`);
+      reject(timeoutError);
+    }, timeoutMs);
+    timer.unref?.();
   });
+  try {
+    return await Promise.race([readPagesViaPlaywright(opts, attempt), timeout]);
+  } catch (err) {
+    if (err === timeoutError) {
+      await forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        ssrfPolicy: opts.ssrfPolicy,
+        reason: "Playwright page enumeration",
+      }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 /**

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -1651,6 +1651,53 @@ async function withPlaywrightSafeReadReconnect<T>(
   }
 }
 
+function normalizePlaywrightOperationTimeoutMs(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+async function withPlaywrightOperationTimeout<T>(opts: {
+  cdpUrl: string;
+  timeoutMs?: number;
+  label: string;
+  ssrfPolicy?: SsrFPolicy;
+  run: () => Promise<T>;
+}): Promise<T> {
+  const timeoutMs = normalizePlaywrightOperationTimeoutMs(opts.timeoutMs);
+  if (timeoutMs === undefined) {
+    return await opts.run();
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutError: Error | undefined;
+  const work = opts.run();
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      timeoutError = new Error(`${opts.label} timed out after ${timeoutMs}ms`);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([work, timeout]);
+  } catch (err) {
+    if (err === timeoutError) {
+      await forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        ssrfPolicy: opts.ssrfPolicy,
+        reason: opts.label,
+      }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 /**
  * List all pages/tabs from the persistent Playwright connection.
  * Used for remote profiles where HTTP-based /json/list is ephemeral.
@@ -1659,6 +1706,7 @@ async function withPlaywrightSafeReadReconnect<T>(
 export async function listPagesViaPlaywright(opts: {
   cdpUrl: string;
   ssrfPolicy?: SsrFPolicy;
+  timeoutMs?: number;
 }): Promise<
   Array<{
     targetId: string;
@@ -1667,58 +1715,67 @@ export async function listPagesViaPlaywright(opts: {
     type: string;
   }>
 > {
-  return await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
-    const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
-    const pages = await getAllPages(browser);
-    const results: Array<{
-      targetId: string;
-      title: string;
-      url: string;
-      type: string;
-    }> = [];
+  const readPages = async () =>
+    await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
+      const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+      const pages = await getAllPages(browser);
+      const results: Array<{
+        targetId: string;
+        title: string;
+        url: string;
+        type: string;
+      }> = [];
 
-    for (const page of pages) {
-      if (isBlockedPageRef(opts.cdpUrl, page)) {
-        continue;
-      }
-      let tid: string | null;
-      try {
-        tid = await pageTargetId(page);
-      } catch (err) {
-        if (isRecoverablePlaywrightDisconnectError(err)) {
-          throw err;
-        }
-        tid = null;
-      }
-      if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
-        let title = "";
-        try {
-          title = await page.title();
-        } catch (err) {
-          if (isRecoverablePlaywrightDisconnectError(err)) {
-            throw err;
-          }
-        }
-        let url = "";
-        try {
-          url = page.url();
-        } catch (err) {
-          if (isRecoverablePlaywrightDisconnectError(err)) {
-            throw err;
-          }
-        }
-        if (!isSelectableCdpBrowserTarget({ url })) {
+      for (const page of pages) {
+        if (isBlockedPageRef(opts.cdpUrl, page)) {
           continue;
         }
-        results.push({
-          targetId: tid,
-          title,
-          url,
-          type: "page",
-        });
+        let tid: string | null;
+        try {
+          tid = await pageTargetId(page);
+        } catch (err) {
+          if (isRecoverablePlaywrightDisconnectError(err)) {
+            throw err;
+          }
+          tid = null;
+        }
+        if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
+          let title = "";
+          try {
+            title = await page.title();
+          } catch (err) {
+            if (isRecoverablePlaywrightDisconnectError(err)) {
+              throw err;
+            }
+          }
+          let url = "";
+          try {
+            url = page.url();
+          } catch (err) {
+            if (isRecoverablePlaywrightDisconnectError(err)) {
+              throw err;
+            }
+          }
+          if (!isSelectableCdpBrowserTarget({ url })) {
+            continue;
+          }
+          results.push({
+            targetId: tid,
+            title,
+            url,
+            type: "page",
+          });
+        }
       }
-    }
-    return results;
+      return results;
+    });
+
+  return await withPlaywrightOperationTimeout({
+    cdpUrl: opts.cdpUrl,
+    timeoutMs: opts.timeoutMs,
+    label: "Playwright page enumeration",
+    ssrfPolicy: opts.ssrfPolicy,
+    run: readPages,
   });
 }
 

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
@@ -52,6 +52,11 @@ describe("browser remote profile tab ops via Playwright", () => {
 
     const tabs = await remote.listTabs();
     expect(tabs.map((t) => t.targetId)).toEqual(["T1"]);
+    expect(listPagesViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
+      ssrfPolicy: { allowPrivateNetwork: true },
+      timeoutMs: 3000,
+    });
 
     const opened = await remote.openTab("http://127.0.0.1:3000");
     expect(opened.targetId).toBe("T2");

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
@@ -40,6 +40,11 @@ describe("browser remote profile tab ops via Playwright", () => {
 
     const tabs = await remote.listTabs();
     expect(tabs.map((t) => t.targetId)).toEqual(["T1"]);
+    expect(listPagesViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
+      ssrfPolicy: { allowPrivateNetwork: true },
+      timeoutMs: 3000,
+    });
 
     const opened = await remote.openTab("http://127.0.0.1:3000");
     expect(opened.targetId).toBe("T2");

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -211,8 +211,17 @@ export function createProfileTabOps({
       const listPagesViaPlaywright = (mod as Partial<PwAiModule> | null)?.listPagesViaPlaywright;
       if (typeof listPagesViaPlaywright === "function") {
         const ssrfPolicy = getCdpControlPolicy();
+        const resolved = state().resolved;
+        const timeoutMs = Math.max(
+          resolved.remoteCdpTimeoutMs,
+          resolved.remoteCdpHandshakeTimeoutMs,
+        );
         await assertCdpEndpointAllowed(profile.cdpUrl, ssrfPolicy);
-        const pages = await listPagesViaPlaywright({ cdpUrl: profile.cdpUrl, ssrfPolicy });
+        const pages = await listPagesViaPlaywright({
+          cdpUrl: profile.cdpUrl,
+          ssrfPolicy,
+          timeoutMs,
+        });
         return pages.filter(isSelectableCdpBrowserTarget).map((p) => ({
           targetId: p.targetId,
           title: p.title,

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -206,8 +206,17 @@ export function createProfileTabOps({
       const listPagesViaPlaywright = (mod as Partial<PwAiModule> | null)?.listPagesViaPlaywright;
       if (typeof listPagesViaPlaywright === "function") {
         const ssrfPolicy = getCdpControlPolicy();
+        const resolved = state().resolved;
+        const timeoutMs = Math.max(
+          resolved.remoteCdpTimeoutMs,
+          resolved.remoteCdpHandshakeTimeoutMs,
+        );
         await assertCdpEndpointAllowed(profile.cdpUrl, ssrfPolicy);
-        const pages = await listPagesViaPlaywright({ cdpUrl: profile.cdpUrl, ssrfPolicy });
+        const pages = await listPagesViaPlaywright({
+          cdpUrl: profile.cdpUrl,
+          ssrfPolicy,
+          timeoutMs,
+        });
         return pages.map((p) => ({
           targetId: p.targetId,
           title: p.title,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -422,9 +422,9 @@ export const FIELD_HELP: Record<string, string> = {
   "browser.ssrfPolicy.hostnameAllowlist":
     "Legacy/alternate hostname allowlist field used by SSRF policy consumers for explicit host exceptions. Use stable exact hostnames and avoid wildcard-like broad patterns.",
   "browser.remoteCdpTimeoutMs":
-    "Timeout in milliseconds for connecting to a remote CDP endpoint before failing the browser attach attempt. Increase for high-latency tunnels, or lower for faster failure detection.",
+    "Timeout in milliseconds for connecting to a remote CDP endpoint before failing the browser attach attempt. The larger of this value and remoteCdpHandshakeTimeoutMs also bounds persistent remote tab enumeration. Increase for high-latency tunnels, or lower for faster failure detection.",
   "browser.remoteCdpHandshakeTimeoutMs":
-    "Timeout in milliseconds for post-connect CDP handshake readiness checks against remote browser targets. Raise this for slow-start remote browsers and lower to fail fast in automation loops.",
+    "Timeout in milliseconds for post-connect CDP handshake readiness checks against remote browser targets. The larger of this value and remoteCdpTimeoutMs also bounds persistent remote tab enumeration. Raise this for slow-start remote browsers and lower to fail fast in automation loops.",
   "discovery.mdns.mode":
     'mDNS broadcast mode ("minimal" default, "full" includes cliPath/sshPort, "off" disables mDNS).',
   discovery:

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -55,9 +55,9 @@ export type BrowserConfig = {
   evaluateEnabled?: boolean;
   /** Base URL of the CDP endpoint (for remote browsers). Default: loopback CDP on the derived port. */
   cdpUrl?: string;
-  /** Remote CDP HTTP timeout (ms). Default: 1500. */
+  /** Remote CDP HTTP timeout and persistent tab-enumeration budget input (ms). Default: 1500. */
   remoteCdpTimeoutMs?: number;
-  /** Remote CDP WebSocket handshake timeout (ms). Default: max(remoteCdpTimeoutMs * 2, 2000). */
+  /** Remote CDP handshake timeout and tab-enumeration budget input (ms). Default: max(remoteCdpTimeoutMs * 2, 2000). */
   remoteCdpHandshakeTimeoutMs?: number;
   /** Local managed browser launch discovery timeout (ms). Default: 15000. */
   localLaunchTimeoutMs?: number;


### PR DESCRIPTION
## Summary
- Fixes #58968 by bounding remote CDP Playwright tab enumeration with the existing remote CDP timeout budget.
- Evicts the scoped cached/in-flight Playwright connection on enumeration timeout so the next request can reconnect instead of reusing a stuck pipe.
- Adds regression coverage for a stuck page-target lookup and verifies remote profile tab listing passes the resolved timeout into the Playwright path.

## Problem
Remote CDP profiles use a persistent Playwright connection for tab listing because HTTP `/json/list` is ephemeral for those providers. When that Playwright-backed enumeration stalls, browser requests can hang behind the stuck CDP operation instead of failing fast.

## Root Cause
`createProfileTabOps().readTabs()` passed only `cdpUrl` and SSRF policy to `listPagesViaPlaywright()`. The lower-level Playwright enumeration path had no operation-level timeout around `connectBrowser()`, `getAllPages()`, or per-page target/title/url reads, and a stuck scoped connection could remain cached or in-flight.

## Architectural Reasoning
The fix reuses the existing browser remote CDP timeout contract rather than adding a new config key. Remote tab listing now uses `max(remoteCdpTimeoutMs, remoteCdpHandshakeTimeoutMs)`, which matches the existing distinction between HTTP discovery and WebSocket handshake budgets. Timeout cleanup goes through the existing scoped Playwright disconnect helper, preserving per-CDP URL isolation and avoiding hidden coupling to other browser profiles.

## Real behavior proof
- **Behavior or issue addressed:** Remote CDP Playwright tab enumeration now returns a bounded timeout error instead of waiting indefinitely on a stalled CDP discovery/enumeration path.
- **Real environment tested:** Windows 11 worktree, Node `v22.15.0`, `pnpm 10.33.2`, branch `hemant/issue-triage-20260509`, commit `9aba9b405ae5c4601211fd0b2b428d9640425b8b`.
- **Exact steps or command run after this patch:** Started a real loopback HTTP endpoint that accepts CDP discovery connections and deliberately never responds; called production `listPagesViaPlaywright()` through `node --import tsx` with `timeoutMs: 100` and an SSRF policy allowing loopback/private access; closed the scoped Playwright connection and destroyed the held socket after the call.
- **Evidence after fix:**

```console
$ node --import tsx - < hanging-cdp-smoke.mjs
{"ok":true,"error":"Playwright page enumeration timed out after 100ms","elapsedMs":309}
```

- **Observed result after fix:** The production browser module returned `Playwright page enumeration timed out after 100ms` and the script exited cleanly instead of hanging on the held CDP request.
- **What was not tested:** I did not use a real remote Chrome host because the failure mode is a stalled CDP endpoint; the local loopback endpoint exercises the same production timeout path with deterministic cleanup. Full `pnpm test extensions/browser` still has unrelated Windows environment failures noted below.

## Testing
- `pnpm test extensions/browser/src/browser/pw-session.connections.test.ts extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/browser/src/browser/pw-session.ts extensions/browser/src/browser/server-context.tab-ops.ts extensions/browser/src/browser/pw-session.connections.test.ts extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts`
- `pnpm tsgo:extensions` from `O:\` subst drive to avoid the repo path-with-spaces launcher bug
- `pnpm tsgo:extensions:test` from `O:\`
- `pnpm lint:extensions` from `O:\`
- `pnpm check:changelog-attributions`
- `git diff --check upstream/main...HEAD`
- `pnpm check:changed --staged` exited 0 with no lane output

Full `pnpm test extensions/browser` was also run locally. It failed on unrelated Windows environment assumptions: local browser auto-detection / missing supported browser launch fixtures and existing `/tmp` path expectations being normalized to `C:\tmp`. The two touched regression test files pass.

## Risk Analysis
Risk is medium because this touches async browser/CDP lifecycle behavior. The change is scoped to remote Playwright tab enumeration, does not alter local managed browser JSON tab listing, and does not change navigation, action, or screenshot behavior. On timeout, OpenClaw drops only the scoped Playwright connection for that CDP URL and leaves the actual remote browser tabs intact.

## Backward Compatibility
No config, API, or response-shape changes. Existing `browser.remoteCdpTimeoutMs` and `browser.remoteCdpHandshakeTimeoutMs` now also bound remote Playwright tab enumeration.

## Screenshots / Logs
The real behavior proof above is terminal output from the after-fix smoke; no UI screenshot is applicable.