### PR TITLE
Filter assistant process chatter from Dreaming session corpus

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2823,3 +2823,23 @@ describe("previewRemHarness", () => {
     expect(preview.deep.candidates[0]?.snippet).toContain("Always check weather");
   });
 });
+
+describe("dreaming session-corpus candidate hygiene", () => {
+  it("rejects assistant process chatter before session-corpus ingestion", () => {
+    expect(__testing.shouldRejectDreamingSessionCorpusSnippet("Assistant: Need commit PR.")).toBe(true);
+    expect(__testing.shouldRejectDreamingSessionCorpusSnippet("Assistant: Now inspect.")).toBe(true);
+    expect(
+      __testing.shouldRejectDreamingSessionCorpusSnippet(
+        "Assistant: Oops worktree maybe not created yet due first command still running. poll.",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves explicit durable signals", () => {
+    expect(
+      __testing.shouldRejectDreamingSessionCorpusSnippet(
+        "Arthur confirmed PR #249 accepted; verification PASS.",
+      ),
+    ).toBe(false);
+  });
+});

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2842,4 +2842,8 @@ describe("dreaming session-corpus candidate hygiene", () => {
       ),
     ).toBe(false);
   });
+
+  it("preserves non-assistant poll requests", () => {
+    expect(__testing.shouldRejectDreamingSessionCorpusSnippet("User: Please poll.")).toBe(false);
+  });
 });

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -586,6 +586,27 @@ function normalizeSessionCorpusSnippet(value: string): string {
   return value.replace(/\s+/g, " ").trim().slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS);
 }
 
