### PR TITLE
fix(memory-lancedb): add retry mechanism for Windows Docker bind mount sync delays

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2627,6 +2627,195 @@ describe("memory plugin e2e", () => {
     }
   });
 
+  test("cleans schema row before using a table reopened after transient create cleanup failure", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const partialVectorSearch = vi.fn(() => {
+      throw new Error("partial table should not be reused");
+    });
+    const partialTable = {
+      vectorSearch: partialVectorSearch,
+      countRows: vi.fn(async () => 0),
+      add: vi.fn(async () => undefined),
+      delete: vi.fn().mockRejectedValueOnce(new Error("temporary bind mount cleanup failure")),
+    };
+    const recoveredDelete = vi.fn(async () => undefined);
+    const recoveredTable = {
+      vectorSearch,
+      countRows: vi.fn(async () => 0),
+      add: vi.fn(async () => undefined),
+      delete: recoveredDelete,
+    };
+    const tableNames = vi.fn().mockResolvedValueOnce([]).mockResolvedValueOnce(["memories"]);
+    const createTable = vi.fn(async () => partialTable);
+    const openTable = vi.fn(async () => recoveredTable);
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames,
+        createTable,
+        openTable,
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: dynamicMemoryPlugin } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+          },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      dynamicMemoryPlugin.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+      if (!recallTool) {
+        throw new Error("memory_recall tool was not registered");
+      }
+
+      const result = await recallTool.execute("test-call-create-cleanup-retry", {
+        query: "hello cleanup retry",
+      });
+
+      expect(result.details?.count).toBe(0);
+      expect(tableNames).toHaveBeenCalledTimes(2);
+      expect(createTable).toHaveBeenCalledTimes(1);
+      expect(partialTable.delete).toHaveBeenCalledWith('id = "__schema__"');
+      expect(openTable).toHaveBeenCalledWith("memories");
+      expect(recoveredDelete).toHaveBeenCalledWith('id = "__schema__"');
+      expect(partialVectorSearch).not.toHaveBeenCalled();
+      expect(vectorSearch).toHaveBeenCalledWith([0.1, 0.2, 0.3]);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("includes Docker bind mount guidance when table initialization retries are exhausted", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const tableNames = vi.fn(async () => {
+      throw new Error("metadata is not ready");
+    });
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames,
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: dynamicMemoryPlugin } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+          },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      dynamicMemoryPlugin.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+      if (!recallTool) {
+        throw new Error("memory_recall tool was not registered");
+      }
+
+      await expect(
+        recallTool.execute("test-call-exhausted-retry", { query: "hello exhausted retry" }),
+      ).rejects.toThrow("If the LanceDB data directory is backed by a Docker bind mount");
+      expect(tableNames).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
   test("config schema accepts storageOptions with string values", async () => {
     const { default: memoryPluginCandidate } = await import("./index.js");
 

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -227,23 +227,47 @@ class MemoryDB {
       ? { storageOptions: this.storageOptions }
       : {};
     this.db = await lancedb.connect(this.dbPath, connectionOptions);
-    const tables = await this.db.tableNames();
 
-    if (tables.includes(TABLE_NAME)) {
-      this.table = await this.db.openTable(TABLE_NAME);
-    } else {
-      this.table = await this.db.createTable(TABLE_NAME, [
-        {
-          id: "__schema__",
-          text: "",
-          vector: Array.from({ length: this.vectorDim }).fill(0),
-          importance: 0,
-          category: "other",
-          createdAt: 0,
-        },
-      ]);
-      await this.table.delete('id = "__schema__"');
+    // Retry mechanism for Windows Docker bind mount sync delays
+    const maxRetries = 3;
+    const retryDelayMs = 100;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const tables = await this.db.tableNames();
+
+        if (tables.includes(TABLE_NAME)) {
+          this.table = await this.db.openTable(TABLE_NAME);
+        } else {
+          this.table = await this.db.createTable(TABLE_NAME, [
+            {
+              id: "__schema__",
+              text: "",
+              vector: Array.from({ length: this.vectorDim }).fill(0),
+              importance: 0,
+              category: "other",
+              createdAt: 0,
+            },
+          ]);
+          await this.table.delete('id = "__schema__"');
+        }
+        return;
+      } catch (error) {
+        lastError = error;
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, retryDelayMs * (attempt + 1)));
+        }
+      }
     }
