### PR TITLE
fix: surface safe native Codex activity in Control UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI: show safe native Codex plan, item, tool, and lifecycle activity in Chat without rendering private reasoning text, so reasoning-enabled Codex runs no longer look stuck behind only the reading indicator. Fixes #80039. Thanks @BunsDev.
 - Media/host-read: allow buffer-verified gzip, tar, and 7z archives in the shared host-local media validator alongside ZIP and document attachments.
 - Plugins/doctor: invalidate persisted plugin registry snapshots when plugin diagnostics point at deleted source paths, so `openclaw doctor` stops repeating stale warnings after a local extension is replaced by a managed npm plugin. Fixes #80087. (#80134) Thanks @hclsys.
 - Cron: let isolated self-cleanup runs inspect their own job run history while keeping other cron jobs and mutation actions blocked. Fixes #80019. Thanks @hclsys.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -99,6 +99,7 @@ Imported themes are stored only in the current browser profile. They are not wri
     - Chat history refreshes request a bounded recent window with per-message text caps so large sessions do not force the browser to render a full transcript payload before the chat becomes usable.
     - Talk through browser realtime sessions. OpenAI uses direct WebRTC, Google Live uses a constrained one-use browser token over WebSocket, and backend-only realtime voice plugins use the Gateway relay transport. Client-owned provider sessions start with `talk.client.create`; Gateway relay sessions start with `talk.session.create`. The relay keeps provider credentials on the Gateway while the browser streams microphone PCM through `talk.session.appendAudio` and forwards `openclaw_agent_consult` provider tool calls through `talk.client.toolCall` for Gateway policy and the larger configured OpenClaw model.
     - Stream tool calls + live tool output cards in Chat (agent events).
+    - Native Codex runs show a compact safe activity indicator for plan, item, tool, and lifecycle progress. The Control UI does not render raw private reasoning text from Codex app-server events; when reasoning visibility is enabled, the indicator only shows approved progress summaries.
 
   </Accordion>
   <Accordion title="Channels, instances, sessions, dreams">

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1731,9 +1731,21 @@
   border: 1px solid var(--border);
   background: var(--panel-strong);
   color: var(--text);
+  max-width: 100%;
   white-space: nowrap;
+  box-sizing: border-box;
   user-select: none;
   animation: fade-in 0.2s var(--ease-out);
