### PR TITLE
[codex] fix update v-prefixed version verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Agents/auth: update successful model auth profile status with one locked store write, reducing post-model reply latency from duplicate `auth-profiles.json` saves. Thanks @mcaxtr.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.
 - Doctor/update: leave live systemd gateway units unchanged during noninteractive update-mode service repair, so update-time doctor does not silently overwrite operator-owned unit directives. Refs #80462.
+- Update: accept optional leading `v` prefixes when verifying exact npm package install targets, so `openclaw update --tag v2026...` does not roll back after installing the matching bare package version. Refs #74069; #80480. Thanks @Kaspre.
 - Codex app-server: preserve prompt-local current-turn context through context-engine prompt projection, so replied-to Telegram messages stay visible to the Codex model input.
 - Telegram: pass agent-scoped media roots through gateway message actions so workspace-local media from the active agent is not rejected as cross-agent access. Thanks @frankekn.
 - CLI/gateway: keep `gateway status --deep` plugin-aware so configured plugin manifest warnings, including missing channel config metadata, stay visible during install and update smoke checks.

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -128,6 +128,57 @@ describe("runGlobalPackageUpdateSteps", () => {
     });
   });
 
+  it("accepts v-prefixed exact npm specs when verifying staged installs", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-v-prefix-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+
+      const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+        if (name !== "global update") {
+          throw new Error(`unexpected step ${name}`);
+        }
+        expect(argv).toContain("openclaw@v2.0.0");
+        const prefixIndex = argv.indexOf("--prefix");
+        const stagePrefix = argv[prefixIndex + 1];
+        if (!stagePrefix) {
+          throw new Error("missing staged prefix");
+        }
+        await writePackageRoot(path.join(stagePrefix, "lib", "node_modules", "openclaw"), "2.0.0");
+        await fs.mkdir(path.join(stagePrefix, "bin"), { recursive: true });
+        await fs.symlink(
+          "../lib/node_modules/openclaw/dist/index.js",
+          path.join(stagePrefix, "bin", "openclaw"),
+        );
+        return {
+          name,
+          command: argv.join(" "),
+          cwd: cwd ?? process.cwd(),
+          durationMs: 1,
+          exitCode: 0,
+        };
+      });
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@v2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.afterVersion).toBe("2.0.0");
+      expect(result.steps.map((step) => step.name)).toEqual([
+        "global update",
+        "global install swap",
+      ]);
+    });
+  });
+
   it("swaps staged npm package roots through the copy fallback when rename crosses devices", async () => {
     await withTempDir({ prefix: "openclaw-package-update-exdev-" }, async (base) => {
       const prefix = path.join(base, "prefix");

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -63,6 +63,14 @@ function normalizePackageTarget(value: string): string {
   return value.trim();
 }
 
+function normalizePackageVersionForComparison(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.replace(/^[vV](?=\d)/, "");
+}
+
 export function isMainPackageTarget(value: string): boolean {
   return normalizeLowercaseStringOrEmpty(normalizePackageTarget(value)) === "main";
 }
@@ -98,7 +106,7 @@ export function resolveExpectedInstalledVersionFromSpec(
   ) {
     return null;
   }
-  return rawVersion;
+  return normalizePackageVersionForComparison(rawVersion);
 }
 
 export async function collectInstalledGlobalPackageErrors(params: {
@@ -108,9 +116,11 @@ export async function collectInstalledGlobalPackageErrors(params: {
   const errors: string[] = [];
   errors.push(...(await collectSourceCheckoutInstallErrors(params.packageRoot)));
   const installedVersion = await readPackageVersion(params.packageRoot);
-  if (params.expectedVersion && installedVersion !== params.expectedVersion) {
+  const expectedComparable = normalizePackageVersionForComparison(params.expectedVersion);
+  const installedComparable = normalizePackageVersionForComparison(installedVersion);
+  if (expectedComparable && installedComparable !== expectedComparable) {
     errors.push(
-      `expected installed version ${params.expectedVersion}, found ${installedVersion ?? "<missing>"}`,
+      `expected installed version ${expectedComparable}, found ${installedComparable ?? "<missing>"}`,
     );
   }
   errors.push(


### PR DESCRIPTION
## Summary

- Normalize optional leading `v`/`V` prefixes when verifying exact npm package install targets.
- Keep the npm install spec intact, so `openclaw@v...` is still passed to npm while installed `package.json` versions compare as bare semver.
- Add a focused staged global-update regression test and changelog entry.

Refs #74069.

## Root Cause

`global install verify` compared the exact install target version directly against the installed package version. A tag like `v2026.5.10-beta.1` can install a package whose `package.json` version is `2026.5.10-beta.1`, so the install succeeded but verification rolled it back.

## Duplicate Check

Before opening this PR I searched open PRs for #74069 and for related update/version-verify wording. I found no exact duplicate PR for the v-prefixed exact-version verification path.

## Real behavior proof

Behavior or issue addressed: `openclaw update --tag v...` should not roll back solely because npm installs the matching bare package version.

Real environment tested: local OpenClaw checkout on this branch using the existing staged npm global-update harness.

Exact steps or command run after this patch:

```bash
env CI=true pnpm test src/infra/package-update-steps.test.ts
pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/infra/update-global.ts src/infra/package-update-steps.test.ts
git diff --check
```

Evidence after fix:

```text
src/infra/package-update-steps.test.ts: 9 tests passed
oxfmt check completed successfully for the touched files
git diff --check completed with no whitespace errors
```

Observed result after fix: the staged update test passes an install spec of `openclaw@v2.0.0`, writes an installed package version of `2.0.0`, and reaches `global install swap` with no `global install verify` failure.

What was not tested: I did not run a live global npm downgrade/update against the real installation, and I did not run broad `check:changed`/full build gates for this focused patch.