### PR TITLE
fix(telegram): classify bare pre-connect grammY errors as recoverable for send context

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -235,8 +235,8 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
           think?: boolean;
           options?: { think?: boolean; num_ctx?: number };
         };
-        expect(requestBody.think).toBe(false);
-        expect(requestBody.options?.think).toBeUndefined();
+        expect(requestBody.think).toBeUndefined();
+        expect(requestBody.options?.think).toBe(false);
         expect(requestBody.options?.num_ctx).toBeUndefined();
       },
     );
@@ -285,8 +285,12 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
         if (typeof requestInit.body !== "string") {
           throw new Error("Expected string request body");
         }
-        const requestBody = JSON.parse(requestInit.body) as { think?: string };
-        expect(requestBody.think).toBe("medium");
+        const requestBody = JSON.parse(requestInit.body) as {
+          think?: string;
+          options?: { think?: string };
+        };
+        expect(requestBody.think).toBeUndefined();
+        expect(requestBody.options?.think).toBe("medium");
       },
     );
   });
@@ -337,8 +341,8 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
           think?: boolean | string;
           options?: { think?: boolean | string; num_ctx?: number };
         };
-        expect(requestBody.think).toBe("low");
-        expect(requestBody.options?.think).toBeUndefined();
+        expect(requestBody.think).toBeUndefined();
+        expect(requestBody.options?.think).toBe("low");
         expect(requestBody.options?.num_ctx).toBeUndefined();
       },
     );
@@ -432,8 +436,8 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
           think?: boolean | string;
           options?: { think?: boolean | string; num_ctx?: number };
         };
-        expect(requestBody.think).toBe("high");
-        expect(requestBody.options?.think).toBeUndefined();
+        expect(requestBody.think).toBeUndefined();
+        expect(requestBody.options?.think).toBe("high");
         expect(requestBody.options?.num_ctx).toBeUndefined();
       },
     );
@@ -1664,6 +1668,7 @@ describe("createOllamaStreamFn", () => {
             temperature?: number;
             top_p?: number;
             streaming?: boolean;
+            think?: boolean;
           };
         };
         expect(requestBody.options.num_ctx).toBe(32768);
@@ -1671,7 +1676,8 @@ describe("createOllamaStreamFn", () => {
         expect(requestBody.options.temperature).toBe(0.7);
         expect(requestBody.options.top_p).toBe(0.9);
         expect(requestBody.options.streaming).toBeUndefined();
-        expect(requestBody.think).toBe(false);
+        expect(requestBody.think).toBeUndefined();
+        expect(requestBody.options.think).toBe(false);
       },
     );
   });
@@ -1759,7 +1765,7 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
-  it("maps configured native Ollama params.thinking=max to the stable top-level think value", async () => {
+  it("maps configured native Ollama params.thinking=max to options.think=high", async () => {
     await withMockNdjsonFetch(
       [
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
@@ -1782,8 +1788,8 @@ describe("createOllamaStreamFn", () => {
           think?: string;
           options?: { think?: string };
         };
-        expect(requestBody.think).toBe("high");
-        expect(requestBody.options?.think).toBeUndefined();
+        expect(requestBody.think).toBeUndefined();
+        expect(requestBody.options?.think).toBe("high");
       },
     );
   });

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -236,7 +236,10 @@ function createOllamaThinkingWrapper(
   const streamFn = baseFn ?? streamSimple;
   return (model, context, options) =>
     streamWithPayloadPatch(streamFn, model, context, options, (payloadRecord) => {
-      payloadRecord.think = think;
+      if (!payloadRecord.options || typeof payloadRecord.options !== "object") {
+        payloadRecord.options = {};
+      }
+      (payloadRecord.options as Record<string, unknown>).think = think;
     });
 }
 
@@ -325,6 +328,10 @@ function resolveOllamaModelOptions(model: ProviderRuntimeModel): Record<string, 
   if (numCtx !== undefined) {
     options.num_ctx = numCtx;
   }
+  const think = resolveOllamaThinkParamValue(params);
+  if (think !== undefined) {
+    options.think = think;
+  }
   return options;
 }
 
@@ -339,10 +346,6 @@ function resolveOllamaTopLevelParams(
         requestParams[key] = value;
       }
     }
-  }
-  const think = resolveOllamaThinkParamValue(params);
-  if (think !== undefined) {
-    requestParams.think = think;
   }
   return Object.keys(requestParams).length > 0 ? requestParams : undefined;
 }

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -127,11 +127,16 @@ describe("isRecoverableTelegramNetworkError", () => {
     ).toBe(true);
   });
 
-  it("skips broad message matches for send context", () => {
+  it("classifies bare pre-connect grammY errors as recoverable for send context", () => {
+    // Bare form: no "after" — socket dropped before bytes hit the wire, safe to retry.
     const networkRequestErr = new Error("Network request for 'sendMessage' failed!");
-    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(false);
+    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(true);
     expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "polling" })).toBe(true);
+  });
 
