### PR TITLE
Harden ACP worker dispatch controls

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -11,6 +11,8 @@ type TestSessionStore = {
 const DOCUMENTED_OPENCLAW_BRIDGE_COMMAND =
   "env OPENCLAW_HIDE_BANNER=1 OPENCLAW_SUPPRESS_NOTES=1 openclaw acp --url ws://127.0.0.1:18789 --token-file ~/.openclaw/gateway.token --session agent:main:main";
 const CODEX_ACP_COMMAND = "npx @zed-industries/codex-acp@0.13.0";
+const CLAUDE_ACP_COMMAND = "npx @agentclientprotocol/claude-agent-acp@0.33.1";
+const GEMINI_ACP_COMMAND = "gemini --acp";
 const CODEX_ACP_WRAPPER_COMMAND = `node "/tmp/openclaw/acpx/codex-acp-wrapper.mjs"`;
 const CODEX_ACP_WRAPPER_COMMAND_WITH_LEASE = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-close ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
 
@@ -278,6 +280,29 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(__testing.isCodexAcpCommand("openclaw acp")).toBe(false);
   });
 
+  it("injects Gemini ACP startup model into the scoped registry", () => {
+    expect(__testing.isGeminiAcpCommand(GEMINI_ACP_COMMAND)).toBe(true);
+    expect(
+      __testing.appendGeminiAcpModelOverride(GEMINI_ACP_COMMAND, {
+        model: "gemini-3.1-pro-preview",
+      }),
+    ).toBe("gemini --acp --model gemini-3.1-pro-preview");
+    expect(__testing.isGeminiAcpCommand("gemini chat")).toBe(false);
+  });
+
+  it("injects Claude ACP startup model through environment overrides", () => {
+    expect(__testing.isClaudeAcpCommand(CLAUDE_ACP_COMMAND)).toBe(true);
+    expect(
+      __testing.appendClaudeAcpEnvOverrides(CLAUDE_ACP_COMMAND, {
+        model: "opus",
+        thinking: "xhigh",
+      }),
+    ).toBe(
+      "env ANTHROPIC_MODEL=opus CLAUDE_ACP_MODEL=opus CLAUDE_ACP_BAKE_MODEL=1 CLAUDE_AGENT_ACP_SKIP_INITIAL_SET_MODEL=1 CLAUDE_ACP_NO_EFFORT_APPLY=1 npx @agentclientprotocol/claude-agent-acp@0.33.1",
+    );
+    expect(__testing.isClaudeAcpCommand("gemini --acp")).toBe(false);
+  });
+
   it("passes gpt-5.5 Codex ACP startup through instead of blocking it", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),
