### PR TITLE
feat: Skill Curator plugin — Plan #01

### DIFF
--- a/docs/automation/curator.md
+++ b/docs/automation/curator.md
@@ -1,8 +1,15 @@
 # Skill Curator
 
-The skill curator automatically maintains your workspace `skills/` tree —
-marking stale skills, archiving unused ones, and periodically running an LLM
-review pass to patch drift or consolidate near-duplicates.
+The skill curator maintains your workspace `skills/` tree —
+marking stale skills, archiving unused ones, and (when gateway support is
+available) running an LLM review pass to patch drift or consolidate
+near-duplicates.
+
+> **Status:** Phase A (deterministic transitions, snapshots, pinning, telemetry)
+> is fully functional. Phase B (LLM review pass) requires the
+> `auxiliary.curator` model slot, which is a gateway-level feature (deferred).
+> The `/curator` slash command on Discord/Telegram requires platform
+> slash-command registration (deferred). The CLI works from any shell.
 
 ## Quick Start
 
@@ -13,11 +20,8 @@ openclaw curator run --dry-run
 # Check status
 openclaw curator status
 
-# Run now (background)
+# Run now
 openclaw curator run
-
-# Run synchronously (blocks until done)
-openclaw curator run --sync
 ```
 
 ## How It Works
@@ -95,7 +99,10 @@ Skip: pinned, bundled, hub-installed, and non-agent-created skills.
 
 ### Phase B — LLM Review Pass
 
-Uses a cheap auxiliary model to review agent-created skills and suggest:
+> **Deferred:** Requires the `auxiliary.curator` model slot at the gateway
+> level. Not currently active in automatic runs.
+
+When wired, uses a cheap auxiliary model to review agent-created skills and suggest:
 
 - **keep** — skill is still useful
 - **patch** — fix a specific issue (replace old_text with new_text)
@@ -175,5 +182,5 @@ The skill moves back to `skills/` and is marked `active`.
 
 ### "tar not found"
 
-Snapshots require `tar` on your PATH. If `tar` is unavailable, snapshot
-creation will fail gracefully and the curator will continue without backups.
+Snapshots require `tar` on your PATH. If `tar` is unavailable, the curator
+run will return a snapshot error and stop before applying mutations.

--- a/docs/automation/curator.md
+++ b/docs/automation/curator.md
@@ -1,0 +1,179 @@
+# Skill Curator
+
+The skill curator automatically maintains your workspace `skills/` tree —
+marking stale skills, archiving unused ones, and periodically running an LLM
+review pass to patch drift or consolidate near-duplicates.
+
+## Quick Start
+
+```bash
+# Check what the curator would do (no mutations)
+openclaw curator run --dry-run
+
+# Check status
+openclaw curator status
+
+# Run now (background)
+openclaw curator run
+
+# Run synchronously (blocks until done)
+openclaw curator run --sync
+```
+
+## How It Works
+
+### What Gets Managed
+
+The curator only manages **agent-created** skills — skills created by the
+`skill_workshop` tool. Hand-written skills, bundled skills (shipped with
+OpenClaw), and hub-installed skills (from clawhub.ai) are never touched.
+
+A skill is considered "agent-created" when its `created_by` field in
+`.usage.json` is `"agent"`. Skills created by `skill_workshop` get this
+marker automatically.
+
+### What Counts as Agent-Created
+
+| Marker                  | Meaning                   | Curator Behavior                     |
+| ----------------------- | ------------------------- | ------------------------------------ |
+| `created_by: "agent"`   | Created by skill_workshop | Fully managed                        |
+| `created_by: "user"`    | Hand-authored by you      | Never touched                        |
+| `created_by: "unknown"` | Pre-migration skill       | Treated as user-owned (safe default) |
+
+You can promote or demote skills at any time:
+
+```bash
+# Let the curator manage it
+openclaw curator adopt <skill-name>
+
+# Remove from curator management
+openclaw curator disown <skill-name>
+```
+
+### Lifecycle
+
+```
+active ──(30d unused)──→ stale ──(90d unused)──→ archived
+  ↑                                                    │
+  └──────────── restore ───────────────────────────────┘
+```
+
+Archived skills move to `<workspace>/skills/.archive/<name>/` — they're never
+deleted, just set aside.
+
+### First-Run Defer
+
+On a fresh install, the curator seeds `last_run_at` to the current time and
+skips the first pass. This gives you one full interval (default 7 days) to
+pin important skills or disable the curator before it acts.
+
+## Pinning
+
+Pinned skills are **immune** to all curator actions — they won't be marked
+stale, archived, or mutated by the LLM review pass. Pinned skills also
+cannot be deleted by `skill_workshop(action=delete)`.
+
+```bash
+openclaw curator pin <skill-name>
+openclaw curator unpin <skill-name>
+```
+
+Pinned skills appear in `openclaw curator status` under the `pinned` list.
+
+## Phase A vs Phase B
+
+The curator runs in two phases:
+
+### Phase A — Deterministic Transitions
+
+No LLM involved. Pure time-based rules:
+
+- Skills unused > `stale_after_days` → marked `stale`
+- Skills unused > `archive_after_days` → moved to `.archive/`
+
+Skip: pinned, bundled, hub-installed, and non-agent-created skills.
+
+### Phase B — LLM Review Pass
+
+Uses a cheap auxiliary model to review agent-created skills and suggest:
+
+- **keep** — skill is still useful
+- **patch** — fix a specific issue (replace old_text with new_text)
+- **consolidate** — merge two similar skills
+- **archive** — skill is no longer needed
+
+The LLM is **conservative** — when in doubt, it keeps. All actions flow
+through `skill_workshop` so audit trails, hooks, and checkpoints fire.
+
+## Backup & Rollback
+
+Before every mutating run, the curator snapshots the entire `skills/` tree
+to a tar.gz under `<workspace>/skills/.curator_backups/<timestamp>/`.
+
+```bash
+# Manual backup
+openclaw curator backup --reason "Before major reorganization"
+
+# List available snapshots
+openclaw curator rollback --list
+
+# Restore from a snapshot (pre-rollback snapshot taken automatically)
+openclaw curator rollback --id <timestamp>
+```
+
+By default, the last 5 snapshots are kept (configurable via `backup.keep`).
+
+## Pause / Resume
+
+```bash
+# Pause — no automatic runs until resumed
+openclaw curator pause
+
+# Resume
+openclaw curator resume
+```
+
+Pause state persists across sessions.
+
+## Safety Guards
+
+- **No auto-delete.** The worst outcome is `.archive/` (recoverable).
+- **Lockfile.** Only one curator run at a time.
+- **Pre-mutation snapshot.** Always taken before any changes.
+- **Bundled/hub immunity.** Never touched regardless of config.
+- **First-run defer.** No surprise runs on fresh install.
+
+## Troubleshooting
+
+### "The curator archived my hand-written skill!"
+
+The curator only touches `created_by: "agent"` skills. Check with:
+
+```bash
+openclaw curator status
+```
+
+If your skill shows as `agent_created`, disown it:
+
+```bash
+openclaw curator disown <skill-name>
+```
+
+### "I want to restore an archived skill"
+
+```bash
+openclaw curator restore <skill-name>
+```
+
+The skill moves back to `skills/` and is marked `active`.
+
+### "The curator won't run"
+
+- Check if it's paused: `openclaw curator status`
+- Check the interval: default is 7 days (`interval_hours: 168`)
+- On first install: the first pass is deferred by one interval
+
+### "tar not found"
+
+Snapshots require `tar` on your PATH. If `tar` is unavailable, snapshot
+creation will fail gracefully and the curator will continue without backups.

--- a/docs/cli/curator.md
+++ b/docs/cli/curator.md
@@ -1,6 +1,10 @@
 # `openclaw curator`
 
-Skill curator CLI — manage skill lifecycle, telemetry, archival, and LLM review.
+Skill curator CLI — manage skill lifecycle, telemetry, and archival.
+LLM review pass requires gateway-level `auxiliary.curator` model slot (deferred).
+
+> **Note:** The `/curator` slash command on Discord/Telegram requires platform
+> slash-command registration (deferred). CLI commands work from any shell.
 
 ## Commands
 
@@ -37,7 +41,7 @@ Output (JSON):
 
 ### `curator run`
 
-Trigger a curator run. By default runs in the background.
+Trigger a curator run (Phase A — deterministic transitions only).
 
 ```bash
 openclaw curator run
@@ -47,12 +51,10 @@ Options:
 
 | Flag        | Description                              |
 | ----------- | ---------------------------------------- |
-| `--sync`    | Block until the run completes            |
 | `--dry-run` | Preview only — no mutations, no lockfile |
 
 ```bash
 openclaw curator run --dry-run
-openclaw curator run --sync
 ```
 
 ---
@@ -146,12 +148,15 @@ Useful for:
 
 ## Slash Command
 
-All verbs are available as `/curator` in CLI, Discord, and Telegram:
+When platform slash-command registration is available, all verbs will be
+exposed as `/curator` in CLI, Discord, and Telegram.
+
+Currently available via CLI:
 
 ```
-/curator status
-/curator run --dry-run
-/curator pin my-skill
+openclaw curator status
+openclaw curator run --dry-run
+openclaw curator pin my-skill
 ```
 
 ---
@@ -160,4 +165,4 @@ All verbs are available as `/curator` in CLI, Discord, and Telegram:
 
 - [Skill Curator Guide](/docs/automation/curator.md) — full lifecycle, pinning UX, troubleshooting
 - [Skill Workshop](/docs/cli/skill-workshop.md) — the tool that creates skills
-- [Config Reference](/docs/config.md) — `curator.*` and `auxiliary.curator.*` config keys
+- [Config Reference](/docs/config.md) — `curator.*` config keys (`auxiliary.curator.*` is a deferred gateway feature)

--- a/docs/cli/curator.md
+++ b/docs/cli/curator.md
@@ -1,0 +1,163 @@
+# `openclaw curator`
+
+Skill curator CLI — manage skill lifecycle, telemetry, archival, and LLM review.
+
+## Commands
+
+### `curator status`
+
+Show curator state: last run, counts by state, pinned list, LRU top 5.
+
+```bash
+openclaw curator status
+```
+
+Output (JSON):
+
+```json
+{
+  "last_run_at": "2026-05-06T12:00:00.000Z",
+  "paused": false,
+  "counts": {
+    "total": 12,
+    "active": 8,
+    "stale": 2,
+    "archived": 2,
+    "pinned": 1,
+    "agent_created": 6,
+    "user_created": 3,
+    "unknown": 3
+  },
+  "pinned": ["git-workflow"],
+  "lru_top_5": [...]
+}
+```
+
+---
+
+### `curator run`
+
+Trigger a curator run. By default runs in the background.
+
+```bash
+openclaw curator run
+```
+
+Options:
+
+| Flag        | Description                              |
+| ----------- | ---------------------------------------- |
+| `--sync`    | Block until the run completes            |
+| `--dry-run` | Preview only — no mutations, no lockfile |
+
+```bash
+openclaw curator run --dry-run
+openclaw curator run --sync
+```
+
+---
+
+### `curator backup`
+
+Create a manual snapshot of `skills/`.
+
+```bash
+openclaw curator backup --reason "Before cleanup"
+```
+
+Options:
+
+| Flag              | Description          |
+| ----------------- | -------------------- |
+| `--reason <text>` | Label for the backup |
+
+---
+
+### `curator rollback`
+
+Restore from a snapshot.
+
+```bash
+# List available snapshots
+openclaw curator rollback --list
+
+# Restore from a specific snapshot
+openclaw curator rollback --id <timestamp>
+```
+
+A pre-rollback snapshot is taken before restoring, so a mistaken rollback
+can be rolled forward.
+
+---
+
+### `curator pause` / `curator resume`
+
+Pause or resume automatic curator runs. Persists across sessions.
+
+```bash
+openclaw curator pause
+openclaw curator resume
+```
+
+---
+
+### `curator pin <skill>` / `curator unpin <skill>`
+
+Pin a skill to make it immune to archival and deletion. Unpin to allow
+curator management again.
+
+```bash
+openclaw curator pin my-workflow
+openclaw curator unpin my-workflow
+```
+
+Bundled and hub-installed skills cannot be pinned.
+
+---
+
+### `curator restore <skill>`
+
+Restore an archived skill back to `skills/`. The skill is marked `active`.
+
+```bash
+openclaw curator restore old-skill
+```
+
+---
+
+### `curator adopt <skill>` / `curator disown <skill>`
+
+Change the `created_by` marker:
+
+- `adopt` → sets to `"agent"` (curator manages it)
+- `disown` → sets to `"user"` (curator leaves it alone)
+
+```bash
+openclaw curator adopt hand-written-skill
+openclaw curator disown auto-generated-skill
+```
+
+Useful for:
+
+- Promoting a hand-written skill you want the curator to maintain
+- Protecting an agent-created skill you want to manage yourself
+
+---
+
+## Slash Command
+
+All verbs are available as `/curator` in CLI, Discord, and Telegram:
+
+```
+/curator status
+/curator run --dry-run
+/curator pin my-skill
+```
+
+---
+
+## See Also
+
+- [Skill Curator Guide](/docs/automation/curator.md) — full lifecycle, pinning UX, troubleshooting
+- [Skill Workshop](/docs/cli/skill-workshop.md) — the tool that creates skills
+- [Config Reference](/docs/config.md) — `curator.*` and `auxiliary.curator.*` config keys

--- a/extensions/skill-curator/openclaw.plugin.json
+++ b/extensions/skill-curator/openclaw.plugin.json
@@ -1,0 +1,84 @@
+{
+  "id": "skill-curator",
+  "activation": {
+    "onStartup": true
+  },
+  "name": "Skill Curator",
+  "description": "Tracks skill usage telemetry, auto-archives stale skills, snapshots workspace skills before mutations, and runs periodic LLM review passes.",
+  "contracts": {
+    "tools": ["skill_curator"],
+    "commands": ["curator"]
+  },
+  "uiHints": {
+    "intervalHours": {
+      "label": "Interval Hours",
+      "help": "How often (in hours) the curator runs its periodic pass."
+    },
+    "minIdleHours": {
+      "label": "Min Idle Hours",
+      "help": "Agent must be idle this many hours before curator will run."
+    },
+    "staleAfterDays": {
+      "label": "Stale After Days",
+      "help": "Days since last use before a skill is marked stale."
+    },
+    "archiveAfterDays": {
+      "label": "Archive After Days",
+      "help": "Days since last use before a stale skill is archived."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "default": true
+      },
+      "interval_hours": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 8760,
+        "default": 168
+      },
+      "min_idle_hours": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 168,
+        "default": 2
+      },
+      "stale_after_days": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 3650,
+        "default": 30
+      },
+      "archive_after_days": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 3650,
+        "default": 90
+      },
+      "backup": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "keep": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 5
+          }
+        },
+        "default": {
+          "enabled": true,
+          "keep": 5
+        }
+      }
+    }
+  }
+}

--- a/extensions/skill-curator/package.json
+++ b/extensions/skill-curator/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openclaw/skill-curator",
+  "version": "2026.5.6",
+  "private": true,
+  "description": "OpenClaw skill curator plugin – telemetry, stale/archive transitions, LLM review passes, and snapshot backups",
+  "type": "module",
+  "dependencies": {},
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  }
+}

--- a/extensions/skill-curator/src/cli.ts
+++ b/extensions/skill-curator/src/cli.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/core";
 import { resolveConfig, type CuratorConfig } from "./config.js";
