### PR TITLE
Add native subagent completion ownership

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -288,9 +288,16 @@ async function deliverTelegramDirectMessageCompletion(params: {
     to: "123456789",
     accountId: "bot-1",
   };
-  const requesterSessionKey = params.requesterSessionKey ?? "agent:main:telegram:123456789";
+  const requesterSessionKey = params.requesterSessionKey ?? "agent:main:telegram:direct:123456789";
   testing.setDepsForTest({
     callGateway: params.callGateway,
+    dispatchGatewayMethodInProcess: (async (method, agentParams, options) =>
+      await params.callGateway({
+        method,
+        params: agentParams,
+        expectFinal: options?.expectFinal,
+        timeoutMs: options?.timeoutMs,
+      })) as typeof runtimeDispatchGatewayMethodInProcess,
     getRequesterSessionActivity: () => ({
       sessionId:
         params.requesterSessionId === null
@@ -298,7 +305,11 @@ async function deliverTelegramDirectMessageCompletion(params: {
           : (params.requesterSessionId ?? "requester-session-telegram"),
       isActive: params.isActive === true,
     }),
-    getRuntimeConfig: () => (params.runtimeConfig ?? {}) as never,
+    getRuntimeConfig: () =>
+      (params.runtimeConfig ?? {
+        plugins: { enabled: false },
+        session: { store: "/tmp/openclaw-subagent-announce-delivery-empty-sessions.json" },
+      }) as never,
     sendMessage: params.sendMessage ?? runtimeSendMessage,
     ...(params.queueEmbeddedAgentMessageWithOutcome
       ? { queueEmbeddedAgentMessageWithOutcome: params.queueEmbeddedAgentMessageWithOutcome }
@@ -2014,6 +2025,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         accountId: "bot-1",
       },
       runtimeConfig: {
+        plugins: { enabled: false },
+        session: { store: "/tmp/openclaw-subagent-announce-delivery-empty-sessions.json" },
         agents: {
           defaults: {
             subagents: {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -621,6 +621,130 @@ describe("resolveSubagentCompletionOrigin", () => {
       to: "telegram:direct:123",
     });
   });
+
+  it("skips the child binding when requester-session-final owns completion delivery", async () => {
+    registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "acct-1",
+      listBySession: (targetSessionKey: string) => {
+        if (targetSessionKey === "agent:worker:subagent:child") {
+          return [
+            {
+              bindingId: "discord:acct-1:child-thread",
+              targetSessionKey,
+              targetKind: "subagent",
+              conversation: {
+                channel: "discord",
+                accountId: "acct-1",
+                conversationId: "child-thread",
+              },
+              status: "active",
+              boundAt: 1,
+            },
+          ];
+        }
+        if (targetSessionKey === "agent:main:main") {
+          return [
+            {
+              bindingId: "discord:acct-1:requester-thread",
+              targetSessionKey,
+              targetKind: "session",
+              conversation: {
+                channel: "discord",
+                accountId: "acct-1",
+                conversationId: "requester-thread",
+              },
+              status: "active",
+              boundAt: 1,
+            },
+          ];
+        }
+        return [];
+      },
+      resolveByConversation: () => null,
+    });
+
+    const origin = await resolveSubagentCompletionOrigin({
+      childSessionKey: "agent:worker:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: {
+        channel: "discord",
+        accountId: "acct-1",
+        to: "channel:requester-thread",
+      },
+      spawnMode: "session",
+      expectsCompletionMessage: true,
+      completionOwner: "requester-session-final",
+    });
+
+    expect(origin).toEqual({
+      channel: "discord",
+      accountId: "acct-1",
+      to: "channel:requester-thread",
+    });
+  });
+
+  it("skips the child binding when origin-bridge-final owns completion delivery", async () => {
+    registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "acct-1",
+      listBySession: (targetSessionKey: string) => {
+        if (targetSessionKey === "agent:worker:subagent:child") {
+          return [
+            {
+              bindingId: "discord:acct-1:child-thread",
+              targetSessionKey,
+              targetKind: "subagent",
+              conversation: {
+                channel: "discord",
+                accountId: "acct-1",
+                conversationId: "child-thread",
+              },
+              status: "active",
+              boundAt: 1,
+            },
+          ];
+        }
+        if (targetSessionKey === "agent:main:main") {
+          return [
+            {
+              bindingId: "discord:acct-1:origin-thread",
+              targetSessionKey,
+              targetKind: "session",
+              conversation: {
+                channel: "discord",
+                accountId: "acct-1",
+                conversationId: "origin-thread",
+              },
+              status: "active",
+              boundAt: 1,
+            },
+          ];
+        }
+        return [];
+      },
+      resolveByConversation: () => null,
+    });
+
+    const origin = await resolveSubagentCompletionOrigin({
+      childSessionKey: "agent:worker:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: {
+        channel: "discord",
+        accountId: "acct-1",
+        to: "channel:origin-thread",
+      },
+      spawnMode: "session",
+      expectsCompletionMessage: true,
+      completionOwner: "origin-bridge-final",
+    });
+
+    expect(origin).toEqual({
+      channel: "discord",
+      accountId: "acct-1",
+      to: "channel:origin-thread",
+    });
+  });
 });
 
 describe("deliverSubagentAnnouncement active requester steering", () => {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -59,7 +59,8 @@ import {
   runSubagentAnnounceDispatch,
   type SubagentAnnounceDeliveryResult,
 } from "./subagent-announce-dispatch.js";
-import type { DeliveryContext } from "./subagent-announce-origin.js";
+import { resolveAnnounceOrigin, type DeliveryContext } from "./subagent-announce-origin.js";
+import type { SubagentCompletionOwner } from "./subagent-completion-owner.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
@@ -451,6 +452,7 @@ export async function resolveSubagentCompletionOrigin(params: {
   childRunId?: string;
   spawnMode?: SpawnSubagentMode;
   expectsCompletionMessage: boolean;
+  completionOwner?: SubagentCompletionOwner;
 }): Promise<DeliveryContext | undefined> {
   const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   const channel = normalizeOptionalLowercaseString(requesterOrigin?.channel);
@@ -470,38 +472,43 @@ export async function resolveSubagentCompletionOrigin(params: {
     channel && conversationId ? { channel, accountId, conversationId } : undefined;
 
   const router = createBoundDeliveryRouter();
-  const requesterRoute = router.resolveDestination({
-    eventKind: "task_completion",
-    targetSessionKey: params.requesterSessionKey,
-    requester: requesterConversation,
-    failClosed: true,
-  });
-  if (requesterRoute.mode === "bound" && requesterRoute.binding) {
+  const resolveBoundOriginForSession = (targetSessionKey: string): DeliveryContext | undefined => {
+    const route = router.resolveDestination({
+      eventKind: "task_completion",
+      targetSessionKey,
+      requester: requesterConversation,
+      failClosed: true,
+    });
+    if (route.mode !== "bound" || !route.binding) {
+      return undefined;
+    }
     return mergeDeliveryContext(
       resolveBoundConversationOrigin({
-        bindingConversation: requesterRoute.binding.conversation,
+        bindingConversation: route.binding.conversation,
         requesterConversation,
         requesterOrigin,
       }),
       requesterOrigin,
     );
+  };
+
+  if (params.completionOwner === "work-thread-final") {
+    const childOrigin = resolveBoundOriginForSession(params.childSessionKey);
+    if (childOrigin) {
+      return childOrigin;
+    }
   }
 
-  const childRoute = router.resolveDestination({
-    eventKind: "task_completion",
-    targetSessionKey: params.childSessionKey,
-    requester: requesterConversation,
-    failClosed: true,
-  });
-  if (childRoute.mode === "bound" && childRoute.binding) {
-    return mergeDeliveryContext(
-      resolveBoundConversationOrigin({
-        bindingConversation: childRoute.binding.conversation,
-        requesterConversation,
-        requesterOrigin,
-      }),
-      requesterOrigin,
-    );
+  const requesterBoundOrigin = resolveBoundOriginForSession(params.requesterSessionKey);
+  if (requesterBoundOrigin) {
+    return requesterBoundOrigin;
+  }
+
+  if (params.completionOwner === undefined) {
+    const childOrigin = resolveBoundOriginForSession(params.childSessionKey);
+    if (childOrigin) {
+      return childOrigin;
+    }
   }
 
   const hookRunner = getGlobalHookRunner();
@@ -517,6 +524,7 @@ export async function resolveSubagentCompletionOrigin(params: {
         childRunId: params.childRunId,
         spawnMode: params.spawnMode,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        completionOwner: params.completionOwner,
       },
       {
         runId: params.childRunId,
@@ -981,6 +989,7 @@ async function sendSubagentAnnounceDirectly(params: {
   sourceChannel?: string;
   sourceTool?: string;
   requesterIsSubagent: boolean;
+  completionOwner?: SubagentCompletionOwner;
   signal?: AbortSignal;
 }): Promise<SubagentAnnounceDeliveryResult> {
   if (params.signal?.aborted) {
@@ -1356,6 +1365,7 @@ export async function deliverSubagentAnnouncement(params: {
   targetRequesterSessionKey: string;
   requesterIsSubagent: boolean;
   expectsCompletionMessage: boolean;
+  completionOwner?: SubagentCompletionOwner;
   bestEffortDeliver?: boolean;
   directIdempotencyKey: string;
   signal?: AbortSignal;
@@ -1387,6 +1397,7 @@ export async function deliverSubagentAnnouncement(params: {
         sourceTool: params.sourceTool,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        completionOwner: params.completionOwner,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
       }),

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -59,7 +59,7 @@ import {
   runSubagentAnnounceDispatch,
   type SubagentAnnounceDeliveryResult,
 } from "./subagent-announce-dispatch.js";
-import { resolveAnnounceOrigin, type DeliveryContext } from "./subagent-announce-origin.js";
+import type { DeliveryContext } from "./subagent-announce-origin.js";
 import type { SubagentCompletionOwner } from "./subagent-completion-owner.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -44,6 +44,7 @@ import {
   getRuntimeConfig,
   waitForEmbeddedAgentRunEnd,
 } from "./subagent-announce.runtime.js";
+import type { SubagentCompletionOwner } from "./subagent-completion-owner.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
@@ -247,6 +248,7 @@ export async function runSubagentAnnounceFlow(params: {
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
   expectsCompletionMessage?: boolean;
+  completionOwner?: SubagentCompletionOwner;
   spawnMode?: SpawnSubagentMode;
   wakeOnDescendantSettle?: boolean;
   signal?: AbortSignal;
@@ -543,6 +545,7 @@ export async function runSubagentAnnounceFlow(params: {
             childRunId: params.childRunId,
             spawnMode: params.spawnMode,
             expectsCompletionMessage,
+            completionOwner: params.completionOwner,
           })
         : targetRequesterOrigin;
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);
@@ -566,6 +569,7 @@ export async function runSubagentAnnounceFlow(params: {
       targetRequesterSessionKey,
       requesterIsSubagent,
       expectsCompletionMessage: expectsCompletionMessage,
+      completionOwner: params.completionOwner,
       bestEffortDeliver: params.bestEffortDeliver,
       directIdempotencyKey,
       signal: params.signal,

--- a/src/agents/subagent-completion-owner.test.ts
+++ b/src/agents/subagent-completion-owner.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  completionOwnerNeedsRequesterFinal,
+  normalizeSubagentCompletionOwner,
+  resolveSubagentCompletionOwner,
+} from "./subagent-completion-owner.js";
+
+describe("subagent completion owner", () => {
+  it("normalizes only supported owner values", () => {
+    expect(normalizeSubagentCompletionOwner("work-thread-final")).toBe("work-thread-final");
+    expect(normalizeSubagentCompletionOwner(" requester-session-final ")).toBe(
+      "requester-session-final",
+    );
+    expect(normalizeSubagentCompletionOwner("unknown")).toBeUndefined();
+    expect(normalizeSubagentCompletionOwner(undefined)).toBeUndefined();
+  });
+
+  it("defaults thread-bound direct delivery to work-thread ownership", () => {
+    expect(
+      resolveSubagentCompletionOwner({
+        expectsCompletionMessage: true,
+        threadBoundDirectDelivery: true,
+      }),
+    ).toBe("work-thread-final");
+  });
+
+  it("defaults requester completion flows to requester-session ownership", () => {
+    expect(
+      resolveSubagentCompletionOwner({
+        expectsCompletionMessage: true,
+        threadBoundDirectDelivery: false,
+      }),
+    ).toBe("requester-session-final");
+  });
+
+  it("respects explicit none and requester-final owners", () => {
+    expect(
+      resolveSubagentCompletionOwner({
+        requestedOwner: "none",
+        expectsCompletionMessage: true,
+        threadBoundDirectDelivery: true,
+      }),
+    ).toBe("none");
+    expect(completionOwnerNeedsRequesterFinal("none")).toBe(false);
+    expect(completionOwnerNeedsRequesterFinal("requester-session-final")).toBe(true);
+    expect(completionOwnerNeedsRequesterFinal("origin-bridge-final")).toBe(true);
+  });
+});

--- a/src/agents/subagent-completion-owner.ts
+++ b/src/agents/subagent-completion-owner.ts
@@ -1,0 +1,44 @@
+export const SUBAGENT_COMPLETION_OWNERS = [
+  "requester-session-final",
+  "work-thread-final",
+  "origin-bridge-final",
+  "none",
+] as const;
+
+export type SubagentCompletionOwner = (typeof SUBAGENT_COMPLETION_OWNERS)[number];
+
+const SUBAGENT_COMPLETION_OWNER_SET = new Set<string>(SUBAGENT_COMPLETION_OWNERS);
+
+export function normalizeSubagentCompletionOwner(
+  value: unknown,
+): SubagentCompletionOwner | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return SUBAGENT_COMPLETION_OWNER_SET.has(normalized)
+    ? (normalized as SubagentCompletionOwner)
+    : undefined;
+}
+
+export function completionOwnerNeedsRequesterFinal(owner: SubagentCompletionOwner): boolean {
+  return owner === "requester-session-final" || owner === "origin-bridge-final";
+}
+
+export function resolveSubagentCompletionOwner(params: {
+  requestedOwner?: unknown;
+  expectsCompletionMessage: boolean;
+  threadBoundDirectDelivery: boolean;
+}): SubagentCompletionOwner {
+  const requested = normalizeSubagentCompletionOwner(params.requestedOwner);
+  if (requested) {
+    return requested;
+  }
+  if (params.threadBoundDirectDelivery) {
+    return "work-thread-final";
+  }
+  if (params.expectsCompletionMessage) {
+    return "requester-session-final";
+  }
+  return "none";
+}

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -493,6 +493,7 @@ export function createSubagentRegistryLifecycleController(params: {
       outcome: entry.delivery?.payload?.outcome ?? entry.outcome,
       expectsCompletionMessage:
         entry.delivery?.payload?.expectsCompletionMessage ?? entry.expectsCompletionMessage,
+      completionOwner: entry.delivery?.payload?.completionOwner ?? entry.completionOwner,
       spawnMode: entry.delivery?.payload?.spawnMode ?? entry.spawnMode,
       frozenResultText: entry.delivery?.payload?.frozenResultText ?? entry.completion?.resultText,
       fallbackFrozenResultText:
@@ -974,6 +975,7 @@ export function createSubagentRegistryLifecycleController(params: {
         outcome: pendingPayload.outcome,
         spawnMode: pendingPayload.spawnMode,
         expectsCompletionMessage: pendingPayload.expectsCompletionMessage,
+        completionOwner: pendingPayload.completionOwner,
         wakeOnDescendantSettle: pendingPayload.wakeOnDescendantSettle === true,
         onDeliveryResult: (delivery) => {
           recordAnnounceDeliveryResult(entry, delivery);

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -12,6 +12,7 @@ import { isAbortedAgentStopReason } from "./run-termination.js";
 import { isRecoverableAgentWaitError, waitForAgentRun } from "./run-wait.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
+import type { SubagentCompletionOwner } from "./subagent-completion-owner.js";
 import {
   clearDeliveryState,
   ensureCompletionState,
@@ -106,6 +107,7 @@ export type RegisterSubagentRunParams = {
   workspaceDir?: string;
   runTimeoutSeconds?: number;
   expectsCompletionMessage?: boolean;
+  completionOwner?: SubagentCompletionOwner;
   spawnMode?: "run" | "session";
   attachmentsDir?: string;
   attachmentsRootDir?: string;
@@ -510,6 +512,7 @@ export function createSubagentRunManager(params: {
       taskName: registerParams.taskName,
       cleanup: registerParams.cleanup,
       expectsCompletionMessage: registerParams.expectsCompletionMessage,
+      completionOwner: registerParams.completionOwner,
       spawnMode,
       label: registerParams.label,
       model: registerParams.model,

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -455,7 +455,7 @@ describe("subagent registry persistence", () => {
       requesterSessionKey: "agent:main:main",
       completionOwner: "origin-bridge-final",
     });
-    expect(restoredEntry?.pendingFinalDeliveryPayload?.completionOwner).toBe("origin-bridge-final");
+    expect(restoredEntry?.delivery?.payload?.completionOwner).toBe("origin-bridge-final");
 
     resetSubagentRegistryForTests({ persist: false });
     addSubagentRunForTests(restoredEntry as never);
@@ -497,6 +497,65 @@ describe("subagent registry persistence", () => {
     expectFields(getSubagentRunByChildSessionKey("agent:main:subagent:live-child"), {
       runId: "run-live",
     });
+  });
+
+  it("normalizes persisted completion owners and drops unknown restored values", async () => {
+    const persisted = {
+      version: 2,
+      runs: {
+        "run-owner-trimmed": {
+          runId: "run-owner-trimmed",
+          childSessionKey: "agent:main:subagent:owner-trimmed",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "trim owner",
+          cleanup: "keep",
+          expectsCompletionMessage: true,
+          completionOwner: " origin-bridge-final ",
+          pendingFinalDeliveryPayload: {
+            requesterSessionKey: "agent:main:main",
+            childSessionKey: "agent:main:subagent:owner-trimmed",
+            childRunId: "run-owner-trimmed",
+            task: "trim owner",
+            expectsCompletionMessage: true,
+            completionOwner: " requester-session-final ",
+          },
+          createdAt: 1,
+          startedAt: 1,
+        },
+        "run-owner-unknown": {
+          runId: "run-owner-unknown",
+          childSessionKey: "agent:main:subagent:owner-unknown",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "unknown owner",
+          cleanup: "keep",
+          expectsCompletionMessage: true,
+          completionOwner: "stale-owner-mode",
+          pendingFinalDeliveryPayload: {
+            requesterSessionKey: "agent:main:main",
+            childSessionKey: "agent:main:subagent:owner-unknown",
+            childRunId: "run-owner-unknown",
+            task: "unknown owner",
+            expectsCompletionMessage: true,
+            completionOwner: "stale-owner-mode",
+          },
+          createdAt: 1,
+          startedAt: 1,
+        },
+      },
+    };
+    await writePersistedRegistry(persisted, { seedChildSessions: false });
+
+    const restored = loadSubagentRegistryFromDisk();
+    expect(restored.get("run-owner-trimmed")?.completionOwner).toBe("origin-bridge-final");
+    expect(restored.get("run-owner-trimmed")?.delivery?.payload?.completionOwner).toBe(
+      "requester-session-final",
+    );
+    expect(restored.get("run-owner-unknown")?.completionOwner).toBeUndefined();
+    expect(
+      restored.get("run-owner-unknown")?.delivery?.payload?.completionOwner,
+    ).toBeUndefined();
   });
 
   it("retries cleanup announce after a failed announce", async () => {

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -429,6 +429,17 @@ describe("subagent registry persistence", () => {
           requesterDisplayKey: "main",
           task: "spaced persisted keys",
           cleanup: "keep",
+          expectsCompletionMessage: true,
+          completionOwner: "origin-bridge-final",
+          pendingFinalDeliveryPayload: {
+            requesterSessionKey: " agent:main:main ",
+            requesterDisplayKey: "main",
+            childSessionKey: " agent:main:subagent:spaced-child ",
+            childRunId: "run-spaced",
+            task: "spaced persisted keys",
+            expectsCompletionMessage: true,
+            completionOwner: "origin-bridge-final",
+          },
           createdAt: 1,
           startedAt: 1,
         },
@@ -442,7 +453,9 @@ describe("subagent registry persistence", () => {
       childSessionKey: "agent:main:subagent:spaced-child",
       controllerSessionKey: "agent:main:subagent:controller",
       requesterSessionKey: "agent:main:main",
+      completionOwner: "origin-bridge-final",
     });
+    expect(restoredEntry?.pendingFinalDeliveryPayload?.completionOwner).toBe("origin-bridge-final");
 
     resetSubagentRegistryForTests({ persist: false });
     addSubagentRunForTests(restoredEntry as never);
@@ -469,6 +482,7 @@ describe("subagent registry persistence", () => {
       requesterDisplayKey: "main",
       task: "live spaced keys",
       cleanup: "keep",
+      completionOwner: "none",
     });
 
     const liveRuns = listSubagentRunsForRequester("agent:main:main");
@@ -478,6 +492,7 @@ describe("subagent registry persistence", () => {
       childSessionKey: "agent:main:subagent:live-child",
       controllerSessionKey: "agent:main:subagent:live-controller",
       requesterSessionKey: "agent:main:main",
+      completionOwner: "none",
     });
     expectFields(getSubagentRunByChildSessionKey("agent:main:subagent:live-child"), {
       runId: "run-live",

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -5,6 +5,7 @@ import { resolveStateDir } from "../config/paths.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
 import { readStringValue } from "../shared/string-coerce.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
+import { normalizeSubagentCompletionOwner } from "./subagent-completion-owner.js";
 import { normalizeSubagentRunState } from "./subagent-delivery-state.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
@@ -135,6 +136,16 @@ export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord> {
         accountId: readStringValue(typed.requesterAccountId),
       },
     );
+    const completionOwner = normalizeSubagentCompletionOwner(typed.completionOwner);
+    const pendingFinalDeliveryPayload =
+      typed.pendingFinalDeliveryPayload && typeof typed.pendingFinalDeliveryPayload === "object"
+        ? {
+            ...typed.pendingFinalDeliveryPayload,
+            completionOwner: normalizeSubagentCompletionOwner(
+              typed.pendingFinalDeliveryPayload.completionOwner,
+            ),
+          }
+        : typed.pendingFinalDeliveryPayload;
     const childSessionKey = readStringValue(typed.childSessionKey)?.trim() ?? "";
     const requesterSessionKey = readStringValue(typed.requesterSessionKey)?.trim() ?? "";
     const controllerSessionKey =
@@ -159,6 +170,8 @@ export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord> {
         requesterOrigin,
         cleanupCompletedAt,
         cleanupHandled,
+        completionOwner,
+        pendingFinalDeliveryPayload,
         spawnMode: typed.spawnMode === "session" ? "session" : "run",
       }),
     );

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -1,5 +1,6 @@
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
+import type { SubagentCompletionOwner } from "./subagent-completion-owner.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
@@ -15,6 +16,7 @@ export type PendingFinalDeliveryPayload = {
   endedAt?: number;
   outcome?: SubagentRunOutcome;
   expectsCompletionMessage?: boolean;
+  completionOwner?: SubagentCompletionOwner;
   spawnMode?: SpawnSubagentMode;
   frozenResultText?: string | null;
   fallbackFrozenResultText?: string | null;
@@ -98,6 +100,7 @@ export type SubagentRunRecord = {
   cleanupHandled?: boolean;
   suppressAnnounceReason?: "steer-restart" | "killed";
   expectsCompletionMessage?: boolean;
+  completionOwner?: SubagentCompletionOwner;
   endedReason?: SubagentLifecycleEndedReason;
   pauseReason?: "sessions_yield";
   wakeOnDescendantSettle?: boolean;

--- a/src/agents/subagent-spawn.thread-binding.test.ts
+++ b/src/agents/subagent-spawn.thread-binding.test.ts
@@ -24,6 +24,7 @@ function firstRegisteredSubagentRun(): {
   requesterDisplayKey?: string;
   requesterOrigin?: { channel?: string; accountId?: string; to?: string };
   expectsCompletionMessage?: boolean;
+  completionOwner?: string;
   spawnMode?: string;
 } {
   const call = hoisted.registerSubagentRunMock.mock.calls[0]?.[0] as
@@ -33,6 +34,7 @@ function firstRegisteredSubagentRun(): {
         requesterDisplayKey?: string;
         requesterOrigin?: { channel?: string; accountId?: string; to?: string };
         expectsCompletionMessage?: boolean;
+        completionOwner?: string;
         spawnMode?: string;
       }
     | undefined;
@@ -190,6 +192,55 @@ describe("spawnSubagentDirect thread binding delivery", () => {
     expect(registeredRun?.requesterOrigin?.accountId).toBe("bot-beta");
     expect(registeredRun?.requesterOrigin?.to).toBe(`room:${boundRoom}`);
     expect(registeredRun?.expectsCompletionMessage).toBe(false);
+    expect(registeredRun?.completionOwner).toBe("work-thread-final");
+    expect(registeredRun?.spawnMode).toBe("session");
+  });
+
+  it("supports explicit origin-bridge-final ownership for thread-bound sessions", async () => {
+    hoisted.hookRunner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "subagent_spawning",
+    );
+    hoisted.hookRunner.runSubagentSpawning.mockResolvedValue({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "matrix",
+        accountId: "sut",
+        to: "room:!child:example",
+        threadId: "$child-thread",
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "reply with a marker",
+        thread: true,
+        mode: "session",
+        context: "isolated",
+        completionOwner: "origin-bridge-final",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "matrix",
+        agentAccountId: "sut",
+        agentTo: "room:!parent:example",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const agentCall = hoisted.callGatewayMock.mock.calls.find(
+      ([call]) => (call as { method?: string }).method === "agent",
+    )?.[0] as { params?: Record<string, unknown> } | undefined;
+    expect(agentCall?.params?.channel).toBe("matrix");
+    expect(agentCall?.params?.to).toBe("room:!child:example");
+    expect(agentCall?.params?.threadId).toBe("$child-thread");
+    expect(agentCall?.params?.deliver).toBe(false);
+
+    const registeredRun = hoisted.registerSubagentRunMock.mock.calls[0]?.[0] as
+      | { expectsCompletionMessage?: boolean; completionOwner?: string; spawnMode?: string }
+      | undefined;
+    expect(registeredRun?.expectsCompletionMessage).toBe(true);
+    expect(registeredRun?.completionOwner).toBe("origin-bridge-final");
     expect(registeredRun?.spawnMode).toBe("session");
   });
 
@@ -281,6 +332,7 @@ describe("spawnSubagentDirect thread binding delivery", () => {
     expect(agentCall?.params?.deliver).toBe(false);
     const registeredRun = firstRegisteredSubagentRun();
     expect(registeredRun?.expectsCompletionMessage).toBe(true);
+    expect(registeredRun?.completionOwner).toBe("requester-session-final");
     expect(registeredRun?.requesterOrigin?.channel).toBe("matrix");
     expect(registeredRun?.requesterOrigin?.accountId).toBe("sut");
     expect(registeredRun?.requesterOrigin?.to).toBe("room:!parent:example");

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -32,6 +32,11 @@ import {
   type SubagentAttachmentReceiptFile,
 } from "./subagent-attachments.js";
 import { resolveSubagentCapabilities } from "./subagent-capabilities.js";
+import {
+  completionOwnerNeedsRequesterFinal,
+  resolveSubagentCompletionOwner,
+  type SubagentCompletionOwner,
+} from "./subagent-completion-owner.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
@@ -141,6 +146,7 @@ export type SpawnSubagentParams = {
   context?: SpawnSubagentContextMode;
   lightContext?: boolean;
   expectsCompletionMessage?: boolean;
+  completionOwner?: SubagentCompletionOwner;
   attachments?: Array<{
     name: string;
     content: string;
@@ -1157,11 +1163,29 @@ export async function spawnSubagentDirect(
 
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
-  const deliverInitialChildRunDirectly =
+  const canDeliverInitialChildRunDirectly =
     requestThreadBinding && spawnMode === "session" && hasBoundThreadDeliveryOrigin;
-  const shouldAnnounceCompletion = deliverInitialChildRunDirectly
-    ? false
-    : expectsCompletionMessage;
+  const completionOwner = resolveSubagentCompletionOwner({
+    requestedOwner: params.completionOwner,
+    expectsCompletionMessage,
+    threadBoundDirectDelivery: canDeliverInitialChildRunDirectly,
+  });
+  if (completionOwner === "work-thread-final" && !canDeliverInitialChildRunDirectly) {
+    await cleanupFailedSpawnBeforeAgentStart({
+      childSessionKey,
+      attachmentAbsDir,
+      emitLifecycleHooks: threadBindingReady,
+      deleteTranscript: true,
+    });
+    return {
+      status: "error",
+      error:
+        'completionOwner="work-thread-final" requires a thread-bound session with a routable delivery origin.',
+      childSessionKey,
+    };
+  }
+  const deliverInitialChildRunDirectly = completionOwner === "work-thread-final";
+  const shouldAnnounceCompletion = completionOwnerNeedsRequesterFinal(completionOwner);
   try {
     const {
       spawnedBy: _spawnedBy,
@@ -1283,6 +1307,7 @@ export async function spawnSubagentDirect(
       workspaceDir: spawnedMetadata.workspaceDir,
       runTimeoutSeconds,
       expectsCompletionMessage: shouldAnnounceCompletion,
+      completionOwner,
       spawnMode,
       attachmentsDir: attachmentAbsDir,
       attachmentsRootDir: attachmentRootDir,

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -341,6 +341,23 @@ describe("sessions_spawn tool", () => {
     expect(spawnContext.inheritedToolAllowlist).toEqual(["sessions_spawn", "read"]);
   });
 
+  it("forwards completionOwner to native subagent spawns", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-subagent-owner", {
+      runtime: "subagent",
+      task: "build feature",
+      completionOwner: "origin-bridge-final",
+    });
+
+    const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
+    expect(spawnArgs.task).toBe("build feature");
+    expect(spawnArgs.completionOwner).toBe("origin-bridge-final");
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
+
   it("accepts taskName as a stable subagent handle", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
@@ -492,6 +509,30 @@ describe("sessions_spawn tool", () => {
 
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects completionOwner for ACP runtime until ACP ownership semantics exist", async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("call-acp-owner", {
+      runtime: "acp",
+      task: "investigate the failing CI run",
+      agentId: "codex",
+      completionOwner: "none",
+    });
+
+    expectDetailFields(result.details, {
+      status: "error",
+      role: "codex",
+    });
+    expect(String(requireRecord(result.details, "details").error)).toContain(
+      'completionOwner is currently supported only for runtime="subagent"',
+    );
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
   });
 
   it("routes to ACP runtime when runtime=acp", async () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -18,6 +18,10 @@ import {
 } from "../inherited-tool-deny.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
+import {
+  normalizeSubagentCompletionOwner,
+  SUBAGENT_COMPLETION_OWNERS,
+} from "../subagent-completion-owner.js";
 import { registerSubagentRun } from "../subagent-registry.js";
 import { resolveSubagentSpawnOwnership } from "../subagent-spawn-ownership.js";
 import {
@@ -184,6 +188,10 @@ function createSessionsSpawnToolSchema(params: {
       : {}),
     mode: optionalStringEnum(spawnModes),
     cleanup: optionalStringEnum(["delete", "keep"] as const),
+    completionOwner: optionalStringEnum(SUBAGENT_COMPLETION_OWNERS, {
+      description:
+        'Native subagent-only. Controls which surface owns the complete final summary for background completion: requester-session-final, work-thread-final, origin-bridge-final, or none. Currently rejected for runtime="acp".',
+    }),
     sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
     context: optionalStringEnum(SUBAGENT_SPAWN_CONTEXT_MODES, {
       description:
@@ -301,12 +309,21 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const expectsCompletionMessage = params.expectsCompletionMessage !== false;
+      const completionOwner = normalizeSubagentCompletionOwner(params.completionOwner);
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
       const context =
         params.context === "fork" || params.context === "isolated" ? params.context : undefined;
       const streamTo = runtime === "acp" && params.streamTo === "parent" ? "parent" : undefined;
       const lightContext = params.lightContext === true;
       const roleContext = requestedAgentId ? { role: requestedAgentId } : {};
+      if (runtime === "acp" && completionOwner) {
+        return jsonResult({
+          status: "error",
+          error:
+            'completionOwner is currently supported only for runtime="subagent"; ACP completion ownership is not implemented yet.',
+          ...roleContext,
+        });
+      }
       if (runtime === "acp" && !acpAvailable) {
         return jsonResult({
           status: "error",
@@ -444,6 +461,7 @@ export function createSessionsSpawnTool(
               label: label || undefined,
               runTimeoutSeconds,
               expectsCompletionMessage: shouldExpectCompletionMessage,
+              completionOwner,
               spawnMode: trackedSpawnMode,
             });
           } catch (err) {
@@ -479,6 +497,7 @@ export function createSessionsSpawnTool(
           context,
           lightContext,
           expectsCompletionMessage,
+          completionOwner,
           attachments,
           attachMountPath:
             params.attachAs && typeof params.attachAs === "object"

--- a/src/auto-reply/reply/queue/settings-runtime.ts
+++ b/src/auto-reply/reply/queue/settings-runtime.ts
@@ -12,10 +12,16 @@ function resolvePluginDebounce(channelKey: string | undefined): number | undefin
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : undefined;
 }
 
+function shouldResolvePluginDebounce(params: ResolveQueueSettingsParams): boolean {
+  return params.pluginDebounceMs === undefined && params.cfg.plugins?.enabled !== false;
+}
+
 export function resolveQueueSettings(params: ResolveQueueSettingsParams): QueueSettings {
   const channelKey = normalizeOptionalLowercaseString(params.channel);
   return resolveQueueSettingsCore({
     ...params,
-    pluginDebounceMs: params.pluginDebounceMs ?? resolvePluginDebounce(channelKey),
+    pluginDebounceMs: shouldResolvePluginDebounce(params)
+      ? resolvePluginDebounce(channelKey)
+      : params.pluginDebounceMs,
   });
 }

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -633,6 +633,11 @@ export type PluginHookSubagentDeliveryTargetEvent = {
   childRunId?: string;
   spawnMode?: "run" | "session";
   expectsCompletionMessage: boolean;
+  completionOwner?:
+    | "requester-session-final"
+    | "work-thread-final"
+    | "origin-bridge-final"
+    | "none";
 };
 
 /**

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -996,6 +996,11 @@
           "enum": ["delete", "keep"],
           "type": "string"
         },
+        "completionOwner": {
+          "description": "Native subagent-only. Controls which surface owns the complete final summary for background completion: requester-session-final, work-thread-final, origin-bridge-final, or none. Currently rejected for runtime=\"acp\".",
+          "enum": ["requester-session-final", "work-thread-final", "origin-bridge-final", "none"],
+          "type": "string"
+        },
         "context": {
           "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1032,6 +1032,11 @@
           "enum": ["delete", "keep"],
           "type": "string"
         },
+        "completionOwner": {
+          "description": "Native subagent-only. Controls which surface owns the complete final summary for background completion: requester-session-final, work-thread-final, origin-bridge-final, or none. Currently rejected for runtime=\"acp\".",
+          "enum": ["requester-session-final", "work-thread-final", "origin-bridge-final", "none"],
+          "type": "string"
+        },
         "context": {
           "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -996,6 +996,11 @@
           "enum": ["delete", "keep"],
           "type": "string"
         },
+        "completionOwner": {
+          "description": "Native subagent-only. Controls which surface owns the complete final summary for background completion: requester-session-final, work-thread-final, origin-bridge-final, or none. Currently rejected for runtime=\"acp\".",
+          "enum": ["requester-session-final", "work-thread-final", "origin-bridge-final", "none"],
+          "type": "string"
+        },
         "context": {
           "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40277,
-    "roughTokens": 10070
+    "chars": 40749,
+    "roughTokens": 10188
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67979,
-    "roughTokens": 16995
+    "chars": 68451,
+    "roughTokens": 17113
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 39998,
-    "roughTokens": 10000
+    "chars": 40470,
+    "roughTokens": 10118
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66176,
-    "roughTokens": 16544
+    "chars": 66648,
+    "roughTokens": 16662
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41093,
-    "roughTokens": 10274
+    "chars": 41565,
+    "roughTokens": 10392
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68214,
-    "roughTokens": 17054
+    "chars": 68686,
+    "roughTokens": 17172
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary

Fixes #80450.

This PR adds an explicit native subagent completion ownership contract so thread-bound long-running subagent work can distinguish:

- `work-thread-final`: the bound work thread owns the complete final summary.
- `requester-session-final`: the requester session owns the complete final summary.
- `origin-bridge-final`: completion is intentionally bridged back through the requester/origin route.
- `none`: no automatic complete final summary is requested.

The change keeps legacy behavior for records without `completionOwner`: missing/legacy owner values still use the existing child-binding-first completion route.

## What changed

- Add a typed native subagent `completionOwner` contract.
- Persist `completionOwner` through subagent run records and pending final-delivery retry payloads.
- Derive native thread-bound spawn delivery behavior from `completionOwner`.
- Update completion routing so explicit requester/origin-owned finals skip the child/work-thread binding and route through the requester side instead.
- Reject `completionOwner` for `runtime="acp"` until ACP completion ownership semantics are implemented.
- Add regression coverage for requester/origin final ownership, native forwarding, ACP rejection, persistence, and owner resolution.

## Validation

Validation was limited to an isolated source checkout. No live gateway, config, or runtime-state tests were run.

Passed:

- `node scripts/run-vitest.mjs run src/agents/subagent-completion-owner.test.ts src/agents/subagent-spawn.thread-binding.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/subagent-registry.persistence.test.ts src/agents/tools/sessions-spawn-tool.test.ts`
  - 9 files / 180 tests passed.
- `node scripts/run-vitest.mjs run src/agents/tools/sessions-spawn-tool.test.ts`
  - 2 files / 68 tests passed after the final schema/test hardening.
- `node scripts/run-oxlint.mjs <changed files>`
  - 0 warnings / 0 errors.
- `node scripts/run-oxlint.mjs --type-check <changed runtime files>`
  - 0 warnings / 0 errors.
- `corepack pnpm check:test-types`
- `git diff --check`

## Real behavior proof

- **Behavior or issue addressed:** Native subagent final-summary ownership now has an explicit contract: `work-thread-final` keeps the complete final in the bound work thread; `requester-session-final` and `origin-bridge-final` route the complete final through the requester/origin side; `none` requests no automatic complete final; missing legacy owner values keep the previous child-binding-first route.
- **Real environment tested:** Isolated non-production OpenClaw source checkout on Linux. The proof used synthetic thread bindings and synthetic delivery targets against the real completion-owner resolver, native subagent delivery selection, and retry/delivery data-shape seams. No production Gateway, live runtime state, live config, or real channel was used.
- **Exact steps or command run after this patch:**

```text
node scripts/run-vitest.mjs run   src/agents/subagent-completion-owner.test.ts   src/agents/subagent-spawn.thread-binding.test.ts   src/agents/subagent-announce-delivery.test.ts   src/agents/subagent-registry.persistence.test.ts   src/agents/tools/sessions-spawn-tool.test.ts
node scripts/run-vitest.mjs run <generated non-production completionOwner proof test>
git diff --check
node scripts/check-no-conflict-markers.mjs
```

- **Evidence after fix:** Terminal output from the isolated proof harness showed the ownership matrix and synthetic requester delivery path:

```text
[nonprod completionOwner route matrix] [
  {"case":"legacy-missing-owner","completionOwner":"<missing>","resolvedTo":"channel:synthetic-child-thread"},
  {"case":"work-thread-final","completionOwner":"work-thread-final","resolvedTo":"channel:synthetic-child-thread"},
  {"case":"requester-session-final","completionOwner":"requester-session-final","resolvedTo":"channel:synthetic-requester-thread"},
  {"case":"origin-bridge-final","completionOwner":"origin-bridge-final","resolvedTo":"channel:synthetic-requester-thread"}
]
[nonprod completionOwner delivery proof] {
  "ownerRows":[
    {"label":"thread-bound default","owner":"work-thread-final"},
    {"label":"requester final default","owner":"requester-session-final"},
    {"label":"explicit none","owner":"none"}
  ],
  "deliveryPath":"direct",
  "delivered":true,
  "gatewayMethod":"agent",
  "gatewayDeliver":true,
  "gatewayTo":"channel:synthetic-requester-thread"
}
Test Files 2 passed (2)
Tests 4 passed (4)

Targeted native subagent ownership suite: 9 files / 222 tests passed.
git diff --check: passed.
conflict-marker scan: passed.
```

- **Observed result after fix:** The synthetic route matrix keeps missing/legacy and `work-thread-final` completions on the work-thread side, while `requester-session-final` and `origin-bridge-final` resolve to the requester side. The delivery proof then verifies requester-owned final delivery uses the requester route and records a direct synthetic delivery to the requester thread. The targeted native subagent suite also covers owner persistence, thread-bound spawn behavior, announce delivery, and spawn-tool validation.
- **What was not tested:** This is non-production proof. It does not exercise the production Gateway, production runtime state, production config, or any real Discord/Telegram/other channel. ACP completion ownership remains out of scope; this PR rejects `completionOwner` for ACP runtime rather than claiming ACP support.

## Scope boundary

This PR intentionally implements native subagent ownership only. ACP support is deferred; callers that pass `completionOwner` with `runtime="acp"` now receive an explicit error instead of silently getting misleading behavior.

