### PR TITLE
fix(message): show dry-run output for send/poll

### DIFF
--- a/src/commands/message-format.test.ts
+++ b/src/commands/message-format.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { MessageActionRunResult } from "../infra/outbound/message-action-runner.js";
+import { formatMessageCliText } from "./message-format.js";
+
+describe("formatMessageCliText", () => {
+  it("shows dry-run line for send results even when handledBy is core", () => {
+    const result: MessageActionRunResult = {
+      kind: "send",
+      action: "send",
+      channel: "slack",
+      to: "channel:C123",
+      handledBy: "core",
+      payload: { messageId: "unknown" },
+      dryRun: true,
+    };
+
+    expect(formatMessageCliText(result)).toEqual(["[dry-run] would run send via slack"]);
+  });
+
+  it("shows dry-run line for poll results even when handledBy is core", () => {
+    const result: MessageActionRunResult = {
+      kind: "poll",
+      action: "poll",
+      channel: "slack",
+      to: "channel:C123",
+      handledBy: "core",
+      payload: { messageId: "unknown" },
+      dryRun: true,
+    };
+
+    expect(formatMessageCliText(result)).toEqual(["[dry-run] would run poll via slack"]);
+  });
+});

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -246,7 +246,7 @@ export function formatMessageCliText(result: MessageActionRunResult): string[] {
   const width = getTerminalTableWidth();
   const opts: FormatOpts = { width };
 
-  if (result.handledBy === "dry-run") {
+  if (result.dryRun) {
     return [muted(`[dry-run] would run ${result.action} via ${result.channel}`)];
   }
 


### PR DESCRIPTION
## Summary
- make CLI formatter use `result.dryRun` instead of `handledBy === "dry-run"`
- ensure `message send --dry-run` and `message poll --dry-run` render `[dry-run]` text instead of success checkmark
- add focused tests for dry-run send/poll formatting

## Why
`send`/`poll` results return `handledBy: "core" | "plugin"` with a separate `dryRun` flag, so the old dry-run branch was unreachable.

Fixes #80507

## Validation
- `CI=true pnpm vitest run src/commands/message-format.test.ts`

## Real behavior proof
- **Behavior or issue addressed**: `message send --dry-run` / `message poll --dry-run` could print success-style output instead of dry-run output.
- **Real environment tested**: Local OpenClaw source checkout on macOS (Darwin arm64), running command-line execution in a real shell.
- **Exact steps or command run after this patch**:
  ```bash
  CI=true pnpm tsx -e "import { formatMessageCliText } from './src/commands/message-format.ts'; const send={kind:'send',action:'send',channel:'slack',to:'channel:C123',handledBy:'core',payload:{messageId:'unknown'},dryRun:true}; const poll={kind:'poll',action:'poll',channel:'slack',to:'channel:C123',handledBy:'core',payload:{messageId:'unknown'},dryRun:true}; console.log('SEND:', formatMessageCliText(send as any).join('\\n')); console.log('POLL:', formatMessageCliText(poll as any).join('\\n'));"
  ```
- **Evidence after fix**:
  ```text
  SEND: [dry-run] would run send via slack
  POLL: [dry-run] would run poll via slack
  ```
- **Observed result after fix**: Both dry-run flows now emit explicit `[dry-run]` output and no longer appear as successful real sends.
- **What was not tested**: End-to-end delivery plugin behavior (out of scope for this formatter-only fix).
