### PR TITLE
fix(google): recover and validate Gemini tool-call thought_signature on replay

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -170,6 +170,30 @@ function requireThinkingConfig(config: Record<string, unknown>): Record<string, 
   return thinkingConfig as Record<string, unknown>;
 }
 
+type GoogleTestContentTurn = Record<string, unknown> & {
+  parts: Array<Record<string, unknown>>;
+};
+
+function isModelTurnWithParts(content: Record<string, unknown>): content is GoogleTestContentTurn {
+  return content.role === "model" && Array.isArray(content.parts);
+}
+
+function getFirstModelTurn(contents: Array<Record<string, unknown>>): GoogleTestContentTurn {
+  const turn = contents.find(isModelTurnWithParts);
+  if (!turn) {
+    throw new Error("Expected at least one Google model turn");
+  }
+  return turn;
+}
+
+function getLastModelTurn(contents: Array<Record<string, unknown>>): GoogleTestContentTurn {
+  const turn = contents.toReversed().find(isModelTurnWithParts);
+  if (!turn) {
+    throw new Error("Expected at least one Google model turn");
+  }
+  return turn;
+}
+
 describe("google transport stream", () => {
   beforeAll(async () => {
     ({
@@ -328,6 +352,103 @@ describe("google transport stream", () => {
     expect(result.content[2]).toHaveProperty("name", "lookup");
     expect(result.content[2]).toHaveProperty("arguments", { q: "hello" });
     expect(result.content[2]).toHaveProperty("thoughtSignature", "call_sig_1");
+  });
+
+  it("merges tool-call thought signatures from sibling SSE parts", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { id: "call_1", name: "lookup", args: { q: "hello" } },
+                  },
+                  { thoughtSignature: "call_sig_merged_1" },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({
+          id: "gemini-3.1-pro-preview",
+          name: "Gemini 3.1 Pro Preview",
+        }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_1",
+        name: "lookup",
+        arguments: { q: "hello" },
+        thoughtSignature: "call_sig_merged_1",
+      },
+    ]);
+  });
+
+  it("keeps explicit thinking signatures after tool-call SSE parts", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { id: "call_1", name: "lookup", args: { q: "hello" } },
+                  },
+                  { thought: true, thoughtSignature: "thought_sig_after_call" },
+                  { thought: true, text: "draft" },
+                  { text: "answer" },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({
+          id: "gemini-3.1-pro-preview",
+          name: "Gemini 3.1 Pro Preview",
+        }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content[0]).toMatchObject({
+      type: "toolCall",
+      id: "call_1",
+      name: "lookup",
+      arguments: { q: "hello" },
+    });
+    expect(result.content[1]).toEqual({
+      type: "thinking",
+      thinking: "draft",
+      thinkingSignature: "thought_sig_after_call",
+    });
+    expect(result.content[2]).toEqual({ type: "text", text: "answer" });
   });
 
   it("builds a lean Gemini 3 first-response retry payload", () => {
@@ -726,7 +847,7 @@ describe("google transport stream", () => {
     });
   });
 
