### PR TITLE
fix(telegram): make pre-connect network failures recoverable in send context

### DIFF
--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -129,11 +129,13 @@ describe("isRecoverableTelegramNetworkError", () => {
     ).toBe(true);
   });
 
-  it("skips broad message matches for send context", () => {
+  it("recovers from bare grammy network-request pre-connect failures in send context", () => {
     const networkRequestErr = new Error("Network request for 'sendMessage' failed!");
-    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(false);
+    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(true);
     expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "polling" })).toBe(true);
+  });
 
+  it("recovers from undici socket failures via snippet match in polling context", () => {
     const undiciSnippetErr = new Error("Undici: socket failure");
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "send" })).toBe(false);
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "polling" })).toBe(true);

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -127,11 +127,13 @@ describe("isRecoverableTelegramNetworkError", () => {
     ).toBe(true);
   });
 
-  it("skips broad message matches for send context", () => {
+  it("recovers from bare grammy network-request pre-connect failures in send context", () => {
     const networkRequestErr = new Error("Network request for 'sendMessage' failed!");
-    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(false);
+    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(true);
     expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "polling" })).toBe(true);
+  });
 
+  it("recovers from undici socket failures via snippet match in polling context", () => {
     const undiciSnippetErr = new Error("Undici: socket failure");
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "send" })).toBe(false);
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "polling" })).toBe(true);

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -59,7 +59,7 @@ const RECOVERABLE_ERROR_NAMES = new Set([
 
 const ALWAYS_RECOVERABLE_MESSAGES = new Set(["fetch failed", "typeerror: fetch failed"]);
 const GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE =
-  /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed\s+after\b.*[!.]?$/i;
+  /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed(?:\s+after\b.*)?[!.]?$/i;
 
 const RECOVERABLE_MESSAGE_SNIPPETS = [
   "undici",

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -55,7 +55,7 @@ const RECOVERABLE_ERROR_NAMES = new Set([
 
 const ALWAYS_RECOVERABLE_MESSAGES = new Set(["fetch failed", "typeerror: fetch failed"]);
 const GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE =
-  /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed\s+after\b.*[!.]?$/i;
+  /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed(?:\s+after\b.*)?[!.]?$/i;
 
 const RECOVERABLE_MESSAGE_SNIPPETS = [
   "undici",


### PR DESCRIPTION
## Summary

grammy's Telegram bot library can emit bare `"Network request for 'X' failed!"` errors for pre-connect failures (DNS resolution, TLS handshake, etc.) — errors that are safe to retry since the request never reached Telegram's servers.

The existing regex `GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE` required the `"\s+after\b"` clause, so these bare pre-connect failures were not classified as recoverable in `context: send` and messages were dropped instead of retried.

## Fix

Relax the regex to make `"after"` optional:

```diff
- const GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE =
-   /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed\s+after.*[!.]?$/i;
+ const GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE =
+   /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed(?:\s+after.*)?[!.]?$/i;
```

| Message | Before | After |
|---------|--------|-------|
| `Network request for 'sendMessage' failed after 2 attempts.` | ✅ recoverable | ✅ recoverable |
| `Network request for 'sendMessage' failed!` | ❌ dropped | ✅ recoverable |
| `Network request for 'X' failed!` | ❌ dropped | ✅ recoverable |

The existing test case covering `"failed after N attempts."` continues to pass — only the pre-connect failure path is corrected.

## Verification

- Regex behavior verified against known grammy error message patterns
- Existing `"failed after N attempts."` test case still passes (same behavior)
- TypeScript syntax check: clean
- 2 files changed, 5 insertions, 3 deletions

Closes #80362
