### PR TITLE
[AI-assisted] fix(channel): refresh WeCom onboarding install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/WeCom: refresh the official onboarding install to `@wecom/wecom-openclaw-plugin@2026.5.7` and update existing managed npm installs instead of failing on the package directory. Fixes #79884. (#80390) Thanks @brokemac79.
 - Anthropic: reseed Claude CLI fresh-session retries from bounded OpenClaw transcript history after session rotation, preventing conversation amnesia. Fixes #80905. (#80934) Thanks @bitloi.
 - Require explicit browser device pairing [AI]. (#81289) Thanks @pgondhi987.
 - Require Control UI pairing before proxy-scoped access [AI]. (#81288) Thanks @pgondhi987.

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -35,9 +35,9 @@
           }
         },
         "install": {
-          "npmSpec": "@wecom/wecom-openclaw-plugin@2026.4.23",
+          "npmSpec": "@wecom/wecom-openclaw-plugin@2026.5.7",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-bnzfdIEEu1/LFvcdyjaTkyxt27w6c7dqhkPezU62OWaqmcdFsUGR3T55USK/O9pIKsNcnL1Tnu1pqKYCWHFgWQ=="
+          "expectedIntegrity": "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug=="
         }
       }
     },

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -12,7 +12,7 @@ describe("channel plugin catalog", () => {
     expect(wecom?.id).toBe("wecom");
     expect(wecom?.pluginId).toBe("wecom-openclaw-plugin");
     expect(wecom?.trustedSourceLinkedOfficialInstall).toBe(true);
-    expect(wecom?.install?.npmSpec).toBe("@wecom/wecom-openclaw-plugin@2026.4.23");
+    expect(wecom?.install?.npmSpec).toBe("@wecom/wecom-openclaw-plugin@2026.5.7");
 
     const yuanbao = getChannelPluginCatalogEntry("yuanbao", options);
     expect(yuanbao?.id).toBe("yuanbao");

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -39,7 +39,7 @@ describeOfficialFallbackChannelCatalogContract({
 
 describeChannelCatalogEntryContract({
   channelId: "wecom",
-  npmSpec: "@wecom/wecom-openclaw-plugin@2026.4.23",
+  npmSpec: "@wecom/wecom-openclaw-plugin@2026.5.7",
   alias: "wework",
 });
 

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -61,7 +61,7 @@ function cliInstallPath(pluginId: string): string {
 
 function useProfileExtensionsDir(): string {
   process.env.OPENCLAW_STATE_DIR = PROFILE_STATE_ROOT;
-  return path.join(PROFILE_STATE_ROOT, "extensions");
+  return path.resolve(PROFILE_STATE_ROOT, "extensions");
 }
 
 function createEnabledPluginConfig(pluginId: string): OpenClawConfig {
@@ -850,10 +850,10 @@ describe("plugins cli install", () => {
 
     await runPluginsCommand(["plugins", "install", "wecom"]);
 
-    expect(npmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@2026.4.23");
+    expect(npmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@2026.5.7");
     expect(npmInstallCall().expectedPluginId).toBe("wecom-openclaw-plugin");
     expect(npmInstallCall().expectedIntegrity).toBe(
-      "sha512-bnzfdIEEu1/LFvcdyjaTkyxt27w6c7dqhkPezU62OWaqmcdFsUGR3T55USK/O9pIKsNcnL1Tnu1pqKYCWHFgWQ==",
+      "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug==",
     );
     expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
   });
@@ -896,15 +896,15 @@ describe("plugins cli install", () => {
     installHooksFromNpmSpec.mockResolvedValue({
       ok: false,
       error:
-        "aborted: npm package integrity drift detected for @wecom/wecom-openclaw-plugin@2026.4.23",
+        "aborted: npm package integrity drift detected for @wecom/wecom-openclaw-plugin@2026.5.7",
     });
 
     await expect(runPluginsCommand(["plugins", "install", "wecom"])).rejects.toThrow("__exit__:1");
 
     expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
-    expect(hookNpmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@2026.4.23");
+    expect(hookNpmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@2026.5.7");
     expect(hookNpmInstallCall().expectedIntegrity).toBe(
-      "sha512-bnzfdIEEu1/LFvcdyjaTkyxt27w6c7dqhkPezU62OWaqmcdFsUGR3T55USK/O9pIKsNcnL1Tnu1pqKYCWHFgWQ==",
+      "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug==",
     );
   });
 

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -417,7 +417,7 @@ describe("ensureChannelSetupPluginInstalled", () => {
     });
 
     expectRecordFields(requireMockCallArg(installPluginFromNpmSpec, 0), "npm install args", {
-      extensionsDir: path.join(profileStateDir, "extensions"),
+      extensionsDir: path.resolve(profileStateDir, "extensions"),
       spec: bundledChatNpmSpec,
     });
   });

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -119,6 +119,7 @@ type NpmPackInstallCall = {
 type NpmSpecInstallCall = {
   expectedIntegrity?: string;
   expectedPluginId?: string;
+  mode?: string;
   spec?: string;
   timeoutMs?: number;
   trustedSourceLinkedOfficialInstall?: boolean;
@@ -445,6 +446,7 @@ describe("ensureOnboardingPluginInstalled", () => {
       NpmSpecInstallCall,
     ];
     expect(npmCall.spec).toBe("@wecom/wecom-openclaw-plugin@1.2.3");
+    expect(npmCall.mode).toBe("update");
     expect(npmCall.expectedPluginId).toBe("demo-plugin");
     expect(npmCall.expectedIntegrity).toBe("sha512-wecom");
     expect(npmCall.trustedSourceLinkedOfficialInstall).toBe(true);

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -625,6 +625,7 @@ async function installPluginFromNpmSpecWithProgress(params: {
     const result = await withTimeout(
       installPluginFromNpmSpec({
         spec: params.npmSpec,
+        mode: "update",
         timeoutMs: ONBOARDING_PLUGIN_INSTALL_TIMEOUT_MS,
         expectedPluginId: params.entry.pluginId,
         expectedIntegrity: params.entry.install.expectedIntegrity,

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -660,7 +660,7 @@ describe("installPluginFromNpmSpec", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("plain-crypto-js");
-      expect(result.error).toContain("node_modules/plain-crypto-js");
+      expect(result.error).toContain(path.join("node_modules", "plain-crypto-js"));
     }
   });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -24,7 +24,7 @@ describe("official external plugin catalog", () => {
     expect(resolveOfficialExternalPluginId(wecomByChannel)).toBe("wecom-openclaw-plugin");
     expect(resolveOfficialExternalPluginId(wecomByPlugin)).toBe("wecom-openclaw-plugin");
     expect(resolveOfficialExternalPluginInstall(wecomByChannel)?.npmSpec).toBe(
-      "@wecom/wecom-openclaw-plugin@2026.4.23",
+      "@wecom/wecom-openclaw-plugin@2026.5.7",
     );
     expect(resolveOfficialExternalPluginId(yuanbaoByChannel)).toBe("openclaw-plugin-yuanbao");
     expect(resolveOfficialExternalPluginInstall(yuanbaoByChannel)?.npmSpec).toBe(

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -140,10 +140,10 @@ describe("buildOfficialChannelCatalog", () => {
         aliases: ["qywx", "wework", "enterprise-wechat"],
       },
       install: {
-        npmSpec: "@wecom/wecom-openclaw-plugin@2026.4.23",
+        npmSpec: "@wecom/wecom-openclaw-plugin@2026.5.7",
         defaultChoice: "npm",
         expectedIntegrity:
-          "sha512-bnzfdIEEu1/LFvcdyjaTkyxt27w6c7dqhkPezU62OWaqmcdFsUGR3T55USK/O9pIKsNcnL1Tnu1pqKYCWHFgWQ==",
+          "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug==",
       },
     });
     expect(


### PR DESCRIPTION
## Summary

Fixes #79884.

Refreshes the official WeCom external channel catalog from `@wecom/wecom-openclaw-plugin@2026.4.23` to the current published `2026.5.7` package and integrity, then makes onboarding/channel wizard npm installs use update mode so an existing managed package directory can be updated instead of failing as "plugin already exists".

## Root Cause

The official external channel catalog still pinned WeCom to `2026.4.23`, while npm latest is `2026.5.7`. The onboarding wizard resolved that catalog entry and called the npm plugin installer in install mode, which rejects an already-existing managed npm package directory before it can update or reuse the installed package.

## What Changed

- Updated the official WeCom catalog `npmSpec` and integrity to the published `2026.5.7` package metadata.
- Passed `mode: "update"` through the onboarding npm install path so existing managed package directories are accepted by the installer update flow.
- Added/updated regression coverage for onboarding npm install mode and catalog consumers.
- Made a few path expectations in touched acceptance lanes portable on Windows so the requested local checks pass from this worktree.
- Rebased onto current `main`, resolved the real catalog-test conflict, and dropped the stale changelog change from the branch diff.

## Real Behavior Proof

- **Behavior or issue addressed:** Adding/configuring the WeCom channel should not try to install the stale `2026.4.23` package, and should not fail simply because the managed WeCom package directory already exists.
- **Real environment tested:** Local OpenClaw checkout on Windows 11, rebased PR branch `fix-wecom-catalog-install-79884` at `e6550d4a81471553bdb062b74bf41d8e6cc4b91e`, with `OPENCLAW_STATE_DIR` and `OPENCLAW_HOME` pointed at isolated proof root `C:\oc80390-proof-20260512223330`; no live OpenClaw install, gateway, or user auth state was used.
- **Exact steps or command run after this patch:** From the PR checkout, first seeded the isolated managed npm root with a real published WeCom package using `npm install @wecom/wecom-openclaw-plugin@2026.5.7 --omit=dev --omit=peer --legacy-peer-deps --no-audit --no-fund --loglevel=error`. Then ran a `node --import tsx --input-type=module` probe that called the rebased branch's `ensureOnboardingPluginInstalled` helper for catalog plugin id `wecom-openclaw-plugin`, npm spec `@wecom/wecom-openclaw-plugin@2026.5.7`, and the expected published integrity.
- **Evidence after fix:** Terminal capture from the isolated proof run:

```text
added 45 packages in 4s
precondition: real managed @wecom/wecom-openclaw-plugin package directory existed before onboarding install helper ran
preSeedPackage: {"name":"@wecom/wecom-openclaw-plugin","version":"2026.5.7"}
installModeControl: {"ok":false,"error":"plugin already exists: C:\\oc80390-proof-20260512223330\\state\\npm\\node_modules\\@wecom\\wecom-openclaw-plugin (delete it first)"}
onboardingResult: {"installed":true,"status":"installed","pluginId":"wecom-openclaw-plugin"}
installedPackage: {"name":"@wecom/wecom-openclaw-plugin","version":"2026.5.7"}
lockEntry.integrity: "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug=="
installedRecord: {"source":"npm","spec":"@wecom/wecom-openclaw-plugin@2026.5.7","resolvedName":"@wecom/wecom-openclaw-plugin","resolvedVersion":"2026.5.7","installPath":"C:\\oc80390-proof-20260512223330\\state\\npm\\node_modules\\@wecom\\wecom-openclaw-plugin"}
progressEvents included: ["stop: Installed WeCom plugin"]
```

- **Observed result after fix:** The control check confirmed the previous install-mode path rejects the already-existing managed package directory with `plugin already exists`, while the patched onboarding path completed through update mode against that same existing real package target and recorded the integrity-pinned `2026.5.7` npm install.
- **What was not tested:** I did not run a full interactive Docker wizard with real WeCom credentials/profile from this machine. This proof exercised the real OpenClaw onboarding plugin-install helper and managed npm package path in an isolated local state directory.

## Validation

- `$env:CI='true'; corepack pnpm install --frozen-lockfile`
- `$env:OPENCLAW_VITEST_MAX_WORKERS='1'; corepack pnpm exec node scripts/test-projects.mjs src/channels/plugins/catalog.test.ts src/channels/plugins/contracts/channel-catalog.contract.test.ts src/cli/plugins-cli.install.test.ts src/commands/channel-setup/plugin-install.test.ts src/commands/onboarding-plugin-install.test.ts src/plugins/install.npm-spec.test.ts src/plugins/official-external-plugin-catalog.test.ts test/official-channel-catalog.test.ts` — 6 shards passed; 8 test files, 183 tests passed, 3 skipped.
- `corepack pnpm exec oxfmt --check --threads=1 scripts/lib/official-external-channel-catalog.json src/channels/plugins/catalog.test.ts src/channels/plugins/contracts/channel-catalog.contract.test.ts src/cli/plugins-cli.install.test.ts src/commands/channel-setup/plugin-install.test.ts src/commands/onboarding-plugin-install.test.ts src/commands/onboarding-plugin-install.ts src/plugins/install.npm-spec.test.ts src/plugins/official-external-plugin-catalog.test.ts test/official-channel-catalog.test.ts`
- `corepack pnpm check:changed`
- `git diff --check`
- `codex review --base origin/main -c model_reasoning_effort='"medium"'` — no discrete correctness issues found.

## Duplicate / Ownership Scan

Before coding and again before opening this PR, I checked for an existing open PR referencing #79884 and for active WeCom catalog/install PRs using the issue number, package name, and WeCom catalog terms. No active duplicate PR was found.

## Security

No new dependencies, permissions, token handling, network surfaces, or install-hook bypasses. The change preserves explicit integrity verification for the official external WeCom package and only switches the wizard path to the installer update mode for existing managed package directories.