### PR TITLE
feat(telegram): presence indicator (typing + phased reactions)

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -38,6 +38,7 @@ import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramGroupPeerId, resolveTelegramStreamMode } from "./bot/helpers.js";
 import { resolveTelegramTransport } from "./fetch.js";
 import { tagTelegramNetworkError } from "./network-errors.js";
+import { createTelegramPresenceIndicator } from "./presence-indicator.js";
 import { resolveTelegramRequestTimeoutMs } from "./request-timeouts.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
@@ -566,6 +567,27 @@ export function createTelegramBotCore(
     minIntervalMs: TELEGRAM_TYPING_COALESCE_MS,
   });
 
+  // Presence indicator (👀 on receive, 👨‍💻 + typing while working, cleared on done).
+  // Shares the same sendChatAction handler as the rest of the channel so that
+  // 401 circuit-breaker state stays consistent.
+  //
+  // grammY narrows reaction emoji to a literal union from Bot API 7.0; we
+  // accept any string (validated by config). Cast preserves runtime behaviour.
+  const setMessageReactionFn = bot.api.setMessageReaction
+    ? (bot.api.setMessageReaction.bind(bot.api) as unknown as (
+        chatId: number | string,
+        messageId: number,
+        reactions: Array<{ type: "emoji"; emoji: string }>,
+      ) => Promise<unknown>)
+    : null;
+  const presenceIndicator = createTelegramPresenceIndicator({
+    setMessageReaction: setMessageReactionFn,
+    sendChatAction: (chatId, action, threadParams) =>
+      sendChatActionHandler.sendChatAction(chatId, action, threadParams),
+    config: telegramCfg.presence,
+    logger: (_level, message) => logVerbose(`telegram: ${message}`),
+  });
+
   const processMessage = createTelegramMessageProcessor({
     bot,
     cfg,
@@ -589,6 +611,7 @@ export function createTelegramBotCore(
     textLimit,
     opts,
     telegramDeps,
+    presence: presenceIndicator,
   });
 
   registerTelegramNativeCommands({
@@ -627,6 +650,7 @@ export function createTelegramBotCore(
     resolveTelegramGroupConfig,
     shouldSkipUpdate,
     processMessage,
+    presence: presenceIndicator,
     logger,
     telegramDeps,
   });

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -122,6 +122,7 @@ import {
   resolveModelSelection,
   type ProviderInfo,
 } from "./model-buttons.js";
+import { NOOP_PRESENCE_INDICATOR } from "./presence-indicator.js";
 import { buildInlineKeyboard } from "./send.js";
 
 export const registerTelegramHandlers = ({
@@ -139,9 +140,11 @@ export const registerTelegramHandlers = ({
   resolveTelegramGroupConfig,
   shouldSkipUpdate,
   processMessage,
+  presence,
   logger,
   telegramDeps,
 }: RegisterTelegramHandlerParams) => {
+  const presenceIndicator = presence ?? NOOP_PRESENCE_INDICATOR;
   const mediaRuntimeOptions = resolveTelegramMediaRuntimeOptions({
     cfg,
     accountId,
@@ -2361,6 +2364,17 @@ export const registerTelegramHandlers = ({
     if (normalizedMsg.from?.id != null && normalizedMsg.from.id === ctx.me?.id) {
       return;
     }
+    // Fire presence "received" hook BEFORE queueing/dispatch so the user sees an
+    // acknowledgement even if the agent is busy. Errors are swallowed inside.
+    if (normalizedMsg.message_id != null) {
+      void presenceIndicator
+        .onMessageReceived({
+          chatId: normalizedMsg.chat.id,
+          messageId: normalizedMsg.message_id,
+          threadId: normalizedMsg.message_thread_id ?? undefined,
+        })
+        .catch(() => undefined);
+    }
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, normalizedMsg),
@@ -2397,6 +2411,16 @@ export const registerTelegramHandlers = ({
 
     const chatId = post.chat.id;
     const syntheticMsg = normalizeChannelPostMessage(post);
+
+    if (syntheticMsg.message_id != null) {
+      void presenceIndicator
+        .onMessageReceived({
+          chatId,
+          messageId: syntheticMsg.message_id,
+          threadId: syntheticMsg.message_thread_id ?? undefined,
+        })
+        .catch(() => undefined);
+    }
 
     await handleInboundMessageLike({
       ctxForDedupe: ctx,

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -238,4 +238,59 @@ describe("telegram bot message processor", () => {
     );
     expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("dispatch exploded"));
   });
+
+  it("invokes presence.onProcessingStart and onProcessingEnd around dispatch", async () => {
+    const onProcessingStart = vi.fn().mockResolvedValue(undefined);
+    const onProcessingEnd = vi.fn().mockResolvedValue(undefined);
+    buildTelegramMessageContext.mockResolvedValue(createMessageContext());
+
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      presence: {
+        onMessageReceived: vi.fn().mockResolvedValue(undefined),
+        onProcessingStart,
+        onProcessingEnd,
+      },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+    await processSampleMessage(processMessage);
+
+    expect(onProcessingStart).toHaveBeenCalledWith({
+      chatId: 123,
+      messageId: 456,
+      threadId: undefined,
+    });
+    expect(onProcessingEnd).toHaveBeenCalledWith({
+      chatId: 123,
+      messageId: 456,
+      threadId: undefined,
+    });
+    // Start must run before dispatch; end must run after.
+    expect(onProcessingStart.mock.invocationCallOrder[0]).toBeLessThan(
+      dispatchTelegramMessage.mock.invocationCallOrder[0],
+    );
+    expect(onProcessingEnd.mock.invocationCallOrder[0]).toBeGreaterThan(
+      dispatchTelegramMessage.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("invokes presence.onProcessingEnd even when dispatch throws", async () => {
+    const onProcessingEnd = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    buildTelegramMessageContext.mockResolvedValue(createMessageContext());
+    dispatchTelegramMessage.mockRejectedValue(new Error("agent exploded"));
+
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+      runtime: { error: vi.fn() },
+      presence: {
+        onMessageReceived: vi.fn().mockResolvedValue(undefined),
+        onProcessingStart: vi.fn().mockResolvedValue(undefined),
+        onProcessingEnd,
+      },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+    await processSampleMessage(processMessage);
+
+    expect(onProcessingEnd).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -20,6 +20,11 @@ import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
+import {
+  NOOP_PRESENCE_INDICATOR,
+  type PresenceCtx,
+  type PresenceIndicator,
+} from "./presence-indicator.js";
 
 const telegramInboundLog = createSubsystemLogger("gateway/channels/telegram").child("inbound");
 
@@ -45,6 +50,8 @@ type TelegramMessageProcessorDeps = Omit<
   textLimit: number;
   telegramDeps: TelegramBotDeps;
   opts: Pick<TelegramBotOptions, "token">;
+  /** Optional presence indicator — defaults to a no-op when omitted. */
+  presence?: PresenceIndicator;
 };
 
 export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
@@ -72,6 +79,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     telegramDeps,
     opts,
   } = deps;
+  const presence: PresenceIndicator = deps.presence ?? NOOP_PRESENCE_INDICATOR;
 
   return async (
     primaryCtx: TelegramContext,
@@ -144,6 +152,18 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         mediaType: allMedia[0]?.contentType,
       }),
     );
+    const presenceCtx: PresenceCtx | null =
+      primaryCtx.message.message_id != null
+        ? {
+            chatId: context.chatId,
+            messageId: primaryCtx.message.message_id,
+            threadId:
+              (primaryCtx.message as { message_thread_id?: number }).message_thread_id ?? undefined,
+          }
+        : null;
+    if (presenceCtx) {
+      await presence.onProcessingStart(presenceCtx).catch(() => undefined);
+    }
     try {
       await dispatchTelegramMessage({
         context,
@@ -172,6 +192,10 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
           buildTelegramThreadParams(context.threadSpec),
         );
       } catch {}
+    } finally {
+      if (presenceCtx) {
+        await presence.onProcessingEnd(presenceCtx).catch(() => undefined);
+      }
     }
   };
 };

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -420,6 +420,8 @@ export type RegisterTelegramHandlerParams = {
     replyChain?: import("./message-cache.js").TelegramReplyChainEntry[],
     promptContext?: import("./bot-message-context.types.js").TelegramPromptContextEntry[],
   ) => Promise<void>;
+  /** Optional presence indicator. When omitted, presence hooks are no-ops. */
+  presence?: import("./presence-indicator.js").PresenceIndicator;
   logger: ReturnType<typeof getChildLogger>;
 };
 

--- a/extensions/telegram/src/presence-indicator.test.ts
+++ b/extensions/telegram/src/presence-indicator.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createTelegramPresenceIndicator,
+  DEFAULT_PRESENCE_REACTION,
+  DEFAULT_PRESENCE_WORKING_REACTION,
+  PRESENCE_TYPING_INTERVAL_MS,
+} from "./presence-indicator.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function makeDeps(overrides: Partial<Parameters<typeof createTelegramPresenceIndicator>[0]> = {}) {
+  const setMessageReaction = vi.fn(async () => undefined);
+  const sendChatAction = vi.fn(async () => undefined);
+  const logger = vi.fn();
+  return {
+    setMessageReaction,
+    sendChatAction,
+    logger,
+    deps: {
+      setMessageReaction,
+      sendChatAction,
+      logger,
+      ...overrides,
+    },
+  };
+}
+
+describe("createTelegramPresenceIndicator — lifecycle", () => {
+  it("sets the received reaction on onMessageReceived", async () => {
+    const { setMessageReaction, deps } = makeDeps();
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onMessageReceived({ chatId: 100, messageId: 7 });
+    expect(setMessageReaction).toHaveBeenCalledWith(100, 7, [
+      { type: "emoji", emoji: DEFAULT_PRESENCE_REACTION },
+    ]);
+  });
+
+  it("swaps to the working reaction on onProcessingStart", async () => {
+    const { setMessageReaction, deps } = makeDeps();
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onMessageReceived({ chatId: 100, messageId: 7 });
+    await presence.onProcessingStart({ chatId: 100, messageId: 7 });
+    expect(setMessageReaction).toHaveBeenNthCalledWith(2, 100, 7, [
+      { type: "emoji", emoji: DEFAULT_PRESENCE_WORKING_REACTION },
+    ]);
+  });
+
+  it("clears the reaction on onProcessingEnd", async () => {
+    const { setMessageReaction, deps } = makeDeps();
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onMessageReceived({ chatId: 100, messageId: 7 });
+    await presence.onProcessingStart({ chatId: 100, messageId: 7 });
+    await presence.onProcessingEnd({ chatId: 100, messageId: 7 });
+    expect(setMessageReaction).toHaveBeenLastCalledWith(100, 7, []);
+  });
+});
+
+describe("createTelegramPresenceIndicator — typing loop", () => {
+  it("does NOT emit sendChatAction if processing finishes within debounce window", async () => {
+    const { sendChatAction, deps } = makeDeps();
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onProcessingStart({ chatId: 100, messageId: 7 });
+    // Finish quickly — under 400ms debounce.
+    await vi.advanceTimersByTimeAsync(100);
+    await presence.onProcessingEnd({ chatId: 100, messageId: 7 });
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sendChatAction).not.toHaveBeenCalled();
+  });
+
+  it("emits the first sendChatAction after the debounce, then every ~4s", async () => {
+    const { sendChatAction, deps } = makeDeps();
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onProcessingStart({ chatId: 100, messageId: 7, threadId: 42 });
+    // Cross the 400ms debounce.
+    await vi.advanceTimersByTimeAsync(400);
+    expect(sendChatAction).toHaveBeenCalledTimes(1);
+    expect(sendChatAction).toHaveBeenLastCalledWith(100, "typing", { message_thread_id: 42 });
+    // Two interval ticks.
+    await vi.advanceTimersByTimeAsync(PRESENCE_TYPING_INTERVAL_MS);
+    expect(sendChatAction).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(PRESENCE_TYPING_INTERVAL_MS);
+    expect(sendChatAction).toHaveBeenCalledTimes(3);
+    await presence.onProcessingEnd({ chatId: 100, messageId: 7, threadId: 42 });
+    await vi.advanceTimersByTimeAsync(PRESENCE_TYPING_INTERVAL_MS * 3);
+    // Stays at 3; loop stopped.
+    expect(sendChatAction).toHaveBeenCalledTimes(3);
+  });
+
+  it("refcounts concurrent processors on the same chat+thread", async () => {
+    const { sendChatAction, deps } = makeDeps();
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onProcessingStart({ chatId: 100, messageId: 1, threadId: 5 });
+    await presence.onProcessingStart({ chatId: 100, messageId: 2, threadId: 5 });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(sendChatAction).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(PRESENCE_TYPING_INTERVAL_MS);
+    expect(sendChatAction).toHaveBeenCalledTimes(2);
+    // First processor ends — loop must continue for the second.
+    await presence.onProcessingEnd({ chatId: 100, messageId: 1, threadId: 5 });
+    await vi.advanceTimersByTimeAsync(PRESENCE_TYPING_INTERVAL_MS);
+    expect(sendChatAction).toHaveBeenCalledTimes(3);
+    // Second processor ends — loop must stop.
+    await presence.onProcessingEnd({ chatId: 100, messageId: 2, threadId: 5 });
+    await vi.advanceTimersByTimeAsync(PRESENCE_TYPING_INTERVAL_MS * 2);
+    expect(sendChatAction).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("createTelegramPresenceIndicator — failure tolerance", () => {
+  it("swallows reaction API failures and logs at warn level", async () => {
+    const setMessageReaction = vi.fn(async () => {
+      throw new Error("403 Forbidden");
+    });
+    const sendChatAction = vi.fn(async () => undefined);
+    const logger = vi.fn();
+    const presence = createTelegramPresenceIndicator({
+      setMessageReaction,
+      sendChatAction,
+      logger,
+    });
+    // Should not throw.
+    await presence.onMessageReceived({ chatId: 100, messageId: 7 });
+    expect(logger).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("setMessageReaction failed"),
+    );
+  });
+
+  it("calls onProcessingEnd cleanup even when the prior reaction call failed", async () => {
+    const setMessageReaction = vi
+      .fn(async () => undefined)
+      .mockImplementationOnce(async () => {
+        throw new Error("400 Bad Request");
+      });
+    const sendChatAction = vi.fn(async () => undefined);
+    const logger = vi.fn();
+    const presence = createTelegramPresenceIndicator({
+      setMessageReaction,
+      sendChatAction,
+      logger,
+    });
+    await presence.onProcessingStart({ chatId: 100, messageId: 7 });
+    await presence.onProcessingEnd({ chatId: 100, messageId: 7 });
+    // Should have attempted clear-call.
+    expect(setMessageReaction).toHaveBeenLastCalledWith(100, 7, []);
+  });
+});
+
+describe("createTelegramPresenceIndicator — config", () => {
+  it("presence.typing = false skips the typing loop entirely", async () => {
+    const { sendChatAction, deps } = makeDeps({ config: { typing: false } });
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onProcessingStart({ chatId: 100, messageId: 7 });
+    await vi.advanceTimersByTimeAsync(PRESENCE_TYPING_INTERVAL_MS * 3);
+    await presence.onProcessingEnd({ chatId: 100, messageId: 7 });
+    expect(sendChatAction).not.toHaveBeenCalled();
+  });
+
+  it("presence.reaction = null disables all reaction calls", async () => {
+    const { setMessageReaction, deps } = makeDeps({
+      config: { reaction: null, workingReaction: null },
+    });
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onMessageReceived({ chatId: 100, messageId: 7 });
+    await presence.onProcessingStart({ chatId: 100, messageId: 7 });
+    await presence.onProcessingEnd({ chatId: 100, messageId: 7 });
+    expect(setMessageReaction).not.toHaveBeenCalled();
+  });
+
+  it("respects custom reaction emoji overrides", async () => {
+    const { setMessageReaction, deps } = makeDeps({
+      config: { reaction: "👋", workingReaction: "⚙️" },
+    });
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onMessageReceived({ chatId: 100, messageId: 7 });
+    expect(setMessageReaction).toHaveBeenLastCalledWith(100, 7, [
+      { type: "emoji", emoji: "👋" },
+    ]);
+    await presence.onProcessingStart({ chatId: 100, messageId: 7 });
+    expect(setMessageReaction).toHaveBeenLastCalledWith(100, 7, [
+      { type: "emoji", emoji: "⚙️" },
+    ]);
+  });
+});
+
+describe("createTelegramPresenceIndicator — orphan watchdog", () => {
+  it("clears a stale reaction after the TTL when onProcessingEnd never fires", async () => {
+    const { setMessageReaction, deps } = makeDeps();
+    const presence = createTelegramPresenceIndicator(deps);
+    await presence.onProcessingStart({ chatId: 100, messageId: 7 });
+    setMessageReaction.mockClear();
+    // Crash path: end is never invoked. Watchdog must fire after 60s.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(setMessageReaction).toHaveBeenCalledWith(100, 7, []);
+  });
+});

--- a/extensions/telegram/src/presence-indicator.ts
+++ b/extensions/telegram/src/presence-indicator.ts
@@ -1,0 +1,286 @@
+/**
+ * Three-phase presence indicator for Telegram messages.
+ *
+ * Lifecycle:
+ *   1. onMessageReceived — set "received" reaction (e.g. 👀) on the inbound message
+ *      immediately, before queueing/dispatch. Lets the user know we got it even if
+ *      the agent is busy.
+ *   2. onProcessingStart — swap reaction to "working" (e.g. 👨‍💻) and begin a typing
+ *      indicator loop calling sendChatAction every ~4s.
+ *   3. onProcessingEnd — stop the typing loop and clear the reaction.
+ *
+ * Failures of the underlying Telegram API calls are swallowed (logged at warn level)
+ * so presence indicator faults never break message dispatch.
+ */
+export interface PresenceIndicator {
+  onMessageReceived(ctx: PresenceCtx): Promise<void>;
+  onProcessingStart(ctx: PresenceCtx): Promise<void>;
+  onProcessingEnd(ctx: PresenceCtx): Promise<void>;
+}
+
+export interface PresenceCtx {
+  chatId: number | string;
+  messageId: number;
+  threadId?: number;
+}
+
+export interface PresenceConfig {
+  /** Enable the typing-indicator loop while the agent processes. Default: true. */
+  typing?: boolean;
+  /** Emoji to set on the user's message when received. `null` disables reactions. */
+  reaction?: string | null;
+  /** Emoji to swap to while the agent is actively working. */
+  workingReaction?: string | null;
+}
+
+/** Default received-emoji (Telegram free-reaction allowlist as of Bot API 7.0). */
+export const DEFAULT_PRESENCE_REACTION = "👀";
+/** Default working-emoji (Telegram free-reaction allowlist as of Bot API 7.0). */
+export const DEFAULT_PRESENCE_WORKING_REACTION = "👨‍💻";
+
+/** Interval between sendChatAction("typing") refreshes (Telegram auto-decays in ~5s). */
+export const PRESENCE_TYPING_INTERVAL_MS = 4000;
+/** Suppress the first typing tick if processing finishes within this window. */
+export const PRESENCE_TYPING_DEBOUNCE_MS = 400;
+/** Watchdog timeout: clear orphan reactions if onProcessingEnd never fires. */
+export const PRESENCE_REACTION_TTL_MS = 60_000;
+
+export type PresenceLogger = (level: "warn", message: string) => void;
+
+/**
+ * Reaction payload accepted by Telegram Bot API `setMessageReaction`.
+ *
+ * grammY narrows the emoji to a string-literal union from Bot API 7.0; for the
+ * presence indicator we only need the structural shape — callers cast as
+ * needed.
+ */
+export type PresenceReaction = { type: "emoji"; emoji: string };
+
+// Reaction sink accepts the structural shape. Callers (bot-core) bind the
+// grammY-typed setMessageReaction here through a runtime cast since both
+// shapes are interchangeable at the JSON layer.
+type ReactionApi = (
+  chatId: number | string,
+  messageId: number,
+  reactions: PresenceReaction[],
+) => Promise<unknown>;
+
+type SendChatActionFn = (
+  chatId: number | string,
+  action: "typing",
+  threadParams?: { message_thread_id?: number },
+) => Promise<unknown>;
+
+export interface TelegramPresenceIndicatorDeps {
+  setMessageReaction: ReactionApi | null;
+  sendChatAction: SendChatActionFn;
+  config?: PresenceConfig;
+  logger?: PresenceLogger;
+  /** Override for tests. */
+  now?: () => number;
+  /** Override for tests. */
+  setInterval?: typeof setInterval;
+  /** Override for tests. */
+  clearInterval?: typeof clearInterval;
+  /** Override for tests. */
+  setTimeout?: typeof setTimeout;
+  /** Override for tests. */
+  clearTimeout?: typeof clearTimeout;
+}
+
+type TypingLoopEntry = {
+  refs: number;
+  timerHandle: ReturnType<typeof setTimeout> | null;
+  intervalHandle: ReturnType<typeof setInterval> | null;
+  threadId?: number;
+};
+
+type ReactionWatchdog = {
+  timer: ReturnType<typeof setTimeout>;
+};
+
+function loopKey(chatId: number | string, threadId?: number): string {
+  return threadId != null ? `${String(chatId)}:${threadId}` : `${String(chatId)}:main`;
+}
+
+function reactionKey(chatId: number | string, messageId: number): string {
+  return `${String(chatId)}:${messageId}`;
+}
+
+/**
+ * Telegram-specific presence indicator. Wires Telegram Bot API setMessageReaction
+ * and sendChatAction("typing") to the three lifecycle hooks.
+ */
+export function createTelegramPresenceIndicator(
+  deps: TelegramPresenceIndicatorDeps,
+): PresenceIndicator {
+  const cfg = deps.config ?? {};
+  const typingEnabled = cfg.typing !== false;
+  const receivedEmoji =
+    cfg.reaction === null ? null : (cfg.reaction ?? DEFAULT_PRESENCE_REACTION);
+  const workingEmoji =
+    cfg.workingReaction === null
+      ? null
+      : (cfg.workingReaction ?? DEFAULT_PRESENCE_WORKING_REACTION);
+  const setReaction = deps.setMessageReaction;
+  const sendChatAction = deps.sendChatAction;
+  const log = deps.logger ?? (() => undefined);
+  const now = deps.now ?? (() => Date.now());
+  const setIntervalImpl = deps.setInterval ?? setInterval;
+  const clearIntervalImpl = deps.clearInterval ?? clearInterval;
+  const setTimeoutImpl = deps.setTimeout ?? setTimeout;
+  const clearTimeoutImpl = deps.clearTimeout ?? clearTimeout;
+
+  const typingLoops = new Map<string, TypingLoopEntry>();
+  const reactionWatchdogs = new Map<string, ReactionWatchdog>();
+  const processingStartTimes = new Map<string, number>();
+
+  const safeSetReaction = async (
+    chatId: number | string,
+    messageId: number,
+    emoji: string | null,
+  ): Promise<void> => {
+    if (!setReaction) {
+      return;
+    }
+    const reactions = emoji ? [{ type: "emoji" as const, emoji }] : [];
+    try {
+      await setReaction(chatId, messageId, reactions);
+    } catch (err) {
+      log("warn", `presence: setMessageReaction failed for ${chatId}/${messageId}: ${String(err)}`);
+    }
+  };
+
+  const safeSendTyping = async (
+    chatId: number | string,
+    threadId?: number,
+  ): Promise<void> => {
+    try {
+      await sendChatAction(
+        chatId,
+        "typing",
+        threadId != null ? { message_thread_id: threadId } : undefined,
+      );
+    } catch (err) {
+      log("warn", `presence: sendChatAction(typing) failed for ${chatId}: ${String(err)}`);
+    }
+  };
+
+  const scheduleReactionWatchdog = (ctx: PresenceCtx): void => {
+    if (!setReaction || workingEmoji === null) {
+      return;
+    }
+    const key = reactionKey(ctx.chatId, ctx.messageId);
+    const existing = reactionWatchdogs.get(key);
+    if (existing) {
+      clearTimeoutImpl(existing.timer);
+    }
+    const timer = setTimeoutImpl(() => {
+      reactionWatchdogs.delete(key);
+      void safeSetReaction(ctx.chatId, ctx.messageId, null);
+    }, PRESENCE_REACTION_TTL_MS);
+    reactionWatchdogs.set(key, { timer });
+  };
+
+  const cancelReactionWatchdog = (ctx: PresenceCtx): void => {
+    const key = reactionKey(ctx.chatId, ctx.messageId);
+    const existing = reactionWatchdogs.get(key);
+    if (existing) {
+      clearTimeoutImpl(existing.timer);
+      reactionWatchdogs.delete(key);
+    }
+  };
+
+  const acquireTypingLoop = (ctx: PresenceCtx): void => {
+    if (!typingEnabled) {
+      return;
+    }
+    const key = loopKey(ctx.chatId, ctx.threadId);
+    const existing = typingLoops.get(key);
+    if (existing) {
+      existing.refs += 1;
+      return;
+    }
+    // First processor for this chat+thread. Defer the first sendChatAction by
+    // PRESENCE_TYPING_DEBOUNCE_MS so quick-replies don't flicker the indicator.
+    const entry: TypingLoopEntry = {
+      refs: 1,
+      timerHandle: null,
+      intervalHandle: null,
+      threadId: ctx.threadId,
+    };
+    entry.timerHandle = setTimeoutImpl(() => {
+      entry.timerHandle = null;
+      const current = typingLoops.get(key);
+      if (!current || current.refs <= 0) {
+        return;
+      }
+      void safeSendTyping(ctx.chatId, ctx.threadId);
+      current.intervalHandle = setIntervalImpl(() => {
+        void safeSendTyping(ctx.chatId, ctx.threadId);
+      }, PRESENCE_TYPING_INTERVAL_MS);
+    }, PRESENCE_TYPING_DEBOUNCE_MS);
+    typingLoops.set(key, entry);
+  };
+
+  const releaseTypingLoop = (ctx: PresenceCtx): void => {
+    if (!typingEnabled) {
+      return;
+    }
+    const key = loopKey(ctx.chatId, ctx.threadId);
+    const entry = typingLoops.get(key);
+    if (!entry) {
+      return;
+    }
+    entry.refs -= 1;
+    if (entry.refs > 0) {
+      return;
+    }
+    if (entry.timerHandle) {
+      clearTimeoutImpl(entry.timerHandle);
+      entry.timerHandle = null;
+    }
+    if (entry.intervalHandle) {
+      clearIntervalImpl(entry.intervalHandle);
+      entry.intervalHandle = null;
+    }
+    typingLoops.delete(key);
+  };
+
+  return {
+    async onMessageReceived(ctx) {
+      if (!setReaction || receivedEmoji === null) {
+        return;
+      }
+      await safeSetReaction(ctx.chatId, ctx.messageId, receivedEmoji);
+    },
+
+    async onProcessingStart(ctx) {
+      processingStartTimes.set(reactionKey(ctx.chatId, ctx.messageId), now());
+      if (setReaction && workingEmoji !== null) {
+        await safeSetReaction(ctx.chatId, ctx.messageId, workingEmoji);
+      }
+      acquireTypingLoop(ctx);
+      scheduleReactionWatchdog(ctx);
+    },
+
+    async onProcessingEnd(ctx) {
+      processingStartTimes.delete(reactionKey(ctx.chatId, ctx.messageId));
+      releaseTypingLoop(ctx);
+      cancelReactionWatchdog(ctx);
+      if (setReaction && (receivedEmoji !== null || workingEmoji !== null)) {
+        await safeSetReaction(ctx.chatId, ctx.messageId, null);
+      }
+    },
+  };
+}
+
+/**
+ * No-op presence indicator. Used when no real implementation is configured —
+ * keeps callsites uniform without a null check.
+ */
+export const NOOP_PRESENCE_INDICATOR: PresenceIndicator = {
+  async onMessageReceived() {},
+  async onProcessingStart() {},
+  async onProcessingEnd() {},
+};

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -220,6 +220,31 @@ export type TelegramAccountConfig = {
   trustedLocalFileRoots?: string[];
   /** Auto-rename DM forum topics on first message using LLM. Default: true. */
   autoTopicLabel?: AutoTopicLabelConfig;
+  /**
+   * Three-phase presence indicator config (👀 on receive, 👨‍💻 + typing while
+   * processing, cleared on done). Defaults to enabled.
+   */
+  presence?: TelegramPresenceConfig;
+};
+
+/**
+ * Per-account presence indicator config. All fields optional and
+ * backward-compatible: existing configs without `presence` default to enabled
+ * with built-in emoji.
+ */
+export type TelegramPresenceConfig = {
+  /** Enable the typing-indicator loop while the agent processes. Default: true. */
+  typing?: boolean;
+  /**
+   * Emoji set on the user's message when received (before queue/dispatch).
+   * Use `null` to disable reactions entirely. Default: "👀".
+   */
+  reaction?: string | null;
+  /**
+   * Emoji swapped in while the agent is actively processing. Use `null` to
+   * skip the swap. Default: "👨‍💻".
+   */
+  workingReaction?: string | null;
 };
 
 export type TelegramDmThreadReplies = "off" | "inbound" | "always";

--- a/src/plugin-sdk/config-contracts.ts
+++ b/src/plugin-sdk/config-contracts.ts
@@ -47,6 +47,7 @@ export type {
   TelegramGroupConfig,
   TelegramInlineButtonsScope,
   TelegramNetworkConfig,
+  TelegramPresenceConfig,
   TelegramTopicConfig,
   TtsAutoMode,
   TtsConfig,


### PR DESCRIPTION
## Summary
- Adds three-phase presence indicator for Telegram messages: 👀 on receive, 👨‍💻 + typing while processing, cleared on done.
- Eliminates silent-agent UX where users can't tell if a message was received or is still being worked on.
- Per-account config under `channels.telegram[.accounts[*]].presence` (`typing`, `reaction`, `workingReaction`); defaults on for new accounts, backward-compatible.

## Implementation
- New `extensions/telegram/src/presence-indicator.ts` exporting `PresenceIndicator` / `PresenceCtx` and a Telegram-specific factory built on the existing Bot API client and the 401-backoff-safe ``sendChatAction`` handler.
- Hook points:
  - ``onMessageReceived`` fires inside ``bot.on('message')`` and ``bot.on('channel_post')`` in ``bot-handlers.runtime.ts``, before queueing/dispatch.
  - ``onProcessingStart`` / ``onProcessingEnd`` wrap ``dispatchTelegramMessage`` in ``bot-message.ts`` using try/finally so the reaction is always cleared.
- Edge cases handled per spec: 400ms debounce on typing, ref-counted per (chatId, threadId) so concurrent processors share one loop, warn-and-swallow on Telegram API failures, and a 60s TTL watchdog that clears orphan reactions if ``onProcessingEnd`` never fires.

## Test plan
- [x] Unit (``presence-indicator.test.ts``): lifecycle order, typing-loop interval, <400ms debounce, reaction state, failure tolerance, ref-counted concurrency, orphan watchdog.
- [x] Config: ``presence.typing: false`` disables the loop; ``presence.reaction: null`` disables reactions entirely; custom emoji overrides respected.
- [x] Processor (``bot-message.test.ts``): ``onProcessingStart`` runs before dispatch and ``onProcessingEnd`` after, including the dispatch-throws path.
- [ ] Manual: send a message via a test bot, verify 👀 → 👨‍💻 → cleared with "typing..." visible.

## Notes
- ``setMessageReaction`` was already wired in the channel; this PR adds an additional explicit lifecycle on top, gated by config so existing ``ackReaction`` users are unaffected when ``presence`` is absent.
- Pre-existing unrelated test failures in ``setup-surface.test.ts``, ``bot.create-telegram-bot.test.ts (pairing)``, ``channel.message-adapter.test.ts``, and ``extensions/whatsapp/src/login.coverage.test.ts`` reproduce on clean ``main`` in this environment (profile-name string mismatches, vitest mock-type drift). Not introduced here.

Reported by @kotaro.