### PR TITLE
fix(telegram): escape unrecognized HTML tags before parse_mode=HTML send

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -3,7 +3,7 @@ import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
-import { markdownToTelegramHtml } from "../format.js";
+import { markdownToTelegramHtml, sanitizeTelegramHtml } from "../format.js";
 import { isSafeToRetrySendError, isTelegramRateLimitError } from "../network-errors.js";
 import {
   buildTelegramSendParams,
@@ -111,7 +111,9 @@ export async function sendTelegramText(
   const linkPreviewEnabled = opts?.linkPreview ?? true;
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
   const textMode = opts?.textMode ?? "markdown";
-  const htmlText = textMode === "html" ? text : markdownToTelegramHtml(text);
+  const htmlText = sanitizeTelegramHtml(
+    textMode === "html" ? text : markdownToTelegramHtml(text),
+  );
   const fallbackText = opts?.plainText ?? text;
   const hasFallbackText = fallbackText.trim().length > 0;
   const sendPlainFallback = async () => {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -202,6 +202,27 @@ describe("deliverReplies", () => {
     messageHookRunner.runMessageSent.mockReset();
   });
 
+  it("sanitizes unrecognized HTML tags in text replies (#49104)", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 1,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "Check <tichita> tag" }],
+      runtime,
+      bot,
+    });
+
+    expect(sendMessage.mock.calls[0]?.[0]).toBe("123");
+    expect(sendMessage.mock.calls[0]?.[1]).toContain("&lt;tichita&gt;");
+    expectRecordFields(mockCallArg(sendMessage, 0, 2), {
+      parse_mode: "HTML",
+    });
+  });
+
   it("skips audioAsVoice-only payloads without logging an error", async () => {
     const runtime = createRuntime(false);
 

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -2,8 +2,34 @@ import { describe, expect, it } from "vitest";
 import {
   markdownToTelegramChunks,
   markdownToTelegramHtml,
+  sanitizeTelegramHtml,
   splitTelegramHtmlChunks,
 } from "./format.js";
+
+describe("sanitizeTelegramHtml", () => {
+  it("escapes unrecognized HTML tags and preserves Telegram-supported tags", () => {
+    const cases = [
+      ["escapes unknown tags", "<tichita>hello</tichita>", "&lt;tichita&gt;hello&lt;/tichita&gt;"],
+      ["preserves known tags", "<b>bold</b> <i>italic</i>", "<b>bold</b> <i>italic</i>"],
+      ["preserves anchors", '<a href="https://x.com">link</a>', '<a href="https://x.com">link</a>'],
+      ["preserves blockquote", "<blockquote>q</blockquote>", "<blockquote>q</blockquote>"],
+      ["preserves code/pre", "<code>c</code> <pre>p</pre>", "<code>c</code> <pre>p</pre>"],
+      ["preserves spoiler", "<tg-spoiler>s</tg-spoiler>", "<tg-spoiler>s</tg-spoiler>"],
+      ["preserves span with tg-spoiler class", '<span class="tg-spoiler">s</span>', '<span class="tg-spoiler">s</span>'],
+      ["escapes span without tg-spoiler class", '<span style="color:red">s</span>', '&lt;span style="color:red"&gt;s&lt;/span&gt;'],
+      ["preserves tg-emoji", '<tg-emoji emoji-id="123">😀</tg-emoji>', '<tg-emoji emoji-id="123">😀</tg-emoji>'],
+      ["preserves tg-time", '<tg-time datetime="2026-01-01">Jan 1</tg-time>', '<tg-time datetime="2026-01-01">Jan 1</tg-time>'],
+      ["escapes br tag", "line1<br/>line2", "line1&lt;br/&gt;line2"],
+      ["escapes mixed known and unknown", "<b>bold</b> <unknown>text</unknown>", "<b>bold</b> &lt;unknown&gt;text&lt;/unknown&gt;"],
+      ["escapes self-closing unknown", "<thinking />", "&lt;thinking /&gt;"],
+      ["leaves already-escaped entities untouched", "&lt;tichita&gt;hello", "&lt;tichita&gt;hello"],
+      ["handles angle brackets with no tag", "3 < 5", "3 < 5"],
+    ] as const;
+    for (const [name, input, expected] of cases) {
+      expect(sanitizeTelegramHtml(input), name).toBe(expected);
+    }
+  });
+});
 
 describe("markdownToTelegramHtml", () => {
   it("handles core markdown-to-telegram conversions", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -19,13 +19,45 @@ export function escapeTelegramHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+function escapeHtmlAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
 function escapeHtml(text: string): string {
   return escapeTelegramHtml(text);
 }
 
-function escapeHtmlAttr(text: string): string {
-  return escapeHtml(text).replace(/"/g, "&quot;");
+const TELEGRAM_ALLOWED_HTML_TAGS = new Set([
+  "b", "strong", "i", "em", "u", "ins", "s", "strike", "del",
+  "spoiler", "tg-spoiler", "span", "code", "pre", "a", "blockquote",
+  "tg-emoji", "tg-time",
+]);
+
+/**
+ * Sanitize HTML for Telegram Bot API parse_mode=HTML.
+ * Telegram only supports a subset of HTML tags; unrecognized tags
+ * cause silent truncation. This function escapes angle brackets for
+ * any tag not in the allowed set.
+ *
+ * For <span>, only class="tg-spoiler" is allowed per Telegram docs.
+ */
+export function sanitizeTelegramHtml(html: string): string {
+  return html.replace(/<\/?([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*?>/g, (match, tagName) => {
+    const tag = tagName.toLowerCase();
+    if (TELEGRAM_ALLOWED_HTML_TAGS.has(tag)) {
+      if (tag === "span") {
+        // Only allow span with class="tg-spoiler"
+        if (/\bclass\s*=\s*["']tg-spoiler["']/i.test(match)) {
+          return match;
+        }
+        return match.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      }
+      return match;
+    }
+    return match.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  });
 }
+
 
 /**
  * File extensions that share TLDs and commonly appear in code/documentation.

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -17,7 +17,7 @@ import { buildTypingThreadParams } from "./bot/helpers.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
-import { renderTelegramHtmlText, splitTelegramHtmlChunks } from "./format.js";
+import { renderTelegramHtmlText, sanitizeTelegramHtml, splitTelegramHtmlChunks } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import {
   isRecoverableTelegramNetworkError,
@@ -687,7 +687,7 @@ export async function sendMessageTelegram(
         if (!chunk.htmlText) {
           return await requestPlain(label);
         }
-        const htmlText = chunk.htmlText;
+        const htmlText = chunk.htmlText ? sanitizeTelegramHtml(chunk.htmlText) : undefined;
         const htmlParams: TelegramSendMessageParams = {
           parse_mode: "HTML" as const,
           ...plainParams,
@@ -834,7 +834,7 @@ export async function sendMessageTelegram(
       caption = split.caption;
       followUpText = split.followUpText;
     }
-    const htmlCaption = caption ? renderHtmlText(caption) : undefined;
+    const htmlCaption = caption ? sanitizeTelegramHtml(renderHtmlText(caption)) : undefined;
     // If text exceeds Telegram's caption limit, send media without caption
     // then send text as a separate follow-up message.
     const needsSeparateText = Boolean(followUpText);
@@ -1377,7 +1377,7 @@ export async function editMessageTelegram(
     channel: "telegram",
     accountId: account.accountId,
   });
-  const htmlText = renderTelegramHtmlText(text, { textMode, tableMode });
+  const htmlText = sanitizeTelegramHtml(renderTelegramHtmlText(text, { textMode, tableMode }));
 
   // Reply markup semantics:
   // - buttons === undefined → don't send reply_markup (keep existing)


### PR DESCRIPTION
fix(telegram): escape unrecognized HTML tags before parse_mode=HTML send

When agent responses contain angle-bracket tags (e.g. <tichita>,
<thinking>) and Telegram delivery pipeline sends with parse_mode=HTML,
Telegram's parser silently truncates everything from the unrecognized tag
onward.

The root cause: sendTelegramText() textMode==='html' path passes the raw
text straight through without escaping. Even though markdownToTelegramHtml()
correctly escapes such tags, the direct HTML path and any upstream callers
that feed raw text into textMode='html' are unprotected.

Fix: add sanitizeTelegramHtml() in format.ts that preserves Telegram's
supported HTML tags (b, i, u, code, pre, a, blockquote, spoiler, etc.) and
escapes all others. Wrap sendTelegramText()'s htmlText through it as
defense-in-depth.

Closes #49104

## Real behavior proof

**Behavior or issue addressed**: Telegram messages containing angle-bracket tags like `<tichita>` are silently truncated when sent with `parse_mode=HTML` because Telegram's parser treats unknown tags as invalid HTML and drops everything from that point onward.

**Real environment tested**: Ubuntu 24.04, Node.js v24.14.1 — reproduced the sanitization logic in an isolated script that mirrors the patched `sanitizeTelegramHtml()` behavior.

**Exact steps or command run after this patch**:
1. Save the patched `sanitizeTelegramHtml` logic into a standalone script (`proof-49104.mjs`)
2. Run `node proof-49104.mjs` with input `"Check <tichita> tag and <b>bold</b> text"`
3. Verify that `<tichita>` is escaped to `&lt;tichita&gt;` while `<b>` is preserved

**Evidence after fix**:
Terminal output from running the patched logic directly:

```
=== Before fix (raw text passed to Telegram) ===
Check <tichita> tag and <b>bold</b> text

=== After fix (sanitized for Telegram parse_mode=HTML) ===
Check &lt;tichita&gt; tag and <b>bold</b> text

=== Verification ===
Contains &lt;tichita&gt;: true
Preserves <b>: true
Preserves </b>: true

=== Additional edge cases ===
Self-closing unknown: &lt;thinking /&gt;
Already escaped: &lt;tichita&gt;hello
Not a tag (3 < 5): 3 < 5
```

**Observed result after fix**: The `sanitizeTelegramHtml` function correctly escapes unrecognized tags (`<tichita>`, `<thinking />`) into `&lt;tichita&gt;` and `&lt;thinking /&gt;`, while preserving Telegram-supported tags (`<b>`, `</b>`). Angle brackets that are not tags (`3 < 5`) remain untouched. Already-escaped entities are not double-escaped.

**What was not tested**: Full end-to-end Telegram Bot API live send (requires a real Telegram bot token and chat). The fix relies on the unit and integration tests in the PR for that coverage.

## Test Plan

- New unit tests in `format.test.ts` cover escaping, preservation, and already-escaped entities
- New integration test in `delivery.test.ts` verifies `<tichita>` is escaped before reaching the Telegram API call
