### PR TITLE
fix(active-memory): isolate recall lane

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -413,6 +413,20 @@ describe("active-memory plugin", () => {
     expect(lastEmbeddedRunParams().authProfileFailurePolicy).toBe("local");
   });
 
+  it("runs recall on a dedicated active-memory lane", async () => {
+    await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    expect(lastEmbeddedRunParams().lane).toBe("active-memory");
+  });
+
   it("registers a session-scoped active-memory toggle command", async () => {
     const command = registeredCommands["active-memory"];
     const sessionKey = "agent:main:active-memory-toggle";

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -44,6 +44,7 @@ const DEFAULT_SETUP_GRACE_TIMEOUT_MS = 0;
 const DEFAULT_QUERY_MODE = "recent" as const;
 const DEFAULT_QMD_SEARCH_MODE = "search" as const;
 const DEFAULT_TRANSCRIPT_DIR = "active-memory";
+const ACTIVE_MEMORY_RECALL_LANE = "active-memory";
 const DEFAULT_CIRCUIT_BREAKER_MAX_TIMEOUTS = 3;
 const DEFAULT_CIRCUIT_BREAKER_COOLDOWN_MS = 60_000;
 const DEFAULT_ACTIVE_MEMORY_TOOLS_ALLOW = ["memory_search", "memory_get"] as const;
@@ -2540,6 +2541,7 @@ async function runRecallSubagent(params: {
       prompt,
       provider: modelRef.provider,
       model: modelRef.model,
+      lane: ACTIVE_MEMORY_RECALL_LANE,
       timeoutMs: embeddedTimeoutMs,
       runId: subagentSessionId,
       trigger: "manual",


### PR DESCRIPTION
## Summary

Active Memory recall could block itself during prompt building.
The parent reply and the recall subagent could use the same queue lane, so recall waited behind the work that was waiting for recall.
This change puts recall on its own `active-memory` lane and adds a regression test for that call.

Fixes #79026.
Related: #72015.

## What Changed

The runtime change is intentionally small.
Recall still runs during `before_prompt_build`; it just no longer competes with the parent session lane.

- Added a named `active-memory` recall lane.
- Passed that lane to `runEmbeddedAgent` for Active Memory recall.
- Added a test that asserts the embedded recall call includes `lane: "active-memory"`.

## Real behavior proof

Behavior addressed: Active Memory recall no longer shares the parent main lane during prompt-build recall.

Real environment tested: Fresh local macOS smoke from the cleaned PR branch. It used `pnpm gateway:dev`, `OPENCLAW_SKIP_CHANNELS=1`, Active Memory enabled, Memory Core enabled, and `scripts/e2e/mock-openai-server.mjs` as a local OpenAI-compatible loopback model endpoint.

Exact steps or command run after this patch: Created an isolated `OPENCLAW_HOME`, wrote a temporary config with `gateway.http.endpoints.chatCompletions.enabled=true`, started the loopback model server, started the local dev gateway, then sent a real webchat turn through `POST /v1/chat/completions` with session `agent:main:direct:proof-80255-fresh`.

Evidence after fix: Runtime output from the fresh smoke:

```text
verdict=pass
environment=local macOS OpenClaw dev gateway + loopback OpenAI-compatible model
gatewayPort=19817
modelPort=20817
readyStatus=200
httpStatus=200
elapsedMs=651
assistant_reply=OPENCLAW_E2E_OK_80255_FRESH
mockRequestCount=2
2026-05-29T20:52:12.721+08:00 [plugins] active-memory: agent=main session=agent:main:direct:proof-80255-fresh activeProvider=loopback activeModel=loopback-chat start timeoutMs=30000 queryChars=42 searchQueryChars=42
2026-05-29T20:52:12.928+08:00 [plugins] active-memory: agent=main session=agent:main:direct:proof-80255-fresh activeProvider=loopback activeModel=loopback-chat done status=ok elapsedMs=209 summaryChars=27
```

Observed result after fix: The gateway returned HTTP 200 with `OPENCLAW_E2E_OK_80255_FRESH`. Active Memory logged `start` and `done status=ok` during the turn, finishing recall in 209ms with no prompt-build timeout.

What was not tested: This smoke did not use a hosted external model provider or a real channel app such as Telegram/Discord. An AWS Crabbox focused rerun was attempted earlier, but the box lost network/DNS/SSH during the run (`run_f1a17d6fa03a`, lease `cbx_d5bb40661343`), so it was not counted as passing proof.

## Testing

Focused local validation passed after the cleanup.

```bash
git diff --check
node scripts/run-vitest.mjs extensions/active-memory/index.test.ts -t "runs recall on a dedicated active-memory lane"
```

Fresh local smoke also passed as described above.

## Risks

Risk is low because this only changes the queue lane for Active Memory's embedded recall subagent.
It does not change memory search behavior, provider selection, channel delivery, or plugin defaults.
