### PR TITLE
test(gateway): cover TUI paired token recovery

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1,7 +1,10 @@
 import { Buffer } from "node:buffer";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "./protocol/client-info.js";
 import { MIN_CLIENT_PROTOCOL_VERSION, PROTOCOL_VERSION } from "./protocol/index.js";
 
 const wsInstances = vi.hoisted((): MockWebSocket[] => []);
@@ -817,7 +820,15 @@ describe("GatewayClient connect auth payload", () => {
     );
   }
 
-  function emitHelloOk(ws: MockWebSocket, connectId: string | undefined) {
+  function emitHelloOk(
+    ws: MockWebSocket,
+    connectId: string | undefined,
+    auth: {
+      role?: string;
+      scopes?: string[];
+      deviceToken?: string;
+    } = { role: "operator", scopes: ["operator.admin"] },
+  ) {
     ws.emitMessage(
       JSON.stringify({
         type: "res",
@@ -825,7 +836,7 @@ describe("GatewayClient connect auth payload", () => {
         ok: true,
         payload: {
           type: "hello-ok",
-          auth: { role: "operator", scopes: ["operator.admin"] },
+          auth,
         },
       }),
     );
@@ -875,6 +886,49 @@ describe("GatewayClient connect auth payload", () => {
 
     expectConnectAuthFields(ws, { token: "shared-token" });
     expect(connectFrameFrom(ws).deviceToken).toBeUndefined();
+    client.stop();
+  });
+
+  it("stores a reissued device token after shared-token TUI reconnect", async () => {
+    loadDeviceAuthTokenMock.mockReturnValue(undefined);
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: path.join(os.tmpdir(), "openclaw-tui-cache-missing-state"),
+    } as NodeJS.ProcessEnv;
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-token",
+      clientName: GATEWAY_CLIENT_NAMES.TUI,
+      clientDisplayName: "openclaw-tui",
+      mode: GATEWAY_CLIENT_MODES.UI,
+      env,
+    });
+    const deviceId = (client as unknown as { opts: { deviceIdentity?: { deviceId?: unknown } } })
+      .opts.deviceIdentity?.deviceId;
+    expect(deviceId).toBeTypeOf("string");
+
+    const { ws, connect } = startClientAndConnect({ client });
+    expectConnectAuthFields(ws, { token: "shared-token" });
+    expect(connectFrameFrom(ws).deviceToken).toBeUndefined();
+
+    emitHelloOk(ws, connect.id, {
+      role: "operator",
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+      deviceToken: "reissued-device-token",
+    });
+
+    await vi.waitFor(() => expect(storeDeviceAuthTokenMock).toHaveBeenCalledOnce());
+    const storeParams = expectRecordFields(
+      storeDeviceAuthTokenMock.mock.calls[0]?.[0],
+      {
+        role: "operator",
+        token: "reissued-device-token",
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+        env,
+      },
+      "store device token params",
+    );
+    expect(storeParams.deviceId).toBe(deviceId);
     client.stop();
   });
 

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -893,6 +893,68 @@ export function registerControlUiAndPairingSuite(): void {
     restoreGatewayToken(prevToken);
   });
 
