### PR TITLE
docs(plugins): clarify desktop-control paths and surface cua-driver positioning

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -51,6 +51,13 @@ OpenClaw-managed runtimes to call TryCua's driver directly, use the upstream
 `cua-driver mcp` server through OpenClaw's MCP registry instead of the
 Codex-specific marketplace flow.
 
+`cua-driver` is an MIT-licensed stdio MCP server that any agent framework can
+call without going through a plugin layer — Codex, Claude, Gemini, or
+OpenClaw-native. Point your agent at `cua-driver mcp` and the full tool surface
+is available. Like Codex Computer Use, it dispatches through Accessibility APIs
+in the background: actions don't move your cursor or raise windows, so the user
+can keep working while the agent drives other apps.
+
 After installing `cua-driver`, either ask it for the OpenClaw command:
 
 ```bash

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -810,6 +810,31 @@ For direct TryCua driver access outside the Codex marketplace flow, register
 See [Codex Computer Use](/plugins/codex-computer-use) for the distinction
 between Codex-owned Computer Use and direct MCP registration.
 
+### Choosing a desktop-control path
+
+OpenClaw has three desktop-control paths. They differ in user experience and
+how each one is reached:
+
+| Criterion | Codex Computer Use | cua-driver MCP | PeekabooBridge |
+|---|---|---|---|
+| Background (no focus steal, user keeps working) | ✅ | ✅ | ❌ |
+| License | Proprietary | MIT | MIT |
+| Harness access | Via Codex plugin marketplace | Direct MCP, any harness | Via Peekaboo CLI / bridge |
+| Distribution | OpenAI marketplace | Direct binary | Homebrew / npm |
+| Menu / dialog / Dock coverage | Limited | Limited | Full |
+
+Peekaboo runs in the foreground: the agent takes control of the cursor and
+raises windows, so the desktop is the agent's while it works. Codex Computer
+Use and direct `cua-driver` MCP both run in the background through
+Accessibility APIs — the user can keep working in their browser while the
+agent drives Numbers, Safari, or any other app.
+
+Between Codex Computer Use and `cua-driver` MCP, the difference is licensing
+and how non-Codex harnesses reach it: Codex Computer Use is a proprietary
+plugin distributed through OpenAI's marketplace, available to other harnesses
+only via the plugin layer; `cua-driver` is an MIT MCP server that any harness
+can call directly.
+
 Minimal config:
 
 ```json5


### PR DESCRIPTION
## Summary

The Codex Computer Use and Peekaboo docs already mention three desktop-control paths — Codex Computer Use, direct `cua-driver` MCP, and PeekabooBridge — but they don't help a reader pick between them. This PR adds the missing positioning:

1. **`docs/plugins/codex-computer-use.md`** — adds one paragraph in the existing "Direct cua-driver MCP" section noting that `cua-driver` is MIT-licensed, callable directly by any harness without a plugin layer, and uses the same background-operation model as Codex Computer Use.

2. **`docs/plugins/codex-harness.md`** — adds a new "Choosing a desktop-control path" subsection with a comparison table covering background operation, license, harness access pattern, distribution, and coverage breadth, plus two short prose paragraphs explaining the foreground/background divide and the Codex-CU-vs-cua-driver license/access difference.

## Comparison table added

| Criterion | Codex Computer Use | cua-driver MCP | PeekabooBridge |
|---|---|---|---|
| Background (no focus steal, user keeps working) | ✅ | ✅ | ❌ |
| License | Proprietary | MIT | MIT |
| Harness access | Via Codex plugin marketplace | Direct MCP, any harness | Via Peekaboo CLI / bridge |
| Distribution | OpenAI marketplace | Direct binary | Homebrew / npm |
| Menu / dialog / Dock coverage | Limited | Limited | Full |

Two real stories the table captures:

- **Peekaboo is the outlier on background**: it's the only path that takes over the desktop. The other two dispatch through Accessibility APIs without moving the cursor or raising windows.
- **Codex CU vs cua-driver** is about licensing and how non-Codex harnesses reach it: Codex CU is proprietary and reachable from other harnesses only via the Codex plugin layer; `cua-driver` is an MIT MCP server any harness can call directly.

## Why this matters

Without the comparison, a reader landing on either page sees three options that look interchangeable. The background-vs-foreground distinction in particular is the practical thing users will care about — whether the agent works invisibly while they keep using their machine, or takes over the desktop entirely.

## Scope

Docs-only. No code, no tests. Two files, +32 lines total.