### PR TITLE
Plugin SDK: add host-owned structured runtime LLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugin SDK/runtime: add `api.runtime.llm.completeStructured(...)` for host-owned structured plugin inference with optional image inputs, JSON/schema validation, auth-profile selection, and the same model/agent override trust gates as `api.runtime.llm.complete`.
 - QA/Mantis: add Telegram live PR evidence automation with Convex-leased credentials, Crabbox transcript capture, motion GIF previews, and inline PR comments.
 - QA/Mantis: add a Telegram desktop scenario builder that leases Crabbox, installs native Telegram Desktop, configures an OpenClaw Telegram gateway with leased bot credentials, and records VNC screenshot/video artifacts.
 - Discord/voice: add realtime voice diagnostics for speaker turns, playback resets, barge-in detection, and audio cutoff analysis.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-32f0b7801c9e5e0b7ec8d7da11cec62713e968abf056560ad6372aac877fdf14  plugin-sdk-api-baseline.json
-e26cfb7da5e6e8addd0bd4669bd53a4188c53f8371cb20216d854f7dd0154b1b  plugin-sdk-api-baseline.jsonl
+52ecf86f124d947b473356aa73ec8ef23545795f945de87fbf5e624fed00b36e  plugin-sdk-api-baseline.json
+7f6fc03a55567fdd00f97be65f7b55129bc94d32f39a3630f59f466e241420a2  plugin-sdk-api-baseline.jsonl

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -208,9 +208,10 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
 - `plugins.entries.<id>.hooks.allowConversationAccess`: when `true`, trusted non-bundled plugins may read raw conversation content from typed hooks such as `llm_input`, `llm_output`, `before_model_resolve`, `before_agent_reply`, `before_agent_run`, `before_agent_finalize`, and `agent_end`.
 - `plugins.entries.<id>.subagent.allowModelOverride`: explicitly trust this plugin to request per-run `provider` and `model` overrides for background subagent runs.
 - `plugins.entries.<id>.subagent.allowedModels`: optional allowlist of canonical `provider/model` targets for trusted subagent overrides. Use `"*"` only when you intentionally want to allow any model.
-- `plugins.entries.<id>.llm.allowModelOverride`: explicitly trust this plugin to request model overrides for `api.runtime.llm.complete`.
-- `plugins.entries.<id>.llm.allowedModels`: optional allowlist of canonical `provider/model` targets for trusted plugin LLM completion overrides. Use `"*"` only when you intentionally want to allow any model.
-- `plugins.entries.<id>.llm.allowAgentIdOverride`: explicitly trust this plugin to run `api.runtime.llm.complete` against a non-default agent id.
+- `plugins.entries.<id>.llm.allowModelOverride`: explicitly trust this plugin to request model overrides for `api.runtime.llm.complete` and `api.runtime.llm.completeStructured`.
+- `plugins.entries.<id>.llm.allowedModels`: optional allowlist of canonical `provider/model` targets for trusted plugin runtime LLM overrides. Use `"*"` only when you intentionally want to allow any model.
+- `plugins.entries.<id>.llm.allowAgentIdOverride`: explicitly trust this plugin to run `api.runtime.llm.complete` / `completeStructured` against a non-default agent id.
+- `plugins.entries.<id>.llm.allowProfileOverride`: explicitly trust this plugin to select a non-default auth profile for `api.runtime.llm.completeStructured`.
 - `plugins.entries.<id>.config`: plugin-defined config object (validated by native OpenClaw plugin schema when available).
 - Channel plugin account/runtime settings live under `channels.<id>` and should be described by the owning plugin's manifest `channelConfigs` metadata, not by a central OpenClaw option registry.
 

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -155,8 +155,49 @@ Provider and channel execution paths must use the active runtime config snapshot
     result includes provider/model/agent attribution plus normalized token,
     cache, and estimated cost usage when available.
 
+    For bounded structured work, use `api.runtime.llm.completeStructured(...)`.
+
+    ```typescript
+    const structured = await api.runtime.llm.completeStructured({
+      instructions: "Extract vendor, total, and searchable tags.",
+      input: [
+        {
+          type: "image",
+          buffer: receiptBuffer,
+          mimeType: "image/png",
+          fileName: "receipt.png",
+        },
+        { type: "text", text: "Prefer the printed total over handwritten notes." },
+      ],
+      schemaName: "receipt.evidence",
+      jsonSchema: {
+        type: "object",
+        properties: {
+          vendor: { type: "string" },
+          total: { type: "number" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+        required: ["vendor", "total"],
+      },
+      purpose: "receipts.extract",
+      profile: "openai-codex:work",
+      maxTokens: 512,
+      timeoutMs: 30000,
+    });
+    ```
+
+    `completeStructured(...)` keeps auth, provider routing, and runtime execution
+    host-owned. Plugins provide instructions, optional text/image inputs, and an
+    optional JSON Schema; the host returns the raw text plus parsed JSON only
+    when `jsonMode: true` or `jsonSchema` is provided.
+
+    For provider/model-explicit media capability routing, use
+    `api.runtime.mediaUnderstanding.extractStructuredWithModel(...)` instead.
+    `completeStructured(...)` is the generic agent-bound runtime lane; the
+    media-understanding helper is the narrower provider-owned image/media lane.
+
     <Warning>
-    Model overrides require operator opt-in via `plugins.entries.<id>.llm.allowModelOverride: true` in config. Use `plugins.entries.<id>.llm.allowedModels` to restrict trusted plugins to specific canonical `provider/model` targets. Cross-agent completions require `plugins.entries.<id>.llm.allowAgentIdOverride: true`.
+    Model overrides require operator opt-in via `plugins.entries.<id>.llm.allowModelOverride: true` in config. Use `plugins.entries.<id>.llm.allowedModels` to restrict trusted plugins to specific canonical `provider/model` targets. Cross-agent completions require `plugins.entries.<id>.llm.allowAgentIdOverride: true`. Auth-profile selection for `completeStructured(...)` requires `plugins.entries.<id>.llm.allowProfileOverride: true`. The same host-owned trust gate applies across runtime LLM surfaces.
     </Warning>
 
   </Accordion>

--- a/src/agents/pi-embedded-runner/context-engine-capabilities.ts
+++ b/src/agents/pi-embedded-runner/context-engine-capabilities.ts
@@ -80,6 +80,22 @@ export function resolveContextEngineCapabilities(
           },
         }).complete(request);
       },