+  test("reissues paired TUI device token when the local device-auth cache is missing", async () => {
+    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+    const tuiClient = {
+      id: GATEWAY_CLIENT_NAMES.TUI,
+      displayName: "openclaw-tui",
+      version: "1.0.0",
+      platform: "linux",
+      mode: GATEWAY_CLIENT_MODES.UI,
+    };
+    const { identity, identityPath } = await seedApprovedOperatorReadPairing({
+      identityPrefix: "openclaw-tui-cache-missing-",
+      clientId: tuiClient.id,
+      clientMode: tuiClient.mode,
+      displayName: tuiClient.displayName,
+      platform: tuiClient.platform,
+      scopes: ["operator.admin", "operator.pairing"],
+    });
+    const pairedBefore = await getPairedDevice(identity.deviceId);
+    const pairedToken = pairedBefore?.tokens?.operator?.token;
+    expect(pairedToken).toBeTypeOf("string");
+
+    const { server, port, prevToken } = await startControlUiServer("secret");
+    const ws = await openWs(port);
+    try {
+      const nonce = await readConnectChallengeNonce(ws);
+      const reconnect = await connectReq(ws, {
+        token: "secret",
+        scopes: ["operator.admin"],
+        client: tuiClient,
+        device: await buildSignedDeviceForIdentity({
+          identityPath,
+          client: tuiClient,
+          scopes: ["operator.admin"],
+          nonce,
+        }),
+      });
+      expect(reconnect.ok, JSON.stringify(reconnect)).toBe(true);
+      const helloOk = reconnect.payload as
+        | {
+            auth?: {
+              deviceToken?: unknown;
+              scopes?: unknown;
+            };
+          }
+        | undefined;
+      expect(helloOk?.auth?.deviceToken).toBe(pairedToken);
+      expectArrayIncludes(helloOk?.auth?.scopes, [
+        "operator.admin",
+        "operator.pairing",
+        "operator.read",
+        "operator.write",
+      ]);
+
+      const pairing = await listDevicePairing();
+      expect(pairing.pending.filter((entry) => entry.deviceId === identity.deviceId)).toEqual([]);
+    } finally {
+      ws.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("does not expose approved access when a paired device id reconnects with a different key", async () => {
     const { identity, identityPath } = await seedApprovedOperatorReadPairing({
       identityPrefix: "openclaw-device-key-mismatch-",


### PR DESCRIPTION
## Summary

- Add gateway integration coverage for a paired `openclaw-tui` identity reconnecting after the local device-auth cache is missing.
- Assert the gateway reissues the existing paired operator token from `devices/paired.json` without creating a scope-upgrade pairing request.
- Add `GatewayClient` coverage that stores the reissued `hello-ok` device token back into the client auth cache.

Refs #80730

## Real behavior proof

Behavior or issue addressed:
`openclaw tui` should not require scope re-approval after restart solely because its local device-auth cache is missing, provided the TUI presents the same paired device identity and valid local gateway auth.

Real environment tested:
OpenClaw source at this PR head (`b7888e4235ced4897b664e9432c2b42e4e0058a3`), local loopback gateway process from the source tree, and the real `GatewayChatClient` backend used by `openclaw tui`. The proof used an isolated temporary `OPENCLAW_STATE_DIR` and did not use the Vitest runner.

Exact steps or command run after this patch:

```bash
timeout 150s node --import tsx /tmp/openclaw-80742-real-proof.mjs
```

The proof script:

- created an isolated OpenClaw state dir and loopback gateway config
- created the normal TUI device identity at `identity/device.json`
- seeded `devices/paired.json` with that `openclaw-tui` identity and an approved operator token
- removed `identity/device-auth.json` before reconnect
- started the gateway from this PR head
- connected through `GatewayChatClient.connect({ url, token })`, the backend path used by `openclaw tui`
- checked the `hello-ok` auth payload, pairing state, and rewritten device-auth cache

Evidence after fix:

```json
{
  "proof": "openclaw tui backend paired-token recovery with missing local cache",
  "repoHead": "b7888e4235ced4897b664e9432c2b42e4e0058a3",
  "seededPairing": {
    "clientId": "openclaw-tui",
    "clientMode": "ui",
    "pairedTokenBefore": "<present:redacted>",
    "cacheExistsBeforeReconnect": false,
    "pendingForDeviceBeforeReconnect": 0
  },
  "reconnect": {
    "helloType": "hello-ok",
    "scopes": [
      "operator.admin",
      "operator.pairing",
      "operator.read",
      "operator.write"
    ],
    "reissuedDeviceToken": "<present:redacted>",
    "reissuedMatchesPairedToken": true,
    "pairedTokenStableAcrossReconnect": true,
    "pendingForDeviceAfterReconnect": 0,
    "cacheRewritten": true,
    "cacheTokenMatchesHelloToken": true,
    "disconnectedDuringProof": null
  }
}
```

Observed result after fix:
The TUI backend reconnect completed with `hello-ok`; the gateway returned the existing paired operator token, did not create a pending pairing/scope-upgrade request, and `GatewayChatClient` rewrote the local `identity/device-auth.json` cache with the returned token.

What was not tested:
A physical machine reboot and full terminal screen rendering. This proof covers the live gateway plus the actual `openclaw tui` gateway-backend reconnect path that owns the cache/token behavior; the existing tests cover the lower-level gateway and client contracts.

## Validation

```bash
timeout 150s env OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/gateway/client.test.ts
timeout 150s env OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/gateway/server.auth.control-ui.test.ts
git diff --check
```

- `src/gateway/server.auth.control-ui.test.ts` passed 27/27 and includes the paired TUI cache-missing reconnect scenario.
- `src/gateway/client.test.ts` passed 37/37 and includes the client persistence scenario.

## Review gates

- Claude CLI review: no P0/P1 findings; P2 test-tightening notes were addressed.
- Codex review: no P0/P1/P2 findings.
