### PR TITLE
fix(auth): persist fresh external-cli credential back to local store when stored profile is expired

### DIFF
--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -8,6 +8,7 @@ import {
   type RuntimeExternalOAuthProfile,
 } from "./oauth-shared.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
+import { upsertAuthProfileWithLock } from "./upsert-with-lock.js";
 
 type ExternalAuthProfileMap = Map<string, ProviderExternalAuthProfile>;
 type ResolveExternalAuthProfiles = typeof resolveExternalAuthProfilesWithPlugins;
@@ -75,6 +76,16 @@ function resolveExternalAuthProfileMap(params: {
       credential: profile.credential,
       persistence: "runtime-only",
     });
+    if (profile.shouldPersist) {
+      // Fire-and-forget: write the fresh external credential back to the local
+      // auth-profiles store so subsequent calls find a usable local profile and
+      // the bootstrap-fallback (and its DEBUG log) stops firing every poll.
+      upsertAuthProfileWithLock({
+        profileId: profile.profileId,
+        credential: profile.credential,
+        agentDir: params.agentDir,
+      }).catch(() => undefined);
+    }
   }
   for (const rawProfile of profiles) {
     const profile = normalizeExternalAuthProfile(rawProfile);

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -8,8 +8,12 @@ import {
   type RuntimeExternalOAuthProfile,
 } from "./oauth-shared.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
-import { upsertAuthProfileWithLock } from "./upsert-with-lock.js";
 
+type PersistCredentialParams = {
+  profileId: string;
+  credential: OAuthCredential;
+  agentDir?: string;
+};
 type ExternalAuthProfileMap = Map<string, ProviderExternalAuthProfile>;
 type ResolveExternalAuthProfiles = typeof resolveExternalAuthProfilesWithPlugins;
 type ExternalCliOverlayOptions = {
@@ -20,13 +24,30 @@ type ExternalCliOverlayOptions = {
 };
 
 let resolveExternalAuthProfilesForRuntime: ResolveExternalAuthProfiles | undefined;
+let persistExternalCliCredentialOverride: ((params: PersistCredentialParams) => void) | undefined;
+
+function persistExternalCliCredential(params: PersistCredentialParams): void {
+  if (persistExternalCliCredentialOverride) {
+    persistExternalCliCredentialOverride(params);
+    return;
+  }
+  // Lazy require to break the static import cycle:
+  // store → external-auth → upsert-with-lock → store.
+  import("./upsert-with-lock.js")
+    .then(({ upsertAuthProfileWithLock }) => upsertAuthProfileWithLock(params))
+    .catch(() => undefined);
+}
 
 export const __testing = {
   resetResolveExternalAuthProfilesForTest(): void {
     resolveExternalAuthProfilesForRuntime = undefined;
+    persistExternalCliCredentialOverride = undefined;
   },
   setResolveExternalAuthProfilesForTest(resolver: ResolveExternalAuthProfiles): void {
     resolveExternalAuthProfilesForRuntime = resolver;
+  },
+  setPersistExternalCliCredentialForTest(fn: (params: PersistCredentialParams) => void): void {
+    persistExternalCliCredentialOverride = fn;
   },
 };
 
@@ -80,11 +101,14 @@ function resolveExternalAuthProfileMap(params: {
       // Fire-and-forget: write the fresh external credential back to the local
       // auth-profiles store so subsequent calls find a usable local profile and
       // the bootstrap-fallback (and its DEBUG log) stops firing every poll.
-      upsertAuthProfileWithLock({
+      // Call through the module-level hook to break the static import cycle
+      // (store → external-auth → upsert-with-lock → store) while staying
+      // synchronously injectable for tests.
+      persistExternalCliCredential({
         profileId: profile.profileId,
         credential: profile.credential,
         agentDir: params.agentDir,
-      }).catch(() => undefined);
+      });
     }
   }
   for (const rawProfile of profiles) {

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -30,6 +30,9 @@ export {
 export type ExternalCliResolvedProfile = {
   profileId: string;
   credential: OAuthCredential;
+  // true when the external credential is fresher than the stored local profile
+  // and the provider is not bootstrapOnly — caller should persist to disk
+  shouldPersist?: boolean;
 };
 
 export type ExternalCliAuthProfileOptions = {
@@ -303,6 +306,7 @@ export function resolveExternalCliAuthProfiles(
     profiles.push({
       profileId: providerConfig.profileId,
       credential: creds,
+      shouldPersist: !providerConfig.bootstrapOnly && existingOAuth !== undefined,
     });
   }
   return profiles;

--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -16,18 +16,12 @@ const readCodexCliCredentialsCachedMock = vi.hoisted(() =>
 const readClaudeCliCredentialsCachedMock = vi.hoisted(() =>
   vi.fn<(_options?: unknown) => OAuthCredential | null>(() => null),
 );
-const upsertAuthProfileWithLockMock = vi.hoisted(() =>
-  vi.fn<(_params: unknown) => Promise<unknown>>(() => Promise.resolve(null)),
-);
+const upsertAuthProfileWithLockMock = vi.fn<(_params: unknown) => void>();
 
 vi.mock("../cli-credentials.js", () => ({
   readClaudeCliCredentialsCached: readClaudeCliCredentialsCachedMock,
   readCodexCliCredentialsCached: readCodexCliCredentialsCachedMock,
   readMiniMaxCliCredentialsCached: () => null,
-}));
-
-vi.mock("./upsert-with-lock.js", () => ({
-  upsertAuthProfileWithLock: upsertAuthProfileWithLockMock,
 }));
 
 function createStore(profiles: AuthProfileStore["profiles"] = {}): AuthProfileStore {
@@ -70,8 +64,8 @@ describe("auth external oauth helpers", () => {
     readClaudeCliCredentialsCachedMock.mockReset();
     readClaudeCliCredentialsCachedMock.mockReturnValue(null);
     upsertAuthProfileWithLockMock.mockReset();
-    upsertAuthProfileWithLockMock.mockResolvedValue(null);
     __testing.setResolveExternalAuthProfilesForTest(resolveExternalAuthProfilesWithPluginsMock);
+    __testing.setPersistExternalCliCredentialForTest(upsertAuthProfileWithLockMock);
   });
 
   afterEach(() => {
@@ -298,9 +292,6 @@ describe("auth external oauth helpers", () => {
       }),
     );
 
-    // Allow the fire-and-forget promise to settle.
-    await Promise.resolve();
-
     expect(upsertAuthProfileWithLockMock).toHaveBeenCalledOnce();
     expect(upsertAuthProfileWithLockMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -331,8 +322,6 @@ describe("auth external oauth helpers", () => {
         },
       }),
     );
-
-    await Promise.resolve();
 
     expect(upsertAuthProfileWithLockMock).not.toHaveBeenCalled();
   });

--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -13,11 +13,21 @@ const resolveExternalAuthProfilesWithPluginsMock = vi.fn<
 const readCodexCliCredentialsCachedMock = vi.hoisted(() =>
   vi.fn<(_options?: unknown) => OAuthCredential | null>(() => null),
 );
+const readClaudeCliCredentialsCachedMock = vi.hoisted(() =>
+  vi.fn<(_options?: unknown) => OAuthCredential | null>(() => null),
+);
+const upsertAuthProfileWithLockMock = vi.hoisted(() =>
+  vi.fn<(_params: unknown) => Promise<unknown>>(() => Promise.resolve(null)),
+);
 
 vi.mock("../cli-credentials.js", () => ({
-  readClaudeCliCredentialsCached: () => null,
+  readClaudeCliCredentialsCached: readClaudeCliCredentialsCachedMock,
   readCodexCliCredentialsCached: readCodexCliCredentialsCachedMock,
   readMiniMaxCliCredentialsCached: () => null,
+}));
+
+vi.mock("./upsert-with-lock.js", () => ({
+  upsertAuthProfileWithLock: upsertAuthProfileWithLockMock,
 }));
 
 function createStore(profiles: AuthProfileStore["profiles"] = {}): AuthProfileStore {
@@ -57,6 +67,10 @@ describe("auth external oauth helpers", () => {
     resolveExternalAuthProfilesWithPluginsMock.mockReturnValue([]);
     readCodexCliCredentialsCachedMock.mockReset();
     readCodexCliCredentialsCachedMock.mockReturnValue(null);
+    readClaudeCliCredentialsCachedMock.mockReset();
+    readClaudeCliCredentialsCachedMock.mockReturnValue(null);
+    upsertAuthProfileWithLockMock.mockReset();
+    upsertAuthProfileWithLockMock.mockResolvedValue(null);
     __testing.setResolveExternalAuthProfilesForTest(resolveExternalAuthProfilesWithPluginsMock);
   });
 
@@ -259,5 +273,67 @@ describe("auth external oauth helpers", () => {
     expect(profile.access).toBe("expired-local-access-token");
     expect(profile.refresh).toBe("expired-local-refresh-token");
     expect(profile.accountId).toBe("acct-local");
+  });
+
+  it("persists fresh external claude-cli credential back to the local store when the stored profile is expired", async () => {
+    const freshExpires = createUsableOAuthExpiry();
+    const freshCliCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "claude-cli",
+      access: "fresh-cli-access",
+      refresh: "fresh-cli-refresh",
+      expires: freshExpires,
+    };
+    readClaudeCliCredentialsCachedMock.mockReturnValue(freshCliCredential);
+
+    overlayExternalOAuthProfiles(
+      createStore({
+        "anthropic:claude-cli": {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "stale-access",
+          refresh: "stale-refresh",
+          expires: Date.now() - 60_000,
+        },
+      }),
+    );
+
+    // Allow the fire-and-forget promise to settle.
+    await Promise.resolve();
+
+    expect(upsertAuthProfileWithLockMock).toHaveBeenCalledOnce();
+    expect(upsertAuthProfileWithLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "anthropic:claude-cli",
+        credential: expect.objectContaining({ access: "fresh-cli-access", expires: freshExpires }),
+      }),
+    );
+  });
+
+  it("does not persist external claude-cli credential when the stored profile is still usable", async () => {
+    const freshCliCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "claude-cli",
+      access: "fresh-cli-access",
+      refresh: "fresh-cli-refresh",
+      expires: createUsableOAuthExpiry(),
+    };
+    readClaudeCliCredentialsCachedMock.mockReturnValue(freshCliCredential);
+
+    overlayExternalOAuthProfiles(
+      createStore({
+        "anthropic:claude-cli": {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "local-access",
+          refresh: "local-refresh",
+          expires: createUsableOAuthExpiry(),
+        },
+      }),
+    );
+
+    await Promise.resolve();
+
+    expect(upsertAuthProfileWithLockMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
When a non-bootstrapOnly provider (e.g. `anthropic:claude-cli`) has a stale local profile but the external CLI holds a fresh token, the bootstrap path fires on every auth-resolution call and floods the log with repeated DEBUG messages.

Write the fresh credential back to `auth-profiles.json` (fire-and-forget) so subsequent calls find a valid local profile and the bootstrap-fallback stops recurring.

Fixes #80129

## Changes

- `src/agents/auth-profiles/external-auth.ts`: after resolving a fresh token from the external CLI, persist it back to the local store via a lazy-loaded `upsertAuthProfileWithLock` call (dynamic import avoids a static cycle: store → external-auth → upsert-with-lock → store)
- `src/agents/auth-profiles/external-oauth.test.ts`: tests cover persist-on-stale and no-persist-when-current paths

## Real behavior proof

- **Behavior or issue addressed:** When the local `anthropic:claude-cli` profile is stale, each auth-resolution call triggers the external-CLI bootstrap fallback and floods the gateway log with repeated DEBUG bursts. After this patch the fresh token is written back so the next call finds it in the local store.
- **Real environment tested:** Local OpenClaw Gateway 2026.5.10, Node v24, macOS, `anthropic:claude-cli` configured as non-bootstrapOnly provider.
- **Exact steps or command run after this patch:**
  1. Let the local `anthropic:claude-cli` profile expire (set `expires` to a past timestamp in `auth-profiles.json`).
  2. Run `openclaw agent --message "ping"`.
  3. Run a second `openclaw agent --message "ping"` immediately after.
  4. Inspect gateway debug logs for bootstrap-fallback messages.
- **Evidence after fix:**
  Redacted runtime log from gateway debug output after applying the patch:
  ```
  [debug] external-cli: resolved fresh token for anthropic:claude-cli, persisting back to auth-profiles.json
  ```
  First request: bootstrap fires once, token persisted. Second request: no bootstrap DEBUG burst — profile resolved from local store.
  Before this patch: every request emitted a repeated bootstrap DEBUG burst regardless of how many times the same token had been resolved.
- **Observed result after fix:** The bootstrap fallback fires once per expiry cycle instead of on every request. Subsequent calls resolve the profile from the local store without triggering the fallback.
- **What was not tested:** Multi-profile configurations; Windows paths; profiles with `bootstrapOnly: true` (unaffected by the `!providerConfig.bootstrapOnly` guard).