+
+    // All retries exhausted - throw with helpful Windows message if applicable
+    const error = lastError instanceof Error ? lastError : new Error(String(lastError));
+    if (process.platform === "win32") {
+      error.message +=
+        "\n\nWindows users: If using Docker, try using volumes instead of bind mounts for the LanceDB data directory.";
+    }
+    throw error;
   }
 
   async store(entry: Omit<MemoryEntry, "id" | "createdAt">): Promise<MemoryEntry> {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -238,7 +238,7 @@ class MemoryDB {
       : {};
     this.db = await lancedb.connect(this.dbPath, connectionOptions);
 
-    // Retry mechanism for Windows Docker bind mount sync delays
+    // Retry transient table metadata errors seen with Docker bind mounts.
     const maxRetries = 3;
     const retryDelayMs = 100;
     let lastError: unknown;
@@ -248,9 +248,11 @@ class MemoryDB {
         const tables = await this.db.tableNames();
 
         if (tables.includes(TABLE_NAME)) {
-          this.table = await this.db.openTable(TABLE_NAME);
+          const table = await this.db.openTable(TABLE_NAME);
+          await table.delete('id = "__schema__"');
+          this.table = table;
         } else {
-          this.table = await this.db.createTable(TABLE_NAME, [
+          const table = await this.db.createTable(TABLE_NAME, [
             {
               id: "__schema__",
               text: "",
@@ -260,7 +262,8 @@ class MemoryDB {
               createdAt: 0,
             },
           ]);
-          await this.table.delete('id = "__schema__"');
+          await table.delete('id = "__schema__"');
+          this.table = table;
         }
         return;
       } catch (error) {
@@ -271,12 +274,10 @@ class MemoryDB {
       }
     }
 
-    // All retries exhausted - throw with helpful Windows message if applicable
+    // All retries exhausted: surface a Docker bind-mount hint for the common sync-delay case.
     const error = lastError instanceof Error ? lastError : new Error(String(lastError));
-    if (process.platform === "win32") {
-      error.message +=
-        "\n\nWindows users: If using Docker, try using volumes instead of bind mounts for the LanceDB data directory.";
-    }
+    error.message +=
+      "\n\nIf the LanceDB data directory is backed by a Docker bind mount, try using a named Docker volume instead.";
     throw error;
   }
 

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -237,23 +237,47 @@ class MemoryDB {
       ? { storageOptions: this.storageOptions }
       : {};
     this.db = await lancedb.connect(this.dbPath, connectionOptions);
-    const tables = await this.db.tableNames();
 
-    if (tables.includes(TABLE_NAME)) {
-      this.table = await this.db.openTable(TABLE_NAME);
-    } else {
-      this.table = await this.db.createTable(TABLE_NAME, [
-        {
-          id: "__schema__",
-          text: "",
-          vector: Array.from({ length: this.vectorDim }).fill(0),
-          importance: 0,
-          category: "other",
-          createdAt: 0,
-        },
-      ]);
-      await this.table.delete('id = "__schema__"');
+    // Retry mechanism for Windows Docker bind mount sync delays
+    const maxRetries = 3;
+    const retryDelayMs = 100;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const tables = await this.db.tableNames();
+
+        if (tables.includes(TABLE_NAME)) {
+          this.table = await this.db.openTable(TABLE_NAME);
+        } else {
+          this.table = await this.db.createTable(TABLE_NAME, [
+            {
+              id: "__schema__",
+              text: "",
+              vector: Array.from({ length: this.vectorDim }).fill(0),
+              importance: 0,
+              category: "other",
+              createdAt: 0,
+            },
+          ]);
+          await this.table.delete('id = "__schema__"');
+        }
+        return;
+      } catch (error) {
+        lastError = error;
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, retryDelayMs * (attempt + 1)));
+        }
+      }
     }
+
+    // All retries exhausted - throw with helpful Windows message if applicable
+    const error = lastError instanceof Error ? lastError : new Error(String(lastError));
+    if (process.platform === "win32") {
+      error.message +=
+        "\n\nWindows users: If using Docker, try using volumes instead of bind mounts for the LanceDB data directory.";
+    }
+    throw error;
   }
 
   async store(entry: Omit<MemoryEntry, "id" | "createdAt">): Promise<MemoryEntry> {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -269,7 +269,9 @@ class MemoryDB {
       } catch (error) {
         lastError = error;
         if (attempt < maxRetries - 1) {
-          await new Promise((resolve) => setTimeout(resolve, retryDelayMs * (attempt + 1)));
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, retryDelayMs * (attempt + 1));
+          });
         }
       }
     }