+  it("skips broad message-snippet matches for send context", () => {
+    // Non-grammy snippets (e.g. "undici") are still blocked for send — only the
+    // specific grammy pre-connect form is safe.
     const undiciSnippetErr = new Error("Undici: socket failure");
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "send" })).toBe(false);
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "polling" })).toBe(true);

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -56,6 +56,11 @@ const RECOVERABLE_ERROR_NAMES = new Set([
 const ALWAYS_RECOVERABLE_MESSAGES = new Set(["fetch failed", "typeerror: fetch failed"]);
 const GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE =
   /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed\s+after\b.*[!.]?$/i;
+// Bare pre-connect form: "Network request for 'sendX' failed!" — no "after",
+// meaning the socket was dropped before bytes hit the wire. Safe to retry for
+// all contexts including "send" because the message was never delivered.
+const GRAMMY_NETWORK_REQUEST_FAILED_BARE_RE =
+  /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed[!.]?\s*$/i;
 
 const RECOVERABLE_MESSAGE_SNIPPETS = [
   "undici",
@@ -260,6 +265,9 @@ export function isRecoverableTelegramNetworkError(
       return true;
     }
     if (message && GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE.test(message)) {
+      return true;
+    }
+    if (message && GRAMMY_NETWORK_REQUEST_FAILED_BARE_RE.test(message)) {
       return true;
     }
     if (allowMessageMatch && message) {

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -25,6 +25,16 @@ export type SessionDisplayRow = {
   providerOverride?: string;
   modelOverride?: string;
   contextTokens?: number;
+  spawnedBy?: string;
+  spawnDepth?: number;
+  sessionFile?: string;
+  label?: string;
+  status?: "running" | "done" | "failed" | "killed" | "timeout";
+  sessionStartedAt?: number;
+  lastInteractionAt?: number;
+  startedAt?: number;
+  endedAt?: number;
+  runtimeMs?: number;
 };
 
 export const SESSION_KEY_PAD = 26;
@@ -56,6 +66,16 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
     contextTokens: entry?.contextTokens,
+    spawnedBy: entry?.spawnedBy,
+    spawnDepth: entry?.spawnDepth,
+    sessionFile: entry?.sessionFile,
+    label: entry?.label,
+    status: entry?.status,
+    sessionStartedAt: entry?.sessionStartedAt,
+    lastInteractionAt: entry?.lastInteractionAt,
+    startedAt: entry?.startedAt,
+    endedAt: entry?.endedAt,
+    runtimeMs: entry?.runtimeMs,
   };
 }
 


### PR DESCRIPTION
Closes #80362

## Summary

`isRecoverableTelegramNetworkError` was returning `false` for bare pre-connect grammY errors (`"Network request for 'sendMessage' failed!"` — no `"after"` suffix) when `context: "send"` was passed, causing the bot to silently drop messages instead of retrying. Bare pre-connect errors occur before any bytes reach the Telegram server, making them safe to retry for all contexts including send.

**Root cause:** The existing `GRAMMY_NETWORK_REQUEST_FAILED_RE` matched the `"failed! After N tries..."` form, not the bare `"failed!"` form. The send-context guard in `isRecoverableTelegramNetworkError` checked only the "after" variant, so bare socket-drop errors were not classified as safe to retry.

## Changes

- `extensions/telegram/src/network-errors.ts`: Add `GRAMMY_NETWORK_REQUEST_FAILED_BARE_RE` to match bare pre-connect form; check it in `isRecoverableTelegramNetworkError` before the send-context rejection guard.
- `extensions/telegram/src/network-errors.test.ts`: 2 new tests for bare pre-connect classification and non-grammY snippet rejection for send context.
- `extensions/ollama/src/stream.ts` + test: route `think` parameter through `options` block (independent fix on same branch).
- `src/commands/sessions-table.ts`: expose subagent runtime metadata fields in `--json` (independent fix on same branch).

## Real Behavior Proof

**Behavior or issue addressed:** `isRecoverableTelegramNetworkError(new Error("Network request for 'sendMessage' failed!"), { context: "send" })` returned `false` (reply dropped). Now returns `true` (retry triggered).

**Real environment tested:** Node.js v22.22.0, tsx/esm TypeScript loader, branch `fix/telegram-bare-network-error-retry-80362`, Linux.

**Exact steps or command run after this patch:**
```
node --import tsx/esm --input-type=module <<'PROOF'
import { isRecoverableTelegramNetworkError } from './extensions/telegram/src/network-errors.ts';
const networkRequestErr = new Error("Network request for 'sendMessage' failed!");
console.log("bare grammY send:", isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" }));
console.log("undici blocked send:", isRecoverableTelegramNetworkError(new Error("undici fetch failed"), { context: "send" }));
console.log("bare grammY polling:", isRecoverableTelegramNetworkError(networkRequestErr, { context: "polling" }));
PROOF
```

**Evidence after fix:**
```
bare grammY send: true
undici blocked send: false
bare grammY polling: true
```

Bare pre-connect grammY errors now return `true` for send context. Non-grammY snippets (e.g. "undici") remain blocked.

**Observed result after fix:** `isRecoverableTelegramNetworkError(new Error("Network request for 'sendMessage' failed!"), { context: "send" })` now returns `true`. Messages that previously dropped silently on socket-close-before-send will be retried. Non-grammY network errors remain non-recoverable for send context.

**What was not tested:** Live Telegram integration with actual dropped connections (no Telegram test account available on test host).