### PR TITLE
Fix ClawDock dashboard dependency starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - fix(matrix): gate name-based allowlist resolution [AI]. (#79007) Thanks @pgondhi987.
 - Slack: include the bot's own root/parent message in new thread sessions so in-thread replies reach the agent with the parent text the user is responding to, instead of only `reply_to_id` metadata. Fixes #79338. Thanks @sxxtony.
 - Docker: keep image builds on the source pnpm workspace policy so pnpm 11 can prune production dependencies without a Docker-only workspace rewrite.
+- Docker/ClawDock: fetch dashboard URLs with `docker compose run --no-deps` so the helper cannot start or recreate the gateway while only printing the Control UI link. Fixes #77574.
 - Agents/compaction: restore info-level gateway logs for embedded compaction start, completion, and incomplete outcomes. (#71961) Thanks @rubencu.
 - Telegram: build reply-aware inbound turns through the shared channel context path so agents see the current reply target inline with the current message.
 - Telegram: recover legacy message cache files that mixed JSON-array and line-delimited entries so restarted gateways preserve reply-window context. (#80567)

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -68,7 +68,7 @@ Docker is **optional**. Use it only if you want a containerized gateway or to va
     Need the URL again?
 
     ```bash
-    docker compose run --rm openclaw-cli dashboard --no-open
+    docker compose run --rm --no-deps openclaw-cli dashboard --no-open
     ```
 
   </Step>
@@ -514,7 +514,7 @@ For npm installs without a source checkout, see [Sandboxing § Images and setup]
     Fetch a fresh dashboard link and approve the browser device:
 
     ```bash
-    docker compose run --rm openclaw-cli dashboard --no-open
+    docker compose run --rm --no-deps openclaw-cli dashboard --no-open
     docker compose run --rm openclaw-cli devices list
     docker compose run --rm openclaw-cli devices approve <requestId>
     ```

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -320,7 +320,7 @@ For the generic Docker flow, see [Docker](/install/docker).
     Reprint a clean dashboard link:
 
     ```bash
-    docker compose run --rm openclaw-cli dashboard --no-open
+    docker compose run --rm --no-deps openclaw-cli dashboard --no-open
     ```
 
     If the UI prompts for shared-secret auth, paste the configured token or

--- a/scripts/clawdock/clawdock-helpers.sh
+++ b/scripts/clawdock/clawdock-helpers.sh
@@ -372,7 +372,7 @@ clawdock-dashboard() {
 
   echo "🦞 Getting dashboard URL..."
   local output exit_status url
-  output=$(_clawdock_compose run --rm openclaw-cli dashboard --no-open 2>&1)
+  output=$(_clawdock_compose run --rm --no-deps openclaw-cli dashboard --no-open 2>&1)
   exit_status=$?
   url=$(printf "%s\n" "$output" | _clawdock_filter_warnings | grep -o 'http[s]\?://[^[:space:]]*' | head -n 1)
   if [[ $exit_status -ne 0 ]]; then

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -48,6 +48,27 @@ exit 0
   await writeFile(logPath, "");
 }
 
+async function writeClawdockDashboardStub(binDir: string, logPath: string) {
+  const dockerStub = `#!/usr/bin/env bash
+set -euo pipefail
+log="$DOCKER_STUB_LOG"
+echo "$*" >>"$log"
+if [[ "\${1:-}" == "compose" && "$*" == *" dashboard --no-open"* ]]; then
+  echo "http://127.0.0.1:18789/?token=test"
+fi
+exit 0
+`;
+  const openerStub = `#!/usr/bin/env bash
+exit 0
+`;
+
+  await mkdir(binDir, { recursive: true });
+  await writeFile(join(binDir, "docker"), dockerStub, { mode: 0o755 });
+  await writeFile(join(binDir, "open"), openerStub, { mode: 0o755 });
+  await writeFile(join(binDir, "xdg-open"), openerStub, { mode: 0o755 });
+  await writeFile(logPath, "");
+}
+
 async function expectMissingPath(path: string): Promise<void> {
   try {
     await stat(path);
@@ -304,6 +325,37 @@ describe("scripts/docker/setup.sh", () => {
       /\bcompose\b.*\brun\b.*\bopenclaw-cli\b/.test(line),
     );
     expect(prestartCliRunLines).toStrictEqual([]);
+  });
+
+  it("keeps clawdock-dashboard from starting compose dependencies", async () => {
+    const rootDir = await sandboxRootTracker.make("clawdock-dashboard");
+    const binDir = join(rootDir, "bin");
+    const logPath = join(rootDir, "docker-stub.log");
+    await writeFile(join(rootDir, "docker-compose.yml"), "services: {}\n");
+    await writeClawdockDashboardStub(binDir, logPath);
+
+    const result = spawnSync(
+      "bash",
+      ["-lc", 'source "$CLAWDOCK_HELPER"; CLAWDOCK_DIR="$CLAWDOCK_TEST_DIR"; clawdock-dashboard'],
+      {
+        cwd: rootDir,
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          HOME: rootDir,
+          DOCKER_STUB_LOG: logPath,
+          CLAWDOCK_HELPER: join(repoRoot, "scripts", "clawdock", "clawdock-helpers.sh"),
+          CLAWDOCK_TEST_DIR: rootDir,
+        },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const log = await readFile(logPath, "utf8");
+    expect(log).toContain("run --rm --no-deps openclaw-cli dashboard --no-open");
+    expect(log).not.toContain("run --rm openclaw-cli dashboard --no-open");
   });
 
   it("forces BuildKit for local and sandbox docker builds", async () => {


### PR DESCRIPTION
## Summary

- Run `clawdock-dashboard` with `docker compose run --no-deps` so printing the Control UI URL cannot start or recreate the `openclaw-gateway` dependency.
- Update Docker/GCP docs to show the same safe dashboard command.
- Add a Docker e2e regression that sources the real ClawDock helper with stubbed `docker`/browser openers and asserts the generated command includes `--no-deps`.

Fixes #77574.

## Root Cause

`clawdock-dashboard` shells out to the `openclaw-cli` Compose service just to run `dashboard --no-open`. That service has `network_mode: "service:openclaw-gateway"` and depends on `openclaw-gateway`, so Compose is allowed to start linked services while the helper is only trying to fetch a URL. Passing `--no-deps` preserves the existing CLI behavior but prevents dependency startup/recreation.

## Real behavior proof

Behavior or issue addressed: fetching a ClawDock dashboard URL should not start, recreate, or restart the `openclaw-gateway` container.

Real environment tested: real Docker Engine / Docker Compose stack on Linux `docker-arr`, OpenClaw PR checkout, published runtime image `ghcr.io/openclaw/openclaw:latest`, Docker 29.4.3 client/server, Docker Compose v5.1.3. The live proof below was captured at PR commit `5d19b737`; after rebasing this branch onto current `main`, the same helper code path remains `docker compose run --rm --no-deps openclaw-cli dashboard --no-open`.

Exact steps or command run after this patch:

```bash
git fetch --depth 1 origin pull/80494/head
git checkout -f FETCH_HEAD
export OPENCLAW_IMAGE=ghcr.io/openclaw/openclaw:latest
export OPENCLAW_CONFIG_DIR="$PWD/.proof-openclaw/config"
export OPENCLAW_WORKSPACE_DIR="$PWD/.proof-openclaw/workspace"
export OPENCLAW_GATEWAY_PORT=18989
export OPENCLAW_BRIDGE_PORT=18990
export OPENCLAW_GATEWAY_BIND=lan
export OPENCLAW_DISABLE_BONJOUR=1
export OPENCLAW_SKIP_ONBOARDING=1
./scripts/docker/setup.sh

source scripts/clawdock/clawdock-helpers.sh
export CLAWDOCK_DIR="$PWD"
clawdock-dashboard
```

Evidence after fix:

```text
$ uname -a
Linux docker-arr 7.0.0-3-pve #1 SMP PREEMPT_DYNAMIC PMX 7.0.0-3 (2026-04-21T22:56Z) x86_64 x86_64 x86_64 GNU/Linux

$ docker version --format "{{.Client.Version}} client / {{.Server.Version}} server"
29.4.3 client / 29.4.3 server

$ docker compose version
Docker Compose version v5.1.3

$ git rev-parse --short HEAD
5d19b737

Before dashboard:
id=9946b4e673fdf478dae303010219907d92de46f1e7bf07cfba277c79a52a7c68
status=running
started=2026-05-11T02:51:17.188445929Z
restartCount=0
image=ghcr.io/openclaw/openclaw:latest

$ clawdock-dashboard
Getting dashboard URL...
Opening: <redacted-dashboard-url>
Please open manually: <redacted-dashboard-url>

After dashboard:
id=9946b4e673fdf478dae303010219907d92de46f1e7bf07cfba277c79a52a7c68
status=running
started=2026-05-11T02:51:17.188445929Z
restartCount=0
image=ghcr.io/openclaw/openclaw:latest

Comparison:
dashboard_exit=0
before_id=9946b4e673fdf478dae303010219907d92de46f1e7bf07cfba277c79a52a7c68
after_id=9946b4e673fdf478dae303010219907d92de46f1e7bf07cfba277c79a52a7c68
id_match=true
before_started=2026-05-11T02:51:17.188445929Z
after_started=2026-05-11T02:51:17.188445929Z
started_match=true
```

Observed result after fix: `clawdock-dashboard` succeeded (`exit=0`) and returned a dashboard URL while `openclaw-gateway` stayed the same running container before and after the helper call. The container ID and `StartedAt` timestamp were unchanged, and `restartCount` stayed `0`, proving the dashboard URL fetch did not start, recreate, or restart the gateway in this real Docker Compose run.

Additional validation:

```text
bash -n scripts/clawdock/clawdock-helpers.sh exited 0 after the 2026-05-11 rebase.
git diff --check upstream/main exited 0 after the 2026-05-11 rebase.
Earlier PR validation at the pre-rebase commit showed src/docker-setup.e2e.test.ts passed with 28 tests.
```

What was not tested: this proof used the published runtime image instead of building a new local image. The tested behavior is the helper's Compose invocation and the gateway container lifecycle around `clawdock-dashboard`.
