### PR TITLE
Fix status cold-path plugin metadata scans

### DIFF
--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -45,6 +45,23 @@ openclaw tasks list [--runtime <name>] [--status <name>] [--json]
 
 Lists tracked background tasks newest first.
 
+Human-readable output annotates stale active records distinctly (`stale-run` /
+`stale-q`) while preserving the canonical lifecycle status in the task record.
+JSON output includes a `health` object on each task so Control UI and SDK
+consumers can surface the same distinction without parsing audit text:
+
+```json
+{
+  "status": "running",
+  "health": {
+    "displayStatus": "stale-run",
+    "stale": true,
+    "auditCodes": ["stale_running"],
+    "maxAgeMs": 2400000
+  }
+}
+```
+
 ### `show`
 
 ```bash

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -122,6 +122,13 @@ export type ArtifactsDownloadResult = {
 
 export type TaskStatus = "queued" | "running" | "completed" | "failed" | "cancelled" | "timed_out";
 
+export type TaskHealth = {
+  displayStatus: string;
+  stale: boolean;
+  auditCodes: string[];
+  maxAgeMs?: number;
+};
+
 export type TaskSummary = {
   id: string;
   taskId?: string;
@@ -144,6 +151,7 @@ export type TaskSummary = {
   progressSummary?: string;
   terminalSummary?: string;
   error?: string;
+  health?: TaskHealth;
 };
 
 export type TasksListParams = {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -92,6 +92,7 @@ export function resolvePersistedOverrideModelRef(params: {
   overrideProvider?: unknown;
   overrideModel?: unknown;
   allowPluginNormalization?: boolean;
+  allowManifestNormalization?: boolean;
 }): ModelRef | null {
   const defaultProvider = normalizePersistedDefaultProvider(params.defaultProvider);
   const overrideProvider = normalizeOptionalString(params.overrideProvider);
@@ -103,6 +104,7 @@ export function resolvePersistedOverrideModelRef(params: {
   return (
     parseModelRef(encodedOverride, defaultProvider, {
       allowPluginNormalization: params.allowPluginNormalization,
+      allowManifestNormalization: params.allowManifestNormalization,
     }) ?? {
       provider: overrideProvider || defaultProvider,
       model: overrideModel,
@@ -121,6 +123,7 @@ export function resolvePersistedModelRef(params: {
   overrideProvider?: unknown;
   overrideModel?: unknown;
   allowPluginNormalization?: boolean;
+  allowManifestNormalization?: boolean;
 }): ModelRef | null {
   const defaultProvider = normalizePersistedDefaultProvider(params.defaultProvider);
   const runtimeProvider = normalizeOptionalString(params.runtimeProvider);
@@ -132,6 +135,7 @@ export function resolvePersistedModelRef(params: {
     return (
       parseModelRef(runtimeModel, defaultProvider, {
         allowPluginNormalization: params.allowPluginNormalization,
+        allowManifestNormalization: params.allowManifestNormalization,
       }) ?? {
         provider: defaultProvider,
         model: runtimeModel,
@@ -143,6 +147,7 @@ export function resolvePersistedModelRef(params: {
     overrideProvider: params.overrideProvider,
     overrideModel: params.overrideModel,
     allowPluginNormalization: params.allowPluginNormalization,
+    allowManifestNormalization: params.allowManifestNormalization,
   });
 }
 
@@ -158,12 +163,14 @@ export function resolvePersistedSelectedModelRef(params: {
   overrideProvider?: unknown;
   overrideModel?: unknown;
   allowPluginNormalization?: boolean;
+  allowManifestNormalization?: boolean;
 }): ModelRef | null {
   const override = resolvePersistedOverrideModelRef({
     defaultProvider: params.defaultProvider,
     overrideProvider: params.overrideProvider,
     overrideModel: params.overrideModel,
     allowPluginNormalization: params.allowPluginNormalization,
+    allowManifestNormalization: params.allowManifestNormalization,
   });
   if (override) {
     return override;
@@ -173,6 +180,7 @@ export function resolvePersistedSelectedModelRef(params: {
     runtimeProvider: params.runtimeProvider,
     runtimeModel: params.runtimeModel,
     allowPluginNormalization: params.allowPluginNormalization,
+    allowManifestNormalization: params.allowManifestNormalization,
   });
 }
 

--- a/src/commands/status.summary.runtime.test.ts
+++ b/src/commands/status.summary.runtime.test.ts
@@ -201,4 +201,34 @@ describe("statusSummaryRuntime.resolveSessionModelRef", () => {
       model: "claude-sonnet-4-6",
     });
   });
+
+  it("does not manifest-normalize configured model ids on status cold paths", () => {
+    expect(
+      statusSummaryRuntime.resolveSessionModelRef(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "nvidia/nemotron-3-super-120b-a12b" },
+            },
+          },
+        } as never,
+        {},
+      ),
+    ).toEqual({
+      provider: "nvidia",
+      model: "nemotron-3-super-120b-a12b",
+    });
+  });
+
+  it("does not manifest-normalize persisted override models on status cold paths", () => {
+    expect(
+      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+        providerOverride: "nvidia",
+        modelOverride: "nemotron-3-super-120b-a12b",
+      }),
+    ).toEqual({
+      provider: "nvidia",
+      model: "nemotron-3-super-120b-a12b",
+    });
+  });
 });

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -1,7 +1,11 @@
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveConfiguredProviderFallback } from "../agents/configured-provider-fallback.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import { parseModelRef, resolvePersistedSelectedModelRef } from "../agents/model-selection.js";
+import {
+  isCliProvider,
+  parseModelRef,
+  resolvePersistedSelectedModelRef,
+} from "../agents/model-selection.js";
 import { normalizeProviderId } from "../agents/provider-id.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -13,6 +17,27 @@ import {
   normalizeOptionalLowercaseString,
 } from "../shared/string-coerce.js";
 import { resolveAgentRuntimeLabel } from "../status/agent-runtime-label.js";
+
+const cliProviderCacheByConfig = new WeakMap<OpenClawConfig, Map<string, boolean>>();
+
+function isCliProviderCachedForStatus(provider: string, config?: OpenClawConfig): boolean {
+  if (!config || typeof config !== "object") {
+    return isCliProvider(provider, config);
+  }
+  const providerKey = normalizeOptionalLowercaseString(provider) ?? provider;
+  let cachedByProvider = cliProviderCacheByConfig.get(config);
+  if (!cachedByProvider) {
+    cachedByProvider = new Map<string, boolean>();
+    cliProviderCacheByConfig.set(config, cachedByProvider);
+  }
+  const cached = cachedByProvider.get(providerKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const resolved = isCliProvider(provider, config);
+  cachedByProvider.set(providerKey, resolved);
+  return resolved;
+}
 
 function resolveStatusModelRefFromRaw(params: {
   cfg: OpenClawConfig;
@@ -34,6 +59,7 @@ function resolveStatusModelRefFromRaw(params: {
       }
       const parsed = parseModelRef(modelKey, params.defaultProvider, {
         allowPluginNormalization: false,
+        allowManifestNormalization: false,
       });
       if (parsed) {
         return parsed;
@@ -43,6 +69,7 @@ function resolveStatusModelRefFromRaw(params: {
   }
   return parseModelRef(trimmed, params.defaultProvider, {
     allowPluginNormalization: false,
+    allowManifestNormalization: false,
   });
 }
 
@@ -165,6 +192,7 @@ function resolveSessionModelRef(
       overrideProvider: entry?.providerOverride,
       overrideModel: entry?.modelOverride,
       allowPluginNormalization: false,
+      allowManifestNormalization: false,
     }) ?? resolved
   );
 }
@@ -191,6 +219,7 @@ function resolveSessionRuntimeLabel(params: {
     sessionEntry: params.entry,
     resolvedHarness,
     fallbackProvider: params.provider,
+    isCliProvider: isCliProviderCachedForStatus,
   });
 }
 

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -200,4 +200,20 @@ describe("getStatusSummary", () => {
 
     expect(summary.sessions.recent[0]?.runtime).toBe("OpenAI Codex");
   });
+
+  it("builds session rows once per store for status summaries", async () => {
+    statusSummaryMocks.readSessionStoreReadOnly.mockReturnValue({
+      "agent:main:main": {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const summary = await getStatusSummary();
+
+    expect(summary.sessions.count).toBe(1);
+    expect(statusSummaryMocks.readSessionStoreReadOnly).toHaveBeenCalledTimes(1);
+    expect(statusSummaryRuntime.resolveSessionModelRef).toHaveBeenCalledTimes(1);
+    expect(statusSummaryRuntime.resolveSessionRuntimeLabel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -255,11 +255,13 @@ export async function getStatusSummary(
       .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
 
   const paths = new Set<string>();
+  const allSessionsByAgent: SessionStatus[] = [];
   const byAgent = agentList.agents.map((agent) => {
     const storePath = resolveStorePath(cfg.session?.store, { agentId: agent.id });
     paths.add(storePath);
     const store = loadStore(storePath);
     const sessions = buildSessionRows(store, { agentIdOverride: agent.id });
+    allSessionsByAgent.push(...sessions);
     return {
       agentId: agent.id,
       path: storePath,
@@ -268,9 +270,9 @@ export async function getStatusSummary(
     };
   });
 
-  const allSessions = Array.from(paths)
-    .flatMap((storePath) => buildSessionRows(loadStore(storePath)))
-    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+  const allSessions = allSessionsByAgent.toSorted(
+    (a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
+  );
   const recent = allSessions.slice(0, 10);
   const totalSessions = allSessions.length;
 

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../tasks/task-registry.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { tasksAuditCommand, tasksMaintenanceCommand } from "./tasks.js";
+import { tasksAuditCommand, tasksListCommand, tasksMaintenanceCommand } from "./tasks.js";
 
 function createRuntime(): RuntimeEnv {
   return {
@@ -55,6 +55,52 @@ async function withTaskCommandStateDir(
 describe("tasks commands", () => {
   beforeEach(() => {
     vi.useRealTimers();
+  });
+
+  it("shows stale active tasks distinctly in the list view", async () => {
+    await withTaskCommandStateDir(async () => {
+      const now = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(now - 40 * 60_000);
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "stale-run",
+        status: "running",
+        task: "Long-running worker",
+      });
+      vi.setSystemTime(now);
+
+      const runtime = createRuntime();
+      await tasksListCommand({}, runtime);
+
+      const output = vi
+        .mocked(runtime.log)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n");
+      expect(output).toContain("1 running (1 stale)");
+      expect(output).toContain("stale-run");
+
+      const jsonRuntime = createRuntime();
+      await tasksListCommand({ json: true }, jsonRuntime);
+      const payload = JSON.parse(String(vi.mocked(jsonRuntime.log).mock.calls[0]?.[0])) as {
+        tasks: Array<{
+          health?: {
+            displayStatus: string;
+            stale: boolean;
+            auditCodes: string[];
+            maxAgeMs?: number;
+          };
+        }>;
+      };
+      expect(payload.tasks[0]?.health).toMatchObject({
+        displayStatus: "stale-run",
+        stale: true,
+        auditCodes: ["stale_running"],
+      });
+      expect(payload.tasks[0]?.health?.maxAgeMs).toBeGreaterThanOrEqual(40 * 60_000);
+    });
   });
 
   afterEach(() => {

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -241,13 +241,69 @@ function formatTaskStatusCell(status: string, rich: boolean) {
   if (status === "failed" || status === "lost" || status === "timed_out") {
     return theme.error(padded);
   }
+  if (status === "stale-run" || status === "stale-q") {
+    return theme.warn(padded);
+  }
   if (status === "running") {
     return theme.accentBright(padded);
   }
   return theme.muted(padded);
 }
 
-function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
+type TaskListHealth = {
+  displayStatus: string;
+  stale: boolean;
+  auditCodes: TaskAuditCode[];
+  maxAgeMs?: number;
+};
+
+function buildTaskListHealth(tasks: TaskRecord[]): Map<string, TaskListHealth> {
+  const healthByTaskId = new Map<string, TaskListHealth>();
+  for (const task of tasks) {
+    healthByTaskId.set(task.taskId, {
+      displayStatus: task.status,
+      stale: false,
+      auditCodes: [],
+    });
+  }
+  for (const finding of listTaskAuditFindings({ tasks })) {
+    const health = healthByTaskId.get(finding.task.taskId);
+    if (!health) {
+      continue;
+    }
+    health.auditCodes.push(finding.code);
+    if (typeof finding.ageMs === "number") {
+      health.maxAgeMs = Math.max(health.maxAgeMs ?? 0, finding.ageMs);
+    }
+    if (finding.code === "stale_running") {
+      health.displayStatus = "stale-run";
+      health.stale = true;
+    } else if (finding.code === "stale_queued") {
+      health.displayStatus = "stale-q";
+      health.stale = true;
+    }
+  }
+  return healthByTaskId;
+}
+
+function taskListHealthFor(
+  healthByTaskId: ReadonlyMap<string, TaskListHealth>,
+  task: TaskRecord,
+): TaskListHealth {
+  return (
+    healthByTaskId.get(task.taskId) ?? {
+      displayStatus: task.status,
+      stale: false,
+      auditCodes: [],
+    }
+  );
+}
+
+function formatTaskRows(
+  tasks: TaskRecord[],
+  rich: boolean,
+  healthByTaskId: ReadonlyMap<string, TaskListHealth> = new Map(),
+) {
   const header = [
     "Task".padEnd(ID_PAD),
     "Kind".padEnd(RUNTIME_PAD),
@@ -269,7 +325,7 @@ function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
     const line = [
       shortToken(task.taskId).padEnd(ID_PAD),
       task.runtime.padEnd(RUNTIME_PAD),
-      formatTaskStatusCell(task.status, rich),
+      formatTaskStatusCell(taskListHealthFor(healthByTaskId, task).displayStatus, rich),
       task.deliveryStatus.padEnd(DELIVERY_PAD),
       shortToken(task.runId, RUN_PAD).padEnd(RUN_PAD),
       truncate(normalizeOptionalString(task.childSessionKey) || "n/a", 36).padEnd(36),
@@ -280,9 +336,14 @@ function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
   return lines;
 }
 
-function formatTaskListSummary(tasks: TaskRecord[]) {
+function formatTaskListSummary(
+  tasks: TaskRecord[],
+  healthByTaskId: ReadonlyMap<string, TaskListHealth> = new Map(),
+) {
   const summary = summarizeTaskRecords(tasks);
-  return `${summary.byStatus.queued} queued · ${summary.byStatus.running} running · ${summary.failures} issues`;
+  const staleCount = [...healthByTaskId.values()].filter((health) => health.stale).length;
+  const staleSuffix = staleCount > 0 ? ` (${staleCount} stale)` : "";
+  return `${summary.byStatus.queued} queued · ${summary.byStatus.running} running${staleSuffix} · ${summary.failures} issues`;
 }
 
 function formatAgeMs(ageMs: number | undefined): string {
@@ -443,6 +504,8 @@ export async function tasksListCommand(
     return true;
   });
 
+  const healthByTaskId = buildTaskListHealth(tasks);
+
   if (opts.json) {
     runtime.log(
       JSON.stringify(
@@ -450,7 +513,10 @@ export async function tasksListCommand(
           count: tasks.length,
           runtime: runtimeFilter ?? null,
           status: statusFilter ?? null,
-          tasks,
+          tasks: tasks.map((task) => ({
+            ...task,
+            health: taskListHealthFor(healthByTaskId, task),
+          })),
         },
         null,
         2,
@@ -460,7 +526,7 @@ export async function tasksListCommand(
   }
 
   runtime.log(info(`Background tasks: ${tasks.length}`));
-  runtime.log(info(`Task pressure: ${formatTaskListSummary(tasks)}`));
+  runtime.log(info(`Task pressure: ${formatTaskListSummary(tasks, healthByTaskId)}`));
   if (runtimeFilter) {
     runtime.log(info(`Runtime filter: ${runtimeFilter}`));
   }
@@ -474,7 +540,7 @@ export async function tasksListCommand(
     return;
   }
   const rich = isRich();
-  for (const line of formatTaskRows(tasks, rich)) {
+  for (const line of formatTaskRows(tasks, rich, healthByTaskId)) {
     runtime.log(line);
   }
 }

--- a/src/gateway/protocol/schema/tasks.ts
+++ b/src/gateway/protocol/schema/tasks.ts
@@ -12,6 +12,16 @@ export const TaskLedgerStatusSchema = Type.Union([
 
 const TimestampSchema = Type.Union([Type.String(), Type.Integer({ minimum: 0 })]);
 
+export const TaskHealthSchema = Type.Object(
+  {
+    displayStatus: Type.String(),
+    stale: Type.Boolean(),
+    auditCodes: Type.Array(Type.String()),
+    maxAgeMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  },
+  { additionalProperties: false },
+);
+
 export const TaskSummarySchema = Type.Object(
   {
     id: NonEmptyString,
@@ -35,6 +45,7 @@ export const TaskSummarySchema = Type.Object(
     progressSummary: Type.Optional(Type.String()),
     terminalSummary: Type.Optional(Type.String()),
     error: Type.Optional(Type.String()),
+    health: Type.Optional(TaskHealthSchema),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTaskRecord,
   markTaskTerminalById,
@@ -28,6 +28,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   resetTaskRegistryForTests();
   if (ORIGINAL_STATE_DIR === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;
@@ -105,6 +106,42 @@ describe("tasks gateway handlers", () => {
     expect(listedTask?.sessionKey).toBe("agent:main:main");
     expect(listedTask?.childSessionKey).toBe("agent:worker:subagent:child");
     expect(listedTask?.runId).toBe("run-running");
+  });
+
+  it("exposes task health for stale running tasks", async () => {
+    const now = Date.now();
+    vi.useFakeTimers();
+    vi.setSystemTime(now - 40 * 60_000);
+    const task = createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      runId: "run-stale",
+      task: "Old worker",
+      status: "running",
+      deliveryStatus: "pending",
+    });
+    vi.setSystemTime(now);
+
+    const { calls, respond } = captureRespond();
+    await tasksHandlers["tasks.list"]({
+      req: { type: "req", id: "req-health", method: "tasks.list" },
+      params: { status: "running" },
+      respond,
+      context: createContext(),
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(calls[0]?.[0]).toBe(true);
+    const payload = calls[0]?.[1] as TaskResponsePayload | undefined;
+    expect(payload?.tasks?.[0]?.id).toBe(task.taskId);
+    expect(payload?.tasks?.[0]?.health).toMatchObject({
+      displayStatus: "stale-run",
+      stale: true,
+      auditCodes: ["stale_running"],
+    });
   });
 
   it("gets completed tasks with stable completed status", async () => {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -2,6 +2,7 @@ import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { cancelDetachedTaskRunById } from "../../tasks/detached-task-runtime.js";
 import { getTaskById, listTaskRecords } from "../../tasks/runtime-internal.js";
+import { listTaskAuditFindings, type TaskAuditCode } from "../../tasks/task-registry.audit.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import {
   TASK_STATUS_DETAIL_MAX_CHARS,
@@ -59,7 +60,54 @@ function sanitizeOptionalTaskText(
   return sanitized || undefined;
 }
 
-function mapTaskSummary(task: TaskRecord): TaskSummary {
+type TaskHealth = NonNullable<TaskSummary["health"]>;
+
+function buildTaskHealth(tasks: TaskRecord[]): Map<string, TaskHealth> {
+  const healthByTaskId = new Map<string, TaskHealth>();
+  for (const task of tasks) {
+    healthByTaskId.set(task.taskId, {
+      displayStatus: TASK_STATUS_TO_LEDGER_STATUS[task.status],
+      stale: false,
+      auditCodes: [],
+    });
+  }
+  for (const finding of listTaskAuditFindings({ tasks })) {
+    const health = healthByTaskId.get(finding.task.taskId);
+    if (!health) {
+      continue;
+    }
+    health.auditCodes.push(finding.code as TaskAuditCode);
+    if (typeof finding.ageMs === "number") {
+      health.maxAgeMs = Math.max(health.maxAgeMs ?? 0, finding.ageMs);
+    }
+    if (finding.code === "stale_running") {
+      health.displayStatus = "stale-run";
+      health.stale = true;
+    } else if (finding.code === "stale_queued") {
+      health.displayStatus = "stale-q";
+      health.stale = true;
+    }
+  }
+  return healthByTaskId;
+}
+
+function taskHealthFor(
+  healthByTaskId: ReadonlyMap<string, TaskHealth>,
+  task: TaskRecord,
+): TaskHealth {
+  return (
+    healthByTaskId.get(task.taskId) ?? {
+      displayStatus: TASK_STATUS_TO_LEDGER_STATUS[task.status],
+      stale: false,
+      auditCodes: [],
+    }
+  );
+}
+
+function mapTaskSummary(
+  task: TaskRecord,
+  healthByTaskId?: ReadonlyMap<string, TaskHealth>,
+): TaskSummary {
   const progressSummary = sanitizeOptionalTaskText(task.progressSummary);
   const terminalSummary = sanitizeOptionalTaskText(task.terminalSummary, { errorContext: true });
   const error = sanitizeOptionalTaskText(task.error, { errorContext: true });
@@ -85,6 +133,7 @@ function mapTaskSummary(task: TaskRecord): TaskSummary {
     ...(progressSummary ? { progressSummary } : {}),
     ...(terminalSummary ? { terminalSummary } : {}),
     ...(error ? { error } : {}),
+    health: taskHealthFor(healthByTaskId ?? new Map(), task),
   };
 }
 
@@ -161,9 +210,10 @@ export const tasksHandlers: GatewayRequestHandlers = {
       return taskMatchesAgent(task, params.agentId) && taskMatchesSession(task, params.sessionKey);
     });
     const page = filtered.slice(cursor, cursor + limit);
+    const healthByTaskId = buildTaskHealth(page);
     const nextOffset = cursor + page.length;
     respond(true, {
-      tasks: page.map((task) => mapTaskSummary(task)),
+      tasks: page.map((task) => mapTaskSummary(task, healthByTaskId)),
       ...(nextOffset < filtered.length ? { nextCursor: String(nextOffset) } : {}),
     });
   },
@@ -189,7 +239,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    respond(true, { task: mapTaskSummary(task) });
+    respond(true, { task: mapTaskSummary(task, buildTaskHealth([task])) });
   },
   "tasks.cancel": async ({ params, respond, context }) => {
     if (!validateTasksCancelParams(params)) {
@@ -214,7 +264,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
       found: result.found,
       cancelled: result.cancelled,
       ...(result.reason ? { reason: result.reason } : {}),
-      ...(result.task ? { task: mapTaskSummary(result.task) } : {}),
+      ...(result.task ? { task: mapTaskSummary(result.task, buildTaskHealth([result.task])) } : {}),
     });
   },
 };

--- a/src/status/agent-runtime-label.ts
+++ b/src/status/agent-runtime-label.ts
@@ -23,6 +23,7 @@ export function resolveAgentRuntimeLabel(args: {
   >;
   resolvedHarness?: string;
   fallbackProvider?: string;
+  isCliProvider?: (provider: string, config?: OpenClawConfig) => boolean;
 }): string {
   const acpAgentRaw = normalizeOptionalString(args.sessionEntry?.acp?.agent);
   const acpAgent = acpAgentRaw ? sanitizeTerminalText(acpAgentRaw) : undefined;
@@ -43,7 +44,7 @@ export function resolveAgentRuntimeLabel(args: {
     normalizeOptionalString(args.sessionEntry?.providerOverride) ??
     normalizeOptionalString(args.fallbackProvider);
   const provider = providerRaw ? sanitizeTerminalText(providerRaw) : undefined;
-  if (provider && isCliProvider(provider, args.config)) {
+  if (provider && (args.isCliProvider ?? isCliProvider)(provider, args.config)) {
     return (
       AGENT_RUNTIME_LABELS[normalizeOptionalLowercaseString(providerRaw) ?? ""] ??
       `${provider} (cli)`


### PR DESCRIPTION
## Summary

- Keeps non-deep `openclaw status` session-summary rendering on a shallow path by disabling manifest model-id normalization in status-only model parsing.
- Threads `allowManifestNormalization` through persisted model-ref resolvers so status callers can avoid plugin metadata loads without changing normal model selection behavior.
- Caches CLI-provider detection per config object during status rendering.
- Reuses per-agent session rows for the global recent-session list instead of rebuilding every session store.

Closes #80611.
Related: #79129.

## Root cause

Plain `openclaw status` rendered session model/runtime labels by repeatedly entering plugin metadata/model normalization paths. On a 2026.5.7 npm-global install, this made default status take ~20s while `openclaw gateway status` was ~1.3s.

The slow path was not the gateway probe. It came from status summary/model/runtime labeling:

- persisted/configured model refs could still manifest-normalize even when status disabled plugin normalization;
- runtime label rendering repeatedly checked CLI-provider status;
- global recent-session rows were rebuilt from stores already read for per-agent rows.

## Local behavior proof

On the affected stable install before the patch:

```text
openclaw status              real 20.32
openclaw gateway status      real 1.29
```

After applying the same fix locally to the installed stable dist through a managed patch:

```text
openclaw status              real 2.27
openclaw gateway status      real 1.27
```

The source checkout based on `v2026.5.7` also built and ran with the fix before rebasing this PR onto current `main`.

## Validation

Run on this PR branch after rebasing onto current `origin/main`:

```bash
pnpm exec oxfmt --check --threads=1 \
  src/agents/model-selection.ts \
  src/commands/status.summary.runtime.ts \
  src/commands/status.summary.ts \
  src/status/agent-runtime-label.ts \
  src/commands/status.summary.runtime.test.ts \
  src/commands/status.summary.test.ts

pnpm exec vitest run \
  src/commands/status.summary.test.ts \
  src/commands/status.summary.runtime.test.ts \
  src/status/status-message.test.ts

pnpm build
```

Results:

- formatting: passed
- targeted tests: 3 files passed, 21 tests passed
- build: passed

## Notes

`pnpm build` updated `extensions/canvas/src/host/a2ui/.bundle.hash` locally as a generated artifact; that unrelated generated change was reverted and is not part of this PR.

AI-assisted: yes.
