### PR TITLE
fix: suppress duplicate visible message.send deliveries

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -644,6 +644,7 @@ export function runAgentAttempt(params: {
     currentThreadTs: params.runContext.currentThreadTs,
     replyToMode: params.runContext.replyToMode,
     hasRepliedRef: params.runContext.hasRepliedRef,
+    explicitMessageSends: params.runContext.explicitMessageSends,
     senderIsOwner: params.opts.senderIsOwner,
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -1004,6 +1004,90 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps Discord final delivery when duplicate message.send had a thread and final route does not", async () => {
+    setActivePluginRegistry(discordRegistry);
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);
+    const explicitMessageSends = {
+      entries: [
+        {
+          channel: "discord",
+          to: "1503167027337236501",
+          threadId: "thread-a",
+          text: "Final synthesis",
+        },
+      ],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "discord",
+        replyTo: "1503167027337236501",
+        runContext: { explicitMessageSends },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Final synthesis" }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      resultCount: 1,
+    });
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Discord final delivery when duplicate message.send had an account and final route does not", async () => {
+    setActivePluginRegistry(discordRegistry);
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);
+    const explicitMessageSends = {
+      entries: [
+        {
+          channel: "discord",
+          to: "1503167027337236501",
+          accountId: "bot-main",
+          text: "Final synthesis",
+        },
+      ],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "discord",
+        replyTo: "1503167027337236501",
+        runContext: { explicitMessageSends },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Final synthesis" }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      resultCount: 1,
+    });
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("emits JSON deliveryStatus before strict delivery failures rethrow", async () => {
     deliverOutboundPayloadsMock.mockRejectedValueOnce(new Error("Slack API timeout"));
     const runtime = {

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -866,6 +866,94 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps Discord media final delivery even when text duplicates an explicit send", async () => {
+    setActivePluginRegistry(discordRegistry);
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);
+    const explicitMessageSends = {
+      entries: [
+        {
+          channel: "discord",
+          to: "1503167027337236501",
+          text: "Here is the rendered chart.",
+        },
+      ],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "discord",
+        replyTo: "1503167027337236501",
+        runContext: { explicitMessageSends },
+      } as AgentCommandOpts,
+      outboundSession: { agentId: "tester" } as never,
+      sessionEntry: undefined,
+      payloads: [{ text: "Here is the rendered chart.", mediaUrls: ["./chart.png"] }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      resultCount: 1,
+    });
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Discord final delivery when duplicate message.send used a different thread", async () => {
+    setActivePluginRegistry(discordRegistry);
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);
+    const explicitMessageSends = {
+      entries: [
+        {
+          channel: "discord",
+          to: "1503167027337236501",
+          threadId: "thread-a",
+          text: "Final synthesis",
+        },
+      ],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "discord",
+        replyTo: "1503167027337236501",
+        threadId: "thread-b",
+        runContext: { explicitMessageSends },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Final synthesis" }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      resultCount: 1,
+    });
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("emits JSON deliveryStatus before strict delivery failures rethrow", async () => {
     deliverOutboundPayloadsMock.mockRejectedValueOnce(new Error("Slack API timeout"));
     const runtime = {

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -825,6 +825,56 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps Discord final delivery when it adds a warning to a prior message.send", async () => {
+    setActivePluginRegistry(discordRegistry);
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);
+    const priorText = [
+      "Finished the maintenance pass with these findings:",
+      "- checked the open pull requests and refreshed each status",
+      "- found one branch needing a focused duplicate-delivery fix",
+      "- validated the exact duplicate path in an isolated checkout",
+      "- left unrelated upstream failures out of this branch",
+      "- prepared a concise follow-up note for reviewer handoff",
+    ].join("\n");
+    const finalText = `${priorText}\n\nWarning: the shared upstream CI queue is still pending, so broad rebase work should wait.`;
+    const explicitMessageSends = {
+      entries: [
+        {
+          channel: "discord",
+          to: "channel-main",
+          text: priorText,
+        },
+      ],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "discord",
+        replyTo: "channel-main",
+        runContext: { explicitMessageSends },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: finalText }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      resultCount: 1,
+    });
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps Discord final delivery when duplicate message.send targeted a different channel", async () => {
     setActivePluginRegistry(discordRegistry);
     deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -63,6 +63,23 @@ const slackRegistry = createTestRegistry([
   },
 ]);
 
