### PR TITLE
fix(slack): route mission replies to canonical threads

### DIFF
--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -3,6 +3,7 @@ import { readBooleanParam } from "openclaw/plugin-sdk/boolean-param";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { parseSlackBlocksInput } from "./blocks-input.js";
+import { detectSlackMissionId, resolveSlackMissionThread } from "./mission-threads.js";
 import {
   createActionGate,
   imageResultFromFile,
@@ -253,7 +254,7 @@ export async function handleSlackAction(
             "Slack replyBroadcast is only supported for text or block thread replies.",
           );
         }
-        const threadTs = resolveThreadTsFromContext(
+        let threadTs = resolveThreadTsFromContext(
           readStringParam(params, "threadTs"),
           to,
           context,
@@ -261,6 +262,21 @@ export async function handleSlackAction(
             suppressImplicitThread: params.topLevel === true || params.threadTs === null,
           },
         );
+        const missionId = detectSlackMissionId(content ?? "");
+        const targetChannelId = parseSlackTarget(to, { defaultKind: "channel" })?.id;
+        if (!threadTs && missionId) {
+          const missionThread = await resolveSlackMissionThread({
+            missionId,
+            accountId: account.accountId,
+            channelId: targetChannelId,
+          });
+          if (!missionThread?.threadTs) {
+            throw new Error(
+              "Refusing Slack top-level post: mission-bound message has no canonical thread",
+            );
+          }
+          threadTs = missionThread.threadTs;
+        }
         const sendOpts = {
           ...writeOpts,
           mediaLocalRoots: context?.mediaLocalRoots,

--- a/extensions/slack/src/mission-threads.test.ts
+++ b/extensions/slack/src/mission-threads.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  detectSlackMissionId,
+  persistSlackMissionThread,
+  resolveSlackMissionThread,
+} from "./mission-threads.js";
+
+let tmpDir: string | undefined;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-slack-mission-"));
+  process.env.OPENCLAW_SLACK_MISSION_THREAD_STORE = path.join(tmpDir, "threads.json");
+});
+
+afterEach(async () => {
+  delete process.env.OPENCLAW_SLACK_MISSION_THREAD_STORE;
+  if (tmpDir) {
+    await rm(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+});
+
+describe("Slack mission thread store", () => {
+  it("detects explicit mission lines", () => {
+    expect(detectSlackMissionId("Mission: thread-routing-final-test")).toBe(
+      "thread-routing-final-test",
+    );
+  });
+
+  it("ignores branch-like text without an explicit mission marker", () => {
+    expect(detectSlackMissionId("Continue feat/read-only-ui-verify now")).toBeUndefined();
+    expect(detectSlackMissionId("THREADING TEST")).toBeUndefined();
+  });
+
+  it("persists and resolves canonical mission threads", async () => {
+    await persistSlackMissionThread({
+      missionId: "feat/thread-routing",
+      channelId: "C123",
+      threadTs: "111.222",
+      ownerAgent: "melvin",
+      createdFromMessageTs: "111.222",
+    });
+
+    const resolved = await resolveSlackMissionThread({
+      missionId: "feat/thread-routing",
+      channelId: "C123",
+    });
+
+    expect(resolved).toMatchObject({
+      platform: "slack",
+      missionId: "feat/thread-routing",
+      channelId: "C123",
+      threadTs: "111.222",
+      ownerAgent: "melvin",
+      createdFromMessageTs: "111.222",
+      routingPolicy: "thread_required",
+    });
+  });
+
+  it("scopes canonical mission threads by Slack account", async () => {
+    await persistSlackMissionThread({
+      missionId: "shared-mission",
+      accountId: "lettuce",
+      teamId: "T_LETTUCE",
+      channelId: "C123",
+      threadTs: "111.222",
+    });
+    await persistSlackMissionThread({
+      missionId: "shared-mission",
+      accountId: "proof",
+      teamId: "T_PROOF",
+      channelId: "C123",
+      threadTs: "333.444",
+    });
+
+    await expect(
+      resolveSlackMissionThread({
+        missionId: "shared-mission",
+        accountId: "lettuce",
+        channelId: "C123",
+      }),
+    ).resolves.toMatchObject({
+      accountId: "lettuce",
+      teamId: "T_LETTUCE",
+      threadTs: "111.222",
+    });
+    await expect(
+      resolveSlackMissionThread({
+        missionId: "shared-mission",
+        accountId: "proof",
+        channelId: "C123",
+      }),
+    ).resolves.toMatchObject({
+      accountId: "proof",
+      teamId: "T_PROOF",
+      threadTs: "333.444",
+    });
+    await expect(
+      resolveSlackMissionThread({
+        missionId: "shared-mission",
+        accountId: "unknown",
+        channelId: "C123",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/extensions/slack/src/mission-threads.ts
+++ b/extensions/slack/src/mission-threads.ts
@@ -1,0 +1,184 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export type SlackMissionThreadEntry = {
+  platform: "slack";
+  missionId: string;
+  accountId?: string;
+  teamId?: string;
+  channelId: string;
+  threadTs: string;
+  ownerAgent: string;
+  createdFromMessageTs: string;
+  createdAt: string;
+  updatedAt: string;
+  routingPolicy: "thread_required";
+};
+
+export type SlackMissionThreadStore = {
+  missions: Record<string, SlackMissionThreadEntry | undefined>;
+};
+
+const DEFAULT_STORE_PATH = path.join(os.homedir(), ".openclaw", "slack-mission-threads.json");
+const MISSION_LINE_RE = /^mission:\s*(.+)$/im;
+const MISSION_CALLED_RE = /mission called:\s*[“"']?([^\n”"']+)[”"']?/im;
+const DEFAULT_SLACK_ACCOUNT_SCOPE = "default";
+
+export function getSlackMissionThreadStorePath(): string {
+  const override = process.env.OPENCLAW_SLACK_MISSION_THREAD_STORE?.trim();
+  return override || DEFAULT_STORE_PATH;
+}
+
+export function detectSlackMissionId(text: string | undefined | null): string | undefined {
+  const value = text?.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  const missionLine = value.match(MISSION_LINE_RE)?.[1]?.trim();
+  if (missionLine) {
+    return missionLine;
+  }
+
+  const missionCalled = value.match(MISSION_CALLED_RE)?.[1]?.trim();
+  if (missionCalled) {
+    return missionCalled;
+  }
+
+  return undefined;
+}
+
+function normalizeOptionalScope(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function resolveSlackMissionScope(params: {
+  accountId?: string | null;
+  teamId?: string | null;
+}): string {
+  const accountId = normalizeOptionalScope(params.accountId);
+  if (accountId) {
+    return `account:${accountId}`;
+  }
+  const teamId = normalizeOptionalScope(params.teamId);
+  if (teamId) {
+    return `team:${teamId}`;
+  }
+  return `account:${DEFAULT_SLACK_ACCOUNT_SCOPE}`;
+}
+
+function resolveSlackMissionStoreKey(params: {
+  missionId: string;
+  accountId?: string | null;
+  teamId?: string | null;
+}): string {
+  return JSON.stringify([resolveSlackMissionScope(params), params.missionId]);
+}
+
+async function readStore(
+  storePath = getSlackMissionThreadStorePath(),
+): Promise<SlackMissionThreadStore> {
+  try {
+    const raw = await readFile(storePath, "utf8");
+    const parsed = JSON.parse(raw) as SlackMissionThreadStore;
+    return parsed && parsed.missions && typeof parsed.missions === "object"
+      ? parsed
+      : { missions: {} };
+  } catch {
+    return { missions: {} };
+  }
+}
+
+async function writeStore(
+  store: SlackMissionThreadStore,
+  storePath = getSlackMissionThreadStorePath(),
+): Promise<void> {
+  await mkdir(path.dirname(storePath), { recursive: true });
+  await writeFile(storePath, JSON.stringify(store, null, 2) + "\n", "utf8");
+}
+
+export async function persistSlackMissionThread(params: {
+  missionId: string;
+  accountId?: string | null;
+  teamId?: string | null;
+  channelId: string;
+  threadTs: string;
+  ownerAgent?: string;
+  createdFromMessageTs?: string;
+  storePath?: string;
+}): Promise<SlackMissionThreadEntry> {
+  const missionId = params.missionId.trim();
+  const channelId = params.channelId.trim();
+  const threadTs = params.threadTs.trim();
+  if (!missionId || !channelId || !threadTs) {
+    throw new Error("missionId, channelId, and threadTs are required");
+  }
+
+  const storePath = params.storePath ?? getSlackMissionThreadStorePath();
+  const store = await readStore(storePath);
+  const storeKey = resolveSlackMissionStoreKey({
+    missionId,
+    accountId: params.accountId,
+    teamId: params.teamId,
+  });
+  const accountId = normalizeOptionalScope(params.accountId);
+  const teamId = normalizeOptionalScope(params.teamId);
+  const existing = store.missions[storeKey];
+  const now = new Date().toISOString();
+  const entry: SlackMissionThreadEntry = {
+    platform: "slack",
+    missionId,
+    ...(accountId ? { accountId } : {}),
+    ...(teamId ? { teamId } : {}),
+    channelId,
+    threadTs,
+    ownerAgent: params.ownerAgent?.trim() || existing?.ownerAgent || "melvin",
+    createdFromMessageTs:
+      params.createdFromMessageTs?.trim() || existing?.createdFromMessageTs || threadTs,
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+    routingPolicy: "thread_required",
+  };
+  store.missions[storeKey] = entry;
+  await writeStore(store, storePath);
+  return entry;
+}
+
+export async function resolveSlackMissionThread(params: {
+  missionId: string;
+  accountId?: string | null;
+  teamId?: string | null;
+  channelId?: string;
+  storePath?: string;
+}): Promise<SlackMissionThreadEntry | undefined> {
+  const missionId = params.missionId.trim();
+  if (!missionId) {
+    return undefined;
+  }
+  const store = await readStore(params.storePath ?? getSlackMissionThreadStorePath());
+  const entry =
+    store.missions[
+      resolveSlackMissionStoreKey({
+        missionId,
+        accountId: params.accountId,
+        teamId: params.teamId,
+      })
+    ];
+  if (!entry) {
+    return undefined;
+  }
+  const accountId = normalizeOptionalScope(params.accountId);
+  if (accountId && entry.accountId && entry.accountId !== accountId) {
+    return undefined;
+  }
+  const teamId = normalizeOptionalScope(params.teamId);
+  if (teamId && entry.teamId && entry.teamId !== teamId) {
+    return undefined;
+  }
+  if (params.channelId && entry.channelId !== params.channelId.trim()) {
+    return undefined;
+  }
+  return entry;
+}

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -352,6 +352,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     message,
     replyToMode: prepared.replyToMode,
   });
+  const preparedMessageThreadId =
+    typeof prepared.ctxPayload.MessageThreadId === "string"
+      ? prepared.ctxPayload.MessageThreadId
+      : undefined;
+  const resolvedStatusThreadTs = statusThreadTs ?? preparedMessageThreadId;
   const sourceReplyDeliveryMode = resolveChannelMessageSourceReplyDeliveryMode({
     cfg,
     ctx: prepared.ctxPayload,
@@ -419,13 +424,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const hasRepliedRef = { value: false };
   const replyPlan = createSlackReplyDeliveryPlan({
     replyToMode: prepared.replyToMode,
-    incomingThreadTs,
+    incomingThreadTs: preparedMessageThreadId ?? incomingThreadTs,
     messageTs,
     hasRepliedRef,
-    isThreadReply,
+    isThreadReply: isThreadReply || Boolean(preparedMessageThreadId),
   });
 
-  const typingTarget = statusThreadTs ? `${message.channel}/${statusThreadTs}` : message.channel;
+  const typingTarget = resolvedStatusThreadTs
+    ? `${message.channel}/${resolvedStatusThreadTs}`
+    : message.channel;
   const typingReaction = ctx.typingReaction;
   const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
     cfg,
@@ -441,7 +448,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         didSetStatus = true;
         await ctx.setSlackThreadStatus({
           channelId: message.channel,
-          threadTs: statusThreadTs,
+          threadTs: resolvedStatusThreadTs,
           status: "is typing...",
         });
         if (typingReaction && message.ts) {
@@ -458,7 +465,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         didSetStatus = false;
         await ctx.setSlackThreadStatus({
           channelId: message.channel,
-          threadTs: statusThreadTs,
+          threadTs: resolvedStatusThreadTs,
           status: "",
         });
         if (typingReaction && message.ts) {
@@ -495,9 +502,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   });
   const streamThreadHint = resolveSlackStreamingThreadHint({
     replyToMode: prepared.replyToMode,
-    incomingThreadTs,
+    incomingThreadTs: preparedMessageThreadId ?? incomingThreadTs,
     messageTs,
-    isThreadReply,
+    isThreadReply: isThreadReply || Boolean(preparedMessageThreadId),
   });
   const previewStreamingEnabled =
     !sourceRepliesAreToolOnly &&

--- a/extensions/slack/src/monitor/message-handler/prepare-routing.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-routing.ts
@@ -9,6 +9,7 @@ import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { resolveSlackReplyToMode } from "../../account-reply-mode.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";
+import { detectSlackMissionId } from "../../mission-threads.js";
 import { parseSlackTarget, type SlackTargetKind } from "../../targets.js";
 import { resolveSlackThreadContext } from "../../threading.js";
 import type { SlackMessageEvent } from "../../types.js";
@@ -203,6 +204,10 @@ export function resolveSlackRoutingContext(params: {
       ? seedCandidateThreadId
       : undefined;
   const roomThreadId = isThreadReply && threadTs ? threadTs : undefined;
+  const missionThreadId =
+    !isThreadReply && isRoomish && detectSlackMissionId(message.text) && threadContext.messageTs
+      ? threadContext.messageTs
+      : undefined;
   const canonicalThreadId = isDirectMessage
     ? isThreadReply
       ? threadTs
@@ -212,7 +217,8 @@ export function resolveSlackRoutingContext(params: {
       : isThreadReply
         ? threadTs
         : autoThreadId;
-  const routedThreadId = canonicalThreadId ?? (isRoomish ? seededRoomThreadId : undefined);
+  const routedThreadId =
+    canonicalThreadId ?? missionThreadId ?? (isRoomish ? seededRoomThreadId : undefined);
   const baseConversationId = resolveSlackBaseConversationId({ message, isDirectMessage });
   const boundThreadRoute = routedThreadId
     ? resolveRuntimeConversationBindingRoute({

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import type { App } from "@slack/bolt";
 import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -1840,6 +1841,47 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       team_id: "T1",
     });
     expect(prepared).toBeNull();
+  });
+
+  it("does not persist mission threads for room messages dropped before ingress accepts them", async () => {
+    const { dir } = storeFixture.makeTmpStorePath();
+    const missionStorePath = path.join(dir, "slack-mission-threads.json");
+    process.env.OPENCLAW_SLACK_MISSION_THREAD_STORE = missionStorePath;
+    try {
+      const slackCtx = createInboundSlackCtx({
+        cfg: {
+          channels: {
+            slack: {
+              enabled: true,
+              groupPolicy: "open",
+              channels: { C0AGENTS: { requireMention: true } },
+            },
+          },
+        } as OpenClawConfig,
+        defaultRequireMention: true,
+      });
+      slackCtx.resolveChannelName = async () => ({ name: "agents", type: "channel" });
+      slackCtx.resolveUserName = async () => ({ name: "Bek" });
+
+      const prepared = await prepareSlackMessage({
+        ctx: slackCtx,
+        account: createSlackAccount(),
+        message: {
+          type: "message",
+          channel: "C0AGENTS",
+          channel_type: "channel",
+          user: "U_BEK",
+          text: "Mission: dropped-before-ingress",
+          ts: "1777244692.409921",
+        } as SlackMessageEvent,
+        opts: { source: "message" },
+      });
+
+      expect(prepared).toBeNull();
+      expect(fs.existsSync(missionStorePath)).toBe(false);
+    } finally {
+      delete process.env.OPENCLAW_SLACK_MISSION_THREAD_STORE;
+    }
   });
 
   it("keeps a regex-mentioned Slack thread root and URL-only follow-up on one parent session", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1,7 +1,6 @@
 import {
   resolveAckReaction,
   shouldAckReaction as shouldAckReactionGate,
-  type AckReactionScope,
 } from "openclaw/plugin-sdk/channel-feedback";
 import {
   buildMentionRegexes,
@@ -35,6 +34,7 @@ import type { ResolvedSlackAccount } from "../../accounts.js";
 import { reactSlackMessage } from "../../actions.js";
 import { formatSlackError } from "../../errors.js";
 import { formatSlackFileReference } from "../../file-reference.js";
+import { detectSlackMissionId, persistSlackMissionThread } from "../../mission-threads.js";
 import { hasSlackThreadParticipationWithPersistence } from "../../sent-thread-cache.js";
 import type { SlackMessageEvent } from "../../types.js";
 import { normalizeAllowListLower, normalizeSlackAllowOwnerEntry } from "../allow-list.js";
@@ -66,6 +66,8 @@ import { resolveSlackRoutingContext } from "./prepare-routing.js";
 import { resolveSlackThreadContextData } from "./prepare-thread-context.js";
 import { isSlackSubteamMentionForBot } from "./subteam-mentions.js";
 import type { PreparedSlackMessage } from "./types.js";
+
+type SlackAckReactionScope = "all" | "direct" | "group-all" | "group-mentions" | "off" | "none";
 
 const mentionRegexCache = new WeakMap<SlackMonitorContext, Map<string, RegExp[]>>();
 const SLACK_ANY_MENTION_RE = /<@[^>]+>|<!subteam\^[^>]+>/;
@@ -542,6 +544,7 @@ export async function prepareSlackMessage(params: {
       return null;
     }
   }
+
   let implicitMentionKinds: ReturnType<typeof implicitMentionKindWhen> = [];
   if (
     !isDirectMessage &&
@@ -592,7 +595,7 @@ export async function prepareSlackMessage(params: {
   const shouldRequireMention = isRoom
     ? (channelConfig?.requireMention ?? ctx.defaultRequireMention)
     : false;
-  if (message._ambiguousThreadReply) {
+  if (message["_ambiguousThreadReply"]) {
     ctx.logger.info(
       {
         channel: message.channel,
@@ -754,7 +757,7 @@ export async function prepareSlackMessage(params: {
     Boolean(
       ackReaction &&
       shouldAckReactionGate({
-        scope: ctx.ackReactionScope as AckReactionScope | undefined,
+        scope: ctx.ackReactionScope as SlackAckReactionScope | undefined,
         isDirect: isDirectMessage,
         isGroup: isRoomish,
         isMentionableGroup: isRoom,
@@ -1016,6 +1019,22 @@ export async function prepareSlackMessage(params: {
   const replyTarget = isDirectMessage ? `channel:${message.channel}` : (ctxPayload.To ?? undefined);
   if (!replyTarget) {
     return null;
+  }
+
+  const missionId = detectSlackMissionId(messageText);
+  const missionThreadTs = missionId
+    ? (threadContext.messageThreadId ?? threadContext.replyToId)
+    : undefined;
+  if (missionId && missionThreadTs) {
+    await persistSlackMissionThread({
+      missionId,
+      accountId: account.accountId,
+      teamId: ctx.teamId || undefined,
+      channelId: message.channel,
+      threadTs: missionThreadTs,
+      ownerAgent: route.agentId ?? "melvin",
+      createdFromMessageTs: message.ts ?? missionThreadTs,
+    });
   }
 
   if (shouldLogVerbose()) {

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -25,7 +25,9 @@ import {
 } from "./blocks-render.js";
 import { compileSlackInteractiveReplies } from "./interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
+import { detectSlackMissionId, resolveSlackMissionThread } from "./mission-threads.js";
 import type { SlackSendIdentity } from "./send.js";
+import { parseSlackTarget } from "./targets.js";
 import { resolveSlackThreadTsValue } from "./thread-ts.js";
 
 const SLACK_MAX_BLOCKS = 50;
@@ -88,10 +90,25 @@ async function sendSlackOutboundMessage(params: {
     resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
     (await loadSlackSendRuntime()).sendMessageSlack;
   const slackIdentity = resolveSlackSendIdentity(params.identity);
-  const threadTs = resolveSlackThreadTsValue({
+  let threadTs = resolveSlackThreadTsValue({
     replyToId: params.replyToId,
     threadId: params.threadId,
   });
+  const missionId = detectSlackMissionId(params.text);
+  const targetChannelId = parseSlackTarget(params.to, { defaultKind: "channel" })?.id;
+  if (!threadTs && missionId) {
+    const missionThread = await resolveSlackMissionThread({
+      missionId,
+      accountId: params.accountId,
+      channelId: targetChannelId,
+    });
+    if (!missionThread?.threadTs) {
+      throw new Error(
+        "Refusing Slack top-level post: mission-bound message has no canonical thread",
+      );
+    }
+    threadTs = missionThread.threadTs;
+  }
   const result = await send(params.to, params.text, {
     cfg: params.cfg,
     threadTs,

--- a/extensions/slack/src/threading.test.ts
+++ b/extensions/slack/src/threading.test.ts
@@ -61,6 +61,22 @@ describe("resolveSlackThreadTargets", () => {
     expect(statusThreadTs).toBeUndefined();
   });
 
+  it("threads mission-bound top-level replies even when reply threading is off", () => {
+    const { replyThreadTs, statusThreadTs, isThreadReply } = resolveSlackThreadTargets({
+      replyToMode: "off",
+      message: {
+        type: "message",
+        channel: "C1",
+        ts: "123",
+        text: "Mission: formalize-openclaw-thread-routing-pr-smoke",
+      },
+    });
+
+    expect(isThreadReply).toBe(false);
+    expect(replyThreadTs).toBe("123");
+    expect(statusThreadTs).toBe("123");
+  });
+
   it("does not treat auto-created top-level thread_ts as a real thread when mode is off", () => {
     expectAutoCreatedTopLevelThreadTsBehavior("off");
   });
@@ -85,6 +101,38 @@ describe("resolveSlackThreadTargets", () => {
 
     expect(context.isThreadReply).toBe(false);
     expect(context.messageThreadId).toBe("123");
+    expect(context.replyToId).toBe("123");
+  });
+
+  it("sets messageThreadId for explicit mission-bound top-level messages", () => {
+    const context = resolveSlackThreadContext({
+      replyToMode: "off",
+      message: {
+        type: "message",
+        channel: "C1",
+        ts: "123",
+        text: "Mission: read-only-ui-verify",
+      },
+    });
+
+    expect(context.isThreadReply).toBe(false);
+    expect(context.messageThreadId).toBe("123");
+    expect(context.replyToId).toBe("123");
+  });
+
+  it("does not thread branch-like top-level messages without explicit mission identity", () => {
+    const context = resolveSlackThreadContext({
+      replyToMode: "off",
+      message: {
+        type: "message",
+        channel: "C1",
+        ts: "123",
+        text: "Continue feat/read-only-ui-verify",
+      },
+    });
+
+    expect(context.isThreadReply).toBe(false);
+    expect(context.messageThreadId).toBeUndefined();
     expect(context.replyToId).toBe("123");
   });
 

--- a/extensions/slack/src/threading.ts
+++ b/extensions/slack/src/threading.ts
@@ -1,4 +1,5 @@
 import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
+import { detectSlackMissionId } from "./mission-threads.js";
 import type { SlackAppMentionEvent, SlackMessageEvent } from "./types.js";
 
 type SlackThreadContext = {
@@ -19,10 +20,11 @@ export function resolveSlackThreadContext(params: {
   const hasThreadTs = typeof incomingThreadTs === "string" && incomingThreadTs.length > 0;
   const isThreadReply =
     hasThreadTs && (incomingThreadTs !== messageTs || Boolean(params.message.parent_user_id));
+  const isMissionBound = Boolean(detectSlackMissionId(params.message.text));
   const replyToId = incomingThreadTs ?? messageTs;
   const messageThreadId = isThreadReply
     ? incomingThreadTs
-    : params.replyToMode === "all"
+    : params.replyToMode === "all" || isMissionBound
       ? messageTs
       : undefined;
   return {
@@ -47,12 +49,8 @@ export function resolveSlackThreadTargets(params: {
   replyToMode: ReplyToMode;
 }) {
   const ctx = resolveSlackThreadContext(params);
-  const { incomingThreadTs, messageTs, isThreadReply } = ctx;
-  const replyThreadTs = isThreadReply
-    ? incomingThreadTs
-    : params.replyToMode === "all"
-      ? messageTs
-      : undefined;
+  const { isThreadReply } = ctx;
+  const replyThreadTs = ctx.messageThreadId;
   const statusThreadTs = replyThreadTs;
   return { replyThreadTs, statusThreadTs, isThreadReply };
 }


### PR DESCRIPTION
## Root Cause

Hermes carries Slack thread affinity as first-class routing state. OpenClaw only propagated Slack thread IDs through some paths. For mission messages in Slack channels, `replyToMode=off` could leave `MessageThreadId` unset, so final replies, streaming hints, Slack tool sends, or routed outbound sends could fall back to top-level channel posts even when the message was mission-bound.

## Before

- Mission-bound top-level Slack messages were not guaranteed to become canonical mission threads.
- Direct Slack dispatcher replies could plan delivery without the prepared mission thread.
- Slack `sendMessage` tool calls with mission text and no thread could post top-level.
- Slack outbound sends reached through routed reply delivery could post top-level if no thread was supplied.
- Restart safety depended on incidental session context rather than durable mission-thread state.

## After

- Inbound Slack mission messages persist `account/workspace-scoped missionId -> channelId/threadTs` in a local JSON registry.
- Mission-bound top-level Slack messages set `MessageThreadId` to the canonical message timestamp.
- Mission-bound Slack room messages get mission-scoped routing/session continuity without making ordinary channel chatter thread-scoped.
- Direct Slack dispatcher reply plans, typing/status targets, and streaming hints use prepared `MessageThreadId`.
- Slack `sendMessage` tool calls resolve canonical mission threads before sending.
- Slack outbound adapter sends resolve canonical mission threads before sending.
- Mission-bound Slack sends with no canonical thread fail closed with:

```text
Refusing Slack top-level post: mission-bound message has no canonical thread
```

- Non-mission Slack sends keep existing behavior.

## Hermes vs OpenClaw

Hermes already treats Slack thread ID as a first-class routing primitive. OpenClaw treated thread routing as optional/context-dependent. This patch makes mission-thread routing deterministic for mission-scoped Slack work without routing Melvin through Hermes or changing Atlas/Hermes behavior.

## Fail-Closed Logic

Mission-bound Slack sends are allowed only when a thread can be resolved from explicit parameters, current Slack context, prepared `MessageThreadId`, or the mission-thread registry. If none resolves in the Slack tool/outbound paths, the send is blocked instead of posting top-level.

Thread enforcement is mission-scoped only. Non-mission Slack messages and normal generic sends are not intentionally changed.

## Local JSON Thread Registry

Default path:

```text
~/.openclaw/slack-mission-threads.json
```

Test override:

```text
OPENCLAW_SLACK_MISSION_THREAD_STORE
```

Stored shape:

```json
{
  "missions": {
    "[\"account:<accountId>\",\"<missionId>\"]": {
      "platform": "slack",
      "missionId": "<missionId>",
      "accountId": "<accountId>",
      "teamId": "T...",
      "channelId": "C...",
      "threadTs": "1234567890.123",
      "ownerAgent": "melvin",
      "createdFromMessageTs": "1234567890.123",
      "createdAt": "...",
      "updatedAt": "...",
      "routingPolicy": "thread_required"
    }
  }
}
```

## Restart Survival

The registry is file-backed under `~/.openclaw`, so canonical mission thread routes survive OpenClaw gateway restarts. Registry keys are scoped by Slack account/workspace identity so two Slack accounts can reuse the same mission id without overwriting each other. Live Slack smoke testing confirmed thread routing survived restart before this PR was opened.

## Files Changed

- `extensions/slack/src/action-runtime.ts`
- `extensions/slack/src/mission-threads.test.ts`
- `extensions/slack/src/mission-threads.ts`
- `extensions/slack/src/monitor/message-handler/dispatch.ts`
- `extensions/slack/src/monitor/message-handler/prepare-routing.ts`
- `extensions/slack/src/monitor/message-handler/prepare.test.ts`
- `extensions/slack/src/monitor/message-handler/prepare.ts`
- `extensions/slack/src/outbound-adapter.ts`
- `extensions/slack/src/threading.test.ts`
- `extensions/slack/src/threading.ts`

## Tests Run

```bash
PATH="/Users/chadwick/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm exec oxfmt --check extensions/slack/src/mission-threads.ts extensions/slack/src/mission-threads.test.ts extensions/slack/src/threading.ts extensions/slack/src/threading.test.ts extensions/slack/src/monitor/message-handler/prepare-routing.ts extensions/slack/src/monitor/message-handler/prepare.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/dispatch.ts extensions/slack/src/action-runtime.ts extensions/slack/src/outbound-adapter.ts

PATH="/Users/chadwick/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm exec oxlint --type-aware extensions/slack/src/mission-threads.ts extensions/slack/src/mission-threads.test.ts extensions/slack/src/threading.ts extensions/slack/src/threading.test.ts extensions/slack/src/monitor/message-handler/prepare-routing.ts extensions/slack/src/monitor/message-handler/prepare.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/dispatch.ts extensions/slack/src/action-runtime.ts extensions/slack/src/outbound-adapter.ts

PATH="/Users/chadwick/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm vitest run extensions/slack/src/mission-threads.test.ts extensions/slack/src/threading.test.ts extensions/slack/src/action-runtime.test.ts extensions/slack/src/outbound-adapter.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts extensions/slack/src/monitor.test.ts

PATH="/Users/chadwick/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm lint --threads=8

PATH="/Users/chadwick/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm tsgo:prod

PATH="/Users/chadwick/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm check:changed
```

Result:

- Formatter check passed.
- Type-aware lint passed with 0 warnings and 0 errors.
- 7 test files passed.
- 167 tests passed.
- Full repo lint passed.
- Prod type check passed.
- Changed-file check passed.

## Real behavior proof

Behavior or issue addressed: OpenClaw Slack mission replies could escape the canonical mission thread and post top-level in a channel. The patch makes mission-thread routing deterministic and fail-closed for mission-bound Slack sends.

Real environment tested: Lettuce+ Mac mini OpenClaw runtime for Melvin, connected to Slack Socket Mode in `#melvin-logs` (`C0AKSLA9C81`) with Atlas/Hermes left separate and untouched.

Exact steps or command run after this patch: Started from a canonical top-level Slack mission container, sent an in-thread status prompt, sent an in-thread completion prompt, then inspected `#melvin-logs` channel history for rogue top-level mission updates.

Evidence after fix: Copied live Slack output from the real Melvin/OpenClaw runtime. Earlier restart smoke showed OpenClaw gateway reconnected to Slack Socket Mode, `#melvin-logs` resolved as `C0AKSLA9C81`, Melvin replied in-thread with `Melvin final threaded OK`, no duplicate OpenClaw gateways or duplicate Slack responders were observed, and Atlas/Hermes remained unaffected.

Post-push final PR smoke copied live output:

- Canonical mission thread: `formalize-openclaw-thread-routing-pr-final-smoke-2026-05-11`
- Channel: `#melvin-logs` (`C0AKSLA9C81`)
- Parent thread TS: `1778501088.707619`
- In-thread status reply from Melvin:

```text
STATUS: WORKING
MISSION: formalize-openclaw-thread-routing-pr-final-smoke-2026-05-11
BLOCKED: no
```

- In-thread completion reply from Melvin:

```text
STATUS: COMPLETE
MISSION: formalize-openclaw-thread-routing-pr-final-smoke-2026-05-11
RESULT: thread routing OK
```

Observed result after fix: Channel history after the smoke showed exactly one top-level mission container and three thread replies; zero rogue top-level mission updates.

What was not tested: Live cross-workspace Slack installs and long-term registry cleanup/TTL behavior were not tested. Multi-account registry isolation is covered by unit regression tests.

## Possible Regressions

- Mission detection now requires an explicit `Mission:` line or `mission called:` marker; casual branch-like text such as `fix/...` is intentionally not mission-bound.
- Mission registry records are account/workspace scoped; old unscoped local records may need to be recreated by posting a fresh canonical mission container after upgrade.
- The local JSON registry has no TTL or cleanup policy yet.
- The guard protects inbound mission registration, Slack dispatcher planning, Slack tool sends, and Slack outbound adapter sends. Any future bespoke Slack write path should explicitly preserve the same invariant.

## Non-Mission Behavior

Non-mission Slack sends are intentionally unaffected. Thread enforcement is mission-scoped only and depends on conservative mission detection.

## São Paulo Merge-Risk Audit

- Regressions: low to moderate. The changed dispatcher behavior only forces thread routing when prepared `MessageThreadId` exists or message text is mission-bound.
- Edge cases: stale registry entries, mission rename, missing explicit mission markers, channel mismatch preventing fallback.
- Blast radius: Slack routing only. No payment, deploy, NOSTR, Lightning, or Atlas/Hermes runtime changes.
- Confidence: 4.7/5 after focused tests, full repo lint, prod types, restart verification, and live Slack smoke.
- Recommendation: merge after CI. Then pull main and restart Melvin/OpenClaw only so the runtime patch is no longer local-only.
