### PR TITLE
Use configured reasoning default in session_status

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -202,6 +202,7 @@ function createCommandsStatusRuntimeModuleMock() {
       includeTranscriptUsage?: boolean;
       taskLineOverride?: string;
       resolveDefaultThinkingLevel?: () => unknown;
+      resolvedReasoningLevel?: string;
     }) => {
       resolveQueueSettingsMock({
         channel: params.statusChannel,
@@ -234,6 +235,7 @@ function createCommandsStatusRuntimeModuleMock() {
           model: { primary },
           thinkingDefault:
             configuredAgent?.thinkingDefault ?? (await params.resolveDefaultThinkingLevel?.()),
+          reasoningDefault: params.resolvedReasoningLevel,
         },
         sessionEntry: params.sessionEntry,
         modelAuth,
@@ -458,6 +460,61 @@ describe("session_status tool", () => {
     await tool.execute("call-transcript-usage", {});
 
     expectRecordFields(mockCallArg(buildStatusMessageMock), { includeTranscriptUsage: true });
+  });
+
+  it("inherits configured reasoningDefault when the session has no override", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+    mockConfig = {
+      ...createMockConfig(),
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: {},
+          reasoningDefault: "stream",
+        },
+        list: [{ id: "main", reasoningDefault: "on" }],
+      },
+    };
+
+    const tool = getSessionStatusTool();
+    await tool.execute("call-reasoning-default", {});
+
+    const statusArg = mockCallArg(buildStatusMessageMock) as Record<string, unknown>;
+    const agent = statusArg.agent as Record<string, unknown>;
+    expect(agent.reasoningDefault).toBe("on");
+  });
+
+  it("keeps an explicit session reasoningLevel over configured defaults", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+        reasoningLevel: "off",
+      },
+    });
+    mockConfig = {
+      ...createMockConfig(),
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: {},
+          reasoningDefault: "stream",
+        },
+        list: [{ id: "main", reasoningDefault: "on" }],
+      },
+    };
+
+    const tool = getSessionStatusTool();
+    await tool.execute("call-reasoning-session", {});
+
+    const statusArg = mockCallArg(buildStatusMessageMock) as Record<string, unknown>;
+    const agent = statusArg.agent as Record<string, unknown>;
+    expect(agent.reasoningDefault).toBe("off");
   });
 
   it("passes spawned workspace to session_status auth labels", async () => {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -1,9 +1,10 @@
 import { Type } from "typebox";
-import type {
-  ElevatedLevel,
-  ReasoningLevel,
-  ThinkLevel,
-  VerboseLevel,
+import {
+  normalizeReasoningLevel,
+  type ElevatedLevel,
+  type ReasoningLevel,
+  type ThinkLevel,
+  type VerboseLevel,
 } from "../../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import {
@@ -69,6 +70,24 @@ const commandsStatusRuntimeLoader = createLazyImportLoader<CommandsStatusRuntime
 
 function loadCommandsStatusRuntime(): Promise<CommandsStatusRuntimeModule> {
   return commandsStatusRuntimeLoader.load();
+}
+
+function resolveStatusReasoningLevel(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionEntry: SessionEntry;
+}): ReasoningLevel {
+  const sessionLevel = normalizeReasoningLevel(params.sessionEntry.reasoningLevel);
+  if (sessionLevel) {
+    return sessionLevel;
+  }
+
+  const agentEntry = params.cfg.agents?.list?.find((entry) => entry.id === params.agentId);
+  return (
+    normalizeReasoningLevel(agentEntry?.reasoningDefault) ??
+    normalizeReasoningLevel(params.cfg.agents?.defaults?.reasoningDefault) ??
+    "off"
+  );
 }
 
 function resolveSessionEntry(params: {
@@ -711,7 +730,11 @@ export function createSessionStatusTool(opts?: {
         resolvedThinkLevel: statusSessionEntry.thinkingLevel as ThinkLevel | undefined,
         resolvedFastMode: statusSessionEntry.fastMode,
         resolvedVerboseLevel: (statusSessionEntry.verboseLevel ?? "off") as VerboseLevel,
-        resolvedReasoningLevel: (statusSessionEntry.reasoningLevel ?? "off") as ReasoningLevel,
+        resolvedReasoningLevel: resolveStatusReasoningLevel({
+          cfg,
+          agentId,
+          sessionEntry: statusSessionEntry,
+        }),
         resolvedElevatedLevel: statusSessionEntry.elevatedLevel as ElevatedLevel | undefined,
         resolveDefaultThinkingLevel: async () => {
           const configuredCatalog = buildConfiguredModelCatalog({ cfg });


### PR DESCRIPTION
## Summary
- Resolve `session_status` reasoning display from the active session override first.
- Fall back to the configured per-agent `reasoningDefault`, then global `agents.defaults.reasoningDefault`, then `off`.
- Add focused coverage for inherited defaults and explicit session override precedence.

## Real behavior proof
- **Behavior or issue addressed:** `session_status` previously displayed reasoning as `off` whenever the session had no explicit `reasoningLevel`, even when the active OpenClaw config set `agents.defaults.reasoningDefault` or a per-agent `reasoningDefault`.
- **Real environment tested:** Local macOS OpenClaw checkout at PR commit `9db3d62e00dbb779baa37d35c0b7ba48b69b4d7c`, using isolated temp `OPENCLAW_STATE_DIR`, `OPENCLAW_HOME`, and `OPENCLAW_CONFIG_PATH` values so live user sessions were not mutated.
- **Exact steps or command run after this patch:** Ran the PR branch `session_status` tool implementation against three isolated temp-state configs: global `agents.defaults.reasoningDefault = "stream"` with no session override, per-agent `agents.list[main].reasoningDefault = "on"` over global `"stream"`, and explicit session `reasoningLevel = "off"` over those defaults.
- **Evidence after fix:** Redacted terminal/live output from the isolated setup:

  ```text
  Config: agents.defaults.reasoningDefault = "stream", no session reasoningLevel
  session_status options line: ... Think: low · Text: low · Reasoning: stream · elevated

  Config: agents.list[main].reasoningDefault = "on" over global "stream", no session reasoningLevel
  session_status options line: ... Think: low · Text: low · Reasoning: on · elevated

  Config: same defaults, with session reasoningLevel = "off"
  session_status omitted the reasoning label, preserving explicit session off

  Tool execution result: ok: true
  Non-fatal optional warning: unauthorized: gateway token missing
  ```

- **Observed result after fix:** `session_status` now inherits the configured global/per-agent reasoning default when no session override exists, and still preserves an explicit session `reasoningLevel = "off"` ahead of config defaults.
- **What was not tested:** No known gaps for this status-display path; broader gateway/live provider suites were not rerun for this narrow local default-resolution change.

## Validation
- `pnpm test src/agents/openclaw-tools.session-status.test.ts -- --maxWorkers=1` (passed: 1 file, 57 tests)
- `pnpm tsgo:core`
- `pnpm tsgo:test:src`
