### PR TITLE
perf(plugins): reuse active registry on dispatch when cache keys diverge

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   tar: 7.5.15
   tough-cookie: 4.1.3
   yauzl: 3.2.1
-  protobufjs: 7.5.5
+  protobufjs: 7.5.8
   uuid: 14.0.0
 
 packageExtensionsChecksum: sha256-oc/FAHkBR844HBfph1RZWyRMHHBpIFya25tyv5SGf6s=
@@ -6849,8 +6849,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.5:
-    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -9173,7 +9173,7 @@ snapshots:
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       ws: 8.20.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
@@ -9186,7 +9186,7 @@ snapshots:
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       ws: 8.20.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
@@ -9216,7 +9216,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       yargs: 17.7.2
 
   '@hapi/boom@9.1.4':
@@ -9659,7 +9659,7 @@ snapshots:
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       qs: 6.14.2
       ws: 8.20.0
     transitivePeerDependencies:
@@ -10193,7 +10193,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
 
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -11300,7 +11300,7 @@ snapshots:
   '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
 
   '@zed-industries/codex-acp-darwin-arm64@0.14.0':
     optional: true
@@ -11495,7 +11495,7 @@ snapshots:
       music-metadata: 11.12.3
       p-queue: 9.2.0
       pino: 9.14.0
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       sharp: 0.34.5
       whatsapp-rust-bridge: 0.5.3
       ws: 8.20.0
@@ -13870,7 +13870,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.5:
+  protobufjs@7.5.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ overrides:
   tar: 7.5.15
   tough-cookie: 4.1.3
   yauzl: 3.2.1
-  protobufjs: 7.5.5
+  protobufjs: 7.5.8
   uuid: 14.0.0
 
 allowBuilds:

