### PR TITLE
fix(agents): recover Anthropic thinking cache misses

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1,5 +1,6 @@
 import type { Model } from "@earendil-works/pi-ai";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { wrapAnthropicStreamWithRecovery } from "./pi-embedded-runner/thinking.js";
 import { attachModelProviderRequestTransport } from "./provider-request-config.js";
 
 const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
@@ -403,6 +404,119 @@ describe("anthropic transport stream", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("OpenClaw transport error: malformed_streaming_fragment");
+  });
+
+  it("recovers thinking-block rejection emitted by the Anthropic transport before content", async () => {
+    const thinkingError =
+      "messages.1.content.0: thinking or redacted_thinking blocks in the latest assistant message cannot be modified";
+    guardedFetchMock
+      .mockResolvedValueOnce(
+        createSseResponse([
+          {
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message: thinkingError,
+            },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        createSseResponse([
+          {
+            type: "message_start",
+            message: { id: "msg_retry", usage: { input_tokens: 8, output_tokens: 0 } },
+          },
+          {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "recovered" },
+          },
+          {
+            type: "content_block_stop",
+            index: 0,
+          },
+          {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn" },
+            usage: { input_tokens: 8, output_tokens: 1 },
+          },
+        ]),
+      );
+    const streamFn = wrapAnthropicStreamWithRecovery(createAnthropicMessagesTransportStreamFn(), {
+      id: "transport-session",
+    });
+    const stream = await Promise.resolve(
+      streamFn(
+        makeAnthropicTransportModel(),
+        {
+          messages: [
+            { role: "user", content: "continue" },
+            {
+              role: "assistant",
+              provider: "anthropic",
+              api: "anthropic-messages",
+              model: "claude-sonnet-4-6",
+              stopReason: "stop",
+              timestamp: 0,
+              content: [
+                { type: "thinking", thinking: "private", thinkingSignature: "sig_1" },
+                { type: "text", text: "visible answer" },
+              ],
+            },
+            { role: "user", content: "next" },
+          ],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const events: Array<{ type?: string }> = [];
+    for await (const event of stream as AsyncIterable<{ type?: string }>) {
+      events.push(event);
+    }
+    const result = await stream.result();
+
+    expect(guardedFetchMock).toHaveBeenCalledTimes(2);
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "done",
+    ]);
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+
+    const firstPayload = JSON.parse(String(guardedFetchMock.mock.calls[0]?.[1]?.body)) as Record<
+      string,
+      unknown
+    >;
+    const retryPayload = JSON.parse(String(guardedFetchMock.mock.calls[1]?.[1]?.body)) as Record<
+      string,
+      unknown
+    >;
+    const firstAssistant = findRecord(
+      firstPayload.messages,
+      (record) => record.role === "assistant",
+    );
+    const retryAssistant = findRecord(
+      retryPayload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(
+      requireArray(firstAssistant.content, "first assistant content").some(
+        (item) => requireRecord(item, "first assistant content item").type === "thinking",
+      ),
+    ).toBe(true);
+    expect(
+      requireArray(retryAssistant.content, "retry assistant content").some(
+        (item) => requireRecord(item, "retry assistant content item").type === "thinking",
+      ),
+    ).toBe(false);
+    expect(retryAssistant.content).toContainEqual({ type: "text", text: "visible answer" });
   });
 
   it("preserves Anthropic OAuth identity and tool-name remapping with transport overrides", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -34,7 +34,9 @@ import {
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
   shouldWarnOnOrphanedUserRepair,
+  shouldRecoverAnthropicThinkingReplay,
   wrapStreamFnRepairMalformedToolCallArguments,
+  wrapStreamFnRecoverAnthropicThinkingBlocks,
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.js";
@@ -106,6 +108,87 @@ function expectSingleToolCallContent(
   expect(item.type).toBe("toolCall");
   expect(item.name).toBe(name);
 }
+
+describe("wrapStreamFnRecoverAnthropicThinkingBlocks", () => {
+  const preservedAnthropicPolicy = {
+    validateAnthropicTurns: true,
+    preserveSignatures: true,
+    dropThinkingBlocks: false,
+  };
+
+  it("enables retry only when preserved Anthropic thinking replay can be rejected", () => {
+    expect(shouldRecoverAnthropicThinkingReplay(preservedAnthropicPolicy)).toBe(true);
+    expect(
+      shouldRecoverAnthropicThinkingReplay({
+        ...preservedAnthropicPolicy,
+        dropThinkingBlocks: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRecoverAnthropicThinkingReplay({
+        ...preservedAnthropicPolicy,
+        validateAnthropicTurns: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("retries once with thinking blocks stripped after the exact Anthropic rejection", async () => {
+    const thinkingError = new Error(
+      "messages.1.content.12: thinking or redacted_thinking blocks in the latest assistant message cannot be modified",
+    );
+    const contexts: Array<{ messages?: Array<{ role?: string; content?: unknown[] }> }> = [];
+    let callCount = 0;
+    const baseFn = vi.fn((_model, context) => {
+      callCount += 1;
+      contexts.push(context as { messages?: Array<{ role?: string; content?: unknown[] }> });
+      if (callCount === 1) {
+        return Promise.reject(thinkingError);
+      }
+      return Promise.resolve({ ok: true });
+    }) as unknown as Parameters<typeof wrapStreamFnRecoverAnthropicThinkingBlocks>[0];
+
+    const wrapped = wrapStreamFnRecoverAnthropicThinkingBlocks(
+      baseFn,
+      preservedAnthropicPolicy,
+      "session-1",
+    );
+    const result = await Promise.resolve(
+      wrapped(
+        {} as never,
+        {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "private", thinkingSignature: "sig_1" },
+                { type: "text", text: "visible answer" },
+              ],
+            },
+          ],
+        } as never,
+        {} as never,
+      ),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(baseFn).toHaveBeenCalledTimes(2);
+    expect(contexts[1]?.messages?.[0]?.content).toEqual([{ type: "text", text: "visible answer" }]);
+  });
+
+  it("leaves the stream function unchanged when thinking is already stripped", () => {
+    const baseFn = vi.fn() as unknown as Parameters<
+      typeof wrapStreamFnRecoverAnthropicThinkingBlocks
+    >[0];
+
+    expect(
+      wrapStreamFnRecoverAnthropicThinkingBlocks(
+        baseFn,
+        { ...preservedAnthropicPolicy, dropThinkingBlocks: true },
+        "session-1",
+      ),
+    ).toBe(baseFn);
+  });
+});
 
 describe("buildEmbeddedAttemptToolRunContext", () => {
   it("carries runtime toolsAllow into coding tool construction", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, StreamFn } from "@earendil-works/pi-agent-core";
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
 import { isAcpRuntimeSpawnAvailable } from "../../../acp/runtime/availability.js";
 import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
@@ -186,7 +186,10 @@ import {
   type ToolSearchCatalogToolExecutor,
   type ToolSearchTargetTranscriptProjection,
 } from "../../tool-search.js";
-import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
+import {
+  shouldAllowProviderOwnedThinkingReplay,
+  type TranscriptPolicy,
+} from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -238,7 +241,11 @@ import {
   resolveEmbeddedAgentStreamFn,
 } from "../stream-resolution.js";
 import { applySystemPromptOverrideToSession } from "../system-prompt.js";
-import { dropReasoningFromHistory, dropThinkingBlocks } from "../thinking.js";
+import {
+  dropReasoningFromHistory,
+  dropThinkingBlocks,
+  wrapAnthropicStreamWithRecovery,
+} from "../thinking.js";
 import {
   collectAllowedToolNames,
   collectCoreBuiltinToolNames,
@@ -409,6 +416,28 @@ const TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES = [
   TOOL_DESCRIBE_RAW_TOOL_NAME,
   TOOL_CALL_RAW_TOOL_NAME,
 ];
+
+type AnthropicThinkingRecoveryPolicy = Pick<
+  TranscriptPolicy,
+  "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks"
+>;
+
+export function shouldRecoverAnthropicThinkingReplay(
+  policy: AnthropicThinkingRecoveryPolicy,
+): boolean {
+  return policy.validateAnthropicTurns && policy.preserveSignatures && !policy.dropThinkingBlocks;
+}
+
+export function wrapStreamFnRecoverAnthropicThinkingBlocks(
+  streamFn: StreamFn,
+  policy: AnthropicThinkingRecoveryPolicy,
+  sessionId: string,
+): StreamFn {
+  if (!shouldRecoverAnthropicThinkingReplay(policy)) {
+    return streamFn;
+  }
+  return wrapAnthropicStreamWithRecovery(streamFn, { id: sessionId });
+}
 
 export function buildCallableToolNamesForEmptyAllowlistCheck(params: {
   effectiveToolNames: string[];
@@ -2311,6 +2340,12 @@ export async function runEmbeddedAttempt(
           return inner(model, nextContext as typeof context, options);
         };
       }
+
+      activeSession.agent.streamFn = wrapStreamFnRecoverAnthropicThinkingBlocks(
+        activeSession.agent.streamFn,
+        transcriptPolicy,
+        activeSession.sessionId ?? params.sessionId ?? params.runId,
+      );
 
       const innerStreamFn = activeSession.agent.streamFn;
       activeSession.agent.streamFn = (model, context, options) => {

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -523,6 +523,96 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     expect(callCount).toBe(1);
   });
 
+  it("retries when a transport stream reports the thinking rejection before content", async () => {
+    const finalMessage = castAgentMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "recovered" }],
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    }) as AssistantMessage;
+    const errorMessage = {
+      ...finalMessage,
+      content: [],
+      stopReason: "error",
+      errorMessage: anthropicThinkingError.message,
+    } as AssistantMessage;
+    const contexts: Array<{ messages?: AgentMessage[] }> = [];
+    let callCount = 0;
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      ((_model, context) => {
+        callCount += 1;
+        contexts.push(context as { messages?: AgentMessage[] });
+        const stream = createAssistantMessageEventStream();
+        queueMicrotask(() => {
+          if (callCount === 1) {
+            stream.push({ type: "start", partial: errorMessage });
+            stream.push({ type: "error", reason: "error", error: errorMessage });
+            stream.end();
+            return;
+          }
+          stream.push({ type: "start", partial: finalMessage });
+          stream.push({ type: "text_start", contentIndex: 0, partial: finalMessage });
+          stream.push({
+            type: "text_delta",
+            contentIndex: 0,
+            delta: "recovered",
+            partial: finalMessage,
+          });
+          stream.push({ type: "done", reason: "stop", message: finalMessage });
+          stream.end();
+        });
+        stream.result = () => Promise.resolve(callCount === 1 ? errorMessage : finalMessage);
+        return stream;
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session" },
+    );
+
+    const response = wrapped(
+      {} as never,
+      {
+        messages: castAgentMessages([
+          {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "secret", thinkingSignature: "sig" },
+              { type: "text", text: "visible answer" },
+            ],
+          },
+        ]),
+      } as never,
+      {} as never,
+    ) as { result: () => Promise<AssistantMessage> } & AsyncIterable<{ type?: string }>;
+    const events: Array<{ type?: string }> = [];
+    for await (const event of response) {
+      events.push(event);
+    }
+
+    await expect(response.result()).resolves.toEqual(finalMessage);
+    expect(callCount).toBe(2);
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "text_start",
+      "text_delta",
+      "done",
+    ]);
+    const retryMessage = contexts[1]?.messages?.[0];
+    if (!retryMessage || !isAssistantMessageWithContent(retryMessage)) {
+      throw new Error("Expected retry context to keep an assistant message");
+    }
+    expect(retryMessage.content).toEqual([{ type: "text", text: "visible answer" }]);
+  });
+
   it("does not retry non-Anthropic-thinking errors", async () => {
     const rateLimitError = new Error("rate limit exceeded");
     let callCount = 0;

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -389,42 +389,115 @@ function shouldRecoverAnthropicThinkingError(
   return true;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPreContentTransportEvent(chunk: unknown): boolean {
+  return isRecord(chunk) && chunk.type === "start";
+}
+
+function recoverableTransportErrorFromChunk(chunk: unknown): Error | undefined {
+  if (!isRecord(chunk) || chunk.type !== "error") {
+    return undefined;
+  }
+  const error = chunk.error;
+  if (isRecord(error) && typeof error.errorMessage === "string") {
+    return new Error(error.errorMessage);
+  }
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === "string") {
+    return new Error(error);
+  }
+  return undefined;
+}
+
+function recoverableTransportErrorFromResult(result: unknown): Error | undefined {
+  if (!isRecord(result) || typeof result.errorMessage !== "string") {
+    return undefined;
+  }
+  return new Error(result.errorMessage);
+}
+
+function flushBufferedChunks(
+  outer: ReturnType<typeof createAssistantMessageEventStream>,
+  bufferedChunks: unknown[],
+): void {
+  for (const chunk of bufferedChunks.splice(0)) {
+    outer.push(chunk as Parameters<typeof outer.push>[0]);
+  }
+}
+
+async function retryAnthropicThinkingStream(
+  outer: ReturnType<typeof createAssistantMessageEventStream>,
+  sessionMeta: RecoverySessionMeta,
+  retry: () => ReturnType<StreamFn>,
+  reason: string,
+): Promise<AssistantMessage> {
+  sessionMeta.recoveredAnthropicThinking = true;
+  log.warn(
+    `[session-recovery] Anthropic thinking error ${reason}; retrying once without thinking blocks: sessionId=${sessionMeta.id}`,
+  );
+  const retryStream = retry();
+  const resolvedRetry = retryStream instanceof Promise ? await retryStream : retryStream;
+  for await (const chunk of resolvedRetry as AsyncIterable<unknown>) {
+    outer.push(chunk as Parameters<typeof outer.push>[0]);
+  }
+  const result = await (resolvedRetry as { result?: () => Promise<AssistantMessage> }).result?.();
+  return result as AssistantMessage;
+}
+
 async function pumpStreamWithRecovery(
   outer: ReturnType<typeof createAssistantMessageEventStream>,
   stream: ReturnType<StreamFn>,
   sessionMeta: RecoverySessionMeta,
   retry: () => ReturnType<StreamFn>,
 ): Promise<AssistantMessage> {
-  let yieldedChunk = false;
+  let emittedContentOrTerminalChunk = false;
+  const bufferedChunks: unknown[] = [];
   try {
     const resolved = stream instanceof Promise ? await stream : stream;
     for await (const chunk of resolved as AsyncIterable<unknown>) {
-      yieldedChunk = true;
+      const transportError = recoverableTransportErrorFromChunk(chunk);
+      if (
+        transportError &&
+        !emittedContentOrTerminalChunk &&
+        shouldRecoverAnthropicThinkingError(transportError, sessionMeta)
+      ) {
+        return retryAnthropicThinkingStream(outer, sessionMeta, retry, "before content");
+      }
+      if (!emittedContentOrTerminalChunk && isPreContentTransportEvent(chunk)) {
+        bufferedChunks.push(chunk);
+        continue;
+      }
+      emittedContentOrTerminalChunk = true;
+      flushBufferedChunks(outer, bufferedChunks);
       outer.push(chunk as Parameters<typeof outer.push>[0]);
     }
     const result = await (resolved as { result?: () => Promise<AssistantMessage> }).result?.();
+    const transportError = recoverableTransportErrorFromResult(result);
+    if (
+      transportError &&
+      !emittedContentOrTerminalChunk &&
+      shouldRecoverAnthropicThinkingError(transportError, sessionMeta)
+    ) {
+      return retryAnthropicThinkingStream(outer, sessionMeta, retry, "before content");
+    }
+    flushBufferedChunks(outer, bufferedChunks);
     return result as AssistantMessage;
   } catch (error: unknown) {
     if (!shouldRecoverAnthropicThinkingError(error, sessionMeta)) {
       throw error;
     }
-    if (yieldedChunk) {
+    if (emittedContentOrTerminalChunk) {
       log.warn(
         `[session-recovery] Anthropic thinking error occurred after streaming began; skipping retry to avoid duplicate chunks: sessionId=${sessionMeta.id}`,
       );
       throw error;
     }
-    sessionMeta.recoveredAnthropicThinking = true;
-    log.warn(
-      `[session-recovery] Anthropic thinking error during stream; retrying once without thinking blocks: sessionId=${sessionMeta.id}`,
-    );
-    const retryStream = retry();
-    const resolvedRetry = retryStream instanceof Promise ? await retryStream : retryStream;
-    for await (const chunk of resolvedRetry as AsyncIterable<unknown>) {
-      outer.push(chunk as Parameters<typeof outer.push>[0]);
-    }
-    const result = await (resolvedRetry as { result?: () => Promise<AssistantMessage> }).result?.();
-    return result as AssistantMessage;
+    return retryAnthropicThinkingStream(outer, sessionMeta, retry, "during stream setup");
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #80625.

- Wire the existing Anthropic thinking-block recovery helper into the production embedded-runner stream path.
- Keep normal Claude 4.6 signed-thinking replay intact, then retry exactly once without thinking blocks only when Anthropic returns the specific "thinking or redacted_thinking blocks ... cannot be modified" rejection.
- Add focused coverage for the runtime gate and retry context so providers that already strip thinking blocks are left unchanged.

Maintainer attribution note:
If this PR is squashed or reworked before merge, please preserve author attribution for Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> or include `Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`.

## Root Cause

Claude replay policy correctly preserves signed thinking blocks for Claude 4.x, but the production stream path never installed the bounded Anthropic recovery wrapper. After a prompt-cache miss, Anthropic can reject the replayed latest assistant thinking block, and the session stayed stuck instead of retrying with only visible assistant content.

## Real behavior proof

Behavior or issue addressed:
Anthropic-compatible sessions that preserve signed thinking blocks can recover from the exact cache-miss rejection instead of permanently failing subsequent turns.

Real environment tested:
Local OpenClaw checkout on macOS, Node project runtime with `tsx`, loading the production embedded-runner recovery wrapper from this branch.

Exact steps or command run after this patch:
```bash
node --import tsx /private/tmp/openclaw-pr-proof/80625-runtime-smoke.mjs
pnpm test src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts extensions/anthropic/stream-wrappers.test.ts
pnpm check:changed -- --base upstream/main
git diff --check
```

Evidence after fix:
Runtime smoke output:
```text
[agent/embedded] [session-recovery] Anthropic thinking request rejected; retrying once without thinking blocks: sessionId=proof-session-80625
{
  "command": "node --import tsx /private/tmp/openclaw-pr-proof/80625-runtime-smoke.mjs",
  "setup": "Loaded the production OpenClaw embedded-runner Anthropic recovery wrapper; local provider stream returns the exact Anthropic cache-miss rejection once, then succeeds.",
  "result": {
    "status": "ok",
    "source": "local-provider-stream"
  },
  "providerCallCount": 2,
  "firstRequest": {
    "hadThinking": true,
    "text": "visible answer"
  },
  "retryRequest": {
    "hadThinking": false,
    "text": "visible answer",
    "content": [
      {
        "type": "text",
        "text": "visible answer"
      }
    ]
  }
}
```

Supplemental verification:
The targeted Vitest shards passed 240 tests across the thinking helper, production wrapper gate, session-history sanitizer, and Anthropic stream wrappers. `check:changed -- --base upstream/main` also passed the core lane, core test typecheck, lint, runtime sidecar loader guard, import-cycle guard, webhook body guard, and pairing guards.

Observed result after fix:
The first provider request carried the preserved signed thinking block and failed with the exact Anthropic cache-miss rejection. The recovery wrapper logged the retry, called the provider a second time, removed the thinking block, preserved the visible assistant text, and resolved successfully.

Not tested:
A live Anthropic prompt-cache-miss session was not run because this environment does not have live Anthropic credentials or the reporter's long-running Telegram session state.
