### PR TITLE
feat(trajectory): allow OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES override for per-event byte cap

### DIFF
--- a/docs/tools/trajectory.md
+++ b/docs/tools/trajectory.md
@@ -199,7 +199,12 @@ The exporter also bounds input size:
 - session files: 50 MiB
 - runtime events: 200,000
 - total exported events: 250,000
-- individual runtime event lines are truncated above 256 KiB
+- individual runtime event lines are truncated above 256 KiB (configurable via `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES`)
+
+`OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES` accepts raw byte counts such as
+`1048576` and `k`/`kb`, `m`/`mb`, or `g`/`gb` suffixes such as `512kb` or `2mb`.
+Invalid, empty, or non-positive values fall back to the 256 KiB default, and the
+effective cap is still clamped below the runtime sidecar file budget.
 
 Review bundles before sharing them outside your team. Redaction is best-effort
 and cannot know every application-specific secret.

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -80,7 +80,9 @@ describe("Codex trajectory recorder", () => {
     expect(content).not.toContain("secret");
     expect(content).not.toContain("sk-test-secret-token");
     expect(content).not.toContain("sk-other-secret-token");
-    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+    }
     expect(fs.existsSync(path.join(tmpDir, "session.trajectory-path.json"))).toBe(true);
   });
 
@@ -154,27 +156,30 @@ describe("Codex trajectory recorder", () => {
     expect(recorder).toBeNull();
   });
 
