### PR TITLE
test(qa-lab): add Codex vs Pi runtime parity harness

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -848,6 +848,7 @@ jobs:
             --output-dir ".artifacts/qa-e2e/runtime-parity"
 
       - name: Generate runtime parity report
+        if: always()
         run: |
           set -euo pipefail
           pnpm openclaw qa parity-report \

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -795,6 +795,76 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
 
+  qa_lab_runtime_parity_release_checks:
+    name: Run QA Lab runtime parity lane
+    needs: [resolve_target]
+    if: contains(fromJSON('["all","qa","qa-parity"]'), needs.resolve_target.outputs.rerun_group)
+    continue-on-error: true
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      QA_PARITY_CONCURRENCY: "1"
+      OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS: "180000"
+      OPENAI_API_KEY: ""
+      ANTHROPIC_API_KEY: ""
+      OPENCLAW_LIVE_OPENAI_KEY: ""
+      OPENCLAW_LIVE_ANTHROPIC_KEY: ""
+      OPENCLAW_LIVE_GEMINI_KEY: ""
+      OPENCLAW_LIVE_SETUP_TOKEN_VALUE: ""
+      OPENCLAW_BUILD_PRIVATE_QA: "1"
+      OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ needs.resolve_target.outputs.revision }}
+          fetch-depth: 1
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "true"
+
+      - name: Build private QA runtime
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: pnpm build
+
+      - name: Run runtime parity lane
+        run: |
+          set -euo pipefail
+          pnpm openclaw qa suite \
+            --provider-mode mock-openai \
+            --parity-pack agentic \
+            --concurrency "${QA_PARITY_CONCURRENCY}" \
+            --model "${OPENCLAW_CI_OPENAI_MODEL}" \
+            --alt-model "openai/gpt-5.5-alt" \
+            --runtime-pair pi,codex \
+            --output-dir ".artifacts/qa-e2e/runtime-parity"
+
+      - name: Generate runtime parity report
+        run: |
+          set -euo pipefail
+          pnpm openclaw qa parity-report \
+            --repo-root . \
+            --runtime-axis \
+            --summary .artifacts/qa-e2e/runtime-parity/qa-suite-summary.json \
+            --output-dir .artifacts/qa-e2e/runtime-parity-report
+
+      - name: Upload runtime parity artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-qa-runtime-parity-${{ needs.resolve_target.outputs.revision }}
+          path: .artifacts/qa-e2e/
+          retention-days: 14
+          if-no-files-found: warn
+
   qa_live_matrix_release_checks:
     name: Run QA Lab live Matrix lane
     needs: [resolve_target]
@@ -1270,6 +1340,7 @@ jobs:
       - package_acceptance_release_checks
       - qa_lab_parity_lane_release_checks
       - qa_lab_parity_report_release_checks
+      - qa_lab_runtime_parity_release_checks
       - qa_live_matrix_release_checks
       - qa_live_telegram_release_checks
       - qa_live_discord_release_checks
@@ -1294,6 +1365,7 @@ jobs:
             "package_acceptance_release_checks=${{ needs.package_acceptance_release_checks.result }}" \
             "qa_lab_parity_lane_release_checks=${{ needs.qa_lab_parity_lane_release_checks.result }}" \
             "qa_lab_parity_report_release_checks=${{ needs.qa_lab_parity_report_release_checks.result }}" \
+            "qa_lab_runtime_parity_release_checks=${{ needs.qa_lab_runtime_parity_release_checks.result }}" \
             "qa_live_matrix_release_checks=${{ needs.qa_live_matrix_release_checks.result }}" \
             "qa_live_telegram_release_checks=${{ needs.qa_live_telegram_release_checks.result }}" \
             "qa_live_discord_release_checks=${{ needs.qa_live_discord_release_checks.result }}" \

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   buildQaAgenticParityComparison,
+  buildQaRuntimeParityReport,
   computeQaAgenticParityMetrics,
   QaParityLabelMismatchError,
   renderQaAgenticParityMarkdownReport,
+  renderQaRuntimeParityMarkdownReport,
   type QaParityReportScenario,
   type QaParitySuiteSummary,