+      completeStructured: async (request) => {
+        const { createRuntimeLlm } = await import("../../plugins/runtime/runtime-llm.runtime.js");
+        return await createRuntimeLlm({
+          getConfig: () => params.config,
+          authority: {
+            caller: { kind: "context-engine", id: params.purpose },
+            requiresBoundAgent: true,
+            ...(sessionKey ? { sessionKey } : {}),
+            ...(agentId ? { agentId } : {}),
+            ...(contextEnginePluginId ? { pluginIdForPolicy: contextEnginePluginId } : {}),
+            allowAgentIdOverride: false,
+            allowModelOverride: false,
+            allowComplete: true,
+          },
+        }).completeStructured(request);
+      },
     },
   };
 }

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -374,6 +374,7 @@ const TARGET_KEYS = [
   "plugins.entries.*.llm.allowModelOverride",
   "plugins.entries.*.llm.allowedModels",
   "plugins.entries.*.llm.allowAgentIdOverride",
+  "plugins.entries.*.llm.allowProfileOverride",
   "plugins.entries.*.apiKey",
   "plugins.entries.*.env",
   "plugins.entries.*.config",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1273,13 +1273,15 @@ export const FIELD_HELP: Record<string, string> = {
   "plugins.entries.*.subagent.allowedModels":
     'Allowed override targets for trusted plugin subagent runs as canonical "provider/model" refs. Use "*" only when you intentionally allow any model.',
   "plugins.entries.*.llm":
-    "Per-plugin api.runtime.llm.complete controls for model and agent override trust. Keep this unset unless a plugin must explicitly steer host-owned completion calls.",
+    "Per-plugin api.runtime.llm.complete and api.runtime.llm.completeStructured controls for model, auth-profile, and agent override trust. Keep this unset unless a plugin must explicitly steer host-owned completion calls.",
   "plugins.entries.*.llm.allowModelOverride":
-    "Explicitly allows this plugin to request model overrides in api.runtime.llm.complete. Keep false unless the plugin is trusted to steer model selection.",
+    "Explicitly allows this plugin to request model overrides in api.runtime.llm.complete or api.runtime.llm.completeStructured. Keep false unless the plugin is trusted to steer model selection.",
   "plugins.entries.*.llm.allowedModels":
     'Allowed override targets for trusted plugin LLM completions as canonical "provider/model" refs. Use "*" only when you intentionally allow any model.',
   "plugins.entries.*.llm.allowAgentIdOverride":
-    "Explicitly allows this plugin to request api.runtime.llm.complete against a non-default agent id. Keep false unless the plugin is trusted for cross-agent model access.",
+    "Explicitly allows this plugin to request runtime.llm completions against a non-default agent id. Keep false unless the plugin is trusted for cross-agent model access.",
+  "plugins.entries.*.llm.allowProfileOverride":
+    "Explicitly allows this plugin to request a non-default auth profile in runtime.llm completions. Keep false unless the plugin is trusted to steer which stored provider credentials/account the host should use.",
   "plugins.entries.*.apiKey":
     "Optional API key field consumed by plugins that accept direct key configuration in entry settings. Use secret/env substitution and avoid committing real credentials into config files.",
   "plugins.entries.*.env":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -950,6 +950,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "plugins.entries.*.llm.allowModelOverride": "Allow Plugin LLM Model Override",
   "plugins.entries.*.llm.allowedModels": "Plugin LLM Allowed Models",
   "plugins.entries.*.llm.allowAgentIdOverride": "Allow Plugin LLM Agent Override",
+  "plugins.entries.*.llm.allowProfileOverride": "Allow Plugin LLM Auth Profile Override",
   "plugins.entries.*.apiKey": "Plugin API Key", // pragma: allowlist secret
   "plugins.entries.*.env": "Plugin Environment Variables",
   "plugins.entries.*.config": "Plugin Config",

--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -25,15 +25,17 @@ export type PluginEntryConfig = {
     allowedModels?: string[];
   };
   llm?: {
-    /** Explicitly allow this plugin to request a model override for api.runtime.llm.complete. */
+    /** Explicitly allow this plugin to request a model override for api.runtime.llm.complete / completeStructured. */
     allowModelOverride?: boolean;
     /**
      * Allowed completion model override targets as canonical provider/model refs.
      * Use "*" to explicitly allow any model for this plugin.
      */
     allowedModels?: string[];
-    /** Explicitly allow this plugin to run completions against a non-default agent id. */
+    /** Explicitly allow this plugin to run runtime.llm calls against a non-default agent id. */
     allowAgentIdOverride?: boolean;
+    /** Explicitly allow this plugin to request a specific auth profile for runtime.llm calls. */
+    allowProfileOverride?: boolean;
   };
   config?: Record<string, unknown>;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -217,6 +217,7 @@ const PluginEntrySchema = z
         allowModelOverride: z.boolean().optional(),
         allowedModels: z.array(z.string()).optional(),
         allowAgentIdOverride: z.boolean().optional(),
+        allowProfileOverride: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -178,6 +178,9 @@ export type ContextEngineRuntimeContext = Record<string, unknown> & {
     complete: (
       params: import("../plugins/runtime/types-core.js").LlmCompleteParams,
     ) => Promise<import("../plugins/runtime/types-core.js").LlmCompleteResult>;
+    completeStructured: (
+      params: import("../plugins/runtime/types-core.js").LlmCompleteStructuredParams,
+    ) => Promise<import("../plugins/runtime/types-core.js").LlmCompleteStructuredResult>;
   };
 };
 

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -728,6 +728,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
     llm: {
       complete: vi.fn(),
+      completeStructured: vi.fn(),
     },
     nodes: {
       list: vi.fn(async () => ({ nodes: [] })),

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -35,6 +35,7 @@ export type NormalizedPluginsConfig = {
         allowedModels?: string[];
         hasAllowedModelsConfig?: boolean;
         allowAgentIdOverride?: boolean;
+        allowProfileOverride?: boolean;
       };
       config?: unknown;
     }
@@ -185,6 +186,8 @@ function normalizePluginEntries(
               : undefined,
             allowAgentIdOverride: (llmRaw as { allowAgentIdOverride?: unknown })
               .allowAgentIdOverride,
+            allowProfileOverride: (llmRaw as { allowProfileOverride?: unknown })
+              .allowProfileOverride,
           }
         : undefined;
     const normalizedLlm =
@@ -192,7 +195,8 @@ function normalizePluginEntries(
       (typeof llm.allowModelOverride === "boolean" ||
         llm.hasAllowedModelsConfig ||
         (Array.isArray(llm.allowedModels) && llm.allowedModels.length > 0) ||
-        typeof llm.allowAgentIdOverride === "boolean")
+        typeof llm.allowAgentIdOverride === "boolean" ||
+        typeof llm.allowProfileOverride === "boolean")
         ? {
             ...(typeof llm.allowModelOverride === "boolean"
               ? { allowModelOverride: llm.allowModelOverride }
@@ -203,6 +207,9 @@ function normalizePluginEntries(
               : {}),
             ...(typeof llm.allowAgentIdOverride === "boolean"
               ? { allowAgentIdOverride: llm.allowAgentIdOverride }
+              : {}),
+            ...(typeof llm.allowProfileOverride === "boolean"
+              ? { allowProfileOverride: llm.allowProfileOverride }
               : {}),
           }
         : undefined;

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -152,6 +152,7 @@ describe("normalizePluginsConfig", () => {
           allowModelOverride: true,
           allowedModels: [" openai/gpt-5.4 ", "", "anthropic/claude-sonnet-4-6"],
           allowAgentIdOverride: false,
+          allowProfileOverride: true,
         },
       })?.llm,
     ).toEqual({
@@ -159,6 +160,7 @@ describe("normalizePluginsConfig", () => {
       hasAllowedModelsConfig: true,
       allowedModels: ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"],
       allowAgentIdOverride: false,
+      allowProfileOverride: true,
     });
   });
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2265,6 +2265,8 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           return {
             complete: (params) =>
               withPluginRuntimePluginIdScope(pluginId, () => llm.complete(params)),
+            completeStructured: (params) =>
+              withPluginRuntimePluginIdScope(pluginId, () => llm.completeStructured(params)),
           } satisfies PluginRuntime["llm"];
         }
         if (prop !== "subagent") {

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -329,6 +329,16 @@ describe("plugin runtime command execution", () => {
         ]);
       },
     },
+    {
+      name: "exposes runtime.llm completion helpers",
+      assert: (runtime: ReturnType<typeof createPluginRuntime>) => {
+        expect(runtime.llm).toMatchObject({
+          complete: expect.any(Function),
+          completeStructured: expect.any(Function),
+        });
+        expectFunctionKeys(runtime.llm, ["complete", "completeStructured"]);
+      },
+    },
   ] as const)("$name", ({ assert }) => {
     expectRuntimeShape(assert);
   });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -111,6 +111,10 @@ function createRuntimeLlmFacade(): PluginRuntime["llm"] {
       const llm = await loadLlm();
       return llm.complete(params);
     },
+    completeStructured: async (params) => {
+      const llm = await loadLlm();
+      return llm.completeStructured(params);
+    },
   };
 }
 

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -424,10 +424,10 @@ describe("runtime.llm.complete", () => {
 
     await expect(
       llm.complete({
-        model: "openai/gpt-5.5",
+        model: "openai/gpt-5.6",
         messages: [{ role: "user", content: "Ping" }],
       }),
-    ).rejects.toThrow('model override "openai/gpt-5.5" is not allowlisted');
+    ).rejects.toThrow('model override "openai/gpt-5.6" is not allowlisted');
   });
 
   it("uses runtime-scoped config and the host preparation/dispatch path", async () => {
@@ -622,11 +622,11 @@ describe("runtime.llm.complete", () => {
     await expect(
       withPluginRuntimePluginIdScope("trusted-plugin", () =>
         llm.complete({
-          model: "openai/gpt-5.5",
+          model: "openai/gpt-5.6",
           messages: [{ role: "user", content: "Ping" }],
         }),
       ),
-    ).rejects.toThrow('model override "openai/gpt-5.5" is not allowlisted');
+    ).rejects.toThrow('model override "openai/gpt-5.6" is not allowlisted');
   });
 
   it("rejects auth-profile suffixes on complete without explicit trust", async () => {
@@ -645,6 +645,29 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "Ping" }],
       }),
     ).rejects.toThrow("cannot override the auth profile");
