### PR TITLE
fix: clear cross-run messaging-tool sent-text state after every compaction

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
@@ -36,6 +36,10 @@ function createCompactionContext(params: {
     state: {
       compactionInFlight: true,
       pendingCompactionRetry: 0,
+      messagingToolSentTexts: [],
+      messagingToolSentTextsNormalized: [],
+      messagingToolSentTargets: [],
+      messagingToolSentMediaUrls: [],
     } as never,
     log: {
       debug: vi.fn(),

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
@@ -34,6 +34,10 @@ function createCompactionContext(params: {
     state: {
       compactionInFlight: true,
       pendingCompactionRetry: 0,
+      messagingToolSentTexts: [],
+      messagingToolSentTextsNormalized: [],
+      messagingToolSentTargets: [],
+      messagingToolSentMediaUrls: [],
     } as never,
     log: {
       debug: vi.fn(),

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -81,6 +81,16 @@ export function handleCompactionEnd(ctx: EmbeddedPiSubscribeContext, evt: Compac
   const reason = normalizeCompactionReason(evt.reason);
   const kind = compactionLogKind(reason);
   ctx.state.compactionInFlight = false;
+  // After every compaction (retry or not), discard messaging-tool sent-text
+  // tracking from the completed run.  Without this, stale entries survive
+  // into the next run and cause `isMessagingToolDuplicateNormalized` to
+  // false-positive on block-reply dedup — silently dropping legitimate
+  // final replies when a previous run called `message(action=send)` or
+  // `sessions_send` and the new text shares a normalized substring.
+  ctx.state.messagingToolSentTexts.length = 0;
+  ctx.state.messagingToolSentTextsNormalized.length = 0;
+  ctx.state.messagingToolSentTargets.length = 0;
+  ctx.state.messagingToolSentMediaUrls.length = 0;
   const willRetry = Boolean(evt.willRetry);
   // Increment counter whenever compaction actually produced a result,
   // regardless of willRetry.  Overflow-triggered compaction sets willRetry=true

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -44,6 +44,16 @@ export function handleCompactionEnd(
   evt: AgentEvent & { willRetry?: unknown; result?: unknown; aborted?: unknown },
 ) {
   ctx.state.compactionInFlight = false;
+  // After every compaction (retry or not), discard messaging-tool sent-text
+  // tracking from the completed run.  Without this, stale entries survive
+  // into the next run and cause `isMessagingToolDuplicateNormalized` to
+  // false-positive on block-reply dedup — silently dropping legitimate
+  // final replies when a previous run called `message(action=send)` or
+  // `sessions_send` and the new text shares a normalized substring.
+  ctx.state.messagingToolSentTexts.length = 0;
+  ctx.state.messagingToolSentTextsNormalized.length = 0;
+  ctx.state.messagingToolSentTargets.length = 0;
+  ctx.state.messagingToolSentMediaUrls.length = 0;
   const willRetry = Boolean(evt.willRetry);
   // Increment counter whenever compaction actually produced a result,
   // regardless of willRetry.  Overflow-triggered compaction sets willRetry=true


### PR DESCRIPTION
## Problem

When a run completes and the session compacts, the arrays tracking texts sent via messaging tools (`message(action=send)`, `sessions_send`, etc.) were only cleared on compaction retries (`willRetry=true`). On normal compaction (`willRetry=false`), stale entries survived into the next run.

`isMessagingToolDuplicateNormalized()` compares the final reply text against these stale entries using substring matching (`normalized.includes(normalizedSent)`). If the new run's text happens to share a normalized substring with any entry from the previous run, the block reply is silently dropped with:

> Skipping message_end block reply - already sent via messaging tool

## Fix

Clear `messagingToolSentTexts`, `messagingToolSentTextsNormalized`, `messagingToolSentTargets`, and `messagingToolSentMediaUrls` unconditionally in the `compaction_end` handler — before the `willRetry` branch — so the next run always starts with a clean slate.

## Verification

- Relevant tests pass (6/6) in `pi-embedded-subscribe.handlers.compaction.test.ts` (updated fixture)
- No logic change to `emitBlockChunk`, `handleMessageEnd`, or the dedup function itself — change is purely about state lifecycle between runs