### PR TITLE
fix(test): restore TypeScript narrowing guards in inbound-dedupe tests after 4fe81c7d9f

### DIFF
--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -75,6 +75,7 @@ describe("inbound dedupe", () => {
     try {
       const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
       expect(firstClaim).toEqual({ status: "claimed", key: expectedKey });
+      if (firstClaim.status !== "claimed") throw new Error("expected claimed status");
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "inflight",
         key: expectedKey,
@@ -110,6 +111,7 @@ describe("inbound dedupe", () => {
     try {
       const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
       expect(firstClaim).toEqual({ status: "claimed", key: expectedKey });
+      if (firstClaim.status !== "claimed") throw new Error("expected claimed status");
       inboundA.commitInboundDedupe(firstClaim.key);
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "duplicate",

--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -75,7 +75,9 @@ describe("inbound dedupe", () => {
     try {
       const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
       expect(firstClaim).toEqual({ status: "claimed", key: expectedKey });
-      if (firstClaim.status !== "claimed") throw new Error("expected claimed status");
+      if (firstClaim.status !== "claimed") {
+        throw new Error("expected claimed status");
+      }
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "inflight",
         key: expectedKey,
@@ -111,7 +113,9 @@ describe("inbound dedupe", () => {
     try {
       const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
       expect(firstClaim).toEqual({ status: "claimed", key: expectedKey });
-      if (firstClaim.status !== "claimed") throw new Error("expected claimed status");
+      if (firstClaim.status !== "claimed") {
+        throw new Error("expected claimed status");
+      }
       inboundA.commitInboundDedupe(firstClaim.key);
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "duplicate",


### PR DESCRIPTION
Fixes #80529.

## Problem

Commit `4fe81c7d9f` ("test: tighten inbound dedupe assertions") removed the
`if (firstClaim.status !== "claimed") throw` type guards that preceded `.key`
accesses, replacing them with `expect().toEqual()` assertions. TypeScript does
not narrow discriminated-union types through vitest `expect` calls, so
`check-test-types` now fails with:

```
src/auto-reply/reply/inbound-dedupe.test.ts(82,48): error TS2339:
  Property 'key' does not exist on type 'InboundDedupeClaimResult'.
  Property 'key' does not exist on type '{ status: "invalid"; }'.
src/auto-reply/reply/inbound-dedupe.test.ts(113,47): error TS2339: (same)
```

`InboundDedupeClaimResult` is `{ status: "invalid" } | { status: "duplicate"; key: string } | { status: "inflight"; key: string } | { status: "claimed"; key: string }`. After `claimInboundDedupe` returns, TypeScript still considers the `invalid` variant possible, so `.key` is not provably safe.

## Fix

Re-add minimal `if (status !== "claimed") throw` narrowing guards immediately after the `expect().toEqual()` assertions on lines 77 and 112. The runtime behaviour and test assertions are unchanged; the guards only exist to give TypeScript proof that the `claimed` branch is selected.

## Real behavior proof

**Behavior or issue addressed:** `check-test-types` CI was broken repo-wide after `4fe81c7d9f` landed on `main`. Any PR rebased on or branched from that commit inherits the failure.

**Real environment tested:** Node.js v22.14.0, pnpm monorepo, tsgo type check via `node_modules/.bin/tsgo -p test/tsconfig/tsconfig.core.test.json --noEmit`.

**Exact steps or command run after this patch:**
```
node_modules/.bin/tsgo -p test/tsconfig/tsconfig.core.test.json --noEmit
echo "exit: $?"
```

**Evidence after fix:**
```
exit: 0
```
No TS2339 errors on `inbound-dedupe.test.ts`. Full tsgo run completes clean.

**Observed result after fix:** `check-test-types` passes. The two narrowing guards give TypeScript proof of the `claimed` discriminant before `.key` is accessed.

**What was not tested:** Runtime test execution (vitest run) — the change is test-types-only; the vitest runtime already passed before this fix since JS does not enforce TS narrowing.