-  it("uses Gemini skip-validator thought signatures for cross-provider tool-call replay", () => {
+  it("re-attaches replayed Gemini thought signatures when a later tool call is missing one", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
@@ -736,11 +857,39 @@ describe("google transport stream", () => {
       messages: [
         {
           role: "assistant",
-          provider: "anthropic",
-          api: "anthropic-messages",
-          model: "claude-opus-4-7",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
           stopReason: "toolUse",
           timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "call_sig_replay_1",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 2,
           content: [
             {
               type: "toolCall",
@@ -753,7 +902,472 @@ describe("google transport stream", () => {
       ],
     } as never);
 
+    // Find the last model-role content; should carry the replayed signature
+    // even though the second stored toolCall block had none.
+    expect(getLastModelTurn(params.contents)).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "call_sig_replay_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("treats the Google transport alias as the same route for signature replay", () => {
+    const model = {
+      ...buildGeminiModel({
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+      }),
+      api: "openclaw-google-generative-ai-transport",
+    } as Model<"openclaw-google-generative-ai-transport">;
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "call_sig_alias_1",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 2,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    expect(getLastModelTurn(params.contents)).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "call_sig_alias_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("keeps text and thinking signatures when the request uses the Google transport alias", () => {
+    const model = {
+      ...buildGeminiModel({
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+      }),
+      api: "openclaw-google-generative-ai-transport",
+    } as Model<"openclaw-google-generative-ai-transport">;
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "stop",
+          timestamp: 0,
+          content: [
+            {
+              type: "thinking",
+              thinking: "plan",
+              thinkingSignature: "think_sig_alias_1",
+            },
+            {
+              type: "text",
+              text: "answer",
+              textSignature: "text_sig_alias_1",
+            },
+          ],
+        },
+      ],
+    } as never);
+
     expect(params.contents[0]).toEqual({
+      role: "model",
+      parts: [
+        {
+          thought: true,
+          text: "plan",
+          thoughtSignature: "think_sig_alias_1",
+        },
+        {
+          text: "answer",
+          thoughtSignature: "text_sig_alias_1",
+        },
+      ],
+    });
+  });
+
+  it("preserves opaque same-route Gemini thought signatures during replay", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "opaque.sig-url_safe~1",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 2,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    expect(getLastModelTurn(params.contents)).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "opaque.sig-url_safe~1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("keeps a tool call's own Gemini thought signature before replay fallback", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "call_sig_first_1",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 2,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "call_sig_second_1",
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const modelTurns = params.contents.filter(isModelTurnWithParts);
+    expect(modelTurns).toHaveLength(2);
+    expect(modelTurns[0]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "call_sig_first_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+    expect(modelTurns[1]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "call_sig_second_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("does not replay Gemini thought signatures from later turns", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 2,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "call_sig_future_1",
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const modelTurns = params.contents.filter(isModelTurnWithParts);
+    expect(modelTurns).toHaveLength(2);
+    expect(modelTurns[0]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "skip_thought_signature_validator",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+    expect(modelTurns[1]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "call_sig_future_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("does not re-attach replayed Gemini thought signatures to a different tool-call part", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "call_sig_replay_1",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 2,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello-again" },
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    expect(getLastModelTurn(params.contents)).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "skip_thought_signature_validator",
+          functionCall: { name: "lookup", args: { q: "hello-again" } },
+        },
+      ],
+    });
+  });
+
+  it("does not replay tool-call thought signatures from a different provider route", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    // Prior turn came from an Anthropic route — its signature looks valid base64
+    // but must NOT be replayed into a Gemini request.
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "anthropic",
+          api: "anthropic",
+          model: "claude-sonnet-4",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_foreign",
+              name: "lookup",
+              arguments: { q: "hello" },
+              // Plausible-looking base64 from a non-Gemini provider
+              thoughtSignature: "msg_01XFDUDYJgAACcnSM2TTgQsA",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_foreign",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Continue." }],
+        },
+      ],
+    } as never);
+
+    // The foreign signature should not be replayed into the Gemini payload.
+    // Gemini 3 still needs the documented skip fallback for unsigned function
+    // calls that came from another route.
+    const firstModelTurn = getFirstModelTurn(params.contents);
+    expect(firstModelTurn).toMatchObject({
       role: "model",
       parts: [
         {
@@ -761,6 +1375,201 @@ describe("google transport stream", () => {
           functionCall: { name: "lookup", args: { q: "hello" } },
         },
       ],
+    });
+    expect(firstModelTurn.parts[0].thoughtSignature).not.toBe("msg_01XFDUDYJgAACcnSM2TTgQsA");
+  });
+
+  it("does not replay prior Gemini thought signatures onto a later foreign route", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "call_sig_google_1",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "anthropic",
+          api: "anthropic",
+          model: "claude-sonnet-4",
+          stopReason: "toolUse",
+          timestamp: 2,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const modelTurns = params.contents.filter(isModelTurnWithParts);
+    expect(modelTurns).toHaveLength(2);
+    expect(modelTurns[1]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "skip_thought_signature_validator",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+    expect(modelTurns[1]?.parts[0].thoughtSignature).not.toBe("call_sig_google_1");
+  });
+
+  it("replaces non-base64 Gemini tool-call thought signatures with the skip fallback", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "reasoning",
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup", args: { q: "hello" } },
+    });
+  });
+
+  it("preserves the skip-validator fallback for unsigned Gemini tool-call replay", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "skip_thought_signature_validator",
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup", args: { q: "hello" } },
+    });
+  });
+
+  it("adds skip-validator fallback to unsigned sibling Gemini 3 tool calls", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_math",
+              name: "math_eval",
+              arguments: { expression: "17*23" },
+              thoughtSignature: "real_sig_1",
+            },
+            {
+              type: "toolCall",
+              id: "call_lookup",
+              name: "lookup_fact",
+              arguments: { key: "beta" },
+            },
+            {
+              type: "toolCall",
+              id: "call_transform",
+              name: "string_transform",
+              arguments: { text: "claw", mode: "reverse" },
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const parts = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts;
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toMatchObject({
+      thoughtSignature: "real_sig_1",
+      functionCall: { name: "math_eval", args: { expression: "17*23" } },
+    });
+    expect(parts[1]).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup_fact", args: { key: "beta" } },
+    });
+    expect(parts[2]).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "string_transform", args: { text: "claw", mode: "reverse" } },
     });
   });
 

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -166,6 +166,30 @@ function requireThinkingConfig(config: Record<string, unknown>): Record<string, 
   return thinkingConfig as Record<string, unknown>;
 }
 
