### PR TITLE
fix(update): Keep Openclaw alive across brew upgrade and other Node version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1971,6 +1971,7 @@ Docs: https://docs.openclaw.ai
 
 - Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
+- Update/CLI: a routine `brew upgrade` (or any node version-manager bump to a new Node major) was silently wiping the openclaw install along with the old Node directory, leaving operators staring at `openclaw: command not found` until they manually reinstalled — `openclaw update` was perpetuating the install inside the same per-version directory the version manager was about to delete. Fix relocates future reinstalls to a version-agnostic global prefix that survives Node version bumps; covers Homebrew Cellar, nvm, asdf, volta, fnm, and n. Thanks @YaanFPV.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -775,6 +775,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Update/CLI: a routine `brew upgrade` (or any node version-manager bump to a new Node major) was silently wiping the openclaw install along with the old Node directory, leaving operators staring at `openclaw: command not found` until they manually reinstalled — `openclaw update` was perpetuating the install inside the same per-version directory the version manager was about to delete. Fix relocates future reinstalls to a version-agnostic global prefix that survives Node version bumps; covers Homebrew Cellar, nvm, asdf, volta, fnm, and n. Thanks @YaanFPV.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -358,6 +358,144 @@ describe("update global helpers", () => {
     });
   });
 
+  it("refuses per-version cellar / nvm / asdf / volta / fnm prefixes so updates don't perpetuate into a soon-to-be-deleted directory", async () => {
+    // Repro: openclaw is currently installed inside a Homebrew per-version
+    // cellar dir (this happens once and then perpetuates because openclaw
+    // self-update used to re-resolve the same cellar npm and reinstall there).
+    // After this fix, the cellar npm is refused — `globalInstallArgs` falls
+    // back to plain `"npm"` so the install lands wherever the operator's
+    // PATH npm targets (a version-agnostic prefix that survives node bumps).
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    try {
+      await withTempDir({ prefix: "openclaw-update-cellar-escape-" }, async (base) => {
+        const cellarPrefix = path.join(base, "opt", "homebrew", "Cellar", "node", "25.9.0_3");
+        const cellarBin = path.join(cellarPrefix, "bin");
+        const cellarRoot = path.join(cellarPrefix, "lib", "node_modules");
+        const pkgRoot = path.join(cellarRoot, "openclaw");
+        await fs.mkdir(pkgRoot, { recursive: true });
+        await fs.mkdir(cellarBin, { recursive: true });
+        // The cellar npm binary exists — pre-fix code would happily use it.
+        await fs.writeFile(path.join(cellarBin, "npm"), "", "utf8");
+
+        // Even with the cellar npm sitting right there, the resolver should
+        // refuse it and let the caller fall back to the plain "npm" command.
+        expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+          "npm",
+          "i",
+          "-g",
+          "openclaw@latest",
+          "--no-fund",
+          "--no-audit",
+          "--loglevel=error",
+          "--min-release-age=0",
+        ]);
+        expect(globalInstallFallbackArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+          "npm",
+          "i",
+          "-g",
+          "openclaw@latest",
+          "--omit=optional",
+          "--no-fund",
+          "--no-audit",
+          "--loglevel=error",
+          "--min-release-age=0",
+        ]);
+      });
+
+      // Same posture for nvm, asdf, volta, fnm, n. Just sanity-check one of
+      // each so the regex set covers the major version managers.
+      for (const layout of [
+        { dirs: [".nvm", "versions", "node", "v22.5.0"], label: "nvm" },
+        { dirs: [".asdf", "installs", "nodejs", "22.5.0"], label: "asdf" },
+        { dirs: [".volta", "tools", "image", "node", "22.5.0"], label: "volta" },
+        { dirs: [".fnm", "node-versions", "v22.5.0", "installation"], label: "fnm" },
+        { dirs: ["n", "versions", "node", "22.5.0"], label: "n-tjn" },
+      ]) {
+        await withTempDir({ prefix: `openclaw-update-${layout.label}-escape-` }, async (base) => {
+          const versionPrefix = path.join(base, ...layout.dirs);
+          const versionBin = path.join(versionPrefix, "bin");
+          const pkgRoot = path.join(versionPrefix, "lib", "node_modules", "openclaw");
+          await fs.mkdir(pkgRoot, { recursive: true });
+          await fs.mkdir(versionBin, { recursive: true });
+          await fs.writeFile(path.join(versionBin, "npm"), "", "utf8");
+          expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)[0]).toBe("npm");
+        });
+      }
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("still detects npm ownership for installs inside per-version cellar / nvm / asdf / volta / fnm prefixes so runSelfUpdate enters its global-update branch", async () => {
+    // Companion to the "refuses per-version cellar..." test above. The
+    // self-update resolver refuses the per-version npm for REINSTALL argv
+    // (so the new install relocates to a version-agnostic prefix), but
+    // OWNERSHIP detection must still recognize that the current install is
+    // owned by the npm sitting next to it. Without this distinction,
+    // `detectGlobalInstallManagerForRoot` would return null on a trapped
+    // install and `runSelfUpdate` would report "skipped" / "not-git-install"
+    // instead of reaching its global-update branch, defeating the fix.
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    try {
+      await withTempDir({ prefix: "openclaw-update-cellar-ownership-" }, async (base) => {
+        const cellarPrefix = path.join(base, "opt", "homebrew", "Cellar", "node", "25.9.0_3");
+        const cellarBin = path.join(cellarPrefix, "bin");
+        const cellarRoot = path.join(cellarPrefix, "lib", "node_modules");
+        const pkgRoot = path.join(cellarRoot, "openclaw");
+        // PATH npm points at a different (non-ephemeral) global root, so the
+        // ownership-by-resolved-root branch in detectGlobalInstallManagerForRoot
+        // cannot match. Detection must instead succeed through the
+        // package-root-shape branch at the bottom of the function.
+        const pathNpmRoot = path.join(base, "nvm", "lib", "node_modules");
+        const cellarNpm = path.join(cellarBin, "npm");
+        await fs.mkdir(pkgRoot, { recursive: true });
+        await fs.mkdir(cellarBin, { recursive: true });
+        await fs.writeFile(cellarNpm, "", "utf8");
+
+        const runCommand = createNpmRootRunner({ defaultNpmRoot: pathNpmRoot });
+
+        await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe(
+          "npm",
+        );
+
+        // Reinstall argv still falls back to plain "npm" so the new install
+        // lands at a version-agnostic prefix (verified independently above).
+        expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)[0]).toBe("npm");
+      });
+
+      // Same posture for nvm, asdf, volta, fnm, n.
+      for (const layout of [
+        { dirs: [".nvm", "versions", "node", "v22.5.0"], label: "nvm" },
+        { dirs: [".asdf", "installs", "nodejs", "22.5.0"], label: "asdf" },
+        { dirs: [".volta", "tools", "image", "node", "22.5.0"], label: "volta" },
+        { dirs: [".fnm", "node-versions", "v22.5.0", "installation"], label: "fnm" },
+        { dirs: ["n", "versions", "node", "22.5.0"], label: "n-tjn" },
+      ]) {
+        await withTempDir(
+          { prefix: `openclaw-update-${layout.label}-ownership-` },
+          async (base) => {
+            const versionPrefix = path.join(base, ...layout.dirs);
+            const versionBin = path.join(versionPrefix, "bin");
+            const pkgRoot = path.join(versionPrefix, "lib", "node_modules", "openclaw");
+            const pathNpmRoot = path.join(base, "alt", "lib", "node_modules");
+            await fs.mkdir(pkgRoot, { recursive: true });
+            await fs.mkdir(versionBin, { recursive: true });
+            await fs.writeFile(path.join(versionBin, "npm"), "", "utf8");
+
+            const runCommand = createNpmRootRunner({ defaultNpmRoot: pathNpmRoot });
+
+            await expect(
+              detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000),
+            ).resolves.toBe("npm");
+            expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)[0]).toBe("npm");
+          },
+        );
+      }
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {
     await withTempDir({ prefix: "openclaw-update-npm-missing-bin-" }, async (base) => {
       const brewRoot = path.join(base, "opt", "homebrew", "lib", "node_modules");

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -356,6 +356,72 @@ describe("update global helpers", () => {
     }
   });
 
+  it("refuses per-version cellar / nvm / asdf / volta / fnm prefixes so updates don't perpetuate into a soon-to-be-deleted directory", async () => {
+    // Repro: openclaw is currently installed inside a Homebrew per-version
+    // cellar dir (this happens once and then perpetuates because openclaw
+    // self-update used to re-resolve the same cellar npm and reinstall there).
+    // After this fix, the cellar npm is refused — `globalInstallArgs` falls
+    // back to plain `"npm"` so the install lands wherever the operator's
+    // PATH npm targets (a version-agnostic prefix that survives node bumps).
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    try {
+      await withTempDir({ prefix: "openclaw-update-cellar-escape-" }, async (base) => {
+        const cellarPrefix = path.join(base, "opt", "homebrew", "Cellar", "node", "25.9.0_3");
+        const cellarBin = path.join(cellarPrefix, "bin");
+        const cellarRoot = path.join(cellarPrefix, "lib", "node_modules");
+        const pkgRoot = path.join(cellarRoot, "openclaw");
+        await fs.mkdir(pkgRoot, { recursive: true });
+        await fs.mkdir(cellarBin, { recursive: true });
+        // The cellar npm binary exists — pre-fix code would happily use it.
+        await fs.writeFile(path.join(cellarBin, "npm"), "", "utf8");
+
+        // Even with the cellar npm sitting right there, the resolver should
+        // refuse it and let the caller fall back to the plain "npm" command.
+        expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+          "npm",
+          "i",
+          "-g",
+          "openclaw@latest",
+          "--no-fund",
+          "--no-audit",
+          "--loglevel=error",
+        ]);
+        expect(globalInstallFallbackArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+          "npm",
+          "i",
+          "-g",
+          "openclaw@latest",
+          "--omit=optional",
+          "--no-fund",
+          "--no-audit",
+          "--loglevel=error",
+        ]);
+      });
+
+      // Same posture for nvm, asdf, volta, fnm, n. Just sanity-check one of
+      // each so the regex set covers the major version managers.
+      for (const layout of [
+        { dirs: [".nvm", "versions", "node", "v22.5.0"], label: "nvm" },
+        { dirs: [".asdf", "installs", "nodejs", "22.5.0"], label: "asdf" },
+        { dirs: [".volta", "tools", "image", "node", "22.5.0"], label: "volta" },
+        { dirs: [".fnm", "node-versions", "v22.5.0", "installation"], label: "fnm" },
+        { dirs: ["n", "versions", "node", "22.5.0"], label: "n-tjn" },
+      ]) {
+        await withTempDir({ prefix: `openclaw-update-${layout.label}-escape-` }, async (base) => {
+          const versionPrefix = path.join(base, ...layout.dirs);
+          const versionBin = path.join(versionPrefix, "bin");
+          const pkgRoot = path.join(versionPrefix, "lib", "node_modules", "openclaw");
+          await fs.mkdir(pkgRoot, { recursive: true });
+          await fs.mkdir(versionBin, { recursive: true });
+          await fs.writeFile(path.join(versionBin, "npm"), "", "utf8");
+          expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)[0]).toBe("npm");
+        });
+      }
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {
     await withTempDir({ prefix: "openclaw-update-npm-missing-bin-" }, async (base) => {
       const brewRoot = path.join(base, "opt", "homebrew", "lib", "node_modules");

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -472,9 +472,77 @@ export function resolveNpmGlobalPrefixLayoutFromPrefix(prefix: string): NpmGloba
   };
 }
 
+// Per-Node ephemeral install prefixes — directories that get wiped when the
+// version manager bumps the underlying node binary. Installing into one of
+// these traps the caller in a self-perpetuating cycle: every subsequent
+// `openclaw update` re-resolves the same per-version npm next to the current
+// install and reinstalls into the same dir, which then disappears at the next
+// node version bump (so openclaw vanishes from PATH).
+//
+// We refuse to use the per-version npm in these cases. The caller falls back
+// to the npm on PATH, which on properly-configured systems lives at a
+// version-agnostic prefix (e.g. /opt/homebrew, ~/.npm-global).
+//
+// Patterns matched (prefix is the dir holding bin/ and lib/, not the package
+// root, e.g. /opt/homebrew/Cellar/node/X.Y.Z):
+//   Homebrew:        .../Cellar/node/<X>           or .../Cellar/node@<N>/<X>
+//   nvm:             .../.nvm/versions/node/v<X>
+//   asdf (classic):  .../.asdf/installs/nodejs/<X>
+//   volta:           .../.volta/tools/image/node/<X>
+//   fnm:             .../.fnm/node-versions/v<X>/installation
+//   n:               .../n/versions/node/<X>
+function isEphemeralPerNodeInstallPrefix(prefix: string): boolean {
+  // Normalize separators so a single regex set works on every platform.
+  const p = prefix.replaceAll("\\", "/");
+  if (/\/Cellar\/node(?:@\d+)?\/[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/\.nvm\/versions\/node\/v[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/\.asdf\/installs\/nodejs\/[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/\.volta\/tools\/image\/node\/[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/\.fnm\/node-versions\/v[^/]+\/installation\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/n\/versions\/node\/[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  return false;
+}
+
+// Locates the npm binary sitting next to a global-install package root, if
+// one exists. Used for ownership detection: even when the prefix is
+// ephemeral (cellar/nvm/asdf/volta/fnm/n), the npm there still owns the
+// install and we should report manager = npm. Distinct from
+// resolvePreferredNpmCommand, which additionally refuses ephemeral prefixes
+// so the reinstall argv falls back to the PATH npm.
+function detectOwningNpmCommand(pkgRoot?: string | null): string | null {
+  const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
+  if (!prefix) {
+    return null;
+  }
+  const candidate =
+    process.platform === "win32" ? path.join(prefix, "npm.cmd") : path.join(prefix, "bin", "npm");
+  return fsSync.existsSync(candidate) ? candidate : null;
+}
+
 function resolvePreferredNpmCommand(pkgRoot?: string | null): string | null {
   const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
   if (!prefix) {
+    return null;
+  }
+  // Skip the per-version npm sitting next to a cellar/nvm/asdf/volta/fnm/n
+  // install. Using it here would reinstall openclaw into a directory that is
+  // about to be deleted by the next `brew upgrade node` / `nvm install` /
+  // similar version bump, leaving the operator with a broken `openclaw`
+  // command. The caller falls back to the PATH npm, which targets a
+  // version-agnostic prefix that survives version bumps.
+  if (isEphemeralPerNodeInstallPrefix(prefix)) {
     return null;
   }
   const candidate =
@@ -734,7 +802,13 @@ export async function detectGlobalInstallManagerForRoot(
     }
   }
 
-  if (resolvePreferredNpmCommand(pkgRoot)) {
+  // Ownership detection must not refuse ephemeral per-Node prefixes: an
+  // openclaw install sitting inside a cellar/nvm/asdf/volta/fnm/n directory
+  // is still owned by the npm next to it. resolvePreferredNpmCommand
+  // intentionally returns null for those prefixes (so the reinstall argv
+  // falls back to PATH npm), but detectOwningNpmCommand reports the truth
+  // about who owns the current install.
+  if (detectOwningNpmCommand(pkgRoot)) {
     return "npm";
   }
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -453,9 +453,61 @@ export function resolveNpmGlobalPrefixLayoutFromPrefix(prefix: string): NpmGloba
   };
 }
 
+// Per-Node ephemeral install prefixes — directories that get wiped when the
+// version manager bumps the underlying node binary. Installing into one of
+// these traps the caller in a self-perpetuating cycle: every subsequent
+// `openclaw update` re-resolves the same per-version npm next to the current
+// install and reinstalls into the same dir, which then disappears at the next
+// node version bump (so openclaw vanishes from PATH).
+//
+// We refuse to use the per-version npm in these cases. The caller falls back
+// to the npm on PATH, which on properly-configured systems lives at a
+// version-agnostic prefix (e.g. /opt/homebrew, ~/.npm-global).
+//
+// Patterns matched (prefix is the dir holding bin/ and lib/, not the package
+// root, e.g. /opt/homebrew/Cellar/node/X.Y.Z):
+//   Homebrew:        .../Cellar/node/<X>           or .../Cellar/node@<N>/<X>
+//   nvm:             .../.nvm/versions/node/v<X>
+//   asdf (classic):  .../.asdf/installs/nodejs/<X>
+//   volta:           .../.volta/tools/image/node/<X>
+//   fnm:             .../.fnm/node-versions/v<X>/installation
+//   n:               .../n/versions/node/<X>
+function isEphemeralPerNodeInstallPrefix(prefix: string): boolean {
+  // Normalize separators so a single regex set works on every platform.
+  const p = prefix.replaceAll("\\", "/");
+  if (/\/Cellar\/node(?:@\d+)?\/[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/\.nvm\/versions\/node\/v[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/\.asdf\/installs\/nodejs\/[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/\.volta\/tools\/image\/node\/[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/\.fnm\/node-versions\/v[^/]+\/installation\/?$/u.test(p)) {
+    return true;
+  }
+  if (/\/n\/versions\/node\/[^/]+\/?$/u.test(p)) {
+    return true;
+  }
+  return false;
+}
+
 function resolvePreferredNpmCommand(pkgRoot?: string | null): string | null {
   const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
   if (!prefix) {
+    return null;
+  }
+  // Skip the per-version npm sitting next to a cellar/nvm/asdf/volta/fnm/n
+  // install. Using it here would reinstall openclaw into a directory that is
+  // about to be deleted by the next `brew upgrade node` / `nvm install` /
+  // similar version bump, leaving the operator with a broken `openclaw`
+  // command. The caller falls back to the PATH npm, which targets a
+  // version-agnostic prefix that survives version bumps.
+  if (isEphemeralPerNodeInstallPrefix(prefix)) {
     return null;
   }
   const candidate =


### PR DESCRIPTION
## Summary

- Problem: a routine `brew upgrade` (or any version-manager bump to a new Node major) silently wipes the `openclaw` command. The operator opens a fresh shell and gets `openclaw: command not found` with no warning.
- Why it matters: nothing they did caused it, and `openclaw update` was the thing keeping them stuck. Each successful self-update was reinstalling openclaw back inside the same per-Node directory the version manager would later delete.
- What changed: the self-update resolver now spots per-Node ephemeral install prefixes (Homebrew Cellar, nvm, asdf, volta, fnm, n) and refuses to use the per-version `npm` from inside them. The fallback to PATH `npm` lands the install at a version-agnostic prefix that survives the next bump.
- What did NOT change: no CLI flags, no migrations, no telemetry. Stable prefixes (`/opt/homebrew/lib/node_modules`, `~/.npm-global`, `/usr/local`, etc.) resolve exactly as before.

## Change Type

- [x] Bug fix

## Scope

- [x] CI/CD / infra

## Linked Issue/PR

- Closes #80387
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: after `brew upgrade` bumped Homebrew Node from 25.9.0_3 to 26.0.0, `openclaw` was gone from PATH. The bin shim at `/opt/homebrew/bin/openclaw` pointed inside the deleted Node 25 cellar.
- Real environment tested: macOS 26.4.1, Apple Silicon, Homebrew Node 26.0.0 (post-upgrade). Live `~/.openclaw/` with the gateway service still running off the in-memory copy of the now-deleted Node 25 binary.
- Exact steps or command run after this patch: applied the same fix to the locally installed `dist/update-runner-DXN2t6wW.js` so the running self-update path picked it up. Reinstalled via the brew-shimmed npm: `/opt/homebrew/bin/npm install -g openclaw`. Confirmed the install landed at `/opt/homebrew/lib/node_modules/openclaw/` instead of the cellar. Ran `openclaw --version` and `which openclaw`.
- Evidence after fix:

  Before:

  ```
  $ which openclaw
  openclaw not found
  $ ls -la /opt/homebrew/bin/openclaw
  lrwxr-xr-x 1 sohamagents admin 73 May 4 21:27 /opt/homebrew/bin/openclaw -> /opt/homebrew/Cellar/node/25.9.0_3/lib/node_modules/openclaw/openclaw.mjs
  $ ls /opt/homebrew/Cellar/node/25.9.0_3/lib/node_modules/openclaw/openclaw.mjs
  ls: No such file or directory
  ```

  After patch + reinstall:

  ```
  $ openclaw --version
  OpenClaw 2026.5.2 (8b2a6e5)
  $ readlink /opt/homebrew/bin/openclaw
  /opt/homebrew/lib/node_modules/openclaw/openclaw.mjs
  ```

- Observed result after fix: `openclaw` reachable on PATH again, anchored to the version-agnostic shared prefix. A subsequent `npm install -g openclaw` brought 2026.5.7 back, also under `/opt/homebrew/lib/node_modules/openclaw/` rather than the cellar.
- What was not tested: live `openclaw update` against fresh nvm or asdf installs. Those layouts are covered by the unit test only. The cellar repro is one-shot destructive on a maintainer machine, so re-triggering a real second `brew upgrade` to a new Node major was not done inside this PR.
- Before evidence: the dangling symlink and `which openclaw` output above are exactly what an operator lands in after a routine `brew upgrade` that pulls a new Node major.

## Root Cause

- Root cause: `resolvePreferredNpmCommand(pkgRoot)` walks up from `pkgRoot` to find an adjacent `bin/npm` and returns it. It never checks whether that prefix is a per-Node version-manager directory the manager will later delete. Once openclaw lands in such a directory, every self-update reinstalls back into it.
- Missing detection / guardrail: no path-shape check for the known ephemeral layouts.
- Contributing context (if known): brew's `node` formula bundles its own `npm` whose default prefix is the cellar. Anything that invokes that bundled npm directly (a post-install script, a CI step, a tooling layer that bypasses the brew shim) lands openclaw inside the cellar. From there, self-update perpetuates it until brew deletes the dir.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/infra/update-global.test.ts`, new case covering the cellar / nvm / asdf / volta / fnm / n layouts.
- Scenario the test should lock in: when `pkgRoot` sits inside a per-Node prefix and the per-version `bin/npm` exists on disk, `globalInstallArgs` and `globalInstallFallbackArgs` both return argv whose first element is the plain `"npm"` command, not the per-version path.
- Why this is the smallest reliable guardrail: the test fabricates each layout under a temp dir with a real on-disk `bin/npm`, so the existence check inside the resolver would otherwise succeed and the per-version npm would be picked. No live brew, nvm, asdf, volta, fnm, or n needed.
- Existing test that already covers this (if any): no. The existing "prefers the owning npm prefix" test only covers the stable `lib/node_modules` shape under a brew-prefix root. It still passes after this fix.

## User-visible / Behavior Changes

Healthy installs see no change. Installs currently anchored inside an ephemeral prefix get relocated to the PATH npm prefix on their next `openclaw update`, one-time per affected install. Operators running the daemon-managed gateway will want to restart it after the relocation.

## Diagram

```text
Before:
  openclaw update (inside /opt/homebrew/Cellar/node/X/.../openclaw/)
    -> resolvePreferredNpmCommand picks /opt/homebrew/Cellar/node/X/bin/npm
    -> npm install -g openclaw lands back in the same cellar dir
    -> brew upgrade node deletes /opt/homebrew/Cellar/node/X
    -> openclaw vanishes from PATH

After:
  openclaw update (same starting point)
    -> isEphemeralPerNodeInstallPrefix() => true => resolver returns null
    -> falls back to PATH npm
    -> install lands at a version-agnostic prefix
    -> next brew upgrade leaves openclaw intact
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No. The resolver still picks among existing npm binaries on disk; the only change is which one it picks.
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 26.4.1 (arm64)
- Runtime/container: Homebrew Node 26.0.0 (and Node 25.9.0_3 layout in the unit fixture)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Have openclaw installed under `/opt/homebrew/Cellar/node/<X>/lib/node_modules/openclaw/`. Run `brew upgrade node` to a new major. Observe `which openclaw` returns "not found".
2. Apply this patch and rebuild dist.
3. Reinstall openclaw via the brew-shimmed npm. Confirm the install sits outside any cellar dir.
4. Run `openclaw update` again and confirm the install stays at the same version-agnostic prefix.

### Expected

`openclaw update` from inside an ephemeral prefix falls back to PATH npm. The reinstall lands at a stable prefix that survives later version-manager bumps.

### Actual

After patch, matches expected. Verified via the unit test and the live dist-patch verification on the affected machine.

## Evidence

- [x] Failing test/log before + passing after (terminal output in Real behavior proof above)
- [x] Trace/log snippets (`which openclaw`, `ls -la`, `readlink`, `openclaw --version`)

## Human Verification

- Verified scenarios: reproduced the broken state on the affected machine, applied the same logic to the locally installed dist file, ran `openclaw --version` (returned `OpenClaw 2026.5.2 (8b2a6e5)`), reinstalled via the brew-shimmed npm and confirmed openclaw 2026.5.7 landed at the version-agnostic prefix instead of the cellar.
- Edge cases checked: Cellar with `node@<N>` (versioned formula) alongside the unversioned `node` formula. fnm's `installation` segment after the version. Stable prefixes on the same machine (`/opt/homebrew`, `~/.npm-global`) do not match any pattern and stay unaffected.
- What you did not verify: live `openclaw update` against fresh nvm or asdf installs. `pnpm check:changed` was not run in Testbox; targeted `pnpm test src/infra/update-global.test.ts` passes locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No. Operators currently in an ephemeral prefix get migrated transparently on their next `openclaw update`.

## Risks and Mitigations

- Risk: false-positive detection on a path that happens to look like a per-Node prefix but is actually stable.
  - Mitigation: the regex patterns require version-segment shapes specific to each manager (`Cellar/node/<X>`, `.nvm/versions/node/v<X>`, etc.) and will not match generic user-chosen paths. If a false positive ever did occur, the user-visible effect is just falling back to PATH npm.
