### PR TITLE
ci: gate bundled-channel-config-metadata staleness in check-shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1331,6 +1331,9 @@ jobs:
           - check_name: check-strict-smoke
             task: strict-smoke
             runner: ubuntu-24.04
+          - check_name: check-bundled-channel-config-metadata
+            task: bundled-channel-config-metadata
+            runner: ubuntu-24.04
     steps:
       - name: Checkout
         shell: bash
@@ -1426,6 +1429,9 @@ jobs:
             strict-smoke)
               # build-artifacts already runs the tsdown/runtime build for the same Node-relevant changes.
               pnpm build:plugin-sdk:strict-smoke
+              ;;
+            bundled-channel-config-metadata)
+              pnpm check:bundled-channel-config-metadata
               ;;
             *)
               echo "Unsupported check task: $TASK" >&2


### PR DESCRIPTION
Fixes #80536

## Problem

`src/config/bundled-channel-config-metadata.generated.ts` is a checked-in codegen output that is **not regenerated by `npm run build`**. When a PR extends an extension's `config-schema.ts` without also hand-editing the bundled file, CI passes but the runtime validator rejects the new field at gateway startup with `must NOT have additional properties`.

The script to detect this already exists (`scripts/generate-bundled-channel-config-metadata.ts --check` / `pnpm check:bundled-channel-config-metadata`) but was never wired into CI.

## Fix

Add a `check-bundled-channel-config-metadata` entry to the `check-shard` matrix and handle the `bundled-channel-config-metadata` task in the runner's case statement.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | +6 lines: matrix entry + case handler |

## Pre-implement audit

1. **Existing-helper check**: `pnpm check:bundled-channel-config-metadata` already exists in `package.json` — no new helper introduced.
2. **Shared-helper caller check**: only `ci.yml` is changed; no shared TS helper is touched.
3. **Broader-fix rival scan**: zero rival PRs for #80536.

## Real behavior proof

- **Behavior or issue addressed:** `src/config/bundled-channel-config-metadata.generated.ts` can become stale when extensions add new config schema fields — PR CI passes but the gateway crashes at startup with `must NOT have additional properties`. This PR wires the existing staleness-check script into the CI check-shard matrix so the stale-generated-file failure is caught in CI before runtime.
- **Real environment tested:** `openclaw/openclaw` main branch, Ubuntu 22.04, Node v22.14.0, repo cloned locally.
- **Exact steps or command run after this patch:** Ran the staleness check directly against the current repo to verify the script works and exits cleanly:
  ```
  node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check
  ```
  To verify the failure path, temporarily corrupted the generated file (appended a dummy field), re-ran, then restored:
  ```
  node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check
  [bundled-channel-config-metadata] stale generated output at src/config/bundled-channel-config-metadata.generated.ts
  (exit 1)
  ```
- **Evidence after fix:** Terminal output from running the check on current main (clean state):
  ```
  $ node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check
  $ echo $?
  0
  ```
  Terminal output with a manually-staled generated file (confirms detection works):
  ```
  $ node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check
  [bundled-channel-config-metadata] stale generated output at src/config/bundled-channel-config-metadata.generated.ts
  $ echo $?
  1
  ```
- **Observed result after fix:** Check exits 0 on a current repo; exits 1 with a clear path-specific error message when the generated file is stale. The new `check-bundled-channel-config-metadata` CI shard will run this check on every PR, catching the staleness class of failure described in #80536 before it reaches runtime.
- **What was not tested:** Windows CI runners. The `pnpm generate:bundled-channel-config-metadata` regeneration workflow itself — this PR only wires the check, not the fix command.