### PR TITLE
fix(telegram): resolve DM topic thread ids

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -78,6 +78,7 @@ import {
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
+  resolveTelegramMessageThreadId,
   shouldUseTelegramDmThreadSession,
   withResolvedTelegramForumFlag,
 } from "./bot/helpers.js";
@@ -433,7 +434,7 @@ export const registerTelegramHandlers = ({
       runtime.error?.(danger(`telegram debounce flush failed: ${String(err)}`));
       const chatId = items[0]?.msg.chat.id;
       if (chatId != null) {
-        const threadId = items[0]?.msg.message_thread_id;
+        const threadId = resolveTelegramMessageThreadId(items[0]?.msg);
         void bot.api
           .sendMessage(
             chatId,
@@ -1587,7 +1588,7 @@ export const registerTelegramHandlers = ({
         }
       }
 
-      const messageThreadId = callbackMessage.message_thread_id;
+      const messageThreadId = resolveTelegramMessageThreadId(callbackMessage);
       const isForum = await resolveTelegramForumFlag({
         chatId,
         chatType: callbackMessage.chat.type,
@@ -2242,11 +2243,12 @@ export const registerTelegramHandlers = ({
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
+    const messageThreadId = resolveTelegramMessageThreadId(normalizedMsg);
     const resolvedThreadId = resolveTelegramForumThreadId({
       isForum,
-      messageThreadId: normalizedMsg.message_thread_id,
+      messageThreadId,
     });
-    const dmThreadId = !isGroup ? normalizedMsg.message_thread_id : undefined;
+    const dmThreadId = !isGroup ? messageThreadId : undefined;
     recordMessageForReplyChain(normalizedMsg, resolvedThreadId ?? dmThreadId);
   };
 
@@ -2368,7 +2370,7 @@ export const registerTelegramHandlers = ({
       chatId: normalizedMsg.chat.id,
       isGroup,
       isForum,
-      messageThreadId: normalizedMsg.message_thread_id,
+      messageThreadId: resolveTelegramMessageThreadId(normalizedMsg),
       senderId: normalizedMsg.from?.id != null ? String(normalizedMsg.from.id) : "",
       senderUsername: normalizedMsg.from?.username ?? "",
       requireConfiguredGroup: false,

--- a/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
@@ -77,6 +77,22 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
     expectRecordedRoute({ to: "telegram:1234", threadId: "42" });
   });
 
+  it("uses direct_messages_topic.topic_id as the DM topic thread id", async () => {
+    const ctx = await buildCtx({
+      message: {
+        chat: { id: 1234, type: "private" },
+        direct_messages_topic: { topic_id: 43 },
+      },
+    });
+
+    if (!ctx?.ctxPayload) {
+      throw new Error("expected Telegram DM topic context payload");
+    }
+    expect(recordInboundSessionMock).toHaveBeenCalled();
+
+    expectRecordedRoute({ to: "telegram:1234", threadId: "43" });
+  });
+
   it("builds Telegram payloads through the shared channel turn context", async () => {
     const { buildChannelTurnContext } = await import("openclaw/plugin-sdk/channel-inbound");
     const buildChannelTurnContextMock = vi.fn(buildChannelTurnContext);

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -32,6 +32,7 @@ import {
   buildTypingThreadParams,
   extractTelegramForumFlag,
   resolveTelegramForumFlag,
+  resolveTelegramMessageThreadId,
   resolveTelegramThreadSpec,
   shouldUseTelegramDmThreadSession,
 } from "./bot/helpers.js";
@@ -145,7 +146,7 @@ export const buildTelegramMessageContext = async ({
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const senderId = msg.from?.id ? String(msg.from.id) : "";
-  const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
+  const messageThreadId = resolveTelegramMessageThreadId(msg);
   const reactionApi =
     typeof bot.api.setMessageReaction === "function"
       ? bot.api.setMessageReaction.bind(bot.api)

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -75,6 +75,7 @@ import {
   resolveTelegramCommandAuthorization,
   resolveTelegramForumFlag,
   resolveTelegramGroupAllowFromContext,
+  resolveTelegramMessageThreadId,
   resolveTelegramThreadSpec,
   shouldUseTelegramDmThreadSession,
 } from "./bot/helpers.js";
@@ -366,7 +367,7 @@ async function resolveTelegramNativeCommandThreadContext(params: {
   const { msg, bot } = params;
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
-  const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
+  const messageThreadId = resolveTelegramMessageThreadId(msg);
   const getChat =
     typeof bot.api.getChat === "function"
       ? (bot.api.getChat.bind(bot.api) as TelegramGetChat)
@@ -838,7 +839,7 @@ export const registerTelegramNativeCommands = ({
   } | null> => {
     const { msg, runtimeCfg, isGroup, isForum, resolvedThreadId, senderId, topicAgentId } = params;
     const chatId = msg.chat.id;
-    const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
+    const messageThreadId = resolveTelegramMessageThreadId(msg);
     const threadSpec = resolveTelegramThreadSpec({
       isGroup,
       isForum,

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -12,9 +12,30 @@ import {
   resolveTelegramDirectPeerId,
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
+  resolveTelegramMessageThreadId,
   resetTelegramForumFlagCacheForTest,
   shouldUseTelegramDmThreadSession,
 } from "./helpers.js";
+
+describe("resolveTelegramMessageThreadId", () => {
+  it("prefers message_thread_id when present", () => {
+    expect(
+      resolveTelegramMessageThreadId({
+        message_thread_id: 42,
+        direct_messages_topic: { topic_id: 43 },
+      }),
+    ).toBe(42);
+  });
+
+  it("falls back to direct_messages_topic.topic_id for private DM topics", () => {
+    expect(resolveTelegramMessageThreadId({ direct_messages_topic: { topic_id: 43 } })).toBe(43);
+  });
+
+  it("returns undefined when no Telegram thread id is present", () => {
+    expect(resolveTelegramMessageThreadId({})).toBeUndefined();
+    expect(resolveTelegramMessageThreadId(null)).toBeUndefined();
+  });
+});
 
 describe("resolveTelegramForumThreadId", () => {
   it.each([

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -83,6 +83,25 @@ export type TelegramThreadSpec = {
   scope: "dm" | "forum" | "none";
 };
 
+type TelegramDirectMessagesTopicCarrier = {
+  message_thread_id?: number;
+  direct_messages_topic?: {
+    topic_id?: number;
+  };
+};
+
+export function resolveTelegramMessageThreadId(msg: unknown): number | undefined {
+  if (!msg || typeof msg !== "object") {
+    return undefined;
+  }
+  const candidate = msg as TelegramDirectMessagesTopicCarrier;
+  if (typeof candidate.message_thread_id === "number") {
+    return candidate.message_thread_id;
+  }
+  const dmTopicId = candidate.direct_messages_topic?.topic_id;
+  return typeof dmTopicId === "number" ? dmTopicId : undefined;
+}
+
 function normalizeTelegramDmThreadReplies(value: unknown): TelegramDmThreadReplies | undefined {
   return value === "off" || value === "inbound" || value === "always" ? value : undefined;
 }

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -9,7 +9,7 @@ import {
   isAbortRequestText,
   isBtwRequestText,
 } from "openclaw/plugin-sdk/command-primitives-runtime";
-import { resolveTelegramForumThreadId } from "./bot/helpers.js";
+import { resolveTelegramForumThreadId, resolveTelegramMessageThreadId } from "./bot/helpers.js";
 
 type TelegramSequentialKeyContext = {
   chat?: { id?: number };
@@ -97,7 +97,7 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     return "telegram:approval";
   }
   const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
-  const messageThreadId = msg?.message_thread_id;
+  const messageThreadId = resolveTelegramMessageThreadId(msg);
   const isForum =
     msg?.chat?.is_forum ?? (msg?.chat?.type === "supergroup" && msg?.is_topic_message === true);
   const threadId = isGroup


### PR DESCRIPTION
## Summary
- add a shared Telegram helper that resolves thread ids from `message_thread_id` or Bot API `direct_messages_topic.topic_id`
- use that helper across Telegram inbound message context, native commands, runtime handlers, and sequential keys
- add regression coverage for BotFather Threaded Mode/private DM topic routing

## Testing
- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-vitest-include.json OPENCLAW_VITEST_MAX_WORKERS=1 corepack pnpm vitest run --config test/vitest/vitest.extension-telegram.config.ts --typecheck --reporter verbose`
- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-vitest-include-2.json OPENCLAW_VITEST_MAX_WORKERS=1 corepack pnpm vitest run --config test/vitest/vitest.extension-telegram.config.ts --typecheck --reporter dot`
- `corepack pnpm format:check extensions/telegram/src/bot/helpers.ts extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/bot-message-context.ts extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts extensions/telegram/src/bot-native-commands.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/sequential-key.ts`
- `git diff --check`