+function shouldRejectDreamingSessionCorpusSnippet(snippet: string): boolean {
+  const value = String(snippet || "").trim();
+  if (!value) return true;
+
+  // Preserve explicit durable signals even when assistant-authored.
+  if (/\bArthur (confirmed|decided|approved|rejected|corrected)\b/i.test(value)) return false;
+  if (/\bdecision\b|\baccepted\b|\bverified\b|\bPASS\b/i.test(value)) return false;
+  if (/\bcommit\s+[0-9a-f]{7,40}\b/i.test(value)) return false;
+  if (/\bPR\s*#\d+\b/i.test(value)) return false;
+
+  // Reject obvious assistant process chatter before it reaches session-corpus.
+  if (/\bAssistant:\s+Need\b/i.test(value)) return true;
+  if (/\bAssistant:\s+Now\b/i.test(value)) return true;
+  if (/\bAssistant:\s+Oops\b/i.test(value)) return true;
+  if (/worktree maybe not created|\bpoll\.?\s*$/i.test(value)) return true;
+  if (/\bNeed commit PR\b|\bcommit PR\b/i.test(value)) return true;
+  if (/^\s*(Assistant:\s*)?(inspect|commit|push|merge|poll)\.?\s*$/i.test(value)) return true;
+
+  return false;
+}
+
 function hashSessionMessageId(value: string): string {
   return createHash("sha1").update(value).digest("hex");
 }
@@ -898,6 +919,9 @@ async function collectSessionIngestionBatches(params: {
       const rawSnippet = lines[index] ?? "";
       const snippet = normalizeSessionCorpusSnippet(rawSnippet);
       if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS) {
+        continue;
+      }
+      if (shouldRejectDreamingSessionCorpusSnippet(snippet)) {
         continue;
       }
       const lineNumber = entry.lineMap[index] ?? index + 1;
@@ -1851,6 +1875,7 @@ async function runPhaseIfTriggered(
 export const __testing = {
   runPhaseIfTriggered,
   previewRemDreaming,
+  shouldRejectDreamingSessionCorpusSnippet,
   constants: {
     LIGHT_SLEEP_EVENT_TEXT,
     REM_SLEEP_EVENT_TEXT,

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -587,22 +587,44 @@ function normalizeSessionCorpusSnippet(value: string): string {
 }
 
 function shouldRejectDreamingSessionCorpusSnippet(snippet: string): boolean {
-  const value = String(snippet || "").trim();
-  if (!value) return true;
+  const value = snippet.trim();
+  if (!value) {
+    return true;
+  }
 
   // Preserve explicit durable signals even when assistant-authored.
-  if (/\bArthur (confirmed|decided|approved|rejected|corrected)\b/i.test(value)) return false;
-  if (/\bdecision\b|\baccepted\b|\bverified\b|\bPASS\b/i.test(value)) return false;
-  if (/\bcommit\s+[0-9a-f]{7,40}\b/i.test(value)) return false;
-  if (/\bPR\s*#\d+\b/i.test(value)) return false;
+  if (/\bArthur (confirmed|decided|approved|rejected|corrected)\b/i.test(value)) {
+    return false;
+  }
+  if (/\bdecision\b|\baccepted\b|\bverified\b|\bPASS\b/i.test(value)) {
+    return false;
+  }
+  if (/\bcommit\s+[0-9a-f]{7,40}\b/i.test(value)) {
+    return false;
+  }
+  if (/\bPR\s*#\d+\b/i.test(value)) {
+    return false;
+  }
 
   // Reject obvious assistant process chatter before it reaches session-corpus.
-  if (/\bAssistant:\s+Need\b/i.test(value)) return true;
-  if (/\bAssistant:\s+Now\b/i.test(value)) return true;
-  if (/\bAssistant:\s+Oops\b/i.test(value)) return true;
-  if (/worktree maybe not created|\bpoll\.?\s*$/i.test(value)) return true;
-  if (/\bNeed commit PR\b|\bcommit PR\b/i.test(value)) return true;
-  if (/^\s*(Assistant:\s*)?(inspect|commit|push|merge|poll)\.?\s*$/i.test(value)) return true;
+  if (/\bAssistant:\s+Need\b/i.test(value)) {
+    return true;
+  }
+  if (/\bAssistant:\s+Now\b/i.test(value)) {
+    return true;
+  }
+  if (/\bAssistant:\s+Oops\b/i.test(value)) {
+    return true;
+  }
+  if (/\bAssistant:\s+.*(?:worktree maybe not created|\bpoll\.?\s*$)/i.test(value)) {
+    return true;
+  }
+  if (/\bNeed commit PR\b|\bcommit PR\b/i.test(value)) {
+    return true;
+  }
+  if (/^\s*(Assistant:\s*)?(inspect|commit|push|merge|poll)\.?\s*$/i.test(value)) {
+    return true;
+  }
 
   return false;
 }


### PR DESCRIPTION
Fixes #80664. Adds a conservative Dreaming session-corpus hygiene gate that rejects obvious assistant internal process chatter (e.g. `Assistant: Need commit PR`, `Assistant: Now inspect`, `Assistant: Oops ... poll`) before snippets enter session-corpus recall and Light/REM/Deep candidate surfaces, while preserving explicit durable signals such as Arthur/user decisions, verified/PASS artifacts, PR numbers, and commit SHAs.

Validation: added focused tests in `dreaming-phases.test.ts`. Local targeted vitest could not run in the original clone because Corepack/pnpm reported `spawnSync pnpm ENOENT` during dependency setup, so tests are included for CI. After that, this branch was also exercised with the real Dreaming light-session ingestion path against a temporary redacted OpenClaw workspace; proof below.

## Real behavior proof

- Behavior or issue addressed: Dreaming session-corpus ingestion should reject obvious assistant internal process chatter before it can enter session-corpus recall / Light / REM / Deep candidate surfaces, while preserving durable decision and verification signals.
- Real environment tested: OpenClaw branch `memory-dreaming-session-corpus-filter` at commit `55b333c6b604df07016a050cb67d3342f8d961ef`, run on a Linux OpenClaw workspace clone with Node `v22.22.0`. The run created a temporary real OpenClaw workspace under `/tmp`, wrote a redacted session transcript under that workspace's `OPENCLAW_STATE_DIR`, then invoked the branch's Dreaming light-session ingestion hook.
- Exact steps or command run after this patch:

```bash
cd /root/.openclaw/workspace/tmp/pr80666-proof/openclaw
git checkout pr-80666
git rev-parse HEAD  # 55b333c6b604df07016a050cb67d3342f8d961ef
node --import tsx tmp/pr80666-real-proof.ts | tee /root/.openclaw/workspace/tmp/pr80666-proof/proof-output.txt
```

- Evidence after fix (terminal capture / copied live output, paths redacted):

```text
PR #80666 Dreaming session-corpus real-workspace proof
repo_head=/root/.openclaw/workspace/tmp/pr80666-proof/openclaw
workspace=/tmp/openclaw-pr80666-real-workspace-REDACTED
state_dir=/tmp/openclaw-pr80666-real-workspace-REDACTED/.state
session_transcript=/tmp/openclaw-pr80666-real-workspace-REDACTED/.state/agents/main/sessions/real-pr80666-redacted-session.jsonl
hook_result={"handled":true,"reason":"memory-core: light dreaming processed"}
corpus_path=/tmp/openclaw-pr80666-real-workspace-REDACTED/memory/.dreams/session-corpus/2026-05-12.txt
rejected:PASS_ABSENT:Assistant: Need commit PR.
rejected:PASS_ABSENT:Assistant: Now inspect.
rejected:PASS_ABSENT:Assistant: Oops worktree maybe not created yet due first command still running. poll.
preserved:PASS_PRESENT:Arthur confirmed PR #80666 accepted; verification PASS; commit c33055e8e2ddc12a3ccdac28cfcf0ad5e1be5940.
preserved:PASS_PRESENT:Assistant: The durable decision is recorded with PR #80666 and PASS evidence.
--- redacted corpus excerpt ---
[main/sessions/main/real-pr80666-redacted-session.jsonl#L4] User: Arthur confirmed PR #80666 accepted; verification PASS; commit c33055e8e2ddc12a3ccdac28cfcf0ad5e1be5940.
[main/sessions/main/real-pr80666-redacted-session.jsonl#L5] Assistant: Assistant: The durable decision is recorded with PR #80666 and PASS evidence.
--- end excerpt ---
```

- Observed result after fix: The generated `memory/.dreams/session-corpus/2026-05-12.txt` omitted all three assistant process-chatter samples (`Need commit PR`, `Now inspect`, and `Oops ... poll`) and retained the durable `Arthur confirmed PR #80666 ... PASS ... commit c33055e8...` signal plus an assistant-authored durable PR/PASS line. This shows the new ingestion-boundary filter runs before the session-corpus artifact is written, while durable PR / PASS / commit evidence is still available to later Dreaming candidate surfaces.
- What was not tested: Full production user data and screenshot/recording capture were not used; the live output above used a temporary redacted workspace and copied terminal output. Full CI remains supplemental.