+type GoogleTestContentTurn = Record<string, unknown> & {
+  parts: Array<Record<string, unknown>>;
+};
+
+function isModelTurnWithParts(content: Record<string, unknown>): content is GoogleTestContentTurn {
+  return content.role === "model" && Array.isArray(content.parts);
+}
+
+function getFirstModelTurn(contents: Array<Record<string, unknown>>): GoogleTestContentTurn {
+  const turn = contents.find(isModelTurnWithParts);
+  if (!turn) {
+    throw new Error("Expected at least one Google model turn");
+  }
+  return turn;
+}
+
+function getLastModelTurn(contents: Array<Record<string, unknown>>): GoogleTestContentTurn {
+  const turn = contents.toReversed().find(isModelTurnWithParts);
+  if (!turn) {
+    throw new Error("Expected at least one Google model turn");
+  }
+  return turn;
+}
+
 describe("google transport stream", () => {
   beforeAll(async () => {
     ({
@@ -797,8 +821,7 @@ describe("google transport stream", () => {
 
     // Find the last model-role content; should carry the replayed signature
     // even though the second stored toolCall block had none.
-    const modelTurns = params.contents.filter((c: { role: string }) => c.role === "model");
-    expect(modelTurns[modelTurns.length - 1]).toMatchObject({
+    expect(getLastModelTurn(params.contents)).toMatchObject({
       role: "model",
       parts: [
         {
@@ -855,23 +878,23 @@ describe("google transport stream", () => {
       ],
     } as never);
 
-    // The foreign signature should be omitted from the Gemini outbound payload
-    const modelTurns = params.contents.filter((c: { role: string }) => c.role === "model");
-    expect(modelTurns[0]).toMatchObject({
+    // The foreign signature should not be replayed into the Gemini payload.
+    // Gemini 3 still needs the documented skip fallback for unsigned function
+    // calls that came from another route.
+    const firstModelTurn = getFirstModelTurn(params.contents);
+    expect(firstModelTurn).toMatchObject({
       role: "model",
       parts: [
         {
+          thoughtSignature: "skip_thought_signature_validator",
           functionCall: { name: "lookup", args: { q: "hello" } },
         },
       ],
     });
-    // Confirm thoughtSignature is absent — not replayed from a foreign route
-    expect(
-      (modelTurns[0] as { parts: Array<Record<string, unknown>> }).parts[0].thoughtSignature,
-    ).toBeUndefined();
+    expect(firstModelTurn.parts[0].thoughtSignature).not.toBe("msg_01XFDUDYJgAACcnSM2TTgQsA");
   });
 
-  it("drops non-base64 Gemini tool-call thought signatures like reasoning", () => {
+  it("replaces non-base64 Gemini tool-call thought signatures with the skip fallback", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
@@ -900,11 +923,13 @@ describe("google transport stream", () => {
     } as never);
 
     const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
-    expect(part).toMatchObject({ functionCall: { name: "lookup", args: { q: "hello" } } });
-    expect(part).not.toHaveProperty("thoughtSignature");
+    expect(part).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup", args: { q: "hello" } },
+    });
   });
 
-  it("drops skip-validator thought signatures before Gemini replay serialization", () => {
+  it("preserves the skip-validator fallback for unsigned Gemini tool-call replay", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
@@ -933,8 +958,10 @@ describe("google transport stream", () => {
     } as never);
 
     const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
-    expect(part).toMatchObject({ functionCall: { name: "lookup", args: { q: "hello" } } });
-    expect(part).not.toHaveProperty("thoughtSignature");
+    expect(part).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup", args: { q: "hello" } },
+    });
   });
 
   it("does not trust cross-provider tool-call thought signatures for non-Gemini-3 models", () => {

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -809,6 +809,68 @@ describe("google transport stream", () => {
     });
   });
 
+  it("does not replay tool-call thought signatures from a different provider route", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    // Prior turn came from an Anthropic route — its signature looks valid base64
+    // but must NOT be replayed into a Gemini request.
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "anthropic",
+          api: "anthropic",
+          model: "claude-sonnet-4",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_foreign",
+              name: "lookup",
+              arguments: { q: "hello" },
+              // Plausible-looking base64 from a non-Gemini provider
+              thoughtSignature: "msg_01XFDUDYJgAACcnSM2TTgQsA",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_foreign",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Continue." }],
+        },
+      ],
+    } as never);
+
+    // The foreign signature should be omitted from the Gemini outbound payload
+    const modelTurns = params.contents.filter((c: { role: string }) => c.role === "model");
+    expect(modelTurns[0]).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+    // Confirm thoughtSignature is absent — not replayed from a foreign route
+    expect(
+      (modelTurns[0] as { parts: Array<Record<string, unknown>> }).parts[0].thoughtSignature,
+    ).toBeUndefined();
+  });
+
   it("drops non-base64 Gemini tool-call thought signatures like reasoning", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -326,6 +326,52 @@ describe("google transport stream", () => {
     expect(result.content[2]).toHaveProperty("thoughtSignature", "call_sig_1");
   });
 
+  it("merges tool-call thought signatures from sibling SSE parts", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { id: "call_1", name: "lookup", args: { q: "hello" } },
+                  },
+                  { thoughtSignature: "call_sig_merged_1" },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({
+          id: "gemini-3.1-pro-preview",
+          name: "Gemini 3.1 Pro Preview",
+        }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_1",
+        name: "lookup",
+        arguments: { q: "hello" },
+        thoughtSignature: "call_sig_merged_1",
+      },
+    ]);
+  });
+
   it("builds a lean Gemini 3 first-response retry payload", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
@@ -694,7 +740,7 @@ describe("google transport stream", () => {
     });
   });
 
