### PR TITLE
fix #80079: [Bug]: Codex ACP Discord thread sessions can fail first turn or keep replies local

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -855,7 +855,9 @@ export class AcpSessionManager {
                 });
               },
             });
-            if (!turnOutcome.sawTerminalEvent) {
+            // Some ACP adapters close their async stream after final output
+            // without emitting a terminal done event.
+            if (!turnOutcome.sawTerminalEvent && !turnOutcome.sawOutput) {
               throw new AcpRuntimeError(
                 "ACP_TURN_FAILED",
                 "ACP turn ended without a terminal done event.",

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -5,7 +5,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AcpSessionRuntimeOptions, SessionAcpMeta } from "../../config/sessions/types.js";
 import { resetHeartbeatWakeStateForTests } from "../../infra/heartbeat-wake.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
-import type { AcpRuntime, AcpRuntimeCapabilities } from "../runtime/types.js";
+import type { AcpRuntime, AcpRuntimeCapabilities, AcpRuntimeEvent } from "../runtime/types.js";
 
 const hoisted = vi.hoisted(() => {
   const listAcpSessionEntriesMock = vi.fn();
@@ -2214,7 +2214,7 @@ describe("AcpSessionManager", () => {
     expect(states.at(-1)).toBe("error");
   });
 
-  it("rejects ACP streams that end without a terminal done event", async () => {
+  it("accepts ACP streams that close after output without a terminal done event", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
       id: "acpx",
@@ -2230,6 +2230,115 @@ describe("AcpSessionManager", () => {
         type: "text_delta" as const,
         stream: "output" as const,
         text: "Starting work...",
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-1",
+    });
+
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states.at(-1)).toBe("idle");
+  });
+
+  it("rejects ACP streams that close without output or a terminal done event", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn.mockImplementation(async function* () {
+      for (const event of [] as AcpRuntimeEvent[]) {
+        yield event;
+      }
+    });
+
+    const manager = new AcpSessionManager();
+    await expectRejectedRecord(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      }),
+      {
+        code: "ACP_TURN_FAILED",
+        message: "ACP turn ended without a terminal done event.",
+      },
+    );
+
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states.at(-1)).toBe("error");
+  });
+
+  it("rejects ACP streams that close after only empty output without a terminal done event", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn.mockImplementation(async function* () {
+      yield {
+        type: "text_delta" as const,
+        stream: "output" as const,
+        text: "   ",
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    await expectRejectedRecord(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      }),
+      {
+        code: "ACP_TURN_FAILED",
+        message: "ACP turn ended without a terminal done event.",
+      },
+    );
+
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states.at(-1)).toBe("error");
+  });
+
+  it("rejects ACP streams that close after only thought output without a terminal done event", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn.mockImplementation(async function* () {
+      yield {
+        type: "text_delta" as const,
+        stream: "thought" as const,
+        text: "Thinking...",
       };
     });
 

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -12,6 +12,20 @@ export type AcpTurnStreamOutcome = {
   sawTerminalEvent: boolean;
 };
 
+function acpEventHasOutputEvidence(
+  event: Extract<AcpRuntimeEvent, { type: "text_delta" | "tool_call" }>,
+): boolean {
+  if (event.type === "text_delta") {
+    return event.stream !== "thought" && Boolean(normalizeText(event.text));
+  }
+  return Boolean(
+    normalizeText(event.text) ||
+    normalizeText(event.title) ||
+    normalizeText(event.status) ||
+    normalizeText(event.toolCallId),
+  );
+}
+
 export async function consumeAcpTurnStream(params: {
   runtime: AcpRuntime;
   turn: AcpRuntimeTurnInput;
@@ -37,7 +51,7 @@ export async function consumeAcpTurnStream(params: {
         normalizeText(event.message) || "ACP turn failed before completion.",
       );
     } else if (event.type === "text_delta" || event.type === "tool_call") {
-      sawOutput = true;
+      sawOutput ||= acpEventHasOutputEvidence(event);
       await params.onOutputEvent?.(event);
     }
     await params.onEvent?.(event);

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -777,12 +777,137 @@ describe("spawnAcpDirect", () => {
       mode: "persistent",
     });
     expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
+    const gatewayCalls = gatewayRequests();
+    const patchCallIndex = gatewayCalls.findIndex((call) => call.method === "sessions.patch");
+    const agentCallIndex = gatewayCalls.findIndex((call) => call.method === "agent");
+    expect(patchCallIndex).toBeGreaterThanOrEqual(0);
+    expect(agentCallIndex).toBeGreaterThanOrEqual(0);
+    const initializeOrder = hoisted.initializeSessionMock.mock.invocationCallOrder[0];
+    const patchOrder = hoisted.callGatewayMock.mock.invocationCallOrder[patchCallIndex];
+    const agentOrder = hoisted.callGatewayMock.mock.invocationCallOrder[agentCallIndex];
+    expect(initializeOrder).toBeLessThan(patchOrder);
+    expect(patchOrder).toBeLessThan(agentOrder);
     const transcriptCalls = hoisted.resolveSessionTranscriptFileMock.mock.calls.map(
       (call: unknown[]) => call[0] as { threadId?: string },
     );
     expect(transcriptCalls).toHaveLength(2);
     expect(transcriptCalls[0]?.threadId).toBeUndefined();
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
+  });
+
+  it("persists child-thread transcript metadata for fresh ACP session entries created during initialize", async () => {
+    let initializedSessionKey: string | undefined;
+    hoisted.loadSessionStoreMock.mockImplementation(() =>
+      initializedSessionKey
+        ? {
+            [initializedSessionKey]: {
+              sessionId: "fresh-sess-123",
+              updatedAt: Date.now(),
+            },
+          }
+        : {},
+    );
+    hoisted.initializeSessionMock.mockImplementationOnce(async (argsUnknown: unknown) => {
+      const args = argsUnknown as AcpInitializeSessionInput;
+      initializedSessionKey = args.sessionKey;
+      const runtimeSessionName = `${args.sessionKey}:runtime`;
+      return {
+        runtime: {
+          close: vi.fn().mockResolvedValue(undefined),
+        },
+        handle: {
+          sessionKey: args.sessionKey,
+          backend: "acpx",
+          runtimeSessionName,
+          agentSessionId: "codex-inner-1",
+          backendSessionId: "acpx-1",
+        },
+        meta: {
+          backend: "acpx",
+          agent: args.agent,
+          runtimeSessionName,
+          identity: {
+            state: "pending",
+            source: "ensure",
+            acpxSessionId: "acpx-1",
+            agentSessionId: "codex-inner-1",
+            lastUpdatedAt: Date.now(),
+          },
+          mode: args.mode,
+          state: "idle",
+          lastActivityAt: Date.now(),
+        },
+      };
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+        agentThreadId: "requester-thread",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    const transcriptCalls = hoisted.resolveSessionTranscriptFileMock.mock.calls.map(
+      (call: unknown[]) => call[0] as { sessionId?: string; threadId?: string },
+    );
+    expect(transcriptCalls).toHaveLength(2);
+    expect(transcriptCalls[0]).toEqual(
+      expect.objectContaining({
+        sessionId: "fresh-sess-123",
+        threadId: undefined,
+      }),
+    );
+    expect(transcriptCalls[1]).toEqual(
+      expect.objectContaining({
+        sessionId: "fresh-sess-123",
+        threadId: "child-thread",
+      }),
+    );
+  });
+
+  it("cleans up a child ACP session when initialization fails before session patching", async () => {
+    hoisted.initializeSessionMock.mockRejectedValueOnce(new Error("acpx unavailable"));
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+        agentThreadId: "requester-thread",
+      },
+    );
+
+    const failed = expectFailedSpawn(result, "error");
+    expect(failed.errorCode).toBe("spawn_failed");
+    expect(failed.error).toBe("acpx unavailable");
+    expect(hoisted.callGatewayMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.patch",
+      }),
+    );
+    expect(hoisted.cleanupFailedAcpSpawnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldDeleteSession: true,
+        deleteTranscript: true,
+      }),
+    );
   });
 
   it("allows ACP resume IDs recorded for the requester session", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -918,9 +918,9 @@ async function initializeAcpSpawnRuntime(params: {
   cwd?: string;
 }): Promise<AcpSpawnInitializedRuntime> {
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
-  const sessionStore = loadSessionStore(storePath);
+  let sessionStore = loadSessionStore(storePath);
   let sessionEntry: SessionEntry | undefined = sessionStore[params.sessionKey];
-  const sessionId = sessionEntry?.sessionId;
+  let sessionId = sessionEntry?.sessionId;
   if (sessionId) {
     sessionEntry = await persistAcpSpawnSessionFileBestEffort({
       sessionId,
@@ -950,6 +950,23 @@ async function initializeAcpSpawnRuntime(params: {
     cwd: params.cwd,
     backendId: params.cfg.acp?.backend,
   });
+
+  if (!sessionId) {
+    sessionStore = loadSessionStore(storePath);
+    sessionEntry = sessionStore[params.sessionKey];
+    sessionId = sessionEntry?.sessionId;
+    if (sessionId) {
+      sessionEntry = await persistAcpSpawnSessionFileBestEffort({
+        sessionId,
+        sessionKey: params.sessionKey,
+        sessionStore,
+        storePath,
+        sessionEntry,
+        agentId: params.targetAgentId,
+        stage: "spawn",
+      });
+    }
+  }
 
   return {
     initialized,
@@ -1285,16 +1302,6 @@ export async function spawnAcpDirect(
   let sessionCreated = false;
   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
   try {
-    await callGateway({
-      method: "sessions.patch",
-      params: {
-        key: sessionKey,
-        spawnedBy: requesterInternalKey,
-        ...subagentEnvelopeState.childSessionPatch,
-        ...(params.label ? { label: params.label } : {}),
-      },
-      timeoutMs: 10_000,
-    });
     sessionCreated = true;
     const initializedSession = await initializeAcpSpawnRuntime({
       cfg,
@@ -1308,6 +1315,17 @@ export async function spawnAcpDirect(
       cwd: runtimeCwd,
     });
     initializedRuntime = initializedSession.runtimeCloseHandle;
+
+    await callGateway({
+      method: "sessions.patch",
+      params: {
+        key: sessionKey,
+        spawnedBy: requesterInternalKey,
+        ...subagentEnvelopeState.childSessionPatch,
+        ...(params.label ? { label: params.label } : {}),
+      },
+      timeoutMs: 10_000,
+    });
 
     if (preparedBinding) {
       ({ binding } = await bindPreparedAcpThread({


### PR DESCRIPTION
## Summary
Fixes #80079

### Issue
[[Bug]: Codex ACP Discord thread sessions can fail first turn or keep replies local](https://github.com/openclaw/openclaw/issues/80079)

### Changes
- fix(acp): require meaningful ACP stream output
- fix(acp): repair codex thread spawns

### Changed Files
```
CHANGELOG.md                                 |  1 +
 src/acp/control-plane/manager.core.ts        |  4 +-
 src/acp/control-plane/manager.test.ts        | 74 +++++++++++++++++++++++++++-
 src/acp/control-plane/manager.turn-stream.ts | 16 +++++-
 src/agents/acp-spawn.test.ts                 | 10 ++++
 src/agents/acp-spawn.ts                      | 23 ++++-----
 6 files changed, 113 insertions(+), 15 deletions(-)
```

## Real behavior proof

content:
  behavior: Codex ACP Discord thread sessions keep the first turn and spawned child replies on the ACP thread path instead of dropping output-only streams or leaving child replies local.
  environment: macOS arm64, Node v24.15.0, local OpenClaw checkout at /Users/zhangguiping/daily_pr_work/openclaw-80079.
  steps: |
    1. Checked out PR branch feat/issue-80079.
    2. Ran the ACP control-plane and ACP spawn regression suites:
       pnpm test src/acp/control-plane/manager.test.ts src/agents/acp-spawn.test.ts -- --reporter=verbose
  evidence: |
    Copied terminal output from the local OpenClaw run:
    src/acp/control-plane/manager.test.ts: 66 tests passed
    src/agents/acp-spawn.test.ts: 57 tests passed
    test passed 2 Vitest shards in 4.40s

    Covered regression paths:
    - ACP streams that close after meaningful output without a terminal done event.
    - Fresh ACP session transcript metadata preserved during initialize.
    - streamTo: parent ACP spawn progress and child dispatch path.
  observedResult: The targeted ACP/Codex regression suites completed successfully, including the paths that previously caused first-turn failure or local-only child replies.
  notTested: Live Discord end-to-end execution was not run because this local environment does not have Discord workspace credentials; the proof is local OpenClaw terminal output plus focused ACP regression coverage.
