### PR TITLE
[codex] make attachment base64 validation stack-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: replace attachment base64 regex validation with stack-safe round-trip canonicalization so large image uploads no longer crash `chat.send`. Fixes #80679.
 - Control UI/performance: scope Nodes polling to the active Nodes tab, debounce stale session-list reconciliation, and bound chat-side session refreshes so long-running dashboards avoid background reload churn. Thanks @BunsDev.
 - Bonjour/Gateway: treat active ciao probing and fresh name-conflict renames as in-progress so the mDNS watchdog waits for probe settlement before retrying, preventing rapid re-advertise loops on Windows, WSL, and other multicast-hostile hosts. (#74778) Refs #74242. Thanks @fuller-stack-dev.
 - Providers/MiniMax: send a minimal Anthropic-compatible user fallback when message conversion filters a turn to an empty payload, so MiniMax M2.7 no longer returns `chat content is empty` after tool-heavy sessions. Fixes #74589. Thanks @neeravmakwana and @DerekEXS.

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -528,6 +528,48 @@ describe("shared attachment validation", () => {
     ).rejects.toThrow(/base64/i);
   });
 
+  it("rejects base64 strings that do not survive a Buffer round-trip", async () => {
+    const bad: ChatAttachment = {
+      type: "image",
+      mimeType: "image/png",
+      fileName: "twisted.png",
+      content: "AB==",
+    };
+
+    expect(() => buildMessageWithAttachments("x", [bad])).toThrow(/base64/i);
+    await expect(
+      parseMessageWithAttachments("x", [bad], { log: { warn: () => {} } }),
+    ).rejects.toThrow(/base64/i);
+  });
+
+  it("handles a large valid image payload without stack overflow", async () => {
+    const large = Buffer.alloc(4_500_000, 1);
+    large.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    const content = large.toString("base64");
+
+    const parsed = await parseMessageWithAttachments(
+      "x",
+      [
+        {
+          type: "image",
+          mimeType: "image/png",
+          fileName: "large.png",
+          content,
+        },
+      ],
+      { log: { warn: () => {} } },
+    );
+
+    try {
+      expect(parsed.images).toHaveLength(0);
+      expect(parsed.offloadedRefs).toHaveLength(1);
+      expect(parsed.offloadedRefs[0]?.mimeType).toBe("image/png");
+      expect(parsed.message).toContain("[media attached: media://inbound/");
+    } finally {
+      await cleanupOffloadedRefs(parsed.offloadedRefs);
+    }
+  });
+
   it("rejects images over limit for both builder and parser without decoding base64", async () => {
     const big = "A".repeat(10_000);
     const att: ChatAttachment = {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { estimateBase64DecodedBytes } from "../media/base64.js";
+import { canonicalizeBase64, estimateBase64DecodedBytes } from "../media/base64.js";
 import { MAX_IMAGE_BYTES } from "../media/constants.js";
 import { extensionForMime, mimeTypeFromFilePath } from "../media/mime.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
@@ -114,11 +114,12 @@ function shouldIgnoreProvidedImageMime(params: {
   return isGenericContainerMime(params.sniffedMime) && isImageMime(params.providedMime);
 }
 
-function isValidBase64(value: string): boolean {
-  if (value.length === 0 || value.length % 4 !== 0) {
-    return false;
+function roundTripBase64(value: string): string | undefined {
+  const canonical = canonicalizeBase64(value);
+  if (!canonical) {
+    return undefined;
   }
-  return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+  return Buffer.from(canonical, "base64").toString("base64") === canonical ? canonical : undefined;
 }
 
 function verifyDecodedSize(buffer: Buffer, estimatedBytes: number, label: string): void {
@@ -193,17 +194,24 @@ function normalizeAttachment(
 function validateAttachmentBase64OrThrow(
   normalized: NormalizedAttachment,
   opts: { maxBytes: number },
-): number {
-  if (!isValidBase64(normalized.base64)) {
+): { base64: string; sizeBytes: number } {
+  if (normalized.base64.length === 0) {
     throw new Error(`attachment ${normalized.label}: invalid base64 content`);
   }
   const sizeBytes = estimateBase64DecodedBytes(normalized.base64);
-  if (sizeBytes <= 0 || sizeBytes > opts.maxBytes) {
+  if (sizeBytes <= 0) {
+    throw new Error(`attachment ${normalized.label}: invalid base64 content`);
+  }
+  if (sizeBytes > opts.maxBytes) {
     throw new Error(
       `attachment ${normalized.label}: exceeds size limit (${sizeBytes} > ${opts.maxBytes} bytes)`,
     );
   }
-  return sizeBytes;
+  const base64 = roundTripBase64(normalized.base64);
+  if (!base64) {
+    throw new Error(`attachment ${normalized.label}: invalid base64 content`);
+  }
+  return { base64, sizeBytes };
 }
 
 export async function parseMessageWithAttachments(
@@ -245,21 +253,14 @@ export async function parseMessageWithAttachments(
         requireImageMime: false,
       });
 
-      const { base64: b64, label, mime } = normalized;
+      const { label, mime } = normalized;
 
-      if (b64.length === 0) {
+      if (normalized.base64.length === 0) {
         throw new UnsupportedAttachmentError("empty-payload", `attachment ${label}: empty payload`);
       }
-      if (!isValidBase64(b64)) {
-        throw new Error(`attachment ${label}: invalid base64 content`);
-      }
-
-      const sizeBytes = estimateBase64DecodedBytes(b64);
-      if (sizeBytes > maxBytes) {
-        throw new Error(
-          `attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes)`,
-        );
-      }
+      const { base64: b64, sizeBytes } = validateAttachmentBase64OrThrow(normalized, {
+        maxBytes,
+      });
 
       const providedMime = normalizeMime(mime);
       const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
@@ -437,9 +438,9 @@ export function buildMessageWithAttachments(
       stripDataUrlPrefix: false,
       requireImageMime: true,
     });
-    validateAttachmentBase64OrThrow(normalized, { maxBytes });
+    const { base64 } = validateAttachmentBase64OrThrow(normalized, { maxBytes });
 
-    const { base64, label, mime } = normalized;
+    const { label, mime } = normalized;
     const safeLabel = label.replace(/\s+/g, "_");
     blocks.push(`![${safeLabel}](data:${mime};base64,${base64})`);
   }


### PR DESCRIPTION
## Summary
Replace attachment base64 regex validation with stack-safe round-trip canonicalization in the Gateway attachment parser.

## Why
Large mobile image uploads could trigger a `RangeError: Maximum call stack size exceeded` during `chat.send` because the parser validated the full payload with a regex. That made image uploads fail before staging and dropped the WebSocket session.

## What changed
- Canonicalize base64 with `Buffer.from(..., 'base64').toString('base64')` and compare against the normalized input.
- Keep the existing size guard before decoding oversized payloads.
- Add regression tests for a large valid image payload and for invalid base64 that does not survive a round trip.
- Add a changelog entry.

## Verification
- `pnpm test src/gateway/chat-attachments.test.ts -- --reporter=verbose`
- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts -- --reporter=verbose -t "logs chat.send attachment parse failures with stack details"`
- `pnpm check:changed`
- `git diff --check`

Fixes #80679
