### PR TITLE
fix local plugin TS source discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Docs: https://docs.openclaw.ai
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.
 - Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.
 - Codex app-server: default native plugin app tool approvals to automatic so non-destructive read tools run when destructive actions are disabled.
+- Plugins: allow untracked local source plugins in the global extensions directory to load TypeScript package entries while keeping managed installs strict about compiled runtime output. Fixes #80503. Thanks @Kaspre.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids in configured proxy/provider-auth model catalogs, so regenerated config keeps testing `google/gemini-3.1-pro-preview` instead of `google/gemini-3-pro-preview`.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while onboarding provider catalog presets, so setup-emitted proxy configs test `google/gemini-3.1-pro-preview` instead of `google/gemini-3-pro-preview`.

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -196,6 +196,13 @@ Packaged installs must ship that JavaScript runtime output. The TypeScript
 source fallback is for source checkouts and local development paths, not for
 npm packages installed into OpenClaw's managed plugin root.
 
+Untracked directories dropped into the global extension root are treated as
+local source checkouts and may load TypeScript entries directly. Directories
+still named by an install record, including `installPath` or `sourcePath`, stay
+managed and keep the compiled-output requirement even when the global scan sees
+them. If you intentionally convert a managed install into an untracked local
+checkout, remove the stale install record first with uninstall or doctor cleanup.
+
 If a managed package warning says it `requires compiled runtime output for
 TypeScript entry ...`, the package was published without the JavaScript files
 OpenClaw needs at runtime. That is a plugin packaging issue, not a local config

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -82,14 +82,12 @@ describe("google provider plugin hooks", () => {
       } as ProviderSanitizeReplayHistoryContext),
     );
 
-    const bootstrapMessage = sanitized?.[0];
+    const bootstrapMessage = sanitized?.[0] as
+      | { role?: string; content?: unknown; timestamp?: unknown }
+      | undefined;
     expect(bootstrapMessage?.role).toBe("user");