@@ -471,21 +496,54 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
-  it("forwards timeout config controls for non-Codex ACP agents", async () => {
+  it("ignores unsupported Claude and Gemini ACP runtime config replays", async () => {
+    const handleFor = (sessionKey: string) =>
+      ({
+        sessionKey,
+        backend: "acpx",
+        runtimeSessionName: sessionKey,
+        acpxRecordId: sessionKey,
+      }) satisfies Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"];
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async (sessionId: string) => ({
+        acpxRecordId: sessionId,
+        agentCommand: sessionId.includes(":claude:") ? CLAUDE_ACP_COMMAND : GEMINI_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+
+    for (const sessionKey of ["agent:claude:acp:test", "agent:gemini:acp:test"]) {
+      const handle = handleFor(sessionKey);
+      for (const [key, value] of [
+        ["model", "opus"],
+        ["thinking", "xhigh"],
+        ["timeout", "240"],
+        ["Timeout_Seconds", "240"],
+      ] as const) {
+        await runtime.setConfigOption({ handle, key, value });
+      }
+    }
+
+    expect(setConfigOption).not.toHaveBeenCalled();
+  });
+
+  it("forwards timeout config controls for generic non-Codex ACP agents", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
-        acpxRecordId: "agent:claude:acp:test",
-        agentCommand: "npx @agentclientprotocol/claude-agent-acp",
+        acpxRecordId: "agent:custom:acp:test",
+        agentCommand: "custom-acp-agent",
       })),
       save: vi.fn(async () => {}),
     };
     const { runtime, delegate } = makeRuntime(baseStore);
     const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
     const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
-      sessionKey: "agent:claude:acp:test",
+      sessionKey: "agent:custom:acp:test",
       backend: "acpx",
-      runtimeSessionName: "agent:claude:acp:test",
-      acpxRecordId: "agent:claude:acp:test",
+      runtimeSessionName: "agent:custom:acp:test",
+      acpxRecordId: "agent:custom:acp:test",
     };
 
     await runtime.setConfigOption({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -229,6 +229,8 @@ function createResetAwareSessionStore(
 const OPENCLAW_BRIDGE_EXECUTABLE = "openclaw";
 const OPENCLAW_BRIDGE_SUBCOMMAND = "acp";
 const CODEX_ACP_AGENT_ID = "codex";
+const GEMINI_ACP_AGENT_ID = "gemini";
+const CLAUDE_ACP_AGENT_ID = "claude";
 const CODEX_ACP_OPENCLAW_PREFIX = "openai-codex/";
 const CODEX_ACP_REASONING_EFFORTS = new Set(["low", "medium", "high", "xhigh"]);
 const CODEX_ACP_THINKING_ALIASES = new Map<string, string | undefined>([
@@ -248,6 +250,10 @@ const CODEX_ACP_THINKING_ALIASES = new Map<string, string | undefined>([
 type CodexAcpModelOverride = {
   model?: string;
   reasoningEffort?: string;
+};
+
+type AgentLaunchOverride = CodexAcpModelOverride & {
+  thinking?: string;
 };
 
 function normalizeAgentName(value: string | undefined): string | undefined {
@@ -390,6 +396,46 @@ function isCodexAcpCommand(command: string | undefined): boolean {
   return /^codex-acp(?:-wrapper)?(?:\.[cm]?js)?$/i.test(scriptName);
 }
 
+function isGeminiAcpCommand(command: string | undefined): boolean {
+  if (!command) {
+    return false;
+  }
+  const parts = unwrapEnvCommand(splitCommandParts(command.trim()));
+  if (!parts.length) {
+    return false;
+  }
+  const commandName = basename(parts[0] ?? "");
+  return (
+    commandName === "gemini" && (parts.includes("--acp") || parts.includes("--experimental-acp"))
+  );
+}
+
+function isClaudeAcpPackageSpec(value: string): boolean {
+  return /^@agentclientprotocol\/claude-agent-acp(?:@.+)?$/i.test(value.trim());
+}
+
+function isClaudeAcpCommand(command: string | undefined): boolean {
+  if (!command) {
+    return false;
+  }
+  const parts = unwrapEnvCommand(splitCommandParts(command.trim()));
+  if (!parts.length) {
+    return false;
+  }
+  if (parts.some(isClaudeAcpPackageSpec)) {
+    return true;
+  }
+  const commandName = basename(parts[0] ?? "");
+  if (/^claude-agent-acp(?:\.exe)?$/i.test(commandName)) {
+    return true;
+  }
+  if (commandName !== "node") {
+    return false;
+  }
+  const scriptName = basename(parts[1] ?? "");
+  return /^claude-agent-acp(?:-wrapper)?(?:\.[cm]?js)?$/i.test(scriptName);
+}
+
 function failUnsupportedCodexAcpModel(rawModel: string, detail?: string): never {
   throw new AcpRuntimeError(
     "ACP_INVALID_RUNTIME_OPTION",
@@ -502,24 +548,66 @@ function appendCodexAcpConfigOverrides(command: string, override: CodexAcpModelO
   return `${command} ${configArgs.map((arg) => `-c ${quoteShellArg(arg)}`).join(" ")}`;
 }
 
+function appendGeminiAcpModelOverride(command: string, override: AgentLaunchOverride): string {
+  if (!override.model) {
+    return command;
+  }
+  return `${command} --model ${quoteShellArg(override.model)}`;
+}
+
+function appendClaudeAcpEnvOverrides(command: string, override: AgentLaunchOverride): string {
+  const entries: Array<[string, string]> = [];
+  if (override.model) {
+    entries.push(["ANTHROPIC_MODEL", override.model]);
+    entries.push(["CLAUDE_ACP_MODEL", override.model]);
+    entries.push(["CLAUDE_ACP_BAKE_MODEL", "1"]);
+    entries.push(["CLAUDE_AGENT_ACP_SKIP_INITIAL_SET_MODEL", "1"]);
+  }
+  if (override.model || override.thinking) {
+    entries.push(["CLAUDE_ACP_NO_EFFORT_APPLY", "1"]);
+  }
+  if (entries.length === 0) {
+    return command;
+  }
+  return `env ${entries.map(([key, value]) => `${key}=${quoteShellArg(value)}`).join(" ")} ${command}`;
+}
+
+function applyAgentLaunchOverride(params: {
+  agentName: string | undefined;
+  command: string | undefined;
+  override: AgentLaunchOverride | undefined;
+}): string | undefined {
+  if (!params.override || typeof params.command !== "string") {
+    return params.command;
+  }
+  if (params.agentName === CODEX_ACP_AGENT_ID && isCodexAcpCommand(params.command)) {
+    return appendCodexAcpConfigOverrides(params.command, params.override);
+  }
+  if (params.agentName === GEMINI_ACP_AGENT_ID && isGeminiAcpCommand(params.command)) {
+    return appendGeminiAcpModelOverride(params.command, params.override);
+  }
+  if (params.agentName === CLAUDE_ACP_AGENT_ID && isClaudeAcpCommand(params.command)) {
+    return appendClaudeAcpEnvOverrides(params.command, params.override);
+  }
+  return params.command;
+}
+
 function createModelScopedAgentRegistry(params: {
   agentRegistry: AcpAgentRegistry;
-  scope: AsyncLocalStorage<CodexAcpModelOverride | undefined>;
+  scope: AsyncLocalStorage<AgentLaunchOverride | undefined>;
   leaseCommand: (command: string | undefined) => string | undefined;
 }): AcpAgentRegistry {
   return {
     resolve(agentName: string): string | undefined {
       const command = params.agentRegistry.resolve(agentName);
       const override = params.scope.getStore();
-      if (
-        !override ||
-        normalizeAgentName(agentName) !== CODEX_ACP_AGENT_ID ||
-        typeof command !== "string" ||
-        !isCodexAcpCommand(command)
-      ) {
-        return params.leaseCommand(command);
-      }
-      return params.leaseCommand(appendCodexAcpConfigOverrides(command, override));
+      return params.leaseCommand(
+        applyAgentLaunchOverride({
+          agentName: normalizeAgentName(agentName),
+          command,
+          override,
+        }),
+      );
     },
     list(): string[] {
       return params.agentRegistry.list();
@@ -564,8 +652,8 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly sessionStore: ResetAwareSessionStore;
   private readonly agentRegistry: AcpAgentRegistry;
   private readonly scopedAgentRegistry: AcpAgentRegistry;
-  private readonly codexAcpModelOverrideScope = new AsyncLocalStorage<
-    CodexAcpModelOverride | undefined
+  private readonly agentLaunchOverrideScope = new AsyncLocalStorage<
+    AgentLaunchOverride | undefined
   >();
   private readonly delegate: BaseAcpxRuntime;
   private readonly bridgeSafeDelegate: BaseAcpxRuntime;
@@ -592,7 +680,7 @@ export class AcpxRuntime implements AcpRuntime {
     this.agentRegistry = options.agentRegistry;
     this.scopedAgentRegistry = createModelScopedAgentRegistry({
       agentRegistry: this.agentRegistry,
-      scope: this.codexAcpModelOverrideScope,
+      scope: this.agentLaunchOverrideScope,
       leaseCommand: (command) => this.commandWithLaunchLease(command),
     });
     const sharedOptions = {
@@ -821,13 +909,29 @@ export class AcpxRuntime implements AcpRuntime {
       agentRegistry: this.agentRegistry,
     });
     const delegate = this.resolveDelegateForCommand(command);
+    const agentName = normalizeAgentName(input.agent);
     const codexModelOverride =
-      normalizeAgentName(input.agent) === CODEX_ACP_AGENT_ID && isCodexAcpCommand(command)
+      agentName === CODEX_ACP_AGENT_ID && isCodexAcpCommand(command)
         ? normalizeCodexAcpModelOverride(input.model, input.thinking)
         : undefined;
+    const geminiModelOverride =
+      agentName === GEMINI_ACP_AGENT_ID && isGeminiAcpCommand(command) && input.model
+        ? { model: input.model }
+        : undefined;
+    const claudeModelOverride =
+      agentName === CLAUDE_ACP_AGENT_ID &&
+      isClaudeAcpCommand(command) &&
+      (input.model || input.thinking)
+        ? { model: input.model, thinking: input.thinking }
+        : undefined;
+    const launchOverride = codexModelOverride ?? geminiModelOverride ?? claudeModelOverride;
     const stableLaunchCommand =
-      codexModelOverride && command
-        ? appendCodexAcpConfigOverrides(command, codexModelOverride)
+      launchOverride && command
+        ? applyAgentLaunchOverride({
+            agentName,
+            command,
+            override: launchOverride,
+          })
         : command;
     const shouldStartWithLease = !(await this.canReuseStablePersistentSession({
       sessionKey: input.sessionKey,
@@ -837,7 +941,7 @@ export class AcpxRuntime implements AcpRuntime {
       resumeSessionId: input.resumeSessionId,
     }));
 
-    if (!codexModelOverride) {
+    if (!launchOverride) {
       return await this.runWithLaunchLease({
         sessionKey: input.sessionKey,
         command: stableLaunchCommand,
@@ -846,18 +950,16 @@ export class AcpxRuntime implements AcpRuntime {
       });
     }
 
-    const normalizedInput = {
-      ...input,
-      ...(codexAcpSessionModelId(codexModelOverride)
-        ? { model: codexAcpSessionModelId(codexModelOverride) }
-        : {}),
-    };
+    const normalizedInput =
+      codexModelOverride && codexAcpSessionModelId(codexModelOverride)
+        ? { ...input, model: codexAcpSessionModelId(codexModelOverride) }
+        : input;
     return await this.runWithLaunchLease({
       sessionKey: input.sessionKey,
       command: stableLaunchCommand,
       enabled: shouldStartWithLease,
       run: () =>
-        this.codexAcpModelOverrideScope.run(codexModelOverride, () =>
+        this.agentLaunchOverrideScope.run(launchOverride, () =>
           delegate.ensureSession(normalizedInput),
         ),
     });
@@ -889,6 +991,29 @@ export class AcpxRuntime implements AcpRuntime {
     const delegate = await this.resolveDelegateForHandle(input.handle);
     const command = await this.resolveCommandForHandle(input.handle);
     const key = input.key.trim().toLowerCase();
+    if (
+      isGeminiAcpCommand(command) &&
+      (key === "model" ||
+        key === "thinking" ||
+        key === "thought_level" ||
+        key === "reasoning_effort" ||
+        key === "timeout" ||
+        key === "timeout_seconds")
+    ) {
+      return;
+    }
+    if (
+      isClaudeAcpCommand(command) &&
+      (key === "model" ||
+        key === "thinking" ||
+        key === "thought_level" ||
+        key === "reasoning_effort" ||
+        key === "effort" ||
+        key === "timeout" ||
+        key === "timeout_seconds")
+    ) {
+      return;
+    }
     if (isCodexAcpCommand(command)) {
       if (key === "timeout" || key === "timeout_seconds") {
         return;
@@ -972,9 +1097,13 @@ export {
 
 export const __testing = {
   appendCodexAcpConfigOverrides,
+  appendClaudeAcpEnvOverrides,
+  appendGeminiAcpModelOverride,
   assertSupportedRuntimeSessionMode,
   codexAcpSessionModelId,
+  isClaudeAcpCommand,
   isCodexAcpCommand,
+  isGeminiAcpCommand,
   normalizeCodexAcpModelOverride,
 };
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -417,6 +417,7 @@ export function createOpenClawTools(
         ]),
     createSessionsYieldTool({
       sessionId: options?.sessionId,
+      agentSessionKey: options?.agentSessionKey,
       onYield: options?.onYield,
     }),
     createSubagentsTool({

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -5,6 +5,7 @@ type SessionsYieldDetails = {
   status?: string;
   message?: string;
   error?: string;
+  note?: string;
 };
 
 describe("sessions_yield tool", () => {
@@ -40,11 +41,20 @@ describe("sessions_yield tool", () => {
     expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker");
   });
 
-  it("returns error without onYield callback", async () => {
+  it("accepts yield for gateway agent session context without onYield callback", async () => {
+    const tool = createSessionsYieldTool({ agentSessionKey: "agent:foreman:discord:channel:123" });
+    const result = await tool.execute("call-1", {});
+    const details = result.details as SessionsYieldDetails;
+    expect(details.status).toBe("yielded");
+    expect(details.message).toBe("Turn yielded.");
+    expect(details.note).toContain("Yield accepted for this gateway session");
+  });
+
+  it("accepts yield for sessionId without onYield callback", async () => {
     const tool = createSessionsYieldTool({ sessionId: "test-session" });
     const result = await tool.execute("call-1", {});
     const details = result.details as SessionsYieldDetails;
-    expect(details.status).toBe("error");
-    expect(details.error).toBe("Yield not supported in this context");
+    expect(details.status).toBe("yielded");
+    expect(details.message).toBe("Turn yielded.");
   });
 });

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -8,6 +8,7 @@ const SessionsYieldToolSchema = Type.Object({
 
 export function createSessionsYieldTool(opts?: {
   sessionId?: string;
+  agentSessionKey?: string;
   onYield?: (message: string) => Promise<void> | void;
 }): AnyAgentTool {
   return {
@@ -19,11 +20,15 @@ export function createSessionsYieldTool(opts?: {
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const message = readStringParam(params, "message") || "Turn yielded.";
-      if (!opts?.sessionId) {
+      if (!opts?.sessionId && !opts?.agentSessionKey) {
         return jsonResult({ status: "error", error: "No session context" });
       }
       if (!opts?.onYield) {
-        return jsonResult({ status: "error", error: "Yield not supported in this context" });
+        return jsonResult({
+          status: "yielded",
+          message,
+          note: "Yield accepted for this gateway session; this runtime cannot interrupt the current model turn, but queued follow-up events can resume the session after the turn ends.",
+        });
       }
       await opts.onYield(message);
       return jsonResult({ status: "yielded", message });


### PR DESCRIPTION
## Summary

- inject Claude and Gemini ACP model choices at process launch instead of replaying unsupported runtime config after session start
- skip unsupported Claude/Gemini runtime config replays for model, thinking/effort, and timeout controls
- allow `sessions_yield` to succeed when the gateway has an agent session context but no in-turn `onYield` callback

## Context

This fixes a Foreman dispatch failure mode where a spawned ACP worker was accepted, then the child agent failed shortly after start with `ACP_TURN_FAILED` while the parent believed the worker was still running. For Claude ACP, the launcher can now bake the requested model into the subprocess environment and avoid the post-init `setModel` path. For Gemini ACP, the requested model is passed with `--model` at launch.

## Tests

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-acpx.config.ts extensions/acpx/src/runtime.test.ts`
- `node scripts/test-projects.mjs src/agents/tools/sessions-yield-tool.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts src/agents/openclaw-tools.ts src/agents/tools/sessions-yield-tool.ts src/agents/tools/sessions-yield-tool.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
