### PR TITLE
docs(browser): note `wait --load networkidle` is unsupported on existing-session profiles (#80587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: preserve the composer draft when Stop is tapped during an active chat run, preventing accidental prompt loss on mobile. Fixes #80586. Thanks @KCALLC.
 - Infra/retry: keep jittered retry delays at or above server-supplied Retry-After lower bounds when the hint can be honored. Fixes #68541. (#68543) Thanks @Feelw00.
 - Docs: clarify that `/model provider/model` is an exact session route, while duplicate bare model ids only use configured fallback order on non-session override paths. Refs #80562. Thanks @gaodaabao.
+- Docs: note that `openclaw browser wait --load networkidle` is not supported on `existing-session` profiles in `browser-control.md`, removing the contradiction with the existing-session feature limitations in `browser.md`. Refs #80587. Thanks @jeffrey701.
 - Redact persisted secret-shaped payloads [AI]. (#79006) Thanks @pgondhi987.
 - Agents: label `.openclaw/sandboxes` exec workdirs as sandbox runs in compact tool summaries instead of showing the full path.
 - OpenAI Codex: surface browser OAuth and device-code login failures instead of treating failed logins as empty successful auth results. Refs #80363.

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -294,6 +294,7 @@ You can wait on more than just time/text:
   - `openclaw browser wait --url "**/dash"`
 - Wait for load state:
   - `openclaw browser wait --load networkidle`
+  - Not supported on `existing-session` profiles; use `--url`, `--fn`, or a selector wait instead. See [browser.md](./browser.md) — _Existing-session feature limitations_.
 - Wait for a JS predicate:
   - `openclaw browser wait --fn "window.ready===true"`
 - Wait for a selector to become visible:


### PR DESCRIPTION
Closes #80587

## Why

`docs/tools/browser-control.md` advertises `openclaw browser wait --load networkidle` in the *Wait power-ups* section without any profile qualifier. `docs/tools/browser.md` then says, inside the **Existing-session feature limitations** accordion, that `wait --load networkidle` is **not** supported. The two pages contradict each other, and a reader who only lands on `browser-control.md` has no signal that the feature gates on profile type.

ClawSweeper's review on #80587 confirms the contradiction is real on `main`: the unsupported case is specifically `existing-session` profiles, while managed `openclaw` profiles continue to support `wait --load networkidle`.

## What

- `docs/tools/browser-control.md`: add a single bullet directly under the existing `wait --load networkidle` example noting it is **not supported on `existing-session` profiles**, suggesting `--url`, `--fn`, or a selector wait as the supported alternatives, and linking back to the canonical `browser.md` *Existing-session feature limitations* section.
- `CHANGELOG.md`: one `Docs:` bullet under `## Unreleased` -> `### Fixes`, matching the style and placement of the other recent `Docs:` entries.

No behavior change. No code touched. Existing `browser.md` text is left alone — it already lives inside the explicit existing-session accordion, which is the correct authoritative place.

## Real behavior proof

**Behavior or issue addressed**: Documentation contradiction reported in #80587 — `browser-control.md` claims `wait --load networkidle` is supported (no profile qualifier) while `browser.md` says it is not. After this patch `browser-control.md` carries the profile qualifier and points to the canonical section in `browser.md`, so a reader hitting either page learns the same thing.

**Real environment tested**: Local Linux checkout of `openclaw/openclaw` at upstream `main` `b8e9492086` (`fix(bonjour): back off probing watchdog repairs`), branched into `docs/browser-control-existing-session-networkidle-80587`. Verified by reading the rendered docs files side by side on disk after applying the patch.

**Exact steps or command run after this patch**: Ran the following on a fresh branch checkout: `git checkout docs/browser-control-existing-session-networkidle-80587 && sed -n '286,298p' docs/tools/browser-control.md && grep -nB2 -A2 'wait --load networkidle' docs/tools/browser.md`.

**Evidence after fix**: After the patch, `docs/tools/browser-control.md` shows a new bullet directly beneath the `openclaw browser wait --load networkidle` example reading literally `Not supported on existing-session profiles; use --url, --fn, or a selector wait instead. See [browser.md](./browser.md) — Existing-session feature limitations.` Live grep on `docs/tools/browser.md` line 646 still returns `wait --load networkidle is not supported. Upload hooks require ref or inputRef, one file at a time, no CSS element. Dialog hooks do not support timeout overrides.` inside the *Existing-session feature limitations* accordion. The two pages now agree on profile boundary.

**Observed result after fix**: Reading `browser-control.md` and `browser.md` side by side no longer reproduces the contradiction reported in #80587. Managed-profile readers see the supported syntax, existing-session readers immediately see the limitation and the supported alternatives, with a cross-link to the authoritative section.

**What was not tested**: No live runtime browser session was launched against `wait --load networkidle`, because this PR does not change runtime behavior — only documentation phrasing in `docs/tools/browser-control.md`. The existing-session capability surface and the runtime-rejection path for `--load networkidle` on existing-session targets were not modified.

## Checklist

- Single docs file changed plus a `Docs:` bullet in `CHANGELOG.md`.
- No behavior change; no code or test files touched.
- References issue #80587 in both the commit message and `CHANGELOG.md` bullet.
- Targets `main`.