-  it("refuses to append through a symlinked parent directory", async () => {
-    const tmpDir = makeTempDir();
-    const targetDir = path.join(tmpDir, "target");
-    const linkDir = path.join(tmpDir, "link");
-    fs.mkdirSync(targetDir);
-    fs.symlinkSync(targetDir, linkDir);
-    const recorder = createCodexTrajectoryRecorder({
-      cwd: tmpDir,
-      attempt: {
-        sessionFile: path.join(linkDir, "session.jsonl"),
-        sessionId: "session-1",
-        model: { api: "responses" },
-      } as never,
-      env: {},
-    });
+  it.runIf(process.platform !== "win32")(
+    "refuses to append through a symlinked parent directory",
+    async () => {
+      const tmpDir = makeTempDir();
+      const targetDir = path.join(tmpDir, "target");
+      const linkDir = path.join(tmpDir, "link");
+      fs.mkdirSync(targetDir);
+      fs.symlinkSync(targetDir, linkDir);
+      const recorder = createCodexTrajectoryRecorder({
+        cwd: tmpDir,
+        attempt: {
+          sessionFile: path.join(linkDir, "session.jsonl"),
+          sessionId: "session-1",
+          model: { api: "responses" },
+        } as never,
+        env: {},
+      });
 
-    recorder?.recordEvent("session.started");
-    await recorder?.flush();
+      recorder?.recordEvent("session.started");
+      await recorder?.flush();
 
-    expect(fs.existsSync(path.join(targetDir, "session.trajectory.jsonl"))).toBe(false);
-  });
+      expect(fs.existsSync(path.join(targetDir, "session.trajectory.jsonl"))).toBe(false);
+    },
+  );
 
   it("honors OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES override", async () => {
     const tmpDir = makeTempDir();

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createCodexTrajectoryRecorder,
   resolveCodexTrajectoryAppendFlags,
+  resolveCodexTrajectoryRuntimeEventMaxBytes,
   resolveCodexTrajectoryPointerFlags,
 } from "./trajectory.js";
 
@@ -65,13 +66,13 @@ describe("Codex trajectory recorder", () => {
       env: {},
     });
 
-    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
-    trajectoryRecorder.recordEvent("session.started", {
+    expect(recorder).not.toBeNull();
+    recorder?.recordEvent("session.started", {
       apiKey: "secret",
       headers: [{ name: "Authorization", value: "Bearer sk-test-secret-token" }],
       command: "curl -H 'Authorization: Bearer sk-other-secret-token'",
     });
-    await trajectoryRecorder.flush();
+    await recorder?.flush();
 
     const filePath = path.join(tmpDir, "session.trajectory.jsonl");
     const content = fs.readFileSync(filePath, "utf8");
@@ -132,9 +133,8 @@ describe("Codex trajectory recorder", () => {
       env: { OPENCLAW_TRAJECTORY_DIR: tmpDir },
     });
 
-    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
-    trajectoryRecorder.recordEvent("session.started");
-    await trajectoryRecorder.flush();
+    recorder?.recordEvent("session.started");
+    await recorder?.flush();
 
     expect(fs.existsSync(path.join(tmpDir, "___evil_session.jsonl"))).toBe(true);
   });
@@ -170,11 +170,45 @@ describe("Codex trajectory recorder", () => {
       env: {},
     });
 
-    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
-    trajectoryRecorder.recordEvent("session.started");
-    await trajectoryRecorder.flush();
+    recorder?.recordEvent("session.started");
+    await recorder?.flush();
 
     expect(fs.existsSync(path.join(targetDir, "session.trajectory.jsonl"))).toBe(false);
+  });
+
+  it("honors OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES override", async () => {
+    const tmpDir = makeTempDir();
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt: {
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        sessionId: "session-1",
+        model: { api: "responses" },
+      } as never,
+      env: { OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "512" },
+    });
+
+    recorder?.recordEvent("context.compiled", {
+      payload: "x".repeat(600),
+    });
+    await recorder?.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    ) as { data?: { truncated?: boolean; reason?: string } };
+    expect(parsed.data).toMatchObject({
+      truncated: true,
+      reason: "trajectory-event-size-limit",
+    });
+  });
+
+  it("clamps configured event caps to the append file budget", () => {
+    expect(
+      resolveCodexTrajectoryRuntimeEventMaxBytes(
+        { OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "1mb" },
+        1_024,
+      ),
+    ).toBe(1_023);
   });
 
   it("truncates events that exceed the runtime event byte limit", async () => {
@@ -189,18 +223,62 @@ describe("Codex trajectory recorder", () => {
       env: {},
     });
 
-    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
-    trajectoryRecorder.recordEvent("context.compiled", {
+    recorder?.recordEvent("context.compiled", {
       fields: Object.fromEntries(
         Array.from({ length: 100 }, (_, index) => [`field-${index}`, "x".repeat(3_000)]),
       ),
     });
-    await trajectoryRecorder.flush();
+    await recorder?.flush();
 
     const parsed = JSON.parse(
       fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
     ) as { data?: { truncated?: boolean; reason?: string } };
-    expect(parsed.data?.truncated).toBe(true);
-    expect(parsed.data?.reason).toBe("trajectory-event-size-limit");
+    expect(parsed.data).toMatchObject({
+      truncated: true,
+      reason: "trajectory-event-size-limit",
+    });
+  });
+
+  it("accepts human-friendly byte-size suffixes for the event cap override", async () => {
+    const tmpDir = makeTempDir();
+    // 1kb = 1024 bytes — create an event between 600-1024 bytes to verify it is NOT truncated
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt: {
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        sessionId: "session-suffix",
+        model: { api: "responses" },
+      } as never,
+      env: { OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "1kb" },
+    });
+
+    recorder?.recordEvent("session.started", { payload: "x".repeat(600) });
+    await recorder?.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    ) as { data?: { truncated?: boolean } };
+    expect(parsed.data?.truncated).not.toBe(true);
+  });
+
+  it("falls back to default on invalid suffix values", async () => {
+    const tmpDir = makeTempDir();
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt: {
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        sessionId: "session-invalid-suffix",
+        model: { api: "responses" },
+      } as never,
+      env: { OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "abc-not-a-size" },
+    });
+
+    // Invalid value falls back to default 262144 bytes — a small event should pass through without truncation
+    recorder?.recordEvent("session.started", { payload: "small" });
+    await recorder?.flush();
+
+    const content = fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8");
+    expect(content).toContain('"type":"session.started"');
+    expect(content).not.toContain('"truncated"');
   });
 });

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -5,11 +5,11 @@
 import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveUserPath } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { resolveUserPath } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   appendRegularFile,
   resolveRegularFileAppendFlags,
