### PR TITLE
fix(acp): reject fractional runtime timeouts

### DIFF
--- a/src/acp/control-plane/runtime-options.test.ts
+++ b/src/acp/control-plane/runtime-options.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { validateRuntimeOptionPatch } from "./runtime-options.js";
+
+describe("ACP runtime options", () => {
+  it("rejects fractional timeoutSeconds numeric patches", () => {
+    expect(() => validateRuntimeOptionPatch({ timeoutSeconds: 1.4 })).toThrow(
+      "Timeout must be a positive integer in seconds.",
+    );
+    expect(() => validateRuntimeOptionPatch({ timeoutSeconds: 1.6 })).toThrow(
+      "Timeout must be a positive integer in seconds.",
+    );
+  });
+});

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -117,16 +117,19 @@ export function validateRuntimeCwdInput(rawCwd: unknown): string {
 }
 
 function validateRuntimeTimeoutSecondsInput(rawTimeout: unknown): number {
-  if (typeof rawTimeout !== "number" || !Number.isFinite(rawTimeout)) {
+  if (
+    typeof rawTimeout !== "number" ||
+    !Number.isFinite(rawTimeout) ||
+    !Number.isInteger(rawTimeout)
+  ) {
     failInvalidOption("Timeout must be a positive integer in seconds.");
   }
-  const timeout = Math.round(rawTimeout);
-  if (timeout < MIN_TIMEOUT_SECONDS || timeout > MAX_TIMEOUT_SECONDS) {
+  if (rawTimeout < MIN_TIMEOUT_SECONDS || rawTimeout > MAX_TIMEOUT_SECONDS) {
     failInvalidOption(
       `Timeout must be between ${MIN_TIMEOUT_SECONDS} and ${MAX_TIMEOUT_SECONDS} seconds.`,
     );
   }
-  return timeout;
+  return rawTimeout;
 }
 
 export function parseRuntimeTimeoutSecondsInput(rawTimeout: unknown): number {


### PR DESCRIPTION
## Summary
- reject fractional numeric ACP runtime timeout patches instead of silently rounding them
- add regression coverage for fractional `timeoutSeconds` values

## Real behavior proof

**Behavior or issue addressed:** ACP runtime option validation should reject fractional numeric `timeoutSeconds` values instead of silently rounding them. Integer seconds should still be accepted.

**Real environment tested:** Local OpenClaw checkout on macOS after `pnpm install`, branch `fix/acp-runtime-timeout-integer`, commit `571ad9f7d6`.

**Exact steps or command run after this patch:** Ran a live Node command with `tsx` import support against the local checkout; called `validateRuntimeOptionPatch` with `1.4`, `1.6`, and integer `2`.

**Evidence after fix:** Terminal output from the live command:

```console
$ node --import tsx -e "import { validateRuntimeOptionPatch } from './src/acp/control-plane/runtime-options.ts'; for (const value of [1.4, 1.6]) { try { console.log(value, validateRuntimeOptionPatch({ timeoutSeconds: value })); } catch (error) { console.log(value, error instanceof Error ? error.message : String(error)); } } console.log('integer', JSON.stringify(validateRuntimeOptionPatch({ timeoutSeconds: 2 })));"
1.4 Timeout must be a positive integer in seconds.
1.6 Timeout must be a positive integer in seconds.
integer {"timeoutSeconds":2}
```

**Observed result after fix:** Fractional numeric timeout patches now fail with `Timeout must be a positive integer in seconds.`, while an integer timeout patch still returns `{ "timeoutSeconds": 2 }`.

**What was not tested:** Full live ACP client session. The proof exercises the actual runtime-options module in a real local OpenClaw checkout; unit and changed-scope checks cover the integration surface.

## Test Plan
- `pnpm test src/acp/control-plane/runtime-options.test.ts src/acp/control-plane/manager.test.ts`
- `pnpm check:changed`

## Notes
The string/config-option path already requires integer seconds via `parseRuntimeTimeoutSecondsInput`; this aligns the numeric runtime patch path with that contract.
