### PR TITLE
fix(gateway): disable startup trace monitor on startup failure

### DIFF
--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -196,9 +196,9 @@ describe("downloadGoogleChatMedia", () => {
         "content-type": "application/octet-stream",
       }),
       arrayBuffer,
-    } as Response;
+    } as unknown as Response;
 
-    await expectDownloadToRejectForResponse(response, "invalid content-length header: 0x3");
+    await expectDownloadToRejectForResponse(response, /invalid content-length header: 0x3/);
     expect(arrayBuffer).not.toHaveBeenCalled();
   });
 

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -64,7 +64,7 @@ describe("performMatrixRequest", () => {
             status: 200,
             headers: new Headers({ "content-length": "0x3" }),
             arrayBuffer,
-          }) as Response,
+          }) as unknown as Response,
       ),
     );
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -395,6 +395,7 @@ function createGatewayStartupTrace() {
         return result;
       } catch (error) {
         const now = performance.now();
+        eventLoopDelay?.disable();
         emitDiagnosticsTimelineEvent(
           {
             type: "span.error",
@@ -418,6 +419,9 @@ function createGatewayStartupTrace() {
         emitEventLoopTimelineSample(name, eventLoopSample);
         last = now;
       }
+    },
+    close() {
+      eventLoopDelay?.disable();
     },
   };
 }
@@ -1747,6 +1751,7 @@ export async function startGatewayServer(
       startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
     }
   } catch (err) {
+    startupTrace.close();
     await closeOnStartupFailure();
     throw err;
   }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -390,6 +390,9 @@ function createGatewayStartupTrace() {
         last = now;
       }
     },
+    close() {
+      eventLoopDelay?.disable();
+    },
   };
 }
 
@@ -1540,6 +1543,7 @@ export async function startGatewayServer(
       startupTrace.detail("memory.post-ready", collectProcessMemoryUsageMb());
     }
   } catch (err) {
+    startupTrace.close();
     await closeOnStartupFailure();
     throw err;
   }


### PR DESCRIPTION
## Summary
- add an explicit `startupTrace.close()` cleanup path in gateway startup tracing
- call `startupTrace.close()` in the startup failure catch path so `monitorEventLoopDelay` is always disabled on failed startup
- keep current extension type tests compiling after latest `main` changed stricter `Response` and regexp expectations

## Real behavior proof
- **Behavior or issue addressed**: Gateway startup tracing with `OPENCLAW_GATEWAY_STARTUP_TRACE=1` no longer leaves the event-loop delay monitor enabled when startup fails before readiness.
- **Real environment tested**: Local Linux checkout of this PR branch at `e81371fe6a0bbc8a84d5c1a51a7a821611f268fa`, running Node through the repo's `tsx` loader against a real temporary `OPENCLAW_CONFIG_PATH`.
- **Exact steps or command run after this patch**: Created a temporary invalid `openclaw.json`, then ran:
  ```sh
  OPENCLAW_CONFIG_PATH="$tmpdir/openclaw.json" OPENCLAW_GATEWAY_STARTUP_TRACE=1 timeout 20s node --import tsx -e 'import("./src/gateway/server.impl.ts").then(async ({ startGatewayServer }) => { try { await startGatewayServer(0, { bind: "loopback", controlUiEnabled: false }); console.log("unexpected startup success"); process.exitCode = 2; } catch (error) { console.log("startup failed as expected"); console.log(String(error instanceof Error ? error.message : error).split("\n")[0]); } })'
  ```
- **Evidence after fix**: Terminal output from the after-fix run:
  ```text
  [gateway] startup trace: config.snapshot.read.file 0.5ms total=26.7ms eventLoopMax=9.9ms
  [gateway] startup trace: config.snapshot.read.hash 0.2ms total=47.1ms eventLoopMax=0.0ms
  [gateway] startup trace: config.snapshot.read.parse 0.3ms total=49.3ms eventLoopMax=0.0ms
  [gateway] startup trace: config.snapshot.read 28.1ms total=53.1ms eventLoopMax=0.0ms
  [gateway] startup trace: config.snapshot 30.6ms total=55.1ms eventLoopMax=0.0ms
  startup failed as expected
  Invalid config at /tmp/openclaw-proof-4texI2/openclaw.json.
  ```
- **Observed result after fix**: The `node --import tsx` gateway startup process exited with status `0` under the `timeout 20s` wrapper after reporting the expected config failure, which shows the startup trace monitor did not keep the process alive after the failed startup path.
- **What was not tested**: Full packaged `openclaw gateway run` startup was not rerun because this source checkout does not contain built `dist/entry.js`; this proof directly imports the gateway server implementation from the PR checkout instead.

## Verification
- `corepack pnpm test src/gateway/server-channels.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server.impl.ts extensions/googlechat/src/targets.test.ts extensions/matrix/src/matrix/sdk/transport.test.ts`
- `git diff --check`
- `pnpm check:test-types`
