### PR TITLE
[Fix] Throttle agent event fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Docs: https://docs.openclaw.ai
 - Plugins doctor: report stale plugin config warnings and avoid claiming full plugin health when config warnings remain. (#81515) Thanks @BKF-Gitty.
 - Sessions: display `model: "<agentId>-acp"` / `modelProvider: "acpx"` (ACP-runtime sentinel) for ACP control-plane sessions in `openclaw sessions` output, instead of the agent's configured model which was misleading. Catalog finding 20. (#79543)
 - Slack: normalize message read `before` and `after` timestamp bounds before calling Slack history or thread reply APIs. Fixes #80835. (#81338) Thanks @honor2030.
+- Gateway: throttle assistant/thinking agent event fanout during streaming bursts without dropping buffered deltas. (#80335) Thanks @samzong.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,6 +491,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: omit generated command highlights for non-POSIX Windows and shell-wrapper approval commands until those command languages have native highlighting support. (#80566) Thanks @jesse-merhi.
 - Telegram: keep verbose tool progress and result drafts separate from the final assistant answer so tool output no longer blends into the final Telegram message. (#80294) Thanks @jalehman.
 - Plugin SDK/Windows: enable the native require fast path for root `openclaw/plugin-sdk` dist aliases instead of forcing Jiti transforms. (#80878) Thanks @medns.
+- Gateway: throttle high-volume assistant and thinking agent event fanout without dropping buffered stream deltas, and clear pending throttle state when runs abort. (#80335) Thanks @samzong.
 
 ## 2026.5.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,7 +491,6 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: omit generated command highlights for non-POSIX Windows and shell-wrapper approval commands until those command languages have native highlighting support. (#80566) Thanks @jesse-merhi.
 - Telegram: keep verbose tool progress and result drafts separate from the final assistant answer so tool output no longer blends into the final Telegram message. (#80294) Thanks @jalehman.
 - Plugin SDK/Windows: enable the native require fast path for root `openclaw/plugin-sdk` dist aliases instead of forcing Jiti transforms. (#80878) Thanks @medns.
-- Gateway: throttle high-volume assistant and thinking agent event fanout without dropping buffered stream deltas, and clear pending throttle state when runs abort. (#80335) Thanks @samzong.
 
 ## 2026.5.9
 

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -285,12 +285,12 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
-  it("does not insert delivery mirrors between assistant tool calls and results", async () => {
+  it("keeps delivery mirrors in transcripts while repair preserves real tool results", async () => {
     writeTranscriptStore();
     const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
     const toolCallId = "call_maniple_list";
 
-    await appendSessionTranscriptMessage({
+    const toolCallResult = await appendSessionTranscriptMessage({
       transcriptPath: sessionFile,
       message: {
         role: "assistant",
@@ -316,8 +316,11 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     if (!mirrorResult.ok) {
       return;
     }
+    expect(mirrorResult.messageId).not.toBe(toolCallResult.messageId);
     const linesAfterMirror = fs.readFileSync(sessionFile, "utf-8").trim().split("\n");
-    expect(linesAfterMirror).toHaveLength(2);
+    expect(linesAfterMirror).toHaveLength(3);
+    const mirrorLine = JSON.parse(linesAfterMirror[2]);
+    expect(mirrorLine.message.model).toBe("delivery-mirror");
 
     await appendSessionTranscriptMessage({
       transcriptPath: sessionFile,
@@ -336,12 +339,22 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as { message?: TranscriptRepairMessage })
       .flatMap((entry) => (entry.message ? [entry.message] : []));
+    expect(messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "assistant",
+      "toolResult",
+    ]);
     const repair = repairToolUseResultPairing(messages, {
       missingToolResultText: "aborted",
     });
 
     expect(repair.added).toHaveLength(0);
-    expect(repair.messages.map((message) => message.role)).toEqual(["assistant", "toolResult"]);
+    expect(repair.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    expect((repair.messages[2] as { model?: string }).model).toBe("delivery-mirror");
   });
 
   it("finds session entry using normalized (lowercased) key", async () => {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
+import { repairToolUseResultPairing } from "../../agents/session-transcript-repair.js";
 import * as transcriptEvents from "../../sessions/transcript-events.js";
 import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { resolveSessionTranscriptPathInDir } from "./paths.js";
@@ -281,6 +283,65 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       expect(messageLine.message.model).toBe("delivery-mirror");
       expect(messageLine.message.content[0].text).toBe("Repeated answer");
     }
+  });
+
+  it("does not insert delivery mirrors between assistant tool calls and results", async () => {
+    writeTranscriptStore();
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    const toolCallId = "call_maniple_list";
+
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: toolCallId,
+            name: "maniple__list_workers",
+            arguments: {},
+          },
+        ],
+        stopReason: "toolUse",
+      },
+    });
+
+    const mirrorResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Maniple List Workers",
+      storePath: fixture.storePath(),
+    });
+
+    expect(mirrorResult.ok).toBe(true);
+    if (!mirrorResult.ok) {
+      return;
+    }
+    const linesAfterMirror = fs.readFileSync(sessionFile, "utf-8").trim().split("\n");
+    expect(linesAfterMirror).toHaveLength(2);
+
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        role: "toolResult",
+        toolCallId,
+        toolName: "maniple__list_workers",
+        content: [{ type: "text", text: "workers listed" }],
+        isError: false,
+      },
+    });
+
+    const messages = fs
+      .readFileSync(sessionFile, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { message?: AgentMessage })
+      .flatMap((entry) => (entry.message ? [entry.message] : []));
+    const repair = repairToolUseResultPairing(messages, {
+      missingToolResultText: "aborted",
+    });
+
+    expect(repair.added).toHaveLength(0);
+    expect(repair.messages.map((message) => message.role)).toEqual(["assistant", "toolResult"]);
   });
 
   it("finds session entry using normalized (lowercased) key", async () => {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 import { repairToolUseResultPairing } from "../../agents/session-transcript-repair.js";
 import * as transcriptEvents from "../../sessions/transcript-events.js";
@@ -20,6 +19,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
   type ExactAssistantMessage = Parameters<
     typeof appendExactAssistantMessageToSessionTranscript
   >[0]["message"];
+  type TranscriptRepairMessage = Parameters<typeof repairToolUseResultPairing>[0][number];
   type TranscriptUpdateEmitterSpy = {
     mock: {
       calls: [string | SessionTranscriptUpdate][];
@@ -334,7 +334,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       .readFileSync(sessionFile, "utf-8")
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as { message?: AgentMessage })
+      .map((line) => JSON.parse(line) as { message?: TranscriptRepairMessage })
       .flatMap((entry) => (entry.message ? [entry.message] : []));
     const repair = repairToolUseResultPairing(messages, {
       missingToolResultText: "aborted",

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -302,6 +302,12 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   if (latestEquivalentAssistantId) {
     return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
   }
+  const tailToolCallAssistantId = isRedundantDeliveryMirror(params.message)
+    ? await findTailAssistantToolCallMessageId(sessionFile)
+    : undefined;
+  if (tailToolCallAssistantId) {
+    return { ok: true, sessionFile, messageId: tailToolCallAssistantId };
+  }
 
   const message = {
     ...params.message,
@@ -359,6 +365,67 @@ async function transcriptHasIdempotencyKey(
 
 function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
   return message.provider === "openclaw" && message.model === "delivery-mirror";
+}
+
+function isAssistantToolCallContentBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return (
+    type === "toolCall" ||
+    type === "toolUse" ||
+    type === "functionCall" ||
+    type === "tool_call" ||
+    type === "tool_use" ||
+    type === "function_call"
+  );
+}
+
+function assistantMessageHasToolCall(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const candidate = message as { role?: unknown; content?: unknown };
+  return (
+    candidate.role === "assistant" &&
+    Array.isArray(candidate.content) &&
+    candidate.content.some(isAssistantToolCallContentBlock)
+  );
+}
+
+async function findTailAssistantToolCallMessageId(
+  transcriptPath: string,
+): Promise<string | undefined> {
+  // Delivery mirrors are UI-only assistant rows. If they are appended as the
+  // child of a tool-call turn before the real tool result lands, raw transcript
+  // assemblers can mistake the pair for missing/corrupt tool output.
+  try {
+    const raw = await fs.promises.readFile(transcriptPath, "utf-8");
+    for (const line of raw.split(/\r?\n/).toReversed()) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line) as {
+          type?: unknown;
+          id?: unknown;
+          message?: unknown;
+        };
+        if (parsed.type !== "message") {
+          continue;
+        }
+        return assistantMessageHasToolCall(parsed.message) && typeof parsed.id === "string"
+          ? parsed.id
+          : undefined;
+      } catch {
+        return undefined;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
 }
 
 function extractAssistantMessageText(message: SessionTranscriptAssistantMessage): string | null {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -302,13 +302,6 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   if (latestEquivalentAssistantId) {
     return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
   }
-  const tailToolCallAssistantId = isRedundantDeliveryMirror(params.message)
-    ? await findTailAssistantToolCallMessageId(sessionFile)
-    : undefined;
-  if (tailToolCallAssistantId) {
-    return { ok: true, sessionFile, messageId: tailToolCallAssistantId };
-  }
-
   const message = {
     ...params.message,
     ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
@@ -365,67 +358,6 @@ async function transcriptHasIdempotencyKey(
 
 function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
   return message.provider === "openclaw" && message.model === "delivery-mirror";
-}
-
-function isAssistantToolCallContentBlock(block: unknown): boolean {
-  if (!block || typeof block !== "object") {
-    return false;
-  }
-  const type = (block as { type?: unknown }).type;
-  return (
-    type === "toolCall" ||
-    type === "toolUse" ||
-    type === "functionCall" ||
-    type === "tool_call" ||
-    type === "tool_use" ||
-    type === "function_call"
-  );
-}
-
-function assistantMessageHasToolCall(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const candidate = message as { role?: unknown; content?: unknown };
-  return (
-    candidate.role === "assistant" &&
-    Array.isArray(candidate.content) &&
-    candidate.content.some(isAssistantToolCallContentBlock)
-  );
-}
-
-async function findTailAssistantToolCallMessageId(
-  transcriptPath: string,
-): Promise<string | undefined> {
-  // Delivery mirrors are UI-only assistant rows. If they are appended as the
-  // child of a tool-call turn before the real tool result lands, raw transcript
-  // assemblers can mistake the pair for missing/corrupt tool output.
-  try {
-    const raw = await fs.promises.readFile(transcriptPath, "utf-8");
-    for (const line of raw.split(/\r?\n/).toReversed()) {
-      if (!line.trim()) {
-        continue;
-      }
-      try {
-        const parsed = JSON.parse(line) as {
-          type?: unknown;
-          id?: unknown;
-          message?: unknown;
-        };
-        if (parsed.type !== "message") {
-          continue;
-        }
-        return assistantMessageHasToolCall(parsed.message) && typeof parsed.id === "string"
-          ? parsed.id
-          : undefined;
-      } catch {
-        return undefined;
-      }
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
 }
 
 function extractAssistantMessageText(message: SessionTranscriptAssistantMessage): string | null {

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -54,6 +54,21 @@ function createOps(params: {
     chatDeltaSentAt: new Map([[runId, Date.now()]]),
     chatDeltaLastBroadcastLen: new Map([[runId, buffer?.length ?? 0]]),
     chatDeltaLastBroadcastText: new Map(buffer !== undefined ? [[runId, buffer]] : []),
+    agentDeltaSentAt: new Map([[`${runId}:assistant`, Date.now()]]),
+    bufferedAgentEvents: new Map([
+      [
+        `${runId}:assistant`,
+        {
+          payload: {
+            runId,
+            seq: 1,
+            stream: "assistant",
+            ts: Date.now(),
+            data: { text: "buffer", delta: "buffer" },
+          },
+        },
+      ],
+    ]),
     chatAbortedRuns: new Map(),
     removeChatRun,
     agentRunSeq: new Map(),
@@ -110,6 +125,8 @@ describe("abortChatRunById", () => {
     expect(ops.chatDeltaSentAt.has(runId)).toBe(false);
     expect(ops.chatDeltaLastBroadcastLen.has(runId)).toBe(false);
     expect(ops.chatDeltaLastBroadcastText.has(runId)).toBe(false);
+    expect(ops.agentDeltaSentAt?.has(`${runId}:assistant`)).toBe(false);
+    expect(ops.bufferedAgentEvents?.has(`${runId}:assistant`)).toBe(false);
     expect(ops.removeChatRun).toHaveBeenCalledWith(runId, runId, sessionKey);
     expect(ops.agentRunSeq.has(runId)).toBe(false);
     expect(ops.agentRunSeq.has("client-run-1")).toBe(false);

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -1,5 +1,6 @@
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import type { BufferedAgentEvent } from "./server-chat-state.js";
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
 
@@ -113,6 +114,8 @@ export type ChatAbortOps = {
   chatDeltaSentAt: Map<string, number>;
   chatDeltaLastBroadcastLen: Map<string, number>;
   chatDeltaLastBroadcastText: Map<string, string>;
+  agentDeltaSentAt: Map<string, number>;
+  bufferedAgentEvents: Map<string, BufferedAgentEvent>;
   chatAbortedRuns: Map<string, number>;
   removeChatRun: (
     sessionId: string,
@@ -178,6 +181,12 @@ export function abortChatRunById(
   ops.chatDeltaSentAt.delete(runId);
   ops.chatDeltaLastBroadcastLen.delete(runId);
   ops.chatDeltaLastBroadcastText.delete(runId);
+  ops.agentDeltaSentAt.delete(runId);
+  ops.agentDeltaSentAt.delete(`${runId}:assistant`);
+  ops.agentDeltaSentAt.delete(`${runId}:thinking`);
+  ops.bufferedAgentEvents.delete(runId);
+  ops.bufferedAgentEvents.delete(`${runId}:assistant`);
+  ops.bufferedAgentEvents.delete(`${runId}:thinking`);
   const removed = ops.removeChatRun(runId, runId, sessionKey);
   broadcastChatAborted(ops, { runId, sessionKey, stopReason, partialText });
   emitAgentEvent({

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -1,6 +1,13 @@
+import type { AgentEventPayload } from "../infra/agent-events.js";
+
 export type ChatRunEntry = {
   sessionKey: string;
   clientRunId: string;
+};
+
+export type BufferedAgentEvent = {
+  sessionKey?: string;
+  payload: AgentEventPayload & { spawnedBy?: string };
 };
 
 export type ChatRunRegistry = {
@@ -71,6 +78,8 @@ export type ChatRunState = {
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
   deltaLastBroadcastText: Map<string, string>;
+  agentDeltaSentAt: Map<string, number>;
+  bufferedAgentEvents: Map<string, BufferedAgentEvent>;
   abortedRuns: Map<string, number>;
   clear: () => void;
 };
@@ -82,6 +91,8 @@ export function createChatRunState(): ChatRunState {
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
   const deltaLastBroadcastText = new Map<string, string>();
+  const agentDeltaSentAt = new Map<string, number>();
+  const bufferedAgentEvents = new Map<string, BufferedAgentEvent>();
   const abortedRuns = new Map<string, number>();
 
   const clear = () => {
@@ -91,6 +102,8 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
     deltaLastBroadcastText.clear();
+    agentDeltaSentAt.clear();
+    bufferedAgentEvents.clear();
     abortedRuns.clear();
   };
 
@@ -101,6 +114,8 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt,
     deltaLastBroadcastLen,
     deltaLastBroadcastText,
+    agentDeltaSentAt,
+    bufferedAgentEvents,
     abortedRuns,
     clear,
   };

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -528,6 +528,51 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it("flushes older cross-stream agent deltas before immediate text", () => {
+    let now = 23_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-agent-cross-stream", {
+      sessionKey: "session-agent-cross-stream",
+      clientRunId: "client-agent-cross-stream",
+    });
+
+    handler({
+      runId: "run-agent-cross-stream",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Think", delta: "Think" },
+    });
+    now = 23_050;
+    handler({
+      runId: "run-agent-cross-stream",
+      seq: 2,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Thinking", delta: "ing" },
+    });
+    now = 23_080;
+    handler({
+      runId: "run-agent-cross-stream",
+      seq: 3,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Answer", delta: "Answer" },
+    });
+
+    const agentCalls = agentBroadcastCalls(broadcast);
+    expect(agentCalls.map(([, payload]) => (payload as { seq?: number }).seq)).toEqual([1, 2, 3]);
+    expect(agentCalls.map(([, payload]) => (payload as { stream?: string }).stream)).toEqual([
+      "thinking",
+      "thinking",
+      "assistant",
+    ]);
+    expect((agentCalls[1]?.[1] as { data?: { delta?: string } }).data?.delta).toBe("ing");
+    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(3);
+    nowSpy.mockRestore();
+  });
+
   it("does not let lifecycle start throttle the first assistant agent event", () => {
     let now = 25_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -141,8 +141,16 @@ describe("agent event handler", () => {
     return broadcast.mock.calls.filter(([event]) => event === "chat");
   }
 
+  function agentBroadcastCalls(broadcast: ReturnType<typeof vi.fn>) {
+    return broadcast.mock.calls.filter(([event]) => event === "agent");
+  }
+
   function sessionChatCalls(nodeSendToSession: ReturnType<typeof vi.fn>) {
     return nodeSendToSession.mock.calls.filter(([, event]) => event === "chat");
+  }
+
+  function sessionAgentCalls(nodeSendToSession: ReturnType<typeof vi.fn>) {
+    return nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
   }
 
   function requireCall<T>(call: T | undefined, label: string): T {
@@ -391,6 +399,255 @@ describe("agent event handler", () => {
     expect(payload.message?.content?.[0]?.text).toBe("Hello world");
     expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
     nowSpy?.mockRestore();
+  });
+
+  it("coalesces assistant agent events under the chat delta throttle", () => {
+    let now = 10_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-agent-throttle", {
+      sessionKey: "session-agent-throttle",
+      clientRunId: "client-agent-throttle",
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      now = 10_000 + i * 20;
+      handler({
+        runId: "run-agent-throttle",
+        seq: i + 1,
+        stream: "assistant",
+        ts: Date.now(),
+        data: { text: "x".repeat(i + 1), delta: "x" },
+      });
+    }
+
+    const agentCalls = agentBroadcastCalls(broadcast);
+    expect(agentCalls).toHaveLength(1);
+    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(1);
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    expect((agentCalls[0]?.[1] as { data?: { text?: string } }).data?.text).toBe("x");
+    nowSpy.mockRestore();
+  });
+
+  it("flushes coalesced assistant agent text before lifecycle end", () => {
+    let now = 20_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-agent-flush", {
+      sessionKey: "session-agent-flush",
+      clientRunId: "client-agent-flush",
+    });
+
+    handler({
+      runId: "run-agent-flush",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello", delta: "Hello" },
+    });
+    now = 20_050;
+    handler({
+      runId: "run-agent-flush",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world", delta: " world" },
+    });
+    now = 20_090;
+    handler({
+      runId: "run-agent-flush",
+      seq: 3,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world!", delta: "!" },
+    });
+    handler({
+      runId: "run-agent-flush",
+      seq: 4,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "end" },
+    });
+
+    const agentCalls = agentBroadcastCalls(broadcast);
+    expect(agentCalls).toHaveLength(3);
+    expect((agentCalls[0]?.[1] as { data?: { text?: string } }).data?.text).toBe("Hello");
+    expect((agentCalls[1]?.[1] as { data?: { delta?: string } }).data?.delta).toBe(" world!");
+    expect((agentCalls[1]?.[1] as { data?: { text?: string } }).data?.text).toBe("Hello world!");
+    expect((agentCalls[1]?.[1] as { seq?: number }).seq).toBe(3);
+    expect((agentCalls[2]?.[1] as { stream?: string; data?: { phase?: string } }).stream).toBe(
+      "lifecycle",
+    );
+    expect((agentCalls[2]?.[1] as { data?: { phase?: string } }).data?.phase).toBe("end");
+    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(3);
+    nowSpy.mockRestore();
+  });
+
+  it("flushes pending assistant agent deltas before post-window text", () => {
+    let now = 22_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-agent-window", {
+      sessionKey: "session-agent-window",
+      clientRunId: "client-agent-window",
+    });
+
+    handler({
+      runId: "run-agent-window",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hel", delta: "Hel" },
+    });
+    now = 22_050;
+    handler({
+      runId: "run-agent-window",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello", delta: "lo" },
+    });
+    now = 22_200;
+    handler({
+      runId: "run-agent-window",
+      seq: 3,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello!", delta: "!" },
+    });
+
+    const agentCalls = agentBroadcastCalls(broadcast);
+    expect(agentCalls).toHaveLength(3);
+    expect((agentCalls[0]?.[1] as { data?: { delta?: string } }).data?.delta).toBe("Hel");
+    expect((agentCalls[1]?.[1] as { data?: { delta?: string } }).data?.delta).toBe("lo");
+    expect((agentCalls[1]?.[1] as { seq?: number }).seq).toBe(2);
+    expect((agentCalls[2]?.[1] as { data?: { delta?: string } }).data?.delta).toBe("!");
+    expect((agentCalls[2]?.[1] as { seq?: number }).seq).toBe(3);
+    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(3);
+    nowSpy.mockRestore();
+  });
+
+  it("does not let lifecycle start throttle the first assistant agent event", () => {
+    let now = 25_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-agent-start", {
+      sessionKey: "session-agent-start",
+      clientRunId: "client-agent-start",
+    });
+
+    handler({
+      runId: "run-agent-start",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "start" },
+    });
+    now = 25_050;
+    handler({
+      runId: "run-agent-start",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello", delta: "Hello" },
+    });
+
+    const agentCalls = agentBroadcastCalls(broadcast);
+    expect(agentCalls).toHaveLength(2);
+    expect((agentCalls[0]?.[1] as { stream?: string }).stream).toBe("lifecycle");
+    expect((agentCalls[1]?.[1] as { data?: { text?: string } }).data?.text).toBe("Hello");
+    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(2);
+    nowSpy.mockRestore();
+  });
+
+  it("coalesces thinking agent events under the chat delta throttle", () => {
+    let now = 27_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-agent-thinking", {
+      sessionKey: "session-agent-thinking",
+      clientRunId: "client-agent-thinking",
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      now = 27_000 + i * 20;
+      handler({
+        runId: "run-agent-thinking",
+        seq: i + 1,
+        stream: "thinking",
+        ts: Date.now(),
+        data: { text: "t".repeat(i + 1), delta: "t" },
+      });
+    }
+
+    const agentCalls = agentBroadcastCalls(broadcast);
+    expect(agentCalls).toHaveLength(1);
+    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(1);
+    expect((agentCalls[0]?.[1] as { stream?: string }).stream).toBe("thinking");
+    expect((agentCalls[0]?.[1] as { data?: { text?: string } }).data?.text).toBe("t");
+    nowSpy.mockRestore();
+  });
+
+  it("does not drop non-cumulative assistant agent events while coalescing text", () => {
+    let now = 30_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-agent-media", {
+      sessionKey: "session-agent-media",
+      clientRunId: "client-agent-media",
+    });
+
+    handler({
+      runId: "run-agent-media",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Look", delta: "Look" },
+    });
+    now = 30_050;
+    handler({
+      runId: "run-agent-media",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Look", delta: "", mediaUrls: ["https://example.test/image.png"] },
+    });
+    now = 30_070;
+    handler({
+      runId: "run-agent-media",
+      seq: 3,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Look elsewhere", delta: "", replace: true },
+    });
+    now = 30_090;
+    handler({
+      runId: "run-agent-media",
+      seq: 4,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Look elsewhere now", delta: " now" },
+    });
+    handler({
+      runId: "run-agent-media",
+      seq: 5,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "end" },
+    });
+
+    const agentCalls = agentBroadcastCalls(broadcast);
+    expect(agentCalls).toHaveLength(5);
+    expect((agentCalls[1]?.[1] as { data?: { mediaUrls?: string[] } }).data?.mediaUrls).toEqual([
+      "https://example.test/image.png",
+    ]);
+    expect((agentCalls[2]?.[1] as { data?: { replace?: boolean } }).data?.replace).toBe(true);
+    expect((agentCalls[3]?.[1] as { data?: { text?: string } }).data?.text).toBe(
+      "Look elsewhere now",
+    );
+    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(5);
+    nowSpy.mockRestore();
   });
 
   it("strips inline directives from assistant chat events", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -770,7 +770,7 @@ export function createAgentEventHandler({
       );
       return;
     }
-    flushBufferedAgentDeltaIfNeeded(clientRunId, stream);
+    flushBufferedAgentDeltaIfNeeded(clientRunId);
     sendAgentPayload(sessionKey, payload);
     chatRunState.agentDeltaSentAt.set(key, now);
   };

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -14,6 +14,7 @@ import {
   shouldSuppressAssistantEventForLiveChat,
 } from "./live-chat-projector.js";
 import type {
+  BufferedAgentEvent,
   ChatRunState,
   SessionEventSubscriberRegistry,
   ToolEventRecipientRegistry,
@@ -230,12 +231,31 @@ export function createAgentEventHandler({
 }: AgentEventHandlerOptions) {
   const pendingTerminalLifecycleErrors = new Map<string, NodeJS.Timeout>();
 
+  type AgentTextThrottleStream = "assistant" | "thinking";
+
+  const agentTextThrottleKey = (clientRunId: string, stream: AgentTextThrottleStream) =>
+    `${clientRunId}:${stream}`;
+
+  const agentTextThrottleKeys = (clientRunId: string) => [
+    clientRunId,
+    agentTextThrottleKey(clientRunId, "assistant"),
+    agentTextThrottleKey(clientRunId, "thinking"),
+  ];
+
+  const clearAgentTextThrottleState = (clientRunId: string) => {
+    for (const key of agentTextThrottleKeys(clientRunId)) {
+      chatRunState.agentDeltaSentAt.delete(key);
+      chatRunState.bufferedAgentEvents.delete(key);
+    }
+  };
+
   const clearBufferedChatState = (clientRunId: string) => {
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.deltaLastBroadcastText.delete(clientRunId);
+    clearAgentTextThrottleState(clientRunId);
   };
 
   const clearPendingTerminalLifecycleError = (runId: string) => {
@@ -410,6 +430,7 @@ export function createAgentEventHandler({
     }
 
     toolEventRecipients.markFinal(evt.runId);
+    clearBufferedChatState(clientRunId);
     clearAgentRunContext(evt.runId);
     agentRunSeq.delete(evt.runId);
     agentRunSeq.delete(clientRunId);
@@ -601,6 +622,7 @@ export function createAgentEventHandler({
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
+    clearAgentTextThrottleState(clientRunId);
     const spawnedBy = resolveSpawnedBy(sessionKey);
     if (jobState === "done") {
       const payload = {
@@ -634,6 +656,123 @@ export function createAgentEventHandler({
     };
     broadcast("chat", payload);
     nodeSendToSession(sessionKey, "chat", payload);
+  };
+
+  const sendAgentPayload = (
+    sessionKey: string | undefined,
+    payload: AgentEventPayload & { spawnedBy?: string },
+  ) => {
+    broadcast("agent", payload);
+    if (sessionKey) {
+      nodeSendToSession(sessionKey, "agent", payload);
+    }
+  };
+
+  const flushBufferedAgentDeltaIfNeeded = (
+    clientRunId: string,
+    stream?: AgentTextThrottleStream,
+  ) => {
+    const keys = stream
+      ? [agentTextThrottleKey(clientRunId, stream)]
+      : agentTextThrottleKeys(clientRunId);
+    const bufferedEntries = keys.flatMap((key) => {
+      const buffered = chatRunState.bufferedAgentEvents.get(key);
+      if (!buffered) {
+        return [];
+      }
+      return [{ key, buffered }];
+    });
+    bufferedEntries.sort((a, b) => a.buffered.payload.seq - b.buffered.payload.seq);
+    for (const { key, buffered } of bufferedEntries) {
+      sendAgentPayload(buffered.sessionKey, buffered.payload);
+      chatRunState.bufferedAgentEvents.delete(key);
+      chatRunState.agentDeltaSentAt.set(key, Date.now());
+    }
+    return bufferedEntries.length > 0;
+  };
+
+  const resolveAgentTextThrottleStream = (
+    evt: AgentEventPayload,
+  ): AgentTextThrottleStream | null => {
+    if (evt.stream === "assistant") {
+      return "assistant";
+    }
+    if (evt.stream === "thinking") {
+      return "thinking";
+    }
+    return null;
+  };
+
+  const isAgentTextThrottleEvent = (evt: AgentEventPayload) =>
+    resolveAgentTextThrottleStream(evt) !== null && typeof evt.data?.text === "string";
+
+  const shouldCoalesceAgentTextEvent = (evt: AgentEventPayload) =>
+    isAgentTextThrottleEvent(evt) &&
+    typeof evt.data.delta === "string" &&
+    evt.data.delta.length > 0 &&
+    !(Array.isArray(evt.data.mediaUrls) && evt.data.mediaUrls.length > 0) &&
+    typeof evt.data.mediaUrl !== "string" &&
+    evt.data.replace !== true &&
+    (evt.stream !== "assistant" || !shouldSuppressAssistantEventForLiveChat(evt.data));
+
+  const shouldAdvanceAgentTextThrottle = (evt: AgentEventPayload) =>
+    isAgentTextThrottleEvent(evt) &&
+    (typeof evt.data.delta === "string" || evt.data.replace === true);
+
+  const buildBufferedAgentEvent = (
+    sessionKey: string | undefined,
+    payload: AgentEventPayload & { spawnedBy?: string },
+  ): BufferedAgentEvent => (sessionKey ? { sessionKey, payload } : { payload });
+
+  const mergeBufferedAgentPayload = (
+    previous: BufferedAgentEvent,
+    next: BufferedAgentEvent,
+  ): BufferedAgentEvent => {
+    if (previous.payload.stream !== next.payload.stream) {
+      return next;
+    }
+    const previousDelta = previous.payload.data.delta;
+    const nextDelta = next.payload.data.delta;
+    if (typeof previousDelta !== "string" || typeof nextDelta !== "string") {
+      return next;
+    }
+    return {
+      ...next,
+      payload: {
+        ...next.payload,
+        data: {
+          ...next.payload.data,
+          delta: `${previousDelta}${nextDelta}`,
+        },
+      },
+    };
+  };
+
+  const sendOrBufferAgentTextEvent = (
+    clientRunId: string,
+    sessionKey: string | undefined,
+    payload: AgentEventPayload & { spawnedBy?: string },
+  ) => {
+    const stream = resolveAgentTextThrottleStream(payload);
+    if (!stream) {
+      sendAgentPayload(sessionKey, payload);
+      return;
+    }
+    const now = Date.now();
+    const key = agentTextThrottleKey(clientRunId, stream);
+    const last = chatRunState.agentDeltaSentAt.get(key);
+    if (last !== undefined && now - last < 150) {
+      const nextBuffered = buildBufferedAgentEvent(sessionKey, payload);
+      const buffered = chatRunState.bufferedAgentEvents.get(key);
+      chatRunState.bufferedAgentEvents.set(
+        key,
+        buffered ? mergeBufferedAgentPayload(buffered, nextBuffered) : nextBuffered,
+      );
+      return;
+    }
+    flushBufferedAgentDeltaIfNeeded(clientRunId, stream);
+    sendAgentPayload(sessionKey, payload);
+    chatRunState.agentDeltaSentAt.set(key, now);
   };
 
   const resolveToolVerboseLevel = (runId: string, sessionKey?: string) => {
@@ -702,6 +841,7 @@ export function createAgentEventHandler({
     const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
     const suppressHeartbeatToolEvents =
       isToolEvent && shouldSuppressHeartbeatToolEvents(clientRunId, evt.runId);
+    const shouldCoalesceAgentEvent = shouldCoalesceAgentTextEvent(evt);
     // Channel/node subscribers respect verbose; authenticated Control UI
     // recipients need tool result payloads to render live tool cards.
     const channelToolPayload =
@@ -714,6 +854,7 @@ export function createAgentEventHandler({
           })()
         : agentPayload;
     if (last > 0 && evt.seq !== last + 1 && isControlUiVisible) {
+      flushBufferedAgentDeltaIfNeeded(clientRunId);
       broadcast("agent", {
         runId: eventRunId,
         stream: "error",
@@ -741,6 +882,7 @@ export function createAgentEventHandler({
         !suppressHeartbeatToolEvents
       ) {
         flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
+        flushBufferedAgentDeltaIfNeeded(clientRunId);
       }
       // Always broadcast tool events to registered WS recipients with
       // tool-events capability, regardless of verboseLevel. The verbose
@@ -772,27 +914,40 @@ export function createAgentEventHandler({
       }
     } else {
       const itemPhase = isItemEvent && typeof evt.data?.phase === "string" ? evt.data.phase : "";
-      if (itemPhase === "start" && isControlUiVisible && sessionKey && !isAborted) {
-        flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
+      if (itemPhase === "start" && isControlUiVisible && !isAborted) {
+        if (sessionKey) {
+          flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
+        }
+        flushBufferedAgentDeltaIfNeeded(clientRunId);
       }
       if (isControlUiVisible) {
-        broadcast("agent", agentPayload);
+        if (shouldCoalesceAgentEvent) {
+          sendOrBufferAgentTextEvent(clientRunId, sessionKey, agentPayload);
+        } else {
+          flushBufferedAgentDeltaIfNeeded(clientRunId);
+          sendAgentPayload(sessionKey, agentPayload);
+          const textThrottleStream = resolveAgentTextThrottleStream(evt);
+          if (textThrottleStream && shouldAdvanceAgentTextThrottle(evt)) {
+            chatRunState.agentDeltaSentAt.set(
+              agentTextThrottleKey(clientRunId, textThrottleStream),
+              Date.now(),
+            );
+          }
+        }
       }
     }
 
     if (isControlUiVisible && sessionKey) {
-      // Send non-heartbeat tool events to node/channel subscribers only when
-      // verbose is enabled; WS clients already received the event above.
-      if (!isToolEvent || (!suppressHeartbeatToolEvents && toolVerbose !== "off")) {
+      // Send tool events to node/channel subscribers only when verbose is enabled;
+      // WS clients already received the event above via broadcastToConnIds.
+      if (isToolEvent && !suppressHeartbeatToolEvents && toolVerbose !== "off") {
         nodeSendToSession(
           sessionKey,
           "agent",
-          isToolEvent
-            ? projectToolSearchCodeEventForChannelPayload({
-                ...channelToolPayload,
-                ...buildSessionEventSnapshot(sessionKey),
-              })
-            : agentPayload,
+          projectToolSearchCodeEventForChannelPayload({
+            ...channelToolPayload,
+            ...buildSessionEventSnapshot(sessionKey),
+          }),
         );
       }
       if (

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -41,7 +41,12 @@ function createMaintenanceTimerDeps() {
     logHealth: { error: () => {} },
     dedupe: new Map(),
     chatAbortControllers: new Map(),
-    chatRunState: { abortedRuns: new Map(), deltaLastBroadcastText: new Map() },
+    chatRunState: {
+      abortedRuns: new Map(),
+      deltaLastBroadcastText: new Map(),
+      agentDeltaSentAt: new Map(),
+      bufferedAgentEvents: new Map(),
+    },
     chatRunBuffers: new Map(),
     chatDeltaSentAt: new Map(),
     chatDeltaLastBroadcastLen: new Map(),
@@ -209,6 +214,33 @@ describe("startGatewayMaintenanceTimers", () => {
     stopMaintenanceTimers(timers);
   });
 
+  it("sweeps orphaned stale agent throttle state once the abort controller is gone", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const runId = "run-agent-orphaned";
+    deps.chatRunState.agentDeltaSentAt.set(runId, Date.now() - ABORTED_RUN_TTL_MS - 1);
+    deps.chatRunState.bufferedAgentEvents.set(runId, {
+      payload: {
+        runId,
+        seq: 1,
+        stream: "assistant",
+        ts: Date.now(),
+        data: { text: "buffer", delta: "buffer" },
+      },
+    });
+
+    const timers = startGatewayMaintenanceTimers(deps);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deps.chatRunState.agentDeltaSentAt.has(runId)).toBe(false);
+    expect(deps.chatRunState.bufferedAgentEvents.has(runId)).toBe(false);
+
+    stopMaintenanceTimers(timers);
+  });
+
   it("clears deltaLastBroadcastLen when aborted runs age out", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
@@ -220,6 +252,16 @@ describe("startGatewayMaintenanceTimers", () => {
     deps.chatDeltaSentAt.set(runId, Date.now() - ABORTED_RUN_TTL_MS - 1);
     deps.chatDeltaLastBroadcastLen.set(runId, 6);
     deps.chatRunState.deltaLastBroadcastText.set(runId, "buffer");
+    deps.chatRunState.agentDeltaSentAt.set(runId, Date.now() - ABORTED_RUN_TTL_MS - 1);
+    deps.chatRunState.bufferedAgentEvents.set(runId, {
+      payload: {
+        runId,
+        seq: 1,
+        stream: "assistant",
+        ts: Date.now(),
+        data: { text: "buffer", delta: "buffer" },
+      },
+    });
 
     const timers = startGatewayMaintenanceTimers(deps);
 
@@ -230,6 +272,8 @@ describe("startGatewayMaintenanceTimers", () => {
     expect(deps.chatDeltaSentAt.has(runId)).toBe(false);
     expect(deps.chatDeltaLastBroadcastLen.has(runId)).toBe(false);
     expect(deps.chatRunState.deltaLastBroadcastText.has(runId)).toBe(false);
+    expect(deps.chatRunState.agentDeltaSentAt.has(runId)).toBe(false);
+    expect(deps.chatRunState.bufferedAgentEvents.has(runId)).toBe(false);
 
     stopMaintenanceTimers(timers);
   });

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -3,6 +3,7 @@ import { sweepStaleRunContexts } from "../infra/agent-events.js";
 import { cleanOldMedia } from "../media/store.js";
 import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
 import { pruneStaleControlPlaneBuckets } from "./control-plane-rate-limit.js";
+import type { ChatRunState } from "./server-chat-state.js";
 import type { ChatRunEntry } from "./server-chat.js";
 import {
   DEDUPE_MAX,
@@ -33,7 +34,10 @@ export function startGatewayMaintenanceTimers(params: {
   logHealth: { error: (msg: string) => void };
   dedupe: Map<string, DedupeEntry>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
-  chatRunState: { abortedRuns: Map<string, number>; deltaLastBroadcastText: Map<string, string> };
+  chatRunState: Pick<
+    ChatRunState,
+    "abortedRuns" | "deltaLastBroadcastText" | "agentDeltaSentAt" | "bufferedAgentEvents"
+  >;
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
   chatDeltaLastBroadcastLen: Map<string, number>;
@@ -127,6 +131,25 @@ export function startGatewayMaintenanceTimers(params: {
       }
     }
 
+    const clearAgentThrottleStateForRun = (runId: string) => {
+      params.chatRunState.agentDeltaSentAt.delete(runId);
+      params.chatRunState.agentDeltaSentAt.delete(`${runId}:assistant`);
+      params.chatRunState.agentDeltaSentAt.delete(`${runId}:thinking`);
+      params.chatRunState.bufferedAgentEvents.delete(runId);
+      params.chatRunState.bufferedAgentEvents.delete(`${runId}:assistant`);
+      params.chatRunState.bufferedAgentEvents.delete(`${runId}:thinking`);
+    };
+
+    const resolveAgentThrottleRunId = (key: string) => {
+      if (key.endsWith(":assistant")) {
+        return key.slice(0, -":assistant".length);
+      }
+      if (key.endsWith(":thinking")) {
+        return key.slice(0, -":thinking".length);
+      }
+      return key;
+    };
+
     for (const [runId, entry] of params.chatAbortControllers) {
       if (now <= entry.expiresAtMs) {
         continue;
@@ -138,6 +161,8 @@ export function startGatewayMaintenanceTimers(params: {
           chatDeltaSentAt: params.chatDeltaSentAt,
           chatDeltaLastBroadcastLen: params.chatDeltaLastBroadcastLen,
           chatDeltaLastBroadcastText: params.chatRunState.deltaLastBroadcastText,
+          agentDeltaSentAt: params.chatRunState.agentDeltaSentAt,
+          bufferedAgentEvents: params.chatRunState.bufferedAgentEvents,
           chatAbortedRuns: params.chatRunState.abortedRuns,
           removeChatRun: params.removeChatRun,
           agentRunSeq: params.agentRunSeq,
@@ -158,6 +183,7 @@ export function startGatewayMaintenanceTimers(params: {
       params.chatDeltaSentAt.delete(runId);
       params.chatDeltaLastBroadcastLen.delete(runId);
       params.chatRunState.deltaLastBroadcastText.delete(runId);
+      clearAgentThrottleStateForRun(runId);
     }
 
     // Prune expired control-plane rate-limit buckets to prevent unbounded
@@ -181,6 +207,21 @@ export function startGatewayMaintenanceTimers(params: {
       params.chatDeltaSentAt.delete(runId);
       params.chatDeltaLastBroadcastLen.delete(runId);
       params.chatRunState.deltaLastBroadcastText.delete(runId);
+      clearAgentThrottleStateForRun(runId);
+    }
+    for (const [key, lastSentAt] of params.chatRunState.agentDeltaSentAt) {
+      const runId = resolveAgentThrottleRunId(key);
+      if (params.chatRunState.abortedRuns.has(runId)) {
+        continue;
+      }
+      if (params.chatAbortControllers.has(runId)) {
+        continue;
+      }
+      if (now - lastSentAt <= ABORTED_RUN_TTL_MS) {
+        continue;
+      }
+      params.chatRunState.agentDeltaSentAt.delete(key);
+      params.chatRunState.bufferedAgentEvents.delete(key);
     }
     // Sweep stale agent run contexts (orphaned when lifecycle end/error is missed).
     sweepStaleRunContexts();

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -157,6 +157,8 @@ const makeContext = (): GatewayRequestContext =>
     chatDeltaSentAt: new Map(),
     chatDeltaLastBroadcastLen: new Map(),
     chatDeltaLastBroadcastText: new Map(),
+    agentDeltaSentAt: new Map(),
+    bufferedAgentEvents: new Map(),
     chatAbortedRuns: new Map(),
     agentRunSeq: new Map(),
     broadcast: vi.fn(),

--- a/src/gateway/server-methods/chat.abort-authorization.test.ts
+++ b/src/gateway/server-methods/chat.abort-authorization.test.ts
@@ -100,6 +100,45 @@ describe("chat.abort authorization", () => {
     expect(context.chatAbortControllers.has("run-1")).toBe(false);
   });
 
+  it("clears agent text throttle state through the real abort caller", async () => {
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([
+        ["run-1", createActiveRun("main", { owner: { connId: "conn-owner", deviceId: "dev-1" } })],
+      ]),
+      agentDeltaSentAt: new Map([["run-1:assistant", Date.now()]]),
+      bufferedAgentEvents: new Map([
+        [
+          "run-1:assistant",
+          {
+            payload: {
+              runId: "run-1",
+              seq: 1,
+              stream: "assistant",
+              ts: Date.now(),
+              data: { text: "pending", delta: "pending" },
+            },
+          },
+        ],
+      ]),
+    });
+
+    const respond = await invokeChatAbortHandler({
+      handler: chatHandlers["chat.abort"],
+      context,
+      request: { sessionKey: "main", runId: "run-1" },
+      client: {
+        connId: "conn-owner",
+        connect: { device: { id: "dev-1" }, scopes: ["operator.write"] },
+      },
+    });
+
+    const [ok, payload] = respond.mock.calls.at(-1) ?? [];
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({ aborted: true, runIds: ["run-1"] });
+    expect(context.agentDeltaSentAt.has("run-1:assistant")).toBe(false);
+    expect(context.bufferedAgentEvents.has("run-1:assistant")).toBe(false);
+  });
+
   it("only aborts session-scoped runs owned by the requester", async () => {
     const context = createChatAbortContext({
       chatAbortControllers: new Map([

--- a/src/gateway/server-methods/chat.abort.test-helpers.ts
+++ b/src/gateway/server-methods/chat.abort.test-helpers.ts
@@ -27,6 +27,8 @@ type ChatAbortTestContext = Record<string, unknown> & {
   chatDeltaSentAt: Map<string, number>;
   chatDeltaLastBroadcastLen: Map<string, number>;
   chatDeltaLastBroadcastText: Map<string, string>;
+  agentDeltaSentAt: Map<string, number>;
+  bufferedAgentEvents: Map<string, unknown>;
   chatAbortedRuns: Map<string, number>;
   removeChatRun: (...args: unknown[]) => { sessionKey: string; clientRunId: string } | undefined;
   agentRunSeq: Map<string, number>;
@@ -46,6 +48,8 @@ export function createChatAbortContext(
     chatDeltaSentAt: new Map(),
     chatDeltaLastBroadcastLen: new Map(),
     chatDeltaLastBroadcastText: new Map(),
+    agentDeltaSentAt: new Map(),
+    bufferedAgentEvents: new Map(),
     chatAbortedRuns: new Map<string, number>(),
     removeChatRun: vi
       .fn()

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -503,6 +503,8 @@ function createChatContext(): Pick<
   | "chatDeltaSentAt"
   | "chatDeltaLastBroadcastLen"
   | "chatDeltaLastBroadcastText"
+  | "agentDeltaSentAt"
+  | "bufferedAgentEvents"
   | "chatAbortedRuns"
   | "addChatRun"
   | "removeChatRun"
@@ -520,6 +522,8 @@ function createChatContext(): Pick<
     chatDeltaSentAt: new Map(),
     chatDeltaLastBroadcastLen: new Map(),
     chatDeltaLastBroadcastText: new Map(),
+    agentDeltaSentAt: new Map(),
+    bufferedAgentEvents: new Map(),
     chatAbortedRuns: new Map(),
     addChatRun: vi.fn(),
     removeChatRun: vi.fn(),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1496,6 +1496,8 @@ function createChatAbortOps(context: GatewayRequestContext): ChatAbortOps {
     chatDeltaSentAt: context.chatDeltaSentAt,
     chatDeltaLastBroadcastLen: context.chatDeltaLastBroadcastLen,
     chatDeltaLastBroadcastText: context.chatDeltaLastBroadcastText,
+    agentDeltaSentAt: context.agentDeltaSentAt,
+    bufferedAgentEvents: context.bufferedAgentEvents,
     chatAbortedRuns: context.chatAbortedRuns,
     removeChatRun: context.removeChatRun,
     agentRunSeq: context.agentRunSeq,

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -13,6 +13,7 @@ import type { PluginNodeCapabilitySurface } from "../plugin-node-capability.js";
 import type { ConnectParams, ErrorShape, RequestFrame } from "../protocol/index.js";
 import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "../server-broadcast-types.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
+import type { BufferedAgentEvent } from "../server-chat-state.js";
 import type { DedupeEntry } from "../server-shared.js";
 import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 
@@ -76,6 +77,8 @@ export type GatewayRequestContext = {
   chatDeltaSentAt: Map<string, number>;
   chatDeltaLastBroadcastLen: Map<string, number>;
   chatDeltaLastBroadcastText: Map<string, string>;
+  agentDeltaSentAt: Map<string, number>;
+  bufferedAgentEvents: Map<string, BufferedAgentEvent>;
   addChatRun: (sessionId: string, entry: { sessionKey: string; clientRunId: string }) => void;
   removeChatRun: (
     sessionId: string,

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -44,6 +44,8 @@ describe("createGatewayRequestContext", () => {
       chatDeltaSentAt: new Map(),
       chatDeltaLastBroadcastLen: new Map(),
       chatDeltaLastBroadcastText: new Map(),
+      agentDeltaSentAt: new Map(),
+      bufferedAgentEvents: new Map(),
       addChatRun: vi.fn(),
       removeChatRun: vi.fn(),
       subscribeSessionEvents: vi.fn(),

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -39,6 +39,8 @@ type GatewayRequestContextParams = {
   chatDeltaSentAt: GatewayRequestContext["chatDeltaSentAt"];
   chatDeltaLastBroadcastLen: GatewayRequestContext["chatDeltaLastBroadcastLen"];
   chatDeltaLastBroadcastText: GatewayRequestContext["chatDeltaLastBroadcastText"];
+  agentDeltaSentAt: GatewayRequestContext["agentDeltaSentAt"];
+  bufferedAgentEvents: GatewayRequestContext["bufferedAgentEvents"];
   addChatRun: GatewayRequestContext["addChatRun"];
   removeChatRun: GatewayRequestContext["removeChatRun"];
   subscribeSessionEvents: GatewayRequestContext["subscribeSessionEvents"];
@@ -136,6 +138,8 @@ export function createGatewayRequestContext(
     chatDeltaSentAt: params.chatDeltaSentAt,
     chatDeltaLastBroadcastLen: params.chatDeltaLastBroadcastLen,
     chatDeltaLastBroadcastText: params.chatDeltaLastBroadcastText,
+    agentDeltaSentAt: params.agentDeltaSentAt,
+    bufferedAgentEvents: params.bufferedAgentEvents,
     addChatRun: params.addChatRun,
     removeChatRun: params.removeChatRun,
     subscribeSessionEvents: params.subscribeSessionEvents,

--- a/src/gateway/server-startup-early.test.ts
+++ b/src/gateway/server-startup-early.test.ts
@@ -48,7 +48,12 @@ describe("startGatewayEarlyRuntime", () => {
       logHealth: { error: () => {} },
       dedupe: new Map(),
       chatAbortControllers: new Map(),
-      chatRunState: { abortedRuns: new Map(), deltaLastBroadcastText: new Map() },
+      chatRunState: {
+        abortedRuns: new Map(),
+        deltaLastBroadcastText: new Map(),
+        agentDeltaSentAt: new Map(),
+        bufferedAgentEvents: new Map(),
+      },
       chatRunBuffers: new Map(),
       chatDeltaSentAt: new Map(),
       chatDeltaLastBroadcastLen: new Map(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1270,6 +1270,8 @@ export async function startGatewayServer(
       chatDeltaSentAt: chatRunState.deltaSentAt,
       chatDeltaLastBroadcastLen: chatRunState.deltaLastBroadcastLen,
       chatDeltaLastBroadcastText: chatRunState.deltaLastBroadcastText,
+      agentDeltaSentAt: chatRunState.agentDeltaSentAt,
+      bufferedAgentEvents: chatRunState.bufferedAgentEvents,
       addChatRun,
       removeChatRun,
       subscribeSessionEvents: sessionEventSubscribers.subscribe,

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -39,6 +39,21 @@ describe("talk realtime gateway relay", () => {
     const broadcast = vi.fn();
     const nodeSendToSession = vi.fn();
     const removeChatRun = vi.fn(() => ({ sessionKey: "main", clientRunId: "run-1" }));
+    const agentDeltaSentAt = new Map([["run-1:assistant", Date.now()]]);
+    const bufferedAgentEvents = new Map([
+      [
+        "run-1:assistant",
+        {
+          payload: {
+            runId: "run-1",
+            seq: 1,
+            stream: "assistant",
+            ts: Date.now(),
+            data: { text: "pending", delta: "pending" },
+          },
+        },
+      ],
+    ]);
     const context = {
       broadcastToConnIds: vi.fn(),
       broadcast,
@@ -59,6 +74,8 @@ describe("talk realtime gateway relay", () => {
       chatDeltaSentAt: new Map(),
       chatDeltaLastBroadcastLen: new Map(),
       chatDeltaLastBroadcastText: new Map(),
+      agentDeltaSentAt,
+      bufferedAgentEvents,
       chatAbortedRuns: new Map(),
       removeChatRun,
       agentRunSeq: new Map(),
@@ -83,6 +100,8 @@ describe("talk realtime gateway relay", () => {
       broadcast,
       nodeSendToSession,
       removeChatRun,
+      agentDeltaSentAt,
+      bufferedAgentEvents,
       session,
     };
   }
@@ -487,8 +506,15 @@ describe("talk realtime gateway relay", () => {
   });
 
   it("aborts linked agent consult runs when the relay turn is cancelled", () => {
-    const { abortController, broadcast, nodeSendToSession, removeChatRun, session } =
-      createAbortableRelayRunFixture();
+    const {
+      abortController,
+      broadcast,
+      nodeSendToSession,
+      removeChatRun,
+      agentDeltaSentAt,
+      bufferedAgentEvents,
+      session,
+    } = createAbortableRelayRunFixture();
     cancelTalkRealtimeRelayTurn({
       relaySessionId: session.relaySessionId,
       connId: "conn-1",
@@ -497,16 +523,26 @@ describe("talk realtime gateway relay", () => {
 
     expect(abortController.signal.aborted).toBe(true);
     expect(removeChatRun).toHaveBeenCalledWith("run-1", "run-1", "main");
+    expect(agentDeltaSentAt.has("run-1:assistant")).toBe(false);
+    expect(bufferedAgentEvents.has("run-1:assistant")).toBe(false);
     expectChatAbortPayload(broadcast, "barge-in");
     expectNodeAbortPayload(nodeSendToSession);
   });
 
   it("aborts linked agent consult runs when the relay session closes", () => {
-    const { abortController, broadcast, nodeSendToSession, session } =
-      createAbortableRelayRunFixture();
+    const {
+      abortController,
+      broadcast,
+      nodeSendToSession,
+      agentDeltaSentAt,
+      bufferedAgentEvents,
+      session,
+    } = createAbortableRelayRunFixture();
     stopTalkRealtimeRelaySession({ relaySessionId: session.relaySessionId, connId: "conn-1" });
 
     expect(abortController.signal.aborted).toBe(true);
+    expect(agentDeltaSentAt.has("run-1:assistant")).toBe(false);
+    expect(bufferedAgentEvents.has("run-1:assistant")).toBe(false);
     expectChatAbortPayload(broadcast, "relay-closed");
     expectNodeAbortPayload(nodeSendToSession);
   });
@@ -517,6 +553,21 @@ describe("talk realtime gateway relay", () => {
     const broadcast = vi.fn();
     const nodeSendToSession = vi.fn();
     const removeChatRun = vi.fn(() => ({ sessionKey: "main", clientRunId: "run-1" }));
+    const agentDeltaSentAt = new Map([["run-1:assistant", Date.now()]]);
+    const bufferedAgentEvents = new Map([
+      [
+        "run-1:assistant",
+        {
+          payload: {
+            runId: "run-1",
+            seq: 1,
+            stream: "assistant",
+            ts: Date.now(),
+            data: { text: "pending", delta: "pending" },
+          },
+        },
+      ],
+    ]);
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -555,6 +606,8 @@ describe("talk realtime gateway relay", () => {
       chatDeltaSentAt: new Map(),
       chatDeltaLastBroadcastLen: new Map(),
       chatDeltaLastBroadcastText: new Map(),
+      agentDeltaSentAt,
+      bufferedAgentEvents,
       chatAbortedRuns: new Map(),
       removeChatRun,
       agentRunSeq: new Map(),
@@ -577,6 +630,8 @@ describe("talk realtime gateway relay", () => {
     bridgeRequest?.onClose?.("error");
 
     expect(abortController.signal.aborted).toBe(true);
+    expect(agentDeltaSentAt.has("run-1:assistant")).toBe(false);
+    expect(bufferedAgentEvents.has("run-1:assistant")).toBe(false);
     expectChatAbortPayload(broadcast, "relay-closed");
     expectNodeAbortPayload(nodeSendToSession);
   });

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginRecord } from "./loader-records.js";
 import { createPluginRegistry } from "./registry.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
+import { createPluginRuntime } from "./runtime/index.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
 function createTestRegistry(runtime: PluginRuntime) {
@@ -19,33 +20,41 @@ function createTestRegistry(runtime: PluginRuntime) {
 }
 
 describe("plugin registry runtime config scope", () => {
-  it("runs deprecated config helpers with the owning plugin scope", async () => {
-    let loadScope = getPluginRuntimeGatewayRequestScope();
-    let writeScope = getPluginRuntimeGatewayRequestScope();
+  it("runs config helpers with the owning plugin scope", async () => {
+    let currentScope = getPluginRuntimeGatewayRequestScope();
+    let mutateScope = getPluginRuntimeGatewayRequestScope();
+    let replaceScope = getPluginRuntimeGatewayRequestScope();
     const config = {} as OpenClawConfig;
     const replaceResult = {
       previousHash: null,
       nextHash: "next",
     } as unknown as Awaited<ReturnType<PluginRuntime["config"]["replaceConfigFile"]>>;
-    const mutateConfigFile: PluginRuntime["config"]["mutateConfigFile"] = async () => ({
-      ...replaceResult,
-      result: undefined,
-    });
+    const mutateConfigFile: PluginRuntime["config"]["mutateConfigFile"] = async () => {
+      mutateScope = getPluginRuntimeGatewayRequestScope();
+      return {
+        ...replaceResult,
+        result: undefined,
+      };
+    };
+    const replaceConfigFile: PluginRuntime["config"]["replaceConfigFile"] = async () => {
+      replaceScope = getPluginRuntimeGatewayRequestScope();
+      return replaceResult;
+    };
+    const loadConfig: PluginRuntime["config"]["loadConfig"] = () => config;
+    const writeConfigFile: PluginRuntime["config"]["writeConfigFile"] = async () => {};
     const configRuntime = {
-      current: vi.fn(() => config),
-      mutateConfigFile,
-      replaceConfigFile: async () => replaceResult,
-      loadConfig: vi.fn(() => {
-        loadScope = getPluginRuntimeGatewayRequestScope();
+      current: vi.fn(() => {
+        currentScope = getPluginRuntimeGatewayRequestScope();
         return config;
       }),
-      writeConfigFile: vi.fn(async () => {
-        writeScope = getPluginRuntimeGatewayRequestScope();
-      }),
+      mutateConfigFile,
+      replaceConfigFile,
+      loadConfig,
+      writeConfigFile,
     } satisfies PluginRuntime["config"];
-    const pluginRegistry = createTestRegistry({
-      config: configRuntime,
-    } as unknown as PluginRuntime);
+    const runtime = createPluginRuntime();
+    runtime.config = configRuntime;
+    const pluginRegistry = createTestRegistry(runtime);
     const record = createPluginRecord({
       id: "legacy-plugin",
       name: "Legacy Plugin",
@@ -56,14 +65,25 @@ describe("plugin registry runtime config scope", () => {
     });
     const api = pluginRegistry.createApi(record, { config });
 
-    expect(api.runtime.config.loadConfig()).toBe(config);
-    await api.runtime.config.writeConfigFile(config);
+    expect(api.runtime.config.current()).toBe(config);
+    await api.runtime.config.mutateConfigFile({
+      afterWrite: { mode: "none", reason: "test" },
+      mutate: () => undefined,
+    });
+    await api.runtime.config.replaceConfigFile({
+      nextConfig: config,
+      afterWrite: { mode: "none", reason: "test" },
+    });
 
-    expect(loadScope).toMatchObject({
+    expect(currentScope).toMatchObject({
       pluginId: "legacy-plugin",
       pluginSource: "/plugins/legacy-plugin/index.js",
     });
-    expect(writeScope).toMatchObject({
+    expect(mutateScope).toMatchObject({
+      pluginId: "legacy-plugin",
+      pluginSource: "/plugins/legacy-plugin/index.js",
+    });
+    expect(replaceScope).toMatchObject({
       pluginId: "legacy-plugin",
       pluginSource: "/plugins/legacy-plugin/index.js",
     });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2399,9 +2399,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           const config = Reflect.get(target, prop, receiver);
           return {
             ...config,
-            loadConfig: () => runWithPluginScope(() => config.loadConfig()),
-            writeConfigFile: (cfg, options) =>
-              runWithPluginScope(() => config.writeConfigFile(cfg, options)),
+            current: () => runWithPluginScope(() => config.current()),
+            mutateConfigFile: (params) => runWithPluginScope(() => config.mutateConfigFile(params)),
+            replaceConfigFile: (params) =>
+              runWithPluginScope(() => config.replaceConfigFile(params)),
           } satisfies PluginRuntime["config"];
         }
         if (prop === "llm") {


### PR DESCRIPTION
## Summary

- Problem: High-volume Gateway `agent` text events could fan out too frequently while a run was streaming, and the throttle path could drop an intermediate buffered delta when a later post-window delta arrived.
- Why it matters: Streaming clients should receive fewer redundant events without losing assistant or thinking text bytes.
- What changed: Added stream-specific Gateway agent-event throttling, cumulative text-delta buffering, lifecycle-safe first text emission, and cleanup for the new throttle state.
- Follow-up fix: Flush pending assistant/thinking agent deltas before sending a post-window delta, and wire the real `chat.abort` request path to clear agent throttle buffers.
- What did NOT change: No protocol shape change, no UI behavior change, no plugin/channel-specific policy, and no live model/provider configuration change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Gateway WebSocket agent-event fanout for assistant text streams must throttle bursts without dropping the buffered middle delta when a later post-window delta arrives.
- Real environment tested: Local isolated OpenClaw Gateway WebSocket server from this worktree, started with loopback binding, external channels/providers skipped, and a real `GatewayClient` connected as an auto-approved operator device with `operator.read`, `operator.write`, and `operator.admin` scopes.
- Exact steps or command run after this patch:
  1. Ran `pnpm exec tsx -` with a temporary proof script that starts `startGatewayServer`, connects `GatewayClient`, registers `sessionKey: "main"`, emits assistant deltas `Hel`, `lo`, and `!` with 50ms/170ms timing around the 150ms throttle window, and asserts the WebSocket client receives all three deltas in order.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live console output from the Gateway proof script.
  ```text
  REAL_BEHAVIOR_PROOF agent event throttle
  gateway=ws://127.0.0.1:56626
  authScopes=["operator.admin","operator.read","operator.write"]
  runId=proof-run-fb786c05-5cff-46c4-bb83-873f4ba2b492
  observedAssistantDeltas=["Hel","lo","!"]
  observedAssistantSeqs=[1,2,3]
  result=middle delta delivered before post-window delta; no assistant text loss
  ```
- Observed result after fix: The real Gateway WebSocket client received the buffered middle assistant delta (`lo`) before the later post-window delta (`!`), preserving assistant text order and content across the throttle boundary.
- What was not tested: External provider credentials, external channel delivery, and UI screenshots; the changed surface is server-side Gateway event fanout and abort cleanup.
- Before evidence (optional but encouraged): The previous implementation deleted the buffered assistant delta when the next post-window delta arrived, so a `Hel` / `lo` / `!` burst could be observed as `Hel` / `!`.

## Root Cause (if applicable)

- Root cause: The throttle state originally treated buffered text as replaceable latest-state, so the next post-window text event deleted the pending buffered delta instead of flushing it first. The direct `chat.abort` request path also did not receive the new agent throttle maps, so it could not clear stale assistant/thinking throttle state.
- Missing detection / guardrail: Gateway event tests covered burst coalescing but did not assert the boundary case where an in-window buffered delta is followed by a post-window delta.
- Contributing context (if known): The event path mixes lifecycle and text payloads under the same `agent` event channel, so throttle state needs to distinguish stream family from run lifecycle and be cleaned through every run-abort path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-chat.agent-events.test.ts`, `src/gateway/server-methods/chat.abort-authorization.test.ts`, `src/gateway/chat-abort.test.ts`, `src/gateway/server-maintenance.test.ts`, `src/gateway/server-startup-early.test.ts`, `src/gateway/server-request-context.test.ts`
- Scenario the test should lock in: High-frequency assistant/thinking text bursts are coalesced with cumulative deltas, buffered deltas are flushed before post-window deltas, lifecycle/start does not seed the text throttle window, and abort/maintenance cleanup removes stream-specific throttle state.
- Why this is the smallest reliable guardrail: The affected behavior is the Gateway server event fanout path and its internal throttle state; focused Gateway tests exercise that path without requiring provider credentials or a live model.
- Existing test that already covers this (if any): Existing burst coverage existed but was not specific enough for the post-window buffered-delta flush and real abort wiring.
- If no new test is added, why not: N/A, new coverage is included.

## User-visible / Behavior Changes

Gateway clients may receive fewer redundant high-frequency assistant/thinking text `agent` events during streaming bursts, while receiving the same cumulative text content after throttled flushes.

## Diagram (if applicable)

```text
Before:
[agent text burst] -> [stream throttle] -> [drop pending buffered delta on post-window send]

After:
[agent text burst] -> [stream throttle] -> [flush pending buffered delta before post-window send]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development worktree
- Runtime/container: Node 22+ with repo `pnpm` scripts
- Model/provider: N/A; the real proof uses Gateway WebSocket agent-event fanout directly and does not require provider credentials
- Integration/channel (if any): Gateway server event fanout
- Relevant config (redacted): Isolated loopback Gateway state; external channels/providers skipped

### Steps

1. Run the real Gateway WebSocket proof script described above.
2. Run focused Gateway event, abort, maintenance, startup, and request-context tests.
3. Run changed-code checks, format validation, and diff validation.

### Expected

- Assistant/thinking text bursts are throttled without losing intermediate deltas.
- Lifecycle/start events do not consume the text throttle window.
- Abort and maintenance cleanup remove stream-specific throttle entries.

### Actual

- Real Gateway WebSocket proof observed assistant deltas `["Hel","lo","!"]` with seqs `[1,2,3]`.
- Focused Gateway tests passed: `Test Files 6 passed (6)`, `Tests 85 passed (85)`.
- `pnpm check:changed`, `pnpm check:changed --staged`, `pnpm format:check -- <changed gateway files>`, and `git diff --check` passed locally.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Real Gateway WebSocket assistant delta fanout, cumulative assistant text delta buffering, thinking stream coalescing, lifecycle/start first-text behavior, media/replace non-coalescing behavior, abort cleanup, and maintenance cleanup.
- Edge cases checked: Stream-specific throttle keys for assistant and thinking text, non-text lifecycle events, media payloads, replace payloads, and completed-run cleanup.
- What you did **not** verify: External provider credentials, external channel delivery, and UI screenshots.
- AI-assisted: Yes, Codex assisted with implementation and review.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Event timing changes can hide regressions if future Gateway event payloads are incorrectly classified as coalescible text.
  - Mitigation: Coalescing is limited to assistant/thinking text deltas, excludes media and replace payloads, and is covered by focused Gateway tests.