+}
+
+.compaction-indicator__text {
+  display: block;
+  flex: 1 1 auto;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .compaction-indicator svg {
@@ -1769,6 +1781,33 @@
 .compaction-indicator--fallback-cleared {
   color: var(--ok);
   border-color: rgba(34, 197, 94, 0.35);
+}
+
+.compaction-indicator--runtime {
+  color: var(--info);
+  border-color: rgba(59, 130, 246, 0.35);
+  max-width: min(680px, calc(100vw - 48px));
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compaction-indicator--runtime svg {
+  animation: compaction-spin 1s linear infinite;
+}
+
+.compaction-indicator--runtime-complete {
+  color: var(--ok);
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+.compaction-indicator--runtime-error {
+  color: var(--danger);
+  border-color: rgba(239, 68, 68, 0.35);
+  max-width: min(680px, calc(100vw - 48px));
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 @keyframes compaction-spin {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -137,6 +137,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.lastError = null;
   state.compactionStatus = null;
   state.fallbackStatus = null;
+  state.runtimeActivityStatus = null;
   state.chatAvatarUrl = null;
   state.chatAvatarSource = null;
   state.chatAvatarStatus = null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2434,6 +2434,7 @@ export function renderApp(state: AppViewState) {
                   sending: state.chatSending,
                   compactionStatus: state.compactionStatus,
                   fallbackStatus: state.fallbackStatus,
+                  runtimeActivityStatus: state.runtimeActivityStatus,
                   assistantAvatarUrl: chatAvatarUrl,
                   messages: state.chatMessages,
                   sideResult: state.chatSideResult,

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleAgentEvent, type FallbackStatus, type ToolStreamEntry } from "./app-tool-stream.ts";
+import {
+  handleAgentEvent,
+  type FallbackStatus,
+  type RuntimeActivityStatus,
+  type ToolStreamEntry,
+} from "./app-tool-stream.ts";
 
 type ToolStreamHost = Parameters<typeof handleAgentEvent>[0];
 type AgentEvent = NonNullable<Parameters<typeof handleAgentEvent>[1]>;
@@ -9,6 +14,8 @@ type MutableHost = ToolStreamHost & {
   compactionClearTimer?: number | null;
   fallbackStatus?: FallbackStatus | null;
   fallbackClearTimer?: number | null;
+  runtimeActivityStatus?: RuntimeActivityStatus | null;
+  runtimeActivityClearTimer?: number | null;
 };
 const TOOL_STREAM_TEST_NOW = new Date("2026-05-09T00:00:00.000Z").getTime();
 
@@ -28,6 +35,8 @@ function createHost(overrides?: Partial<MutableHost>): MutableHost {
     compactionClearTimer: null,
     fallbackStatus: null,
     fallbackClearTimer: null,
+    runtimeActivityStatus: null,
+    runtimeActivityClearTimer: null,
     ...overrides,
   };
 }
@@ -75,6 +84,13 @@ function requireFallbackStatus(host: MutableHost): FallbackStatus {
     throw new Error("expected fallback status");
   }
   return host.fallbackStatus;
+}
+
+function requireRuntimeActivity(host: MutableHost): RuntimeActivityStatus {
+  if (!host.runtimeActivityStatus) {
+    throw new Error("expected runtime activity");
+  }
+  return host.runtimeActivityStatus;
 }
 
 function useToolStreamFakeTimers(): void {
@@ -378,5 +394,138 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     expect(host.compactionClearTimer).toBeNull();
 
     vi.useRealTimers();
+  });
+});
+
+describe("app-tool-stream runtime activity handling", () => {
+  beforeAll(() => {
+    const globalWithWindow = globalThis as typeof globalThis & {
+      window?: Window & typeof globalThis;
+    };
+    if (!globalWithWindow.window) {
+      globalWithWindow.window = globalThis as unknown as Window & typeof globalThis;
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("surfaces safe plan updates as runtime activity", () => {
+    useToolStreamFakeTimers();
+    const host = createHost();
+
+    handleAgentEvent(host, agentEvent("run-1", 1, "lifecycle", { phase: "start" }));
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 2, "plan", {
+        phase: "update",
+        source: "codex-app-server",
+        explanation: "Inspect the Control UI event path\nwithout raw reasoning.",
+      }),
+    );
+
+    expect(requireRuntimeActivity(host)).toMatchObject({
+      runId: "run-1",
+      sessionKey: "main",
+      phase: "active",
+      source: "codex-app-server",
+      lines: ["Plan: Inspect the Control UI event path without raw reasoning."],
+    });
+  });
+
+  it("does not expose raw reasoning item content", () => {
+    useToolStreamFakeTimers();
+    const host = createHost();
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "item", {
+        phase: "start",
+        kind: "analysis",
+        title: "Reasoning",
+        status: "running",
+        meta: "private chain of thought",
+        progressText: "private chain of thought",
+      }),
+    );
+
+    const activity = requireRuntimeActivity(host);
+    expect(activity.lines).toEqual(["Reasoning (running)"]);
+    expect(activity.lines.join("\n")).not.toContain("private chain of thought");
+  });
+
+  it("ignores runtime activity for other sessions", () => {
+    useToolStreamFakeTimers();
+    const host = createHost();
+
+    handleAgentEvent(
+      host,
+      agentEvent(
+        "run-1",
+        1,
+        "plan",
+        {
+          phase: "update",
+          source: "codex-app-server",
+          steps: ["patch chat"],
+        },
+        "other",
+      ),
+    );
+
+    expect(host.runtimeActivityStatus).toBeNull();
+  });
+
+  it("only completes matching runtime activity lifecycle runs", () => {
+    useToolStreamFakeTimers();
+    const host = createHost();
+
+    handleAgentEvent(host, agentEvent("run-1", 1, "lifecycle", { phase: "start" }));
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 2, "plan", {
+        phase: "update",
+        source: "codex-app-server",
+        steps: ["patch chat"],
+      }),
+    );
+
+    handleAgentEvent(host, agentEvent("run-2", 3, "lifecycle", { phase: "end" }));
+    expect(requireRuntimeActivity(host).phase).toBe("active");
+
+    handleAgentEvent(host, agentEvent("run-1", 4, "lifecycle", { phase: "end" }));
+    expect(requireRuntimeActivity(host)).toMatchObject({
+      phase: "complete",
+      completedAt: TOOL_STREAM_TEST_NOW,
+    });
+
+    vi.advanceTimersByTime(8_000);
+    expect(host.runtimeActivityStatus).toBeNull();
+    expect(host.runtimeActivityClearTimer).toBeNull();
+  });
+
+  it("uses tool name and metadata without args or results for runtime activity", () => {
+    useToolStreamFakeTimers();
+    const host = createHost();
+    const longMeta = `${"checking syntax ".repeat(20)}secret-token`;
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "tool", {
+        phase: "start",
+        name: "bash",
+        toolCallId: "tool-1",
+        meta: longMeta,
+        args: { command: "cat secret-token" },
+        result: { text: "secret output" },
+      }),
+    );
+
+    const line = requireRuntimeActivity(host).lines.at(-1) ?? "";
+    expect(line).toContain("Tool: bash checking syntax");
+    expect(line.length).toBeLessThanOrEqual(167);
+    expect(line).not.toContain("cat secret-token");
+    expect(line).not.toContain("secret output");
   });
 });

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -6,6 +6,9 @@ import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 const TOOL_STREAM_LIMIT = 50;
 const TOOL_STREAM_THROTTLE_MS = 80;
 const TOOL_OUTPUT_CHAR_LIMIT = 120_000;
