### PR TITLE
Fix Discord realtime voice playback stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/OpenAI: keep realtime Discord voice sessions hearing follow-up turns with OpenAI realtime and prebuffer assistant playback to avoid choppy starts. (#80505) Thanks @Solvely-Colin.
 - Media: prevent image metadata probing from invoking external decoder delegates on unrecognized image bytes, and stop fallback chaining after real processing errors.
 - Media: install Sharp with the root package and fall back to sips, Windows native imaging, ImageMagick, GraphicsMagick, or ffmpeg for image resizing/conversion when Sharp is unavailable. Fixes #83401. Thanks @scotthuang.
 - Telegram: deliver generated media completions back into forum topics by preserving topic IDs across requester-agent handoff. (#83556) Thanks @fuller-stack-dev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/OpenAI realtime voice: finalize GPT-Realtime-2 backend voice turns with trailing silence and prebuffer Discord VC playback so assistant audio starts cleanly instead of stuttering or cutting off.
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.
 - Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.
 - Codex app-server: default native plugin app tool approvals to automatic so non-destructive read tools run when destructive actions are disabled.

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -762,6 +762,7 @@ describe("DiscordVoiceManager", () => {
           audioSink?: {
             sendAudio: (audio: Buffer) => void;
           };
+          onEvent?: (event: { direction: "server"; type: string }) => void;
         }
       | undefined;
     player.state.status = "playing";
@@ -781,6 +782,7 @@ describe("DiscordVoiceManager", () => {
     );
     expect(subscribeCall?.[0]).toBe("u1");
     expect(requireRecord(subscribeCall?.[1], "subscribe options").end).toBeTypeOf("object");
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
   });
 
   it("interrupts realtime playback when an already-active speaker keeps talking", async () => {
@@ -819,6 +821,7 @@ describe("DiscordVoiceManager", () => {
           audioSink?: {
             sendAudio: (audio: Buffer) => void;
           };
+          onEvent?: (event: { direction: "server"; type: string }) => void;
         }
       | undefined;
     const player = getLastAudioPlayer();
@@ -838,6 +841,7 @@ describe("DiscordVoiceManager", () => {
     expect(lastTimestampCall).toBeLessThan(firstBargeInCall);
     expect(player.stop).not.toHaveBeenCalled();
     expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
   });
 
   it("does not interrupt realtime provider state when local playback is already idle", async () => {
@@ -880,6 +884,95 @@ describe("DiscordVoiceManager", () => {
     expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();
     expect(player.stop).not.toHaveBeenCalled();
     expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+  });
+
+  it("sends trailing realtime silence when a speaker turn closes", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      allowFrom: ["discord:u1"],
+      voice: {
+        enabled: true,
+        mode: "bidi",
+        realtime: {
+          provider: "openai",
+          providers: {
+            openai: {
+              silenceDurationMs: 450,
+            },
+          },
+        },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const turn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u1",
+    );
+
+    turn?.sendInputAudio(Buffer.alloc(3840));
+    turn?.close();
+
+    expect(realtimeSessionMock.sendAudio).toHaveBeenCalledTimes(2);
+    const trailingSilence = realtimeSessionMock.sendAudio.mock.calls.at(-1)?.[0] as
+      | Buffer
+      | undefined;
+    expect(trailingSilence).toBeInstanceOf(Buffer);
+    expect(trailingSilence?.length).toBe(33_600);
+    expect(trailingSilence?.equals(Buffer.alloc(33_600))).toBe(true);
+  });
+
+  it("clamps configured realtime trailing silence before allocating audio", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      allowFrom: ["discord:u1"],
+      voice: {
+        enabled: true,
+        mode: "bidi",
+        realtime: {
+          provider: "openai",
+          providers: {
+            openai: {
+              silenceDurationMs: 60_000,
+            },
+          },
+        },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const turn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u1",
+    );
+
+    turn?.sendInputAudio(Buffer.alloc(3840));
+    turn?.close();
+
+    const trailingSilence = realtimeSessionMock.sendAudio.mock.calls.at(-1)?.[0] as
+      | Buffer
+      | undefined;
+    expect(trailingSilence).toBeInstanceOf(Buffer);
+    expect(trailingSilence?.length).toBe(144_000);
+    expect(trailingSilence?.equals(Buffer.alloc(144_000))).toBe(true);
   });
 
   it("ignores realtime capture during playback when barge-in is disabled", async () => {
@@ -1229,11 +1322,12 @@ describe("DiscordVoiceManager", () => {
       | undefined;
 
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
     expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
     expect(player.play).toHaveBeenCalledTimes(1);
     const firstStream = lastAudioResourceInput() as { writableEnded?: boolean } | undefined;
-    expect(firstStream?.writableEnded).toBe(false);
-    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
     expect(firstStream?.writableEnded).toBe(true);
 
     const idleHandler = player.on.mock.calls.find(([event]) => event === "idle")?.[1] as
@@ -1243,8 +1337,88 @@ describe("DiscordVoiceManager", () => {
     idleHandler?.();
 
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
+    expect(player.play).toHaveBeenCalledTimes(1);
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
     expect(createAudioResourceMock).toHaveBeenCalledTimes(2);
     expect(player.play).toHaveBeenCalledTimes(2);
+  });
+
+  it("prebuffers realtime output before starting Discord playback", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const player = getLastAudioPlayer();
+    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
+      | {
+          audioSink?: {
+            sendAudio: (audio: Buffer) => void;
+          };
+          onEvent?: (event: { direction: "server"; type: string }) => void;
+        }
+      | undefined;
+
+    for (let index = 0; index < 49; index += 1) {
+      bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    }
+
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+
+    expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
+    expect(player.play).toHaveBeenCalledTimes(1);
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
+  });
+
+  it("discards prebuffered realtime output when the response is cancelled", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const player = getLastAudioPlayer();
+    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
+      | {
+          audioSink?: {
+            sendAudio: (audio: Buffer) => void;
+          };
+          onEvent?: (event: { detail?: string; direction: "server"; type: string }) => void;
+        }
+      | undefined;
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.cancelled" });
+
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+    expect(player.stop).toHaveBeenCalledWith(true);
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    bridgeParams?.onEvent?.({
+      detail: "response completed with status=cancelled",
+      direction: "server",
+      type: "response.done",
+    });
+
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+    expect(player.stop).toHaveBeenCalledTimes(2);
   });
 
   it("applies Discord realtime model and voice overrides during provider auto-selection", async () => {
@@ -1619,6 +1793,66 @@ describe("DiscordVoiceManager", () => {
       | (() => void)
       | undefined;
     idleHandler?.();
+    expectUserMessageIncludes("second answer");
+  });
+
+  it("drains queued exact speech after cancelled prebuffered output is discarded", async () => {
+    agentCommandMock
+      .mockResolvedValueOnce({ payloads: [{ text: "first answer" }] })
+      .mockResolvedValueOnce({ payloads: [{ text: "second answer" }] });
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const player = getLastAudioPlayer();
+    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
+      | {
+          audioSink?: { sendAudio: (audio: Buffer) => void };
+          onEvent?: (event: { detail?: string; direction: "server"; type: string }) => void;
+          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+        }
+      | undefined;
+
+    const firstTurn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    firstTurn?.sendInputAudio(Buffer.alloc(8));
+    bridgeParams?.onTranscript?.("user", "first question", true);
+
+    await new Promise((resolve) => setTimeout(resolve, 260));
+    await vi.waitFor(() => expectUserMessageIncludes("first answer"));
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+
+    const secondTurn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    secondTurn?.sendInputAudio(Buffer.alloc(8));
+    bridgeParams?.onTranscript?.("user", "second question", true);
+
+    await new Promise((resolve) => setTimeout(resolve, 260));
+    expectUserMessageNotIncludes("second answer");
+
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.cancelled" });
+
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+    expect(player.stop).toHaveBeenCalledWith(true);
     expectUserMessageIncludes("second answer");
   });
 

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -828,6 +828,50 @@ describe("DiscordVoiceManager", () => {
     expect(trailingSilence?.equals(Buffer.alloc(33_600))).toBe(true);
   });
 
+  it("clamps configured realtime trailing silence before allocating audio", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      allowFrom: ["discord:u1"],
+      voice: {
+        enabled: true,
+        mode: "bidi",
+        realtime: {
+          provider: "openai",
+          providers: {
+            openai: {
+              silenceDurationMs: 60_000,
+            },
+          },
+        },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const turn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u1",
+    );
+
+    turn?.sendInputAudio(Buffer.alloc(3840));
+    turn?.close();
+
+    const trailingSilence = realtimeSessionMock.sendAudio.mock.calls.at(-1)?.[0] as
+      | Buffer
+      | undefined;
+    expect(trailingSilence).toBeInstanceOf(Buffer);
+    expect(trailingSilence?.length).toBe(144_000);
+    expect(trailingSilence?.equals(Buffer.alloc(144_000))).toBe(true);
+  });
+
   it("ignores realtime capture during playback when barge-in is disabled", async () => {
     const connection = createConnectionMock();
     joinVoiceChannelMock.mockReturnValueOnce(connection);
@@ -1234,6 +1278,47 @@ describe("DiscordVoiceManager", () => {
     expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
     expect(player.play).toHaveBeenCalledTimes(1);
     bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
+  });
+
+  it("discards prebuffered realtime output when the response is cancelled", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const player = getLastAudioPlayer();
+    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
+      | {
+          audioSink?: {
+            sendAudio: (audio: Buffer) => void;
+          };
+          onEvent?: (event: { detail?: string; direction: "server"; type: string }) => void;
+        }
+      | undefined;
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.cancelled" });
+
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+    expect(player.stop).toHaveBeenCalledWith(true);
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    bridgeParams?.onEvent?.({
+      detail: "response completed with status=cancelled",
+      direction: "server",
+      type: "response.done",
+    });
+
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+    expect(player.stop).toHaveBeenCalledTimes(2);
   });
 
   it("applies Discord realtime model and voice overrides during provider auto-selection", async () => {

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -1696,6 +1696,66 @@ describe("DiscordVoiceManager", () => {
     expectUserMessageIncludes("second answer");
   });
 
+  it("drains queued exact speech after cancelled prebuffered output is discarded", async () => {
+    agentCommandMock
+      .mockResolvedValueOnce({ payloads: [{ text: "first answer" }] })
+      .mockResolvedValueOnce({ payloads: [{ text: "second answer" }] });
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const player = getLastAudioPlayer();
+    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
+      | {
+          audioSink?: { sendAudio: (audio: Buffer) => void };
+          onEvent?: (event: { detail?: string; direction: "server"; type: string }) => void;
+          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+        }
+      | undefined;
+
+    const firstTurn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    firstTurn?.sendInputAudio(Buffer.alloc(8));
+    bridgeParams?.onTranscript?.("user", "first question", true);
+
+    await new Promise((resolve) => setTimeout(resolve, 260));
+    await vi.waitFor(() => expectUserMessageIncludes("first answer"));
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+
+    const secondTurn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    secondTurn?.sendInputAudio(Buffer.alloc(8));
+    bridgeParams?.onTranscript?.("user", "second question", true);
+
+    await new Promise((resolve) => setTimeout(resolve, 260));
+    expectUserMessageNotIncludes("second answer");
+
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.cancelled" });
+
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+    expect(player.stop).toHaveBeenCalledWith(true);
+    expectUserMessageIncludes("second answer");
+  });
+
   it("matches agent-proxy consult tool calls to the pending transcript", async () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "owner answer" }] })

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -659,6 +659,7 @@ describe("DiscordVoiceManager", () => {
           audioSink?: {
             sendAudio: (audio: Buffer) => void;
           };
+          onEvent?: (event: { direction: "server"; type: string }) => void;
         }
       | undefined;
     player.state.status = "playing";
@@ -678,6 +679,7 @@ describe("DiscordVoiceManager", () => {
     );
     expect(subscribeCall?.[0]).toBe("u1");
     expect(requireRecord(subscribeCall?.[1], "subscribe options").end).toBeTypeOf("object");
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
   });
 
   it("interrupts realtime playback when an already-active speaker keeps talking", async () => {
@@ -716,6 +718,7 @@ describe("DiscordVoiceManager", () => {
           audioSink?: {
             sendAudio: (audio: Buffer) => void;
           };
+          onEvent?: (event: { direction: "server"; type: string }) => void;
         }
       | undefined;
     const player = getLastAudioPlayer();
@@ -735,6 +738,7 @@ describe("DiscordVoiceManager", () => {
     expect(lastTimestampCall).toBeLessThan(firstBargeInCall);
     expect(player.stop).not.toHaveBeenCalled();
     expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
   });
 
   it("does not interrupt realtime provider state when local playback is already idle", async () => {
@@ -777,6 +781,51 @@ describe("DiscordVoiceManager", () => {
     expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();
     expect(player.stop).not.toHaveBeenCalled();
     expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+  });
+
+  it("sends trailing realtime silence when a speaker turn closes", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      allowFrom: ["discord:u1"],
+      voice: {
+        enabled: true,
+        mode: "bidi",
+        realtime: {
+          provider: "openai",
+          providers: {
+            openai: {
+              silenceDurationMs: 450,
+            },
+          },
+        },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const turn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u1",
+    );
+
+    turn?.sendInputAudio(Buffer.alloc(3840));
+    turn?.close();
+
+    expect(realtimeSessionMock.sendAudio).toHaveBeenCalledTimes(2);
+    const trailingSilence = realtimeSessionMock.sendAudio.mock.calls.at(-1)?.[0] as
+      | Buffer
+      | undefined;
+    expect(trailingSilence).toBeInstanceOf(Buffer);
+    expect(trailingSilence?.length).toBe(33_600);
+    expect(trailingSilence?.equals(Buffer.alloc(33_600))).toBe(true);
   });
 
   it("ignores realtime capture during playback when barge-in is disabled", async () => {
@@ -1127,13 +1176,14 @@ describe("DiscordVoiceManager", () => {
       | undefined;
 
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
     expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
     expect(player.play).toHaveBeenCalledTimes(1);
     const firstStream = createAudioResourceMock.mock.calls.at(-1)?.[0] as
       | { writableEnded?: boolean }
       | undefined;
-    expect(firstStream?.writableEnded).toBe(false);
-    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
     expect(firstStream?.writableEnded).toBe(true);
 
     const idleHandler = player.on.mock.calls.find(([event]) => event === "idle")?.[1] as
@@ -1143,8 +1193,47 @@ describe("DiscordVoiceManager", () => {
     idleHandler?.();
 
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
+    expect(player.play).toHaveBeenCalledTimes(1);
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
     expect(createAudioResourceMock).toHaveBeenCalledTimes(2);
     expect(player.play).toHaveBeenCalledTimes(2);
+  });
+
+  it("prebuffers realtime output before starting Discord playback", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const player = getLastAudioPlayer();
+    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
+      | {
+          audioSink?: {
+            sendAudio: (audio: Buffer) => void;
+          };
+          onEvent?: (event: { direction: "server"; type: string }) => void;
+        }
+      | undefined;
+
+    for (let index = 0; index < 49; index += 1) {
+      bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    }
+
+    expect(createAudioResourceMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+
+    expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
+    expect(player.play).toHaveBeenCalledTimes(1);
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
   });
 
   it("applies Discord realtime model and voice overrides during provider auto-selection", async () => {

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -47,6 +47,10 @@ const DISCORD_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS = 250;
 const DISCORD_REALTIME_FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const DISCORD_REALTIME_DUPLICATE_ERROR_SUPPRESS_MS = 60_000;
 const REALTIME_PCM16_BYTES_PER_SAMPLE = 2;
+const DISCORD_RAW_PCM_FRAME_BYTES = 3_840;
+const DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES = 25;
+const DISCORD_REALTIME_TRAILING_SILENCE_MIN_MS = 700;
+const DISCORD_REALTIME_TRAILING_SILENCE_MAX_MS = 3_000;
 const DISCORD_REALTIME_FORCED_CONSULT_TRAILING_FRAGMENT_WORDS = new Set([
   "a",
   "about",
@@ -151,6 +155,14 @@ function formatRealtimeInterruptionLog(event: RealtimeVoiceBridgeEvent): string 
     }
   }
   return undefined;
+}
+
+function isRealtimeResponseCancelled(event: RealtimeVoiceBridgeEvent): boolean {
+  return (
+    event.direction === "server" &&
+    (event.type === "response.cancelled" ||
+      (event.type === "response.done" && event.detail?.includes("status=cancelled") === true))
+  );
 }
 
 function shouldLogRealtimeVerboseEvent(event: RealtimeVoiceBridgeEvent): boolean {
@@ -330,6 +342,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   private outputAudioChunks = 0;
   private outputAudioStartedAt: number | undefined;
   private outputStreamEnding = false;
+  private outputPacedBuffer: Buffer = Buffer.alloc(0);
+  private outputPlaybackStarted = false;
+  private realtimeProviderId: string | undefined;
   private queuedExactSpeechMessages: string[] = [];
   private exactSpeechResponseActive = false;
   private exactSpeechAudioStarted = false;
@@ -384,6 +399,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       defaultModel: this.realtimeConfig?.model,
       noRegisteredProviderMessage: "No configured realtime voice provider registered",
     });
+    this.realtimeProviderId = resolved.provider.id;
     const isAgentProxy = isDiscordAgentProxyVoiceMode(this.params.mode);
     const defaultToolPolicy: RealtimeVoiceAgentConsultToolPolicy = isAgentProxy
       ? "owner"
@@ -450,7 +466,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
           if (this.exactSpeechResponseActive && !this.exactSpeechAudioStarted) {
             this.completeExactSpeechResponse(event.type);
           }
-          this.finishOutputAudioStream(event.type);
+          this.finishOutputAudioStream(event.type, {
+            playBuffered: !isRealtimeResponseCancelled(event),
+          });
         }
         const interruptionLog = formatRealtimeInterruptionLog(event);
         if (interruptionLog) {
@@ -496,6 +514,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     this.clearOutputAudio("session-close");
     this.bridge?.close();
     this.bridge = null;
+    this.realtimeProviderId = undefined;
     const voiceSdk = loadDiscordVoiceSdk();
     this.params.entry.player.off(voiceSdk.AudioPlayerStatus.Idle, this.playerIdleHandler);
   }
@@ -544,6 +563,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       sendInputAudio: (discordPcm48kStereo) =>
         this.sendInputAudioForTurn(turn, discordPcm48kStereo),
       close: () => {
+        this.sendRealtimeTrailingSilenceForTurn(turn);
         this.logSpeakerTurnClosed(turn);
         turn.closed = true;
         this.prunePendingSpeakerTurns();
@@ -603,7 +623,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   isBargeInEnabled(): boolean {
-    const providerId = this.realtimeConfig?.provider ?? "openai";
+    const providerId = this.realtimeProviderId ?? this.realtimeConfig?.provider ?? "openai";
     return resolveDiscordRealtimeBargeIn({
       realtimeConfig: this.realtimeConfig,
       providerId,
@@ -637,7 +657,6 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     if (this.exactSpeechResponseActive) {
       this.exactSpeechAudioStarted = true;
     }
-    stream.write(discordPcm);
     this.outputAudioDiscordBytes += discordPcm.length;
     this.outputAudioRealtimeBytes += realtimePcm24kMono.length;
     this.outputAudioChunks += 1;
@@ -645,16 +664,17 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       realtimePcm24kMono,
       REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ.sampleRateHz,
     );
+    this.queueOutputAudio(stream, discordPcm);
   }
 
   private ensureOutputStream(): PassThrough {
     if (this.outputStream && !this.outputStream.destroyed && !this.outputStream.writableEnded) {
       return this.outputStream;
     }
-    const voiceSdk = loadDiscordVoiceSdk();
-    const stream = new PassThrough();
+    const stream = new PassThrough({ highWaterMark: DISCORD_RAW_PCM_FRAME_BYTES * 128 });
     this.outputStream = stream;
-    this.outputAudioStartedAt = Date.now();
+    this.outputPacedBuffer = Buffer.alloc(0);
+    this.outputPlaybackStarted = false;
     stream.once("close", () => {
       if (this.outputStream === stream) {
         this.logOutputAudioStopped("stream-close");
@@ -663,15 +683,45 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
         this.completeExactSpeechResponse("stream-close", { drain: false });
       }
     });
+    return stream;
+  }
+
+  private queueOutputAudio(stream: PassThrough, discordPcm: Buffer): void {
+    if (this.outputPlaybackStarted) {
+      stream.write(discordPcm);
+      return;
+    }
+    this.outputPacedBuffer =
+      this.outputPacedBuffer.length > 0
+        ? Buffer.concat([this.outputPacedBuffer, discordPcm])
+        : discordPcm;
+    if (
+      this.outputPacedBuffer.length >=
+      DISCORD_RAW_PCM_FRAME_BYTES * DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES
+    ) {
+      this.startOutputPlayback(stream);
+    }
+  }
+
+  private startOutputPlayback(stream: PassThrough): void {
+    if (this.outputPlaybackStarted || stream.destroyed) {
+      return;
+    }
+    const voiceSdk = loadDiscordVoiceSdk();
+    if (this.outputPacedBuffer.length > 0) {
+      stream.write(this.outputPacedBuffer);
+      this.outputPacedBuffer = Buffer.alloc(0);
+    }
     const resource = voiceSdk.createAudioResource(stream, {
       inputType: voiceSdk.StreamType.Raw,
     });
     this.params.entry.player.play(resource);
+    this.outputPlaybackStarted = true;
+    this.outputAudioStartedAt = Date.now();
     const realtimeConfig = this.realtimeConfig;
     logger.info(
       `discord voice: realtime audio playback started guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} mode=${this.params.mode} model=${realtimeConfig?.model ?? "provider-default"} voice=${realtimeConfig?.voice ?? "provider-default"}`,
     );
-    return stream;
   }
 
   private clearOutputAudio(reason = "clear"): void {
@@ -683,12 +733,17 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const stream = this.outputStream;
     this.logOutputAudioStopped(reason);
     this.outputStream = null;
+    this.outputPacedBuffer = Buffer.alloc(0);
+    this.outputPlaybackStarted = false;
     this.resetOutputAudioStats();
     stream?.end();
     stream?.destroy();
   }
 
-  private finishOutputAudioStream(reason: string): void {
+  private finishOutputAudioStream(
+    reason: string,
+    { playBuffered = true }: { playBuffered?: boolean } = {},
+  ): void {
     const stream = this.outputStream;
     if (!stream || stream.destroyed || this.outputStreamEnding) {
       return;
@@ -697,6 +752,14 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     logger.info(
       `discord voice: realtime audio playback finishing reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${Math.floor(this.outputAudioTimestampMs)} chunks=${this.outputAudioChunks}`,
     );
+    if (playBuffered) {
+      this.startOutputPlayback(stream);
+    } else {
+      this.resetOutputStream(reason);
+      this.params.entry.player.stop(true);
+      this.completeExactSpeechResponse(reason);
+      return;
+    }
     stream.end();
   }
 
@@ -774,6 +837,8 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     this.outputAudioChunks = 0;
     this.outputAudioStartedAt = undefined;
     this.outputStreamEnding = false;
+    this.outputPacedBuffer = Buffer.alloc(0);
+    this.outputPlaybackStarted = false;
   }
 
   private syncOutputAudioTimestamp(): void {
@@ -792,6 +857,31 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const sinceLastAudioMs = turn.lastAudioAt ? Date.now() - turn.lastAudioAt : undefined;
     logger.info(
       `discord voice: realtime speaker turn closed guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} owner=${turn.context.senderIsOwner} hasAudio=${turn.hasAudio} chunks=${turn.inputChunks} discordBytes=${turn.inputDiscordBytes} realtimeBytes=${turn.inputRealtimeBytes} elapsedMs=${elapsedMs}${sinceLastAudioMs === undefined ? "" : ` sinceLastAudioMs=${sinceLastAudioMs}`} interruptedPlayback=${turn.interruptedPlayback}`,
+    );
+  }
+
+  private sendRealtimeTrailingSilenceForTurn(turn: PendingSpeakerTurn): void {
+    if (!this.bridge || this.stopped || turn.closed || !turn.hasAudio) {
+      return;
+    }
+    const providerId = this.realtimeProviderId ?? this.realtimeConfig?.provider ?? "openai";
+    const providerConfig = this.realtimeConfig?.providers?.[providerId];
+    const rawSilenceDurationMs = providerConfig?.silenceDurationMs;
+    const configuredSilenceDurationMs =
+      typeof rawSilenceDurationMs === "number" && Number.isFinite(rawSilenceDurationMs)
+        ? rawSilenceDurationMs
+        : 0;
+    const silenceMs = Math.min(
+      DISCORD_REALTIME_TRAILING_SILENCE_MAX_MS,
+      Math.max(DISCORD_REALTIME_TRAILING_SILENCE_MIN_MS, configuredSilenceDurationMs),
+    );
+    const silenceBytes =
+      Math.ceil((REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ.sampleRateHz * silenceMs) / 1_000) *
+      REALTIME_PCM16_BYTES_PER_SAMPLE;
+    const silence = Buffer.alloc(silenceBytes);
+    this.bridge.sendAudio(silence);
+    logger.info(
+      `discord voice: realtime trailing silence sent guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} silenceMs=${silenceMs} realtimeBytes=${silence.length}`,
     );
   }
 

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -726,6 +726,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     } else {
       this.resetOutputStream(reason);
       this.params.entry.player.stop(true);
+      this.completeExactSpeechResponse(reason);
       return;
     }
     stream.end();

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -46,6 +46,8 @@ const DISCORD_REALTIME_LOG_PREVIEW_CHARS = 500;
 const DISCORD_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS = 250;
 const DISCORD_REALTIME_FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const REALTIME_PCM16_BYTES_PER_SAMPLE = 2;
+const DISCORD_RAW_PCM_FRAME_BYTES = 3_840;
+const DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES = 25;
 const DISCORD_REALTIME_FORCED_CONSULT_TRAILING_FRAGMENT_WORDS = new Set([
   "a",
   "about",
@@ -329,6 +331,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   private outputAudioChunks = 0;
   private outputAudioStartedAt: number | undefined;
   private outputStreamEnding = false;
+  private outputPacedBuffer: Buffer = Buffer.alloc(0);
+  private outputPlaybackStarted = false;
+  private realtimeProviderId: string | undefined;
   private queuedExactSpeechMessages: string[] = [];
   private exactSpeechResponseActive = false;
   private exactSpeechAudioStarted = false;
@@ -380,6 +385,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       defaultModel: this.realtimeConfig?.model,
       noRegisteredProviderMessage: "No configured realtime voice provider registered",
     });
+    this.realtimeProviderId = resolved.provider.id;
     const isAgentProxy = isDiscordAgentProxyVoiceMode(this.params.mode);
     const defaultToolPolicy: RealtimeVoiceAgentConsultToolPolicy = isAgentProxy
       ? "owner"
@@ -489,6 +495,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     this.clearOutputAudio("session-close");
     this.bridge?.close();
     this.bridge = null;
+    this.realtimeProviderId = undefined;
     const voiceSdk = loadDiscordVoiceSdk();
     this.params.entry.player.off(voiceSdk.AudioPlayerStatus.Idle, this.playerIdleHandler);
   }
@@ -513,6 +520,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       sendInputAudio: (discordPcm48kStereo) =>
         this.sendInputAudioForTurn(turn, discordPcm48kStereo),
       close: () => {
+        this.sendRealtimeTrailingSilenceForTurn(turn);
         this.logSpeakerTurnClosed(turn);
         turn.closed = true;
         this.prunePendingSpeakerTurns();
@@ -572,7 +580,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   isBargeInEnabled(): boolean {
-    const providerId = this.realtimeConfig?.provider ?? "openai";
+    const providerId = this.realtimeProviderId ?? this.realtimeConfig?.provider ?? "openai";
     return resolveDiscordRealtimeBargeIn({
       realtimeConfig: this.realtimeConfig,
       providerId,
@@ -606,7 +614,6 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     if (this.exactSpeechResponseActive) {
       this.exactSpeechAudioStarted = true;
     }
-    stream.write(discordPcm);
     this.outputAudioDiscordBytes += discordPcm.length;
     this.outputAudioRealtimeBytes += realtimePcm24kMono.length;
     this.outputAudioChunks += 1;
@@ -614,16 +621,17 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       realtimePcm24kMono,
       REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ.sampleRateHz,
     );
+    this.queueOutputAudio(stream, discordPcm);
   }
 
   private ensureOutputStream(): PassThrough {
     if (this.outputStream && !this.outputStream.destroyed && !this.outputStream.writableEnded) {
       return this.outputStream;
     }
-    const voiceSdk = loadDiscordVoiceSdk();
-    const stream = new PassThrough();
+    const stream = new PassThrough({ highWaterMark: DISCORD_RAW_PCM_FRAME_BYTES * 128 });
     this.outputStream = stream;
-    this.outputAudioStartedAt = Date.now();
+    this.outputPacedBuffer = Buffer.alloc(0);
+    this.outputPlaybackStarted = false;
     stream.once("close", () => {
       if (this.outputStream === stream) {
         this.logOutputAudioStopped("stream-close");
@@ -632,15 +640,45 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
         this.completeExactSpeechResponse("stream-close", { drain: false });
       }
     });
+    return stream;
+  }
+
+  private queueOutputAudio(stream: PassThrough, discordPcm: Buffer): void {
+    if (this.outputPlaybackStarted) {
+      stream.write(discordPcm);
+      return;
+    }
+    this.outputPacedBuffer =
+      this.outputPacedBuffer.length > 0
+        ? Buffer.concat([this.outputPacedBuffer, discordPcm])
+        : discordPcm;
+    if (
+      this.outputPacedBuffer.length >=
+      DISCORD_RAW_PCM_FRAME_BYTES * DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES
+    ) {
+      this.startOutputPlayback(stream);
+    }
+  }
+
+  private startOutputPlayback(stream: PassThrough): void {
+    if (this.outputPlaybackStarted || stream.destroyed) {
+      return;
+    }
+    const voiceSdk = loadDiscordVoiceSdk();
+    if (this.outputPacedBuffer.length > 0) {
+      stream.write(this.outputPacedBuffer);
+      this.outputPacedBuffer = Buffer.alloc(0);
+    }
     const resource = voiceSdk.createAudioResource(stream, {
       inputType: voiceSdk.StreamType.Raw,
     });
     this.params.entry.player.play(resource);
+    this.outputPlaybackStarted = true;
+    this.outputAudioStartedAt = Date.now();
     const realtimeConfig = this.realtimeConfig;
     logger.info(
       `discord voice: realtime audio playback started guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} mode=${this.params.mode} model=${realtimeConfig?.model ?? "provider-default"} voice=${realtimeConfig?.voice ?? "provider-default"}`,
     );
-    return stream;
   }
 
   private clearOutputAudio(reason = "clear"): void {
@@ -652,6 +690,8 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const stream = this.outputStream;
     this.logOutputAudioStopped(reason);
     this.outputStream = null;
+    this.outputPacedBuffer = Buffer.alloc(0);
+    this.outputPlaybackStarted = false;
     this.resetOutputAudioStats();
     stream?.end();
     stream?.destroy();
@@ -666,6 +706,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     logger.info(
       `discord voice: realtime audio playback finishing reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${Math.floor(this.outputAudioTimestampMs)} chunks=${this.outputAudioChunks}`,
     );
+    this.startOutputPlayback(stream);
     stream.end();
   }
 
@@ -743,6 +784,8 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     this.outputAudioChunks = 0;
     this.outputAudioStartedAt = undefined;
     this.outputStreamEnding = false;
+    this.outputPacedBuffer = Buffer.alloc(0);
+    this.outputPlaybackStarted = false;
   }
 
   private syncOutputAudioTimestamp(): void {
@@ -761,6 +804,27 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const sinceLastAudioMs = turn.lastAudioAt ? Date.now() - turn.lastAudioAt : undefined;
     logger.info(
       `discord voice: realtime speaker turn closed guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} owner=${turn.context.senderIsOwner} hasAudio=${turn.hasAudio} chunks=${turn.inputChunks} discordBytes=${turn.inputDiscordBytes} realtimeBytes=${turn.inputRealtimeBytes} elapsedMs=${elapsedMs}${sinceLastAudioMs === undefined ? "" : ` sinceLastAudioMs=${sinceLastAudioMs}`} interruptedPlayback=${turn.interruptedPlayback}`,
+    );
+  }
+
+  private sendRealtimeTrailingSilenceForTurn(turn: PendingSpeakerTurn): void {
+    if (!this.bridge || this.stopped || turn.closed || !turn.hasAudio) {
+      return;
+    }
+    const providerId = this.realtimeProviderId ?? this.realtimeConfig?.provider ?? "openai";
+    const providerConfig = this.realtimeConfig?.providers?.[providerId];
+    const configuredSilenceDurationMs = providerConfig?.silenceDurationMs;
+    const silenceMs = Math.max(
+      700,
+      typeof configuredSilenceDurationMs === "number" ? configuredSilenceDurationMs : 0,
+    );
+    const silenceBytes =
+      Math.ceil((REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ.sampleRateHz * silenceMs) / 1_000) *
+      REALTIME_PCM16_BYTES_PER_SAMPLE;
+    const silence = Buffer.alloc(silenceBytes);
+    this.bridge.sendAudio(silence);
+    logger.info(
+      `discord voice: realtime trailing silence sent guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} silenceMs=${silenceMs} realtimeBytes=${silence.length}`,
     );
   }
 

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -48,6 +48,8 @@ const DISCORD_REALTIME_FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const REALTIME_PCM16_BYTES_PER_SAMPLE = 2;
 const DISCORD_RAW_PCM_FRAME_BYTES = 3_840;
 const DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES = 25;
+const DISCORD_REALTIME_TRAILING_SILENCE_MIN_MS = 700;
+const DISCORD_REALTIME_TRAILING_SILENCE_MAX_MS = 3_000;
 const DISCORD_REALTIME_FORCED_CONSULT_TRAILING_FRAGMENT_WORDS = new Set([
   "a",
   "about",
@@ -152,6 +154,14 @@ function formatRealtimeInterruptionLog(event: RealtimeVoiceBridgeEvent): string 
     }
   }
   return undefined;
+}
+
+function isRealtimeResponseCancelled(event: RealtimeVoiceBridgeEvent): boolean {
+  return (
+    event.direction === "server" &&
+    (event.type === "response.cancelled" ||
+      (event.type === "response.done" && event.detail?.includes("status=cancelled") === true))
+  );
 }
 
 function shouldLogRealtimeVerboseEvent(event: RealtimeVoiceBridgeEvent): boolean {
@@ -452,7 +462,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
           if (this.exactSpeechResponseActive && !this.exactSpeechAudioStarted) {
             this.completeExactSpeechResponse(event.type);
           }
-          this.finishOutputAudioStream(event.type);
+          this.finishOutputAudioStream(event.type, {
+            playBuffered: !isRealtimeResponseCancelled(event),
+          });
         }
         const interruptionLog = formatRealtimeInterruptionLog(event);
         if (interruptionLog) {
@@ -697,7 +709,10 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     stream?.destroy();
   }
 
-  private finishOutputAudioStream(reason: string): void {
+  private finishOutputAudioStream(
+    reason: string,
+    { playBuffered = true }: { playBuffered?: boolean } = {},
+  ): void {
     const stream = this.outputStream;
     if (!stream || stream.destroyed || this.outputStreamEnding) {
       return;
@@ -706,7 +721,13 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     logger.info(
       `discord voice: realtime audio playback finishing reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${Math.floor(this.outputAudioTimestampMs)} chunks=${this.outputAudioChunks}`,
     );
-    this.startOutputPlayback(stream);
+    if (playBuffered) {
+      this.startOutputPlayback(stream);
+    } else {
+      this.resetOutputStream(reason);
+      this.params.entry.player.stop(true);
+      return;
+    }
     stream.end();
   }
 
@@ -813,10 +834,14 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     }
     const providerId = this.realtimeProviderId ?? this.realtimeConfig?.provider ?? "openai";
     const providerConfig = this.realtimeConfig?.providers?.[providerId];
-    const configuredSilenceDurationMs = providerConfig?.silenceDurationMs;
-    const silenceMs = Math.max(
-      700,
-      typeof configuredSilenceDurationMs === "number" ? configuredSilenceDurationMs : 0,
+    const rawSilenceDurationMs = providerConfig?.silenceDurationMs;
+    const configuredSilenceDurationMs =
+      typeof rawSilenceDurationMs === "number" && Number.isFinite(rawSilenceDurationMs)
+        ? rawSilenceDurationMs
+        : 0;
+    const silenceMs = Math.min(
+      DISCORD_REALTIME_TRAILING_SILENCE_MAX_MS,
+      Math.max(DISCORD_REALTIME_TRAILING_SILENCE_MIN_MS, configuredSilenceDurationMs),
     );
     const silenceBytes =
       Math.ceil((REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ.sampleRateHz * silenceMs) / 1_000) *

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -110,7 +110,7 @@ type SentRealtimeEvent = {
     audio?: {
       input?: {
         format?: Record<string, unknown>;
-        noise_reduction?: Record<string, unknown>;
+        noise_reduction?: Record<string, unknown> | null;
         transcription?: Record<string, unknown>;
         turn_detection?: {
           create_response?: boolean;
@@ -668,7 +668,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     const inputAudio = requireNestedRecord(session, ["audio", "input"]);
     expectRecordFields(inputAudio, "session audio input", {
       format: { type: "audio/pcmu" },
-      noise_reduction: { type: "near_field" },
+      noise_reduction: null,
       transcription: { model: "gpt-4o-mini-transcribe" },
     });
     expect(requireNestedRecord(session, ["audio", "output"])).toEqual({

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -110,7 +110,7 @@ type SentRealtimeEvent = {
     audio?: {
       input?: {
         format?: Record<string, unknown>;
-        noise_reduction?: Record<string, unknown>;
+        noise_reduction?: Record<string, unknown> | null;
         transcription?: Record<string, unknown>;
         turn_detection?: {
           create_response?: boolean;
@@ -653,7 +653,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     const inputAudio = requireNestedRecord(session, ["audio", "input"]);
     expectRecordFields(inputAudio, "session audio input", {
       format: { type: "audio/pcmu" },
-      noise_reduction: { type: "near_field" },
+      noise_reduction: null,
       transcription: { model: "gpt-4o-mini-transcribe" },
     });
     expect(requireNestedRecord(session, ["audio", "output"])).toEqual({

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -159,7 +159,7 @@ type RealtimeGaSessionUpdate = {
       input: {
         format: OpenAIRealtimeAudioFormatConfig;
         turn_detection: RealtimeTurnDetectionConfig;
-        noise_reduction?: { type: "near_field" };
+        noise_reduction?: { type: "near_field" } | null;
         transcription?: { model: string };
       };
       output: {
@@ -772,7 +772,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         audio: {
           input: {
             format: this.resolveRealtimeAudioFormat(),
-            noise_reduction: { type: "near_field" },
+            noise_reduction: null,
             transcription: { model: OPENAI_REALTIME_INPUT_TRANSCRIPTION_MODEL },
             turn_detection: {
               type: "server_vad",

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -159,7 +159,7 @@ type RealtimeGaSessionUpdate = {
       input: {
         format: OpenAIRealtimeAudioFormatConfig;
         turn_detection: RealtimeTurnDetectionConfig;
-        noise_reduction?: { type: "near_field" };
+        noise_reduction?: { type: "near_field" } | null;
         transcription?: { model: string };
       };
       output: {
@@ -759,7 +759,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         audio: {
           input: {
             format: this.resolveRealtimeAudioFormat(),
-            noise_reduction: { type: "near_field" },
+            noise_reduction: null,
             transcription: { model: OPENAI_REALTIME_INPUT_TRANSCRIPTION_MODEL },
             turn_detection: {
               type: "server_vad",


### PR DESCRIPTION
## Summary

- Problem: Discord VC sessions using the OpenAI realtime backend path for GPT-Realtime-2 could stop recognizing later user speech after the first reply, and assistant audio could start choppy or cut off.
- Why it matters: This makes bidirectional near-realtime Discord voice unusable for interruptible conversation, tool use, and work execution.
- What changed: The OpenAI GA backend bridge now sends `noise_reduction: null` for the PCMU/server-VAD backend session, Discord realtime turns append trailing silence before closing, and Discord output playback prebuffers raw PCM before starting the audio player.
- What did NOT change (scope boundary): Browser/WebRTC realtime sessions, Azure realtime sessions, model/voice config, tool policy, and Discord voice permissions are unchanged.
- AI-assisted: Yes. Built with Codex, then live-tested in Discord VC and validated on Crabbox Linux.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Discord VC with OpenAI `gpt-realtime-2`/`cedar` OAuth realtime should keep hearing subsequent user turns and deliver clean assistant playback.
- Real environment tested: Local macOS OpenClaw Discord VC instance connected to a real Discord voice channel, OpenAI realtime provider using `gpt-realtime-2` and `cedar`; Crabbox Linux host `gsd-build.fluxlabs.net` for repeatable validation.
- Exact steps or command run after this patch:
  1. Joined the Discord voice channel with OpenClaw configured for bidirectional realtime OpenAI voice.
  2. Spoke multiple turns, including interrupting/continuing after the first assistant reply.
  3. Watched `openclaw logs --follow` for speech start/stop, commit, transcript, response done, playback start, and playback stop events.
  4. Ran focused and extension validation on Crabbox:
     - `pnpm test extensions/openai/realtime-voice-provider.test.ts extensions/discord/src/voice/manager.e2e.test.ts -- --reporter=dot`
     - `pnpm check:changed`
     - `pnpm test:extension discord -- --reporter=dot`
     - `pnpm test:extension openai -- --reporter=dot`
     - `pnpm build`
     - `codex review --uncommitted`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - Redacted runtime log excerpt copied from the live OpenClaw Discord VC run (`~/.openclaw/logs/gateway.log`, captured after joining the real VC and speaking multiple turns):

    ```text
    2026-05-10T20:57:42.839-04:00 [discord] voice: realtime trailing silence sent guild=<redacted> channel=<redacted> user=<redacted> speaker=Kidlion silenceMs=700 realtimeBytes=33600
    2026-05-10T20:57:43.243-04:00 [discord] voice: realtime user transcript (81 chars): Is there a way to speed up tool usage so that way there's not as long of a pause?
    2026-05-10T20:57:44.681-04:00 [discord] voice: realtime audio playback started guild=<redacted> channel=<redacted> mode=bidi model=gpt-realtime-2 voice=cedar
    2026-05-10T20:57:45.979-04:00 [discord] voice: realtime assistant transcript (54 chars): Let me think through some ways to cut that pause down.
    2026-05-10T20:57:46.035-04:00 [discord] voice: realtime audio playback finishing reason=response.done guild=<redacted> channel=<redacted> audioMs=3350 chunks=9
    2026-05-10T20:57:47.569-04:00 [discord] voice: realtime audio playback stopped reason=stream-close guild=<redacted> channel=<redacted> audioMs=3350 elapsedMs=2934 chunks=9 discordBytes=643200 realtimeBytes=160800
    2026-05-10T20:58:34.695-04:00 [discord] voice: realtime trailing silence sent guild=<redacted> channel=<redacted> user=<redacted> speaker=Kidlion silenceMs=700 realtimeBytes=33600
    2026-05-10T20:58:35.256-04:00 [discord] voice: realtime user transcript (274 chars): Okay, I want to do the same thing we just did with CoinPilot, but I want you to tell me how many folders, not files, are in the project folder. And take that practice of what you just said, give a little sentence while parallel checking, so that way it doesn't feel as long.
    2026-05-10T20:58:36.330-04:00 [discord] voice: realtime audio playback started guild=<redacted> channel=<redacted> mode=bidi model=gpt-realtime-2 voice=cedar
    2026-05-10T20:58:37.465-04:00 [discord] voice: realtime assistant transcript (65 chars): Let me check that project folder count while I talk this through.
    2026-05-10T20:58:37.521-04:00 [discord] voice: realtime audio playback finishing reason=response.done guild=<redacted> channel=<redacted> audioMs=3400 chunks=9
    2026-05-10T20:58:39.220-04:00 [discord] voice: realtime audio playback stopped reason=stream-close guild=<redacted> channel=<redacted> audioMs=3400 elapsedMs=3049 chunks=9 discordBytes=652800 realtimeBytes=163200
    2026-05-10T20:58:49.099-04:00 [discord] voice: realtime audio playback started guild=<redacted> channel=<redacted> mode=bidi model=gpt-realtime-2 voice=cedar
    2026-05-10T20:58:49.380-04:00 [discord] voice: realtime assistant transcript (6 chars): 10,324
    2026-05-10T20:58:49.382-04:00 [discord] voice: realtime audio playback finishing reason=response.done guild=<redacted> channel=<redacted> audioMs=2700 chunks=7
    2026-05-10T20:58:51.187-04:00 [discord] voice: realtime audio playback stopped reason=stream-close guild=<redacted> channel=<redacted> audioMs=2700 elapsedMs=2111 chunks=7 discordBytes=518400 realtimeBytes=129600
    2026-05-10T20:59:04.519-04:00 [discord] voice: realtime trailing silence sent guild=<redacted> channel=<redacted> user=<redacted> speaker=Kidlion silenceMs=700 realtimeBytes=33600
    2026-05-10T20:59:04.993-04:00 [discord] voice: realtime user transcript (123 chars): So a long pause between that. I think it was up to four or five seconds, so I don't know if it started as you were talking.
    2026-05-10T20:59:07.892-04:00 [discord] voice: realtime consult requested call=<redacted> voiceSession=<redacted> supervisorSession=<redacted> agent=aiden question=User observed a 4-5 second pause and suspects the tool call may not start until after speaking...
    2026-05-10T20:59:14.846-04:00 [discord] voice: realtime audio playback started guild=<redacted> channel=<redacted> mode=bidi model=gpt-realtime-2 voice=cedar
    2026-05-10T20:59:19.598-04:00 [discord] voice: realtime assistant transcript (411 chars): That’s likely possible. If the system waits to finish speaking filler before starting the tool call, the filler adds latency instead of hiding it...
    2026-05-10T20:59:19.600-04:00 [discord] voice: realtime audio playback finishing reason=response.done guild=<redacted> channel=<redacted> audioMs=26700 chunks=67
    2026-05-10T20:59:40.936-04:00 [discord] voice: realtime audio playback stopped reason=stream-close guild=<redacted> channel=<redacted> audioMs=26700 elapsedMs=26225 chunks=67 discordBytes=5126400 realtimeBytes=1281600
    ```

  - Live Discord VC logs showed user audio reaching the realtime backend on later turns after changing backend GA `noise_reduction` to `null`.
  - Live playback timing was close to generated audio duration after adding prebuffering, for example about `12.35s` generated vs `11.76s` playback and about `17.5s` generated vs `16.96s` playback.
  - No repeated `write after end` stream errors were observed after the output stream cleanup and prebuffer changes.
  - Human tester feedback after the final patch: "this seems really good now"; remaining "small stutters" were not clearly attributable to this path.
  - Crabbox focused tests passed: Discord voice e2e `59 passed`, OpenAI provider `43 passed`.
  - Crabbox extension lanes passed: Discord `145 passed` test files / `1405 passed` tests; OpenAI `22 passed` test files / `262 passed` tests.
  - `pnpm check:changed` passed on Crabbox.
  - `pnpm build` passed on Crabbox.
  - `codex review --uncommitted` found no discrete correctness issues in the current changes.
- Observed result after fix: The bot heard repeated user turns, produced transcripts/responses after the first turn, and assistant audio started cleanly enough for live VC testing.
- What was not tested: Azure realtime, browser/WebRTC realtime, and visual UI flows. A full `pnpm check` run is currently blocked by an unrelated main-branch temp-path guard in `src/auto-reply/reply/context-treemap.ts`, which this PR does not touch. A broad `pnpm test -- --reporter=dot` run on Crabbox exited 1; the visible failure was an unrelated `src/gateway/probe.auth.integration.test.ts` local authenticated probe test, while the touched OpenAI and Discord extension lanes passed.
- Before evidence (optional but encouraged): Before this patch, the first reply could work but later user speech stopped appearing in logs; assistant delivery was audibly choppy, and the output path could hit stream timing/ending issues.

## Root Cause (if applicable)

- Root cause: The backend OpenAI GA realtime bridge was enabling `noise_reduction: { type: "near_field" }` on the PCMU/server-VAD backend session path. In live Discord VC testing this prevented reliable speech detection/transcription after the initial response. Separately, Discord playback began immediately on tiny raw PCM chunks with no preroll, making the audio player susceptible to underrun/stutter and short-response stream ending races.
- Missing detection / guardrail: Tests asserted the problematic backend noise-reduction payload and did not cover speaker-turn trailing silence or output prebuffer behavior.
- Contributing context (if known): The WebRTC/browser session path still uses near-field noise reduction; the failure was isolated to the backend bridge used by Discord VC.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/openai/realtime-voice-provider.test.ts`
  - `extensions/discord/src/voice/manager.e2e.test.ts`
- Scenario the test should lock in:
  - Backend GA session updates send `noise_reduction: null`.
  - Closing a realtime Discord speaker turn with audio sends at least 700ms of PCM16/24k trailing silence.
  - Realtime output audio prebuffers before starting Discord raw playback and still starts on `response.done` for short replies.
- Why this is the smallest reliable guardrail: These tests cover the exact provider payload and Discord voice stream lifecycle without requiring live OpenAI/Discord credentials in CI.
- Existing test that already covers this (if any): Existing provider and Discord realtime tests covered nearby flows but not these failure conditions.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Discord realtime voice with OpenAI GPT-Realtime-2 should keep recognizing follow-up turns and start assistant audio more cleanly. No new user config or migration is required.

## Diagram (if applicable)

```text
Before:
Discord speech -> backend realtime session with near_field NR -> later turns may not transcript
Realtime audio chunks -> Discord player immediately -> possible underrun/stutter

After:
Discord speech -> backend realtime session with noise_reduction null -> VAD/transcript continues
Speaker turn close -> trailing silence -> turn finalizes
Realtime audio chunks -> prebuffer -> Discord player -> cleaner playback start
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS for live Discord VC; Ubuntu 24.04 ARM64 on Crabbox for validation
- Runtime/container: OpenClaw local dev runtime; Crabbox static Linux host
- Model/provider: OpenAI realtime `gpt-realtime-2`, voice `cedar`
- Integration/channel (if any): Discord voice channel
- Relevant config (redacted): Discord voice realtime bidirectional mode with OpenAI OAuth provider; no secrets included here

### Steps

1. Configure Discord realtime voice for OpenAI `gpt-realtime-2` and join a Discord VC.
2. Speak a first turn, wait for the assistant reply, then speak additional turns.
3. Watch logs for input speech events/transcripts/responses and listen for output stutter.
4. Run the targeted OpenAI provider and Discord voice test lanes on Crabbox.

### Expected

- The bot continues hearing/transcribing after the first reply.
- Speaker turns finalize without requiring extra manual speech/noise.
- Assistant playback starts cleanly and short replies still play.

### Actual

- After the patch, repeated live Discord VC turns produced realtime events and replies.
- Focused provider/Discord e2e tests, extension lanes, `check:changed`, and build passed.
- Broad full-repo validation still has unrelated failures outside this touched surface, documented above.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Live Discord VC multi-turn realtime conversation, follow-up speech detection after first reply, assistant playback delivery, targeted provider and Discord e2e tests, Discord extension lane, OpenAI extension lane, changed-file checks, build, and Codex review.
- Edge cases checked: Short realtime replies that finish before the preroll threshold, player idle then subsequent output, realtime speaker-turn close after input audio, and provider-specific barge-in config lookup after provider resolution.
- What you did **not** verify: Azure realtime, browser/WebRTC realtime, every full-repo test shard to green.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Adding at least 700ms of trailing silence may slightly delay backend turn finalization after speaker close.
  - Mitigation: It is only sent for realtime turns that actually carried audio and mirrors the live behavior needed for reliable server VAD finalization.
- Risk: Output prebuffering adds a small playback startup delay.
  - Mitigation: It trades a small preroll for cleaner Discord raw PCM playback and still starts on `response.done` for short replies.
- Risk: Disabling near-field noise reduction may reduce input cleanup for this backend bridge.
  - Mitigation: The change is scoped to the backend GA PCMU path that failed in live Discord VC testing; WebRTC/browser and Azure paths keep their existing noise-reduction behavior.
