### PR TITLE
infer model run: add Gateway timeout override

### DIFF
--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -672,6 +672,7 @@ async function runModelRun(params: {
   files?: string[];
   model?: string;
   thinking?: ThinkLevel;
+  timeoutMs?: number;
   transport: CapabilityTransport;
 }) {
   const cfg = getRuntimeConfig();
@@ -808,13 +809,14 @@ async function runModelRun(params: {
       provider,
       model,
       ...(params.thinking ? { thinking: params.thinking } : {}),
+      ...(params.timeoutMs !== undefined ? { timeout: Math.ceil(params.timeoutMs / 1000) } : {}),
       modelRun: true,
       promptMode: "none",
       cleanupBundleMcpOnRunEnd: true,
       idempotencyKey: randomIdempotencyKey(),
     },
     expectFinal: true,
-    timeoutMs: 120_000,
+    timeoutMs: params.timeoutMs ?? 120_000,
     clientName: hasModelOverride ? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT : GATEWAY_CLIENT_NAMES.CLI,
     mode: hasModelOverride ? GATEWAY_CLIENT_MODES.BACKEND : GATEWAY_CLIENT_MODES.CLI,
     ...(hasModelOverride ? { scopes: [ADMIN_SCOPE] } : {}),
@@ -1677,6 +1679,7 @@ export function registerCapabilityCli(program: Command) {
     .option("--file <path>", "Image file", collectOption, [])
     .option("--model <provider/model>", "Model override")
     .option("--thinking <level>", "Thinking level override")
+    .option("--timeout-ms <ms>", "Gateway wait timeout in milliseconds")
     .option("--local", "Force local execution", false)
     .option("--gateway", "Force gateway execution", false)
     .option("--json", "Output JSON", false)
@@ -1684,17 +1687,25 @@ export function registerCapabilityCli(program: Command) {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const prompt = requireModelRunPrompt(opts.prompt);
         const thinking = normalizeModelRunThinking(opts.thinking);
+        const timeoutMs = parseOptionalFiniteNumber(opts.timeoutMs, "--timeout-ms");
+        if (timeoutMs !== undefined && timeoutMs <= 0) {
+          throw new Error("--timeout-ms must be greater than 0");
+        }
         const transport = resolveTransport({
           local: Boolean(opts.local),
           gateway: Boolean(opts.gateway),
           supported: ["local", "gateway"],
           defaultTransport: "local",
         });
+        if (timeoutMs !== undefined && transport !== "gateway") {
+          throw new Error("--timeout-ms is only supported with --gateway");
+        }
         const result = await runModelRun({
           prompt,
           files: opts.file as string[] | undefined,
           model: opts.model as string | undefined,
           thinking,
+          timeoutMs: timeoutMs === undefined ? undefined : Math.ceil(timeoutMs),
           transport,
         });
         emitJsonOrText(defaultRuntime, Boolean(opts.json), result, formatEnvelopeForText);


### PR DESCRIPTION
# PR draft: add `--timeout-ms` to `infer model run`

## Title

`infer model run`: add Gateway timeout override

## Body

### Summary

Adds a `--timeout-ms <ms>` flag to `openclaw infer model run` for Gateway-backed model-run canaries.

The flag is intentionally scoped to `--gateway` runs. When provided, it controls both:

- the CLI's Gateway client wait budget, and
- the Gateway agent run timeout (`timeout: ceil(timeoutMs / 1000)`).

The existing default remains 120 seconds when the flag is omitted.

### Motivation

`openclaw infer model run --gateway` is useful as a lightweight model canary. In current main it already uses the model-run path (`modelRun: true`, `promptMode: "none"`) and supports `--thinking`, which avoids accidentally running a full normal agent turn.

The remaining limitation is the fixed 120 second Gateway wait budget. That is fine for small smokes, but it is too short for intentionally long-running model canaries, large-context probes, or reasoning-model validation. Without a flag, users have to drop down to raw `openclaw gateway call agent` requests to align client/server timeouts.

### Behavior

```bash
openclaw infer model run --gateway --json \
  --model <provider/model> \
  --timeout-ms 300000 \
  --prompt 'Reply with exactly: OK'
```

- `--timeout-ms` must be finite and greater than zero.
- `--timeout-ms` is only accepted with `--gateway`; local transport is unchanged.
- If omitted, behavior remains unchanged (`120_000` ms Gateway wait timeout).

### Notes

This does not change global agent defaults, provider config, or model metadata. It also does not alter the existing `modelRun: true` / `promptMode: "none"` behavior.

The client and server timeout budgets are intentionally coupled for this CLI flag so a single model-run command has one clear deadline. If separate client/server budgets are needed later, that can be added as a more advanced follow-up.

### Validation

Suggested checks:

```bash
openclaw infer model run --gateway --json \
  --model <provider/model> \
  --timeout-ms 300000 \
  --prompt 'Reply with exactly: TIMEOUT_FLAG_OK'
```

```bash
openclaw infer model run --gateway --json \
  --model <provider/model> \
  --thinking off \
  --timeout-ms 300000 \
  --prompt 'Reply with exactly: THINKING_TIMEOUT_OK'
```

```bash
openclaw infer model run --local --model <provider/model> --timeout-ms 300000 --prompt OK
# expected: clear CLI error because --timeout-ms is Gateway-only
```

## Real behavior proof

- Behavior or issue addressed: `openclaw infer model run --gateway --timeout-ms` now applies one explicit deadline to both the Gateway client wait budget and the Gateway `agent` request's seconds-level `timeout` field.
- Real environment tested: Disposable source checkout on Linux with a staged `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` and a loopback-only stage Gateway WebSocket endpoint. No production Gateway, production state directory, live model provider, or installed runtime was used.
- Exact steps or command run after this patch: Ran the source-stage CLI path against a loopback-only stage Gateway endpoint:

```bash
quick path: stage endpoint replies immediately
OPENCLAW_STATE_DIR=<temp-state> \
OPENCLAW_CONFIG_PATH=<temp-state>/openclaw.json \
OPENCLAW_GATEWAY_URL=ws://<loopback-host>:<redacted-port> \
OPENCLAW_GATEWAY_TOKEN=<redacted> \
openclaw infer model run --gateway --json \
  --model openai/gpt-stage \
  --timeout-ms 1501 \
  --prompt 'stage quick'

timeout path: stage endpoint accepts the agent request but delays the final response
OPENCLAW_STATE_DIR=<temp-state> \
OPENCLAW_CONFIG_PATH=<temp-state>/openclaw.json \
OPENCLAW_GATEWAY_URL=ws://<loopback-host>:<redacted-port> \
OPENCLAW_GATEWAY_TOKEN=<redacted> \
openclaw infer model run --gateway --json \
  --model openai/gpt-stage \
  --timeout-ms 250 \
  --prompt 'stage delay'
```

- Evidence after fix: Terminal capture / copied live output from the source-stage CLI run, redacted:

```text
quick_exit=0
{
  "ok": true,
  "capability": "model.run",
  "transport": "gateway",
  "provider": "stage-provider",
  "model": "stage-model",
  "attempts": [],
  "outputs": [
    {
      "text": "stage gateway reply (quick)",
      "mediaUrl": null
    }
  ]
}

stage Gateway observed the quick agent request params:
{
  "agentId": "main",
  "message": "stage quick",
  "provider": "openai",
  "model": "gpt-stage",
  "timeout": 2,
  "modelRun": true,
  "promptMode": "none",
  "cleanupBundleMcpOnRunEnd": true,
  "idempotencyKey": "<redacted>"
}

delay_exit=1
GatewayTransportError: gateway timeout after 250ms
Gateway target: ws://<loopback-host>:<redacted-port>
Source: env OPENCLAW_GATEWAY_URL
Config: <temp-state>/openclaw.json

stage Gateway observed the delayed agent request params:
{
  "agentId": "main",
  "message": "stage delay",
  "provider": "openai",
  "model": "gpt-stage",
  "timeout": 1,
  "modelRun": true,
  "promptMode": "none",
  "cleanupBundleMcpOnRunEnd": true,
  "idempotencyKey": "<redacted>"
}
```

- Observed result after fix: The quick command completed through Gateway transport and forwarded `--timeout-ms 1501` as `timeout: 2` seconds on the `agent` request. The delayed command failed with `gateway timeout after 250ms`, showing the CLI wait budget also used the explicit `--timeout-ms` value. Existing `modelRun: true` and `promptMode: "none"` fields remained present.
- What was not tested: Production Gateway, production state directory, live provider call, or live installed runtime. The proof intentionally used a disposable source checkout and loopback-only stage Gateway endpoint.