-    expect(
-      bootstrapMessage && "content" in bootstrapMessage ? bootstrapMessage.content : undefined,
-    ).toBe("(session bootstrap)");
-    expect(typeof (bootstrapMessage as { timestamp?: unknown } | undefined)?.timestamp).toBe(
-      "number",
-    );
+    expect(bootstrapMessage?.content).toBe("(session bootstrap)");
+    expect(typeof bootstrapMessage?.timestamp).toBe("number");
     expect(sanitized?.[1]).toEqual({
       role: "assistant",
       content: [{ type: "text", text: "hello" }],

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { bundledDistPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
 import { listBuiltRuntimeEntryCandidates } from "./package-entrypoints.js";
 import {
@@ -402,7 +403,7 @@ function expectBundleCandidateMatch(params: {
 async function expectRejectedPackageExtensionEntry(params: {
   stateDir: string;
   setup: (stateDir: string) => boolean | void;
-  expectedDiagnostic?: "escapes" | "none" | "runtime";
+  expectedDiagnostic?: "escapes" | "none" | "not_found" | "runtime";
   expectedId?: string;
   expectedDiagnosticPluginId?: string;
 }) {
@@ -431,6 +432,14 @@ async function expectRejectedPackageExtensionEntry(params: {
     expect(
       result.diagnostics.some(
         (entry) => entry.level === "warn" && entry.message.includes("compiled runtime output"),
+      ),
+    ).toBe(true);
+    return;
+  }
+  if (params.expectedDiagnostic === "not_found") {
+    expect(
+      result.diagnostics.some(
+        (entry) => entry.level === "error" && entry.message.includes("extension entry not found"),
       ),
     ).toBe(true);
     return;
@@ -841,7 +850,34 @@ describe("discoverOpenClawPlugins", () => {
     expectCandidateIds(candidates, { includes: ["pack/one", "pack/two"] });
   });
 
-  it("skips source-only TypeScript entries for installed package plugins", async () => {
+  it("discovers untracked global package plugins that point at TypeScript source", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "local-source-pack");
+    mkdirSafe(pluginDir);
+
+    writePluginPackageManifest({
+      packageDir: pluginDir,
+      packageName: "@openclaw/local-source-pack",
+      extensions: ["./index.ts"],
+    });
+    writePluginManifest({ pluginDir, id: "local-source-pack" });
+    writePluginEntry(path.join(pluginDir, "index.ts"));
+
+    const result = await discoverWithStateDir(stateDir, {});
+
+    expectCandidateSource(
+      result.candidates,
+      "local-source-pack",
+      fs.realpathSync(path.join(pluginDir, "index.ts")),
+    );
+    expectNoDiagnostic({
+      diagnostics: result.diagnostics,
+      pluginId: "local-source-pack",
+      messageIncludes: "requires compiled runtime output",
+    });
+  });
+
+  it("still requires compiled runtime output for tracked installed package plugins", async () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "extensions", "source-only-pack");
     mkdirSafe(path.join(pluginDir, "src"));
@@ -853,7 +889,13 @@ describe("discoverOpenClawPlugins", () => {
     });
     writePluginEntry(path.join(pluginDir, "src", "index.ts"));
 
-    const result = await discoverWithStateDir(stateDir, {});
+    const installRecords = {
+      "source-only-pack": {
+        source: "path",
+        installPath: pluginDir,
+      },
+    } satisfies Record<string, PluginInstallRecord>;
+    const result = await discoverWithStateDir(stateDir, { installRecords });
 
     expectCandidateIds(result.candidates, { excludes: ["source-only-pack"] });
     expect(
@@ -867,6 +909,128 @@ describe("discoverOpenClawPlugins", () => {
           entry.message.includes("disable/uninstall the plugin"),
       ),
     ).toBe(true);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("treats install record sourcePath dirs as managed during global scans", async () => {
+    const stateDir = makeTempDir();
+    const sourceDir = path.join(stateDir, "extensions", "source-path-pack");
+    const installDir = path.join(stateDir, "installed", "source-path-pack");
+    mkdirSafe(path.join(sourceDir, "src"));
+    mkdirSafe(installDir);
+
+    writePluginPackageManifest({
+      packageDir: sourceDir,
+      packageName: "@openclaw/source-path-pack",
+      extensions: ["./src/index.ts"],
+    });
+    writePluginEntry(path.join(sourceDir, "src", "index.ts"));
+
+    const installRecords = {
+      "source-path-pack": {
+        source: "path",
+        installPath: installDir,
+        sourcePath: sourceDir,
+      },
+    } satisfies Record<string, PluginInstallRecord>;
+    const result = await discoverWithStateDir(stateDir, { installRecords });
+
+    expectCandidateIds(result.candidates, { excludes: ["source-path-pack"] });
+    expectDiagnostic({
+      diagnostics: result.diagnostics,
+      level: "warn",
+      pluginId: "source-path-pack",
+      messageIncludes: "requires compiled runtime output",
+      source: sourceDir,
+    });
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.skipIf(!canCreateDirectorySymlinks)(
+    "treats symlinked install record sourcePath dirs as managed during global scans",
+    async () => {
+      const stateDir = makeTempDir();
+      const globalExt = path.join(stateDir, "extensions");
+      const actualSourceDir = path.join(stateDir, "source-checkouts", "source-path-symlink-pack");
+      const linkedSourceDir = path.join(globalExt, "source-path-symlink-pack");
+      const installDir = path.join(stateDir, "installed", "source-path-symlink-pack");
+      mkdirSafe(globalExt);
+      mkdirSafe(path.join(actualSourceDir, "src"));
+      mkdirSafe(installDir);
+
+      writePluginPackageManifest({
+        packageDir: actualSourceDir,
+        packageName: "@openclaw/source-path-symlink-pack",
+        extensions: ["./src/index.ts"],
+      });
+      writePluginEntry(path.join(actualSourceDir, "src", "index.ts"));
+      symlinkDirectory(actualSourceDir, linkedSourceDir);
+
+      const installRecords = {
+        "source-path-symlink-pack": {
+          source: "path",
+          installPath: installDir,
+          sourcePath: linkedSourceDir,
+        },
+      } satisfies Record<string, PluginInstallRecord>;
+      const result = await discoverWithStateDir(stateDir, { installRecords });
+
+      expectCandidateIds(result.candidates, { excludes: ["source-path-symlink-pack"] });
+      expectDiagnostic({
+        diagnostics: result.diagnostics,
+        level: "warn",
+        pluginId: "source-path-symlink-pack",
+        messageIncludes: "requires compiled runtime output",
+        source: linkedSourceDir,
+      });
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it("discovers global plugin directories with package metadata but no package entries", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "metadata-only-pack");
+    mkdirSafe(pluginDir);
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/metadata-only-pack", version: "0.0.1" }),
+      "utf-8",
+    );
+    writePluginManifest({ pluginDir, id: "metadata-only-pack" });
+    writePluginEntry(path.join(pluginDir, "index.ts"));
+
+    const result = await discoverWithStateDir(stateDir, {});
+
+    expectCandidateSource(
+      result.candidates,
+      "metadata-only-pack",
+      fs.realpathSync(path.join(pluginDir, "index.ts")),
+    );
+  });
+
+  it("keeps explicit runtime extension entries strict for untracked global packages", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "missing-runtime-pack");
+    mkdirSafe(pluginDir);
+
+    writePluginPackageManifest({
+      packageDir: pluginDir,
+      packageName: "@openclaw/missing-runtime-pack",
+      extensions: ["./index.ts"],
+      runtimeExtensions: ["./dist/index.js"],
+    });
+    writePluginManifest({ pluginDir, id: "missing-runtime-pack" });
+    writePluginEntry(path.join(pluginDir, "index.ts"));
+
+    const result = await discoverWithStateDir(stateDir, {});
+
+    expectCandidateIds(result.candidates, { excludes: ["missing-runtime-pack"] });
+    expectDiagnostic({
+      diagnostics: result.diagnostics,
+      level: "error",
+      source: pluginDir,
+      messageIncludes: "runtime extension entry not found: ./dist/index.js",
+    });
   });
 
   it("lets a valid bundled plugin win when a managed package is source-only TypeScript", () => {
@@ -897,6 +1061,12 @@ describe("discoverOpenClawPlugins", () => {
       env: buildDiscoveryEnvWithOverrides(stateDir, {
         OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
       }),
+      installRecords: {
+        discord: {
+          source: "path",
+          installPath: installedPluginDir,
+        },
+      },
     });
 
     const discordCandidates = result.candidates.filter(
@@ -1039,6 +1209,31 @@ describe("discoverOpenClawPlugins", () => {
           entry.message.includes("./dist/setup-entry.js"),
       ),
     ).toBe(true);
+  });
+
+  it("reports missing declared setup entries for package plugins", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "missing-setup-pack");
+    mkdirSafe(path.join(pluginDir, "dist"));
+
+    writePluginPackageManifest({
+      packageDir: pluginDir,
+      packageName: "@openclaw/missing-setup-pack",
+      extensions: ["./dist/index.js"],
+      setupEntry: "./src/setup-entry.ts",
+    });
+    writePluginEntry(path.join(pluginDir, "dist", "index.js"));
+
+    const result = await discoverWithStateDir(stateDir, {});
+    const candidate = requireCandidateById(result.candidates, "missing-setup-pack");
+
+    expect(candidate.setupSource).toBeUndefined();
+    expectDiagnostic({
+      diagnostics: result.diagnostics,
+      level: "error",
+      source: pluginDir,
+      messageIncludes: "setup entry not found: src/setup-entry.ts",
+    });
   });
 
   it("rejects package runtimeExtensions that do not match extension entries", async () => {
@@ -1197,6 +1392,38 @@ describe("discoverOpenClawPlugins", () => {
     });
 
     expectCandidateIds(candidates, { includes: ["downloadable"] });
+  });
+
+  it("keeps trusted bundled package fallback from missing TypeScript metadata to JavaScript", () => {
+    const stateDir = makeTempDir();
+    const bundledDir = path.join(stateDir, "bundled");
+    const pluginDir = path.join(bundledDir, "downloadable");
+    mkdirSafe(pluginDir);
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/downloadable",
+        openclaw: {
+          extensions: ["./index.ts"],
+        },
+      }),
+      "utf-8",
+    );
+    writePluginManifest({ pluginDir, id: "downloadable" });
+    writePluginEntry(path.join(pluginDir, "index.js"));
+
+    const { candidates, diagnostics } = discoverOpenClawPlugins({
+      env: buildDiscoveryEnvWithOverrides(stateDir, {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      }),
+    });
+
+    expectCandidateSource(
+      candidates,
+      "downloadable",
+      fs.realpathSync(path.join(pluginDir, "index.js")),
+    );
+    expect(diagnostics).toStrictEqual([]);
   });
 
   it("discovers source-checkout-only bundled plugins alongside built bundled plugins", () => {
@@ -1548,7 +1775,7 @@ describe("discoverOpenClawPlugins", () => {
     },
     {
       name: "rejects missing TypeScript package runtime entries without escape diagnostics",
-      expectedDiagnostic: "runtime" as const,
+      expectedDiagnostic: "not_found" as const,
       setup: (stateDir: string) => {
         const globalExt = path.join(stateDir, "extensions", "missing-entry-pack");
         mkdirSafe(globalExt);

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -15,6 +15,7 @@ import {
   resolvePackagedBundledLoadPathAlias,
 } from "./bundled-load-path-aliases.js";
 import { listBundledSourceOverlayDirs } from "./bundled-source-overlays.js";
+import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import type { PluginBundleFormat, PluginDiagnostic, PluginFormat } from "./manifest-types.js";
 import {
   DEFAULT_PLUGIN_ENTRY_CANDIDATES,
@@ -29,7 +30,6 @@ import {
   resolvePackageRuntimeExtensionSources,
   resolvePackageSetupSource,
 } from "./package-entry-resolution.js";
-import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { formatPosixMode, isPathInside, safeRealpathSync, safeStatSync } from "./path-safety.js";
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -411,6 +411,73 @@ function collectInstalledPluginRecordPaths(
   return paths;
 }
 
+// Discovery follows the install ledger's primary path choice; managed
+// classification needs every recorded path so a sourcePath under the global
+// extensions root does not get rescanned as an untracked local plugin.
+function collectManagedPluginRecordPaths(
+  installRecords: Record<string, PluginInstallRecord> | undefined,
+  env: NodeJS.ProcessEnv,
+): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+  for (const record of Object.values(installRecords ?? {})) {
+    for (const rawPath of [record.installPath, record.sourcePath]) {
+      if (typeof rawPath !== "string" || !rawPath.trim()) {
+        continue;
+      }
+      const resolved = resolveUserPath(rawPath, env);
+      if (seen.has(resolved) || !fs.existsSync(resolved)) {
+        continue;
+      }
+      seen.add(resolved);
+      paths.push(resolved);
+    }
+  }
+  return paths;
+}
+
+function resolveManagedPluginDirKey(
+  installedPath: string,
+  realpathCache: Map<string, string>,
+): string | null {
+  const stat = safeStatSync(installedPath);
+  if (!stat) {
+    return null;
+  }
+  const pluginDir = stat.isFile() ? path.dirname(installedPath) : installedPath;
+  return safeRealpathSync(pluginDir, realpathCache) ?? path.resolve(pluginDir);
+}
+
+function collectManagedPluginDirKeys(
+  installedPaths: readonly string[],
+  realpathCache: Map<string, string>,
+): Set<string> {
+  const dirs = new Set<string>();
+  for (const installedPath of installedPaths) {
+    const key = resolveManagedPluginDirKey(installedPath, realpathCache);
+    if (key) {
+      dirs.add(key);
+    }
+  }
+  return dirs;
+}
+
+function isManagedPluginDir(params: {
+  dir: string;
+  realpath?: string;
+  managedPluginDirs?: Set<string>;
+  realpathCache: Map<string, string>;
+}): boolean {
+  if (!params.managedPluginDirs || params.managedPluginDirs.size === 0) {
+    return false;
+  }
+  const key =
+    params.realpath ??
+    safeRealpathSync(params.dir, params.realpathCache) ??
+    path.resolve(params.dir);
+  return params.managedPluginDirs.has(key);
+}
+
 function readPackageManifest(
   dir: string,
   rejectHardlinks = true,
@@ -631,6 +698,9 @@ function discoverInDirectory(params: {
   env: NodeJS.ProcessEnv;
   ownershipUid?: number | null;
   workspaceDir?: string;
+  requireBuiltRuntimeEntry?: boolean;
+  managedPluginDirs?: Set<string>;
+  skipRootDirKeys?: Set<string>;
   candidates: PluginCandidate[];
   diagnostics: PluginDiagnostic[];
   seen: Set<string>;
@@ -694,6 +764,18 @@ function discoverInDirectory(params: {
     }
 
     const fullPathRealPath = safeRealpathSync(fullPath, params.realpathCache) ?? undefined;
+    const fullPathDirKey = fullPathRealPath ?? path.resolve(fullPath);
+    if (params.skipRootDirKeys?.has(fullPathDirKey)) {
+      continue;
+    }
+    const requireBuiltRuntimeEntry =
+      params.requireBuiltRuntimeEntry ??
+      isManagedPluginDir({
+        dir: fullPath,
+        realpath: fullPathRealPath,
+        managedPluginDirs: params.managedPluginDirs,
+        realpathCache: params.realpathCache,
+      });
     const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
       origin: params.origin,
       rootDir: fullPath,
@@ -714,6 +796,7 @@ function discoverInDirectory(params: {
       ...(fullPathRealPath !== undefined ? { packageRootRealPath: fullPathRealPath } : {}),
       manifest,
       origin: params.origin,
+      requireBuiltRuntimeEntry,
       sourceLabel: fullPath,
       diagnostics: params.diagnostics,
       rejectHardlinks,
@@ -727,6 +810,7 @@ function discoverInDirectory(params: {
         extensions,
         origin: params.origin,
         pluginIdHint: derivePackagePluginIdHint({ manifestId, packageName: manifest?.name }),
+        requireBuiltRuntimeEntry,
         sourceLabel: fullPath,
         diagnostics: params.diagnostics,
         rejectHardlinks,
@@ -863,6 +947,9 @@ function discoverFromPath(params: {
   origin: PluginOrigin;
   ownershipUid?: number | null;
   workspaceDir?: string;
+  requireBuiltRuntimeEntry?: boolean;
+  managedPluginDirs?: Set<string>;
+  skipRootDirKeys?: Set<string>;
   env: NodeJS.ProcessEnv;
   candidates: PluginCandidate[];
   diagnostics: PluginDiagnostic[];
@@ -906,6 +993,14 @@ function discoverFromPath(params: {
 
   if (stat.isDirectory()) {
     const resolvedRealPath = safeRealpathSync(resolved, params.realpathCache) ?? undefined;
+    const requireBuiltRuntimeEntry =
+      params.requireBuiltRuntimeEntry ??
+      isManagedPluginDir({
+        dir: resolved,
+        realpath: resolvedRealPath,
+        managedPluginDirs: params.managedPluginDirs,
+        realpathCache: params.realpathCache,
+      });
     const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
       origin: params.origin,
       rootDir: resolved,
@@ -926,6 +1021,7 @@ function discoverFromPath(params: {
       ...(resolvedRealPath !== undefined ? { packageRootRealPath: resolvedRealPath } : {}),
       manifest,
       origin: params.origin,
+      requireBuiltRuntimeEntry,
       sourceLabel: resolved,
       diagnostics: params.diagnostics,
       rejectHardlinks,
@@ -939,6 +1035,7 @@ function discoverFromPath(params: {
         extensions,
         origin: params.origin,
         pluginIdHint: derivePackagePluginIdHint({ manifestId, packageName: manifest?.name }),
+        requireBuiltRuntimeEntry,
         sourceLabel: resolved,
         diagnostics: params.diagnostics,
         rejectHardlinks,
@@ -1017,6 +1114,11 @@ function discoverFromPath(params: {
       diagnostics: params.diagnostics,
       seen: params.seen,
       realpathCache: params.realpathCache,
+      ...(params.requireBuiltRuntimeEntry !== undefined
+        ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry }
+        : {}),
+      ...(params.managedPluginDirs ? { managedPluginDirs: params.managedPluginDirs } : {}),
+      ...(params.skipRootDirKeys ? { skipRootDirKeys: params.skipRootDirKeys } : {}),
     });
     return;
   }
@@ -1164,12 +1266,20 @@ export function discoverOpenClawPlugins(params: {
           skipDirectories: readChildDirectoryNames(roots.stock),
         });
       }
-      for (const installedPath of collectInstalledPluginRecordPaths(params.installRecords, env)) {
+      const installedPaths = collectInstalledPluginRecordPaths(params.installRecords, env);
+      const installedPluginDirKeys = collectManagedPluginDirKeys(installedPaths, realpathCache);
+      const managedPluginDirs = collectManagedPluginDirKeys(
+        collectManagedPluginRecordPaths(params.installRecords, env),
+        realpathCache,
+      );
+      for (const installedPath of installedPaths) {
         discoverFromPath({
           rawPath: installedPath,
           origin: "global",
           ownershipUid: params.ownershipUid,
           workspaceDir,
+          requireBuiltRuntimeEntry: true,
+          managedPluginDirs,
           env,
           candidates: result.candidates,
           diagnostics: result.diagnostics,
@@ -1184,6 +1294,8 @@ export function discoverOpenClawPlugins(params: {
         origin: "global",
         env,
         ownershipUid: params.ownershipUid,
+        managedPluginDirs,
+        skipRootDirKeys: installedPluginDirKeys,
         candidates: result.candidates,
         diagnostics: result.diagnostics,
         seen,

--- a/src/plugins/package-entry-resolution.ts
+++ b/src/plugins/package-entry-resolution.ts
@@ -461,10 +461,13 @@ function resolvePackageRuntimeEntrySource(params: {
   packageDir: string;
   packageRootRealPath?: string;
   entryPath: string;
+  sourceEntryLabel?: string;
   runtimeEntryPath?: string;
   runtimeEntryLabel?: string;
   pluginIdHint?: string;
   origin: PluginOrigin;
+  // undefined preserves the origin default; false explicitly allows source fallback.
+  requireBuiltRuntimeEntry?: boolean;
   sourceLabel: string;
   diagnostics: PluginDiagnostic[];
   rejectHardlinks?: boolean;
@@ -530,7 +533,7 @@ function resolvePackageRuntimeEntrySource(params: {
       }
     }
     if (
-      shouldRequireBuiltRuntimeEntry(params.origin) &&
+      (params.requireBuiltRuntimeEntry ?? shouldRequireBuiltRuntimeEntry(params.origin)) &&
       isTypeScriptPackageEntry(safeEntry.relativePath)
     ) {
       params.diagnostics.push({
@@ -551,17 +554,30 @@ function resolvePackageRuntimeEntrySource(params: {
     return safeEntry.existingSource;
   }
 
-  return resolvePackageEntrySource({
-    packageDir: params.packageDir,
-    ...(params.packageRootRealPath !== undefined
-      ? { packageRootRealPath: params.packageRootRealPath }
-      : {}),
-    entryPath: params.entryPath,
-    pluginIdHint: params.pluginIdHint,
-    sourceLabel: params.sourceLabel,
-    diagnostics: params.diagnostics,
-    rejectHardlinks: params.rejectHardlinks,
+  if (params.rejectHardlinks === false) {
+    const trustedFallbackSource = resolvePackageEntrySource({
+      packageDir: params.packageDir,
+      ...(params.packageRootRealPath !== undefined
+        ? { packageRootRealPath: params.packageRootRealPath }
+        : {}),
+      entryPath: params.entryPath,
+      pluginIdHint: params.pluginIdHint,
+      sourceLabel: params.sourceLabel,
+      diagnostics: params.diagnostics,
+      rejectHardlinks: params.rejectHardlinks,
+    });
+    if (trustedFallbackSource) {
+      return trustedFallbackSource;
+    }
+  }
+
+  params.diagnostics.push({
+    level: "error",
+    ...(params.pluginIdHint ? { pluginId: params.pluginIdHint } : {}),
+    message: `${params.sourceEntryLabel ?? "extension entry"} not found: ${safeEntry.relativePath}`,
+    source: params.sourceLabel,
   });
+  return null;
 }
 
 export function resolvePackageSetupSource(params: {
@@ -569,6 +585,7 @@ export function resolvePackageSetupSource(params: {
   packageRootRealPath?: string;
   manifest: PackageManifest | null;
   origin: PluginOrigin;
+  requireBuiltRuntimeEntry?: boolean;
   sourceLabel: string;
   diagnostics: PluginDiagnostic[];
   rejectHardlinks?: boolean;
@@ -584,10 +601,14 @@ export function resolvePackageSetupSource(params: {
       ? { packageRootRealPath: params.packageRootRealPath }
       : {}),
     entryPath: setupEntryPath,
+    sourceEntryLabel: "setup entry",
     runtimeEntryPath: normalizeOptionalString(packageManifest?.runtimeSetupEntry),
     runtimeEntryLabel: "runtime setup entry",
     pluginIdHint: packageManifest?.plugin?.id ?? packageManifest?.channel?.id,
     origin: params.origin,
+    ...(params.requireBuiltRuntimeEntry !== undefined
+      ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry }
+      : {}),
     sourceLabel: params.sourceLabel,
     diagnostics: params.diagnostics,
     rejectHardlinks: params.rejectHardlinks,
@@ -601,6 +622,7 @@ export function resolvePackageRuntimeExtensionSources(params: {
   extensions: readonly string[];
   origin: PluginOrigin;
   pluginIdHint?: string;
+  requireBuiltRuntimeEntry?: boolean;
   sourceLabel: string;
   diagnostics: PluginDiagnostic[];
   rejectHardlinks?: boolean;
@@ -626,10 +648,14 @@ export function resolvePackageRuntimeExtensionSources(params: {
         ? { packageRootRealPath: params.packageRootRealPath }
         : {}),
       entryPath,
+      sourceEntryLabel: "extension entry",
       runtimeEntryPath: runtimeResolution.runtimeExtensions[index],
       runtimeEntryLabel: "runtime extension entry",
       pluginIdHint: params.pluginIdHint,
       origin: params.origin,
+      ...(params.requireBuiltRuntimeEntry !== undefined
+        ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry }
+        : {}),
       sourceLabel: params.sourceLabel,
       diagnostics: params.diagnostics,
       rejectHardlinks: params.rejectHardlinks,


### PR DESCRIPTION
Fixes #80503

## Summary

- Distinguish managed package installs from untracked local source checkouts when deciding whether a package entry must have compiled runtime output.
- Keep install-record `installPath` and `sourcePath` directories strict, including realpath and symlink cases, while allowing untracked global extension dirs to load TypeScript source entries.
- Preserve strict handling for explicit `runtimeExtensions` entries and trusted bundled fallback behavior.
- Add regression tests, docs, and changelog coverage for the discovery policy.

## Root Cause

Global package discovery used `origin = "global"` as a proxy for "managed install". That routed untracked local source checkouts under the global extension root through the package-install validation path, so a plugin with both `package.json` and `openclaw.plugin.json` could be skipped with the compiled-runtime warning even though it was a local source checkout.

This patch classifies managed package directories from the plugin install records instead of the broad global-origin label. Install-record paths remain strict because those represent installed packages. Untracked directories discovered by scanning the global extension root are allowed to fall back to TypeScript package entries for local development/source-checkout use.

## Real Behavior Proof

Behavior or issue addressed: TypeScript-source plugins under the global extension root were silently skipped when the directory contained both `package.json` and `openclaw.plugin.json`.

Real environment tested: local OpenClaw checkout with targeted plugin discovery harnesses and unit tests.

Exact steps or command run after this patch:

- `node_modules/.bin/oxfmt --check --threads=1 src/plugins/discovery.ts src/plugins/discovery.test.ts src/plugins/package-entry-resolution.ts CHANGELOG.md docs/tools/plugin.md`
- `git diff --check`
- `timeout 60s env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/plugins/discovery.test.ts`
- `timeout 120s node --import tsx /tmp/openclaw-80503-proof.mjs`

Evidence after fix:

Terminal output from the local OpenClaw checkout:

```text
$ timeout 120s node --import tsx /tmp/openclaw-80503-proof.mjs
plugin discovery proof passed
(node:8) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
```

- `plugin discovery proof passed`
- The proof covers:
  - untracked global package plugin with TypeScript source entry loads
  - tracked install-record package remains strict and skips source-only TS entry with compiled-runtime diagnostic
  - install-record `sourcePath` under the global scan remains managed and strict
  - package metadata without package entries falls back to `index.ts`
  - missing explicit runtime/setup entries emit diagnostics
  - bundled trusted plugin precedence/fallback behavior is preserved

Observed result after fix: untracked source-checkout plugins can load from TypeScript package entries, while managed installs still require compiled runtime output.

What was not tested: a broad full-repo test/build gate, due host CPU cooling constraints. The targeted formatter, discovery unit suite, proof harness, Claude review, and Codex review were run instead.

## Review

- Codex `/review`, full-scope uncommitted review with 900s timeout: no discrete correctness issues found.
- Claude CLI review over the full diff with 900s timeout: LGTM; optional follow-ups only, no blockers.
