### PR TITLE
fix(secrets): allow hash in exec SecretRef ids

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -868,7 +868,7 @@ Validation:
 - `provider` pattern: `^[a-z][a-z0-9_-]{0,63}$`
 - `source: "env"` id pattern: `^[A-Z][A-Z0-9_]{0,127}$`
 - `source: "file"` id: absolute JSON pointer (for example `"/providers/openai/apiKey"`)
-- `source: "exec"` id pattern: `^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$`
+- `source: "exec"` id pattern: `^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,255}$` (supports AWS-style `secret#json_key` selectors)
 - `source: "exec"` ids must not contain `.` or `..` slash-delimited path segments (for example `a/../b` is rejected)
 
 ### Supported credential surface

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -108,13 +108,13 @@ Use one object shape everywhere:
   </Tab>
   <Tab title="exec">
     ```json5
-    { source: "exec", provider: "vault", id: "providers/openai/apiKey" }
+    { source: "exec", provider: "vault", id: "providers/openai/apiKey#value" }
     ```
 
     Validation:
 
     - `provider` must match `^[a-z][a-z0-9_-]{0,63}$`
-    - `id` must match `^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$`
+    - `id` must match `^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,255}$` (supports selectors such as `secret#json_key`)
     - `id` must not contain `.` or `..` as slash-delimited path segments (for example `a/../b` is rejected)
 
   </Tab>

--- a/src/secrets/ref-contract.ts
+++ b/src/secrets/ref-contract.ts
@@ -6,13 +6,13 @@ import {
 
 const FILE_SECRET_REF_SEGMENT_PATTERN = /^(?:[^~]|~0|~1)*$/;
 export const SECRET_PROVIDER_ALIAS_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
-const EXEC_SECRET_REF_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/;
+const EXEC_SECRET_REF_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,255}$/;
 
 export const SINGLE_VALUE_FILE_REF_ID = "value";
 export const FILE_SECRET_REF_ID_ABSOLUTE_JSON_SCHEMA_PATTERN = "^/";
 export const FILE_SECRET_REF_ID_INVALID_ESCAPE_JSON_SCHEMA_PATTERN = "~(?:[^01]|$)";
 export const EXEC_SECRET_REF_ID_JSON_SCHEMA_PATTERN =
-  "^(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$";
+  "^(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9][A-Za-z0-9._:/#-]{0,255}$";
 
 export type ExecSecretRefIdValidationReason = "pattern" | "traversal-segment";
 
@@ -102,8 +102,8 @@ export function isValidExecSecretRefId(value: string): boolean {
 
 export function formatExecSecretRefIdValidationMessage(): string {
   return [
-    "Exec secret reference id must match /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/",
+    "Exec secret reference id must match /^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,255}$/",
     'and must not include "." or ".." path segments',
-    '(example: "vault/openai/api-key").',
+    '(example: "vault/openai/api-key" or "aws/secret#json_key").',
   ].join(" ");
 }

--- a/src/test-utils/secret-ref-test-vectors.ts
+++ b/src/test-utils/secret-ref-test-vectors.ts
@@ -21,6 +21,7 @@ export const VALID_EXEC_SECRET_REF_IDS = [
   "vault/openai/api-key",
   "vault:secret/mykey",
   "providers/openai/apiKey",
+  "gravity/shared/slack-gateway/credentials#bot_token",
   "a..b/c",
   "a/.../b",
   "a/.well-known/key",


### PR DESCRIPTION
## Summary
- allow `#` in exec SecretRef ids while preserving traversal-segment rejection
- add a shared valid test vector for the documented AWS Secrets Manager `secret#json_key` convention
- keep config, plan, gateway protocol, and plugin SDK validation in parity
- sync the public configuration reference with the broadened exec SecretRef id pattern

## Real behavior proof

- **Behavior or issue addressed:** exec SecretRef ids that include an AWS-style JSON-key selector such as `gravity/shared/slack-gateway/credentials#bot_token` should pass OpenClaw config validation and reach the exec provider path instead of being rejected by the SecretRef id contract.
- **Real environment tested:** Local OpenClaw CLI on macOS from branch `fix/secretref-exec-hash-ids`, with `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` pointed at isolated `/private/tmp/openclaw-pr-proof` files so no user gateway state was touched.
- **Exact steps or command run after this patch:** `OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-pr-proof/80712-openclaw.json OPENCLAW_STATE_DIR=/private/tmp/openclaw-pr-proof/state-80712 pnpm openclaw config validate --json`
- **Evidence after fix:** Copied terminal output from the real CLI run:

  ```text
  $ OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-pr-proof/80712-openclaw.json OPENCLAW_STATE_DIR=/private/tmp/openclaw-pr-proof/state-80712 pnpm openclaw config validate --json
  $ node scripts/run-node.mjs config validate --json
  {"valid":true,"path":"/private/tmp/openclaw-pr-proof/80712-openclaw.json"}
  ```

- **Observed result after fix:** The config containing `models.providers.openai.apiKey.id = "gravity/shared/slack-gateway/credentials#bot_token"` returned `valid: true`, confirming the real OpenClaw config validation path now accepts `#json_key` exec SecretRef ids.
- **Not tested:** Did not call a live AWS Secrets Manager resolver; this proof verifies the OpenClaw validation/gateway config path accepts the documented exec SecretRef id so the configured provider can resolve it at runtime.

## Validation
- `pnpm test src/secrets/ref-contract.test.ts src/secrets/exec-secret-ref-id-parity.test.ts src/config/config.secrets-schema.test.ts src/gateway/protocol/primitives.secretref.test.ts src/plugin-sdk/secret-input.test.ts src/secrets/plan.test.ts src/secrets/resolve.test.ts`
- `pnpm exec oxfmt --check --threads=1 docs/gateway/configuration-reference.md src/secrets/ref-contract.ts src/secrets/ref-contract.test.ts src/secrets/exec-secret-ref-id-parity.test.ts src/test-utils/secret-ref-test-vectors.ts`
- `git diff --check`

Fixes #80712
