### PR TITLE
[codex] Add manifest plugin auth requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,6 +377,7 @@ Docs: https://docs.openclaw.ai
 - Google/Gemini: normalize proxy-prefixed retired Gemini 3 Pro Preview catalog rows, so emitted configs use `google/gemini-3.1-pro-preview` for Gemini 3.1 testing.
 - Google/Gemini: normalize retired Gemini 3 Pro Preview ids inside per-agent model overrides before writing config, so agent-specific config emits `google/gemini-3.1-pro-preview` for Gemini 3.1 testing.
 - Google/Gemini: normalize retired Gemini 3 Pro Preview ids in subagent, heartbeat, compaction, and subagent-tool model config during writes, so current config keeps emitting `google/gemini-3.1-pro-preview`.
+- Plugins: add metadata-only `authRequirements` manifests plus derived setup/auth hints so install, setup, and ClawBench planners can prepare plugin auth without loading plugin runtime.
 - Docs/subagents: document `agents.defaults.subagents.announceTimeoutMs` in the sub-agent and configuration references. (#75509) Thanks @akrimm702.
 - Cron: add direct `cron.get`, `openclaw cron get <id>`, and agent-tool `get` support for inspecting one stored cron job by id. (#75117) Thanks @samzong.
 - Agents/tools: add per-sender tool policies with canonical channel-scoped sender keys, so operators can restrict dangerous tools by requester identity across global, agent, group, core, bundled, and plugin tool surfaces. (#66933) Thanks @JerranC.

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -194,6 +194,7 @@ openclaw plugins install npm:@scope/plugin-name@1.0.1
 
 OpenClaw checks the advertised plugin API / minimum gateway compatibility before install. When the selected ClawHub version publishes a ClawPack artifact, OpenClaw downloads the versioned npm-pack `.tgz`, verifies the ClawHub digest header and the artifact digest, then installs it through the normal archive path. Older ClawHub versions without ClawPack metadata still install through the legacy package archive verification path. Recorded installs keep their ClawHub source metadata, artifact kind, npm integrity, npm shasum, tarball name, and ClawPack digest facts for later updates.
 Unversioned ClawHub installs keep an unversioned recorded spec so `openclaw plugins update` can follow newer ClawHub releases; explicit version or tag selectors such as `clawhub:pkg@1.2.3` and `clawhub:pkg@beta` remain pinned to that selector.
+Native OpenClaw plugin manifests can also advertise `authRequirements`, which gives setup, install, and test planners a metadata-only view of provider credentials, channel accounts, external services, or host runtime capabilities that may be needed after install.
 
 #### Marketplace shorthand
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -124,6 +124,16 @@ or npm install metadata. Those belong in your plugin code and `package.json`.
       "onboardingScopes": ["text-inference"]
     }
   ],
+  "authRequirements": [
+    {
+      "id": "openrouter-api-key",
+      "kind": "provider",
+      "provider": "openrouter",
+      "authMethods": ["api-key"],
+      "envVars": ["OPENROUTER_API_KEY"],
+      "setupRefs": ["providerAuthChoices:openrouter-api-key"]
+    }
+  ],
   "uiHints": {
     "apiKey": {
       "label": "API key",
@@ -173,6 +183,7 @@ or npm install metadata. Those belong in your plugin code and `package.json`.
 | `providerAuthChoices`                | No       | `object[]`                       | Cheap auth-choice metadata for onboarding pickers, preferred-provider resolution, and simple CLI flag wiring.                                                                                                                       |
 | `activation`                         | No       | `object`                         | Cheap activation planner metadata for startup, provider, command, channel, route, and capability-triggered loading. Metadata only; plugin runtime still owns actual behavior.                                                       |
 | `setup`                              | No       | `object`                         | Cheap setup/onboarding descriptors that discovery and setup surfaces can inspect without loading plugin runtime.                                                                                                                    |
+| `authRequirements`                   | No       | `object[]`                       | Declarative auth requirements for install, setup, and test planners. Use this to describe provider credentials, channel accounts, external services, and host runtime capabilities without loading plugin runtime.                  |
 | `qaRunners`                          | No       | `object[]`                       | Cheap QA runner descriptors used by the shared `openclaw qa` host before plugin runtime loads.                                                                                                                                      |
 | `contracts`                          | No       | `object`                         | Static capability ownership snapshot for external auth hooks, speech, realtime transcription, realtime voice, media-understanding, image-generation, music-generation, video-generation, web-fetch, web search, and tool ownership. |
 | `mediaUnderstandingProviderMetadata` | No       | `Record<string, object>`         | Cheap media-understanding defaults for provider ids declared in `contracts.mediaUnderstandingProviders`.                                                                                                                            |
@@ -320,6 +331,65 @@ If a tool has no `toolMetadata`, OpenClaw preserves the existing behavior and
 loads the owning plugin when the tool contract matches policy. For hot-path
 tools whose factory depends on auth/config, plugin authors should declare
 `toolMetadata` instead of making core import runtime to ask.
+
+## authRequirements reference
+
+Use `authRequirements` when a plugin needs an install, setup, or test planner to
+understand the auth it will need without executing plugin code. This is a
+metadata contract only. It does not grant credentials, validate tokens, or
+replace plugin runtime auth checks.
+
+The field is optional and additive. Existing plugins that only declare
+`setup.providers`, `providerAuthChoices`, deprecated `providerAuthEnvVars`, or
+`channelEnvVars` continue to work; generic planners can derive compatibility
+hints from those older fields while plugins migrate to explicit
+`authRequirements`.
+
+```json
+{
+  "authRequirements": [
+    {
+      "id": "host-structured-llm",
+      "kind": "host-capability",
+      "capability": "runtime.llm.completeStructured",
+      "description": "Uses the user's configured model auth for structured analysis.",
+      "mockable": true
+    },
+    {
+      "id": "slack-bot-token",
+      "kind": "channel-account",
+      "channel": "slack",
+      "envVars": ["SLACK_BOT_TOKEN"],
+      "setupRefs": ["channelEnvVars:slack"]
+    }
+  ]
+}
+```
+
+| Field         | Required | Type                                                                                                                         | What it means                                                                                                      |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `id`          | Yes      | `string`                                                                                                                     | Stable requirement id used by setup, install, and test planners.                                                   |
+| `kind`        | Yes      | `"host-capability"` \| `"provider"` \| `"oauth"` \| `"api-key"` \| `"secret"` \| `"channel-account"` \| `"external-service"` | Broad requirement family.                                                                                          |
+| `label`       | No       | `string`                                                                                                                     | User-facing short label for setup surfaces.                                                                        |
+| `description` | No       | `string`                                                                                                                     | Human-readable explanation of why the credential or capability is needed.                                          |
+| `capability`  | No       | `string`                                                                                                                     | Host runtime capability that can satisfy the requirement, for example `runtime.llm.completeStructured`.            |
+| `provider`    | No       | `string`                                                                                                                     | Provider id that owns the credential or auth choice.                                                               |
+| `channel`     | No       | `string`                                                                                                                     | Channel id that owns the account credential.                                                                       |
+| `service`     | No       | `string`                                                                                                                     | External service name when the requirement is not a model provider or channel.                                     |
+| `authMethods` | No       | `string[]`                                                                                                                   | Setup/auth method ids, such as `api-key`, `oauth`, or provider-specific method ids.                                |
+| `scopes`      | No       | `string[]`                                                                                                                   | OAuth scopes or planner scopes needed by this requirement.                                                         |
+| `envVars`     | No       | `string[]`                                                                                                                   | Environment variables that can satisfy or signal this requirement without loading runtime.                         |
+| `configPaths` | No       | `string[]`                                                                                                                   | Config paths that can satisfy or signal this requirement.                                                          |
+| `secretRefs`  | No       | `string[]`                                                                                                                   | SecretRef surfaces or credential buckets relevant to this requirement.                                             |
+| `setupRefs`   | No       | `string[]`                                                                                                                   | Links to related manifest setup descriptors, such as `setup.providers:openai` or `providerAuthChoices:openai-key`. |
+| `optional`    | No       | `boolean`                                                                                                                    | Whether the plugin can run without this requirement.                                                               |
+| `mockable`    | No       | `boolean`                                                                                                                    | Whether automated benches can replace this requirement with a mock or fixture.                                     |
+| `manual`      | No       | `boolean`                                                                                                                    | Whether setup requires a manual out-of-band step that a planner should surface instead of auto-configuring.        |
+
+Use `kind: "host-capability"` when the plugin should rely on the user's
+existing OpenClaw runtime auth instead of asking for a plugin-owned provider
+secret. Use provider, channel, OAuth, API-key, secret, or external-service
+requirements when the plugin owns a credential surface of its own.
 
 ## providerAuthChoices reference
 
@@ -526,6 +596,10 @@ OpenClaw can also derive simple setup choices from `setup.providers[].authMethod
 when no setup entry is available, or when `setup.requiresRuntime: false`
 declares setup runtime unnecessary. Explicit `providerAuthChoices` entries stay
 preferred for custom labels, CLI flags, onboarding scope, and assistant metadata.
+Install and test planners can also derive compatibility auth requirements from
+`setup.providers`, `providerAuthChoices`, deprecated `providerAuthEnvVars`, and
+`channelEnvVars`, but new plugins should declare explicit `authRequirements`
+when they need a stable modular auth plan.
 
 Set `requiresRuntime: false` only when those descriptors are sufficient for the
 setup surface. OpenClaw treats explicit `false` as a descriptor-only contract
@@ -1340,6 +1414,7 @@ See [Configuration reference](/gateway/configuration) for the full `plugins.*` s
 - Exclusive plugin kinds are selected through `plugins.slots.*`: `kind: "memory"` via `plugins.slots.memory`, `kind: "context-engine"` via `plugins.slots.contextEngine` (default `legacy`).
 - Declare exclusive plugin kind in this manifest. Runtime-entry `OpenClawPluginDefinition.kind` is deprecated and remains only as a compatibility fallback for older plugins.
 - Env-var metadata (`setup.providers[].envVars`, deprecated `providerAuthEnvVars`, and `channelEnvVars`) is declarative only. Status, audit, cron delivery validation, and other read-only surfaces still apply plugin trust and effective activation policy before treating an env var as configured.
+- `authRequirements` is also declarative only. It lets setup, install, and test planners prepare an auth plan before runtime loads, but runtime still enforces its own credential checks.
 - For runtime wizard metadata that requires provider code, see [Provider runtime hooks](/plugins/architecture-internals#provider-runtime-hooks).
 - If your plugin depends on native modules, document the build steps and any package-manager allowlist requirements (for example, pnpm `allow-build-scripts` + `pnpm rebuild <package>`).
 

--- a/src/plugins/auth-requirements.test.ts
+++ b/src/plugins/auth-requirements.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { collectPluginAuthRequirements } from "./auth-requirements.js";
+
+describe("collectPluginAuthRequirements", () => {
+  it("keeps explicit manifest requirements ahead of derived compatibility hints", () => {
+    const requirements = collectPluginAuthRequirements({
+      id: "assistant-plugin",
+      authRequirements: [
+        {
+          id: "host-structured-llm",
+          kind: "host-capability",
+          capability: "runtime.llm.completeStructured",
+          mockable: true,
+        },
+      ],
+      setup: {
+        providers: [
+          {
+            id: "demo-provider",
+            authMethods: ["api-key"],
+            envVars: ["DEMO_API_KEY"],
+          },
+        ],
+      },
+      providerAuthChoices: [
+        {
+          provider: "demo-provider",
+          method: "api-key",
+          choiceId: "demo-provider-api-key",
+        },
+      ],
+      channelEnvVars: {
+        "demo-channel": ["DEMO_CHANNEL_TOKEN"],
+      },
+    });
+
+    expect(requirements).toEqual([
+      {
+        pluginId: "assistant-plugin",
+        source: "manifest",
+        requirement: {
+          id: "host-structured-llm",
+          kind: "host-capability",
+          capability: "runtime.llm.completeStructured",
+          mockable: true,
+        },
+      },
+      {
+        pluginId: "assistant-plugin",
+        source: "setup-provider",
+        requirement: {
+          id: "provider:demo-provider",
+          kind: "provider",
+          provider: "demo-provider",
+          setupRefs: ["setup.providers:demo-provider"],
+          authMethods: ["api-key"],
+          envVars: ["DEMO_API_KEY"],
+        },
+      },
+      {
+        pluginId: "assistant-plugin",
+        source: "provider-auth-choice",
+        requirement: {
+          id: "provider-auth-choice:demo-provider-api-key",
+          kind: "provider",
+          provider: "demo-provider",
+          authMethods: ["api-key"],
+          setupRefs: ["providerAuthChoices:demo-provider-api-key"],
+        },
+      },
+      {
+        pluginId: "assistant-plugin",
+        source: "channel-env-vars",
+        requirement: {
+          id: "channel:demo-channel",
+          kind: "channel-account",
+          channel: "demo-channel",
+          envVars: ["DEMO_CHANNEL_TOKEN"],
+          setupRefs: ["channelEnvVars:demo-channel"],
+        },
+      },
+    ]);
+  });
+
+  it("can return only explicit manifest requirements", () => {
+    const requirements = collectPluginAuthRequirements(
+      {
+        id: "demo",
+        authRequirements: [
+          {
+            id: "host-llm",
+            kind: "host-capability",
+            capability: "runtime.llm.complete",
+          },
+        ],
+        channelEnvVars: {
+          discord: ["DISCORD_BOT_TOKEN"],
+        },
+      },
+      { includeDerived: false },
+    );
+
+    expect(requirements).toEqual([
+      {
+        pluginId: "demo",
+        source: "manifest",
+        requirement: {
+          id: "host-llm",
+          kind: "host-capability",
+          capability: "runtime.llm.complete",
+        },
+      },
+    ]);
+  });
+
+  it("derives provider env vars only when setup providers do not cover the provider", () => {
+    const requirements = collectPluginAuthRequirements({
+      id: "demo",
+      setup: {
+        providers: [{ id: "covered", envVars: ["COVERED_API_KEY"] }],
+      },
+      providerAuthEnvVars: {
+        covered: ["LEGACY_COVERED_API_KEY"],
+        legacy: ["LEGACY_API_KEY"],
+      },
+    });
+
+    expect(requirements.map((entry) => entry.requirement.id)).toEqual([
+      "provider:covered",
+      "provider-env:legacy",
+    ]);
+  });
+});

--- a/src/plugins/auth-requirements.test.ts
+++ b/src/plugins/auth-requirements.test.ts
@@ -113,11 +113,17 @@ describe("collectPluginAuthRequirements", () => {
     ]);
   });
 
-  it("derives provider env vars only when setup providers do not cover the provider", () => {
+  it("merges legacy provider env vars into setup provider requirements", () => {
     const requirements = collectPluginAuthRequirements({
       id: "demo",
       setup: {
-        providers: [{ id: "covered", envVars: ["COVERED_API_KEY"] }],
+        providers: [
+          {
+            id: "covered",
+            authMethods: ["api-key"],
+            envVars: ["COVERED_API_KEY"],
+          },
+        ],
       },
       providerAuthEnvVars: {
         covered: ["LEGACY_COVERED_API_KEY"],
@@ -125,9 +131,30 @@ describe("collectPluginAuthRequirements", () => {
       },
     });
 
-    expect(requirements.map((entry) => entry.requirement.id)).toEqual([
-      "provider:covered",
-      "provider-env:legacy",
+    expect(requirements).toEqual([
+      {
+        pluginId: "demo",
+        source: "setup-provider",
+        requirement: {
+          id: "provider:covered",
+          kind: "provider",
+          provider: "covered",
+          setupRefs: ["setup.providers:covered", "providerAuthEnvVars:covered"],
+          authMethods: ["api-key"],
+          envVars: ["COVERED_API_KEY", "LEGACY_COVERED_API_KEY"],
+        },
+      },
+      {
+        pluginId: "demo",
+        source: "provider-env-vars",
+        requirement: {
+          id: "provider-env:legacy",
+          kind: "provider",
+          provider: "legacy",
+          envVars: ["LEGACY_API_KEY"],
+          setupRefs: ["providerAuthEnvVars:legacy"],
+        },
+      },
     ]);
   });
 });

--- a/src/plugins/auth-requirements.ts
+++ b/src/plugins/auth-requirements.ts
@@ -1,0 +1,147 @@
+import type {
+  PluginManifestAuthRequirement,
+  PluginManifestProviderAuthChoice,
+  PluginManifestSetup,
+} from "./manifest.js";
+
+export type PluginAuthRequirementSource =
+  | "manifest"
+  | "setup-provider"
+  | "provider-auth-choice"
+  | "provider-env-vars"
+  | "channel-env-vars";
+
+export type PluginAuthRequirementCarrier = {
+  id: string;
+  authRequirements?: readonly PluginManifestAuthRequirement[];
+  setup?: PluginManifestSetup;
+  providerAuthChoices?: readonly PluginManifestProviderAuthChoice[];
+  providerAuthEnvVars?: Readonly<Record<string, readonly string[]>>;
+  channelEnvVars?: Readonly<Record<string, readonly string[]>>;
+};
+
+export type PluginAuthRequirementPlanItem = {
+  pluginId: string;
+  source: PluginAuthRequirementSource;
+  requirement: PluginManifestAuthRequirement;
+};
+
+export type PluginAuthRequirementCollectionOptions = {
+  includeDerived?: boolean;
+};
+
+function normalizeStringList(values: readonly string[] | undefined): string[] {
+  return Array.from(new Set((values ?? []).map((value) => value.trim()).filter(Boolean)));
+}
+
+function cloneRequirement(
+  requirement: PluginManifestAuthRequirement,
+): PluginManifestAuthRequirement {
+  return {
+    ...requirement,
+    ...(requirement.authMethods ? { authMethods: [...requirement.authMethods] } : {}),
+    ...(requirement.scopes ? { scopes: [...requirement.scopes] } : {}),
+    ...(requirement.envVars ? { envVars: [...requirement.envVars] } : {}),
+    ...(requirement.configPaths ? { configPaths: [...requirement.configPaths] } : {}),
+    ...(requirement.secretRefs ? { secretRefs: [...requirement.secretRefs] } : {}),
+    ...(requirement.setupRefs ? { setupRefs: [...requirement.setupRefs] } : {}),
+  };
+}
+
+function toSortedEntries(
+  values: Readonly<Record<string, readonly string[]>> | undefined,
+): Array<[string, string[]]> {
+  return Object.entries(values ?? {})
+    .map(([id, list]): [string, string[]] => [id.trim(), normalizeStringList(list)])
+    .filter(([id, list]) => id.length > 0 && list.length > 0)
+    .toSorted(([left], [right]) => left.localeCompare(right));
+}
+
+/**
+ * Returns the manifest-declared auth requirements plus compatibility hints
+ * derived from existing manifest metadata. This is intentionally control-plane
+ * only: it does not read secrets, validate credentials, or load plugin runtime.
+ */
+export function collectPluginAuthRequirements(
+  plugin: PluginAuthRequirementCarrier,
+  options: PluginAuthRequirementCollectionOptions = {},
+): PluginAuthRequirementPlanItem[] {
+  const includeDerived = options.includeDerived !== false;
+  const collected: PluginAuthRequirementPlanItem[] = [];
+  const seenRequirementIds = new Set<string>();
+  const setupProviderIds = new Set<string>();
+
+  const pushRequirement = (
+    source: PluginAuthRequirementSource,
+    requirement: PluginManifestAuthRequirement,
+  ) => {
+    if (!requirement.id || seenRequirementIds.has(requirement.id)) {
+      return;
+    }
+    seenRequirementIds.add(requirement.id);
+    collected.push({
+      pluginId: plugin.id,
+      source,
+      requirement: cloneRequirement(requirement),
+    });
+  };
+
+  for (const requirement of plugin.authRequirements ?? []) {
+    pushRequirement("manifest", requirement);
+  }
+
+  if (!includeDerived) {
+    return collected;
+  }
+
+  for (const provider of plugin.setup?.providers ?? []) {
+    const authMethods = normalizeStringList(provider.authMethods);
+    const envVars = normalizeStringList(provider.envVars);
+    setupProviderIds.add(provider.id);
+    pushRequirement("setup-provider", {
+      id: `provider:${provider.id}`,
+      kind: "provider",
+      provider: provider.id,
+      setupRefs: [`setup.providers:${provider.id}`],
+      ...(authMethods.length > 0 ? { authMethods } : {}),
+      ...(envVars.length > 0 ? { envVars } : {}),
+    });
+  }
+
+  for (const choice of plugin.providerAuthChoices ?? []) {
+    const scopes = normalizeStringList(choice.onboardingScopes);
+    pushRequirement("provider-auth-choice", {
+      id: `provider-auth-choice:${choice.choiceId}`,
+      kind: "provider",
+      provider: choice.provider,
+      authMethods: [choice.method],
+      setupRefs: [`providerAuthChoices:${choice.choiceId}`],
+      ...(scopes.length > 0 ? { scopes } : {}),
+    });
+  }
+
+  for (const [provider, envVars] of toSortedEntries(plugin.providerAuthEnvVars)) {
+    if (setupProviderIds.has(provider)) {
+      continue;
+    }
+    pushRequirement("provider-env-vars", {
+      id: `provider-env:${provider}`,
+      kind: "provider",
+      provider,
+      envVars,
+      setupRefs: [`providerAuthEnvVars:${provider}`],
+    });
+  }
+
+  for (const [channel, envVars] of toSortedEntries(plugin.channelEnvVars)) {
+    pushRequirement("channel-env-vars", {
+      id: `channel:${channel}`,
+      kind: "channel-account",
+      channel,
+      envVars,
+      setupRefs: [`channelEnvVars:${channel}`],
+    });
+  }
+
+  return collected;
+}

--- a/src/plugins/auth-requirements.ts
+++ b/src/plugins/auth-requirements.ts
@@ -94,15 +94,23 @@ export function collectPluginAuthRequirements(
     return collected;
   }
 
+  const providerEnvVarEntries = toSortedEntries(plugin.providerAuthEnvVars);
+  const providerEnvVarsById = new Map(providerEnvVarEntries);
+
   for (const provider of plugin.setup?.providers ?? []) {
     const authMethods = normalizeStringList(provider.authMethods);
-    const envVars = normalizeStringList(provider.envVars);
+    const legacyEnvVars = providerEnvVarsById.get(provider.id) ?? [];
+    const envVars = normalizeStringList([...(provider.envVars ?? []), ...legacyEnvVars]);
+    const setupRefs = [`setup.providers:${provider.id}`];
+    if (legacyEnvVars.length > 0) {
+      setupRefs.push(`providerAuthEnvVars:${provider.id}`);
+    }
     setupProviderIds.add(provider.id);
     pushRequirement("setup-provider", {
       id: `provider:${provider.id}`,
       kind: "provider",
       provider: provider.id,
-      setupRefs: [`setup.providers:${provider.id}`],
+      setupRefs,
       ...(authMethods.length > 0 ? { authMethods } : {}),
       ...(envVars.length > 0 ? { envVars } : {}),
     });
@@ -120,7 +128,7 @@ export function collectPluginAuthRequirements(
     });
   }
 
-  for (const [provider, envVars] of toSortedEntries(plugin.providerAuthEnvVars)) {
+  for (const [provider, envVars] of providerEnvVarEntries) {
     if (setupProviderIds.has(provider)) {
       continue;
     }

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -740,6 +740,14 @@ describe("loadPluginManifestRegistry", () => {
           assistantVisibility: "visible",
         },
       ],
+      authRequirements: [
+        {
+          id: "host-structured-llm",
+          kind: "host-capability",
+          capability: "runtime.llm.completeStructured",
+          mockable: true,
+        },
+      ],
       configSchema: { type: "object" },
     });
 
@@ -805,6 +813,14 @@ describe("loadPluginManifestRegistry", () => {
         choiceLabel: "OpenAI API key",
         assistantPriority: 10,
         assistantVisibility: "visible",
+      },
+    ]);
+    expect(registry.plugins[0]?.authRequirements).toEqual([
+      {
+        id: "host-structured-llm",
+        kind: "host-capability",
+        capability: "runtime.llm.completeStructured",
+        mockable: true,
       },
     ]);
   });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -217,6 +217,7 @@ export type PluginManifestRecord = {
   providerAuthChoices?: PluginManifest["providerAuthChoices"];
   activation?: PluginManifestActivation;
   setup?: PluginManifestSetup;
+  authRequirements?: PluginManifest["authRequirements"];
   packageManifest?: OpenClawPackageManifest;
   packageDependencies?: PluginDependencySpecMap;
   packageOptionalDependencies?: PluginDependencySpecMap;
@@ -534,6 +535,7 @@ function buildRecord(params: {
     providerAuthChoices: params.manifest.providerAuthChoices,
     activation: params.manifest.activation,
     setup: params.manifest.setup,
+    authRequirements: params.manifest.authRequirements,
     packageManifest: params.candidate.packageManifest,
     packageDependencies: params.candidate.packageDependencies,
     packageOptionalDependencies: params.candidate.packageOptionalDependencies,

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -749,6 +749,8 @@ function matchesInstalledPluginRecord(params: {
   if (!record) {
     return false;
   }
+  const resolvedCandidateRoot = resolveUserPath(params.candidate.rootDir, params.env);
+  const candidateRoot = safeRealpathSync(resolvedCandidateRoot) ?? resolvedCandidateRoot;
   const resolvedCandidateSource = resolveUserPath(params.candidate.source, params.env);
   const candidateSource = safeRealpathSync(resolvedCandidateSource) ?? resolvedCandidateSource;
   const trackedPaths = [record.installPath, record.sourcePath]
@@ -761,7 +763,12 @@ function matchesInstalledPluginRecord(params: {
     return false;
   }
   return trackedPaths.some((trackedPath) => {
-    return candidateSource === trackedPath || isPathInside(trackedPath, candidateSource);
+    return (
+      candidateRoot === trackedPath ||
+      candidateSource === trackedPath ||
+      isPathInside(trackedPath, candidateRoot) ||
+      isPathInside(trackedPath, candidateSource)
+    );
   });
 }
 

--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -40,6 +40,64 @@ describe("loadPluginManifest JSON5 tolerance", () => {
     }
   });
 
+  it("normalizes manifest auth requirements", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "auth-demo",
+        configSchema: { type: "object" },
+        authRequirements: [
+          {
+            id: " host-llm ",
+            kind: "host-capability",
+            label: "Host LLM",
+            description: "Use the user's configured model auth.",
+            capability: " runtime.llm.completeStructured ",
+            provider: "",
+            authMethods: [" ", "model-auth"],
+            scopes: ["text-inference"],
+            envVars: ["OPENCLAW_HOST_MODEL"],
+            configPaths: ["agents.defaultModel"],
+            secretRefs: ["modelAuthProfile"],
+            setupRefs: ["setup.providers:host"],
+            optional: false,
+            mockable: true,
+            manual: true,
+          },
+          {
+            id: "ignored",
+            kind: "unknown",
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const result = loadPluginManifest(dir, false);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.authRequirements).toEqual([
+        {
+          id: "host-llm",
+          kind: "host-capability",
+          label: "Host LLM",
+          description: "Use the user's configured model auth.",
+          capability: "runtime.llm.completeStructured",
+          authMethods: ["model-auth"],
+          scopes: ["text-inference"],
+          envVars: ["OPENCLAW_HOST_MODEL"],
+          configPaths: ["agents.defaultModel"],
+          secretRefs: ["modelAuthProfile"],
+          setupRefs: ["setup.providers:host"],
+          mockable: true,
+          manual: true,
+        },
+      ]);
+    }
+  });
+
   it("uses native JSON parsing for standard JSON manifests", () => {
     const json5Parse = vi.spyOn(JSON5, "parse");
     const dir = makeTempDir();

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -230,6 +230,43 @@ export type PluginManifestSetup = {
   requiresRuntime?: boolean;
 };
 
+export type PluginManifestAuthRequirementKind =
+  | "host-capability"
+  | "provider"
+  | "oauth"
+  | "api-key"
+  | "secret"
+  | "channel-account"
+  | "external-service";
+
+export type PluginManifestAuthRequirement = {
+  /** Stable requirement id used by setup, install, and test planners. */
+  id: string;
+  /** Broad requirement family. */
+  kind: PluginManifestAuthRequirementKind;
+  /** User-facing label and explanatory text for setup surfaces. */
+  label?: string;
+  description?: string;
+  /** Host runtime capability that can satisfy this requirement. */
+  capability?: string;
+  /** Provider, channel, or external service that owns the required credential. */
+  provider?: string;
+  channel?: string;
+  service?: string;
+  /** Setup/auth method ids, OAuth scopes, or local credential signals. */
+  authMethods?: string[];
+  scopes?: string[];
+  envVars?: string[];
+  configPaths?: string[];
+  secretRefs?: string[];
+  /** Links to setup providers, auth choices, or channel descriptors in this manifest. */
+  setupRefs?: string[];
+  /** Hints for automated benches and install planners. */
+  optional?: boolean;
+  mockable?: boolean;
+  manual?: boolean;
+};
+
 export type PluginManifestQaRunner = {
   /** Subcommand mounted beneath `openclaw qa`, for example `matrix`. */
   commandName: string;
@@ -363,6 +400,11 @@ export type PluginManifest = {
   activation?: PluginManifestActivation;
   /** Cheap setup/onboarding metadata exposed before plugin runtime loads. */
   setup?: PluginManifestSetup;
+  /**
+   * Declarative auth requirements used by install, setup, and test planners
+   * without importing plugin runtime.
+   */
+  authRequirements?: PluginManifestAuthRequirement[];
   /** Cheap QA runner metadata exposed before plugin runtime loads. */
   qaRunners?: PluginManifestQaRunner[];
   skills?: string[];
@@ -1305,6 +1347,76 @@ function normalizeManifestSetup(value: unknown): PluginManifestSetup | undefined
   return Object.keys(setup).length > 0 ? setup : undefined;
 }
 
+const MANIFEST_AUTH_REQUIREMENT_KINDS = new Set<PluginManifestAuthRequirementKind>([
+  "host-capability",
+  "provider",
+  "oauth",
+  "api-key",
+  "secret",
+  "channel-account",
+  "external-service",
+]);
+
+function normalizeManifestAuthRequirementKind(
+  value: unknown,
+): PluginManifestAuthRequirementKind | undefined {
+  const kind = normalizeOptionalString(value);
+  return kind && MANIFEST_AUTH_REQUIREMENT_KINDS.has(kind as PluginManifestAuthRequirementKind)
+    ? (kind as PluginManifestAuthRequirementKind)
+    : undefined;
+}
+
+function normalizeManifestAuthRequirements(
+  value: unknown,
+): PluginManifestAuthRequirement[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized: PluginManifestAuthRequirement[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const id = normalizeOptionalString(entry.id) ?? "";
+    const kind = normalizeManifestAuthRequirementKind(entry.kind);
+    if (!id || !kind) {
+      continue;
+    }
+    const label = normalizeOptionalString(entry.label) ?? "";
+    const description = normalizeOptionalString(entry.description) ?? "";
+    const capability = normalizeOptionalString(entry.capability) ?? "";
+    const provider = normalizeOptionalString(entry.provider) ?? "";
+    const channel = normalizeOptionalString(entry.channel) ?? "";
+    const service = normalizeOptionalString(entry.service) ?? "";
+    const authMethods = normalizeTrimmedStringList(entry.authMethods);
+    const scopes = normalizeTrimmedStringList(entry.scopes);
+    const envVars = normalizeTrimmedStringList(entry.envVars);
+    const configPaths = normalizeTrimmedStringList(entry.configPaths);
+    const secretRefs = normalizeTrimmedStringList(entry.secretRefs);
+    const setupRefs = normalizeTrimmedStringList(entry.setupRefs);
+    normalized.push({
+      id,
+      kind,
+      ...(label ? { label } : {}),
+      ...(description ? { description } : {}),
+      ...(capability ? { capability } : {}),
+      ...(provider ? { provider } : {}),
+      ...(channel ? { channel } : {}),
+      ...(service ? { service } : {}),
+      ...(authMethods.length > 0 ? { authMethods } : {}),
+      ...(scopes.length > 0 ? { scopes } : {}),
+      ...(envVars.length > 0 ? { envVars } : {}),
+      ...(configPaths.length > 0 ? { configPaths } : {}),
+      ...(secretRefs.length > 0 ? { secretRefs } : {}),
+      ...(setupRefs.length > 0 ? { setupRefs } : {}),
+      ...(entry.optional === true ? { optional: true } : {}),
+      ...(entry.mockable === true ? { mockable: true } : {}),
+      ...(entry.manual === true ? { manual: true } : {}),
+    });
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 function normalizeManifestQaRunners(value: unknown): PluginManifestQaRunner[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -1627,6 +1739,7 @@ export function loadPluginManifest(
   const providerAuthChoices = normalizeProviderAuthChoices(raw.providerAuthChoices);
   const activation = normalizeManifestActivation(raw.activation);
   const setup = normalizeManifestSetup(raw.setup);
+  const authRequirements = normalizeManifestAuthRequirements(raw.authRequirements);
   const qaRunners = normalizeManifestQaRunners(raw.qaRunners);
   const skills = normalizeTrimmedStringList(raw.skills);
   const contracts = normalizeManifestContracts(raw.contracts);
@@ -1683,6 +1796,7 @@ export function loadPluginManifest(
       providerAuthChoices,
       activation,
       setup,
+      authRequirements,
       qaRunners,
       skills,
       name,

--- a/src/plugins/plugin-registry.ts
+++ b/src/plugins/plugin-registry.ts
@@ -1,2 +1,3 @@
+export * from "./auth-requirements.js";
 export * from "./plugin-registry-contributions.js";
 export * from "./plugin-registry-snapshot.js";


### PR DESCRIPTION
## Summary

- Add optional native plugin manifest `authRequirements` metadata for provider credentials, channel accounts, external services, and host runtime capabilities.
- Carry the metadata through manifest registry records and export `collectPluginAuthRequirements()` from the plugin registry barrel so benches/setup/install surfaces can consume explicit requirements plus derived hints from existing `setup.providers`, `providerAuthChoices`, provider env vars, and channel env vars.
- Preserve legacy `providerAuthEnvVars` hints by merging them into the matching derived `setup.providers` requirement instead of dropping them when both metadata surfaces mention the same provider.
- Document the contract and ClawHub install implication, with a changelog entry.

## Compatibility

This is additive and metadata-only. Existing native plugins keep loading because `authRequirements` is optional, malformed entries are skipped by the normalizer, compatible bundle manifests are unchanged, and runtime credential checks still stay plugin-owned.

## Real behavior proof

- Behavior or issue addressed: plugin install/setup/test planners can read a manifest-only auth plan, including a provider declared through both `setup.providers` and legacy `providerAuthEnvVars`, without executing plugin runtime code.
- Real environment tested: local OpenClaw checkout on macOS, Node via the repo toolchain, using a temporary native plugin manifest loaded by the real manifest loader.
- Exact steps or command run after this patch: `node --import tsx` from the repo root to write a temporary `openclaw.plugin.json`, load it with `loadPluginManifest(...)`, and call `collectPluginAuthRequirements(...)`.
- Evidence after fix: terminal output from that real Node command:

```json
[
  {
    "source": "setup-provider",
    "id": "provider:demo",
    "envVars": [
      "DEMO_API_KEY",
      "DEMO_LEGACY_API_KEY"
    ],
    "setupRefs": [
      "setup.providers:demo",
      "providerAuthEnvVars:demo"
    ]
  },
  {
    "source": "provider-env-vars",
    "id": "provider-env:legacy",
    "envVars": [
      "LEGACY_API_KEY"
    ],
    "setupRefs": [
      "providerAuthEnvVars:legacy"
    ]
  },
  {
    "source": "channel-env-vars",
    "id": "channel:slack",
    "envVars": [
      "SLACK_BOT_TOKEN"
    ],
    "setupRefs": [
      "channelEnvVars:slack"
    ]
  }
]
```

- Observed result after fix: the derived `provider:demo` requirement keeps the new setup descriptor, carries both the new and legacy env-var hints, and records both setup references; the unmatched legacy provider and channel hints remain separate plan items.
- What was not tested: no real secret lookup or credential validation, because this PR is intentionally metadata-only and runtime auth remains plugin-owned.

## Verification

- `node --import tsx` real manifest-loader/auth-plan proof above
- `pnpm test src/plugins/auth-requirements.test.ts src/plugins/manifest.json5-tolerance.test.ts src/plugins/manifest-registry.test.ts -- --reporter=verbose`
- `pnpm deadcode:unused-files`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/cli/plugins.md docs/plugins/manifest.md src/plugins/auth-requirements.ts src/plugins/auth-requirements.test.ts src/plugins/manifest.ts src/plugins/manifest-registry.ts src/plugins/manifest-registry.test.ts src/plugins/manifest.json5-tolerance.test.ts src/plugins/plugin-registry.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
