### PR TITLE
fix(codex): avoid app-server probe during onboarding detection

### DIFF
--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -122,6 +122,23 @@ async function createCodexFixture(): Promise<{
   return { root, homeDir, codexHome, stateDir, workspaceDir };
 }
 
+async function createEmptyCodexFixture(): Promise<{
+  root: string;
+  homeDir: string;
+  codexHome: string;
+  stateDir: string;
+  workspaceDir: string;
+}> {
+  const root = await makeTempRoot();
+  const homeDir = path.join(root, "home");
+  const codexHome = path.join(root, ".codex");
+  const stateDir = path.join(root, "state");
+  const workspaceDir = path.join(root, "workspace");
+  vi.stubEnv("HOME", homeDir);
+  await fs.mkdir(codexHome, { recursive: true });
+  return { root, homeDir, codexHome, stateDir, workspaceDir };
+}
+
 afterEach(async () => {
   vi.unstubAllEnvs();
   appServerRequest.mockReset();
@@ -134,6 +151,39 @@ afterEach(async () => {
 describe("buildCodexMigrationProvider", () => {
   beforeEach(() => {
     appServerRequest.mockRejectedValue(new Error("codex app-server unavailable"));
+  });
+
+  it("detects Codex state without starting app-server plugin inventory", async () => {
+    const fixture = await createCodexFixture();
+    const provider = buildCodexMigrationProvider();
+
+    const detection = await provider.detect!(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expect(detection.found).toBe(true);
+    expect(detection.source).toBe(fixture.codexHome);
+    expect(appServerRequest).not.toHaveBeenCalled();
+  });
+
+  it("ignores an empty Codex home during detection without starting app-server", async () => {
+    const fixture = await createEmptyCodexFixture();
+    const provider = buildCodexMigrationProvider();
+
+    const detection = await provider.detect!(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expect(detection.found).toBe(false);
+    expect(appServerRequest).not.toHaveBeenCalled();
   });
 
   it("plans Codex skills while keeping plugins and native config explicit", async () => {

--- a/extensions/codex/src/migration/provider.ts
+++ b/extensions/codex/src/migration/provider.ts
@@ -18,7 +18,9 @@ export function buildCodexMigrationProvider(
     description:
       "Inventory and promote Codex CLI skills while keeping Codex native plugins and hooks explicit.",
     async detect(ctx) {
-      const source = await discoverCodexSource(ctx.source);
+      const source = await discoverCodexSource(ctx.source, {
+        includeAppServerPluginInventory: false,
+      });
       const found = hasCodexSource(source);
       return {
         found,

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -56,6 +56,10 @@ type CodexSource = {
   archivePaths: CodexArchiveSource[];
 };
 
+type DiscoverCodexSourceOptions = {
+  includeAppServerPluginInventory?: boolean;
+};
+
 function defaultCodexHome(): string {
   return resolveHomePath(process.env.CODEX_HOME?.trim() || "~/.codex");
 }
@@ -216,7 +220,10 @@ function pluginNameFromSummary(summary: v2.PluginSummary): string | undefined {
   return undefined;
 }
 
-export async function discoverCodexSource(input?: string): Promise<CodexSource> {
+export async function discoverCodexSource(
+  input?: string,
+  options: DiscoverCodexSourceOptions = {},
+): Promise<CodexSource> {
   const codexHome = resolveHomePath(input?.trim() || defaultCodexHome());
   const codexSkillsDir = path.join(codexHome, "skills");
   const agentsSkillsDir = personalAgentsSkillsDir();
@@ -231,7 +238,10 @@ export async function discoverCodexSource(input?: string): Promise<CodexSource> 
     root: agentsSkillsDir,
     sourceLabel: "personal AgentSkill",
   });
-  const sourcePluginDiscovery = await discoverInstalledCuratedPlugins(codexHome);
+  const sourcePluginDiscovery =
+    options.includeAppServerPluginInventory === false
+      ? { plugins: [] }
+      : await discoverInstalledCuratedPlugins(codexHome);
   const sourcePluginNames = new Set(
     sourcePluginDiscovery.plugins.flatMap((plugin) =>
       plugin.pluginName ? [plugin.pluginName] : [],


### PR DESCRIPTION
## Summary

- Problem: `openclaw onboard` migration-source detection could start the Codex app-server before the user chose a migration import, so a partial or canceled Codex auth state could surface `codex app-server write failed` during beta onboarding.
- Why it matters: onboarding on a fresh VPS should not launch Codex app-server just to decide whether an import prompt is available.
- What changed: Codex migration detection now performs a filesystem-only source scan; the explicit migration plan/apply path still inventories installed Codex plugins through app-server when the user actually imports Codex state.
- What did NOT change (scope boundary): no new config surface, no daemon install behavior changes, and no change to Codex plugin migration during explicit `openclaw migrate codex` or `--import-from codex` flows.
- Current-main note: The branch is rebased over #80822, so explicit migration planning keeps main #80822 isolated app-server inventory client; only onboarding detection skips app-server inventory.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Onboarding should not invoke the Codex CLI/app-server during migration source detection before the user selects an import.
- Real environment tested: Ubuntu 24.04 checkout at PR head `127ee8441a9430858b2fdc8d64320b8aa3776c2f`; Node 22.22.2; isolated `HOME` and `CODEX_HOME`; a fake `codex` executable first in `PATH`; and a minimal source `~/.codex/skills/example` directory.
- Exact steps or command run after this patch:

```sh
tmp=$(mktemp -d)
mkdir -p "$tmp/bin" "$tmp/home/.codex/skills/example"
printf '#!/bin/sh\necho "$@" >> "%s/codex-called"\nexit 42\n' "$tmp" > "$tmp/bin/codex"
chmod +x "$tmp/bin/codex"
HOME="$tmp/home" CODEX_HOME="$tmp/home/.codex" PATH="$tmp/bin:$PATH" pnpm openclaw onboard --non-interactive --accept-risk --flow quickstart --auth-choice skip --mode local --gateway-port 19991 --gateway-auth token --gateway-token test-token --no-install-daemon --skip-channels --skip-skills --skip-bootstrap --skip-search --skip-health --skip-ui --json
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ node scripts/run-node.mjs onboard --non-interactive --accept-risk --flow quickstart --auth-choice skip --mode local --gateway-port 19991 --gateway-auth token --gateway-token test-token --no-install-daemon --skip-channels --skip-skills --skip-bootstrap --skip-search --skip-health --skip-ui --json
Updated ~/.openclaw/openclaw.json
Workspace OK: ~/.openclaw/workspace
Sessions OK: ~/.openclaw/agents/main/sessions
{
  "ok": true,
  "mode": "local",
  "workspace": "<proof-root>/home/.openclaw/workspace",
  "authChoice": "skip",
  "gateway": {
    "port": 19991,
    "bind": "loopback",
    "authMode": "token",
    "tailscaleMode": "off"
  },
  "installDaemon": false,
  "skipSkills": true,
  "skipHealth": true
}
codex-invoked=no
exit-code=0
```

- Observed result after fix: The real `pnpm openclaw onboard` command completed successfully at PR head `127ee8441a9430858b2fdc8d64320b8aa3776c2f`, and the fake `codex` executable was never invoked, proving detection did not start Codex app-server.
- What was not tested: Full systemd daemon installation on the originally affected VPS; broad validation is GitHub PR CI.
- Before evidence (optional but encouraged): The reported beta path showed `22:39:34 [agent/embedded] codex app-server write failed` immediately after the onboarding risk acknowledgement. The base implementation called `discoverInstalledCuratedPlugins()` from `discoverCodexSource()` during provider detection, which starts `codex app-server --listen stdio://`.

## Root Cause (if applicable)

- Root cause: The Codex migration provider used the same discovery routine for lightweight onboarding detection and explicit migration planning. That routine queried Codex app-server plugin inventory unconditionally.
- Missing detection / guardrail: There was no regression coverage asserting that `provider.detect()` avoids app-server/plugin inventory side effects.
- Contributing context (if known): Partial or canceled Codex auth can leave app-server startup/write paths noisy enough for the generic embedded-agent warning to leak during onboarding.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/migration/provider.test.ts`
- Scenario the test should lock in: Codex provider detection finds real Codex filesystem state and ignores empty Codex homes without calling app-server plugin inventory.
- Why this is the smallest reliable guardrail: The bug is in the migration provider detection seam; the test mocks the app-server request boundary and asserts it is not touched during detection.
- Existing test that already covers this (if any): Existing planning tests still cover app-server plugin inventory for explicit migration plans.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw onboard` no longer starts Codex app-server while merely checking whether a Codex import option should be shown. Explicit Codex migration still inventories Codex plugins when the user chooses that migration flow.

## Diagram (if applicable)

```text
Before:
onboard risk acknowledgement -> migration detection -> Codex app-server plugin/list -> warning can leak

After:
onboard risk acknowledgement -> filesystem-only migration detection -> import choice or normal onboarding
explicit Codex import -> migration plan -> Codex app-server plugin/list
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: The change removes an early `codex app-server` command execution from onboarding detection. Explicit Codex migration still uses the existing app-server path.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 local development host for PR-head proof; original report was Ubuntu VPS on the beta channel.
- Runtime/container: Node 22.22.2; OpenClaw CLI from this checkout.
- Model/provider: `--auth-choice skip` for the onboarding proof.
- Integration/channel (if any): Codex migration provider detection.
- Relevant config (redacted): Isolated temporary `HOME` and `CODEX_HOME`; temporary gateway token value only.

### Steps

1. Put a fake `codex` executable first in `PATH` that records invocations and exits non-zero.
2. Create a minimal temporary `CODEX_HOME` with `skills/example` so Codex filesystem state is detectable.
3. Run non-interactive `pnpm openclaw onboard` with daemon, channel, skill, search, bootstrap, UI, and health setup skipped.

### Expected

- Onboarding succeeds.
- The fake `codex` executable is not invoked during migration detection.

### Actual

- Onboarding succeeded with JSON summary.
- The proof marker printed `codex-invoked=no` and `exit-code=0`.
- Targeted test passed after rebase: `pnpm test extensions/codex/src/migration/provider.test.ts` (13 tests). Local Codex review against current upstream `main` found no actionable correctness issues.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ubuntu PR-head onboarding proof with a fake `codex` executable confirmed no Codex CLI/app-server invocation during detection; targeted migration provider regression test passed; local Codex review against current upstream `main` found no actionable correctness issues.
- Edge cases checked: Empty Codex home detection stays false without app-server; explicit migration planning still calls app-server plugin inventory.
- What you did **not** verify: Owner performs final manual verification on the affected Ubuntu VPS outside this agent run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Onboarding detection no longer treats app-server-only Codex plugin inventory as a reason to auto-show the import option.
  - Mitigation: Explicit Codex migration flows still run full plugin inventory, and normal Codex installs leave filesystem state such as skills, config, hooks, or cached plugin bundles for detection.