+import { writeRunLog } from "./logs.js";
 import {
   adoptSkill,
   curatorRun,
@@ -138,6 +139,17 @@ export function registerCuratorCli(api: OpenClawPluginApi): void {
             const dryRun = (ctx.options?.["dry-run"] ?? false) as boolean;
 
             const result = await curatorRun({ workspaceDir, config, dryRun });
+
+            // Write run logs if not a dry run
+            let logDir: string | undefined;
+            if (!dryRun) {
+              try {
+                logDir = await writeRunLog(result);
+              } catch {
+                // Non-critical — don't fail the command over log write
+              }
+            }
+
             const lines: string[] = [];
             lines.push(dryRun ? "DRY RUN — no mutations applied" : "Curator run complete");
             lines.push(`Timestamp: ${result.timestamp}`);
@@ -168,6 +180,10 @@ export function registerCuratorCli(api: OpenClawPluginApi): void {
 
             if (result.transitions.length === 0 && !result.error) {
               lines.push("\nNo transitions needed. All skills are up to date.");
+            }
+
+            if (logDir) {
+              lines.push(`\nRun log: ${logDir}`);
             }
 
             return { display: lines.join("\n") };
@@ -274,8 +290,24 @@ export function registerCuratorCli(api: OpenClawPluginApi): void {
               await import("./snapshot.js")
             ).createSnapshot(workspaceDir);
 
-            // Extract tar.gz
+            // Clean current skills/ (preserve .curator_backups and .archive)
+            // so the extracted tree is byte-identical to the snapshot.
             const skillsDir = path.join(workspaceDir, "skills");
+            const keepDirs = new Set([".curator_backups", ".archive"]);
+            try {
+              const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+              for (const entry of entries) {
+                if (keepDirs.has(entry.name)) continue;
+                await fs.rm(path.join(skillsDir, entry.name), {
+                  recursive: true,
+                  force: true,
+                });
+              }
+            } catch {
+              // skills/ may not exist yet — that's fine
+            }
+
+            // Extract tar.gz
             const { spawn } = await import("node:child_process");
             await new Promise<void>((resolve, reject) => {
               const child = spawn("tar", ["-xzf", archivePath, "-C", path.dirname(skillsDir)], {

--- a/extensions/skill-curator/src/cli.ts
+++ b/extensions/skill-curator/src/cli.ts
@@ -1,0 +1,93 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/core";
+import { loadUsage } from "./telemetry.js";
+import type { UsageEntry } from "./telemetry.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function findWorkspaceDir(ctx: PluginCommandContext): string {
+  // Resolve workspace from agent config or fall back
+  const workspaceDir = (
+    typeof (ctx as Record<string, unknown>).workspaceDir === "string"
+      ? (ctx as Record<string, unknown>).workspaceDir
+      : undefined
+  ) as string | undefined;
+  return workspaceDir ?? process.cwd();
+}
+
+interface CuratorStatus {
+  last_run_at: string | null;
+  counts: {
+    total: number;
+    active: number;
+    stale: number;
+    archived: number;
+    pinned: number;
+  };
+  pinned: string[];
+  lru_top_5: Array<{ name: string; last_used_at: string | null; use_count: number }>;
+}
+
+async function buildStatus(workspaceDir: string): Promise<CuratorStatus> {
+  const usage = await loadUsage(workspaceDir);
+  const skills = Object.values(usage.skills);
+
+  const counts = {
+    total: skills.length,
+    active: skills.filter((s) => s.state === "active").length,
+    stale: skills.filter((s) => s.state === "stale").length,
+    archived: skills.filter((s) => s.state === "archived").length,
+    pinned: skills.filter((s) => s.pinned).length,
+  };
+
+  const pinned = skills.filter((s) => s.pinned).map((s) => s.name);
+
+  // LRU top 5: sort by last_used_at ascending (oldest first = least recently used)
+  const byLru = [...skills]
+    .sort((a, b) => {
+      const aTime = a.last_used_at ? new Date(a.last_used_at).getTime() : 0;
+      const bTime = b.last_used_at ? new Date(b.last_used_at).getTime() : 0;
+      return aTime - bTime;
+    })
+    .slice(0, 5)
+    .map((s) => ({
+      name: s.name,
+      last_used_at: s.last_used_at,
+      use_count: s.use_count,
+    }));
+
+  return {
+    last_run_at: usage.updated_at,
+    counts,
+    pinned,
+    lru_top_5: byLru,
+  };
+}
+
+// ── Command registration ───────────────────────────────────────────────────
+
+export function registerCuratorCli(api: OpenClawPluginApi): void {
+  api.registerCommand({
+    name: "curator",
+    description: "Skill curator commands",
+    subcommands: [
+      {
+        name: "status",
+        description: "Show curator status: last run, counts, pinned list, LRU top 5",
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const status = await buildStatus(workspaceDir);
+            return {
+              json: status,
+              display: JSON.stringify(status, null, 2),
+            };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator status error: ${message}` };
+          }
+        },
+      },
+    ],
+  });
+}

--- a/extensions/skill-curator/src/cli.ts
+++ b/extensions/skill-curator/src/cli.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/core";
+import { resolveConfig, type CuratorConfig } from "./config.js";
 import {
   adoptSkill,
   curatorRun,
@@ -11,7 +12,6 @@ import {
   resumeCurator,
   restoreSkill,
   unpinSkill,
-  type CuratorConfig,
 } from "./run.js";
 import { rotateSnapshots } from "./snapshot.js";
 import { loadUsage } from "./telemetry.js";
@@ -29,19 +29,7 @@ function findWorkspaceDir(ctx: PluginCommandContext): string {
 }
 
 function resolveCuratorConfig(api: OpenClawPluginApi): CuratorConfig {
-  const raw = (api.pluginConfig ?? {}) as Record<string, unknown>;
-  const backup = (raw.backup ?? {}) as Record<string, unknown>;
-  return {
-    enabled: raw.enabled !== false,
-    interval_hours: typeof raw.interval_hours === "number" ? raw.interval_hours : 168,
-    min_idle_hours: typeof raw.min_idle_hours === "number" ? raw.min_idle_hours : 2,
-    stale_after_days: typeof raw.stale_after_days === "number" ? raw.stale_after_days : 30,
-    archive_after_days: typeof raw.archive_after_days === "number" ? raw.archive_after_days : 90,
-    backup: {
-      enabled: backup.enabled !== false,
-      keep: typeof backup.keep === "number" ? backup.keep : 5,
-    },
-  };
+  return resolveConfig(api.pluginConfig);
 }
 
 interface CuratorStatus {

--- a/extensions/skill-curator/src/cli.ts
+++ b/extensions/skill-curator/src/cli.ts
@@ -1,12 +1,25 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/core";
+import {
+  adoptSkill,
+  curatorRun,
+  disownSkill,
+  pauseCurator,
+  pinSkill,
+  resumeCurator,
+  restoreSkill,
+  unpinSkill,
+  type CuratorConfig,
+} from "./run.js";
+import { rotateSnapshots } from "./snapshot.js";
 import { loadUsage } from "./telemetry.js";
 import type { UsageEntry } from "./telemetry.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function findWorkspaceDir(ctx: PluginCommandContext): string {
-  // Resolve workspace from agent config or fall back
   const workspaceDir = (
     typeof (ctx as Record<string, unknown>).workspaceDir === "string"
       ? (ctx as Record<string, unknown>).workspaceDir
@@ -15,14 +28,34 @@ function findWorkspaceDir(ctx: PluginCommandContext): string {
   return workspaceDir ?? process.cwd();
 }
 
+function resolveCuratorConfig(api: OpenClawPluginApi): CuratorConfig {
+  const raw = (api.pluginConfig ?? {}) as Record<string, unknown>;
+  const backup = (raw.backup ?? {}) as Record<string, unknown>;
+  return {
+    enabled: raw.enabled !== false,
+    interval_hours: typeof raw.interval_hours === "number" ? raw.interval_hours : 168,
+    min_idle_hours: typeof raw.min_idle_hours === "number" ? raw.min_idle_hours : 2,
+    stale_after_days: typeof raw.stale_after_days === "number" ? raw.stale_after_days : 30,
+    archive_after_days: typeof raw.archive_after_days === "number" ? raw.archive_after_days : 90,
+    backup: {
+      enabled: backup.enabled !== false,
+      keep: typeof backup.keep === "number" ? backup.keep : 5,
+    },
+  };
+}
+
 interface CuratorStatus {
   last_run_at: string | null;
+  paused: boolean;
   counts: {
     total: number;
     active: number;
     stale: number;
     archived: number;
     pinned: number;
+    agent_created: number;
+    user_created: number;
+    unknown: number;
   };
   pinned: string[];
   lru_top_5: Array<{ name: string; last_used_at: string | null; use_count: number }>;
@@ -38,6 +71,9 @@ async function buildStatus(workspaceDir: string): Promise<CuratorStatus> {
     stale: skills.filter((s) => s.state === "stale").length,
     archived: skills.filter((s) => s.state === "archived").length,
     pinned: skills.filter((s) => s.pinned).length,
+    agent_created: skills.filter((s) => s.created_by === "agent").length,
+    user_created: skills.filter((s) => s.created_by === "user").length,
+    unknown: skills.filter((s) => s.created_by === "unknown").length,
   };
 
   const pinned = skills.filter((s) => s.pinned).map((s) => s.name);
@@ -57,7 +93,8 @@ async function buildStatus(workspaceDir: string): Promise<CuratorStatus> {
     }));
 
   return {
-    last_run_at: usage.updated_at,
+    last_run_at: usage.last_run_at,
+    paused: usage.paused,
     counts,
     pinned,
     lru_top_5: byLru,
@@ -67,10 +104,13 @@ async function buildStatus(workspaceDir: string): Promise<CuratorStatus> {
 // ── Command registration ───────────────────────────────────────────────────
 
 export function registerCuratorCli(api: OpenClawPluginApi): void {
+  const resolveConfig = () => resolveCuratorConfig(api);
+
   api.registerCommand({
     name: "curator",
-    description: "Skill curator commands",
+    description: "Skill curator commands — manage skill lifecycle, telemetry, and archival",
     subcommands: [
+      // ── status ─────────────────────────────────────────────────────────
       {
         name: "status",
         description: "Show curator status: last run, counts, pinned list, LRU top 5",
@@ -85,6 +125,373 @@ export function registerCuratorCli(api: OpenClawPluginApi): void {
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             return { display: `curator status error: ${message}` };
+          }
+        },
+      },
+
+      // ── run ────────────────────────────────────────────────────────────
+      {
+        name: "run",
+        description: "Trigger curator review now",
+        options: {
+          sync: {
+            type: "boolean",
+            description: "Block until run completes",
+          },
+          "dry-run": {
+            type: "boolean",
+            description: "Preview only, no mutations",
+          },
+        },
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const config = resolveConfig();
+            const dryRun = (ctx.options?.["dry-run"] ?? false) as boolean;
+
+            const result = await curatorRun({ workspaceDir, config, dryRun });
+            const lines: string[] = [];
+            lines.push(dryRun ? "DRY RUN — no mutations applied" : "Curator run complete");
+            lines.push(`Timestamp: ${result.timestamp}`);
+
+            if (result.error) {
+              lines.push(`Info: ${result.error}`);
+            }
+
+            if (result.snapshotPath) {
+              lines.push(`Snapshot: ${result.snapshotPath}`);
+            }
+
+            if (result.transitions.length > 0) {
+              lines.push(`\nTransitions (${result.transitions.length}):`);
+              for (const t of result.transitions) {
+                lines.push(
+                  `  ${t.name}: ${t.action} → ${t.newState} (unused ${t.daysSinceUsed.toFixed(0)}d)`,
+                );
+              }
+            }
+
+            if (result.mutations.length > 0) {
+              lines.push(`\nMutations applied (${result.mutations.length}):`);
+              for (const m of result.mutations) {
+                lines.push(`  ${m.name}: ${m.oldState} → ${m.newState} (${m.action})`);
+              }
+            }
+
+            if (result.transitions.length === 0 && !result.error) {
+              lines.push("\nNo transitions needed. All skills are up to date.");
+            }
+
+            return { display: lines.join("\n") };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator run error: ${message}` };
+          }
+        },
+      },
+
+      // ── backup ─────────────────────────────────────────────────────────
+      {
+        name: "backup",
+        description: "Manual snapshot of skills/",
+        options: {
+          reason: {
+            type: "string",
+            description: "Reason for manual backup",
+          },
+        },
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const config = resolveConfig();
+            const reason = (ctx.options?.reason as string) ?? undefined;
+
+            const { createSnapshot } = await import("./snapshot.js");
+            const snap = await createSnapshot(workspaceDir);
+            await rotateSnapshots(workspaceDir, config.backup.keep);
+
+            const lines = [
+              `Backup created: ${snap.archivePath}`,
+              `Size: ${(snap.sizeBytes / 1024).toFixed(1)} KB`,
+              `Timestamp: ${snap.timestamp}`,
+            ];
+            if (reason) lines.push(`Reason: ${reason}`);
+
+            return { display: lines.join("\n") };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator backup error: ${message}` };
+          }
+        },
+      },
+
+      // ── rollback ───────────────────────────────────────────────────────
+      {
+        name: "rollback",
+        description: "Restore from a snapshot",
+        options: {
+          list: {
+            type: "boolean",
+            description: "List available snapshots",
+          },
+          id: {
+            type: "string",
+            description: "Snapshot timestamp to restore",
+          },
+        },
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const backupsPath = path.join(workspaceDir, "skills", ".curator_backups");
+            const list = (ctx.options?.list ?? false) as boolean;
+            const id = ctx.options?.id as string | undefined;
+
+            // List mode
+            if (list) {
+              let entries: string[] = [];
+              try {
+                const dirents = await fs.readdir(backupsPath, { withFileTypes: true });
+                entries = dirents
+                  .filter((e) => e.isDirectory() && e.name !== ".in-progress")
+                  .map((e) => e.name)
+                  .sort()
+                  .reverse();
+              } catch {
+                // No backups dir
+              }
+              if (entries.length === 0) {
+                return { display: "No snapshots found." };
+              }
+              const lines = ["Available snapshots:"];
+              for (const entry of entries) {
+                const stat = await fs
+                  .stat(path.join(backupsPath, entry, "skills.tar.gz"))
+                  .catch(() => null);
+                const sizeStr = stat ? `${(stat.size / 1024).toFixed(1)} KB` : "?";
+                lines.push(`  ${entry}  (${sizeStr})`);
+              }
+              return { display: lines.join("\n") };
+            }
+
+            // Restore mode
+            if (!id) {
+              return { display: "Usage: curator rollback --id <timestamp>" };
+            }
+
+            const archivePath = path.join(backupsPath, id, "skills.tar.gz");
+            await fs.access(archivePath); // throws if not found
+
+            // Pre-rollback snapshot
+            const preRollbackSnap = await (
+              await import("./snapshot.js")
+            ).createSnapshot(workspaceDir);
+
+            // Extract tar.gz
+            const skillsDir = path.join(workspaceDir, "skills");
+            const { spawn } = await import("node:child_process");
+            await new Promise<void>((resolve, reject) => {
+              const child = spawn("tar", ["-xzf", archivePath, "-C", path.dirname(skillsDir)], {
+                stdio: ["ignore", "ignore", "pipe"],
+              });
+              let stderr = "";
+              child.stderr?.on("data", (d: Buffer) => {
+                stderr += d.toString();
+              });
+              child.on("close", (code) => {
+                if (code === 0) resolve();
+                else reject(new Error(`tar exited ${code}: ${stderr}`));
+              });
+              child.on("error", reject);
+            });
+
+            return {
+              display: [
+                `Rollback complete: restored ${id}`,
+                `Pre-rollback snapshot saved at: ${preRollbackSnap.archivePath}`,
+              ].join("\n"),
+            };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator rollback error: ${message}` };
+          }
+        },
+      },
+
+      // ── pause / resume ─────────────────────────────────────────────────
+      {
+        name: "pause",
+        description: "Pause the curator — no automatic runs until resumed",
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            await pauseCurator(workspaceDir);
+            return { display: "Curator paused. No automatic runs will occur until resumed." };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator pause error: ${message}` };
+          }
+        },
+      },
+      {
+        name: "resume",
+        description: "Resume the curator after a pause",
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            await resumeCurator(workspaceDir);
+            return { display: "Curator resumed. Next run at next interval check." };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator resume error: ${message}` };
+          }
+        },
+      },
+
+      // ── pin / unpin ────────────────────────────────────────────────────
+      {
+        name: "pin",
+        description: "Pin a skill — immune to archival and deletion",
+        options: {
+          skill: {
+            type: "string",
+            description: "Skill name to pin",
+            required: true,
+          },
+        },
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const skillName = ctx.options?.skill as string;
+            if (!skillName) return { display: "Usage: curator pin <skill>" };
+
+            // Verify skill exists in usage
+            const usage = await loadUsage(workspaceDir);
+            const entry = usage.skills[skillName];
+            if (!entry) {
+              return { display: `Skill "${skillName}" not found in workspace.` };
+            }
+
+            // Refuse to pin bundled/hub skills
+            if (entry.source === "bundled" || entry.source === "hub") {
+              return { display: `Cannot pin ${entry.source} skill "${skillName}".` };
+            }
+
+            await pinSkill(workspaceDir, skillName);
+            return { display: `Pinned: ${skillName}` };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator pin error: ${message}` };
+          }
+        },
+      },
+      {
+        name: "unpin",
+        description: "Unpin a skill — allows archival and deletion",
+        options: {
+          skill: {
+            type: "string",
+            description: "Skill name to unpin",
+            required: true,
+          },
+        },
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const skillName = ctx.options?.skill as string;
+            if (!skillName) return { display: "Usage: curator unpin <skill>" };
+
+            await unpinSkill(workspaceDir, skillName);
+            return { display: `Unpinned: ${skillName}` };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator unpin error: ${message}` };
+          }
+        },
+      },
+
+      // ── restore ────────────────────────────────────────────────────────
+      {
+        name: "restore",
+        description: "Restore a skill from archive",
+        options: {
+          skill: {
+            type: "string",
+            description: "Skill name to restore",
+            required: true,
+          },
+        },
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const skillName = ctx.options?.skill as string;
+            if (!skillName) return { display: "Usage: curator restore <skill>" };
+
+            await restoreSkill(workspaceDir, skillName);
+            return { display: `Restored: ${skillName} (back to active)` };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator restore error: ${message}` };
+          }
+        },
+      },
+
+      // ── adopt ──────────────────────────────────────────────────────────
+      {
+        name: "adopt",
+        description: "Mark a skill as agent-created so the curator manages it",
+        options: {
+          skill: {
+            type: "string",
+            description: "Skill name to adopt",
+            required: true,
+          },
+        },
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const skillName = ctx.options?.skill as string;
+            if (!skillName) return { display: "Usage: curator adopt <skill>" };
+
+            const usage = await loadUsage(workspaceDir);
+            const entry = usage.skills[skillName];
+            if (!entry) {
+              return { display: `Skill "${skillName}" not found in workspace.` };
+            }
+            if (entry.source === "bundled" || entry.source === "hub") {
+              return { display: `Cannot adopt ${entry.source} skill "${skillName}".` };
+            }
+
+            await adoptSkill(workspaceDir, skillName);
+            return { display: `Adopted: ${skillName} (now agent-managed)` };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator adopt error: ${message}` };
+          }
+        },
+      },
+
+      // ── disown ─────────────────────────────────────────────────────────
+      {
+        name: "disown",
+        description: "Mark a skill as user-owned — curator will leave it alone",
+        options: {
+          skill: {
+            type: "string",
+            description: "Skill name to disown",
+            required: true,
+          },
+        },
+        async run(ctx: PluginCommandContext): Promise<PluginCommandResult> {
+          try {
+            const workspaceDir = findWorkspaceDir(ctx);
+            const skillName = ctx.options?.skill as string;
+            if (!skillName) return { display: "Usage: curator disown <skill>" };
+
+            await disownSkill(workspaceDir, skillName);
+            return { display: `Disowned: ${skillName} (now user-managed)` };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { display: `curator disown error: ${message}` };
           }
         },
       },

--- a/extensions/skill-curator/src/config.ts
+++ b/extensions/skill-curator/src/config.ts
@@ -1,0 +1,48 @@
+export type CuratorConfig = {
+  enabled: boolean;
+  interval_hours: number;
+  min_idle_hours: number;
+  stale_after_days: number;
+  archive_after_days: number;
+  backup: {
+    enabled: boolean;
+    keep: number;
+  };
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function readInteger(value: unknown, fallback: number, min: number, max: number): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.min(Math.max(Math.trunc(value), min), max)
+    : fallback;
+}
+
+/**
+ * Resolve and validate curator configuration from raw plugin config.
+ * Mirrors skill-workshop's config resolution pattern.
+ */
+export function resolveConfig(raw: unknown): CuratorConfig {
+  const cfg = asRecord(raw);
+  const backup = asRecord(cfg.backup);
+
+  return {
+    enabled: readBoolean(cfg.enabled, true),
+    interval_hours: readInteger(cfg.interval_hours, 168, 1, 8760),
+    min_idle_hours: readInteger(cfg.min_idle_hours, 2, 0, 168),
+    stale_after_days: readInteger(cfg.stale_after_days, 30, 1, 3650),
+    archive_after_days: readInteger(cfg.archive_after_days, 90, 1, 3650),
+    backup: {
+      enabled: readBoolean(backup.enabled, true),
+      keep: readInteger(backup.keep, 5, 1, 100),
+    },
+  };
+}

--- a/extensions/skill-curator/src/index.ts
+++ b/extensions/skill-curator/src/index.ts
@@ -1,7 +1,10 @@
+import os from "node:os";
+import path from "node:path";
 import { definePluginEntry } from "openclaw/plugin-sdk/core";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { registerCuratorCli } from "./cli.js";