+const RUNTIME_ACTIVITY_LINE_LIMIT = 5;
+const RUNTIME_ACTIVITY_LINE_CHAR_LIMIT = 160;
+const RUNTIME_ACTIVITY_TOAST_DURATION_MS = 8000;
 
 export type AgentEventPayload = {
   runId: string;
@@ -28,6 +31,18 @@ export type ToolStreamEntry = {
   message: Record<string, unknown>;
 };
 
+export type RuntimeActivityStatus = {
+  runId: string;
+  sessionKey?: string;
+  phase: "active" | "complete" | "error";
+  lines: string[];
+  startedAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  error?: string;
+  source?: string;
+};
+
 type ToolStreamHost = {
   sessionKey: string;
   chatRunId: string | null;
@@ -38,6 +53,8 @@ type ToolStreamHost = {
   toolStreamOrder: string[];
   chatToolMessages: Record<string, unknown>[];
   toolStreamSyncTimer: number | null;
+  runtimeActivityStatus?: RuntimeActivityStatus | null;
+  runtimeActivityClearTimer?: number | null;
   chatModelOverrides?: Record<string, ChatModelOverride | null>;
 };
 
@@ -259,6 +276,200 @@ function syncToolStreamMessages(host: ToolStreamHost) {
     .filter((msg): msg is Record<string, unknown> => Boolean(msg));
 }
 
+function clearRuntimeActivityTimer(host: ToolStreamHost) {
+  if (host.runtimeActivityClearTimer != null) {
+    window.clearTimeout(host.runtimeActivityClearTimer);
+    host.runtimeActivityClearTimer = null;
+  }
+}
+
+function clearRuntimeActivity(host: ToolStreamHost) {
+  clearRuntimeActivityTimer(host);
+  host.runtimeActivityStatus = null;
+}
+
+function scheduleRuntimeActivityClear(host: ToolStreamHost) {
+  clearRuntimeActivityTimer(host);
+  host.runtimeActivityClearTimer = window.setTimeout(() => {
+    host.runtimeActivityStatus = null;
+    host.runtimeActivityClearTimer = null;
+  }, RUNTIME_ACTIVITY_TOAST_DURATION_MS);
+}
+
+function eventIsForVisibleSession(host: ToolStreamHost, payload: AgentEventPayload): boolean {
+  const sessionKey = toTrimmedString(payload.sessionKey);
+  if (sessionKey) {
+    return sessionKey === host.sessionKey;
+  }
+  return Boolean(host.chatRunId && payload.runId === host.chatRunId);
+}
+
+function runtimeActivitySource(data: Record<string, unknown>): string | undefined {
+  return (
+    toTrimmedString(data.source) ??
+    toTrimmedString(data.backend) ??
+    toTrimmedString(data.runtime) ??
+    undefined
+  );
+}
+
+function normalizeActivityLine(value: unknown): string | null {
+  const text = toTrimmedString(value);
+  if (!text) {
+    return null;
+  }
+  const compact = text.replace(/\s+/g, " ");
+  const truncated = truncateText(compact, RUNTIME_ACTIVITY_LINE_CHAR_LIMIT);
+  return truncated.truncated ? `${truncated.text}…` : truncated.text;
+}
+
+function appendRuntimeActivityLine(host: ToolStreamHost, line: string | null) {
+  const safeLine = normalizeActivityLine(line);
+  if (!safeLine || !host.runtimeActivityStatus) {
+    return;
+  }
+  const current = host.runtimeActivityStatus.lines;
+  if (current.at(-1) === safeLine) {
+    host.runtimeActivityStatus = {
+      ...host.runtimeActivityStatus,
+      updatedAt: Date.now(),
+    };
+    return;
+  }
+  host.runtimeActivityStatus = {
+    ...host.runtimeActivityStatus,
+    lines: [...current, safeLine].slice(-RUNTIME_ACTIVITY_LINE_LIMIT),
+    updatedAt: Date.now(),
+  };
+}
+
+function ensureRuntimeActivity(host: ToolStreamHost, payload: AgentEventPayload) {
+  if (!eventIsForVisibleSession(host, payload)) {
+    return false;
+  }
+  clearRuntimeActivityTimer(host);
+  const data = payload.data ?? {};
+  const source = runtimeActivitySource(data);
+  const sessionKey = toTrimmedString(payload.sessionKey) ?? host.sessionKey;
+  const now = Date.now();
+  const existing = host.runtimeActivityStatus;
+  if (!existing || existing.runId !== payload.runId || existing.phase !== "active") {
+    host.runtimeActivityStatus = {
+      runId: payload.runId,
+      sessionKey,
+      phase: "active",
+      lines: [],
+      startedAt: now,
+      updatedAt: now,
+      ...(source ? { source } : {}),
+    };
+    return true;
+  }
+  host.runtimeActivityStatus = {
+    ...existing,
+    sessionKey: existing.sessionKey ?? sessionKey,
+    updatedAt: now,
+    ...(source && !existing.source ? { source } : {}),
+  };
+  return true;
+}
+
+function handleRuntimeLifecycleEvent(host: ToolStreamHost, payload: AgentEventPayload) {
+  const data = payload.data ?? {};
+  const phase = toTrimmedString(data.phase);
+  if (phase === "start") {
+    ensureRuntimeActivity(host, payload);
+    return;
+  }
+  if (phase !== "end" && phase !== "error") {
+    return;
+  }
+  const status = host.runtimeActivityStatus;
+  if (!status || status.runId !== payload.runId) {
+    return;
+  }
+  const now = Date.now();
+  const error =
+    phase === "error"
+      ? (normalizeActivityLine(data.error) ??
+        normalizeActivityLine(data.message) ??
+        "Runtime error")
+      : undefined;
+  host.runtimeActivityStatus = {
+    ...status,
+    phase: phase === "error" ? "error" : "complete",
+    updatedAt: now,
+    completedAt: now,
+    ...(error ? { error } : {}),
+  };
+  scheduleRuntimeActivityClear(host);
+}
+
+function firstStringValue(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  for (const entry of value) {
+    const text = toTrimmedString(entry);
+    if (text) {
+      return text;
+    }
+  }
+  return null;
+}
+
+function handleRuntimePlanEvent(host: ToolStreamHost, payload: AgentEventPayload) {
+  if (!ensureRuntimeActivity(host, payload)) {
+    return;
+  }
+  const data = payload.data ?? {};
+  const phase = toTrimmedString(data.phase);
+  if (phase && phase !== "update") {
+    return;
+  }
+  const detail =
+    normalizeActivityLine(data.explanation) ??
+    normalizeActivityLine(firstStringValue(data.steps)) ??
+    normalizeActivityLine(data.title) ??
+    "planning";
+  appendRuntimeActivityLine(host, detail ? `Plan: ${detail}` : null);
+}
+
+function handleRuntimeItemEvent(host: ToolStreamHost, payload: AgentEventPayload) {
+  if (!ensureRuntimeActivity(host, payload)) {
+    return;
+  }
+  const data = payload.data ?? {};
+  const title = normalizeActivityLine(data.title);
+  const name = normalizeActivityLine(data.name);
+  const meta = normalizeActivityLine(data.meta);
+  const status = normalizeActivityLine(data.status);
+  const kind = normalizeLowercaseStringOrEmpty(toTrimmedString(data.kind) ?? "");
+  const isReasoningItem =
+    normalizeLowercaseStringOrEmpty(title ?? "") === "reasoning" ||
+    normalizeLowercaseStringOrEmpty(name ?? "") === "reasoning" ||
+    kind === "reasoning";
+  if (isReasoningItem) {
+    appendRuntimeActivityLine(host, status ? `Reasoning (${status})` : "Reasoning");
+    return;
+  }
+  const label = name ?? title ?? (kind || "Activity");
+  const details = [meta, status ? `(${status})` : null].filter(Boolean).join(" ");
+  appendRuntimeActivityLine(host, normalizeActivityLine(details ? `${label}: ${details}` : label));
+}
+
+function handleRuntimeToolEvent(host: ToolStreamHost, payload: AgentEventPayload) {
+  if (!ensureRuntimeActivity(host, payload)) {
+    return;
+  }
+  const data = payload.data ?? {};
+  const name = normalizeActivityLine(data.name) ?? "tool";
+  const meta = normalizeActivityLine(data.meta);
+  const phase = normalizeActivityLine(data.phase);
+  const suffix = meta ?? (phase && !name ? phase : null);
+  appendRuntimeActivityLine(host, suffix ? `Tool: ${name} ${suffix}` : `Tool: ${name}`);
+}
+
 export function flushToolStreamSync(host: ToolStreamHost) {
   if (host.toolStreamSyncTimer != null) {
     clearTimeout(host.toolStreamSyncTimer);
@@ -290,6 +501,7 @@ export function resetToolStream(host: ToolStreamHost) {
   host.toolStreamOrder = [];
   host.chatToolMessages = [];
   host.chatStreamSegments = [];
+  clearRuntimeActivity(host);
 }
 
 export type CompactionStatus = {
@@ -503,6 +715,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
 
   if (payload.stream === "lifecycle") {
+    handleRuntimeLifecycleEvent(host, payload);
     handleLifecycleCompactionEvent(host as CompactionHost, payload);
     handleLifecycleFallbackEvent(host as CompactionHost, payload);
     return;
@@ -510,6 +723,16 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
 
   if (payload.stream === "fallback") {
     handleLifecycleFallbackEvent(host as CompactionHost, payload);
+    return;
+  }
+
+  if (payload.stream === "plan") {
+    handleRuntimePlanEvent(host, payload);
+    return;
+  }
+
+  if (payload.stream === "item") {
+    handleRuntimeItemEvent(host, payload);
     return;
   }
 
@@ -526,6 +749,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
 
   const data = payload.data ?? {};
+  handleRuntimeToolEvent(host, payload);
   const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : "";
   if (!toolCallId) {
     return;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,6 +1,6 @@
 import type { ChatSendOptions } from "./app-chat.ts";
 import type { EventLogEntry } from "./app-events.ts";
-import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
+import type { CompactionStatus, FallbackStatus, RuntimeActivityStatus } from "./app-tool-stream.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "./chat/input-history.ts";
 import type { RealtimeTalkStatus } from "./chat/realtime-talk.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
@@ -100,6 +100,7 @@ export type AppViewState = {
   chatSideResultTerminalRuns: Set<string>;
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;
+  runtimeActivityStatus: RuntimeActivityStatus | null;
   chatAvatarUrl: string | null;
   chatAvatarSource?: string | null;
   chatAvatarStatus?: "none" | "local" | "remote" | "data" | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -63,6 +63,7 @@ import {
   type ToolStreamEntry,
   type CompactionStatus,
   type FallbackStatus,
+  type RuntimeActivityStatus,
 } from "./app-tool-stream.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { normalizeAssistantIdentity } from "./assistant-identity.ts";
@@ -214,6 +215,7 @@ export class OpenClawApp extends LitElement {
   @state() chatSideResult: ChatSideResult | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() fallbackStatus: FallbackStatus | null = null;
+  @state() runtimeActivityStatus: RuntimeActivityStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatAvatarSource: string | null = null;
   @state() chatAvatarStatus: "none" | "local" | "remote" | "data" | null = null;

--- a/ui/src/ui/chat/run-controls.test.ts
+++ b/ui/src/ui/chat/run-controls.test.ts
@@ -10,7 +10,11 @@ import {
 } from "./context-notice.ts";
 import { renderChatRunControls, type ChatRunControlsProps } from "./run-controls.ts";
 import { renderSideResult } from "./side-result-render.ts";
-import { renderCompactionIndicator, renderFallbackIndicator } from "./status-indicators.ts";
+import {
+  renderCompactionIndicator,
+  renderFallbackIndicator,
+  renderRuntimeActivityIndicator,
+} from "./status-indicators.ts";
 
 vi.mock("../icons.ts", () => ({
   icons: {},
@@ -222,6 +226,72 @@ describe("chat status indicators", () => {
       );
       expect(container.querySelector(".compaction-indicator--fallback")).toBeNull();
       expect(container.querySelector(".compaction-indicator--complete")).toBeNull();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("renders native Codex runtime activity fallback and privacy title", () => {
+    const container = document.createElement("div");
+    render(
+      renderRuntimeActivityIndicator(
+        {
+          runId: "run-1",
+          sessionKey: "main",
+          phase: "active",
+          lines: [],
+          startedAt: 1_000,
+          updatedAt: 1_000,
+          source: "codex-app-server",
+        },
+        { visibleReasoningUnavailable: true },
+      ),
+      container,
+    );
+
+    const indicator = container.querySelector(".compaction-indicator--runtime");
+    expect(indicator?.getAttribute("role")).toBe("status");
+    expect(indicator?.textContent).toContain("Codex running: waiting for safe progress");
+    expect(indicator?.getAttribute("title")).toContain("Private reasoning text is not shown");
+  });
+
+  it("renders runtime activity lines and hides stale completed activity", () => {
+    const container = document.createElement("div");
+    const nowSpy = vi.spyOn(Date, "now");
+    try {
+      nowSpy.mockReturnValue(10_000);
+      render(
+        renderRuntimeActivityIndicator({
+          runId: "run-1",
+          sessionKey: "main",
+          phase: "active",
+          lines: ["Plan: patch chat", "Tool: bash checking syntax"],
+          startedAt: 9_000,
+          updatedAt: 9_500,
+          source: "codex-app-server",
+        }),
+        container,
+      );
+
+      let indicator = container.querySelector(".compaction-indicator--runtime");
+      expect(indicator?.getAttribute("role")).toBe("status");
+      expect(indicator?.textContent).toContain("Codex: Tool: bash checking syntax");
+      expect(indicator?.getAttribute("title")).toContain("Plan: patch chat");
+
+      nowSpy.mockReturnValue(20_000);
+      render(
+        renderRuntimeActivityIndicator({
+          runId: "run-1",
+          phase: "complete",
+          lines: ["Plan: patch chat"],
+          startedAt: 1_000,
+          updatedAt: 10_000,
+          completedAt: 10_000,
+          source: "codex-app-server",
+        }),
+        container,
+      );
+      expect(container.querySelector(".compaction-indicator--runtime-complete")).toBeNull();
     } finally {
       nowSpy.mockRestore();
     }

--- a/ui/src/ui/chat/status-indicators.ts
+++ b/ui/src/ui/chat/status-indicators.ts
@@ -1,9 +1,14 @@
 import { html, nothing } from "lit";
-import type { CompactionStatus, FallbackStatus } from "../app-tool-stream.ts";
+import type {
+  CompactionStatus,
+  FallbackStatus,
+  RuntimeActivityStatus,
+} from "../app-tool-stream.ts";
 import { icons } from "../icons.ts";
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
 const FALLBACK_TOAST_DURATION_MS = 8000;
+const RUNTIME_ACTIVITY_TOAST_DURATION_MS = 8000;
 
 export function renderCompactionIndicator(status: CompactionStatus | null | undefined) {
   if (!status) {
@@ -66,7 +71,58 @@ export function renderFallbackIndicator(status: FallbackStatus | null | undefine
   const icon = phase === "cleared" ? icons.check : icons.brain;
   return html`
     <div class=${className} role="status" aria-live="polite" title=${details}>
-      ${icon} ${message}
+      ${icon} <span class="compaction-indicator__text">${message}</span>
+    </div>
+  `;
+}
+
+export function renderRuntimeActivityIndicator(
+  status: RuntimeActivityStatus | null | undefined,
+  opts: { visibleReasoningUnavailable?: boolean } = {},
+) {
+  if (!status) {
+    return nothing;
+  }
+  if (status.completedAt) {
+    const elapsed = Date.now() - status.completedAt;
+    if (elapsed >= RUNTIME_ACTIVITY_TOAST_DURATION_MS) {
+      return nothing;
+    }
+  }
+  const latestLine = status.lines.at(-1);
+  const message =
+    status.phase === "error"
+      ? status.error
+        ? `Codex run error: ${status.error}`
+        : "Codex run error"
+      : status.phase === "complete"
+        ? "Codex run complete"
+        : latestLine
+          ? `Codex: ${latestLine}`
+          : "Codex running: waiting for safe progress";
+  const details = [
+    opts.visibleReasoningUnavailable
+      ? "Private reasoning text is not shown; safe activity events are shown when available."
+      : null,
+    ...status.lines,
+  ]
+    .filter(Boolean)
+    .join(" • ");
+  const className =
+    status.phase === "error"
+      ? "compaction-indicator compaction-indicator--runtime-error"
+      : status.phase === "complete"
+        ? "compaction-indicator compaction-indicator--runtime-complete"
+        : "compaction-indicator compaction-indicator--runtime";
+  const icon =
+    status.phase === "complete"
+      ? icons.check
+      : status.phase === "error"
+        ? icons.brain
+        : icons.loader;
+  return html`
+    <div class=${className} role="status" aria-live="polite" title=${details}>
+      ${icon} <span class="compaction-indicator__text">${message}</span>
     </div>
   `;
 }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -3,7 +3,11 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import { t } from "../../i18n/index.ts";
-import type { CompactionStatus, FallbackStatus } from "../app-tool-stream.ts";
+import type {
+  CompactionStatus,
+  FallbackStatus,
+  RuntimeActivityStatus,
+} from "../app-tool-stream.ts";
 import {
   getChatAttachmentPreviewUrl,
   registerChatAttachmentPayload,
@@ -41,7 +45,11 @@ import {
   type SlashCommandCategory,
   type SlashCommandDef,
 } from "../chat/slash-commands.ts";
-import { renderCompactionIndicator, renderFallbackIndicator } from "../chat/status-indicators.ts";
+import {
+  renderCompactionIndicator,
+  renderFallbackIndicator,
+  renderRuntimeActivityIndicator,
+} from "../chat/status-indicators.ts";
 import { getExpandedToolCards, syncToolCardExpansionState } from "../chat/tool-expansion-state.ts";
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
@@ -64,6 +72,7 @@ export type ChatProps = {
   canAbort?: boolean;
   compactionStatus?: CompactionStatus | null;
   fallbackStatus?: FallbackStatus | null;
+  runtimeActivityStatus?: RuntimeActivityStatus | null;
   messages: unknown[];
   sideResult?: ChatSideResult | null;
   toolMessages: unknown[];
@@ -915,6 +924,11 @@ export function renderChat(props: ChatProps) {
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";
   const showReasoning = props.showThinking && reasoningLevel !== "off";
+  const runtimeId = activeSession?.agentRuntime?.id?.toLowerCase() ?? "";
+  const runtimeActivityIsCodex =
+    runtimeId === "codex" ||
+    runtimeId === "codex-app-server" ||
+    props.runtimeActivityStatus?.source === "codex-app-server";
   const assistantIdentity = {
     name: props.assistantName,
     avatar: resolveAssistantDisplayAvatar(props),
@@ -1338,6 +1352,10 @@ export function renderChat(props: ChatProps) {
       ${renderSideResult(props.sideResult, props.onDismissSideResult)}
       ${renderFallbackIndicator(props.fallbackStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
+      ${renderRuntimeActivityIndicator(
+        runtimeActivityIsCodex ? props.runtimeActivityStatus : null,
+        { visibleReasoningUnavailable: showReasoning },
+      )}
       ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null, {
         compactBusy,
         compactDisabled: !props.connected || isBusy || Boolean(props.canAbort),


### PR DESCRIPTION
## Summary
- Surface safe native Codex plan, item, tool, and lifecycle activity in the Control UI chat status area.
- Keep raw Codex reasoning text private: reasoning items render only as generic activity and tool activity excludes args/results.
- Document the Chat behavior and add a changelog fix for #80039.

Fixes #80039

## Verification
- `pnpm test ui/src/ui/app-tool-stream.node.test.ts ui/src/ui/chat/run-controls.test.ts extensions/codex/src/app-server/event-projector.test.ts`
- `pnpm ui:build`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/web/control-ui.md ui/src/styles/components.css ui/src/ui/app-render.helpers.ts ui/src/ui/app-render.ts ui/src/ui/app-tool-stream.node.test.ts ui/src/ui/app-tool-stream.ts ui/src/ui/app-view-state.ts ui/src/ui/app.ts ui/src/ui/chat/run-controls.test.ts ui/src/ui/chat/status-indicators.ts ui/src/ui/views/chat.ts`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
- Browser plugin fixture QA against the Vite-served Control UI modules/styles at desktop and 390x760 mobile viewports. The local gateway on `127.0.0.1:18789` was protocol-mismatched with this checkout, so a full live native Codex prompt was not run in this worktree.