### PR TITLE
[runtime]: fix runtime override precedence over pinned harness

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -755,10 +755,12 @@ describe("embedded attempt harness pinning", () => {
     );
   });
 
-  it("pins a fresh unpinned session to the default PI harness", async () => {
+  it("lets runtime overrides replace stale harness pins", async () => {
     const sessionEntry: SessionEntry = {
-      sessionId: "fresh-session",
+      sessionId: "runtime-override-session",
       updatedAt: Date.now(),
+      agentRuntimeOverride: "custom-harness",
+      agentHarnessId: "pi",
     };
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
@@ -775,11 +777,11 @@ describe("embedded attempt harness pinning", () => {
       sessionAgentId: "main",
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
-      body: "start",
+      body: "continue",
       isFallbackRetry: false,
       resolvedThinkLevel: "medium",
       timeoutMs: 1_000,
-      runId: "run-fresh-no-pin",
+      runId: "run-runtime-override-harness",
       opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
       runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
       spawnedBy: undefined,
@@ -789,12 +791,12 @@ describe("embedded attempt harness pinning", () => {
       agentDir: tmpDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "openai",
-      sessionHasHistory: false,
+      sessionHasHistory: true,
     });
 
     expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        agentHarnessId: "pi",
+        agentHarnessId: "custom-harness",
       }),
     );
   });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -16,7 +16,7 @@ import { getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
 import { FailoverError } from "../failover-error.js";
 import { resolveAgentHarnessPolicy } from "../harness/selection.js";
 import { isCliRuntimeAlias, resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
-import { isCliProvider } from "../model-selection.js";
+import { isCliProvider, normalizeProviderId } from "../model-selection.js";
 import { prepareSessionManagerForRun } from "../pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent, type EmbeddedPiRunResult } from "../pi-embedded.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
@@ -282,6 +282,9 @@ export function runAgentAttempt(params: {
   );
   const bootstrapPromptWarningSignature =
     bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
+  const agentRuntimeOverride = isRawModelRun
+    ? undefined
+    : params.sessionEntry?.agentRuntimeOverride?.trim();
   const sessionPinnedAgentHarnessId = isRawModelRun
     ? "pi"
     : resolveSessionPinnedAgentHarnessId({
@@ -291,10 +294,8 @@ export function runAgentAttempt(params: {
         sessionHasHistory: params.sessionHasHistory,
         sessionId: params.sessionId,
         sessionKey: params.sessionKey ?? params.sessionId,
+        runtimeOverride: agentRuntimeOverride,
       });
-  const agentRuntimeOverride = isRawModelRun
-    ? undefined
-    : params.sessionEntry?.agentRuntimeOverride?.trim();
   const cliExecutionProvider = isRawModelRun
     ? params.providerOverride
     : (resolveCliRuntimeExecutionProvider({
@@ -507,9 +508,20 @@ function resolveSessionPinnedAgentHarnessId(params: {
   sessionHasHistory?: boolean;
   sessionId: string;
   sessionKey: string;
+  runtimeOverride?: string;
 }): string | undefined {
   if (params.sessionEntry?.sessionId !== params.sessionId) {
     return resolveConfiguredAgentHarnessId(params);
+  }
+  const runtimeOverride = params.runtimeOverride?.trim();
+  const normalizedRuntimeOverride = runtimeOverride ? normalizeProviderId(runtimeOverride) : "";
+  if (
+    runtimeOverride &&
+    normalizedRuntimeOverride !== "auto" &&
+    normalizedRuntimeOverride !== "default" &&
+    !isCliRuntimeAlias(runtimeOverride)
+  ) {
+    return runtimeOverride;
   }
   if (params.sessionEntry.agentHarnessId) {
     return params.sessionEntry.agentHarnessId;

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -59,6 +59,7 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "../../agents/auth-profiles.js";
+import { clearAgentHarnesses, registerAgentHarness } from "../../agents/harness/registry.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -156,6 +157,7 @@ function setDirectiveTestProviders(providers: ProviderPlugin[]): void {
 
 beforeEach(() => {
   setDirectiveTestProviders([]);
+  clearAgentHarnesses();
   clearRuntimeAuthProfileStoreSnapshots();
   replaceRuntimeAuthProfileStoreSnapshots([
     {
@@ -172,6 +174,7 @@ beforeEach(() => {
 
 afterEach(() => {
   setDirectiveTestProviders([]);
+  clearAgentHarnesses();
   clearRuntimeAuthProfileStoreSnapshots();
 });
 
@@ -564,15 +567,24 @@ describe("/model chat UX", () => {
     expect(sessionEntry.authProfileOverride).toBe(OPENAI_DATE_PROFILE_ID);
   });
 
-  it("persists provider-compatible runtime overrides for mixed-content messages", async () => {
+  it("persists registered plugin runtime overrides and clears stale harness pins", async () => {
+    registerAgentHarness({
+      id: "custom-harness",
+      label: "Custom Harness",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn() as never,
+    });
+
     const { sessionEntry } = await persistModelDirectiveForTest({
-      command: "/model openai/gpt-4o --runtime codex hello",
+      command: "/model openai/gpt-4o --runtime custom-harness hello",
       allowedModelKeys: ["openai/gpt-4o"],
+      sessionEntry: createSessionEntry({ agentHarnessId: "pi" }),
     });
 
     expect(sessionEntry.providerOverride).toBe("openai");
     expect(sessionEntry.modelOverride).toBe("gpt-4o");
-    expect(sessionEntry.agentRuntimeOverride).toBe("codex");
+    expect(sessionEntry.agentRuntimeOverride).toBe("custom-harness");
+    expect(sessionEntry.agentHarnessId).toBeUndefined();
   });
 
   it("canonicalizes legacy Codex app-server runtime overrides during persistence", async () => {
@@ -588,13 +600,14 @@ describe("/model chat UX", () => {
     const { sessionEntry } = await persistModelDirectiveForTest({
       command: "/model openai/gpt-4o --runtime default hello",
       allowedModelKeys: ["openai/gpt-4o"],
-      sessionEntry: createSessionEntry({ agentRuntimeOverride: "codex" }),
+      sessionEntry: createSessionEntry({ agentHarnessId: "codex", agentRuntimeOverride: "codex" }),
       provider: "openai",
       model: "gpt-4o",
       initialModelLabel: "openai/gpt-4o",
     });
 
     expect(sessionEntry.agentRuntimeOverride).toBeUndefined();
+    expect(sessionEntry.agentHarnessId).toBeUndefined();
   });
 
   it("ignores runtime overrides that do not belong to the selected provider", async () => {

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -5,6 +5,7 @@ import {
 } from "../../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { listAgentHarnessIds } from "../../agents/harness/registry.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { listLegacyRuntimeModelProviderAliases } from "../../agents/model-runtime-aliases.js";
 import { normalizeProviderId, type ModelAliasIndex } from "../../agents/model-selection.js";
@@ -63,6 +64,13 @@ function resolveModelRuntimeOverride(params: {
     if (runtime === aliasRuntime || (aliasRuntime === "codex" && runtime === "codex-app-server")) {
       return { kind: "set", runtime: alias.runtime };
     }
+  }
+
+  const registeredHarnessRuntime = listAgentHarnessIds().find(
+    (id) => normalizeProviderId(id) === runtime,
+  );
+  if (registeredHarnessRuntime) {
+    return { kind: "set", runtime: registeredHarnessRuntime };
   }
 
   return { kind: "invalid", runtime: rawRuntime };
@@ -255,9 +263,17 @@ export async function persistInlineDirectives(params: {
             delete sessionEntry.agentRuntimeOverride;
             updated = true;
           }
+          if (sessionEntry.agentHarnessId) {
+            delete sessionEntry.agentHarnessId;
+            updated = true;
+          }
         } else if (runtimeOverride?.kind === "set") {
           if (sessionEntry.agentRuntimeOverride !== runtimeOverride.runtime) {
             sessionEntry.agentRuntimeOverride = runtimeOverride.runtime;
+            updated = true;
+          }
+          if (sessionEntry.agentHarnessId) {
+            delete sessionEntry.agentHarnessId;
             updated = true;
           }
         } else if (runtimeOverride?.kind === "invalid") {


### PR DESCRIPTION
## Problem

We verified a session state where an explicit runtime override should have higher priority than an existing embedded harness pin, but the agent command path still used the stale `agentHarnessId` first.

That can happen after a session has already been pinned to a harness, then the user switches to a model/runtime combination that should use a custom harness plugin. The persisted session can contain both values:

```json
{
  "agentRuntimeOverride": "custom-harness",
  "agentHarnessId": "pi"
}
```

In that case, the runtime override is the newer and more explicit choice, but the execution path kept passing the old pinned harness id. The custom harness plugin never got selected for the next turn.

## Fix

- Allow `/model <provider>/<model> --runtime <registered harness>` to persist a registered custom harness plugin runtime.
- Clear stale `agentHarnessId` pins when a model runtime override is changed or reset.
- In the agent command path, let non-CLI `agentRuntimeOverride` take precedence over an existing embedded harness pin.

## Validation

```bash
PATH=/Users/bytedance/.nvm/versions/node/v24.8.0/bin:$PATH pnpm vitest run src/auto-reply/reply/directive-handling.model.test.ts src/agents/command/attempt-execution.cli.test.ts
```

Result: 3 test files passed, 75 tests passed.
