### PR TITLE
fix(/v1/responses): accept text field on requests for OpenAI SDK 6.x parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/OpenAI-compatible: accept the `text` field on `/v1/responses` requests so clients using the OpenAI Node SDK >= 6.x or `@langchain/openai` >= 1.x (e.g. n8n's AI Agent) no longer fail with `Unrecognized key: "text"`. The schema validates `text.format` for `text`/`json_schema`/`json_object` and `text.verbosity` per the OpenAI spec; only the default `format.type === "text"` is honored at runtime today.
 - Redact persisted secret-shaped payloads [AI]. (#79006) Thanks @pgondhi987.
 - OpenAI Codex: surface browser OAuth and device-code login failures instead of treating failed logins as empty successful auth results. Refs #80363.
 - CLI agents: carry runtime-only current-turn sender/reply context into CLI model prompts while keeping prompt-build hook input and transcript text clean.

--- a/src/gateway/open-responses.schema.test.ts
+++ b/src/gateway/open-responses.schema.test.ts
@@ -1,0 +1,111 @@
+/**
+ * OpenResponses request schema unit tests
+ *
+ * Pinpoints the request-shape contract for `/v1/responses`. The `text` field
+ * in particular is auto-populated by current OpenAI Node SDKs (>= 6.x) and
+ * @langchain/openai (>= 1.x) on every request, so the schema must accept it
+ * even when the gateway does not yet honor non-default formats at runtime.
+ */
+
+import { describe, expect, it } from "vitest";
+import { CreateResponseBodySchema } from "./open-responses.schema.js";
+
+const baseRequest = {
+  model: "openclaw",
+  input: "hello",
+} as const;
+
+describe("CreateResponseBodySchema", () => {
+  describe("text field (OpenAI Responses parity)", () => {
+    it("accepts the default text format auto-populated by the OpenAI SDK", () => {
+      const result = CreateResponseBodySchema.safeParse({
+        ...baseRequest,
+        text: { format: { type: "text" } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a json_schema format request", () => {
+      const result = CreateResponseBodySchema.safeParse({
+        ...baseRequest,
+        text: {
+          format: {
+            type: "json_schema",
+            name: "user",
+            schema: { type: "object", properties: { id: { type: "string" } } },
+            strict: true,
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a json_object format request", () => {
+      const result = CreateResponseBodySchema.safeParse({
+        ...baseRequest,
+        text: { format: { type: "json_object" } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts text.verbosity without a format", () => {
+      const result = CreateResponseBodySchema.safeParse({
+        ...baseRequest,
+        text: { verbosity: "low" },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts an empty text object", () => {
+      const result = CreateResponseBodySchema.safeParse({
+        ...baseRequest,
+        text: {},
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects an unknown format type", () => {
+      const result = CreateResponseBodySchema.safeParse({
+        ...baseRequest,
+        text: { format: { type: "yaml" } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a json_schema format missing required fields", () => {
+      const result = CreateResponseBodySchema.safeParse({
+        ...baseRequest,
+        text: { format: { type: "json_schema" } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects unknown top-level keys on text", () => {
+      const result = CreateResponseBodySchema.safeParse({
+        ...baseRequest,
+        text: { format: { type: "text" }, unexpected: "value" },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  it("still rejects unknown top-level fields", () => {
+    const result = CreateResponseBodySchema.safeParse({
+      ...baseRequest,
+      definitelyNotASupportedField: 1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts the full request shape an OpenAI SDK 6.x client sends today", () => {
+    const result = CreateResponseBodySchema.safeParse({
+      ...baseRequest,
+      tools: [{ type: "function", name: "echo" }],
+      tool_choice: "auto",
+      stream: false,
+      text: { format: { type: "text" } },
+      store: false,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -214,6 +214,34 @@ export const CreateResponseBodySchema = z
       })
       .optional(),
     truncation: z.enum(["auto", "disabled"]).optional(),
+    // Phase 1: accepted for OpenAI parity; only `format.type === "text"` is
+    // honored at runtime. The OpenAI Node SDK and @langchain/openai >= 1.x
+    // auto-populate `text: { format: { type: "text" } }` on every
+    // /v1/responses request, so rejecting unknown fields here breaks any
+    // current OpenAI-compatible client (e.g. n8n's AI Agent).
+    // `json_schema` and `json_object` formats are not yet enforced; see the
+    // schema test for the parse-time contract.
+    text: z
+      .object({
+        format: z
+          .discriminatedUnion("type", [
+            z.object({ type: z.literal("text") }).strict(),
+            z
+              .object({
+                type: z.literal("json_schema"),
+                name: z.string(),
+                schema: z.record(z.string(), z.unknown()),
+                description: z.string().optional(),
+                strict: z.boolean().optional(),
+              })
+              .strict(),
+            z.object({ type: z.literal("json_object") }).strict(),
+          ])
+          .optional(),
+        verbosity: z.enum(["low", "medium", "high"]).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- Problem: `/v1/responses` rejects every request from clients using the current OpenAI Node SDK (`openai` >= 6.x) or `@langchain/openai` >= 1.x with `Bad request - please check your parameters: Unrecognized key: "text"`. The OpenAI SDK auto-populates a top-level `text: { format: { type: "text" } }` field on every Responses-API request, but `CreateResponseBodySchema` is `.strict()` and does not include `text`.
- Why it matters: this breaks n8n's AI Agent (Tools Agent V3) and any other downstream client using a current OpenAI SDK against OpenClaw's "OpenAI-compatible" Responses endpoint. The endpoint is effectively unusable from those clients today.
- What changed: added `text` to `CreateResponseBodySchema` with an OpenAI-spec-shaped object — `format` is a discriminated union over `text` / `json_schema` / `json_object`, plus optional `verbosity`. Schema acceptance only; no runtime behavior change.
- What did NOT change (scope boundary): `openresponses-http.ts` agent dispatch, prompt build, or output handling. Only the request schema. `format.type === "json_schema"` and `"json_object"` parse successfully but are not yet enforced at runtime; that belongs in a follow-up PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `/v1/responses` returns HTTP 400 `Unrecognized key: "text"` when called by any current OpenAI Node SDK (`openai` 6.37.0 in this case, via `@langchain/openai` 1.1.3 inside n8n 2.19.5).
- Real environment tested: macOS 15 (Darwin 25.4.0), OpenClaw `2026.5.4` running as the dedicated `openclaw` LaunchDaemon, gateway on `127.0.0.1:18789` with `gateway.auth.mode: token` and `gateway.http.endpoints.responses.enabled: true`. n8n 2.19.5 self-hosted via `npx n8n`, AI Agent node `@n8n/n8n-nodes-langchain.agent` v3.1.
- Exact steps or command run: enabled the `responses` endpoint, configured an n8n OpenAI credential against `http://localhost:18789/v1` with the gateway bearer token, wired an AI Agent (Tools Agent V3) with model `openclaw`, executed the workflow.
- Evidence after fix (terminal capture from this Mac):

Before (live, against the production-installed OpenClaw on this machine):

```
$ curl -s -X POST http://localhost:18789/v1/responses \
    -H \"authorization: Bearer \$TOKEN\" -H \"content-type: application/json\" \
    -d '{\"model\":\"openclaw\",\"input\":\"hi\",\"text\":{\"format\":{\"type\":\"text\"}}}' \
    -w \"\\nHTTP %{http_code}\\n\"
{\"error\":{\"message\":\": Unrecognized key: \\\"text\\\"\",\"type\":\"invalid_request_error\"}}
HTTP 400
```

n8n surfaces the same as a `LangChain MODEL_NOT_FOUND` (404 wrapper) on the AI Agent node:

```
NodeOperationError: The resource you are requesting could not be found
  at executeBatch (.../@n8n/n8n-nodes-langchain/.../ToolsAgent/V3/helpers/executeBatch.ts:113:11)
  at ExecuteContext.toolsAgentExecute (.../ToolsAgent/V3/execute.ts:46:66)
```

After (patched schema parsed in isolation against the same request bodies a current OpenAI SDK / n8n sends):

```
$ node --experimental-strip-types -e \"...import patched schema...\"
ACCEPT   auto-populated default (n8n / openai SDK 6.x)
ACCEPT   json_schema structured output
ACCEPT   verbosity only
REJECT   invalid format type
           Invalid discriminator value. Expected 'text' | 'json_schema' | 'json_object'
REJECT   unknown top-level field (regression check)
           Unrecognized key: \"notARealField\"
```

- Observed result after fix: requests that previously 400'd at the schema layer now parse successfully; the strict-validation contract on the rest of the body is preserved (still rejects unknown top-level keys and invalid format types).
- What was not tested: full n8n round-trip against the patched gateway. The patched OpenClaw build was validated via the schema in isolation; swapping the deployed npm-bundled `openresponses-http-*.js` on the live install and re-running the n8n workflow is the next verification step but requires replacing a globally-installed bundled file (out of scope for this PR's evidence). Unit + parity tests cover the schema contract.

## Root Cause

- Root cause: `CreateResponseBodySchema` declared `.strict()` and the `text` field was not in its allowed-keys list. OpenAI's Responses API spec defines `text.format` (and a newer `text.verbosity`), and the `openai` Node SDK >= 6.x auto-populates `text: { format: { type: \"text\" } }` on every request even when no structured output is requested. The strict schema rejects that auto-populated field, returning HTTP 400 before the request reaches the agent runtime.
- Missing detection / guardrail: parity tests only covered fields previously sent by Codex / direct curl probes; no test exercised the request shape produced by an unmodified `openai` SDK or `@langchain/openai` instance at the versions n8n ships with.
- Contributing context: the existing schema already has a documented \"Phase 1: ignore but accept these fields\" group (`temperature`, `top_p`, `metadata`, `store`, `previous_response_id`, `reasoning`, `truncation`). `text` belongs in the same accept-but-don't-yet-honor bucket for OpenAI-SDK parity.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/open-responses.schema.test.ts` (new, colocated). 10 cases pinning the `text` contract: default `text` accepted, `json_schema` accepted, `json_object` accepted, `verbosity` only, empty `text`, unknown `format.type` rejected, `json_schema` missing required fields rejected, unknown top-level keys on `text` rejected, plus a regression case asserting the rest of `CreateResponseBodySchema` stays strict, and a full-shape happy path matching what an OpenAI SDK 6.x client sends today.
- Scenario the test should lock in: the gateway must accept the request body shape any current OpenAI SDK / LangChain ChatOpenAI 1.x emits, while still rejecting unknown top-level fields and malformed `text.format` payloads.
- Why this is the smallest reliable guardrail: the regression is a schema-level contract violation; a colocated zod-schema unit test is the cheapest place to catch it. A live HTTP test would also catch it but adds gateway boot, auth, and agent setup cost for no extra signal.
- Existing test that already covers this (if any): none. `openresponses-parity.test.ts` covers `input_image`, `input_file`, and tool-definition shape but not the OpenAI-SDK-emitted `text` field.
- If no new test is added, why not: N/A — added.

## User-visible / Behavior Changes

- Requests carrying `text` (any OpenAI-SDK >= 6.x or `@langchain/openai` >= 1.x client) no longer fail with HTTP 400 at the schema layer.
- Default `text.format.type === \"text\"` is the only format honored at runtime; no change to current default-text output behavior.
- `text.format.type === \"json_schema\"` and `\"json_object\"` are accepted by the schema but silently produce regular text output; runtime enforcement is intentionally left for a follow-up since it requires changes to the agent dispatch path.
- No new defaults, no config keys.

## Diagram (if applicable)

N/A — schema-only change.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

The change is purely a request-validation widening on an already-authenticated, already-feature-flagged endpoint (`gateway.http.endpoints.responses.enabled`). No new fields are persisted, logged, or forwarded; non-text formats are silently treated as text.

## Repro + Verification

### Environment

- OS: macOS 15 (Darwin 25.4.0)
- Runtime/container: native macOS install via `npm i -g openclaw` (LaunchDaemon as user `openclaw`)
- Model/provider: `openai-codex/gpt-5.5` (default agent), accessed via the `openclaw` model id over the `/v1/responses` endpoint
- Integration/channel: HTTP via `n8n` 2.19.5 AI Agent (Tools Agent V3) using `@n8n/n8n-nodes-langchain` 3.1, `@langchain/openai` 1.1.3, `openai` 6.37.0
- Relevant config (redacted):

```json
{
  \"gateway\": {
    \"auth\": { \"mode\": \"token\", \"token\": \"<48-char redacted>\" },
    \"http\": {
      \"endpoints\": {
        \"chatCompletions\": { \"enabled\": true },
        \"responses\":       { \"enabled\": true }
      }
    }
  }
}
```

### Steps

1. Enable `gateway.http.endpoints.responses.enabled: true` and restart the gateway.
2. `curl` the endpoint with the SDK-default body shape:
   `curl -X POST http://localhost:18789/v1/responses -H 'authorization: Bearer $TOKEN' -H 'content-type: application/json' -d '{\"model\":\"openclaw\",\"input\":\"hi\",\"text\":{\"format\":{\"type\":\"text\"}}}'`

### Expected

- HTTP 200 with a Responses-shaped JSON body (`object: \"response\"`, `output[].content[].text`).

### Actual (before this PR)

- HTTP 400 with `{\"error\":{\"message\":\": Unrecognized key: \\\"text\\\"\",\"type\":\"invalid_request_error\"}}`. n8n surfaces this as a LangChain `MODEL_NOT_FOUND` 404 on the AI Agent node and the workflow halts.

## Evidence

- [x] Failing test/log before + passing after (terminal capture above)
- [x] Trace/log snippets (n8n stack trace above)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

What I personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/gateway/open-responses.schema.test.ts` — 10/10 pass.
  - `pnpm test src/gateway/openresponses-parity.test.ts src/gateway/openresponses-phase.test.ts src/gateway/open-responses.schema.test.ts` — 34/34 pass.
  - `pnpm check:changed` — green (lint, runtime sidecar guard, import cycles, webhook/auth lints).
  - `pnpm check:test-types` — green (`tsgo:core:test` and `tsgo:extensions:test`).
  - `pnpm format:check` on every changed file — green (auto-formatted with `oxfmt`).
  - `pnpm build` — clean.
  - `pnpm check:changelog-attributions` — green.
  - Schema parity proof: parsed the SDK-default request body, a `json_schema` request, a `verbosity`-only request, an invalid `format.type`, and an unknown top-level key against the patched schema; first three accepted, last two rejected with clear messages.
- Edge cases checked: empty `text` object, `verbosity` without `format`, malformed `json_schema` (missing `name`/`schema`), unknown top-level key on `text`, unknown top-level key on the request (regression check that the rest of the schema stays `.strict()`).
- What I did **not** verify:
  - End-to-end n8n round-trip against a swapped-in patched gateway build. Doing that requires replacing the bundled `openresponses-http-*.js` in a global npm install; I left it for a follow-up rather than tampering with the user's running OpenClaw install.
  - Runtime enforcement of `text.format.type === \"json_schema\" | \"json_object\"` (intentionally out of scope; requires agent-dispatch changes and likely a separate design discussion).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — strictly widens what the schema accepts; nothing previously accepted is now rejected.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: clients that send `text.format.type === \"json_schema\"` may now expect structured-output enforcement that the runtime does not yet provide, and silently receive plain text.
  - Mitigation: documented this in the schema comment and in CHANGELOG so the limitation is discoverable; runtime enforcement can be added in a follow-up PR without further schema changes. The default OpenAI SDK auto-populated case (`text.format.type === \"text\"`) is the dominant real-world request shape today and is fully honored.