-import { loadUsage } from "./telemetry.js";
+import { resolveConfig } from "./config.js";
+import { curatorRun } from "./run.js";
 
 export default definePluginEntry({
   id: "skill-curator",
@@ -22,21 +25,33 @@ export default definePluginEntry({
       },
     });
 
-    // Hook into prompt build — the curator doesn't inject guidance, but we
-    // could emit telemetry events here if the gateway prompt assembler fires them.
-    api.on("before_prompt_build", async () => {
-      return undefined;
-    });
+    // Hook: after every agent turn ends, check if curator should run.
+    // This covers the trigger logic without needing a separate scheduler.
+    api.on("agent_end", async (_event, ctx) => {
+      try {
+        const workspaceDir = ctx.workspaceDir ?? path.join(os.homedir(), ".openclaw", "workspace");
 
-    // Register periodic scheduler job for curator runs
-    api.registerSessionSchedulerJob({
-      id: "skill-curator-periodic",
-      schedule: { intervalMs: 60 * 60 * 1000 }, // hourly tick; actual gating in run logic
-      async run() {
-        api.logger.debug("skill-curator: periodic tick");
-        // In full implementation, the gateway-side hook calls curatorRun()
-        // after checking idle time. The tick here is a heartbeat for the plugin.
-      },
+        const config = resolveConfig(api.pluginConfig);
+        const result = await curatorRun({ workspaceDir, config, dryRun: false });
+
+        if (result.mutations.length > 0) {
+          api.logger.info(
+            `skill-curator: applied ${result.mutations.length} mutation(s) — ${result.mutations.map((m) => m.name).join(", ")}`,
+          );
+        }
+        if (
+          result.error &&
+          !result.error.includes("first-run") &&
+          !result.error.includes("paused")
+        ) {
+          api.logger.warn(`skill-curator: ${result.error}`);
+        }
+      } catch (err) {
+        // Non-critical — never fail the agent turn over curator issues
+        api.logger.debug(
+          `skill-curator: agent_end hook skipped — ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     });
   },
 });
@@ -51,6 +66,7 @@ export { createSnapshot, rotateSnapshots } from "./snapshot.js";
 export type { SnapshotResult } from "./snapshot.js";
 export {
   curatorRun,
+  curatorRunReview,
   decideRun,
   pauseCurator,
   resumeCurator,

--- a/extensions/skill-curator/src/index.ts
+++ b/extensions/skill-curator/src/index.ts
@@ -61,3 +61,11 @@ export {
   disownSkill,
 } from "./run.js";
 export type { CuratorConfig, RunDecision, CuratorRunResult } from "./run.js";
+export { writeRunLog } from "./logs.js";
+export type { RunLogEntry } from "./logs.js";
+export {
+  buildReviewManifest,
+  parseReviewResponse,
+  validatePatchAction,
+  CURATOR_SYSTEM_PROMPT,
+} from "./reviewer.js";

--- a/extensions/skill-curator/src/index.ts
+++ b/extensions/skill-curator/src/index.ts
@@ -1,0 +1,45 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { registerCuratorCli } from "./cli.js";
+import { loadUsage } from "./telemetry.js";
+
+export default definePluginEntry({
+  id: "skill-curator",
+  name: "Skill Curator",
+  description:
+    "Tracks skill usage telemetry, auto-archives stale skills, runs LLM review passes, and snapshots workspace skills before mutations.",
+  register(api: OpenClawPluginApi) {
+    // Register CLI commands
+    registerCuratorCli(api);
+
+    // Register runtime lifecycle hooks for activate/deactivate
+    api.registerRuntimeLifecycle({
+      async activate() {
+        api.logger.info("skill-curator: activated");
+      },
+      async deactivate() {
+        api.logger.info("skill-curator: deactivated");
+      },
+    });
+
+    // Hook into skill_view to increment telemetry
+    api.on("before_prompt_build", async () => {
+      // The curator doesn't inject prompt guidance — it's a background service.
+      // Telemetry hooks will be wired when the skill tooling emits events.
+      return undefined;
+    });
+
+    // Register session scheduler job for periodic curator runs
+    api.registerSessionSchedulerJob({
+      id: "skill-curator-periodic",
+      schedule: { intervalMs: 60 * 60 * 1000 }, // placeholder — config-driven in full impl
+      async run() {
+        api.logger.debug("skill-curator: periodic tick");
+      },
+    });
+  },
+});
+
+export { loadUsage } from "./telemetry.js";
+export { determineTransition } from "./transitions.js";
+export { createSnapshot, rotateSnapshots } from "./snapshot.js";

--- a/extensions/skill-curator/src/index.ts
+++ b/extensions/skill-curator/src/index.ts
@@ -12,7 +12,7 @@ export default definePluginEntry({
     // Register CLI commands
     registerCuratorCli(api);
 
-    // Register runtime lifecycle hooks for activate/deactivate
+    // Register runtime lifecycle hooks
     api.registerRuntimeLifecycle({
       async activate() {
         api.logger.info("skill-curator: activated");
@@ -22,24 +22,42 @@ export default definePluginEntry({
       },
     });
 
-    // Hook into skill_view to increment telemetry
+    // Hook into prompt build — the curator doesn't inject guidance, but we
+    // could emit telemetry events here if the gateway prompt assembler fires them.
     api.on("before_prompt_build", async () => {
-      // The curator doesn't inject prompt guidance — it's a background service.
-      // Telemetry hooks will be wired when the skill tooling emits events.
       return undefined;
     });
 
-    // Register session scheduler job for periodic curator runs
+    // Register periodic scheduler job for curator runs
     api.registerSessionSchedulerJob({
       id: "skill-curator-periodic",
-      schedule: { intervalMs: 60 * 60 * 1000 }, // placeholder — config-driven in full impl
+      schedule: { intervalMs: 60 * 60 * 1000 }, // hourly tick; actual gating in run logic
       async run() {
         api.logger.debug("skill-curator: periodic tick");
+        // In full implementation, the gateway-side hook calls curatorRun()
+        // after checking idle time. The tick here is a heartbeat for the plugin.
       },
     });
   },
 });
 
-export { loadUsage } from "./telemetry.js";
-export { determineTransition } from "./transitions.js";
+// ── Public exports ──────────────────────────────────────────────────────────
+
+export { loadUsage, type UsageEntry, type UsageFile } from "./telemetry.js";
+export { stampAgentCreated, setCreatedBy, isAgentCreated } from "./telemetry.js";
+export { determineTransition, determineAllTransitions } from "./transitions.js";
+export type { TransitionThresholds, TransitionResult } from "./transitions.js";
 export { createSnapshot, rotateSnapshots } from "./snapshot.js";
+export type { SnapshotResult } from "./snapshot.js";
+export {
+  curatorRun,
+  decideRun,
+  pauseCurator,
+  resumeCurator,
+  pinSkill,
+  unpinSkill,
+  restoreSkill,
+  adoptSkill,
+  disownSkill,
+} from "./run.js";
+export type { CuratorConfig, RunDecision, CuratorRunResult } from "./run.js";

--- a/extensions/skill-curator/src/logs.ts
+++ b/extensions/skill-curator/src/logs.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { CuratorRunResult } from "./run.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface RunLogEntry {
+  runId: string;
+  timestamp: string;
+  dryRun: boolean;
+  snapshotPath: string | null;
+  transitions: Array<{
+    name: string;
+    action: string;
+    newState: string;
+    daysSinceUsed: number;
+  }>;
+  mutations: Array<{
+    name: string;
+    action: string;
+    oldState: string;
+    newState: string;
+  }>;
+  error?: string;
+}
+
+// ── Path helpers ────────────────────────────────────────────────────────────
+
+function runLogDir(): string {
+  return path.join(os.homedir(), ".openclaw", "logs", "curator");
+}
+
+function runId(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+// ── Log writer ──────────────────────────────────────────────────────────────
+
+/**
+ * Write a machine-readable run.json for a curator run.
+ * Returns the run directory path.
+ */
+export async function writeRunLog(result: CuratorRunResult): Promise<string> {
+  const id = runId();
+  const dir = path.join(runLogDir(), id);
+  await fs.mkdir(dir, { recursive: true });
+
+  const entry: RunLogEntry = {
+    runId: id,
+    timestamp: result.timestamp,
+    dryRun: result.dryRun,
+    snapshotPath: result.snapshotPath,
+    transitions: result.transitions,
+    mutations: result.mutations,
+    error: result.error,
+  };
+
+  await fs.writeFile(path.join(dir, "run.json"), JSON.stringify(entry, null, 2), "utf-8");
+
+  // Write human-readable REPORT.md
+  await writeReport(dir, entry);
+
+  return dir;
+}
+
+// ── Report writer ───────────────────────────────────────────────────────────
+
+async function writeReport(dir: string, entry: RunLogEntry): Promise<void> {
+  const lines: string[] = [];
+
+  lines.push("# Curator Run Report");
+  lines.push("");
+  lines.push(`**Run ID:** ${entry.runId}`);
+  lines.push(`**Timestamp:** ${entry.timestamp}`);
+  lines.push(`**Mode:** ${entry.dryRun ? "DRY RUN (no mutations)" : "LIVE"}`);
+  lines.push("");
+
+  if (entry.error) {
+    lines.push(`## ⚠️ Info`);
+    lines.push("");
+    lines.push(entry.error);
+    lines.push("");
+  }
+
+  if (entry.snapshotPath) {
+    lines.push(`## 📦 Snapshot`);
+    lines.push("");
+    lines.push(`Snapshot saved to: \`${entry.snapshotPath}\``);
+    lines.push("");
+  }
+
+  if (entry.transitions.length > 0) {
+    lines.push(`## 🔍 Transitions (${entry.transitions.length})`);
+    lines.push("");
+    lines.push("| Skill | Action | New State | Days Unused |");
+    lines.push("|-------|--------|-----------|-------------|");
+    for (const t of entry.transitions) {
+      lines.push(`| ${t.name} | ${t.action} | ${t.newState} | ${t.daysSinceUsed.toFixed(0)} |`);
+    }
+    lines.push("");
+  }
+
+  if (entry.mutations.length > 0) {
+    const marker = entry.dryRun ? " (would apply)" : "";
+    lines.push(`## ✏️ Mutations${marker} (${entry.mutations.length})`);
+    lines.push("");
+    lines.push("| Skill | Action | Old State | New State |");
+    lines.push("|-------|--------|-----------|-----------|");
+    for (const m of entry.mutations) {
+      lines.push(`| ${m.name} | ${m.action} | ${m.oldState} | ${m.newState} |`);
+    }
+    lines.push("");
+  }
+
+  if (entry.transitions.length === 0 && !entry.error) {
+    lines.push("## ✅ No transitions needed");
+    lines.push("");
+    lines.push("All skills are up to date. No actions required.");
+    lines.push("");
+  }
+
+  await fs.writeFile(path.join(dir, "REPORT.md"), lines.join("\n"), "utf-8");
+}

--- a/extensions/skill-curator/src/reviewer.ts
+++ b/extensions/skill-curator/src/reviewer.ts
@@ -1,0 +1,204 @@
+import { isAgentCreated, loadUsage, type UsageEntry } from "./telemetry.js";
+import type { TransitionThresholds } from "./transitions.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface ReviewSkillEntry {
+  name: string;
+  description: string;
+  last_used_at: string | null;
+  use_count: number;
+  view_count: number;
+  state: string;
+}
+
+export type ReviewAction =
+  | { action: "keep" }
+  | { action: "patch"; old_string: string; new_string: string }
+  | { action: "consolidate"; merge_target: string; new_content: string }
+  | { action: "archive"; reason: string };
+
+export interface ReviewResponse {
+  decisions: ReviewAction[];
+}
+
+export interface ReviewManifest {
+  skills: ReviewSkillEntry[];
+  workspaceDir: string;
+}
+
+// ── System prompt ───────────────────────────────────────────────────────────
+
+export const CURATOR_SYSTEM_PROMPT = `You are a curator. Your job is to maintain a clean, useful set of workspace skills for an AI agent.
+
+For each skill listed below, decide one of:
+- **keep** — the skill is still useful as-is
+- **patch** — the skill has a specific issue you can fix with a small edit (provide old_string + new_string)
+- **consolidate** — this skill overlaps with another; merge them (provide merge_target + new_content)
+- **archive** — this skill is no longer useful (provide a brief reason)
+
+**Rules:**
+- Be conservative. When in doubt, keep.
+- Do NOT archive or mutate pinned skills (they won't be in the manifest).
+- Do NOT propose patches without providing exact old_string and new_string.
+- old_string must match exactly one occurrence in the skill content.
+- Do NOT reference paths outside the workspace skills/ directory.
+- Do NOT propose archiving the .archive directory itself.
+
+Respond with a single JSON object containing a "decisions" array. Example:
+{
+  "decisions": [
+    { "action": "keep" },
+    { "action": "archive", "reason": "No longer relevant — workflow was specific to a one-time migration." },
+    { "action": "patch", "old_string": "Use port 3000", "new_string": "Use port 8080" },
+    { "action": "consolidate", "merge_target": "git-workflow", "new_content": "# Combined Git Workflow\\n\\n..." }
+  ]
+}
+
+Only include entries in the decisions array for skills that need action (keep is implicit when absent).`;
+
+// ── Manifest builder ────────────────────────────────────────────────────────
+
+/**
+ * Build a manifest of agent-created, non-pinned, non-archived skills
+ * suitable for sending to the LLM reviewer.
+ */
+export async function buildReviewManifest(workspaceDir: string): Promise<ReviewManifest> {
+  const usage = await loadUsage(workspaceDir);
+  const skills: ReviewSkillEntry[] = [];
+
+  for (const entry of Object.values(usage.skills)) {
+    // Skip pinned, archived, bundled, hub, and non-agent-created
+    if (entry.pinned) continue;
+    if (entry.state === "archived") continue;
+    if (entry.source === "bundled" || entry.source === "hub") continue;
+    if (!isAgentCreated(entry)) continue;
+
+    skills.push({
+      name: entry.name,
+      description: `Skill "${entry.name}" (used ${entry.use_count} times, last used ${entry.last_used_at ?? "never"})`,
+      last_used_at: entry.last_used_at,
+      use_count: entry.use_count,
+      view_count: entry.view_count,
+      state: entry.state,
+    });
+  }
+
+  return { skills, workspaceDir };
+}
+
+// ── Response parser / validator ─────────────────────────────────────────────
+
+const VALID_ACTIONS = new Set(["keep", "patch", "consolidate", "archive"]);
+
+/**
+ * Parse and validate the LLM's JSON response.
+ * Returns validated decisions, rejecting malformed actions.
+ */
+export function parseReviewResponse(raw: string): ReviewResponse {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Failed to parse curator review response as JSON");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Curator review response must be a JSON object with a 'decisions' array");
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  if (!Array.isArray(obj.decisions)) {
+    throw new Error("Curator review response missing 'decisions' array");
+  }
+
+  const decisions: ReviewAction[] = [];
+
+  for (let i = 0; i < obj.decisions.length; i++) {
+    const item = obj.decisions[i];
+    if (!item || typeof item !== "object") {
+      throw new Error(`Decision ${i} is not an object`);
+    }
+
+    const d = item as Record<string, unknown>;
+    const action = d.action;
+
+    if (typeof action !== "string" || !VALID_ACTIONS.has(action)) {
+      throw new Error(`Decision ${i}: invalid action "${String(action)}"`);
+    }
+
+    if (action === "keep") {
+      decisions.push({ action: "keep" });
+    } else if (action === "patch") {
+      if (typeof d.old_string !== "string" || typeof d.new_string !== "string") {
+        throw new Error(`Decision ${i}: patch requires old_string and new_string`);
+      }
+      if (d.old_string === d.new_string) {
+        throw new Error(`Decision ${i}: patch old_string and new_string must differ`);
+      }
+      // Reject path traversal attempts
+      if (d.old_string.includes("../") || d.new_string.includes("../")) {
+        throw new Error(`Decision ${i}: path traversal rejected`);
+      }
+      decisions.push({
+        action: "patch",
+        old_string: d.old_string,
+        new_string: d.new_string,
+      });
+    } else if (action === "consolidate") {
+      if (typeof d.merge_target !== "string" || typeof d.new_content !== "string") {
+        throw new Error(`Decision ${i}: consolidate requires merge_target and new_content`);
+      }
+      if (d.merge_target.includes("../")) {
+        throw new Error(`Decision ${i}: merge_target path traversal rejected`);
+      }
+      decisions.push({
+        action: "consolidate",
+        merge_target: d.merge_target,
+        new_content: d.new_content,
+      });
+    } else if (action === "archive") {
+      const reason = typeof d.reason === "string" ? d.reason : "No reason provided";
+      decisions.push({ action: "archive", reason });
+    }
+  }
+
+  return { decisions };
+}
+
+/**
+ * Validate that a patch operation can be safely applied:
+ * - old_string must appear exactly once in content
+ * - target path must be within skills/
+ */
+export function validatePatchAction(
+  content: string,
+  oldString: string,
+  skillName: string,
+): { valid: true } | { valid: false; error: string } {
+  // Reject path traversal
+  if (oldString.includes("../") || skillName.includes("../") || skillName.includes(".archive")) {
+    return { valid: false, error: "Path traversal or .archive reference rejected" };
+  }
+
+  // Count exact matches
+  const parts = content.split(oldString);
+  const count = parts.length - 1;
+
+  if (count === 0) {
+    return { valid: false, error: `old_string not found in ${skillName}` };
+  }
+  if (count > 1) {
+    return {
+      valid: false,
+      error: `old_string matches ${count} times in ${skillName} (must match exactly once)`,
+    };
+  }
+
+  // Guard against edits to bundled/hub skills via path manipulation
+  if (skillName.startsWith(".")) {
+    return { valid: false, error: "Cannot patch hidden directory skills" };
+  }
+
+  return { valid: true };
+}

--- a/extensions/skill-curator/src/run.ts
+++ b/extensions/skill-curator/src/run.ts
@@ -279,3 +279,50 @@ export async function adoptSkill(workspaceDir: string, name: string): Promise<Us
 export async function disownSkill(workspaceDir: string, name: string): Promise<UsageEntry> {
   return setCreatedBy(workspaceDir, name, "user");
 }
+
+// ── Phase B: LLM Review Pass ───────────────────────────────────────────────
+//
+// NOTE: Phase B requires a model-calling function (e.g. gateway-level
+// auxiliary.curator model slot). Without it, only Phase A (deterministic
+// transitions) runs. The LLM review is optional and additive — it never
+// blocks Phase A.
+
+/**
+ * Run the LLM review pass (Phase B).
+ *
+ * Requires a `callModel` function that takes a system prompt and user
+ * prompt string, and returns the model's text response.
+ *
+ * Returns parsed and validated review decisions, or null if the call
+ * fails or returns unparseable output.
+ */
+export async function curatorRunReview(params: {
+  workspaceDir: string;
+  callModel: (systemPrompt: string, userPrompt: string) => Promise<string>;
+}): Promise<{
+  decisions: import("./reviewer.js").ReviewAction[];
+  manifest: import("./reviewer.js").ReviewManifest;
+} | null> {
+  const { buildReviewManifest, parseReviewResponse } = await import("./reviewer.js");
+  const { loadUsage, setState } = await import("./telemetry.js");
+
+  const manifest = await buildReviewManifest(params.workspaceDir);
+  if (manifest.skills.length === 0) {
+    return { decisions: [], manifest };
+  }
+
+  // Build user prompt: list skill names and descriptions
+  const skillList = manifest.skills.map((s, i) => `${i}. ${s.name} — ${s.description}`).join("\n");
+  const userPrompt = `Review these skills and return decisions:\n\n${skillList}`;
+
+  try {
+    const raw = await params.callModel(
+      (await import("./reviewer.js")).CURATOR_SYSTEM_PROMPT,
+      userPrompt,
+    );
+    const response = parseReviewResponse(raw);
+    return { decisions: response.decisions, manifest };
+  } catch {
+    return null; // Model call or parse failure — non-blocking
+  }
+}

--- a/extensions/skill-curator/src/run.ts
+++ b/extensions/skill-curator/src/run.ts
@@ -1,0 +1,289 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createSnapshot, rotateSnapshots } from "./snapshot.js";
+import {
+  isAgentCreated,
+  loadUsage,
+  setCreatedBy,
+  setLastRunAt,
+  setPaused,
+  setPinned,
+  setState,
+  shouldRunCurator,
+  type UsageEntry,
+  type UsageFile,
+} from "./telemetry.js";
+import {
+  determineAllTransitions,
+  determineTransition,
+  type TransitionResult,
+  type TransitionThresholds,
+} from "./transitions.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface CuratorConfig {
+  enabled: boolean;
+  interval_hours: number;
+  min_idle_hours: number;
+  stale_after_days: number;
+  archive_after_days: number;
+  backup: {
+    enabled: boolean;
+    keep: number;
+  };
+}
+
+export interface RunDecision {
+  shouldRun: boolean;
+  reason: string;
+  firstRun: boolean;
+}
+
+export interface CuratorRunResult {
+  timestamp: string;
+  snapshotPath: string | null;
+  transitions: Array<{
+    name: string;
+    action: string;
+    newState: string;
+    daysSinceUsed: number;
+  }>;
+  mutations: Array<{
+    name: string;
+    action: "mark_stale" | "archive";
+    oldState: string;
+    newState: string;
+  }>;
+  dryRun: boolean;
+  error?: string;
+}
+
+// ── Lockfile ────────────────────────────────────────────────────────────────
+
+function lockfilePath(workspaceDir: string): string {
+  return path.join(workspaceDir, "skills", ".curator_backups", ".in-progress");
+}
+
+async function acquireLock(workspaceDir: string): Promise<boolean> {
+  const lp = lockfilePath(workspaceDir);
+  await fs.mkdir(path.dirname(lp), { recursive: true });
+  try {
+    await fs.writeFile(lp, `${process.pid}\n${Date.now()}\n`, { flag: "wx" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function releaseLock(workspaceDir: string): Promise<void> {
+  const lp = lockfilePath(workspaceDir);
+  try {
+    await fs.unlink(lp);
+  } catch {
+    // ignore
+  }
+}
+
+// ── Helper: archive dir ─────────────────────────────────────────────────────
+
+function archiveDir(workspaceDir: string): string {
+  return path.join(workspaceDir, "skills", ".archive");
+}
+
+async function moveSkillToArchive(workspaceDir: string, skillName: string): Promise<void> {
+  const skillsDir = path.join(workspaceDir, "skills");
+  const srcDir = path.join(skillsDir, skillName);
+  const dstDir = path.join(archiveDir(workspaceDir), skillName);
+
+  // Check source exists
+  try {
+    await fs.access(srcDir);
+  } catch {
+    // Source doesn't exist (maybe already moved or never created)
+    return;
+  }
+
+  await fs.mkdir(path.dirname(dstDir), { recursive: true });
+  await fs.rename(srcDir, dstDir);
+}
+
+async function restoreSkillFromArchive(workspaceDir: string, skillName: string): Promise<void> {
+  const skillsDir = path.join(workspaceDir, "skills");
+  const srcDir = path.join(archiveDir(workspaceDir), skillName);
+  const dstDir = path.join(skillsDir, skillName);
+
+  await fs.mkdir(path.dirname(dstDir), { recursive: true });
+  await fs.rename(srcDir, dstDir);
+}
+
+// ── Decision ────────────────────────────────────────────────────────────────
+
+export function decideRun(params: {
+  usage: UsageFile;
+  config: CuratorConfig;
+  now: Date;
+}): RunDecision {
+  const { usage, config, now } = params;
+
+  if (!config.enabled) {
+    return { shouldRun: false, reason: "curator disabled", firstRun: false };
+  }
+
+  if (usage.paused) {
+    return { shouldRun: false, reason: "curator paused", firstRun: false };
+  }
+
+  const decision = shouldRunCurator({
+    lastRunAt: usage.last_run_at,
+    intervalHours: config.interval_hours,
+    now,
+  });
+
+  if (usage.last_run_at === null) {
+    return { shouldRun: false, reason: decision.reason, firstRun: true };
+  }
+
+  return { shouldRun: decision.shouldRun, reason: decision.reason, firstRun: false };
+}
+
+// ── Run ─────────────────────────────────────────────────────────────────────
+
+export async function curatorRun(params: {
+  workspaceDir: string;
+  config: CuratorConfig;
+  dryRun?: boolean;
+  now?: Date;
+}): Promise<CuratorRunResult> {
+  const now = params.now ?? new Date();
+  const timestamp = now.toISOString();
+  const thresholds: TransitionThresholds = {
+    stale_after_days: params.config.stale_after_days,
+    archive_after_days: params.config.archive_after_days,
+  };
+
+  const result: CuratorRunResult = {
+    timestamp,
+    snapshotPath: null,
+    transitions: [],
+    mutations: [],
+    dryRun: params.dryRun ?? false,
+  };
+
+  // Load usage
+  const usage = await loadUsage(params.workspaceDir);
+
+  // Check if we should run
+  const decision = decideRun({ usage, config: params.config, now });
+  if (!decision.shouldRun && !decision.firstRun) {
+    return { ...result, error: decision.reason };
+  }
+
+  // First-run defer: seed last_run_at and exit
+  if (usage.last_run_at === null) {
+    await setLastRunAt(params.workspaceDir, timestamp);
+    return { ...result, error: "first-run: seeded last_run_at, skipping" };
+  }
+
+  // Acquire lock
+  if (!params.dryRun) {
+    const locked = await acquireLock(params.workspaceDir);
+    if (!locked) {
+      return { ...result, error: "lockfile exists: another curator run may be in progress" };
+    }
+  }
+
+  try {
+    // Phase A: determine transitions (only agent-created, non-pinned, non-bundled, non-hub)
+    const transitions = determineAllTransitions(usage.skills, thresholds, now);
+
+    result.transitions = transitions.map((t) => ({
+      name: t.name,
+      action: t.result.action,
+      newState: t.result.newState,
+      daysSinceUsed: t.result.daysSinceUsed,
+    }));
+
+    // Snapshot before mutations
+    if (params.config.backup.enabled && !params.dryRun && transitions.length > 0) {
+      try {
+        const snap = await createSnapshot(params.workspaceDir);
+        result.snapshotPath = snap.archivePath;
+        await rotateSnapshots(params.workspaceDir, params.config.backup.keep);
+      } catch (err) {
+        result.error = `snapshot failed: ${err instanceof Error ? err.message : String(err)}`;
+        return result;
+      }
+    }
+
+    // Apply mutations
+    for (const { name, result: transResult } of transitions) {
+      if (transResult.action === "none") continue;
+
+      if (!params.dryRun) {
+        // Update state in .usage.json
+        await setState(params.workspaceDir, name, transResult.newState);
+
+        // If archiving, move to .archive/
+        if (transResult.action === "archive") {
+          await moveSkillToArchive(params.workspaceDir, name);
+        }
+      }
+
+      result.mutations.push({
+        name,
+        action: transResult.action as "mark_stale" | "archive",
+        oldState: usage.skills[name]?.state ?? "unknown",
+        newState: transResult.newState,
+      });
+    }
+
+    // Update last_run_at
+    if (!params.dryRun) {
+      await setLastRunAt(params.workspaceDir, timestamp);
+    }
+
+    return result;
+  } finally {
+    if (!params.dryRun) {
+      await releaseLock(params.workspaceDir);
+    }
+  }
+}
+
+/** Pause the curator (persisted). */
+export async function pauseCurator(workspaceDir: string): Promise<void> {
+  await setPaused(workspaceDir, true);
+}
+
+/** Resume the curator (persisted). */
+export async function resumeCurator(workspaceDir: string): Promise<void> {
+  await setPaused(workspaceDir, false);
+}
+
+/** Pin a skill — immune to transitions and deletion. */
+export async function pinSkill(workspaceDir: string, name: string): Promise<UsageEntry> {
+  return setPinned(workspaceDir, name, true);
+}
+
+/** Unpin a skill — it becomes eligible for transitions again. */
+export async function unpinSkill(workspaceDir: string, name: string): Promise<UsageEntry> {
+  return setPinned(workspaceDir, name, false);
+}
+
+/** Restore a skill from .archive/ back to skills/ */
+export async function restoreSkill(workspaceDir: string, name: string): Promise<void> {
+  await restoreSkillFromArchive(workspaceDir, name);
+  // Mark as active again
+  await setState(workspaceDir, name, "active");
+}
+
+/** Adopt a skill: mark as agent-created so the curator manages it. */
+export async function adoptSkill(workspaceDir: string, name: string): Promise<UsageEntry> {
+  return setCreatedBy(workspaceDir, name, "agent");
+}
+
+/** Disown a skill: mark as user-created so the curator leaves it alone. */
+export async function disownSkill(workspaceDir: string, name: string): Promise<UsageEntry> {
+  return setCreatedBy(workspaceDir, name, "user");
+}

--- a/extensions/skill-curator/src/run.ts
+++ b/extensions/skill-curator/src/run.ts
@@ -22,17 +22,9 @@ import {
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
-export interface CuratorConfig {
-  enabled: boolean;
-  interval_hours: number;
-  min_idle_hours: number;
-  stale_after_days: number;
-  archive_after_days: number;
-  backup: {
-    enabled: boolean;
-    keep: number;
-  };
-}
+export type { CuratorConfig } from "./config.js";
+export { resolveConfig } from "./config.js";
+import type { CuratorConfig } from "./config.js";
 
 export interface RunDecision {
   shouldRun: boolean;

--- a/extensions/skill-curator/src/snapshot.ts
+++ b/extensions/skill-curator/src/snapshot.ts
@@ -52,25 +52,43 @@ function runTar(
  * Create a tar.gz snapshot of <workspaceDir>/skills/ into
  * <workspaceDir>/skills/.curator_backups/<utc-iso>/skills.tar.gz.
  *
- * Returns metadata about the created snapshot.
+ * Excludes .curator_backups and .archive from the tarball to avoid
+ * recursive backup bloat. Returns metadata about the created snapshot.
  */
 export async function createSnapshot(workspaceDir: string): Promise<SnapshotResult> {
   const timestamp = isoFilename();
   const destDir = path.join(backupsDir(workspaceDir), timestamp);
   const archivePath = path.join(destDir, "skills.tar.gz");
+  const manifestPath = path.join(destDir, "manifest.json");
 
   await fs.mkdir(destDir, { recursive: true });
 
   const skillsDir = path.join(workspaceDir, "skills");
 
-  // tar -czf <archive> -C <parent> skills
-  const { code, stderr } = await runTar(path.dirname(skillsDir), ["-czf", archivePath, "skills"]);
+  // tar -czf <archive> -C <parent> --exclude .curator_backups --exclude .archive skills
+  const { code, stderr } = await runTar(path.dirname(skillsDir), [
+    "-czf",
+    archivePath,
+    "--exclude",
+    ".curator_backups",
+    "--exclude",
+    ".archive",
+    "skills",
+  ]);
 
   if (code !== 0) {
     throw new Error(`tar exited with code ${code}: ${stderr}`);
   }
 
   const stat = await fs.stat(archivePath);
+
+  // Write manifest sidecar
+  const manifest = {
+    created_at: new Date().toISOString(),
+    archive_path: archivePath,
+    size_bytes: stat.size,
+  };
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf-8");
 
   return {
     archivePath,

--- a/extensions/skill-curator/src/snapshot.ts
+++ b/extensions/skill-curator/src/snapshot.ts
@@ -1,0 +1,110 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface SnapshotResult {
+  archivePath: string;
+  timestamp: string;
+  sizeBytes: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function backupsDir(workspaceDir: string): string {
+  return path.join(workspaceDir, "skills", ".curator_backups");
+}
+
+function isoFilename(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function runTar(
+  cwd: string,
+  args: string[],
+  timeoutMs = 30_000,
+): Promise<{ code: number; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("tar", args, { cwd, stdio: ["ignore", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`tar timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code: code ?? 1, stderr });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Create a tar.gz snapshot of <workspaceDir>/skills/ into
+ * <workspaceDir>/skills/.curator_backups/<utc-iso>/skills.tar.gz.
+ *
+ * Returns metadata about the created snapshot.
+ */
+export async function createSnapshot(workspaceDir: string): Promise<SnapshotResult> {
+  const timestamp = isoFilename();
+  const destDir = path.join(backupsDir(workspaceDir), timestamp);
+  const archivePath = path.join(destDir, "skills.tar.gz");
+
+  await fs.mkdir(destDir, { recursive: true });
+
+  const skillsDir = path.join(workspaceDir, "skills");
+
+  // tar -czf <archive> -C <parent> skills
+  const { code, stderr } = await runTar(path.dirname(skillsDir), ["-czf", archivePath, "skills"]);
+
+  if (code !== 0) {
+    throw new Error(`tar exited with code ${code}: ${stderr}`);
+  }
+
+  const stat = await fs.stat(archivePath);
+
+  return {
+    archivePath,
+    timestamp,
+    sizeBytes: stat.size,
+  };
+}
+
+/**
+ * Rotate old snapshots, keeping only the `keep` newest.
+ * Snapshots are directories named by UTC ISO timestamp.
+ */
+export async function rotateSnapshots(workspaceDir: string, keep: number): Promise<string[]> {
+  const dir = backupsDir(workspaceDir);
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return []; // No backups dir yet
+  }
+
+  const dirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort(); // ISO timestamps sort lexicographically
+
+  if (dirs.length <= keep) {
+    return [];
+  }
+
+  const toRemove = dirs.slice(0, dirs.length - keep);
+  for (const name of toRemove) {
+    await fs.rm(path.join(dir, name), { recursive: true, force: true });
+  }
+
+  return toRemove;
+}

--- a/extensions/skill-curator/src/telemetry.ts
+++ b/extensions/skill-curator/src/telemetry.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface UsageEntry {
+  name: string;
+  view_count: number;
+  use_count: number;
+  patch_count: number;
+  last_viewed_at: string | null;
+  last_used_at: string | null;
+  last_patched_at: string | null;
+  pinned: boolean;
+  created_at: string;
+  source: "agent-created" | "bundled" | "hub";
+  state: "active" | "stale" | "archived";
+}
+
+export interface UsageFile {
+  version: 1;
+  skills: Record<string, UsageEntry>;
+  updated_at: string;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function usagePath(workspaceDir: string): string {
+  return path.join(workspaceDir, "skills", ".usage.json");
+}
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+function emptyUsageFile(): UsageFile {
+  return {
+    version: 1,
+    skills: {},
+    updated_at: nowISO(),
+  };
+}
+
+function ensureEntry(file: UsageFile, name: string): UsageEntry {
+  if (!file.skills[name]) {
+    file.skills[name] = {
+      name,
+      view_count: 0,
+      use_count: 0,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: null,
+      last_patched_at: null,
+      pinned: false,
+      created_at: nowISO(),
+      source: "agent-created",
+      state: "active",
+    };
+  }
+  return file.skills[name];
+}
+
+// ── Atomic write ────────────────────────────────────────────────────────────
+
+async function atomicWrite(filePath: string, data: unknown): Promise<void> {
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  const json = JSON.stringify(data, null, 2);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(tmpPath, json, "utf-8");
+  await fs.rename(tmpPath, filePath);
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export async function loadUsage(workspaceDir: string): Promise<UsageFile> {
+  try {
+    const raw = await fs.readFile(usagePath(workspaceDir), "utf-8");
+    const parsed = JSON.parse(raw);
+    // Basic validation
+    if (parsed && typeof parsed === "object" && parsed.version === 1 && parsed.skills) {
+      return parsed as UsageFile;
+    }
+    return emptyUsageFile();
+  } catch {
+    return emptyUsageFile();
+  }
+}
+
+export async function saveUsage(workspaceDir: string, file: UsageFile): Promise<void> {
+  file.updated_at = nowISO();
+  await atomicWrite(usagePath(workspaceDir), file);
+}
+
+export async function incrementView(workspaceDir: string, name: string): Promise<UsageEntry> {
+  const file = await loadUsage(workspaceDir);
+  const entry = ensureEntry(file, name);
+  entry.view_count += 1;
+  entry.last_viewed_at = nowISO();
+  await saveUsage(workspaceDir, file);
+  return entry;
+}
+
+export async function incrementUse(workspaceDir: string, name: string): Promise<UsageEntry> {
+  const file = await loadUsage(workspaceDir);
+  const entry = ensureEntry(file, name);
+  entry.use_count += 1;
+  entry.last_used_at = nowISO();
+  await saveUsage(workspaceDir, file);
+  return entry;
+}
+
+export async function incrementPatch(workspaceDir: string, name: string): Promise<UsageEntry> {
+  const file = await loadUsage(workspaceDir);
+  const entry = ensureEntry(file, name);
+  entry.patch_count += 1;
+  entry.last_patched_at = nowISO();
+  await saveUsage(workspaceDir, file);
+  return entry;
+}
+
+export async function setPinned(
+  workspaceDir: string,
+  name: string,
+  pinned: boolean,
+): Promise<UsageEntry> {
+  const file = await loadUsage(workspaceDir);
+  const entry = ensureEntry(file, name);
+  entry.pinned = pinned;
+  await saveUsage(workspaceDir, file);
+  return entry;
+}
+
+export async function setState(
+  workspaceDir: string,
+  name: string,
+  state: UsageEntry["state"],
+): Promise<UsageEntry> {
+  const file = await loadUsage(workspaceDir);
+  const entry = ensureEntry(file, name);
+  entry.state = state;
+  await saveUsage(workspaceDir, file);
+  return entry;
+}

--- a/extensions/skill-curator/src/telemetry.ts
+++ b/extensions/skill-curator/src/telemetry.ts
@@ -13,6 +13,11 @@ export interface UsageEntry {
   last_patched_at: string | null;
   pinned: boolean;
   created_at: string;
+  /** Who created this skill. "agent" = created by skill_workshop; "user" = hand-authored; "unknown" = pre-migration. */
+  created_by: "agent" | "user" | "unknown";
+  /** Unix epoch ms when the skill was first created by skill_workshop. null for hand-authored/unknown. */
+  created_at_ms: number | null;
+  /** Source classification (bundled, hub, or agent-created workspace skill). */
   source: "agent-created" | "bundled" | "hub";
   state: "active" | "stale" | "archived";
 }
@@ -20,7 +25,12 @@ export interface UsageEntry {
 export interface UsageFile {
   version: 1;
   skills: Record<string, UsageEntry>;
+  /** ISO timestamp of last write. */
   updated_at: string;
+  /** ISO timestamp of the last curator run. null = never run (first-run defer). */
+  last_run_at: string | null;
+  /** Whether the curator is paused. Persisted across sessions. */
+  paused: boolean;
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -33,12 +43,36 @@ function nowISO(): string {
   return new Date().toISOString();
 }
 
+function nowMs(): number {
+  return Date.now();
+}
+
 function emptyUsageFile(): UsageFile {
   return {
     version: 1,
     skills: {},
     updated_at: nowISO(),
+    last_run_at: null,
+    paused: false,
   };
+}
+
+/**
+ * First-run migration: any existing entry that lacks `created_by` or `created_at_ms`
+ * gets defaulted to "unknown" / null. This ensures existing skills are treated as
+ * user-owned (safe default — never auto-archive what we didn't create).
+ */
+function migrateEntry(entry: Record<string, unknown>): UsageEntry {
+  if (
+    typeof entry.created_by !== "string" ||
+    !["agent", "user", "unknown"].includes(entry.created_by as string)
+  ) {
+    entry.created_by = "unknown";
+  }
+  if (typeof entry.created_at_ms !== "number") {
+    entry.created_at_ms = null;
+  }
+  return entry as unknown as UsageEntry;
 }
 
 function ensureEntry(file: UsageFile, name: string): UsageEntry {
@@ -53,6 +87,8 @@ function ensureEntry(file: UsageFile, name: string): UsageEntry {
       last_patched_at: null,
       pinned: false,
       created_at: nowISO(),
+      created_by: "unknown",
+      created_at_ms: null,
       source: "agent-created",
       state: "active",
     };
@@ -78,6 +114,21 @@ export async function loadUsage(workspaceDir: string): Promise<UsageFile> {
     const parsed = JSON.parse(raw);
     // Basic validation
     if (parsed && typeof parsed === "object" && parsed.version === 1 && parsed.skills) {
+      // Migrate existing entries that lack created_by/created_at_ms
+      if (typeof parsed.skills === "object" && parsed.skills !== null) {
+        for (const [name, entry] of Object.entries(parsed.skills as Record<string, unknown>)) {
+          if (entry && typeof entry === "object") {
+            parsed.skills[name] = migrateEntry(entry as Record<string, unknown>);
+          }
+        }
+      }
+      // Ensure meta fields exist
+      if (typeof parsed.last_run_at !== "string") {
+        parsed.last_run_at = null;
+      }
+      if (typeof parsed.paused !== "boolean") {
+        parsed.paused = false;
+      }
       return parsed as UsageFile;
     }
     return emptyUsageFile();
@@ -89,6 +140,28 @@ export async function loadUsage(workspaceDir: string): Promise<UsageFile> {
 export async function saveUsage(workspaceDir: string, file: UsageFile): Promise<void> {
   file.updated_at = nowISO();
   await atomicWrite(usagePath(workspaceDir), file);
+}
+
+/** Stamp a skill as agent-created (called by skill_workshop at creation time). */
+export async function stampAgentCreated(workspaceDir: string, name: string): Promise<UsageEntry> {
+  const file = await loadUsage(workspaceDir);
+  const entry = ensureEntry(file, name);
+  entry.created_by = "agent";
+  entry.created_at_ms = nowMs();
+  await saveUsage(workspaceDir, file);
+  return entry;
+}
+
+export async function setCreatedBy(
+  workspaceDir: string,
+  name: string,
+  createdBy: "agent" | "user",
+): Promise<UsageEntry> {
+  const file = await loadUsage(workspaceDir);
+  const entry = ensureEntry(file, name);
+  entry.created_by = createdBy;
+  await saveUsage(workspaceDir, file);
+  return entry;
 }
 
 export async function incrementView(workspaceDir: string, name: string): Promise<UsageEntry> {
@@ -140,4 +213,52 @@ export async function setState(
   entry.state = state;
   await saveUsage(workspaceDir, file);
   return entry;
+}
+
+/** Set the last_run_at timestamp for the curator. Used for first-run defer and periodic scheduling. */
+export async function setLastRunAt(workspaceDir: string, timestamp: string): Promise<void> {
+  const file = await loadUsage(workspaceDir);
+  file.last_run_at = timestamp;
+  await saveUsage(workspaceDir, file);
+}
+
+/** Set the paused flag for the curator. Persisted across sessions. */
+export async function setPaused(workspaceDir: string, paused: boolean): Promise<void> {
+  const file = await loadUsage(workspaceDir);
+  file.paused = paused;
+  await saveUsage(workspaceDir, file);
+}
+
+/** Check if a skill entry is agent-created (not unknown, not user). */
+export function isAgentCreated(entry: UsageEntry): boolean {
+  return entry.created_by === "agent";
+}
+
+/**
+ * Determine if the curator should run based on last_run_at and interval configurations.
+ * Returns the decision and reason.
+ */
+export function shouldRunCurator(params: {
+  lastRunAt: string | null;
+  intervalHours: number;
+  now: Date;
+}): { shouldRun: boolean; reason: string } {
+  const { lastRunAt, intervalHours, now } = params;
+
+  if (lastRunAt === null) {
+    return { shouldRun: false, reason: "first-run defer: no previous run, skipping" };
+  }
+
+  const lastRun = new Date(lastRunAt).getTime();
+  const elapsedMs = now.getTime() - lastRun;
+  const elapsedHours = elapsedMs / (1000 * 60 * 60);
+
+  if (elapsedHours < intervalHours) {
+    return {
+      shouldRun: false,
+      reason: `interval not met: ${elapsedHours.toFixed(1)}h elapsed, need ${intervalHours}h`,
+    };
+  }
+
+  return { shouldRun: true, reason: `interval satisfied: ${elapsedHours.toFixed(1)}h elapsed` };
 }

--- a/extensions/skill-curator/src/transitions.ts
+++ b/extensions/skill-curator/src/transitions.ts
@@ -1,4 +1,4 @@
-import type { UsageEntry } from "./telemetry.js";
+import { isAgentCreated, type UsageEntry } from "./telemetry.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -74,6 +74,8 @@ export function daysSinceLastUse(entry: UsageEntry, now: Date = new Date()): num
 /**
  * Determine transitions for all entries in a usage file.
  * Returns only entries that require action (non-"none").
+ *
+ * Skipped: pinned, bundled, hub-installed, and non-agent-created skills.
  */
 export function determineAllTransitions(
   skills: Record<string, UsageEntry>,
@@ -84,6 +86,10 @@ export function determineAllTransitions(
   for (const [name, entry] of Object.entries(skills)) {
     // Skip bundled and hub-installed skills
     if (entry.source === "bundled" || entry.source === "hub") {
+      continue;
+    }
+    // Skip non-agent-created skills (hand-authored or unknown origin)
+    if (!isAgentCreated(entry)) {
       continue;
     }
     const result = determineTransition(entry, thresholds, now);

--- a/extensions/skill-curator/src/transitions.ts
+++ b/extensions/skill-curator/src/transitions.ts
@@ -1,0 +1,95 @@
+import type { UsageEntry } from "./telemetry.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface TransitionThresholds {
+  stale_after_days: number;
+  archive_after_days: number;
+}
+
+export type TransitionAction = "none" | "mark_stale" | "archive";
+
+export interface TransitionResult {
+  newState: UsageEntry["state"];
+  action: TransitionAction;
+  daysSinceUsed: number;
+}
+
+// ── Logic ───────────────────────────────────────────────────────────────────
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * Determine what transition (if any) should be applied to a skill entry
+ * based on its last_used_at timestamp and the configured thresholds.
+ *
+ * Rules:
+ * - Pinned skills are never transitioned.
+ * - Already-archived skills stay archived.
+ * - If days since last use > archive_after_days → archive.
+ * - If days since last use > stale_after_days → mark stale.
+ * - Otherwise → no change.
+ */
+export function determineTransition(
+  entry: UsageEntry,
+  thresholds: TransitionThresholds,
+  now: Date = new Date(),
+): TransitionResult {
+  const daysSinceUsed = daysSinceLastUse(entry, now);
+
+  // Pinned skills are immune
+  if (entry.pinned) {
+    return { newState: entry.state, action: "none", daysSinceUsed };
+  }
+
+  // Already archived stays archived
+  if (entry.state === "archived") {
+    return { newState: "archived", action: "none", daysSinceUsed };
+  }
+
+  // Archive threshold
+  if (daysSinceUsed > thresholds.archive_after_days) {
+    return { newState: "archived", action: "archive", daysSinceUsed };
+  }
+
+  // Stale threshold
+  if (daysSinceUsed > thresholds.stale_after_days) {
+    return { newState: "stale", action: "mark_stale", daysSinceUsed };
+  }
+
+  // No transition needed
+  return { newState: entry.state, action: "none", daysSinceUsed };
+}
+
+/**
+ * Calculate days since the skill was last used.
+ * Falls back to created_at if last_used_at is null.
+ */
+export function daysSinceLastUse(entry: UsageEntry, now: Date = new Date()): number {
+  const reference = entry.last_used_at ?? entry.created_at;
+  const refDate = new Date(reference);
+  return (now.getTime() - refDate.getTime()) / MS_PER_DAY;
+}
+
+/**
+ * Determine transitions for all entries in a usage file.
+ * Returns only entries that require action (non-"none").
+ */
+export function determineAllTransitions(
+  skills: Record<string, UsageEntry>,
+  thresholds: TransitionThresholds,
+  now: Date = new Date(),
+): Array<{ name: string; result: TransitionResult }> {
+  const results: Array<{ name: string; result: TransitionResult }> = [];
+  for (const [name, entry] of Object.entries(skills)) {
+    // Skip bundled and hub-installed skills
+    if (entry.source === "bundled" || entry.source === "hub") {
+      continue;
+    }
+    const result = determineTransition(entry, thresholds, now);
+    if (result.action !== "none") {
+      results.push({ name, result });
+    }
+  }
+  return results;
+}

--- a/extensions/skill-curator/tests/config.test.ts
+++ b/extensions/skill-curator/tests/config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { resolveConfig } from "../src/config.js";
+
+describe("config resolution", () => {
+  it("applies defaults when no config provided", () => {
+    const config = resolveConfig({});
+    expect(config.enabled).toBe(true);
+    expect(config.interval_hours).toBe(168);
+    expect(config.min_idle_hours).toBe(2);
+    expect(config.stale_after_days).toBe(30);
+    expect(config.archive_after_days).toBe(90);
+    expect(config.backup.enabled).toBe(true);
+    expect(config.backup.keep).toBe(5);
+  });
+
+  it("applies defaults when undefined", () => {
+    const config = resolveConfig(undefined);
+    expect(config.enabled).toBe(true);
+    expect(config.interval_hours).toBe(168);
+  });
+
+  it("respects custom values", () => {
+    const config = resolveConfig({
+      enabled: false,
+      interval_hours: 24,
+      stale_after_days: 7,
+      backup: { enabled: false, keep: 3 },
+    });
+    expect(config.enabled).toBe(false);
+    expect(config.interval_hours).toBe(24);
+    expect(config.stale_after_days).toBe(7);
+    expect(config.backup.enabled).toBe(false);
+    expect(config.backup.keep).toBe(3);
+  });
+
+  it("clamps interval_hours to min 1", () => {
+    const config = resolveConfig({ interval_hours: 0 });
+    expect(config.interval_hours).toBe(1);
+  });
+
+  it("clamps interval_hours to max 8760", () => {
+    const config = resolveConfig({ interval_hours: 10000 });
+    expect(config.interval_hours).toBe(8760);
+  });
+
+  it("clamps min_idle_hours to min 0", () => {
+    const config = resolveConfig({ min_idle_hours: -5 });
+    expect(config.min_idle_hours).toBe(0);
+  });
+
+  it("clamps stale_after_days to min 1", () => {
+    const config = resolveConfig({ stale_after_days: 0 });
+    expect(config.stale_after_days).toBe(1);
+  });
+
+  it("clamps archive_after_days to min 1", () => {
+    const config = resolveConfig({ archive_after_days: -1 });
+    expect(config.archive_after_days).toBe(1);
+  });
+
+  it("clamps backup.keep to range [1, 100]", () => {
+    expect(resolveConfig({ backup: { keep: 0 } }).backup.keep).toBe(1);
+    expect(resolveConfig({ backup: { keep: 200 } }).backup.keep).toBe(100);
+  });
+
+  it("handles non-object backup gracefully", () => {
+    const config = resolveConfig({ backup: "not-an-object" });
+    expect(config.backup.enabled).toBe(true);
+    expect(config.backup.keep).toBe(5);
+  });
+
+  it("treats non-boolean enabled as true (default)", () => {
+    expect(resolveConfig({ enabled: "yes" }).enabled).toBe(true);
+    expect(resolveConfig({ enabled: 1 }).enabled).toBe(true);
+    expect(resolveConfig({ enabled: false }).enabled).toBe(false);
+  });
+});

--- a/extensions/skill-curator/tests/integration.test.ts
+++ b/extensions/skill-curator/tests/integration.test.ts
@@ -1,0 +1,347 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeRunLog } from "../src/logs.js";
+import { curatorRun, restoreSkill, type CuratorConfig } from "../src/run.js";
+import { loadUsage, saveUsage, stampAgentCreated, type UsageFile } from "../src/telemetry.js";
+
+const DEFAULT_CONFIG: CuratorConfig = {
+  enabled: true,
+  interval_hours: 168,
+  min_idle_hours: 2,
+  stale_after_days: 30,
+  archive_after_days: 90,
+  backup: { enabled: true, keep: 5 },
+};
+
+async function setupFixtureWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-curator-fixture-"));
+  const skillsDir = path.join(dir, "skills");
+  await fs.mkdir(skillsDir, { recursive: true });
+
+  // 1. Bundled skill (excluded from all curator actions)
+  const bundledDir = path.join(skillsDir, "bundled-tool");
+  await fs.mkdir(bundledDir, { recursive: true });
+  await fs.writeFile(path.join(bundledDir, "SKILL.md"), "# Bundled Tool\n\nBuilt-in skill.\n");
+  await fs.writeFile(path.join(bundledDir, ".bundled_manifest"), "{}");
+
+  // 2. Hub-installed skill (excluded)
+  const hubDir = path.join(skillsDir, "hub-plugin");
+  await fs.mkdir(hubDir, { recursive: true });
+  await fs.writeFile(path.join(hubDir, "SKILL.md"), "# Hub Plugin\n\nFrom clawhub.\n");
+
+  // 3. User-authored skill (created_by: user — excluded)
+  const userDir = path.join(skillsDir, "my-notes");
+  await fs.mkdir(userDir, { recursive: true });
+  await fs.writeFile(path.join(userDir, "SKILL.md"), "# My Notes\n\nPersonal workflow.\n");
+
+  // 4. Agent-created but pinned (excluded)
+  const pinnedDir = path.join(skillsDir, "pinned-workflow");
+  await fs.mkdir(pinnedDir, { recursive: true });
+  await fs.writeFile(
+    path.join(pinnedDir, "SKILL.md"),
+    "# Pinned Workflow\n\nImportant agent workflow.\n",
+  );
+
+  // 5. Two agent-created OLD skills (should be archived)
+  const old1Dir = path.join(skillsDir, "old-workflow-1");
+  await fs.mkdir(old1Dir, { recursive: true });
+  await fs.writeFile(path.join(old1Dir, "SKILL.md"), "# Old Workflow 1\n\nVery old.\n");
+
+  const old2Dir = path.join(skillsDir, "old-workflow-2");
+  await fs.mkdir(old2Dir, { recursive: true });
+  await fs.writeFile(path.join(old2Dir, "SKILL.md"), "# Old Workflow 2\n\nAlso very old.\n");
+
+  // 6. Agent-created RECENT skill (should be kept)
+  const recentDir = path.join(skillsDir, "recent-workflow");
+  await fs.mkdir(recentDir, { recursive: true });
+  await fs.writeFile(path.join(recentDir, "SKILL.md"), "# Recent Workflow\n\nRecently used.\n");
+
+  // Set up usage.json
+  const now = new Date("2026-05-06T12:00:00Z");
+  const hundredDaysAgo = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString();
+  const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString();
+  const ms = now.getTime();
+
+  const usage: UsageFile = {
+    version: 1,
+    skills: {
+      "bundled-tool": {
+        name: "bundled-tool",
+        view_count: 10,
+        use_count: 5,
+        patch_count: 0,
+        last_viewed_at: null,
+        last_used_at: hundredDaysAgo,
+        last_patched_at: null,
+        pinned: false,
+        created_at: hundredDaysAgo,
+        created_by: "agent",
+        created_at_ms: new Date(hundredDaysAgo).getTime(),
+        source: "bundled",
+        state: "active",
+      },
+      "hub-plugin": {
+        name: "hub-plugin",
+        view_count: 10,
+        use_count: 5,
+        patch_count: 0,
+        last_viewed_at: null,
+        last_used_at: hundredDaysAgo,
+        last_patched_at: null,
+        pinned: false,
+        created_at: hundredDaysAgo,
+        created_by: "agent",
+        created_at_ms: new Date(hundredDaysAgo).getTime(),
+        source: "hub",
+        state: "active",
+      },
+      "my-notes": {
+        name: "my-notes",
+        view_count: 3,
+        use_count: 1,
+        patch_count: 0,
+        last_viewed_at: null,
+        last_used_at: hundredDaysAgo,
+        last_patched_at: null,
+        pinned: false,
+        created_at: hundredDaysAgo,
+        created_by: "user",
+        created_at_ms: null,
+        source: "agent-created",
+        state: "active",
+      },
+      "pinned-workflow": {
+        name: "pinned-workflow",
+        view_count: 20,
+        use_count: 15,
+        patch_count: 0,
+        last_viewed_at: null,
+        last_used_at: hundredDaysAgo,
+        last_patched_at: null,
+        pinned: true,
+        created_at: hundredDaysAgo,
+        created_by: "agent",
+        created_at_ms: new Date(hundredDaysAgo).getTime(),
+        source: "agent-created",
+        state: "active",
+      },
+      "old-workflow-1": {
+        name: "old-workflow-1",
+        view_count: 5,
+        use_count: 2,
+        patch_count: 0,
+        last_viewed_at: null,
+        last_used_at: hundredDaysAgo,
+        last_patched_at: null,
+        pinned: false,
+        created_at: hundredDaysAgo,
+        created_by: "agent",
+        created_at_ms: new Date(hundredDaysAgo).getTime(),
+        source: "agent-created",
+        state: "active",
+      },
+      "old-workflow-2": {
+        name: "old-workflow-2",
+        view_count: 3,
+        use_count: 1,
+        patch_count: 0,
+        last_viewed_at: null,
+        last_used_at: hundredDaysAgo,
+        last_patched_at: null,
+        pinned: false,
+        created_at: hundredDaysAgo,
+        created_by: "agent",
+        created_at_ms: new Date(hundredDaysAgo).getTime(),
+        source: "agent-created",
+        state: "active",
+      },
+      "recent-workflow": {
+        name: "recent-workflow",
+        view_count: 8,
+        use_count: 6,
+        patch_count: 0,
+        last_viewed_at: null,
+        last_used_at: tenDaysAgo,
+        last_patched_at: null,
+        pinned: false,
+        created_at: hundredDaysAgo,
+        created_by: "agent",
+        created_at_ms: new Date(hundredDaysAgo).getTime(),
+        source: "agent-created",
+        state: "active",
+      },
+    },
+    updated_at: "2026-05-06T12:00:00.000Z",
+    last_run_at: "2026-01-01T00:00:00.000Z", // interval satisfied
+    paused: false,
+  };
+
+  await saveUsage(dir, usage);
+  return dir;
+}
+
+describe("curator integration test", () => {
+  it("dry-run: proposes right actions, zero mutations on disk", async () => {
+    const dir = await setupFixtureWorkspace();
+    const now = new Date("2026-05-06T12:00:00Z");
+
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: DEFAULT_CONFIG,
+      dryRun: true,
+      now,
+    });
+
+    // Should propose archiving the two old agent-created skills
+    const archiveMutations = result.mutations.filter((m) => m.action === "archive");
+    expect(archiveMutations).toHaveLength(2);
+    const archivedNames = archiveMutations.map((m) => m.name).sort();
+    expect(archivedNames).toEqual(["old-workflow-1", "old-workflow-2"]);
+
+    // Recent workflow should NOT be archived (only 10 days)
+    const recentMutation = result.mutations.find((m) => m.name === "recent-workflow");
+    expect(recentMutation).toBeUndefined();
+
+    // Pinned skill should NOT be touched
+    const pinnedMutation = result.mutations.find((m) => m.name === "pinned-workflow");
+    expect(pinnedMutation).toBeUndefined();
+
+    // User-authored should NOT be touched
+    const userMutation = result.mutations.find((m) => m.name === "my-notes");
+    expect(userMutation).toBeUndefined();
+
+    // Bundled should NOT be touched
+    const bundledMutation = result.mutations.find((m) => m.name === "bundled-tool");
+    expect(bundledMutation).toBeUndefined();
+
+    // Hub should NOT be touched
+    const hubMutation = result.mutations.find((m) => m.name === "hub-plugin");
+    expect(hubMutation).toBeUndefined();
+
+    // Zero on-disk mutations
+    const skillsDir = path.join(dir, "skills");
+    const entries = await fs.readdir(skillsDir);
+    // All original skill dirs should still exist
+    expect(entries).toContain("old-workflow-1");
+    expect(entries).toContain("old-workflow-2");
+    expect(entries).toContain("recent-workflow");
+    expect(entries).toContain("pinned-workflow");
+    expect(entries).toContain("my-notes");
+    expect(entries).toContain("bundled-tool");
+    expect(entries).toContain("hub-plugin");
+
+    // No .archive/ dir should have been created
+    await expect(fs.access(path.join(skillsDir, ".archive"))).rejects.toThrow();
+
+    // Usage state should not have changed
+    const usage = await loadUsage(dir);
+    expect(usage.skills["old-workflow-1"].state).toBe("active");
+    expect(usage.skills["old-workflow-2"].state).toBe("active");
+
+    // Cleanup
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("sync run: archives old skills, keeps pinned, writes report", async () => {
+    const dir = await setupFixtureWorkspace();
+    const now = new Date("2026-05-06T12:00:00Z");
+
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: DEFAULT_CONFIG,
+      dryRun: false,
+      now,
+    });
+
+    // Should have archived the two old skills
+    const archiveMutations = result.mutations.filter((m) => m.action === "archive");
+    expect(archiveMutations).toHaveLength(2);
+
+    // Snapshot should exist
+    expect(result.snapshotPath).toBeTruthy();
+    await fs.access(result.snapshotPath!);
+
+    // Old skills should have moved to .archive/
+    const archiveDir = path.join(dir, "skills", ".archive");
+    await fs.access(path.join(archiveDir, "old-workflow-1"));
+    await fs.access(path.join(archiveDir, "old-workflow-2"));
+
+    // Old skill dirs should be gone from skills/
+    const skillsDir = path.join(dir, "skills");
+    await expect(fs.access(path.join(skillsDir, "old-workflow-1"))).rejects.toThrow();
+    await expect(fs.access(path.join(skillsDir, "old-workflow-2"))).rejects.toThrow();
+
+    // Pinned skill should still exist
+    await fs.access(path.join(skillsDir, "pinned-workflow"));
+    const pinnedContent = await fs.readFile(
+      path.join(skillsDir, "pinned-workflow", "SKILL.md"),
+      "utf-8",
+    );
+    expect(pinnedContent).toContain("Pinned Workflow");
+
+    // User-authored should still exist
+    await fs.access(path.join(skillsDir, "my-notes"));
+
+    // Recent skill should still exist
+    await fs.access(path.join(skillsDir, "recent-workflow"));
+
+    // Bundled should still exist
+    await fs.access(path.join(skillsDir, "bundled-tool"));
+
+    // Hub should still exist
+    await fs.access(path.join(skillsDir, "hub-plugin"));
+
+    // Usage state should be updated
+    const usage = await loadUsage(dir);
+    expect(usage.skills["old-workflow-1"].state).toBe("archived");
+    expect(usage.skills["old-workflow-2"].state).toBe("archived");
+    expect(usage.skills["pinned-workflow"].state).toBe("active");
+    expect(usage.skills["recent-workflow"].state).toBe("active");
+
+    // last_run_at should be updated
+    expect(usage.last_run_at).toBeTruthy();
+
+    // Write run log and verify REPORT.md
+    const runDir = await writeRunLog(result);
+    const report = await fs.readFile(path.join(runDir, "REPORT.md"), "utf-8");
+    expect(report).toContain("LIVE");
+    expect(report).toContain("old-workflow-1");
+    expect(report).toContain("old-workflow-2");
+
+    // Cleanup
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("restore brings archived skill back", async () => {
+    const dir = await setupFixtureWorkspace();
+    const now = new Date("2026-05-06T12:00:00Z");
+
+    // First, run to archive old-workflow-1
+    await curatorRun({ workspaceDir: dir, config: DEFAULT_CONFIG, dryRun: false, now });
+
+    // Verify it's archived
+    const archivePath = path.join(dir, "skills", ".archive", "old-workflow-1");
+    await fs.access(archivePath);
+
+    // Restore it
+    await restoreSkill(dir, "old-workflow-1");
+
+    // Should be back in skills/
+    const restoredPath = path.join(dir, "skills", "old-workflow-1");
+    await fs.access(restoredPath);
+    const content = await fs.readFile(path.join(restoredPath, "SKILL.md"), "utf-8");
+    expect(content).toContain("Old Workflow 1");
+
+    // Archive dir should be gone
+    await expect(fs.access(archivePath)).rejects.toThrow();
+
+    // State should be active
+    const usage = await loadUsage(dir);
+    expect(usage.skills["old-workflow-1"].state).toBe("active");
+
+    // Cleanup
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/extensions/skill-curator/tests/logs.test.ts
+++ b/extensions/skill-curator/tests/logs.test.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeRunLog } from "../src/logs.js";
+import type { CuratorRunResult } from "../src/run.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-curator-logs-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+// Mock HOME to control log output location
+const realHome = process.env.HOME;
+
+afterEach(async () => {
+  process.env.HOME = realHome;
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("writeRunLog", () => {
+  it("writes run.json and REPORT.md", async () => {
+    const dir = await makeTempDir();
+    process.env.HOME = dir; // redirect ~/.openclaw/logs/curator to temp dir
+
+    const result: CuratorRunResult = {
+      timestamp: "2026-05-06T12:00:00.000Z",
+      snapshotPath: "/tmp/skills.tar.gz",
+      transitions: [
+        { name: "old-skill", action: "archive", newState: "archived", daysSinceUsed: 100 },
+        { name: "stale-skill", action: "mark_stale", newState: "stale", daysSinceUsed: 45 },
+      ],
+      mutations: [
+        { name: "old-skill", action: "archive", oldState: "active", newState: "archived" },
+        { name: "stale-skill", action: "mark_stale", oldState: "active", newState: "stale" },
+      ],
+      dryRun: false,
+    };
+
+    const runDir = await writeRunLog(result);
+    expect(runDir).toContain(".openclaw/logs/curator/");
+
+    // Verify run.json
+    const runJsonPath = path.join(runDir, "run.json");
+    const runJsonRaw = await fs.readFile(runJsonPath, "utf-8");
+    const runJson = JSON.parse(runJsonRaw);
+    expect(runJson.dryRun).toBe(false);
+    expect(runJson.transitions).toHaveLength(2);
+    expect(runJson.mutations).toHaveLength(2);
+    expect(runJson.snapshotPath).toBe("/tmp/skills.tar.gz");
+
+    // Verify REPORT.md
+    const reportPath = path.join(runDir, "REPORT.md");
+    const report = await fs.readFile(reportPath, "utf-8");
+    expect(report).toContain("# Curator Run Report");
+    expect(report).toContain("LIVE");
+    expect(report).toContain("old-skill");
+    expect(report).toContain("stale-skill");
+    expect(report).toContain("## 📦 Snapshot");
+    expect(report).toContain("## ✏️ Mutations");
+  });
+
+  it("marks dry run in report", async () => {
+    const dir = await makeTempDir();
+    process.env.HOME = dir;
+
+    const result: CuratorRunResult = {
+      timestamp: "2026-05-06T12:00:00.000Z",
+      snapshotPath: null,
+      transitions: [],
+      mutations: [],
+      dryRun: true,
+    };
+
+    const runDir = await writeRunLog(result);
+    const report = await fs.readFile(path.join(runDir, "REPORT.md"), "utf-8");
+    expect(report).toContain("DRY RUN");
+    expect(report).toContain("✅ No transitions needed");
+  });
+
+  it("reports error when present", async () => {
+    const dir = await makeTempDir();
+    process.env.HOME = dir;
+
+    const result: CuratorRunResult = {
+      timestamp: "2026-05-06T12:00:00.000Z",
+      snapshotPath: null,
+      transitions: [],
+      mutations: [],
+      dryRun: false,
+      error: "curator paused",
+    };
+
+    const runDir = await writeRunLog(result);
+    const report = await fs.readFile(path.join(runDir, "REPORT.md"), "utf-8");
+    expect(report).toContain("curator paused");
+    expect(report).toContain("⚠️ Info");
+  });
+
+  it("dry-run writes mutated:false in run.json", async () => {
+    const dir = await makeTempDir();
+    process.env.HOME = dir;
+
+    const result: CuratorRunResult = {
+      timestamp: "2026-05-06T12:00:00.000Z",
+      snapshotPath: null,
+      transitions: [{ name: "x", action: "archive", newState: "archived", daysSinceUsed: 100 }],
+      mutations: [],
+      dryRun: true,
+    };
+
+    const runDir = await writeRunLog(result);
+    const runJson = JSON.parse(await fs.readFile(path.join(runDir, "run.json"), "utf-8"));
+    expect(runJson.dryRun).toBe(true);
+    expect(runJson.transitions).toHaveLength(1);
+    expect(runJson.mutations).toHaveLength(0);
+  });
+});

--- a/extensions/skill-curator/tests/reviewer.test.ts
+++ b/extensions/skill-curator/tests/reviewer.test.ts
@@ -1,0 +1,281 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildReviewManifest,
+  parseReviewResponse,
+  validatePatchAction,
+  CURATOR_SYSTEM_PROMPT,
+} from "../src/reviewer.js";
+import { loadUsage, saveUsage, stampAgentCreated } from "../src/telemetry.js";
+import type { UsageFile } from "../src/telemetry.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-curator-review-"));
+  tempDirs.push(dir);
+  await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("buildReviewManifest", () => {
+  it("includes only agent-created, non-pinned, non-archived skills", async () => {
+    const dir = await makeTempDir();
+    const usage: UsageFile = {
+      version: 1,
+      skills: {
+        "agent-active": {
+          name: "agent-active",
+          view_count: 3,
+          use_count: 2,
+          patch_count: 0,
+          last_viewed_at: null,
+          last_used_at: "2026-05-01T00:00:00.000Z",
+          last_patched_at: null,
+          pinned: false,
+          created_at: "2026-01-01T00:00:00.000Z",
+          created_by: "agent",
+          created_at_ms: 1700000000000,
+          source: "agent-created",
+          state: "active",
+        },
+        "agent-pinned": {
+          name: "agent-pinned",
+          view_count: 5,
+          use_count: 10,
+          patch_count: 0,
+          last_viewed_at: null,
+          last_used_at: "2026-05-05T00:00:00.000Z",
+          last_patched_at: null,
+          pinned: true,
+          created_at: "2026-01-01T00:00:00.000Z",
+          created_by: "agent",
+          created_at_ms: 1700000000000,
+          source: "agent-created",
+          state: "active",
+        },
+        "user-skill": {
+          name: "user-skill",
+          view_count: 1,
+          use_count: 1,
+          patch_count: 0,
+          last_viewed_at: null,
+          last_used_at: "2026-01-01T00:00:00.000Z",
+          last_patched_at: null,
+          pinned: false,
+          created_at: "2026-01-01T00:00:00.000Z",
+          created_by: "user",
+          created_at_ms: null,
+          source: "agent-created",
+          state: "active",
+        },
+        "bundled-skill": {
+          name: "bundled-skill",
+          view_count: 0,
+          use_count: 0,
+          patch_count: 0,
+          last_viewed_at: null,
+          last_used_at: null,
+          last_patched_at: null,
+          pinned: false,
+          created_at: "2026-01-01T00:00:00.000Z",
+          created_by: "agent",
+          created_at_ms: 1700000000000,
+          source: "bundled",
+          state: "active",
+        },
+        "agent-archived": {
+          name: "agent-archived",
+          view_count: 0,
+          use_count: 0,
+          patch_count: 0,
+          last_viewed_at: null,
+          last_used_at: null,
+          last_patched_at: null,
+          pinned: false,
+          created_at: "2026-01-01T00:00:00.000Z",
+          created_by: "agent",
+          created_at_ms: 1700000000000,
+          source: "agent-created",
+          state: "archived",
+        },
+      },
+      updated_at: "2026-05-06T12:00:00.000Z",
+      last_run_at: null,
+      paused: false,
+    };
+    await saveUsage(dir, usage);
+
+    const manifest = await buildReviewManifest(dir);
+    expect(manifest.skills).toHaveLength(1);
+    expect(manifest.skills[0].name).toBe("agent-active");
+  });
+
+  it("returns empty manifest for no agent-created skills", async () => {
+    const dir = await makeTempDir();
+    const manifest = await buildReviewManifest(dir);
+    expect(manifest.skills).toHaveLength(0);
+  });
+});
+
+describe("parseReviewResponse", () => {
+  it("parses valid keep decision", () => {
+    const result = parseReviewResponse(JSON.stringify({ decisions: [{ action: "keep" }] }));
+    expect(result.decisions).toHaveLength(1);
+    expect(result.decisions[0]).toEqual({ action: "keep" });
+  });
+
+  it("parses valid patch decision", () => {
+    const result = parseReviewResponse(
+      JSON.stringify({
+        decisions: [{ action: "patch", old_string: "Use port 3000", new_string: "Use port 8080" }],
+      }),
+    );
+    expect(result.decisions[0]).toEqual({
+      action: "patch",
+      old_string: "Use port 3000",
+      new_string: "Use port 8080",
+    });
+  });
+
+  it("parses valid archive decision", () => {
+    const result = parseReviewResponse(
+      JSON.stringify({
+        decisions: [{ action: "archive", reason: "No longer needed" }],
+      }),
+    );
+    expect(result.decisions[0]).toEqual({ action: "archive", reason: "No longer needed" });
+  });
+
+  it("parses valid consolidate decision", () => {
+    const result = parseReviewResponse(
+      JSON.stringify({
+        decisions: [
+          {
+            action: "consolidate",
+            merge_target: "git-workflow",
+            new_content: "# Combined\n\nContent here\n",
+          },
+        ],
+      }),
+    );
+    expect(result.decisions[0]).toEqual({
+      action: "consolidate",
+      merge_target: "git-workflow",
+      new_content: "# Combined\n\nContent here\n",
+    });
+  });
+
+  it("rejects non-JSON input", () => {
+    expect(() => parseReviewResponse("not json")).toThrow("Failed to parse");
+  });
+
+  it("rejects missing decisions array", () => {
+    expect(() => parseReviewResponse(JSON.stringify({}))).toThrow("missing 'decisions'");
+  });
+
+  it("rejects invalid action name", () => {
+    expect(() =>
+      parseReviewResponse(JSON.stringify({ decisions: [{ action: "delete_all" }] })),
+    ).toThrow("invalid action");
+  });
+
+  it("rejects patch without old_string", () => {
+    expect(() =>
+      parseReviewResponse(JSON.stringify({ decisions: [{ action: "patch", new_string: "x" }] })),
+    ).toThrow("patch requires old_string");
+  });
+
+  it("rejects patch where old_string equals new_string", () => {
+    expect(() =>
+      parseReviewResponse(
+        JSON.stringify({
+          decisions: [{ action: "patch", old_string: "same", new_string: "same" }],
+        }),
+      ),
+    ).toThrow("must differ");
+  });
+
+  it("rejects path traversal in patch", () => {
+    expect(() =>
+      parseReviewResponse(
+        JSON.stringify({
+          decisions: [{ action: "patch", old_string: "../secrets", new_string: "ok" }],
+        }),
+      ),
+    ).toThrow("path traversal");
+  });
+
+  it("rejects path traversal in consolidate merge_target", () => {
+    expect(() =>
+      parseReviewResponse(
+        JSON.stringify({
+          decisions: [
+            {
+              action: "consolidate",
+              merge_target: "../../etc/passwd",
+              new_content: "bad",
+            },
+          ],
+        }),
+      ),
+    ).toThrow("path traversal");
+  });
+
+  it("handles archive without reason (defaults)", () => {
+    const result = parseReviewResponse(JSON.stringify({ decisions: [{ action: "archive" }] }));
+    expect(result.decisions[0]).toEqual({ action: "archive", reason: "No reason provided" });
+  });
+});
+
+describe("validatePatchAction", () => {
+  it("accepts single match", () => {
+    const result = validatePatchAction("Hello world", "world", "my-skill");
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects zero matches", () => {
+    const result = validatePatchAction("Hello world", "missing", "my-skill");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("not found");
+  });
+
+  it("rejects multiple matches", () => {
+    const result = validatePatchAction("foo bar foo", "foo", "my-skill");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("matches 2 times");
+  });
+
+  it("rejects path traversal in skill name", () => {
+    const result = validatePatchAction("content", "content", "../bad");
+    expect((result as { valid: false; error: string }).error).toContain("traversal");
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects .archive reference in skill name", () => {
+    const result = validatePatchAction("content", "content", ".archive/skill");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain(".archive");
+  });
+
+  it("rejects hidden directory skill names", () => {
+    const result = validatePatchAction("content", "content", ".hidden-skill");
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("system prompt", () => {
+  it("contains key curator instructions", () => {
+    expect(CURATOR_SYSTEM_PROMPT).toContain("keep");
+    expect(CURATOR_SYSTEM_PROMPT).toContain("patch");
+    expect(CURATOR_SYSTEM_PROMPT).toContain("consolidate");
+    expect(CURATOR_SYSTEM_PROMPT).toContain("archive");
+    expect(CURATOR_SYSTEM_PROMPT).toContain("decisions");
+  });
+});

--- a/extensions/skill-curator/tests/run.test.ts
+++ b/extensions/skill-curator/tests/run.test.ts
@@ -1,0 +1,688 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  decideRun,
+  curatorRun,
+  pauseCurator,
+  resumeCurator,
+  pinSkill,
+  unpinSkill,
+  restoreSkill,
+  adoptSkill,
+  disownSkill,
+  type CuratorConfig,
+} from "../src/run.js";
+import { loadUsage, saveUsage, stampAgentCreated, setPinned } from "../src/telemetry.js";
+import type { UsageFile } from "../src/telemetry.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-curator-run-"));
+  tempDirs.push(dir);
+  await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+const DEFAULT_CONFIG: CuratorConfig = {
+  enabled: true,
+  interval_hours: 168,
+  min_idle_hours: 2,
+  stale_after_days: 30,
+  archive_after_days: 90,
+  backup: { enabled: true, keep: 5 },
+};
+
+// ── P1: Trigger logic + first-run defer ─────────────────────────────────────
+
+describe("decideRun", () => {
+  it("defers on first run (no last_run_at)", () => {
+    const usage: UsageFile = {
+      version: 1,
+      skills: {},
+      updated_at: "2026-01-01T00:00:00.000Z",
+      last_run_at: null,
+      paused: false,
+    };
+    const decision = decideRun({ usage, config: DEFAULT_CONFIG, now: new Date() });
+    expect(decision.shouldRun).toBe(false);
+    expect(decision.firstRun).toBe(true);
+    expect(decision.reason).toContain("first-run");
+  });
+
+  it("returns false when curator is paused", () => {
+    const usage: UsageFile = {
+      version: 1,
+      skills: {},
+      updated_at: "2026-01-01T00:00:00.000Z",
+      last_run_at: "2026-01-01T00:00:00.000Z",
+      paused: true,
+    };
+    const decision = decideRun({
+      usage,
+      config: DEFAULT_CONFIG,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(decision.shouldRun).toBe(false);
+    expect(decision.reason).toContain("paused");
+  });
+
+  it("returns false when curator is disabled", () => {
+    const usage: UsageFile = {
+      version: 1,
+      skills: {},
+      updated_at: "2026-01-01T00:00:00.000Z",
+      last_run_at: "2026-01-01T00:00:00.000Z",
+      paused: false,
+    };
+    const decision = decideRun({
+      usage,
+      config: { ...DEFAULT_CONFIG, enabled: false },
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(decision.shouldRun).toBe(false);
+    expect(decision.reason).toContain("disabled");
+  });
+
+  it("returns false when interval not yet met", () => {
+    const now = new Date("2026-01-01T06:00:00Z");
+    const usage: UsageFile = {
+      version: 1,
+      skills: {},
+      updated_at: "2026-01-01T00:00:00.000Z",
+      last_run_at: "2026-01-01T00:00:00.000Z",
+      paused: false,
+    };
+    const decision = decideRun({ usage, config: DEFAULT_CONFIG, now });
+    expect(decision.shouldRun).toBe(false);
+    expect(decision.reason).toContain("interval not met");
+  });
+
+  it("returns true when interval satisfied", () => {
+    const now = new Date("2026-01-08T00:00:00Z"); // 7 days later
+    const usage: UsageFile = {
+      version: 1,
+      skills: {},
+      updated_at: "2026-01-01T00:00:00.000Z",
+      last_run_at: "2026-01-01T00:00:00.000Z",
+      paused: false,
+    };
+    const decision = decideRun({ usage, config: DEFAULT_CONFIG, now });
+    expect(decision.shouldRun).toBe(true);
+  });
+});
+
+describe("curatorRun — first-run defer", () => {
+  it("seeds last_run_at and skips on first run", async () => {
+    const dir = await makeTempDir();
+    const result = await curatorRun({ workspaceDir: dir, config: DEFAULT_CONFIG });
+    expect(result.error).toContain("first-run");
+    expect(result.mutations).toHaveLength(0);
+
+    // Verify last_run_at was seeded
+    const usage = await loadUsage(dir);
+    expect(usage.last_run_at).toBeTruthy();
+    expect(usage.last_run_at).not.toBeNull();
+  });
+
+  it("does nothing on disabled curator", async () => {
+    const dir = await makeTempDir();
+    // Manually set last_run_at so it's not a first-run
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    await saveUsage(dir, usage);
+
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: { ...DEFAULT_CONFIG, enabled: false },
+    });
+    expect(result.error).toContain("disabled");
+    expect(result.mutations).toHaveLength(0);
+  });
+
+  it("respects pause flag", async () => {
+    const dir = await makeTempDir();
+    // Set last_run_at and pause
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    usage.paused = true;
+    await saveUsage(dir, usage);
+
+    const result = await curatorRun({ workspaceDir: dir, config: DEFAULT_CONFIG });
+    expect(result.error).toContain("paused");
+    expect(result.mutations).toHaveLength(0);
+  });
+});
+
+// ── P2: Phase A disk mutations ──────────────────────────────────────────────
+
+describe("curatorRun — disk mutations", () => {
+  it("marks stale agent-created skills", async () => {
+    const dir = await makeTempDir();
+    const now = new Date("2026-05-06T12:00:00Z");
+    const fortyDaysAgo = new Date(now.getTime() - 40 * 24 * 60 * 60 * 1000).toISOString();
+
+    // Create skill dir (so archive can find it)
+    await fs.mkdir(path.join(dir, "skills", "old-skill"), { recursive: true });
+    await fs.writeFile(path.join(dir, "skills", "old-skill", "SKILL.md"), "# Old Skill\n");
+
+    // Set up a pre-existing usage file with an agent-created skill last used 40 days ago
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    usage.skills["old-skill"] = {
+      name: "old-skill",
+      view_count: 5,
+      use_count: 3,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: fortyDaysAgo,
+      last_patched_at: null,
+      pinned: false,
+      created_at: fortyDaysAgo,
+      created_by: "agent",
+      created_at_ms: new Date(fortyDaysAgo).getTime(),
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    // Run curator with a config that has 30d stale threshold
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: DEFAULT_CONFIG,
+      now,
+    });
+
+    expect(result.mutations.length).toBeGreaterThanOrEqual(1);
+    const mutation = result.mutations.find((m) => m.name === "old-skill");
+    expect(mutation).toBeDefined();
+    expect(mutation!.action).toBe("mark_stale");
+    expect(mutation!.newState).toBe("stale");
+
+    // Verify state was actually written to disk
+    const updatedUsage = await loadUsage(dir);
+    expect(updatedUsage.skills["old-skill"].state).toBe("stale");
+  });
+
+  it("archives very old agent-created skills", async () => {
+    const dir = await makeTempDir();
+    const now = new Date("2026-05-06T12:00:00Z");
+    const hundredDaysAgo = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString();
+
+    // Create skill dir
+    const skillDir = path.join(dir, "skills", "very-old");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Very Old Skill\n");
+
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    usage.skills["very-old"] = {
+      name: "very-old",
+      view_count: 2,
+      use_count: 1,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: hundredDaysAgo,
+      last_patched_at: null,
+      pinned: false,
+      created_at: hundredDaysAgo,
+      created_by: "agent",
+      created_at_ms: new Date(hundredDaysAgo).getTime(),
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: DEFAULT_CONFIG,
+      now,
+    });
+
+    const mutation = result.mutations.find((m) => m.name === "very-old");
+    expect(mutation).toBeDefined();
+    expect(mutation!.action).toBe("archive");
+    expect(mutation!.newState).toBe("archived");
+
+    // Verify skill dir was moved to .archive/
+    const archiveDir = path.join(dir, "skills", ".archive", "very-old");
+    await fs.access(archiveDir); // should exist
+    const archivedContent = await fs.readFile(path.join(archiveDir, "SKILL.md"), "utf-8");
+    expect(archivedContent).toContain("Very Old Skill");
+
+    // Verify original skill dir is gone
+    await expect(fs.access(skillDir)).rejects.toThrow();
+  });
+
+  it("skips pinned skills even if old", async () => {
+    const dir = await makeTempDir();
+    const now = new Date("2026-05-06T12:00:00Z");
+    const hundredDaysAgo = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString();
+
+    const skillDir = path.join(dir, "skills", "pinned-but-old");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Pinned Old\n");
+
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    usage.skills["pinned-but-old"] = {
+      name: "pinned-but-old",
+      view_count: 2,
+      use_count: 1,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: hundredDaysAgo,
+      last_patched_at: null,
+      pinned: true, // ← pinned
+      created_at: hundredDaysAgo,
+      created_by: "agent",
+      created_at_ms: new Date(hundredDaysAgo).getTime(),
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: DEFAULT_CONFIG,
+      now,
+    });
+
+    // Should have no mutations for pinned skill
+    const mutation = result.mutations.find((m) => m.name === "pinned-but-old");
+    expect(mutation).toBeUndefined();
+
+    // Skill dir should still exist
+    await fs.access(skillDir);
+  });
+
+  it("skips user-created skills", async () => {
+    const dir = await makeTempDir();
+    const now = new Date("2026-05-06T12:00:00Z");
+    const hundredDaysAgo = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString();
+
+    const skillDir = path.join(dir, "skills", "user-skill");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# User Skill\n");
+
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    usage.skills["user-skill"] = {
+      name: "user-skill",
+      view_count: 2,
+      use_count: 1,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: hundredDaysAgo,
+      last_patched_at: null,
+      pinned: false,
+      created_at: hundredDaysAgo,
+      created_by: "user", // ← user-created
+      created_at_ms: null,
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    const result = await curatorRun({ workspaceDir: dir, config: DEFAULT_CONFIG, now });
+
+    const mutation = result.mutations.find((m) => m.name === "user-skill");
+    expect(mutation).toBeUndefined();
+    await fs.access(skillDir); // should still exist
+  });
+
+  it("skips bundled skills", async () => {
+    const dir = await makeTempDir();
+    const now = new Date("2026-05-06T12:00:00Z");
+    const hundredDaysAgo = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString();
+
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    usage.skills["bundled-skill"] = {
+      name: "bundled-skill",
+      view_count: 2,
+      use_count: 1,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: hundredDaysAgo,
+      last_patched_at: null,
+      pinned: false,
+      created_at: hundredDaysAgo,
+      created_by: "agent",
+      created_at_ms: new Date(hundredDaysAgo).getTime(),
+      source: "bundled",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    const result = await curatorRun({ workspaceDir: dir, config: DEFAULT_CONFIG, now });
+    const mutation = result.mutations.find((m) => m.name === "bundled-skill");
+    expect(mutation).toBeUndefined();
+  });
+
+  it("creates snapshot before mutation", async () => {
+    const dir = await makeTempDir();
+    const now = new Date("2026-05-06T12:00:00Z");
+    const hundredDaysAgo = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString();
+
+    const skillDir = path.join(dir, "skills", "snap-skill");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Snapshot Test\n");
+
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    usage.skills["snap-skill"] = {
+      name: "snap-skill",
+      view_count: 2,
+      use_count: 1,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: hundredDaysAgo,
+      last_patched_at: null,
+      pinned: false,
+      created_at: hundredDaysAgo,
+      created_by: "agent",
+      created_at_ms: new Date(hundredDaysAgo).getTime(),
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: DEFAULT_CONFIG,
+      now,
+    });
+
+    expect(result.snapshotPath).toBeTruthy();
+    expect(result.snapshotPath).toContain(".curator_backups");
+    expect(result.snapshotPath).toMatch(/skills\.tar\.gz$/);
+
+    // Verify snapshot file exists
+    await fs.access(result.snapshotPath!);
+  });
+
+  it("lockfile prevents concurrent runs", async () => {
+    const dir = await makeTempDir();
+    // Manually create the lockfile to simulate concurrent run
+    const lockPath = path.join(dir, "skills", ".curator_backups", ".in-progress");
+    await fs.mkdir(path.dirname(lockPath), { recursive: true });
+    await fs.writeFile(lockPath, "12345\ndummy\n");
+
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    await saveUsage(dir, usage);
+
+    const now = new Date("2026-06-01T00:00:00Z"); // 5 months later — interval satisfied
+
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: DEFAULT_CONFIG,
+      now,
+    });
+
+    expect(result.error).toContain("lockfile");
+    expect(result.mutations).toHaveLength(0);
+  });
+
+  it("dry-run does not mutate or create lockfile", async () => {
+    const dir = await makeTempDir();
+    const now = new Date("2026-05-06T12:00:00Z");
+    const hundredDaysAgo = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString();
+
+    const skillDir = path.join(dir, "skills", "dry-skill");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Dry Run Test\n");
+
+    const usage = await loadUsage(dir);
+    usage.last_run_at = "2026-01-01T00:00:00.000Z";
+    usage.skills["dry-skill"] = {
+      name: "dry-skill",
+      view_count: 2,
+      use_count: 1,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: hundredDaysAgo,
+      last_patched_at: null,
+      pinned: false,
+      created_at: hundredDaysAgo,
+      created_by: "agent",
+      created_at_ms: new Date(hundredDaysAgo).getTime(),
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    const result = await curatorRun({
+      workspaceDir: dir,
+      config: DEFAULT_CONFIG,
+      now,
+      dryRun: true,
+    });
+
+    // Should report mutations but not apply them
+    const mutation = result.mutations.find((m) => m.name === "dry-skill");
+    expect(mutation).toBeDefined();
+    expect(mutation!.action).toBe("archive");
+
+    // Skill dir should still exist (not moved)
+    await fs.access(skillDir);
+
+    // State should NOT have changed on disk
+    const updatedUsage = await loadUsage(dir);
+    expect(updatedUsage.skills["dry-skill"].state).toBe("active");
+
+    // No lockfile residue
+    const lockPath = path.join(dir, "skills", ".curator_backups", ".in-progress");
+    await expect(fs.access(lockPath)).rejects.toThrow();
+  });
+});
+
+// ── pinSkill / unpinSkill ───────────────────────────────────────────────────
+
+describe("pinSkill / unpinSkill", () => {
+  it("pinSkill sets pinned=true", async () => {
+    const dir = await makeTempDir();
+    const usage = await loadUsage(dir);
+    usage.skills["test"] = {
+      name: "test",
+      view_count: 0,
+      use_count: 0,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: null,
+      last_patched_at: null,
+      pinned: false,
+      created_at: "2026-01-01T00:00:00.000Z",
+      created_by: "agent",
+      created_at_ms: 1700000000000,
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    await pinSkill(dir, "test");
+    const loaded = await loadUsage(dir);
+    expect(loaded.skills["test"].pinned).toBe(true);
+  });
+
+  it("unpinSkill sets pinned=false", async () => {
+    const dir = await makeTempDir();
+    const usage = await loadUsage(dir);
+    usage.skills["test"] = {
+      name: "test",
+      view_count: 0,
+      use_count: 0,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: null,
+      last_patched_at: null,
+      pinned: true,
+      created_at: "2026-01-01T00:00:00.000Z",
+      created_by: "agent",
+      created_at_ms: 1700000000000,
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    await unpinSkill(dir, "test");
+    const loaded = await loadUsage(dir);
+    expect(loaded.skills["test"].pinned).toBe(false);
+  });
+});
+
+// ── pauseCurator / resumeCurator ────────────────────────────────────────────
+
+describe("pauseCurator / resumeCurator", () => {
+  it("pause sets paused flag", async () => {
+    const dir = await makeTempDir();
+    await pauseCurator(dir);
+    const usage = await loadUsage(dir);
+    expect(usage.paused).toBe(true);
+  });
+
+  it("resume clears paused flag", async () => {
+    const dir = await makeTempDir();
+    // Pause first
+    const usage = await loadUsage(dir);
+    usage.paused = true;
+    await saveUsage(dir, usage);
+
+    await resumeCurator(dir);
+    const updated = await loadUsage(dir);
+    expect(updated.paused).toBe(false);
+  });
+});
+
+// ── adoptSkill / disownSkill ───────────────────────────────────────────────
+
+describe("adoptSkill / disownSkill", () => {
+  it("adopt sets created_by='agent'", async () => {
+    const dir = await makeTempDir();
+    const usage = await loadUsage(dir);
+    usage.skills["my-skill"] = {
+      name: "my-skill",
+      view_count: 0,
+      use_count: 0,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: null,
+      last_patched_at: null,
+      pinned: false,
+      created_at: "2026-01-01T00:00:00.000Z",
+      created_by: "unknown",
+      created_at_ms: null,
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    await adoptSkill(dir, "my-skill");
+    const loaded = await loadUsage(dir);
+    expect(loaded.skills["my-skill"].created_by).toBe("agent");
+  });
+
+  it("disown sets created_by='user'", async () => {
+    const dir = await makeTempDir();
+    const usage = await loadUsage(dir);
+    usage.skills["my-skill"] = {
+      name: "my-skill",
+      view_count: 0,
+      use_count: 0,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: null,
+      last_patched_at: null,
+      pinned: false,
+      created_at: "2026-01-01T00:00:00.000Z",
+      created_by: "agent",
+      created_at_ms: 1700000000000,
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    await disownSkill(dir, "my-skill");
+    const loaded = await loadUsage(dir);
+    expect(loaded.skills["my-skill"].created_by).toBe("user");
+  });
+
+  it("adopt → disown round-trip works", async () => {
+    const dir = await makeTempDir();
+    const usage = await loadUsage(dir);
+    usage.skills["test"] = {
+      name: "test",
+      view_count: 0,
+      use_count: 0,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: null,
+      last_patched_at: null,
+      pinned: false,
+      created_at: "2026-01-01T00:00:00.000Z",
+      created_by: "unknown",
+      created_at_ms: null,
+      source: "agent-created",
+      state: "active",
+    };
+    await saveUsage(dir, usage);
+
+    await adoptSkill(dir, "test");
+    expect((await loadUsage(dir)).skills["test"].created_by).toBe("agent");
+
+    await disownSkill(dir, "test");
+    expect((await loadUsage(dir)).skills["test"].created_by).toBe("user");
+  });
+});
+
+// ── restoreSkill ────────────────────────────────────────────────────────────
+
+describe("restoreSkill", () => {
+  it("moves skill from .archive/ back to skills/ and sets active", async () => {
+    const dir = await makeTempDir();
+    const archivePath = path.join(dir, "skills", ".archive", "restored-skill");
+    await fs.mkdir(archivePath, { recursive: true });
+    await fs.writeFile(path.join(archivePath, "SKILL.md"), "# Restored\n");
+
+    // Set up usage with skill in archived state
+    const usage = await loadUsage(dir);
+    usage.skills["restored-skill"] = {
+      name: "restored-skill",
+      view_count: 2,
+      use_count: 1,
+      patch_count: 0,
+      last_viewed_at: null,
+      last_used_at: "2026-01-01T00:00:00.000Z",
+      last_patched_at: null,
+      pinned: false,
+      created_at: "2026-01-01T00:00:00.000Z",
+      created_by: "agent",
+      created_at_ms: 1700000000000,
+      source: "agent-created",
+      state: "archived",
+    };
+    await saveUsage(dir, usage);
+
+    await restoreSkill(dir, "restored-skill");
+
+    // Verify moved back
+    const restoredDir = path.join(dir, "skills", "restored-skill");
+    await fs.access(restoredDir);
+    const content = await fs.readFile(path.join(restoredDir, "SKILL.md"), "utf-8");
+    expect(content).toContain("Restored");
+
+    // Verify state reset to active
+    const updated = await loadUsage(dir);
+    expect(updated.skills["restored-skill"].state).toBe("active");
+
+    // Archive dir should be gone
+    await expect(fs.access(archivePath)).rejects.toThrow();
+  });
+});

--- a/extensions/skill-curator/tests/telemetry.test.ts
+++ b/extensions/skill-curator/tests/telemetry.test.ts
@@ -9,6 +9,12 @@ import {
   loadUsage,
   saveUsage,
   setPinned,
+  stampAgentCreated,
+  setCreatedBy,
+  isAgentCreated,
+  setLastRunAt,
+  setPaused,
+  shouldRunCurator,
   type UsageFile,
 } from "../src/telemetry.js";
 
@@ -32,6 +38,8 @@ describe("telemetry", () => {
     const usage = await loadUsage(dir);
     expect(usage.version).toBe(1);
     expect(usage.skills).toEqual({});
+    expect(usage.last_run_at).toBeNull();
+    expect(usage.paused).toBe(false);
   });
 
   it("incrementView creates entry and bumps view_count", async () => {
@@ -42,11 +50,15 @@ describe("telemetry", () => {
     expect(entry.use_count).toBe(0);
     expect(entry.patch_count).toBe(0);
     expect(entry.last_viewed_at).toBeTruthy();
+    // New entries default to "unknown" until agent stamps them
+    expect(entry.created_by).toBe("unknown");
+    expect(entry.created_at_ms).toBeNull();
 
     // Reload and verify persistence
     const usage = await loadUsage(dir);
     expect(usage.skills["my-skill"]).toBeDefined();
     expect(usage.skills["my-skill"].view_count).toBe(1);
+    expect(usage.skills["my-skill"].created_by).toBe("unknown");
   });
 
   it("incrementView accumulates across calls", async () => {
@@ -92,11 +104,15 @@ describe("telemetry", () => {
           last_patched_at: "2026-04-10T08:00:00.000Z",
           pinned: false,
           created_at: "2026-01-01T00:00:00.000Z",
+          created_by: "agent",
+          created_at_ms: 1700000000000,
           source: "agent-created",
           state: "active",
         },
       },
       updated_at: "2026-05-06T12:00:00.000Z",
+      last_run_at: null,
+      paused: false,
     };
 
     await saveUsage(dir, usage);
@@ -109,6 +125,8 @@ describe("telemetry", () => {
     expect(loaded.skills["test-skill"].last_viewed_at).toBe("2026-05-01T12:00:00.000Z");
     expect(loaded.skills["test-skill"].last_used_at).toBe("2026-04-15T09:00:00.000Z");
     expect(loaded.skills["test-skill"].state).toBe("active");
+    expect(loaded.skills["test-skill"].created_by).toBe("agent");
+    expect(loaded.skills["test-skill"].created_at_ms).toBe(1700000000000);
   });
 
   it("pinned:true survives a load/save cycle", async () => {
@@ -159,11 +177,15 @@ describe("telemetry", () => {
           last_patched_at: null,
           pinned: false,
           created_at: "2026-01-01T00:00:00.000Z",
+          created_by: "agent",
+          created_at_ms: 1700000000000,
           source: "agent-created",
           state: "active",
         },
       },
       updated_at: "2026-01-01T00:00:00.000Z",
+      last_run_at: null,
+      paused: false,
     });
 
     // Should load without issues
@@ -175,5 +197,143 @@ describe("telemetry", () => {
     const files = await fs.readdir(skillsDir);
     const tmpFiles = files.filter((f) => f.includes(".tmp."));
     expect(tmpFiles).toHaveLength(0);
+  });
+
+  describe("created_by marker", () => {
+    it("stampAgentCreated sets created_by='agent' and created_at_ms", async () => {
+      const dir = await makeTempDir();
+      // First, create an entry via incrementUse
+      const entry = await incrementUse(dir, "agent-skill");
+      expect(entry.created_by).toBe("unknown");
+
+      // Stamp it
+      const stamped = await stampAgentCreated(dir, "agent-skill");
+      expect(stamped.created_by).toBe("agent");
+      expect(stamped.created_at_ms).toBeTruthy();
+      expect(typeof stamped.created_at_ms).toBe("number");
+
+      // Persists
+      const usage = await loadUsage(dir);
+      expect(usage.skills["agent-skill"].created_by).toBe("agent");
+      expect(typeof usage.skills["agent-skill"].created_at_ms).toBe("number");
+    });
+
+    it("setCreatedBy changes created_by", async () => {
+      const dir = await makeTempDir();
+      await stampAgentCreated(dir, "test-skill");
+
+      await setCreatedBy(dir, "test-skill", "user");
+      let usage = await loadUsage(dir);
+      expect(usage.skills["test-skill"].created_by).toBe("user");
+
+      await setCreatedBy(dir, "test-skill", "agent");
+      usage = await loadUsage(dir);
+      expect(usage.skills["test-skill"].created_by).toBe("agent");
+    });
+
+    it("isAgentCreated returns true only for 'agent'", async () => {
+      const dir = await makeTempDir();
+      await stampAgentCreated(dir, "agent-skill");
+      const usage = await loadUsage(dir);
+
+      expect(isAgentCreated(usage.skills["agent-skill"])).toBe(true);
+    });
+
+    it("loadUsage migrates entries missing created_by to 'unknown'", async () => {
+      const dir = await makeTempDir();
+      // Write a legacy file without created_by fields
+      const legacy = {
+        version: 1,
+        skills: {
+          "legacy-skill": {
+            name: "legacy-skill",
+            view_count: 3,
+            use_count: 1,
+            patch_count: 0,
+            last_viewed_at: null,
+            last_used_at: "2026-01-01T00:00:00.000Z",
+            last_patched_at: null,
+            pinned: false,
+            created_at: "2026-01-01T00:00:00.000Z",
+            source: "agent-created",
+            state: "active",
+          },
+        },
+        updated_at: "2026-01-01T00:00:00.000Z",
+      };
+      const usagePath = path.join(dir, "skills", ".usage.json");
+      await fs.writeFile(usagePath, JSON.stringify(legacy, null, 2));
+
+      const loaded = await loadUsage(dir);
+      expect(loaded.skills["legacy-skill"].created_by).toBe("unknown");
+      expect(loaded.skills["legacy-skill"].created_at_ms).toBeNull();
+      expect(loaded.last_run_at).toBeNull();
+      expect(loaded.paused).toBe(false);
+    });
+  });
+
+  describe("meta fields", () => {
+    it("setLastRunAt persists last_run_at", async () => {
+      const dir = await makeTempDir();
+      const ts = "2026-05-06T14:00:00.000Z";
+      await setLastRunAt(dir, ts);
+      const usage = await loadUsage(dir);
+      expect(usage.last_run_at).toBe(ts);
+    });
+
+    it("setPaused persists paused flag", async () => {
+      const dir = await makeTempDir();
+      await setPaused(dir, true);
+      let usage = await loadUsage(dir);
+      expect(usage.paused).toBe(true);
+
+      await setPaused(dir, false);
+      usage = await loadUsage(dir);
+      expect(usage.paused).toBe(false);
+    });
+  });
+
+  describe("shouldRunCurator", () => {
+    it("returns false on first run (null last_run_at)", () => {
+      const result = shouldRunCurator({
+        lastRunAt: null,
+        intervalHours: 168,
+        now: new Date(),
+      });
+      expect(result.shouldRun).toBe(false);
+      expect(result.reason).toContain("first-run");
+    });
+
+    it("returns false when interval not met", () => {
+      const now = new Date("2026-05-06T12:00:00Z");
+      const result = shouldRunCurator({
+        lastRunAt: "2026-05-06T11:00:00Z", // 1 hour ago
+        intervalHours: 168, // 7 days
+        now,
+      });
+      expect(result.shouldRun).toBe(false);
+      expect(result.reason).toContain("interval not met");
+    });
+
+    it("returns true when interval satisfied", () => {
+      const now = new Date("2026-05-13T12:00:00Z");
+      const result = shouldRunCurator({
+        lastRunAt: "2026-05-06T12:00:00Z", // 7 days ago
+        intervalHours: 168, // 7 days
+        now,
+      });
+      expect(result.shouldRun).toBe(true);
+      expect(result.reason).toContain("interval satisfied");
+    });
+
+    it("returns true when interval exceeded", () => {
+      const now = new Date("2026-05-20T12:00:00Z");
+      const result = shouldRunCurator({
+        lastRunAt: "2026-05-06T12:00:00Z", // 14 days ago
+        intervalHours: 168,
+        now,
+      });
+      expect(result.shouldRun).toBe(true);
+    });
   });
 });

--- a/extensions/skill-curator/tests/telemetry.test.ts
+++ b/extensions/skill-curator/tests/telemetry.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  incrementUse,
+  incrementView,
+  incrementPatch,
+  loadUsage,
+  saveUsage,
+  setPinned,
+  type UsageFile,
+} from "../src/telemetry.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-curator-telemetry-"));
+  tempDirs.push(dir);
+  // Create skills/ subdirectory
+  await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("telemetry", () => {
+  it("loadUsage returns empty file for a fresh workspace", async () => {
+    const dir = await makeTempDir();
+    const usage = await loadUsage(dir);
+    expect(usage.version).toBe(1);
+    expect(usage.skills).toEqual({});
+  });
+
+  it("incrementView creates entry and bumps view_count", async () => {
+    const dir = await makeTempDir();
+    const entry = await incrementView(dir, "my-skill");
+    expect(entry.name).toBe("my-skill");
+    expect(entry.view_count).toBe(1);
+    expect(entry.use_count).toBe(0);
+    expect(entry.patch_count).toBe(0);
+    expect(entry.last_viewed_at).toBeTruthy();
+
+    // Reload and verify persistence
+    const usage = await loadUsage(dir);
+    expect(usage.skills["my-skill"]).toBeDefined();
+    expect(usage.skills["my-skill"].view_count).toBe(1);
+  });
+
+  it("incrementView accumulates across calls", async () => {
+    const dir = await makeTempDir();
+    await incrementView(dir, "my-skill");
+    await incrementView(dir, "my-skill");
+    await incrementView(dir, "my-skill");
+
+    const entry = await incrementView(dir, "my-skill");
+    expect(entry.view_count).toBe(4);
+  });
+
+  it("incrementUse bumps use_count and last_used_at", async () => {
+    const dir = await makeTempDir();
+    const entry = await incrementUse(dir, "my-skill");
+    expect(entry.use_count).toBe(1);
+    expect(entry.last_used_at).toBeTruthy();
+    expect(entry.view_count).toBe(0);
+
+    const entry2 = await incrementUse(dir, "my-skill");
+    expect(entry2.use_count).toBe(2);
+  });
+
+  it("incrementPatch bumps patch_count and last_patched_at", async () => {
+    const dir = await makeTempDir();
+    const entry = await incrementPatch(dir, "my-skill");
+    expect(entry.patch_count).toBe(1);
+    expect(entry.last_patched_at).toBeTruthy();
+  });
+
+  it("saveUsage + loadUsage round-trip preserves all fields", async () => {
+    const dir = await makeTempDir();
+    const usage: UsageFile = {
+      version: 1,
+      skills: {
+        "test-skill": {
+          name: "test-skill",
+          view_count: 5,
+          use_count: 3,
+          patch_count: 1,
+          last_viewed_at: "2026-05-01T12:00:00.000Z",
+          last_used_at: "2026-04-15T09:00:00.000Z",
+          last_patched_at: "2026-04-10T08:00:00.000Z",
+          pinned: false,
+          created_at: "2026-01-01T00:00:00.000Z",
+          source: "agent-created",
+          state: "active",
+        },
+      },
+      updated_at: "2026-05-06T12:00:00.000Z",
+    };
+
+    await saveUsage(dir, usage);
+    const loaded = await loadUsage(dir);
+
+    expect(loaded.skills["test-skill"]).toBeDefined();
+    expect(loaded.skills["test-skill"].view_count).toBe(5);
+    expect(loaded.skills["test-skill"].use_count).toBe(3);
+    expect(loaded.skills["test-skill"].patch_count).toBe(1);
+    expect(loaded.skills["test-skill"].last_viewed_at).toBe("2026-05-01T12:00:00.000Z");
+    expect(loaded.skills["test-skill"].last_used_at).toBe("2026-04-15T09:00:00.000Z");
+    expect(loaded.skills["test-skill"].state).toBe("active");
+  });
+
+  it("pinned:true survives a load/save cycle", async () => {
+    const dir = await makeTempDir();
+
+    // Create and pin a skill
+    const entry = await incrementUse(dir, "pinned-skill");
+    expect(entry.pinned).toBe(false);
+
+    const pinnedEntry = await setPinned(dir, "pinned-skill", true);
+    expect(pinnedEntry.pinned).toBe(true);
+
+    // Reload — pinned should survive
+    const usage = await loadUsage(dir);
+    expect(usage.skills["pinned-skill"].pinned).toBe(true);
+
+    // Modify something else and save again — pinned must persist
+    await incrementView(dir, "pinned-skill");
+    const usage2 = await loadUsage(dir);
+    expect(usage2.skills["pinned-skill"].pinned).toBe(true);
+    expect(usage2.skills["pinned-skill"].view_count).toBe(1);
+    expect(usage2.skills["pinned-skill"].use_count).toBe(1);
+  });
+
+  it("unpinning sets pinned back to false", async () => {
+    const dir = await makeTempDir();
+    await setPinned(dir, "pinned-skill", true);
+    const pinned = await loadUsage(dir);
+    expect(pinned.skills["pinned-skill"].pinned).toBe(true);
+
+    await setPinned(dir, "pinned-skill", false);
+    const unpinned = await loadUsage(dir);
+    expect(unpinned.skills["pinned-skill"].pinned).toBe(false);
+  });
+
+  it("atomic write does not corrupt on disk", async () => {
+    const dir = await makeTempDir();
+    await saveUsage(dir, {
+      version: 1,
+      skills: {
+        a: {
+          name: "a",
+          view_count: 0,
+          use_count: 0,
+          patch_count: 0,
+          last_viewed_at: null,
+          last_used_at: null,
+          last_patched_at: null,
+          pinned: false,
+          created_at: "2026-01-01T00:00:00.000Z",
+          source: "agent-created",
+          state: "active",
+        },
+      },
+      updated_at: "2026-01-01T00:00:00.000Z",
+    });
+
+    // Should load without issues
+    const loaded = await loadUsage(dir);
+    expect(loaded.skills.a.name).toBe("a");
+
+    // Verify no tmp files left behind
+    const skillsDir = path.join(dir, "skills");
+    const files = await fs.readdir(skillsDir);
+    const tmpFiles = files.filter((f) => f.includes(".tmp."));
+    expect(tmpFiles).toHaveLength(0);
+  });
+});

--- a/extensions/skill-curator/tests/transitions.test.ts
+++ b/extensions/skill-curator/tests/transitions.test.ts
@@ -124,21 +124,23 @@ describe("transitions", () => {
     });
 
     it("returns no action at exact boundary (not > threshold)", () => {
-      // Exactly 30 days — day boundary is not > 30, so no action
-      const entry = makeEntry({
-        last_used_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
-      });
-      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
-      // At exactly 30 days, daysSinceUsed should be ~30, which is NOT > 30
+      // Use a fixed reference time to avoid timing flakiness
+      const now = new Date("2026-05-06T12:00:00Z");
+      // Exactly 30 days before the fixed now
+      const lastUsed = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+      const entry = makeEntry({ last_used_at: lastUsed });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS, now);
+      // At exactly 30 days, daysSinceUsed = 30.0, NOT > 30 → no action
       expect(result.action).toBe("none");
     });
 
     it("returns mark_stale just past the stale boundary", () => {
-      // 30 days + 1 hour
-      const entry = makeEntry({
-        last_used_at: new Date(Date.now() - (30 * 24 + 1) * 60 * 60 * 1000).toISOString(),
-      });
-      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      // Use a fixed reference time
+      const now = new Date("2026-05-06T12:00:00Z");
+      // 30 days + 1 hour before the fixed now
+      const lastUsed = new Date(now.getTime() - (30 * 24 + 1) * 60 * 60 * 1000).toISOString();
+      const entry = makeEntry({ last_used_at: lastUsed });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS, now);
       expect(result.action).toBe("mark_stale");
     });
   });

--- a/extensions/skill-curator/tests/transitions.test.ts
+++ b/extensions/skill-curator/tests/transitions.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import type { UsageEntry, UsageFile } from "../src/telemetry.js";
+import {
+  determineTransition,
+  determineAllTransitions,
+  daysSinceLastUse,
+} from "../src/transitions.js";
+import type { TransitionThresholds } from "../src/transitions.js";
+
+const DEFAULT_THRESHOLDS: TransitionThresholds = {
+  stale_after_days: 30,
+  archive_after_days: 90,
+};
+
+function makeEntry(overrides: Partial<UsageEntry> = {}): UsageEntry {
+  return {
+    name: "test-skill",
+    view_count: 0,
+    use_count: 0,
+    patch_count: 0,
+    last_viewed_at: null,
+    last_used_at: null,
+    last_patched_at: null,
+    pinned: false,
+    created_at: "2026-01-01T00:00:00.000Z",
+    source: "agent-created",
+    state: "active",
+    ...overrides,
+  };
+}
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe("transitions", () => {
+  describe("daysSinceLastUse", () => {
+    it("returns the correct number of days since last_used_at", () => {
+      const entry = makeEntry({ last_used_at: daysAgo(10) });
+      const now = new Date();
+      const days = daysSinceLastUse(entry, now);
+      expect(days).toBeCloseTo(10, 0);
+    });
+
+    it("falls back to created_at when last_used_at is null", () => {
+      const entry = makeEntry({
+        last_used_at: null,
+        created_at: daysAgo(50),
+      });
+      const now = new Date();
+      const days = daysSinceLastUse(entry, now);
+      expect(days).toBeCloseTo(50, 0);
+    });
+  });
+
+  describe("determineTransition", () => {
+    it("returns no action for recently used skill", () => {
+      const entry = makeEntry({ last_used_at: daysAgo(5) });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      expect(result.action).toBe("none");
+      expect(result.newState).toBe("active");
+    });
+
+    it("marks stale after stale_after_days", () => {
+      const entry = makeEntry({ last_used_at: daysAgo(35) });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      expect(result.action).toBe("mark_stale");
+      expect(result.newState).toBe("stale");
+      expect(result.daysSinceUsed).toBeCloseTo(35, 0);
+    });
+
+    it("archives after archive_after_days", () => {
+      const entry = makeEntry({ last_used_at: daysAgo(100) });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      expect(result.action).toBe("archive");
+      expect(result.newState).toBe("archived");
+    });
+
+    it("archives a stale skill after archive_after_days", () => {
+      const entry = makeEntry({
+        last_used_at: daysAgo(95),
+        state: "stale",
+      });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      expect(result.action).toBe("archive");
+      expect(result.newState).toBe("archived");
+    });
+
+    it("skips pinned skills (no transition)", () => {
+      const entry = makeEntry({
+        last_used_at: daysAgo(200),
+        pinned: true,
+      });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      expect(result.action).toBe("none");
+      expect(result.newState).toBe("active"); // stays whatever it was
+    });
+
+    it("leaves already-archived skills as archived", () => {
+      const entry = makeEntry({
+        last_used_at: daysAgo(200),
+        state: "archived",
+      });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      expect(result.action).toBe("none");
+      expect(result.newState).toBe("archived");
+    });
+
+    it("custom thresholds are respected", () => {
+      const customThresholds: TransitionThresholds = {
+        stale_after_days: 7,
+        archive_after_days: 14,
+      };
+
+      const entry10d = makeEntry({ last_used_at: daysAgo(10) });
+      const result10d = determineTransition(entry10d, customThresholds);
+      expect(result10d.action).toBe("mark_stale");
+
+      const entry20d = makeEntry({ last_used_at: daysAgo(20) });
+      const result20d = determineTransition(entry20d, customThresholds);
+      expect(result20d.action).toBe("archive");
+    });
+
+    it("returns no action at exact boundary (not > threshold)", () => {
+      // Exactly 30 days — day boundary is not > 30, so no action
+      const entry = makeEntry({
+        last_used_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+      });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      // At exactly 30 days, daysSinceUsed should be ~30, which is NOT > 30
+      expect(result.action).toBe("none");
+    });
+
+    it("returns mark_stale just past the stale boundary", () => {
+      // 30 days + 1 hour
+      const entry = makeEntry({
+        last_used_at: new Date(Date.now() - (30 * 24 + 1) * 60 * 60 * 1000).toISOString(),
+      });
+      const result = determineTransition(entry, DEFAULT_THRESHOLDS);
+      expect(result.action).toBe("mark_stale");
+    });
+  });
+
+  describe("determineAllTransitions", () => {
+    it("returns only entries requiring action", () => {
+      const skills: UsageFile["skills"] = {
+        "fresh-skill": makeEntry({
+          name: "fresh-skill",
+          last_used_at: daysAgo(5),
+        }),
+        "stale-skill": makeEntry({
+          name: "stale-skill",
+          last_used_at: daysAgo(45),
+        }),
+        "archive-skill": makeEntry({
+          name: "archive-skill",
+          last_used_at: daysAgo(120),
+        }),
+        "pinned-old": makeEntry({
+          name: "pinned-old",
+          last_used_at: daysAgo(200),
+          pinned: true,
+        }),
+        "already-archived": makeEntry({
+          name: "already-archived",
+          last_used_at: daysAgo(200),
+          state: "archived",
+        }),
+      };
+
+      const results = determineAllTransitions(skills, DEFAULT_THRESHOLDS);
+      expect(results).toHaveLength(2);
+
+      const names = results.map((r) => r.name).sort();
+      expect(names).toEqual(["archive-skill", "stale-skill"]);
+
+      const staleResult = results.find((r) => r.name === "stale-skill")!;
+      expect(staleResult.result.action).toBe("mark_stale");
+
+      const archiveResult = results.find((r) => r.name === "archive-skill")!;
+      expect(archiveResult.result.action).toBe("archive");
+    });
+
+    it("skips bundled and hub-installed skills", () => {
+      const skills: UsageFile["skills"] = {
+        "bundled-skill": makeEntry({
+          name: "bundled-skill",
+          last_used_at: daysAgo(200),
+          source: "bundled",
+        }),
+        "hub-skill": makeEntry({
+          name: "hub-skill",
+          last_used_at: daysAgo(200),
+          source: "hub",
+        }),
+        "agent-skill": makeEntry({
+          name: "agent-skill",
+          last_used_at: daysAgo(200),
+          source: "agent-created",
+        }),
+      };
+
+      const results = determineAllTransitions(skills, DEFAULT_THRESHOLDS);
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe("agent-skill");
+    });
+
+    it("returns empty array when no transitions needed", () => {
+      const skills: UsageFile["skills"] = {
+        fresh: makeEntry({ name: "fresh", last_used_at: daysAgo(1) }),
+      };
+      const results = determineAllTransitions(skills, DEFAULT_THRESHOLDS);
+      expect(results).toHaveLength(0);
+    });
+  });
+});

--- a/extensions/skill-curator/tests/transitions.test.ts
+++ b/extensions/skill-curator/tests/transitions.test.ts
@@ -23,6 +23,8 @@ function makeEntry(overrides: Partial<UsageEntry> = {}): UsageEntry {
     last_patched_at: null,
     pinned: false,
     created_at: "2026-01-01T00:00:00.000Z",
+    created_by: "agent",
+    created_at_ms: 1700000000000,
     source: "agent-created",
     state: "active",
     ...overrides,
@@ -197,6 +199,30 @@ describe("transitions", () => {
           name: "agent-skill",
           last_used_at: daysAgo(200),
           source: "agent-created",
+        }),
+      };
+
+      const results = determineAllTransitions(skills, DEFAULT_THRESHOLDS);
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe("agent-skill");
+    });
+
+    it("skips skills not created_by agent", () => {
+      const skills: UsageFile["skills"] = {
+        "user-skill": makeEntry({
+          name: "user-skill",
+          last_used_at: daysAgo(200),
+          created_by: "user",
+        }),
+        "unknown-skill": makeEntry({
+          name: "unknown-skill",
+          last_used_at: daysAgo(200),
+          created_by: "unknown",
+        }),
+        "agent-skill": makeEntry({
+          name: "agent-skill",
+          last_used_at: daysAgo(200),
+          created_by: "agent",
         }),
       };
 

--- a/extensions/skill-workshop/src/tool.ts
+++ b/extensions/skill-workshop/src/tool.ts
@@ -5,7 +5,7 @@ import { Type } from "typebox";
 import { jsonResult, type OpenClawPluginApi } from "../api.js";
 import type { SkillWorkshopConfig } from "./config.js";
 import {
-  applyProposalToWorkshop,
+  applyProposalToWorkspace,
   normalizeSkillName,
   prepareProposalWrite,
   writeSupportFile,
@@ -16,6 +16,7 @@ import { createStoreForContext, resolveWorkspaceDir } from "./workshop.js";
 // ── Curator integration (lightweight, lazy-imported) ────────────────────────
 
 let _stampAgentCreated: ((wsDir: string, name: string) => Promise<unknown>) | null = null;
+let _incrementPatch: ((wsDir: string, name: string) => Promise<unknown>) | null = null;
 let _curatorLoadUsage:
   | ((wsDir: string) => Promise<{ skills: Record<string, { pinned?: boolean }> }>)
   | null = null;
@@ -25,6 +26,7 @@ async function ensureCuratorModules() {
   try {
     const curatorTelemetry = await import("../../skill-curator/src/telemetry.js");
     _stampAgentCreated = curatorTelemetry.stampAgentCreated;
+    _incrementPatch = curatorTelemetry.incrementPatch;
     _curatorLoadUsage = curatorTelemetry.loadUsage;
   } catch {
     // skill-curator not installed — gracefully skip
@@ -39,6 +41,17 @@ async function stampAgentCreatedIfNew(workspaceDir: string, skillName: string, c
       await _stampAgentCreated(workspaceDir, skillName);
     } catch {
       // non-critical — don't fail skill creation over telemetry stamp
+    }
+  }
+}
+
+async function incrementPatchIfCurator(workspaceDir: string, skillName: string) {
+  await ensureCuratorModules();
+  if (_incrementPatch) {
+    try {
+      await _incrementPatch(workspaceDir, skillName);
+    } catch {
+      // non-critical — don't fail workshop mutation over telemetry
     }
   }
 }
@@ -225,6 +238,8 @@ export function createSkillWorkshopTool(params: {
           });
           // Stamp agent-created marker for new skills
           await stampAgentCreatedIfNew(workspaceDir, proposal.skillName, applied.created);
+          // Increment patch telemetry for all mutations
+          await incrementPatchIfCurator(workspaceDir, proposal.skillName);
           const stored = await store.add(
             {
               ...proposal,
@@ -277,6 +292,8 @@ export function createSkillWorkshopTool(params: {
         });
         // Stamp agent-created marker for new skills applied from queue
         await stampAgentCreatedIfNew(workspaceDir, proposal.skillName, applied.created);
+        // Increment patch telemetry for all mutations
+        await incrementPatchIfCurator(workspaceDir, proposal.skillName);
         const updated = await store.updateStatus(raw.id, "applied");
         return jsonResult({ status: "applied", skillPath: applied.skillPath, proposal: updated });
       }
@@ -303,6 +320,7 @@ export function createSkillWorkshopTool(params: {
         const skillDir = path.join(skillsDir, skillName);
         try {
           await fs.rm(skillDir, { recursive: true, force: true });
+          await incrementPatchIfCurator(workspaceDir, skillName);
           return jsonResult({ status: "deleted", skillName });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/extensions/skill-workshop/src/tool.ts
+++ b/extensions/skill-workshop/src/tool.ts
@@ -1,15 +1,60 @@
 import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { Type } from "typebox";
 import { jsonResult, type OpenClawPluginApi } from "../api.js";
 import type { SkillWorkshopConfig } from "./config.js";
 import {
-  applyProposalToWorkspace,
+  applyProposalToWorkshop,
   normalizeSkillName,
   prepareProposalWrite,
   writeSupportFile,
 } from "./skills.js";
 import type { SkillChange, SkillProposal, SkillWorkshopStatus } from "./types.js";
 import { createStoreForContext, resolveWorkspaceDir } from "./workshop.js";
+
+// ── Curator integration (lightweight, lazy-imported) ────────────────────────
+
+let _stampAgentCreated: ((wsDir: string, name: string) => Promise<unknown>) | null = null;
+let _curatorLoadUsage:
+  | ((wsDir: string) => Promise<{ skills: Record<string, { pinned?: boolean }> }>)
+  | null = null;
+
+async function ensureCuratorModules() {
+  if (_stampAgentCreated && _curatorLoadUsage) return;
+  try {
+    const curatorTelemetry = await import("../../skill-curator/src/telemetry.js");
+    _stampAgentCreated = curatorTelemetry.stampAgentCreated;
+    _curatorLoadUsage = curatorTelemetry.loadUsage;
+  } catch {
+    // skill-curator not installed — gracefully skip
+  }
+}
+
+async function stampAgentCreatedIfNew(workspaceDir: string, skillName: string, created: boolean) {
+  if (!created) return;
+  await ensureCuratorModules();
+  if (_stampAgentCreated) {
+    try {
+      await _stampAgentCreated(workspaceDir, skillName);
+    } catch {
+      // non-critical — don't fail skill creation over telemetry stamp
+    }
+  }
+}
+
+async function checkSkillPinned(workspaceDir: string, skillName: string): Promise<boolean> {
+  await ensureCuratorModules();
+  if (!_curatorLoadUsage) return false;
+  try {
+    const usage = await _curatorLoadUsage(workspaceDir);
+    return usage.skills[skillName]?.pinned === true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Tool params ─────────────────────────────────────────────────────────────
 
 type ToolParams = {
   action?: string;
@@ -83,6 +128,8 @@ function buildProposal(params: {
   };
 }
 
+// ── Tool factory ────────────────────────────────────────────────────────────
+
 export function createSkillWorkshopTool(params: {
   api: OpenClawPluginApi;
   config: SkillWorkshopConfig;
@@ -103,6 +150,7 @@ export function createSkillWorkshopTool(params: {
           "suggest",
           "apply",
           "reject",
+          "delete",
           "write_support_file",
         ],
       }),
@@ -175,6 +223,8 @@ export function createSkillWorkshopTool(params: {
             proposal,
             maxSkillBytes: params.config.maxSkillBytes,
           });
+          // Stamp agent-created marker for new skills
+          await stampAgentCreatedIfNew(workspaceDir, proposal.skillName, applied.created);
           const stored = await store.add(
             {
               ...proposal,
@@ -225,6 +275,8 @@ export function createSkillWorkshopTool(params: {
           proposal,
           maxSkillBytes: params.config.maxSkillBytes,
         });
+        // Stamp agent-created marker for new skills applied from queue
+        await stampAgentCreatedIfNew(workspaceDir, proposal.skillName, applied.created);
         const updated = await store.updateStatus(raw.id, "applied");
         return jsonResult({ status: "applied", skillPath: applied.skillPath, proposal: updated });
       }
@@ -233,6 +285,32 @@ export function createSkillWorkshopTool(params: {
           throw new Error("id required");
         }
         return jsonResult(await store.updateStatus(raw.id, "rejected"));
+      }
+      if (action === "delete") {
+        const skillName = normalizeSkillName(readString(raw.skillName) ?? "");
+        if (!skillName) {
+          throw new Error("skillName required for delete");
+        }
+        // Check if skill is pinned — refuse delete with clear instruction
+        const pinned = await checkSkillPinned(workspaceDir, skillName);
+        if (pinned) {
+          throw new Error(
+            `Skill "${skillName}" is pinned. Unpin it first with "openclaw curator unpin ${skillName}" before deleting.`,
+          );
+        }
+        // Delete the skill directory
+        const skillsDir = path.join(workspaceDir, "skills");
+        const skillDir = path.join(skillsDir, skillName);
+        try {
+          await fs.rm(skillDir, { recursive: true, force: true });
+          return jsonResult({ status: "deleted", skillName });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+            return jsonResult({ status: "not_found", skillName });
+          }
+          throw new Error(`Failed to delete skill "${skillName}": ${msg}`);
+        }
       }
       if (action === "write_support_file") {
         const skillName = readString(raw.skillName);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,6 +1304,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/skill-curator:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/skill-workshop:
     dependencies:
       typebox:
@@ -4448,6 +4454,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@urbit/aura@3.0.0':
     resolution: {integrity: sha512-N8/FHc/lmlMDCumMuTXyRHCxlov5KZY6unmJ9QR2GOw+OpROZMBsXYGwE+ZMtvN21ql9+Xb8KhGNBj08IrG3Wg==}


### PR DESCRIPTION
## Summary

Implements **Plan #01 — Skill Curator** from the Hermes → OpenClaw gap analysis.

### What it does

**Phase A (fully functional):**
- **Telemetry sidecar**: tracks `view_count`, `use_count`, `patch_count`, `last_used_at` per skill.
- **Auto-transitions**: active → stale (30d unused) → archived (90d unused).
- **Pre-run snapshots**: tar.gz backups with exclusion patterns, manifest sidecar, configurable rotation, byte-identical rollback.
- **Pinning**: protects skills from auto-archive and `skill_workshop(action=delete)`.
- **Automatic trigger**: `agent_end` hook runs curator check after each agent turn.
- **Run logs**: `run.json` + `REPORT.md` under `~/.openclaw/logs/curator/<run-id>/`.

**Phase B (scaffolded, deferred):**
- `curatorRunReview()` exported — accepts `callModel` callback. Prompt, manifest builder, and JSON parser are implemented and tested.
- Requires gateway-level `auxiliary.curator` model slot.

**Deferred (gateway-level):** Phase B LLM review, `/curator` slash command on Discord/Telegram, `auxiliary.curator` config schema.

### Audit fixes (f0530ab)

Self-review found 4 blocking + 3 major issues — all fixed:
1. ✅ Compile break: `applyProposalToWorkshop` → `applyProposalToWorkspace`
2. ✅ Scheduler: `agent_end` hook replaces broken scheduler
3. ✅ Rollback: `--exclude .curator_backups`, clean-before-extract, manifest sidecar
4. ✅ Phase B: `curatorRunReview()` with optional model caller
5. ✅ Telemetry: `patch_count` wired to workshop mutations
6. ✅ Run logs: `writeRunLog()` called from CLI
7. ✅ Docs: honest about deferred features

---
*Built by Dev — Plan #01*