+  });
+
+  it("treats same-as-default auth-profile suffixes on complete as profile-only overrides", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+        allowProfileOverride: true,
+      },
+    });
+
+    await llm.complete({
+      model: "openai/gpt-5.5@openai-codex:work",
+      messages: [{ role: "user", content: "Ping" }],
+    });
+
+    expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelRef: undefined,
+        preferredProfile: "openai-codex:work",
+      }),
+    );
   });
 
   it("returns parsed structured JSON for text-only completion and validates the schema", async () => {
@@ -836,13 +859,12 @@ describe("runtime.llm.complete", () => {
     ).rejects.toThrow("cannot override the auth profile");
   });
 
-  it("treats auth-profile suffixes in structured model refs as profile overrides when trusted", async () => {
+  it("treats same-as-default auth-profile suffixes in structured model refs as profile-only overrides when trusted", async () => {
     const llm = createRuntimeLlm({
       getConfig: () => cfg,
       authority: {
         caller: { kind: "host", id: "runtime-test" },
         allowComplete: true,
-        allowModelOverride: true,
         allowProfileOverride: true,
       },
     });
@@ -856,13 +878,13 @@ describe("runtime.llm.complete", () => {
 
     expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        modelRef: "openai/gpt-5.5",
+        modelRef: undefined,
         preferredProfile: "openai-codex:work",
       }),
     );
   });
 
-  it("allows auth-profile suffixes through plugin llm policy", async () => {
+  it("allows same-as-default auth-profile suffixes through plugin llm policy", async () => {
     const llm = createRuntimeLlm({
       getConfig: () => ({
         ...cfg,
@@ -870,8 +892,6 @@ describe("runtime.llm.complete", () => {
           entries: {
             "trusted-plugin": {
               llm: {
-                allowModelOverride: true,
-                allowedModels: ["openai/gpt-5.5"],
                 allowProfileOverride: true,
               },
             },
@@ -894,7 +914,34 @@ describe("runtime.llm.complete", () => {
 
     expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        modelRef: "openai/gpt-5.5",
+        modelRef: undefined,
+        preferredProfile: "openai-codex:work",
+      }),
+    );
+  });
+
+  it("requires both model and profile trust when the structured model ref changes the target model", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+        allowModelOverride: true,
+        allowedModels: ["openai/gpt-5.4"],
+        allowProfileOverride: true,
+      },
+    });
+
+    await llm.completeStructured({
+      model: "openai/gpt-5.4@openai-codex:work",
+      instructions: "Extract summary.",
+      input: [{ type: "text", text: "Hello" }],
+      jsonMode: false,
+    });
+
+    expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelRef: "openai/gpt-5.4",
         preferredProfile: "openai-codex:work",
       }),
     );

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -629,6 +629,24 @@ describe("runtime.llm.complete", () => {
     ).rejects.toThrow('model override "openai/gpt-5.5" is not allowlisted');
   });
 
+  it("rejects auth-profile suffixes on complete without explicit trust", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+        allowModelOverride: true,
+      },
+    });
+
+    await expect(
+      llm.complete({
+        model: "openai/gpt-5.5@openai-codex:work",
+        messages: [{ role: "user", content: "Ping" }],
+      }),
+    ).rejects.toThrow("cannot override the auth profile");
+  });
+
   it("returns parsed structured JSON for text-only completion and validates the schema", async () => {
     const llm = createRuntimeLlm({
       getConfig: () => cfg,
@@ -835,6 +853,44 @@ describe("runtime.llm.complete", () => {
       input: [{ type: "text", text: "Hello" }],
       jsonMode: false,
     });
+
+    expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelRef: "openai/gpt-5.5",
+        preferredProfile: "openai-codex:work",
+      }),
+    );
+  });
+
+  it("allows auth-profile suffixes through plugin llm policy", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => ({
+        ...cfg,
+        plugins: {
+          entries: {
+            "trusted-plugin": {
+              llm: {
+                allowModelOverride: true,
+                allowedModels: ["openai/gpt-5.5"],
+                allowProfileOverride: true,
+              },
+            },
+          },
+        },
+      }),
+      authority: {
+        allowComplete: true,
+      },
+    });
+
+    await withPluginRuntimePluginIdScope("trusted-plugin", () =>
+      llm.completeStructured({
+        model: "openai/gpt-5.5@openai-codex:work",
+        instructions: "Extract summary.",
+        input: [{ type: "text", text: "Hello" }],
+        jsonMode: false,
+      }),
+    );
 
     expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -798,6 +798,74 @@ describe("runtime.llm.complete", () => {
     );
   });
 
+  it("rejects auth-profile suffixes in structured model refs without explicit trust", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+        allowModelOverride: true,
+      },
+    });
+
+    await expect(
+      llm.completeStructured({
+        model: "openai/gpt-5.5@openai-codex:work",
+        instructions: "Extract summary.",
+        input: [{ type: "text", text: "Hello" }],
+        jsonMode: false,
+      }),
+    ).rejects.toThrow("cannot override the auth profile");
+  });
+
+  it("treats auth-profile suffixes in structured model refs as profile overrides when trusted", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+        allowModelOverride: true,
+        allowProfileOverride: true,
+      },
+    });
+
+    await llm.completeStructured({
+      model: "openai/gpt-5.5@openai-codex:work",
+      instructions: "Extract summary.",
+      input: [{ type: "text", text: "Hello" }],
+      jsonMode: false,
+    });
+
+    expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelRef: "openai/gpt-5.5",
+        preferredProfile: "openai-codex:work",
+      }),
+    );
+  });
+
+  it("rejects conflicting explicit and embedded structured auth-profile overrides", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+        allowModelOverride: true,
+        allowProfileOverride: true,
+      },
+    });
+
+    await expect(
+      llm.completeStructured({
+        model: "openai/gpt-5.5@openai-codex:work",
+        profile: "openai-codex:other",
+        instructions: "Extract summary.",
+        input: [{ type: "text", text: "Hello" }],
+        jsonMode: false,
+      }),
+    ).rejects.toThrow("conflicting auth profiles");
+  });
+
   it("falls back to the configured image model for structured image input", async () => {
     const llm = createRuntimeLlm({
       getConfig: () => cfg,

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -9,12 +9,17 @@ const hoisted = vi.hoisted(() => ({
   prepareSimpleCompletionModelForAgent: vi.fn(),
   completeWithPreparedSimpleCompletionModel: vi.fn(),
   resolveSimpleCompletionSelectionForAgent: vi.fn(),
+  resolveAutoImageModel: vi.fn(),
 }));
 
 vi.mock("../../agents/simple-completion-runtime.js", () => ({
   prepareSimpleCompletionModelForAgent: hoisted.prepareSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel: hoisted.completeWithPreparedSimpleCompletionModel,
   resolveSimpleCompletionSelectionForAgent: hoisted.resolveSimpleCompletionSelectionForAgent,
+}));
+
+vi.mock("../../media-understanding/runner.js", () => ({
+  resolveAutoImageModel: hoisted.resolveAutoImageModel,
 }));
 
 const cfg = {
@@ -25,7 +30,7 @@ const cfg = {
   },
 } satisfies OpenClawConfig;
 
-function createPreparedModel(modelId = "gpt-5.5") {
+function createPreparedModel(modelId = "gpt-5.5", input: string[] = ["text"]) {
   return {
     selection: {
       provider: "openai",
@@ -37,7 +42,7 @@ function createPreparedModel(modelId = "gpt-5.5") {
       id: modelId,
       name: modelId,
       api: "openai",
-      input: ["text"],
+      input,
       reasoning: false,
       contextWindow: 128_000,
       maxTokens: 4096,
@@ -90,6 +95,7 @@ function primeCompletionMocks() {
       cost: { total: 0.0042 },
     },
   });
+  hoisted.resolveAutoImageModel.mockResolvedValue(null);
 }
 
 describe("runtime.llm.complete", () => {
@@ -97,6 +103,7 @@ describe("runtime.llm.complete", () => {
     hoisted.prepareSimpleCompletionModelForAgent.mockReset();
     hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
+    hoisted.resolveAutoImageModel.mockReset();
     primeCompletionMocks();
   });
 
@@ -125,6 +132,46 @@ describe("runtime.llm.complete", () => {
       purpose: "memory-maintenance",
       sessionKey: "agent:ada:session:abc",
     });
+  });
+
+  it("binds context-engine structured completions to the active session agent", async () => {
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"summary":"ok"}' }],
+      usage: {
+        input: 4,
+        output: 3,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 7,
+        cost: { total: 0.001 },
+      },
+    });
+    const runtimeContext = resolveContextEngineCapabilities({
+      config: cfg,
+      sessionKey: "agent:ada:session:abc",
+      purpose: "context-engine.after-turn",
+    });
+
+    const result = await runtimeContext.llm!.completeStructured({
+      instructions: "Extract a short summary.",
+      input: [{ type: "text", text: "Customer said the rollout worked." }],
+      jsonMode: true,
+      purpose: "memory-maintenance",
+    });
+
+    expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        agentId: "ada",
+      }),
+    );
+    expect(result.agentId).toBe("ada");
+    expect(result.audit).toMatchObject({
+      caller: { kind: "context-engine", id: "context-engine.after-turn" },
+      purpose: "memory-maintenance",
+      sessionKey: "agent:ada:session:abc",
+    });
+    expect(result.parsed).toEqual({ summary: "ok" });
   });
 
   it("uses trusted context-engine attribution inside plugin runtime scope", async () => {
@@ -580,6 +627,312 @@ describe("runtime.llm.complete", () => {
         }),
       ),
     ).rejects.toThrow('model override "openai/gpt-5.5" is not allowlisted');
