### PR TITLE
fix(capability-provider): merge manifest realtime voice/transcription providers when active registry is partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Voice-call: resolve manifest-declared realtime voice and realtime transcription providers when the active runtime registry only contains a subset (e.g. `google` loaded but `openai` not yet), so `voice-call` no longer fails at startup with `Realtime voice provider "openai" is not registered` when another provider's plugin happened to load first. Fixes #80483.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -533,6 +533,56 @@ describe("resolvePluginCapabilityProviders", () => {
     expectActiveRegistryLookup(["fal", "xai"]);
   });
 
+  // Regression for #80483: when the active runtime registry has *some*
+  // realtimeVoiceProviders (e.g. google because the google plugin happened to
+  // load eagerly) but not the one voice-call has configured (e.g. openai),
+  // resolvePluginCapabilityProviders used to early-return with only the active
+  // providers, and voice-call's startup would throw "Realtime voice provider
+  // 'openai' is not registered". The merge-when-active list now includes
+  // realtime voice (and transcription) so the manifest-declared providers are
+  // still resolved.
+  it("merges manifest-declared realtime voice providers missing from the active registry", () => {
+    const active = createEmptyPluginRegistry();
+    active.realtimeVoiceProviders.push({
+      pluginId: "google",
+      pluginName: "google",
+      source: "test",
+      provider: { id: "google" },
+    } as never);
+    const loaded = createEmptyPluginRegistry();
+    loaded.realtimeVoiceProviders.push({
+      pluginId: "openai",
+      pluginName: "openai",
+      source: "test",
+      provider: { id: "openai" },
+    } as never);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openai",
+          origin: "bundled",
+          contracts: { realtimeVoiceProviders: ["openai"] },
+        },
+        {
+          id: "google",
+          origin: "bundled",
+          contracts: { realtimeVoiceProviders: ["google"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : loaded,
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "realtimeVoiceProviders",
+      cfg: { plugins: { allow: ["openai", "google"] } } as OpenClawConfig,
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["google", "openai"]);
+  });
+
   it("cold-loads enabled external manifest-contract providers missing from startup registry", () => {
     const loaded = createEmptyPluginRegistry();
     loaded.speechProviders.push({

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -71,10 +71,18 @@ function shouldResolveWhenPluginsAreGloballyDisabled(key: CapabilityProviderRegi
 }
 
 function shouldMergeManifestProvidersWhenActive(key: CapabilityProviderRegistryKey): boolean {
+  // For these capability kinds, the configured/requested provider may not be the
+  // same as what happens to be in the active runtime registry, and the resolver
+  // needs to see all manifest-declared providers (not just the ones that loaded
+  // first). Without this, `resolveConfiguredRealtimeVoiceProvider` throws
+  // "Realtime voice provider \"X\" is not registered" when X's bundled plugin
+  // hasn't been eagerly loaded but another provider (e.g. google) has. (#80483)
   return (
     key === "imageGenerationProviders" ||
     key === "videoGenerationProviders" ||
-    key === "musicGenerationProviders"
+    key === "musicGenerationProviders" ||
+    key === "realtimeVoiceProviders" ||
+    key === "realtimeTranscriptionProviders"
   );
 }
 


### PR DESCRIPTION
## Summary

When the active runtime plugin registry has *some* realtime-voice (or realtime-transcription) providers but not the one the configured plugin (e.g. `voice-call`) actually asks for — because that provider's host plugin hasn't been eagerly loaded yet — `resolvePluginCapabilityProviders` short-circuits to the active set and skips merging in manifest-declared bundled-compat providers. The realtime resolver then throws `"Realtime voice provider 'X' is not registered"` at startup.

Concrete repro: enable `voice-call` with `realtime.enabled: true` and `realtime.provider: "openai"`, but with the agent on `xai/grok-4` and no OpenAI model in the catalog. At gateway startup, `google`'s plugin loads (it's pulled in by the memory boot path because it provides `memoryEmbeddingProviders: ["gemini"]`) and registers `realtimeVoiceProviders: ["google"]`. `openai`'s bundled plugin doesn't load (`activation.onStartup: false` and no eager-load trigger). When voice-call's runtime asks for the openai realtime provider, the lookup sees active=`[google]`, treats it as a complete result, and fails. See #80483 for the full trace.

The same shape of problem was fixed for realtime *transcription* in #61224 by passing `fullConfig` to the webhook server, but the realtime-voice path is gated by a separate lever: `shouldMergeManifestProvidersWhenActive`, which only returned `true` for image/video/music generation. This PR extends it to cover realtime-voice and realtime-transcription so the manifest-declared bundled-compat providers are still resolved when the active registry contains only a partial set.

## Changes

- `src/plugins/capability-provider-runtime.ts`: add `realtimeVoiceProviders` and `realtimeTranscriptionProviders` to `shouldMergeManifestProvidersWhenActive`, with a comment pointing at the bug.
- `src/plugins/capability-provider-runtime.test.ts`: add a regression test that mirrors the existing image-generation merge test for realtime voice — active=`[google]`, manifest=`[google, openai]`, config requests both; expects `[google, openai]` in the result.
- `CHANGELOG.md`: Unreleased Fixes entry.

## Test plan
- [x] `pnpm exec vitest run --config test/vitest/vitest.plugins.config.ts src/plugins/capability-provider-runtime.test.ts` — 40/40 pass.
- [x] Manual end-to-end: with this fix the gateway loads voice-call's realtime runtime successfully against `openai` even when only `google` is in the active registry at startup.

Fixes #80483.