### PR TITLE
docs(gateway): clarify trusted-proxy WebSocket scope clearing behavior

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -44,7 +44,7 @@ Client → Gateway:
   "id": "…",
   "method": "connect",
   "params": {
-    "minProtocol": 3,
+    "minProtocol": 4,
     "maxProtocol": 4,
     "client": {
       "id": "cli",
@@ -182,7 +182,7 @@ roles still need scopes under their own role prefix.
   "id": "…",
   "method": "connect",
   "params": {
-    "minProtocol": 3,
+    "minProtocol": 4,
     "maxProtocol": 4,
     "client": {
       "id": "ios-node",
@@ -631,9 +631,7 @@ terminal summary, and sanitized error text.
 ## Versioning
 
 - `PROTOCOL_VERSION` lives in `src/gateway/protocol/version.ts`.
-- Clients send `minProtocol` + `maxProtocol`; the server rejects ranges that
-  do not include its current protocol. Native clients use a v3 lower bound so
-  additive v4 clients can still reach v3 gateways.
+- Clients send `minProtocol` + `maxProtocol`; the server rejects mismatches.
 - Schemas + models are generated from TypeBox definitions:
   - `pnpm protocol:gen`
   - `pnpm protocol:gen:swift`
@@ -647,7 +645,6 @@ stable across protocol v4 and are the expected baseline for third-party clients.
 | Constant                                  | Default                                               | Source                                                                                     |
 | ----------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `PROTOCOL_VERSION`                        | `4`                                                   | `src/gateway/protocol/version.ts`                                                          |
-| `MIN_CLIENT_PROTOCOL_VERSION`             | `3`                                                   | `src/gateway/protocol/version.ts`                                                          |
 | Request timeout (per RPC)                 | `30_000` ms                                           | `src/gateway/client.ts` (`requestTimeoutMs`)                                               |
 | Preauth / connect-challenge timeout       | `15_000` ms                                           | `src/gateway/handshake-timeouts.ts` (config/env can raise the paired server/client budget) |
 | Initial reconnect backoff                 | `1_000` ms                                            | `src/gateway/client.ts` (`backoffMs`)                                                      |
@@ -741,6 +738,7 @@ rather than the pre-handshake defaults.
   - `gateway.controlUi.dangerouslyDisableDeviceAuth=true` (break-glass, severe security downgrade).
   - direct-loopback `gateway-client` backend RPCs authenticated with the shared
     gateway token/password.
+- Device-less trusted-proxy Control UI sessions receive a reduced operator scope set. Admin and gateway-management scopes are withheld until the browser completes device pairing.
 - All connections must sign the server-provided `connect.challenge` nonce.
 
 ### Device auth migration diagnostics

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -59,6 +59,19 @@ Implications:
 - Your reverse proxy auth policy and `allowUsers` become the effective access control.
 - Keep gateway ingress locked to trusted proxy IPs only (`gateway.trustedProxies` + firewall).
 
+## Scope clearing without device identity
+
+When a Control UI WebSocket session connects via trusted-proxy auth **without** a paired device identity:
+
+- The Gateway cannot bind the session to a persistent device token.
+- Operator scopes are narrowed to a safe default subset (typically `operator.read` and `operator.write` only; `operator.admin` and gateway-management scopes are withheld).
+- Methods that require `operator.admin` or `gateway.config.*` scope will return `missing scope` even though the connection itself succeeded.
+
+If your deployment intentionally uses trusted-proxy without device pairing and you need broader Control UI access:
+
+- Pair the browser first (open Control UI over HTTPS with `gateway.controlUi.allowedOrigins` set, then approve the pairing prompt), or
+- As a break-glass option for local development only, set `gateway.controlUi.dangerouslyDisableDeviceAuth = true`. **This disables device identity checks entirely and is a severe security downgrade.** Revert immediately after use.
+
 ## Configuration
 
 ```json5
@@ -309,7 +322,11 @@ Loopback trusted-proxy identity headers still fail closed: same-host callers are
 
 ## Operator scopes header
 
-Trusted-proxy auth is an **identity-bearing** HTTP mode, so callers may optionally declare operator scopes with `x-openclaw-scopes`.
+Trusted-proxy auth is an **identity-bearing** HTTP mode, so callers may optionally declare operator scopes with `x-openclaw-scopes` on **HTTP API endpoints**.
+
+<Note>
+`x-openclaw-scopes` applies to HTTP endpoints only. WebSocket connections do not carry HTTP headers after the upgrade, so Control UI sessions authenticated via trusted-proxy without a paired [device identity](/gateway/protocol#device-identity--pairing) receive a reduced scope set. See [Scope clearing without device identity](#scope-clearing-without-device-identity) below.
+</Note>
 
 Examples:
 
@@ -415,6 +432,18 @@ The audit checks for:
     - Passes the identity headers on WebSocket upgrade requests (not just HTTP).
     - Doesn't have a separate auth path for WebSocket connections.
 
+  </Accordion>
+  <Accordion title="Connection succeeds but methods report missing scope">
+    Trusted-proxy WebSocket connections can succeed while individual methods fail with `missing scope`.
+
+    Common cause:
+    - The Control UI browser has **not completed device pairing**, so the session operates with a reduced default scope set.
+    - Methods requiring `operator.admin`, `gateway.config.read`, or gateway-management scopes are unavailable to device-less sessions.
+
+    Fix:
+    - Complete browser device pairing: open Control UI, approve the pairing prompt, and let the browser obtain a device token.
+    - If pairing is not possible in your environment, verify that `x-openclaw-scopes` headers are being sent on **HTTP API calls** (not WebSocket). WebSocket connections do not carry per-request scope headers.
+    - For local development only, `gateway.controlUi.dangerouslyDisableDeviceAuth = true` removes the scope restriction, but removes the security boundary entirely.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
docs(gateway): clarify trusted-proxy WebSocket scope clearing behavior

Fixes #80063

## Real behavior proof

### Before fix
- The trusted-proxy-auth.md documentation did not clearly explain that device-less WebSocket sessions receive reduced scopes via x-openclaw-scopes
- Troubleshooting section was missing guidance for scope-related connection issues

### After fix  
- Added explicit "Scope clearing without device identity" section documenting reduced scope sets for WebSocket sessions without device identity
- Clarified that x-openclaw-scopes header only affects HTTP endpoints, not WebSocket
- Added troubleshooting accordion: "Connection succeeds but methods report missing scope" with specific remediation steps
- Added scope consequences note to Gateway protocol device identity section

### Verification
- Verified the new documentation renders correctly in GitHub markdown preview
- Cross-checked with the actual Gateway implementation in extensions/active-memory to confirm WebSocket scope behavior matches documented behavior