@@ -38,7 +38,58 @@ const AUTHORIZATION_VALUE_RE = /\b(Bearer|Basic)\s+[A-Za-z0-9+/._~=-]{8,}/giu;
 const JWT_VALUE_RE = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/gu;
 const COOKIE_PAIR_RE = /\b([A-Za-z][A-Za-z0-9_.-]{1,64})=([A-Za-z0-9+/._~%=-]{16,})(?=;|\s|$)/gu;
 const TRAJECTORY_RUNTIME_FILE_MAX_BYTES = 50 * 1024 * 1024;
-const TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = 256 * 1024;
+
+const DEFAULT_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = 256 * 1024;
+
+export function resolveCodexTrajectoryRuntimeEventMaxBytes(
+  env: NodeJS.ProcessEnv = process.env,
+  maxFileBytes = TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
+): number {
+  const raw = env.OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES?.trim();
+  const maxJsonLineBytes = Math.max(1, Math.floor(maxFileBytes) - 1);
+  if (!raw) {
+    return Math.min(DEFAULT_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES, maxJsonLineBytes);
+  }
+  try {
+    const parsed = parseCodexTrajectoryEventByteSize(raw);
+    if (parsed > 0) {
+      return Math.min(parsed, maxJsonLineBytes);
+    }
+  } catch {
+    // Fall through to default on invalid input.
+  }
+  return Math.min(DEFAULT_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES, maxJsonLineBytes);
+}
+
+/**
+ * Minimal byte-size parser for the trajectory event cap env var.
+ * Supports: raw integers, `kb`, `mb`, `gb` suffixes.
+ */
+function parseCodexTrajectoryEventByteSize(raw: string): number {
+  const lower = raw.toLowerCase().replace(/\s+/g, "");
+  const m = /^(\d+(?:\.\d+)?)([a-z]*)$/.exec(lower);
+  if (!m) {
+    throw new Error(`invalid byte size: ${raw}`);
+  }
+  const [, numStr, unit] = m;
+  const num = Number.parseFloat(numStr);
+  switch (unit) {
+    case "kb":
+    case "k":
+      return Math.floor(num * 1024);
+    case "mb":
+    case "m":
+      return Math.floor(num * 1024 * 1024);
+    case "gb":
+    case "g":
+      return Math.floor(num * 1024 * 1024 * 1024);
+    case "":
+    case "b":
+      return Math.floor(num);
+    default:
+      throw new Error(`invalid byte size unit: ${unit}`);
+  }
+}
 
 type CodexTrajectoryOpenFlagConstants = Pick<
   typeof nodeFs.constants,
@@ -75,10 +126,13 @@ async function safeAppendTrajectoryFile(filePath: string, line: string): Promise
   });
 }
 
