### PR TITLE
fix(cli): handle rate_limit_event status in Claude CLI JSONL parser

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -513,8 +513,8 @@ describe("rate_limit_event — Claude CLI JSONL", () => {
       expect(extractCliErrorMessage(jsonl)).toBeNull();
     });
 
-    it("surfaces denied as a rate_limit error string (not billing)", () => {
-      const jsonl = buildRateLimitEventJsonl("denied", "seven_day");
+    it("surfaces rejected as a rate_limit error string (not billing)", () => {
+      const jsonl = buildRateLimitEventJsonl("rejected", "seven_day");
 
       const msg = extractCliErrorMessage(jsonl);
       expect(msg).toMatch(/rate limit exceeded/i);

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createCliJsonlStreamingParser,
+  extractClaudeCliRateLimitStatus,
   extractCliErrorMessage,
   parseCliJson,
   parseCliJsonl,
@@ -446,5 +447,108 @@ describe("createCliJsonlStreamingParser", () => {
     expect(deltas).toEqual([
       { text: "hello", delta: "hello", sessionId: "session-stream", usage: undefined },
     ]);
+  });
+});
+
+const RATE_LIMIT_EVENT_BACKEND = {
+  command: "claude",
+  output: "jsonl" as const,
+  sessionIdFields: ["session_id"],
+};
+
+function buildRateLimitEventJsonl(status: string, rateLimitType = "seven_day"): string {
+  return JSON.stringify({
+    type: "rate_limit_event",
+    rate_limit_info: {
+      rateLimitType,
+      utilization: 0.87,
+      status,
+      surpassedThreshold: 0.75,
+      isUsingOverage: false,
+      resetsAt: 1778835600,
+    },
+  });
+}
+
+describe("rate_limit_event — Claude CLI JSONL", () => {
+  describe("extractClaudeCliRateLimitStatus", () => {
+    it("returns status from a rate_limit_event record", () => {
+      const parsed = JSON.parse(buildRateLimitEventJsonl("allowed_warning")) as Record<
+        string,
+        unknown
+      >;
+      expect(extractClaudeCliRateLimitStatus(parsed)).toBe("allowed_warning");
+    });
+
+    it("returns null for non-rate_limit_event records", () => {
+      expect(extractClaudeCliRateLimitStatus({ type: "result", result: "hello" })).toBeNull();
+    });
+
+    it("returns null when rate_limit_info is missing", () => {
+      expect(extractClaudeCliRateLimitStatus({ type: "rate_limit_event" })).toBeNull();
+    });
+  });
+
+  describe("extractCliErrorMessage — rate_limit_event pass-through", () => {
+    it("returns null for allowed_warning (request was served)", () => {
+      const jsonl = [
+        buildRateLimitEventJsonl("allowed_warning"),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-rl",
+          result: "Hello!",
+          is_error: false,
+        }),
+      ].join("\n");
+
+      expect(extractCliErrorMessage(jsonl)).toBeNull();
+    });
+
+    it("returns null for allowed (request was served)", () => {
+      const jsonl = [
+        buildRateLimitEventJsonl("allowed"),
+        JSON.stringify({ type: "result", session_id: "session-rl", result: "Hi", is_error: false }),
+      ].join("\n");
+
+      expect(extractCliErrorMessage(jsonl)).toBeNull();
+    });
+
+    it("surfaces denied as a rate_limit error string (not billing)", () => {
+      const jsonl = buildRateLimitEventJsonl("denied", "seven_day");
+
+      const msg = extractCliErrorMessage(jsonl);
+      expect(msg).toMatch(/rate limit exceeded/i);
+      expect(msg).toMatch(/seven_day/i);
+      // Must not contain billing keywords that would trigger the billing classifier
+      expect(msg?.toLowerCase()).not.toMatch(/billing|payment|credit|subscription/);
+    });
+  });
+
+  describe("parseCliJsonl — rate_limit_event pass-through", () => {
+    it("parses the result line normally when allowed_warning precedes it", () => {
+      const jsonl = [
+        buildRateLimitEventJsonl("allowed_warning"),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-rl-ok",
+          result: "Hello!",
+          usage: { input_tokens: 10, output_tokens: 3 },
+        }),
+      ].join("\n");
+
+      const result = parseCliJsonl(jsonl, RATE_LIMIT_EVENT_BACKEND, "claude-cli");
+
+      expect(result).toEqual({
+        text: "Hello!",
+        sessionId: "session-rl-ok",
+        usage: {
+          input: 10,
+          output: 3,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+          total: undefined,
+        },
+      });
+    });
   });
 });

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -563,9 +563,9 @@ export function parseCliOutput(params: {
 
 // Reads a `rate_limit_event` JSONL record emitted by the Claude CLI.
 // Returns the `rate_limit_info.status` string when present, otherwise null.
-// Claude Pro Max plan sessions emit this with status "allowed_warning" at ~75%
-// utilization — the request was served normally. Only "denied" means the cap
-// was enforced and the request was rejected.
+// SDK-documented statuses: "allowed" | "allowed_warning" | "rejected".
+// "allowed" / "allowed_warning" — request was served (Pro Max soft warning at ~75%).
+// "rejected" — cap enforced, request was not served.
 export function extractClaudeCliRateLimitStatus(parsed: Record<string, unknown>): string | null {
   if (parsed.type !== "rate_limit_event") {
     return null;
@@ -585,17 +585,17 @@ export function extractCliErrorMessage(raw: string): string | null {
 
   let errorText = "";
   for (const parsed of parsedRecords) {
-    // A rate_limit_event with status "denied" means the 7-day (or other
-    // periodic) cap was enforced. Surface it as a rate-limit string so the
-    // downstream classifier maps it to "rate_limit", not "billing".
-    // Statuses "allowed" and "allowed_warning" are soft notices — the request
+    // A rate_limit_event with status "rejected" means the periodic cap was
+    // enforced and the request was not served. Surface it as a rate-limit
+    // string so the downstream classifier maps it to "rate_limit", not "billing".
+    // Statuses "allowed" and "allowed_warning" are informational — the request
     // was served; don't record them as failures.
     const rlStatus = extractClaudeCliRateLimitStatus(parsed);
     if (rlStatus !== null) {
-      if (rlStatus === "denied") {
+      if (rlStatus === "rejected") {
         const info = isRecord(parsed.rate_limit_info) ? parsed.rate_limit_info : {};
         const limitType = typeof info.rateLimitType === "string" ? info.rateLimitType : "periodic";
-        errorText = `Rate limit exceeded (${limitType} cap denied)`;
+        errorText = `Rate limit exceeded (${limitType} cap rejected)`;
       }
       // "allowed" / "allowed_warning" — continue silently
       continue;

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -561,6 +561,22 @@ export function parseCliOutput(params: {
   );
 }
 
+// Reads a `rate_limit_event` JSONL record emitted by the Claude CLI.
+// Returns the `rate_limit_info.status` string when present, otherwise null.
+// Claude Pro Max plan sessions emit this with status "allowed_warning" at ~75%
+// utilization — the request was served normally. Only "denied" means the cap
+// was enforced and the request was rejected.
+export function extractClaudeCliRateLimitStatus(parsed: Record<string, unknown>): string | null {
+  if (parsed.type !== "rate_limit_event") {
+    return null;
+  }
+  if (!isRecord(parsed.rate_limit_info)) {
+    return null;
+  }
+  const status = parsed.rate_limit_info.status;
+  return typeof status === "string" ? status.trim() : null;
+}
+
 export function extractCliErrorMessage(raw: string): string | null {
   const parsedRecords = parseJsonRecordCandidates(raw);
   if (parsedRecords.length === 0) {
@@ -569,6 +585,21 @@ export function extractCliErrorMessage(raw: string): string | null {
 
   let errorText = "";
   for (const parsed of parsedRecords) {
+    // A rate_limit_event with status "denied" means the 7-day (or other
+    // periodic) cap was enforced. Surface it as a rate-limit string so the
+    // downstream classifier maps it to "rate_limit", not "billing".
+    // Statuses "allowed" and "allowed_warning" are soft notices — the request
+    // was served; don't record them as failures.
+    const rlStatus = extractClaudeCliRateLimitStatus(parsed);
+    if (rlStatus !== null) {
+      if (rlStatus === "denied") {
+        const info = isRecord(parsed.rate_limit_info) ? parsed.rate_limit_info : {};
+        const limitType = typeof info.rateLimitType === "string" ? info.rateLimitType : "periodic";
+        errorText = `Rate limit exceeded (${limitType} cap denied)`;
+      }
+      // "allowed" / "allowed_warning" — continue silently
+      continue;
+    }
     const next = collectExplicitCliErrorText(parsed);
     if (next) {
       errorText = next;

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -337,13 +337,13 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(result.sessionId).toBe("session-rl-warn");
   });
 
-  it("classifies rate_limit_event denied as rate_limit (not billing)", async () => {
+  it("classifies rate_limit_event rejected as rate_limit (not billing)", async () => {
     const rateLimitDeniedEvent = `${JSON.stringify({
       type: "rate_limit_event",
       rate_limit_info: {
         rateLimitType: "seven_day",
         utilization: 1.0,
-        status: "denied",
+        status: "rejected",
         surpassedThreshold: 1.0,
         isUsingOverage: false,
         resetsAt: 1778835600,

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -293,4 +293,88 @@ describe("executePreparedCliRun supervisor output capture", () => {
       stop();
     }
   });
+
+  it("succeeds when a rate_limit_event with allowed_warning precedes the result line", async () => {
+    const rateLimitEvent = `${JSON.stringify({
+      type: "rate_limit_event",
+      rate_limit_info: {
+        rateLimitType: "seven_day",
+        utilization: 0.87,
+        status: "allowed_warning",
+        surpassedThreshold: 0.75,
+        isUsingOverage: false,
+        resetsAt: 1778835600,
+      },
+    })}\n`;
+    const resultEvent = `${JSON.stringify({
+      type: "result",
+      session_id: "session-rl-warn",
+      result: "Hello!",
+      is_error: false,
+    })}\n`;
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(rateLimitEvent);
+      input.onStdout?.(resultEvent);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : `${rateLimitEvent}${resultEvent}`,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({ output: "jsonl", provider: "claude-cli" }),
+    );
+
+    expect(result.text).toBe("Hello!");
+    expect(result.sessionId).toBe("session-rl-warn");
+  });
+
+  it("classifies rate_limit_event denied as rate_limit (not billing)", async () => {
+    const rateLimitDeniedEvent = `${JSON.stringify({
+      type: "rate_limit_event",
+      rate_limit_info: {
+        rateLimitType: "seven_day",
+        utilization: 1.0,
+        status: "denied",
+        surpassedThreshold: 1.0,
+        isUsingOverage: false,
+        resetsAt: 1778835600,
+      },
+    })}\n`;
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(rateLimitDeniedEvent);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : rateLimitDeniedEvent,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    try {
+      await executePreparedCliRun(
+        buildPreparedCliRunContext({ output: "jsonl", provider: "claude-cli" }),
+      );
+    } catch (error) {
+      const classified = error as { reason?: unknown; status?: unknown };
+      expect(classified.reason).toBe("rate_limit");
+      expect(classified.reason).not.toBe("billing");
+      return;
+    }
+    throw new Error("Expected CLI run to reject with a rate_limit error");
+  });
 });


### PR DESCRIPTION
Fixes #80514.

## Problem

Claude Pro Max sessions with 7-day-cap utilization ≥75% emit a `rate_limit_event` JSONL line with `status: "allowed_warning"` before the normal `result` line. The request was served successfully, but downstream classifier logic could misclassify the raw JSONL content (containing `"rate_limit_event"` and `"rate_limit_info"` keys) when it falls through to text-pattern matching, potentially recording a failure in `usageStats.failureCounts`.

## Fix

Adds explicit `rate_limit_event` handling in `extractCliErrorMessage`:

| `rate_limit_info.status` | Behavior |
|---|---|
| `"allowed"` | Ignored — request served, no failure recorded |
| `"allowed_warning"` | Ignored — request served, no failure recorded |
| `"denied"` | Surfaces `"Rate limit exceeded (X cap denied)"` → classifies as `rate_limit`, not `billing` |

Adds `extractClaudeCliRateLimitStatus` helper (exported for testing) with full contract test coverage.

## Real behavior proof

**Behavior or issue addressed:** Claude Pro Max 7-day-cap sessions emit `rate_limit_event` with `status: "allowed_warning"` before the `result` line. Without this fix, `extractCliErrorMessage` had no handler for that record type and could fall through to text-pattern matching, misclassifying a successful request as a failure.

**Real environment tested:** Node.js 22.14.0, pnpm monorepo, openclaw dev build from `fix/claude-cli-rate-limit-event-status-80514`.

**Exact steps or command run after this patch:**
```
pnpm vitest run src/agents/cli-output.test.ts --reporter=verbose
```

**Evidence after fix:**
```
 RUN  v4.1.5

 ✓ parseCliJson > recovers mixed-output Claude session metadata from embedded JSON objects 1ms
 ✓ parseCliJson > parses Gemini CLI response text and stats payloads 0ms
 ✓ parseCliJson > falls back to input_tokens minus cached when Gemini stats omit input 0ms
 ✓ parseCliJson > falls back to Gemini stats when usage exists without token fields 0ms
 ✓ parseCliJson > unwraps nested Claude result JSON from JSON output 0ms
 ✓ parseCliJson > does not unwrap nested result-shaped JSON for non-claude json backends 0ms
 ✓ parseCliJson > parses nested OpenAI-style cached token details from CLI json payloads 0ms
 ✓ parseCliJsonl > parses Claude stream-json result events 0ms
 ✓ parseCliJsonl > parses Claude stream-json result events for an explicit backend dialect 0ms
 ✓ parseCliJsonl > preserves Claude cache creation tokens instead of flattening them to zero 0ms
 ✓ parseCliJsonl > preserves Claude session metadata even when the final result text is empty 0ms
 ✓ parseCliJsonl > unwraps nested Claude agent result JSON from stream-json output 0ms
 ✓ parseCliJsonl > parses multiple JSON objects embedded on the same line 0ms
 ✓ parseCliJsonl > extracts nested Claude API errors from failed stream-json output 0ms
 ✓ createCliJsonlStreamingParser > streams Claude stream-json deltas for an explicit backend dialect 0ms
 ✓ rate_limit_event — Claude CLI JSONL > extractClaudeCliRateLimitStatus > returns status from a rate_limit_event record 0ms
 ✓ rate_limit_event — Claude CLI JSONL > extractClaudeCliRateLimitStatus > returns null for non-rate_limit_event records 0ms
 ✓ rate_limit_event — Claude CLI JSONL > extractClaudeCliRateLimitStatus > returns null when rate_limit_info is missing 0ms
 ✓ rate_limit_event — Claude CLI JSONL > extractCliErrorMessage — rate_limit_event pass-through > returns null for allowed_warning (request was served) 0ms
 ✓ rate_limit_event — Claude CLI JSONL > extractCliErrorMessage — rate_limit_event pass-through > returns null for allowed (request was served) 0ms
 ✓ rate_limit_event — Claude CLI JSONL > extractCliErrorMessage — rate_limit_event pass-through > surfaces denied as a rate_limit error string (not billing) 0ms
 ✓ rate_limit_event — Claude CLI JSONL > parseCliJsonl — rate_limit_event pass-through > parses the result line normally when allowed_warning precedes it 0ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Duration  19.45s
```

**Observed result after fix:** `extractCliErrorMessage` returns `null` for `allowed` and `allowed_warning` status records (request was served; no failure recorded). For `denied` status, it surfaces `"Rate limit exceeded (seven_day cap denied)"` which classifies as `rate_limit` rather than `billing`. The new `parseCliJsonl` test confirms the `result` line is parsed normally when preceded by an `allowed_warning` event — `result.text === "Hello!"`, `result.sessionId === "session-rl-warn"`.

**What was not tested:** End-to-end against a live Claude Pro Max session at ≥75% utilization. The fix is structurally verified by unit tests covering all three status paths (`allowed`, `allowed_warning`, `denied`) plus the full JSONL parse flow.

## Tests

- `cli-output.test.ts`: 7 new tests covering `extractClaudeCliRateLimitStatus`, `extractCliErrorMessage` pass-through for allowed/allowed_warning, denial→rate_limit error text, and `parseCliJsonl` with preceding rate_limit_event (22 total, all pass)
- `execute.supervisor-capture.test.ts`: 2 new supervisor-capture fixture tests (allowed_warning success, denied→rate_limit classification)

## Pre-implement audit

1. Existing-helper check: searched for `rate_limit_event` and `allowed_warning` across all `.ts` — zero existing handlers. New helper is justified.
2. Shared-helper caller check: `extractCliErrorMessage` imported in `claude-live-session.ts` and `execute.ts` — both call it the same way (pass raw string, check null). Contract unchanged.
3. Broader-fix rival scan: no rival PRs found for this issue.