### PR TITLE
feat(diagnostics): classify skill and tool usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Packaging: exclude documentation images and assets from the npm tarball, reducing published package size without affecting runtime docs search or CLI behavior. Thanks @SebTardif.
 - Media understanding: stop auto-probing Gemini CLI and use Antigravity CLI only as a lower-priority image/video fallback after configured provider APIs.
 - Diagnostics: emit sanitized `secrets.prepare` timeline spans for Gateway secret preparation so operators can distinguish secret startup latency without exposing provider names, secret ids, or secret values. (#83019) Thanks @samzong.
+- Diagnostics: export bounded skill usage metrics/spans and tool source/owner labels for core, plugin, MCP, and channel tool execution without exposing raw paths or session identifiers. (#80370) Thanks @gauravprasadgp.
 - Agents/subagents: limit default sub-agent bootstrap context to `AGENTS.md` and `TOOLS.md`, keeping persona, identity, user, memory, heartbeat, and setup files out of delegated workers by default. (#85283) Thanks @100yenadmin.
 - Maintainer skills: exclude plugin SDK/API boundary work from `openclaw-landable-bug-sweep` so bugbash sweeps stay focused on small paper-cut fixes.
 - QA-Lab/diagnostics: extend the OpenTelemetry smoke harness to prove trace, metric, and log export, and add first-class Prometheus and observability smoke aliases.

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -70,11 +70,11 @@ openclaw plugins enable diagnostics-otel
 
 ## Signals exported
 
-| Signal      | What goes in it                                                                                                                                                     |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Metrics** | Counters and histograms for token usage, cost, run duration, message flow, Talk events, queue lanes, session state/recovery, exec, and memory pressure.             |
-| **Traces**  | Spans for model usage, model calls, harness lifecycle, tool execution, exec, webhook/message processing, context assembly, and tool loops.                          |
-| **Logs**    | Structured `logging.file` records exported over OTLP when `diagnostics.otel.logs` is enabled; log bodies are withheld unless content capture is explicitly enabled. |
+| Signal      | What goes in it                                                                                                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Metrics** | Counters and histograms for token usage, cost, run duration, skill usage, message flow, Talk events, queue lanes, session state/recovery, tool execution, exec, and memory pressure. |
+| **Traces**  | Spans for model usage, model calls, harness lifecycle, skill usage, tool execution, exec, webhook/message processing, context assembly, and tool loops.                              |
+| **Logs**    | Structured `logging.file` records exported over OTLP when `diagnostics.otel.logs` is enabled; log bodies are withheld unless content capture is explicitly enabled.                  |
 
 Toggle `traces`, `metrics`, and `logs` independently. All three default to on
 when `diagnostics.otel.enabled` is true.
@@ -126,9 +126,9 @@ when `diagnostics.otel.enabled` is true.
 ## Privacy and content capture
 
 Raw model/tool content is **not** exported by default. Spans carry bounded
-identifiers (channel, provider, model, error category, hash-only request ids)
-and never include prompt text, response text, tool inputs, tool outputs, or
-session keys.
+identifiers (channel, provider, model, error category, hash-only request ids,
+tool source, tool owner, and skill name/source) and never include prompt text,
+response text, tool inputs, tool outputs, skill file paths, or session keys.
 OTLP log records keep severity, logger, code location, trusted trace context,
 and sanitized attributes by default, but the raw log message body is exported
 only when `diagnostics.otel.captureContent` is set to boolean `true`. Granular
@@ -189,6 +189,7 @@ message bodies are also approved for export.
 - `openclaw.model_call.request_bytes` (histogram, UTF-8 byte size of the final model request payload; no raw payload content)
 - `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed model response events; no raw response content)
 - `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event)
+- `openclaw.skill.used` (counter, attrs: `openclaw.skill.name`, `openclaw.skill.source`, `openclaw.skill.activation`, optional `openclaw.agent`, optional `openclaw.toolName`)
 
 ### Message flow
 

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -96,8 +96,9 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
 | `openclaw_model_tokens_total`                 | counter   | `agent`, `channel`, `model`, `provider`, `token_type`                                     |
 | `openclaw_gen_ai_client_token_usage`          | histogram | `model`, `provider`, `token_type`                                                         |
 | `openclaw_model_cost_usd_total`               | counter   | `agent`, `channel`, `model`, `provider`                                                   |
-| `openclaw_tool_execution_total`               | counter   | `error_category`, `outcome`, `params_kind`, `tool`                                        |
-| `openclaw_tool_execution_duration_seconds`    | histogram | `error_category`, `outcome`, `params_kind`, `tool`                                        |
+| `openclaw_skill_used_total`                   | counter   | `activation`, `agent`, `skill`, `source`                                                  |
+| `openclaw_tool_execution_total`               | counter   | `error_category`, `outcome`, `params_kind`, `tool`, `tool_owner`, `tool_source`           |
+| `openclaw_tool_execution_duration_seconds`    | histogram | `error_category`, `outcome`, `params_kind`, `tool`, `tool_owner`, `tool_source`           |
 | `openclaw_harness_run_total`                  | counter   | `channel`, `error_category`, `harness`, `model`, `outcome`, `phase`, `plugin`, `provider` |
 | `openclaw_harness_run_duration_seconds`       | histogram | `channel`, `error_category`, `harness`, `model`, `outcome`, `phase`, `plugin`, `provider` |
 | `openclaw_message_received_total`             | counter   | `channel`, `source`                                                                       |
@@ -171,6 +172,9 @@ histogram_quantile(
   0.95,
   sum by (le, lane) (rate(openclaw_queue_lane_wait_seconds_bucket[5m]))
 ) < 2
+
+# Skill usage, split by bounded source
+sum by (skill, source) (increase(openclaw_skill_used_total[24h]))
 
 # Dropped Prometheus series (cardinality alarm)
 increase(openclaw_prometheus_series_dropped_total[15m]) > 0

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1552,6 +1552,49 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("exports skill usage counter and span without raw identifiers", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
+    await service.start(ctx);
+
+    emitTrustedDiagnosticEvent({
+      type: "skill.used",
+      agentId: "main",
+      runId: "run-should-not-export",
+      sessionKey: "session-should-not-export",
+      skillName: "tiny-llm-brainstorm",
+      skillSource: "workspace",
+      activation: "read",
+      toolName: "read",
+      trace: {
+        traceId: TRACE_ID,
+        spanId: TOOL_SPAN_ID,
+        parentSpanId: CHILD_SPAN_ID,
+        traceFlags: "01",
+      },
+    });
+    await flushDiagnosticEvents();
+
+    const expectedAttrs = {
+      "openclaw.agent": "main",
+      "openclaw.skill.activation": "read",
+      "openclaw.skill.name": "tiny-llm-brainstorm",
+      "openclaw.skill.source": "workspace",
+      "openclaw.toolName": "read",
+    };
+    expect(telemetryState.counters.get("openclaw.skill.used")?.add).toHaveBeenCalledWith(
+      1,
+      expectedAttrs,
+    );
+    const skillSpanCall = telemetryState.tracer.startSpan.mock.calls.find(
+      (call) => call[0] === "openclaw.skill.used",
+    );
+    expect(skillSpanCall?.[1]).toMatchObject({ attributes: expectedAttrs });
+    expect(JSON.stringify(skillSpanCall)).not.toContain("run-should-not-export");
+    expect(JSON.stringify(skillSpanCall)).not.toContain("session-should-not-export");
+    await service.stop?.(ctx);
+  });
+
   test("exports run, model call, and tool execution lifecycle spans", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
@@ -1686,6 +1729,7 @@ describe("diagnostics-otel service", () => {
     const toolCall = startedSpanCall("openclaw.tool.execution");
     const toolOptions = toolCall?.[1];
     expect(toolOptions?.attributes?.["openclaw.toolName"]).toBe("read");
+    expect(toolOptions?.attributes?.["openclaw.tool.source"]).toBe("core");
     expect(toolOptions?.attributes?.["openclaw.errorCategory"]).toBe("TypeError");
     expect(toolOptions?.attributes?.["openclaw.errorCode"]).toBe("429");
     expect(toolOptions?.attributes?.["openclaw.tool.params.kind"]).toBe("object");
@@ -1728,6 +1772,7 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(harnessDuration?.[1] ?? {}, "openclaw.sessionKey")).toBe(false);
     const toolDuration = lastHistogramRecord("openclaw.tool.execution.duration_ms");
     expect(toolDuration?.[0]).toBe(20);
+    expect(toolDuration?.[1]?.["openclaw.tool.source"]).toBe("core");
     expect(Object.hasOwn(toolDuration?.[1] ?? {}, "openclaw.errorCode")).toBe(false);
     expect(Object.hasOwn(toolDuration?.[1] ?? {}, "openclaw.runId")).toBe(false);
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -998,6 +998,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         unit: "1",
         description: "Detected repetitive tool-call loop events",
       });
+      const skillUsedCounter = meter.createCounter("openclaw.skill.used", {
+        unit: "1",
+        description: "Skills used by agent runs",
+      });
       const modelCallDurationHistogram = meter.createHistogram("openclaw.model_call.duration_ms", {
         unit: "ms",
         description: "Model call duration",
@@ -2263,9 +2267,43 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         >,
       ): Record<string, string | number | boolean> => ({
         "openclaw.toolName": evt.toolName,
+        "openclaw.tool.source": lowCardinalityAttr(evt.toolSource, "core"),
         "gen_ai.tool.name": evt.toolName,
+        ...(evt.toolOwner ? { "openclaw.tool.owner": lowCardinalityAttr(evt.toolOwner) } : {}),
         ...paramsSummaryAttrs(evt.paramsSummary),
       });
+
+      const skillUsedAttrs = (
+        evt: Extract<DiagnosticEventPayload, { type: "skill.used" }>,
+      ): Record<string, string | number | boolean> => ({
+        "openclaw.skill.name": lowCardinalityAttr(evt.skillName, "skill"),
+        "openclaw.skill.source": lowCardinalityAttr(evt.skillSource),
+        "openclaw.skill.activation": lowCardinalityAttr(evt.activation),
+        ...(evt.agentId ? { "openclaw.agent": lowCardinalityAttr(evt.agentId) } : {}),
+        ...(evt.toolName ? { "openclaw.toolName": lowCardinalityAttr(evt.toolName, "tool") } : {}),
+      });
+
+      const recordSkillUsed = (
+        evt: Extract<DiagnosticEventPayload, { type: "skill.used" }>,
+        metadata: DiagnosticEventMetadata,
+      ) => {
+        if (!metadata.trusted) {
+          return;
+        }
+        const attrs = skillUsedAttrs(evt);
+        skillUsedCounter.add(1, attrs);
+        if (!tracesEnabled) {
+          return;
+        }
+        const spanAttrs: Record<string, string | number | boolean> = { ...attrs };
+        addRunAttrs(spanAttrs, evt);
+        const span = spanWithDuration("openclaw.skill.used", spanAttrs, 0, {
+          parentContext: activeTrustedParentContext(evt, metadata),
+          endTimeMs: evt.ts,
+        });
+        setSpanAttrs(span, spanAttrs);
+        span.end(evt.ts);
+      };
 
       const recordToolExecutionStarted = (
         evt: Extract<DiagnosticEventPayload, { type: "tool.execution.started" }>,
@@ -2288,10 +2326,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         evt: Extract<DiagnosticEventPayload, { type: "tool.execution.completed" }>,
         metadata: DiagnosticEventMetadata,
       ) => {
-        const attrs = {
-          "openclaw.toolName": evt.toolName,
-          ...paramsSummaryAttrs(evt.paramsSummary),
-        };
+        const attrs = toolExecutionBaseAttrs(evt);
         toolExecutionDurationHistogram.record(evt.durationMs, attrs);
         if (!tracesEnabled) {
           return;
@@ -2320,9 +2355,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         metadata: DiagnosticEventMetadata,
       ) => {
         const attrs = {
-          "openclaw.toolName": evt.toolName,
+          ...toolExecutionBaseAttrs(evt),
           "openclaw.errorCategory": lowCardinalityAttr(evt.errorCategory, "other"),
-          ...paramsSummaryAttrs(evt.paramsSummary),
         };
         toolExecutionDurationHistogram.record(evt.durationMs, attrs);
         if (!tracesEnabled) {
@@ -2657,6 +2691,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "tool.execution.blocked":
               recordToolExecutionBlocked(evt, metadata);
+              return;
+            case "skill.used":
+              recordSkillUsed(evt, metadata);
               return;
             case "exec.process.completed":
               recordExecProcessCompleted(evt);

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -144,7 +144,7 @@ describe("diagnostics-prometheus service", () => {
     const rendered = testApi.renderPrometheusMetrics(store);
 
     expect(rendered).toContain(
-      'openclaw_tool_execution_total{error_category="other",outcome="error",params_kind="unknown",tool="tool"} 1',
+      'openclaw_tool_execution_total{error_category="other",outcome="error",params_kind="unknown",tool="tool",tool_owner="none",tool_source="core"} 1',
     );
     expect(rendered).not.toContain("Bearer");
     expect(rendered).not.toContain("sk-secret");
@@ -212,6 +212,36 @@ describe("diagnostics-prometheus service", () => {
 
     expect(rendered).toContain('openclaw_queue_lane_size{lane="dreaming-narrative"} 2');
     expect(rendered).not.toContain("session-main");
+  });
+
+  it("records skill usage metrics without raw paths or session identifiers", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(
+      store,
+      {
+        ...baseEvent(),
+        type: "skill.used",
+        agentId: "main",
+        runId: "run-should-not-export",
+        sessionKey: "session-should-not-export",
+        skillName: "tiny-llm-brainstorm",
+        skillSource: "workspace",
+        activation: "read",
+        toolName: "read",
+      },
+      trusted,
+    );
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain("# TYPE openclaw_skill_used_total counter");
+    expect(rendered).toContain(
+      'openclaw_skill_used_total{activation="read",agent="main",skill="tiny-llm-brainstorm",source="workspace"} 1',
+    );
+    expect(rendered).not.toContain("run-should-not-export");
+    expect(rendered).not.toContain("session-should-not-export");
+    expect(rendered).not.toContain("SKILL.md");
   });
 
   it("bounds messaging labels without exporting raw chat identifiers", () => {

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -334,6 +334,8 @@ function toolExecutionLabels(evt: {
   errorCategory?: string;
   paramsSummary?: { kind: string };
   toolName: string;
+  toolOwner?: string;
+  toolSource?: string;
   type: string;
 }): LabelSet {
   return {
@@ -344,6 +346,22 @@ function toolExecutionLabels(evt: {
     outcome: evt.type === "tool.execution.error" ? "error" : "completed",
     params_kind: lowCardinalityLabel(evt.paramsSummary?.kind),
     tool: lowCardinalityLabel(evt.toolName, "tool"),
+    tool_owner: lowCardinalityLabel(evt.toolOwner, "none"),
+    tool_source: lowCardinalityLabel(evt.toolSource, "core"),
+  };
+}
+
+function skillLabels(evt: {
+  activation: string;
+  agentId?: string;
+  skillName: string;
+  skillSource?: string;
+}): LabelSet {
+  return {
+    activation: lowCardinalityLabel(evt.activation, "unknown"),
+    agent: lowCardinalityLabel(evt.agentId),
+    skill: lowCardinalityLabel(evt.skillName, "skill"),
+    source: lowCardinalityLabel(evt.skillSource),
   };
 }
 
@@ -514,6 +532,9 @@ function recordDiagnosticEvent(
         "Tool executions completed by outcome.",
         toolExecutionLabels(evt),
       );
+      return;
+    case "skill.used":
+      store.counter("openclaw_skill_used_total", "Skills used by agent runs.", skillLabels(evt));
       return;
     case "harness.run.completed":
     case "harness.run.error":

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -11,10 +12,12 @@ import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-sessio
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { setPluginToolMeta } from "../plugins/tools.js";
 import {
   runBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./pi-tools.before-tool-call.js";
+import { createCanonicalFixtureSkill } from "./skills.test-helpers.js";
 import { CRITICAL_THRESHOLD } from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -98,6 +101,21 @@ describe("before_tool_call loop detection behavior", () => {
       if (evt.type.startsWith("tool.execution.")) {
         emitted.push(evt);
       }
+    });
+    const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+    try {
+      await run(emitted, flush);
+    } finally {
+      stop();
+    }
+  }
+
+  async function withDiagnosticEvents(
+    run: (emitted: DiagnosticEventPayload[], flush: () => Promise<void>) => Promise<void>,
+  ) {
+    const emitted: DiagnosticEventPayload[] = [];
+    const stop = onInternalDiagnosticEvent((evt) => {
+      emitted.push(evt);
     });
     const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
     try {
@@ -475,6 +493,220 @@ describe("before_tool_call loop detection behavior", () => {
       expect(typeof completed.durationMs).toBe("number");
       expect(JSON.stringify(emitted)).not.toContain("sk-1234567890abcdef1234567890abcdef");
       expect(JSON.stringify(emitted)).not.toContain("pwd");
+    });
+  });
+
+  it("classifies plugin and MCP tool execution diagnostics with bounded owner labels", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+    const rawTool = { name: "mcp_search", execute } as unknown as AnyAgentTool;
+    setPluginToolMeta(rawTool, { pluginId: "bundle-mcp", optional: false });
+    const tool = wrapToolWithBeforeToolCallHook(rawTool, {
+      agentId: "main",
+      sessionKey: "session-key",
+      loopDetection: { enabled: false },
+    });
+
+    await withToolExecutionEvents(async (emitted, flush) => {
+      await tool.execute("tool-call-mcp", { query: "status" }, undefined, undefined);
+      await flush();
+
+      expectEventFields(emitted[0], {
+        type: "tool.execution.started",
+        toolName: "mcp_search",
+        toolSource: "mcp",
+        toolOwner: "bundle-mcp",
+      });
+      expectEventFields(emitted[1], {
+        type: "tool.execution.completed",
+        toolSource: "mcp",
+        toolOwner: "bundle-mcp",
+      });
+    });
+  });
+
+  it("emits skill usage diagnostics when a run reads a known skill instruction file", async () => {
+    const workspaceDir = path.join("/tmp", "openclaw-skill-usage");
+    const skillBaseDir = path.join(workspaceDir, ".agents", "skills", "demo-skill");
+    const skillFilePath = path.join(skillBaseDir, "SKILL.md");
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "skill" }] });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      sessionId: "session-id",
+      runId: "run-1",
+      workspaceDir,
+      skillsSnapshot: {
+        prompt: "",
+        skills: [{ name: "demo-skill" }],
+        resolvedSkills: [
+          createCanonicalFixtureSkill({
+            name: "demo-skill",
+            description: "Demo",
+            filePath: skillFilePath,
+            baseDir: skillBaseDir,
+            source: "workspace",
+          }),
+        ],
+      },
+      loopDetection: { enabled: false },
+    });
+
+    await withDiagnosticEvents(async (emitted, flush) => {
+      await tool.execute(
+        "tool-call-skill-read",
+        { path: path.join(".agents", "skills", "demo-skill", "SKILL.md") },
+        undefined,
+        undefined,
+      );
+      await flush();
+
+      expect(emitted.map((evt) => evt.type)).toEqual([
+        "tool.execution.started",
+        "skill.used",
+        "tool.execution.completed",
+      ]);
+      expectEventFields(emitted[1], {
+        type: "skill.used",
+        agentId: "main",
+        runId: "run-1",
+        sessionKey: "session-key",
+        sessionId: "session-id",
+        skillName: "demo-skill",
+        skillSource: "workspace",
+        activation: "read",
+        toolName: "read",
+        toolCallId: "tool-call-skill-read",
+      });
+      expect(JSON.stringify(emitted)).not.toContain("SKILL.md");
+      expect(JSON.stringify(emitted)).not.toContain(skillBaseDir);
+    });
+  });
+
+  it("matches home-compacted skill instruction paths from prompts", async () => {
+    const skillBaseDir = path.join(os.homedir(), ".openclaw", "skills", "home-skill");
+    const skillFilePath = path.join(skillBaseDir, "SKILL.md");
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "skill" }] });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/openclaw-workspace",
+      skillsSnapshot: {
+        prompt: "",
+        skills: [{ name: "home-skill" }],
+        resolvedSkills: [
+          createCanonicalFixtureSkill({
+            name: "home-skill",
+            description: "Home skill",
+            filePath: skillFilePath,
+            baseDir: skillBaseDir,
+            source: "openclaw-managed",
+          }),
+        ],
+      },
+      loopDetection: { enabled: false },
+    });
+
+    await withDiagnosticEvents(async (emitted, flush) => {
+      await tool.execute(
+        "tool-call-home-skill",
+        { path: "~/.openclaw/skills/home-skill/SKILL.md" },
+        undefined,
+        undefined,
+      );
+      await flush();
+
+      expectEventFields(emitted[1], {
+        type: "skill.used",
+        skillName: "home-skill",
+        skillSource: "workspace",
+        activation: "read",
+        toolName: "read",
+      });
+      expect(JSON.stringify(emitted)).not.toContain(os.homedir());
+    });
+  });
+
+  it("does not count unused read params as skill usage", async () => {
+    const workspaceDir = path.join("/tmp", "openclaw-skill-unused-param");
+    const skillBaseDir = path.join(workspaceDir, ".agents", "skills", "demo-skill");
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "readme" }] });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      workspaceDir,
+      skillsSnapshot: {
+        prompt: "",
+        skills: [{ name: "demo-skill" }],
+        resolvedSkills: [
+          createCanonicalFixtureSkill({
+            name: "demo-skill",
+            description: "Demo",
+            filePath: path.join(skillBaseDir, "SKILL.md"),
+            baseDir: skillBaseDir,
+            source: "workspace",
+          }),
+        ],
+      },
+      loopDetection: { enabled: false },
+    });
+
+    await withDiagnosticEvents(async (emitted, flush) => {
+      await tool.execute(
+        "tool-call-unused-skill-param",
+        {
+          path: "README.md",
+          file: path.join(".agents", "skills", "demo-skill", "SKILL.md"),
+        },
+        undefined,
+        undefined,
+      );
+      await flush();
+
+      expect(emitted.map((evt) => evt.type)).toEqual([
+        "tool.execution.started",
+        "tool.execution.completed",
+      ]);
+    });
+  });
+
+  it("emits skill usage diagnostics for command-dispatched skill tools", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "sent" }] });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "message", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      sessionId: "session-id",
+      skillCommand: {
+        commandName: "set_profile",
+        skillName: "matrix-profile",
+        skillSource: "workspace",
+        toolName: "message",
+      },
+      loopDetection: { enabled: false },
+    });
+
+    await withDiagnosticEvents(async (emitted, flush) => {
+      await tool.execute(
+        "tool-call-skill-command",
+        { command: "display name", commandName: "set_profile", skillName: "matrix-profile" },
+        undefined,
+        undefined,
+      );
+      await flush();
+
+      expect(emitted.map((evt) => evt.type)).toEqual([
+        "tool.execution.started",
+        "skill.used",
+        "tool.execution.completed",
+      ]);
+      expectEventFields(emitted[1], {
+        type: "skill.used",
+        skillName: "matrix-profile",
+        skillSource: "workspace",
+        activation: "command",
+        toolName: "message",
+        toolCallId: "tool-call-skill-command",
+      });
+      expect(JSON.stringify(emitted)).not.toContain("display name");
     });
   });
 

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import {
@@ -7,6 +9,7 @@ import {
 import {
   emitTrustedDiagnosticEvent,
   type DiagnosticToolParamsSummary,
+  type DiagnosticToolSource,
 } from "../infra/diagnostic-events.js";
 import {
   createChildDiagnosticTraceContext,
@@ -17,7 +20,7 @@ import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
-import { copyPluginToolMeta } from "../plugins/tools.js";
+import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tools.js";
 import { hasTrustedToolPolicies, runTrustedToolPolicies } from "../plugins/trusted-tool-policy.js";
 import {
   PluginApprovalResolutions,
@@ -28,7 +31,7 @@ import {
 } from "../plugins/types.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { isPlainObject } from "../utils.js";
-import { copyChannelAgentToolMeta } from "./channel-tools.js";
+import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import {
   getCodeModeExecBeforeHookMetadata,
   getCodeModeExecBeforeHookMetadataForToolKind,
@@ -38,6 +41,8 @@ import {
 } from "./code-mode-control-tools.js";
 import { adjustedParamsByToolCallId } from "./pi-tools.before-tool-call.state.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import { resolveSkillTelemetrySource, resolveSkillTelemetrySourceValue } from "./skills/source.js";
+import type { SkillSnapshot, SkillTelemetrySource } from "./skills/types.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -65,6 +70,8 @@ export type HookContext = {
   config?: OpenClawConfig;
   /** Tool execution cwd for host-derived path facts. */
   cwd?: string;
+  /** Host workspace used to resolve relative tool params for diagnostics only. */
+  workspaceDir?: string;
   sessionKey?: string;
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
@@ -73,6 +80,13 @@ export type HookContext = {
   channelId?: string;
   loopDetection?: ToolLoopDetectionConfig;
   onToolOutcome?: ToolOutcomeObserver;
+  skillsSnapshot?: SkillSnapshot;
+  skillCommand?: {
+    commandName: string;
+    skillName: string;
+    skillSource?: SkillTelemetrySource;
+    toolName?: string;
+  };
   sandbox?: {
     root: string;
     bridge: SandboxFsBridge;
@@ -178,6 +192,137 @@ function unwrapErrorCause(err: unknown): unknown {
     return err;
   }
   return err;
+}
+
+type ToolDiagnosticIdentity = {
+  toolSource: DiagnosticToolSource;
+  toolOwner?: string;
+};
+
+function resolveToolDiagnosticIdentity(tool: AnyAgentTool): ToolDiagnosticIdentity {
+  const pluginMeta = getPluginToolMeta(tool);
+  if (pluginMeta) {
+    return pluginMeta.pluginId === "bundle-mcp"
+      ? { toolSource: "mcp", toolOwner: pluginMeta.pluginId }
+      : { toolSource: "plugin", toolOwner: pluginMeta.pluginId };
+  }
+  const channelMeta = getChannelAgentToolMeta(tool as never);
+  if (channelMeta) {
+    return { toolSource: "channel", toolOwner: channelMeta.channelId };
+  }
+  return { toolSource: "core" };
+}
+
+type SkillUsageMatch = {
+  skillName: string;
+  skillSource: SkillTelemetrySource;
+  activation: "command" | "read";
+};
+
+function resolveRelativeToolPath(candidate: string, ctx?: HookContext): string | undefined {
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed === "~") {
+    return os.homedir();
+  }
+  if (trimmed.startsWith("~/")) {
+    return path.resolve(os.homedir(), trimmed.slice(2));
+  }
+  if (path.isAbsolute(trimmed)) {
+    return path.resolve(trimmed);
+  }
+  const base = ctx?.workspaceDir ?? ctx?.cwd;
+  return base ? path.resolve(base, trimmed) : undefined;
+}
+
+function readToolPathCandidates(params: unknown, ctx?: HookContext): string[] {
+  if (!isPlainObject(params)) {
+    return [];
+  }
+  const candidates = typeof params.path === "string" ? [params.path] : [];
+  return candidates
+    .map((candidate) => resolveRelativeToolPath(candidate, ctx))
+    .filter((candidate): candidate is string => Boolean(candidate));
+}
+
+function skillInstructionPaths(snapshot: SkillSnapshot | undefined): Map<string, SkillUsageMatch> {
+  const matches = new Map<string, SkillUsageMatch>();
+  for (const skill of snapshot?.resolvedSkills ?? []) {
+    const skillName = typeof skill.name === "string" ? skill.name.trim() : "";
+    if (!skillName) {
+      continue;
+    }
+    const match = {
+      skillName,
+      skillSource: resolveSkillTelemetrySource(skill),
+      activation: "read" as const,
+    };
+    const filePath = typeof skill.filePath === "string" ? skill.filePath.trim() : "";
+    if (filePath && path.isAbsolute(filePath)) {
+      matches.set(path.resolve(filePath), match);
+    }
+    const baseDir = typeof skill.baseDir === "string" ? skill.baseDir.trim() : "";
+    if (baseDir && path.isAbsolute(baseDir)) {
+      matches.set(path.resolve(baseDir, "SKILL.md"), match);
+    }
+  }
+  return matches;
+}
+
+function findSkillUsageMatch(params: {
+  toolName: string;
+  toolParams: unknown;
+  ctx?: HookContext;
+}): SkillUsageMatch | undefined {
+  const command = params.ctx?.skillCommand;
+  if (command) {
+    const commandToolName = normalizeToolName(command.toolName ?? params.toolName);
+    if (!commandToolName || commandToolName === params.toolName) {
+      return {
+        skillName: command.skillName,
+        skillSource: resolveSkillTelemetrySourceValue(command.skillSource),
+        activation: "command",
+      };
+    }
+  }
+
+  if (params.toolName !== "read" || !params.ctx?.skillsSnapshot?.resolvedSkills?.length) {
+    return undefined;
+  }
+  const skillPaths = skillInstructionPaths(params.ctx.skillsSnapshot);
+  for (const candidate of readToolPathCandidates(params.toolParams, params.ctx)) {
+    const match = skillPaths.get(candidate);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+function emitSkillUsedDiagnostic(params: {
+  ctx?: HookContext;
+  match: SkillUsageMatch;
+  toolName: string;
+  toolCallId?: string;
+}): void {
+  const trace = params.ctx?.trace
+    ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(params.ctx.trace))
+    : undefined;
+  emitTrustedDiagnosticEvent({
+    type: "skill.used",
+    ...(params.ctx?.runId && { runId: params.ctx.runId }),
+    ...(params.ctx?.sessionKey && { sessionKey: params.ctx.sessionKey }),
+    ...(params.ctx?.sessionId && { sessionId: params.ctx.sessionId }),
+    ...(params.ctx?.agentId && { agentId: params.ctx.agentId }),
+    ...(trace && { trace }),
+    skillName: params.match.skillName,
+    skillSource: params.match.skillSource,
+    activation: params.match.activation,
+    toolName: params.toolName,
+    ...(params.toolCallId && { toolCallId: params.toolCallId }),
+  });
 }
 
 async function requestPluginToolApproval(params: {
@@ -740,6 +885,7 @@ export function wrapToolWithBeforeToolCallHook(
     return tool;
   }
   const toolName = tool.name || "tool";
+  const diagnosticIdentity = resolveToolDiagnosticIdentity(tool);
   const diagnosticOptions = { emitDiagnostics: options.emitDiagnostics !== false };
   const wrappedTool: AnyAgentTool = {
     ...tool,
@@ -768,6 +914,7 @@ export function wrapToolWithBeforeToolCallHook(
           ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
           ...(trace && { trace }),
           toolName: normalizedToolName,
+          ...diagnosticIdentity,
           ...(toolCallId && { toolCallId }),
           paramsSummary: summarizeToolParams(outcome.params ?? hookParams),
         };
@@ -809,6 +956,7 @@ export function wrapToolWithBeforeToolCallHook(
         ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
         ...(trace && { trace }),
         toolName: normalizedToolName,
+        ...diagnosticIdentity,
         ...(toolCallId && { toolCallId }),
         paramsSummary: summarizeToolParams(executeParams),
       };
@@ -829,7 +977,20 @@ export function wrapToolWithBeforeToolCallHook(
           toolCallId,
           result,
         });
+        const skillMatch = findSkillUsageMatch({
+          toolName: normalizedToolName,
+          toolParams: executeParams,
+          ctx,
+        });
         if (diagnosticOptions.emitDiagnostics) {
+          if (skillMatch) {
+            emitSkillUsedDiagnostic({
+              ctx,
+              match: skillMatch,
+              toolName: normalizedToolName,
+              toolCallId,
+            });
+          }
           emitTrustedDiagnosticEvent({
             type: "tool.execution.completed",
             ...eventBase,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -1076,6 +1076,8 @@ export function createOpenClawCodingTools(options?: {
         agentId,
         ...(options?.config ? { config: options.config } : {}),
         cwd: sandboxRoot ?? workspaceRoot,
+        workspaceDir: workspaceRoot,
+        ...(options?.skillsSnapshot ? { skillsSnapshot: options.skillsSnapshot } : {}),
         ...(sandboxRoot && allowWorkspaceWrites
           ? { sandbox: { root: sandboxRoot, bridge: sandboxFsBridge! } }
           : {}),

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -244,6 +244,7 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     expect(longCmd?.description.endsWith("…")).toBe(true);
     expect(shortCmd?.description).toBe("Short description");
     expect(cmd?.dispatch).toEqual({ kind: "tool", toolName: "sessions_send", argMode: "raw" });
+    expect(cmd?.skillSource).toBe("workspace");
   });
 
   it("inherits agents.defaults.skills when agentId is provided", async () => {

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -25,6 +25,7 @@ export type {
   SkillEntry,
   SkillInstallSpec,
   SkillSnapshot,
+  SkillTelemetrySource,
   SkillsInstallPreferences,
 } from "./skills/types.js";
 export {

--- a/src/agents/skills/command-specs.ts
+++ b/src/agents/skills/command-specs.ts
@@ -6,6 +6,7 @@ import {
   normalizeOptionalLowercaseString,
 } from "../../shared/string-coerce.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
+import { resolveSkillTelemetrySource } from "./source.js";
 import type { SkillEligibilityContext, SkillCommandSpec, SkillEntry } from "./types.js";
 import {
   filterWorkspaceSkillEntriesWithOptions,
@@ -157,6 +158,7 @@ export function buildWorkspaceSkillCommandSpecs(
       name: unique,
       skillName: rawName,
       description,
+      skillSource: resolveSkillTelemetrySource(entry.skill),
       ...(dispatch ? { dispatch } : {}),
     });
   }

--- a/src/agents/skills/source.ts
+++ b/src/agents/skills/source.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { Skill } from "./skill-contract.js";
+import type { SkillTelemetrySource } from "./types.js";
 
 type SkillSourceCompat = Skill & {
   sourceInfo?: {
@@ -15,4 +16,26 @@ export function resolveSkillSource(skill: Skill): string {
   }
   const legacy = normalizeOptionalString(compatSkill.sourceInfo?.source) ?? "";
   return legacy || "unknown";
+}
+
+export function resolveSkillTelemetrySourceValue(value: unknown): SkillTelemetrySource {
+  const source = normalizeOptionalString(value) ?? "";
+  if (source === "bundled" || source === "openclaw-bundled") {
+    return "bundled";
+  }
+  if (
+    source === "workspace" ||
+    source === "openclaw-workspace" ||
+    source === "openclaw-managed" ||
+    source === "openclaw-extra" ||
+    source === "agents-skills-personal" ||
+    source === "agents-skills-project"
+  ) {
+    return "workspace";
+  }
+  return "unknown";
+}
+
+export function resolveSkillTelemetrySource(skill: Skill): SkillTelemetrySource {
+  return resolveSkillTelemetrySourceValue(resolveSkillSource(skill));
 }

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -48,10 +48,14 @@ export type SkillCommandDispatchSpec = {
   argMode?: "raw";
 };
 
+export type SkillTelemetrySource = "bundled" | "unknown" | "workspace";
+
 export type SkillCommandSpec = {
   name: string;
   skillName: string;
   description: string;
+  /** Bounded source label used for diagnostics. */
+  skillSource?: SkillTelemetrySource;
   /** Localized descriptions for native command surfaces that support them. */
   descriptionLocalizations?: Record<string, string>;
   /** Optional deterministic dispatch behavior for this command. */

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -667,6 +667,7 @@ describe("handleInlineActions", () => {
         name: "set_profile",
         skillName: "matrix-profile",
         description: "Set Matrix profile",
+        skillSource: "workspace",
         dispatch: {
           kind: "tool",
           toolName: "message",
@@ -698,9 +699,18 @@ describe("handleInlineActions", () => {
     );
 
     expect(result).toEqual({ kind: "reply", reply: { text: "✅ Done." } });
-    expect(mockObjectArg(createOpenClawToolsMock, "createOpenClawTools")).not.toHaveProperty(
-      "senderIsOwner",
-    );
+    const toolsArgs = mockObjectArg(createOpenClawToolsMock, "createOpenClawTools");
+    expect(toolsArgs).not.toHaveProperty("senderIsOwner");
+    expect(toolsArgs.beforeToolCallHookContext).toMatchObject({
+      cwd: "/tmp",
+      workspaceDir: "/tmp",
+      skillCommand: {
+        commandName: "set_profile",
+        skillName: "matrix-profile",
+        skillSource: "workspace",
+        toolName: "message",
+      },
+    });
     const toolCall = mockCallArgs(toolExecute, "toolExecute");
     expect(toolCall?.[0]).toMatch(/^cmd_/);
     expect(toolCall?.[1]).toEqual({

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -294,6 +294,14 @@ export async function handleInlineActions(params: {
         model,
         senderId: command.senderId,
         currentChannelId: command.channelId,
+        skillCommand: {
+          name: skillInvocation.command.name,
+          skillName: skillInvocation.command.skillName,
+          ...(skillInvocation.command.skillSource
+            ? { skillSource: skillInvocation.command.skillSource }
+            : {}),
+          toolName: dispatch.toolName,
+        },
       });
 
       const tool = authorizedTools.find((candidate) => candidate.name === dispatch.toolName);

--- a/src/auto-reply/reply/skill-tool-dispatch.runtime.ts
+++ b/src/auto-reply/reply/skill-tool-dispatch.runtime.ts
@@ -8,6 +8,7 @@ import {
 import type { AnyAgentTool } from "../../agents/pi-tools.types.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status.js";
 import { resolveSenderToolPolicy } from "../../agents/sender-tool-policy.js";
+import type { SkillCommandSpec } from "../../agents/skills.js";
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
@@ -49,6 +50,9 @@ export function resolveSkillDispatchTools(params: {
   model: string;
   senderId?: string;
   currentChannelId?: string;
+  skillCommand?: Pick<SkillCommandSpec, "name" | "skillName" | "skillSource"> & {
+    toolName?: string;
+  };
 }): AnyAgentTool[] {
   const channel =
     resolveGatewayMessageChannel(params.ctx.Surface) ??
@@ -135,6 +139,21 @@ export function resolveSkillDispatchTools(params: {
     inheritedToolPolicy,
   ];
   const inheritedToolAllowlist: string[] = [];
+  const beforeToolCallHookContext = params.skillCommand
+    ? {
+        cwd: params.workspaceDir,
+        workspaceDir: params.workspaceDir,
+        ...(params.sessionEntry?.skillsSnapshot
+          ? { skillsSnapshot: params.sessionEntry.skillsSnapshot }
+          : {}),
+        skillCommand: {
+          commandName: params.skillCommand.name,
+          skillName: params.skillCommand.skillName,
+          skillSource: params.skillCommand.skillSource ?? "unknown",
+          ...(params.skillCommand.toolName ? { toolName: params.skillCommand.toolName } : {}),
+        },
+      }
+    : undefined;
   const tools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
     agentChannel: channel,
@@ -154,6 +173,7 @@ export function resolveSkillDispatchTools(params: {
     requesterSenderId: params.senderId,
     sessionId: params.sessionEntry?.sessionId,
     currentChannelId: params.currentChannelId,
+    ...(beforeToolCallHookContext ? { beforeToolCallHookContext } : {}),
     modelProvider: params.provider,
     modelId: params.model,
     pluginToolAllowlist: collectExplicitAllowlist(explicitPolicyList),

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -373,11 +373,15 @@ export type DiagnosticToolParamsSummary =
   | { kind: "string"; length: number }
   | { kind: "number" | "boolean" | "null" | "undefined" | "other" };
 
+export type DiagnosticToolSource = "channel" | "core" | "mcp" | "plugin";
+
 type DiagnosticToolExecutionBaseEvent = DiagnosticBaseEvent & {
   runId?: string;
   sessionKey?: string;
   sessionId?: string;
   toolName: string;
+  toolSource?: DiagnosticToolSource;
+  toolOwner?: string;
   toolCallId?: string;
   paramsSummary?: DiagnosticToolParamsSummary;
 };
@@ -402,6 +406,22 @@ export type DiagnosticToolExecutionBlockedEvent = DiagnosticToolExecutionBaseEve
   type: "tool.execution.blocked";
   deniedReason: string;
   reason: string;
+};
+
+export type DiagnosticSkillTelemetrySource = "bundled" | "unknown" | "workspace";
+export type DiagnosticSkillActivation = "command" | "read";
+
+export type DiagnosticSkillUsedEvent = DiagnosticBaseEvent & {
+  type: "skill.used";
+  runId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  skillName: string;
+  skillSource: DiagnosticSkillTelemetrySource;
+  activation: DiagnosticSkillActivation;
+  toolName?: string;
+  toolCallId?: string;
 };
 
 export type DiagnosticExecProcessCompletedEvent = DiagnosticBaseEvent & {
@@ -656,6 +676,7 @@ export type DiagnosticEventPayload =
   | DiagnosticToolExecutionCompletedEvent
   | DiagnosticToolExecutionErrorEvent
   | DiagnosticToolExecutionBlockedEvent
+  | DiagnosticSkillUsedEvent
   | DiagnosticExecProcessCompletedEvent
   | DiagnosticRunStartedEvent
   | DiagnosticRunCompletedEvent
@@ -717,6 +738,7 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "tool.execution.completed",
   "tool.execution.error",
   "tool.execution.blocked",
+  "skill.used",
   "exec.process.completed",
   "message.delivery.started",
   "message.delivery.completed",

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -387,20 +387,34 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       break;
     case "tool.execution.started":
       record.toolName = event.toolName;
+      record.source = event.toolSource;
+      record.pluginId = event.toolOwner;
       break;
     case "tool.execution.completed":
       record.toolName = event.toolName;
+      record.source = event.toolSource;
+      record.pluginId = event.toolOwner;
       record.durationMs = event.durationMs;
       break;
     case "tool.execution.error":
       record.toolName = event.toolName;
+      record.source = event.toolSource;
+      record.pluginId = event.toolOwner;
       record.durationMs = event.durationMs;
       assignReasonCode(record, event.errorCategory);
       break;
     case "tool.execution.blocked":
       record.toolName = event.toolName;
+      record.source = event.toolSource;
+      record.pluginId = event.toolOwner;
       record.outcome = "blocked";
       assignReasonCode(record, event.deniedReason);
+      break;
+    case "skill.used":
+      record.toolName = event.toolName;
+      record.source = event.skillSource;
+      record.action = event.activation;
+      record.target = event.skillName;
       break;
     case "exec.process.completed":
       record.target = event.target;


### PR DESCRIPTION
## Summary
- rewrites the original broad skill telemetry PR into one canonical diagnostics contract for skill and tool usage
- adds trusted `skill.used` diagnostic events for successful skill reads and command-dispatched skill tools without exporting raw paths, params, run ids, or session keys
- adds bounded `tool_source` / `tool_owner` labels for core, plugin, MCP, and channel tool execution
- updates OpenTelemetry, Prometheus, docs, changelog, and focused regression coverage while keeping labels low-cardinality

## Verification
- `git diff --check origin/main...HEAD`
- `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- AWS Crabbox focused regression run `run_a025b130b08b` / `cbx_b6a6fe523e2b` on c7a.8xlarge: `pnpm test:serial src/agents/pi-tools.before-tool-call.e2e.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/agents/skills.test.ts extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-prometheus/src/service.test.ts` -> 5 shards passed, 161 tests passed
- AWS Crabbox fresh-PR gate `run_607180ab0238` / `cbx_12408152a349` on c7a.8xlarge: `pnpm check:changed` -> passed
- AWS Crabbox observability smoke `run_81b7bfc3aece` / `cbx_858db1d32be3` on c7a.8xlarge: `pnpm qa:observability:smoke` -> passed

## Real behavior proof
Behavior addressed: operators now get bounded skill usage and tool source/owner telemetry from the diagnostics exporters, so skill, MCP, plugin, channel, and core tool activity can be distinguished without leaking raw skill paths, tool params, run ids, or session keys.

Real environment tested: AWS Crabbox Linux c7a.8xlarge fresh checkout of `openclaw/openclaw#80370`, running the OpenClaw QA-lab Gateway against a local OTLP receiver and the Prometheus diagnostics scrape path.

Exact steps or command run after this patch: `pnpm qa:observability:smoke` from the fresh PR checkout.

Evidence after fix: terminal console output from AWS Crabbox run `run_81b7bfc3aece` / lease `cbx_858db1d32be3`:

```text
[qa-suite] gateway ready: http://127.0.0.1:33625
[qa-suite] scenario pass (1/1): otel-trace-smoke
[qa-suite] run complete: passed=1 failed=0 total=1
qa-otel-smoke: passed spans=18 metrics=67 logs=12 traces=2 metricRequests=15 logRequests=7
[qa-suite] gateway ready: http://127.0.0.1:43289
[qa-suite] scenario pass (1/1): docker-prometheus-smoke
[qa-suite] run complete: passed=1 failed=0 total=1
run details provider=aws lease=cbx_858db1d32be3 slug=crimson-shrimp run=run_81b7bfc3aece type=c7a.8xlarge
{"provider":"aws","leaseId":"cbx_858db1d32be3","runId":"run_81b7bfc3aece","machineType":"c7a.8xlarge","exitCode":0}
```

Observed result after fix: the OpenClaw Gateway emitted OTLP traces, metrics, and logs to the receiver, then completed the Prometheus diagnostics smoke successfully from the same PR branch. The OTLP smoke reported 18 spans, 67 metrics, 12 logs, 2 trace requests, 15 metric requests, and 7 log requests; the Prometheus scenario reported `passed=1 failed=0 total=1`.

What was not tested: no live third-party MCP server or external plugin service was used in this smoke; those classifications are covered by OpenClaw tool metadata paths and exporter regression coverage.