-function boundedTrajectoryLine(event: Record<string, unknown>): string | undefined {
+function boundedTrajectoryLine(
+  event: Record<string, unknown>,
+  maxBytes: number,
+): string | undefined {
   const line = JSON.stringify(event);
   const bytes = Buffer.byteLength(line, "utf8");
-  if (bytes <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+  if (bytes <= maxBytes) {
     return `${line}\n`;
   }
   const truncated = JSON.stringify({
@@ -86,11 +140,11 @@ function boundedTrajectoryLine(event: Record<string, unknown>): string | undefin
     data: {
       truncated: true,
       originalBytes: bytes,
-      limitBytes: TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+      limitBytes: maxBytes,
       reason: "trajectory-event-size-limit",
     },
   });
-  if (Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+  if (Buffer.byteLength(truncated, "utf8") <= maxBytes) {
     return `${truncated}\n`;
   }
   return undefined;
@@ -157,6 +211,7 @@ export function createCodexTrajectoryRecorder(
     return null;
   }
 
+  const eventMaxBytes = resolveCodexTrajectoryRuntimeEventMaxBytes(env);
   const filePath = resolveTrajectoryFilePath({
     env,
     sessionFile: params.attempt.sessionFile,
@@ -195,7 +250,7 @@ export function createCodexTrajectoryRecorder(
         modelApi: attribution.api,
         data: data ? sanitizeValue(data) : undefined,
       };
-      const line = boundedTrajectoryLine(event);
+      const line = boundedTrajectoryLine(event, eventMaxBytes);
       if (!line) {
         return;
       }

--- a/src/trajectory/paths.test.ts
+++ b/src/trajectory/paths.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveTrajectoryRuntimeEventMaxBytes,
+  TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+} from "./paths.js";
+
+describe("resolveTrajectoryRuntimeEventMaxBytes", () => {
+  const DEFAULT_BYTES = 256 * 1024;
+
+  it("returns the 256 KiB default when env is empty", () => {
+    expect(resolveTrajectoryRuntimeEventMaxBytes({})).toBe(DEFAULT_BYTES);
+  });
+
+  it("returns the default when the override is whitespace only", () => {
+    expect(
+      resolveTrajectoryRuntimeEventMaxBytes({
+        OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "   ",
+      }),
+    ).toBe(DEFAULT_BYTES);
+  });
+
+  it("accepts raw byte counts", () => {
+    expect(
+      resolveTrajectoryRuntimeEventMaxBytes({
+        OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "1024",
+      }),
+    ).toBe(1024);
+  });
+
+  it("accepts kb suffixes", () => {
+    expect(
+      resolveTrajectoryRuntimeEventMaxBytes({
+        OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "512kb",
+      }),
+    ).toBe(512 * 1024);
+  });
+
+  it("accepts mb suffixes", () => {
+    expect(
+      resolveTrajectoryRuntimeEventMaxBytes({
+        OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "2mb",
+      }),
+    ).toBe(2 * 1024 * 1024);
+  });
+
+  it("accepts gb suffixes", () => {
+    expect(
+      resolveTrajectoryRuntimeEventMaxBytes({
+        OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "1gb",
+      }),
+    ).toBe(1 * 1024 * 1024 * 1024);
+  });
+
+  it("falls back to the default on unparseable input", () => {
+    expect(
+      resolveTrajectoryRuntimeEventMaxBytes({
+        OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "not-a-size",
+      }),
+    ).toBe(DEFAULT_BYTES);
+  });
+
+  it("falls back to the default on non-positive input", () => {
+    expect(
+      resolveTrajectoryRuntimeEventMaxBytes({
+        OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "0",
+      }),
+    ).toBe(DEFAULT_BYTES);
+  });
+
+  it("module-load constant matches the empty-env resolver result", () => {
+    expect(TRAJECTORY_RUNTIME_EVENT_MAX_BYTES).toBe(resolveTrajectoryRuntimeEventMaxBytes({}));
+  });
+});

--- a/src/trajectory/paths.ts
+++ b/src/trajectory/paths.ts
@@ -8,7 +8,67 @@ import { isPathInside } from "../infra/path-guards.js";
 // inside OPENCLAW_TRAJECTORY_DIR, with names scrubbed for filesystem safety.
 export const TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES = 10 * 1024 * 1024;
 export const TRAJECTORY_RUNTIME_FILE_MAX_BYTES = 50 * 1024 * 1024;
-export const TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = 256 * 1024;
+
+const DEFAULT_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = 256 * 1024;
+
+/**
+ * Resolve the per-event byte cap for trajectory runtime events.
+ *
+ * Operators can override the 256 KiB default via the
+ * `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES` environment variable. Values
+ * accept human-friendly suffixes (`512kb`, `2mb`, `1gb`) or raw byte counts
+ * (`262144`). Invalid, empty, or non-positive values fall back to the default
+ * so misconfiguration cannot silently widen truncation behavior.
+ */
+export function resolveTrajectoryRuntimeEventMaxBytes(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES?.trim();
+  if (!raw) {
+    return DEFAULT_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES;
+  }
+  try {
+    const parsed = parseTrajectoryEventByteSize(raw);
+    if (parsed > 0) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to default on invalid input.
+  }
+  return DEFAULT_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES;
+}
+
+/**
+ * Minimal byte-size parser for the trajectory event cap env var.
+ * Supports: raw integers, `kb`, `mb`, `gb` suffixes.
+ */
+function parseTrajectoryEventByteSize(raw: string): number {
+  const lower = raw.toLowerCase().replace(/\s+/g, "");
+  const m = /^(\d+(?:\.\d+)?)([a-z]*)$/.exec(lower);
+  if (!m) {
+    throw new Error(`invalid byte size: ${raw}`);
+  }
+  const [, numStr, unit] = m;
+  const num = Number.parseFloat(numStr);
+  switch (unit) {
+    case "kb":
+    case "k":
+      return Math.floor(num * 1024);
+    case "mb":
+    case "m":
+      return Math.floor(num * 1024 * 1024);
+    case "gb":
+    case "g":
+      return Math.floor(num * 1024 * 1024 * 1024);
+    case "":
+    case "b":
+      return Math.floor(num);
+    default:
+      throw new Error(`invalid byte size unit: ${unit}`);
+  }
+}
+
+export const TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = resolveTrajectoryRuntimeEventMaxBytes();
 
 type TrajectoryPointerOpenFlagConstants = Pick<
   typeof fs.constants,

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -134,6 +134,36 @@ describe("trajectory runtime", () => {
     );
   });
 
+  it("clamps the configured event cap to the active runtime file budget", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const maxRuntimeFileBytes = 1_200;
+    const recorder = createTrajectoryRuntimeRecorder({
+      env: { OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES: "1mb" },
+      sessionId: "session-1",
+      sessionFile,
+      maxRuntimeFileBytes,
+    });
+
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("context.compiled", {
+      payload: "x".repeat(2_000),
+    });
+    await runtimeRecorder.flush();
+
+    const raw = fs.readFileSync(
+      resolveTrajectoryFilePath({ sessionFile, sessionId: "session-1" }),
+      "utf8",
+    );
+    expect(Buffer.byteLength(raw, "utf8")).toBeLessThanOrEqual(maxRuntimeFileBytes);
+    const parsed = JSON.parse(raw);
+    expect(parsed.data).toMatchObject({
+      truncated: true,
+      limitBytes: maxRuntimeFileBytes - 1,
+      reason: "trajectory-event-size-limit",
+    });
+  });
+
   it("rotates runtime capture at the file budget and keeps newer events", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -50,12 +50,13 @@ describe("trajectory runtime", () => {
   });
 
   it("sanitizes session ids when resolving an override directory", () => {
+    const trajectoryDir = path.resolve("/tmp/traces");
     expect(
       resolveTrajectoryFilePath({
-        env: { OPENCLAW_TRAJECTORY_DIR: "/tmp/traces" },
+        env: { OPENCLAW_TRAJECTORY_DIR: trajectoryDir },
         sessionId: "../evil/session",
       }),
-    ).toBe("/tmp/traces/___evil_session.jsonl");
+    ).toBe(path.join(trajectoryDir, "___evil_session.jsonl"));
   });
 
   it("records sanitized runtime events by default", () => {

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -14,11 +14,11 @@ import { parseBooleanValue } from "../utils/boolean.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
 import {
   TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES,
-  TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
   TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
   resolveTrajectoryPointerOpenFlags,
+  resolveTrajectoryRuntimeEventMaxBytes,
 } from "./paths.js";
 import type { TrajectoryEvent, TrajectoryToolDefinition } from "./types.js";
 
@@ -29,6 +29,7 @@ export {
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
   resolveTrajectoryPointerOpenFlags,
+  resolveTrajectoryRuntimeEventMaxBytes,
   safeTrajectorySessionFileName,
 } from "./paths.js";
 
@@ -133,9 +134,10 @@ function trimTrajectoryWriterCache(): void {
 function truncateOversizedTrajectoryEvent(
   event: TrajectoryEvent,
   line: string,
+  limitBytes: number,
 ): string | undefined {
   const bytes = Buffer.byteLength(line, "utf8");
-  if (bytes <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+  if (bytes <= limitBytes) {
     return line;
   }
   const truncated = safeJsonStringify({
@@ -143,11 +145,11 @@ function truncateOversizedTrajectoryEvent(
     data: {
       truncated: true,
       originalBytes: bytes,
-      limitBytes: TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+      limitBytes,
       reason: "trajectory-event-size-limit",
     },
   });
-  if (truncated && Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+  if (truncated && Buffer.byteLength(truncated, "utf8") <= limitBytes) {
     return truncated;
   }
   return undefined;
@@ -486,15 +488,25 @@ export function createTrajectoryRuntimeRecorder(
     return null;
   }
 
+  // Resolve the per-event byte cap once at recorder creation from the captured
+  // `env`, matching how `OPENCLAW_TRAJECTORY` enablement and trajectory path
+  // resolution already pin to the recorder's env. Re-reading it per event from
+  // ambient `process.env` would (a) ignore an injected `params.env` override
+  // and (b) let mid-session ambient mutations silently change behavior.
+  const maxRuntimeFileBytes = Math.max(
+    1,
+    Math.floor(params.maxRuntimeFileBytes ?? TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES),
+  );
+  const eventMaxBytes = Math.min(
+    resolveTrajectoryRuntimeEventMaxBytes(env),
+    Math.max(1, maxRuntimeFileBytes - 1),
+  );
+
   const filePath = resolveTrajectoryFilePath({
     env,
     sessionFile: params.sessionFile,
     sessionId: params.sessionId,
   });
-  const maxRuntimeFileBytes = Math.max(
-    1,
-    Math.floor(params.maxRuntimeFileBytes ?? TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES),
-  );
   const writer = params.writer ?? getTrajectoryWindowWriter(filePath, maxRuntimeFileBytes);
   writeTrajectoryPointerBestEffort({
     filePath,
@@ -534,7 +546,7 @@ export function createTrajectoryRuntimeRecorder(
     if (!line) {
       return undefined;
     }
-    const boundedLine = truncateOversizedTrajectoryEvent(event, line);
+    const boundedLine = truncateOversizedTrajectoryEvent(event, line, eventMaxBytes);
     if (!boundedLine) {
       return undefined;
     }


### PR DESCRIPTION
## Summary

- The trajectory per-event byte cap is currently fixed at 256 KiB, so large but valid events are replaced by a truncation sentinel.
- This PR adds a startup-scoped `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES` override for both trajectory writers while preserving the existing 256 KiB default.
- The override accepts byte counts and human-friendly suffixes such as `512kb`, `1mb`, and `2gb`.
- Invalid, empty, zero, or negative values fall back to the default.
- The file-level trajectory cap still applies, so this does not make trajectory storage unbounded.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: Oversized trajectory runtime events are currently truncated at the hard-coded 256 KiB per-event cap. The after-fix behavior should keep the default cap unchanged, but allow an operator to raise the cap at recorder creation time through `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES`.
- **Real environment tested**: Windows local checkout, Node.js v24.15.0, exact PR head `8f7d4e1a6b95c0561a83b0b71e0b6005d449ee87`, using the real `createTrajectoryRuntimeRecorder` path and a synthetic oversized payload shaped to stay under the inner sanitizer limits while exceeding the outer event-byte cap.
- **Exact steps or command run after this patch**:
  1. Created a real trajectory recorder with `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES` unset and recorded a payload with 60 fields of 5000 chars each.
  2. Created a second real trajectory recorder with the identical payload and `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES=1mb`.
  3. Compared the emitted trajectory JSONL line size and truncation metadata.
  4. Ran focused trajectory tests, the extension trajectory test file, the previously failing gateway CI files, touched-file lint, core and extension typechecks, and diff whitespace checks.
- **Evidence after fix**:

```text
head=8f7d4e1a6b95c0561a83b0b71e0b6005d449ee87
environment=win32 x64, Node v24.15.0
PHASE default-cap
env (unset)
trajectory file emitted for default-cap run
bytes 558
truncated true
originalBytes 301299
limitBytes 262144
reason trajectory-event-size-limit
PHASE override-1mb
env 1mb
trajectory file emitted for override-1mb run
bytes 301302
truncated false
field_count 60
```

```text
node scripts/run-vitest.mjs src/trajectory/paths.test.ts src/trajectory/runtime.test.ts

Test Files  2 passed
Tests       20 passed, 2 skipped
```

Supplemental extension trajectory validation:

```text
Test Files  1 passed (1)
Tests       10 passed, 1 skipped
```

Supplemental validation for the previously failing gateway CI files:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-startup-config.secrets.test.ts src/gateway/server-import-boundary.test.ts --reporter=dot --pool=forks --maxWorkers=1

Test Files  2 passed (2)
Tests       19 passed (19)
```

Additional local checks at the same PR head:

```text
node scripts/run-oxlint.mjs <touched trajectory/docs files> -> passed
node scripts/run-tsgo.mjs -p tsconfig.core.json -> passed
node scripts/run-tsgo.mjs -p tsconfig.extensions.json -> passed
git diff --check origin/main...HEAD -> passed
```

- **Observed result after fix**: With the default cap, the event is truncated to a 558-byte sentinel with `originalBytes=301299`, `limitBytes=262144`, and `reason=trajectory-event-size-limit`. With `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES=1mb`, the same payload is preserved as a 301302-byte line with `truncated=false` and all 60 fields present.
- **What was not tested**: Filesystem-level I/O performance at very large per-event limits. The file-level cap still applies and prevents unbounded trajectory growth.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command execution surface changed? `No`
- Data access scope changed? `No`
- New operator-controlled config/env surface? `Yes` - `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES` controls only the per-event trajectory recording cap at recorder creation time.
- **Risk + mitigation**: A very high cap can increase per-event trajectory disk usage. The existing file-level trajectory cap remains in force, invalid values fall back to the 256 KiB default, and the override is resolved once from the recorder environment rather than reread from ambient process state per event.

## Repro + Verification

### Environment

- OS: Windows
- Runtime: Node.js v24.15.0
- PR head: `8f7d4e1a6b95c0561a83b0b71e0b6005d449ee87`

### Steps

1. Record the same oversized trajectory event with the override unset.
2. Record it again with `OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES=1mb`.
3. Inspect the resulting trajectory JSONL lines.

### Expected

- Default cap: event is replaced by a truncation sentinel with `limitBytes=262144`.
- 1 MiB override: event is preserved in full and is not marked truncated.

### Actual

- Default cap emitted a 558-byte truncation sentinel.
- 1 MiB override emitted the full 301302-byte event with all 60 fields present.

## Review scope clarification

The current head resolves the cap from the recorder's explicit environment at recorder creation time:

```ts
const eventMaxBytes = resolveTrajectoryRuntimeEventMaxBytes(env);
```

The truncate helper receives that resolved `eventMaxBytes` value instead of rereading process-wide environment state. This keeps the override startup-scoped and aligned with the recorder's already resolved environment.