### PR DESCRIPTION
Hey! 👋

This PR hardens the memory-lancedb plugin initialization path for transient LanceDB table metadata errors seen with Docker bind-mounted data directories.

## The Problem

When a LanceDB data directory is backed by a host bind mount, table metadata can be briefly unavailable after table creation. The previous one-shot initialization path could fail during startup, and the first retry version still had two gaps:

- a table created before `__schema__` cleanup could be reopened and used before cleanup was retried
- the bind-mount guidance was gated on `process.platform === "win32"`, which misses Linux containers running on Docker Desktop

## The Solution

The retry loop now keeps the table local until cleanup succeeds, retries cleanup when a table is reopened, and surfaces generic Docker bind-mount guidance after retry exhaustion.

## What Changed

- Updated `extensions/memory-lancedb/index.ts` to only cache the table after `__schema__` cleanup succeeds.
- Added Docker bind-mount guidance on retry exhaustion regardless of host/runtime platform.
- Added focused coverage in `extensions/memory-lancedb/index.test.ts` for transient create-cleanup failure and exhausted retry diagnostics.

## Real behavior proof

**Behavior or issue addressed:** memory-lancedb can initialize a LanceDB-backed memory table, store a memory, and recall it after this initialization retry hardening.

**Real environment tested:** local OpenClaw plugin registration path using the actual memory-lancedb plugin, actual `@lancedb/lancedb` storage in a temporary database, and a local OpenAI-compatible embeddings endpoint.

**Exact steps or command run after this patch:**

```console
$ NODE_OPTIONS=--no-deprecation node --import tsx /tmp/openclaw-memory-lancedb-real-smoke.ts
```

**Evidence after fix:** copied live console output from the real smoke run:

```console
OpenClaw memory-lancedb real setup smoke
dbPath: <temp>/lancedb
registered tools: memory_forget, memory_recall, memory_store
embedding requests: 2
store action: created
stored id format: uuid
recall count: 1
recalled category: preference
recalled text: I prefer deterministic OpenClaw memory proof runs.
startup log: info:memory-lancedb: plugin registered (db: <temp>/lancedb, lazy init)
```

**Observed result after fix:** `memory_store` created a UUID-backed memory in the LanceDB table, and `memory_recall` returned one recalled preference from that same temporary LanceDB database.

**What was not tested:** I did not run a Windows Docker Desktop bind-mount reproduction locally. The real smoke covers the actual plugin + LanceDB store/recall path; the focused regression tests cover transient cleanup retry and the exhausted-retry Docker bind-mount diagnostic.

## Testing

```console
$ pnpm test extensions/memory-lancedb/index.test.ts
Test Files  1 passed (1)
Tests  46 passed (46)
[test] passed 1 Vitest shard in 12.34s
```

```console
$ pnpm exec oxfmt --check --threads=1 extensions/memory-lancedb/index.ts extensions/memory-lancedb/index.test.ts
All matched files use the correct format.
```

```console
$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-lancedb/index.ts extensions/memory-lancedb/index.test.ts
Found 0 warnings and 0 errors.
```

```console
$ git diff --check
# no output
```

Fixes #58139
