### PR TITLE
Expose transcript update emitter to plugins

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -431,7 +431,7 @@ Provider and channel execution paths must use the active runtime config snapshot
 
   </Accordion>
   <Accordion title="api.runtime.events">
-    Event subscriptions.
+    Event subscriptions and transcript update notifications.
 
     ```typescript
     api.runtime.events.onAgentEvent((event) => {
@@ -440,7 +440,13 @@ Provider and channel execution paths must use the active runtime config snapshot
     api.runtime.events.onSessionTranscriptUpdate((update) => {
       /* ... */
     });
+    api.runtime.events.emitSessionTranscriptUpdate(sessionFile);
     ```
+
+    `emitSessionTranscriptUpdate(sessionFile)` should be called only after the
+    plugin has durably written to the transcript file. It accepts the transcript
+    file path and broadcasts a reload notification; it does not accept or publish
+    synthetic message payloads.
 
   </Accordion>
   <Accordion title="api.runtime.logging">

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -682,6 +682,8 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
     events: {
       onAgentEvent: vi.fn(() => () => {}) as unknown as PluginRuntime["events"]["onAgentEvent"],
+      emitSessionTranscriptUpdate:
+        vi.fn() as unknown as PluginRuntime["events"]["emitSessionTranscriptUpdate"],
       onSessionTranscriptUpdate: vi.fn(
         () => () => {},
       ) as unknown as PluginRuntime["events"]["onSessionTranscriptUpdate"],

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -12,10 +12,7 @@ import {
   setHeartbeatWakeHandler,
 } from "../../infra/heartbeat-wake.js";
 import * as execModule from "../../process/exec.js";
-import {
-  emitSessionTranscriptUpdate,
-  onSessionTranscriptUpdate,
-} from "../../sessions/transcript-events.js";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { VERSION } from "../../version.js";
 
 const runtimeModelAuthMocks = vi.hoisted(() => ({
@@ -168,12 +165,6 @@ describe("plugin runtime command execution", () => {
       expected: onSessionTranscriptUpdate,
     },
     {
-      name: "exposes runtime.events.emitSessionTranscriptUpdate",
-      readValue: (runtime: ReturnType<typeof createPluginRuntime>) =>
-        runtime.events.emitSessionTranscriptUpdate,
-      expected: emitSessionTranscriptUpdate,
-    },
-    {
       name: "exposes runtime.system.requestHeartbeat",
       readValue: (runtime: ReturnType<typeof createPluginRuntime>) =>
         runtime.system.requestHeartbeat,
@@ -192,6 +183,19 @@ describe("plugin runtime command execution", () => {
     },
   ] as const)("$name", ({ readValue, expected }) => {
     expectRuntimeValue(readValue, expected);
+  });
+
+  it("exposes a path-only runtime.events.emitSessionTranscriptUpdate wrapper", () => {
+    const updates: unknown[] = [];
+    const cleanup = onSessionTranscriptUpdate((update) => updates.push(update));
+    try {
+      const runtime = createPluginRuntime();
+      expect(typeof runtime.events.emitSessionTranscriptUpdate).toBe("function");
+      expect(runtime.events.emitSessionTranscriptUpdate("/tmp/session.jsonl")).toBeUndefined();
+      expect(updates).toEqual([{ sessionFile: "/tmp/session.jsonl" }]);
+    } finally {
+      cleanup();
+    }
   });
 
   it("maps deprecated runtime.system.requestHeartbeatNow to an immediate compatibility wake", async () => {

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -12,7 +12,10 @@ import {
   setHeartbeatWakeHandler,
 } from "../../infra/heartbeat-wake.js";
 import * as execModule from "../../process/exec.js";
-import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import {
+  emitSessionTranscriptUpdate,
+  onSessionTranscriptUpdate,
+} from "../../sessions/transcript-events.js";
 import { VERSION } from "../../version.js";
 
 const runtimeModelAuthMocks = vi.hoisted(() => ({
@@ -163,6 +166,12 @@ describe("plugin runtime command execution", () => {
       readValue: (runtime: ReturnType<typeof createPluginRuntime>) =>
         runtime.events.onSessionTranscriptUpdate,
       expected: onSessionTranscriptUpdate,
+    },
+    {
+      name: "exposes runtime.events.emitSessionTranscriptUpdate",
+      readValue: (runtime: ReturnType<typeof createPluginRuntime>) =>
+        runtime.events.emitSessionTranscriptUpdate,
+      expected: emitSessionTranscriptUpdate,
     },
     {
       name: "exposes runtime.system.requestHeartbeat",

--- a/src/plugins/runtime/runtime-events.ts
+++ b/src/plugins/runtime/runtime-events.ts
@@ -1,9 +1,13 @@
 import { onAgentEvent } from "../../infra/agent-events.js";
 import {
-  emitSessionTranscriptUpdate,
+  emitSessionTranscriptUpdate as emitTranscriptUpdate,
   onSessionTranscriptUpdate,
 } from "../../sessions/transcript-events.js";
 import type { PluginRuntime } from "./types.js";
+
+export function emitSessionTranscriptUpdate(sessionFile: string): void {
+  emitTranscriptUpdate(sessionFile);
+}
 
 export function createRuntimeEvents(): PluginRuntime["events"] {
   return {

--- a/src/plugins/runtime/runtime-events.ts
+++ b/src/plugins/runtime/runtime-events.ts
@@ -1,10 +1,14 @@
 import { onAgentEvent } from "../../infra/agent-events.js";
-import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import {
+  emitSessionTranscriptUpdate,
+  onSessionTranscriptUpdate,
+} from "../../sessions/transcript-events.js";
 import type { PluginRuntime } from "./types.js";
 
 export function createRuntimeEvents(): PluginRuntime["events"] {
   return {
     onAgentEvent,
+    emitSessionTranscriptUpdate,
     onSessionTranscriptUpdate,
   };
 }

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -287,7 +287,7 @@ export type PluginRuntimeCore = {
   };
   events: {
     onAgentEvent: typeof import("../../infra/agent-events.js").onAgentEvent;
-    emitSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").emitSessionTranscriptUpdate;
+    emitSessionTranscriptUpdate: typeof import("./runtime-events.js").emitSessionTranscriptUpdate;
     onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onSessionTranscriptUpdate;
   };
   logging: {

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -287,6 +287,7 @@ export type PluginRuntimeCore = {
   };
   events: {
     onAgentEvent: typeof import("../../infra/agent-events.js").onAgentEvent;
+    emitSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").emitSessionTranscriptUpdate;
     onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onSessionTranscriptUpdate;
   };
   logging: {


### PR DESCRIPTION
## Summary
- expose emitSessionTranscriptUpdate on plugin runtime events
- keep onSessionTranscriptUpdate listener support unchanged
- cover the runtime event surface in tests

## Test
- pnpm exec vitest run src/plugins/runtime/index.test.ts