+  });
+
+  it("returns parsed structured JSON for text-only completion and validates the schema", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+      content: [{ type: "text", text: '```json\n{"summary":"ok"}\n```' }],
+      usage: {
+        input: 4,
+        output: 3,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 7,
+        cost: { total: 0.001 },
+      },
+    });
+
+    const result = await llm.completeStructured({
+      instructions: "Extract a short summary.",
+      input: [{ type: "text", text: "Customer said the rollout worked." }],
+      schemaName: "support.summary",
+      jsonSchema: {
+        type: "object",
+        properties: { summary: { type: "string" } },
+        required: ["summary"],
+      },
+      systemPrompt: "Be precise.",
+      purpose: "structured.summary",
+    });
+
+    expect(result).toMatchObject({
+      text: '```json\n{"summary":"ok"}\n```',
+      parsed: { summary: "ok" },
+      contentType: "json",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+    expect(hoisted.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          systemPrompt: "Be precise.",
+          messages: [
+            expect.objectContaining({
+              role: "user",
+              content: [
+                expect.objectContaining({
+                  type: "text",
+                  text: expect.stringContaining("Schema name: support.summary"),
+                }),
+                expect.objectContaining({
+                  type: "text",
+                  text: "Customer said the rollout worked.",
+                }),
+              ],
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("supports image-plus-text structured completion with the host-owned llm runtime", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+    hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce(
+      createPreparedModel("gpt-5.5", ["text", "image"]),
+    );
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"caption":"receipt","tags":["finance"]}' }],
+      usage: {
+        input: 10,
+        output: 6,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 16,
+        cost: { total: 0.002 },
+      },
+    });
+
+    const result = await llm.completeStructured({
+      instructions: "Extract searchable receipt metadata.",
+      input: [
+        {
+          type: "image",
+          buffer: Buffer.from("hello"),
+          mimeType: "image/png",
+          fileName: "receipt.png",
+        },
+        { type: "text", text: "Prefer the printed total over handwritten notes." },
+      ],
+      jsonMode: true,
+    });
+
+    expect(result.parsed).toEqual({ caption: "receipt", tags: ["finance"] });
+    expect(hoisted.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              role: "user",
+              content: expect.arrayContaining([
+                expect.objectContaining({
+                  type: "image",
+                  mimeType: "image/png",
+                  data: Buffer.from("hello").toString("base64"),
+                }),
+                expect.objectContaining({
+                  type: "text",
+                  text: "Prefer the printed total over handwritten notes.",
+                }),
+              ]),
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("rejects structured auth-profile overrides without explicit trust", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+
+    await expect(
+      llm.completeStructured({
+        instructions: "Extract summary.",
+        input: [{ type: "text", text: "Hello" }],
+        profile: "openai-codex:work",
+        jsonMode: false,
+      }),
+    ).rejects.toThrow("cannot override the auth profile");
+  });
+
+  it("forwards preferred auth profiles into structured completion prep when trusted", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+        allowProfileOverride: true,
+      },
+    });
+
+    await llm.completeStructured({
+      instructions: "Extract summary.",
+      input: [{ type: "text", text: "Hello" }],
+      profile: "openai-codex:work",
+      jsonMode: false,
+    });
+
+    expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preferredProfile: "openai-codex:work",
+      }),
+    );
+  });
+
+  it("falls back to the configured image model for structured image input", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+    hoisted.resolveAutoImageModel.mockResolvedValueOnce({
+      provider: "google",
+      model: "gemini-3.1-flash-image-preview",
+    });
+    hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce(
+      createPreparedModel("gemini-3.1-flash-image-preview", ["text", "image"]),
+    );
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"summary":"ok"}' }],
+      usage: {
+        input: 2,
+        output: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 4,
+        cost: { total: 0.001 },
+      },
+    });
+
+    const result = await llm.completeStructured({
+      instructions: "Extract receipt fields.",
+      input: [{ type: "image", buffer: Buffer.from("hello"), mimeType: "image/png" }],
+      jsonMode: true,
+    });
+
+    expect(result.parsed).toEqual({ summary: "ok" });
+    expect(hoisted.resolveAutoImageModel).toHaveBeenCalledWith(expect.objectContaining({ cfg }));
+    expect(hoisted.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelRef: "google/gemini-3.1-flash-image-preview",
+      }),
+    );
+  });
+
+  it("rejects structured image input when neither the active nor fallback image model supports images", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+    hoisted.resolveAutoImageModel.mockResolvedValueOnce(null);
+
+    await expect(
+      llm.completeStructured({
+        instructions: "Extract receipt fields.",
+        input: [{ type: "image", buffer: Buffer.from("hello"), mimeType: "image/png" }],
+      }),
+    ).rejects.toThrow("does not support image input");
+  });
+
+  it("returns controlled errors for invalid structured JSON", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+      content: [{ type: "text", text: "not json" }],
+      usage: {
+        input: 2,
+        output: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 4,
+        cost: { total: 0.001 },
+      },
+    });
+
+    await expect(
+      llm.completeStructured({
+        instructions: "Extract summary.",
+        input: [{ type: "text", text: "Hello" }],
+        jsonMode: true,
+      }),
+    ).rejects.toThrow("returned invalid JSON");
+  });
+
+  it("aborts structured completions when timeoutMs elapses", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+    hoisted.completeWithPreparedSimpleCompletionModel.mockImplementationOnce(
+      async ({ options }: { options?: { signal?: AbortSignal } }) =>
+        await new Promise((_, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(options.signal?.reason ?? new Error("aborted")),
+            { once: true },
+          );
+        }),
+    );
+
+    await expect(
+      llm.completeStructured({
+        instructions: "Extract summary.",
+        input: [{ type: "text", text: "Hello" }],
+        jsonMode: false,
+        timeoutMs: 1,
+      }),
+    ).rejects.toThrow("timed out");
+  });
+
+  it("applies the same model-override trust rules to structured completion", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        allowComplete: true,
+      },
+    });
+
+    await expect(
+      withPluginRuntimePluginIdScope("plain-plugin", () =>
+        llm.completeStructured({
+          model: "openai/gpt-5.4",
+          instructions: "Extract summary.",
+          input: [{ type: "text", text: "Ping" }],
+        }),
+      ),
+    ).rejects.toThrow("cannot override the target model");
   });
 
   it("denies completions when runtime authority disables the capability", async () => {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -4,6 +4,10 @@ import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
 import { normalizeUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getChildLogger } from "../../logging.js";
+import {
+  type JsonSchemaObject,
+  validateJsonSchemaValue,
+} from "../../plugin-sdk/json-schema-runtime.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
@@ -13,6 +17,9 @@ import type {
   LlmCompleteCaller,
   LlmCompleteParams,
   LlmCompleteResult,
+  LlmCompleteStructuredInput,
+  LlmCompleteStructuredParams,
+  LlmCompleteStructuredResult,
   LlmCompleteUsage,
   PluginRuntimeCore,
   RuntimeLogger,
@@ -27,6 +34,7 @@ export type RuntimeLlmAuthority = {
   requiresBoundAgent?: boolean;
   allowAgentIdOverride?: boolean;
   allowModelOverride?: boolean;
+  allowProfileOverride?: boolean;
   allowedModels?: readonly string[];
   allowComplete?: boolean;
   denyReason?: string;
@@ -41,6 +49,7 @@ export type CreateRuntimeLlmOptions = {
 type RuntimeLlmOverridePolicy = {
   allowAgentIdOverride: boolean;
   allowModelOverride: boolean;
+  allowProfileOverride: boolean;
   hasConfiguredAllowedModels: boolean;
   allowAnyModel: boolean;
   allowedModels: Set<string>;
@@ -93,7 +102,7 @@ function resolveRuntimeConfig(options: CreateRuntimeLlmOptions): OpenClawConfig 
 }
 
 async function resolveAgentId(params: {
-  request: LlmCompleteParams;
+  request: Pick<LlmCompleteParams, "agentId">;
   cfg: OpenClawConfig;
   authority?: RuntimeLlmAuthority;
   allowAgentIdOverride: boolean;
@@ -129,6 +138,126 @@ function buildSystemPrompt(params: LlmCompleteParams): string | undefined {
       .map((message) => normalizeOptionalString(message.content)),
   ].filter((segment): segment is string => Boolean(segment));
   return segments.length > 0 ? segments.join("\n\n") : undefined;
+}
+
+function stripCodeFences(raw: string): string {
+  const trimmed = raw.trim();
+  const match = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return match ? (match[1] ?? "").trim() : trimmed;
+}
+
+function buildStructuredInstructions(params: LlmCompleteStructuredParams): string {
+  const sections = [params.instructions.trim()];
+  if (normalizeOptionalString(params.schemaName)) {
+    sections.push(`Schema name: ${params.schemaName!.trim()}`);
+  }
+  if (params.jsonSchema !== undefined) {
+    sections.push(`JSON schema:\n${JSON.stringify(params.jsonSchema)}`);
+  }
+  if (shouldUseJsonMode(params)) {
+    sections.push("Return valid JSON only. Do not wrap the JSON in Markdown fences.");
+  }
+  return sections.join("\n\n");
+}
+
+function shouldUseJsonMode(
+  params: Pick<LlmCompleteStructuredParams, "jsonMode" | "jsonSchema">,
+): boolean {
+  return params.jsonMode === true || params.jsonSchema !== undefined;
+}
+
+function hasImageInput(input: LlmCompleteStructuredInput[]): boolean {
+  return input.some((entry) => entry.type === "image");
+}
+
+function buildStructuredMessages(params: { request: LlmCompleteStructuredParams }): Message[] {
+  const now = Date.now();
+  return [
+    {
+      role: "user" as const,
+      timestamp: now,
+      content: [
+        { type: "text" as const, text: buildStructuredInstructions(params.request) },
+        ...params.request.input.map((entry) =>
+          entry.type === "text"
+            ? { type: "text" as const, text: entry.text }
+            : {
+                type: "image" as const,
+                data: entry.buffer.toString("base64"),
+                mimeType: normalizeOptionalString(entry.mimeType) ?? "image/png",
+              },
+        ),
+      ],
+    },
+  ];
+}
+
+function createCompletionSignal(
+  signal: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+): { signal: AbortSignal | undefined; cleanup: () => void } {
+  if (timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return { signal, cleanup: () => undefined };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error("Plugin LLM completion timed out")),
+    timeoutMs,
+  );
+  timer.unref?.();
+  let detachParentAbort: (() => void) | undefined;
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+    } else {
+      const onAbort = () => controller.abort(signal.reason);
+      signal.addEventListener("abort", onAbort, { once: true });
+      detachParentAbort = () => signal.removeEventListener("abort", onAbort);
+    }
+  }
+  return {
+    signal:
+      typeof AbortSignal.any === "function"
+        ? AbortSignal.any([controller.signal, ...(signal ? [signal] : [])])
+        : controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      detachParentAbort?.();
+    },
+  };
+}
+
+function parseStructuredText(params: { text: string; jsonMode: boolean; jsonSchema?: unknown }): {
+  parsed?: unknown;
+  contentType: "json" | "text";
+} {
+  if (!params.jsonMode) {
+    return { contentType: "text" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFences(params.text));
+  } catch {
+    throw new Error("Plugin LLM structured completion returned invalid JSON.");
+  }
+  if (
+    params.jsonSchema &&
+    typeof params.jsonSchema === "object" &&
+    !Array.isArray(params.jsonSchema)
+  ) {
+    const validation = validateJsonSchemaValue({
+      schema: params.jsonSchema as JsonSchemaObject,
+      cacheKey: "runtime.llm.completeStructured",
+      value: parsed,
+      cache: false,
+    });
+    if (!validation.ok) {
+      const message =
+        validation.errors.map((entry) => entry.text).join("; ") || "invalid structured JSON";
+      throw new Error(`Plugin LLM structured completion JSON did not match schema: ${message}`);
+    }
+  }
+  return { parsed, contentType: "json" };
 }
 
 function buildMessages(params: {
@@ -217,6 +346,10 @@ function finiteOption(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function modelSupportsImageInput(model: { input?: unknown }): boolean {
+  return Array.isArray(model.input) && model.input.includes("image");
+}
+
 function normalizeAllowedModelRef(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -241,6 +374,7 @@ function normalizeAllowedModelRef(raw: string): string | null {
 function buildPolicyFromEntry(entry: {
   allowAgentIdOverride?: boolean;
   allowModelOverride?: boolean;
+  allowProfileOverride?: boolean;
   hasAllowedModelsConfig?: boolean;
   allowedModels?: readonly string[];
 }): RuntimeLlmOverridePolicy {
@@ -260,6 +394,7 @@ function buildPolicyFromEntry(entry: {
   return {
     allowAgentIdOverride: entry.allowAgentIdOverride === true,
     allowModelOverride: entry.allowModelOverride === true,
+    allowProfileOverride: entry.allowProfileOverride === true,
     hasConfiguredAllowedModels: entry.hasAllowedModelsConfig === true,
     allowAnyModel,
     allowedModels,
@@ -298,6 +433,7 @@ function resolveAuthorityModelPolicy(
   if (
     authority?.allowAgentIdOverride !== true &&
     authority?.allowModelOverride !== true &&
+    authority?.allowProfileOverride !== true &&
     authority?.allowedModels === undefined
   ) {
     return undefined;
@@ -305,9 +441,29 @@ function resolveAuthorityModelPolicy(
   return buildPolicyFromEntry({
     allowAgentIdOverride: authority.allowAgentIdOverride,
     allowModelOverride: authority.allowModelOverride,
+    allowProfileOverride: authority.allowProfileOverride,
     hasAllowedModelsConfig: authority.allowedModels !== undefined,
     allowedModels: authority.allowedModels,
   });
+}
+
+function assertAllowedProfileOverride(params: {
+  requestedProfile: string | undefined;
+  pluginPolicyId: string | undefined;
+  authorityPolicy: RuntimeLlmOverridePolicy | undefined;
+  pluginPolicy: RuntimeLlmOverridePolicy | undefined;
+}): void {
+  if (!params.requestedProfile) {
+    return;
+  }
+  if (params.authorityPolicy?.allowProfileOverride) {
+    return;
+  }
+  if (params.pluginPolicy?.allowProfileOverride) {
+    return;
+  }
+  const owner = params.pluginPolicyId ? ` for plugin "${params.pluginPolicyId}"` : "";
+  throw new Error(`Plugin LLM completion cannot override the auth profile${owner}.`);
 }
 
 function assertAllowedModelOverride(params: {
@@ -354,74 +510,114 @@ function assertAllowedModelOverride(params: {
  */
 export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginRuntimeCore["llm"] {
   const logger = options.logger ?? toRuntimeLogger(defaultLogger);
+  async function prepareRuntimeCall(params: {
+    model?: string;
+    agentId?: string;
+    profile?: string;
+    preferImageModel?: boolean;
+  }) {
+    const caller = resolveTrustedCaller(options.authority);
+    const [
+      {
+        prepareSimpleCompletionModelForAgent,
+        completeWithPreparedSimpleCompletionModel,
+        resolveSimpleCompletionSelectionForAgent,
+      },
+      cfg,
+    ] = await Promise.all([
+      import("../../agents/simple-completion-runtime.js"),
+      Promise.resolve(resolveRuntimeConfig(options)),
+    ]);
+    const pluginPolicyId = resolvePluginPolicyId(options.authority, caller);
+    const pluginPolicy = resolvePluginLlmOverridePolicy(cfg, pluginPolicyId);
+    const authorityPolicy = resolveAuthorityModelPolicy(options.authority);
+    const agentId = await resolveAgentId({
+      request: params,
+      cfg,
+      authority: options.authority,
+      allowAgentIdOverride:
+        options.authority?.allowAgentIdOverride === false
+          ? false
+          : authorityPolicy?.allowAgentIdOverride === true ||
+            pluginPolicy?.allowAgentIdOverride === true,
+    });
+    const requestedModel = normalizeOptionalString(params.model);
+    const requestedProfile = normalizeOptionalString(params.profile);
+    assertAllowedProfileOverride({
+      requestedProfile,
+      pluginPolicyId,
+      authorityPolicy,
+      pluginPolicy,
+    });
+    if (requestedModel) {
+      const selection = resolveSimpleCompletionSelectionForAgent({
+        cfg,
+        agentId,
+        modelRef: requestedModel,
+      });
+      const normalizedSelection = selection
+        ? normalizeModelRef(selection.provider, selection.modelId)
+        : null;
+      const resolvedModelRef = normalizedSelection
+        ? `${normalizedSelection.provider}/${normalizedSelection.model}`
+        : null;
+      assertAllowedModelOverride({
+        resolvedModelRef,
+        pluginPolicyId,
+        authorityPolicy,
+        pluginPolicy,
+      });
+    }
+
+    let hostResolvedModelRef = requestedModel;
+    if (!hostResolvedModelRef && params.preferImageModel) {
+      const [{ resolveAutoImageModel }, { resolveAgentDir }] = await Promise.all([
+        import("../../media-understanding/runner.js"),
+        import("../../agents/agent-scope.js"),
+      ]);
+      const imageModel = await resolveAutoImageModel({
+        cfg,
+        agentDir: resolveAgentDir(cfg, agentId),
+      });
+      if (imageModel?.provider && imageModel?.model) {
+        hostResolvedModelRef = `${imageModel.provider}/${imageModel.model}`;
+      }
+    }
+
+    const prepared = await prepareSimpleCompletionModelForAgent({
+      cfg,
+      agentId,
+      modelRef: hostResolvedModelRef,
+      preferredProfile: requestedProfile,
+      allowMissingApiKeyModes: ["aws-sdk"],
+    });
+
+    if ("error" in prepared) {
+      throw new Error(`Plugin LLM completion failed: ${prepared.error}`);
+    }
+
+    return {
+      caller,
+      cfg,
+      agentId,
+      prepared,
+      completeWithPreparedSimpleCompletionModel,
+    };
+  }
+
   return {
     complete: async (params: LlmCompleteParams): Promise<LlmCompleteResult> => {
-      const caller = resolveTrustedCaller(options.authority);
       if (options.authority?.allowComplete === false) {
         const reason = options.authority.denyReason ?? "capability denied";
         logger.warn("plugin llm completion denied", {
-          caller,
+          caller: resolveTrustedCaller(options.authority),
           purpose: params.purpose,
           reason,
         });
         throw new Error(`Plugin LLM completion denied: ${reason}`);
       }
-
-      const [
-        {
-          prepareSimpleCompletionModelForAgent,
-          completeWithPreparedSimpleCompletionModel,
-          resolveSimpleCompletionSelectionForAgent,
-        },
-        cfg,
-      ] = await Promise.all([
-        import("../../agents/simple-completion-runtime.js"),
-        Promise.resolve(resolveRuntimeConfig(options)),
-      ]);
-      const pluginPolicyId = resolvePluginPolicyId(options.authority, caller);
-      const pluginPolicy = resolvePluginLlmOverridePolicy(cfg, pluginPolicyId);
-      const authorityPolicy = resolveAuthorityModelPolicy(options.authority);
-      const agentId = await resolveAgentId({
-        request: params,
-        cfg,
-        authority: options.authority,
-        allowAgentIdOverride:
-          options.authority?.allowAgentIdOverride === false
-            ? false
-            : authorityPolicy?.allowAgentIdOverride === true ||
-              pluginPolicy?.allowAgentIdOverride === true,
-      });
-      const requestedModel = normalizeOptionalString(params.model);
-      if (requestedModel) {
-        const selection = resolveSimpleCompletionSelectionForAgent({
-          cfg,
-          agentId,
-          modelRef: requestedModel,
-        });
-        const normalizedSelection = selection
-          ? normalizeModelRef(selection.provider, selection.modelId)
-          : null;
-        const resolvedModelRef = normalizedSelection
-          ? `${normalizedSelection.provider}/${normalizedSelection.model}`
-          : null;
-        assertAllowedModelOverride({
-          resolvedModelRef,
-          pluginPolicyId,
-          authorityPolicy,
-          pluginPolicy,
-        });
-      }
-
-      const prepared = await prepareSimpleCompletionModelForAgent({
-        cfg,
-        agentId,
-        modelRef: params.model,
-        allowMissingApiKeyModes: ["aws-sdk"],
-      });
-
-      if ("error" in prepared) {
-        throw new Error(`Plugin LLM completion failed: ${prepared.error}`);
-      }
+      const { caller, cfg, agentId, prepared, completeWithPreparedSimpleCompletionModel } =
+        await prepareRuntimeCall(params);
 
       const context = {
         systemPrompt: buildSystemPrompt(params),
@@ -480,6 +676,105 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
           ...(options.authority?.sessionKey ? { sessionKey: options.authority.sessionKey } : {}),
         },
       };
+    },
+    completeStructured: async (
+      params: LlmCompleteStructuredParams,
+    ): Promise<LlmCompleteStructuredResult> => {
+      if (options.authority?.allowComplete === false) {
+        const reason = options.authority.denyReason ?? "capability denied";
+        logger.warn("plugin llm structured completion denied", {
+          caller: resolveTrustedCaller(options.authority),
+          purpose: params.purpose,
+          reason,
+        });
+        throw new Error(`Plugin LLM structured completion denied: ${reason}`);
+      }
+      if (params.input.length === 0) {
+        throw new Error("Plugin LLM structured completion requires at least one input.");
+      }
+      if (!params.instructions.trim()) {
+        throw new Error("Plugin LLM structured completion requires instructions.");
+      }
+
+      const imageInput = hasImageInput(params.input);
+      const { caller, cfg, agentId, prepared, completeWithPreparedSimpleCompletionModel } =
+        await prepareRuntimeCall({
+          ...params,
+          preferImageModel: imageInput,
+        });
+      if (imageInput && !modelSupportsImageInput(prepared.model)) {
+        throw new Error(
+          `Plugin LLM structured completion model does not support image input: ${prepared.selection.provider}/${prepared.selection.modelId}`,
+        );
+      }
+
+      const { signal, cleanup } = createCompletionSignal(
+        params.signal,
+        finiteOption(params.timeoutMs),
+      );
+      try {
+        const result = await completeWithPreparedSimpleCompletionModel({
+          model: prepared.model,
+          auth: prepared.auth,
+          cfg,
+          context: {
+            systemPrompt: normalizeOptionalString(params.systemPrompt),
+            messages: buildStructuredMessages({ request: params }),
+          },
+          options: {
+            maxTokens: finiteOption(params.maxTokens),
+            temperature: finiteOption(params.temperature),
+            signal,
+          },
+        });
+
+        const text = result.content
+          .filter((c): c is { type: "text"; text: string } => c.type === "text")
+          .map((c) => c.text)
+          .join("");
+        const normalizedUsage = normalizeUsage(result.usage as UsageLike | undefined);
+        const usage = buildUsage({
+          rawUsage: result.usage,
+          normalized: normalizedUsage,
+          cfg,
+          provider: prepared.selection.provider,
+          model: prepared.selection.modelId,
+        });
+        const structured = parseStructuredText({
+          text,
+          jsonMode: shouldUseJsonMode(params),
+          jsonSchema: params.jsonSchema,
+        });
+
+        logger.info("plugin llm structured completion", {
+          caller,
+          purpose: params.purpose,
+          sessionKey: options.authority?.sessionKey,
+          agentId,
+          provider: prepared.selection.provider,
+          model: prepared.selection.modelId,
+          usage,
+          contentType: structured.contentType,
+          imageInput,
+        });
+
+        return {
+          text,
+          provider: prepared.selection.provider,
+          model: prepared.selection.modelId,
+          agentId,
+          usage,
+          parsed: structured.parsed,
+          contentType: structured.contentType,
+          audit: {
+            caller,
+            ...(params.purpose ? { purpose: params.purpose } : {}),
+            ...(options.authority?.sessionKey ? { sessionKey: options.authority.sessionKey } : {}),
+          },
+        };
+      } finally {
+        cleanup();
+      }
     },
   };
 }

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -351,6 +351,22 @@ function modelSupportsImageInput(model: { input?: unknown }): boolean {
   return Array.isArray(model.input) && model.input.includes("image");
 }
 
+function normalizeResolvedSelectionModelRef(
+  selection:
+    | {
+        provider: string;
+        modelId: string;
+      }
+    | null
+    | undefined,
+): string | null {
+  if (!selection) {
+    return null;
+  }
+  const normalized = normalizeModelRef(selection.provider, selection.modelId);
+  return `${normalized.provider}/${normalized.model}`;
+}
+
 function normalizeAllowedModelRef(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -565,27 +581,34 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
       authorityPolicy,
       pluginPolicy,
     });
+    let effectiveRequestedModelRef = requestedModelRef;
     if (requestedModelRef) {
       const selection = resolveSimpleCompletionSelectionForAgent({
         cfg,
         agentId,
         modelRef: requestedModelRef,
       });
-      const normalizedSelection = selection
-        ? normalizeModelRef(selection.provider, selection.modelId)
-        : null;
-      const resolvedModelRef = normalizedSelection
-        ? `${normalizedSelection.provider}/${normalizedSelection.model}`
-        : null;
-      assertAllowedModelOverride({
-        resolvedModelRef,
-        pluginPolicyId,
-        authorityPolicy,
-        pluginPolicy,
+      const defaultSelection = resolveSimpleCompletionSelectionForAgent({
+        cfg,
+        agentId,
       });
+      const resolvedModelRef = normalizeResolvedSelectionModelRef(selection);
+      const defaultResolvedModelRef = normalizeResolvedSelectionModelRef(defaultSelection);
+      const changesTargetModel =
+        defaultResolvedModelRef === null || resolvedModelRef !== defaultResolvedModelRef;
+      if (changesTargetModel) {
+        assertAllowedModelOverride({
+          resolvedModelRef,
+          pluginPolicyId,
+          authorityPolicy,
+          pluginPolicy,
+        });
+      } else {
+        effectiveRequestedModelRef = undefined;
+      }
     }
 
-    let hostResolvedModelRef = requestedModelRef;
+    let hostResolvedModelRef = effectiveRequestedModelRef;
     if (!hostResolvedModelRef && params.preferImageModel) {
       const [{ resolveAutoImageModel }, { resolveAgentDir }] = await Promise.all([
         import("../../media-understanding/runner.js"),

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -1,4 +1,5 @@
 import type { Api, Message } from "@mariozechner/pi-ai";
+import { splitTrailingAuthProfile } from "../../agents/model-ref-profile.js";
 import { normalizeModelRef } from "../../agents/model-selection.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
 import { normalizeUsage } from "../../agents/usage.js";
@@ -542,18 +543,33 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
             pluginPolicy?.allowAgentIdOverride === true,
     });
     const requestedModel = normalizeOptionalString(params.model);
+    const splitRequestedModel = requestedModel
+      ? splitTrailingAuthProfile(requestedModel)
+      : { model: undefined, profile: undefined };
+    const requestedModelRef = normalizeOptionalString(splitRequestedModel.model);
+    const requestedProfileFromModel = normalizeOptionalString(splitRequestedModel.profile);
     const requestedProfile = normalizeOptionalString(params.profile);
+    if (
+      requestedProfile &&
+      requestedProfileFromModel &&
+      requestedProfile !== requestedProfileFromModel
+    ) {
+      throw new Error(
+        "Plugin LLM completion received conflicting auth profiles in model and profile fields.",
+      );
+    }
+    const effectiveRequestedProfile = requestedProfile ?? requestedProfileFromModel;
     assertAllowedProfileOverride({
-      requestedProfile,
+      requestedProfile: effectiveRequestedProfile,
       pluginPolicyId,
       authorityPolicy,
       pluginPolicy,
     });
-    if (requestedModel) {
+    if (requestedModelRef) {
       const selection = resolveSimpleCompletionSelectionForAgent({
         cfg,
         agentId,
-        modelRef: requestedModel,
+        modelRef: requestedModelRef,
       });
       const normalizedSelection = selection
         ? normalizeModelRef(selection.provider, selection.modelId)
@@ -569,7 +585,7 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
       });
     }
 
-    let hostResolvedModelRef = requestedModel;
+    let hostResolvedModelRef = requestedModelRef;
     if (!hostResolvedModelRef && params.preferImageModel) {
       const [{ resolveAutoImageModel }, { resolveAgentDir }] = await Promise.all([
         import("../../media-understanding/runner.js"),
@@ -588,7 +604,7 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
       cfg,
       agentId,
       modelRef: hostResolvedModelRef,
-      preferredProfile: requestedProfile,
+      preferredProfile: effectiveRequestedProfile,
       allowMissingApiKeyModes: ["aws-sdk"],
     });
 

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -108,6 +108,22 @@ export type LlmCompleteUsage = {
   costUsd?: number;
 };
 
+export type LlmCompleteStructuredTextInput = {
+  type: "text";
+  text: string;
+};
+
+export type LlmCompleteStructuredImageInput = {
+  type: "image";
+  buffer: Buffer;
+  mimeType?: string;
+  fileName?: string;
+};
+
+export type LlmCompleteStructuredInput =
+  | LlmCompleteStructuredTextInput
+  | LlmCompleteStructuredImageInput;
+
 export type LlmCompleteParams = {
   messages: LlmCompleteMessage[];
   /** Model ref (e.g. "anthropic/claude-sonnet-4-6"); defaults to the target agent's configured model. */
@@ -122,6 +138,30 @@ export type LlmCompleteParams = {
   agentId?: string;
 };
 
+export type LlmCompleteStructuredParams = {
+  input: LlmCompleteStructuredInput[];
+  instructions: string;
+  /** Model ref (e.g. "anthropic/claude-sonnet-4-6"); defaults to the target agent's configured model. */
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+  systemPrompt?: string;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  /** Human-readable reason for audit/debug output. */
+  purpose?: string;
+  /** Agent whose model/credentials to use. Session-bound capabilities may disallow overrides. */
+  agentId?: string;
+  /**
+   * Preferred auth profile id when the selected provider supports profile-backed auth.
+   * Requires host trust via plugins.entries.<id>.llm.allowProfileOverride or an equivalent authority policy.
+   */
+  profile?: string;
+  schemaName?: string;
+  jsonSchema?: unknown;
+  jsonMode?: boolean;
+};
+
 export type LlmCompleteResult = {
   text: string;
   provider: string;
@@ -133,6 +173,11 @@ export type LlmCompleteResult = {
     purpose?: string;
     sessionKey?: string;
   };
+};
+
+export type LlmCompleteStructuredResult = LlmCompleteResult & {
+  parsed?: unknown;
+  contentType: "json" | "text";
 };
 
 type RuntimeRunEmbeddedPiAgent = (
@@ -312,6 +357,9 @@ export type PluginRuntimeCore = {
   taskFlow: import("./runtime-taskflow.types.js").PluginRuntimeTaskFlow;
   llm: {
     complete: (params: LlmCompleteParams) => Promise<LlmCompleteResult>;
+    completeStructured: (
+      params: LlmCompleteStructuredParams,
+    ) => Promise<LlmCompleteStructuredResult>;
   };
   modelAuth: {
     /** Resolve auth for a model. Only provider/model, optional cfg, and workspaceDir are used. */


### PR DESCRIPTION
## Why this should exist

OpenClaw already has two useful but incomplete lanes for plugin-side model work:

- `api.runtime.llm.complete(...)` for trusted host-owned text completion
- `api.runtime.mediaUnderstanding.extractStructuredWithModel(...)` in [#79334](https://github.com/openclaw/openclaw/pull/79334) for provider-owned media-first structured extraction

What is still missing is the general middle lane for plugins that need **bounded host-owned structured inference** without:

- handling OAuth/API credentials directly,
- inventing bespoke shell bridges, or
- stretching media-understanding into every structured workload.

That gap shows up across a lot more than one plugin family:

- **knowledge-base plugins** turning text or screenshots into normalized evidence
- **support plugins** extracting issue summaries, repro steps, and error clues from screenshots plus notes
- **CRM plugins** extracting companies, people, dates, action items, and sentiment from inbound content
- **finance/admin plugins** extracting vendor, totals, tax, and due dates from receipts or invoices
- **migration/import plugins** mapping arbitrary raw content into plugin-owned JSON before storage

The goal of this PR is to make that generic host-owned lane first-class.

## What this adds

This PR adds:

- `api.runtime.llm.completeStructured(...)`
- typed structured input blocks for text and optional images
- optional `jsonMode`, `jsonSchema`, `schemaName`, `timeoutMs`, and `profile`
- parsed JSON results when JSON mode is requested
- the same host-owned model/auth/runtime preparation path as `api.runtime.llm.complete(...)`
- the same trust gating model for model and agent overrides, plus a new explicit gate for auth-profile overrides

## Why this belongs under `runtime.llm`

This API is deliberately the **generic agent-bound runtime lane**.

It reuses the same host-owned completion path as `complete(...)`, then adds the structured affordances plugin authors actually need:

- prompt shaping
- optional image inputs
- JSON/schema validation
- timeout control
- controlled typed output

That makes it the right home for general structured plugin inference.

## Boundary vs `#79334`

This PR is a **sister**, not a replacement.

- `runtime.llm.completeStructured(...)` is the **generic agent-bound structured inference lane**
- `mediaUnderstanding.extractStructuredWithModel(...)` in `#79334` remains the **narrower provider-owned media capability lane**

That separation keeps both seams honest:

- use `runtime.llm.completeStructured(...)` when the plugin wants host-owned structured inference against the active agent/runtime path
- use `mediaUnderstanding.extractStructuredWithModel(...)` when the plugin wants explicit provider/model media-routing behavior

```mermaid
flowchart LR
  Plugin["Trusted plugin"] --> LLM["api.runtime.llm.completeStructured(...)\nagent-bound generic lane"]
  Plugin --> Media["api.runtime.mediaUnderstanding.extractStructuredWithModel(...)\nprovider-owned media lane"]
  LLM --> Host["host-owned simple completion runtime"]
  Media --> Provider["media-understanding provider registry"]
```

## Safety and trust model

This stays host-owned end to end.

Plugins do **not** receive raw OAuth tokens, refresh tokens, or provider secrets.

The host still owns:

- auth resolution
- provider runtime preparation
- model routing
- timeout handling
- agent binding
- trust gating

This PR also closes a subtle trust gap by treating auth-profile selection as a real override. `profile` now requires explicit opt-in via:

- `plugins.entries.<id>.llm.allowProfileOverride: true`

The full runtime trust picture is now:

- model overrides: `allowModelOverride` + optional `allowedModels`
- cross-agent calls: `allowAgentIdOverride`
- auth-profile selection: `allowProfileOverride`

Embedded model-ref suffixes now flow through that same gate, and conflicting `profile` vs `model@profile` inputs fail closed.

## Behavior details

A few implementation details here are deliberate and worth calling out:

- **JSON mode is explicit**: parsed JSON is only returned when `jsonMode: true` or `jsonSchema` is provided
- **Image inputs respect host image fallback behavior**: when the active model is text-only, structured image calls reuse the host image-model fallback path instead of failing early when a configured image model exists
- **Context-engine parity is preserved**: session-bound context-engine runtime hooks now expose `completeStructured(...)` alongside `complete(...)`

## Example

```ts
const result = await api.runtime.llm.completeStructured({
  instructions: "Extract vendor, total, and searchable tags.",
  input: [
    {
      type: "image",
      buffer: receiptBuffer,
      mimeType: "image/png",
      fileName: "receipt.png",
    },
    { type: "text", text: "Prefer the printed total over handwritten notes." },
  ],
  jsonSchema: {
    type: "object",
    properties: {
      vendor: { type: "string" },
      total: { type: "number" },
      tags: { type: "array", items: { type: "string" } },
    },
    required: ["vendor", "total"],
  },
  purpose: "receipts.extract",
});
```

## What changed

- add `LlmCompleteStructured*` runtime types
- add `runtime.llm.completeStructured(...)` to the plugin runtime facade
- add trust gating for auth-profile override selection
- extend the plugin config schema/docs with `plugins.entries.<id>.llm.allowProfileOverride`
- reuse host image-model fallback routing for structured image calls
- expose `completeStructured(...)` to context-engine runtime hooks
- add runtime tests for JSON/schema validation, image inputs, profile trust, image fallback behavior, timeout behavior, and context-engine binding
- add regression tests that block `model@profile` bypasses and reject conflicting explicit vs embedded auth-profile selection
- regenerate the plugin SDK API baseline

## Validation

- `pnpm test -- src/plugins/runtime/runtime-llm.runtime.test.ts src/plugins/runtime/index.test.ts src/plugins/config-state.test.ts src/config/schema.help.quality.test.ts`
- `pnpm plugin-sdk:api:gen`
- `pnpm plugin-sdk:api:check`
- `pnpm check:changed`

## Real behavior proof

- Behavior or issue addressed:
  - Plugins could express auth-profile selection either as `profile: "..."` or as a trailing model-ref suffix like `openai/gpt-5.5@work`.
  - Before this fix, the new trust gate only checked the explicit `profile` field, so embedded `model@profile` requests could steer credential selection without `allowProfileOverride`.

- Real environment tested:
  - Local OpenClaw checkout on `codex/plugin-inference-followup` using the real runtime implementation through `node --import tsx` on macOS, with no test mocks in the proof command.

- Exact steps or command run after this patch:
  ```bash
  node --import tsx -e 'import { createRuntimeLlm } from "./src/plugins/runtime/runtime-llm.runtime.ts"; const cfg = { agents: { defaults: { model: "openai/gpt-5.5" } } }; const llm = createRuntimeLlm({ getConfig: () => cfg, authority: { caller: { kind: "host", id: "proof" }, allowComplete: true, allowModelOverride: true, agentId: "ada" } }); for (const [label, params] of [["embedded-profile-blocked", { model: "openai/gpt-5.5@openai-codex:work", instructions: "Extract summary.", input: [{ type: "text", text: "Hello" }] }],["conflicting-profile-rejected", { model: "openai/gpt-5.5@openai-codex:work", profile: "openai-codex:other", instructions: "Extract summary.", input: [{ type: "text", text: "Hello" }] }]]) { try { await llm.completeStructured(params); console.log(label + ": UNEXPECTED_SUCCESS"); } catch (error) { console.log(label + ": " + (error instanceof Error ? error.message : String(error))); } }'
  ```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  Terminal capture:
  ```text
  embedded-profile-blocked: Plugin LLM completion cannot override the auth profile.
  conflicting-profile-rejected: Plugin LLM completion received conflicting auth profiles in model and profile fields.
  ```

  Supplemental focused regression coverage:
  ```text
  ✓ rejects structured auth-profile overrides without explicit trust
  ✓ rejects auth-profile suffixes in structured model refs without explicit trust
  ✓ treats auth-profile suffixes in structured model refs as profile overrides when trusted
  ✓ rejects conflicting explicit and embedded structured auth-profile overrides
  ```

- Observed result after fix:
  - The real runtime now fails closed on both bypass shapes before host auth preparation.
  - Structured callers can no longer pick a credential profile through `model@profile` unless `allowProfileOverride` is explicitly trusted.
  - Conflicting explicit and embedded profile selections are rejected instead of being resolved implicitly.

- What was not tested:
  - A live provider-backed completion after an allowed profile override was not exercised in this proof step.
  - The trusted-path wiring is covered by the focused runtime tests above.

- Before evidence (optional but encouraged):
  - Before this patch, `profile` was gated but the embedded `model@profile` form was not normalized before auth-profile policy evaluation.

## Non-goals

- no raw OAuth/token exposure to plugins
- no plugin-specific routes or schemas in core
- no replacement of `#79334`
- no tool-using long-running agent workflow lane

Closes #80188.
