### PR TITLE
fix: add @zed-industries/codex-acp to minimumReleaseAgeExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,8 @@ minimumReleaseAgeExclude:
   - "@mariozechner/*"
   - "@openai/codex"
   - "@openai/codex-*"
+  - "@zed-industries/codex-acp"
+  - "@zed-industries/codex-acp-*"
   - "@typescript/native-preview*"
   - "@types/node"
   - "@rolldown/*"


### PR DESCRIPTION
## Problem

`@zed-industries/codex-acp` and its platform-specific packages (`@zed-industries/codex-acp-darwin-arm64`, `-x64`, `-linux-arm64`, etc.) are transitive dependencies that release frequently. The `minimumReleaseAge: 2880` (48-hour) guard in `pnpm-workspace.yaml` blocks `pnpm install` whenever a new version ships less than 48 hours before a scheduled install run, causing the install to fail.

## Fix

Add `@zed-industries/codex-acp` and `@zed-industries/codex-acp-*` to `minimumReleaseAgeExclude`, matching the pattern already used for `@openai/codex` and `@openai/codex-*`.

## Why this pattern is safe

These are native binary packages (Zed ACP runtime). They follow the same release cadence pattern as `@openai/codex-*` which is already excluded. Blocking on release age provides no meaningful safety benefit for first-party tooling packages from known publishers.