### PR TITLE
fix(doctor): suppress --fix trailer when no pending config changes remain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/agents: keep stale `sessions_send` ACP manager and `web_fetch` runtime chunks importable after package updates, preventing live gateways from breaking before restart. Fixes #78804. Thanks @Gomesy72.
 - Gateway/install: preserve service environment value-source metadata in `openclaw gateway install`, so systemd reinstall paths keep env-file-backed secrets out of inline unit metadata. Refs #77406, #77427. Thanks @stainlu and @brokemac79.
 - Auto-reply/reset: include inbound sender context in bare `/new` and `/reset` model prompts while keeping startup instructions out of transcript prompts, so agents see sender identity on the first reset turn. Fixes #77360. Thanks @srb11e.
+- Doctor: only print the `Run "openclaw doctor --fix" to apply changes.` trailer when the run actually has pending config changes, so a clean re-run after a successful `--fix` ends with `Doctor complete.` only. Fixes #80435.
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.
 - Agents/auth: update successful model auth profile status with one locked store write, reducing post-model reply latency from duplicate `auth-profiles.json` saves. Thanks @mcaxtr.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -288,6 +288,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     cfg,
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig: finalized.shouldWriteConfig,
+    pendingChanges,
     sourceConfigValid: snapshot.valid,
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyMigrationPartiallyValid ? { skipPluginValidationOnWrite: true } : {}),

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -387,6 +387,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     cfg,
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig: finalized.shouldWriteConfig,
+    pendingChanges,
     sourceConfigValid: snapshot.valid,
     preservedLegacyRootKeys: ["defaultModel"],
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -141,4 +141,48 @@ describe("doctor health contributions", () => {
       }),
     ).toBe(false);
   });
+
+  it("skips the doctor --fix trailer when no pending config changes remain", async () => {
+    const contribution = requireDoctorContribution("doctor:write-config");
+    const log = vi.fn();
+    const cfg = {};
+    const ctx = {
+      runtime: { log },
+      options: {},
+      prompter: { shouldRepair: false },
+      configResult: { cfg, shouldWriteConfig: false, pendingChanges: false },
+      cfg,
+      cfgForPersistence: cfg,
+      sourceConfigValid: true,
+      configPath: "/tmp/openclaw-doctor-trailer.json",
+      env: {},
+    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("prints the doctor --fix trailer when pending config changes await --fix", async () => {
+    const contribution = requireDoctorContribution("doctor:write-config");
+    const log = vi.fn();
+    const cfg = {};
+    const ctx = {
+      runtime: { log },
+      options: {},
+      prompter: { shouldRepair: false },
+      configResult: { cfg, shouldWriteConfig: false, pendingChanges: true },
+      cfg,
+      cfgForPersistence: cfg,
+      sourceConfigValid: true,
+      configPath: "/tmp/openclaw-doctor-trailer.json",
+      env: {},
+    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("openclaw doctor --fix"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("to apply changes."));
+  });
 });

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -982,5 +982,47 @@ describe("doctor health contributions", () => {
         }),
       );
     });
+
+    it("skips the doctor --fix trailer when no pending config changes remain", async () => {
+      const cfg = {};
+      const log = vi.fn();
+      const ctx = {
+        runtime: { log },
+        options: {},
+        prompter: buildDoctorPrompter(false),
+        configResult: { cfg, shouldWriteConfig: false, pendingChanges: false },
+        cfg,
+        cfgForPersistence: cfg,
+        sourceConfigValid: true,
+        configPath: "/tmp/openclaw-doctor-trailer.json",
+        env: {},
+      } as unknown as Parameters<(typeof writeConfigContribution)["run"]>[0];
+
+      await writeConfigContribution.run(ctx);
+
+      expect(log).not.toHaveBeenCalled();
+    });
+
+    it("prints the doctor --fix trailer when pending config changes await --fix", async () => {
+      const cfg = {};
+      const log = vi.fn();
+      const ctx = {
+        runtime: { log },
+        options: {},
+        prompter: buildDoctorPrompter(false),
+        configResult: { cfg, shouldWriteConfig: false, pendingChanges: true },
+        cfg,
+        cfgForPersistence: cfg,
+        sourceConfigValid: true,
+        configPath: "/tmp/openclaw-doctor-trailer.json",
+        env: {},
+      } as unknown as Parameters<(typeof writeConfigContribution)["run"]>[0];
+
+      await writeConfigContribution.run(ctx);
+
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("openclaw doctor --fix"));
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("to apply changes."));
+    });
   });
 });

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1023,6 +1023,30 @@ describe("doctor health contributions", () => {
       expect(log).not.toHaveBeenCalled();
     });
 
