### PR TITLE
fix(slack): require delivery receipts for replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI: strip generic OSC terminal escape payloads from sanitized output fields, preventing clipboard/title escape bodies from leaking into commitment tables and other terminal-safe text. Thanks @shakkernerd.
+- Slack: require concrete `chat.postMessage` timestamps before marking replies delivered, emit `message_sent` correlation for normal inbound replies, and warn when message-tool-only final text is intentionally suppressed. Fixes #80715. Thanks @cblustein-cpu.
 - Build: replace selected build utility `tsx` preloads with Node native type stripping so Node 26 build paths no longer emit `DEP0205` module loader deprecation warnings. (#78584) Thanks @keshavbotagent.
 - Media generation: honor configured music and video generation timeouts when tool calls omit `timeoutMs`, matching image generation behavior. (#80687)
 - CLI/update/status: label beta-channel plugin fallback and model-pricing refresh failures as warnings, keeping mixed beta/latest plugin cohorts visible without making core update or Gateway reachability look failed. Fixes #80689. Thanks @BKF-Gitty.

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -4,9 +4,22 @@ const FINAL_REPLY_TEXT = "final answer";
 const THREAD_TS = "thread-1";
 const SAME_TEXT = "same reply";
 
+function slackDeliveryResult(overrides?: { messageId?: string; channelId?: string }) {
+  return {
+    target: "channel:C123",
+    messageId: overrides?.messageId ?? "171234.999",
+    channelId: overrides?.channelId ?? "C123",
+    threadTs: THREAD_TS,
+  };
+}
+
 const createSlackDraftStreamMock = vi.fn();
-const deliverRepliesMock = vi.fn(async () => {});
+const deliverRepliesMock = vi.fn(async () => [slackDeliveryResult()]);
 const finalizeSlackPreviewEditMock = vi.fn(async () => {});
+const messageHookRunnerMock = {
+  hasHooks: vi.fn<(name?: string) => boolean>(() => false),
+  runMessageSent: vi.fn<(event: unknown, hookCtx: unknown) => Promise<void>>(async () => {}),
+};
 const postMessageMock = vi.fn(async () => ({ ok: true, ts: "171234.999" }));
 const updateLastRouteMock = vi.fn(async () => {});
 const appendSlackStreamMock = vi.fn(async () => {});
@@ -205,6 +218,7 @@ function createPreparedSlackMessage(params?: {
     threadTs?: string;
     status: string;
   }) => Promise<void>;
+  runtime?: Record<string, unknown>;
   typingReaction?: string;
   ackReactionMessageTs?: string;
   ackReactionPromise?: Promise<boolean> | null;
@@ -217,7 +231,7 @@ function createPreparedSlackMessage(params?: {
   return {
     ctx: {
       cfg: params?.cfg ?? {},
-      runtime: {},
+      runtime: params?.runtime ?? {},
       botToken: "xoxb-test",
       app: { client: { chat: { postMessage: postMessageMock } } },
       teamId: "T1",
@@ -500,6 +514,10 @@ vi.mock("openclaw/plugin-sdk/outbound-runtime", () => ({
   resolveAgentOutboundIdentity: () => undefined,
 }));
 
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getGlobalHookRunner: () => messageHookRunnerMock,
+}));
+
 vi.mock("openclaw/plugin-sdk/reply-history", () => ({
   clearHistoryEntriesIfEnabled: () => {},
 }));
@@ -712,7 +730,12 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   beforeEach(() => {
     createSlackDraftStreamMock.mockReset();
     deliverRepliesMock.mockReset();
+    deliverRepliesMock.mockResolvedValue([slackDeliveryResult()]);
     finalizeSlackPreviewEditMock.mockReset();
+    messageHookRunnerMock.hasHooks.mockReset();
+    messageHookRunnerMock.hasHooks.mockReturnValue(false);
+    messageHookRunnerMock.runMessageSent.mockReset();
+    messageHookRunnerMock.runMessageSent.mockResolvedValue(undefined);
     postMessageMock.mockClear();
     updateLastRouteMock.mockReset();
     appendSlackStreamMock.mockReset();
@@ -755,6 +778,110 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("emits message_sent with Slack delivery correlation after normal reply delivery", async () => {
+    messageHookRunnerMock.hasHooks.mockImplementation((name) => name === "message_sent");
+    deliverRepliesMock.mockResolvedValueOnce([
+      slackDeliveryResult({ messageId: "171234.555", channelId: "C999" }),
+    ]);
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        route: { sessionKey: "agent:agent-1:slack:channel:c999:thread:171234.111" },
+      }),
+    );
+
+    expect(messageHookRunnerMock.runMessageSent).toHaveBeenCalledTimes(1);
+    const [event, hookCtx] = messageHookRunnerMock.runMessageSent.mock.calls[0] as unknown as [
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ];
+    expect(event).toMatchObject({
+      to: "channel:C123",
+      content: FINAL_REPLY_TEXT,
+      success: true,
+      messageId: "171234.555",
+      sessionKey: "agent:agent-1:slack:channel:c999:thread:171234.111",
+    });
+    expect(hookCtx).toMatchObject({
+      channelId: "slack",
+      accountId: "default",
+      conversationId: "C999",
+      messageId: "171234.555",
+      sessionKey: "agent:agent-1:slack:channel:c999:thread:171234.111",
+    });
+  });
+
+  it("keeps rapid same-session final replies observable with distinct Slack message ids", async () => {
+    messageHookRunnerMock.hasHooks.mockImplementation((name) => name === "message_sent");
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "first final" } },
+      { kind: "final", payload: { text: "second final" } },
+    ];
+    deliverRepliesMock
+      .mockResolvedValueOnce([slackDeliveryResult({ messageId: "171234.001", channelId: "C123" })])
+      .mockResolvedValueOnce([slackDeliveryResult({ messageId: "171234.002", channelId: "C123" })]);
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(2);
+    expect(messageHookRunnerMock.runMessageSent).toHaveBeenCalledTimes(2);
+    const events = messageHookRunnerMock.runMessageSent.mock.calls.map(
+      ([event]) =>
+        event as {
+          content?: unknown;
+          messageId?: unknown;
+          success?: unknown;
+        },
+    );
+    expect(events).toEqual([
+      expect.objectContaining({
+        content: "first final",
+        messageId: "171234.001",
+        success: true,
+      }),
+      expect.objectContaining({
+        content: "second final",
+        messageId: "171234.002",
+        success: true,
+      }),
+    ]);
+  });
+
+  it("does not mark normal delivery complete when deliverReplies returns no Slack identity", async () => {
+    const runtimeError = vi.fn();
+    messageHookRunnerMock.hasHooks.mockImplementation((name) => name === "message_sent");
+    deliverRepliesMock.mockResolvedValueOnce([]);
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: { messages: { statusReactions: { enabled: true } } },
+        runtime: { error: runtimeError },
+        ackReactionMessageTs: "171234.111",
+        ackReactionPromise: Promise.resolve(true),
+      }),
+    );
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("delivery returned no Slack message identity"),
+    );
+    expect(messageHookRunnerMock.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "channel:C123",
+        content: FINAL_REPLY_TEXT,
+        success: false,
+        error: "Slack delivery returned no message identity",
+      }),
+      expect.objectContaining({
+        channelId: "slack",
+        accountId: "default",
+        conversationId: "C123",
+      }),
+    );
+    expect(statusReactionControllerMock.setDone).not.toHaveBeenCalled();
+    expect(statusReactionControllerMock.restoreInitial).toHaveBeenCalledTimes(1);
   });
 
   it("updates non-main DM last-route metadata on the prepared thread session", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -30,11 +30,18 @@ import {
 } from "openclaw/plugin-sdk/channel-streaming";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
+  buildCanonicalSentMessageHookContext,
+  fireAndForgetHook,
+  toPluginMessageContext,
+  toPluginMessageSentEvent,
+} from "openclaw/plugin-sdk/hook-runtime";
+import {
   type ChannelTurnRecordOptions,
   hasVisibleInboundReplyDispatch,
   runInboundReplyTurn,
 } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { resolveAgentOutboundIdentity } from "openclaw/plugin-sdk/outbound-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-history";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
