### PR TITLE
fix: require mediated delivery for subagent announce completions

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1164,6 +1164,63 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("reports subagent group completions that miss required message-tool delivery", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [
+          {
+            text: "Child result that must not be raw-sent.",
+          },
+        ],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      sessionId: "requester-session-channel",
+      isActive: false,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-channel-subagent-message-tool",
+      sourceTool: "subagent_announce",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:openclaw:subagent:child-123",
+          childSessionId: "child-123",
+          announceType: "subagent task",
+          taskLabel: "channel completion smoke",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Raw child result that should stay internal.",
+          replyInstruction: "Let the requester/orchestrator deliver the final response.",
+        },
+      ],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        delivered: false,
+        path: "direct",
+        error: "completion agent did not deliver through the message tool",
+      }),
+    );
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          deliver: false,
+          channel: "slack",
+          accountId: "acct-1",
+          to: "channel:C123",
+          threadId: undefined,
+        }),
+      }),
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("does not fallback for generated media group completions when message tool evidence exists", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -56,7 +56,11 @@ import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
 const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
-const AGENT_MEDIATED_COMPLETION_TOOLS = new Set(["music_generate", "video_generate"]);
+const AGENT_MEDIATED_COMPLETION_TOOLS = new Set([
+  "music_generate",
+  "video_generate",
+  "subagent_announce",
+]);
 
 type SubagentAnnounceDeliveryDeps = {
   callGateway: typeof callGateway;


### PR DESCRIPTION
## Summary

Treat `subagent_announce` completions like other agent-mediated completion sources so group/channel completions do not fall back to raw child-result delivery when the completion agent fails to deliver through the message tool.

## Why

Subagent completion events are internal handoff data. In visible group/channel surfaces, the requester/orchestrator should deliver a normal user-facing response. If the completion agent does not use the message tool, the runtime should report the missing mediated delivery instead of raw-sending child output.

## Change

- Add `subagent_announce` to the agent-mediated completion source set.
- Add regression coverage proving channel completions with `subagent_announce` do not raw-send fallback output when message-tool delivery is missing.

## Tests

```bash
npm test -- --run src/agents/subagent-announce-delivery.test.ts
```

Result: 31/31 passed.

## Real behavior proof

**Behavior or issue addressed:** Subagent completion events could fall back to raw child-result delivery in visible group/channel surfaces if the completion agent did not deliver through the message tool.

**Real environment tested:** Moeed's live OpenClaw 2026.5.5 installation on macOS with the installed runtime hotfix matching this source change.

**Exact steps or command run after the patch:** Applied/verified the local installed-runtime hotfix with the OpenClaw reapply bundle, inspected the installed runtime marker, and verified the bundle against the live installed OpenClaw version.

**Evidence after fix:** Copied live terminal output from the real OpenClaw setup:

```text
/opt/homebrew/lib/node_modules/openclaw/dist/subagent-announce-delivery-*.js:
const AGENT_MEDIATED_COMPLETION_TOOLS = new Set(["music_generate", "video_generate", "subagent_announce"]);
error: "completion agent did not deliver through the message tool"
```

Live patch verification command output:

```text
Installed OpenClaw version: 2026.5.5
already patched
telegram-buttons-and-leak-hotfix: verified
```

**Observed result after fix:** `subagent_announce` is handled through the mediated-delivery guard in the installed runtime, so group/channel completion paths require message-tool/orchestrator delivery instead of falling back to raw child-result output.

**What was not tested:** I did not send another raw child result into a public Telegram group after the patch; the live verification confirms the installed runtime carries the mediated-delivery guard, and the targeted regression covers the fallback path.
## Contributor response to ClawSweeper proof request

Additional live proof from the later subagent delivery validation:

After applying the equivalent installed-runtime fix locally, a native subagent smoke completion returned through the internal `subagent_announce` completion path for Operator mediation rather than as a raw child-result message in Telegram.

Redacted live evidence:

```text
Native subagent smoke marker: SUBAGENT_RESTART_POLISH_OK_20260512
Observed delivery path: internal subagent_announce completion event to Operator
Observed user-facing behaviour: no raw child-result dump posted directly to the Telegram group
```

This is the behaviour the PR is intended to preserve: `subagent_announce` completions are treated as mediated agent completions, so the requester/orchestrator owns the visible user-facing report and raw child output is not used as a fallback visible message.

The installed runtime was also inspected after the hotfix and showed:

```text
AGENT_MEDIATED_COMPLETION_TOOLS includes "subagent_announce"
Missing mediated delivery produces: "completion agent did not deliver through the message tool"
```

Targeted regression remains:

```text
src/agents/subagent-announce-delivery.test.ts: 31/31 passed
```
