### PR TITLE
fix(cli-runner): inject system prompt on --resume sessions

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -130,6 +130,49 @@ describe("buildCliArgs", () => {
     ).toEqual(["exec", "resume", "thread-123", "--model", "gpt-5.4"]);
   });
 
+  it("injects --append-system-prompt-file on resumed Claude CLI sessions", () => {
+    expect(
+      buildCliArgs({
+        backend: {
+          command: "claude",
+          systemPromptFileArg: "--append-system-prompt-file",
+        },
+        baseArgs: ["--resume", "session-uuid-123", "-p"],
+        modelId: "claude-sonnet-4-6",
+        systemPrompt: "You are a helpful assistant",
+        systemPromptFilePath: "/tmp/openclaw/system-prompt.md",
+        useResume: true,
+      }),
+    ).toEqual([
+      "--resume",
+      "session-uuid-123",
+      "-p",
+      "--append-system-prompt-file",
+      "/tmp/openclaw/system-prompt.md",
+    ]);
+  });
+
+  it("injects system prompt arg on resumed sessions when no file arg is configured", () => {
+    expect(
+      buildCliArgs({
+        backend: {
+          command: "claude",
+          systemPromptArg: "--append-system-prompt",
+        },
+        baseArgs: ["--resume", "session-uuid-123", "-p"],
+        modelId: "claude-sonnet-4-6",
+        systemPrompt: "You are a helpful assistant",
+        useResume: true,
+      }),
+    ).toEqual([
+      "--resume",
+      "session-uuid-123",
+      "-p",
+      "--append-system-prompt",
+      "You are a helpful assistant",
+    ]);
+  });
+
   it("strips the internal cache boundary from CLI system prompt args", () => {
     expect(
       buildCliArgs({

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -278,16 +278,15 @@ export async function executePreparedCliRun(
   );
   const systemPromptArg = resolveSystemPromptUsage({
     backend,
-    isNewSession: isNew,
+    isNewSession: isNew || useResume,
     systemPrompt: context.systemPrompt,
   });
-  const systemPromptFile =
-    !useResume && systemPromptArg
-      ? await writeCliSystemPromptFile({
-          backend,
-          systemPrompt: systemPromptArg,
-        })
-      : undefined;
+  const systemPromptFile = systemPromptArg
+    ? await writeCliSystemPromptFile({
+        backend,
+        systemPrompt: systemPromptArg,
+      })
+    : undefined;
 
   const basePrompt = cliSessionIdToUse
     ? params.prompt

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -373,15 +373,9 @@ export function buildCliArgs(params: {
   if (params.backend.modelArg && params.modelId) {
     args.push(params.backend.modelArg, params.modelId);
   }
-  if (
-    !params.useResume &&
-    params.systemPrompt &&
-    params.systemPromptFilePath &&
-    params.backend.systemPromptFileArg
-  ) {
+  if (params.systemPrompt && params.systemPromptFilePath && params.backend.systemPromptFileArg) {
     args.push(params.backend.systemPromptFileArg, params.systemPromptFilePath);
   } else if (
-    !params.useResume &&
     params.systemPrompt &&
     params.systemPromptFilePath &&
     params.backend.systemPromptFileConfigKey
@@ -393,7 +387,7 @@ export function buildCliArgs(params: {
         params.systemPromptFilePath,
       ),
     );
-  } else if (!params.useResume && params.systemPrompt && params.backend.systemPromptArg) {
+  } else if (params.systemPrompt && params.backend.systemPromptArg) {
     args.push(params.backend.systemPromptArg, stripSystemPromptCacheBoundary(params.systemPrompt));
   }
   if (!params.useResume && params.sessionId) {


### PR DESCRIPTION
## Summary

Fixes #80374. When resuming a Claude CLI session with `--resume`, the `--append-system-prompt-file` flag was silently dropped, causing harness initialization files (SOUL.md, IDENTITY.md, AGENTS.md) to not be loaded.

**Root cause — three independent guards all blocked the path:**

1. `buildCliArgs` (`helpers.ts`) had `!params.useResume &&` on all three system-prompt injection branches, preventing them from emitting on resumed sessions.
2. `execute.ts` had `!useResume && systemPromptArg` guarding the temp-file write, so the file was never created.
3. `resolveSystemPromptUsage` was called with `isNewSession: isNew` (`false` on resume) — causing it to return `null` for the default `"first"` policy.

**Fix:** Remove all three `!useResume` guards and pass `isNewSession: isNew || useResume` so resume is treated like a new session for system-prompt injection.

## Real behavior proof

**Behavior or issue addressed:**
`--append-system-prompt-file` (and `--append-system-prompt`) flags are omitted from the Claude CLI invocation on session resume, so SOUL.md / IDENTITY.md / AGENTS.md content is never injected into the resumed context. Fresh sessions work; resumed sessions silently revert to generic Claude.

**Real environment tested:**
Node.js 22, openclaw local build from this branch, `src/agents/cli-runner/helpers.ts` `buildCliArgs` invoked directly via unit harness.

**Exact steps or command run after this patch:**
```
node --experimental-vm-modules node_modules/vitest/vitest.mjs run src/agents/cli-runner.helpers.test.ts --reporter=verbose
```

**Evidence after fix:**
```
✓ buildCliArgs > keeps passing model overrides on resumed CLI sessions
✓ buildCliArgs > injects --append-system-prompt-file on resumed Claude CLI sessions
✓ buildCliArgs > injects system prompt arg on resumed sessions when no file arg is configured
✓ buildCliArgs > strips the internal cache boundary from CLI system prompt args
✓ buildCliArgs > passes Codex system prompts via a model instructions file config override
✓ buildCliArgs > passes Claude system prompts through its file flag

Test Files  2 passed (2)
     Tests  42 passed (42)
```

The new test `injects --append-system-prompt-file on resumed Claude CLI sessions` calls `buildCliArgs` with `useResume: true` and asserts the output array contains `['--append-system-prompt-file', '/tmp/openclaw/system-prompt.md']` — this test failed before the fix (output was missing those args) and passes after.

**Observed result after fix:**
Resumed sessions now emit `--append-system-prompt-file <path>` in the Claude CLI argument list, matching fresh-session behavior. The system prompt temp file is written and the flag injected regardless of whether `useResume` is true or false.

**What was not tested:**
End-to-end session resume against a live Claude CLI binary — the arg-assembly path is fully covered; the integration path (Claude CLI actually reading and honoring the appended prompt) relies on Claude CLI's existing `--append-system-prompt-file` behavior.