### PR TITLE
fix(agents): extend session-write-lock payload-less orphan grace from 5s to 30s

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -282,7 +282,7 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
-  it("reclaims payload-less orphan lock files after the short init grace", async () => {
+  it("preserves short-timeout recovery for payload-less orphan lock files", async () => {
     await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
       await fs.writeFile(lockPath, "", "utf8");
       const orphanDate = new Date(Date.now() - 10_000);
@@ -290,13 +290,51 @@ describe("acquireSessionWriteLock", () => {
 
       const lock = await acquireSessionWriteLock({
         sessionFile,
-        timeoutMs: 10_000,
+        timeoutMs: 500,
         staleMs: 60_000,
       });
       const raw = await fs.readFile(lockPath, "utf8");
       const payload = JSON.parse(raw) as { pid?: unknown };
       expect(payload.pid).toBe(process.pid);
       await lock.release();
+    });
+  });
+
+  it("reclaims payload-less orphan lock files past the 30s init grace", async () => {
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      await fs.writeFile(lockPath, "", "utf8");
+      const orphanDate = new Date(Date.now() - 35_000);
+      await fs.utimes(lockPath, orphanDate, orphanDate);
+
+      // 35s > 30s grace, so the payload-less lock is reclaimed.
+      const lock = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 30_000,
+        staleMs: 60_000,
+      });
+      const raw = await fs.readFile(lockPath, "utf8");
+      const payload = JSON.parse(raw) as { pid?: unknown };
+      expect(payload.pid).toBe(process.pid);
+      await lock.release();
+    });
+  });
+
+  it("preserves payload-less lock files within the 30s cleanup grace", async () => {
+    await withTempSessionLockFile(async ({ root }) => {
+      const lockPath = path.join(root, "sessions.jsonl.lock");
+      await fs.writeFile(lockPath, "", "utf8");
+      const orphanDate = new Date(Date.now() - 10_000);
+      await fs.utimes(lockPath, orphanDate, orphanDate);
+
+      const result = await cleanStaleLockFiles({
+        sessionsDir: root,
+        staleMs: 60_000,
+        removeStale: true,
+      });
+
+      expect(result.cleaned).toEqual([]);
+      expect(result.locks).toHaveLength(1);
+      await expect(fs.access(lockPath)).resolves.toBeUndefined();
     });
   });
 

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -52,9 +52,12 @@ const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old", "hold-exceeded"]);
 function yieldEventLoop(): Promise<void> {
   return new Promise<void>((resolve) => setImmediate(resolve));
 }
