### PR TITLE
fix(lmstudio): resolve env-template API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/sessions: clear stored CLI provider resume bindings on non-subagent `/reset` so the next turn starts a fresh provider-side CLI conversation instead of resuming old context. (#83448) Thanks @jasonyliu.
 - Doctor: preserve legacy whole-agent Claude CLI intent by moving matching Anthropic model selections to model-scoped runtime policy before removing stale runtime pins. Fixes #83491. Thanks @danielcrick.
 - Discord/OpenAI: keep realtime Discord voice sessions hearing follow-up turns with OpenAI realtime and prebuffer assistant playback to avoid choppy starts. (#80505) Thanks @Solvely-Colin.
+- LM Studio: resolve env-template API keys like `${LMSTUDIO_API_KEY}` through the standard SecretInput path instead of sending the raw template as the bearer token, and preserve header-auth and discovery-key precedence when the template is unset. Fixes #80495. (#80568) Thanks @MonkeyLeeT.
 - Discord/subagents: route the initial reply from thread-bound delegated sessions into the bound Discord thread instead of the parent channel. Fixes #83170. (#83172) Thanks @100menotu001.
 - Gateway/sessions: rotate failed agent sessions when their transcript file is missing instead of wedging per-channel lanes. Fixes #83488. (#83553) Thanks @LLagoon3.
 - Media: prevent image metadata probing from invoking external decoder delegates on unrecognized image bytes, and stop fallback chaining after real processing errors.
@@ -626,7 +627,6 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenCode Go: stop sending unsupported reasoning parameters to Kimi K2.5/K2.6, avoiding OpenCode Go payload-validation failures while preserving DeepSeek V4 reasoning support.
 - Providers/OpenRouter: normalize invalid Chat Completions reasoning replay fields while preserving valid OpenRouter reasoning pass-back, avoiding follow-up turn 500s without affecting stock OpenAI calls. (#82101) Thanks @sliverp.
 - Installer: handle noninteractive git installs from moving refs without tag-fetch conflicts, while keeping immutable refs on frozen lockfile installs. (#81875) Thanks @keshavbotagent.
-- LM Studio: resolve arbitrary env-template API keys such as `${LMSTUDIO_API_KEY}` instead of sending the env var name as a literal bearer token. Refs #80495. Thanks @jpereze12.
 - Codex app-server: inject native client factories per run and compaction attempt instead of using module-scope test state, avoiding temporal-dead-zone reads during cyclic startup. (#81148) Thanks @bdjben.
 - Plugin skills: replace generated Windows plugin-skill directories before publishing the current skill link, avoiding repeated `EINVAL` warnings from stale non-symlink entries. Fixes #81432. (#81446) Thanks @hclsys and @vincentkoc.
 - Channels/config: treat channel entries with only `enabled: true` as configured state so plugin-backed channels can auto-enable from an explicit on switch. Fixes #81323. (#81331) Thanks @EvanYao826 and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,6 +626,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenCode Go: stop sending unsupported reasoning parameters to Kimi K2.5/K2.6, avoiding OpenCode Go payload-validation failures while preserving DeepSeek V4 reasoning support.
 - Providers/OpenRouter: normalize invalid Chat Completions reasoning replay fields while preserving valid OpenRouter reasoning pass-back, avoiding follow-up turn 500s without affecting stock OpenAI calls. (#82101) Thanks @sliverp.
 - Installer: handle noninteractive git installs from moving refs without tag-fetch conflicts, while keeping immutable refs on frozen lockfile installs. (#81875) Thanks @keshavbotagent.
+- LM Studio: resolve arbitrary env-template API keys such as `${LMSTUDIO_API_KEY}` instead of sending the env var name as a literal bearer token. Refs #80495. Thanks @jpereze12.
 - Codex app-server: inject native client factories per run and compaction attempt instead of using module-scope test state, avoiding temporal-dead-zone reads during cyclic startup. (#81148) Thanks @bdjben.
 - Plugin skills: replace generated Windows plugin-skill directories before publishing the current skill link, avoiding repeated `EINVAL` warnings from stale non-symlink entries. Fixes #81432. (#81446) Thanks @hclsys and @vincentkoc.
 - Channels/config: treat channel entries with only `enabled: true` as configured state so plugin-backed channels can auto-enable from an explicit on switch. Fixes #81323. (#81331) Thanks @EvanYao826 and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Memory: skip managed dreaming cron reconciliation warnings for ordinary cron and heartbeat hook contexts that cannot manage Gateway cron. (#77027) Thanks @rubencu.
 - Cron: treat Codex app-server turn acceptance, CLI process spawn, and tool starts as execution milestones, preventing isolated runs from tripping the early startup watchdog after work has begun.
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.
+- LM Studio: resolve arbitrary env-template API keys such as `${LMSTUDIO_API_KEY}` instead of sending the env var name as a literal bearer token. Refs #80495. Thanks @jpereze12.
 - Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.
 - Codex app-server: default native plugin app tool approvals to automatic so non-destructive read tools run when destructive actions are disabled.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.

--- a/extensions/lmstudio/src/runtime.test.ts
+++ b/extensions/lmstudio/src/runtime.test.ts
@@ -261,6 +261,30 @@ describe("lmstudio-runtime", () => {
     ).resolves.toBe("template-lmstudio-key");
   });
 
+  it("resolves arbitrary env-template api keys from config", async () => {
+    await expect(
+      resolveLmstudioConfiguredApiKey({
+        config: buildLmstudioConfig({
+          apiKey: "${LMSTUDIO_API_KEY}",
+        }),
+        env: {
+          LMSTUDIO_API_KEY: "custom-template-lmstudio-key",
+        },
+      }),
+    ).resolves.toBe("custom-template-lmstudio-key");
+  });
+
+  it("throws a path-specific error when an env-template api key cannot be resolved", async () => {
+    await expect(
+      resolveLmstudioConfiguredApiKey({
+        config: buildLmstudioConfig({
+          apiKey: "${LMSTUDIO_API_KEY}",
+        }),
+        env: {},
+      }),
+    ).rejects.toThrow(/models\.providers\.lmstudio\.apiKey/i);
+  });
+
   it("throws a path-specific error when a SecretRef header cannot be resolved", async () => {
     const headerRef = {
       "X-Proxy-Auth": {

--- a/extensions/lmstudio/src/runtime.test.ts
+++ b/extensions/lmstudio/src/runtime.test.ts
@@ -140,6 +140,24 @@ describe("lmstudio-runtime", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("allows header-only runtime auth when an api key env template is unset", async () => {
+    resolveApiKeyForProviderMock.mockRejectedValueOnce(
+      new Error('No API key found for provider "lmstudio". Auth store: /tmp/auth-profiles.json.'),
+    );
+
+    await expect(
+      resolveLmstudioRuntimeApiKey({
+        config: buildLmstudioConfig({
+          apiKey: "${LMSTUDIO_API_KEY}",
+          headers: {
+            Authorization: "Bearer proxy-token",
+          },
+        }),
+        env: {},
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("suppresses profile runtime auth when Authorization is configured", async () => {
     resolveApiKeyForProviderMock.mockResolvedValueOnce({
       apiKey: "stale-profile-key",

--- a/extensions/lmstudio/src/runtime.ts
+++ b/extensions/lmstudio/src/runtime.ts
@@ -74,6 +74,7 @@ export async function resolveLmstudioConfiguredApiKey(params: {
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   path?: string;
+  allowUnresolved?: boolean;
 }): Promise<string | undefined> {
   const providerConfig = params.config?.models?.providers?.[LMSTUDIO_PROVIDER_ID];
   const apiKeyInput = providerConfig?.apiKey;
@@ -95,6 +96,9 @@ export async function resolveLmstudioConfiguredApiKey(params: {
         })
       : { value: directApiKey };
     if (resolved.unresolvedRefReason) {
+      if (params.allowUnresolved) {
+        return undefined;
+      }
       throw new Error(`${path}: ${resolved.unresolvedRefReason}`);
     }
     const resolvedValue = normalizeOptionalSecretInput(resolved.value);
@@ -120,6 +124,9 @@ export async function resolveLmstudioConfiguredApiKey(params: {
     unresolvedReasonStyle: "detailed",
   });
   if (resolved.unresolvedRefReason) {
+    if (params.allowUnresolved) {
+      return undefined;
+    }
     throw new Error(`${path}: ${resolved.unresolvedRefReason}`);
   }
   const resolvedValue = normalizeOptionalSecretInput(resolved.value);
@@ -219,6 +226,7 @@ export async function resolveLmstudioRuntimeApiKey(params: {
     configuredApiKeyPromise ??= resolveLmstudioConfiguredApiKey({
       config,
       env: params.env,
+      allowUnresolved: hasAuthorizationHeader,
     });
     return await configuredApiKeyPromise;
   };

--- a/extensions/lmstudio/src/runtime.ts
+++ b/extensions/lmstudio/src/runtime.ts
@@ -81,14 +81,29 @@ export async function resolveLmstudioConfiguredApiKey(params: {
     return undefined;
   }
 
+  const path = params.path ?? "models.providers.lmstudio.apiKey";
+  const env = params.env ?? process.env;
   const directApiKey = normalizeOptionalSecretInput(apiKeyInput);
   if (directApiKey !== undefined) {
-    const trimmed = normalizeApiKeyConfig(directApiKey).trim();
+    const resolved = params.config
+      ? await resolveConfiguredSecretInputString({
+          config: params.config,
+          env,
+          value: directApiKey,
+          path,
+          unresolvedReasonStyle: "detailed",
+        })
+      : { value: directApiKey };
+    if (resolved.unresolvedRefReason) {
+      throw new Error(`${path}: ${resolved.unresolvedRefReason}`);
+    }
+    const resolvedValue = normalizeOptionalSecretInput(resolved.value);
+    const trimmed = resolvedValue ? normalizeApiKeyConfig(resolvedValue).trim() : "";
     if (!trimmed) {
       return undefined;
     }
     if (isKnownEnvApiKeyMarker(trimmed)) {
-      const envValue = normalizeOptionalSecretInput((params.env ?? process.env)[trimmed]);
+      const envValue = normalizeOptionalSecretInput(env[trimmed]);
       return envValue;
     }
     return isNonSecretApiKeyMarker(trimmed) ? undefined : trimmed;
@@ -97,10 +112,9 @@ export async function resolveLmstudioConfiguredApiKey(params: {
   if (!params.config) {
     return undefined;
   }
-  const path = params.path ?? "models.providers.lmstudio.apiKey";
   const resolved = await resolveConfiguredSecretInputString({
     config: params.config,
-    env: params.env ?? process.env,
+    env,
     value: apiKeyInput,
     path,
     unresolvedReasonStyle: "detailed",

--- a/extensions/lmstudio/src/setup.test.ts
+++ b/extensions/lmstudio/src/setup.test.ts
@@ -1366,6 +1366,38 @@ describe("lmstudio setup", () => {
     });
   });
 
+  it("discoverLmstudioProvider ignores an unresolved apiKey template when discoveryApiKey is resolved", async () => {
+    discoverLmstudioModelsMock.mockResolvedValueOnce([
+      createModel("qwen3-8b-instruct", "Qwen3 8B"),
+    ]);
+
+    await discoverLmstudioProvider(
+      buildDiscoveryContext({
+        discoveryApiKey: "resolved-discovery-key",
+        config: {
+          models: {
+            providers: {
+              lmstudio: {
+                baseUrl: "http://localhost:1234/v1",
+                api: "openai-completions",
+                apiKey: "${LMSTUDIO_API_KEY}",
+                models: [],
+              },
+            },
+          },
+        } as OpenClawConfig,
+        env: {},
+      }),
+    );
+
+    expect(discoverLmstudioModelsMock).toHaveBeenCalledWith({
+      baseUrl: "http://localhost:1234/v1",
+      apiKey: "resolved-discovery-key",
+      headers: undefined,
+      quiet: false,
+    });
+  });
+
   it("discoverLmstudioProvider suppresses stale discovery apiKey when Authorization header auth is configured", async () => {
     discoverLmstudioModelsMock.mockResolvedValueOnce([
       createModel("qwen3-8b-instruct", "Qwen3 8B"),

--- a/extensions/lmstudio/src/setup.test.ts
+++ b/extensions/lmstudio/src/setup.test.ts
@@ -1142,6 +1142,20 @@ describe("lmstudio setup", () => {
       },
     },
     {
+      name: "ignores unresolved apiKey template when Authorization header is configured",
+      providerPatch: {
+        apiKey: "${LMSTUDIO_API_KEY}",
+        headers: {
+          Authorization: "Bearer custom-token",
+        },
+      },
+      expectedProviderPatch: {
+        headers: {
+          Authorization: "Bearer custom-token",
+        },
+      },
+    },
+    {
       name: "still injects lmstudio-local when only non-auth headers are configured",
       providerPatch: {
         headers: {

--- a/extensions/lmstudio/src/setup.test.ts
+++ b/extensions/lmstudio/src/setup.test.ts
@@ -1123,6 +1123,20 @@ describe("lmstudio setup", () => {
       },
     },
     {
+      name: "ignores unresolved apiKey template when Authorization header is configured",
+      providerPatch: {
+        apiKey: "${LMSTUDIO_API_KEY}",
+        headers: {
+          Authorization: "Bearer custom-token",
+        },
+      },
+      expectedProviderPatch: {
+        headers: {
+          Authorization: "Bearer custom-token",
+        },
+      },
+    },
+    {
       name: "still injects lmstudio-local when only non-auth headers are configured",
       providerPatch: {
         headers: {

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -760,18 +760,6 @@ export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Pro
   }
   const hasExplicitModels = Array.isArray(explicit?.models) && explicit.models.length > 0;
   const { apiKey, discoveryApiKey } = ctx.resolveProviderApiKey(PROVIDER_ID);
-  let configuredDiscoveryApiKey: string | undefined;
-  try {
-    configuredDiscoveryApiKey = await resolveLmstudioConfiguredApiKey({
-      config: ctx.config,
-      env: ctx.env,
-    });
-  } catch (error) {
-    if (isLmstudioDiscoveryConfigResolutionError(error)) {
-      return null;
-    }
-    throw error;
-  }
   let resolvedHeaders: Record<string, string> | undefined;
   try {
     resolvedHeaders = await resolveLmstudioProviderHeaders({
@@ -786,6 +774,19 @@ export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Pro
     throw error;
   }
   const hasAuthorizationHeader = hasLmstudioAuthorizationHeader(resolvedHeaders);
+  let configuredDiscoveryApiKey: string | undefined;
+  try {
+    configuredDiscoveryApiKey = await resolveLmstudioConfiguredApiKey({
+      config: ctx.config,
+      env: ctx.env,
+      allowUnresolved: hasAuthorizationHeader,
+    });
+  } catch (error) {
+    if (isLmstudioDiscoveryConfigResolutionError(error)) {
+      return null;
+    }
+    throw error;
+  }
   const resolvedDiscoveryApiKey = hasAuthorizationHeader
     ? undefined
     : (discoveryApiKey ?? configuredDiscoveryApiKey);

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -779,7 +779,7 @@ export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Pro
     configuredDiscoveryApiKey = await resolveLmstudioConfiguredApiKey({
       config: ctx.config,
       env: ctx.env,
-      allowUnresolved: hasAuthorizationHeader,
+      allowUnresolved: hasAuthorizationHeader || Boolean(discoveryApiKey),
     });
   } catch (error) {
     if (isLmstudioDiscoveryConfigResolutionError(error)) {


### PR DESCRIPTION
## Summary

- Resolve LM Studio configured `apiKey` strings through the standard SecretInput path before falling back to known env-marker handling.
- Fix arbitrary env-template keys like `${LMSTUDIO_API_KEY}` being treated as literal API keys.
- Preserve higher-precedence auth when an optional configured `apiKey` env template is unset, including `headers.Authorization` and resolved discovery/profile auth.
- Add LM Studio runtime and discovery regressions for custom env-template API keys, unresolved-template errors, header-auth precedence, and discovery-key precedence.

Refs #80495. This addresses the auth-resolution portion only; native `/api/v1/chat` inference fallback remains separate provider/API scope.

## Reported Repro

- #80495 reports an LM Studio config using an env-backed API key where OpenClaw sent the env var marker/name as the bearer token instead of the resolved value.
- Source inspection matched that report: arbitrary `${ENV}` apiKey templates did not go through the generic SecretInput resolution path unless the env var name was a registered provider marker.

## After-Fix Proof

- `pnpm test extensions/lmstudio/src/runtime.test.ts extensions/lmstudio/src/setup.test.ts -- --reporter=verbose` passed: 2 files, 53 tests.
- The focused regressions prove `${LMSTUDIO_API_KEY}` resolves to the configured env value before auth header construction.
- The regressions prove unresolved `${LMSTUDIO_API_KEY}` still reports a path-specific error when no other auth satisfies the provider.
- The regressions prove `headers.Authorization` continues to satisfy auth when `${LMSTUDIO_API_KEY}` is unset, covering both runtime auth and discovery/setup behavior.
- The regressions prove a resolved `discoveryApiKey` continues to take precedence over a stale unset configured `apiKey` template during provider discovery.

No live LM Studio server verification was run for this branch.

## Verification

- `pnpm test extensions/lmstudio/src/runtime.test.ts extensions/lmstudio/src/setup.test.ts -- --reporter=verbose`
- `pnpm tsgo:extensions`
- `pnpm tsgo:test:extensions`
- `pnpm format:check -- extensions/lmstudio/src/setup.ts extensions/lmstudio/src/setup.test.ts extensions/lmstudio/src/runtime.ts extensions/lmstudio/src/runtime.test.ts CHANGELOG.md`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/lmstudio/src/setup.ts extensions/lmstudio/src/setup.test.ts extensions/lmstudio/src/runtime.ts extensions/lmstudio/src/runtime.test.ts`
- `git diff --check`
