### PR TITLE
fix(gateway): reduce WebChat ingress latency

### DIFF
--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -25,6 +25,7 @@ Status: the macOS/iOS SwiftUI chat UI talks directly to the Gateway WebSocket.
 - The UI connects to the Gateway WebSocket and uses `chat.history`, `chat.send`, and `chat.inject`.
 - `chat.history` is bounded for stability: Gateway may truncate long text fields, omit heavy metadata, and replace oversized entries with `[chat.history omitted: message too large]`.
 - `chat.history` follows the active transcript branch for modern append-only session files, so abandoned rewrite branches and superseded prompt copies are not rendered in WebChat.
+- `chat.send` eagerly persists WebChat agent-run user turns before agent-lane dispatch. Pi skips re-persisting that same user turn only when the active run session matches the eager transcript write. Ephemeral side-result commands such as `/btw` stay out of the durable transcript.
 - Compaction entries render as an explicit compacted-history divider. The divider explains that earlier turns are preserved in a checkpoint and links to the Sessions checkpoint controls, where operators can branch or restore the pre-compaction view when their permissions allow it.
 - Control UI remembers the backing Gateway `sessionId` returned by `chat.history` and includes it on follow-up `chat.send` calls, so reconnects and page refreshes continue the same stored conversation unless the user starts or resets a session.
 - Control UI coalesces duplicate in-flight submits for the same session, message, and attachments before generating a new `chat.send` run id; the Gateway still dedupes repeated requests that reuse the same idempotency key.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -965,7 +965,28 @@ export async function runEmbeddedPiAgent(
       const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit(params.config);
       let activeSessionId = params.sessionId;
       let activeSessionFile = params.sessionFile;
-      let suppressNextUserMessagePersistence = params.suppressNextUserMessagePersistence ?? false;
+      const suppressionSessionId = normalizeOptionalString(
+        params.suppressNextUserMessagePersistenceSessionId,
+      );
+      let suppressNextUserMessagePersistence =
+        params.suppressNextUserMessagePersistence === true &&
+        (!suppressionSessionId || suppressionSessionId === params.sessionId);
+      let suppressNextUserMessagePersistenceEntryId = suppressNextUserMessagePersistence
+        ? normalizeOptionalString(params.suppressNextUserMessagePersistenceEntryId)
+        : undefined;
+      if (
+        params.suppressNextUserMessagePersistence === true &&
+        suppressionSessionId &&
+        suppressionSessionId !== params.sessionId
+      ) {
+        log.warn(
+          `ignored eager user transcript suppression after session rollover: sessionKey=${sanitizeForLog(
+            params.sessionKey ?? "",
+          )} persistedSessionId=${redactRunIdentifier(
+            sanitizeForLog(suppressionSessionId),
+          )} activeSessionId=${redactRunIdentifier(sanitizeForLog(params.sessionId))}`,
+        );
+      }
       // Pi owns JSONL persistence; this marker only lets the outer retry avoid
       // replaying the same inbound channel message after overflow compaction.
       let lastPersistedCurrentMessageId: string | number | undefined;
@@ -980,6 +1001,7 @@ export async function runEmbeddedPiAgent(
       const continueFromCurrentTranscript = () => {
         nextAttemptPromptOverride = MID_TURN_PRECHECK_CONTINUATION_PROMPT;
         suppressNextUserMessagePersistence = true;
+        suppressNextUserMessagePersistenceEntryId = undefined;
       };
       const maybeEscalateRateLimitProfileFallback = (params: {
         failoverProvider: string;
@@ -1372,6 +1394,7 @@ export async function runEmbeddedPiAgent(
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
             suppressNextUserMessagePersistence,
+            suppressNextUserMessagePersistenceEntryId,
             onUserMessagePersisted,
           })
             .catch((err: unknown): never => {
@@ -1887,6 +1910,7 @@ export async function runEmbeddedPiAgent(
                   // compacted transcript and suppress the next user append.
                   nextAttemptPromptOverride = MID_TURN_PRECHECK_CONTINUATION_PROMPT;
                   suppressNextUserMessagePersistence = true;
+                  suppressNextUserMessagePersistenceEntryId = undefined;
                 }
                 continue;
               }

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  makeAgentAssistantMessage,
+  makeAgentUserMessage,
+} from "../../test-helpers/agent-message-fixtures.js";
 
 const musicGenerationTaskStatusMocks = vi.hoisted(() => ({
   buildActiveMusicGenerationTaskPromptContextForSession: vi.fn(),
@@ -28,6 +32,8 @@ vi.mock("../../../plugins/host-hook-state.js", () => hostHookStateMocks);
 
 import {
   forgetPromptBuildDrainCacheForRun,
+  resolveTrailingUserPromptRepair,
+  resolveSuppressedCurrentUserTranscriptContext,
   resolvePromptSubmissionSkipReason,
   resolveAttemptPrependSystemContext,
   resolvePromptBuildHookResult,
@@ -141,6 +147,124 @@ describe("resolvePromptSubmissionSkipReason", () => {
         imageCount: 0,
       }),
     ).toBe("empty_prompt_history_images");
+  });
+});
+
+describe("resolveSuppressedCurrentUserTranscriptContext", () => {
+  it("removes the eagerly persisted current user turn from model history", () => {
+    const earlier = makeAgentAssistantMessage({
+      content: [{ type: "text", text: "ready" }],
+      timestamp: 1,
+    });
+    const eagerUser = makeAgentUserMessage({ content: "ship it", timestamp: 2 });
+
+    const result = resolveSuppressedCurrentUserTranscriptContext({
+      messages: [earlier, eagerUser],
+      leafEntry: {
+        type: "message",
+        id: "entry-eager",
+        message: eagerUser,
+      },
+      suppressNextUserMessagePersistence: true,
+      suppressNextUserMessagePersistenceEntryId: "entry-eager",
+    });
+
+    expect(result.suppressed).toBe(true);
+    expect(result.messages).toEqual([earlier]);
+  });
+
+  it("keeps history unchanged when the suppression entry id does not match the active leaf", () => {
+    const eagerUser = makeAgentUserMessage({ content: "ship it", timestamp: 2 });
+
+    const result = resolveSuppressedCurrentUserTranscriptContext({
+      messages: [eagerUser],
+      leafEntry: {
+        type: "message",
+        id: "entry-other",
+        message: eagerUser,
+      },
+      suppressNextUserMessagePersistence: true,
+      suppressNextUserMessagePersistenceEntryId: "entry-eager",
+    });
+
+    expect(result.suppressed).toBe(false);
+    expect(result.messages).toEqual([eagerUser]);
+  });
+
+  it("keeps history unchanged when no eager transcript entry id is supplied", () => {
+    const eagerUser = makeAgentUserMessage({ content: "ship it", timestamp: 2 });
+
+    const result = resolveSuppressedCurrentUserTranscriptContext({
+      messages: [eagerUser],
+      leafEntry: {
+        type: "message",
+        id: "entry-eager",
+        message: eagerUser,
+      },
+      suppressNextUserMessagePersistence: true,
+    });
+
+    expect(result.suppressed).toBe(false);
+    expect(result.messages).toEqual([eagerUser]);
+  });
+});
+
+describe("resolveTrailingUserPromptRepair", () => {
+  it("repairs the older trailing user left after eager current-user suppression", () => {
+    const earlier = makeAgentAssistantMessage({
+      content: [{ type: "text", text: "ready" }],
+      timestamp: 1,
+    });
+    const olderUser = makeAgentUserMessage({ content: "older active turn", timestamp: 2 });
+    const eagerUser = makeAgentUserMessage({ content: "current inbound turn", timestamp: 3 });
+
+    const suppressed = resolveSuppressedCurrentUserTranscriptContext({
+      messages: [earlier, olderUser, eagerUser],
+      leafEntry: {
+        type: "message",
+        id: "entry-eager",
+        message: eagerUser,
+      },
+      suppressNextUserMessagePersistence: true,
+      suppressNextUserMessagePersistenceEntryId: "entry-eager",
+    });
+
+    const repair = resolveTrailingUserPromptRepair({
+      prompt: "current inbound turn",
+      trigger: "user",
+      messages: suppressed.messages,
+    });
+
+    expect(repair.repaired).toBe(true);
+    expect(repair.merged).toBe(true);
+    expect(repair.removeMessage).toBe(true);
+    expect(repair.messages).toEqual([earlier]);
+    expect(repair.prompt).toBe(
+      "[Queued user message that arrived while the previous turn was still active]\n" +
+        "older active turn\n\n" +
+        "current inbound turn",
+    );
+  });
+
+  it("leaves model history unchanged when it does not end with a user message", () => {
+    const earlier = makeAgentAssistantMessage({
+      content: [{ type: "text", text: "ready" }],
+      timestamp: 1,
+    });
+
+    const repair = resolveTrailingUserPromptRepair({
+      prompt: "current inbound turn",
+      trigger: "user",
+      messages: [earlier],
+    });
+
+    expect(repair).toEqual({
+      prompt: "current inbound turn",
+      messages: [earlier],
+      repaired: false,
+      merged: false,
+      removeMessage: false,
+    });
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type {
   ContextEnginePromptCacheInfo,
@@ -452,6 +453,83 @@ export function mergeOrphanedTrailingUserPrompt(params: {
     merged: true,
     removeLeaf: true,
   };
+}
+
+export function resolveTrailingUserPromptRepair(params: {
+  prompt: string;
+  trigger: EmbeddedRunAttemptParams["trigger"];
+  messages: AgentMessage[];
+  mergeOrphanedTrailingUserPrompt?: typeof mergeOrphanedTrailingUserPrompt;
+}): {
+  prompt: string;
+  messages: AgentMessage[];
+  repaired: boolean;
+  merged: boolean;
+  removeMessage: boolean;
+} {
+  const trailingMessage = params.messages.at(-1);
+  if (!isUserMessage(trailingMessage)) {
+    return {
+      prompt: params.prompt,
+      messages: params.messages,
+      repaired: false,
+      merged: false,
+      removeMessage: false,
+    };
+  }
+  const promptMerge = (params.mergeOrphanedTrailingUserPrompt ?? mergeOrphanedTrailingUserPrompt)({
+    prompt: params.prompt,
+    trigger: params.trigger,
+    leafMessage: trailingMessage,
+  });
+  return {
+    prompt: promptMerge.prompt,
+    messages: promptMerge.removeLeaf ? params.messages.slice(0, -1) : params.messages,
+    repaired: true,
+    merged: promptMerge.merged,
+    removeMessage: promptMerge.removeLeaf,
+  };
+}
+
+function isUserMessage(value: unknown): value is Extract<AgentMessage, { role: "user" }> {
+  return Boolean(
+    value && typeof value === "object" && (value as { role?: unknown }).role === "user",
+  );
+}
+
+export function resolveSuppressedCurrentUserTranscriptContext(params: {
+  messages: AgentMessage[];
+  leafEntry?: {
+    id?: string;
+    type?: string;
+    message?: AgentMessage;
+  };
+  suppressNextUserMessagePersistence?: boolean;
+  suppressNextUserMessagePersistenceEntryId?: string;
+}): { messages: AgentMessage[]; suppressed: boolean } {
+  if (params.suppressNextUserMessagePersistence !== true) {
+    return { messages: params.messages, suppressed: false };
+  }
+  if (!params.suppressNextUserMessagePersistenceEntryId) {
+    return { messages: params.messages, suppressed: false };
+  }
+  const leafEntry = params.leafEntry;
+  if (leafEntry?.type !== "message" || !isUserMessage(leafEntry.message)) {
+    return { messages: params.messages, suppressed: false };
+  }
+  if (leafEntry.id !== params.suppressNextUserMessagePersistenceEntryId) {
+    return { messages: params.messages, suppressed: false };
+  }
+  const lastMessage = params.messages.at(-1);
+  if (!isUserMessage(lastMessage)) {
+    return { messages: params.messages, suppressed: false };
+  }
+  const leafText = extractUserMessagePromptText(leafEntry.message.content);
+  const lastText = extractUserMessagePromptText(lastMessage.content);
+  if (lastMessage !== leafEntry.message && (!leafText || leafText !== lastText)) {
+    return { messages: params.messages, suppressed: false };
+  }
+  return { messages: params.messages.slice(0, -1), suppressed: true };
 }
 
 export function resolveAttemptFsWorkspaceOnly(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -301,6 +301,8 @@ import {
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
   resolvePromptSubmissionSkipReason,
+  resolveSuppressedCurrentUserTranscriptContext,
+  resolveTrailingUserPromptRepair,
   shouldWarnOnOrphanedUserRepair,
   shouldInjectHeartbeatPrompt,
 } from "./attempt.prompt-helpers.js";
@@ -380,6 +382,7 @@ export {
   resolveAttemptPrependSystemContext,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
+  resolveTrailingUserPromptRepair,
   shouldWarnOnOrphanedUserRepair,
   shouldInjectHeartbeatPrompt,
 } from "./attempt.prompt-helpers.js";
@@ -1893,6 +1896,18 @@ export async function runEmbeddedAttempt(
         applySystemPromptOverrideToSession(activeSession, "");
         systemPromptText = "";
       }
+      const eagerUserTranscriptSuppression = resolveSuppressedCurrentUserTranscriptContext({
+        messages: activeSession.agent.state.messages,
+        leafEntry: isRawModelRun ? undefined : sessionManager.getLeafEntry(),
+        suppressNextUserMessagePersistence: params.suppressNextUserMessagePersistence,
+        suppressNextUserMessagePersistenceEntryId: params.suppressNextUserMessagePersistenceEntryId,
+      });
+      if (eagerUserTranscriptSuppression.suppressed) {
+        // The gateway already persisted this WebChat user turn. Keep the JSONL
+        // leaf so Pi appends the assistant below it, but don't replay that same
+        // user turn in history while also submitting it as the current prompt.
+        activeSession.agent.state.messages = eagerUserTranscriptSuppression.messages;
+      }
       if (typeof activeSession.agent.convertToLlm === "function") {
         const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
         activeSession.agent.convertToLlm = async (messages) =>
@@ -3047,7 +3062,36 @@ export async function runEmbeddedAttempt(
         );
         // Repair orphaned trailing user messages so new prompts don't violate role ordering.
         const leafEntry = isRawModelRun ? null : sessionManager.getLeafEntry();
-        if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
+        if (eagerUserTranscriptSuppression.suppressed) {
+          const orphanPromptMerge = resolveTrailingUserPromptRepair({
+            prompt: effectivePrompt,
+            trigger: params.trigger,
+            messages: activeSession.agent.state.messages,
+            mergeOrphanedTrailingUserPrompt:
+              resolveMessageMergeStrategy().mergeOrphanedTrailingUserPrompt,
+          });
+          if (orphanPromptMerge.repaired) {
+            effectivePrompt = orphanPromptMerge.prompt;
+            activeSession.agent.state.messages = orphanPromptMerge.messages;
+            const orphanRepairMessage =
+              `${
+                orphanPromptMerge.removeMessage
+                  ? orphanPromptMerge.merged
+                    ? "Merged and removed"
+                    : "Removed already-queued"
+                  : "Preserved"
+              } orphaned user message` +
+              (orphanPromptMerge.removeMessage
+                ? " from model history while preserving the eager session leaf. "
+                : " without changing model history. ") +
+              `runId=${params.runId} sessionId=${params.sessionId} trigger=${params.trigger}`;
+            if (shouldWarnOnOrphanedUserRepair(params.trigger)) {
+              log.warn(orphanRepairMessage);
+            } else {
+              log.debug(orphanRepairMessage);
+            }
+          }
+        } else if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
           const orphanPromptMerge = resolveMessageMergeStrategy().mergeOrphanedTrailingUserPrompt({
             prompt: effectivePrompt,
             trigger: params.trigger,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -220,6 +220,8 @@ export type RunEmbeddedPiAgentParams = {
    */
   allowTransientCooldownProbe?: boolean;
   suppressNextUserMessagePersistence?: boolean;
+  suppressNextUserMessagePersistenceSessionId?: string;
+  suppressNextUserMessagePersistenceEntryId?: string;
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
   /**
    * Dispose bundled MCP runtimes when the overall run ends instead of preserving

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -82,6 +82,34 @@ function redactTranscriptMessage(message: AgentMessage, cfg?: OpenClawConfig): A
   } as unknown as AgentMessage;
 }
 
+export function applySessionMessagePersistenceTransforms(params: {
+  message: AgentMessage;
+  config?: OpenClawConfig;
+  inputProvenance?: InputProvenance;
+  agentId?: string;
+  sessionKey?: string;
+  runBeforeMessageWriteHooks?: boolean;
+}): AgentMessage | null {
+  let message = applyInputProvenanceToUserMessage(params.message, params.inputProvenance);
+  const hookRunner = getGlobalHookRunner();
+  if (params.runBeforeMessageWriteHooks && hookRunner?.hasHooks("before_message_write")) {
+    const result = hookRunner.runBeforeMessageWrite(
+      { message },
+      {
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      },
+    );
+    if (result?.block) {
+      return null;
+    }
+    if (result?.message) {
+      message = result.message;
+    }
+  }
+  return redactTranscriptMessage(message, params.config);
+}
+
 /**
  * Apply the tool-result guard to a SessionManager exactly once and expose
  * a flush method on the instance for easy teardown handling.

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -45,6 +45,12 @@ export type GetReplyOptions = {
   images?: ImageContent[];
   /** Original inline/offloaded attachment order for inbound images. */
   imageOrder?: PromptImageOrderEntry[];
+  /** If true, Pi should not persist the next user message because the caller already did. */
+  suppressNextUserMessagePersistence?: boolean;
+  /** Session id that already owns the eagerly persisted user message. */
+  suppressNextUserMessagePersistenceSessionId?: string;
+  /** Transcript entry id that already owns the eagerly persisted user message. */
+  suppressNextUserMessagePersistenceEntryId?: string;
   /** Notifies when an agent run actually starts (useful for webchat command handling). */
   onAgentRunStart?: (runId: string) => void;
   onReplyStart?: () => Promise<void> | void;

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -92,5 +92,9 @@ export function buildEmbeddedRunBaseParams(params: {
     timeoutMs: params.run.timeoutMs,
     runId: params.runId,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    suppressNextUserMessagePersistence: params.run.suppressNextUserMessagePersistence,
+    suppressNextUserMessagePersistenceSessionId:
+      params.run.suppressNextUserMessagePersistenceSessionId,
+    suppressNextUserMessagePersistenceEntryId: params.run.suppressNextUserMessagePersistenceEntryId,
   };
 }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -314,6 +314,11 @@ export function createFollowupRunner(params: {
                 verboseLevel: run.verboseLevel,
                 reasoningLevel: run.reasoningLevel,
                 suppressToolErrorWarnings: opts?.suppressToolErrorWarnings,
+                suppressNextUserMessagePersistence: run.suppressNextUserMessagePersistence,
+                suppressNextUserMessagePersistenceSessionId:
+                  run.suppressNextUserMessagePersistenceSessionId,
+                suppressNextUserMessagePersistenceEntryId:
+                  run.suppressNextUserMessagePersistenceEntryId,
                 execOverrides: run.execOverrides,
                 bashElevated: run.bashElevated,
                 timeoutMs: run.timeoutMs,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1050,6 +1050,10 @@ export async function runPreparedReply(
       extraSystemPromptStatic: extraSystemPromptStaticParts.join("\n\n"),
       skipProviderRuntimeHints: useFastReplyRuntime,
       allowEmptyAssistantReplyAsSilent,
+      suppressNextUserMessagePersistence: opts?.suppressNextUserMessagePersistence,
+      suppressNextUserMessagePersistenceSessionId:
+        opts?.suppressNextUserMessagePersistenceSessionId,
+      suppressNextUserMessagePersistenceEntryId: opts?.suppressNextUserMessagePersistenceEntryId,
       ...(!useFastReplyRuntime &&
       isReasoningTagProvider(provider, {
         config: cfg,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -101,6 +101,9 @@ export type FollowupRun = {
     skipProviderRuntimeHints?: boolean;
     silentExpected?: boolean;
     allowEmptyAssistantReplyAsSilent?: boolean;
+    suppressNextUserMessagePersistence?: boolean;
+    suppressNextUserMessagePersistenceSessionId?: string;
+    suppressNextUserMessagePersistenceEntryId?: string;
   };
 };
 

--- a/src/gateway/server-methods/chat-user-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-user-transcript-persistence.ts
@@ -1,0 +1,180 @@
+import { getCliSessionBinding } from "../../agents/cli-session.js";
+import {
+  isEmbeddedPiRunActive,
+  resolveActiveEmbeddedRunSessionId,
+} from "../../agents/pi-embedded-runner/runs.js";
+import { initSessionState } from "../../auto-reply/reply/session.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import {
+  DEFAULT_RESET_TRIGGERS,
+  evaluateSessionFreshness,
+  resolveChannelResetConfig,
+  resolveSessionLifecycleTimestamps,
+  resolveSessionResetPolicy,
+  resolveSessionResetType,
+  resolveThreadFlag,
+  type SessionEntry,
+} from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadSessionEntry } from "../session-utils.js";
+import type { GatewayRequestContext } from "./types.js";
+
+export type ChatSendTranscriptSessionTarget = {
+  storePath: string;
+  entry?: SessionEntry;
+  sessionId?: string;
+  sessionKey: string;
+};
+
+export function isChatSendResetCommandMessage(message: string, cfg: OpenClawConfig): boolean {
+  const trimmed = message.trim().toLowerCase();
+  if (!trimmed) {
+    return false;
+  }
+  const resetTriggers = cfg.session?.resetTriggers?.length
+    ? cfg.session.resetTriggers
+    : DEFAULT_RESET_TRIGGERS;
+  for (const trigger of resetTriggers) {
+    const normalized = trigger.trim().toLowerCase();
+    if (!normalized) {
+      continue;
+    }
+    if (trimmed === normalized || trimmed.startsWith(`${normalized} `)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasProviderOwnedSessionEntry(entry: SessionEntry | undefined): boolean {
+  const provider =
+    typeof entry?.providerOverride === "string" ? entry.providerOverride : entry?.modelProvider;
+  return Boolean(provider && getCliSessionBinding(entry, provider));
+}
+
+export function isChatSendSessionBusyForEagerPersistence(params: {
+  context: Pick<GatewayRequestContext, "chatAbortControllers">;
+  rawSessionKey: string;
+  sessionKey: string;
+  clientRunId: string;
+  sessionId?: string;
+}): boolean {
+  for (const [runId, active] of params.context.chatAbortControllers) {
+    if (runId === params.clientRunId) {
+      continue;
+    }
+    if (active.sessionKey === params.rawSessionKey || active.sessionKey === params.sessionKey) {
+      return true;
+    }
+  }
+
+  const activeSessionId =
+    resolveActiveEmbeddedRunSessionId(params.sessionKey) ??
+    resolveActiveEmbeddedRunSessionId(params.rawSessionKey) ??
+    params.sessionId;
+  return Boolean(activeSessionId && isEmbeddedPiRunActive(activeSessionId));
+}
+
+function isGroupChatContext(ctx: MsgContext): boolean {
+  const chatType = typeof ctx.ChatType === "string" ? ctx.ChatType.toLowerCase() : "";
+  return chatType === "group" || chatType === "channel";
+}
+
+function shouldRefreshChatSendTranscriptSessionTarget(params: {
+  cfg: OpenClawConfig;
+  ctx: MsgContext;
+  sessionKey: string;
+  entry?: SessionEntry;
+  storePath: string;
+  agentId: string;
+  now: number;
+}): boolean {
+  const entry = params.entry;
+  if (
+    !entry?.sessionId ||
+    typeof entry.updatedAt !== "number" ||
+    !Number.isFinite(entry.updatedAt)
+  ) {
+    return false;
+  }
+  const sessionCfg = params.cfg.session;
+  const isThread = resolveThreadFlag({
+    sessionKey: params.sessionKey,
+    messageThreadId: params.ctx.MessageThreadId,
+    threadLabel: params.ctx.ThreadLabel,
+    threadStarterBody: params.ctx.ThreadStarterBody,
+    parentSessionKey: params.ctx.ParentSessionKey,
+  });
+  const resetPolicy = resolveSessionResetPolicy({
+    sessionCfg,
+    resetType: resolveSessionResetType({
+      sessionKey: params.sessionKey,
+      isGroup: isGroupChatContext(params.ctx),
+      isThread,
+    }),
+    resetOverride: resolveChannelResetConfig({
+      sessionCfg,
+      channel:
+        (params.ctx.OriginatingChannel as string | undefined) ??
+        params.ctx.Surface ??
+        params.ctx.Provider,
+    }),
+  });
+  if (hasProviderOwnedSessionEntry(entry) && resetPolicy.configured !== true) {
+    return false;
+  }
+  const lifecycleTimestamps = resolveSessionLifecycleTimestamps({
+    entry,
+    agentId: params.agentId,
+    storePath: params.storePath,
+  });
+  return !evaluateSessionFreshness({
+    updatedAt: entry.updatedAt,
+    sessionStartedAt: lifecycleTimestamps.sessionStartedAt,
+    lastInteractionAt: lifecycleTimestamps.lastInteractionAt,
+    now: params.now,
+    policy: resetPolicy,
+  }).fresh;
+}
+
+export async function resolveChatSendTranscriptSessionTarget(params: {
+  sessionKey: string;
+  backingSessionId?: string;
+  cfg: OpenClawConfig;
+  ctx: MsgContext;
+  agentId: string;
+  message: string;
+  now: number;
+}): Promise<ChatSendTranscriptSessionTarget> {
+  const { storePath, entry } = loadSessionEntry(params.sessionKey, { skipCache: true });
+  if (
+    !isChatSendResetCommandMessage(params.message, params.cfg) &&
+    shouldRefreshChatSendTranscriptSessionTarget({
+      cfg: params.cfg,
+      ctx: params.ctx,
+      sessionKey: params.sessionKey,
+      entry,
+      storePath,
+      agentId: params.agentId,
+      now: params.now,
+    })
+  ) {
+    const initialized = await initSessionState({
+      ctx: params.ctx,
+      cfg: params.cfg,
+      commandAuthorized: true,
+    });
+    return {
+      storePath: initialized.storePath,
+      entry: initialized.sessionEntry,
+      sessionId: initialized.sessionId,
+      sessionKey: initialized.sessionKey,
+    };
+  }
+  return {
+    storePath,
+    entry,
+    sessionId: entry?.sessionId ?? params.backingSessionId,
+    sessionKey: params.sessionKey,
+  };
+}

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -3263,6 +3263,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await waitForAssertion(() => {
       expect(mockState.maxActiveSaveMediaCalls).toBe(1);
       expect(mockState.savedMediaCalls).toHaveLength(2);
+      const userUpdate = findUserUpdate();
+      expect(userUpdateMessage(userUpdate)?.content).toBe("serial please");
+      expect(context.dedupe.has("chat:idem-image-serial-save")).toBe(true);
     });
   });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1032,10 +1032,10 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
   message: string;
   savedImages: SavedMedia[];
   cfg: OpenClawConfig;
-}) {
+}): Promise<{ changed: boolean; message?: AgentMessage; messageId?: string }> {
   const mediaFields = resolveChatSendTranscriptMediaFields(params.savedImages);
   if (!("MediaPath" in mediaFields)) {
-    return;
+    return { changed: false };
   }
   const index = await readSessionTranscriptIndex(params.transcriptPath);
   const target = index?.entries.toReversed().find((entry) => {
@@ -1057,13 +1057,13 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
   });
   const targetMessage = target?.record.message as Record<string, unknown> | undefined;
   if (!target || !target.id || !targetMessage) {
-    return;
+    return { changed: false };
   }
   const rewrittenMessage = {
     ...targetMessage,
     ...mediaFields,
-  };
-  await rewriteTranscriptEntriesInSessionFile({
+  } as AgentMessage;
+  const result = await rewriteTranscriptEntriesInSessionFile({
     sessionFile: params.transcriptPath,
     sessionKey: params.sessionKey,
     config: params.cfg,
@@ -1071,11 +1071,30 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
       replacements: [
         {
           entryId: target.id,
-          message: rewrittenMessage as AgentMessage,
+          message: rewrittenMessage,
         },
       ],
     },
   });
+  if (!result.changed) {
+    return { changed: false };
+  }
+  const rewrittenIndex = await readSessionTranscriptIndex(params.transcriptPath);
+  const rewrittenEntryId = rewrittenIndex?.entries.toReversed().find((entry) => {
+    const message = entry.record.message as Record<string, unknown> | undefined;
+    if (!message || message.role !== "user") {
+      return false;
+    }
+    return (
+      extractTranscriptUserText((message as { content?: unknown }).content) === params.message &&
+      (message as { MediaPath?: unknown }).MediaPath === mediaFields.MediaPath
+    );
+  })?.id;
+  return {
+    changed: true,
+    message: rewrittenMessage,
+    ...(rewrittenEntryId ? { messageId: rewrittenEntryId } : {}),
+  };
 }
 
 function extractChatHistoryBlockText(message: unknown): string | undefined {
@@ -2225,12 +2244,16 @@ export const chatHandlers: GatewayRequestHandlers = {
         status: "started" as const,
       };
       respond(true, ackPayload, undefined, { runId: clientRunId });
+      let persistedImagesSnapshot: SavedMedia[] | null = null;
       const persistedImagesPromise = persistChatSendImages({
         images: parsedImages,
         imageOrder,
         offloadedRefs,
         client,
         logGateway: context.logGateway,
+      }).then((images) => {
+        persistedImagesSnapshot = images;
+        return images;
       });
       const pluginBoundMediaFields =
         explicitOriginTargetsPlugin && parsedImages.length > 0
@@ -2320,6 +2343,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       let userTranscriptPersistedEntryId: string | undefined;
       const isResetCommandMessage = isChatSendResetCommandMessage(parsedMessage, cfg);
       const skipDurableUserTranscript = isBtwRequestText(parsedMessage) || isResetCommandMessage;
+      const hasTranscriptMedia = parsedImages.length > 0 || offloadedRefs.length > 0;
       const hookRunner = getGlobalHookRunner();
       const hasBeforeAgentRunGate = hookRunner?.hasHooks("before_agent_run") === true;
       const hasBeforeMessageWriteHook = hookRunner?.hasHooks("before_message_write") === true;
@@ -2387,7 +2411,13 @@ export const chatHandlers: GatewayRequestHandlers = {
               if (!transcriptPath) {
                 return;
               }
-              const persistedImages = await persistedImagesPromise;
+              const persistedImages =
+                timing === "eager" ? (persistedImagesSnapshot ?? []) : await persistedImagesPromise;
+              const shouldDeferTranscriptMessageEmit =
+                timing === "eager" &&
+                hasTranscriptMedia &&
+                persistedImagesSnapshot === null &&
+                !isAcpBridgeClient(client);
               const message = applySessionMessagePersistenceTransforms({
                 message: buildChatSendTranscriptMessage({
                   message: parsedMessage,
@@ -2416,7 +2446,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               emitSessionTranscriptUpdate({
                 sessionFile: transcriptPath,
                 sessionKey: target.sessionKey,
-                message,
+                ...(shouldDeferTranscriptMessageEmit ? {} : { message }),
                 messageId,
               });
             },
@@ -2458,13 +2488,21 @@ export const chatHandlers: GatewayRequestHandlers = {
           return;
         }
         transcriptMediaRewriteDone = true;
-        await rewriteChatSendUserTurnMediaPaths({
+        const rewriteResult = await rewriteChatSendUserTurnMediaPaths({
           transcriptPath,
           sessionKey,
           message: parsedMessage,
           savedImages: await persistedImagesPromise,
           cfg,
         });
+        if (rewriteResult.message) {
+          emitSessionTranscriptUpdate({
+            sessionFile: transcriptPath,
+            sessionKey,
+            message: rewriteResult.message,
+            messageId: rewriteResult.messageId,
+          });
+        }
       };
       const appendWebchatAgentMediaTranscriptIfNeeded = async (payload: ReplyPayload) => {
         if (!agentRunStarted || appendedWebchatAgentMedia || !isMediaBearingPayload(payload)) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -7,14 +7,17 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
+import { applySessionMessagePersistenceTransforms } from "../../agents/session-tool-result-guard-wrapper.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { isBtwRequestText } from "../../auto-reply/reply/btw-command.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
+import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
 import { streamSessionTranscriptLines } from "../../config/sessions/transcript-stream.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -119,6 +122,11 @@ import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
+import {
+  isChatSendResetCommandMessage,
+  isChatSendSessionBusyForEagerPersistence,
+  resolveChatSendTranscriptSessionTarget,
+} from "./chat-user-transcript-persistence.js";
 import {
   buildWebchatAssistantMessageFromReplyPayloads,
   buildWebchatAudioContentBlocksFromReplyPayloads,
@@ -2307,40 +2315,109 @@ export const chatHandlers: GatewayRequestHandlers = {
       let appendedWebchatAgentMedia = false;
       let userTranscriptUpdatePromise: Promise<void> | null = null;
       let agentRunStarted = false;
-      const hasBeforeAgentRunGate = getGlobalHookRunner()?.hasHooks("before_agent_run") === true;
-      const emitUserTranscriptUpdate = async () => {
+      let userTranscriptPersisted = false;
+      let userTranscriptPersistedSessionId: string | undefined;
+      let userTranscriptPersistedEntryId: string | undefined;
+      const isResetCommandMessage = isChatSendResetCommandMessage(parsedMessage, cfg);
+      const skipDurableUserTranscript = isBtwRequestText(parsedMessage) || isResetCommandMessage;
+      const hookRunner = getGlobalHookRunner();
+      const hasBeforeAgentRunGate = hookRunner?.hasHooks("before_agent_run") === true;
+      const hasBeforeMessageWriteHook = hookRunner?.hasHooks("before_message_write") === true;
+      const canEagerPersistUserTranscript = () =>
+        !hasBeforeAgentRunGate &&
+        !hasBeforeMessageWriteHook &&
+        !isChatSendSessionBusyForEagerPersistence({
+          context,
+          rawSessionKey,
+          sessionKey,
+          clientRunId,
+          sessionId: backingSessionId,
+        });
+      const canFallbackPersistUserTranscript = () =>
+        !isChatSendSessionBusyForEagerPersistence({
+          context,
+          rawSessionKey,
+          sessionKey,
+          clientRunId,
+          sessionId: backingSessionId,
+        });
+      const persistUserTranscriptUpdate = async (timing: "eager" | "fallback") => {
+        if (skipDurableUserTranscript) {
+          return;
+        }
+        if (timing === "eager" && !canEagerPersistUserTranscript()) {
+          return;
+        }
+        if (timing === "fallback" && !canFallbackPersistUserTranscript()) {
+          return;
+        }
+        if (userTranscriptPersisted) {
+          return;
+        }
         if (userTranscriptUpdatePromise) {
           await userTranscriptUpdatePromise;
-          return;
+          if (userTranscriptPersisted || timing === "eager") {
+            return;
+          }
+          userTranscriptUpdatePromise = null;
         }
         userTranscriptUpdatePromise = (async () => {
           await measureDiagnosticsTimelineSpan(
             "gateway.chat_send.emit_user_transcript",
             async () => {
-              const { storePath: latestStorePath, entry: latestEntry } =
-                loadSessionEntry(sessionKey);
-              const resolvedSessionId = latestEntry?.sessionId ?? backingSessionId;
+              const target = await resolveChatSendTranscriptSessionTarget({
+                sessionKey,
+                backingSessionId,
+                cfg,
+                ctx,
+                agentId,
+                message: parsedMessage,
+                now,
+              });
+              const resolvedSessionId = target.sessionId;
               if (!resolvedSessionId) {
                 return;
               }
               const transcriptPath = resolveTranscriptPath({
                 sessionId: resolvedSessionId,
-                storePath: latestStorePath,
-                sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
+                storePath: target.storePath,
+                sessionFile: target.entry?.sessionFile,
                 agentId,
               });
               if (!transcriptPath) {
                 return;
               }
               const persistedImages = await persistedImagesPromise;
-              emitSessionTranscriptUpdate({
-                sessionFile: transcriptPath,
-                sessionKey,
+              const message = applySessionMessagePersistenceTransforms({
                 message: buildChatSendTranscriptMessage({
                   message: parsedMessage,
                   savedImages: persistedImages,
                   timestamp: now,
-                }),
+                }) as AgentMessage,
+                config: cfg,
+                inputProvenance: ctx.InputProvenance,
+                agentId,
+                sessionKey: target.sessionKey,
+                runBeforeMessageWriteHooks: timing === "fallback",
+              });
+              if (!message) {
+                return;
+              }
+              const { messageId } = await appendSessionTranscriptMessage({
+                transcriptPath,
+                message,
+                now,
+                sessionId: resolvedSessionId,
+                config: cfg,
+              });
+              userTranscriptPersisted = true;
+              userTranscriptPersistedSessionId = resolvedSessionId;
+              userTranscriptPersistedEntryId = messageId;
+              emitSessionTranscriptUpdate({
+                sessionFile: transcriptPath,
+                sessionKey: target.sessionKey,
+                message,
+                messageId,
               });
             },
             {
@@ -2350,7 +2427,16 @@ export const chatHandlers: GatewayRequestHandlers = {
             },
           );
         })();
-        await userTranscriptUpdatePromise;
+        try {
+          await userTranscriptUpdatePromise;
+        } catch (err) {
+          userTranscriptUpdatePromise = null;
+          throw err;
+        } finally {
+          if (!userTranscriptPersisted) {
+            userTranscriptUpdatePromise = null;
+          }
+        }
       };
       let transcriptMediaRewriteDone = false;
       const rewriteUserTranscriptMedia = async () => {
@@ -2493,6 +2579,14 @@ export const chatHandlers: GatewayRequestHandlers = {
         },
       });
 
+      try {
+        await persistUserTranscriptUpdate("eager");
+      } catch (transcriptErr) {
+        context.logGateway.warn(
+          `webchat eager user transcript update failed: ${formatForLog(transcriptErr)}`,
+        );
+      }
+
       void measureDiagnosticsTimelineSpan(
         "gateway.chat_send.dispatch_inbound",
         () =>
@@ -2507,10 +2601,17 @@ export const chatHandlers: GatewayRequestHandlers = {
               imageOrder: imageOrder.length > 0 ? imageOrder : undefined,
               thinkingLevelOverride: p.thinking,
               fastModeOverride: p.fastMode,
+              ...(userTranscriptPersisted
+                ? {
+                    suppressNextUserMessagePersistence: true,
+                    suppressNextUserMessagePersistenceSessionId: userTranscriptPersistedSessionId,
+                    suppressNextUserMessagePersistenceEntryId: userTranscriptPersistedEntryId,
+                  }
+                : {}),
               onAgentRunStart: (runId) => {
                 agentRunStarted = true;
                 if (!hasBeforeAgentRunGate) {
-                  void emitUserTranscriptUpdate();
+                  void persistUserTranscriptUpdate("eager");
                 }
                 const connId = typeof client?.connId === "string" ? client.connId : undefined;
                 const wantsToolEvents = hasGatewayClientCap(
@@ -2538,7 +2639,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           attributes: chatSendTraceAttributes,
         },
       )
-        .then(async () => {
+        .then(async (dispatchResult) => {
           await measureDiagnosticsTimelineSpan(
             "gateway.chat_send.post_dispatch",
             async () => {
@@ -2550,7 +2651,6 @@ export const chatHandlers: GatewayRequestHandlers = {
               // assistant turn, so it appends a gateway-injected assistant entry before
               // broadcasting the final UI event.
               if (!agentRunStarted) {
-                await emitUserTranscriptUpdate();
                 const btwReplies = deliveredReplies
                   .map((entry) => entry.payload)
                   .filter(isBtwReplyPayload);
@@ -2578,6 +2678,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                     sessionKey,
                   });
                 } else {
+                  if (dispatchResult.beforeAgentRunBlocked !== true) {
+                    await persistUserTranscriptUpdate("fallback");
+                  }
                   const rawFinalPayloads = appendedWebchatAgentMedia
                     ? []
                     : deliveredReplies
@@ -2730,7 +2833,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                   });
                 }
               } else if (!hasBeforeAgentRunGate) {
-                await emitUserTranscriptUpdate().catch((transcriptErr) => {
+                await persistUserTranscriptUpdate("eager").catch((transcriptErr) => {
                   context.logGateway.warn(
                     `webchat user transcript update failed after agent run: ${formatForLog(transcriptErr)}`,
                   );
@@ -2764,7 +2867,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           const emitAfterError =
             agentRunStarted && hasBeforeAgentRunGate
               ? Promise.resolve()
-              : emitUserTranscriptUpdate();
+              : persistUserTranscriptUpdate(agentRunStarted ? "eager" : "fallback");
           await emitAfterError.catch((transcriptErr) => {
             context.logGateway.warn(
               `webchat user transcript update failed after error: ${formatForLog(transcriptErr)}`,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import type { GetReplyOptions } from "../auto-reply/get-reply-options.types.js";
 import { clearConfigCache } from "../config/config.js";
+import { clearSessionStoreCacheForTest, type SessionEntry } from "../config/sessions.js";
+import { writeSessionStoreCache } from "../config/sessions/store-cache.js";
+import * as hookRunnerGlobal from "../plugins/hook-runner-global.js";
+import * as transcriptEvents from "../sessions/transcript-events.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { __setMaxChatHistoryMessagesBytesForTest } from "./server-constants.js";
 import type { GatewayRequestContext, RespondFn } from "./server-methods/shared-types.js";
@@ -110,6 +114,143 @@ async function writeGatewayConfig(config: Record<string, unknown>) {
 
 async function writeMainSessionTranscript(sessionDir: string, lines: string[]) {
   await fs.writeFile(path.join(sessionDir, "sess-main.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+}
+
+async function readTranscriptRecords(
+  transcriptPath: string,
+): Promise<Array<Record<string, unknown>>> {
+  const raw = await fs.readFile(transcriptPath, "utf-8").catch((err: unknown) => {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return "";
+    }
+    throw err;
+  });
+  return raw
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function readSessionTranscriptRecords(
+  sessionDir: string,
+  sessionId: string,
+): Promise<Array<Record<string, unknown>>> {
+  return readTranscriptRecords(path.join(sessionDir, `${sessionId}.jsonl`));
+}
+
+type ChatSendResponse = { id: string; ok: boolean; payload?: unknown; error?: unknown };
+
+type ChatSendDispatchParams = {
+  dispatcher: {
+    sendFinalReply: (payload: { text: string }) => boolean;
+    markComplete: () => void;
+    waitForIdle: () => Promise<void>;
+  };
+  replyOptions?: Pick<
+    GetReplyOptions,
+    | "onAgentRunStart"
+    | "suppressNextUserMessagePersistence"
+    | "suppressNextUserMessagePersistenceSessionId"
+    | "suppressNextUserMessagePersistenceEntryId"
+  >;
+};
+
+function createChatSendContext(
+  params: {
+    activeRuns?: Map<string, { sessionKey: string; sessionId?: string }>;
+  } = {},
+): GatewayRequestContext {
+  return {
+    loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
+    logGateway: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    agentRunSeq: new Map<string, number>(),
+    chatAbortControllers: params.activeRuns ?? new Map(),
+    chatAbortedRuns: new Map(),
+    chatRunBuffers: new Map(),
+    chatDeltaSentAt: new Map(),
+    chatDeltaLastBroadcastLen: new Map(),
+    addChatRun: vi.fn(),
+    removeChatRun: vi.fn(),
+    broadcast: vi.fn(),
+    nodeSendToSession: vi.fn(),
+    registerToolEventRecipient: vi.fn(),
+    dedupe: new Map(),
+  } as unknown as GatewayRequestContext;
+}
+
+async function writeMainWebchatSession(entry: Partial<SessionEntry> = {}) {
+  await writeSessionStore({
+    entries: {
+      main: {
+        sessionId: "sess-main",
+        updatedAt: Date.now(),
+        ...entry,
+      },
+    },
+  });
+}
+
+async function callWebchatChatSend(params: {
+  context: GatewayRequestContext;
+  responses: ChatSendResponse[];
+  requestId: string;
+  message: string;
+  idempotencyKey: string;
+}) {
+  const requestParams = {
+    sessionKey: "main",
+    message: params.message,
+    idempotencyKey: params.idempotencyKey,
+  };
+  const { chatHandlers } = await import("./server-methods/chat.js");
+  await chatHandlers["chat.send"]({
+    req: {
+      type: "req",
+      id: params.requestId,
+      method: "chat.send",
+      params: requestParams,
+    },
+    params: requestParams,
+    client: {
+      connect: {
+        client: {
+          id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+          mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+        },
+        scopes: ["operator.write"],
+      },
+    } as never,
+    isWebchatConnect: () => true,
+    respond: ((ok, payload, error) => {
+      params.responses.push({ id: params.requestId, ok, payload, error });
+    }) as RespondFn,
+    context: params.context,
+  });
+}
+
+function expectChatSendStarted(params: {
+  responses: ChatSendResponse[];
+  requestId: string;
+  runId: string;
+}) {
+  expect(params.responses).toContainEqual({
+    id: params.requestId,
+    ok: true,
+    payload: { runId: params.runId, status: "started" },
+    error: undefined,
+  });
+}
+
+function findUserTranscriptEntries(records: Array<Record<string, unknown>>, content?: string) {
+  return records.filter((record) => {
+    const message = record.message as { role?: unknown; content?: unknown } | undefined;
+    return message?.role === "user" && (content === undefined || message.content === content);
+  });
 }
 
 async function fetchHistoryMessages(
@@ -423,7 +564,9 @@ describe("gateway server chat", () => {
         payload: { runId: "idem-active-a", status: "in_flight" },
         error: undefined,
       });
-      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
       expect(context.addChatRun).toHaveBeenCalledTimes(1);
 
       dispatchRelease.resolve();
@@ -536,6 +679,652 @@ describe("gateway server chat", () => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
       expect(context.addChatRun).toHaveBeenCalledTimes(2);
     } finally {
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send persists WebChat user turns before dispatch enters the agent lane", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const dispatchRelease = createDeferred<void>();
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeMainWebchatSession();
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext();
+      let dispatchParams: ChatSendDispatchParams | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        dispatchParams = params as ChatSendDispatchParams;
+        dispatchParams?.replyOptions?.onAgentRunStart?.("idem-eager-user");
+        await dispatchRelease.promise;
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-eager-user",
+        message: "show quickly",
+        idempotencyKey: "idem-eager-user",
+      });
+
+      expectChatSendStarted({
+        responses,
+        requestId: "send-eager-user",
+        runId: "idem-eager-user",
+      });
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistence).toBe(true);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceSessionId).toBe(
+        "sess-main",
+      );
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceEntryId).toEqual(
+        expect.any(String),
+      );
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:main",
+          messageId: expect.any(String),
+          message: expect.objectContaining({
+            role: "user",
+            content: "show quickly",
+          }),
+        }),
+      );
+
+      const records = await readSessionTranscriptRecords(sessionDir, "sess-main");
+      const durableUserEntries = findUserTranscriptEntries(records);
+      expect(durableUserEntries).toHaveLength(1);
+      expect(durableUserEntries[0]).toEqual(
+        expect.objectContaining({
+          type: "message",
+          id: expect.any(String),
+          parentId: null,
+          message: expect.objectContaining({
+            role: "user",
+            content: "show quickly",
+          }),
+        }),
+      );
+
+      dispatchRelease.resolve();
+      await vi.waitFor(() => {
+        expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      emitSpy.mockRestore();
+      dispatchRelease.resolve();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send skips WebChat transcript persistence for reset commands", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeMainWebchatSession();
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext();
+      let dispatchParams: ChatSendDispatchParams | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        dispatchParams = params as ChatSendDispatchParams;
+        dispatchParams.dispatcher.sendFinalReply({ text: "reset handled" });
+        dispatchParams.dispatcher.markComplete();
+        await dispatchParams.dispatcher.waitForIdle();
+        return {
+          queuedFinal: true,
+          counts: { tool: 0, block: 0, final: 1 },
+        };
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-reset-user",
+        message: "/new clean branch",
+        idempotencyKey: "idem-reset-user",
+      });
+
+      expectChatSendStarted({
+        responses,
+        requestId: "send-reset-user",
+        runId: "idem-reset-user",
+      });
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistence).toBeUndefined();
+      expect(
+        dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceSessionId,
+      ).toBeUndefined();
+      expect(
+        dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceEntryId,
+      ).toBeUndefined();
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(await readSessionTranscriptRecords(sessionDir, "sess-main")).toHaveLength(0);
+
+      await vi.waitFor(() => {
+        expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      emitSpy.mockRestore();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send applies transcript redaction before eager WebChat persistence", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const dispatchRelease = createDeferred<void>();
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    const secret = "sk-1234567890abcdef";
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeMainWebchatSession();
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext();
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        (params as ChatSendDispatchParams).replyOptions?.onAgentRunStart?.("idem-redacted-user");
+        await dispatchRelease.promise;
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-redacted-user",
+        message: `please inspect OPENAI_API_KEY=${secret}`,
+        idempotencyKey: "idem-redacted-user",
+      });
+
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+      const records = await readSessionTranscriptRecords(sessionDir, "sess-main");
+      const rawTranscript = JSON.stringify(records);
+      expect(rawTranscript).not.toContain(secret);
+      expect(rawTranscript).toContain("OPENAI_API_KEY=");
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            role: "user",
+            content: expect.not.stringContaining(secret),
+          }),
+        }),
+      );
+
+      dispatchRelease.resolve();
+      await vi.waitFor(() => {
+        expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      emitSpy.mockRestore();
+      dispatchRelease.resolve();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send skips eager WebChat persistence when message-write hooks are registered", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const dispatchRelease = createDeferred<void>();
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    const hookRunnerSpy = vi.spyOn(hookRunnerGlobal, "getGlobalHookRunner").mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "before_message_write",
+    } as never);
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeMainWebchatSession();
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext();
+      let dispatchParams: ChatSendDispatchParams | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        dispatchParams = params as ChatSendDispatchParams;
+        dispatchParams?.replyOptions?.onAgentRunStart?.("idem-hooked-user");
+        await dispatchRelease.promise;
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-hooked-user",
+        message: "do not bypass hooks",
+        idempotencyKey: "idem-hooked-user",
+      });
+
+      expectChatSendStarted({
+        responses,
+        requestId: "send-hooked-user",
+        runId: "idem-hooked-user",
+      });
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistence).toBeUndefined();
+      expect(
+        dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceSessionId,
+      ).toBeUndefined();
+      expect(
+        dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceEntryId,
+      ).toBeUndefined();
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(await readSessionTranscriptRecords(sessionDir, "sess-main")).toHaveLength(0);
+
+      dispatchRelease.resolve();
+      await vi.waitFor(() => {
+        expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      hookRunnerSpy.mockRestore();
+      emitSpy.mockRestore();
+      dispatchRelease.resolve();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send retries fallback persistence when eager WebChat persistence has no session yet", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext();
+      let dispatchParams: ChatSendDispatchParams | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        dispatchParams = params as ChatSendDispatchParams;
+        await writeMainWebchatSession();
+        dispatchParams.dispatcher.sendFinalReply({ text: "first non-agent reply" });
+        dispatchParams.dispatcher.markComplete();
+        await dispatchParams.dispatcher.waitForIdle();
+        return {
+          queuedFinal: true,
+          counts: { tool: 0, block: 0, final: 1 },
+        };
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-first-fallback-user",
+        message: "first fallback user",
+        idempotencyKey: "idem-first-fallback-user",
+      });
+
+      expectChatSendStarted({
+        responses,
+        requestId: "send-first-fallback-user",
+        runId: "idem-first-fallback-user",
+      });
+      await vi.waitFor(
+        () => {
+          expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 1000, interval: 5 },
+      );
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistence).toBeUndefined();
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:main",
+          message: expect.objectContaining({
+            role: "user",
+            content: "first fallback user",
+          }),
+        }),
+      );
+      const emitCall = emitSpy.mock.calls.find((call) => {
+        const payload = call[0] as { message?: { role?: unknown; content?: unknown } };
+        return (
+          payload.message?.role === "user" && payload.message.content === "first fallback user"
+        );
+      });
+      const sessionFile = (emitCall?.[0] as { sessionFile?: string } | undefined)?.sessionFile;
+      expect(sessionFile).toEqual(expect.any(String));
+      const records = await readTranscriptRecords(sessionFile as string);
+      const userEntries = findUserTranscriptEntries(records, "first fallback user");
+      expect(userEntries).toHaveLength(1);
+    } finally {
+      emitSpy.mockRestore();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send applies message-write hooks when fallback persistence records a non-agent WebChat turn", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    const runBeforeMessageWrite = vi.fn(
+      (event: { message: { role?: string; content?: unknown } }) => ({
+        message: {
+          ...event.message,
+          content: "hook transformed fallback user",
+        },
+      }),
+    );
+    const hookRunnerSpy = vi.spyOn(hookRunnerGlobal, "getGlobalHookRunner").mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "before_message_write",
+      runBeforeMessageWrite,
+    } as never);
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeMainWebchatSession();
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext();
+      let dispatchParams: ChatSendDispatchParams | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        dispatchParams = params as ChatSendDispatchParams;
+        dispatchParams.dispatcher.sendFinalReply({ text: "non-agent hook reply" });
+        dispatchParams.dispatcher.markComplete();
+        await dispatchParams.dispatcher.waitForIdle();
+        return {
+          queuedFinal: true,
+          counts: { tool: 0, block: 0, final: 1 },
+        };
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-hook-fallback-user",
+        message: "fallback hook original",
+        idempotencyKey: "idem-hook-fallback-user",
+      });
+
+      expectChatSendStarted({
+        responses,
+        requestId: "send-hook-fallback-user",
+        runId: "idem-hook-fallback-user",
+      });
+      await vi.waitFor(() => {
+        expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistence).toBeUndefined();
+      expect(runBeforeMessageWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            role: "user",
+            content: "fallback hook original",
+          }),
+        }),
+        expect.objectContaining({
+          agentId: "main",
+          sessionKey: "agent:main:main",
+        }),
+      );
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:main",
+          message: expect.objectContaining({
+            role: "user",
+            content: "hook transformed fallback user",
+          }),
+        }),
+      );
+      const records = await readSessionTranscriptRecords(sessionDir, "sess-main");
+      const userEntries = findUserTranscriptEntries(records);
+      expect(userEntries).toHaveLength(1);
+      expect((userEntries[0]?.message as { content?: unknown } | undefined)?.content).toBe(
+        "hook transformed fallback user",
+      );
+      expect(JSON.stringify(records)).not.toContain("fallback hook original");
+    } finally {
+      hookRunnerSpy.mockRestore();
+      emitSpy.mockRestore();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send defers eager WebChat persistence while the same session has an active run", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const dispatchRelease = createDeferred<void>();
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeMainWebchatSession();
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext({
+        activeRuns: new Map([
+          [
+            "active-existing",
+            {
+              sessionKey: "main",
+              sessionId: "sess-main",
+            },
+          ],
+        ]),
+      });
+      let dispatchParams: ChatSendDispatchParams | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        dispatchParams = params as ChatSendDispatchParams;
+        dispatchParams?.replyOptions?.onAgentRunStart?.("idem-queued-user");
+        await dispatchRelease.promise;
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-queued-user",
+        message: "wait behind active run",
+        idempotencyKey: "idem-queued-user",
+      });
+
+      expectChatSendStarted({
+        responses,
+        requestId: "send-queued-user",
+        runId: "idem-queued-user",
+      });
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistence).toBeUndefined();
+      expect(
+        dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceSessionId,
+      ).toBeUndefined();
+      expect(
+        dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceEntryId,
+      ).toBeUndefined();
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(await readSessionTranscriptRecords(sessionDir, "sess-main")).toHaveLength(0);
+
+      dispatchRelease.resolve();
+      await vi.waitFor(() => {
+        expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      emitSpy.mockRestore();
+      dispatchRelease.resolve();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send persists WebChat user turns into the active session after daily rollover", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      const staleAt = Date.now() - 72 * 60 * 60 * 1000;
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            sessionStartedAt: staleAt,
+            lastInteractionAt: staleAt,
+            updatedAt: staleAt,
+          },
+        },
+      });
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          type: "session",
+          id: "sess-main",
+          timestamp: new Date(staleAt).toISOString(),
+        }),
+      ]);
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext();
+      let dispatchParams: ChatSendDispatchParams | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        dispatchParams = params as ChatSendDispatchParams;
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-rollover-eager-user",
+        message: "visible after rollover",
+        idempotencyKey: "idem-rollover-eager-user",
+      });
+
+      expectChatSendStarted({
+        responses,
+        requestId: "send-rollover-eager-user",
+        runId: "idem-rollover-eager-user",
+      });
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+
+      const store = JSON.parse(
+        await fs.readFile(path.join(sessionDir, "sessions.json"), "utf-8"),
+      ) as Record<string, { sessionFile?: string; sessionId?: string }>;
+      const activeEntry = store["agent:main:main"];
+      const activeSessionId = activeEntry?.sessionId;
+      expect(activeSessionId).toEqual(expect.any(String));
+      expect(activeSessionId).not.toBe("sess-main");
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistence).toBe(true);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceSessionId).toBe(
+        activeSessionId,
+      );
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:main",
+          message: expect.objectContaining({
+            role: "user",
+            content: "visible after rollover",
+          }),
+        }),
+      );
+
+      const activeTranscriptPath =
+        activeEntry?.sessionFile ?? path.join(sessionDir, `${activeSessionId}.jsonl`);
+      const activeRecords = await readTranscriptRecords(activeTranscriptPath);
+      const activeUserEntries = findUserTranscriptEntries(activeRecords, "visible after rollover");
+      expect(activeUserEntries).toHaveLength(1);
+
+      const staleFiles = (await fs.readdir(sessionDir)).filter((name) =>
+        name.startsWith("sess-main.jsonl"),
+      );
+      for (const staleFile of staleFiles) {
+        const staleRaw = await fs.readFile(path.join(sessionDir, staleFile), "utf-8");
+        expect(staleRaw).not.toContain("visible after rollover");
+      }
+
+      await vi.waitFor(() => {
+        expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      emitSpy.mockRestore();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send ignores stale session-store cache before eager WebChat persistence", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      const storePath = path.join(sessionDir, "sessions.json");
+      testState.sessionStorePath = storePath;
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-fresh",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const staleStore: Record<string, SessionEntry> = {
+        "agent:main:main": {
+          sessionId: "sess-stale",
+          updatedAt: Date.now() - 1_000,
+        },
+      };
+      const stat = await fs.stat(storePath);
+      writeSessionStoreCache({
+        storePath,
+        store: staleStore,
+        mtimeMs: stat.mtimeMs,
+        sizeBytes: stat.size,
+        serialized: JSON.stringify(staleStore),
+      });
+
+      const responses: ChatSendResponse[] = [];
+      const context = createChatSendContext();
+      let dispatchParams: ChatSendDispatchParams | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (params: unknown) => {
+        dispatchParams = params as ChatSendDispatchParams;
+      });
+
+      await callWebchatChatSend({
+        context,
+        responses,
+        requestId: "send-cache-race-eager-user",
+        message: "fresh cache target",
+        idempotencyKey: "idem-cache-race-eager-user",
+      });
+
+      expectChatSendStarted({
+        responses,
+        requestId: "send-cache-race-eager-user",
+        runId: "idem-cache-race-eager-user",
+      });
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistence).toBe(true);
+      expect(dispatchParams?.replyOptions?.suppressNextUserMessagePersistenceSessionId).toBe(
+        "sess-fresh",
+      );
+
+      const freshRecords = await readSessionTranscriptRecords(sessionDir, "sess-fresh");
+      const freshUserEntries = findUserTranscriptEntries(freshRecords, "fresh cache target");
+      expect(freshUserEntries).toHaveLength(1);
+
+      const staleRecords = await readSessionTranscriptRecords(sessionDir, "sess-stale");
+      const staleUserEntries = findUserTranscriptEntries(staleRecords, "fresh cache target");
+      expect(staleUserEntries).toHaveLength(0);
+    } finally {
+      clearSessionStoreCacheForTest();
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -699,7 +699,7 @@ export function resolveDeletedAgentIdFromSessionKey(
   return agentId;
 }
 
-export function loadSessionEntry(sessionKey: string) {
+export function loadSessionEntry(sessionKey: string, opts: { skipCache?: boolean } = {}) {
   const cfg = getRuntimeConfig();
   const key = normalizeOptionalString(sessionKey) ?? "";
   const target = resolveGatewaySessionStoreTarget({
@@ -707,7 +707,7 @@ export function loadSessionEntry(sessionKey: string) {
     key,
   });
   const storePath = target.storePath;
-  const store = loadSessionStore(storePath);
+  const store = loadSessionStore(storePath, opts.skipCache ? { skipCache: true } : undefined);
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys);
   const legacyKey = freshestMatch?.key !== target.canonicalKey ? freshestMatch?.key : undefined;
   return {


### PR DESCRIPTION
## Summary
- Persist WebChat user turns to the active session JSONL immediately after `chat.send` ACK and before agent dispatch enters the serialized session lane.
- Pass an entry-scoped suppression marker through reply options, queued followups, and the embedded Pi runner so Pi does not append the same current user turn again.
- Handle session rollover, stale session-store cache, hooks, reset commands, active same-session runs, and trailing user history repair without changing normal assistant persistence.

## Verification
- `corepack pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/web/webchat.md src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/params.ts src/agents/session-tool-result-guard-wrapper.ts src/auto-reply/get-reply-options.types.ts src/auto-reply/reply/agent-runner-run-params.ts src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/queue/types.ts src/gateway/server-methods/chat.ts src/gateway/server-methods/chat-user-transcript-persistence.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/session-utils.ts`
- `corepack pnpm test src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/auto-reply/reply/agent-runner-utils.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/followup-runner.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`
- `corepack pnpm tsgo:core`
- `corepack pnpm tsgo:core:test`
- `corepack pnpm check:changed`
- `corepack pnpm build`
- `git diff --check`

## Real behavior proof
- Behavior or issue addressed: WebChat direct messages submitted through the gateway could wait behind a stuck or cleaning same-session agent lane before the user turn was written to the active session JSONL. In the reproduced case, the message arrived through the ClawStation WebSocket path around 22:10 but was not visible through WebChat history until about 22:13.
- Real environment tested: Windows local OpenClaw gateway with the existing ClawStation configuration, direct/private WebChat delivery from ClawStation to an OpenClaw agent, local session JSONL storage, and the user's configured model/provider setup. Runtime logs and private identifiers were redacted before inclusion here.
- Exact steps or command run after this patch: Built and started the patched local OpenClaw gateway, sent a private message from ClawStation to an agent, watched gateway/session logs, checked WebChat visibility, then repeated after triggering the session rollover edge case that previously logged `ignored eager user transcript suppression after session rollover`.
- Evidence after fix: Redacted runtime log / copied live output from the local setup:
```text
before: websocket receive ~=22:10, lane diagnostic active=1 queued=1 last=run:completed, user transcript append ~=22:13:07, chat.history visible ~=22:13:16
after: ClawStation private message submitted through WebSocket, WebChat displayed the user turn immediately after gateway ACK, before the agent lane finished; no duplicate user turn appeared in OpenClaw WebUI
rollover retest: eager user transcript was written to the active rolled session, Pi suppression matched the persisted entry id, and the agent response continued normally
health check while preparing PR: Invoke-RestMethod http://127.0.0.1:18790/health -> {"ok":true,"status":"live"}
```
- Observed result after fix: The user turn is visible in WebChat as soon as the gateway eagerly appends it to the active session transcript, instead of waiting for the serialized agent lane. The Pi runner does not append the same current user turn a second time, reset commands are not written as durable user transcript entries, hook-gated paths still use fallback persistence, and session rollover uses the active session rather than the stale pre-rollover session.
- What was not tested: I did not test a freshly built `main` Control UI against the user's running 5.7 gateway because the gateway protocol versions differ; that combination previously produced a protocol mismatch. The PR branch was validated with targeted gateway/Pi tests and `pnpm build` instead.

## AI-assisted disclosure
- This PR was developed with Codex assistance. I reviewed the code paths manually, ran the verification above, and understand the change.
- I attempted the repository-requested local Codex review with `codex review --base origin/main`, `codex review --uncommitted`, and `codex review --commit HEAD`; each attempt timed out locally without producing findings.