-// A payload-less lock can be left behind if shutdown lands between open("wx")
-// and the owner metadata write. Keep the grace short so 10s callers recover.
-const ORPHAN_LOCK_PAYLOAD_GRACE_MS = 5_000;
+// A payload-less lock can be left behind during the window between open("wx")
+// and the owner metadata write if the owner is suspended (CPU pressure,
+// container freeze, I/O stall, GC pause). 30 s covers realistic system
+// pauses while staying well below DEFAULT_TIMEOUT_GRACE_MS (120 s).
+const ORPHAN_LOCK_PAYLOAD_GRACE_MS = 30_000;
+const SHORT_TIMEOUT_ORPHAN_LOCK_PAYLOAD_GRACE_MS = 5_000;
 
 type CleanupState = {
   registered: boolean;
@@ -565,6 +568,7 @@ async function shouldReclaimContendedLockFile(
   details: LockInspectionDetails,
   staleMs: number,
   nowMs: number,
+  orphanPayloadGraceMs = ORPHAN_LOCK_PAYLOAD_GRACE_MS,
 ): Promise<boolean> {
   if (!details.stale) {
     return false;
@@ -575,11 +579,18 @@ async function shouldReclaimContendedLockFile(
   try {
     const stat = await fs.stat(lockPath);
     const ageMs = Math.max(0, nowMs - stat.mtimeMs);
-    return ageMs > Math.min(staleMs, ORPHAN_LOCK_PAYLOAD_GRACE_MS);
+    return ageMs > Math.min(staleMs, orphanPayloadGraceMs);
   } catch (error) {
     const code = (error as { code?: string } | null)?.code;
     return code !== "ENOENT";
   }
+}
+
+function resolveOrphanLockPayloadGraceMs(timeoutMs: number): number {
+  if (timeoutMs < ORPHAN_LOCK_PAYLOAD_GRACE_MS) {
+    return SHORT_TIMEOUT_ORPHAN_LOCK_PAYLOAD_GRACE_MS;
+  }
+  return ORPHAN_LOCK_PAYLOAD_GRACE_MS;
 }
 
 async function shouldRemoveLockDuringCleanup(
@@ -779,6 +790,7 @@ export async function acquireSessionWriteLock(params: {
   });
   const staleMs = resolvePositiveMs(params.staleMs, defaultOptions.staleMs);
   const maxHoldMs = resolvePositiveMs(params.maxHoldMs, defaultOptions.maxHoldMs);
+  const orphanPayloadGraceMs = resolveOrphanLockPayloadGraceMs(timeoutMs);
   const sessionFile = path.resolve(params.sessionFile);
   const sessionDir = path.dirname(sessionFile);
   const normalizedSessionFile = await resolveNormalizedSessionFile(sessionFile);
@@ -816,7 +828,13 @@ export async function acquireSessionWriteLock(params: {
             readOwnerProcessArgs: readProcessArgsSync,
             respectMaxHold: !heldByThisProcess,
           });
-          return await shouldReclaimContendedLockFile(lockPath, inspected, staleMs, nowMs);
+          return await shouldReclaimContendedLockFile(
+            lockPath,
+            inspected,
+            staleMs,
+            nowMs,
+            orphanPayloadGraceMs,
+          );
         },
         shouldRemoveStaleLock: async ({ lockPath, normalizedTargetPath, payload }) => {
           await yieldEventLoop();
@@ -831,7 +849,13 @@ export async function acquireSessionWriteLock(params: {
             readOwnerProcessArgs: readProcessArgsSync,
             respectMaxHold: !heldByThisProcess,
           });
-          return await shouldReclaimContendedLockFile(lockPath, inspected, staleMs, nowMs);
+          return await shouldReclaimContendedLockFile(
+            lockPath,
+            inspected,
+            staleMs,
+            nowMs,
+            orphanPayloadGraceMs,
+          );
         },
       });
       return { release: lock.release };


### PR DESCRIPTION
## Summary

`ORPHAN_LOCK_PAYLOAD_GRACE_MS` in `src/agents/session-write-lock.ts` is set to 5 seconds.
A payload-less lock file is left behind during the window between `open("wx")` creating
the file and the owner writing its metadata. If the owning process is suspended (CPU
pressure, container freeze, I/O stall) for more than 5 seconds before it can write the
payload, a concurrent process will incorrectly reclaim the lock as stale.

`shouldReclaimContendedLockFile()` (private helper in `src/agents/session-write-lock.ts`)
only consults `ORPHAN_LOCK_PAYLOAD_GRACE_MS` when the lock payload is missing or has
an invalid `createdAt`. `dead-pid` and `recycled-pid` reclaims use `staleMs` directly
and are unaffected by this PR.

This PR raises the grace from 5 s to 30 s, which is still well below the default
stale timeout (`DEFAULT_TIMEOUT_GRACE_MS = 120 s`) but covers realistic system pauses.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Payload-less session write-lock files now get a 30s grace for default/long acquire timeouts and cleanup sweeps, while callers that explicitly use an acquire timeout below 30s keep the old 5s compatibility grace.
- Real environment tested: Windows Server local checkout, Node.js v24.15.0, local OpenClaw checkout at exact PR head `8f40425ccdbe37c41c4edac29b731c406ccd1f99`.
- Exact steps or command run after this patch: Rebased the PR onto current `origin/main` (`94df665cdcc99a26b2375920879d290923a8041f`), then ran:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/session-write-lock.test.ts --reporter=dot --pool=forks --maxWorkers=1
```

- Evidence after fix: Terminal output from the exact-head run (local path redacted):

```text
RUN  v4.1.7 <local OpenClaw checkout>

Test Files  1 passed (1)
Tests       47 passed (47)
```

- Observed result after fix: The focused suite passes on exact head `8f40425ccdbe37c41c4edac29b731c406ccd1f99`. The added lock tests cover all three intended branches: a 10s-old payload-less lock is still reclaimed for a short `timeoutMs: 500` acquire path, a 35s-old payload-less lock is reclaimed for the long `timeoutMs: 30_000` acquire path, and cleanup scans a real `sessions.jsonl.lock` file but preserves it inside the 30s cleanup grace (`result.locks` confirms the file was actually inspected).
- What was not tested: A live multi-process contention rerun after this final rebase. Earlier two-process real-host evidence in this PR established the original race; this refresh verifies the exact current head and the short-timeout compatibility behavior added after review.


**Behavior addressed:** payload-less orphan lock files reclaimed prematurely under
system load, causing potential session data races. The race window opens between
`open("wx")` succeeding (creating an empty lock file) and the owner writing its
`{pid, createdAt, starttime}` metadata. If the owner is suspended in this window
longer than the grace, a concurrent process will treat the empty lock as orphaned
and remove it, creating a window where two processes hold the same logical lock.

**Environment tested:** Linux 6.8.0-106-generic (x64) on a real production host
(hostname redacted to `<host>`), patched local build at HEAD, Node v24.14.1,
multi-agent cron setup with 5+ concurrent sessions.

**Steps run after the patch:**

```bash
node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts
```

**Evidence after fix:**

5秒→30秒的宽限期仅在无载荷锁（payload-less lock）存活超过5秒时触发，在生产环境中，这种情况发生在 CPU 饱和 / 容器冻结 / 长 GC 暂停期间。为了在可控的时序下重现**竞争方**的决策，一个双进程竞争测试夹具（`e2e-contention.mjs`）会启动两个独立的 Node 子进程来运行真实的 `session-write-lock.ts` 模块（不使用模拟）：

- `P_owner` 使用 `O_EXCL|O_CREAT` 打开锁附属文件，然后休眠 12 秒再写入载荷元数据——这模拟了§"修补前证据"中捕获到的生产停滞（在生产主机上，由于事件循环压力，持锁时间长达 75636 毫秒）。
- `P_contender` 等待 8 秒，然后尝试获取同一个锁。

该测试夹具在 Linux 验证主机上运行了两次，**一次针对 `upstream/main`**（未修补的基线），**一次针对此 PR 的头部提交 `ee62b6947482`**，使用字节级相同的时序。两次运行之间只有源代码树不同。

**运行 1 — 未修补的 `main`（`ORPHAN_LOCK_PAYLOAD_GRACE_MS = 5_000`）：**

```jsonl
{"ts":"2026-05-16T13:00:00.987Z","role":"owner","pid":7123,"event":"module-loaded","ORPHAN_LOCK_PAYLOAD_GRACE_MS":"unknown","lockPath":"/tmp/openclaw-pr80686-fixture/fixture-session.json.lock"}
{"ts":"2026-05-16T13:00:00.988Z","role":"owner","pid":7123,"event":"owner-start"}
{"ts":"2026-05-16T13:00:00.989Z","role":"owner","pid":7123,"event":"owner-opened-empty-lock","stallMs":12000}
{"ts":"2026-05-16T13:00:02.958Z","role":"contender","pid":7165,"event":"module-loaded","ORPHAN_LOCK_PAYLOAD_GRACE_MS":"unknown","lockPath":"/tmp/openclaw-pr80686-fixture/fixture-session.json.lock"}
{"ts":"2026-05-16T13:00:02.959Z","role":"contender","pid":7165,"event":"contender-waiting","delayMs":8000}
{"ts":"2026-05-16T13:00:10.966Z","role":"contender","pid":7165,"event":"contender-attempting","lockPath":"/tmp/openclaw-pr80686-fixture/fixture-session.json.lock"}
{"ts":"2026-05-16T13:00:10.970Z","role":"contender","pid":7165,"event":"contender-acquired","decision":"reclaimed-or-original-was-released"}
{"ts":"2026-05-16T13:00:10.970Z","role":"contender","pid":7165,"event":"contender-released"}
{"ts":"2026-05-16T13:00:12.992Z","role":"owner","pid":7123,"event":"owner-wrote-payload"}
{"ts":"2026-05-16T13:00:12.992Z","role":"owner","pid":7123,"event":"owner-released"}
```

竞争方在 `13:00:10.970Z` 获取了锁——在尝试后 4 毫秒，且比持有方在 `13:00:12.992Z` 完成其停滞**早了 2 秒**。这 2 秒的窗口就是确切的竞态条件：两个进程同时认为自己持有同一个逻辑锁。

**运行 2 — 已修补的 PR 头部 `ee62b6947482`（`ORPHAN_LOCK_PAYLOAD_GRACE_MS = 30_000`）：**

```jsonl
{"ts":"2026-05-16T13:01:44.587Z","role":"owner","pid":7930,"event":"module-loaded","ORPHAN_LOCK_PAYLOAD_GRACE_MS":"unknown","lockPath":"/tmp/openclaw-pr80686-fixture/fixture-session.json.lock"}
{"ts":"2026-05-16T13:01:44.588Z","role":"owner","pid":7930,"event":"owner-start"}
{"ts":"2026-05-16T13:01:44.590Z","role":"owner","pid":7930,"event":"owner-opened-empty-lock","stallMs":12000}
{"ts":"2026-05-16T13:01:46.518Z","role":"contender","pid":7964,"event":"module-loaded","ORPHAN_LOCK_PAYLOAD_GRACE_MS":"unknown","lockPath":"/tmp/openclaw-pr80686-fixture/fixture-session.json.lock"}
{"ts":"2026-05-16T13:01:46.519Z","role":"contender","pid":7964,"event":"contender-waiting","delayMs":8000}
{"ts":"2026-05-16T13:01:54.519Z","role":"contender","pid":7964,"event":"contender-attempting","lockPath":"/tmp/openclaw-pr80686-fixture/fixture-session.json.lock"}
{"ts":"2026-05-16T13:01:56.595Z","role":"owner","pid":7930,"event":"owner-wrote-payload"}
{"ts":"2026-05-16T13:01:56.596Z","role":"owner","pid":7930,"event":"owner-released"}
{"ts":"2026-05-16T13:01:56.602Z","role":"contender","pid":7964,"event":"contender-acquired","decision":"reclaimed-or-original-was-released"}
{"ts":"2026-05-16T13:01:56.603Z","role":"contender","pid":7964,"event":"contender-released"}
```

竞争方在 `13:01:54.519Z` 尝试获取（在持有方打开空锁后约 10 秒——与运行 1 相同），但**没有**回收锁。它一直等到持有方在 `13:01:56.596Z` 自然完成其停滞，然后在 `13:01:56.602Z` 获取了锁——在释放后 6 毫秒，在尝试后 2083 毫秒。持有方和竞争方从未同时持有锁；竞态条件被消除了。

两次运行中竞争方行为的差异，正是由于此 PR 更改的**确切**谓词（`shouldReclaimContendedLockFile`，第 456 行：`return ageMs > Math.min(staleMs, ORPHAN_LOCK_PAYLOAD_GRACE_MS);`）所致。当 `ORPHAN_LOCK_PAYLOAD_GRACE_MS = 5_000` 时，`Math.min(staleMs, 5000) = 5000`，一个 10 秒龄的无载荷锁是可回收的。当 `ORPHAN_LOCK_PAYLOAD_GRACE_MS = 30_000` 时，`Math.min(staleMs, 30000) = 30000`，同一个锁将被保留。

注意：`ORPHAN_LOCK_PAYLOAD_GRACE_MS` 在测试夹具输出中显示为 `"unknown"`，因为该模块将其声明为模块私有的 `const` 而不是 `export const`；测试夹具通过 `await import(...)` 进行探测，当该符号无法从外部读取时回退到 `"unknown"`。运行 1 和运行 2 之间的行为差异就是证明，而不是常量值的外部可读性。

`dead-pid`（进程已死）和 `recycled-pid`（进程 ID 已被回收）的回收路径不受此 PR 的影响，并保持立即回收（它们绕过了宽限期）。

**Observed result after fix:** Under `ORPHAN_LOCK_PAYLOAD_GRACE_MS = 30_000`,
the contender reclaim decision for a payload-less lock with `ageMs` in the
`(5_000, 30_000)` window flips from `true` (incorrectly reclaim, current `main`
behavior) to `false` (correctly preserve, this PR's behavior). The grace is
bounded by `Math.min(staleMs, ORPHAN_LOCK_PAYLOAD_GRACE_MS)`, so the original
`DEFAULT_TIMEOUT_GRACE_MS = 120_000` upper bound is unchanged. `dead-pid` and
`recycled-pid` reclaims continue to fire immediately as before.

**What was not tested:** Behavior when the process crashes permanently after
`open("wx")` without ever writing a payload. In that pathological case the 30 s
grace delays recovery by 25 s compared to the previous 5 s. This is acceptable
because (a) the `staleMs` upper bound (120 s) is the primary recovery mechanism,
and (b) a crash between `open("wx")` and the metadata write is itself extremely
rare (microsecond-window for a process that survived `open`).

**Before evidence:** On the same production host (hostname redacted to `<host>`),
the watchdog logged `releasing lock held` more than 500 times in the past 30
days, with a max single hold of approximately 640 s under Event Loop pressure
(P99 = 77 ms, max = 1071 ms in a 2026-05-14 sample). These are holder
self-release events (the holder's watchdog warning when it took longer than
15 s to release; `max=15000ms` in the log line is the warn threshold, not a
grace value). They do not exercise `ORPHAN_LOCK_PAYLOAD_GRACE_MS`, but they
prove the environment regularly stalls beyond 5 s, which is the exact condition
that lets a payload-less metadata-write window exceed 5 s in the first place.

```text
2026-05-03T00:03:36+08:00 <host> node[1381]: [session-write-lock] releasing lock held for 75636ms (max=15000ms): sessions.json.lock
2026-05-03T00:05:44+08:00 <host> node[1381]: [session-write-lock] releasing lock held for 28299ms (max=15000ms): sessions.json.lock
2026-05-03T00:08:28+08:00 <host> node[1381]: [session-write-lock] releasing lock held for 55385ms (max=15000ms): sessions.json.lock
2026-05-03T00:10:40+08:00 <host> node[1381]: [session-write-lock] releasing lock held for 28397ms (max=15000ms): sessions.json.lock
2026-05-03T00:14:34+08:00 <host> node[1381]: [session-write-lock] releasing lock held for 55802ms (max=15000ms): sessions.json.lock

# Concurrent unrelated lock-cleanup events on the same host (different code path; dead-pid reclaim):
2026-05-13T09:05:25.440+08:00 <host> [gateway] removed stale session lock: .../<sid>.jsonl.lock (dead-pid)
2026-05-13T09:05:25.445+08:00 <host> [gateway] removed stale session lock: .../<sid>.jsonl.lock (dead-pid)
```

