### PR TITLE
acp: cancel queued SessionActorQueue items on caller abort

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1996,11 +1996,15 @@ export class AcpSessionManager {
     this.throwIfAborted(signal);
 
     let actorStarted = false;
-    const queued = this.actorQueue.run(actorKey, async () => {
-      actorStarted = true;
-      this.throwIfAborted(signal);
-      return await op();
-    });
+    const queued = this.actorQueue.run(
+      actorKey,
+      async () => {
+        actorStarted = true;
+        this.throwIfAborted(signal);
+        return await op();
+      },
+      { signal },
+    );
     if (!signal) {
       return await queued;
     }
@@ -2030,6 +2034,9 @@ export class AcpSessionManager {
         if (actorStarted) {
           return;
         }
+        logVerbose(
+          `acp-manager: actor queue abort-before-start actorKey=${actorKey} pending=${this.actorQueue.getPendingCountForSession(actorKey)}`,
+        );
         try {
           this.throwIfAborted(signal);
         } catch (error) {

--- a/src/acp/control-plane/session-actor-queue.test.ts
+++ b/src/acp/control-plane/session-actor-queue.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { SessionActorQueue } from "./session-actor-queue.js";
+
+function deferred<T>() {
+  let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  if (!resolve) {
+    throw new Error("Expected deferred resolver to be initialized");
+  }
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(rounds = 10): Promise<void> {
+  for (let index = 0; index < rounds; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+async function runWithAbortBeforeStart<T>(params: {
+  queue: SessionActorQueue;
+  actorKey: string;
+  op: () => Promise<T>;
+  signal: AbortSignal;
+}): Promise<T> {
+  let actorStarted = false;
+  const queued = params.queue.run(params.actorKey, async () => {
+    actorStarted = true;
+    if (params.signal.aborted) {
+      throw new Error("aborted");
+    }
+    return await params.op();
+  });
+
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      if (actorStarted) {
+        return;
+      }
+      params.queue.markAbortBeforeStart(params.actorKey);
+      reject(new Error("aborted before start"));
+    };
+    params.signal.addEventListener("abort", onAbort, { once: true });
+    queued.then(resolve, reject);
+    if (params.signal.aborted) {
+      onAbort();
+    }
+  });
+}
+
+describe("SessionActorQueue diagnostics", () => {
+  it("reports previous tail and pending state for an abort-before-start queued actor", async () => {
+    const queue = new SessionActorQueue();
+    const actorKey = "agent:main:explicit:koura-recruiting-test-001";
+    const firstGate = deferred<void>();
+    const firstRun = queue.run(actorKey, async () => {
+      await firstGate.promise;
+    });
+    await flushMicrotasks();
+
+    const controller = new AbortController();
+    const secondRun = runWithAbortBeforeStart({
+      queue,
+      actorKey,
+      signal: controller.signal,
+      op: async () => undefined,
+    });
+    await flushMicrotasks();
+    controller.abort();
+
+    await expect(secondRun).rejects.toThrow("aborted before start");
+    expect(queue.getPendingCountForSession(actorKey)).toBe(2);
+    expect(queue.getTailMapForTesting().has(actorKey)).toBe(true);
+    expect(queue.getDiagnosticSnapshot(actorKey)).toMatchObject({
+      actorKey,
+      actorStarted: false,
+      abortBeforeStart: true,
+      pendingCount: 2,
+      previousTailPresent: true,
+      settleTime: null,
+    });
+
+    firstGate.resolve();
+    await firstRun;
+    await flushMicrotasks();
+  });
+});
+
+describe("SessionActorQueue cancellable queued item via signal", () => {
+  it("does not call op() when signal aborts before the actor starts", async () => {
+    const queue = new SessionActorQueue();
+    const actorKey = "test-actor-no-op";
+    const firstGate = deferred<void>();
+    const firstRun = queue.run(actorKey, async () => {
+      await firstGate.promise;
+    });
+    await flushMicrotasks();
+
+    const controller = new AbortController();
+    let opCalled = false;
+    const secondRun = queue.run(
+      actorKey,
+      async () => {
+        opCalled = true;
+        return "second-result";
+      },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    controller.abort();
+
+    // Predecessor settles, allowing the cancelled item to reach the head of the queue.
+    firstGate.resolve();
+    await firstRun;
+    await flushMicrotasks();
+
+    await expect(secondRun).rejects.toMatchObject({ name: "AbortError" });
+    expect(opCalled).toBe(false);
+  });
+
+  it("decrements pending immediately on abort-before-start", async () => {
+    const queue = new SessionActorQueue();
+    const actorKey = "test-actor-early-decrement";
+    const firstGate = deferred<void>();
+    const firstRun = queue.run(actorKey, async () => {
+      await firstGate.promise;
+    });
+    await flushMicrotasks();
+    expect(queue.getPendingCountForSession(actorKey)).toBe(1);
+
+    const controller = new AbortController();
+    const secondRun = queue.run(actorKey, async () => "should-not-run", {
+      signal: controller.signal,
+    });
+    await flushMicrotasks();
+    expect(queue.getPendingCountForSession(actorKey)).toBe(2);
+
+    controller.abort();
+    await flushMicrotasks();
+    // Cancelled item is logically gone even though its slot still occupies the chain.
+    expect(queue.getPendingCountForSession(actorKey)).toBe(1);
+
+    firstGate.resolve();
+    await firstRun;
+    await expect(secondRun).rejects.toMatchObject({ name: "AbortError" });
+    await flushMicrotasks();
+    // Both items have settled; pending must not go negative or double-decrement.
+    expect(queue.getPendingCountForSession(actorKey)).toBe(0);
+  });
+
+  it("decrements pending only once across cancel and onSettle", async () => {
+    const queue = new SessionActorQueue();
+    const actorKey = "test-actor-decrement-once";
+    const controller = new AbortController();
+    const cancelled = queue.run(actorKey, async () => "never", { signal: controller.signal });
+    expect(queue.getPendingCountForSession(actorKey)).toBe(1);
+
+    controller.abort();
+    await flushMicrotasks();
+    // Cancellation decrement (early) lands; the queue chain still settles the
+    // wrapped task asynchronously, but pending must remain at 0, not -1.
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    await flushMicrotasks();
+    expect(queue.getPendingCountForSession(actorKey)).toBe(0);
+  });
+
+  it("preserves per-key serialization for cancelled items (third does not jump ahead)", async () => {
+    const queue = new SessionActorQueue();
+    const actorKey = "test-actor-serialization";
+    const firstGate = deferred<void>();
+
+    const firstRun = queue.run(actorKey, async () => {
+      await firstGate.promise;
+      return "first";
+    });
+    await flushMicrotasks();
+
+    const controller = new AbortController();
+    const cancelled = queue.run(actorKey, async () => "second", { signal: controller.signal });
+    await flushMicrotasks();
+
+    let thirdStarted = false;
+    const thirdRun = queue.run(actorKey, async () => {
+      thirdStarted = true;
+      return "third";
+    });
+    await flushMicrotasks();
+
+    controller.abort();
+    await flushMicrotasks();
+    // Even though item 2 is cancelled, item 3 must wait until item 1 settles.
+    expect(thirdStarted).toBe(false);
+
+    firstGate.resolve();
+    await firstRun;
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    await thirdRun;
+    expect(thirdStarted).toBe(true);
+  });
+
+  it("rejects immediately when run() is called with an already-aborted signal", async () => {
+    const queue = new SessionActorQueue();
+    const actorKey = "test-actor-pre-aborted";
+    const controller = new AbortController();
+    controller.abort();
+
+    let opCalled = false;
+    const result = queue.run(
+      actorKey,
+      async () => {
+        opCalled = true;
+        return "noop";
+      },
+      { signal: controller.signal },
+    );
+
+    await expect(result).rejects.toMatchObject({ name: "AbortError" });
+    await flushMicrotasks();
+    expect(opCalled).toBe(false);
+    expect(queue.getPendingCountForSession(actorKey)).toBe(0);
+  });
+
+  it("keeps the queue alive after a cancelled item — subsequent tasks still run", async () => {
+    const queue = new SessionActorQueue();
+    const actorKey = "test-actor-keeps-alive";
+    const controller = new AbortController();
+    controller.abort();
+    const cancelled = queue.run(actorKey, async () => "noop", { signal: controller.signal });
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    await flushMicrotasks();
+
+    const followup = await queue.run(actorKey, async () => "followup-result");
+    expect(followup).toBe("followup-result");
+    expect(queue.getPendingCountForSession(actorKey)).toBe(0);
+  });
+
+  it("backward-compatible: run() without signal behaves identically to before", async () => {
+    const queue = new SessionActorQueue();
+    const actorKey = "test-actor-backward-compat";
+    const result = await queue.run(actorKey, async () => "ok");
+    expect(result).toBe("ok");
+    expect(queue.getPendingCountForSession(actorKey)).toBe(0);
+  });
+});

--- a/src/acp/control-plane/session-actor-queue.ts
+++ b/src/acp/control-plane/session-actor-queue.ts
@@ -1,8 +1,45 @@
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 
+export type SessionActorQueueDiagnosticSnapshot = {
+  actorKey: string;
+  enqueueTime: number;
+  actorStarted: boolean;
+  settleTime: number | null;
+  abortBeforeStart: boolean;
+  previousTailPresent: boolean;
+  previousTailAgeMs: number | null;
+  pendingCount: number;
+  tailPresent: boolean;
+};
+
+type SessionActorQueueDiagnosticState = Omit<
+  SessionActorQueueDiagnosticSnapshot,
+  "pendingCount" | "tailPresent"
+>;
+
+export type SessionActorQueueRunOptions = {
+  /**
+   * Optional cancellation signal. When the signal aborts before the queued
+   * item reaches the head of the queue, the item is marked cancelled:
+   * - The item's slot in the per-key chain is preserved (serialization holds)
+   * - `op()` is NOT called when the chain reaches the cancelled slot
+   * - `pendingBySession` is decremented exactly once, immediately on abort
+   * - The returned promise rejects with a DOMException of name "AbortError"
+   * If the signal aborts after the actor has started, the cancellation has
+   * no effect on the running op; the caller is responsible for honoring the
+   * signal inside `op()`.
+   */
+  signal?: AbortSignal;
+};
+
+function makeAbortError(): DOMException {
+  return new DOMException("Aborted before start", "AbortError");
+}
+
 export class SessionActorQueue {
   private readonly queue = new KeyedAsyncQueue();
   private readonly pendingBySession = new Map<string, number>();
+  private readonly diagnosticsBySession = new Map<string, SessionActorQueueDiagnosticState>();
 
   getTailMapForTesting(): Map<string, Promise<void>> {
     return this.queue.getTailMapForTesting();
@@ -20,19 +57,173 @@ export class SessionActorQueue {
     return this.pendingBySession.get(actorKey) ?? 0;
   }
 
-  async run<T>(actorKey: string, op: () => Promise<T>): Promise<T> {
-    return this.queue.enqueue(actorKey, op, {
-      onEnqueue: () => {
-        this.pendingBySession.set(actorKey, (this.pendingBySession.get(actorKey) ?? 0) + 1);
-      },
-      onSettle: () => {
-        const pending = (this.pendingBySession.get(actorKey) ?? 1) - 1;
-        if (pending <= 0) {
-          this.pendingBySession.delete(actorKey);
-        } else {
-          this.pendingBySession.set(actorKey, pending);
-        }
-      },
+  getDiagnosticSnapshot(actorKey: string): SessionActorQueueDiagnosticSnapshot | null {
+    const diagnostic = this.diagnosticsBySession.get(actorKey);
+    if (!diagnostic) {
+      return null;
+    }
+    return {
+      ...diagnostic,
+      pendingCount: this.getPendingCountForSession(actorKey),
+      tailPresent: this.queue.getTailMapForTesting().has(actorKey),
+    };
+  }
+
+  markAbortBeforeStart(actorKey: string): void {
+    const diagnostic = this.diagnosticsBySession.get(actorKey);
+    if (!diagnostic) {
+      return;
+    }
+    this.diagnosticsBySession.set(actorKey, {
+      ...diagnostic,
+      abortBeforeStart: true,
     });
+  }
+
+  private decrementPendingFor(actorKey: string): void {
+    const pending = (this.pendingBySession.get(actorKey) ?? 1) - 1;
+    if (pending <= 0) {
+      this.pendingBySession.delete(actorKey);
+    } else {
+      this.pendingBySession.set(actorKey, pending);
+    }
+  }
+
+  async run<T>(
+    actorKey: string,
+    op: () => Promise<T>,
+    options?: SessionActorQueueRunOptions,
+  ): Promise<T> {
+    const now = Date.now();
+    const previous = this.diagnosticsBySession.get(actorKey);
+    const previousTailPresent = this.queue.getTailMapForTesting().has(actorKey);
+    const previousTailAgeMs =
+      previousTailPresent && previous ? Math.max(0, now - previous.enqueueTime) : null;
+
+    // Per-item state, captured in this closure. We deliberately do not put
+    // these flags on the per-actorKey diagnostic state, because the diagnostic
+    // map is overwritten by each newer enqueue. Each call to run() owns its
+    // own item flags.
+    const itemState = {
+      cancelled: false,
+      actorStarted: false,
+      pendingDecremented: false,
+    };
+
+    const decrementOnce = () => {
+      if (itemState.pendingDecremented) {
+        return;
+      }
+      itemState.pendingDecremented = true;
+      this.decrementPendingFor(actorKey);
+    };
+
+    const signal = options?.signal;
+    let onAbort: (() => void) | null = null;
+    if (signal) {
+      onAbort = () => {
+        if (itemState.actorStarted) {
+          // Caller must honor the signal inside op(); we do not interfere.
+          return;
+        }
+        if (itemState.cancelled) {
+          return;
+        }
+        itemState.cancelled = true;
+        // Reflect cancellation in the per-key diagnostic state, matching the
+        // existing markAbortBeforeStart semantics so observability remains
+        // consistent across both the manager-level and queue-level paths.
+        const diagnostic = this.diagnosticsBySession.get(actorKey);
+        if (diagnostic) {
+          this.diagnosticsBySession.set(actorKey, {
+            ...diagnostic,
+            abortBeforeStart: true,
+          });
+        }
+        // Decrement pending eagerly so observability does not stay inflated
+        // while we wait for the predecessor tail to settle.
+        decrementOnce();
+      };
+      if (signal.aborted) {
+        // Pre-aborted: mark cancelled before we even enqueue. The wrapped task
+        // will reject with AbortError when it runs; pending decrement happens
+        // eagerly in onAbort below (called synchronously after enqueue).
+        itemState.cancelled = true;
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    const cleanupSignal = () => {
+      if (signal && onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    };
+
+    try {
+      const result = await this.queue.enqueue(
+        actorKey,
+        async () => {
+          if (itemState.cancelled) {
+            // Caller aborted before the actor reached the head of the queue.
+            // Skip op() entirely so cancellation has zero side effect on the
+            // protected resource. onSettle below still fires for the wrapped
+            // task itself, which is why decrementOnce is idempotent.
+            throw makeAbortError();
+          }
+          itemState.actorStarted = true;
+          const diagnostic = this.diagnosticsBySession.get(actorKey);
+          if (diagnostic) {
+            this.diagnosticsBySession.set(actorKey, {
+              ...diagnostic,
+              actorStarted: true,
+            });
+          }
+          return await op();
+        },
+        {
+          onEnqueue: () => {
+            this.pendingBySession.set(actorKey, (this.pendingBySession.get(actorKey) ?? 0) + 1);
+            this.diagnosticsBySession.set(actorKey, {
+              actorKey,
+              enqueueTime: now,
+              actorStarted: false,
+              settleTime: null,
+              abortBeforeStart: false,
+              previousTailPresent,
+              previousTailAgeMs,
+            });
+            // If we were pre-aborted at the start of run(), the listener path
+            // didn't run because we never registered it. Decrement now so
+            // pending stays in sync.
+            if (itemState.cancelled && signal?.aborted) {
+              const diagnostic = this.diagnosticsBySession.get(actorKey);
+              if (diagnostic) {
+                this.diagnosticsBySession.set(actorKey, {
+                  ...diagnostic,
+                  abortBeforeStart: true,
+                });
+              }
+              decrementOnce();
+            }
+          },
+          onSettle: () => {
+            const diagnostic = this.diagnosticsBySession.get(actorKey);
+            if (diagnostic) {
+              this.diagnosticsBySession.set(actorKey, {
+                ...diagnostic,
+                settleTime: Date.now(),
+              });
+            }
+            // decrementOnce is idempotent: safe whether we already decremented
+            // eagerly on cancellation or this is the first time.
+            decrementOnce();
+          },
+        },
+      );
+      return result;
+    } finally {
+      cleanupSignal();
+    }
   }
 }


### PR DESCRIPTION
This PR is narrower than #52747 and targets a different failure mode:
it makes already-enqueued `SessionActorQueue` items cancellable on
caller abort, so `pendingBySession` does not stay inflated when the
predecessor tail never settles. Complementary to #52747's lane task
timeout work and #80239's Pi abort cleanup; does not add any config
or runtime timeout behavior.

## Summary

When a caller's `AbortSignal` fires before its actor reaches the head
of the per-key queue:

- the queued slot is marked cancelled (per-call closure flag),
- `pendingBySession` is decremented eagerly (idempotent, exactly once),
- the wrapped task throws `AbortError` instead of running `op()` when
  its turn arrives,
- per-key serialization invariant is preserved (later same-key tasks
  still wait for predecessor).

`withSessionActor` now forwards its existing signal to
`actorQueue.run(actorKey, op, { signal })` and the manager-side
abort-handling is simplified. The existing diagnostic log line
(`acp-manager: actor queue abort-before-start ...`) is preserved.

## Why

Without caller-side cancellation, `withSessionActor` could reject the
caller's promise on abort-before-start but had no way to remove or
cancel the already-enqueued item. If the predecessor tail did not
settle, the queued item could not reach `finally(onSettle)`, so
`pendingBySession` could not decrement and liveness diagnostics
reported `queued=N last=run:completed` for the actor key
indefinitely.

Sandbox repro reproduces the stale state in a few lines using a
non-settling first task, a same-key enqueue, an abort-before-start
on the second caller, and a measurement of `pendingBySession`.

## What changed

- `src/acp/control-plane/session-actor-queue.ts`: `run()` accepts an
  optional `signal: AbortSignal`. Per-call closure tracks `cancelled`,
  `actorStarted`, `pendingDecremented` flags. Signal listener
  decrements pending eagerly when actor has not started; the wrapped
  task throws `AbortError` when the cancelled slot reaches the queue
  head. Public Plugin SDK (`src/plugin-sdk/keyed-async-queue.ts`) is
  not changed — cancellation is implemented one level up.
- `src/acp/control-plane/manager.core.ts`: `withSessionActor` passes
  its existing signal to `actorQueue.run(actorKey, op, { signal })`.
  Manager-side `markAbortBeforeStart` call and the inline abort
  listener are no longer needed on this path; the queue takes over.
  Diagnostic log preserved verbatim.
- `src/acp/control-plane/session-actor-queue.test.ts`: 7 new tests
  covering signal-based cancellation, eager pending decrement,
  idempotent decrement, per-key serialization preservation,
  pre-aborted signal, queue still alive after cancelled item,
  backwards-compatibility for callers without signal. Existing
  diagnostic test preserved.

## Verification

pnpm test src/acp/control-plane/session-actor-queue.test.ts
✓ 8 passed

pnpm test src/acp/control-plane/session-actor-queue.test.ts
          src/acp/control-plane/manager.test.ts
✓ 64 passed

pnpm check:changed       ✓ EXIT 0
pnpm build               ✓ EXIT 0
pnpm exec oxfmt --check  ✓ clean

Live runtime validation on macOS gateway:
- Built from cherry-pick onto `v2026.5.6` tag
- Restarted gateway with patched `dist/` (smoke run 4.6s, status ok)
- Patched bundle contains `Aborted before start`, `pendingDecremented`,
  `actor queue abort-before-start` markers — fix loaded in memory
- 24h passive monitor observed no new
  `queued=N last=run:completed` stale liveness warnings

## Real behavior proof

- **Behavior or issue addressed:** Caller abort-before-start for already-enqueued `SessionActorQueue` items no longer leaves `pendingBySession` inflated when the predecessor tail never settles.
- **Real environment tested:** macOS live OpenClaw gateway setup, patched npm install built from cherry-pick onto `v2026.5.6`.
- **Exact steps or command run after this patch:** Cherry-picked the source fix onto `v2026.5.6`, built, rsynced patched `dist/` into the live npm install, restarted the gateway, then ran a live smoke request against the restarted gateway process.
- **Evidence after fix:** Live output/runtime evidence from the patched setup: gateway restarted with pid `18313`; smoke run completed in `4.6s` with `status ok`; no Codex schema errors were observed. Patched bundle `dist/manager-D7F0BwP2.js` contains the after-fix markers `Aborted before start`, `pendingDecremented`, and `actor queue abort-before-start`. A 24h passive monitor is still running and has observed `0` stale queue warnings so far.
- **Observed result after fix:** The patched live gateway stayed up after restart, the smoke request succeeded, the patched queue cancellation markers were loaded in the running bundle, and passive monitoring has not seen new `queued=N last=run:completed` stale liveness warnings.
- **What was not tested:** Cross-OS live gateway validation was not repeated for this PR; local validation covered tests, changed checks, build, and formatter.

## Notes for reviewers

- This is intentionally separate from #52747 because the failure
  modes differ: #52747 targets a lane task that has *started but is
  stuck*, while this PR targets a caller cancellation *before the
  actor starts*. The two are complementary; either can be merged
  without conflicting with the other's intent, though both touch
  `session-actor-queue.ts` and `manager.core.ts` and will require a
  rebase of the second-merged PR.
- Public Plugin SDK is intentionally untouched. Backwards
  compatibility: `run(actorKey, op)` without `options` behaves
  identically to before.
- An earlier deployment experiment confirmed that `dist`-only
  patching across version lines is unsafe (Codex schema + Control
  UI mismatch). The fix in this PR is targeted at the source level
  and rebuilds cleanly on the same release line.
- May address parts of #13744 (session lock timeout) by reducing
  queue pressure that contributes to lock contention, though
  #13744's primary scope is the lock itself.

