### PR TITLE
[codex] Fix npm-installed skill CLI PATH detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/UI: compact exec and tool progress rows by hiding redundant shell tool names, replacing known workspace paths with short context markers, and preserving Discord trace scrubbing for compact command lines.
+- Gateway/Skills: include npm-global and configured npm prefix bin directories in gateway PATH bootstrap, so npm-installed skill CLIs such as `clawhub` and `mcporter` no longer appear as missing in Skills status. Fixes #80206. Thanks @AdoShan.
 - ACPX: run and await the embedded ACP backend startup probe by default so the gateway `ready` signal no longer fires before the acpx runtime has either become usable or reported a probe failure; set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` to restore lazy startup. Fixes #79596. Thanks @bzelones.
 - OpenAI-compatible models: strip prior assistant reasoning fields from replayed Chat Completions history by default, preventing oMLX/vLLM Qwen follow-up turns from rejecting or stalling on stale `reasoning` payloads. Fixes #46637. Thanks @zipzagster and @lexhoefsloot.
 - CLI/onboarding: give non-Azure custom providers a safe generated context window and heal legacy 4k wizard entries without overwriting explicit valid small model limits, preventing first-turn compaction loops. Fixes #79428. (#79911) Thanks @Jefsky.

--- a/src/infra/path-env.test.ts
+++ b/src/infra/path-env.test.ts
@@ -1,3 +1,4 @@
+import type { PathLike } from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureOpenClawCliOnPath } from "./path-env.js";
@@ -12,32 +13,46 @@ const setDir = (p: string) => state.dirs.add(abs(p));
 const setExe = (p: string) => state.executables.add(abs(p));
 
 vi.mock("node:fs", async () => {
+  const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   const pathMod = await import("node:path");
-  const absInMock = (p: string) => pathMod.resolve(p);
+  const absInMock = (p: PathLike) =>
+    pathMod.resolve(typeof p === "string" ? p : p instanceof URL ? p.pathname : p.toString());
+  const actualReadFileSync = actual.readFileSync.bind(actual);
 
-  const wrapped = {
-    ...actual,
-    constants: { ...actual.constants, X_OK: actual.constants.X_OK ?? 1 },
-    accessSync: (p: string, mode?: number) => {
-      const resolved = absInMock(p);
-      if (state.executables.has(resolved)) {
-        return;
-      }
-      actual.accessSync(p, mode);
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:fs")>("node:fs"),
+    {
+      constants: { ...actual.constants, X_OK: actual.constants.X_OK ?? 1 },
+      accessSync: ((p: PathLike, mode?: number) => {
+        const resolved = absInMock(p);
+        if (state.executables.has(resolved)) {
+          return;
+        }
+        actual.accessSync(p, mode);
+      }) as typeof actual.accessSync,
+      statSync: ((p: PathLike) => {
+        const resolved = absInMock(p);
+        if (state.dirs.has(resolved)) {
+          return {
+            isDirectory: () => true,
+          };
+        }
+        return actual.statSync(p);
+      }) as typeof actual.statSync,
+      readFileSync: ((
+        p: PathLike | number,
+        options?: BufferEncoding | { encoding?: BufferEncoding | null },
+      ) => {
+        const resolved = typeof p === "number" ? "" : absInMock(p);
+        if (resolved.endsWith(pathMod.join("case-npmrc-prefix", ".npmrc"))) {
+          return "prefix=~/.npm-packages\n";
+        }
+        return actualReadFileSync(p, options as never);
+      }) as typeof actual.readFileSync,
     },
-    statSync: (p: string) => {
-      const resolved = absInMock(p);
-      if (state.dirs.has(resolved)) {
-        return {
-          isDirectory: () => true,
-        };
-      }
-      return actual.statSync(p);
-    },
-  };
-
-  return { ...wrapped, default: wrapped };
+    { mirrorToDefault: true },
+  );
 });
 
 vi.mock("./env.js", () => ({
@@ -53,6 +68,8 @@ describe("ensureOpenClawCliOnPath", () => {
     "HOMEBREW_PREFIX",
     "HOMEBREW_BREW_FILE",
     "XDG_BIN_HOME",
+    "NPM_CONFIG_PREFIX",
+    "npm_config_prefix",
   ] as const;
   let envSnapshot: Record<(typeof envKeys)[number], string | undefined>;
 
@@ -105,6 +122,8 @@ describe("ensureOpenClawCliOnPath", () => {
     delete process.env.HOMEBREW_PREFIX;
     delete process.env.HOMEBREW_BREW_FILE;
     delete process.env.XDG_BIN_HOME;
+    delete process.env.NPM_CONFIG_PREFIX;
+    delete process.env.npm_config_prefix;
   }
 
   function expectPathsAfter(parts: string[], anchor: string, expectedPaths: string[]) {
@@ -271,11 +290,14 @@ describe("ensureOpenClawCliOnPath", () => {
   it("places all user-writable home dirs after system dirs", () => {
     const { tmp, appCli } = setupAppCliRoot("case-user-writable-after-system");
     const localBin = path.join(tmp, ".local", "bin");
+    const npmGlobalBin = path.join(tmp, ".npm-global", "bin");
     const pnpmBin = path.join(tmp, ".local", "share", "pnpm");
     const bunBin = path.join(tmp, ".bun", "bin");
     const yarnBin = path.join(tmp, ".yarn", "bin");
     setDir(path.join(tmp, ".local"));
     setDir(localBin);
+    setDir(path.join(tmp, ".npm-global"));
+    setDir(npmGlobalBin);
     setDir(path.join(tmp, ".local", "share"));
     setDir(pnpmBin);
     setDir(path.join(tmp, ".bun"));
@@ -291,7 +313,64 @@ describe("ensureOpenClawCliOnPath", () => {
       homeDir: tmp,
       platform: "linux",
     });
-    expectPathsAfter(updated, "/usr/bin", [localBin, pnpmBin, bunBin, yarnBin]);
+    expectPathsAfter(updated, "/usr/bin", [localBin, npmGlobalBin, pnpmBin, bunBin, yarnBin]);
+  });
+
+  it("appends npm global prefix bin dirs after system dirs", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-npm-prefix");
+    const npmPrefix = path.join(tmp, "npm-prefix");
+    const npmPrefixBin = path.join(npmPrefix, "bin");
+    const npmConfigPrefix = path.join(tmp, "npm-config-prefix");
+    const npmConfigPrefixBin = path.join(npmConfigPrefix, "bin");
+    const managedNpmBin = path.join(tmp, ".openclaw", "tools", "node", "npm", "bin");
+    const npmGlobalBin = path.join(tmp, ".npm-global", "bin");
+    setDir(npmPrefix);
+    setDir(npmPrefixBin);
+    setDir(npmConfigPrefix);
+    setDir(npmConfigPrefixBin);
+    setDir(path.join(tmp, ".openclaw"));
+    setDir(path.join(tmp, ".openclaw", "tools"));
+    setDir(path.join(tmp, ".openclaw", "tools", "node"));
+    setDir(path.join(tmp, ".openclaw", "tools", "node", "npm"));
+    setDir(managedNpmBin);
+    setDir(path.join(tmp, ".npm-global"));
+    setDir(npmGlobalBin);
+
+    resetBootstrapEnv("/usr/bin:/bin");
+    process.env.NPM_CONFIG_PREFIX = npmPrefix;
+    process.env.npm_config_prefix = npmConfigPrefix;
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "darwin",
+    });
+
+    expectPathsAfter(updated, "/usr/bin", [
+      npmPrefixBin,
+      npmConfigPrefixBin,
+      managedNpmBin,
+      npmGlobalBin,
+    ]);
+  });
+
+  it("appends user .npmrc prefix bin dirs after system dirs", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-npmrc-prefix");
+    const npmrcPrefixBin = path.join(tmp, ".npm-packages", "bin");
+    setDir(path.join(tmp, ".npm-packages"));
+    setDir(npmrcPrefixBin);
+
+    resetBootstrapEnv("/usr/bin:/bin");
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "darwin",
+    });
+
+    expectPathsAfter(updated, "/usr/bin", [npmrcPrefixBin]);
   });
 
   it.each([

--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -30,6 +30,73 @@ function isDirectory(dirPath: string): boolean {
   }
 }
 
+function expandHomeDir(candidate: string, homeDir: string): string {
+  const withHomeEnv = candidate.replace(/\$\{HOME\}/g, homeDir);
+  if (withHomeEnv !== candidate) {
+    return withHomeEnv;
+  }
+  if (candidate === "~") {
+    return homeDir;
+  }
+  if (candidate.startsWith("~/") || candidate.startsWith("~\\")) {
+    return path.join(homeDir, candidate.slice(2));
+  }
+  return candidate;
+}
+
+function resolveNpmPrefixBinDir(
+  prefix: string | undefined,
+  homeDir: string,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const trimmed = prefix?.trim().replace(/^['"]|['"]$/g, "");
+  if (!trimmed) {
+    return undefined;
+  }
+  const expanded = expandHomeDir(trimmed, homeDir);
+  if (!path.isAbsolute(expanded)) {
+    return undefined;
+  }
+  return platform === "win32" ? path.normalize(expanded) : path.join(expanded, "bin");
+}
+
+function readUserNpmPrefix(homeDir: string): string | undefined {
+  try {
+    const npmrc = fs.readFileSync(path.join(homeDir, ".npmrc"), "utf8");
+    let prefix: string | undefined;
+    for (const line of npmrc.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith(";")) {
+        continue;
+      }
+      const match = /^prefix\s*=\s*(.+)$/i.exec(trimmed);
+      if (match) {
+        prefix = match[1]?.trim();
+      }
+    }
+    return prefix;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveNpmGlobalBinDirs(opts: { homeDir: string; platform: NodeJS.Platform }): string[] {
+  const dirs: string[] = [];
+  for (const prefix of [
+    process.env.NPM_CONFIG_PREFIX,
+    process.env.npm_config_prefix,
+    readUserNpmPrefix(opts.homeDir),
+    path.join(opts.homeDir, ".openclaw", "tools", "node", "npm"),
+  ]) {
+    const binDir = resolveNpmPrefixBinDir(prefix, opts.homeDir, opts.platform);
+    if (binDir) {
+      dirs.push(binDir);
+    }
+  }
+  dirs.push(path.join(opts.homeDir, ".npm-global", "bin"));
+  return dirs;
+}
+
 function mergePath(params: { existing: string; prepend?: string[]; append?: string[] }): string {
   const partsExisting = params.existing
     .split(path.delimiter)
@@ -113,6 +180,7 @@ function candidateBinDirs(opts: EnsureOpenClawPathOpts): { prepend: string[]; ap
     append.push(process.env.XDG_BIN_HOME);
   }
   append.push(path.join(homeDir, ".local", "bin"));
+  append.push(...resolveNpmGlobalBinDirs({ homeDir, platform }));
   append.push(path.join(homeDir, ".local", "share", "pnpm"));
   append.push(path.join(homeDir, ".bun", "bin"));
   append.push(path.join(homeDir, ".yarn", "bin"));


### PR DESCRIPTION
Summary
- Add npm global bin discovery to the gateway PATH bootstrap, including `NPM_CONFIG_PREFIX`, lowercase `npm_config_prefix`, user `.npmrc` `prefix`, OpenClaw-managed npm tool installs, and `~/.npm-global/bin`.
- Keep these npm/user-writable paths appended after trusted system dirs so they do not shadow OS binaries.
- Add path-env regression coverage and a changelog entry for #80206.

Root cause
- Skills status checks `requires.bins` through the gateway process PATH, while npm-installed skill CLIs can live in npm global prefix directories that were not included by the gateway's minimal PATH bootstrap.

Verification
- `pnpm test src/infra/path-env.test.ts -- --reporter=verbose`
- `pnpm test src/agents/skills.buildworkspaceskillstatus.test.ts -- --reporter=verbose`
- `git diff --check`
- `pnpm check:changed`

Fixes #80206