@@ -73,6 +80,7 @@ import {
   readSlackReplyBlocks,
   resolveDeliveredSlackReplyThreadTs,
   resolveSlackThreadTs,
+  type SlackReplyDeliveryResult,
 } from "../replies.js";
 import {
   createReplyDispatcherWithTyping,
@@ -194,6 +202,58 @@ function buildSlackTurnDeliveryKey(params: SlackTurnDeliveryAttempt): string | n
     mediaUrls: reply.mediaUrls,
     blocks: slackBlocks ?? null,
   });
+}
+
+function hasSlackReplyDeliveryIdentity(results: readonly SlackReplyDeliveryResult[]): boolean {
+  return results.some(
+    (result) => Boolean(result.messageId.trim()) || Boolean(result.channelId.trim()),
+  );
+}
+
+function hasSendableSlackReplyPayload(payload: ReplyPayload): boolean {
+  const reply = resolveSendableOutboundReplyParts(payload);
+  const slackBlocks = readSlackReplyBlocks(payload);
+  return reply.hasContent || Boolean(slackBlocks?.length);
+}
+
+function resolveSlackMessageSentHookContent(payload: ReplyPayload): string {
+  const reply = resolveSendableOutboundReplyParts(payload);
+  return reply.trimmedText;
+}
+
+function emitSlackMessageSentHook(params: {
+  to: string;
+  content: string;
+  success: boolean;
+  accountId?: string;
+  conversationId?: string;
+  sessionKey?: string;
+  messageId?: string;
+  error?: string;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("message_sent")) {
+    return;
+  }
+  const canonical = buildCanonicalSentMessageHookContext({
+    to: params.to,
+    content: params.content,
+    success: params.success,
+    error: params.error,
+    channelId: "slack",
+    accountId: params.accountId,
+    conversationId: params.conversationId ?? params.to,
+    sessionKey: params.sessionKey,
+    messageId: params.messageId,
+  });
+  fireAndForgetHook(
+    hookRunner.runMessageSent(
+      toPluginMessageSentEvent(canonical),
+      toPluginMessageContext(canonical),
+    ),
+    "slack: message_sent plugin hook failed",
+    logVerbose,
+  );
 }
 
 function readSlackStreamRecipientTeamCache(params: {
@@ -531,6 +591,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let usedReplyThreadTs: string | undefined;
   let usedBlockReplyThreadTs: string | undefined;
   let observedReplyDelivery = false;
+  let deliveryAttemptWithoutIdentity = false;
   const deliveryTracker = createSlackTurnDeliveryTracker();
   const resolveDeliveryThreadTs = (params: {
     kind: ReplyDispatchKind;
@@ -555,6 +616,38 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       usedBlockReplyThreadTs = deliveredThreadTs;
     }
   };
+  const sessionKeyForMessageHooks = prepared.ctxPayload.SessionKey ?? route.sessionKey;
+  const emitMessageSentSuccessHooks = (
+    payload: ReplyPayload,
+    deliveryResults: readonly SlackReplyDeliveryResult[],
+  ) => {
+    const content = resolveSlackMessageSentHookContent(payload);
+    for (const result of deliveryResults) {
+      if (!result.messageId.trim() && !result.channelId.trim()) {
+        continue;
+      }
+      emitSlackMessageSentHook({
+        to: result.target,
+        content,
+        success: true,
+        accountId: account.accountId,
+        conversationId: result.channelId || prepared.replyTarget,
+        sessionKey: sessionKeyForMessageHooks,
+        messageId: result.messageId || undefined,
+      });
+    }
+  };
+  const emitMessageSentFailureHook = (payload: ReplyPayload, error: string) => {
+    emitSlackMessageSentHook({
+      to: prepared.replyTarget,
+      content: resolveSlackMessageSentHookContent(payload),
+      success: false,
+      accountId: account.accountId,
+      conversationId: message.channel,
+      sessionKey: sessionKeyForMessageHooks,
+      error,
+    });
+  };
   const deliverPendingStreamFallback = async (
     session: SlackStreamSession,
     err: SlackStreamNotDeliveredError,
@@ -569,10 +662,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     if (!fallbackText) {
       return false;
     }
+    const fallbackPayload = { text: fallbackText } as ReplyPayload;
     try {
-      await deliverReplies({
+      const deliveryResults = await deliverReplies({
         cfg: ctx.cfg,
-        replies: [{ text: fallbackText } as ReplyPayload],
+        replies: [fallbackPayload],
         target: prepared.replyTarget,
         token: ctx.botToken,
         accountId: account.accountId,
@@ -582,6 +676,17 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         replyToMode: prepared.replyToMode,
         ...(slackIdentity ? { identity: slackIdentity } : {}),
       });
+      if (!hasSlackReplyDeliveryIdentity(deliveryResults)) {
+        deliveryAttemptWithoutIdentity = true;
+        emitMessageSentFailureHook(fallbackPayload, "Slack delivery returned no message identity");
+        runtime.error?.(
+          danger(
+            "slack-stream: fallback deliverReplies returned no Slack message identity; delivery status is ambiguous",
+          ),
+        );
+        return false;
+      }
+      emitMessageSentSuccessHooks(fallbackPayload, deliveryResults);
       markSlackStreamFallbackDelivered(session);
       observedReplyDelivery = true;
       usedReplyThreadTs ??= session.threadTs;
@@ -590,6 +695,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       );
       return true;
     } catch (postErr) {
+      emitMessageSentFailureHook(fallbackPayload, formatSlackError(postErr));
       runtime.error?.(
         danger(
           `slack-stream: fallback deliverReplies failed after ${err.slackCode}: ${formatErrorMessage(postErr)}`,
@@ -615,18 +721,39 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       logVerbose("slack: suppressed duplicate normal delivery within the same turn");
       return;
     }
-    await deliverReplies({
-      cfg: ctx.cfg,
-      replies: [params.payload],
-      target: prepared.replyTarget,
-      token: ctx.botToken,
-      accountId: account.accountId,
-      runtime,
-      textLimit: ctx.textLimit,
-      replyThreadTs,
-      replyToMode: prepared.replyToMode,
-      ...(slackIdentity ? { identity: slackIdentity } : {}),
-    });
+    let deliveryResults: SlackReplyDeliveryResult[];
+    try {
+      deliveryResults = await deliverReplies({
+        cfg: ctx.cfg,
+        replies: [params.payload],
+        target: prepared.replyTarget,
+        token: ctx.botToken,
+        accountId: account.accountId,
+        runtime,
+        textLimit: ctx.textLimit,
+        replyThreadTs,
+        replyToMode: prepared.replyToMode,
+        ...(slackIdentity ? { identity: slackIdentity } : {}),
+      });
+    } catch (err) {
+      if (hasSendableSlackReplyPayload(params.payload)) {
+        emitMessageSentFailureHook(params.payload, formatSlackError(err));
+      }
+      throw err;
+    }
+    if (!hasSlackReplyDeliveryIdentity(deliveryResults)) {
+      if (hasSendableSlackReplyPayload(params.payload)) {
+        deliveryAttemptWithoutIdentity = true;
+        emitMessageSentFailureHook(params.payload, "Slack delivery returned no message identity");
+        runtime.error?.(
+          danger(
+            `slack: ${params.kind} reply delivery returned no Slack message identity; delivery status is ambiguous`,
+          ),
+        );
+      }
+      return;
+    }
+    emitMessageSentSuccessHooks(params.payload, deliveryResults);
     observedReplyDelivery = true;
     const deliveredThreadTs = resolveDeliveredSlackReplyThreadTs({
       replyToMode: prepared.replyToMode,
@@ -1300,7 +1427,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   }
 
   const anyReplyDelivered = hasVisibleInboundReplyDispatch(
-    { queuedFinal, counts },
+    {
+      queuedFinal,
+      counts: deliveryAttemptWithoutIdentity ? {} : counts,
+    },
     {
       observedReplyDelivery,
       fallbackDelivered: streamFallbackDelivered,

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -13,6 +13,17 @@ import { deliverSlackSlashReplies } from "./replies.js";
 
 const SLACK_TEST_CFG = { channels: { slack: { botToken: "xoxb-test" } } };
 
+function slackSendResult(overrides?: { messageId?: string; channelId?: string }) {
+  const messageId = overrides?.messageId ?? "171234.567";
+  return {
+    messageId,
+    channelId: overrides?.channelId ?? "C123",
+    receipt: {
+      platformMessageIds: [messageId],
+    },
+  };
+}
+
 function baseParams(overrides?: Record<string, unknown>) {
   return {
     cfg: SLACK_TEST_CFG,
@@ -46,9 +57,9 @@ describe("deliverReplies identity passthrough", () => {
 
   beforeEach(() => {
     sendMock.mockReset();
+    sendMock.mockResolvedValue(slackSendResult());
   });
   it("passes identity to sendMessageSlack for text replies", async () => {
-    sendMock.mockResolvedValue(undefined);
     const identity = { username: "Bot", iconEmoji: ":robot:" };
     await deliverReplies(baseParams({ identity }));
 
@@ -58,7 +69,6 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("passes identity to sendMessageSlack for media replies", async () => {
-    sendMock.mockResolvedValue(undefined);
     const identity = { username: "Bot", iconUrl: "https://example.com/icon.png" };
     await deliverReplies(
       baseParams({
@@ -73,7 +83,6 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("omits identity key when not provided", async () => {
-    sendMock.mockResolvedValue(undefined);
     await deliverReplies(baseParams());
 
     expect(sendMock).toHaveBeenCalledOnce();
@@ -81,7 +90,6 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("delivers block-only replies through to sendMessageSlack", async () => {
-    sendMock.mockResolvedValue(undefined);
     const blocks = [
       {
         type: "actions",
@@ -119,8 +127,6 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("renders interactive replies into Slack blocks during delivery", async () => {
-    sendMock.mockResolvedValue(undefined);
-
     await deliverReplies(
       baseParams({
         replies: [
@@ -156,8 +162,6 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("rejects replies when merged Slack blocks exceed the platform limit", async () => {
-    sendMock.mockResolvedValue(undefined);
-
     await expect(
       deliverReplies(
         baseParams({
@@ -177,6 +181,64 @@ describe("deliverReplies identity passthrough", () => {
         }),
       ),
     ).rejects.toThrow(/Slack blocks cannot exceed 50 items/i);
+  });
+
+  it("returns delivered Slack identities for text replies", async () => {
+    sendMock.mockResolvedValueOnce(slackSendResult({ messageId: "171234.999", channelId: "C123" }));
+
+    const results = await deliverReplies(
+      baseParams({
+        replyThreadTs: "171234.100",
+        replyToMode: "all",
+      }),
+    );
+
+    expect(results).toStrictEqual([
+      {
+        target: "C123",
+        messageId: "171234.999",
+        channelId: "C123",
+        threadTs: "171234.100",
+      },
+    ]);
+  });
+
+  it("returns delivered Slack identities for block-only replies", async () => {
+    sendMock.mockResolvedValueOnce(slackSendResult({ messageId: "171234.888", channelId: "C123" }));
+    const blocks = [{ type: "divider" }];
+
+    const results = await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            channelData: {
+              slack: {
+                blocks,
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(results).toStrictEqual([
+      {
+        target: "C123",
+        messageId: "171234.888",
+        channelId: "C123",
+      },
+    ]);
+  });
+
+  it("returns no delivery identities for empty replies", async () => {
+    const results = await deliverReplies(
+      baseParams({
+        replies: [{ text: " " }],
+      }),
+    );
+
+    expect(results).toStrictEqual([]);
+    expect(sendMock).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -15,7 +15,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackReplyBlocks } from "../reply-blocks.js";
-import { sendMessageSlack, type SlackSendIdentity } from "./send.runtime.js";
+import { sendMessageSlack, type SlackSendIdentity, type SlackSendResult } from "./send.runtime.js";
 
 export function readSlackReplyBlocks(payload: ReplyPayload) {
   return resolveSlackReplyBlocks(payload);
@@ -32,6 +32,26 @@ export function resolveDeliveredSlackReplyThreadTs(params: {
   return inlineReplyToId ?? params.replyThreadTs;
 }
 
+export type SlackReplyDeliveryResult = {
+  target: string;
+  messageId: string;
+  channelId: string;
+  threadTs?: string;
+};
+
+function createSlackReplyDeliveryResult(params: {
+  target: string;
+  threadTs?: string;
+  sent: SlackSendResult;
+}): SlackReplyDeliveryResult {
+  return {
+    target: params.target,
+    messageId: params.sent.messageId,
+    channelId: params.sent.channelId,
+    ...(params.threadTs ? { threadTs: params.threadTs } : {}),
+  };
+}
+
 export async function deliverReplies(params: {
   cfg: OpenClawConfig;
   replies: ReplyPayload[];
@@ -43,7 +63,8 @@ export async function deliverReplies(params: {
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all" | "batched";
   identity?: SlackSendIdentity;
-}) {
+}): Promise<SlackReplyDeliveryResult[]> {
+  const results: SlackReplyDeliveryResult[] = [];
   for (const payload of params.replies) {
     const threadTs = resolveDeliveredSlackReplyThreadTs({
       replyToMode: params.replyToMode,
@@ -64,7 +85,7 @@ export async function deliverReplies(params: {
       if (trimmed && isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
         continue;
       }
-      await sendMessageSlack(params.target, trimmed, {
+      const sent = await sendMessageSlack(params.target, trimmed, {
         cfg: params.cfg,
         token: params.token,
         threadTs,
@@ -72,6 +93,7 @@ export async function deliverReplies(params: {
         ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
         ...(params.identity ? { identity: params.identity } : {}),
       });
+      results.push(createSlackReplyDeliveryResult({ target: params.target, threadTs, sent }));
       params.runtime.log?.(`delivered reply to ${params.target}`);
       continue;
     }
@@ -89,16 +111,17 @@ export async function deliverReplies(params: {
           }
         : undefined,
       sendText: async (trimmed) => {
-        await sendMessageSlack(params.target, trimmed, {
+        const sent = await sendMessageSlack(params.target, trimmed, {
           cfg: params.cfg,
           token: params.token,
           threadTs,
           accountId: params.accountId,
           ...(params.identity ? { identity: params.identity } : {}),
         });
+        results.push(createSlackReplyDeliveryResult({ target: params.target, threadTs, sent }));
       },
       sendMedia: async ({ mediaUrl, caption }) => {
-        await sendMessageSlack(params.target, caption ?? "", {
+        const sent = await sendMessageSlack(params.target, caption ?? "", {
           cfg: params.cfg,
           token: params.token,
           mediaUrl,
@@ -106,12 +129,14 @@ export async function deliverReplies(params: {
           accountId: params.accountId,
           ...(params.identity ? { identity: params.identity } : {}),
         });
+        results.push(createSlackReplyDeliveryResult({ target: params.target, threadTs, sent }));
       },
     });
     if (delivered !== "empty") {
       params.runtime.log?.(`delivered reply to ${params.target}`);
     }
   }
+  return results;
 }
 
 export type SlackRespondFn = (payload: {

--- a/extensions/slack/src/monitor/send.runtime.ts
+++ b/extensions/slack/src/monitor/send.runtime.ts
@@ -1,1 +1,1 @@
-export { sendMessageSlack, type SlackSendIdentity } from "../send.js";
+export { sendMessageSlack, type SlackSendIdentity, type SlackSendResult } from "../send.js";

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -312,6 +312,37 @@ describe("sendMessageSlack blocks", () => {
     expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects text sends when Slack omits the posted message timestamp", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockResolvedValueOnce({ ok: true });
+
+    await expect(
+      sendMessageSlack("channel:C123", "hello", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+      }),
+    ).rejects.toThrow(/message timestamp.*ambiguous/i);
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects block sends when Slack omits the posted message timestamp", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockResolvedValueOnce({ ok: true });
+
+    await expect(
+      sendMessageSlack("channel:C123", "", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        blocks: [{ type: "divider" }],
+      }),
+    ).rejects.toThrow(/message timestamp.*ambiguous/i);
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("derives fallback text from image blocks", async () => {
     const client = createSlackSendTestClient();
     await sendMessageSlack("channel:C123", "", {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -351,6 +351,16 @@ async function postSlackMessageBestEffort(params: {
   }
 }
 
+function requireSlackPostMessageTs(response: { ts?: string }, context: string): string {
+  const ts = typeof response.ts === "string" ? response.ts.trim() : "";
+  if (!ts) {
+    throw new Error(
+      `Slack ${context} response did not include a message timestamp; delivery status is ambiguous.`,
+    );
+  }
+  return ts;
+}
+
 export type SlackSendResult = {
   messageId: string;
   channelId: string;
@@ -718,7 +728,7 @@ async function sendMessageSlackQueuedInner(params: {
       blocks,
       unfurl,
     });
-    const messageId = response.ts ?? "unknown";
+    const messageId = requireSlackPostMessageTs(response, "chat.postMessage blocks");
     return {
       messageId,
       channelId,
@@ -781,10 +791,8 @@ async function sendMessageSlackQueuedInner(params: {
         identity: opts.identity,
         unfurl,
       });
-      lastMessageId = response.ts ?? lastMessageId;
-      if (response.ts) {
-        sentMessageIds.push(response.ts);
-      }
+      lastMessageId = requireSlackPostMessageTs(response, "chat.postMessage text");
+      sentMessageIds.push(lastMessageId);
     }
   } else {
     for (const chunk of resolvedChunks.length ? resolvedChunks : [""]) {
@@ -797,14 +805,12 @@ async function sendMessageSlackQueuedInner(params: {
         identity: opts.identity,
         unfurl,
       });
-      lastMessageId = response.ts ?? lastMessageId;
-      if (response.ts) {
-        sentMessageIds.push(response.ts);
-      }
+      lastMessageId = requireSlackPostMessageTs(response, "chat.postMessage text");
+      sentMessageIds.push(lastMessageId);
     }
   }
 
-  const messageId = lastMessageId || "unknown";
+  const messageId = lastMessageId;
   return {
     messageId,
     channelId,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -520,6 +520,7 @@ const automaticGroupReplyConfig = {
   },
 } as const satisfies OpenClawConfig;
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
+let shouldEmitSuppressedSourceReplyDiagnostic: typeof import("./dispatch-from-config.js").shouldEmitSuppressedSourceReplyDiagnostic;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tryDispatchAcpReplyHook;
 type DispatchReplyArgs = Parameters<
@@ -527,7 +528,8 @@ type DispatchReplyArgs = Parameters<
 >[0];
 
 beforeAll(async () => {
-  ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
+  ({ dispatchReplyFromConfig, shouldEmitSuppressedSourceReplyDiagnostic } =
+    await import("./dispatch-from-config.js"));
   await import("./dispatch-acp.js");
   await import("./dispatch-acp-command-bypass.js");
   await import("./dispatch-acp-tts.runtime.js");
@@ -4657,6 +4659,37 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(replyDispatchEvent?.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(replyDispatchEvent?.sendPolicy).toBe("allow");
     expect(replyDispatchCall?.[1]).toBeDefined();
+  });
+
+  it("diagnoses only non-empty final text suppressed by message-tool-only delivery", () => {
+    expect(
+      shouldEmitSuppressedSourceReplyDiagnostic({
+        suppressDelivery: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+        reply: { text: "final reply" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldEmitSuppressedSourceReplyDiagnostic({
+        suppressDelivery: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+        reply: { text: "reasoning", isReasoning: true },
+      }),
+    ).toBe(false);
+    expect(
+      shouldEmitSuppressedSourceReplyDiagnostic({
+        suppressDelivery: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+        reply: { text: " " },
+      }),
+    ).toBe(false);
+    expect(
+      shouldEmitSuppressedSourceReplyDiagnostic({
+        suppressDelivery: false,
+        sourceReplyDeliveryMode: "automatic",
+        reply: { text: "visible reply" },
+      }),
+    ).toBe(false);
   });
 
   it("preserves hook-blocked metadata when source delivery is message-tool-only", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -48,6 +48,7 @@ import {
   logSessionStateChange,
   markDiagnosticSessionProgress,
 } from "../../logging/diagnostic.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   buildPluginBindingDeclinedText,
   buildPluginBindingErrorText,
@@ -101,6 +102,8 @@ import {
   resolveSourceReplyVisibilityPolicy,
 } from "./source-reply-delivery-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
+
+const dispatchLog = createSubsystemLogger("auto-reply/dispatch");
 
 const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
 const getReplyFromConfigRuntimeLoader = createLazyImportLoader(
@@ -354,6 +357,20 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
       };
     },
   });
+}
+
+export function shouldEmitSuppressedSourceReplyDiagnostic(params: {
+  suppressDelivery: boolean;
+  sourceReplyDeliveryMode: "automatic" | "message_tool_only";
+  reply: ReplyPayload;
+}): boolean {
+  if (!params.suppressDelivery || params.sourceReplyDeliveryMode !== "message_tool_only") {
+    return false;
+  }
+  if (params.reply.isReasoning === true) {
+    return false;
+  }
+  return resolveSendableOutboundReplyParts(params.reply).hasText;
 }
 
 export type {
@@ -1565,6 +1582,21 @@ export async function dispatchReplyFromConfig(
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {
+        if (
+          shouldEmitSuppressedSourceReplyDiagnostic({
+            suppressDelivery,
+            sourceReplyDeliveryMode,
+            reply,
+          })
+        ) {
+          dispatchLog.warn("source final reply suppressed by message_tool_only", {
+            channel,
+            chatType: ctx.ChatType,
+            sessionKey,
+            reason: deliverySuppressionReason,
+            textLength: resolveSendableOutboundReplyParts(reply).trimmedText.length,
+          });
+        }
         continue;
       }
       attemptedFinalDelivery = true;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2746,16 +2746,22 @@ describe("deliverOutboundPayloads", () => {
       channel: "matrix",
       to: "!room:example",
       payloads: [{ text: "hello" }],
+      session: { key: "agent:main:matrix:room:example" },
       deps: { matrix: sendMatrix },
     });
 
     const sentCall = hookMocks.runner.runMessageSent.mock.calls[0] as
-      | [{ content?: unknown; success?: unknown; to?: unknown }, { channelId?: unknown }]
+      | [
+          { content?: unknown; sessionKey?: unknown; success?: unknown; to?: unknown },
+          { channelId?: unknown; sessionKey?: unknown },
+        ]
       | undefined;
     expect(sentCall?.[0]?.to).toBe("!room:example");
     expect(sentCall?.[0]?.content).toBe("hello");
     expect(sentCall?.[0]?.success).toBe(true);
+    expect(sentCall?.[0]?.sessionKey).toBe("agent:main:matrix:room:example");
     expect(sentCall?.[1]?.channelId).toBe("matrix");
+    expect(sentCall?.[1]?.sessionKey).toBe("agent:main:matrix:room:example");
   });
 
   it("short-circuits lower-priority message_sending hooks after cancel=true", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -988,6 +988,7 @@ function createMessageSentEmitter(params: {
       channelId: params.channel,
       accountId: params.accountId ?? undefined,
       conversationId: params.to,
+      sessionKey: params.sessionKeyForInternalHooks,
       messageId: event.messageId,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,


### PR DESCRIPTION
## Summary

  - Problem: Slack replies could be composed in the transcript while the delivery path treated ambiguous or
  unobservable sends as successful.
  - Why it matters: operators had no reliable Slack `ts` correlation or failure signal when normal inbound
  replies failed to appear in Slack.
  - What changed: Slack `chat.postMessage` replies now require a concrete timestamp, `deliverReplies` returns
  delivery identities, Slack dispatch marks delivery only after a real identity, and normal Slack replies emit
  `message_sent` correlation.
  - What did NOT change (scope boundary): no Slack delivery policy change, no auto-promotion of
  `message_tool_only` replies, no new Slack API fetch-back/reconciliation.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #80715
  - Related #78046, #77320, #78061
  - [x] This PR fixes a bug or regression

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: Slack normal inbound replies are no longer marked delivered without a concrete
  Slack message identity; delivery correlation is emitted through `message_sent`.
  - Real environment tested: local OpenClaw checkout on macOS; no live Slack workspace credentials available
  locally.
  - Exact steps or command run after this patch: `pnpm test ...`, `pnpm build`, `pnpm check:changed`
  - Evidence after fix: targeted tests pass and changed gate passes; live Slack proof is blocked by missing local
  Slack credentials.
  - Observed result after fix: mocked Slack sends without `ts` now fail as ambiguous; successful sends propagate
  Slack timestamps into dispatch and hooks.
  - What was not tested: live Slack Socket Mode delivery against a real workspace.
  - Before evidence: issue report shows transcript-composed replies with no matching Slack
  `conversations.replies` / `conversations.history` messages.

  ## Root Cause (if applicable)

  - Root cause: Slack `chat.postMessage` results without `ts` could fall through as `"unknown"`, and
  `deliverReplies` returned `void`, so the dispatcher treated completed function calls as successful delivery
  without a concrete Slack receipt.
  - Missing detection / guardrail: normal Slack replies did not emit `message_sent` correlation, and
  `message_tool_only` final-text suppression had only verbose logging.
  - Contributing context (if known): rapid same-session replies and Slack thread replies made the lack of
  platform receipt/correlation hard to distinguish from successful transcript completion.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `extensions/slack/src/send.blocks.test.ts`, `extensions/slack/src/monitor/
  replies.test.ts`, `extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`, `src/infra/
  outbound/deliver.test.ts`, `src/auto-reply/reply/dispatch-from-config.test.ts`
  - Scenario the test should lock in: missing Slack `ts` rejects; delivered Slack IDs flow through reply delivery
  and `message_sent`; no-identity results do not mark delivery complete.
  - Why this is the smallest reliable guardrail: it exercises the Slack send, reply-delivery, dispatch, and hook
  seams without requiring live Slack credentials.
  - Existing test that already covers this (if any): Slack send queue serialization coverage existed, but not
  receipt validation/correlation.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  Slack delivery ambiguity now surfaces instead of being treated as success. Plugins observing `message_sent` can
  now correlate normal Slack inbound replies with the delivered Slack timestamp.

  ## Diagram (if applicable)

  ```text
  Before:
  [assistant final] -> [deliverReplies returns] -> [marked delivered without Slack ts]

  After:
  [assistant final] -> [chat.postMessage ts required] -> [delivery identity returned] -> [message_sent
  correlation]
```

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: macOS local development checkout
  - Runtime/container: local Node/pnpm, no container
  - Model/provider: N/A for targeted regression tests
  - Integration/channel (if any): Slack
  - Relevant config (redacted): no live Slack credentials found locally

  ### Steps

  1. Run targeted Slack/core regression tests.
  2. Run pnpm build.
  3. Run pnpm check:changed.

  ### Expected

  - Slack sends without a chat.postMessage timestamp fail as ambiguous.
  - Successful Slack reply delivery returns real message identity and emits message_sent.

  ### Actual

  - All targeted tests passed.
  - Build passed.
  - Changed gate passed.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: missing Slack ts, reply identity propagation, no-identity dispatch handling, message_sent
    correlation, message-tool-only suppression diagnostic, rapid same-session replies.
  - Edge cases checked: block sends, text sends, media-adjacent send path preservation, generic outbound session-
    key correlation.
  - What you did not verify: live Slack Socket Mode delivery, because no Slack keys were present in ~/.profile
    and no local Slack credential files were found.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk: Slack API responses that previously produced "unknown" message IDs now fail as ambiguous.
      - Mitigation: Slack chat.postMessage should return ts for successful message posts; failing loudly is safer
        than marking an uncorrelated reply delivered.

### Built with Codex