### PR TITLE
fix(sessions): rotate reset transcripts and clear compaction state

### DIFF
--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -237,6 +237,72 @@ function resolvePathWithinSessionsDir(
   return path.resolve(realBase, normalized);
 }
 
+const GENERATED_UUID_SESSION_FILE_RE =
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(-topic-.+)?\.jsonl$/i;
+
+function resolveGeneratedSessionFileSuffix(
+  previousSessionId: string,
+  previousSessionFile: string,
+): string | undefined {
+  const baseName = path.basename(previousSessionFile);
+  if (baseName === `${previousSessionId}.jsonl`) {
+    return ".jsonl";
+  }
+  const topicPrefix = `${previousSessionId}-topic-`;
+  if (baseName.startsWith(topicPrefix) && baseName.endsWith(".jsonl")) {
+    return baseName.slice(previousSessionId.length);
+  }
+  const generatedUuidMatch = GENERATED_UUID_SESSION_FILE_RE.exec(baseName);
+  if (generatedUuidMatch) {
+    return `${generatedUuidMatch[2] ?? ""}.jsonl`;
+  }
+  return undefined;
+}
+
+export function resolveRotatedGeneratedSessionFilePath(params: {
+  previousSessionId: string;
+  nextSessionId: string;
+  previousSessionFile?: string;
+  sessionsDir: string;
+  agentId?: string;
+}): string | undefined {
+  const previousSessionFile = params.previousSessionFile?.trim();
+  if (!previousSessionFile || params.previousSessionId === params.nextSessionId) {
+    return undefined;
+  }
+  try {
+    resolvePathWithinSessionsDir(params.sessionsDir, previousSessionFile, {
+      agentId: params.agentId,
+    });
+  } catch {
+    if (!path.isAbsolute(previousSessionFile)) {
+      return undefined;
+    }
+    const relative = path.relative(
+      path.resolve(params.sessionsDir),
+      path.resolve(previousSessionFile),
+    );
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+      return undefined;
+    }
+  }
+  const generatedSuffix = resolveGeneratedSessionFileSuffix(
+    params.previousSessionId,
+    previousSessionFile,
+  );
+  if (!generatedSuffix) {
+    return undefined;
+  }
+  const nextFileName = `${params.nextSessionId}${generatedSuffix}`;
+  try {
+    return resolvePathWithinSessionsDir(params.sessionsDir, nextFileName, {
+      agentId: params.agentId,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveSessionTranscriptPathInDir(
   sessionId: string,
   sessionsDir: string,

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../config.js";
 import type { SessionConfig } from "../types.base.js";
 import { resolveSessionLifecycleTimestamps } from "./lifecycle.js";
 import {
+  resolveRotatedGeneratedSessionFilePath,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionTranscriptPathInDir,
@@ -39,6 +40,86 @@ describe("session path safety", () => {
     const resolved = resolveSessionTranscriptPathInDir("sess-1", sessionsDir, "topic/a+b");
 
     expect(resolved).toBe(path.resolve(sessionsDir, "sess-1-topic-topic%2Fa%2Bb.jsonl"));
+  });
+
+  it("resolves rotated generated transcript paths safely", () => {
+    withTempDirSync({ prefix: "openclaw-rotated-session-file-" }, (tmpDir) => {
+      const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      const previousSessionId = "11111111-1111-4111-8111-111111111111";
+      const nextSessionId = "22222222-2222-4222-8222-222222222222";
+      const driftedUuid = "33333333-3333-4333-8333-333333333333";
+
+      expect(
+        resolveRotatedGeneratedSessionFilePath({
+          previousSessionId,
+          nextSessionId,
+          previousSessionFile: path.join(sessionsDir, `${previousSessionId}.jsonl`),
+          sessionsDir,
+          agentId: "main",
+        }),
+      ).toBe(path.join(sessionsDir, `${nextSessionId}.jsonl`));
+
+      expect(
+        resolveRotatedGeneratedSessionFilePath({
+          previousSessionId,
+          nextSessionId,
+          previousSessionFile: path.join(sessionsDir, `${previousSessionId}-topic-ops.jsonl`),
+          sessionsDir,
+          agentId: "main",
+        }),
+      ).toBe(path.join(sessionsDir, `${nextSessionId}-topic-ops.jsonl`));
+
+      expect(
+        resolveRotatedGeneratedSessionFilePath({
+          previousSessionId,
+          nextSessionId,
+          previousSessionFile: path.join(sessionsDir, `${driftedUuid}.jsonl`),
+          sessionsDir,
+          agentId: "main",
+        }),
+      ).toBe(path.join(sessionsDir, `${nextSessionId}.jsonl`));
+
+      expect(
+        resolveRotatedGeneratedSessionFilePath({
+          previousSessionId,
+          nextSessionId,
+          previousSessionFile: path.join(sessionsDir, "custom-transcript.jsonl"),
+          sessionsDir,
+          agentId: "main",
+        }),
+      ).toBeUndefined();
+
+      expect(
+        resolveRotatedGeneratedSessionFilePath({
+          previousSessionId,
+          nextSessionId,
+          previousSessionFile: "../outside/11111111-1111-4111-8111-111111111111.jsonl",
+          sessionsDir,
+          agentId: "main",
+        }),
+      ).toBeUndefined();
+
+      expect(
+        resolveRotatedGeneratedSessionFilePath({
+          previousSessionId,
+          nextSessionId,
+          previousSessionFile: path.join(tmpDir, "outside", `${previousSessionId}.jsonl`),
+          sessionsDir,
+          agentId: "main",
+        }),
+      ).toBeUndefined();
+
+      expect(
+        resolveRotatedGeneratedSessionFilePath({
+          previousSessionId,
+          nextSessionId: previousSessionId,
+          previousSessionFile: path.join(sessionsDir, `${previousSessionId}.jsonl`),
+          sessionsDir,
+          agentId: "main",
+        }),
+      ).toBeUndefined();
+    });
   });
 
   it("falls back to derived path when sessionFile is outside known agent sessions dirs", () => {

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -53,6 +53,122 @@ test("sessions.reset recomputes model from defaults instead of stale runtime mod
   expect((await fs.stat(sessionFile)).isFile()).toBe(true);
 });
 
+test("sessions.reset rotates generated transcript path and clears compaction state", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  testState.agentConfig = {
+    model: {
+      primary: "openai/gpt-test-a",
+    },
+  };
+
+  const oldSessionId = "11111111-1111-4111-8111-111111111111";
+  const oldSessionFile = path.join(dir, `${oldSessionId}.jsonl`);
+  await fs.writeFile(
+    oldSessionFile,
+    `${JSON.stringify({ role: "user", content: "old" })}\n`,
+    "utf-8",
+  );
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(oldSessionId, {
+        sessionFile: oldSessionFile,
+        compactionCount: 7,
+        compactionCheckpoints: [
+          {
+            checkpointId: "checkpoint-1",
+            sessionKey: "agent:main:main",
+            sessionId: oldSessionId,
+            createdAt: Date.now(),
+            reason: "auto-threshold",
+            preCompaction: {
+              sessionId: "sess-before-compaction",
+              sessionFile: path.join(dir, "sess-before-compaction.jsonl"),
+            },
+            postCompaction: {
+              sessionId: oldSessionId,
+              sessionFile: oldSessionFile,
+            },
+          },
+        ],
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: {
+      sessionId: string;
+      sessionFile?: string;
+      compactionCount?: number;
+      compactionCheckpoints?: unknown[];
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  const nextSessionId = reset.payload?.entry.sessionId;
+  const nextSessionFile = reset.payload?.entry.sessionFile;
+  if (!nextSessionId || !nextSessionFile) {
+    throw new Error("expected reset session id and file");
+  }
+  expect(nextSessionId).not.toBe(oldSessionId);
+  expect(nextSessionFile).toBe(path.join(dir, `${nextSessionId}.jsonl`));
+  expect(reset.payload?.entry.compactionCount).toBe(0);
+  expect(reset.payload?.entry.compactionCheckpoints).toBeUndefined();
+  expect((await fs.stat(nextSessionFile)).isFile()).toBe(true);
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    { sessionFile?: string; compactionCount?: number; compactionCheckpoints?: unknown[] }
+  >;
+  expect(store["agent:main:main"]?.sessionFile).toBe(nextSessionFile);
+  expect(store["agent:main:main"]?.compactionCount).toBe(0);
+  expect(store["agent:main:main"]?.compactionCheckpoints).toBeUndefined();
+});
+
+test("sessions.reset preserves generated topic transcript suffix", async () => {
+  const { dir } = await createSessionStoreDir();
+  testState.agentConfig = {
+    model: {
+      primary: "openai/gpt-test-a",
+    },
+  };
+
+  const oldSessionId = "33333333-3333-4333-8333-333333333333";
+  const oldSessionFile = path.join(dir, `${oldSessionId}-topic-ops.jsonl`);
+  await fs.writeFile(
+    oldSessionFile,
+    `${JSON.stringify({ role: "user", content: "old topic" })}\n`,
+    "utf-8",
+  );
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(oldSessionId, {
+        sessionFile: oldSessionFile,
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    entry: {
+      sessionId: string;
+      sessionFile?: string;
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  const nextSessionId = reset.payload?.entry.sessionId;
+  const nextSessionFile = reset.payload?.entry.sessionFile;
+  if (!nextSessionId || !nextSessionFile) {
+    throw new Error("expected reset session id and file");
+  }
+  expect(nextSessionFile).toBe(path.join(dir, `${nextSessionId}-topic-ops.jsonl`));
+  expect((await fs.stat(nextSessionFile)).isFile()).toBe(true);
+});
+
 test("sessions.reset drops cached skills snapshot so /new rebuilds visible skills", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -21,7 +21,11 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../config/sessions.js";
-import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import {
+  resolveRotatedGeneratedSessionFilePath,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+} from "../config/sessions/paths.js";
 import { resolveResetPreservedSelection } from "../config/sessions/reset-preserved-selection.js";
 import type { SessionAcpMeta } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -558,14 +562,27 @@ export async function performGatewaySessionReset(params: {
     oldSessionFile = currentEntry?.sessionFile;
     const now = Date.now();
     const nextSessionId = randomUUID();
-    const sessionFile = resolveSessionFilePath(
-      nextSessionId,
-      currentEntry?.sessionFile ? { sessionFile: currentEntry.sessionFile } : undefined,
-      resolveSessionFilePathOptions({
-        storePath,
-        agentId: sessionAgentId,
-      }),
-    );
+    const sessionFilePathOptions = resolveSessionFilePathOptions({
+      storePath,
+      agentId: sessionAgentId,
+    });
+    const rotatedGeneratedSessionFile =
+      currentEntry?.sessionId && currentEntry?.sessionFile
+        ? resolveRotatedGeneratedSessionFilePath({
+            previousSessionId: currentEntry.sessionId,
+            nextSessionId,
+            previousSessionFile: currentEntry.sessionFile,
+            sessionsDir: path.dirname(storePath),
+            agentId: sessionAgentId,
+          })
+        : undefined;
+    const sessionFile =
+      rotatedGeneratedSessionFile ??
+      resolveSessionFilePath(
+        nextSessionId,
+        currentEntry?.sessionFile ? { sessionFile: currentEntry.sessionFile } : undefined,
+        sessionFilePathOptions,
+      );
     const nextEntry: SessionEntry = {
       sessionId: nextSessionId,
       sessionFile,
@@ -593,8 +610,8 @@ export async function performGatewaySessionReset(params: {
       model: resolvedModel.model,
       modelProvider: resolvedModel.provider,
       contextTokens: resetEntry?.contextTokens,
-      compactionCount: currentEntry?.compactionCount,
-      compactionCheckpoints: currentEntry?.compactionCheckpoints,
+      compactionCount: 0,
+      compactionCheckpoints: undefined,
       sendPolicy: currentEntry?.sendPolicy,
       queueMode: currentEntry?.queueMode,
       queueDebounceMs: currentEntry?.queueDebounceMs,


### PR DESCRIPTION
## Summary

Fix `sessions.reset` so a reset creates a fresh generated transcript path for the new session id and clears stale compaction state.

This source patch makes permanent the behavior we previously had to protect with a local installed-dist hotfix: reset should not keep pointing at an old heavy transcript/checkpoint lineage after generating a new `sessionId`.

## Problem

Before this change, `sessions.reset` generated a new `sessionId` but could preserve the old `sessionFile`, `compactionCount`, and `compactionCheckpoints`. In practice that can make a reset session continue to inherit old heavy transcript/checkpoint state, defeating the reset and risking immediate context/compaction failures on the next turn.

## Changes

- Add `resolveRotatedGeneratedSessionFilePath(...)` for safe generated transcript rotation.
- Rotate generated UUID transcript names from `<oldSessionId>.jsonl` to `<newSessionId>.jsonl`.
- Preserve generated topic suffixes, e.g. `<oldSessionId>-topic-ops.jsonl` → `<newSessionId>-topic-ops.jsonl`.
- Preserve custom/non-generated session file behavior by falling back to the existing `resolveSessionFilePath(...)` path.
- Clear reset compaction state with `compactionCount: 0` and `compactionCheckpoints` left undefined (omitted when serialized).
- Add regression coverage for helper behavior, topic transcript rotation, compaction cleanup, and custom transcript preservation.


## Real behavior proof

- **Behavior or issue addressed:** `sessions.reset` should not keep a reset session attached to an old heavy transcript file or stale compaction checkpoint lineage after generating a new `sessionId`.
- **Real environment tested:** Mac mini, Darwin 25.4.0 arm64, live OpenClaw 2026.5.7 installation plus isolated source worktree `goran/session-reset-sourcefix-20260510`.
- **Exact steps or command run after fix:** Live installed runtime was verified with OpenClaw system-test L2 and the session reset guard; the source patch was then verified in an isolated worktree with targeted reset/session tests. No live install from this PR branch was performed.
- **Evidence after fix:** Copied terminal output from the real Mac mini setup:

```text
$ python3 skills/system-test/scripts/system_test.py --level L2 --json
session_reset_guard: pass — guard markers present in 1 dist file(s)
active_session_model_route_divergence: pass — recent active sessions match configured primary models
memory_embedding_coverage: pass — missing embeddings 0
openclaw_docs_index_freshness: pass — docs index fresh
summary: 45 passed, 0 failed, 0 warnings

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/sessions/sessions.test.ts
runtime-config src/config/sessions/sessions.test.ts: 29 tests passed

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.sessions.reset-models.test.ts src/gateway/server.sessions.reset-hooks.test.ts src/gateway/server.sessions.compaction.test.ts src/gateway/session-utils.fs.test.ts
gateway targeted reset/compaction/session-utils suite: 4 files passed, 101 tests passed
```

- **Observed result after fix:** The live OpenClaw setup is stable with the equivalent reset-rotation/checkpoint-clearing behavior guarded at L1/L2, and the source patch reproduces that behavior with regression coverage for generated UUID transcripts, topic transcript suffixes, drifted UUID basenames, custom transcript preservation, escape rejection, and compaction cleanup.
- **What was not tested:** This PR branch was not installed into the live runtime; live runtime remains protected by the existing guarded installed-dist hotfix until a separate release/update integration gate.

## Tests

- `corepack pnpm exec oxfmt --check --threads=1 src/config/sessions/paths.ts src/config/sessions/sessions.test.ts src/gateway/session-reset-service.ts src/gateway/server.sessions.reset-models.test.ts`
- `corepack pnpm exec oxlint src/config/sessions/paths.ts src/config/sessions/sessions.test.ts src/gateway/session-reset-service.ts src/gateway/server.sessions.reset-models.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/sessions/sessions.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.sessions.reset-models.test.ts src/gateway/server.sessions.reset-hooks.test.ts src/gateway/server.sessions.compaction.test.ts src/gateway/session-utils.fs.test.ts`

## Review evidence

A local Claude Opus/Max read-only review first returned `APPROVE_WITH_CHANGES` because helper/topic/custom-path test coverage was incomplete. After adding those tests, the final Claude review returned `APPROVE` with no remaining blocker.

## Notes

- This is source-only; no live runtime install is included in this PR.
- Existing custom session file behavior is intentionally preserved.
- The helper treats UUID-shaped drifted basenames as generated, which is intentional for first reset after a previous stale session-file bug.
