### PR TITLE
docs(browser): clarify wait --load networkidle is not supported on existing-session

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -806,6 +806,7 @@ You can wait on more than just time/text:
   - `openclaw browser wait --url "**/dash"`
 - Wait for load state:
   - `openclaw browser wait --load networkidle`
+  - **Note:** `--load networkidle` is supported on the managed `openclaw` browser and remote-CDP profiles. It is not yet supported on `existing-session` / `user` profiles.
 - Wait for a JS predicate:
   - `openclaw browser wait --fn "window.ready===true"`
 - Wait for a selector to become visible:


### PR DESCRIPTION
## Summary

Fixes #80587

The "Wait power-ups" section in `docs/tools/browser.md` listed `--load networkidle` as a supported option with no caveats. Meanwhile the existing-session limitations section (further down the page) correctly noted it is not yet supported on `existing-session` / `user` profiles.

This contradiction caused repeated user confusion — readers hitting the power-ups section first assumed universal support across all browser profiles.

## Change

Added a single inline note under the `--load networkidle` bullet making the profile scope explicit:

```
**Note:** `--load networkidle` is supported on the managed `openclaw` browser and remote-CDP profiles. It is not yet supported on `existing-session` / `user` profiles.
```

Both docs sections now tell a consistent story. No code changes.

## Testing

Docs-only change. Verified the surrounding context renders correctly and the note is placed where a reader first encounters the feature.