+    it("does not write or print the doctor --fix trailer for non-repair drift without pending config changes", async () => {
+      const log = vi.fn();
+      const ctx = {
+        runtime: { log, error: vi.fn(), exit: vi.fn() },
+        options: {},
+        prompter: buildDoctorPrompter(false),
+        configResult: {
+          cfg: { gateway: { mode: "local" } },
+          shouldWriteConfig: false,
+          pendingChanges: false,
+        },
+        cfg: { gateway: { mode: "remote" } },
+        cfgForPersistence: { gateway: { mode: "local" } },
+        sourceConfigValid: true,
+        configPath: "/tmp/openclaw-doctor-trailer.json",
+        env: {},
+      } as unknown as Parameters<(typeof writeConfigContribution)["run"]>[0];
+
+      await writeConfigContribution.run(ctx);
+
+      expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+      expect(log).not.toHaveBeenCalled();
+    });
+
     it("prints the doctor --fix trailer when pending config changes await --fix", async () => {
       const cfg = {};
       const log = vi.fn();

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1023,8 +1023,9 @@ describe("doctor health contributions", () => {
       expect(log).not.toHaveBeenCalled();
     });
 
-    it("does not write or print the doctor --fix trailer for non-repair drift without pending config changes", async () => {
+    it("writes health-phase config drift without printing the doctor --fix trailer", async () => {
       const log = vi.fn();
+      const nextConfig = { gateway: { mode: "remote" } };
       const ctx = {
         runtime: { log, error: vi.fn(), exit: vi.fn() },
         options: {},
@@ -1034,7 +1035,7 @@ describe("doctor health contributions", () => {
           shouldWriteConfig: false,
           pendingChanges: false,
         },
-        cfg: { gateway: { mode: "remote" } },
+        cfg: nextConfig,
         cfgForPersistence: { gateway: { mode: "local" } },
         sourceConfigValid: true,
         configPath: "/tmp/openclaw-doctor-trailer.json",
@@ -1043,7 +1044,11 @@ describe("doctor health contributions", () => {
 
       await writeConfigContribution.run(ctx);
 
-      expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+      expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nextConfig,
+        }),
+      );
       expect(log).not.toHaveBeenCalled();
     });
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -983,6 +983,26 @@ describe("doctor health contributions", () => {
       );
     });
 
+    it("skips the doctor --fix trailer when no pending config changes were recorded", async () => {
+      const cfg = {};
+      const log = vi.fn();
+      const ctx = {
+        runtime: { log },
+        options: {},
+        prompter: buildDoctorPrompter(false),
+        configResult: { cfg, shouldWriteConfig: false },
+        cfg,
+        cfgForPersistence: cfg,
+        sourceConfigValid: true,
+        configPath: "/tmp/openclaw-doctor-trailer.json",
+        env: {},
+      } as unknown as Parameters<(typeof writeConfigContribution)["run"]>[0];
+
+      await writeConfigContribution.run(ctx);
+
+      expect(log).not.toHaveBeenCalled();
+    });
+
     it("skips the doctor --fix trailer when no pending config changes remain", async () => {
       const cfg = {};
       const log = vi.fn();

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -12,6 +12,7 @@ type DoctorConfigResult = {
   cfg: OpenClawConfig;
   path?: string;
   shouldWriteConfig?: boolean;
+  pendingChanges?: boolean;
   sourceConfigValid?: boolean;
   sourceLastTouchedVersion?: string;
   skipPluginValidationOnWrite?: boolean;
@@ -606,7 +607,7 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
     }
     return;
   }
-  if (!ctx.prompter.shouldRepair) {
+  if (!ctx.prompter.shouldRepair && ctx.configResult.pendingChanges) {
     ctx.runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 }

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -906,9 +906,8 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
   const { replaceConfigFile } = await loadConfigModule();
   const { logConfigUpdated } = await import("../config/logging.js");
   const { shortenHomePath } = await import("../utils.js");
-  const changedDuringRepair =
-    ctx.prompter.shouldRepair && JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
-  const shouldWriteConfig = ctx.configResult.shouldWriteConfig === true || changedDuringRepair;
+  const changedDuringHealth = JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
+  const shouldWriteConfig = ctx.configResult.shouldWriteConfig === true || changedDuringHealth;
   if (shouldWriteConfig) {
     const updateDoctorRun = isUpdateDoctorRun(ctx.env ?? process.env);
     ctx.cfg = applyWizardMetadata(ctx.cfg, {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -906,9 +906,9 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
   const { replaceConfigFile } = await loadConfigModule();
   const { logConfigUpdated } = await import("../config/logging.js");
   const { shortenHomePath } = await import("../utils.js");
-  const shouldWriteConfig =
-    ctx.configResult.shouldWriteConfig ||
-    JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
+  const changedDuringRepair =
+    ctx.prompter.shouldRepair && JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
+  const shouldWriteConfig = ctx.configResult.shouldWriteConfig === true || changedDuringRepair;
   if (shouldWriteConfig) {
     const updateDoctorRun = isUpdateDoctorRun(ctx.env ?? process.env);
     ctx.cfg = applyWizardMetadata(ctx.cfg, {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -24,6 +24,7 @@ type DoctorConfigResult = {
   cfg: OpenClawConfig;
   path?: string;
   shouldWriteConfig?: boolean;
+  pendingChanges?: boolean;
   sourceConfigValid?: boolean;
   sourceLastTouchedVersion?: string;
   skipPluginValidationOnWrite?: boolean;
@@ -950,7 +951,7 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
     }
     return;
   }
-  if (!ctx.prompter.shouldRepair) {
+  if (!ctx.prompter.shouldRepair && ctx.configResult.pendingChanges) {
     ctx.runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 }

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -573,9 +573,8 @@ async function runBrowserHealth(ctx: DoctorHealthFlowContext): Promise<void> {
 }
 
 async function runOpenAIOAuthTlsHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  const { noteOpenAIOAuthTlsPrerequisites } = await import(
-    "../plugins/provider-openai-chatgpt-oauth-tls.js"
-  );
+  const { noteOpenAIOAuthTlsPrerequisites } =
+    await import("../plugins/provider-openai-chatgpt-oauth-tls.js");
   await noteOpenAIOAuthTlsPrerequisites({
     cfg: ctx.cfg,
     deep: ctx.options.deep === true,
@@ -951,7 +950,7 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
     }
     return;
   }
-  if (!ctx.prompter.shouldRepair && ctx.configResult.pendingChanges) {
+  if (!ctx.prompter.shouldRepair && ctx.configResult.pendingChanges === true) {
     ctx.runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 }


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` (without `--fix`) prints `Run "openclaw doctor --fix" to apply changes.` on every run, even when nothing in the run actually had a pending config change. After a successful `--fix` settles the workspace, a follow-up plain `doctor` invocation still emits the trailer, training operators to ignore a non-actionable cue.
- Why it matters: the trailer is the "you have something to apply" signal. When it fires on a clean state, it makes `Doctor complete.` ambiguous — users either re-run `--fix` for nothing or learn to ignore the line everywhere, including the cases where it does mean something.
- What changed: thread the already-tracked `pendingChanges` flag from `loadAndMaybeMigrateDoctorConfig` through the doctor config result, and gate the trailer in `runWriteConfigHealth` on it. The trailer now only emits when the config flow actually flagged at least one pending repair the user could apply.
- What did NOT change (scope boundary): no behavior change for `--fix` runs, no behavior change when `pendingChanges` is truly set, no edits to other doctor panels or contributions, no rename/move.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX (CLI diagnostics output)

## Linked Issue/PR

- Closes #80435
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: the unconditional `Run "openclaw doctor --fix" to apply changes.` trailer that `runWriteConfigHealth` emits whenever `--fix` is not passed, regardless of whether anything was actually pending.
- Real environment tested: local macOS (Darwin 24.6.0, Node v24.10.0) checkout of `openclaw/openclaw` at `upstream/main`, run with `pnpm dev doctor`.
- Exact steps or command run after this patch:
  - `pnpm install --frozen-lockfile`
  - `pnpm test src/flows/doctor-health-contributions.test.ts`
  - `pnpm check:changed` (lint core + tsgo core + tsgo core tests + import-cycles + boundary guards)
  - `OPENCLAW_HOME=/tmp/openclaw-trailer-test pnpm dev doctor --fix --non-interactive` (× 2 to settle)
  - `OPENCLAW_HOME=/tmp/openclaw-trailer-test pnpm dev doctor --non-interactive` (the previously failing invocation)
- Evidence after fix:
  - Unit lane: `Test Files 1 passed (1); Tests 11 passed (11)` — includes the two new regression cases for `doctor:write-config`.
  - `pnpm check:changed`: exits 0 with `Found 0 warnings and 0 errors.` on lint, clean typecheck on `tsgo:core` and `tsgo:core:test`, `0 runtime value cycle(s)` from `check:import-cycles`.
  - Settled clean re-run ends with `└  Doctor complete.` and no trailing `Run "openclaw doctor --fix" to apply changes.` line.
- Observed result after fix: on the clean re-run, the trailer is gone; runs that genuinely have pending repairs queued continue to print it (covered by the second new unit test).
- What was not tested: I did not reproduce the exact source-checkout + entrypoint-mismatch host layout from the bug report on this machine (no spare gateway-install/migration setup), so the live trailer-on-clean-state observation comes from a fresh `OPENCLAW_HOME` rather than the reporter's npm-over-pnpm upgrade scenario. The function-level regression test mirrors the same code path either way.

## Root Cause

- Root cause: `runWriteConfigHealth` reached its `else` branch whenever `shouldWriteConfig` resolved to `false`, and then emitted the trailer based only on whether `--fix` was missing. There was no signal of whether any earlier health contribution would have *had* something to apply, so the message printed even on a fully settled run.
- Missing detection / guardrail: there was no unit test asserting that the trailer is suppressed on a clean run. The new `doctor:write-config — skips the doctor --fix trailer when no pending config changes remain` test closes that gap.
- Contributing context (if known): `loadAndMaybeMigrateDoctorConfig` already tracks `pendingChanges` locally for `finalizeDoctorConfigFlow`, but it wasn't surfaced on the returned `DoctorConfigResult`, so downstream contributions had no way to consult it.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/flows/doctor-health-contributions.test.ts`
- Scenarios locked in:
  - `doctor:write-config` skips the `--fix` trailer when `configResult.pendingChanges === false` and `prompter.shouldRepair === false`.
  - `doctor:write-config` still prints the `--fix` trailer when `configResult.pendingChanges === true` and `prompter.shouldRepair === false`.
- Why this is the smallest reliable guardrail: the bug lives entirely in the single branch in `runWriteConfigHealth`; exercising both `pendingChanges` values against the live `doctor:write-config` contribution is enough to lock in the gate without standing up the whole doctor flow.
- Existing test that already covers this: none — the existing tests in this file assert ordering and the legacy update-skip helper, not trailer emission.

## User-visible / Behavior Changes

`openclaw doctor` (no `--fix`) no longer prints `Run "openclaw doctor --fix" to apply changes.` on runs where no health contribution flagged a pending config change. Runs that do have pending changes are unchanged.

## Diagram

```text
Before:
doctor --non-interactive (clean state) -> Doctor complete. + "Run openclaw doctor --fix to apply changes."

After:
doctor --non-interactive (clean state) -> Doctor complete.
doctor --non-interactive (pending change) -> Doctor complete. + "Run openclaw doctor --fix to apply changes."
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin 24.6.0), reporter saw it on Ubuntu 24.04 aarch64
- Runtime/container: Node v24.10.0 (reporter: Node v22.22.2)
- Model/provider: N/A — pure doctor CLI diagnostics
- Integration/channel (if any): N/A
- Relevant config (redacted): a settled `~/.openclaw/openclaw.json` where the previous `--fix` exited without `Updated ~/.openclaw/openclaw.json`

### Steps

1. `openclaw doctor --fix --non-interactive` until it exits cleanly with no `Updated ~/.openclaw/openclaw.json` line.
2. `openclaw doctor --non-interactive` immediately afterward.
3. Observe the trailer.

### Expected

The settled re-run ends with `└  Doctor complete.` and no trailing `Run "openclaw doctor --fix" to apply changes.` line.

### Actual (pre-fix)

The settled re-run ends with `Run "openclaw doctor --fix" to apply changes.` followed by `└  Doctor complete.`, even though no panel reported a pending change.

## Evidence

- [x] Failing-then-passing unit assertions covering both `pendingChanges` branches (`src/flows/doctor-health-contributions.test.ts`).
- [x] Trace/log snippet from `pnpm dev doctor --non-interactive` on settled `OPENCLAW_HOME` showing `Doctor complete.` with no trailer.

## Human Verification

- Verified scenarios:
  - Settled clean re-run of `pnpm dev doctor --non-interactive` against a freshly populated `OPENCLAW_HOME` ends with `Doctor complete.` and no trailer.
  - `pnpm test src/flows/doctor-health-contributions.test.ts` — 11 passed, including the two new cases.
  - `pnpm check:changed` — green on lint core, runtime sidecar loader guard, import-cycles, webhook body guard, pairing guards, changelog attributions, dup coverage, `tsgo:core`, `tsgo:core:test`, oxlint core.
- Edge cases checked:
  - `pendingChanges === undefined` (older test mocks / future callers) — falsy, trailer suppressed; backwards compatible with existing inline-context tests in this file.
  - `pendingChanges === true && shouldRepair === false` — trailer still prints (covered by the second new unit test).
  - `pendingChanges === true && shouldRepair === true` — function takes the write branch, never reaches the trailer.
- What I did **not** verify: a live reproduction of the original Ubuntu 24.04 aarch64 layout with `auditGatewayServiceConfig` returning a non-empty issue list, because that requires the reporter's npm-over-pnpm upgrade setup.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — `pendingChanges` is added as an optional field on `DoctorConfigResult`; existing mocks/test fixtures that omit it observe the previous "no trailer" outcome they already had when nothing was pending.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a future contribution might want the trailer to fire on a state that isn't surfaced via `configResult.pendingChanges`.
  - Mitigation: any new pending state should be threaded through `loadAndMaybeMigrateDoctorConfig` (now trivial — just OR it into the existing local `pendingChanges`). The regression test locks the contract for `runWriteConfigHealth`.

AI-assisted: drafted with Claude Code; human-run real behavior proof and unit test verification on local checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)