### PR TITLE
fix(embedded): disable idle watchdog for thinking-enabled model runs

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2383,6 +2383,7 @@ export async function runEmbeddedAttempt(
         runTimeoutMs: params.timeoutMs !== configuredRunTimeoutMs ? params.timeoutMs : undefined,
         modelRequestTimeoutMs: (params.model as { requestTimeoutMs?: number }).requestTimeoutMs,
         model: params.model as { baseUrl?: string },
+        thinkingEnabled: params.thinkLevel !== undefined && params.thinkLevel !== "off",
       });
       if (idleTimeoutMs > 0) {
         activeSession.agent.streamFn = streamWithIdleTimeout(

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -225,6 +225,25 @@ describe("resolveLlmIdleTimeoutMs", () => {
       30_000,
     );
   });
+
+  it("disables the default idle watchdog when thinkingEnabled is true", () => {
+    expect(resolveLlmIdleTimeoutMs({ thinkingEnabled: true })).toBe(0);
+  });
+
+  it("keeps the default idle watchdog when thinkingEnabled is false", () => {
+    expect(resolveLlmIdleTimeoutMs({ thinkingEnabled: false })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
+  });
+
+  it("still honors an explicit provider request timeout when thinkingEnabled", () => {
+    expect(resolveLlmIdleTimeoutMs({ thinkingEnabled: true, modelRequestTimeoutMs: 300_000 })).toBe(
+      300_000,
+    );
+  });
+
+  it("still applies agents.defaults.timeoutSeconds when thinkingEnabled", () => {
+    const cfg = { agents: { defaults: { timeoutSeconds: 60 } } } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs({ cfg, thinkingEnabled: true })).toBe(60_000);
+  });
 });
 
 describe("streamWithIdleTimeout", () => {

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -118,6 +118,7 @@ export function resolveLlmIdleTimeoutMs(params?: {
   runTimeoutMs?: number;
   modelRequestTimeoutMs?: number;
   model?: { baseUrl?: string; id?: string; provider?: string };
+  thinkingEnabled?: boolean;
 }): number {
   const clampTimeoutMs = (valueMs: number) => Math.min(Math.floor(valueMs), MAX_SAFE_TIMEOUT_MS);
   const clampImplicitTimeoutMs = (valueMs: number) =>
@@ -183,6 +184,14 @@ export function resolveLlmIdleTimeoutMs(params?: {
     isLocalProviderBaseUrl(baseUrl) &&
     !isOllamaCloudModel(params?.model)
   ) {
+    return 0;
+  }
+
+  // Cloud thinking models (e.g. Gemini 2.5 Flash with thinking=medium) can
+  // legitimately produce no stream chunks for well over 120s while the model
+  // reasons server-side before emitting any tokens. Applying the default
+  // network-silence watchdog to these runs causes false-positive timeouts.
+  if (params?.thinkingEnabled) {
     return 0;
   }
 


### PR DESCRIPTION
## Root cause

`resolveLlmIdleTimeoutMs` applies a 120s network-silence watchdog by default for cloud providers. Cloud thinking models (e.g. Gemini 2.5 Flash with `thinking=medium`) can produce **zero** stream chunks for well over 120s while the model reasons server-side, before emitting any tokens. The watchdog fires prematurely, producing `FailoverError: LLM request timed out` even though Google's own metrics show zero errors for the same requests (as documented in #80349).

## Fix

Add `thinkingEnabled?: boolean` to `resolveLlmIdleTimeoutMs`. When `thinkingEnabled === true`, return `0` (watchdog disabled) — the same bypass already applied to local providers, which share the same "legitimately silent during thinking" characteristic.

The call site in `attempt.ts` passes `thinkingEnabled: params.thinkLevel !== undefined && params.thinkLevel !== "off"`.

Per-run and `agentTimeoutSeconds` hard caps still apply, so genuinely hung requests can still be cancelled via explicit `timeoutSeconds` config.

## Files changed

- `src/agents/pi-embedded-runner/run/llm-idle-timeout.ts` — add `thinkingEnabled?` param, return 0 when true (after local-provider check)
- `src/agents/pi-embedded-runner/run/attempt.ts` — pass `thinkingEnabled` at the call site
- `src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts` — 4 new test cases for the bypass

## Real behavior proof

**Behavior or issue addressed:** `resolveLlmIdleTimeoutMs` returned `120_000` (120s watchdog) for cloud thinking model runs. With `thinkingEnabled: true`, it now returns `0` (watchdog off), preventing false-positive `FailoverError: LLM request timed out.` during Gemini 2.5 Flash thinking phases.

**Real environment tested:** DGX workstation, Node.js v22.22.0, tsx/esm TypeScript loader — same environment used for all PR development.

**Exact steps or command run after this patch:**
```
node --import tsx/esm --input-type=module <<'EOF'
import { resolveLlmIdleTimeoutMs } from './src/agents/pi-embedded-runner/run/llm-idle-timeout.ts';
const withThinking    = resolveLlmIdleTimeoutMs({ thinkingEnabled: true });
const withoutThinking = resolveLlmIdleTimeoutMs({ thinkingEnabled: false });
const withTimeout     = resolveLlmIdleTimeoutMs({ thinkingEnabled: true, modelRequestTimeoutMs: 30000 });
console.log('thinkingEnabled=true  ->', withThinking);
console.log('thinkingEnabled=false ->', withoutThinking);
console.log('thinkingEnabled=true + modelRequestTimeoutMs=30000 ->', withTimeout);
EOF
```

**Evidence after fix:**
```
$ node --import tsx/esm --input-type=module <<EOF
import { resolveLlmIdleTimeoutMs } from './src/agents/pi-embedded-runner/run/llm-idle-timeout.ts';
const withThinking    = resolveLlmIdleTimeoutMs({ thinkingEnabled: true });
const withoutThinking = resolveLlmIdleTimeoutMs({ thinkingEnabled: false });
const withTimeout     = resolveLlmIdleTimeoutMs({ thinkingEnabled: true, modelRequestTimeoutMs: 30000 });
console.log('thinkingEnabled=true  ->', withThinking);
console.log('thinkingEnabled=false ->', withoutThinking);
console.log('thinkingEnabled=true + modelRequestTimeoutMs=30000 ->', withTimeout);
EOF
thinkingEnabled=true  -> 0
thinkingEnabled=false -> 120000
thinkingEnabled=true + modelRequestTimeoutMs=30000 -> 30000
```

Before patch: `resolveLlmIdleTimeoutMs({ thinkingEnabled: true })` → `120000` (watchdog fires at 120s).
After patch: `resolveLlmIdleTimeoutMs({ thinkingEnabled: true })` → `0` (watchdog disabled; per-run/agentTimeout caps still apply).

**Observed result after fix:** Returns `0` for thinking-enabled runs, matching existing local-provider bypass behavior. All 136 tests pass.

**What was not tested:** Live Gemini 2.5 Flash end-to-end — requires a Google API key reproducing the 125s hang from #80349.

Fixes #80349