### PR TITLE
Guard cron announce delivery against implicit last routing

### DIFF
--- a/scripts/lib/docker-e2e-logs.sh
+++ b/scripts/lib/docker-e2e-logs.sh
@@ -52,7 +52,10 @@ run_logged_print_heartbeat() {
   previous_term_trap="$(trap -p TERM || true)"
   previous_hup_trap="$(trap -p HUP || true)"
   terminate_heartbeat_command() {
-    kill -TERM "$command_pid" 2>/dev/null || true
+    # Terminate the whole child process group when possible. Some GitHub-hosted
+    # runners can leave the shell wrapper alive if only the recorded command pid
+    # receives TERM while it is waiting on its own foreground child.
+    kill -TERM -- "-$command_pid" 2>/dev/null || kill -TERM "$command_pid" 2>/dev/null || true
     local grace_seconds="${OPENCLAW_DOCKER_E2E_HEARTBEAT_TERM_GRACE_SECONDS:-30}"
     if ! [[ "$grace_seconds" =~ ^[0-9]+$ ]] || [ "$grace_seconds" -lt 1 ]; then
       grace_seconds="30"
@@ -66,7 +69,7 @@ run_logged_print_heartbeat() {
       fi
       /bin/sleep 0.1
     done
-    kill -KILL "$command_pid" 2>/dev/null || true
+    kill -KILL -- "-$command_pid" 2>/dev/null || kill -KILL "$command_pid" 2>/dev/null || true
   }
   restore_heartbeat_traps() {
     if [ -n "$previous_int_trap" ]; then

--- a/scripts/lib/docker-e2e-logs.sh
+++ b/scripts/lib/docker-e2e-logs.sh
@@ -52,10 +52,7 @@ run_logged_print_heartbeat() {
   previous_term_trap="$(trap -p TERM || true)"
   previous_hup_trap="$(trap -p HUP || true)"
   terminate_heartbeat_command() {
-    # Terminate the whole child process group when possible. Some GitHub-hosted
-    # runners can leave the shell wrapper alive if only the recorded command pid
-    # receives TERM while it is waiting on its own foreground child.
-    kill -TERM -- "-$command_pid" 2>/dev/null || kill -TERM "$command_pid" 2>/dev/null || true
+    kill -TERM "$command_pid" 2>/dev/null || true
     local grace_seconds="${OPENCLAW_DOCKER_E2E_HEARTBEAT_TERM_GRACE_SECONDS:-30}"
     if ! [[ "$grace_seconds" =~ ^[0-9]+$ ]] || [ "$grace_seconds" -lt 1 ]; then
       grace_seconds="30"
@@ -69,7 +66,7 @@ run_logged_print_heartbeat() {
       fi
       /bin/sleep 0.1
     done
-    kill -KILL -- "-$command_pid" 2>/dev/null || kill -KILL "$command_pid" 2>/dev/null || true
+    kill -KILL "$command_pid" 2>/dev/null || true
   }
   restore_heartbeat_traps() {
     if [ -n "$previous_int_trap" ]; then

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -23,8 +23,17 @@ import {
   readCronRunLogEntriesPageAll,
 } from "../../cron/run-log.js";
 import { applyJobPatch } from "../../cron/service/jobs.js";
-import { isInvalidCronSessionTargetIdError } from "../../cron/session-target.js";
-import type { CronDelivery, CronJob, CronJobCreate, CronJobPatch } from "../../cron/types.js";
+import {
+  isInvalidCronSessionTargetIdError,
+  resolveCronDeliverySessionKey,
+} from "../../cron/session-target.js";
+import type {
+  CronDelivery,
+  CronJob,
+  CronJobCreate,
+  CronJobPatch,
+  CronPayload,
+} from "../../cron/types.js";
 import { validateScheduleTimestamp } from "../../cron/validate-timestamp.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
@@ -59,26 +68,63 @@ function listConfiguredAnnounceChannelIds(cfg: OpenClawConfig): string[] {
   });
 }
 
+type CronAnnounceDeliveryField = "delivery.channel" | "delivery.failureDestination.channel";
+
+function isImplicitLastRouteValue(value: unknown): boolean {
+  return typeof value === "string" && value.trim().toLowerCase() === "last";
+}
+
+function formatDeterministicAnnounceRouteError(field: CronAnnounceDeliveryField): string {
+  const target = field === "delivery.channel" ? "delivery" : "delivery.failureDestination";
+  const modeHint =
+    target === "delivery"
+      ? 'or set delivery.mode="none"'
+      : 'or use delivery.failureDestination.mode="webhook"';
+  return `${field} cannot use implicit last routing when multiple channels are configured; explicitly set ${target}.channel and ${target}.to, use a provider-prefixed ${target}.to, ${modeHint}`;
+}
+
+function assertNoImplicitLastAnnounceRoute(params: {
+  cfg: OpenClawConfig;
+  channel?: string;
+  to?: string;
+  field: CronAnnounceDeliveryField;
+  allowSessionLastRoute?: boolean;
+}) {
+  if (listConfiguredAnnounceChannelIds(params.cfg).length <= 1) {
+    return;
+  }
+  const normalizedChannel = normalizeMessageChannel(params.channel);
+  const hasDeterministicChannel =
+    Boolean(normalizedChannel && normalizedChannel !== "last") ||
+    Boolean(resolveTargetPrefixedChannel(params.to));
+  if (
+    !params.allowSessionLastRoute &&
+    !hasDeterministicChannel &&
+    (isImplicitLastRouteValue(params.channel) || isImplicitLastRouteValue(params.to))
+  ) {
+    throw new Error(formatDeterministicAnnounceRouteError(params.field));
+  }
+}
+
 function assertConfiguredAnnounceChannel(params: {
   cfg: OpenClawConfig;
   channel?: string;
-  field: "delivery.channel" | "delivery.failureDestination.channel";
+  field: CronAnnounceDeliveryField;
+  allowSessionLastRoute?: boolean;
 }) {
-  // `last` defers channel selection to runtime session context; every concrete
-  // announce channel must be one the gateway can actually deliver through.
-  if (params.channel === "last") {
-    return;
-  }
-
   const configuredChannels = listConfiguredAnnounceChannelIds(params.cfg).toSorted();
   const normalizedChannel = normalizeMessageChannel(params.channel);
+  if (
+    normalizedChannel === "last" &&
+    (configuredChannels.length <= 1 || params.allowSessionLastRoute)
+  ) {
+    return;
+  }
   if (!normalizedChannel) {
-    if (configuredChannels.length <= 1) {
+    if (configuredChannels.length <= 1 || params.allowSessionLastRoute) {
       return;
     }
-    throw new Error(
-      `${params.field} is required when multiple channels are configured: ${configuredChannels.join(", ")}`,
-    );
+    throw new Error(formatDeterministicAnnounceRouteError(params.field));
   }
 
   if (configuredChannels.length === 0) {
@@ -107,7 +153,7 @@ function resolveAnnounceValidationChannel(params: {
 function assertCompatibleAnnounceTarget(params: {
   channel?: string;
   to?: string;
-  field: "delivery.channel" | "delivery.failureDestination.channel";
+  field: CronAnnounceDeliveryField;
 }) {
   if (!params.channel || params.channel === "last") {
     return;
@@ -121,8 +167,62 @@ function assertCompatibleAnnounceTarget(params: {
   }
 }
 
-function assertValidCronAnnounceDelivery(params: { cfg: OpenClawConfig; delivery?: CronDelivery }) {
+function isIsolatedLikeAgentTurn(params: {
+  sessionTarget?: string;
+  payload?: CronPayload;
+}): boolean {
+  return (
+    params.payload?.kind === "agentTurn" &&
+    typeof params.sessionTarget === "string" &&
+    (params.sessionTarget === "isolated" ||
+      params.sessionTarget === "current" ||
+      params.sessionTarget.startsWith("session:"))
+  );
+}
+
+function assertValidCronAnnounceDelivery(params: {
+  cfg: OpenClawConfig;
+  delivery?: CronDelivery;
+  sessionTarget?: string;
+  sessionKey?: string;
+  payload?: CronPayload;
+}) {
+  const allowSessionLastRoute = Boolean(
+    resolveCronDeliverySessionKey({
+      sessionTarget: params.sessionTarget,
+      sessionKey: params.sessionKey,
+    }),
+  );
+  const implicitIsolatedAgentTurnDelivery =
+    !params.delivery &&
+    isIsolatedLikeAgentTurn({
+      sessionTarget: params.sessionTarget,
+      payload: params.payload,
+    });
+
+  if (implicitIsolatedAgentTurnDelivery) {
+    assertNoImplicitLastAnnounceRoute({
+      cfg: params.cfg,
+      channel: "last",
+      field: "delivery.channel",
+      allowSessionLastRoute,
+    });
+    assertConfiguredAnnounceChannel({
+      cfg: params.cfg,
+      channel: "last",
+      field: "delivery.channel",
+      allowSessionLastRoute,
+    });
+  }
+
   if (params.delivery && (params.delivery.mode ?? "announce") === "announce") {
+    assertNoImplicitLastAnnounceRoute({
+      cfg: params.cfg,
+      channel: params.delivery.channel,
+      to: params.delivery.to,
+      field: "delivery.channel",
+      allowSessionLastRoute,
+    });
     assertCompatibleAnnounceTarget({
       channel: params.delivery.channel,
       to: params.delivery.to,
@@ -135,6 +235,7 @@ function assertValidCronAnnounceDelivery(params: { cfg: OpenClawConfig; delivery
         to: params.delivery.to,
       }),
       field: "delivery.channel",
+      allowSessionLastRoute,
     });
   }
 
@@ -148,6 +249,13 @@ function assertValidCronAnnounceDelivery(params: { cfg: OpenClawConfig; delivery
     ) {
       return;
     }
+    assertNoImplicitLastAnnounceRoute({
+      cfg: params.cfg,
+      channel: failureDestination.channel,
+      to: failureDestination.to,
+      field: "delivery.failureDestination.channel",
+      allowSessionLastRoute,
+    });
     assertCompatibleAnnounceTarget({
       channel: failureDestination.channel,
       to: failureDestination.to,
@@ -160,6 +268,7 @@ function assertValidCronAnnounceDelivery(params: { cfg: OpenClawConfig; delivery
         to: failureDestination.to,
       }),
       field: "delivery.failureDestination.channel",
+      allowSessionLastRoute,
     });
   }
 }
@@ -168,6 +277,9 @@ function assertValidCronCreateDelivery(cfg: OpenClawConfig, jobCreate: CronJobCr
   assertValidCronAnnounceDelivery({
     cfg,
     delivery: jobCreate.delivery,
+    sessionTarget: jobCreate.sessionTarget,
+    sessionKey: jobCreate.sessionKey,
+    payload: jobCreate.payload,
   });
 }
 
@@ -177,19 +289,30 @@ function assertValidCronUpdatePatch(params: {
   currentJob: CronJob;
   patch: CronJobPatch;
 }) {
-  // Apply the full patch so service-owned payload/session constraints are
-  // checked before mutation; configured-channel checks stay delivery-scoped so
-  // stale existing delivery does not block unrelated updates like disabling.
+  const shouldValidateDeliveryOutcome =
+    "delivery" in params.patch ||
+    "payload" in params.patch ||
+    "sessionTarget" in params.patch ||
+    "enabled" in params.patch ||
+    "schedule" in params.patch;
+  if (!shouldValidateDeliveryOutcome) {
+    return;
+  }
+
   const nextJob = structuredClone(params.currentJob);
   applyJobPatch(nextJob, params.patch, {
     defaultAgentId: params.defaultAgentId,
   });
-  if ("delivery" in params.patch) {
-    assertValidCronAnnounceDelivery({
-      cfg: params.cfg,
-      delivery: nextJob.delivery,
-    });
+  if (!nextJob.enabled) {
+    return;
   }
+  assertValidCronAnnounceDelivery({
+    cfg: params.cfg,
+    delivery: nextJob.delivery,
+    sessionTarget: nextJob.sessionTarget,
+    sessionKey: nextJob.sessionKey,
+    payload: nextJob.payload,
+  });
 }
 
 function resolveCronJobId(params: CronJobIdParams): string | undefined {
@@ -468,7 +591,10 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
+    context.logGateway.info("cron: job created", {
+      jobId: job.id,
+      schedule: jobCreate.schedule,
+    });
     respond(true, job, undefined);
   },
   "cron.update": async ({ params, respond, context }) => {

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -167,12 +167,12 @@ function assertCompatibleAnnounceTarget(params: {
   }
 }
 
-function isIsolatedLikeAgentTurn(params: {
+function isDetachedOutputJob(params: {
   sessionTarget?: string;
   payload?: CronPayload;
 }): boolean {
   return (
-    params.payload?.kind === "agentTurn" &&
+    (params.payload?.kind === "agentTurn" || params.payload?.kind === "command") &&
     typeof params.sessionTarget === "string" &&
     (params.sessionTarget === "isolated" ||
       params.sessionTarget === "current" ||
@@ -193,14 +193,14 @@ function assertValidCronAnnounceDelivery(params: {
       sessionKey: params.sessionKey,
     }),
   );
-  const implicitIsolatedAgentTurnDelivery =
+  const implicitDetachedOutputDelivery =
     !params.delivery &&
-    isIsolatedLikeAgentTurn({
+    isDetachedOutputJob({
       sessionTarget: params.sessionTarget,
       payload: params.payload,
     });
 
-  if (implicitIsolatedAgentTurnDelivery) {
+  if (implicitDetachedOutputDelivery) {
     assertNoImplicitLastAnnounceRoute({
       cfg: params.cfg,
       channel: "last",
@@ -293,6 +293,7 @@ function assertValidCronUpdatePatch(params: {
     "delivery" in params.patch ||
     "payload" in params.patch ||
     "sessionTarget" in params.patch ||
+    "sessionKey" in params.patch ||
     "enabled" in params.patch ||
     "schedule" in params.patch;
   if (!shouldValidateDeliveryOutcome) {

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { CronDelivery, CronJob } from "../../cron/types.js";
+import type { CronDelivery, CronJob, CronPayload, CronSessionTarget } from "../../cron/types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
@@ -282,6 +282,18 @@ function agentTurnCronParams(overrides: Record<string, unknown> = {}) {
     sessionTarget: "isolated",
     wakeMode: "next-heartbeat",
     payload: { kind: "agentTurn", message: "hello" },
+    ...overrides,
+  };
+}
+
+function commandCronParams(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "command cron job",
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "command", argv: ["echo", "hello"] },
     ...overrides,
   };
 }
@@ -1181,6 +1193,44 @@ describe("cron method validation", () => {
     expect(payload.delivery).toEqual({ mode: "announce" });
   });
 
+  it("accepts current-session implicit command delivery on add when current resolves to a stored session", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+    const sessionKey = "agent:main:slack:direct:U123";
+
+    const { context, respond } = await invokeCronAdd(
+      commandCronParams({
+        name: "current session implicit command delivery add",
+        sessionTarget: "current",
+        sessionKey,
+      }),
+    );
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expectCronSuccess(respond);
+    const payload = requireCronAddPayload(context);
+    expect(payload.sessionTarget).toBe(`session:${sessionKey}`);
+    expect(payload.sessionKey).toBe(sessionKey);
+    expect(payload.delivery).toEqual({ mode: "announce" });
+  });
+
+  it("accepts stored-session implicit command delivery on add when multiple channels are configured", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+    const sessionKey = "agent:main:telegram:direct:direct-123";
+
+    const { context, respond } = await invokeCronAdd(
+      commandCronParams({
+        name: "stored session implicit command delivery add",
+        sessionTarget: `session:${sessionKey}`,
+      }),
+    );
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expectCronSuccess(respond);
+    const payload = requireCronAddPayload(context);
+    expect(payload.sessionTarget).toBe(`session:${sessionKey}`);
+    expect(payload.delivery).toEqual({ mode: "announce" });
+  });
+
   it("accepts enabled=true patches for current-session implicit delivery", async () => {
     setRuntimeConfig(createMultiChannelConfig());
     const sessionKey = "agent:main:slack:direct:U123";
@@ -1221,6 +1271,36 @@ describe("cron method validation", () => {
     expect(context.cron.add).toHaveBeenCalled();
     expectCronSuccess(respond);
   });
+
+  it.each([
+    { payload: { kind: "agentTurn", message: "hello" } },
+    { payload: { kind: "command", argv: ["echo", "hello"] } },
+  ] satisfies Array<{ payload: CronPayload }>)(
+    "rejects clearing sessionKey when it would make current implicit $payload.kind delivery nondeterministic",
+    async ({ payload }) => {
+      setRuntimeConfig(createMultiChannelConfig());
+
+      const { context, respond } = await invokeCronUpdate(
+        {
+          id: "cron-1",
+          patch: {
+            sessionKey: null,
+          },
+        },
+        createCronJob({
+          sessionTarget: "current",
+          sessionKey: "agent:main:slack:direct:U123",
+          payload,
+          delivery: undefined,
+        }),
+      );
+
+      expect(context.cron.update).not.toHaveBeenCalled();
+      expectResponseError(respond, {
+        messageIncludes: "cannot use implicit last routing",
+      });
+    },
+  );
 
   it("accepts enabled=true patches for stored session implicit delivery", async () => {
     setRuntimeConfig(createMultiChannelConfig());
@@ -1348,27 +1428,49 @@ describe("cron method validation", () => {
     });
   });
 
-  it("rejects enabled=true patches that would activate implicit isolated agentTurn announce delivery", async () => {
-    setRuntimeConfig(createMultiChannelConfig());
+  it.each([
+    {
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "hello" },
+    },
+    {
+      sessionTarget: "current",
+      payload: { kind: "agentTurn", message: "hello" },
+    },
+    {
+      sessionTarget: "isolated",
+      payload: { kind: "command", argv: ["echo", "hello"] },
+    },
+    {
+      sessionTarget: "current",
+      payload: { kind: "command", argv: ["echo", "hello"] },
+    },
+  ] satisfies Array<{ sessionTarget: CronSessionTarget; payload: CronPayload }>)(
+    "rejects enabled=true patches that would activate implicit $sessionTarget $payload.kind announce delivery",
+    async ({ payload, sessionTarget }) => {
+      setRuntimeConfig(createMultiChannelConfig());
 
-    const { context, respond } = await invokeCronUpdate(
-      {
-        id: "cron-1",
-        patch: {
-          enabled: true,
+      const { context, respond } = await invokeCronUpdate(
+        {
+          id: "cron-1",
+          patch: {
+            enabled: true,
+          },
         },
-      },
-      createCronJob({
-        enabled: false,
-        delivery: undefined,
-      }),
-    );
+        createCronJob({
+          enabled: false,
+          delivery: undefined,
+          sessionTarget,
+          payload,
+        }),
+      );
 
-    expect(context.cron.update).not.toHaveBeenCalled();
-    expectResponseError(respond, {
-      messageIncludes: "cannot use implicit last routing",
-    });
-  });
+      expect(context.cron.update).not.toHaveBeenCalled();
+      expectResponseError(respond, {
+        messageIncludes: "cannot use implicit last routing",
+      });
+    },
+  );
 
   it("rejects failureDestination.channel=last without a provider-prefixed target on update", async () => {
     setRuntimeConfig(createMultiChannelConfig());
@@ -1397,47 +1499,86 @@ describe("cron method validation", () => {
     });
   });
 
-  it("rejects omitted isolated agentTurn delivery on add when multiple channels are configured", async () => {
-    setRuntimeConfig(createMultiChannelConfig());
-
-    const { context, respond } = await invokeCronAdd({
-      name: "implicit announce add",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
+  it.each([
+    {
       sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
       payload: { kind: "agentTurn", message: "hello" },
-    });
+    },
+    {
+      sessionTarget: "current",
+      payload: { kind: "agentTurn", message: "hello" },
+    },
+    {
+      sessionTarget: "isolated",
+      payload: { kind: "command", argv: ["echo", "hello"] },
+    },
+    {
+      sessionTarget: "current",
+      payload: { kind: "command", argv: ["echo", "hello"] },
+    },
+  ] satisfies Array<{ sessionTarget: CronSessionTarget; payload: CronPayload }>)(
+    "rejects omitted $sessionTarget $payload.kind delivery on add when multiple channels are configured",
+    async ({ payload, sessionTarget }) => {
+      setRuntimeConfig(createMultiChannelConfig());
 
-    expect(context.cron.add).not.toHaveBeenCalled();
-    expectResponseError(respond, {
-      messageIncludes: "cannot use implicit last routing",
-    });
-  });
+      const { context, respond } = await invokeCronAdd(
+        agentTurnCronParams({
+          name: "implicit announce add",
+          sessionTarget,
+          payload,
+        }),
+      );
 
-  it("rejects update patches that would create implicit isolated agentTurn announce delivery", async () => {
-    setRuntimeConfig(createMultiChannelConfig());
+      expect(context.cron.add).not.toHaveBeenCalled();
+      expectResponseError(respond, {
+        messageIncludes: "cannot use implicit last routing",
+      });
+    },
+  );
 
-    const { context, respond } = await invokeCronUpdate(
-      {
-        id: "cron-1",
-        patch: {
-          sessionTarget: "isolated",
-          payload: { kind: "agentTurn", message: "hello" },
+  it.each([
+    {
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "hello" },
+    },
+    {
+      sessionTarget: "current",
+      payload: { kind: "agentTurn", message: "hello" },
+    },
+    {
+      sessionTarget: "isolated",
+      payload: { kind: "command", argv: ["echo", "hello"] },
+    },
+    {
+      sessionTarget: "current",
+      payload: { kind: "command", argv: ["echo", "hello"] },
+    },
+  ] satisfies Array<{ sessionTarget: CronSessionTarget; payload: CronPayload }>)(
+    "rejects update patches that would create implicit $sessionTarget $payload.kind announce delivery",
+    async ({ payload, sessionTarget }) => {
+      setRuntimeConfig(createMultiChannelConfig());
+
+      const { context, respond } = await invokeCronUpdate(
+        {
+          id: "cron-1",
+          patch: {
+            sessionTarget,
+            payload,
+          },
         },
-      },
-      createCronJob({
-        sessionTarget: "main",
-        payload: { kind: "systemEvent", text: "hello" },
-        delivery: undefined,
-      }),
-    );
+        createCronJob({
+          sessionTarget: "main",
+          payload: { kind: "systemEvent", text: "hello" },
+          delivery: undefined,
+        }),
+      );
 
-    expect(context.cron.update).not.toHaveBeenCalled();
-    expectResponseError(respond, {
-      messageIncludes: "cannot use implicit last routing",
-    });
-  });
+      expect(context.cron.update).not.toHaveBeenCalled();
+      expectResponseError(respond, {
+        messageIncludes: "cannot use implicit last routing",
+      });
+    },
+  );
 
   it("rejects target ids mistakenly supplied as delivery.channel providers", async () => {
     setRuntimeConfig(slackConfig({ includeMainSession: true }));

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -78,7 +78,11 @@ function createCronContext(currentJob?: CronJob) {
       add: vi.fn(async () => ({ id: "cron-1" })),
       update: vi.fn(async () => ({ id: "cron-1" })),
       remove: vi.fn(async () => ({ ok: true, removed: true })),
-      enqueueRun: vi.fn(async () => ({ ok: true, enqueued: true, runId: "run-1" })),
+      enqueueRun: vi.fn(async () => ({
+        ok: true,
+        enqueued: true,
+        runId: "run-1",
+      })),
       getDefaultAgentId: vi.fn(() => "main"),
       getJob: vi.fn(() => currentJob),
       wake: vi.fn(() => ({ ok: true }) as const),
@@ -96,7 +100,10 @@ type CronMethod = keyof typeof cronHandlers;
 async function invokeCron(
   method: CronMethod,
   params: Record<string, unknown>,
-  options: { currentJob?: CronJob; context?: ReturnType<typeof createCronContext> } = {},
+  options: {
+    currentJob?: CronJob;
+    context?: ReturnType<typeof createCronContext>;
+  } = {},
 ) {
   const context = options.context ?? createCronContext(options.currentJob);
   const respond = vi.fn();
@@ -259,6 +266,14 @@ function slackConfig(params: { includeMainSession?: boolean } = {}): OpenClawCon
   } as OpenClawConfig;
 }
 
+function createMultiChannelConfig(): OpenClawConfig {
+  return telegramSlackConfig({ includeMainSession: true });
+}
+
+function createSingleChannelConfig(): OpenClawConfig {
+  return telegramConfig();
+}
+
 function agentTurnCronParams(overrides: Record<string, unknown> = {}) {
   return {
     name: "cron job",
@@ -336,7 +351,10 @@ function expectResponseError(
 }
 
 function expectInvalidCronPatternError(respond: ReturnType<typeof vi.fn>): void {
-  expectResponseError(respond, { code: "INVALID_REQUEST", messageIncludes: "CronPattern" });
+  expectResponseError(respond, {
+    code: "INVALID_REQUEST",
+    messageIncludes: "CronPattern",
+  });
 }
 
 describe("cron method validation", () => {
@@ -418,7 +436,11 @@ describe("cron method validation", () => {
         },
       },
       createCronJob({
-        delivery: { mode: "announce", channel: "telegram", to: "-1001234567890" },
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "-1001234567890",
+        },
       }),
     );
 
@@ -467,7 +489,10 @@ describe("cron method validation", () => {
       }),
     );
     expect(agentTurn.context.cron.add).not.toHaveBeenCalled();
-    expectResponseError(agentTurn.respond, { code: "INVALID_REQUEST", messageIncludes: "message" });
+    expectResponseError(agentTurn.respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "message",
+    });
 
     const systemEvent = await invokeCronAdd({
       name: "blank system event",
@@ -478,7 +503,10 @@ describe("cron method validation", () => {
       payload: { kind: "systemEvent", text: "   " },
     });
     expect(systemEvent.context.cron.add).not.toHaveBeenCalled();
-    expectResponseError(systemEvent.respond, { code: "INVALID_REQUEST", messageIncludes: "text" });
+    expectResponseError(systemEvent.respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "text",
+    });
   });
 
   it("rejects ambiguous announce delivery on add when multiple channels are configured", async () => {
@@ -492,7 +520,9 @@ describe("cron method validation", () => {
     );
 
     expect(context.cron.add).not.toHaveBeenCalled();
-    expectResponseError(respond, { messageIncludes: "delivery.channel is required" });
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
   });
 
   it("accepts provider-prefixed announce target without delivery.channel when multiple channels are configured", async () => {
@@ -562,7 +592,9 @@ describe("cron method validation", () => {
     );
 
     expect(context.cron.add).not.toHaveBeenCalled();
-    expectResponseError(respond, { messageIncludes: "belongs to telegram, not slack" });
+    expectResponseError(respond, {
+      messageIncludes: "belongs to telegram, not slack",
+    });
   });
 
   it("accepts provider-prefixed announce targets when delivery.channel uses a channel alias", async () => {
@@ -596,7 +628,9 @@ describe("cron method validation", () => {
     );
 
     expect(context.cron.update).not.toHaveBeenCalled();
-    expectResponseError(respond, { messageIncludes: "belongs to telegram, not slack" });
+    expectResponseError(respond, {
+      messageIncludes: "belongs to telegram, not slack",
+    });
   });
 
   it("accepts completion webhook delivery patches and nullable clears", async () => {
@@ -759,21 +793,31 @@ describe("cron method validation", () => {
     const { context, respond } = await invokeCronAdd(
       agentTurnCronParams({
         name: "underscored mismatch add",
-        delivery: { mode: "announce", channel: "slack", to: "synology_chat:123" },
+        delivery: {
+          mode: "announce",
+          channel: "slack",
+          to: "synology_chat:123",
+        },
       }),
     );
 
     expect(context.cron.add).not.toHaveBeenCalled();
-    expectResponseError(respond, { messageIncludes: "belongs to synology-chat, not slack" });
+    expectResponseError(respond, {
+      messageIncludes: "belongs to synology-chat, not slack",
+    });
   });
 
   it("rejects ambiguous announce delivery on update when multiple channels are configured", async () => {
     setRuntimeConfig(telegramSlackConfig({ includeMainSession: true }));
 
-    const { context, respond } = await invokeCronUpdateDelivery({ mode: "announce" });
+    const { context, respond } = await invokeCronUpdateDelivery({
+      mode: "announce",
+    });
 
     expect(context.cron.update).not.toHaveBeenCalled();
-    expectResponseError(respond, { messageIncludes: "delivery.channel is required" });
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
   });
 
   it("loads the cron job before validating update delivery patches", async () => {
@@ -818,7 +862,9 @@ describe("cron method validation", () => {
     expect(context.cron.readJob).toHaveBeenCalledWith("cron-1");
     expect(context.cron.getJob).not.toHaveBeenCalled();
     expect(context.cron.update).not.toHaveBeenCalled();
-    expectResponseError(respond, { messageIncludes: "delivery.channel is required" });
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
   });
 
   it("does not revalidate stale delivery config for unrelated updates", async () => {
@@ -836,8 +882,561 @@ describe("cron method validation", () => {
       }),
     );
 
-    expect(context.cron.update).toHaveBeenCalledWith("cron-1", { enabled: false });
+    expect(context.cron.update).toHaveBeenCalledWith("cron-1", {
+      enabled: false,
+    });
     expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts delivery.channel=last with a provider-prefixed target on add", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "prefixed last channel announce add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { mode: "announce", channel: "last", to: "telegram:123" },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts delivery.channel=last with a provider-prefixed target on update", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          delivery: { mode: "announce", channel: "last", to: "telegram:123" },
+        },
+      },
+      createCronJob({
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts delivery.failureDestination.channel=last with a provider-prefixed target on add", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "prefixed last failure destination channel add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+        failureDestination: {
+          mode: "announce",
+          channel: "last",
+          to: "slack:ops",
+        },
+      },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts delivery.failureDestination.mode=webhook on add when multiple channels are configured", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "failure destination webhook add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+        failureDestination: {
+          mode: "webhook",
+          to: "https://example.invalid/cron-failed",
+        },
+      },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts delivery.failureDestination.to=last when failureDestination.channel is explicit", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "explicit failure destination target named last add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+        failureDestination: { mode: "announce", channel: "slack", to: "last" },
+      },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts delivery.mode=none on add when multiple channels are configured", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "silent add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { mode: "none" },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts delivery.to=last when delivery.channel is explicit", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "explicit channel target named last add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { mode: "announce", channel: "telegram", to: "last" },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts enabled=false patches that disable legacy implicit isolated agentTurn delivery", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          enabled: false,
+        },
+      },
+      createCronJob({
+        enabled: true,
+        delivery: undefined,
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts enabled=true patches with provider-prefixed deterministic announce delivery", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          enabled: true,
+          delivery: { mode: "announce", channel: "last", to: "telegram:123" },
+        },
+      },
+      createCronJob({
+        enabled: false,
+        delivery: undefined,
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts failureDestination.channel=last with a provider-prefixed target on update", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          delivery: {
+            failureDestination: {
+              mode: "announce",
+              channel: "last",
+              to: "slack:ops",
+            },
+          },
+        },
+      },
+      createCronJob({
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts failureDestination.to=last on update when failureDestination.channel is explicit", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          delivery: {
+            failureDestination: {
+              mode: "announce",
+              channel: "slack",
+              to: "last",
+            },
+          },
+        },
+      },
+      createCronJob({
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("preserves single-channel last-route announce compatibility", async () => {
+    setRuntimeConfig(createSingleChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "single channel last add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { mode: "announce", channel: "last", to: "last" },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts omitted stored session delivery on add when multiple channels are configured", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+    const sessionKey = "agent:main:telegram:direct:direct-123";
+
+    const { context, respond } = await invokeCronAdd({
+      name: "stored session implicit delivery add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: `session:${sessionKey}`,
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expectCronSuccess(respond);
+    const payload = requireCronAddPayload(context);
+    expect(payload.sessionTarget).toBe(`session:${sessionKey}`);
+    expect(payload.delivery).toEqual({ mode: "announce" });
+  });
+
+  it("accepts current-session implicit delivery on add when current resolves to a stored session", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+    const sessionKey = "agent:main:slack:direct:U123";
+
+    const { context, respond } = await invokeCronAdd({
+      name: "current session implicit delivery add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "current",
+      sessionKey,
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expectCronSuccess(respond);
+    const payload = requireCronAddPayload(context);
+    expect(payload.sessionTarget).toBe(`session:${sessionKey}`);
+    expect(payload.sessionKey).toBe(sessionKey);
+    expect(payload.delivery).toEqual({ mode: "announce" });
+  });
+
+  it("accepts enabled=true patches for current-session implicit delivery", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+    const sessionKey = "agent:main:slack:direct:U123";
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          enabled: true,
+        },
+      },
+      createCronJob({
+        enabled: false,
+        sessionTarget: "current",
+        sessionKey,
+        delivery: undefined,
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("accepts explicit last routing on add when a stored session makes it deterministic", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+    const sessionKey = "agent:main:telegram:group:ops";
+
+    const { context, respond } = await invokeCronAdd({
+      name: "stored session last delivery add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: `session:${sessionKey}`,
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { mode: "announce", channel: "last" },
+    });
+
+    expect(context.cron.add).toHaveBeenCalled();
+    expectCronSuccess(respond);
+  });
+
+  it("accepts enabled=true patches for stored session implicit delivery", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+    const sessionKey = "agent:main:telegram:direct:direct-123";
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          enabled: true,
+        },
+      },
+      createCronJob({
+        enabled: false,
+        sessionTarget: `session:${sessionKey}`,
+        delivery: undefined,
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("rejects current implicit delivery on add without a current session context", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "current without session implicit add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "current",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
+  });
+
+  it("rejects delivery.channel=last without a provider-prefixed target on add", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "last channel announce add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { mode: "announce", channel: "last", to: "123" },
+    });
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
+  });
+
+  it("rejects delivery.failureDestination.channel=last without a provider-prefixed target on add", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "last failure destination channel add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+        failureDestination: { mode: "announce", channel: "last", to: "ops" },
+      },
+    });
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
+  });
+
+  it("rejects delivery.failureDestination.to=last without a deterministic channel on add", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "last failure destination target add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+        failureDestination: { mode: "announce", to: "last" },
+      },
+    });
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
+  });
+
+  it("rejects delivery.to=last without a deterministic channel on add when multiple channels are configured", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "last target announce add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { mode: "announce", to: "last" },
+    });
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
+  });
+
+  it("rejects enabled=true patches that would activate implicit isolated agentTurn announce delivery", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          enabled: true,
+        },
+      },
+      createCronJob({
+        enabled: false,
+        delivery: undefined,
+      }),
+    );
+
+    expect(context.cron.update).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
+  });
+
+  it("rejects failureDestination.channel=last without a provider-prefixed target on update", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          delivery: {
+            failureDestination: {
+              mode: "announce",
+              channel: "last",
+              to: "ops",
+            },
+          },
+        },
+      },
+      createCronJob({
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      }),
+    );
+
+    expect(context.cron.update).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
+  });
+
+  it("rejects omitted isolated agentTurn delivery on add when multiple channels are configured", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronAdd({
+      name: "implicit announce add",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
+  });
+
+  it("rejects update patches that would create implicit isolated agentTurn announce delivery", async () => {
+    setRuntimeConfig(createMultiChannelConfig());
+
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "hello" },
+        },
+      },
+      createCronJob({
+        sessionTarget: "main",
+        payload: { kind: "systemEvent", text: "hello" },
+        delivery: undefined,
+      }),
+    );
+
+    expect(context.cron.update).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      messageIncludes: "cannot use implicit last routing",
+    });
   });
 
   it("rejects target ids mistakenly supplied as delivery.channel providers", async () => {
@@ -855,7 +1454,9 @@ describe("cron method validation", () => {
     );
 
     expect(context.cron.add).not.toHaveBeenCalled();
-    expectResponseError(respond, { messageIncludes: "delivery.channel must be one of: slack" });
+    expectResponseError(respond, {
+      messageIncludes: "delivery.channel must be one of: slack",
+    });
   });
 
   it("returns INVALID_REQUEST when cron.add throws a croner parse error (#74066)", async () => {
@@ -1030,7 +1631,10 @@ describe("cron method validation", () => {
         sessionKey,
       });
       expect(context.cron.wake).not.toHaveBeenCalled();
-      expectResponseError(respond, { code: "INVALID_REQUEST", messageIncludes: "sessionKey" });
+      expectResponseError(respond, {
+        code: "INVALID_REQUEST",
+        messageIncludes: "sessionKey",
+      });
     });
 
     it("rejects a contradictory explicit agentId + agent-prefixed sessionKey pair", async () => {


### PR DESCRIPTION
## Summary

- reject ambiguous cron announce delivery that would resolve to implicit `last` routing when multiple message channels are configured
- preserve deterministic routes, including provider-prefixed `delivery.to`, explicit `delivery.channel`, `delivery.mode: "none"`, webhook failure destinations, and single-channel compatibility
- validate add/update paths that can create or activate ambiguous delivery outcomes, including failure destinations

## Why

In multi-channel deployments, cron follow-up/final-update jobs can be scheduled with implicit announce delivery and later fail during delivery resolution because no deterministic channel exists. This adds an admission-time guard so those jobs fail fast with an actionable validation error instead of silently scheduling an undeliverable result.

## Tests

- `corepack pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/cron.ts src/gateway/server-methods/cron.validation.test.ts`
- `corepack pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-methods/cron.ts src/gateway/server-methods/cron.validation.test.ts`
- `corepack pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/cron.validation.test.ts src/gateway/server.cron.test.ts`
  - 2 files, 43 tests passed
- `git diff --check main..HEAD`

## Notes

Full typecheck/build was left to CI; local broad validation was not run because the guarded heavy-run fallback image was unavailable locally.

## Real behavior proof

- **Behavior addressed:** In multi-channel deployments, isolated/current/session cron `agentTurn` jobs with `announce` delivery could be accepted with implicit `last` routing, then later fail because no deterministic delivery channel existed. This patch adds admission-time validation so ambiguous announce routes fail fast while deterministic routes remain accepted.
- **Real setup tested:** Non-production staged OpenClaw source checkout on Linux, using a synthetic runtime config with two configured message channels (`slack`, `telegram`) and a temporary synthetic cron jobs file. The proof invoked the real gateway `cron.add` / `cron.update` handler paths and real `GatewayCronService` persistence path from this PR head. No production Gateway, production config, or production runtime state was touched.
- **Exact steps or command run after this patch:**

```text
PR80438_HEAD=7e2dbb524f16c9a9f02363891c2684cf73b64947 node --import tsx <non-production configured cron proof runner>
corepack pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/cron.validation.test.ts -t '<six focused multi-channel add/update cases>' --reporter verbose
```

- **Evidence after fix:**

```json
{
  "proof": "PR #80438 non-production configured multi-channel cron add/update proof",
  "head": "7e2dbb524f16c9a9f02363891c2684cf73b64947",
  "productionGatewayConfigRuntimeTouched": false,
  "config": { "channels": ["slack", "telegram"], "cronStore": "temporary synthetic jobs file" },
  "state": { "home": "temporary synthetic home", "runtime": "temporary synthetic state" },
  "cases": [
    { "case": "ambiguous implicit announce add is rejected", "result": "PASS", "method": "cron.add", "ok": false },
    { "case": "provider-prefixed announce add is accepted", "result": "PASS", "method": "cron.add", "ok": true },
    { "case": "ambiguous announce update is rejected", "result": "PASS", "method": "cron.update", "ok": false },
    { "case": "provider-prefixed activation update is accepted", "result": "PASS", "method": "cron.update", "ok": true },
    { "case": "disabling legacy ambiguous job is accepted", "result": "PASS", "method": "cron.update", "ok": true },
    { "case": "re-enabling legacy ambiguous job is rejected", "result": "PASS", "method": "cron.update", "ok": false }
  ]
}
```

- **Observed result after fix:** In a configured two-channel synthetic Gateway cron setup, ambiguous implicit `last` announce routes are rejected for both add and update, deterministic provider-prefixed announce routes are accepted for add and activation/update, disabling a legacy ambiguous job is accepted, and re-enabling/activating a legacy ambiguous job is rejected.
- **What was not tested:** This was intentionally non-production and does not claim a live production Gateway run. Broad typecheck/build remains covered by CI; this proof is scoped to the configured multi-channel cron add/update behavior gate.