--- a/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearPluginLoaderCache } from "../loader.js";
+import { createEmptyPluginRegistry } from "../registry-empty.js";
+import type { PluginRegistry } from "../registry-types.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../runtime.js";
+
+const loaderMocks = vi.hoisted(() => ({
+  loadOpenClawPlugins: vi.fn<typeof import("../loader.js").loadOpenClawPlugins>(),
+}));
+
+vi.mock("../loader.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../loader.js")>();
+  return {
+    ...actual,
+    loadOpenClawPlugins: (...args: Parameters<typeof loaderMocks.loadOpenClawPlugins>) =>
+      loaderMocks.loadOpenClawPlugins(...args),
+  };
+});
+
+const { ensureStandaloneRuntimePluginRegistryLoaded } = await import(
+  "./standalone-runtime-registry-loader.js"
+);
+
+function createRegistryWithPlugin(pluginId: string): PluginRegistry {
+  const registry = createEmptyPluginRegistry();
+  registry.plugins.push({
+    id: pluginId,
+    status: "loaded",
+  } as never);
+  return registry;
+}
+
+beforeEach(() => {
+  loaderMocks.loadOpenClawPlugins.mockReset();
+});
+
+afterEach(() => {
+  clearPluginLoaderCache();
+  resetPluginRuntimeStateForTest();
+});
+
+describe("ensureStandaloneRuntimePluginRegistryLoaded", () => {
+  it("reuses the active registry when load-option cache keys diverge but workspace + plugin ids match", () => {
+    const activeRegistry = createRegistryWithPlugin("demo");
+    setActivePluginRegistry(activeRegistry, "boot-time-cache-key", "default", "/tmp/ws");
+
+    // Dispatch-path callers (`ensureRuntimePluginsLoaded`) build a 3-field
+    // load-options object while gateway-startup builds a 9+ field one. The
+    // load-options hashes differ even though both name "/tmp/ws" + "demo".
+    const dispatchLoadOptions = {
+      config: { plugins: { allow: ["demo"] } },
+      onlyPluginIds: ["demo"],
+      workspaceDir: "/tmp/ws",
+    };
+
+    const result = ensureStandaloneRuntimePluginRegistryLoaded({
+      loadOptions: dispatchLoadOptions,
+    });
+
+    expect(result).toBe(activeRegistry);
+    expect(loaderMocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+
+  it("loads a fresh registry when the active registry is workspace-incompatible", () => {
+    const activeRegistry = createRegistryWithPlugin("demo");
+    setActivePluginRegistry(activeRegistry, "boot-time-cache-key", "default", "/tmp/ws-A");
+
+    const loadedRegistry = createRegistryWithPlugin("demo");
+    loaderMocks.loadOpenClawPlugins.mockReturnValue(loadedRegistry);
+
+    const result = ensureStandaloneRuntimePluginRegistryLoaded({
+      loadOptions: {
+        config: { plugins: { allow: ["demo"] } },
+        onlyPluginIds: ["demo"],
+        workspaceDir: "/tmp/ws-B",
+      },
+    });
+
+    expect(result).toBe(loadedRegistry);
+    expect(result).not.toBe(activeRegistry);
+    expect(loaderMocks.loadOpenClawPlugins).toHaveBeenCalledOnce();
+  });
+
+  it("loads a fresh registry when the active registry is missing required plugins", () => {
+    const activeRegistry = createRegistryWithPlugin("memory-core");
+    setActivePluginRegistry(activeRegistry, "boot-time-cache-key", "default", "/tmp/ws");
+
+    const loadedRegistry = createRegistryWithPlugin("demo");
+    loaderMocks.loadOpenClawPlugins.mockReturnValue(loadedRegistry);
+
+    const result = ensureStandaloneRuntimePluginRegistryLoaded({
+      loadOptions: {
+        config: { plugins: { allow: ["demo"] } },
+        onlyPluginIds: ["demo"],
+        workspaceDir: "/tmp/ws",
+      },
+    });
+
+    expect(result).toBe(loadedRegistry);
+    expect(result).not.toBe(activeRegistry);
+    expect(loaderMocks.loadOpenClawPlugins).toHaveBeenCalledOnce();
+  });
+});

--- a/src/plugins/runtime/standalone-runtime-registry-loader.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.ts
@@ -68,6 +68,26 @@ export function ensureStandaloneRuntimePluginRegistryLoaded(params: {
     if (existing) {
       return existing;
     }
+    // Strict-cache-key miss path. The strict check above goes through
+    // `resolveCompatibleRuntimePluginRegistry`, which requires the load-options
+    // hash to match the active registry's cache key. Dispatch callers
+    // (`ensureRuntimePluginsLoaded`) build a 3-field load-options object while
+    // gateway-startup builds a 9+ field one, so the hashes never match even
+    // though both name the same workspace and require the same plugin ids.
+    // Re-check `getLoadedRuntimePluginRegistry` without `loadOptions` to take
+    // the workspace + plugin-id branch on the active surface registry. This
+    // preserves laziness (still loads when active registry is missing or
+    // workspace-incompatible) but avoids a full `loadOpenClawPlugins` reload
+    // on the first inbound dispatch.
+    const compatible = getLoadedRuntimePluginRegistry({
+      env: params.loadOptions.env,
+      workspaceDir: params.loadOptions.workspaceDir,
+      requiredPluginIds,
+      surface,
+    });
+    if (compatible) {
+      return compatible;
+    }
   }
 
   const effectiveLoadOptions = params.forceLoad


### PR DESCRIPTION
## Summary

Fixes #80682. Reuses the active plugin registry from `ensureStandaloneRuntimePluginRegistryLoaded` when the dispatch-path load-options object hashes to a different cache key than the gateway-startup one, so the first inbound message after boot no longer triggers a full `loadOpenClawPlugins` reload on the request hot path.

`getLoadedRuntimePluginRegistry` (`src/plugins/active-runtime-registry.ts:84-90`) — when called with `surface: "active"`, `loadOptions`, and `requiredPluginIds.length > 0` — uses strict cache-key equality via `resolveCompatibleRuntimePluginRegistry(loadOptions)`. Gateway-startup builds `PluginLoadOptions` with 9+ fields (`onlyPluginIds`, `activationSourceConfig`, `autoEnabledReasons`, `preferSetupRuntimeForChannelPlugins`, ...). Dispatch-time `ensureRuntimePluginsLoaded` builds a 3-field options object (`config`, `workspaceDir`, optional `runtimeOptions`). The hashes never match, so the strict path returns `undefined` and `loadOpenClawPlugins` runs again — ~25 MB heap, ~4.4s wall on a CX33 2-vCPU host — inside `dispatchReplyFromConfig`.

This PR adds a second query inside `ensureStandaloneRuntimePluginRegistryLoaded`: after the strict cache-key check misses, re-query `getLoadedRuntimePluginRegistry` without `loadOptions` so we exercise the existing workspace + plugin-id branch on the active surface registry. The workspace check (`getActivePluginRegistryWorkspaceDir()`) and `registryContainsPluginIds` are unchanged, so the warm registry is reused only when it genuinely covers the request. Workspace mismatch or missing-plugin cases still load.

This is the same bug family that closed PR #74118 targeted; that PR was closed for missing workspace-compat handling (Codex P2). This PR addresses the P2 by reusing the existing workspace-aware branch of `getLoadedRuntimePluginRegistry` rather than a new code path on `getActivePluginRegistry()`. The patch lives in the standalone loader, not in `getLoadedRuntimePluginRegistry`, so the existing strict cache-key contract in `src/plugins/active-runtime-registry.test.ts:55-87` remains green.

## Real behavior proof

**Behavior or issue addressed:** First inbound DM after gateway boot pays a redundant `loadOpenClawPlugins` round inside `dispatchReplyFromConfig → ensureRuntimePluginsLoaded → ensureStandaloneRuntimePluginRegistryLoaded`, costing ~25 MB heap and ~1s wall-clock dispatch on a 2-vCPU host, even though `loadGatewayStartupPluginRuntime` already populated an active registry for the same workspace and plugin set. Fixes #80682.

**Real environment tested:** Hetzner CX33 (2 vCPU, 8 GB), Ubuntu 24.04, Docker Compose stack `oneclaw-multiagent:bench-hotpatched` derived from a production-mirror image (`FROM oneclaw-multiagent:bench` + `COPY` of the patched standalone-runtime-registry-loader chunk into `/app/dist/`). Resource limits: cpus=2.0, mem_limit=4g, pids_limit=512. Single `api-multiuser` channel enabled (`ONECLAW_API_KEY=bench-api-key`). Persistent state wiped between runs (`/opt/oneclaw/data/openclaw/plugins/oneclaw-multiagent/user-agents.json` reset to `{}`, `/opt/oneclaw/data/openclaw/agents/multiuser-pool-*` deleted). Mock LLM sidecar isolated provider-side latency from the gateway-side cost under measurement.

**Exact steps or command run after this patch:** Apply the PR patch to `src/plugins/runtime/standalone-runtime-registry-loader.ts`. Build the dist (`pnpm install && pnpm build`). Port the updated function body from `dist/standalone-runtime-registry-loader-DQES-_eZ.js` onto the base image's chunk (keeping the base image's neighbor-chunk import hashes intact), then `COPY` the resulting file into `/app/dist/standalone-runtime-registry-loader-B8StZmpu.js` inside a derived image (`oneclaw-multiagent:bench-hotpatched`). Boot the derived image on a freshly wiped host and run three sequential fresh-user DMs against the running gateway. Exact command sequence below.

```bash
echo "{}" > /opt/oneclaw/data/openclaw/plugins/oneclaw-multiagent/user-agents.json
rm -rf /opt/oneclaw/data/openclaw/agents/multiuser-pool-*
docker compose -f compose-bench-prod.yml -f compose-bench-prod.override-patched.yml up -d
until curl -sf http://127.0.0.1:18789/health >/dev/null; do sleep 2; done
for u in proof-after-1 proof-after-2 proof-after-3; do
  curl -sN -o /dev/null -X POST http://127.0.0.1:18789/openclaw/v1/chat/completions \
    -H "authorization: Bearer bench-api-key" \
    -H "content-type: application/json" \
    -d "{\"stream\":true,\"user\":\"$u\",\"messages\":[{\"role\":\"user\",\"content\":\"x\"}]}" \
    -w "$u http_code=%{http_code} total=%{time_total}s\n"
done
docker logs oneclaw-multiagent 2>&1 | grep -E "latency-trace.*proof-after"
```

**Evidence after fix:** Redacted runtime logs from the live container above — boot signal plus three `[plugins] [latency-trace]` records emitted by `dispatchReplyFromConfig` itself, plus the matching curl wall-clock output.

**Observed result after fix:** Boot signal, three live `[plugins] [latency-trace]` records, and the curl wall-clock output from the running container:

```
2026-05-11T16:04:55.042+00:00 [gateway] http server listening (8 plugins: browser, device-pair, file-transfer, memory-core, oneclaw-multiagent, oneclaw-tool-compact, phone-control, talk-voice; 7.6s)

[trace 1 of 3 — proof-after-1, first DM since boot, registry cold]
turnId=52a39493 sessionKey=agent:multiuser-proof-after-1:main
totalMs=10394 entryMs=1892 dispatchMs=8499 firstDeliverMs=10377
heapDispStartMB=202.3 heapEndMB=365.1 heapDeltaDispMB=162.9 gcCount=25 gcMs=318

[trace 2 of 3 — proof-after-2, registry warm]
turnId=4195b7f3 sessionKey=agent:multiuser-proof-after-2:main
totalMs=7244 entryMs=1928 dispatchMs=5313 firstDeliverMs=7230
heapDispStartMB=208.1 heapEndMB=240.0 heapDeltaDispMB=31.9 gcCount=60 gcMs=384

[trace 3 of 3 — proof-after-3, registry warm]
turnId=ee706a49 sessionKey=agent:multiuser-proof-after-3:main
totalMs=6628 entryMs=1563 dispatchMs=5062 firstDeliverMs=6613
heapDispStartMB=231.0 heapEndMB=241.0 heapDeltaDispMB=10.0 gcCount=19 gcMs=87

curl wall-clock:
proof-after-1 http_code=200 total=10.431555s
proof-after-2 http_code=200 total=7.252838s
proof-after-3 http_code=200 total=6.636774s
```

Comparison against the unpatched HEAD `b1abf9d8ae` on the same host, same compose, same wipe protocol (first row of `bench/heap-prof/ramp-postrebase/traces-P1-4-8.log` from the preceding bench session):

| Metric (first fresh-user DM) | Unpatched | Patched | Delta |
| --- | ---: | ---: | ---: |
| `totalMs` | 11310 | 10394 | **−916 ms** (−8.1%) |
| `dispatchMs` | 9499 | 8499 | **−1000 ms** (−10.5%) |
| `heapDeltaDispMB` | 266.1 | 162.9 | **−103.2 MB** (−38.7%) |

Steady-state (DM#2/#3) is unchanged within noise as expected — those calls already hit the strict-cache-key path in upstream, so the workspace-aware reuse only fires once per process.

**What was not tested:**
- Forked-runtime / subagent surfaces (`pinActivePluginChannelRegistry`, `pinActivePluginHttpRouteRegistry`) — patch leaves the post-load installation path untouched, but the channel and http-route surfaces were not exercised end-to-end on the running container.
- A multi-workspace gateway with `getActivePluginRegistryWorkspaceDir()` divergent from the dispatch caller's workspace. The "workspace-incompatible" regression in the new test file covers the logic, but no multi-workspace gateway was stood up to confirm production behavior.
- Real provider network calls. The patched code path runs before any provider call, so this should not affect the result, but no real provider was exercised.
- Repro on Linux ARM64 or macOS — bench host was Linux x86_64 only.

## Verification

Added `src/plugins/runtime/standalone-runtime-registry-loader.test.ts` with three regression cases:
- Cache-key-miss but workspace + plugin-ids match → reuses active registry, `loadOpenClawPlugins` not called
- Workspace mismatch → loads a fresh registry
- Missing required plugin → loads a fresh registry

```
$ pnpm vitest run src/plugins/runtime/standalone-runtime-registry-loader.test.ts
RUN  v4.1.5 /tmp/openclaw-fork
Test Files  1 passed (1)
     Tests  3 passed (3)
  Duration  1.89s
```

Targeted plugin-contract lane:

```
$ pnpm test:contracts:plugins
Test Files  62 passed (62)
     Tests  833 passed (833)
  Duration  43.06s
```

## AI-assisted

This patch was developed with AI assistance. Per `AGENTS.md` guidance, surfacing here: bench data, root-cause attribution, and patch text were prepared by Claude Code from heap-profile + heap-snapshot evidence on the linked repro. The author ran the patched-image build, state wipe, and curl bench above on their own setup; the numbers in the "Real behavior proof" section are from that run.
