### PR TITLE
[AI-assisted] fix: accept boolean true for contracts.tools in plugin manifest

### DIFF
--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -802,7 +802,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const webFetchProviders = normalizeTrimmedStringList(value.webFetchProviders);
   const webSearchProviders = normalizeTrimmedStringList(value.webSearchProviders);
   const migrationProviders = normalizeTrimmedStringList(value.migrationProviders);
-  const tools = normalizeTrimmedStringList(value.tools);
+  const tools = value.tools === true ? ["*"] : normalizeTrimmedStringList(value.tools);
   const contracts = {
     ...(embeddedExtensionFactories.length > 0 ? { embeddedExtensionFactories } : {}),
     ...(agentToolResultMiddleware.length > 0 ? { agentToolResultMiddleware } : {}),

--- a/src/plugins/tool-contracts.test.ts
+++ b/src/plugins/tool-contracts.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  findUndeclaredPluginToolNames,
+  normalizePluginToolContractNames,
+} from "./tool-contracts.js";
+
+describe("normalizePluginToolContractNames", () => {
+  it("returns empty array when contracts is undefined", () => {
+    expect(normalizePluginToolContractNames(undefined)).toEqual([]);
+  });
+
+  it("returns empty array when tools is undefined", () => {
+    expect(normalizePluginToolContractNames({ tools: undefined })).toEqual([]);
+  });
+
+  it("normalizes explicit tool names", () => {
+    expect(normalizePluginToolContractNames({ tools: ["foo", "bar"] })).toEqual(["foo", "bar"]);
+  });
+
+  it("returns wildcard when tools contains '*'", () => {
+    expect(normalizePluginToolContractNames({ tools: ["*"] })).toEqual(["*"]);
+  });
+
+  it("collapses mixed names with wildcard to just wildcard", () => {
+    expect(normalizePluginToolContractNames({ tools: ["foo", "*", "bar"] })).toEqual(["*"]);
+  });
+});
+
+describe("findUndeclaredPluginToolNames", () => {
+  it("returns undeclared names", () => {
+    expect(
+      findUndeclaredPluginToolNames({ declaredNames: ["foo"], toolNames: ["foo", "bar"] }),
+    ).toEqual(["bar"]);
+  });
+
+  it("returns empty when all declared", () => {
+    expect(
+      findUndeclaredPluginToolNames({ declaredNames: ["foo", "bar"], toolNames: ["foo"] }),
+    ).toEqual([]);
+  });
+
+  it("returns empty when wildcard is declared", () => {
+    expect(
+      findUndeclaredPluginToolNames({
+        declaredNames: ["*"],
+        toolNames: ["anything", "goes", "here"],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/plugins/tool-contracts.ts
+++ b/src/plugins/tool-contracts.ts
@@ -3,7 +3,11 @@ import type { PluginManifestContracts } from "./manifest.js";
 export function normalizePluginToolContractNames(
   contracts: Pick<PluginManifestContracts, "tools"> | undefined,
 ): string[] {
-  return normalizePluginToolNames(contracts?.tools);
+  const names = normalizePluginToolNames(contracts?.tools);
+  if (names.includes("*")) {
+    return ["*"];
+  }
+  return names;
 }
 
 export function normalizePluginToolNames(names: readonly string[] | undefined): string[] {
@@ -22,5 +26,8 @@ export function findUndeclaredPluginToolNames(params: {
   toolNames: readonly string[];
 }): string[] {
   const declared = new Set(normalizePluginToolNames(params.declaredNames));
+  if (declared.has("*")) {
+    return [];
+  }
   return normalizePluginToolNames(params.toolNames).filter((name) => !declared.has(name));
 }


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested. Prompt summary available on request.

## Summary
- Problem: Plugin manifest parser silently drops `contracts.tools: true` (boolean), causing `registerTool` to fail with "plugin must declare contracts.tools before registering agent tools"
- Why it matters: Blocks all native plugin developers from registering agent tools when using the boolean shorthand documented in third-party examples
- What changed: Manifest normalization now treats `contracts.tools: true` as the wildcard marker `["*"]`; tool contract validation treats `"*"` as allowing any tool name
- What did NOT change (scope boundary): No changes to registry.ts, plugin loading, or any other contract fields. Only `manifest.ts` (1 line) and `tool-contracts.ts` (wildcard handling) touched.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Plugin SDK

## Linked Issue/PR
- Closes #80621
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `normalizeTrimmedStringList()` only accepts arrays; when `value.tools` is boolean `true`, it returns `[]`, so the contracts object omits the `tools` key entirely
- Missing detection / guardrail: No test covered the boolean shorthand path for `contracts.tools`
- Contributing context (if known): The manifest schema type (`tools?: string[]`) did not account for the boolean shorthand that plugin authors naturally use from JSON config

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/plugins/tool-contracts.test.ts`
- Scenario the test should lock in: `normalizePluginToolContractNames` returns `["*"]` when tools contains `"*"`, and `findUndeclaredPluginToolNames` returns `[]` when declared names include `"*"`
- Why this is the smallest reliable guardrail: Tests the exact normalization functions that gate tool registration, without needing full registry setup
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
Plugins declaring `"contracts": { "tools": true }` in their manifest will now successfully register tools via `api.registerTool()`.

## Security Impact (required)
- New permissions/capabilities? No
- The wildcard `"*"` marker only affects the declaring plugin own tool registration validation. It does not grant cross-plugin capabilities or bypass any security boundary. Plugin tool registration was already gated by the contracts declaration; this fix simply accepts the boolean shorthand as equivalent to "allow any tool name from this plugin".