+const discordRegistry = createTestRegistry([
+  {
+    pluginId: "discord",
+    source: "test",
+    plugin: createOutboundTestPlugin({
+      id: "discord",
+      outbound: {
+        deliveryMode: "direct",
+        sendText: async ({ to, text }) => ({
+          channel: "discord",
+          messageId: `${to}:${text}`,
+        }),
+      },
+    }),
+  },
+]);
+
 function createResult(overrides: Partial<RunResult> = {}): RunResult {
   return {
     meta: {
@@ -717,6 +734,136 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     });
     expectRuntimeErrorIncludes(runtime, "Unknown channel");
     expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses duplicate Discord final delivery after same-turn current-channel message.send", async () => {
+    setActivePluginRegistry(discordRegistry);
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);
+    const explicitMessageSends = {
+      entries: [
+        {
+          channel: "discord",
+          to: "1503167027337236501",
+          accountId: "bot-main",
+          threadId: "1503167027337236501",
+          text: "Final synthesis\n\n- one\n- two\n- three",
+        },
+      ],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "discord",
+        replyTo: "1503167027337236501",
+        replyAccountId: "bot-main",
+        threadId: "1503167027337236501",
+        runContext: { explicitMessageSends },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Final synthesis\n\n- one\n- two\n- three" }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: false,
+      status: "suppressed",
+      succeeded: true,
+      reason: "duplicate_explicit_message_send",
+    });
+    expect(delivered.payloads).toEqual([
+      { text: "Final synthesis\n\n- one\n- two\n- three", mediaUrl: null },
+    ]);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps Discord final delivery when same-turn message.send text is different", async () => {
+    setActivePluginRegistry(discordRegistry);
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);
+    const explicitMessageSends = {
+      entries: [
+        {
+          channel: "discord",
+          to: "1503167027337236501",
+          text: "I sent a short progress update.",
+        },
+      ],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "discord",
+        replyTo: "1503167027337236501",
+        runContext: { explicitMessageSends },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "This is the distinct final answer that should still be delivered." }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      resultCount: 1,
+    });
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Discord final delivery when duplicate message.send targeted a different channel", async () => {
+    setActivePluginRegistry(discordRegistry);
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "discord", messageId: "normal" }]);
+    const explicitMessageSends = {
+      entries: [
+        {
+          channel: "discord",
+          to: "other-channel",
+          text: "Final synthesis",
+        },
+      ],
+    };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "discord",
+        replyTo: "1503167027337236501",
+        runContext: { explicitMessageSends },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "Final synthesis" }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      resultCount: 1,
+    });
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
   });
 
   it("emits JSON deliveryStatus before strict delivery failures rethrow", async () => {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -286,12 +286,12 @@ function routeMatchesExplicitMessageSend(params: {
   }
   const sendAccountId = normalizeRoutePart(params.send.accountId);
   const accountId = normalizeRoutePart(params.accountId);
-  if (sendAccountId && accountId && sendAccountId !== accountId) {
+  if (sendAccountId !== accountId) {
     return false;
   }
   const sendThreadId = normalizeRoutePart(params.send.threadId);
   const threadId = normalizeRoutePart(params.threadId);
-  if (sendThreadId && threadId && sendThreadId !== threadId) {
+  if (sendThreadId !== threadId) {
     return false;
   }
   return true;

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -28,7 +28,11 @@ import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { isNestedAgentLane } from "../lanes.js";
 import type { EmbeddedPiRunMeta } from "../pi-embedded-runner/types.js";
-import type { AgentCommandOpts, AgentCommandResultMetaOverrides } from "./types.js";
+import type {
+  AgentCommandOpts,
+  AgentCommandResultMetaOverrides,
+  ExplicitMessageSendRecord,
+} from "./types.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../pi-embedded.js"))["runEmbeddedPiAgent"]>>;
 type DurableSendResult = Awaited<ReturnType<typeof sendDurableMessageBatch>>;
@@ -225,6 +229,162 @@ function noVisiblePayloadStatus(): AgentCommandDeliveryStatus {
     reason: "no_visible_payload",
     resultCount: 0,
   };
+}
+
+function duplicateExplicitMessageSendStatus(): AgentCommandDeliveryStatus {
+  return {
+    requested: true,
+    attempted: false,
+    status: "suppressed",
+    succeeded: true,
+    reason: "duplicate_explicit_message_send",
+    resultCount: 0,
+  };
+}
+
+function normalizeRoutePart(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const text = String(value).trim();
+  return text ? text : undefined;
+}
+
+function normalizeDuplicateVisibleText(value: string): string {
+  return value
+    .replace(/\r\n?/gu, "\n")
+    .replace(/[\t ]+\n/gu, "\n")
+    .replace(/[\t ]+/gu, " ")
+    .replace(/\n{3,}/gu, "\n\n")
+    .trim();
+}
+
+function tokenizeDuplicateVisibleText(value: string): string[] {
+  return (
+    normalizeDuplicateVisibleText(value)
+      .toLocaleLowerCase()
+      .match(/[\p{L}\p{N}]+/gu) ?? []
+  );
+}
+
+function duplicateVisibleTextSimilarity(left: string, right: string): number {
+  const leftTokens = tokenizeDuplicateVisibleText(left);
+  const rightTokens = tokenizeDuplicateVisibleText(right);
+  if (leftTokens.length === 0 || rightTokens.length === 0) {
+    return 0;
+  }
+  const counts = new Map<string, number>();
+  for (const token of leftTokens) {
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  let overlap = 0;
+  for (const token of rightTokens) {
+    const count = counts.get(token) ?? 0;
+    if (count <= 0) {
+      continue;
+    }
+    overlap += 1;
+    if (count === 1) {
+      counts.delete(token);
+    } else {
+      counts.set(token, count - 1);
+    }
+  }
+  return (2 * overlap) / (leftTokens.length + rightTokens.length);
+}
+
+function isDuplicateVisibleText(
+  candidate: string | undefined,
+  sentText: string | undefined,
+): boolean {
+  if (!candidate || !sentText) {
+    return false;
+  }
+  const left = normalizeDuplicateVisibleText(candidate);
+  const right = normalizeDuplicateVisibleText(sentText);
+  if (!left || !right) {
+    return false;
+  }
+  if (left === right) {
+    return true;
+  }
+  const shorter = left.length <= right.length ? left : right;
+  const longer = left.length <= right.length ? right : left;
+  if (shorter.length >= 160 && longer.includes(shorter) && shorter.length / longer.length >= 0.9) {
+    return true;
+  }
+  const minTokenCount = Math.min(
+    tokenizeDuplicateVisibleText(left).length,
+    tokenizeDuplicateVisibleText(right).length,
+  );
+  return minTokenCount >= 40 && duplicateVisibleTextSimilarity(left, right) >= 0.94;
+}
+
+function routeMatchesExplicitMessageSend(params: {
+  send: ExplicitMessageSendRecord;
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  threadId?: string | number | null;
+}): boolean {
+  if (normalizeRoutePart(params.send.channel) !== normalizeRoutePart(params.channel)) {
+    return false;
+  }
+  if (normalizeRoutePart(params.send.to) !== normalizeRoutePart(params.to)) {
+    return false;
+  }
+  const sendAccountId = normalizeRoutePart(params.send.accountId);
+  const accountId = normalizeRoutePart(params.accountId);
+  if (sendAccountId && accountId && sendAccountId !== accountId) {
+    return false;
+  }
+  const sendThreadId = normalizeRoutePart(params.send.threadId);
+  const threadId = normalizeRoutePart(params.threadId);
+  if (sendThreadId && threadId && sendThreadId !== threadId) {
+    return false;
+  }
+  return true;
+}
+
+function shouldSuppressDuplicateExplicitMessageDelivery(params: {
+  explicitSends: ExplicitMessageSendRecord[] | undefined;
+  deliveryChannel?: string;
+  deliveryTarget?: string;
+  accountId?: string;
+  threadId?: string | number | null;
+  deliveryPayloads: NormalizedOutboundPayload[];
+}): boolean {
+  if (!params.explicitSends?.length || !params.deliveryPayloads.length) {
+    return false;
+  }
+  const hasNonTextPayload = params.deliveryPayloads.some(
+    (payload) =>
+      payload.mediaUrls.length > 0 ||
+      payload.audioAsVoice === true ||
+      payload.presentation !== undefined ||
+      payload.interactive !== undefined ||
+      payload.channelData !== undefined,
+  );
+  if (hasNonTextPayload) {
+    return false;
+  }
+  const finalText = params.deliveryPayloads
+    .map((payload) => payload.text.trim())
+    .filter(Boolean)
+    .join("\n\n");
+  if (!finalText) {
+    return false;
+  }
+  return params.explicitSends.some(
+    (send) =>
+      routeMatchesExplicitMessageSend({
+        send,
+        channel: params.deliveryChannel,
+        to: params.deliveryTarget,
+        accountId: params.accountId,
+        threadId: params.threadId,
+      }) && isDuplicateVisibleText(finalText, send.text),
+  );
 }
 
 async function normalizeReplyMediaPathsForDelivery(params: {
@@ -504,6 +664,27 @@ export async function deliverAgentCommandResult(params: {
   }
 
   const deliveryPayloads = projectOutboundPayloadPlanForOutbound(outboundPayloadPlan);
+  if (
+    deliver &&
+    !deliveryStatus &&
+    shouldSuppressDuplicateExplicitMessageDelivery({
+      explicitSends: opts.runContext?.explicitMessageSends?.entries,
+      deliveryChannel,
+      deliveryTarget,
+      accountId: resolvedAccountId,
+      threadId: resolvedThreadTarget ?? resolvedThreadId,
+      deliveryPayloads,
+    })
+  ) {
+    deliveryStatus = duplicateExplicitMessageSendStatus();
+    emitJsonEnvelope(deliveryStatus);
+    return {
+      payloads: normalizedPayloads,
+      meta: resultMeta,
+      deliverySucceeded: true,
+      deliveryStatus,
+    };
+  }
   if (deliveryPayloads.length === 0) {
     deliveryStatus = deliver ? (deliveryStatus ?? noVisiblePayloadStatus()) : undefined;
     const deliverySucceeded = deliveryStatus?.succeeded === true ? true : undefined;

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -243,7 +243,7 @@ function duplicateExplicitMessageSendStatus(): AgentCommandDeliveryStatus {
 }
 
 function normalizeRoutePart(value: unknown): string | undefined {
-  if (value === null || value === undefined) {
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
     return undefined;
   }
   const text = String(value).trim();

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -259,40 +259,6 @@ function normalizeDuplicateVisibleText(value: string): string {
     .trim();
 }
 
-function tokenizeDuplicateVisibleText(value: string): string[] {
-  return (
-    normalizeDuplicateVisibleText(value)
-      .toLocaleLowerCase()
-      .match(/[\p{L}\p{N}]+/gu) ?? []
-  );
-}
-
-function duplicateVisibleTextSimilarity(left: string, right: string): number {
-  const leftTokens = tokenizeDuplicateVisibleText(left);
-  const rightTokens = tokenizeDuplicateVisibleText(right);
-  if (leftTokens.length === 0 || rightTokens.length === 0) {
-    return 0;
-  }
-  const counts = new Map<string, number>();
-  for (const token of leftTokens) {
-    counts.set(token, (counts.get(token) ?? 0) + 1);
-  }
-  let overlap = 0;
-  for (const token of rightTokens) {
-    const count = counts.get(token) ?? 0;
-    if (count <= 0) {
-      continue;
-    }
-    overlap += 1;
-    if (count === 1) {
-      counts.delete(token);
-    } else {
-      counts.set(token, count - 1);
-    }
-  }
-  return (2 * overlap) / (leftTokens.length + rightTokens.length);
-}
-
 function isDuplicateVisibleText(
   candidate: string | undefined,
   sentText: string | undefined,
@@ -302,22 +268,7 @@ function isDuplicateVisibleText(
   }
   const left = normalizeDuplicateVisibleText(candidate);
   const right = normalizeDuplicateVisibleText(sentText);
-  if (!left || !right) {
-    return false;
-  }
-  if (left === right) {
-    return true;
-  }
-  const shorter = left.length <= right.length ? left : right;
-  const longer = left.length <= right.length ? right : left;
-  if (shorter.length >= 160 && longer.includes(shorter) && shorter.length / longer.length >= 0.9) {
-    return true;
-  }
-  const minTokenCount = Math.min(
-    tokenizeDuplicateVisibleText(left).length,
-    tokenizeDuplicateVisibleText(right).length,
-  );
-  return minTokenCount >= 40 && duplicateVisibleTextSimilarity(left, right) >= 0.94;
+  return Boolean(left && right && left === right);
 }
 
 function routeMatchesExplicitMessageSend(params: {

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -26,6 +26,18 @@ export type AgentCommandResultMetaOverrides = {
 
 export type AcpTurnSource = "manual_spawn";
 
+export type ExplicitMessageSendRecord = {
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string | null;
+  text?: string;
+};
+
+export type ExplicitMessageSendTracker = {
+  entries: ExplicitMessageSendRecord[];
+};
+
 export type AgentRunContext = {
   messageChannel?: string;
   accountId?: string;
@@ -36,6 +48,8 @@ export type AgentRunContext = {
   currentThreadTs?: string;
   replyToMode?: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
+  /** Explicit message.send calls made by this same agent turn. */
+  explicitMessageSends?: ExplicitMessageSendTracker;
 };
 
 export type AgentCommandOpts = {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -10,6 +10,7 @@ import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import type { ExplicitMessageSendTracker } from "./command/types.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import {
   isToolExplicitlyAllowedByFactoryPolicy,
@@ -105,6 +106,8 @@ export function createOpenClawTools(
     hasRepliedRef?: { value: boolean };
     /** Fail closed instead of posting same-channel thread-originated replies at the root. */
     sameChannelThreadRequired?: boolean;
+    /** Explicit message.send calls made by this same agent turn. */
+    explicitMessageSends?: ExplicitMessageSendTracker;
     /** If true, the model has native vision capability */
     modelHasVision?: boolean;
     /** Active model provider for provider-specific tool gating. */
@@ -302,6 +305,7 @@ export function createOpenClawTools(
         replyToMode: options?.replyToMode,
         hasRepliedRef: options?.hasRepliedRef,
         sameChannelThreadRequired: options?.sameChannelThreadRequired,
+        explicitMessageSends: options?.explicitMessageSends,
         sandboxRoot: options?.sandboxRoot,
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1405,6 +1405,7 @@ export async function runEmbeddedPiAgent(
             currentMessageId: params.currentMessageId,
             replyToMode: params.replyToMode,
             hasRepliedRef: params.hasRepliedRef,
+            explicitMessageSends: params.explicitMessageSends,
             sessionFile: activeSessionFile,
             workspaceDir: resolvedWorkspace,
             agentDir,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1427,6 +1427,7 @@ export async function runEmbeddedAttempt(
             toolConstructionPlan: toolConstructionPlan.codingToolConstructionPlan,
             replyToMode: params.replyToMode,
             hasRepliedRef: params.hasRepliedRef,
+            explicitMessageSends: params.explicitMessageSends,
             modelHasVision: params.model.input?.includes("image") ?? false,
             requireExplicitMessageTarget:
               params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -14,6 +14,7 @@ import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../../bash-tools.exec-types.js";
 import type { AgentStreamParams, ClientToolDefinition } from "../../command/shared-types.js";
+import type { ExplicitMessageSendTracker } from "../../command/types.js";
 import type { AgentInternalEvent } from "../../internal-events.js";
 import type { BlockReplyPayload } from "../../pi-embedded-payloads.js";
 import type {
@@ -87,6 +88,8 @@ export type RunEmbeddedPiAgentParams = {
   replyToMode?: "off" | "first" | "all" | "batched";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
   hasRepliedRef?: { value: boolean };
+  /** Explicit message.send calls made by this same agent turn. */
+  explicitMessageSends?: ExplicitMessageSendTracker;
   /** Require explicit message tool targets (no implicit last-route sends). */
   requireExplicitMessageTarget?: boolean;
   /** If true, omit the message tool from the tool list. */

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -25,6 +25,7 @@ import type { ProcessToolDefaults } from "./bash-tools.process.js";
 import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
+import type { ExplicitMessageSendTracker } from "./command/types.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
@@ -424,6 +425,8 @@ export function createOpenClawCodingTools(options?: {
   replyToMode?: "off" | "first" | "all" | "batched";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
   hasRepliedRef?: { value: boolean };
+  /** Explicit message.send calls made by this same agent turn. */
+  explicitMessageSends?: ExplicitMessageSendTracker;
   /** Allow plugin tools for this run to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
   /** Runtime-scoped explicit allowlist used to materialize matching plugin tools. */
@@ -947,6 +950,7 @@ export function createOpenClawCodingTools(options?: {
           modelId: options?.modelId,
           replyToMode: options?.replyToMode,
           hasRepliedRef: options?.hasRepliedRef,
+          explicitMessageSends: options?.explicitMessageSends,
           modelHasVision: options?.modelHasVision,
           requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
           sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -447,7 +447,7 @@ describe("message tool secret scoping", () => {
     expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(input?.toolContext?.currentChannelProvider).toBe("telegram");
     expect(input?.toolContext?.currentChannelId).toBe("-5150615830");
-    expect(input?.params).toEqual({ action: "send", message: "hi" });
+    expect(input?.params).toMatchObject({ action: "send", message: "hi" });
 
     const secretResolveCall = latestSecretResolveCall();
     expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual(["channels.telegram.botToken"]);
@@ -475,7 +475,7 @@ describe("message tool secret scoping", () => {
     expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(input?.toolContext?.currentChannelProvider).toBe("discord");
     expect(input?.toolContext?.currentChannelId).toBe("user:123456789");
-    expect(input?.params).toEqual({ action: "send", message: "hi" });
+    expect(input?.params).toMatchObject({ action: "send", message: "hi" });
 
     const secretResolveCall = latestSecretResolveCall();
     expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual(["channels.discord.token"]);
@@ -503,7 +503,7 @@ describe("message tool secret scoping", () => {
     expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(input?.toolContext?.currentChannelProvider).toBe("msteams");
     expect(input?.toolContext?.currentChannelId).toBe("user:user-1");
-    expect(input?.params).toEqual({ action: "send", message: "hi" });
+    expect(input?.params).toMatchObject({ action: "send", message: "hi" });
 
     const secretResolveCall = latestSecretResolveCall();
     expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual(["channels.msteams.appPassword"]);
@@ -531,7 +531,7 @@ describe("message tool secret scoping", () => {
     expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(input?.toolContext?.currentChannelProvider).toBe("telegram");
     expect(input?.toolContext?.currentChannelId).toBe("123456789");
-    expect(input?.params).toEqual({ action: "send", message: "hi" });
+    expect(input?.params).toMatchObject({ action: "send", message: "hi" });
 
     const secretResolveCall = latestSecretResolveCall();
     expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual(["channels.telegram.botToken"]);

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -776,6 +776,48 @@ describe("message tool agent routing", () => {
     expect(call?.sessionKey).toBe("agent:alpha:main");
   });
 
+  it("stamps sends with a stable tool-call idempotency key", async () => {
+    mockSendResult({ channel: "discord", to: "channel:C123" });
+
+    const tool = createMessageTool({
+      agentSessionKey: "agent:main:discord:channel:c123",
+      sessionId: "session-1",
+      currentChannelProvider: "discord",
+      currentChannelId: "channel:C123",
+      currentMessageId: "msg-1",
+      config: {} as never,
+      runMessageAction: mocks.runMessageAction as never,
+    });
+
+    await tool.execute("call-send-1", {
+      action: "send",
+      message: "hi",
+    });
+
+    const call = mocks.runMessageAction.mock.calls[0]?.[0];
+    expect(call?.params?.idempotencyKey).toBe(
+      "tool:agent:main:discord:channel:c123:session-1:discord:channel:C123:msg-1:call-send-1",
+    );
+  });
+
+  it("preserves caller-provided message idempotency keys", async () => {
+    mockSendResult({ channel: "discord", to: "channel:C123" });
+
+    const call = await executeSend({
+      action: {
+        target: "channel:C123",
+        message: "hi",
+        idempotencyKey: "caller-idem-1",
+      },
+      toolOptions: {
+        currentChannelProvider: "discord",
+        currentChannelId: "channel:C123",
+      },
+    });
+
+    expect(call?.params?.idempotencyKey).toBe("caller-idem-1");
+  });
+
   it("uses agentThreadId as ambient thread context when currentThreadTs is absent", async () => {
     mockSendResult({ channel: "slack", to: "channel:C123" });
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -835,7 +835,7 @@ function buildMessageToolDescription(options?: {
 }
 
 function normalizeRoutePart(value: unknown): string | undefined {
-  if (value === null || value === undefined) {
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
     return undefined;
   }
   const text = String(value).trim();

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -32,6 +32,7 @@ import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js"
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
+import type { ExplicitMessageSendTracker } from "../command/types.js";
 import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
@@ -552,6 +553,7 @@ type MessageToolOptions = {
   replyToMode?: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
   sameChannelThreadRequired?: boolean;
+  explicitMessageSends?: ExplicitMessageSendTracker;
   sandboxRoot?: string;
   requireExplicitTarget?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
@@ -832,6 +834,52 @@ function buildMessageToolDescription(options?: {
   );
 }
 
+function normalizeRoutePart(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const text = String(value).trim();
+  return text ? text : undefined;
+}
+
+function recordCurrentChannelExplicitSend(params: {
+  result: Awaited<ReturnType<typeof runMessageAction>>;
+  actionParams: Record<string, unknown>;
+  currentChannelProvider?: string;
+  currentChannelId?: string;
+  currentThreadTs?: string;
+  accountId?: string;
+  explicitMessageSends?: ExplicitMessageSendTracker;
+}) {
+  const tracker = params.explicitMessageSends;
+  if (!tracker || params.result.kind !== "send" || params.result.dryRun) {
+    return;
+  }
+  const currentChannel = normalizeMessageChannel(params.currentChannelProvider);
+  if (!currentChannel || params.result.channel !== currentChannel) {
+    return;
+  }
+  const currentTarget = normalizeRoutePart(params.currentChannelId);
+  if (!currentTarget || normalizeRoutePart(params.result.to) !== currentTarget) {
+    return;
+  }
+  const text =
+    normalizeRoutePart(params.actionParams.message) ??
+    normalizeRoutePart(params.actionParams.caption) ??
+    undefined;
+  const threadId = normalizeRoutePart(params.actionParams.threadId) ?? params.currentThreadTs;
+  tracker.entries.push({
+    channel: params.result.channel,
+    to: params.result.to,
+    ...(params.accountId ? { accountId: params.accountId } : {}),
+    ...(threadId !== undefined ? { threadId } : {}),
+    ...(text !== undefined ? { text } : {}),
+  });
+  if (tracker.entries.length > 20) {
+    tracker.entries.splice(0, tracker.entries.length - 20);
+  }
+}
+
 function appendMessageToolVisibleReplyHint(
   description: string,
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode,
@@ -1041,6 +1089,16 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
         inboundEventKind: options?.inboundEventKind,
         abortSignal: signal,
+      });
+
+      recordCurrentChannelExplicitSend({
+        result,
+        actionParams: params,
+        currentChannelProvider: options?.currentChannelProvider,
+        currentChannelId: options?.currentChannelId,
+        currentThreadTs,
+        accountId: accountId ?? undefined,
+        explicitMessageSends: options?.explicitMessageSends,
       });
 
       const toolResult = getToolResult(result);

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -967,7 +967,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
     displaySummary: "Send and manage messages across configured channels.",
     description,
     parameters: schema,
-    execute: async (_toolCallId, args, signal) => {
+    execute: async (toolCallId, args, signal) => {
       // Check if already aborted before doing any work
       if (signal?.aborted) {
         const err = new Error("Message send aborted");
@@ -976,6 +976,24 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       }
       // Shallow-copy so we don't mutate the original event args (used for logging/dedup).
       const params = { ...(args as Record<string, unknown>) };
+      if (typeof params.idempotencyKey !== "string" || !params.idempotencyKey.trim()) {
+        const toolCallKey = typeof toolCallId === "string" ? toolCallId.trim() : "";
+        if (toolCallKey) {
+          const scope = [
+            options?.agentSessionKey,
+            options?.sessionId,
+            options?.currentChannelProvider,
+            options?.currentChannelId,
+            currentThreadTs,
+            options?.currentMessageId == null ? undefined : String(options.currentMessageId),
+          ]
+            .filter(
+              (value): value is string => typeof value === "string" && value.trim().length > 0,
+            )
+            .join(":");
+          params.idempotencyKey = `tool:${scope || "global"}:${toolCallKey}`;
+        }
+      }
 
       // Strip reasoning tags from text fields — models may include <think>…</think>
       // in tool arguments, and the messaging tool send path has no other tag filtering.

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1611,6 +1611,7 @@ export const agentHandlers: GatewayRequestHandlers = {
                 groupChannel: resolvedGroupChannel,
                 groupSpace: resolvedGroupSpace,
                 currentThreadTs: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
+                explicitMessageSends: { entries: [] },
               },
               ...(execApprovalFollowupElevatedDefaults
                 ? { bashElevated: execApprovalFollowupElevatedDefaults }

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -26,6 +26,7 @@ import {
   type DiagnosticEventPayload,
 } from "../diagnostic-events.js";
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
+import { resetOutboundSendIdempotencyForTest } from "./send-idempotency.js";
 
 const mocks = vi.hoisted(() => ({
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
@@ -287,6 +288,7 @@ describe("deliverOutboundPayloads", () => {
 
   beforeEach(() => {
     resetDiagnosticEventsForTest();
+    resetOutboundSendIdempotencyForTest();
     releasePinnedPluginChannelRegistry();
     setActivePluginRegistry(defaultRegistry);
     mocks.appendAssistantMessageToSessionTranscript.mockClear();
@@ -358,6 +360,92 @@ describe("deliverOutboundPayloads", () => {
       gifPlayback: undefined,
     });
     expect(results).toEqual([{ channel: "matrix", messageId: "m1", roomId: "!room:example" }]);
+  });
+
+  it("dedupes replayed identical idempotent explicit sends to the same route", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+    const request = {
+      cfg: matrixChunkConfig,
+      channel: "matrix" as const,
+      to: "!room:example",
+      payloads: [{ text: "hello replay" }],
+      deps: { matrix: sendMatrix },
+      idempotencyKey: "tool:run-1:call-1",
+    };
+
+    const first = await deliverOutboundPayloads(request);
+    const replay = await deliverOutboundPayloads(request);
+
+    expect(first).toHaveLength(1);
+    expect(replay).toStrictEqual([]);
+    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dedupe a different message on the same route and idempotency scope", async () => {
+    const sendMatrix = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
+    const base = {
+      cfg: matrixChunkConfig,
+      channel: "matrix" as const,
+      to: "!room:example",
+      deps: { matrix: sendMatrix },
+      idempotencyKey: "tool:run-1:call-1",
+    };
+
+    await deliverOutboundPayloads({ ...base, payloads: [{ text: "first visible message" }] });
+    await deliverOutboundPayloads({ ...base, payloads: [{ text: "legitimate follow-up" }] });
+
+    expect(sendMatrix.mock.calls.map((call) => call[1])).toEqual([
+      "first visible message",
+      "legitimate follow-up",
+    ]);
+    expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(2);
+  });
+
+  it("dedupes replayed split batch content as one idempotent send", async () => {
+    const sendMatrix = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
+    const request = {
+      cfg: { channels: { matrix: { textChunkLimit: 2 } } } as OpenClawConfig,
+      channel: "matrix" as const,
+      to: "!room:example",
+      payloads: [{ text: "abcd" }],
+      deps: { matrix: sendMatrix },
+      idempotencyKey: "tool:run-1:split-call",
+    };
+
+    const first = await deliverOutboundPayloads(request);
+    const replay = await deliverOutboundPayloads(request);
+
+    expect(first.map((result) => result.messageId)).toEqual(["m1", "m2"]);
+    expect(replay).toStrictEqual([]);
+    expect(sendMatrix.mock.calls.map((call) => call[1])).toEqual(["ab", "cd"]);
+    expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps non-idempotent repeated sends visible", async () => {
+    const sendMatrix = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
+    const request = {
+      cfg: matrixChunkConfig,
+      channel: "matrix" as const,
+      to: "!room:example",
+      payloads: [{ text: "repeat me intentionally" }],
+      deps: { matrix: sendMatrix },
+    };
+
+    await deliverOutboundPayloads(request);
+    await deliverOutboundPayloads(request);
+
+    expect(sendMatrix).toHaveBeenCalledTimes(2);
+    expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(2);
   });
 
   it("reports unsupported durable final delivery when required capabilities are missing", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -81,6 +81,7 @@ import {
 import { createReplyToDeliveryPolicy } from "./reply-policy.js";
 import { stripInternalRuntimeScaffolding } from "./sanitize-text.js";
 import { type OutboundSendDeps } from "./send-deps.js";
+import { buildOutboundSendIdempotencyKey, runOutboundSendOnce } from "./send-idempotency.js";
 import type { OutboundSessionContext } from "./session-context.js";
 import type { OutboundChannel } from "./targets.js";
 
@@ -646,6 +647,8 @@ type DeliverOutboundPayloadsCoreParams = {
   mirror?: DeliveryMirror;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
+  /** Stable key for idempotent explicit sends across same-run replay/retry. */
+  idempotencyKey?: string;
 };
 
 type DeliverOutboundPayloadsCoreRuntimeParams = DeliverOutboundPayloadsCoreParams & {
@@ -1196,57 +1199,78 @@ export async function deliverOutboundPayloadsInternal(
     ? createRenderedMessageBatchPlan(queuePayloads)
     : renderedBatchPlan;
 
-  // Write-ahead delivery queue: persist before sending, remove after success.
-  const queueId = params.skipQueue
-    ? null
-    : await enqueueDelivery({
-        channel,
-        to,
-        accountId: params.accountId,
-        payloads: queuePayloads,
-        renderedBatchPlan: queueRenderedBatchPlan,
-        threadId: params.threadId,
-        replyToId: params.replyToId,
-        replyToMode: params.replyToMode,
-        formatting: params.formatting,
-        identity: params.identity,
-        bestEffort: params.bestEffort,
-        gifPlayback: params.gifPlayback,
-        forceDocument: params.forceDocument,
-        silent: params.silent,
-        mirror: params.mirror,
-        session: params.session,
-        gatewayClientScopes: params.gatewayClientScopes,
-      }).catch((err: unknown) => {
-        if (queuePolicy === "required") {
-          throw err;
-        }
-        return null;
-      }); // Best-effort delivery falls back to direct send if the queue write fails.
+  const idempotencyKey = buildOutboundSendIdempotencyKey({
+    idempotencyKey: params.idempotencyKey,
+    channel,
+    to,
+    accountId: params.accountId,
+    threadId: params.threadId,
+    replyToId: params.replyToId,
+    replyToMode: params.replyToMode,
+    payloads: queuePayloads,
+    renderedBatchPlan: queueRenderedBatchPlan,
+  });
 
-  if (queueId) {
-    params.onDeliveryIntent?.({
-      id: queueId,
-      channel,
-      to,
-      ...(params.accountId ? { accountId: params.accountId } : {}),
-      queuePolicy,
-    });
-  }
+  const delivery = await runOutboundSendOnce({
+    key: idempotencyKey,
+    duplicateValue: [] as OutboundDeliveryResult[],
+    shouldRemember: (results) => results.length > 0,
+    run: async () => {
+      // Write-ahead delivery queue: persist before sending, remove after success.
+      const queueId = params.skipQueue
+        ? null
+        : await enqueueDelivery({
+            channel,
+            to,
+            accountId: params.accountId,
+            payloads: queuePayloads,
+            renderedBatchPlan: queueRenderedBatchPlan,
+            threadId: params.threadId,
+            replyToId: params.replyToId,
+            replyToMode: params.replyToMode,
+            formatting: params.formatting,
+            identity: params.identity,
+            bestEffort: params.bestEffort,
+            gifPlayback: params.gifPlayback,
+            forceDocument: params.forceDocument,
+            silent: params.silent,
+            mirror: params.mirror,
+            session: params.session,
+            gatewayClientScopes: params.gatewayClientScopes,
+          }).catch((err: unknown) => {
+            if (queuePolicy === "required") {
+              throw err;
+            }
+            return null;
+          }); // Best-effort delivery falls back to direct send if the queue write fails.
 
-  if (!queueId) {
-    return await deliverOutboundPayloadsWithQueueCleanup(params, null);
-  }
+      if (queueId) {
+        params.onDeliveryIntent?.({
+          id: queueId,
+          channel,
+          to,
+          ...(params.accountId ? { accountId: params.accountId } : {}),
+          queuePolicy,
+        });
+      }
 
-  // Hold the same in-process claim used by recovery/drain while the live send
-  // owns this queue entry.
-  const claimResult = await withActiveDeliveryClaim(queueId, () =>
-    deliverOutboundPayloadsWithQueueCleanup(params, queueId),
-  );
-  if (claimResult.status === "claimed-by-other-owner") {
-    return [];
-  }
-  return claimResult.value;
+      if (!queueId) {
+        return await deliverOutboundPayloadsWithQueueCleanup(params, null);
+      }
+
+      // Hold the same in-process claim used by recovery/drain while the live send
+      // owns this queue entry.
+      const claimResult = await withActiveDeliveryClaim(queueId, () =>
+        deliverOutboundPayloadsWithQueueCleanup(params, queueId),
+      );
+      if (claimResult.status === "claimed-by-other-owner") {
+        return [];
+      }
+      return claimResult.value;
+    },
+  });
+
+  return delivery.value;
 }
 
 async function deliverOutboundPayloadsWithQueueCleanup(

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -265,6 +265,18 @@ describe("sendMessage", () => {
     );
   });
 
+  it("propagates the send idempotency key into direct durable delivery", async () => {
+    await sendMessage({
+      cfg: {},
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+      idempotencyKey: "idem-send-1",
+    });
+
+    expectDeliveryCallFields({ idempotencyKey: "idem-send-1" });
+  });
+
   it("maps voice media sends onto outbound audioAsVoice payloads", async () => {
     await sendMessage({
       cfg: {},

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -399,6 +399,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       silent: params.silent,
       mediaAccess: params.mediaAccess,
       formatting: params.parseMode ? { parseMode: params.parseMode } : undefined,
+      idempotencyKey: params.idempotencyKey,
       mirror: params.mirror
         ? {
             ...params.mirror,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -105,6 +105,10 @@ async function sendCoreMessage(params: {
     queuePolicy: params.queuePolicy,
     deps: params.ctx.deps,
     gateway: params.ctx.gateway,
+    idempotencyKey:
+      typeof params.ctx.params.idempotencyKey === "string"
+        ? params.ctx.params.idempotencyKey
+        : undefined,
     mirror: params.ctx.mirror,
     abortSignal: params.ctx.abortSignal,
     silent: params.ctx.silent,

--- a/src/infra/outbound/send-idempotency.ts
+++ b/src/infra/outbound/send-idempotency.ts
@@ -53,7 +53,7 @@ function pruneSent(state: OutboundSendIdempotencyState, now: number): void {
     }
   }
   while (state.sent.size > OUTBOUND_SEND_IDEMPOTENCY_MAX_SENT) {
-    const firstKey = state.sent.keys().next().value as string | undefined;
+    const firstKey = state.sent.keys().next().value;
     if (!firstKey) {
       break;
     }

--- a/src/infra/outbound/send-idempotency.ts
+++ b/src/infra/outbound/send-idempotency.ts
@@ -1,0 +1,143 @@
+import { createHash } from "node:crypto";
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import type { QueuedRenderedMessageBatchPlan } from "./delivery-queue-storage.js";
+
+const OUTBOUND_SEND_IDEMPOTENCY_STATE = Symbol.for(
+  "openclaw.outbound.explicit-send-idempotency.v1",
+);
+const OUTBOUND_SEND_IDEMPOTENCY_TTL_MS = 10 * 60 * 1000;
+const OUTBOUND_SEND_IDEMPOTENCY_MAX_SENT = 1_000;
+
+type OutboundSendIdempotencyState = {
+  inFlight: Set<string>;
+  sent: Map<string, number>;
+};
+
+export type OutboundSendIdempotencyResult<T> =
+  | { status: "executed"; value: T }
+  | { status: "duplicate"; value: T };
+
+function resolveOutboundSendIdempotencyState(): OutboundSendIdempotencyState {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalStore[OUTBOUND_SEND_IDEMPOTENCY_STATE];
+  if (existing && typeof existing === "object") {
+    return existing as OutboundSendIdempotencyState;
+  }
+  const created: OutboundSendIdempotencyState = {
+    inFlight: new Set<string>(),
+    sent: new Map<string, number>(),
+  };
+  globalStore[OUTBOUND_SEND_IDEMPOTENCY_STATE] = created;
+  return created;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const entries = Object.keys(record)
+    .toSorted()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+  return `{${entries.join(",")}}`;
+}
+
+function pruneSent(state: OutboundSendIdempotencyState, now: number): void {
+  const cutoff = now - OUTBOUND_SEND_IDEMPOTENCY_TTL_MS;
+  for (const [key, timestamp] of state.sent) {
+    if (timestamp < cutoff) {
+      state.sent.delete(key);
+    }
+  }
+  while (state.sent.size > OUTBOUND_SEND_IDEMPOTENCY_MAX_SENT) {
+    const firstKey = state.sent.keys().next().value as string | undefined;
+    if (!firstKey) {
+      break;
+    }
+    state.sent.delete(firstKey);
+  }
+}
+
+function digestStable(value: unknown): string {
+  return createHash("sha256").update(stableStringify(value)).digest("hex").slice(0, 32);
+}
+
+function normalizeThreadId(value: string | number | null | undefined): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const text = String(value).trim();
+  return text || undefined;
+}
+
+export function buildOutboundSendIdempotencyKey(params: {
+  idempotencyKey?: string | null;
+  channel: string;
+  to: string;
+  accountId?: string | null;
+  threadId?: string | number | null;
+  replyToId?: string | null;
+  replyToMode?: string | null;
+  payloads: readonly ReplyPayload[];
+  renderedBatchPlan?: QueuedRenderedMessageBatchPlan;
+}): string | undefined {
+  const idempotencyKey =
+    typeof params.idempotencyKey === "string" ? params.idempotencyKey.trim() : "";
+  if (!idempotencyKey) {
+    return undefined;
+  }
+  const routeAndContentDigest = digestStable({
+    channel: params.channel,
+    to: params.to,
+    accountId: params.accountId ?? undefined,
+    threadId: normalizeThreadId(params.threadId),
+    replyToId: params.replyToId ?? undefined,
+    replyToMode: params.replyToMode ?? undefined,
+    payloads: params.payloads,
+    renderedBatchPlan: params.renderedBatchPlan,
+  });
+  return `${idempotencyKey}:${routeAndContentDigest}`;
+}
+
+export async function runOutboundSendOnce<T>(params: {
+  key?: string;
+  duplicateValue: T;
+  shouldRemember?: (value: T) => boolean;
+  run: () => Promise<T>;
+}): Promise<OutboundSendIdempotencyResult<T>> {
+  const key = params.key;
+  if (!key) {
+    return { status: "executed", value: await params.run() };
+  }
+
+  const state = resolveOutboundSendIdempotencyState();
+  const now = Date.now();
+  pruneSent(state, now);
+  if (state.inFlight.has(key) || state.sent.has(key)) {
+    return { status: "duplicate", value: params.duplicateValue };
+  }
+
+  state.inFlight.add(key);
+  try {
+    const value = await params.run();
+    if (params.shouldRemember?.(value) ?? true) {
+      state.sent.set(key, Date.now());
+      pruneSent(state, Date.now());
+    }
+    return { status: "executed", value };
+  } catch (error) {
+    state.sent.delete(key);
+    throw error;
+  } finally {
+    state.inFlight.delete(key);
+  }
+}
+
+export function resetOutboundSendIdempotencyForTest(): void {
+  const state = resolveOutboundSendIdempotencyState();
+  state.inFlight.clear();
+  state.sent.clear();
+}


### PR DESCRIPTION
## Summary
- track same-turn current-channel `message.send` calls in agent run context
- suppress automatic final delivery only when its normalized visible text exactly matches a same-turn explicit send to the same channel/target
- keep near-duplicate final replies with added warning/correction text, cross-target sends, media/interactive payloads, and normal final deliveries unchanged

## Review notes
- narrowed the duplicate predicate by removing substring and token-similarity matching; the guard now requires exact normalized visible-text equality
- added a regression test covering a prior `message.send` followed by a longer final reply that adds a warning; that final reply is delivered instead of suppressed
- did not exercise a production Gateway or live Discord channel for proof; validation below is from an isolated source checkout and mocked Discord delivery seam

## Tests
- `git diff --check`
- `CI=1 vitest run src/agents/command/delivery.test.ts --bail=1 --testNamePattern 'duplicate|warning'`

## Real behavior proof

- Behavior or issue addressed: A native assistant turn could explicitly send a visible `message.send` response and then also produce a final reply with the same visible text, causing duplicate visible delivery. Follow-up review also identified two adjacent safety boundaries: near-duplicate final replies with added warning/correction text must still deliver, and one-sided route metadata must not count as a duplicate route match.
- Real environment tested: Non-production isolated OpenClaw source checkout on Linux at PR head `fcd79f6f32e0309a7d6ca1e712165713868ff91b`, using mocked/synthetic Discord and outbound delivery seams. No production/live Gateway, runtime config, runtime state, real Discord channel, or real Discord send was used or claimed.
- Exact steps or command run after this patch:

```text
git diff --check origin/main...HEAD
node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/command/delivery.test.ts --pool=threads --maxWorkers=1 --reporter=verbose --testNamePattern "suppresses duplicate Discord final delivery after same-turn current-channel message.send|keeps Discord final delivery when it adds a warning|keeps Discord final delivery when duplicate message.send had a thread and final route does not|keeps Discord final delivery when duplicate message.send had an account and final route does not"
node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/outbound/deliver.test.ts --pool=threads --maxWorkers=1 --reporter=verbose --testNamePattern "dedupes replayed identical idempotent explicit sends to the same route|dedupes replayed split batch content as one idempotent send|keeps non-idempotent repeated sends visible"
node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/message-tool.test.ts --pool=threads --maxWorkers=1 --reporter=verbose --testNamePattern "stamps sends with a stable tool-call idempotency key|preserves caller-provided message idempotency keys"
```

- Evidence after fix: Copied terminal output from the non-production isolated checkout:

```text
NON-PRODUCTION PROOF BOUNDARY
repo: openclaw/openclaw PR #80445
head: fcd79f6f32e0309a7d6ca1e712165713868ff91b
scope: isolated source checkout + mocked/synthetic Discord/outbound delivery seams; no production Gateway/runtime config/state or live Discord channel

git diff --check origin/main...HEAD: PASS

src/agents/command/delivery.test.ts:
  ✓ suppresses duplicate Discord final delivery after same-turn current-channel message.send
  ✓ keeps Discord final delivery when it adds a warning to a prior message.send
  ✓ keeps Discord final delivery when duplicate message.send had a thread and final route does not
  ✓ keeps Discord final delivery when duplicate message.send had an account and final route does not
  Test Files 1 passed; Tests 4 passed | 21 skipped

src/infra/outbound/deliver.test.ts:
  ✓ dedupes replayed identical idempotent explicit sends to the same route
  ✓ dedupes replayed split batch content as one idempotent send
  ✓ keeps non-idempotent repeated sends visible
  Test Files 1 passed; Tests 3 passed | 82 skipped

src/agents/tools/message-tool.test.ts:
  ✓ stamps sends with a stable tool-call idempotency key
  ✓ preserves caller-provided message idempotency keys
  Test Files 1 passed; Tests 2 passed | 48 skipped
```

- Observed result after fix: Exact normalized visible-text duplicates from same-turn current-channel `message.send` are suppressed at final delivery; warning/correction final replies still deliver; one-sided `threadId`/`accountId` route metadata mismatches still deliver; replayed explicit sends with the same idempotency scope/content/route dedupe while non-idempotent repeated sends remain visible.
- What was not tested: No production/live Gateway/runtime/config/state or real Discord channel was exercised. This is non-production seam proof, not live Discord proof; if maintainers require live proof specifically, a maintainer override or live validation by someone with an approved non-sensitive environment is still needed.
