### PR TITLE
fix(control-ui): restore `has-copy` class on chat bubbles with action buttons

### DIFF
--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -172,6 +172,10 @@ function chatHtml(opts: { sideResult?: boolean; singleAgent?: boolean } = {}) {
                           <p>The chat shell should stay compact and readable.</p>
                           <pre><code>const importantLongIdentifier = "control-ui-chat-responsive-regression-fixture-keeps-code-scrollable"; console.log(importantLongIdentifier);</code></pre>
                         </div>
+                        <div class="chat-bubble-actions">
+                          <button class="chat-expand-btn" aria-label="expand">${iconSvg()}</button>
+                          <button class="chat-copy-btn" aria-label="copy">${iconSvg()}</button>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -441,4 +445,32 @@ describeBrowserLayout("chat responsive browser layout", () => {
       await page.close();
     }
   });
+
+  // Regression: on narrow viewports (max-width:640px) the .chat-bubble-actions
+  // floating buttons (copy + expand) used to overlap the message text because
+  // .chat-bubble.has-copy dropped its padding-right to 12px while the actions
+  // stayed pinned at top:6px;right:8px. The bubble must reserve enough right
+  // padding so the text never overlaps the action buttons.
+  it.each([
+    [320, 568],
+    [430, 932],
+    [600, 800],
+  ] as const)(
+    "keeps .chat-bubble-actions clear of message text at %ix%i",
+    async (width, height) => {
+      const page = await openFixture(width, height);
+      try {
+        const bubble = await getBoundingBox(page, ".chat-bubble.has-copy");
+        const text = await getBoundingBox(page, ".chat-bubble.has-copy .chat-text");
+        const actions = await getBoundingBox(page, ".chat-bubble.has-copy .chat-bubble-actions");
+        // Actions must be inside the bubble's right edge.
+        expect(actions.x + actions.width).toBeLessThanOrEqual(bubble.x + bubble.width + 0.5);
+        // Critically: text's right edge must not extend into the actions' rect.
+        // Allow 0.5px of subpixel rounding tolerance.
+        expect(text.x + text.width).toBeLessThanOrEqual(actions.x + 0.5);
+      } finally {
+        await page.close();
+      }
+    },
+  );
 });

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -466,6 +466,29 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector('[aria-label="Read aloud"]')).toBeNull();
   });
 
+  // Regression: assistant bubbles with copy/expand action buttons MUST carry the
+  // `has-copy` CSS class so the .chat-bubble.has-copy padding rules apply and
+  // the floating action buttons don't overlap message text. This bug shipped
+  // when an unrelated refactor accidentally dropped the class from
+  // bubbleClasses (see commit ead8be96fd).
+  it("marks assistant bubbles with .has-copy when action buttons are rendered", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content:
+        "Thanks Todd! The email draft is ready to customize with individual regional manager names where you want to send them out.",
+      timestamp: 1000,
+    });
+
+    const bubble = container.querySelector(".chat-bubble");
+    const actions = container.querySelector(".chat-bubble-actions");
+    expect(bubble).not.toBeNull();
+    expect(actions).not.toBeNull();
+    // When .chat-bubble-actions is rendered, the bubble MUST have .has-copy so
+    // its padding-right reserves room for the absolutely-positioned buttons.
+    expect(bubble?.classList.contains("has-copy")).toBe(true);
+  });
+
   it("positions delete confirm by message side", () => {
     const container = document.createElement("div");
     clearDeleteConfirmSkip();

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1441,11 +1441,17 @@ function renderGroupedMessage(
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
 
   const isToolMessage = normalizedRole === "tool" || isToolResult;
+  // Whether this bubble will render the floating .chat-bubble-actions (copy +
+  // expand buttons). Must be computed BEFORE bubbleClasses so the `has-copy`
+  // CSS class — which adds the right padding that keeps action buttons from
+  // overlapping message text — is applied when the actions are visible.
+  const willRenderBubbleActions = canCopyMarkdown || canExpand;
   const bubbleClasses = [
     "chat-bubble",
     isToolMessage ? "chat-bubble--tool-shell" : "",
     opts.isStreaming ? "streaming" : "",
     "fade-in",
+    willRenderBubbleActions ? "has-copy" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -1491,7 +1497,7 @@ function renderGroupedMessage(
         : "Tool output";
   const toolMessageIcon = singleToolDisplay ? icons[singleToolDisplay.icon] : icons.zap;
 
-  const hasActions = canCopyMarkdown || canExpand;
+  const hasActions = willRenderBubbleActions;
   const duplicateCount = Math.max(1, Math.floor(opts.duplicateCount ?? 1));
 
   return html`


### PR DESCRIPTION
## Summary

Assistant chat bubbles that render the floating `.chat-bubble-actions` (copy + expand buttons) need the `has-copy` class so the matching `.chat-bubble.has-copy { padding-right: 70px; }` rule reserves space for those absolutely-positioned buttons. Without the class, the buttons sit on top of the message text.

A Sandpaw customer reported this exact symptom: the rightmost word of the latest assistant message was visually obscured by the copy/expand icons. Screenshot:

![overlap bug](https://github.com/openclaw/openclaw/assets/placeholder/bubble-overlap.png)

## Root cause

The class was correctly added by #61872 and #62121 (thanks @jjjojoj) back in April, but an unrelated refactor (`ead8be96fd`, _Add tweakcn custom theme import_) rebuilt the `bubbleClasses` array and accidentally dropped `has-copy`. The CSS rules in `grouped.css` / `layout.css` still exist, so re-adding the class restores the intended padding without any CSS churn.

```ts
// Before (buggy)
const bubbleClasses = [
  "chat-bubble",
  isToolMessage ? "chat-bubble--tool-shell" : "",
  opts.isStreaming ? "streaming" : "",
  "fade-in",
];
```

The `<div class="chat-bubble-actions">` then rendered conditionally based on `canCopyMarkdown || canExpand`, but the bubble never picked up `has-copy`, so the CSS that reserves right-padding for those buttons did not apply.

## Changes

- **`ui/src/ui/chat/grouped-render.ts`** — compute `willRenderBubbleActions` once, before building `bubbleClasses`, and append `has-copy` when the action row will render. Reuse it for the existing `hasActions` variable so the two stay in sync (single source of truth for \"does this bubble show action buttons?\").
- **`ui/src/ui/chat/grouped-render.test.ts`** — regression unit test asserting that an assistant bubble with action buttons carries `has-copy`. **Fails without the fix.**
- **`ui/src/ui/chat/chat-responsive.browser.test.ts`** — defensive layout regression: at 320 / 430 / 600 px viewports, `.chat-text` must not visually extend into the `.chat-bubble-actions` rect (catches a future CSS-only regression where the class is present but padding-right is reduced).

## Verification

\`\`\`
pnpm exec vitest run \\
  ui/src/ui/chat/grouped-render.test.ts \\
  ui/src/ui/chat/chat-responsive.browser.test.ts
\`\`\`

→ 55/55 pass with fix; the new unit test fails without the fix (verified with stash → restore).

cc @jjjojoj — restoring your original `has-copy` wiring.