### PR TITLE
fix: resolve per-model api override in auth hooks and transport selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI/update: preserve managed Gateway service environment during package cutovers so macOS LaunchAgent repair/restart reads the pre-update service state instead of caller shell state. (#83026)
+- Agents/providers: honor per-model `api` and `baseUrl` overrides in custom provider auth hooks and transport selection. Fixes #80487. (#80488) Thanks @huveewomg.
 - Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.
 - CLI/update: start managed Gateway update handoff helpers from a stable existing directory and tolerate deleted cwd/package roots during macOS LaunchAgent handoff. Fixes #83808. (#83875) Thanks @jason-allen-oneal.
 - Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1093,6 +1093,7 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 8192,
+        maxTokens: 4096,
       },
       cfg: {
         models: {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -72,6 +72,7 @@ vi.mock("../plugins/provider-runtime.js", async () => {
           };
         };
       };
+      modelApi?: string;
       context: { providerConfig?: { api?: string; baseUrl?: string; models?: unknown[] } };
     }) => {
       if (params.provider === "plugin-web") {
@@ -106,9 +107,11 @@ vi.mock("../plugins/provider-runtime.js", async () => {
           mode: "oauth" as const,
         };
       }
+      const effectiveApi = params.modelApi ?? params.context.providerConfig?.api;
       if (
-        params.context.providerConfig?.api === "ollama" &&
-        params.context.providerConfig.baseUrl?.startsWith("http://192.168.")
+        effectiveApi === "ollama" &&
+        (params.context.providerConfig?.baseUrl?.startsWith("http://192.168.") ||
+          params.modelApi === "ollama")
       ) {
         return {
           apiKey: "ollama-local",
@@ -127,6 +130,7 @@ let formatMissingAuthError: typeof import("./model-auth.js").formatMissingAuthEr
 let hasUsableCustomProviderApiKey: typeof import("./model-auth.js").hasUsableCustomProviderApiKey;
 let hasSyntheticLocalProviderAuthConfig: typeof import("./model-auth.js").hasSyntheticLocalProviderAuthConfig;
 let requireApiKey: typeof import("./model-auth.js").requireApiKey;
+let getApiKeyForModel: typeof import("./model-auth.js").getApiKeyForModel;
 let resolveApiKeyForProvider: typeof import("./model-auth.js").resolveApiKeyForProvider;
 let resolveAwsSdkEnvVarName: typeof import("./model-auth.js").resolveAwsSdkEnvVarName;
 let resolveModelAuthMode: typeof import("./model-auth.js").resolveModelAuthMode;
@@ -144,6 +148,7 @@ beforeAll(async () => {
     applyLocalNoAuthHeaderOverride,
     formatMissingAuthError,
     hasSyntheticLocalProviderAuthConfig,
+    getApiKeyForModel,
     hasUsableCustomProviderApiKey,
     requireApiKey,
     resolveApiKeyForProvider,
@@ -1072,6 +1077,52 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
     expectAuthFields(auth, {
       apiKey: "ollama-local",
       source: "models.providers.ollama-gpu1 (synthetic local key)",
+      mode: "api-key",
+    });
+  });
+
+  it("resolves synthetic auth when model overrides api to ollama within a non-ollama provider", async () => {
+    const auth = await getApiKeyForModel({
+      model: {
+        id: "my-router/local-llama",
+        name: "Local Llama",
+        provider: "my-router",
+        api: "ollama",
+        baseUrl: "http://localhost:11434",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+      },
+      cfg: {
+        models: {
+          providers: {
+            "my-router": {
+              baseUrl: "http://localhost:8080/v1",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "my-router/local-llama",
+                  name: "Local Llama",
+                  api: "ollama",
+                  baseUrl: "http://localhost:11434",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      },
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(auth, {
+      apiKey: "ollama-local",
+      source: "models.providers.my-router (synthetic local key)",
       mode: "api-key",
     });
   });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -389,6 +389,7 @@ type SyntheticProviderAuthResolution = {
 function resolveProviderSyntheticRuntimeAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
+  modelApi?: string;
 }): SyntheticProviderAuthResolution {
   const resolveFromConfig = (
     config: OpenClawConfig | undefined,
@@ -403,6 +404,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
           provider: params.provider,
           providerConfig,
         },
+        modelApi: params.modelApi,
       }) ?? undefined
     );
   };
@@ -433,6 +435,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
 function resolveSyntheticLocalProviderAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
+  modelApi?: string;
 }): ResolvedProviderAuth | null {
   const syntheticProviderAuth = resolveProviderSyntheticRuntimeAuth(params);
   if (syntheticProviderAuth.auth) {
@@ -510,12 +513,14 @@ function shouldDeferSyntheticProfileAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
   resolvedApiKey: string | undefined;
+  modelApi?: string;
 }): boolean {
   const providerConfig = resolveProviderConfig(params.cfg, params.provider);
   return (
     shouldDeferProviderSyntheticProfileAuthWithPlugin({
       provider: params.provider,
       config: params.cfg,
+      modelApi: params.modelApi,
       context: {
         config: params.cfg,
         provider: params.provider,
@@ -551,6 +556,7 @@ export async function resolveApiKeyForProvider(params: {
   lockedProfile?: boolean;
   forceRefresh?: boolean;
   credentialPrecedence?: ProviderCredentialPrecedence;
+  modelApi?: string;
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId, preferredProfile } = params;
   const agentDir = params.agentDir?.trim() || (cfg ? resolveDefaultAgentDir(cfg) : undefined);
@@ -599,6 +605,7 @@ export async function resolveApiKeyForProvider(params: {
         cfg,
         provider,
         resolvedApiKey: resolved.apiKey,
+        modelApi: params.modelApi,
       })
     ) {
       return resolveApiKeyForProvider({ ...params, profileId: undefined, lockedProfile: true }) //
@@ -731,6 +738,7 @@ export async function resolveApiKeyForProvider(params: {
             cfg,
             provider,
             resolvedApiKey: resolved.apiKey,
+            modelApi: params.modelApi,
           })
         ) {
           deferredAuthProfileResult ??= result;
@@ -766,7 +774,7 @@ export async function resolveApiKeyForProvider(params: {
     return deferredAuthProfileResult;
   }
 
-  const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({ cfg, provider });
+  const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({ cfg, provider, modelApi: params.modelApi });
   if (syntheticLocalAuth) {
     return syntheticLocalAuth;
   }
@@ -964,6 +972,7 @@ export async function getApiKeyForModel(params: {
     workspaceDir: params.workspaceDir,
     lockedProfile: params.lockedProfile,
     credentialPrecedence: params.credentialPrecedence,
+    modelApi: params.model.api,
   });
 }
 

--- a/src/agents/pi-embedded-runner/model.inline-provider.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.ts
@@ -141,7 +141,7 @@ export function buildInlineProviderModels(
     return (entry?.models ?? []).map((model) => {
       const transport = resolveInlineProviderTransport({
         api: model.api ?? entry?.api,
-        baseUrl: entry?.baseUrl,
+        baseUrl: (model as InlineModelEntry).baseUrl ?? entry?.baseUrl,
       });
       const modelHeaders = sanitizeModelHeaders((model as InlineModelEntry).headers, {
         stripSecretRefMarkers: true,

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -709,6 +709,46 @@ describe("resolveModel", () => {
     expect(result.error).toBe("Unknown model: openai/typoed-model");
   });
 
+  it("resolves per-model api and baseUrl override in fallback model", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "my-router": {
+            baseUrl: "http://localhost:8080",
+            api: "ollama",
+            models: [
+              {
+                id: "my-router/claude",
+                name: "Claude via Router",
+                api: "anthropic-messages",
+                input: ["text", "image"],
+                contextWindow: 200_000,
+              },
+              {
+                id: "my-router/gpt",
+                name: "GPT via Router",
+                api: "openai-completions",
+                baseUrl: "http://localhost:8080/v1",
+                input: ["text"],
+                contextWindow: 400_000,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const claude = resolveModelForTest("my-router", "my-router/claude", "/tmp/agent", cfg);
+    const claudeModel = expectResolvedModel(claude);
+    expect(claudeModel.api).toBe("anthropic-messages");
+    expect(claudeModel.baseUrl).toBe("http://localhost:8080");
+
+    const gpt = resolveModelForTest("my-router", "my-router/gpt", "/tmp/agent", cfg);
+    const gptModel = expectResolvedModel(gpt);
+    expect(gptModel.api).toBe("openai-completions");
+    expect(gptModel.baseUrl).toBe("http://localhost:8080/v1");
+  });
+
   it("defaults baseUrl-only local custom fallback models to chat completions", () => {
     const cfg = {
       agents: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -655,7 +655,7 @@ function applyConfiguredProviderOverrides(params: {
       providerConfig.api ??
       discoveredModel.api ??
       resolveConfiguredProviderDefaultApi(providerConfig),
-    baseUrl: providerConfig.baseUrl ?? discoveredModel.baseUrl,
+    baseUrl: metadataOverrideModel?.baseUrl ?? providerConfig.baseUrl ?? discoveredModel.baseUrl,
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
     runtimeHooks: params.runtimeHooks,
@@ -913,8 +913,8 @@ function resolveConfiguredFallbackModel(params: {
   }
   const fallbackTransport = resolveProviderTransport({
     provider,
-    api: resolveConfiguredProviderDefaultApi(providerConfig) ?? "openai-responses",
-    baseUrl: providerConfig?.baseUrl,
+    api: normalizeResolvedTransportApi(configuredModel?.api) ?? resolveConfiguredProviderDefaultApi(providerConfig) ?? "openai-responses",
+    baseUrl: configuredModel?.baseUrl ?? providerConfig?.baseUrl,
     cfg,
     workspaceDir,
     runtimeHooks,

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -99,9 +99,9 @@ function matchesProviderPluginRef(provider: ProviderPlugin, providerId: string):
   );
 }
 
-function resolveProviderHookRefs(provider: string, providerConfig?: ModelProviderConfig): string[] {
+function resolveProviderHookRefs(provider: string, providerConfig?: ModelProviderConfig, modelApi?: string): string[] {
   const refs = [provider];
-  const apiRef = normalizeOptionalString(providerConfig?.api);
+  const apiRef = normalizeOptionalString(modelApi ?? providerConfig?.api);
   if (apiRef && normalizeProviderId(apiRef) !== normalizeProviderId(provider)) {
     refs.push(apiRef);
   }
@@ -851,8 +851,9 @@ export function resolveProviderSyntheticAuthWithPlugin(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   context: ProviderResolveSyntheticAuthContext;
+  modelApi?: string;
 }) {
-  const providerRefs = resolveProviderHookRefs(params.provider, params.context.providerConfig);
+  const providerRefs = resolveProviderHookRefs(params.provider, params.context.providerConfig, params.modelApi);
   const discoveryPluginIds = [
     ...new Set(
       providerRefs.flatMap(
@@ -985,8 +986,9 @@ export function shouldDeferProviderSyntheticProfileAuthWithPlugin(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   context: ProviderDeferSyntheticProfileAuthContext;
+  modelApi?: string;
 }) {
-  const providerRefs = resolveProviderHookRefs(params.provider, params.context.providerConfig);
+  const providerRefs = resolveProviderHookRefs(params.provider, params.context.providerConfig, params.modelApi);
   for (const providerRef of providerRefs) {
     const resolved = resolveProviderRuntimePlugin({
       ...params,


### PR DESCRIPTION
## Summary

- **Problem:** Per-model `api` and `baseUrl` overrides within a custom provider are accepted by the config schema but ignored by auth resolution and transport selection. A model with `api: "anthropic-messages"` under an `openai-completions` provider still routes through the OpenAI adapter.
- **What changed:**
  1. **Auth** (`provider-runtime.ts`, `model-auth.ts`): `resolveProviderHookRefs` accepts `modelApi`, threaded through `getApiKeyForModel`, synthetic auth, and profile deferral.
  2. **Transport** (`model.ts`): `resolveConfiguredFallbackModel` checks `configuredModel.api`/`baseUrl` before provider defaults. Discovered-model path uses `metadataOverrideModel.baseUrl` to preserve the models-add safeguard.
  3. **Inline providers** (`model.inline-provider.ts`): `buildInlineProviderModels` honors model-level `baseUrl`.
- **Scope boundary:** No config schema changes. All new parameters are optional. No plugin registration changes. Per-model `api: "ollama"` under a non-ollama provider is a separate plugin architecture limitation, not addressed here.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80487
- Related #57099, #57811, #63218
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Per-model `api` overrides ignored for both auth and transport. Models route through the provider-level adapter regardless of their own `api` field.
- **Real environment tested:** OpenClaw 2026.5.12 Docker (`latest-testing` with compiled JS patches applied), custom LLM router with mixed `openai-completions` and `anthropic-messages` models under a single provider.
- **Exact steps or command run after this patch:**
  1. Configure provider with `api: "openai-completions"`, add models with `api: "anthropic-messages"` override
  2. Send chat messages using each model type
  3. Observe router logs for which HTTP endpoint is hit
- **Observed result after fix:** GPT models route to `POST /v1/chat/completions` (inherited). Anthropic models route to `POST /v1/messages` (per-model override). Auth resolves correctly for both.
- **Evidence after fix:** Router logs confirming correct transport:
```
POST /v1/chat/completions HTTP/1.1" 200 OK    <- GPT model (inherited provider-level api)
POST /v1/messages HTTP/1.1" 200 OK            <- Anthropic model (per-model override)
```
- **What was not tested:** Per-model `api: "ollama"` under a non-ollama provider — fails with `"No API provider registered for api: ollama"`. This is a plugin architecture limitation (ollama is not transport-aware in `createSupportedTransportStreamFn`) and is outside the scope of this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.
