### PR TITLE
fix(session-reset): clear orphaned reply operations on session reset

### DIFF
--- a/src/gateway/session-reset-reply-cleanup.test.ts
+++ b/src/gateway/session-reset-reply-cleanup.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression test for: session reset not clearing orphaned reply operations.
+ *
+ * When a session was reset, ensureSessionRuntimeCleanup() cleared command lanes
+ * and aborted the embedded run — but did NOT call forceClearReplyRunBySessionId().
+ * This left an orphaned reply operation in the registry, which caused stuck-session
+ * recovery to skip lane resets indefinitely (reason=active_reply_work).
+ *
+ * Fix: forceClearReplyRunBySessionId() is now called explicitly after abortEmbeddedPiRun().
+ * This test verifies that after clearing session state, no reply operation remains for
+ * the old session ID, so stuck-session recovery can proceed.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
+import {
+  __testing as replyRunTesting,
+  createReplyOperation,
+  isReplyRunActiveForSessionId,
+  forceClearReplyRunBySessionId,
+} from "../auto-reply/reply/reply-run-registry.js";
+import { clearSessionResetRuntimeState } from "../auto-reply/reply/session-reset-cleanup.js";
+import {
+  __testing as recoveryTesting,
+  recoverStuckDiagnosticSession,
+} from "../logging/diagnostic-stuck-session-recovery.runtime.js";
+import {
+  enqueueCommandInLane,
+  getQueueSize,
+  resetCommandLane,
+  resetCommandQueueStateForTest,
+} from "../process/command-queue.js";
+
+function delay(ms: number): Promise<"blocked"> {
+  return new Promise((resolve) => setTimeout(() => resolve("blocked"), ms));
+}
+
+describe("session reset clears orphaned reply operations", () => {
+  afterEach(() => {
+    recoveryTesting.resetRecoveriesInFlight();
+    replyRunTesting.resetReplyRunRegistry();
+    resetCommandQueueStateForTest();
+  });
+
+  it("reply operation stays active after clearSessionResetRuntimeState alone (demonstrating the gap)", () => {
+    const sessionKey = "agent:claw-ux:discord:channel:123";
+    const sessionId = "old-session-id";
+
+    createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+    expect(isReplyRunActiveForSessionId(sessionId)).toBe(true);
+
+    // clearSessionResetRuntimeState only clears queues/events — not reply operations
+    clearSessionResetRuntimeState([sessionKey, sessionId]);
+    expect(isReplyRunActiveForSessionId(sessionId)).toBe(true);
+  });
+
+  it("forceClearReplyRunBySessionId clears the orphaned reply (the fix)", () => {
+    const sessionKey = "agent:claw-ux:discord:channel:123";
+    const sessionId = "old-session-id";
+
+    createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+    expect(isReplyRunActiveForSessionId(sessionId)).toBe(true);
+
+    // This is what the fix adds to ensureSessionRuntimeCleanup()
+    const cleared = forceClearReplyRunBySessionId(sessionId, new Error("session-reset-cleanup"));
+    expect(cleared).toBe(true);
+    expect(isReplyRunActiveForSessionId(sessionId)).toBe(false);
+  });
+
+  it("lane is unblockable while orphaned reply exists, clearable once it is gone", async () => {
+    const sessionKey = "agent:claw-ux:discord:channel:456";
+    const sessionId = "old-session-orphaned";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+
+    // Simulate a stuck lane: active task that never resolves + queued work
+    void enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+    const queued = enqueueCommandInLane(lane, async () => "drained", {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    // Create an orphaned reply operation (session reset happened, run ended, reply stuck)
+    createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+    expect(getQueueSize(lane)).toBe(2);
+
+    // Without the fix: recovery skips because active_reply_work
+    await recoverStuckDiagnosticSession({ sessionId, sessionKey, ageMs: 180_000, queueDepth: 1 });
+    // Lane still stuck: queued task remains blocked
+    await expect(Promise.race([queued, delay(50)])).resolves.toBe("blocked");
+    expect(getQueueSize(lane)).toBe(2);
+
+    // The fix: session reset now calls forceClearReplyRunBySessionId
+    forceClearReplyRunBySessionId(sessionId, new Error("session-reset-cleanup"));
+    expect(isReplyRunActiveForSessionId(sessionId)).toBe(false);
+
+    // Lane reset now succeeds — no reply operation blocking it
+    expect(resetCommandLane(lane)).toBeGreaterThan(0);
+    await expect(queued).resolves.toBe("drained");
+  });
+});

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -10,6 +10,7 @@ import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
 import { retireSessionMcpRuntime } from "../agents/pi-bundle-mcp-tools.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
+import { forceClearReplyRunBySessionId } from "../auto-reply/reply/reply-run-registry.js";
 import {
   buildSessionEndHookPayload,
   buildSessionStartHookPayload,
@@ -225,6 +226,7 @@ async function ensureSessionRuntimeCleanup(params: {
     return undefined;
   }
   abortEmbeddedPiRun(params.sessionId);
+  forceClearReplyRunBySessionId(params.sessionId, new Error("session-reset-cleanup"));
   const ended = await waitForEmbeddedPiRunEnd(params.sessionId, 15_000);
   clearBootstrapSnapshot(params.target.canonicalKey);
   if (ended) {


### PR DESCRIPTION
## Problem

When a session is reset via `ensureSessionRuntimeCleanup()`, the code:
1. Clears command lanes via `clearSessionResetRuntimeState()` ✓
2. Aborts the embedded run via `abortEmbeddedPiRun()` ✓
3. **Does NOT clear reply operations** ✗

This leaves an orphaned entry in `replyRunState.activeSessionIdsByKey` for the old session ID.

The stuck-session recovery then repeatedly detects this orphaned entry as `active_reply_work` and skips lane resets indefinitely:

```
stuck session recovery skipped: reason=active_reply_work action=keep_lane
sessionId=<reset-session> age=590s queueDepth=1
```

The channel lane stays stuck in `processing` state. All subsequent messages queue but never execute until a gateway restart.

## Root cause

`clearSessionResetRuntimeState()` calls `clearSessionQueues()` which clears followup queues and command lanes — but has no code path to clear reply operations from `replyRunState`.

`abortEmbeddedPiRun()` signals the embedded run to abort. If the run ends cleanly via `forceClearEmbeddedPiRun()`, it calls `forceClearReplyRunBySessionId()` as part of that. But if the embedded run has already ended before the reset (the typical stuck scenario), `abortEmbeddedPiRun()` is a no-op and reply operations are never cleared.

## Fix

Call `forceClearReplyRunBySessionId()` explicitly in `ensureSessionRuntimeCleanup()` after `abortEmbeddedPiRun()`. This is a no-op when there is no active reply operation, and correctly clears the orphaned entry when there is one.

## Test

Added `src/gateway/session-reset-reply-cleanup.test.ts` with three tests:
1. Documents that `clearSessionResetRuntimeState` alone does NOT clear reply operations (the gap)
2. Verifies `forceClearReplyRunBySessionId` correctly clears the orphaned reply (the fix)
3. Integration: shows recovery skips with orphaned reply, succeeds after it is cleared

All 9 tests in the affected test suite pass.

## Observed in production

Log pattern before fix:
```
stuck session: sessionId=unknown sessionKey=agent:claw-ux:discord:channel:1501969104943185971 
  state=processing age=590s queueDepth=1 reason=queued_work_without_active_run 
  classification=stale_session_state recovery=checking
stuck session recovery skipped: reason=active_reply_work action=keep_lane 
  sessionId=afb2df39 age=590s queueDepth=1 activeSessionId=afb2df39
```
Gateway restart required to recover.