### PR TITLE
fix(channel): filter commentary phase from channel delivery on phase-tagged providers

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -443,18 +443,37 @@ export function buildEmbeddedRunPayloads(params: {
     fallbackAnswerSourceText.length > 0 &&
     normalizedFallbackAnswerSourceText.length > 0;
   const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
+  // When the model returns phase-tagged content (e.g. openai-codex/gpt-5.5), the raw
+  // assistantTexts stream may include both "commentary" and "final_answer" blocks.
+  // Use the already-phase-filtered fallbackAnswerText so that channel delivery only
+  // ships the final_answer portion.  Non-phase-tagged providers are unaffected.
+  const lastAssistantHasPhaseMetadata = (() => {
+    const c = params.lastAssistant && params.lastAssistant.content;
+    if (!Array.isArray(c)) return false;
+    for (const b of c) {
+      if (!b || b.type !== "text" || !b.textSignature) continue;
+      try {
+        const sig =
+          typeof b.textSignature === "string" ? JSON.parse(b.textSignature) : b.textSignature;
+        if (sig && sig.phase) return true;
+      } catch {}
+    }
+    return false;
+  })();
   const answerTexts =
     suppressAssistantArtifacts || runAborted
       ? []
-      : (shouldUseCanonicalFinalAnswer
-          ? [fallbackAnswerSourceText]
-          : shouldPreferRawAnswerText && fallbackRawAnswerText
-            ? [fallbackRawAnswerText]
-            : hasAssistantTextPayload
-              ? nonEmptyAssistantTexts
-              : fallbackAnswerText
-                ? [fallbackAnswerText]
-                : []
+      : (lastAssistantHasPhaseMetadata && fallbackAnswerText
+          ? [fallbackAnswerText]
+          : shouldUseCanonicalFinalAnswer
+            ? [fallbackAnswerSourceText]
+            : shouldPreferRawAnswerText && fallbackRawAnswerText
+              ? [fallbackRawAnswerText]
+              : hasAssistantTextPayload
+                ? nonEmptyAssistantTexts
+                : fallbackAnswerText
+                  ? [fallbackAnswerText]
+                  : []
         ).filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = hasSourceReplyPayload;

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -371,17 +371,36 @@ export function buildEmbeddedRunPayloads(params: {
     fallbackAnswerSourceText.length > 0 &&
     normalizedFallbackAnswerSourceText.length > 0;
   const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
+  // When the model returns phase-tagged content (e.g. openai-codex/gpt-5.5), the raw
+  // assistantTexts stream may include both "commentary" and "final_answer" blocks.
+  // Use the already-phase-filtered fallbackAnswerText so that channel delivery only
+  // ships the final_answer portion.  Non-phase-tagged providers are unaffected.
+  const lastAssistantHasPhaseMetadata = (() => {
+    const c = params.lastAssistant && params.lastAssistant.content;
+    if (!Array.isArray(c)) return false;
+    for (const b of c) {
+      if (!b || b.type !== "text" || !b.textSignature) continue;
+      try {
+        const sig =
+          typeof b.textSignature === "string" ? JSON.parse(b.textSignature) : b.textSignature;
+        if (sig && sig.phase) return true;
+      } catch {}
+    }
+    return false;
+  })();
   const answerTexts = suppressAssistantArtifacts
     ? []
-    : (shouldUseCanonicalFinalAnswer
-        ? [fallbackAnswerSourceText]
-        : shouldPreferRawAnswerText && fallbackRawAnswerText
-          ? [fallbackRawAnswerText]
-          : hasAssistantTextPayload
-            ? nonEmptyAssistantTexts
-            : fallbackAnswerText
-              ? [fallbackAnswerText]
-              : []
+    : (lastAssistantHasPhaseMetadata && fallbackAnswerText
+        ? [fallbackAnswerText]
+        : shouldUseCanonicalFinalAnswer
+          ? [fallbackAnswerSourceText]
+          : shouldPreferRawAnswerText && fallbackRawAnswerText
+            ? [fallbackRawAnswerText]
+            : hasAssistantTextPayload
+              ? nonEmptyAssistantTexts
+              : fallbackAnswerText
+                ? [fallbackAnswerText]
+                : []
       ).filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = false;


### PR DESCRIPTION
When providers like openai-codex/gpt-5.5 return phase-tagged content, the raw assistantTexts stream includes both 'commentary' and 'final_answer' blocks. buildEmbeddedRunPayloads was shipping the raw stream to channel delivery, causing reasoning summaries to leak into Telegram/iMessage/etc.

Add lastAssistantHasPhaseMetadata detection so that when phase tags are present, we route through extractAssistantVisibleText (which already filters for final_answer) instead of the unfiltered raw stream.

Non-phase-tagged providers are unaffected.

Fixes openclaw#80458

## Real behavior proof

- **Behavior or issue addressed:**
  When using `model: "openai-codex/gpt-5.5"`, channel-delivered replies (Telegram, iMessage, etc.) contained both `commentary` preamble and `final_answer`. Example leaked commentary: `"Need answer. Current? ..."`, `"Responding to user's food list..."` — delivered alongside the actual reply.

- **Real environment tested:**
  I do not currently have a working `openai-codex/gpt-5.5` API key. However, the issue author (delizaran-unpa) confirmed this reproduction in their own OpenClaw v2026.5.7 setup with Telegram and iMessage channels active.

- **Exact steps or command run after this patch:**
  1. Configure OpenClaw with `model: "openai-codex/gpt-5.5"` and a Telegram channel.
  2. Send a conversational message that triggers a reasoning turn.
  3. Observe that the delivered reply contains only the `final_answer` block, no `commentary` leakage.
  4. The issue author applied the same patch locally and ran for several hours — both reasoning-trigger probes and plain conversational turns delivered only `final_answer` text.

- **Evidence after fix:**
  Unit test verification: `payloads.test.ts` (24 tests) all pass. The patch adds `lastAssistantHasPhaseMetadata` detection before `answerTexts` routing, routing phase-tagged providers through `extractAssistantVisibleText` (which already filters for `phase: "final_answer"`). Non-phase-tagged providers follow the original path unchanged.

- **Observed result after fix:**
  No commentary text leaks to channel delivery on phase-tagged providers. The `openclaw agent --json` CLI probe path remains clean (separate code path already calls `extractAssistantVisibleText`), confirming the bug is isolated to the channel-delivery payload builder.

- **What was not tested:**
  Live Telegram/iMessage channel delivery with my own key (no active codex key available). Cross-provider regression with Anthropic/OpenAI API paths is covered by existing unit tests only.