### PR TITLE
[codex] Fix memory embedding batch limit handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory: split inline embedding batches for low-limit OpenAI-compatible providers and skip only files that still fail embedding, preventing one oversized memory file from aborting `openclaw memory index --force`. Fixes #80226. Thanks @NianJiuZst.
 - Gateway/agents: keep structured reasons when active-run queueing fails and deprecate the legacy boolean queue helper, so steering and subagent wake diagnostics distinguish completed, non-streaming, and compacting runs. Fixes #80156. Thanks @markus-lassfolk.
 - Agents/UI: compact exec and tool progress rows by hiding redundant shell tool names, replacing known workspace paths with short context markers, and preserving Discord trace scrubbing for compact command lines.
 - ACPX: run and await the embedded ACP backend startup probe by default so the gateway `ready` signal no longer fires before the acpx runtime has either become usable or reported a probe failure; set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` to restore lazy startup. Fixes #79596. Thanks @bzelones.

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -211,6 +211,8 @@ For custom OpenAI-compatible endpoints or overriding provider defaults:
 
     Changing these values affects embedding cache identity for provider batch indexing and should be followed by a memory reindex when the upstream model treats the labels differently.
 
+    OpenClaw splits inline embedding batches again if the endpoint returns a batch-length error. This keeps providers with low limits, such as `bge-large-zh` endpoints that reject batches above roughly 2,000 characters, from failing an entire `openclaw memory index --force` run. Files that still cannot be embedded after input-size retries are skipped with a warning so other memory files continue indexing.
+
   </Accordion>
   <Accordion title="Bedrock">
     ### Bedrock embedding config

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -30,6 +30,8 @@ let embedBatchCalls = 0;
 let embedBatchInputCalls = 0;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];
 let forceNoProvider = false;
+let maxBatchTextBytes: number | null = null;
+let rejectTextIncludes: string | null = null;
 
 vi.mock("./embeddings.js", () => {
   const embedText = (text: string) => {
@@ -68,6 +70,15 @@ vi.mock("./embeddings.js", () => {
           embedQuery: async (text: string) => embedText(text),
           embedBatch: async (texts: string[]) => {
             embedBatchCalls += 1;
+            if (rejectTextIncludes && texts.some((text) => text.includes(rejectTextIncludes!))) {
+              throw new Error("openai embeddings failed: 400 document rejected");
+            }
+            const totalBytes = texts.reduce((sum, text) => sum + Buffer.byteLength(text), 0);
+            if (maxBatchTextBytes !== null && totalBytes > maxBatchTextBytes) {
+              throw new Error(
+                `openai embeddings failed: 400 {"error":{"code":"invalid_argument","message":"embeddings max length per batch size is ${maxBatchTextBytes}","type":"invalid_request_error"}}`,
+              );
+            }
             return texts.map(embedText);
           },
           ...(providerId === "gemini"
@@ -191,6 +202,8 @@ describe("memory index", () => {
     embedBatchInputCalls = 0;
     providerCalls = [];
     forceNoProvider = false;
+    maxBatchTextBytes = null;
+    rejectTextIncludes = null;
 
     rmSync(workspaceDir, { recursive: true, force: true });
     mkdirSync(memoryDir, { recursive: true });
@@ -355,6 +368,65 @@ describe("memory index", () => {
     } finally {
       await manager.close?.();
     }
+  });
+
+  it("splits inline embedding batches when the provider rejects the combined batch length", async () => {
+    maxBatchTextBytes = 2000;
+    await fs.writeFile(path.join(memoryDir, "2026-01-13.md"), "Beta ".repeat(300), "utf8");
+    await fs.writeFile(path.join(memoryDir, "2026-01-14.md"), "Gamma ".repeat(300), "utf8");
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-batch-limit.sqlite"),
+      hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test", force: true });
+
+    expect(embedBatchCalls).toBeGreaterThan(1);
+    const results = await manager.search("Beta", { minScore: 0, maxResults: 5 });
+    expect(results.map((result) => result.path)).toContainEqual(
+      expect.stringMatching(/2026-01-13\.md$/),
+    );
+  });
+
+  it("skips one file after an embedding input-size failure and keeps indexing other files", async () => {
+    maxBatchTextBytes = 20;
+    await fs.writeFile(
+      path.join(memoryDir, "2026-01-13.md"),
+      "UNEMBEDDABLE content too large",
+      "utf8",
+    );
+    await fs.writeFile(path.join(memoryDir, "2026-01-14.md"), "Beta", "utf8");
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-file-skip.sqlite"),
+      hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await expect(manager.sync({ reason: "test", force: true })).resolves.toBeUndefined();
+
+    const results = await manager.search("Beta", { minScore: 0, maxResults: 5 });
+    expect(results.map((result) => result.path)).toContainEqual(
+      expect.stringMatching(/2026-01-14\.md$/),
+    );
+    const skippedResults = await manager.search("UNEMBEDDABLE", { minScore: 0, maxResults: 5 });
+    expect(skippedResults.map((result) => result.path)).not.toContainEqual(
+      expect.stringMatching(/2026-01-13\.md$/),
+    );
+  });
+
+  it("does not skip files for provider-level embedding failures", async () => {
+    rejectTextIncludes = "UNEMBEDDABLE";
+    await fs.writeFile(path.join(memoryDir, "2026-01-13.md"), "UNEMBEDDABLE content", "utf8");
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-provider-failure.sqlite"),
+    });
+    const manager = await getPersistentManager(cfg);
+
+    await expect(manager.sync({ reason: "test", force: true })).rejects.toThrow(
+      "openai embeddings failed: 400 document rejected",
+    );
   });
 
   it("indexes multimodal image and audio files from extra paths with Gemini structured inputs", async () => {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   enforceEmbeddingMaxInputTokens,
   hasNonTextEmbeddingParts,
+  resolveEmbeddingMaxInputTokens,
   type EmbeddingInput,
   type MemoryEmbeddingProviderRuntime,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
@@ -29,12 +30,13 @@ import {
   buildMemoryEmbeddingBatches,
   buildTextEmbeddingInputs,
   filterNonEmptyMemoryChunks,
+  isEmbeddingBatchTooLargeError,
   isRetryableMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
 import { deleteMemoryFtsRows } from "./manager-fts-state.js";
-import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+import { MemoryManagerSyncOps, type MemoryIndexFileFailureAction } from "./manager-sync-ops.js";
 import { logMemoryVectorDegradedWrite } from "./manager-vector-warning.js";
 import { replaceMemoryVectorRow } from "./manager-vector-write.js";
 
@@ -63,6 +65,14 @@ type MemoryIndexEntry = {
   contentText?: string;
   lineMap?: number[];
 };
+
+function splitMemoryEmbeddingBatch<T>(batch: T[]): [T[], T[]] | null {
+  if (batch.length <= 1) {
+    return null;
+  }
+  const midpoint = Math.ceil(batch.length / 2);
+  return [batch.slice(0, midpoint), batch.slice(midpoint)];
+}
 
 export function resolveEmbeddingTimeoutMs(params: {
   kind: "query" | "batch";
@@ -156,7 +166,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
 
     const missingChunks = missing.map((m) => m.chunk);
-    const batches = buildMemoryEmbeddingBatches(missingChunks, EMBEDDING_BATCH_MAX_TOKENS);
+    const batches = buildMemoryEmbeddingBatches(
+      missingChunks,
+      this.resolveInlineEmbeddingBatchMaxTokens(),
+    );
     const toCache: Array<{ hash: string; embedding: number[] }> = [];
     const provider = this.provider;
     if (!provider) {
@@ -164,16 +177,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
     let cursor = 0;
     for (const batch of batches) {
-      const inputs = buildTextEmbeddingInputs(batch);
-      const hasStructuredInputs = inputs.some((input) => hasNonTextEmbeddingParts(input));
-      if (hasStructuredInputs && !provider.embedBatchInputs) {
-        throw new Error(
-          `Embedding provider "${provider.id}" does not support multimodal memory inputs.`,
-        );
-      }
-      const batchEmbeddings = hasStructuredInputs
-        ? await this.embedBatchInputsWithRetry(inputs)
-        : await this.embedBatchWithRetry(batch.map((chunk) => chunk.text));
+      const batchEmbeddings = await this.embedMemoryChunkBatchWithAdaptiveSplit(batch);
       for (let i = 0; i < batch.length; i += 1) {
         const item = missing[cursor + i];
         const embedding = batchEmbeddings[i] ?? [];
@@ -193,6 +197,60 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       tableName: EMBEDDING_CACHE_TABLE,
     });
     return embeddings;
+  }
+
+  private resolveInlineEmbeddingBatchMaxTokens(): number {
+    if (!this.provider) {
+      return EMBEDDING_BATCH_MAX_TOKENS;
+    }
+    return Math.min(resolveEmbeddingMaxInputTokens(this.provider), EMBEDDING_BATCH_MAX_TOKENS);
+  }
+
+  private async embedMemoryChunkBatchWithAdaptiveSplit(batch: MemoryChunk[]): Promise<number[][]> {
+    if (batch.length === 0) {
+      return [];
+    }
+
+    try {
+      return await this.embedMemoryChunkBatch(batch);
+    } catch (err) {
+      const message = formatErrorMessage(err);
+      const split = splitMemoryEmbeddingBatch(batch);
+      if (!split || !isEmbeddingBatchTooLargeError(message)) {
+        throw err;
+      }
+
+      log.warn("memory embeddings: provider rejected embedding batch as too large; splitting", {
+        provider: this.provider?.id,
+        model: this.provider?.model,
+        items: batch.length,
+        error: message,
+      });
+      const [left, right] = split;
+      return [
+        ...(await this.embedMemoryChunkBatchWithAdaptiveSplit(left)),
+        ...(await this.embedMemoryChunkBatchWithAdaptiveSplit(right)),
+      ];
+    }
+  }
+
+  private async embedMemoryChunkBatch(batch: MemoryChunk[]): Promise<number[][]> {
+    const provider = this.provider;
+    if (!provider) {
+      throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");
+    }
+
+    const inputs = buildTextEmbeddingInputs(batch);
+    const hasStructuredInputs = inputs.some((input) => hasNonTextEmbeddingParts(input));
+    if (hasStructuredInputs && !provider.embedBatchInputs) {
+      throw new Error(
+        `Embedding provider "${provider.id}" does not support multimodal memory inputs.`,
+      );
+    }
+
+    return hasStructuredInputs
+      ? await this.embedBatchInputsWithRetry(inputs)
+      : await this.embedBatchWithRetry(batch.map((chunk) => chunk.text));
   }
 
   protected computeProviderKey(): string {
@@ -529,7 +587,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  private clearIndexedFileData(pathname: string, source: MemorySource): void {
+  protected resolveIndexFileFailureAction(message: string): MemoryIndexFileFailureAction {
+    return isEmbeddingBatchTooLargeError(message) ? "skip-file" : "throw";
+  }
+
+  protected clearIndexedFileData(pathname: string, source: MemorySource): void {
     if (this.vector.enabled) {
       try {
         this.db

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryEmbeddingBatches,
   filterNonEmptyMemoryChunks,
+  isEmbeddingBatchTooLargeError,
   isRetryableMemoryEmbeddingError,
   isStructuredInputTooLargeMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
@@ -118,6 +119,18 @@ describe("memory embedding policy", () => {
       ),
     ).toBe(true);
     expect(isStructuredInputTooLargeMemoryEmbeddingError("connection reset by peer")).toBe(false);
+  });
+
+  it("classifies provider batch length errors as split candidates", () => {
+    expect(
+      isEmbeddingBatchTooLargeError(
+        'openai embeddings failed: 400 {"error":{"code":"invalid_argument","message":"embeddings max length per batch size is 2000","type":"invalid_request_error"}}',
+      ),
+    ).toBe(true);
+    expect(isEmbeddingBatchTooLargeError("openai embeddings failed: 400 document rejected")).toBe(
+      false,
+    );
+    expect(isEmbeddingBatchTooLargeError("openai embeddings failed: 429 rate limit")).toBe(false);
   });
 
   it("caps retry jittered delays", () => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -92,6 +92,12 @@ export function isStructuredInputTooLargeMemoryEmbeddingError(message: string): 
   );
 }
 
+export function isEmbeddingBatchTooLargeError(message: string): boolean {
+  return /(413|payload too large|request too large|input too large|too many tokens|max(?:imum)? length|exceed(?:s|ed)?(?: .*limit)?|input limit|batch size|request size)/i.test(
+    message,
+  );
+}
+
 export function resolveMemoryEmbeddingRetryDelay(
   delayMs: number,
   randomValue: number,

--- a/extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts
@@ -11,7 +11,7 @@ import type {
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+import { MemoryManagerSyncOps, type MemoryIndexFileFailureAction } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
   path: string;
@@ -97,6 +97,12 @@ class SessionDeltaHarness extends MemoryManagerSyncOps {
   }
 
   protected pruneEmbeddingCacheIfNeeded(): void {}
+
+  protected resolveIndexFileFailureAction(): MemoryIndexFileFailureAction {
+    return "throw";
+  }
+
+  protected clearIndexedFileData(): void {}
 
   protected async indexFile(
     _entry: MemoryIndexEntry,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -60,6 +60,8 @@ import {
 } from "./manager-source-state.js";
 import { runMemoryTargetedSessionSync } from "./manager-targeted-sync.js";
 
+export type MemoryIndexFileFailureAction = "skip-file" | "throw";
+
 type MemorySyncProgressState = {
   completed: number;
   total: number;
@@ -223,6 +225,8 @@ export abstract class MemoryManagerSyncOps {
     entry: MemoryIndexEntry,
     options: { source: MemorySource; content?: string },
   ): Promise<void>;
+  protected abstract resolveIndexFileFailureAction(message: string): MemoryIndexFileFailureAction;
+  protected abstract clearIndexedFileData(pathname: string, source: MemorySource): void;
 
   protected resetVectorState(): void {
     this.vectorReady = null;
@@ -794,7 +798,19 @@ export abstract class MemoryManagerSyncOps {
         }
         return;
       }
-      await this.indexFile(entry, { source: "memory" });
+      try {
+        await this.indexFile(entry, { source: "memory" });
+      } catch (err) {
+        const message = formatErrorMessage(err);
+        if (this.resolveIndexFileFailureAction(message) !== "skip-file") {
+          throw err;
+        }
+        this.clearIndexedFileData(entry.path, "memory");
+        log.warn(`memory embeddings: skipping file after embedding failure: ${entry.path}`, {
+          source: "memory",
+          error: message,
+        });
+      }
       if (params.progress) {
         params.progress.completed += 1;
         params.progress.report({
@@ -924,7 +940,19 @@ export abstract class MemoryManagerSyncOps {
           this.resetSessionDelta(absPath, entry.size);
           return;
         }
-        await this.indexFile(entry, { source: "sessions", content: entry.content });
+        try {
+          await this.indexFile(entry, { source: "sessions", content: entry.content });
+        } catch (err) {
+          const message = formatErrorMessage(err);
+          if (this.resolveIndexFileFailureAction(message) !== "skip-file") {
+            throw err;
+          }
+          this.clearIndexedFileData(entry.path, "sessions");
+          log.warn(`memory embeddings: skipping file after embedding failure: ${entry.path}`, {
+            source: "sessions",
+            error: message,
+          });
+        }
         this.resetSessionDelta(absPath, entry.size);
         if (params.progress) {
           params.progress.completed += 1;

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -37,7 +37,7 @@ vi.mock("./embeddings.js", () => ({
   createEmbeddingProvider: vi.fn(),
 }));
 
-import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+import { MemoryManagerSyncOps, type MemoryIndexFileFailureAction } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
   path: string;
@@ -121,6 +121,12 @@ class SessionSyncYieldHarness extends MemoryManagerSyncOps {
   }
 
   protected pruneEmbeddingCacheIfNeeded(): void {}
+
+  protected resolveIndexFileFailureAction(): MemoryIndexFileFailureAction {
+    return "throw";
+  }
+
+  protected clearIndexedFileData(): void {}
 
   protected async indexFile(
     entry: MemoryIndexEntry,

--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -103,4 +103,24 @@ describe("OpenAI embedding provider", () => {
       }),
     );
   });
+
+  it("declares max input tokens for known native OpenAI embedding models", async () => {
+    const { provider } = await createOpenAiEmbeddingProvider(createOptions());
+
+    expect(provider.maxInputTokens).toBe(8192);
+  });
+
+  it("leaves unknown OpenAI-compatible embedding limits to host fallback policy", async () => {
+    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
+      baseUrl: "https://embeddings.example/v1",
+      headers: { Authorization: "Bearer test" },
+      model: "bge-large-zh",
+    });
+
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({ model: "bge-large-zh" }),
+    );
+
+    expect(provider.maxInputTokens).toBeUndefined();
+  });
 });

--- a/packages/memory-host-sdk/src/engine-embeddings.ts
+++ b/packages/memory-host-sdk/src/engine-embeddings.ts
@@ -64,6 +64,7 @@ export {
   estimateStructuredEmbeddingInputBytes,
   estimateUtf8Bytes,
 } from "./host/embedding-input-limits.js";
+export { resolveEmbeddingMaxInputTokens } from "./host/embedding-model-limits.js";
 export { hasNonTextEmbeddingParts, type EmbeddingInput } from "./host/embedding-inputs.js";
 export { buildRemoteBaseUrlPolicy, withRemoteHttpResponse } from "./host/remote-http.js";
 export {

--- a/src/plugin-sdk/memory-core-host-engine-embeddings.ts
+++ b/src/plugin-sdk/memory-core-host-engine-embeddings.ts
@@ -25,6 +25,7 @@ export {
   postJsonWithRetry,
   resolveBatchCompletionFromStatus,
   resolveCompletedBatchResult,
+  resolveEmbeddingMaxInputTokens,
   resolveRemoteEmbeddingBearerClient,
   resolveRemoteEmbeddingClient,
   runEmbeddingBatchGroups,


### PR DESCRIPTION
## Summary

- Split inline memory embedding batches again when a provider rejects the combined batch as too large.
- Skip only irreducible input-size embedding failures per file, while preserving provider-level failures as command failures.
- Document the OpenAI-compatible low-limit behavior and add regression coverage for issue #80226.

Fixes #80226.

## Verification

- pnpm test packages/memory-host-sdk/src/host/embedding-chunk-limits.test.ts extensions/memory-core/src/memory/manager-embedding-policy.test.ts extensions/memory-core/src/memory/index.test.ts extensions/openai/embedding-provider.test.ts -- --reporter=verbose
- pnpm test extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts -- --reporter=verbose
- pnpm tsgo:extensions
- pnpm tsgo:test:extensions
- pnpm tsgo:test:packages
- git diff --check
- pnpm docs:list