+  type QaRuntimeParitySuiteSummary,
 } from "./agentic-parity-report.js";
 
 const FULL_PARITY_PASS_SCENARIOS: QaParityReportScenario[] = [
@@ -27,6 +30,82 @@ function withScenarioOverride(name: string, override: Partial<QaParityReportScen
   return FULL_PARITY_PASS_SCENARIOS.map((scenario) =>
     scenario.name === name ? { ...scenario, ...override } : scenario,
   );
+}
+
+function makeRuntimeParitySummary(): QaRuntimeParitySuiteSummary {
+  return {
+    scenarios: [
+      {
+        name: "Approval turn tool followthrough",
+        status: "pass",
+        steps: [],
+        runtimeParity: {
+          scenarioId: "approval-turn-tool-followthrough",
+          drift: "none",
+          cells: {
+            pi: {
+              runtime: "pi",
+              transcriptBytes: '{"role":"assistant"}\n',
+              toolCalls: [{ tool: "read_file", argsHash: "a", resultHash: "r" }],
+              finalText: "done",
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              wallClockMs: 20,
+              bootStateLines: [],
+            },
+            codex: {
+              runtime: "codex",
+              transcriptBytes: '{"role":"assistant"}\n',
+              toolCalls: [{ tool: "read_file", argsHash: "a", resultHash: "r" }],
+              finalText: "done",
+              usage: { inputTokens: 8, outputTokens: 4, totalTokens: 12 },
+              wallClockMs: 18,
+              bootStateLines: [],
+            },
+          },
+        },
+      },
+      {
+        name: "Compaction retry after mutating tool",
+        status: "fail",
+        steps: [],
+        runtimeParity: {
+          scenarioId: "compaction-retry-after-mutating-tool",
+          drift: "tool-call-shape",
+          driftDetails: "tool call 1 differs",
+          cells: {
+            pi: {
+              runtime: "pi",
+              transcriptBytes: '{"role":"assistant"}\n',
+              toolCalls: [{ tool: "read_file", argsHash: "a", resultHash: "r" }],
+              finalText: "done",
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              wallClockMs: 20,
+              bootStateLines: [],
+            },
+            codex: {
+              runtime: "codex",
+              transcriptBytes: '{"role":"assistant"}\n',
+              toolCalls: [{ tool: "read_file", argsHash: "b", resultHash: "r" }],
+              finalText: "done",
+              usage: { inputTokens: 9, outputTokens: 4, totalTokens: 13 },
+              wallClockMs: 19,
+              bootStateLines: [],
+            },
+          },
+        },
+      },
+    ],
+    counts: {
+      total: 2,
+      passed: 1,
+      failed: 1,
+    },
+    run: {
+      providerMode: "mock-openai",
+      primaryModel: "openai/gpt-5.5",
+      runtimePair: ["pi", "codex"],
+    },
+  };
 }
 
 describe("qa agentic parity report", () => {
@@ -714,5 +793,34 @@ status=done`,
     expect(report).toContain(
       "# OpenClaw Agentic Parity Report — openai/gpt-5.5-alt vs openai/gpt-5.5",
     );
+  });
+
+  it("builds a runtime parity report from suite summaries", () => {
+    const report = buildQaRuntimeParityReport({
+      summary: makeRuntimeParitySummary(),
+      comparedAt: "2026-05-10T00:00:00.000Z",
+    });
+
+    expect(report.runtimePair).toEqual(["pi", "codex"]);
+    expect(report.pass).toBe(false);
+    expect(report.driftCounts.none).toBe(1);
+    expect(report.driftCounts["tool-call-shape"]).toBe(1);
+    expect(report.failures).toContain(
+      "Compaction retry after mutating tool drift=tool-call-shape (tool call 1 differs).",
+    );
+  });
+
+  it("renders a readable runtime parity markdown report", () => {
+    const report = renderQaRuntimeParityMarkdownReport(
+      buildQaRuntimeParityReport({
+        summary: makeRuntimeParitySummary(),
+        comparedAt: "2026-05-10T00:00:00.000Z",
+      }),
+    );
+
+    expect(report).toContain("# OpenClaw Runtime Parity Report — pi vs codex");
+    expect(report).toContain("| Tool-call-shape drift | 1 |");
+    expect(report).toContain("### Compaction retry after mutating tool");
+    expect(report).toContain("- drift: tool-call-shape");
   });
 });

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -2,6 +2,12 @@ import {
   QA_AGENTIC_PARITY_SCENARIO_TITLES,
   QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES,
 } from "./agentic-parity.js";
+import type {
+  RuntimeId,
+  RuntimeParityCell,
+  RuntimeParityDrift,
+  RuntimeParityResult,
+} from "./runtime-parity.js";
 
 type QaParityReportStep = {
   name: string;
@@ -29,6 +35,7 @@ type QaParityRunBlock = {
   primaryModelName?: string;
   providerMode?: string;
   scenarioIds?: readonly string[] | null;
+  runtimePair?: [RuntimeId, RuntimeId] | null;
 };
 
 export type QaParitySuiteSummary = {
@@ -40,6 +47,42 @@ export type QaParitySuiteSummary = {
   };
   /** Self-describing run metadata — see PR L #64789 for the writer side. */
   run?: QaParityRunBlock;
+};
+
+type QaRuntimeParitySuiteScenario = QaParityReportScenario & {
+  runtimeParity?: RuntimeParityResult;
+};
+
+export type QaRuntimeParitySuiteSummary = Omit<QaParitySuiteSummary, "scenarios"> & {
+  scenarios: QaRuntimeParitySuiteScenario[];
+};
+
+type QaRuntimeParityScenarioReport = {
+  name: string;
+  status: "pass" | "fail";
+  drift: RuntimeParityDrift | "missing";
+  driftDetails?: string;
+  piStatus: "pass" | "fail" | "missing";
+  codexStatus: "pass" | "fail" | "missing";
+  piTokens: number;
+  codexTokens: number;
+  piToolCalls: number;
+  codexToolCalls: number;
+};
+
+export type QaRuntimeParityReport = {
+  runtimePair: [RuntimeId, RuntimeId];
+  comparedAt: string;
+  providerMode?: string;
+  primaryModel?: string;
+  totalScenarios: number;
+  passedScenarios: number;
+  failedScenarios: number;
+  driftCounts: Record<RuntimeParityDrift, number>;
+  scenarios: QaRuntimeParityScenarioReport[];
+  pass: boolean;
+  failures: string[];
+  notes: string[];
 };
 
 type QaAgenticParityMetrics = {
@@ -195,6 +238,33 @@ export function computeQaAgenticParityMetrics(
 
 function formatPercent(value: number) {
   return `${(value * 100).toFixed(1)}%`;
+}
+
+function buildRuntimeParityDriftCounts(): Record<RuntimeParityDrift, number> {
+  return {
+    none: 0,
+    "text-only": 0,
+    "tool-call-shape": 0,
+    "tool-result-shape": 0,
+    structural: 0,
+    "failure-mode": 0,
+  };
+}
+
+function normalizeRuntimePair(
+  pair: [RuntimeId, RuntimeId] | null | undefined,
+): [RuntimeId, RuntimeId] {
+  if (pair?.[0] && pair?.[1]) {
+    return pair;
+  }
+  return ["pi", "codex"];
+}
+
+function runtimeCellStatus(cell: RuntimeParityCell | undefined): "pass" | "fail" | "missing" {
+  if (!cell) {
+    return "missing";
+  }
+  return cell.runtimeErrorClass || cell.transportErrorClass ? "fail" : "pass";
 }
 
 function requiredCoverageStatus(
@@ -533,6 +603,141 @@ export function renderQaAgenticParityMarkdownReport(comparison: QaAgenticParityC
 
   lines.push("## Notes", "");
   for (const note of comparison.notes) {
+    lines.push(`- ${note}`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export function buildQaRuntimeParityReport(params: {
+  summary: QaRuntimeParitySuiteSummary;
+  comparedAt?: string;
+}): QaRuntimeParityReport {
+  const runtimePair = normalizeRuntimePair(params.summary.run?.runtimePair);
+  const driftCounts = buildRuntimeParityDriftCounts();
+  const failures: string[] = [];
+  const scenarios = params.summary.scenarios.map((scenario) => {
+    const parity = scenario.runtimeParity;
+    if (!parity) {
+      failures.push(`Missing runtime parity capture for ${scenario.name}.`);
+      return {
+        name: scenario.name,
+        status: scenario.status === "pass" ? "pass" : "fail",
+        drift: "missing",
+        driftDetails: scenario.details,
+        piStatus: "missing",
+        codexStatus: "missing",
+        piTokens: 0,
+        codexTokens: 0,
+        piToolCalls: 0,
+        codexToolCalls: 0,
+      } satisfies QaRuntimeParityScenarioReport;
+    }
+    driftCounts[parity.drift] += 1;
+    const piCell = parity.cells.pi;
+    const codexCell = parity.cells.codex;
+    const piStatus = runtimeCellStatus(piCell);
+    const codexStatus = runtimeCellStatus(codexCell);
+    const status = scenario.status === "pass" ? "pass" : "fail";
+    if (status === "fail") {
+      failures.push(
+        `${scenario.name} drift=${parity.drift}${parity.driftDetails ? ` (${parity.driftDetails})` : ""}.`,
+      );
+    }
+    return {
+      name: scenario.name,
+      status,
+      drift: parity.drift,
+      driftDetails: parity.driftDetails,
+      piStatus,
+      codexStatus,
+      piTokens: piCell.usage.totalTokens,
+      codexTokens: codexCell.usage.totalTokens,
+      piToolCalls: piCell.toolCalls.length,
+      codexToolCalls: codexCell.toolCalls.length,
+    } satisfies QaRuntimeParityScenarioReport;
+  });
+
+  const totalScenarios = params.summary.counts?.total ?? scenarios.length;
+  const passedScenarios =
+    params.summary.counts?.passed ??
+    scenarios.filter((scenario) => scenario.status === "pass").length;
+  const failedScenarios =
+    params.summary.counts?.failed ??
+    scenarios.filter((scenario) => scenario.status === "fail").length;
+
+  return {
+    runtimePair,
+    comparedAt: params.comparedAt ?? new Date().toISOString(),
+    providerMode: params.summary.run?.providerMode,
+    primaryModel: params.summary.run?.primaryModel,
+    totalScenarios,
+    passedScenarios,
+    failedScenarios,
+    driftCounts,
+    scenarios,
+    pass: failures.length === 0 && failedScenarios === 0,
+    failures,
+    notes: [
+      "Runtime parity treats none and text-only drift as pass; all structural, tool-shape, and failure-mode drift classes fail the lane.",
+      "Token totals here are assistant-message usage captured from the normalized transcript, not provider transport payloads.",
+    ],
+  };
+}
+
+export function renderQaRuntimeParityMarkdownReport(report: QaRuntimeParityReport): string {
+  const lines = [
+    `# OpenClaw Runtime Parity Report — ${report.runtimePair[0]} vs ${report.runtimePair[1]}`,
+    "",
+    `- Compared at: ${report.comparedAt}`,
+    `- Provider mode: ${report.providerMode ?? "unknown"}`,
+    `- Primary model: ${report.primaryModel ?? "unknown"}`,
+    `- Verdict: ${report.pass ? "pass" : "fail"}`,
+    "",
+    "## Aggregate Metrics",
+    "",
+    "| Metric | Value |",
+    "| --- | ---: |",
+    `| Total scenarios | ${report.totalScenarios} |`,
+    `| Passed scenarios | ${report.passedScenarios} |`,
+    `| Failed scenarios | ${report.failedScenarios} |`,
+    `| No drift | ${report.driftCounts.none} |`,
+    `| Text-only drift | ${report.driftCounts["text-only"]} |`,
+    `| Tool-call-shape drift | ${report.driftCounts["tool-call-shape"]} |`,
+    `| Tool-result-shape drift | ${report.driftCounts["tool-result-shape"]} |`,
+    `| Structural drift | ${report.driftCounts.structural} |`,
+    `| Failure-mode drift | ${report.driftCounts["failure-mode"]} |`,
+    "",
+  ];
+
+  if (report.failures.length > 0) {
+    lines.push("## Gate Failures", "");
+    for (const failure of report.failures) {
+      lines.push(`- ${failure}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Scenario Comparison", "");
+  for (const scenario of report.scenarios) {
+    lines.push(`### ${scenario.name}`, "");
+    lines.push(`- status: ${scenario.status}`);
+    lines.push(`- drift: ${scenario.drift}`);
+    lines.push(
+      `- pi: ${scenario.piStatus} (${scenario.piToolCalls} tool calls, ${scenario.piTokens} tokens)`,
+    );
+    lines.push(
+      `- codex: ${scenario.codexStatus} (${scenario.codexToolCalls} tool calls, ${scenario.codexTokens} tokens)`,
+    );
+    if (scenario.driftDetails) {
+      lines.push(`- details: ${scenario.driftDetails}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Notes", "");
+  for (const note of report.notes) {
     lines.push(`- ${note}`);
   }
   lines.push("");

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -240,6 +240,27 @@ describe("qa cli runtime", () => {
     });
   });
 
+  it("passes runtime-pair suite selection through to the host runner", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      providerMode: "mock-openai",
+      scenarioIds: ["approval-turn-tool-followthrough"],
+      runtimePair: "pi,codex",
+    });
+
+    expect(runQaSuiteFromRuntime).toHaveBeenCalledWith({
+      repoRoot: path.resolve("/tmp/openclaw-repo"),
+      outputDir: undefined,
+      transportId: "qa-channel",
+      providerMode: "mock-openai",
+      primaryModel: undefined,
+      alternateModel: undefined,
+      fastMode: undefined,
+      scenarioIds: ["approval-turn-tool-followthrough"],
+      runtimePair: ["pi", "codex"],
+    });
+  });
+
   it("drops blank suite model refs so provider defaults apply", async () => {
     await runQaSuiteCommand({
       repoRoot: "/tmp/openclaw-repo",
@@ -769,6 +790,76 @@ describe("qa cli runtime", () => {
     }
   });
 
+  it("writes a runtime-axis parity report from one summary", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-runtime-parity-"));
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      await fs.writeFile(
+        path.join(repoRoot, "runtime-summary.json"),
+        JSON.stringify({
+          scenarios: [
+            {
+              name: "Approval turn tool followthrough",
+              status: "fail",
+              steps: [],
+              runtimeParity: {
+                scenarioId: "approval-turn-tool-followthrough",
+                drift: "tool-call-shape",
+                driftDetails: "tool call 1 differs",
+                cells: {
+                  pi: {
+                    runtime: "pi",
+                    transcriptBytes: '{"role":"assistant"}\n',
+                    toolCalls: [{ tool: "read_file", argsHash: "a", resultHash: "r" }],
+                    finalText: "done",
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                    wallClockMs: 10,
+                    bootStateLines: [],
+                  },
+                  codex: {
+                    runtime: "codex",
+                    transcriptBytes: '{"role":"assistant"}\n',
+                    toolCalls: [{ tool: "read_file", argsHash: "b", resultHash: "r" }],
+                    finalText: "done",
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                    wallClockMs: 10,
+                    bootStateLines: [],
+                  },
+                },
+              },
+            },
+          ],
+          counts: { total: 1, passed: 0, failed: 1 },
+          run: {
+            providerMode: "mock-openai",
+            primaryModel: "openai/gpt-5.5",
+            runtimePair: ["pi", "codex"],
+          },
+        }),
+        "utf8",
+      );
+
+      await runQaParityReportCommand({
+        repoRoot,
+        runtimeAxis: true,
+        summary: "runtime-summary.json",
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(stdoutWrite).toHaveBeenCalledWith(
+        expect.stringContaining("QA runtime parity report:"),
+      );
+      expect(stdoutWrite).toHaveBeenCalledWith(
+        expect.stringContaining("QA runtime parity verdict: fail"),
+      );
+    } finally {
+      process.exitCode = priorExitCode;
+      await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("prints a markdown coverage report from scenario metadata", async () => {
     await runQaCoverageReportCommand({ repoRoot: process.cwd() });
 
@@ -932,6 +1023,24 @@ describe("qa cli runtime", () => {
       disk: "24G",
     });
     expect(runQaSuiteFromRuntime).not.toHaveBeenCalled();
+  });
+
+  it("passes runtime-pair suite selection through to the multipass runner", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      runner: "multipass",
+      providerMode: "mock-openai",
+      scenarioIds: ["approval-turn-tool-followthrough"],
+      runtimePair: "codex,pi",
+      allowFailures: true,
+    });
+
+    expect(runQaMultipass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoRoot: path.resolve("/tmp/openclaw-repo"),
+        runtimePair: ["pi", "codex"],
+      }),
+    );
   });
 
   it("passes live suite selection through to the multipass runner", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -3,8 +3,11 @@ import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   buildQaAgenticParityComparison,
+  buildQaRuntimeParityReport,
   renderQaAgenticParityMarkdownReport,
+  renderQaRuntimeParityMarkdownReport,
   type QaParitySuiteSummary,
+  type QaRuntimeParitySuiteSummary,
 } from "./agentic-parity-report.js";
 import { resolveQaParityPackScenarioIds } from "./agentic-parity.js";
 import { runQaCharacterEval, type QaCharacterModelOptions } from "./character-eval.js";
@@ -38,6 +41,7 @@ import {
   type QaProviderMode,
   type QaProviderModeInput,
 } from "./run-config.js";
+import type { RuntimeId } from "./runtime-parity.js";
 import { readQaScenarioPack } from "./scenario-catalog.js";
 import { runQaSuiteFromRuntime } from "./suite-launch.runtime.js";
 import { readQaSuiteFailedScenarioCountFromSummary } from "./suite-summary.js";
@@ -130,6 +134,27 @@ function parseQaPositiveIntegerOption(label: string, value: number | undefined) 
 function normalizeQaOptionalModelRef(input: string | undefined) {
   const model = input?.trim();
   return model && model.length > 0 ? model : undefined;
+}
+
+function parseQaRuntimePair(value: string | undefined): [RuntimeId, RuntimeId] | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+  const parts = value
+    .split(",")
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  if (parts.length !== 2) {
+    throw new Error('--runtime-pair must use exactly two runtimes, e.g. "pi,codex".');
+  }
+  const [left, right] = parts;
+  if ((left !== "pi" && left !== "codex") || (right !== "pi" && right !== "codex")) {
+    throw new Error('--runtime-pair only supports "pi" and "codex".');
+  }
+  if (left === right) {
+    throw new Error("--runtime-pair must compare two different runtimes.");
+  }
+  return ["pi", "codex"];
 }
 
 async function readQaFailedScenarioCountFromSummary(summaryPath: string) {
@@ -480,6 +505,7 @@ export async function runQaSuiteCommand(opts: {
   memory?: string;
   disk?: string;
   preflight?: boolean;
+  runtimePair?: string;
 }) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const transportId = normalizeQaTransportId(opts.transportId);
@@ -493,6 +519,7 @@ export async function runQaSuiteCommand(opts: {
     throw new Error(`--runner must be one of host or multipass, got "${opts.runner}".`);
   }
   const providerMode = normalizeQaProviderMode(opts.providerMode);
+  const runtimePair = parseQaRuntimePair(opts.runtimePair);
   const claudeCliAuthMode = parseQaCliBackendAuthMode(opts.cliAuthMode);
   const primaryModel = normalizeQaOptionalModelRef(opts.primaryModel);
   const alternateModel = normalizeQaOptionalModelRef(opts.alternateModel);
@@ -527,6 +554,7 @@ export async function runQaSuiteCommand(opts: {
       ...(opts.concurrency !== undefined
         ? { concurrency: parseQaPositiveIntegerOption("--concurrency", opts.concurrency) }
         : {}),
+      ...(runtimePair ? { runtimePair } : {}),
       image: opts.image,
       cpus: parseQaPositiveIntegerOption("--cpus", opts.cpus),
       memory: opts.memory,
@@ -572,6 +600,7 @@ export async function runQaSuiteCommand(opts: {
     ...(opts.concurrency !== undefined
       ? { concurrency: parseQaPositiveIntegerOption("--concurrency", opts.concurrency) }
       : {}),
+    ...(runtimePair ? { runtimePair } : {}),
   });
   process.stdout.write(`QA suite watch: ${result.watchUrl}\n`);
   process.stdout.write(`QA suite report: ${result.reportPath}\n`);
@@ -584,11 +613,13 @@ export async function runQaSuiteCommand(opts: {
 
 export async function runQaParityReportCommand(opts: {
   repoRoot?: string;
-  candidateSummary: string;
-  baselineSummary: string;
+  candidateSummary?: string;
+  baselineSummary?: string;
   candidateLabel?: string;
   baselineLabel?: string;
   outputDir?: string;
+  runtimeAxis?: boolean;
+  summary?: string;
 }) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const outputDir =
@@ -596,6 +627,35 @@ export async function runQaParityReportCommand(opts: {
     path.join(repoRoot, ".artifacts", "qa-e2e", `parity-${Date.now().toString(36)}`);
   await fs.mkdir(outputDir, { recursive: true });
 
+  if (opts.runtimeAxis === true) {
+    if (!opts.summary?.trim()) {
+      throw new Error("--runtime-axis requires --summary.");
+    }
+    const summaryPath = path.resolve(repoRoot, opts.summary);
+    const summary = JSON.parse(
+      await fs.readFile(summaryPath, "utf8"),
+    ) as QaRuntimeParitySuiteSummary;
+    const reportPayload = buildQaRuntimeParityReport({ summary });
+    const report = renderQaRuntimeParityMarkdownReport(reportPayload);
+    const reportPath = path.join(outputDir, "qa-runtime-parity-report.md");
+    const runtimeSummaryPath = path.join(outputDir, "qa-runtime-parity-summary.json");
+    await fs.writeFile(reportPath, report, "utf8");
+    await fs.writeFile(runtimeSummaryPath, `${JSON.stringify(reportPayload, null, 2)}\n`, "utf8");
+
+    process.stdout.write(`QA runtime parity report: ${reportPath}\n`);
+    process.stdout.write(`QA runtime parity summary: ${runtimeSummaryPath}\n`);
+    process.stdout.write(`QA runtime parity verdict: ${reportPayload.pass ? "pass" : "fail"}\n`);
+    if (!reportPayload.pass) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (!opts.candidateSummary?.trim() || !opts.baselineSummary?.trim()) {
+    throw new Error(
+      "--candidate-summary and --baseline-summary are required unless --runtime-axis is set.",
+    );
+  }
   const candidateSummaryPath = path.resolve(repoRoot, opts.candidateSummary);
   const baselineSummaryPath = path.resolve(repoRoot, opts.baselineSummary);
   const candidateSummary = JSON.parse(

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -49,6 +49,7 @@ async function runQaSuite(opts: {
   memory?: string;
   disk?: string;
   preflight?: boolean;
+  runtimePair?: string;
 }) {
   const runtime = await loadQaLabCliRuntime();
   await runtime.runQaSuiteCommand(opts);
@@ -56,11 +57,13 @@ async function runQaSuite(opts: {
 
 async function runQaParityReport(opts: {
   repoRoot?: string;
-  candidateSummary: string;
-  baselineSummary: string;
+  candidateSummary?: string;
+  baselineSummary?: string;
   candidateLabel?: string;
   baselineLabel?: string;
   outputDir?: string;
+  runtimeAxis?: boolean;
+  summary?: string;
 }) {
   const runtime = await loadQaLabCliRuntime();
   await runtime.runQaParityReportCommand(opts);
@@ -275,6 +278,7 @@ export function registerQaLabCli(program: Command) {
     .option("--cpus <count>", "Multipass vCPU count", (value: string) => Number(value))
     .option("--memory <size>", "Multipass memory size")
     .option("--disk <size>", "Multipass disk size")
+    .option("--runtime-pair <pair>", "Run each scenario under both runtimes, e.g. pi,codex")
     .action(
       async (opts: {
         repoRoot?: string;
@@ -297,6 +301,7 @@ export function registerQaLabCli(program: Command) {
         memory?: string;
         disk?: string;
         preflight?: boolean;
+        runtimePair?: string;
       }) => {
         await runQaSuite({
           repoRoot: opts.repoRoot,
@@ -319,14 +324,17 @@ export function registerQaLabCli(program: Command) {
           memory: opts.memory,
           disk: opts.disk,
           preflight: opts.preflight,
+          runtimePair: opts.runtimePair,
         });
       },
     );
 
   qa.command("parity-report")
-    .description("Compare two QA suite summaries and write an agentic parity gate report")
-    .requiredOption("--candidate-summary <path>", "Candidate qa-suite-summary.json path")
-    .requiredOption("--baseline-summary <path>", "Baseline qa-suite-summary.json path")
+    .description("Write either a model-axis parity gate report or a runtime-axis parity report")
+    .option("--candidate-summary <path>", "Candidate qa-suite-summary.json path")
+    .option("--baseline-summary <path>", "Baseline qa-suite-summary.json path")
+    .option("--runtime-axis", "Interpret --summary as a runtime-pair qa-suite-summary.json", false)
+    .option("--summary <path>", "Runtime-axis qa-suite-summary.json path")
     .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
     .option(
       "--candidate-label <label>",
@@ -338,11 +346,13 @@ export function registerQaLabCli(program: Command) {
     .action(
       async (opts: {
         repoRoot?: string;
-        candidateSummary: string;
-        baselineSummary: string;
+        candidateSummary?: string;
+        baselineSummary?: string;
         candidateLabel?: string;
         baselineLabel?: string;
         outputDir?: string;
+        runtimeAxis?: boolean;
+        summary?: string;
       }) => {
         await runQaParityReport(opts);
       },

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -497,6 +497,7 @@ export async function startQaGatewayChild(params: {
   enabledPluginIds?: string[];
   forwardHostHome?: boolean;
   mutateConfig?: (cfg: OpenClawConfig) => OpenClawConfig;
+  runtimeEnvPatch?: NodeJS.ProcessEnv;
 }) {
   const tempRoot = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-qa-suite-"),
@@ -674,6 +675,12 @@ export async function startQaGatewayChild(params: {
           forwardHostHomeForClaudeCli: liveProviderIds.includes("claude-cli"),
           claudeCliAuthMode: params.claudeCliAuthMode,
         });
+        if (params.runtimeEnvPatch) {
+          env = {
+            ...env,
+            ...params.runtimeEnvPatch,
+          };
+        }
       }
       await fs.writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, {
         encoding: "utf8",

--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -151,6 +151,17 @@ describe("qa multipass runtime", () => {
     expect(plan.qaCommand).toEqual(expect.arrayContaining(["--allow-failures"]));
   });
 
+  it("forwards --runtime-pair into the guest qa suite command when requested", () => {
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-runtime-pair-test"),
+      runtimePair: ["pi", "codex"],
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expect(plan.qaCommand).toEqual(expect.arrayContaining(["--runtime-pair", "pi,codex"]));
+  });
+
   it("redacts forwarded live secrets in the persisted artifact script", () => {
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
     const plan = createQaMultipassPlan({

--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -9,6 +9,7 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import type { QaProviderMode } from "./model-selection.js";
 import { resolveQaForwardedLiveEnv, resolveQaLiveProviderConfigPath } from "./providers/env.js";
 import { DEFAULT_QA_LIVE_PROVIDER_MODE, getQaProvider } from "./providers/index.js";
+import type { RuntimeId } from "./runtime-parity.js";
 
 const MULTIPASS_MOUNTED_REPO_PATH = "/workspace/openclaw-host";
 const MULTIPASS_GUEST_REPO_PATH = "/workspace/openclaw";
@@ -74,6 +75,7 @@ type QaMultipassPlan = {
   alternateModel?: string;
   fastMode?: boolean;
   thinkingDefault?: string;
+  runtimePair?: [RuntimeId, RuntimeId];
   scenarioIds: string[];
   forwardedEnv: Record<string, string>;
   hostCodexHomePath?: string;
@@ -240,6 +242,7 @@ export function createQaMultipassPlan(params: {
   allowFailures?: boolean;
   scenarioIds?: string[];
   concurrency?: number;
+  runtimePair?: [RuntimeId, RuntimeId];
   image?: string;
   cpus?: number;
   memory?: string;
@@ -279,6 +282,7 @@ export function createQaMultipassPlan(params: {
       ...(params.thinkingDefault ? ["--thinking", params.thinkingDefault] : []),
       ...(params.allowFailures ? ["--allow-failures"] : []),
       ...(params.concurrency ? ["--concurrency", String(params.concurrency)] : []),
+      ...(params.runtimePair ? ["--runtime-pair", params.runtimePair.join(",")] : []),
     ],
     scenarioIds,
   );
@@ -303,6 +307,7 @@ export function createQaMultipassPlan(params: {
     alternateModel: params.alternateModel,
     fastMode: params.fastMode,
     thinkingDefault: params.thinkingDefault,
+    runtimePair: params.runtimePair,
     scenarioIds,
     forwardedEnv,
     hostCodexHomePath,
@@ -551,6 +556,7 @@ export async function runQaMultipass(params: {
   allowFailures?: boolean;
   scenarioIds?: string[];
   concurrency?: number;
+  runtimePair?: [RuntimeId, RuntimeId];
   image?: string;
   cpus?: number;
   memory?: string;

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -1,0 +1,313 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  captureRuntimeParityCell,
+  runRuntimeParityScenario,
+  type RuntimeId,
+  type RuntimeParityCell,
+  type RuntimeParityToolCall,
+} from "./runtime-parity.js";
+
+const tempRoots: string[] = [];
+
+function makeToolCall(overrides: Partial<RuntimeParityToolCall> = {}): RuntimeParityToolCall {
+  return {
+    tool: "read_file",
+    argsHash: "args-a",
+    resultHash: "result-a",
+    ...overrides,
+  };
+}
+
+function makeCell(
+  runtime: RuntimeId,
+  overrides: Partial<RuntimeParityCell> = {},
+): RuntimeParityCell {
+  return {
+    runtime,
+    transcriptBytes: '{"role":"assistant"}\n',
+    toolCalls: [],
+    finalText: "same reply",
+    usage: {
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    },
+    wallClockMs: 25,
+    bootStateLines: [],
+    ...overrides,
+  };
+}
+
+function normalizeForStableHashForTest(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeForStableHashForTest(entry));
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .toSorted((left, right) => left.localeCompare(right))
+        .map((key) => [key, normalizeForStableHashForTest(record[key])]),
+    );
+  }
+  return value;
+}
+
+function stableHashForTest(value: unknown) {
+  return createHash("sha256")
+    .update(JSON.stringify(normalizeForStableHashForTest(value)) ?? "null")
+    .digest("hex");
+}
+
+async function createRuntimeParityGatewayTempRoot(transcriptBytes: string) {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "runtime-parity-"));
+  tempRoots.push(tempRoot);
+  const sessionsDir = path.join(tempRoot, "state", "agents", "qa", "sessions");
+  await fs.mkdir(sessionsDir, { recursive: true });
+  await fs.writeFile(
+    path.join(sessionsDir, "sessions.json"),
+    JSON.stringify({
+      "session-1": {
+        sessionId: "session-1",
+        sessionFile: "session-1.jsonl",
+        updatedAt: 1,
+      },
+    }),
+    "utf8",
+  );
+  await fs.writeFile(path.join(sessionsDir, "session-1.jsonl"), transcriptBytes, "utf8");
+  return tempRoot;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((tempRoot) => fs.rm(tempRoot, { recursive: true, force: true })),
+  );
+  vi.unstubAllGlobals();
+});
+
+describe("runtime parity", () => {
+  it("classifies identical cells as none", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "same",
+      runCell: async (runtime) => ({
+        scenarioStatus: "pass",
+        cell: makeCell(runtime),
+      }),
+    });
+
+    expect(result.drift).toBe("none");
+  });
+
+  it("classifies final-text-only differences as text-only", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "text-only",
+      runCell: async (runtime) => ({
+        scenarioStatus: "pass",
+        cell: makeCell(runtime, {
+          finalText: runtime === "pi" ? "hello from pi" : "hello from codex",
+        }),
+      }),
+    });
+
+    expect(result.drift).toBe("text-only");
+  });
+
+  it("classifies tool call shape drift", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "tool-call-shape",
+      runCell: async (runtime) => ({
+        scenarioStatus: "pass",
+        cell: makeCell(runtime, {
+          toolCalls: [makeToolCall(runtime === "pi" ? {} : { argsHash: "args-b" })],
+        }),
+      }),
+    });
+
+    expect(result.drift).toBe("tool-call-shape");
+  });
+
+  it("classifies tool result shape drift", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "tool-result-shape",
+      runCell: async (runtime) => ({
+        scenarioStatus: "pass",
+        cell: makeCell(runtime, {
+          toolCalls: [makeToolCall(runtime === "pi" ? {} : { resultHash: "result-b" })],
+        }),
+      }),
+    });
+
+    expect(result.drift).toBe("tool-result-shape");
+  });
+
+  it("classifies transcript-structure drift", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "structural",
+      runCell: async (runtime) => ({
+        scenarioStatus: "pass",
+        cell: makeCell(runtime, {
+          transcriptBytes:
+            runtime === "pi" ? '{"role":"assistant"}\n' : '{"role":"assistant"}\n{"role":"tool"}\n',
+        }),
+      }),
+    });
+
+    expect(result.drift).toBe("structural");
+  });
+
+  it("classifies runtime failures before other drift types", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "failure-mode",
+      runCell: async (runtime) => ({
+        scenarioStatus: runtime === "pi" ? "fail" : "pass",
+        cell: makeCell(runtime, runtime === "pi" ? { runtimeErrorClass: "timeout" } : {}),
+      }),
+    });
+
+    expect(result.drift).toBe("failure-mode");
+  });
+
+  it("surfaces tool-call-shape when one runtime fails because the tool path drifted", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "tool-call-failure",
+      runCell: async (runtime) => ({
+        scenarioStatus: runtime === "pi" ? "pass" : "fail",
+        cell: makeCell(runtime, {
+          toolCalls: runtime === "pi" ? [makeToolCall()] : [],
+          ...(runtime === "codex" ? { runtimeErrorClass: "tool-error" } : {}),
+        }),
+      }),
+    });
+
+    expect(result.drift).toBe("tool-call-shape");
+  });
+
+  it("surfaces tool-result-shape when a downstream timeout follows divergent tool output", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "tool-result-timeout",
+      runCell: async (runtime) => ({
+        scenarioStatus: runtime === "pi" ? "pass" : "fail",
+        cell: makeCell(runtime, {
+          toolCalls: [makeToolCall(runtime === "pi" ? {} : { resultHash: "result-b" })],
+          ...(runtime === "codex" ? { runtimeErrorClass: "timeout" } : {}),
+        }),
+      }),
+    });
+
+    expect(result.drift).toBe("tool-result-shape");
+  });
+
+  it("prefers provider-side mock request snapshots for tool call rows", async () => {
+    const tempRoot = await createRuntimeParityGatewayTempRoot('{"message":{"role":"assistant"}}\n');
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          {
+            plannedToolName: "read",
+            plannedToolArgs: { path: "QA_KICKOFF_TASK.md" },
+            toolOutput: "",
+          },
+          {
+            toolOutput: JSON.stringify({
+              status: "ok",
+              text: "QA mission: Understand this OpenClaw repo from source + docs before acting.",
+            }),
+          },
+        ],
+      }),
+    );
+
+    const cell = await captureRuntimeParityCell({
+      runtime: "codex",
+      gateway: {
+        tempRoot,
+      },
+      scenarioResult: {
+        status: "pass",
+      },
+      wallClockMs: 42,
+      mockBaseUrl: "http://127.0.0.1:9999",
+    });
+
+    expect(cell.toolCalls).toEqual([
+      {
+        tool: "read",
+        argsHash: stableHashForTest({ path: "QA_KICKOFF_TASK.md" }),
+        resultHash: stableHashForTest({
+          status: "ok",
+          text: "QA mission: Understand this OpenClaw repo from source + docs before acting.",
+        }),
+      },
+    ]);
+  });
+
+  it("captures chained provider-side tool plans and error outputs in request order", async () => {
+    const tempRoot = await createRuntimeParityGatewayTempRoot('{"message":{"role":"assistant"}}\n');
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          {
+            plannedToolName: "read",
+            plannedToolArgs: { path: "audit-fixture/README.md" },
+            toolOutput: "",
+          },
+          {
+            toolOutput: JSON.stringify({
+              status: "ok",
+              text: "Release readiness task",
+            }),
+            plannedToolName: "write",
+            plannedToolArgs: { path: "release-audit.json", content: "{}" },
+          },
+          {
+            toolOutput: JSON.stringify({
+              status: "failed",
+              error: "permission denied",
+            }),
+          },
+        ],
+      }),
+    );
+
+    const cell = await captureRuntimeParityCell({
+      runtime: "pi",
+      gateway: {
+        tempRoot,
+      },
+      scenarioResult: {
+        status: "pass",
+      },
+      wallClockMs: 42,
+      mockBaseUrl: "http://127.0.0.1:9999",
+    });
+
+    expect(cell.toolCalls).toEqual([
+      {
+        tool: "read",
+        argsHash: stableHashForTest({ path: "audit-fixture/README.md" }),
+        resultHash: stableHashForTest({
+          status: "ok",
+          text: "Release readiness task",
+        }),
+      },
+      {
+        tool: "write",
+        argsHash: stableHashForTest({ content: "{}", path: "release-audit.json" }),
+        resultHash: stableHashForTest({
+          status: "failed",
+          error: "permission denied",
+        }),
+        errorClass: "tool-result-error",
+      },
+    ]);
+  });
+});

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1,0 +1,899 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type RuntimeId = "pi" | "codex";
+
+export type RuntimeParityToolCall = {
+  tool: string;
+  argsHash: string;
+  resultHash: string;
+  errorClass?: string;
+};
+
+export type RuntimeParityUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+};
+
+export type RuntimeParityCell = {
+  runtime: RuntimeId;
+  transcriptBytes: string;
+  toolCalls: RuntimeParityToolCall[];
+  finalText: string;
+  usage: RuntimeParityUsage;
+  wallClockMs: number;
+  transportErrorClass?: string;
+  runtimeErrorClass?: string;
+  bootStateLines: string[];
+};
+
+export type RuntimeParityDrift =
+  | "none"
+  | "text-only"
+  | "tool-call-shape"
+  | "tool-result-shape"
+  | "structural"
+  | "failure-mode";
+
+export type RuntimeParityResult = {
+  scenarioId: string;
+  cells: { pi: RuntimeParityCell; codex: RuntimeParityCell };
+  drift: RuntimeParityDrift;
+  driftDetails?: string;
+};
+
+export type RuntimeParityScenarioExecution = {
+  scenarioStatus: "pass" | "fail";
+  scenarioDetails?: string;
+  cell: RuntimeParityCell;
+};
+
+type QaGatewayLike = {
+  logs?: () => string;
+  tempRoot: string;
+};
+
+type QaSuiteScenarioLike = {
+  details?: string;
+  status: "pass" | "fail";
+};
+
+type RuntimeParityCaptureParams = {
+  runtime: RuntimeId;
+  gateway: QaGatewayLike;
+  scenarioResult: QaSuiteScenarioLike;
+  wallClockMs: number;
+  agentId?: string;
+  mockBaseUrl?: string;
+};
+
+type RuntimeParitySessionEntry = {
+  sessionId?: string;
+  sessionFile?: string;
+  updatedAt?: number;
+};
+
+type RuntimeParityTranscriptRecord = {
+  message: Record<string, unknown>;
+  role: "user" | "assistant" | "tool" | "toolResult";
+};
+
+type RuntimeParityMockRequestSnapshot = {
+  plannedToolName?: string;
+  plannedToolArgs?: unknown;
+  toolOutput?: string;
+};
+
+type RuntimeParityPendingToolCall = RuntimeParityToolCall & {
+  _resolved: boolean;
+};
+
+const DEFAULT_AGENT_ID = "qa";
+const BOOT_STATE_LINE_RE =
+  /\b(?:FailoverError|No API key found|Codex app-server|auth profile|runtime policy|restart mode:|plugin|doctor)\b/i;
+const TOOL_RESULT_ERROR_RE = /\b(?:error|failed|failure|timeout|denied|enoent|not found)\b/i;
+
+function normalizeTextForParity(text: string) {
+  return text.replace(/\s+/gu, " ").trim();
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeForStableHash(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeForStableHash(entry));
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .toSorted((left, right) => left.localeCompare(right))
+        .map((key) => [key, normalizeForStableHash(record[key])]),
+    );
+  }
+  return value;
+}
+
+function stableHash(value: unknown) {
+  return sha256(JSON.stringify(normalizeForStableHash(value)) ?? "null");
+}
+
+function isMessageRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readUsageTotals(raw: unknown): RuntimeParityUsage {
+  const usage = isMessageRecord(raw) ? raw : {};
+  const inputTokens =
+    readFiniteNumber(usage.input) ??
+    readFiniteNumber(usage.inputTokens) ??
+    readFiniteNumber(usage.input_tokens) ??
+    0;
+  const outputTokens =
+    readFiniteNumber(usage.output) ??
+    readFiniteNumber(usage.outputTokens) ??
+    readFiniteNumber(usage.output_tokens) ??
+    0;
+  const cacheRead = readFiniteNumber(usage.cacheRead) ?? readFiniteNumber(usage.cache_read_tokens);
+  const cacheWrite =
+    readFiniteNumber(usage.cacheWrite) ?? readFiniteNumber(usage.cache_write_tokens);
+  const componentTotal = inputTokens + outputTokens + (cacheRead ?? 0) + (cacheWrite ?? 0);
+  const totalTokens =
+    readFiniteNumber(usage.total) ??
+    readFiniteNumber(usage.totalTokens) ??
+    readFiniteNumber(usage.total_tokens) ??
+    componentTotal;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    ...(cacheRead !== undefined ? { cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cacheWrite } : {}),
+  };
+}
+
+function addUsage(target: RuntimeParityUsage, next: RuntimeParityUsage) {
+  target.inputTokens += next.inputTokens;
+  target.outputTokens += next.outputTokens;
+  target.totalTokens += next.totalTokens;
+  if (next.cacheRead !== undefined) {
+    target.cacheRead = (target.cacheRead ?? 0) + next.cacheRead;
+  }
+  if (next.cacheWrite !== undefined) {
+    target.cacheWrite = (target.cacheWrite ?? 0) + next.cacheWrite;
+  }
+}
+
+function extractAssistantText(message: Record<string, unknown>) {
+  const rawContent = message.content;
+  if (typeof rawContent === "string") {
+    return rawContent.trim();
+  }
+  if (!Array.isArray(rawContent)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of rawContent) {
+    if (typeof block === "string") {
+      if (block.trim()) {
+        parts.push(block.trim());
+      }
+      continue;
+    }
+    if (!isMessageRecord(block)) {
+      continue;
+    }
+    const text = readNonEmptyString(block.text);
+    if (text) {
+      parts.push(text);
+      continue;
+    }
+    const nestedText = readNonEmptyString(block.content);
+    if (
+      nestedText &&
+      (block.type === "output_text" || block.type === "text" || block.type === "message")
+    ) {
+      parts.push(nestedText);
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+function normalizeToolCallId(value: unknown) {
+  return readNonEmptyString(value);
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  if (!value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isMessageRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractToolCalls(message: Record<string, unknown>): Array<{
+  id?: string;
+  tool: string;
+  args: unknown;
+}> {
+  const calls: Array<{ id?: string; tool: string; args: unknown }> = [];
+  const rawContent = message.content;
+  if (Array.isArray(rawContent)) {
+    for (const block of rawContent) {
+      if (!isMessageRecord(block)) {
+        continue;
+      }
+      const type = readNonEmptyString(block.type)?.toLowerCase();
+      if (type !== "tool_use" && type !== "toolcall" && type !== "tool_call") {
+        continue;
+      }
+      const tool = readNonEmptyString(block.name) ?? "unknown";
+      calls.push({
+        id:
+          normalizeToolCallId(block.id) ??
+          normalizeToolCallId(block.toolCallId) ??
+          normalizeToolCallId(block.toolUseId),
+        tool,
+        args: block.input ?? block.arguments ?? block.args ?? block.payload ?? null,
+      });
+    }
+  }
+  const rawToolCalls =
+    message.tool_calls ?? message.toolCalls ?? message.function_call ?? message.functionCall;
+  const toolCalls = Array.isArray(rawToolCalls) ? rawToolCalls : rawToolCalls ? [rawToolCalls] : [];
+  for (const call of toolCalls) {
+    if (!isMessageRecord(call)) {
+      continue;
+    }
+    const functionRecord = isMessageRecord(call.function) ? call.function : undefined;
+    const tool =
+      readNonEmptyString(call.name) ?? readNonEmptyString(functionRecord?.name) ?? "unknown";
+    calls.push({
+      id:
+        normalizeToolCallId(call.id) ??
+        normalizeToolCallId(call.toolCallId) ??
+        normalizeToolCallId(call.toolUseId),
+      tool,
+      args:
+        call.arguments ?? functionRecord?.arguments ?? call.input ?? functionRecord?.input ?? null,
+    });
+  }
+  return calls;
+}
+
+function extractToolResults(message: Record<string, unknown>): Array<{
+  id?: string;
+  tool?: string;
+  result: unknown;
+  errorClass?: string;
+}> {
+  const results: Array<{ id?: string; tool?: string; result: unknown; errorClass?: string }> = [];
+  const toolName =
+    readNonEmptyString(message.toolName) ??
+    readNonEmptyString(message.tool_name) ??
+    readNonEmptyString(message.name) ??
+    readNonEmptyString(message.tool);
+  if ((message.role === "tool" || message.role === "toolResult") && message.content !== undefined) {
+    const contentText = extractAssistantText(message);
+    results.push({
+      tool: toolName,
+      result: message.content,
+      ...(TOOL_RESULT_ERROR_RE.test(contentText) ? { errorClass: "tool-result-error" } : {}),
+    });
+  }
+  const rawContent = message.content;
+  if (!Array.isArray(rawContent)) {
+    return results;
+  }
+  for (const block of rawContent) {
+    if (!isMessageRecord(block)) {
+      continue;
+    }
+    const type = readNonEmptyString(block.type)?.toLowerCase();
+    if (type !== "tool_result" && type !== "tool_result_error") {
+      continue;
+    }
+    const content = block.content ?? block.result ?? block.output ?? block.text ?? null;
+    const contentText =
+      typeof content === "string"
+        ? content
+        : Array.isArray(content)
+          ? JSON.stringify(content)
+          : JSON.stringify(content ?? "");
+    results.push({
+      id:
+        normalizeToolCallId(block.tool_use_id) ??
+        normalizeToolCallId(block.toolUseId) ??
+        normalizeToolCallId(block.tool_call_id) ??
+        normalizeToolCallId(block.toolCallId),
+      tool: toolName,
+      result: content,
+      ...(block.is_error === true ||
+      type === "tool_result_error" ||
+      TOOL_RESULT_ERROR_RE.test(contentText)
+        ? { errorClass: "tool-result-error" }
+        : {}),
+    });
+  }
+  return results;
+}
+
+function classifyToolResultError(params: {
+  rawOutput: string;
+  parsedOutput: Record<string, unknown> | undefined;
+}) {
+  const error = readNonEmptyString(params.parsedOutput?.error);
+  if (error) {
+    return "tool-result-error";
+  }
+  const status = readNonEmptyString(params.parsedOutput?.status);
+  if (status && /\b(?:error|failed|failure)\b/i.test(status)) {
+    return "tool-result-error";
+  }
+  if (!params.parsedOutput) {
+    const normalized = params.rawOutput.trim().toLowerCase();
+    if (
+      normalized.startsWith("error:") ||
+      normalized.startsWith("failed:") ||
+      normalized.includes("unsupported call:") ||
+      normalized.includes("permission denied") ||
+      normalized.includes("no such file") ||
+      normalized.includes("enoent")
+    ) {
+      return "tool-result-error";
+    }
+  }
+  return undefined;
+}
+
+function resolveToolCallOrder(records: RuntimeParityTranscriptRecord[]): RuntimeParityToolCall[] {
+  const ordered: RuntimeParityPendingToolCall[] = [];
+  const byId = new Map<string, number>();
+  const unresolvedByTool = new Map<string, number[]>();
+  const unresolvedOrder: number[] = [];
+
+  const enqueueUnresolved = (tool: string, index: number) => {
+    const indices = unresolvedByTool.get(tool) ?? [];
+    indices.push(index);
+    unresolvedByTool.set(tool, indices);
+    unresolvedOrder.push(index);
+  };
+
+  const markResolved = (index: number) => {
+    ordered[index] = { ...ordered[index], _resolved: true };
+    const unresolvedIndex = unresolvedOrder.indexOf(index);
+    if (unresolvedIndex >= 0) {
+      unresolvedOrder.splice(unresolvedIndex, 1);
+    }
+    const toolIndices = unresolvedByTool.get(ordered[index].tool);
+    if (!toolIndices) {
+      return;
+    }
+    const nextIndices = toolIndices.filter((candidate) => candidate !== index);
+    if (nextIndices.length > 0) {
+      unresolvedByTool.set(ordered[index].tool, nextIndices);
+      return;
+    }
+    unresolvedByTool.delete(ordered[index].tool);
+  };
+
+  const matchPendingIndex = (result: { id?: string; tool?: string }) => {
+    if (result.id && byId.has(result.id)) {
+      return byId.get(result.id);
+    }
+    if (result.tool) {
+      const toolIndices = unresolvedByTool.get(result.tool);
+      if (toolIndices && toolIndices.length > 0) {
+        return toolIndices[0];
+      }
+    }
+    return unresolvedOrder[0];
+  };
+
+  for (const record of records) {
+    if (record.role === "assistant") {
+      for (const call of extractToolCalls(record.message)) {
+        const index =
+          ordered.push({
+            tool: call.tool,
+            argsHash: stableHash(call.args),
+            resultHash: stableHash(null),
+            _resolved: false,
+          }) - 1;
+        if (call.id) {
+          byId.set(call.id, index);
+        }
+        enqueueUnresolved(call.tool, index);
+      }
+    }
+    if (record.role === "user" || record.role === "tool" || record.role === "toolResult") {
+      for (const result of extractToolResults(record.message)) {
+        const pendingIndex = matchPendingIndex(result);
+        const nextValue: RuntimeParityToolCall = {
+          tool:
+            result.tool ??
+            (pendingIndex !== undefined ? ordered[pendingIndex]?.tool : undefined) ??
+            "unknown",
+          argsHash:
+            pendingIndex !== undefined
+              ? (ordered[pendingIndex]?.argsHash ?? stableHash(null))
+              : stableHash(null),
+          resultHash: stableHash(result.result),
+          ...(result.errorClass ? { errorClass: result.errorClass } : {}),
+        };
+        if (pendingIndex === undefined || !ordered[pendingIndex]) {
+          ordered.push({ ...nextValue, _resolved: true });
+          continue;
+        }
+        ordered[pendingIndex] = {
+          ...nextValue,
+          _resolved: true,
+        };
+        markResolved(pendingIndex);
+      }
+    }
+  }
+
+  return ordered.map(({ _resolved: _ignored, ...toolCall }) => toolCall);
+}
+
+function resolveToolCallOrderFromMockRequests(
+  requests: RuntimeParityMockRequestSnapshot[],
+): RuntimeParityToolCall[] {
+  const ordered: RuntimeParityPendingToolCall[] = [];
+  const unresolvedOrder: number[] = [];
+
+  const enqueueUnresolved = (index: number) => {
+    unresolvedOrder.push(index);
+  };
+
+  const markResolved = (index: number) => {
+    ordered[index] = { ...ordered[index], _resolved: true };
+    const unresolvedIndex = unresolvedOrder.indexOf(index);
+    if (unresolvedIndex >= 0) {
+      unresolvedOrder.splice(unresolvedIndex, 1);
+    }
+  };
+
+  for (const request of requests) {
+    const rawToolOutput = readNonEmptyString(request.toolOutput) ?? "";
+    if (rawToolOutput) {
+      const pendingIndex = unresolvedOrder[0];
+      const parsedOutput = parseJsonRecord(rawToolOutput);
+      const resolvedCall: RuntimeParityToolCall = {
+        tool: pendingIndex !== undefined ? (ordered[pendingIndex]?.tool ?? "unknown") : "unknown",
+        argsHash:
+          pendingIndex !== undefined
+            ? (ordered[pendingIndex]?.argsHash ?? stableHash(null))
+            : stableHash(null),
+        resultHash: stableHash(parsedOutput ?? rawToolOutput),
+        ...(classifyToolResultError({
+          rawOutput: rawToolOutput,
+          parsedOutput,
+        })
+          ? { errorClass: "tool-result-error" }
+          : {}),
+      };
+      if (pendingIndex === undefined || !ordered[pendingIndex]) {
+        ordered.push({ ...resolvedCall, _resolved: true });
+      } else {
+        ordered[pendingIndex] = {
+          ...resolvedCall,
+          _resolved: true,
+        };
+        markResolved(pendingIndex);
+      }
+    }
+
+    const plannedToolName = readNonEmptyString(request.plannedToolName);
+    if (!plannedToolName) {
+      continue;
+    }
+    ordered.push({
+      tool: plannedToolName,
+      argsHash: stableHash(request.plannedToolArgs ?? null),
+      resultHash: stableHash(null),
+      _resolved: false,
+    });
+    enqueueUnresolved(ordered.length - 1);
+  }
+
+  return ordered.map(({ _resolved: _ignored, ...toolCall }) => toolCall);
+}
+
+function classifyScenarioError(details: string | undefined): string | undefined {
+  const normalized = normalizeTextForParity(details ?? "").toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.includes("no api key found")) {
+    return "missing-api-key";
+  }
+  if (normalized.includes("failover")) {
+    return "failover";
+  }
+  if (normalized.includes("timeout") || normalized.includes("timed out")) {
+    return "timeout";
+  }
+  if (normalized.includes("codex app-server")) {
+    return "codex-app-server";
+  }
+  if (
+    normalized.includes("auth profile") ||
+    normalized.includes("oauth") ||
+    normalized.includes("api key")
+  ) {
+    return "auth";
+  }
+  if (normalized.includes("tool")) {
+    return "tool-error";
+  }
+  return "scenario-failure";
+}
+
+function extractBootStateLines(logs: string | undefined): string[] {
+  if (!logs) {
+    return [];
+  }
+  return logs
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && BOOT_STATE_LINE_RE.test(line))
+    .slice(-30);
+}
+
+function buildTranscriptRecords(transcriptBytes: string): RuntimeParityTranscriptRecord[] {
+  const records: RuntimeParityTranscriptRecord[] = [];
+  for (const line of transcriptBytes.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      const message = isMessageRecord(parsed.message) ? parsed.message : undefined;
+      const role = readNonEmptyString(message?.role);
+      if (
+        !message ||
+        (role !== "user" && role !== "assistant" && role !== "tool" && role !== "toolResult")
+      ) {
+        continue;
+      }
+      records.push({
+        message,
+        role,
+      });
+    } catch {
+      // Ignore malformed QA transcript rows and keep the classifier deterministic.
+    }
+  }
+  return records;
+}
+
+function extractFinalAssistantText(records: RuntimeParityTranscriptRecord[]) {
+  let lastAssistantText = "";
+  for (const record of records) {
+    if (record.role !== "assistant") {
+      continue;
+    }
+    const text = extractAssistantText(record.message);
+    if (text) {
+      lastAssistantText = text;
+    }
+  }
+  return normalizeTextForParity(lastAssistantText);
+}
+
+function aggregateUsage(records: RuntimeParityTranscriptRecord[]): RuntimeParityUsage {
+  const totals: RuntimeParityUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+  for (const record of records) {
+    if (record.role !== "assistant") {
+      continue;
+    }
+    const usage = readUsageTotals(record.message.usage ?? null);
+    addUsage(totals, usage);
+  }
+  return totals;
+}
+
+function compareToolCallShape(
+  left: RuntimeParityToolCall[],
+  right: RuntimeParityToolCall[],
+): string | undefined {
+  if (left.length !== right.length) {
+    return `tool call count differs (${left.length} vs ${right.length})`;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    const leftCall = left[index];
+    const rightCall = right[index];
+    if (!leftCall || !rightCall) {
+      return `tool call row ${index + 1} missing`;
+    }
+    if (leftCall.tool !== rightCall.tool || leftCall.argsHash !== rightCall.argsHash) {
+      return `tool call ${index + 1} differs (${leftCall.tool}/${leftCall.argsHash} vs ${rightCall.tool}/${rightCall.argsHash})`;
+    }
+  }
+  return undefined;
+}
+
+function compareToolResultShape(
+  left: RuntimeParityToolCall[],
+  right: RuntimeParityToolCall[],
+): string | undefined {
+  const total = Math.min(left.length, right.length);
+  for (let index = 0; index < total; index += 1) {
+    const leftCall = left[index];
+    const rightCall = right[index];
+    if (!leftCall || !rightCall) {
+      continue;
+    }
+    if (
+      leftCall.resultHash !== rightCall.resultHash ||
+      (leftCall.errorClass ?? "") !== (rightCall.errorClass ?? "")
+    ) {
+      return `tool result ${index + 1} differs (${leftCall.tool})`;
+    }
+  }
+  return undefined;
+}
+
+function isHardFailureRuntimeError(errorClass: string | undefined) {
+  return (
+    errorClass === "missing-api-key" ||
+    errorClass === "failover" ||
+    errorClass === "codex-app-server" ||
+    errorClass === "auth" ||
+    errorClass === "capture-missing"
+  );
+}
+
+function classifyRuntimeParityCells(params: {
+  pi: RuntimeParityCell;
+  codex: RuntimeParityCell;
+  piScenarioStatus: "pass" | "fail";
+  codexScenarioStatus: "pass" | "fail";
+}): Pick<RuntimeParityResult, "drift" | "driftDetails"> {
+  if (
+    isHardFailureRuntimeError(params.pi.runtimeErrorClass) ||
+    isHardFailureRuntimeError(params.codex.runtimeErrorClass) ||
+    params.pi.transportErrorClass ||
+    params.codex.transportErrorClass
+  ) {
+    return {
+      drift: "failure-mode",
+      driftDetails:
+        params.pi.transportErrorClass || params.codex.transportErrorClass
+          ? "at least one runtime hit a transport failure"
+          : "at least one runtime hit a hard runtime failure",
+    };
+  }
+
+  const toolCallShapeDetails = compareToolCallShape(params.pi.toolCalls, params.codex.toolCalls);
+  if (toolCallShapeDetails) {
+    return { drift: "tool-call-shape", driftDetails: toolCallShapeDetails };
+  }
+
+  const toolResultShapeDetails = compareToolResultShape(
+    params.pi.toolCalls,
+    params.codex.toolCalls,
+  );
+  if (toolResultShapeDetails) {
+    return { drift: "tool-result-shape", driftDetails: toolResultShapeDetails };
+  }
+
+  const piTranscriptLines = params.pi.transcriptBytes.trim().length
+    ? params.pi.transcriptBytes.trim().split(/\r?\n/u).length
+    : 0;
+  const codexTranscriptLines = params.codex.transcriptBytes.trim().length
+    ? params.codex.transcriptBytes.trim().split(/\r?\n/u).length
+    : 0;
+  if (
+    piTranscriptLines !== codexTranscriptLines ||
+    (!params.pi.finalText && !!params.codex.finalText) ||
+    (!!params.pi.finalText && !params.codex.finalText)
+  ) {
+    return {
+      drift: "structural",
+      driftDetails: `transcript/final-text structure differs (${piTranscriptLines} lines vs ${codexTranscriptLines})`,
+    };
+  }
+
+  if (
+    params.piScenarioStatus === "fail" ||
+    params.codexScenarioStatus === "fail" ||
+    params.pi.runtimeErrorClass ||
+    params.codex.runtimeErrorClass
+  ) {
+    return {
+      drift: "failure-mode",
+      driftDetails:
+        params.piScenarioStatus === params.codexScenarioStatus
+          ? "at least one runtime failed"
+          : `scenario status differs (${params.piScenarioStatus} vs ${params.codexScenarioStatus})`,
+    };
+  }
+
+  if (
+    normalizeTextForParity(params.pi.finalText) === normalizeTextForParity(params.codex.finalText)
+  ) {
+    return { drift: "none" };
+  }
+
+  return { drift: "text-only", driftDetails: "final text differs after whitespace normalization" };
+}
+
+function resolveSessionTranscriptFile(params: {
+  sessionsDir: string;
+  sessionId: string;
+  sessionEntry?: RuntimeParitySessionEntry;
+}): string | undefined {
+  const explicitSessionFile = readNonEmptyString(params.sessionEntry?.sessionFile);
+  if (explicitSessionFile) {
+    const candidate = path.isAbsolute(explicitSessionFile)
+      ? explicitSessionFile
+      : path.join(params.sessionsDir, explicitSessionFile);
+    return candidate;
+  }
+  const baseName = `${params.sessionId}.jsonl`;
+  return path.join(params.sessionsDir, baseName);
+}
+
+async function readRuntimeParitySessionEntries(params: {
+  stateDir: string;
+  agentId: string;
+}): Promise<Array<RuntimeParitySessionEntry>> {
+  const storePath = path.join(
+    params.stateDir,
+    "agents",
+    params.agentId,
+    "sessions",
+    "sessions.json",
+  );
+  try {
+    const raw = await fs.readFile(storePath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, RuntimeParitySessionEntry>;
+    return Object.values(parsed)
+      .filter((entry) => readNonEmptyString(entry?.sessionId))
+      .toSorted((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+  } catch {
+    return [];
+  }
+}
+
+async function loadRuntimeParityTranscripts(params: {
+  gateway: QaGatewayLike;
+  agentId: string;
+}): Promise<string> {
+  const sessionsDir = path.join(
+    params.gateway.tempRoot,
+    "state",
+    "agents",
+    params.agentId,
+    "sessions",
+  );
+  const sessionEntries = await readRuntimeParitySessionEntries({
+    stateDir: path.join(params.gateway.tempRoot, "state"),
+    agentId: params.agentId,
+  });
+  const transcripts: string[] = [];
+  for (const sessionEntry of sessionEntries) {
+    const sessionId = readNonEmptyString(sessionEntry.sessionId);
+    if (!sessionId) {
+      continue;
+    }
+    const sessionFile = resolveSessionTranscriptFile({
+      sessionsDir,
+      sessionId,
+      sessionEntry,
+    });
+    if (!sessionFile) {
+      continue;
+    }
+    try {
+      const transcript = await fs.readFile(sessionFile, "utf8");
+      if (transcript.trim().length > 0) {
+        transcripts.push(transcript.trimEnd());
+      }
+    } catch {
+      // Ignore missing transcript files so failed cells still render.
+    }
+  }
+  return transcripts.join("\n");
+}
+
+async function loadRuntimeParityMockToolCalls(
+  mockBaseUrl: string | undefined,
+): Promise<RuntimeParityToolCall[] | null> {
+  const normalizedBaseUrl = mockBaseUrl?.trim().replace(/\/+$/u, "");
+  if (!normalizedBaseUrl) {
+    return null;
+  }
+  try {
+    const response = await fetch(`${normalizedBaseUrl}/debug/requests`);
+    if (!response.ok) {
+      return null;
+    }
+    const payload = (await response.json()) as unknown;
+    if (!Array.isArray(payload)) {
+      return null;
+    }
+    const requests = payload.filter(isMessageRecord).map(
+      (entry): RuntimeParityMockRequestSnapshot => ({
+        plannedToolName: readNonEmptyString(entry.plannedToolName),
+        plannedToolArgs: entry.plannedToolArgs ?? null,
+        toolOutput: readNonEmptyString(entry.toolOutput) ?? "",
+      }),
+    );
+    return resolveToolCallOrderFromMockRequests(requests);
+  } catch {
+    return null;
+  }
+}
+
+export async function captureRuntimeParityCell(
+  params: RuntimeParityCaptureParams,
+): Promise<RuntimeParityCell> {
+  const agentId = params.agentId ?? DEFAULT_AGENT_ID;
+  const transcriptBytes = await loadRuntimeParityTranscripts({
+    gateway: params.gateway,
+    agentId,
+  });
+  const transcriptRecords = buildTranscriptRecords(transcriptBytes);
+  const mockToolCalls = await loadRuntimeParityMockToolCalls(params.mockBaseUrl);
+  return {
+    runtime: params.runtime,
+    transcriptBytes,
+    toolCalls: mockToolCalls ?? resolveToolCallOrder(transcriptRecords),
+    finalText: extractFinalAssistantText(transcriptRecords),
+    usage: aggregateUsage(transcriptRecords),
+    wallClockMs: params.wallClockMs,
+    ...(classifyScenarioError(params.scenarioResult.details)
+      ? { runtimeErrorClass: classifyScenarioError(params.scenarioResult.details) }
+      : {}),
+    bootStateLines: extractBootStateLines(params.gateway.logs?.()),
+  };
+}
+
+export async function runRuntimeParityScenario(params: {
+  scenarioId: string;
+  runCell: (runtime: RuntimeId) => Promise<RuntimeParityScenarioExecution>;
+}): Promise<RuntimeParityResult> {
+  const [pi, codex] = await Promise.all([params.runCell("pi"), params.runCell("codex")]);
+  const drift = classifyRuntimeParityCells({
+    pi: pi.cell,
+    codex: codex.cell,
+    piScenarioStatus: pi.scenarioStatus,
+    codexScenarioStatus: codex.scenarioStatus,
+  });
+  return {
+    scenarioId: params.scenarioId,
+    cells: {
+      pi: pi.cell,
+      codex: codex.cell,
+    },
+    drift: drift.drift,
+    ...(drift.driftDetails ? { driftDetails: drift.driftDetails } : {}),
+  };
+}

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -1,10 +1,12 @@
 import type { QaProviderMode } from "./model-selection.js";
+import type { RuntimeId, RuntimeParityResult } from "./runtime-parity.js";
 
 type QaSuiteSummaryScenario = {
   name: string;
   status: "pass" | "fail";
   steps: unknown[];
   details?: string;
+  runtimeParity?: RuntimeParityResult;
 };
 
 export type QaSuiteSummaryJson = {
@@ -35,6 +37,7 @@ export type QaSuiteSummaryJson = {
     fastMode: boolean;
     concurrency: number;
     scenarioIds: string[] | null;
+    runtimePair?: [RuntimeId, RuntimeId] | null;
   };
 };
 

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -46,6 +46,15 @@ describe("buildQaSuiteSummaryJson", () => {
     expect(json.run.scenarioIds).toEqual(scenarioIds);
   });
 
+  it("records the runtime pair when the suite runs the runtime axis", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      runtimePair: ["pi", "codex"],
+    });
+
+    expect(json.run.runtimePair).toEqual(["pi", "codex"]);
+  });
+
   it("treats an empty scenarioIds array as unspecified (no filter)", () => {
     // A CLI path that omits --scenario passes an empty array to runQaSuite.
     // The summary must encode that as null so downstream parity/report
@@ -96,6 +105,50 @@ describe("buildQaSuiteSummaryJson", () => {
       total: 2,
       passed: 1,
       failed: 1,
+    });
+  });
+
+  it("preserves scenario-level runtime parity payloads", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      scenarios: [
+        {
+          name: "Scenario A",
+          status: "pass" as const,
+          steps: [],
+          runtimeParity: {
+            scenarioId: "scenario-a",
+            drift: "none" as const,
+            cells: {
+              pi: {
+                runtime: "pi" as const,
+                transcriptBytes: "",
+                toolCalls: [],
+                finalText: "done",
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                wallClockMs: 10,
+                bootStateLines: [],
+              },
+              codex: {
+                runtime: "codex" as const,
+                transcriptBytes: "",
+                toolCalls: [],
+                finalText: "done",
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                wallClockMs: 10,
+                bootStateLines: [],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(json.scenarios[0]).toMatchObject({
+      runtimeParity: {
+        scenarioId: "scenario-a",
+        drift: "none",
+      },
     });
   });
 

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -85,4 +85,51 @@ describe("qa suite", () => {
     );
     expect(qaSuiteProgressTesting.sanitizeQaSuiteProgressValue("\u0000\u0001")).toBe("<empty>");
   });
+
+  it("builds a codex mock runtime env patch that stays on the QA mock provider", () => {
+    expect(
+      qaSuiteProgressTesting.buildQaRuntimeEnvPatch({
+        providerMode: "mock-openai",
+        forcedRuntime: "codex",
+        mockBaseUrl: "http://127.0.0.1:44080",
+      }),
+    ).toEqual({
+      OPENCLAW_BUILD_PRIVATE_QA: "1",
+      OPENCLAW_QA_FORCE_RUNTIME: "codex",
+      OPENCLAW_CODEX_APP_SERVER_ARGS:
+        "app-server -c openai_base_url=http://127.0.0.1:44080/v1 --listen stdio://",
+      OPENAI_API_KEY: "qa-mock-openai-key",
+      CODEX_API_KEY: "qa-mock-openai-key",
+    });
+  });
+
+  it("omits mock OpenAI rewiring for non-codex runtime overrides", () => {
+    expect(
+      qaSuiteProgressTesting.buildQaRuntimeEnvPatch({
+        providerMode: "mock-openai",
+        forcedRuntime: "pi",
+        mockBaseUrl: "http://127.0.0.1:44080",
+      }),
+    ).toEqual({
+      OPENCLAW_BUILD_PRIVATE_QA: "1",
+      OPENCLAW_QA_FORCE_RUNTIME: "pi",
+    });
+  });
+
+  it("remaps mock-openai model refs onto the app-server OpenAI provider for codex cells only", () => {
+    expect(
+      qaSuiteProgressTesting.remapModelRefForForcedRuntime({
+        modelRef: "mock-openai/gpt-5.5",
+        providerMode: "mock-openai",
+        forcedRuntime: "codex",
+      }),
+    ).toBe("openai/gpt-5.5");
+    expect(
+      qaSuiteProgressTesting.remapModelRefForForcedRuntime({
+        modelRef: "mock-openai/gpt-5.5",
+        providerMode: "mock-openai",
+        forcedRuntime: "pi",
+      }),
+    ).toBe("mock-openai/gpt-5.5");
+  });
 });

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -29,6 +29,13 @@ import {
 import type { QaTransportAdapter } from "./qa-transport.js";
 import { renderQaMarkdownReport, type QaReportCheck, type QaReportScenario } from "./report.js";
 import { defaultQaModelForMode } from "./run-config.js";
+import {
+  captureRuntimeParityCell,
+  runRuntimeParityScenario,
+  type RuntimeId,
+  type RuntimeParityCell,
+  type RuntimeParityResult,
+} from "./runtime-parity.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import { runScenarioFlow } from "./scenario-flow-runner.js";
 import {
@@ -60,6 +67,7 @@ export type QaSuiteScenarioResult = {
   status: "pass" | "fail";
   steps: QaReportCheck[];
   details?: string;
+  runtimeParity?: RuntimeParityResult;
 };
 
 type QaSuiteEnvironment = {
@@ -86,6 +94,9 @@ export type QaSuiteRunParams = {
   enabledPluginIds?: string[];
   controlUiEnabled?: boolean;
   transportReadyTimeoutMs?: number;
+  forcedRuntime?: RuntimeId;
+  runtimePair?: [RuntimeId, RuntimeId];
+  captureRuntimeParityCell?: boolean;
 };
 
 function parseQaSuiteBooleanEnv(value: string | undefined): boolean | undefined {
@@ -185,6 +196,7 @@ export type QaSuiteResult = {
   report: string;
   scenarios: QaSuiteScenarioResult[];
   watchUrl: string;
+  runtimeParityCell?: RuntimeParityCell;
 };
 
 async function runScenario(name: string, steps: QaSuiteStep[]): Promise<QaSuiteScenarioResult> {
@@ -263,6 +275,59 @@ async function runScenarioDefinition(
   });
 }
 
+function isRuntimeParityPass(result: RuntimeParityResult) {
+  return result.drift === "none" || result.drift === "text-only";
+}
+
+function formatRuntimeParityCellDetails(cell: RuntimeParityCell) {
+  const errors = [cell.transportErrorClass, cell.runtimeErrorClass].filter(Boolean).join(", ");
+  return [
+    `runtime=${cell.runtime}`,
+    `wallMs=${cell.wallClockMs}`,
+    `toolCalls=${cell.toolCalls.length}`,
+    `finalChars=${cell.finalText.length}`,
+    `tokens=${cell.usage.totalTokens}`,
+    ...(errors ? [`errors=${errors}`] : []),
+  ].join(" ");
+}
+
+function buildRuntimeParityScenarioResult(params: {
+  scenarioName: string;
+  result: RuntimeParityResult;
+}): QaSuiteScenarioResult {
+  const driftStepStatus = isRuntimeParityPass(params.result) ? "pass" : "fail";
+  return {
+    name: params.scenarioName,
+    status: driftStepStatus,
+    details: params.result.driftDetails ?? `runtime drift classified as ${params.result.drift}`,
+    steps: [
+      {
+        name: params.result.cells.pi.runtime,
+        status:
+          params.result.cells.pi.runtimeErrorClass || params.result.cells.pi.transportErrorClass
+            ? "fail"
+            : "pass",
+        details: formatRuntimeParityCellDetails(params.result.cells.pi),
+      },
+      {
+        name: params.result.cells.codex.runtime,
+        status:
+          params.result.cells.codex.runtimeErrorClass ||
+          params.result.cells.codex.transportErrorClass
+            ? "fail"
+            : "pass",
+        details: formatRuntimeParityCellDetails(params.result.cells.codex),
+      },
+      {
+        name: "runtime drift",
+        status: driftStepStatus,
+        details: params.result.driftDetails ?? params.result.drift,
+      },
+    ],
+    runtimeParity: params.result,
+  };
+}
+
 function createQaSuiteReportNotes(params: {
   transport: QaTransportAdapter;
   providerMode: QaProviderMode;
@@ -279,6 +344,47 @@ function normalizeQaSuiteModelRef(input: string | undefined, fallback: string) {
   return model && model.length > 0 ? model : fallback;
 }
 
+function remapModelRefForForcedRuntime(params: {
+  modelRef: string;
+  providerMode: QaProviderMode;
+  forcedRuntime?: RuntimeId;
+}) {
+  if (params.forcedRuntime !== "codex" || params.providerMode !== "mock-openai") {
+    return params.modelRef;
+  }
+  const split = splitModelRef(params.modelRef);
+  if (!split || split.provider !== "mock-openai") {
+    return params.modelRef;
+  }
+  return `openai/${split.model}`;
+}
+
+function buildQaRuntimeEnvPatch(params: {
+  providerMode: QaProviderMode;
+  forcedRuntime?: RuntimeId;
+  mockBaseUrl?: string;
+}): NodeJS.ProcessEnv | undefined {
+  const patch: NodeJS.ProcessEnv = {};
+  if (params.forcedRuntime) {
+    patch.OPENCLAW_BUILD_PRIVATE_QA = "1";
+    patch.OPENCLAW_QA_FORCE_RUNTIME = params.forcedRuntime;
+  }
+  if (params.forcedRuntime !== "codex" || params.providerMode !== "mock-openai") {
+    return Object.keys(patch).length > 0 ? patch : undefined;
+  }
+  const mockBaseUrl = params.mockBaseUrl?.trim().replace(/\/+$/u, "");
+  if (!mockBaseUrl) {
+    return Object.keys(patch).length > 0 ? patch : undefined;
+  }
+  // The forced codex lane uses the Codex app-server's native OpenAI provider
+  // path, so pin the managed app-server to the QA mock endpoint instead of
+  // leaking to the maintainer's real OpenAI config.
+  patch.OPENCLAW_CODEX_APP_SERVER_ARGS = `app-server -c openai_base_url=${mockBaseUrl}/v1 --listen stdio://`;
+  patch.OPENAI_API_KEY = "qa-mock-openai-key";
+  patch.CODEX_API_KEY = "qa-mock-openai-key";
+  return patch;
+}
+
 export type QaSuiteSummaryJsonParams = {
   scenarios: QaSuiteScenarioResult[];
   startedAt: Date;
@@ -290,6 +396,7 @@ export type QaSuiteSummaryJsonParams = {
   fastMode: boolean;
   concurrency: number;
   scenarioIds?: readonly string[];
+  runtimePair?: [RuntimeId, RuntimeId];
 };
 
 /**
@@ -339,8 +446,227 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSui
       concurrency: params.concurrency,
       scenarioIds:
         params.scenarioIds && params.scenarioIds.length > 0 ? [...params.scenarioIds] : null,
+      runtimePair: params.runtimePair ?? null,
     },
   };
+}
+
+async function runQaRuntimeParitySuite(params: {
+  repoRoot: string;
+  outputDir: string;
+  startedAt: Date;
+  providerMode: QaProviderMode;
+  transportId: QaTransportId;
+  primaryModel: string;
+  alternateModel: string;
+  fastMode: boolean;
+  thinkingDefault?: QaThinkingLevel;
+  claudeCliAuthMode?: QaCliBackendAuthMode;
+  enabledPluginIds?: string[];
+  concurrency: number;
+  selectedCatalogScenarios: ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"];
+  startLab?: QaSuiteStartLabFn;
+  lab?: QaLabServerHandle;
+  progressEnabled: boolean;
+  scenarioIds?: readonly string[];
+  runtimePair: [RuntimeId, RuntimeId];
+}) {
+  const ownsLab = !params.lab;
+  const startLab = requireQaSuiteStartLab(params.startLab);
+  const lab =
+    params.lab ??
+    (await startLab({
+      repoRoot: params.repoRoot,
+      host: "127.0.0.1",
+      port: 0,
+      embeddedGateway: "disabled",
+    }));
+  const transport = createQaTransportAdapter({
+    id: params.transportId,
+    state: lab.state,
+  });
+  const liveScenarioOutcomes: QaLabScenarioOutcome[] = params.selectedCatalogScenarios.map(
+    (scenario) => ({
+      id: scenario.id,
+      name: scenario.title,
+      status: "pending",
+    }),
+  );
+  lab.setScenarioRun({
+    kind: "suite",
+    status: "running",
+    startedAt: params.startedAt.toISOString(),
+    scenarios: [...liveScenarioOutcomes],
+  });
+
+  try {
+    const scenarios = await mapQaSuiteWithConcurrency(
+      params.selectedCatalogScenarios,
+      params.concurrency,
+      async (scenario, index): Promise<QaSuiteScenarioResult> => {
+        const scenarioIdForLog = sanitizeQaSuiteProgressValue(scenario.id);
+        writeQaSuiteProgress(
+          params.progressEnabled,
+          `runtime pair start (${index + 1}/${params.selectedCatalogScenarios.length}): ${scenarioIdForLog}`,
+        );
+        liveScenarioOutcomes[index] = {
+          id: scenario.id,
+          name: scenario.title,
+          status: "running",
+          startedAt: new Date().toISOString(),
+        };
+        lab.setScenarioRun({
+          kind: "suite",
+          status: "running",
+          startedAt: params.startedAt.toISOString(),
+          scenarios: [...liveScenarioOutcomes],
+        });
+
+        const parity = await runRuntimeParityScenario({
+          scenarioId: scenario.id,
+          runCell: async (runtime) => {
+            const cellOutputDir = path.join(
+              params.outputDir,
+              "runtime-cells",
+              scenario.id,
+              runtime,
+            );
+            const cellStartedAt = Date.now();
+            const cellResult = await runQaSuite({
+              repoRoot: params.repoRoot,
+              outputDir: cellOutputDir,
+              providerMode: params.providerMode,
+              transportId: params.transportId,
+              primaryModel: remapModelRefForForcedRuntime({
+                modelRef: params.primaryModel,
+                providerMode: params.providerMode,
+                forcedRuntime: runtime,
+              }),
+              alternateModel: remapModelRefForForcedRuntime({
+                modelRef: params.alternateModel,
+                providerMode: params.providerMode,
+                forcedRuntime: runtime,
+              }),
+              fastMode: params.fastMode,
+              thinkingDefault: params.thinkingDefault,
+              claudeCliAuthMode: params.claudeCliAuthMode,
+              scenarioIds: [scenario.id],
+              concurrency: 1,
+              enabledPluginIds: params.enabledPluginIds,
+              startLab,
+              controlUiEnabled: scenarioRequiresControlUi(scenario),
+              forcedRuntime: runtime,
+              captureRuntimeParityCell: true,
+            });
+            const scenarioResult =
+              cellResult.scenarios[0] ??
+              ({
+                name: scenario.title,
+                status: "fail",
+                details: "runtime parity cell returned no scenario result",
+                steps: [
+                  {
+                    name: "runtime parity cell",
+                    status: "fail",
+                    details: "runtime parity cell returned no scenario result",
+                  },
+                ],
+              } satisfies QaSuiteScenarioResult);
+            const fallbackCell = {
+              runtime,
+              transcriptBytes: "",
+              toolCalls: [],
+              finalText: "",
+              usage: {
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              wallClockMs: Math.max(1, Date.now() - cellStartedAt),
+              runtimeErrorClass: "capture-missing",
+              bootStateLines: [],
+            } satisfies RuntimeParityCell;
+            return {
+              scenarioStatus: scenarioResult.status,
+              scenarioDetails: scenarioResult.details,
+              cell: cellResult.runtimeParityCell ?? fallbackCell,
+            };
+          },
+        });
+
+        const result = buildRuntimeParityScenarioResult({
+          scenarioName: scenario.title,
+          result: parity,
+        });
+        liveScenarioOutcomes[index] = {
+          id: scenario.id,
+          name: scenario.title,
+          status: result.status,
+          details: result.details,
+          steps: result.steps,
+          startedAt: liveScenarioOutcomes[index]?.startedAt,
+          finishedAt: new Date().toISOString(),
+        };
+        lab.setScenarioRun({
+          kind: "suite",
+          status: "running",
+          startedAt: params.startedAt.toISOString(),
+          scenarios: [...liveScenarioOutcomes],
+        });
+        writeQaSuiteProgress(
+          params.progressEnabled,
+          `runtime pair ${result.status} (${index + 1}/${params.selectedCatalogScenarios.length}): ${scenarioIdForLog}`,
+        );
+        return result;
+      },
+      {
+        startStaggerMs: resolveQaSuiteWorkerStartStaggerMs(params.concurrency),
+      },
+    );
+
+    const finishedAt = new Date();
+    const { report, reportPath, summaryPath } = await writeQaSuiteArtifacts({
+      outputDir: params.outputDir,
+      startedAt: params.startedAt,
+      finishedAt,
+      scenarios,
+      transport,
+      providerMode: params.providerMode,
+      primaryModel: params.primaryModel,
+      alternateModel: params.alternateModel,
+      fastMode: params.fastMode,
+      concurrency: params.concurrency,
+      scenarioIds:
+        params.scenarioIds && params.scenarioIds.length > 0
+          ? params.selectedCatalogScenarios.map((scenario) => scenario.id)
+          : undefined,
+      runtimePair: params.runtimePair,
+    });
+    lab.setLatestReport({
+      outputPath: reportPath,
+      markdown: report,
+      generatedAt: finishedAt.toISOString(),
+    } satisfies QaLabLatestReport);
+    lab.setScenarioRun({
+      kind: "suite",
+      status: "completed",
+      startedAt: params.startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      scenarios: [...liveScenarioOutcomes],
+    });
+    return {
+      outputDir: params.outputDir,
+      reportPath,
+      summaryPath,
+      report,
+      scenarios,
+      watchUrl: lab.baseUrl,
+    } satisfies QaSuiteResult;
+  } finally {
+    if (ownsLab) {
+      await lab.stop();
+    }
+  }
 }
 
 async function writeQaSuiteArtifacts(params: {
@@ -360,6 +686,7 @@ async function writeQaSuiteArtifacts(params: {
   fastMode: boolean;
   concurrency: number;
   scenarioIds?: readonly string[];
+  runtimePair?: [RuntimeId, RuntimeId];
 }) {
   const report = renderQaMarkdownReport({
     title: "OpenClaw QA Scenario Suite",
@@ -450,6 +777,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
     ...new Set([
       ...collectQaSuitePluginIds(selectedCatalogScenarios),
       ...(params?.enabledPluginIds ?? []).map((pluginId) => pluginId.trim()).filter(Boolean),
+      ...(params?.forcedRuntime && params.forcedRuntime !== "pi" ? [params.forcedRuntime] : []),
     ]),
   ];
   const gatewayConfigPatch = collectQaSuiteGatewayConfigPatch(selectedCatalogScenarios);
@@ -464,6 +792,29 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
     progressEnabled,
     `run start: scenarios=${selectedCatalogScenarios.length} concurrency=${concurrency} transport=${transportId}`,
   );
+
+  if (params?.runtimePair) {
+    return await runQaRuntimeParitySuite({
+      repoRoot,
+      outputDir,
+      startedAt,
+      providerMode,
+      transportId,
+      primaryModel,
+      alternateModel,
+      fastMode,
+      thinkingDefault: params.thinkingDefault,
+      claudeCliAuthMode: params.claudeCliAuthMode,
+      enabledPluginIds: params.enabledPluginIds,
+      concurrency,
+      selectedCatalogScenarios,
+      startLab: params.startLab,
+      lab: params.lab,
+      progressEnabled,
+      scenarioIds: params.scenarioIds,
+      runtimePair: params.runtimePair,
+    });
+  }
 
   if (concurrency > 1 && selectedCatalogScenarios.length > 1) {
     const ownsLab = !params?.lab;
@@ -743,6 +1094,11 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
     mutateConfig: gatewayConfigPatch
       ? (cfg) => applyQaMergePatch(cfg, gatewayConfigPatch) as OpenClawConfig
       : undefined,
+    runtimeEnvPatch: buildQaRuntimeEnvPatch({
+      providerMode,
+      forcedRuntime: params?.forcedRuntime,
+      mockBaseUrl: mock?.baseUrl,
+    }),
   });
   writeQaSuiteProgress(
     progressEnabled,
@@ -840,6 +1196,19 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       });
     }
 
+    const runtimeParityCell =
+      params?.captureRuntimeParityCell &&
+      params.forcedRuntime &&
+      selectedCatalogScenarios.length === 1 &&
+      scenarios.length > 0
+        ? await captureRuntimeParityCell({
+            runtime: params.forcedRuntime,
+            gateway,
+            scenarioResult: scenarios[0],
+            wallClockMs: Math.max(1, Date.now() - startedAt.getTime()),
+            mockBaseUrl: mock?.baseUrl,
+          })
+        : undefined;
     const finishedAt = new Date();
     const metrics = buildQaSuiteRuntimeMetrics({
       startedAt,
@@ -897,6 +1266,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       report,
       scenarios,
       watchUrl: lab.baseUrl,
+      ...(runtimeParityCell ? { runtimeParityCell } : {}),
     } satisfies QaSuiteResult;
   } catch (error) {
     preserveGatewayRuntimeDir = path.join(outputDir, "artifacts", "gateway-runtime");
@@ -923,7 +1293,9 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
 }
 
 export const qaSuiteProgressTesting = {
+  buildQaRuntimeEnvPatch,
   parseQaSuiteBooleanEnv,
+  remapModelRefForForcedRuntime,
   resolveQaSuiteTransportReadyTimeoutMs,
   sanitizeQaSuiteProgressValue,
   shouldLogQaSuiteProgress,

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
+
+const ORIGINAL_BUILD_PRIVATE_QA = process.env.OPENCLAW_BUILD_PRIVATE_QA;
+const ORIGINAL_QA_FORCE_RUNTIME = process.env.OPENCLAW_QA_FORCE_RUNTIME;
+
+vi.mock("./agent-scope.js", () => ({
+  listAgentEntries: () => [],
+  resolveSessionAgentIds: () => ({ sessionAgentId: undefined }),
+}));
+
+function restoreEnv(
+  name: "OPENCLAW_BUILD_PRIVATE_QA" | "OPENCLAW_QA_FORCE_RUNTIME",
+  value: string | undefined,
+): void {
+  if (value == null) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function makeProviderRuntimeConfig(runtime: string): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.example/v1",
+          agentRuntime: { id: runtime },
+          models: [],
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+afterEach(() => {
+  restoreEnv("OPENCLAW_BUILD_PRIVATE_QA", ORIGINAL_BUILD_PRIVATE_QA);
+  restoreEnv("OPENCLAW_QA_FORCE_RUNTIME", ORIGINAL_QA_FORCE_RUNTIME);
+});
+
+describe("resolveModelRuntimePolicy", () => {
+  it("ignores the QA force-runtime override when the private QA gate is unset", () => {
+    delete process.env.OPENCLAW_BUILD_PRIVATE_QA;
+    process.env.OPENCLAW_QA_FORCE_RUNTIME = "pi";
+
+    expect(
+      resolveModelRuntimePolicy({
+        config: makeProviderRuntimeConfig("codex"),
+        provider: "openai",
+        modelId: "gpt-5.5",
+      }),
+    ).toEqual({
+      policy: { id: "codex" },
+      source: "provider",
+    });
+  });
+
+  it("respects the QA force-runtime override when the private QA gate is set", () => {
+    process.env.OPENCLAW_BUILD_PRIVATE_QA = "1";
+    process.env.OPENCLAW_QA_FORCE_RUNTIME = "pi";
+
+    expect(
+      resolveModelRuntimePolicy({
+        config: makeProviderRuntimeConfig("codex"),
+        provider: "openai",
+        modelId: "gpt-5.5",
+      }),
+    ).toEqual({
+      policy: { id: "pi" },
+      source: "model",
+    });
+  });
+
+  it("ignores invalid QA force-runtime values even when the private QA gate is set", () => {
+    process.env.OPENCLAW_BUILD_PRIVATE_QA = "1";
+    process.env.OPENCLAW_QA_FORCE_RUNTIME = "bogus";
+
+    expect(
+      resolveModelRuntimePolicy({
+        config: makeProviderRuntimeConfig("codex"),
+        provider: "openai",
+        modelId: "gpt-5.5",
+      }),
+    ).toEqual({
+      policy: { id: "codex" },
+      source: "provider",
+    });
+  });
+});

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -139,6 +139,13 @@ function resolveModelConfig(params: {
   );
 }
 
+/**
+ * Resolves the configured runtime policy for a provider/model pair.
+ *
+ * Test-only note: private QA builds may temporarily force the `pi` or `codex`
+ * runtime via `OPENCLAW_QA_FORCE_RUNTIME`, but only when
+ * `OPENCLAW_BUILD_PRIVATE_QA === "1"`.
+ */
 export function resolveModelRuntimePolicy(params: {
   config?: OpenClawConfig;
   provider?: string;
@@ -146,6 +153,15 @@ export function resolveModelRuntimePolicy(params: {
   agentId?: string;
   sessionKey?: string;
 }): ResolvedModelRuntimePolicy {
+  // Test-only QA seam for Phase 1 runtime forcing. This must remain inert
+  // outside private QA builds.
+  if (process.env.OPENCLAW_BUILD_PRIVATE_QA === "1") {
+    const forcedRuntime = process.env.OPENCLAW_QA_FORCE_RUNTIME?.trim().toLowerCase();
+    if (forcedRuntime === "pi" || forcedRuntime === "codex") {
+      return { policy: { id: forcedRuntime }, source: "model" };
+    }
+  }
+
   const agentModelPolicy = resolveAgentModelEntryRuntimePolicy(params);
   if (agentModelPolicy.policy) {
     return agentModelPolicy;


### PR DESCRIPTION
## Why

Codex is moving toward the default OpenAI runtime, but the existing release parity checks compare model behavior, not runtime behavior. That leaves a known blind spot: the same scenario and same model can pass under Pi while drifting under Codex at the tool layer.

This adds the Phase 1 runtime axis from #80172 so qa-lab can run each scenario once as `pi` and once as `codex`, capture per-runtime cells, and classify drift at the tool/result/structure/failure level instead of only reporting a session-level pass/fail.

Part of #80171.
Closes #80172.
Detected follow-up drift: #80236.

## What Changed

- Adds the private-QA-only `OPENCLAW_QA_FORCE_RUNTIME=pi|codex` override in `resolveModelRuntimePolicy`, gated by `OPENCLAW_BUILD_PRIVATE_QA=1`.
- Adds `extensions/qa-lab/src/runtime-parity.ts` with the runtime cell shape, assistant-message usage capture, provider-side mock `/debug/requests` tool capture, and six-bucket drift classifier.
- Adds `qa suite --runtime-pair pi,codex` and runtime-axis `qa parity-report --runtime-axis --summary <path>`.
- Extends suite summaries and runtime parity Markdown reporting with per-runtime cells and aggregate drift counts.
- Wires `qa_lab_runtime_parity_release_checks` into `openclaw-release-checks.yml` next to the existing model-axis parity lane.

## Real-Behavior Proof

The harness caught a real drift in `approval-turn-tool-followthrough`:

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 \
OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
OPENCLAW_QA_SUITE_PROGRESS=1 \
pnpm openclaw qa suite \
  --provider-mode mock-openai \
  --scenario approval-turn-tool-followthrough \
  --concurrency 1 \
  --runtime-pair pi,codex \
  --output-dir .artifacts/qa-e2e/runtime-parity-proof-approval-remap5
```

The suite exits nonzero because drift is present, but it writes the runtime summary. The follow-up report command:

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 \
OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
pnpm openclaw qa parity-report \
  --repo-root . \
  --runtime-axis \
  --summary .artifacts/qa-e2e/runtime-parity-proof-approval-remap5/qa-suite-summary.json \
  --output-dir .artifacts/qa-e2e/runtime-parity-proof-approval-remap5-report
```

Observed report excerpt:

```md
| Tool-result-shape drift | 1 |

- Approval turn tool followthrough drift=tool-result-shape (tool result 1 differs (read)).

pi: pass (1 tool calls, 256 tokens)
codex: fail (1 tool calls, 176 tokens)
```

The captured cells show both runtimes planned `read` with the same args hash, while Codex returned `unsupported call: read`. I filed that runtime bug as #80236 instead of hiding it in the harness PR.

## Verification

```bash
pnpm exec vitest run --config test/vitest/vitest.extension-qa.config.ts \
  extensions/qa-lab/src/runtime-parity.test.ts \
  extensions/qa-lab/src/suite.summary-json.test.ts \
  extensions/qa-lab/src/agentic-parity-report.test.ts \
  extensions/qa-lab/src/cli.runtime.test.ts \
  extensions/qa-lab/src/multipass.runtime.test.ts \
  extensions/qa-lab/src/suite.test.ts

pnpm exec vitest run --config test/vitest/vitest.agents.config.ts \
  src/agents/model-runtime-policy.test.ts

pnpm tsgo:core
pnpm tsgo:core:test
pnpm tsgo:extensions:test
pnpm check:test-types
pnpm exec oxlint --type-aware --tsconfig config/tsconfig/oxlint.json --allow eslint/no-underscore-dangle \
  extensions/qa-lab/src/runtime-parity.ts \
  extensions/qa-lab/src/runtime-parity.test.ts \
  extensions/qa-lab/src/suite.ts \
  extensions/qa-lab/src/suite.test.ts \
  extensions/qa-lab/src/suite-summary.ts \
  extensions/qa-lab/src/suite.summary-json.test.ts \
  extensions/qa-lab/src/agentic-parity-report.ts \
  extensions/qa-lab/src/agentic-parity-report.test.ts \
  extensions/qa-lab/src/cli.ts \
  extensions/qa-lab/src/cli.runtime.ts \
  extensions/qa-lab/src/cli.runtime.test.ts \
  extensions/qa-lab/src/multipass.runtime.ts \
  extensions/qa-lab/src/multipass.runtime.test.ts \
  extensions/qa-lab/src/gateway-child.ts \
  src/agents/model-runtime-policy.ts \
  src/agents/model-runtime-policy.test.ts
```

## Non-Goals

- Does not add the Phase 2 per-tool fixture set yet.
- Does not add Phase 3 Codex plugin lifecycle cells yet.
- Does not add Phase 4 token-efficiency reporting beyond capturing per-cell assistant-message usage.
- Does not add Phase 5 JSONL replay yet.
