### PR TITLE
[AI-assisted] fix(gateway): suppress heartbeat tool cards in webchat

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -960,6 +960,44 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
+  it("suppresses heartbeat tool events for Control UI and verbose node subscribers", () => {
+    const {
+      broadcastToConnIds,
+      nodeSendToSession,
+      sessionEventSubscribers,
+      toolEventRecipients,
+      handler,
+    } = createHarness({
+      resolveSessionKeyForRun: () => "session-heartbeat",
+    });
+
+    registerAgentRunContext("run-heartbeat-tool", {
+      sessionKey: "session-heartbeat",
+      isHeartbeat: true,
+      verboseLevel: "on",
+    });
+    toolEventRecipients.add("run-heartbeat-tool", "conn-run");
+    sessionEventSubscribers.subscribe("conn-session");
+
+    handler({
+      runId: "run-heartbeat-tool",
+      seq: 1,
+      stream: "tool",
+      ts: 1_234,
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "tool-heartbeat-1",
+        args: { path: "HEARTBEAT.md" },
+      },
+    });
+
+    expect(broadcastToConnIds).not.toHaveBeenCalled();
+    const nodeToolCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
+    expect(nodeToolCalls).toHaveLength(0);
+    resetAgentRunContextForTest();
+  });
+
   it("hydrates run-scoped tool events with session ownership metadata", () => {
     const { broadcastToConnIds, toolEventRecipients, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-1",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -84,6 +84,10 @@ function shouldHideHeartbeatChatOutput(runId: string, sourceRunId?: string): boo
   }
 }
 
+function shouldSuppressHeartbeatToolEvents(runId: string, sourceRunId?: string): boolean {
+  return Boolean(resolveHeartbeatContext(runId, sourceRunId)?.isHeartbeat);
+}
+
 function normalizeHeartbeatChatFinalText(params: {
   runId: string;
   sourceRunId?: string;
@@ -613,6 +617,8 @@ export function createAgentEventHandler({
     const isToolEvent = evt.stream === "tool";
     const isItemEvent = evt.stream === "item";
     const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
+    const suppressHeartbeatToolEvents =
+      isToolEvent && shouldSuppressHeartbeatToolEvents(clientRunId, evt.runId);
     // Channel/node subscribers respect verbose; authenticated Control UI
     // recipients need tool result payloads to render live tool cards.
     const channelToolPayload =
@@ -645,7 +651,13 @@ export function createAgentEventHandler({
       const toolPhase = typeof evt.data?.phase === "string" ? evt.data.phase : "";
       // Flush pending assistant text before tool-start events so clients can
       // render complete pre-tool text above tool cards (not truncated by delta throttle).
-      if (toolPhase === "start" && isControlUiVisible && sessionKey && !isAborted) {
+      if (
+        toolPhase === "start" &&
+        isControlUiVisible &&
+        sessionKey &&
+        !isAborted &&
+        !suppressHeartbeatToolEvents
+      ) {
         flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
       }
       // Always broadcast tool events to registered WS recipients with
@@ -653,7 +665,7 @@ export function createAgentEventHandler({
       // setting only controls whether tool details are sent as channel
       // messages to messaging surfaces (Telegram, Discord, etc.).
       const recipients = toolEventRecipients.get(evt.runId);
-      if (isControlUiVisible && recipients && recipients.size > 0) {
+      if (isControlUiVisible && !suppressHeartbeatToolEvents && recipients && recipients.size > 0) {
         broadcastToConnIds(
           "agent",
           sessionKey ? { ...agentPayload, ...buildSessionEventSnapshot(sessionKey) } : agentPayload,
@@ -665,7 +677,7 @@ export function createAgentEventHandler({
       // not know the runId in advance, so they cannot register as run-scoped
       // tool recipients. Mirror tool lifecycle onto a session-scoped event so
       // they can render live pending tool cards without polling history.
-      if (isControlUiVisible && sessionKey) {
+      if (isControlUiVisible && sessionKey && !suppressHeartbeatToolEvents) {
         const sessionSubscribers = sessionEventSubscribers.getAll();
         if (sessionSubscribers.size > 0) {
           broadcastToConnIds(
@@ -687,9 +699,9 @@ export function createAgentEventHandler({
     }
 
     if (isControlUiVisible && sessionKey) {
-      // Send tool events to node/channel subscribers only when verbose is enabled;
-      // WS clients already received the event above via broadcastToConnIds.
-      if (!isToolEvent || toolVerbose !== "off") {
+      // Send non-heartbeat tool events to node/channel subscribers only when
+      // verbose is enabled; WS clients already received the event above.
+      if (!isToolEvent || (!suppressHeartbeatToolEvents && toolVerbose !== "off")) {
         nodeSendToSession(
           sessionKey,
           "agent",


### PR DESCRIPTION
## Summary

Fixes #79735.

Heartbeat runs already suppress `HEARTBEAT_OK` text in webchat by default, but their live tool events could still reach visible Gateway/WebChat tool-event surfaces. This keeps heartbeat tool execution internal by suppressing heartbeat-originated tool broadcasts on the Gateway paths that feed Control UI run-scoped tool recipients, session-scoped `session.tool` subscribers, and verbose node/channel subscribers.

## Root Cause

`server-chat.ts` used the heartbeat context for assistant text suppression, but the tool-event branch still mirrored Control-UI-visible tool events to live subscribers. That meant a heartbeat `read` call for `HEARTBEAT.md` could render as live tool activity even when the heartbeat text itself stayed hidden.

## What Changed

- Added a heartbeat tool-event guard at the Gateway chat projection boundary.
- Suppressed heartbeat tool events for Control UI run-scoped recipients and `session.tool` subscribers.
- Suppressed the same heartbeat tool events from verbose node/channel forwarding.
- Left heartbeat final/delta text visibility, session lifecycle updates, compact indicators, and non-heartbeat tool cards unchanged.
- Added focused regression coverage for Control UI, session-scoped, and verbose node subscriber paths.

## Real Behavior Proof

- **Behavior or issue addressed:** Heartbeat-originated tool events should not create visible live tool cards or verbose tool-event output such as `read HEARTBEAT.md`, while normal non-heartbeat tool cards and heartbeat text visibility handling remain unchanged.
- **Real environment tested:** Local OpenClaw checkout on Windows 11, branch `fix-webchat-heartbeat-tool-events-79735`, Node/pnpm workspace after `corepack pnpm install`. This exercises the Gateway `server-chat.ts` projection code path with run-scoped tool recipients, session-scoped `session.tool` subscribers, and verbose node forwarding enabled in the regression.
- **Exact steps or command run after this patch:** From `C:\oc79735`, I rebased onto current `openclaw/main`, patched the `/review` finding, then ran the validation commands listed below.
- **Evidence after fix:** The focused regression registers tool recipients/subscribers, emits a heartbeat-originated `read HEARTBEAT.md` tool event with verbose enabled, and observes that no Control UI `agent`, `session.tool`, or node/channel `agent` broadcast is produced. The test file reports `56 passed`.
- **Observed result after fix:** Heartbeat tool events are suppressed from the visible live broadcast paths under test. Non-heartbeat tool handling remains covered by existing tests.
- **What was not tested:** I did not run a full browser-rendered WebChat session with a scheduled 30-minute heartbeat against a live remote provider from this machine.

## Validation

- `CI=true corepack pnpm test src/gateway/server-chat.agent-events.test.ts`
- `CI=true corepack pnpm exec oxfmt --check --threads=1 src/gateway/server-chat.ts src/gateway/server-chat.agent-events.test.ts`
- `git diff --check origin/main...HEAD`
- `CI=true node scripts/run-oxlint-shards.mjs --threads=8`
- `CI=true corepack pnpm check:changed`
- `codex review --base origin/main -c model_reasoning_effort='"medium"'`

## Duplicate / Ownership Scan

Before coding and again before opening this PR, I checked for existing PRs referencing #79735 and for active heartbeat/webchat tool-card fixes. No exact #79735 PR exists. Older adjacent PRs such as #69084 and #76896 address heartbeat text/history filtering, but they do not cover the live `session.tool` / verbose node forwarding leak path fixed here.

## Security

No new permissions, dependencies, network calls, token handling, install hooks, or code execution paths. The change only suppresses existing Gateway live-display events for heartbeat-originated tool activity.