### PR TITLE
fix: respect session context window in preflight compaction

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -779,6 +779,56 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
   });
 
+  it("uses persisted session context window for preflight compaction gating", async () => {
+    const sessionFile = path.join(rootDir, "persisted-context-window-session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({
+        message: {
+          role: "assistant",
+          content: "large but not near active context",
+          usage: { input: 148_000, output: 1_000 },
+        },
+      })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 30_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+      contextTokens: 272_000,
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 128_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+  });
+
   it("triggers preflight compaction when the active transcript exceeds the configured byte threshold", async () => {
     const sessionFile = path.join(rootDir, "large-session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -483,12 +483,22 @@ export async function runPreflightCompactionIfNeeded(params: {
     return entry ?? params.sessionEntry;
   }
 
-  const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+  const resolvedContextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
     provider: params.followupRun.run.provider,
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
+  const persistedContextWindowTokens =
+    typeof entry.contextTokens === "number" &&
+    Number.isFinite(entry.contextTokens) &&
+    entry.contextTokens > 0
+      ? Math.floor(entry.contextTokens)
+      : undefined;
+  const contextWindowTokens = Math.max(
+    resolvedContextWindowTokens,
+    persistedContextWindowTokens ?? 0,
+  );
   const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
   const reserveTokensFloor =
     memoryFlushPlan?.reserveTokensFloor ??


### PR DESCRIPTION
## Summary

Fixes preflight compaction thresholding so sessions use the active session's persisted `contextTokens` when it is larger than the resolved model context window.

This prevents safeguard compaction from firing too early in long-context sessions, for example compacting around ~148k tokens in an active 272k-token session.

## Why

A session can persist the actual active context window on the `SessionEntry`. When preflight compaction resolves a smaller context window from model/config routing, the threshold can be too low and compaction can run unnecessarily even though the active session still has substantial headroom.

## Change

- Resolve the model/config context window as before.
- Read `entry.contextTokens` when present and valid.
- Use the larger value for preflight compaction gating.
- Add a regression test covering the false-positive compaction case.

## Test

```bash
npm test -- --run src/auto-reply/reply/agent-runner-memory.test.ts
```

Result: 16/16 passed.

## Real behavior proof

**Behavior or issue addressed:** Preflight safeguard compaction could fire too early in a long-context Telegram session, compacting around 90k-150k tokens even though the active session had a 272k-token context window.

**Real environment tested:** Moeed's live OpenClaw 2026.5.5 gateway on macOS, Telegram System topic, using the installed runtime hotfix that matches this source change.

**Exact steps or command run after the patch:** Applied the source-equivalent installed runtime hotfix, restarted the gateway, sent normal Telegram System-topic replies, inspected the active session store, and scanned the live gateway log for post-hotfix compaction notices/triggers.

**Evidence after fix:** Copied live terminal output from the real OpenClaw setup:

```text
sessionId: 86ae751a-3d4a-4c93-9c3c-d784dda1db2c
contextTokens: 272000
totalTokens: 161452
totalTokensFresh: True
compactionCount: 1
post_hotfix_compaction_events_found: False
```

Installed runtime marker check from the same machine:

```text
dist hotfix marker: present
source hotfix marker: present
compaction-notifier: disabled
notifyUser: False
```

**Observed result after fix:** Normal Telegram replies continued in the System topic while the session sat around 161k/272k tokens, and the gateway log scan found no post-hotfix `preflightCompaction triggered`, `Compacting context`, or `Context compacted` events during the verification window.

**What was not tested:** I did not force the session above the real 272k-token threshold; the verification focused on the false-positive early-compaction case that this patch fixes.