-  it("uses Gemini skip-validator thought signatures for cross-provider tool-call replay", () => {
+  it("re-attaches replayed Gemini thought signatures when a later tool call is missing one", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
@@ -704,9 +750,9 @@ describe("google transport stream", () => {
       messages: [
         {
           role: "assistant",
-          provider: "anthropic",
-          api: "anthropic-messages",
-          model: "claude-opus-4-7",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
           stopReason: "toolUse",
           timestamp: 0,
           content: [
@@ -715,21 +761,118 @@ describe("google transport stream", () => {
               id: "call_1",
               name: "lookup",
               arguments: { q: "hello" },
+              thoughtSignature: "call_sig_replay_1",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 2,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello-again" },
             },
           ],
         },
       ],
     } as never);
 
-    expect(params.contents[0]).toEqual({
+    // Find the last model-role content; should carry the replayed signature
+    // even though the second stored toolCall block had none.
+    const modelTurns = params.contents.filter((c: { role: string }) => c.role === "model");
+    expect(modelTurns[modelTurns.length - 1]).toMatchObject({
       role: "model",
       parts: [
         {
-          thoughtSignature: "skip_thought_signature_validator",
-          functionCall: { name: "lookup", args: { q: "hello" } },
+          thoughtSignature: "call_sig_replay_1",
+          functionCall: { name: "lookup", args: { q: "hello-again" } },
         },
       ],
     });
+  });
+
+  it("drops non-base64 Gemini tool-call thought signatures like reasoning", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "reasoning",
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).toMatchObject({ functionCall: { name: "lookup", args: { q: "hello" } } });
+    expect(part).not.toHaveProperty("thoughtSignature");
+  });
+
+  it("drops skip-validator thought signatures before Gemini replay serialization", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "skip_thought_signature_validator",
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).toMatchObject({ functionCall: { name: "lookup", args: { q: "hello" } } });
+    expect(part).not.toHaveProperty("thoughtSignature");
   });
 
   it("does not trust cross-provider tool-call thought signatures for non-Gemini-3 models", () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -38,7 +38,8 @@ import {
   resolveGoogleVertexAuthorizedUserHeaders,
 } from "./vertex-adc.js";
 
-type GoogleTransportApi = "google-generative-ai" | "google-vertex";
+type CanonicalGoogleTransportApi = "google-generative-ai" | "google-vertex";
+type GoogleTransportApi = CanonicalGoogleTransportApi | "openclaw-google-generative-ai-transport";
 
 type GoogleTransportModel = Model<GoogleTransportApi> & {
   headers?: Record<string, string>;
@@ -91,7 +92,7 @@ type GoogleTransportContentBlock =
 type MutableAssistantOutput = {
   role: "assistant";
   content: Array<GoogleTransportContentBlock>;
-  api: GoogleTransportApi;
+  api: CanonicalGoogleTransportApi;
   provider: string;
   model: string;
   usage: {
@@ -164,6 +165,106 @@ function retainThoughtSignature(existing: string | undefined, incoming: string |
     return incoming;
   }
   return existing;
+}
+
+function stableStringifyGoogleToolCallValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringifyGoogleToolCallValue(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .toSorted()
+      .map((key) => `${JSON.stringify(key)}:${stableStringifyGoogleToolCallValue(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function isJsonLikeThoughtSignature(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("{") ||
+    trimmed.startsWith("[") ||
+    trimmed.includes('":') ||
+    trimmed.includes('","') ||
+    trimmed.includes('"type"')
+  );
+}
+
+function sanitizeGeminiToolCallThoughtSignature(
+  thoughtSignature: string | undefined,
+): string | undefined {
+  if (typeof thoughtSignature !== "string") {
+    return undefined;
+  }
+  const trimmed = thoughtSignature.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (isJsonLikeThoughtSignature(trimmed)) {
+    return undefined;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(trimmed);
+  if (
+    lowered === "reasoning" ||
+    lowered === normalizeLowercaseStringOrEmpty(GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP)
+  ) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function isSameGoogleTransportRoute(
+  source: { api?: string; provider?: string; model?: string },
+  model: GoogleTransportModel,
+): boolean {
+  return (
+    source.provider === model.provider &&
+    normalizeGoogleTransportRouteApi(source.api) === normalizeGoogleTransportRouteApi(model.api) &&
+    source.model === model.id
+  );
+}
+
+function normalizeGoogleTransportRouteApi(
+  api: string | undefined,
+): CanonicalGoogleTransportApi | undefined {
+  switch (api) {
+    case "google-generative-ai":
+    case "openclaw-google-generative-ai-transport":
+      return "google-generative-ai";
+    case "google-vertex":
+      return "google-vertex";
+    default:
+      return undefined;
+  }
+}
+
+function normalizeGoogleTransportModelRoute(model: GoogleTransportModel): GoogleTransportModel {
+  const api = normalizeGoogleTransportRouteApi(model.api);
+  return api && api !== model.api ? Object.assign({}, model, { api }) : model;
+}
+
+function normalizeGoogleTransportMessageRoutes(messages: Context["messages"]): Context["messages"] {
+  return messages.map((msg) => {
+    if (msg.role !== "assistant") {
+      return msg;
+    }
+    const api = normalizeGoogleTransportRouteApi(msg.api);
+    return api && api !== msg.api ? Object.assign({}, msg, { api }) : msg;
+  });
+}
+
+function toolCallThoughtSignatureReplayKey(block: {
+  id: string;
+  name: string;
+  arguments: unknown;
+}): string {
+  return [
+    block.id,
+    block.name,
+    stableStringifyGoogleToolCallValue(coerceTransportToolCallArguments(block.arguments)),
+  ].join("\u0000");
 }
 
 function mapToolChoice(
@@ -385,9 +486,12 @@ function normalizeGoogleThinkingConfig(
 
 function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
   const contents: Array<Record<string, unknown>> = [];
+  const replayToolCallThoughtSignatures = new Map<string, string>();
+  const shouldReplayToolCallThoughtSignature = requiresToolCallThoughtSignature(model.id);
+  const routeModel = normalizeGoogleTransportModelRoute(model);
   const transformedMessages = transformTransportMessages(
-    context.messages,
-    model,
+    normalizeGoogleTransportMessageRoutes(context.messages),
+    routeModel,
     (id) => (requiresToolCallId(model.id) ? normalizeToolCallId(id) : id),
     {
       preserveCrossModelToolCallThoughtSignature: requiresToolCallThoughtSignature(model.id),
@@ -422,8 +526,9 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     }
 
     if (msg.role === "assistant") {
-      const isSameProviderAndModel = msg.provider === model.provider && msg.model === model.id;
+      const isSameRoute = isSameGoogleTransportRoute(msg, model);
       const parts: Array<Record<string, unknown>> = [];
+      const nextReplayToolCallThoughtSignatures = new Map<string, string>();
       for (const block of msg.content) {
         if (block.type === "text") {
           if (!block.text.trim()) {
@@ -431,7 +536,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           }
           parts.push({
             text: sanitizeTransportPayloadText(block.text),
-            ...(isSameProviderAndModel && block.textSignature
+            ...(isSameRoute && block.textSignature
               ? { thoughtSignature: block.textSignature }
               : {}),
           });
@@ -441,7 +546,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           if (!block.thinking.trim()) {
             continue;
           }
-          if (isSameProviderAndModel) {
+          if (isSameRoute) {
             parts.push({
               thought: true,
               text: sanitizeTransportPayloadText(block.thinking),
@@ -453,9 +558,25 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           continue;
         }
         if (block.type === "toolCall") {
+          const replayKey = toolCallThoughtSignatureReplayKey(block);
+          const replayedThoughtSignature =
+            shouldReplayToolCallThoughtSignature && isSameRoute
+              ? replayToolCallThoughtSignatures.get(replayKey)
+              : undefined;
+          // Use a block's own same-route signature first; otherwise fall back
+          // to a same-route replayed value from already-converted context.
+          // Never replay signatures from foreign providers — Gemini requires
+          // its own signatures returned exactly as issued.
+          const ownSignature = isSameRoute
+            ? sanitizeGeminiToolCallThoughtSignature(block.thoughtSignature)
+            : undefined;
+          if (ownSignature) {
+            nextReplayToolCallThoughtSignatures.set(replayKey, ownSignature);
+          }
           const thoughtSignature =
-            (isSameProviderAndModel ? block.thoughtSignature : undefined) ??
-            (requiresToolCallThoughtSignature(model.id)
+            ownSignature ??
+            replayedThoughtSignature ??
+            (shouldReplayToolCallThoughtSignature
               ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
               : undefined);
           parts.push({
@@ -467,6 +588,9 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
             ...(thoughtSignature ? { thoughtSignature } : {}),
           });
         }
+      }
+      for (const [key, signature] of nextReplayToolCallThoughtSignatures) {
+        replayToolCallThoughtSignatures.set(key, signature);
       }
       if (parts.length > 0) {
         contents.push({ role: "model", parts });
@@ -640,7 +764,7 @@ async function buildGoogleVertexHeaders(
 }
 
 function buildGoogleTransportRequestUrl(
-  kind: GoogleTransportApi,
+  kind: CanonicalGoogleTransportApi,
   model: GoogleTransportModel,
   options: GoogleTransportOptions | undefined,
 ): string {
@@ -673,7 +797,7 @@ function resolveGoogleGemini3FirstResponseRetryMs(env = process.env): number {
 }
 
 function shouldRetryGoogleGemini3FirstResponse(params: {
-  kind: GoogleTransportApi;
+  kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
 }): boolean {
   if (params.kind !== "google-generative-ai") {
@@ -846,7 +970,7 @@ async function openGoogleSseAttempt(params: {
 }
 
 async function openGoogleSseChunks(params: {
-  kind: GoogleTransportApi;
+  kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
   options: GoogleTransportOptions | undefined;
   guardedFetch: ReturnType<typeof buildGuardedModelFetch>;
@@ -927,7 +1051,7 @@ async function openGoogleSseChunks(params: {
 }
 
 async function buildGoogleTransportHeaders(params: {
-  kind: GoogleTransportApi;
+  kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
   apiKey: string | undefined;
   optionHeaders: Record<string, string> | undefined;
@@ -1042,7 +1166,7 @@ function pushTextBlockEnd(
   }
 }
 
-function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
+function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): StreamFn {
   return (rawModel, context, rawOptions) => {
     const model = rawModel as GoogleTransportModel;
     const options = rawOptions as GoogleTransportOptions | undefined;
@@ -1102,6 +1226,16 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
               const hasText = typeof part.text === "string";
               if (hasText || (hasThoughtSignature && !part.functionCall)) {
+                if (hasThoughtSignature && !hasText && part.thought !== true) {
+                  const latestBlock = output.content[output.content.length - 1];
+                  if (latestBlock?.type === "toolCall") {
+                    latestBlock.thoughtSignature = retainThoughtSignature(
+                      latestBlock.thoughtSignature,
+                      part.thoughtSignature,
+                    );
+                    continue;
+                  }
+                }
                 const isThinking = part.thought === true || !hasText;
                 const currentBlock = output.content[currentBlockIndex];
                 if (
@@ -1168,6 +1302,15 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 const isDuplicate = output.content.some(
                   (block) => block.type === "toolCall" && block.id === providedId,
                 );
+                const existingToolCall =
+                  typeof providedId === "string"
+                    ? output.content.find(
+                        (
+                          block,
+                        ): block is Extract<GoogleTransportContentBlock, { type: "toolCall" }> =>
+                          block.type === "toolCall" && block.id === providedId,
+                      )
+                    : undefined;
                 const toolCallId =
                   providedId && !isDuplicate
                     ? providedId
@@ -1177,7 +1320,10 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                   id: toolCallId,
                   name: part.functionCall.name || "",
                   arguments: part.functionCall.args ?? {},
-                  thoughtSignature: part.thoughtSignature,
+                  thoughtSignature: retainThoughtSignature(
+                    existingToolCall?.thoughtSignature,
+                    part.thoughtSignature,
+                  ),
                 };
                 output.content.push(toolCall);
                 const blockIndex = output.content.length - 1;

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -138,6 +138,8 @@ type GoogleSseChunk = {
 
 let toolCallCounter = 0;
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
+const GEMINI_THOUGHT_SIGNATURE_PATTERN = /^[A-Za-z0-9_+/=-]+$/;
+const GEMINI_THOUGHT_SIGNATURE_MIN_LENGTH = 8;
 
 function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -164,6 +166,63 @@ function retainThoughtSignature(existing: string | undefined, incoming: string |
     return incoming;
   }
   return existing;
+}
+
+function isJsonLikeThoughtSignature(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("{") ||
+    trimmed.startsWith("[") ||
+    trimmed.includes('":') ||
+    trimmed.includes('","') ||
+    trimmed.includes('"type"')
+  );
+}
+
+function sanitizeGeminiToolCallThoughtSignature(
+  thoughtSignature: string | undefined,
+): string | undefined {
+  if (typeof thoughtSignature !== "string") {
+    return undefined;
+  }
+  const trimmed = thoughtSignature.trim();
+  if (trimmed.length < GEMINI_THOUGHT_SIGNATURE_MIN_LENGTH) {
+    return undefined;
+  }
+  if (isJsonLikeThoughtSignature(trimmed)) {
+    return undefined;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(trimmed);
+  if (
+    lowered === "reasoning" ||
+    lowered === normalizeLowercaseStringOrEmpty(GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP)
+  ) {
+    return undefined;
+  }
+  if (!GEMINI_THOUGHT_SIGNATURE_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function collectToolCallThoughtSignatures(context: Context): Map<string, string> {
+  const sigById = new Map<string, string>();
+  for (const msg of context.messages ?? []) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+      continue;
+    }
+    for (const block of msg.content) {
+      if (block.type !== "toolCall") {
+        continue;
+      }
+      const signature = sanitizeGeminiToolCallThoughtSignature(block.thoughtSignature);
+      if (!signature) {
+        continue;
+      }
+      sigById.set(block.id, signature);
+    }
+  }
+  return sigById;
 }
 
 function mapToolChoice(
@@ -385,6 +444,9 @@ function normalizeGoogleThinkingConfig(
 
 function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
   const contents: Array<Record<string, unknown>> = [];
+  const replayToolCallThoughtSignatures = requiresToolCallThoughtSignature(model.id)
+    ? collectToolCallThoughtSignatures(context)
+    : new Map<string, string>();
   const transformedMessages = transformTransportMessages(
     context.messages,
     model,
@@ -453,11 +515,13 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           continue;
         }
         if (block.type === "toolCall") {
-          const thoughtSignature =
-            (isSameProviderAndModel ? block.thoughtSignature : undefined) ??
-            (requiresToolCallThoughtSignature(model.id)
-              ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
-              : undefined);
+          const replayedThoughtSignature = replayToolCallThoughtSignatures.get(block.id);
+          const thoughtSignature = sanitizeGeminiToolCallThoughtSignature(
+            retainThoughtSignature(block.thoughtSignature, replayedThoughtSignature) ??
+              (requiresToolCallThoughtSignature(model.id)
+                ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
+                : undefined),
+          );
           parts.push({
             functionCall: {
               name: block.name,
@@ -1098,6 +1162,16 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
               const hasText = typeof part.text === "string";
               if (hasText || (hasThoughtSignature && !part.functionCall)) {
+                if (hasThoughtSignature && !hasText) {
+                  const latestBlock = output.content[output.content.length - 1];
+                  if (latestBlock?.type === "toolCall") {
+                    latestBlock.thoughtSignature = retainThoughtSignature(
+                      latestBlock.thoughtSignature,
+                      part.thoughtSignature,
+                    );
+                    continue;
+                  }
+                }
                 const isThinking = part.thought === true || !hasText;
                 const currentBlock = output.content[currentBlockIndex];
                 if (
@@ -1164,6 +1238,15 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 const isDuplicate = output.content.some(
                   (block) => block.type === "toolCall" && block.id === providedId,
                 );
+                const existingToolCall =
+                  typeof providedId === "string"
+                    ? output.content.find(
+                        (
+                          block,
+                        ): block is Extract<GoogleTransportContentBlock, { type: "toolCall" }> =>
+                          block.type === "toolCall" && block.id === providedId,
+                      )
+                    : undefined;
                 const toolCallId =
                   providedId && !isDuplicate
                     ? providedId
@@ -1173,7 +1256,10 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                   id: toolCallId,
                   name: part.functionCall.name || "",
                   arguments: part.functionCall.args ?? {},
-                  thoughtSignature: part.thoughtSignature,
+                  thoughtSignature: retainThoughtSignature(
+                    existingToolCall?.thoughtSignature,
+                    part.thoughtSignature,
+                  ),
                 };
                 output.content.push(toolCall);
                 const blockIndex = output.content.length - 1;

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -205,6 +205,15 @@ function sanitizeGeminiToolCallThoughtSignature(
   return trimmed;
 }
 
+function isSameGoogleTransportRoute(
+  source: { api?: string; provider?: string; model?: string },
+  model: GoogleTransportModel,
+): boolean {
+  return (
+    source.provider === model.provider && source.api === model.api && source.model === model.id
+  );
+}
+
 function collectToolCallThoughtSignatures(
   context: Context,
   model: GoogleTransportModel,
@@ -219,9 +228,7 @@ function collectToolCallThoughtSignatures(
     // sanitizer but are not valid Gemini-issued values and must not be
     // replayed. Gemini requires its own signatures returned exactly as issued.
     const source = msg as { api?: string; provider?: string; model?: string };
-    const isSameRoute =
-      source.provider === model.provider && source.api === model.api && source.model === model.id;
-    if (!isSameRoute) {
+    if (!isSameGoogleTransportRoute(source, model)) {
       continue;
     }
     for (const block of msg.content) {
@@ -497,7 +504,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     }
 
     if (msg.role === "assistant") {
-      const isSameProviderAndModel = msg.provider === model.provider && msg.model === model.id;
+      const isSameRoute = isSameGoogleTransportRoute(msg, model);
       const parts: Array<Record<string, unknown>> = [];
       for (const block of msg.content) {
         if (block.type === "text") {
@@ -506,7 +513,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           }
           parts.push({
             text: sanitizeTransportPayloadText(block.text),
-            ...(isSameProviderAndModel && block.textSignature
+            ...(isSameRoute && block.textSignature
               ? { thoughtSignature: block.textSignature }
               : {}),
           });
@@ -516,7 +523,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           if (!block.thinking.trim()) {
             continue;
           }
-          if (isSameProviderAndModel) {
+          if (isSameRoute) {
             parts.push({
               thought: true,
               text: sanitizeTransportPayloadText(block.thinking),
@@ -533,13 +540,14 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           // otherwise fall back to a same-route replayed value from context.
           // Never replay signatures from foreign providers — Gemini requires
           // its own signatures returned exactly as issued.
-          const ownSignature = isSameProviderAndModel ? block.thoughtSignature : undefined;
-          const thoughtSignature = sanitizeGeminiToolCallThoughtSignature(
+          const ownSignature = isSameRoute
+            ? sanitizeGeminiToolCallThoughtSignature(block.thoughtSignature)
+            : undefined;
+          const thoughtSignature =
             retainThoughtSignature(ownSignature, replayedThoughtSignature) ??
-              (requiresToolCallThoughtSignature(model.id)
-                ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
-                : undefined),
-          );
+            (requiresToolCallThoughtSignature(model.id)
+              ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
+              : undefined);
           parts.push({
             functionCall: {
               name: block.name,

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -205,10 +205,23 @@ function sanitizeGeminiToolCallThoughtSignature(
   return trimmed;
 }
 
-function collectToolCallThoughtSignatures(context: Context): Map<string, string> {
+function collectToolCallThoughtSignatures(
+  context: Context,
+  model: GoogleTransportModel,
+): Map<string, string> {
   const sigById = new Map<string, string>();
   for (const msg of context.messages ?? []) {
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+      continue;
+    }
+    // Only trust thought signatures from the same Google route. Signatures
+    // from other providers (e.g. Anthropic, OpenAI) may pass the base64
+    // sanitizer but are not valid Gemini-issued values and must not be
+    // replayed. Gemini requires its own signatures returned exactly as issued.
+    const source = msg as { api?: string; provider?: string; model?: string };
+    const isSameRoute =
+      source.provider === model.provider && source.api === model.api && source.model === model.id;
+    if (!isSameRoute) {
       continue;
     }
     for (const block of msg.content) {
@@ -445,7 +458,7 @@ function normalizeGoogleThinkingConfig(
 function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
   const contents: Array<Record<string, unknown>> = [];
   const replayToolCallThoughtSignatures = requiresToolCallThoughtSignature(model.id)
-    ? collectToolCallThoughtSignatures(context)
+    ? collectToolCallThoughtSignatures(context, model)
     : new Map<string, string>();
   const transformedMessages = transformTransportMessages(
     context.messages,
@@ -516,8 +529,13 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
         }
         if (block.type === "toolCall") {
           const replayedThoughtSignature = replayToolCallThoughtSignatures.get(block.id);
+          // Use stored signature only when it came from the same Google route;
+          // otherwise fall back to a same-route replayed value from context.
+          // Never replay signatures from foreign providers — Gemini requires
+          // its own signatures returned exactly as issued.
+          const ownSignature = isSameProviderAndModel ? block.thoughtSignature : undefined;
           const thoughtSignature = sanitizeGeminiToolCallThoughtSignature(
-            retainThoughtSignature(block.thoughtSignature, replayedThoughtSignature) ??
+            retainThoughtSignature(ownSignature, replayedThoughtSignature) ??
               (requiresToolCallThoughtSignature(model.id)
                 ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
                 : undefined),


### PR DESCRIPTION
Replaces #79827 with the same head commit moved.

Fixes #72879.

## Summary

Addresses Gemini `thought_signature` replay failures observed on v2026.5.7 during native Google tool-call replay. The fix is limited to `extensions/google/transport-stream.ts` and regression tests.

The PR covers four related failure modes:

1. Native Google streaming can deliver a `functionCall` and its `thoughtSignature` across sibling SSE parts; the parser now merges the signature back onto the tool call.
2. Multi-turn Gemini replay can serialize a stored tool call that no longer has its original signature; the serializer now reuses a valid same-route signature from already-converted prior assistant history.
3. Foreign/provider-route signatures can look plausible but are not Gemini-issued; replay trust is exact by `provider + api + model`.
4. Clearly invalid stored values such as `reasoning` are sanitized, opaque same-route Gemini signatures are preserved, and Gemini 3's documented `skip_thought_signature_validator` fallback is still used for unsigned Gemini function-call replay.

## Fix details

### Parser merge across SSE parts

The native Google parser previously stored `thoughtSignature: part.thoughtSignature` from a single SSE part. Thinking/text parsers already used `retainThoughtSignature(...)` to merge values across sibling parts in the same turn. This PR applies the same merge behavior to tool-call parts and attaches orphan `thoughtSignature`-only parts back to the most recent tool-call block instead of discarding them.

### Native replay injection

Adds a native-Google replay helper that walks prior assistant messages, collects same-route tool-call signatures by tool-call shape (`id`, `name`, and normalized args), and re-attaches them at serialization time when the stored block is missing one. Replay is gated to Gemini 3 models and to the same native Google transport route.

### Route-exact trust boundary

Stored signatures are trusted only when the prior message route matches the current Google transport route by `provider`, `api`, and `model`. This prevents Anthropic/OpenAI-compatible signatures or sentinels from being replayed into native Gemini requests.

### Validation guard plus fallback preservation

`sanitizeGeminiToolCallThoughtSignature` filters outbound real signatures that are clearly invalid: empty strings, JSON-like payloads, known bad sentinels such as `reasoning`, and the fallback sentinel itself when it appears as a stored real signature. It does not require base64url formatting because Gemini signatures are opaque. After sanitizing real signatures, unsigned Gemini 3 tool-call replay still emits `skip_thought_signature_validator` as the fallback.

## Evidence

The linked issue includes a direct Gemini API repro matrix showing that replay without a thought signature fails with the production 400 and replay with the real returned signature succeeds: https://github.com/openclaw/openclaw/issues/72879#issuecomment-4412392166

Network/proxy/DNS were ruled out. The bug is in native Google replay serialization and streamed tool-call parsing.

## Real behavior proof

Behavior addressed: Native Google Gemini tool-call replay must not send foreign/provider-route thought signatures, must preserve valid same-route Gemini signatures, must recover signatures split across sibling SSE parts, and must keep the Gemini 3 `skip_thought_signature_validator` fallback for unsigned function-call replay.

Real environment tested: Current PR head `0e9ae5716b` rebased during this cleanup onto `main` at `9a11e76458` with local focused validation in this Codex worktree. A later live GCP Crabbox fresh-PR run tested #80358 on lease `cbx_7ba4cd7ef191` / `coral-lobster`, project `abs-crabbox`, zone `us-central1-a`, `e2-standard-4` on-demand, Linux amd64, Node `v22.22.2`, pnpm `11.1.0`, using a redacted real Gemini API key against `google/gemini-3-flash-preview`. Earlier remote Linux proof also ran on Azure Crabbox VM `cbx_ace9a5d36d50` / `swift-krill`, `Standard_D8ads_v6` on-demand in `eastus2`, Linux amd64, Node `v22.22.2`, pnpm `10.33.2`, at PR commit `826de52bec9d24469dc245b88b5e00a964c2050f` before the final hygiene commits.

Exact steps or command run after this patch: On the final PR head, ran:

```sh
git fetch origin main
git rebase origin/main
git reset --soft origin/main
scripts/committer "fix(google): recover Gemini tool-call thought signatures" extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts
git diff --check origin/main..HEAD
node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts
pnpm exec oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts
pnpm exec oxlint extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts
git push --force-with-lease fork HEAD:fix/gemini-thought-signature-replay
```

The later GCP Crabbox fresh-PR run used a redacted env profile and an uploaded script so the Gemini key was not printed:

```sh
crabbox run \
  --provider gcp \
  --type e2-standard-4 \
  --market on-demand \
  --fresh-pr openclaw/openclaw#80358 \
  --env-from-profile <redacted-gemini-profile> \
  --allow-env GEMINI_API_KEY \
  --allow-env OPENCLAW_LIVE_TEST \
  --allow-env OPENCLAW_LIVE_TEST_QUIET \
  --timing-json \
  --script /tmp/openclaw-gemini-regression-remote.sh
```

The uploaded script installed Node/pnpm on the raw GCP VM, ran `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts`, then made a real Gemini 3 Flash tool-call turn and replayed the returned assistant/tool-result transcript back to Gemini.

The earlier Azure Crabbox run used the same touched files with:

```sh
pnpm install --frozen-lockfile
pnpm exec oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts
pnpm test extensions/google/transport-stream.test.ts
pnpm check:test-types
```

Evidence after fix: Current-head focused validation passed locally: whitespace diff check, Google transport regression suite (`50` tests passed), formatter, and oxlint. The branch now contains a single focused commit and still changes only `extensions/google/transport-stream.ts` and `extensions/google/transport-stream.test.ts`. Terminal output from the Azure Crabbox real Linux VM showed the remote environment and command output:

```text
provisioning provider=azure lease=cbx_ace9a5d36d50 slug=swift-krill class=standard preferred_type=Standard_D8ads_v6 location=eastus2 rg=crabbox-leases-eastus2 keep=false
provisioned lease=cbx_ace9a5d36d50 server=crabbox-swift-krill-2b8202d3 type=Standard_D8ads_v6
running on 20.62.109.43 set -euxo pipefail
+ node --version
v22.22.2
+ pnpm --version
10.33.2
+ env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm exec oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts
Checking formatting...
All matched files use the correct format.
+ env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test extensions/google/transport-stream.test.ts
✓ extension-providers extensions/google/transport-stream.test.ts (39 tests) 3394ms
Test Files 1 passed (1)
Tests 39 passed (39)
+ env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm check:test-types
command complete in 1m51.073s total=2m11.191s
run summary sync=19.577s command=1m51.073s total=2m11.191s sync_skipped=false exit=0
{"provider":"azure","leaseId":"cbx_ace9a5d36d50","slug":"swift-krill","exitCode":0}
```

The later GCP Crabbox fresh-PR run tested the current PR with a real Gemini API call. The key was forwarded as a redacted secret and was not printed:

```text
fresh-pr checkout openclaw/openclaw#80358 -> 34.55.66.176:/work/crabbox/cbx_7ba4cd7ef191/fresh-pr-openclaw-openclaw-80358
lease=cbx_7ba4cd7ef191 slug=coral-lobster provider=gcp target=linux type=e2-standard-4
remote-runtime node=v22.22.2 pnpm=11.1.0
CRABBOX_PHASE:transport-regression
✓ extension-providers ../../extensions/google/transport-stream.test.ts (50 tests) 7878ms
Test Files 1 passed (1)
Tests 50 passed (50)
CRABBOX_PHASE:live-gemini-replay
remote-live-gemini-replay: model=google/gemini-3-flash-preview
{"phase":"first","stopReason":"toolUse","toolCalls":1,"retainedThoughtSignature":true,"signatureLength":72}
{"phase":"replay","stopReason":"stop","textMatched":true}
run summary sync=38.594s command=5m6.323s total=5m44.917s sync_skipped=false exit=0 sync_steps=ssh:6.844s,git_seed:31.75s command_phases=user-command:1m7.608s,transport-regression:3m48.298s,live-gemini-replay:10.416s
{"provider":"gcp","leaseId":"cbx_7ba4cd7ef191","slug":"coral-lobster","syncMs":38593,"syncSkipped":false,"commandMs":306323,"totalMs":344917,"exitCode":0}
```

Observed result after fix: The Google transport now keeps Gemini-issued tool-call signatures on the same provider/API/model route, rejects foreign or sentinel values before native replay, preserves opaque same-route signatures, and falls back to `skip_thought_signature_validator` only for unsigned Gemini 3 function-call replay. The PR's focused regression tests cover these cases; the GCP live run additionally proved a real Gemini 3 Flash tool call returned a retained signature and accepted the replayed assistant/tool-result transcript with `stopReason: "stop"`.

What was not tested: A final live call against `gemini-3.1-pro-preview` did not complete because Google returned `RESOURCE_EXHAUSTED` for this key with free-tier limits of 0 on `gemini-3.1-pro`. The same Gemini 3 thought-signature replay contract was live-tested with `gemini-3-flash-preview`. No Vertex AI live replay run was performed.
