### PR TITLE
docs: add quick and full PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/full_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/full_change.md
@@ -1,7 +1,3 @@
-## PR Template Options
-
-For small changes, you can use the [quick fix template](https://github.com/openclaw/openclaw/compare?template=quick_fix.md). For broader changes, continue with this full template or use `?template=full_change.md` on the compare URL.
-
 ## Summary
 
 Describe the problem and fix in 2–5 bullets:
@@ -9,7 +5,7 @@ Describe the problem and fix in 2–5 bullets:
 If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.
 
 - Problem:
-- Solution:
+- Why it matters:
 - What changed:
 - What did NOT change (scope boundary):
 
@@ -38,12 +34,6 @@ If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta
 - Closes #
 - Related #
 - [ ] This PR fixes a bug or regression
-
-## Motivation
-
-Explain why this change should exist now. Link it to the user pain, failure mode, maintainer need, or product goal. If this is purely mechanical, write `N/A`.
-
--
 
 ## Real behavior proof (required for external PRs)
 

--- a/.github/PULL_REQUEST_TEMPLATE/full_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/full_change.md
@@ -1,7 +1,3 @@
-## PR Template Options
-
-For small changes, you can use the [quick fix template](https://github.com/openclaw/openclaw/compare?template=quick_fix.md). For broader changes, continue with this full template or use `?template=full_change.md` on the compare URL.
-
 ## Summary
 
 Describe the problem and fix in 2–5 bullets:

--- a/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
@@ -1,0 +1,30 @@
+## Summary
+
+Briefly describe the fix in 1–2 sentences.
+
+Fixes: #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Documentation fix
+- [ ] Typo/grammar fix
+- [ ] Chore / small DX cleanup
+
+## Verification
+
+- [ ] I tested this locally
+- [ ] I verified the fix resolves the issue
+- [ ] Not applicable (explain below)
+
+## Real behavior proof
+- Behavior or issue addressed:
+- Real environment tested:
+- Exact steps or command run after this patch:
+- Evidence after fix:
+- Observed result after fix:
+- What was not tested:
+
+## Security Impact
+- New permissions/capabilities, secrets handling, network calls, or command/tool execution changes? (`Yes/No`)
+- If yes, explain risk + mitigation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,15 @@ We cap at **20 open PRs per author**. If you exceed this, the `r: too-many-prs` 
 
 For coordinated change sets that genuinely need more than 20 PRs, join the **#clawtributors** channel in Discord and talk to maintainers first.
 
+## Pull Request Templates
+
+Use the PR template that matches the size and risk of your change:
+
+- [Quick fix](https://github.com/openclaw/openclaw/compare?template=quick_fix.md) for small bug fixes, documentation fixes, typos, and focused DX cleanup.
+- [Full change](https://github.com/openclaw/openclaw/compare?template=full_change.md) for features, refactors, security-sensitive changes, behavior changes, or broader runtime work.
+
+When opening a PR from a fork, GitHub also accepts `?template=quick_fix.md` or `?template=full_change.md` on the compare URL. Keep the filled template focused; do not remove required proof or security-impact details that apply to your change.
+
 ## Before You PR
 
 - Test locally with your OpenClaw instance


### PR DESCRIPTION
## Summary
- Add separate quick-fix and full-change pull request templates.
- Keep the existing comprehensive template available as `full_change.md` and as the default fallback.
- Add contributor guidance for selecting a template with GitHub's `?template=` compare URL parameter.

Fixes #59737.

## Verification
- `git diff --cached --check`
- `find .github -maxdepth 3 -type f | sort | rg 'PULL_REQUEST_TEMPLATE|pull_request_template'`
- `rg -n 'Behavior or issue addressed|Real environment tested|Exact steps or command run after this patch|Evidence after fix|Observed result after fix|What was not tested|quick_fix|full_change|template=' .github/PULL_REQUEST_TEMPLATE/quick_fix.md CONTRIBUTING.md .github/pull_request_template.md`
- `wc -l .github/PULL_REQUEST_TEMPLATE/quick_fix.md`

## Real behavior proof
- **Behavior or issue addressed:** The repository only had one comprehensive root PR template, and issue #59737 asks for separate quick/full PR templates plus contributor guidance for choosing them.
- **Real environment tested:** Local OpenClaw repository checkout on Linux.
- **Exact steps or command run after this patch:**

```bash
git diff --cached --check
find .github -maxdepth 3 -type f | sort | rg 'PULL_REQUEST_TEMPLATE|pull_request_template'
rg -n 'Behavior or issue addressed|Real environment tested|Exact steps or command run after this patch|Evidence after fix|Observed result after fix|What was not tested|quick_fix|full_change|template=' .github/PULL_REQUEST_TEMPLATE/quick_fix.md CONTRIBUTING.md .github/pull_request_template.md
wc -l .github/PULL_REQUEST_TEMPLATE/quick_fix.md
```

- **Evidence after fix:** Copied live output from the local checkout:

```text
.github/PULL_REQUEST_TEMPLATE/full_change.md
.github/PULL_REQUEST_TEMPLATE/quick_fix.md
.github/pull_request_template.md
.github/pull_request_template.md:3:For small changes, you can use the [quick fix template](https://github.com/openclaw/openclaw/compare?template=quick_fix.md). For broader changes, continue with this full template or use `?template=full_change.md` on the compare URL.
CONTRIBUTING.md:110:- [Quick fix](https://github.com/openclaw/openclaw/compare?template=quick_fix.md) for small bug fixes, documentation fixes, typos, and focused DX cleanup.
CONTRIBUTING.md:111:- [Full change](https://github.com/openclaw/openclaw/compare?template=full_change.md) for features, refactors, security-sensitive changes, behavior changes, or broader runtime work.
CONTRIBUTING.md:113:When opening a PR from a fork, GitHub also accepts `?template=quick_fix.md` or `?template=full_change.md` on the compare URL. Keep the filled template focused; do not remove required proof or security-impact details that apply to your change.
.github/PULL_REQUEST_TEMPLATE/quick_fix.md:21:- Behavior or issue addressed:
.github/PULL_REQUEST_TEMPLATE/quick_fix.md:22:- Real environment tested:
.github/PULL_REQUEST_TEMPLATE/quick_fix.md:23:- Exact steps or command run after this patch:
.github/PULL_REQUEST_TEMPLATE/quick_fix.md:24:- Evidence after fix:
.github/PULL_REQUEST_TEMPLATE/quick_fix.md:25:- Observed result after fix:
.github/PULL_REQUEST_TEMPLATE/quick_fix.md:26:- What was not tested:
30 .github/PULL_REQUEST_TEMPLATE/quick_fix.md
```

- **Observed result after fix:** The repository now has `.github/PULL_REQUEST_TEMPLATE/quick_fix.md`, `.github/PULL_REQUEST_TEMPLATE/full_change.md`, the root fallback template remains present, and contributor guidance documents the `?template=` selection path.
- **What was not tested:** Live GitHub PR creation UI behavior beyond using GitHub's documented `?template=` URL convention.

## Security impact
No new permissions, capabilities, secrets handling, network calls, or command/tool execution changes.
